### PR TITLE
feat(browser): Add the forceSameTabNavigation configuration to prevent AI from opening new pages during operations, thus avoiding task interruptions.

### DIFF
--- a/apps/site/docs/en/API.md
+++ b/apps/site/docs/en/API.md
@@ -15,7 +15,7 @@ Here are the common options for all agents:
 
 And also, puppeteer agent has an extra option:
 
-* `trackingActiveTab`: If true, the agent will track the newly opened tab. Default is false.
+* `forceSameTabNavigation`: If true, the agent will limit the popup to the current page. Default is true.
 
 ## Methods
 

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -148,8 +148,8 @@ target:
   # string, the path to save the aiQuery result, optional
   output: <path-to-output-file>
 
-  # boolean, if track the newly opened tab, true for default in yaml script
-  trackingActiveTab: <boolean>
+  # boolean, if limit the popup to the current page, true for default in yaml script
+  forceSameTabNavigation: <boolean>
 
   # string, the bridge mode to use, optional, default is false, can be 'newTabWithUrl' or 'currentTab'. More details see the following section
   bridgeMode: false | 'newTabWithUrl' | 'currentTab'

--- a/apps/site/docs/en/bridge-mode-by-chrome-extension.mdx
+++ b/apps/site/docs/en/bridge-mode-by-chrome-extension.mdx
@@ -79,13 +79,13 @@ You should always call `connectCurrentTab` or `connectNewTabWithUrl` before doin
 Each of the agent instance can only connect to one tab instance, and it cannot be reconnected after destroy.
 :::
 
-### `connectCurrentTab(options?: { trackingActiveTab?: boolean })`
+### `connectCurrentTab(options?: { forceSameTabNavigation?: boolean })`
 
 Connect to the current active tab on Chrome as the starting point.
 
-If `trackingActiveTab` is true, the agent will always track the active tab. For example, if you switch to another tab or a new tab is opened, the agent will track the latest active tab. Otherwise, the agent will only track the tab you connected to initially.
+If `forceSameTabNavigation` is true(default is true), the agent will limit the popup to the current page. For example, if you switch to another tab or a new tab is opened, the agent will limit the popup to the latest active tab. Otherwise, the agent will not limit the popup.
 
-### `connectNewTabWithUrl(url: string, options?: { trackingActiveTab?: boolean })`
+### `connectNewTabWithUrl(url: string, options?: { forceSameTabNavigation?: boolean })`
 
 Create a new tab with url and connect to immediately.
 

--- a/apps/site/docs/en/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/en/integrate-with-puppeteer.mdx
@@ -100,13 +100,13 @@ After the above command executes successfully, the console will output: `Midscen
 
 ## More options in PuppeteerAgent constructor
 
-### To track newly opened tab
+### To limit the popup to the current page
 
-If you want to track the newly opened tab (like clicking a link with `target="_blank"`), you can set the `trackingActiveTab` option to `true`:
+If you want to limit the popup to the current page (like clicking a link with `target="_blank"`), you can set the `forceSameTabNavigation` option to `true`:
 
 ```typescript
 const mid = new PuppeteerAgent(page, {
-  trackingActiveTab: true,
+  forceSameTabNavigation: true,
 });
 ```
 

--- a/apps/site/docs/zh/API.md
+++ b/apps/site/docs/zh/API.md
@@ -15,7 +15,7 @@ Midscene 中每个 Agent 都有自己的构造函数。
 
 在 puppeteer 中，还有一个额外的参数：
 
-* `trackingActiveTab: boolean`: 如果为 true，则跟踪新打开的标签页。默认值为 false。
+* `forceSameTabNavigation: boolean`: 如果为 true，则限制页面在当前 tab 打开。默认值为 true。
 
 ## 方法
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -148,8 +148,8 @@ target:
   # 输出 aiQuery 结果的 JSON 文件路径，可选
   output: <path-to-output-file>
 
-  # 是否跟踪新打开的标签页，可选，默认 true
-  trackingActiveTab: <boolean>
+  # 是否限制页面在当前 tab 打开，可选，默认 true
+  forceSameTabNavigation: <boolean>
 
   # 桥接模式，可选，默认 false，可以为 'newTabWithUrl' 或 'currentTab'。更多详情请参阅后文
   bridgeMode: false | 'newTabWithUrl' | 'currentTab'

--- a/apps/site/docs/zh/bridge-mode-by-chrome-extension.mdx
+++ b/apps/site/docs/zh/bridge-mode-by-chrome-extension.mdx
@@ -79,13 +79,13 @@ tsx demo-new-tab.ts
 每个 agent 实例只能连接到一个标签页实例，并且一旦被销毁就无法重新连接，需要重新创建 agent 实例。
 :::
 
-### `connectCurrentTab(options?: { trackingActiveTab?: boolean })`
+### `connectCurrentTab(options?: { forceSameTabNavigation?: boolean })`
 
 连接到当前已激活的标签页。
 
-如果 `trackingActiveTab` 为 true，则 agent 将始终跟踪当前激活的标签页。例如，如果你切换到另一个标签页或打开一个新的标签页，agent 将跟踪最新激活的标签页。否则，agent 将只跟踪你最初连接的标签页。
+如果 `forceSameTabNavigation` 为 true(默认是 true)，则 agent 将限制页面在当前 tab 打开。例如，如果你切换到另一个标签页或打开一个新的标签页，agent 将限制在上次打开的页面。否则，agent 将不限制页面在当前 tab 打开。
 
-### `connectNewTabWithUrl(url: string, options?: { trackingActiveTab?: boolean })`
+### `connectNewTabWithUrl(url: string, options?: { forceSameTabNavigation?: boolean })`
 
 创建一个新标签页，并立即连接到它。
 

--- a/apps/site/docs/zh/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/zh/integrate-with-puppeteer.mdx
@@ -98,13 +98,13 @@ npx tsx demo.ts
 
 当上面的命令执行成功后，会在控制台输出：`Midscene - report file updated: /path/to/report/some_id.html`， 通过浏览器打开该文件即可看到报告。
 
-## 如何跟踪新打开的标签页
+## 如何限制页面在当前 tab 打开
 
-如果你想要跟踪新打开的标签页（比如点击一个带有 `target="_blank"` 属性的链接），你可以设置 `trackingActiveTab` 选项为 `true`：
+如果你想要限制页面在当前 tab 打开（比如点击一个带有 `target="_blank"` 属性的链接），你可以设置 `forceSameTabNavigation` 选项为 `true`：
 
 ```typescript
 const mid = new PuppeteerAgent(page, {
-  trackingActiveTab: true,
+  forceSameTabNavigation: true,
 });
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "js-yaml": "4.1.0",
     "restore-cursor": "5.1.0",
     "typescript": "~5.0.4",
-    "vitest": "^1.6.0",
+    "vitest": "3.0.5",
     "yargs": "17.7.2"
   },
   "engines": {

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -19,7 +19,7 @@
     "playwright": "1.44.1",
     "@playwright/test": "^1.44.1",
     "typescript": "~5.0.4",
-    "vitest": "^1.6.0"
+    "vitest": "3.0.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/midscene/package.json
+++ b/packages/midscene/package.json
@@ -56,7 +56,7 @@
     "dotenv": "16.4.5",
     "langsmith": "0.3.7",
     "typescript": "~5.0.4",
-    "vitest": "^1.6.0"
+    "vitest": "3.0.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/midscene/src/yaml.d.ts
+++ b/packages/midscene/src/yaml.d.ts
@@ -24,7 +24,7 @@ export interface MidsceneYamlScriptEnv {
   };
   cookie?: string;
   output?: string;
-  trackingActiveTab?: boolean; // if track the newly opened tab, true for default in yaml script
+  forceSameTabNavigation?: boolean; // if track the newly opened tab, true for default in yaml script
 
   // bridge mode config
   bridgeMode?: false | 'newTabWithUrl' | 'currentTab';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -96,7 +96,7 @@
     "typescript": "~5.0.4",
     "@types/node": "^18.0.0",
     "rimraf": "~3.0.2",
-    "vitest": "^1.6.0",
+    "vitest": "3.0.5",
     "js-sha256": "0.11.0"
   },
   "sideEffects": [],

--- a/packages/visualizer/src/component/playground-component.tsx
+++ b/packages/visualizer/src/component/playground-component.tsx
@@ -187,8 +187,8 @@ export function Playground({
   const forceSameTabNavigation = useEnvConfig(
     (state) => state.forceSameTabNavigation,
   );
-  const setforceSameTabNavigation = useEnvConfig(
-    (state) => state.setforceSameTabNavigation,
+  const setForceSameTabNavigation = useEnvConfig(
+    (state) => state.setForceSameTabNavigation,
   );
   const configAlreadySet = Object.keys(config || {}).length >= 1;
   const runResultRef = useRef<HTMLHeadingElement>(null);
@@ -245,7 +245,7 @@ export function Playground({
     {
       label: (
         <Checkbox
-          onChange={(e) => setforceSameTabNavigation(e.target.checked)}
+          onChange={(e) => setForceSameTabNavigation(e.target.checked)}
           checked={forceSameTabNavigation}
         >
           {trackingTip}
@@ -261,7 +261,7 @@ export function Playground({
         <Dropdown menu={{ items: configItems }}>
           <Space>
             <SettingOutlined />
-            {forceSameTabNavigation ? trackingTip : 'focus on current tab'}
+            {forceSameTabNavigation ? trackingTip : "don't track popup"}
           </Space>
         </Dropdown>
       </div>

--- a/packages/visualizer/src/component/playground-component.tsx
+++ b/packages/visualizer/src/component/playground-component.tsx
@@ -229,7 +229,7 @@ export function Playground({
     if (uiContextPreview) return;
     if (!showContextPreview) return;
 
-    getAgent()
+    getAgent(forceSameTabNavigation)
       ?.getUIContext()
       .then((context: UIContext) => {
         setUiContextPreview(context);

--- a/packages/visualizer/src/component/playground-component.tsx
+++ b/packages/visualizer/src/component/playground-component.tsx
@@ -149,8 +149,8 @@ const serverLaunchTip = (
 );
 
 // remember to destroy the agent when the tab is destroyed: agent.page.destroy()
-export const extensionAgentForTab = (trackingActiveTab?: boolean) => {
-  const page = new ChromeExtensionProxyPage(trackingActiveTab || false);
+export const extensionAgentForTab = (forceSameTabNavigation = true) => {
+  const page = new ChromeExtensionProxyPage(forceSameTabNavigation);
   return new ChromeExtensionProxyPageAgent(page);
 };
 
@@ -168,7 +168,7 @@ export function Playground({
   dryMode = false,
 }: {
   getAgent: (
-    trackingActiveTab?: boolean,
+    forceSameTabNavigation?: boolean,
   ) => StaticPageAgent | ChromeExtensionProxyPageAgent | null;
   hideLogo?: boolean;
   showContextPreview?: boolean;
@@ -184,9 +184,11 @@ export function Playground({
   const [verticalMode, setVerticalMode] = useState(false);
   const [form] = Form.useForm();
   const { config, serviceMode, setServiceMode } = useEnvConfig();
-  const trackingActiveTab = useEnvConfig((state) => state.trackingActiveTab);
-  const setTrackingActiveTab = useEnvConfig(
-    (state) => state.setTrackingActiveTab,
+  const forceSameTabNavigation = useEnvConfig(
+    (state) => state.forceSameTabNavigation,
+  );
+  const setforceSameTabNavigation = useEnvConfig(
+    (state) => state.setforceSameTabNavigation,
   );
   const configAlreadySet = Object.keys(config || {}).length >= 1;
   const runResultRef = useRef<HTMLHeadingElement>(null);
@@ -238,13 +240,13 @@ export function Playground({
       });
   }, [uiContextPreview, showContextPreview, getAgent]);
 
-  const trackingTip = 'track newly-opened tabs';
+  const trackingTip = 'limit popup to current tab';
   const configItems = [
     {
       label: (
         <Checkbox
-          onChange={(e) => setTrackingActiveTab(e.target.checked)}
-          checked={trackingActiveTab}
+          onChange={(e) => setforceSameTabNavigation(e.target.checked)}
+          checked={forceSameTabNavigation}
         >
           {trackingTip}
         </Checkbox>
@@ -259,7 +261,7 @@ export function Playground({
         <Dropdown menu={{ items: configItems }}>
           <Space>
             <SettingOutlined />
-            {trackingActiveTab ? trackingTip : 'focus on current tab'}
+            {forceSameTabNavigation ? trackingTip : 'focus on current tab'}
           </Space>
         </Dropdown>
       </div>
@@ -289,7 +291,7 @@ export function Playground({
     });
     let result: PlaygroundResult = { ...blankResult };
 
-    const activeAgent = getAgent(trackingActiveTab);
+    const activeAgent = getAgent(forceSameTabNavigation);
     const thisRunningId = Date.now();
     try {
       if (!activeAgent) {
@@ -396,7 +398,7 @@ export function Playground({
     // setTimeout(() => {
     //   runResultRef.current?.scrollIntoView({ behavior: 'smooth' });
     // }, 50);
-  }, [form, getAgent, serviceMode, serverValid, trackingActiveTab]);
+  }, [form, getAgent, serviceMode, serverValid, forceSameTabNavigation]);
 
   let placeholder = 'What do you want to do?';
   const selectedType = Form.useWatch('type', form);

--- a/packages/visualizer/src/component/store.tsx
+++ b/packages/visualizer/src/component/store.tsx
@@ -135,8 +135,8 @@ export const useEnvConfig = create<{
   configString: string;
   setConfig: (config: Record<string, string>) => void;
   loadConfig: (configString: string) => void;
-  trackingActiveTab: boolean;
-  setTrackingActiveTab: (trackingActiveTab: boolean) => void;
+  forceSameTabNavigation: boolean;
+  setforceSameTabNavigation: (forceSameTabNavigation: boolean) => void;
   history: HistoryItem[];
   clearHistory: () => void;
   addHistory: (history: HistoryItem) => void;
@@ -149,7 +149,7 @@ export const useEnvConfig = create<{
   const savedServiceMode = localStorage.getItem(
     SERVICE_MODE_KEY,
   ) as ServiceModeType | null;
-  const savedTrackingActiveTab =
+  const savedforceSameTabNavigation =
     localStorage.getItem(TRACKING_ACTIVE_TAB_KEY) !== 'false';
   return {
     serviceMode: ifInExtension
@@ -169,12 +169,12 @@ export const useEnvConfig = create<{
       set({ config, configString });
       localStorage.setItem(CONFIG_KEY, configString);
     },
-    trackingActiveTab: savedTrackingActiveTab,
-    setTrackingActiveTab: (trackingActiveTab: boolean) => {
-      set({ trackingActiveTab });
+    forceSameTabNavigation: savedforceSameTabNavigation,
+    setforceSameTabNavigation: (forceSameTabNavigation: boolean) => {
+      set({ forceSameTabNavigation });
       localStorage.setItem(
         TRACKING_ACTIVE_TAB_KEY,
-        trackingActiveTab.toString(),
+        forceSameTabNavigation.toString(),
       );
     },
     history: getHistoryFromLocalStorage(),

--- a/packages/visualizer/src/component/store.tsx
+++ b/packages/visualizer/src/component/store.tsx
@@ -136,7 +136,7 @@ export const useEnvConfig = create<{
   setConfig: (config: Record<string, string>) => void;
   loadConfig: (configString: string) => void;
   forceSameTabNavigation: boolean;
-  setforceSameTabNavigation: (forceSameTabNavigation: boolean) => void;
+  setForceSameTabNavigation: (forceSameTabNavigation: boolean) => void;
   history: HistoryItem[];
   clearHistory: () => void;
   addHistory: (history: HistoryItem) => void;
@@ -149,7 +149,7 @@ export const useEnvConfig = create<{
   const savedServiceMode = localStorage.getItem(
     SERVICE_MODE_KEY,
   ) as ServiceModeType | null;
-  const savedforceSameTabNavigation =
+  const savedForceSameTabNavigation =
     localStorage.getItem(TRACKING_ACTIVE_TAB_KEY) !== 'false';
   return {
     serviceMode: ifInExtension
@@ -169,8 +169,8 @@ export const useEnvConfig = create<{
       set({ config, configString });
       localStorage.setItem(CONFIG_KEY, configString);
     },
-    forceSameTabNavigation: savedforceSameTabNavigation,
-    setforceSameTabNavigation: (forceSameTabNavigation: boolean) => {
+    forceSameTabNavigation: savedForceSameTabNavigation,
+    setForceSameTabNavigation: (forceSameTabNavigation: boolean) => {
       set({ forceSameTabNavigation });
       localStorage.setItem(
         TRACKING_ACTIVE_TAB_KEY,

--- a/packages/visualizer/src/extension/popup.tsx
+++ b/packages/visualizer/src/extension/popup.tsx
@@ -21,7 +21,7 @@ declare const __VERSION__: string;
 
 function PlaygroundPopup() {
   const extensionVersion = getExtensionVersion();
-  const { popupTab, setPopupTab, trackingActiveTab } = useEnvConfig();
+  const { popupTab, setPopupTab, forceSameTabNavigation } = useEnvConfig();
 
   const items = [
     {
@@ -32,8 +32,8 @@ function PlaygroundPopup() {
         <div className="popup-playground-container">
           <Playground
             hideLogo
-            getAgent={(trackingActiveTab?: boolean) => {
-              return extensionAgentForTab(trackingActiveTab);
+            getAgent={(forceSameTabNavigation?: boolean) => {
+              return extensionAgentForTab(forceSameTabNavigation);
             }}
             showContextPreview={false}
           />

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -100,7 +100,7 @@
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AI_TEST_TYPE=web npm run test",
-    "test:ai:temp": "MIDSCENE_CACHE=true AI_TEST_TYPE=web BRIDGE_MODE=true vitest --run tests/ai/bridge/temp.test.ts",
+    "test:ai:temp": "MIDSCENE_CACHE=true AI_TEST_TYPE=web BRIDGE_MODE=true vitest --run tests/ai/bridge/open-new-tab.test.ts",
     "test:ai:bridge": "MIDSCENE_CACHE=true BRIDGE_MODE=true AI_TEST_TYPE=web npm run test --inspect tests/ai/bridge/temp.test.ts",
     "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=web npm run test",
     "test:ai:all": "npm run test:ai:web && npm run test:ai:native",
@@ -146,7 +146,7 @@
     "playwright": "1.44.1",
     "puppeteer": "24.2.0",
     "typescript": "~5.0.4",
-    "vitest": "^1.6.0",
+    "vitest": "3.0.5",
     "webdriverio": "9.0.6"
   },
   "peerDependencies": {

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -100,7 +100,7 @@
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AI_TEST_TYPE=web npm run test",
-    "test:ai:temp": "AI_TEST_TYPE=web BRIDGE_MODE=true vitest --run tests/ai/bridge/temp.test.ts",
+    "test:ai:temp": "MIDSCENE_CACHE=true AI_TEST_TYPE=web BRIDGE_MODE=true vitest --run tests/ai/bridge/temp.test.ts",
     "test:ai:bridge": "MIDSCENE_CACHE=true BRIDGE_MODE=true AI_TEST_TYPE=web npm run test --inspect tests/ai/bridge/temp.test.ts",
     "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=web npm run test",
     "test:ai:all": "npm run test:ai:web && npm run test:ai:native",

--- a/packages/web-integration/src/bridge-mode/common.ts
+++ b/packages/web-integration/src/bridge-mode/common.ts
@@ -16,9 +16,9 @@ export enum BridgeEvent {
 export interface BridgeConnectTabOptions {
   /**
    * If true, the page will always track the active tab.
-   * @default false
+   * @default true
    */
-  trackingActiveTab?: boolean;
+  forceSameTabNavigation?: boolean;
 }
 
 export enum MouseEvent {

--- a/packages/web-integration/src/bridge-mode/page-browser-side.ts
+++ b/packages/web-integration/src/bridge-mode/page-browser-side.ts
@@ -21,9 +21,9 @@ export class ChromeExtensionPageBrowserSide extends ChromeExtensionProxyPage {
       message: string,
       type: 'log' | 'status',
     ) => void = () => {},
-    trackingActiveTab = false,
+    forceSameTabNavigation = true,
   ) {
-    super(trackingActiveTab);
+    super(forceSameTabNavigation);
   }
 
   private async setupBridgeClient() {
@@ -104,7 +104,7 @@ export class ChromeExtensionPageBrowserSide extends ChromeExtensionProxyPage {
   public async connectNewTabWithUrl(
     url: string,
     options: BridgeConnectTabOptions = {
-      trackingActiveTab: true,
+      forceSameTabNavigation: true,
     },
   ) {
     const tab = await chrome.tabs.create({ url });
@@ -114,14 +114,14 @@ export class ChromeExtensionPageBrowserSide extends ChromeExtensionProxyPage {
     // new tab
     this.onLogMessage(`Creating new tab: ${url}`, 'log');
 
-    if (options?.trackingActiveTab) {
-      this.trackingActiveTab = true;
+    if (options?.forceSameTabNavigation) {
+      this.forceSameTabNavigation = true;
     }
   }
 
   public async connectCurrentTab(
     options: BridgeConnectTabOptions = {
-      trackingActiveTab: true,
+      forceSameTabNavigation: true,
     },
   ) {
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -131,8 +131,8 @@ export class ChromeExtensionPageBrowserSide extends ChromeExtensionProxyPage {
 
     this.onLogMessage(`Connected to current tab: ${tabs[0]?.url}`, 'log');
 
-    if (options?.trackingActiveTab) {
-      this.trackingActiveTab = true;
+    if (options?.forceSameTabNavigation) {
+      this.forceSameTabNavigation = true;
     }
   }
 

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -7,6 +7,7 @@
 
 import assert from 'node:assert';
 import type { WebKeyInput } from '@/common/page';
+import { limitOpenNewTabScript } from '@/common/ui-utils';
 import type { AbstractPage } from '@/page';
 import type { BaseElement, ElementTreeNode, Point, Size } from '@midscene/core';
 import type { ElementInfo } from '@midscene/shared/extractor';
@@ -103,6 +104,17 @@ export default class ChromeExtensionProxyPage implements AbstractPage {
         await chrome.debugger.attach({ tabId: currentTabId }, '1.3');
         // wait util the debugger banner in Chrome appears
         await sleep(500);
+
+        if (this.forceSameTabNavigation) {
+          await chrome.debugger.sendCommand(
+            { tabId: currentTabId },
+            'Runtime.evaluate',
+            {
+              expression: limitOpenNewTabScript,
+            },
+          );
+        }
+
         this.tabIdOfDebuggerAttached = currentTabId;
 
         await this.enableWaterFlowAnimation();

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -28,7 +28,7 @@ declare const __VERSION__: string;
 export default class ChromeExtensionProxyPage implements AbstractPage {
   pageType = 'chrome-extension-proxy';
 
-  public trackingActiveTab: boolean;
+  public forceSameTabNavigation: boolean;
   private version: string = __VERSION__;
 
   private viewportSize?: Size;
@@ -41,12 +41,12 @@ export default class ChromeExtensionProxyPage implements AbstractPage {
 
   private destroyed = false;
 
-  constructor(trackingActiveTab: boolean) {
-    this.trackingActiveTab = trackingActiveTab;
+  constructor(forceSameTabNavigation: boolean) {
+    this.forceSameTabNavigation = forceSameTabNavigation;
   }
 
   public async getTabId() {
-    if (this.activeTabId && !this.trackingActiveTab) {
+    if (this.activeTabId && !this.forceSameTabNavigation) {
       return this.activeTabId;
     }
     const tabId = await chrome.tabs

--- a/packages/web-integration/src/common/agent.ts
+++ b/packages/web-integration/src/common/agent.ts
@@ -27,7 +27,7 @@ import { printReportMsg, reportFileName } from './utils';
 import { type WebUIContext, parseContextFromWebPage } from './utils';
 
 export interface PageAgentOpt {
-  trackingActiveTab?: boolean /* if tracking the newly created tab, default false */;
+  forceSameTabNavigation?: boolean /* if limit the new tab to the current page, default true */;
   testId?: string;
   cacheId?: string;
   groupName?: string;

--- a/packages/web-integration/src/common/task-cache.ts
+++ b/packages/web-integration/src/common/task-cache.ts
@@ -258,9 +258,12 @@ export class TaskCache {
         if (!this.midscenePkgInfo) {
           return undefined;
         }
+        const jsonDataPkgVersion = jsonData.pkgVersion.split('.');
+        const midscenePkgInfoPkgVersion =
+          this.midscenePkgInfo.version.split('.');
         if (
-          jsonData.pkgName !== this.midscenePkgInfo.name ||
-          jsonData.pkgVersion !== this.midscenePkgInfo.version
+          jsonDataPkgVersion[0] !== midscenePkgInfoPkgVersion[0] ||
+          jsonDataPkgVersion[1] !== midscenePkgInfoPkgVersion[1]
         ) {
           return undefined;
         }

--- a/packages/web-integration/src/common/ui-utils.ts
+++ b/packages/web-integration/src/common/ui-utils.ts
@@ -87,3 +87,22 @@ export function paramStr(task: ExecutionTask) {
     ? value
     : JSON.stringify(value, undefined, 2);
 }
+
+export const limitOpenNewTabScript = `
+// Intercept the window.open method
+window.open = function() { 
+  console.log('Blocked window.open:', arguments);
+  return null;
+};
+
+// Block all a tag clicks
+document.addEventListener('click', function(e) {
+  const target = e.target.closest('a');
+  if (target && target.target === '_blank') {
+    e.preventDefault();
+    console.log('Blocked new tab:', target.href);
+    window.location.href = target.href;
+    target.removeAttribute('target');
+  }
+}, true);
+`;

--- a/packages/web-integration/src/common/utils.ts
+++ b/packages/web-integration/src/common/utils.ts
@@ -23,7 +23,6 @@ import { uuid } from '@midscene/shared/utils';
 import dayjs from 'dayjs';
 import { WebElementInfo } from '../web-element';
 import type { WebPage } from './page';
-
 export type WebUIContext = UIContext<WebElementInfo> & {
   url: string;
 };
@@ -41,18 +40,6 @@ export async function parseContextFromWebPage(
 
   let screenshotBase64: string;
   let tree: ElementTreeNode<ElementInfo>;
-
-  // ref: packages/web-integration/src/playwright/ai-fixture.ts popup logic
-  // During test execution, a new page might be opened through a connection, and the page remains confined to the same page instance.
-  // The page may go through opening, closing, and reopening; if the page is closed, evaluate may return undefined, which can lead to errors.
-  // Therefore, when the page is closed, wait for 500ms before attempting to evaluate again.
-  if (
-    'isClosed' in page &&
-    typeof page.isClosed === 'function' &&
-    page.isClosed()
-  ) {
-    await sleep(1000);
-  }
 
   await Promise.all([
     page.screenshotBase64().then((base64) => {

--- a/packages/web-integration/src/common/utils.ts
+++ b/packages/web-integration/src/common/utils.ts
@@ -13,7 +13,7 @@ import {
   MIDSCENE_USE_VLM_UI_TARS,
   getAIConfig,
 } from '@midscene/core/env';
-import { uploadTestInfoToServer } from '@midscene/core/utils';
+import { sleep, uploadTestInfoToServer } from '@midscene/core/utils';
 import { NodeType } from '@midscene/shared/constants';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { traverseTree, treeToList } from '@midscene/shared/extractor';
@@ -41,6 +41,18 @@ export async function parseContextFromWebPage(
 
   let screenshotBase64: string;
   let tree: ElementTreeNode<ElementInfo>;
+
+  // ref: packages/web-integration/src/playwright/ai-fixture.ts popup logic
+  // During test execution, a new page might be opened through a connection, and the page remains confined to the same page instance.
+  // The page may go through opening, closing, and reopening; if the page is closed, evaluate may return undefined, which can lead to errors.
+  // Therefore, when the page is closed, wait for 500ms before attempting to evaluate again.
+  if (
+    'isClosed' in page &&
+    typeof page.isClosed === 'function' &&
+    page.isClosed()
+  ) {
+    await sleep(1000);
+  }
 
   await Promise.all([
     page.screenshotBase64().then((base64) => {

--- a/packages/web-integration/src/playwright/index.ts
+++ b/packages/web-integration/src/playwright/index.ts
@@ -1,5 +1,32 @@
+import { PageAgent, type PageAgentOpt } from '@/common/agent';
+import type { Page as PlaywrightPage } from 'playwright';
+import { WebPage as PlaywrightWebPage } from './page';
+
 export type { PlayWrightAiFixtureType } from './ai-fixture';
 export { PlaywrightAiFixture } from './ai-fixture';
-export { PageAgent as PlaywrightAgent } from '@/common/agent';
-export { WebPage as PlaywrightWebPage } from './page';
 export { overrideAIConfig } from '@midscene/core/env';
+export { WebPage as PlaywrightWebPage } from './page';
+
+export class PlaywrightAgent extends PageAgent {
+  constructor(page: PlaywrightPage, opts?: PageAgentOpt) {
+    const webPage = new PlaywrightWebPage(page);
+    super(webPage, opts);
+
+    const { forceSameTabNavigation = true } = opts ?? {};
+
+    if (forceSameTabNavigation) {
+      page.on('popup', async (popup) => {
+        if (!popup) {
+          console.warn(
+            'got a popup event, but the popup is not ready yet, skip',
+          );
+          return;
+        }
+        const url = await popup.url();
+        console.log(`Popup opened: ${url}`);
+        await popup.close(); // Close the newly opened TAB
+        await page.goto(url);
+      });
+    }
+  }
+}

--- a/packages/web-integration/src/playwright/page.ts
+++ b/packages/web-integration/src/playwright/page.ts
@@ -1,8 +1,9 @@
+import type { PageAgentOpt } from '@/common/agent';
 import type { Page as PlaywrightPageType } from 'playwright';
 import { Page as BasePage } from '../puppeteer/base-page';
 
 export class WebPage extends BasePage<'playwright', PlaywrightPageType> {
-  constructor(page: PlaywrightPageType) {
+  constructor(page: PlaywrightPageType, opts?: PageAgentOpt) {
     super(page, 'playwright');
   }
 }

--- a/packages/web-integration/src/playwright/page.ts
+++ b/packages/web-integration/src/playwright/page.ts
@@ -3,7 +3,7 @@ import type { Page as PlaywrightPageType } from 'playwright';
 import { Page as BasePage } from '../puppeteer/base-page';
 
 export class WebPage extends BasePage<'playwright', PlaywrightPageType> {
-  constructor(page: PlaywrightPageType, opts?: PageAgentOpt) {
+  constructor(page: PlaywrightPageType) {
     super(page, 'playwright');
   }
 }

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -164,9 +164,9 @@ export async function puppeteerAgentForTarget(
   const agent = new PuppeteerAgent(page, {
     autoPrintReportMsg: false,
     testId: preference?.testId,
-    trackingActiveTab:
-      typeof target.trackingActiveTab !== 'undefined'
-        ? target.trackingActiveTab
+    forceSameTabNavigation:
+      typeof target.forceSameTabNavigation !== 'undefined'
+        ? target.forceSameTabNavigation
         : true, // true for default in yaml script
   });
 

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -84,6 +84,7 @@ export class Page<
     // const viewportSize = await this.size();
     const imgType = 'jpeg';
     const path = getTmpFile(imgType)!;
+    await this.waitForNavigation();
     await this.underlyingPage.screenshot({
       path,
       type: imgType,

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -35,15 +35,9 @@ export class Page<
   }
 
   async waitForNavigation() {
-    if (this.pageType === 'puppeteer') {
-      await (this.underlyingPage as PuppeteerPage).waitForNavigation();
-    } else if (this.pageType === 'playwright') {
-      await (this.underlyingPage as PlaywrightPage).waitForURL(
-        this.underlyingPage.url(),
-        {
-          waitUntil: 'load',
-        },
-      );
+    // issue: https://github.com/puppeteer/puppeteer/issues/3323
+    if (this.pageType === 'puppeteer' || this.pageType === 'playwright') {
+      await (this.underlyingPage as PuppeteerPage).waitForSelector('html');
     }
   }
 
@@ -52,6 +46,7 @@ export class Page<
     // const scripts = await getExtraReturnLogic();
     // const captureElementSnapshot = await this.evaluate(scripts);
     // return captureElementSnapshot as ElementInfo[];
+    await this.waitForNavigation();
     const tree = await this.getElementsNodeTree();
     return treeToList(tree);
   }
@@ -267,7 +262,5 @@ export class Page<
     return this.mouse.wheel(scrollDistance, 0);
   }
 
-  async destroy(): Promise<void> {
-    //
-  }
+  async destroy(): Promise<void> {}
 }

--- a/packages/web-integration/tests/ai/bridge/agent.test.ts
+++ b/packages/web-integration/tests/ai/bridge/agent.test.ts
@@ -58,9 +58,9 @@ describe.skipIf(!process.env.BRIDGE_MODE)(
       await agent.destroy();
     });
 
-    it('agent in cli side, current tab, tracking active tab', async () => {
+    it('agent in cli side, current tab, limit popup to current page', async () => {
       const agent = new AgentOverChromeBridge();
-      await agent.connectCurrentTab({ trackingActiveTab: true });
+      await agent.connectCurrentTab({ forceSameTabNavigation: true });
 
       await agent.ai('click "文库"，sleep 1500ms，type "AI 101" and hit Enter');
       await sleep(3000);

--- a/packages/web-integration/tests/ai/bridge/agent.test.ts
+++ b/packages/web-integration/tests/ai/bridge/agent.test.ts
@@ -8,9 +8,13 @@ vi.setConfig({
   testTimeout: 60 * 1000,
 });
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const describeIf = process.env.BRIDGE_MODE ? describe : describe.skip;
 
-describe.skipIf(!process.env.BRIDGE_MODE)(
+describeIf(
   'fully functional agent in server(cli) side',
+  {
+    timeout: 3 * 60 * 10,
+  },
   () => {
     it('basic', async () => {
       const page = getBridgePageInCliSide();
@@ -66,8 +70,5 @@ describe.skipIf(!process.env.BRIDGE_MODE)(
       await sleep(3000);
       await agent.destroy();
     });
-  },
-  {
-    timeout: 3 * 60 * 10,
   },
 );

--- a/packages/web-integration/tests/ai/bridge/keyboard-event.test.ts
+++ b/packages/web-integration/tests/ai/bridge/keyboard-event.test.ts
@@ -9,8 +9,13 @@ vi.setConfig({
 });
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe.skipIf(!process.env.BRIDGE_MODE)(
+const describeIf = process.env.BRIDGE_MODE ? describe : describe.skip;
+
+describeIf(
   'keyboard event in bridge mode',
+  {
+    timeout: 3 * 60 * 10,
+  },
   () => {
     it('page in cli side scroll down', async () => {
       const agent = new AgentOverChromeBridge();
@@ -33,8 +38,5 @@ describe.skipIf(!process.env.BRIDGE_MODE)(
 
       await agent.destroy();
     });
-  },
-  {
-    timeout: 3 * 60 * 10,
   },
 );

--- a/packages/web-integration/tests/ai/bridge/open-new-tab.test.ts
+++ b/packages/web-integration/tests/ai/bridge/open-new-tab.test.ts
@@ -1,0 +1,32 @@
+import {
+  AgentOverChromeBridge,
+  getBridgePageInCliSide,
+} from '@/bridge-mode/agent-cli-side';
+import { sleep } from '@midscene/core/utils';
+import { describe, expect, it, test, vi } from 'vitest';
+
+vi.setConfig({
+  testTimeout: 300 * 1000,
+});
+
+const describeIf = process.env.BRIDGE_MODE ? describe : describe.skip;
+
+describeIf('open new tab in bridge mode', () => {
+  it(
+    'open new tab',
+    {
+      timeout: 3 * 60 * 1000,
+    },
+    async () => {
+      const agent = new AgentOverChromeBridge();
+      await agent.connectNewTabWithUrl('https://www.baidu.com');
+
+      await agent.aiAction(
+        'search "midscene github" and open the first result',
+      );
+      await agent.aiAssert('the page is "midscene github"');
+
+      await agent.destroy();
+    },
+  );
+});

--- a/packages/web-integration/tests/ai/bridge/temp.test.ts
+++ b/packages/web-integration/tests/ai/bridge/temp.test.ts
@@ -9,7 +9,9 @@ vi.setConfig({
   testTimeout: 300 * 1000,
 });
 
-describe.skipIf(!process.env.BRIDGE_MODE)('drag event', () => {
+const describeIf = process.env.BRIDGE_MODE ? describe : describe.skip;
+
+describeIf('drag event', () => {
   it('agent in cli side, current tab', async () => {
     const agent = new AgentOverChromeBridge({
       cacheId: 'finish-form-and-submit',

--- a/packages/web-integration/tests/ai/bridge/temp.test.ts
+++ b/packages/web-integration/tests/ai/bridge/temp.test.ts
@@ -12,14 +12,15 @@ vi.setConfig({
 describe.skipIf(!process.env.BRIDGE_MODE)('drag event', () => {
   it('agent in cli side, current tab', async () => {
     const agent = new AgentOverChromeBridge({
-      // cacheId: 'finish-form-and-submit',
+      cacheId: 'finish-form-and-submit',
     });
     await agent.connectCurrentTab();
 
     await sleep(2000);
 
-    await agent.aiAction('输入 "Happy Birthday，只需要输入即可"');
-    await agent.aiQuery('输入框内容：Array<string>');
+    await agent.aiAction(
+      'Use the test data to complete the form,Comply with the following restrictions: 1. The Captcha code is not required 2. No need to click the register button',
+    );
 
     await agent.destroy();
   });

--- a/packages/web-integration/tests/ai/web/playwright/ai-online-order.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/ai-online-order.spec.ts
@@ -1,4 +1,3 @@
-import { generateTestDataPath } from '@/debug';
 import { expect } from 'playwright/test';
 import { test } from './fixture';
 

--- a/packages/web-integration/tests/ai/web/playwright/fixture.ts
+++ b/packages/web-integration/tests/ai/web/playwright/fixture.ts
@@ -2,4 +2,8 @@ import type { PlayWrightAiFixtureType } from '@/index';
 import { PlaywrightAiFixture } from '@/index';
 import { test as base } from '@playwright/test';
 
-export const test = base.extend<PlayWrightAiFixtureType>(PlaywrightAiFixture());
+export const test = base.extend<PlayWrightAiFixtureType>(
+  PlaywrightAiFixture({
+    forceSameTabNavigation: false,
+  }),
+);

--- a/packages/web-integration/tests/ai/web/playwright/fixture.ts
+++ b/packages/web-integration/tests/ai/web/playwright/fixture.ts
@@ -2,8 +2,4 @@ import type { PlayWrightAiFixtureType } from '@/index';
 import { PlaywrightAiFixture } from '@/index';
 import { test as base } from '@playwright/test';
 
-export const test = base.extend<PlayWrightAiFixtureType>(
-  PlaywrightAiFixture({
-    forceSameTabNavigation: false,
-  }),
-);
+export const test = base.extend<PlayWrightAiFixtureType>(PlaywrightAiFixture());

--- a/packages/web-integration/tests/ai/web/playwright/open-new-tab.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/open-new-tab.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'playwright/test';
+import { test } from './fixture';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('https://cn.bing.com');
+});
+
+const CACHE_TIME_OUT = process.env.MIDSCENE_CACHE;
+
+test('test open new tab', async ({ page, ai, aiAssert, aiQuery }) => {
+  if (CACHE_TIME_OUT) {
+    test.setTimeout(200 * 1000);
+  }
+  await ai('search "midscene github" and open the github page');
+  await aiAssert('the page is "midscene github"');
+});

--- a/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
@@ -1,0 +1,27 @@
+import { PuppeteerAgent } from '@/puppeteer';
+import { sleep } from '@midscene/core/utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { launchPage } from './utils';
+
+vi.setConfig({
+  testTimeout: 120 * 1000,
+});
+
+describe('open new tab integration', () => {
+  let resetFn: () => Promise<void>;
+  afterEach(async () => {
+    if (resetFn) {
+      await resetFn();
+    }
+  });
+
+  it('open new tab', async () => {
+    const { originPage, reset } = await launchPage('https://www.bing.com/');
+    resetFn = reset;
+    const agent = new PuppeteerAgent(originPage, {
+      cacheId: 'puppeteer-open-new-tab',
+    });
+    await agent.aiAction('search "midscene github" and open the first result');
+    await agent.aiAssert('the page is "midscene github"');
+  });
+});

--- a/packages/web-integration/tests/ai/web/puppeteer/showcase.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/showcase.test.ts
@@ -130,7 +130,7 @@ describe(
       const { originPage, reset } = await launchPage('https://www.baidu.com/');
       resetFn = reset;
       const mid = new PuppeteerAgent(originPage, {
-        trackingActiveTab: false,
+        forceSameTabNavigation: false,
       });
       await mid.aiAction('Tap hao123 in the navigation bar');
       await sleep(6000);
@@ -144,7 +144,7 @@ describe(
       const { originPage, reset } = await launchPage('https://www.baidu.com/');
       resetFn = reset;
       const mid = new PuppeteerAgent(originPage, {
-        trackingActiveTab: true,
+        forceSameTabNavigation: true,
       });
       await mid.aiAction('Tap hao123 in the navigation bar');
 

--- a/packages/web-integration/vitest.config.ts
+++ b/packages/web-integration/vitest.config.ts
@@ -15,9 +15,8 @@ dotenv.config({
 const aiTestType = process.env.AI_TEST_TYPE;
 const unitTests = ['tests/unit-test/**/*.test.ts'];
 const aiWebTests = [
-  'tests/ai/web/puppeteer/agent.test.ts',
-  // 'tests/ai/web/**/*.test.ts',
-  // 'tests/ai/bridge/**/*.test.ts',
+  'tests/ai/web/**/*.test.ts',
+  'tests/ai/bridge/**/*.test.ts',
 ];
 const aiNativeTests = ['tests/ai/native/**/*.test.ts'];
 // const aiNativeTests = ['tests/ai/native/appium/dongchedi.test.ts'];

--- a/packages/web-integration/vitest.config.ts
+++ b/packages/web-integration/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
   },
   test: {
     include: testFiles,
+    testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
   },
   define: {
     __VERSION__: `'${version}'`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -239,8 +239,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
 
   packages/visualizer:
     dependencies:
@@ -418,8 +418,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
       webdriverio:
         specifier: 9.0.6
         version: 9.0.6
@@ -3914,17 +3914,46 @@ packages:
   '@vitest/expect@1.6.0':
     resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
 
+  '@vitest/expect@3.0.5':
+    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
+
+  '@vitest/mocker@3.0.5':
+    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.0.5':
+    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
+
   '@vitest/runner@1.6.0':
     resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+
+  '@vitest/runner@3.0.5':
+    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
   '@vitest/snapshot@1.6.0':
     resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
 
+  '@vitest/snapshot@3.0.5':
+    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
+
   '@vitest/spy@1.6.0':
     resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
 
+  '@vitest/spy@3.0.5':
+    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
+
   '@vitest/utils@1.6.0':
     resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+
+  '@vitest/utils@3.0.5':
+    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
 
   '@vue/compiler-core@3.5.12':
     resolution: {integrity: sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==}
@@ -4266,6 +4295,10 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -4578,6 +4611,10 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+    engines: {node: '>=12'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -4629,6 +4666,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -5158,6 +5199,10 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge-ts@7.1.3:
     resolution: {integrity: sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ==}
     engines: {node: '>=16.0.0'}
@@ -5443,6 +5488,9 @@ packages:
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -5590,6 +5638,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.21.1:
     resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
@@ -6999,6 +7051,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -7028,6 +7083,9 @@ packages:
 
   magic-string@0.30.12:
     resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -7855,8 +7913,15 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
@@ -9410,6 +9475,9 @@ packages:
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
@@ -9700,6 +9768,9 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
@@ -9708,8 +9779,20 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
@@ -10122,6 +10205,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.0.5:
+    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@5.4.10:
     resolution: {integrity: sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10166,6 +10254,34 @@ packages:
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.0.5:
+    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.5
+      '@vitest/ui': 3.0.5
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -14383,7 +14499,7 @@ snapshots:
 
   '@puppeteer/browsers@2.4.0':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.4.0
@@ -15308,11 +15424,35 @@ snapshots:
       '@vitest/utils': 1.6.0
       chai: 4.5.0
 
+  '@vitest/expect@3.0.5':
+    dependencies:
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
+      chai: 5.1.2
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.0.5(vite@5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0))':
+    dependencies:
+      '@vitest/spy': 3.0.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
+
+  '@vitest/pretty-format@3.0.5':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@1.6.0':
     dependencies:
       '@vitest/utils': 1.6.0
       p-limit: 5.0.0
       pathe: 1.1.2
+
+  '@vitest/runner@3.0.5':
+    dependencies:
+      '@vitest/utils': 3.0.5
+      pathe: 2.0.3
 
   '@vitest/snapshot@1.6.0':
     dependencies:
@@ -15320,9 +15460,19 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@3.0.5':
+    dependencies:
+      '@vitest/pretty-format': 3.0.5
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
   '@vitest/spy@1.6.0':
     dependencies:
       tinyspy: 2.2.1
+
+  '@vitest/spy@3.0.5':
+    dependencies:
+      tinyspy: 3.0.2
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -15330,6 +15480,12 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@3.0.5':
+    dependencies:
+      '@vitest/pretty-format': 3.0.5
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.5.12':
     dependencies:
@@ -15793,6 +15949,8 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
@@ -16172,6 +16330,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.1.2:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -16223,6 +16389,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.1: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -16842,6 +17010,8 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-eql@5.0.2: {}
+
   deepmerge-ts@7.1.3: {}
 
   deepmerge@4.3.1: {}
@@ -17231,6 +17401,8 @@ snapshots:
 
   es-module-lexer@1.5.4: {}
 
+  es-module-lexer@1.6.0: {}
+
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -17489,6 +17661,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.1.0: {}
 
   express@4.21.1:
     dependencies:
@@ -18324,7 +18498,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18378,7 +18552,7 @@ snapshots:
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19149,6 +19323,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.1.3: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -19178,6 +19354,10 @@ snapshots:
   lru-cache@7.18.3: {}
 
   magic-string@0.30.12:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -20338,7 +20518,11 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
   pathval@1.1.1: {}
+
+  pathval@2.0.0: {}
 
   pbkdf2@3.1.2:
     dependencies:
@@ -20739,7 +20923,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       lru-cache: 7.18.3
@@ -22133,6 +22317,8 @@ snapshots:
 
   std-env@3.7.0: {}
 
+  std-env@3.8.0: {}
+
   stoppable@1.1.0: {}
 
   stream-browserify@3.0.0:
@@ -22463,6 +22649,8 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.3(picomatch@4.0.2)
@@ -22470,7 +22658,13 @@ snapshots:
 
   tinypool@0.8.4: {}
 
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyspy@2.2.1: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
@@ -22957,6 +23151,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.0.5(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
@@ -23049,6 +23261,43 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0):
+    dependencies:
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
+      vite-node: 3.0.5(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 18.19.62
+      jsdom: 24.1.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vm-browserify@1.1.2: {}
 
   vue-template-compiler@2.7.16:
@@ -23072,7 +23321,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@22.8.5)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.8.5)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
 
   packages/midscene:
     dependencies:
@@ -214,8 +214,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0)
 
   packages/shared:
     dependencies:
@@ -3911,9 +3911,6 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@vitest/expect@1.6.0':
-    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
-
   '@vitest/expect@3.0.5':
     resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
 
@@ -3931,26 +3928,14 @@ packages:
   '@vitest/pretty-format@3.0.5':
     resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
 
-  '@vitest/runner@1.6.0':
-    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
-
   '@vitest/runner@3.0.5':
     resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
-
-  '@vitest/snapshot@1.6.0':
-    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
 
   '@vitest/snapshot@3.0.5':
     resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
-  '@vitest/spy@1.6.0':
-    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
-
   '@vitest/spy@3.0.5':
     resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
-
-  '@vitest/utils@1.6.0':
-    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
 
   '@vitest/utils@3.0.5':
     resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
@@ -4292,9 +4277,6 @@ packages:
   assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4607,10 +4589,6 @@ packages:
   centra@2.7.0:
     resolution: {integrity: sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
@@ -4663,9 +4641,6 @@ packages:
     resolution: {integrity: sha512-xghkzKgMxpAfeP9OJfVrErtv8BU4h5kHYQyheHC0j0RYRVNWti0qI3+HkFgWBKejq2UE2wOnoWZlvDKFj6jFoA==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -4849,9 +4824,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
@@ -5194,10 +5166,6 @@ packages:
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
-
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -5624,10 +5592,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   execa@9.3.0:
     resolution: {integrity: sha512-l6JFbqnHEadBoVAVpN5dl2yCyfX28WoBAGaoQcNmLLSedOxTxcn2Qa83s8I/PA5i56vWru2OHOtrwF7Om2vqlg==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -5921,9 +5885,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
@@ -5939,10 +5900,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -6311,10 +6268,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
   human-signals@7.0.0:
     resolution: {integrity: sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==}
     engines: {node: '>=18.18.0'}
@@ -6612,10 +6565,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -6737,9 +6686,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -6922,10 +6868,6 @@ packages:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
     engines: {node: '>= 12.13.0'}
 
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-
   locate-app@2.5.0:
     resolution: {integrity: sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==}
 
@@ -7047,9 +6989,6 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
@@ -7367,10 +7306,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -7438,9 +7373,6 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
-
-  mlly@1.7.2:
-    resolution: {integrity: sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==}
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
@@ -7644,10 +7576,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -7709,10 +7637,6 @@ packages:
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
 
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
@@ -7910,14 +7834,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -7990,9 +7908,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
@@ -9472,9 +9387,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
@@ -9564,10 +9476,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
@@ -9583,9 +9491,6 @@ packages:
   strip-json-comments@5.0.1:
     resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
     engines: {node: '>=14.16'}
-
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
   strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -9775,20 +9680,12 @@ packages:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
-
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -9980,9 +9877,6 @@ packages:
   typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
-
-  ufo@1.5.4:
-    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -10200,11 +10094,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@1.6.0:
-    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   vite-node@3.0.5:
     resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -10239,31 +10128,6 @@ packages:
       sugarss:
         optional: true
       terser:
-        optional: true
-
-  vitest@1.6.0:
-    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.0
-      '@vitest/ui': 1.6.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@3.0.5:
@@ -15418,12 +15282,6 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/expect@1.6.0':
-    dependencies:
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      chai: 4.5.0
-
   '@vitest/expect@3.0.5':
     dependencies:
       '@vitest/spy': 3.0.5
@@ -15439,26 +15297,22 @@ snapshots:
     optionalDependencies:
       vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
 
+  '@vitest/mocker@3.0.5(vite@5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0))':
+    dependencies:
+      '@vitest/spy': 3.0.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
+
   '@vitest/pretty-format@3.0.5':
     dependencies:
       tinyrainbow: 2.0.0
-
-  '@vitest/runner@1.6.0':
-    dependencies:
-      '@vitest/utils': 1.6.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
 
   '@vitest/runner@3.0.5':
     dependencies:
       '@vitest/utils': 3.0.5
       pathe: 2.0.3
-
-  '@vitest/snapshot@1.6.0':
-    dependencies:
-      magic-string: 0.30.12
-      pathe: 1.1.2
-      pretty-format: 29.7.0
 
   '@vitest/snapshot@3.0.5':
     dependencies:
@@ -15466,20 +15320,9 @@ snapshots:
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@1.6.0':
-    dependencies:
-      tinyspy: 2.2.1
-
   '@vitest/spy@3.0.5':
     dependencies:
       tinyspy: 3.0.2
-
-  '@vitest/utils@1.6.0':
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
 
   '@vitest/utils@3.0.5':
     dependencies:
@@ -15510,7 +15353,7 @@ snapshots:
       '@vue/compiler-ssr': 3.5.12
       '@vue/shared': 3.5.12
       estree-walker: 2.0.2
-      magic-string: 0.30.12
+      magic-string: 0.30.17
       postcss: 8.4.47
       source-map-js: 1.2.1
     optional: true
@@ -15947,8 +15790,6 @@ snapshots:
       object-is: 1.1.6
       util: 0.12.5
 
-  assertion-error@1.1.0: {}
-
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
@@ -16320,16 +16161,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@5.1.2:
     dependencies:
       assertion-error: 2.0.1
@@ -16385,10 +16216,6 @@ snapshots:
       semver: 7.6.3
       table: 6.8.2
       type-fest: 3.13.1
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   check-error@2.1.1: {}
 
@@ -16603,8 +16430,6 @@ snapshots:
   compute-scroll-into-view@3.1.0: {}
 
   concat-map@0.0.1: {}
-
-  confbox@0.1.8: {}
 
   connect-history-api-fallback@2.0.0: {}
 
@@ -17005,10 +16830,6 @@ snapshots:
   decode-uri-component@0.4.1: {}
 
   dedent@0.7.0: {}
-
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
 
   deep-eql@5.0.2: {}
 
@@ -17629,18 +17450,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   execa@9.3.0:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -17993,8 +17802,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-func-name@2.0.2: {}
-
   get-intrinsic@1.2.4:
     dependencies:
       es-errors: 1.3.0
@@ -18010,8 +17817,6 @@ snapshots:
       pump: 3.0.2
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1: {}
 
   get-stream@9.0.1:
     dependencies:
@@ -18569,8 +18374,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  human-signals@5.0.0: {}
-
   human-signals@7.0.0: {}
 
   humanize-ms@1.2.1:
@@ -18851,8 +18654,6 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-stream@3.0.0: {}
-
   is-stream@4.0.1: {}
 
   is-string@1.0.7:
@@ -18967,8 +18768,6 @@ snapshots:
       base64-js: 1.5.1
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -19215,11 +19014,6 @@ snapshots:
 
   loader-utils@3.3.1: {}
 
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.7.2
-      pkg-types: 1.2.1
-
   locate-app@2.5.0:
     dependencies:
       '@promptbook/utils': 0.69.5
@@ -19318,10 +19112,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
 
   loupe@3.1.3: {}
 
@@ -19907,8 +19697,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-fn@4.0.0: {}
-
   mimic-function@5.0.1: {}
 
   min-document@2.19.0:
@@ -19967,13 +19755,6 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
-
-  mlly@1.7.2:
-    dependencies:
-      acorn: 8.14.0
-      pathe: 1.1.2
-      pkg-types: 1.2.1
-      ufo: 1.5.4
 
   moment@2.30.1:
     optional: true
@@ -20199,10 +19980,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -20289,10 +20066,6 @@ snapshots:
       yocto-queue: 0.1.0
 
   p-limit@4.0.0:
-    dependencies:
-      yocto-queue: 1.1.1
-
-  p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.1.1
 
@@ -20516,11 +20289,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
 
   pathval@2.0.0: {}
 
@@ -20592,12 +20361,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pkg-types@1.2.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.2
-      pathe: 1.1.2
 
   pkg-up@3.1.0:
     dependencies:
@@ -22315,8 +22078,6 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  std-env@3.7.0: {}
-
   std-env@3.8.0: {}
 
   stoppable@1.1.0: {}
@@ -22419,8 +22180,6 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
-  strip-final-newline@3.0.0: {}
-
   strip-final-newline@4.0.0: {}
 
   strip-indent@3.0.0:
@@ -22430,10 +22189,6 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.1: {}
-
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
 
   strnum@1.0.5: {}
 
@@ -22656,13 +22411,9 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinypool@0.8.4: {}
-
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}
-
-  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -22859,8 +22610,6 @@ snapshots:
   typescript@5.6.3: {}
 
   typical@4.0.0: {}
-
-  ufo@1.5.4: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -23115,42 +22864,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.0(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.7(supports-color@5.5.0)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.0(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.7(supports-color@5.5.0)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@3.0.5(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
@@ -23169,10 +22882,28 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.0.5(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.5.1
       rollup: 4.24.3
     optionalDependencies:
       '@types/node': 18.19.62
@@ -23183,83 +22914,13 @@ snapshots:
   vite@5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.5.1
       rollup: 4.24.3
     optionalDependencies:
       '@types/node': 22.8.5
       fsevents: 2.3.3
       sass-embedded: 1.83.4
       terser: 5.36.0
-
-  vitest@1.6.0(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0):
-    dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.3.7(supports-color@5.5.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.12
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.10(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
-      vite-node: 1.6.0(@types/node@18.19.62)(sass-embedded@1.83.4)(terser@5.36.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 18.19.62
-      jsdom: 24.1.1
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.0(@types/node@22.8.5)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0):
-    dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.3.7(supports-color@5.5.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.12
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
-      vite-node: 1.6.0(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.8.5
-      jsdom: 24.1.1
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0):
     dependencies:
@@ -23286,6 +22947,43 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.62
+      jsdom: 24.1.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.8.5)(jsdom@24.1.1)(sass-embedded@1.83.4)(terser@5.36.0):
+    dependencies:
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 5.4.10(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
+      vite-node: 3.0.5(@types/node@22.8.5)(sass-embedded@1.83.4)(terser@5.36.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.8.5
       jsdom: 24.1.1
     transitivePeerDependencies:
       - less
@@ -23412,7 +23110,7 @@ snapshots:
       browserslist: 4.24.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
+      es-module-lexer: 1.6.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1


### PR DESCRIPTION
This pull request includes a significant update to the `forceSameTabNavigation` option, which replaces the `trackingActiveTab` option across various files and documentation. Additionally, it includes a version update for the `vitest` package in multiple `package.json` files.

### Major Changes:

#### Option Replacement:
* Replaced `trackingActiveTab` with `forceSameTabNavigation` in the Puppeteer agent options documentation (`apps/site/docs/en/API.md`, `apps/site/docs/en/automate-with-scripts-in-yaml.mdx`, `apps/site/docs/en/bridge-mode-by-chrome-extension.mdx`, `apps/site/docs/en/integrate-with-puppeteer.mdx`) [[1]](diffhunk://#diff-f893cb0b8ca5a5936f1d7212ac6692ddcbd137a791d2acc52bc68c02e50dba4cL18-R18) [[2]](diffhunk://#diff-d3e4fa8d5682494209edcf6d15f980b94825ac1e2f2d8ae0646ef37253cee7ccL151-R152) [[3]](diffhunk://#diff-adcfd7ce10f70ed815ad4cf84c05fbbf1f3f329992c2d048c1aa81459e123b1bL82-R88) [[4]](diffhunk://#diff-a5cfb3532dcd96511b942f4e487efbf7d9c52f7959d2f238b1adf2f272a0f6f8L103-R109).
* Updated the same option replacement in the Chinese documentation (`apps/site/docs/zh/API.md`, `apps/site/docs/zh/automate-with-scripts-in-yaml.mdx`, `apps/site/docs/zh/bridge-mode-by-chrome-extension.mdx`, `apps/site/docs/zh/integrate-with-puppeteer.mdx`) [[1]](diffhunk://#diff-f2f28aed5f6ad8de5a2ce1ddf9ab53a31f0283f3366ce69448951451188b9efeL18-R18) [[2]](diffhunk://#diff-e55d1cae6f243f1ace7a858bf1c692f00cfae949da8b5d0b7c63f850aeb02e37L151-R152) [[3]](diffhunk://#diff-a8049a9c66c315148221230a9778afbf2b8b9e7c421ba08f1f64fe6237d6ba39L82-R88) [[4]](diffhunk://#diff-364e7adcd47c7247b8ff89155c5ad930135e11b73d3fecd91a330c524ef1fe7aL101-R107).

#### Code Updates:
* Updated the `forceSameTabNavigation` option in the `playground-component.tsx` and related store and popup files (`packages/visualizer/src/component/playground-component.tsx`, `packages/visualizer/src/component/store.tsx`, `packages/visualizer/src/extension/popup.tsx`) [[1]](diffhunk://#diff-a451f7651baf0d98ff4534f971b0c90519d4250720a0a1e10f6dce94ea2e589aL152-R153) [[2]](diffhunk://#diff-46e97db3134f38028e0b02850fb0f924b6d469122bfe6006f3280c9866abc915L138-R139) [[3]](diffhunk://#diff-5b3bb038ed0ce9c4a91705ef7f1d1f5e3acccb3e9b2f25999976d34989a87c98L24-R24).

#### Package Updates:
* Updated `vitest` version from `^1.6.0` to `3.0.5` in multiple `package.json` files (`packages/cli/package.json`, `packages/shared/package.json`, `packages/web-integration/package.json`) [[1]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L43-R43) [[2]](diffhunk://#diff-3752b1e4e3e2032593e21e9268ec0379680a59e4e7b8517d0d5492a71530d3e8L99-R99) [[3]](diffhunk://#diff-2cdeafd8af50bbc6cc1e13e9e82702b13573e48dd8d3c56453a668d989509ab2L149-R149).

#### Bridge Mode:
* Changed the `trackingActiveTab` to `forceSameTabNavigation` in the bridge mode files (`packages/web-integration/src/bridge-mode/common.ts`, `packages/web-integration/src/bridge-mode/page-browser-side.ts`) [[1]](diffhunk://#diff-9862d9a07e02368756e33bc4867c956f771cddaf2efc7983e932079a900eb285L19-R21) [[2]](diffhunk://#diff-c5586dbfad4ce6bfcbadb7b059d33269182f65473bd507beb32020dd21735d66L24-R26).

#### Additional Code Changes:
* Added `limitOpenNewTabScript` import in `chrome-extension/page.ts` (`packages/web-integration/src/chrome-extension/page.ts`).