### PR TITLE
chore: update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-present Midscene.js
+Copyright (c) 2024-present Bytedance, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-present Midscene.js
+Copyright (c) 2024-present Bytedance, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/midscene/LICENSE
+++ b/packages/midscene/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-present Midscene.js
+Copyright (c) 2024-present Bytedance, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
update license, use the same license as other Bytedance projects, such as Rspack https://github.com/web-infra-dev/rspack/blob/main/LICENSE