### PR TITLE
feat(visualizer): update playground to support multiple steps

### DIFF
--- a/packages/visualizer/src/component/playground-component.less
+++ b/packages/visualizer/src/component/playground-component.less
@@ -2,7 +2,8 @@
 
 body {
   margin: 0;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   font-size: 14px;
 }
 
@@ -30,7 +31,7 @@ body {
   .playground-left-panel {
     width: 100%;
     height: 100%;
-    background-color: #FFF;
+    background-color: #fff;
 
     display: flex;
     flex-direction: column;
@@ -38,7 +39,7 @@ body {
     overflow-y: auto !important;
 
     .ant-form {
-    height: 100%;
+      height: 100%;
 
       flex-grow: 1;
       display: flex;
@@ -70,21 +71,39 @@ body {
       margin-top: 4px;
     }
 
+    .ant-input-group {
+      margin-bottom: 4px;
+      border-left: 3px solid @border-color;
+      border-radius: 8px;
+    }
+
+    .active {
+      border-left-color: @primary-color;
+    }
+
+    .fail {
+      border-left-color: @main-orange;
+    }
+
+    .ant-select {
+      width: 90px;
+      border-radius: 0px;
+    }
+
     .ant-input {
-      padding-bottom: 40px;
+      width: calc(100% - 90px);
+      + .ant-btn {
+        position: absolute;
+        right: 0px;
+        z-index: 999;
+      }
     }
 
     .form-controller-wrapper {
-      position: absolute;
-      bottom: 8px;
-      padding: 0 12px;
-      left: 0px;
       display: flex;
+      align-items: center;
       flex-direction: row;
-      justify-content: space-between;
       width: 100%;
-      box-sizing: border-box;
-      align-items: flex-end;
       gap: 8px;
     }
 
@@ -98,13 +117,13 @@ body {
       gap: 2px;
       color: @weak-text;
       flex-wrap: wrap;
+      margin-top: 4px;
     }
 
     .history-selector {
       margin-right: 8px;
     }
   }
-
 
   .loading-container {
     display: flex;
@@ -160,7 +179,7 @@ body {
     pre {
       display: block;
       word-wrap: break-word;
-      white-space: pre-wrap;    
+      white-space: pre-wrap;
     }
   }
 }


### PR DESCRIPTION
### Update Chrome Plugin Playground:
<img width="641" alt="image" src="https://github.com/user-attachments/assets/acf653f4-5f91-4234-ba4e-edc72e6e36be" />


**中文说明：**
- 支持插入步骤，默认提供 5 个步骤输入框（建议不要太多，否则很卡）
- 每一行可独立选择类型并输入 prompt
- 点击输入框切换到该行，激活后左侧会有高亮，右侧会有运行按钮
- 执行时，会从当前激活的步骤开始运行后面所有步骤，每个步骤可激活后查看结果
- 执行失败的行左侧会标记为红色
- 使用 Copy 按钮可以按 js 或 yaml 格式复制出代码形式的步骤


**Instructions:**

- It supports inserting steps. By default, 5 step input boxes are provided (it is recommended not to have too many, otherwise it will be very slow).
- For each line, you can independently select the type and enter the prompt.
- Click on the input box to switch to that line. After activation, there will be a highlight on the left side and a run button on the right side.
- When executing, it will start running all the subsequent steps from the currently activated step. You can view the results after activating each step.
- The left side of the line with an execution failure will be marked in red.
- You can use the "Copy" button to copy the steps in the form of code in either JavaScript or YAML format.
