### PR TITLE
fix: bing-search.yaml add tasks

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -57,10 +57,13 @@ Write a yaml file to `bing-search.yaml`
 ```yaml
 target:
   url: https://www.bing.com
-flow:
-  - ai: search for 'weather today'
-  - sleep: 3000
-  - aiAssert: the result shows the weather info
+
+tasks:
+  - name: search weather
+    flow:
+      - ai: search for 'weather today'
+      - sleep: 3000
+      - aiAssert: the result shows the weather info
 ```
 
 Run this script

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -57,10 +57,13 @@ npm i @midscene/cli --save-dev
 ```yaml
 target:
   url: https://www.bing.com
-flow:
-  - ai: 搜索 "今日天气"
-  - sleep: 3000
-  - aiAssert: 结果显示天气信息
+
+tasks:
+  - name: 搜索天气
+    flow:
+      - ai: 搜索 "今日天气"
+      - sleep: 3000
+      - aiAssert: 结果显示天气信息
 ```
 
 运行脚本


### PR DESCRIPTION
`bing-search.yaml` should have a `tasks` filed according to the document