### PR TITLE
feat(cache): optimize cache logic id and export overrideAIConfig

### DIFF
--- a/packages/web-integration/src/common/task-cache.ts
+++ b/packages/web-integration/src/common/task-cache.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { AIElementIdResponse, PlanningAction } from '@midscene/core';
+import {
+  type AIElementIdResponse,
+  type PlanningAction,
+  getAIConfig,
+} from '@midscene/core';
 import {
   getLogDirByType,
   stringifyDumpData,
@@ -200,7 +204,7 @@ export class TaskCache {
       return undefined;
     }
     const cacheFile = join(getLogDirByType('cache'), `${this.cacheId}.json`);
-    if (process.env.MIDSCENE_CACHE === 'true' && existsSync(cacheFile)) {
+    if (getAIConfig('MIDSCENE_CACHE') === 'true' && existsSync(cacheFile)) {
       try {
         const data = readFileSync(cacheFile, 'utf8');
         const jsonData = JSON.parse(data);

--- a/packages/web-integration/src/common/task-cache.ts
+++ b/packages/web-integration/src/common/task-cache.ts
@@ -54,9 +54,9 @@ export class TaskCache {
 
   midscenePkgInfo: ReturnType<typeof getRunningPkgInfo> | null;
 
-  constructor(opts?: { fileName?: string }) {
+  constructor(opts?: { cacheId?: string }) {
     this.midscenePkgInfo = getRunningPkgInfo();
-    this.cacheId = generateCacheId(opts?.fileName);
+    this.cacheId = opts?.cacheId || '';
     this.cache = this.readCacheFromFile() || {
       aiTasks: [],
     };
@@ -196,7 +196,7 @@ export class TaskCache {
   }
 
   readCacheFromFile() {
-    if (ifInBrowser) {
+    if (ifInBrowser || !this.cacheId) {
       return undefined;
     }
     const cacheFile = join(getLogDirByType('cache'), `${this.cacheId}.json`);
@@ -223,7 +223,7 @@ export class TaskCache {
 
   writeCacheToFile() {
     const midscenePkgInfo = getRunningPkgInfo();
-    if (!midscenePkgInfo) {
+    if (!midscenePkgInfo || !this.cacheId) {
       return;
     }
 

--- a/packages/web-integration/src/common/tasks.ts
+++ b/packages/web-integration/src/common/tasks.ts
@@ -55,7 +55,7 @@ export class PageTaskExecutor {
     this.insight = insight;
 
     this.taskCache = new TaskCache({
-      fileName: opts?.cacheId,
+      cacheId: opts?.cacheId,
     });
   }
 

--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -43,7 +43,7 @@ export const PlaywrightAiFixture = () => {
 
       pageAgentMap[idForPage] = new PageAgent(new PlaywrightWebPage(page), {
         testId: `playwright-${testId}-${idForPage}`,
-        cacheId: taskFile,
+        cacheId: `${taskFile}(${taskTitle})`,
         groupName: taskTitle,
         groupDescription: taskFile,
         generateReport: false, // we will generate it in the reporter

--- a/packages/web-integration/src/playwright/index.ts
+++ b/packages/web-integration/src/playwright/index.ts
@@ -2,3 +2,4 @@ export type { PlayWrightAiFixtureType } from './ai-fixture';
 export { PlaywrightAiFixture } from './ai-fixture';
 export { PageAgent as PlaywrightAgent } from '@/common/agent';
 export { WebPage as PlaywrightWebPage } from './page';
+export { overrideAIConfig } from '@midscene/core';

--- a/packages/web-integration/src/puppeteer/index.ts
+++ b/packages/web-integration/src/puppeteer/index.ts
@@ -9,3 +9,5 @@ export class PuppeteerAgent extends PageAgent {
     super(webPage, opts);
   }
 }
+
+export { overrideAIConfig } from '@midscene/core';

--- a/packages/web-integration/tests/ai/web/puppeteer/showcase.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/showcase.test.ts
@@ -9,7 +9,10 @@ describe(
       const { originPage, reset } = await launchPage(
         'https://www.saucedemo.com/',
       );
-      const mid = new PuppeteerAgent(originPage);
+      const mid = new PuppeteerAgent(originPage, {
+        cacheId: 'puppeteer(Sauce Demo by Swag Lab)',
+      });
+
       await mid.aiAction(
         'type "standard_user" in user name input, type "secret_sauce" in password, click "Login"',
       );


### PR DESCRIPTION
> use case

```js
import {  overrideAIConfig } from '@midscene/web/puppeteer';

overrideAIConfig({
 'MIDSCENE_OPENAI_INIT_CONFIG_JSON': 'xxxx',
 'MIDSCENE_MODEL_NAME': 'xxx'
})

```