### PR TITLE
feat 模拟点击事件需要先把鼠标位置移动到对应区域

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -444,6 +444,11 @@ export default class ChromeExtensionProxyPage implements AbstractPage {
     click: async (x: number, y: number) => {
       await this.showMousePointer(x, y);
       await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
+        type: 'mouseMoved',
+        x,
+        y,
+      });
+      await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
         type: 'mousePressed',
         x,
         y,


### PR DESCRIPTION
目标测试页面如下
![image](https://github.com/user-attachments/assets/4e28b75a-d895-4109-8490-bb54cc77bf42)
点击模块或者表格单元格都会触发一个智能条，智能条的位置依赖点击时鼠标的位置，
发现使用midscene时模拟点击事件总是调不出智能条，需要先把鼠标移动到对应位置才能出现
故模拟点击行为应该有三步：移动鼠标到对应位置(mouseMoved)=>点击(mousePressed)=释放(mouseReleased)