### PR TITLE
docs: lazy loading report.gif

### DIFF
--- a/apps/site/docs/en/index.mdx
+++ b/apps/site/docs/en/index.mdx
@@ -62,7 +62,7 @@ Midscene wants to provide a way to make automation more stable and easier to deb
 What's more, there is a playground in the report file for you to adjust your prompt without re-running all your scripts.
 
 <p align="center">
-  <img src="/report.gif" alt="visualized report" />
+  <img src="/report.gif" alt="visualized report" loading="lazy" />
 </p>
 
 ## Support both general-purpose LLM and open-source model

--- a/apps/site/docs/zh/index.mdx
+++ b/apps/site/docs/zh/index.mdx
@@ -48,9 +48,8 @@ Midscene 希望让自动化脚本变得更稳定、更易于调试，因此我�
 此外，Midscene 报告里还集成了一个 Playground，用以在报告中重新运行 Prompt 并进行调优。
 
 <p align="center">
-  <img src="/report.gif" alt="visualized report" />
+  <img src="/report.gif" alt="visualized report" loading="lazy" />
 </p>
-
 
 ## 自定义模型
 


### PR DESCRIPTION
`report.gif` has a size of 3.6MB and is loaded by default on the home page.

Let's lazy loading `report.gif` to improve the first screen experience and reduce bandwidth.