### PR TITLE
feat(yaml): Add cache support for yaml files, allowing file-level caching to improve execution speed and stability. Cache ID is automatically set to yaml filename.

### DIFF
--- a/apps/site/docs/en/caching.mdx
+++ b/apps/site/docs/en/caching.mdx
@@ -41,6 +41,14 @@ import { Tab, Tabs } from 'rspress/theme';
     });
     ```
   </Tab>
+
+  <Tab label="Yaml">
+    ```diff
+    - npx midscene ./bing-search.yaml
+    + # Add cache identifier, cacheId is the yaml filename
+    + MIDSCENE_CACHE=true npx midscene ./bing-search.yaml
+    ```
+  </Tab>
 </Tabs>
 
 **Effect**

--- a/apps/site/docs/zh/caching.mdx
+++ b/apps/site/docs/zh/caching.mdx
@@ -42,6 +42,13 @@ import { Tab, Tabs } from 'rspress/theme';
     });
     ```
   </Tab>
+  <Tab label="Yaml">
+    ```diff
+    - npx midscene ./bing-search.yaml
+    + # 增加缓存标识, cacheId 为 yaml 文件名
+    + MIDSCENE_CACHE=true npx midscene ./bing-search.yaml
+    ```
+  </Tab>
 </Tabs>
 
 

--- a/packages/cli/src/yaml-runner.ts
+++ b/packages/cli/src/yaml-runner.ts
@@ -46,6 +46,7 @@ export async function playYamlFiles(
       headed: options?.headed,
       keepWindow: options?.keepWindow,
       testId: fileName,
+      cacheId: fileName,
     };
     const player = new ScriptPlayer(script, async (target) => {
       const freeFn: FreeFn[] = [];
@@ -102,6 +103,7 @@ export async function playYamlFiles(
 
       const agent = new AgentOverChromeBridge({
         closeNewTabsAfterDisconnect: target.closeNewTabsAfterDisconnect,
+        cacheId: fileName,
       });
 
       if (target.bridgeMode === 'newTabWithUrl') {

--- a/packages/web-integration/modern.config.ts
+++ b/packages/web-integration/modern.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     define: {
       __VERSION__: version,
     },
+    sourceMap: true,
     // splitting: true,
   },
 });

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -156,6 +156,7 @@ export async function puppeteerAgentForTarget(
     headed?: boolean;
     keepWindow?: boolean;
     testId?: string;
+    cacheId?: string;
   },
 ) {
   const { page, freeFn } = await launchPuppeteerPage(target, preference);
@@ -164,6 +165,7 @@ export async function puppeteerAgentForTarget(
   const agent = new PuppeteerAgent(page, {
     autoPrintReportMsg: false,
     testId: preference?.testId,
+    cacheId: preference?.cacheId,
     forceSameTabNavigation:
       typeof target.forceSameTabNavigation !== 'undefined'
         ? target.forceSameTabNavigation


### PR DESCRIPTION
```diff
- npx midscene ./bing-search.yaml
+ # Add cache identifier, cacheId is the yaml filename
+ MIDSCENE_CACHE=true npx midscene ./bing-search.yaml
```