### PR TITLE
feat(core): fix MIDSCENE_CACHE=true not work

### DIFF
--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -92,9 +92,9 @@ export const getAIConfig = (
   }
 
   if (typeof userConfig[configKey] !== 'undefined') {
-    return userConfig[configKey];
+    return userConfig[configKey]?.trim();
   }
-  return allConfigFromEnv()[configKey];
+  return allConfigFromEnv()[configKey]?.trim();
 };
 
 export const getAIConfigInBoolean = (configKey: keyof typeof userConfig) => {


### PR DESCRIPTION
Handle the issue where `MIDSCENE_CACHE=true` and users manually misconfigured spaces in the `.env` configuration, resulting in caching or configuration not taking effect.