### PR TITLE
fix: improve waitForNetworkIdle with timeout handling

### DIFF
--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -189,10 +189,10 @@ export type PlayWrightAiFixtureType = {
   aiWaitFor: (assertion: string, opt?: AgentWaitForOpt) => Promise<void>;
 };
 
-function waitForNetworkIdle(page: OriginPlaywrightPage) {
-  const timeout = 20 * 1000;
-  return Promise.race([
-    page.waitForLoadState('networkidle'),
-    new Promise((resolve) => setTimeout(resolve, timeout)),
-  ]);
+async function waitForNetworkIdle(page: OriginPlaywrightPage, timeout = 20000) {
+  try {
+    await page.waitForLoadState('networkidle', { timeout });
+  } catch (error) {
+    console.warn(`Network idle timeout exceeded: ${error.message}`);
+  }
 }

--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -192,7 +192,7 @@ export type PlayWrightAiFixtureType = {
 async function waitForNetworkIdle(page: OriginPlaywrightPage, timeout = 20000) {
   try {
     await page.waitForLoadState('networkidle', { timeout });
-  } catch (error) {
-    console.warn(`Network idle timeout exceeded: ${error.message}`);
+  } catch (error: any) { 
+    console.warn(`Network idle timeout exceeded: ${error instanceof Error ? error.message : String(error)}`);
   }
 }


### PR DESCRIPTION
fix: improve waitForNetworkIdle with timeout handling

- Added explicit timeout parameter to avoid indefinite waiting
- Wrapped waitForLoadState in try-catch to log timeout errors
- Prevents tests from hanging if network idle state is not reached