### PR TITLE
fix click event should move the mouse to the click area first

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -444,6 +444,13 @@ export default class ChromeExtensionProxyPage implements AbstractPage {
     click: async (x: number, y: number) => {
       await this.showMousePointer(x, y);
       await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
+        type: 'mouseMoved',
+        x,
+        y,
+        button: 'left',
+        clickCount: 1,
+      });
+      await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
         type: 'mousePressed',
         x,
         y,

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -442,14 +442,7 @@ export default class ChromeExtensionProxyPage implements AbstractPage {
 
   mouse = {
     click: async (x: number, y: number) => {
-      await this.showMousePointer(x, y);
-      await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
-        type: 'mouseMoved',
-        x,
-        y,
-        button: 'left',
-        clickCount: 1,
-      });
+      await this.mouse.move(x, y);
       await this.sendCommandToDebugger('Input.dispatchMouseEvent', {
         type: 'mousePressed',
         x,


### PR DESCRIPTION
I test my page:
![image](https://github.com/user-attachments/assets/40e99f69-e62c-483e-abb9-95bafbbf6bf5)

Clicking on a module or table cell will trigger a smart bar, which appears based on the mouse position at the time of the click.

It was found that when using midscene to simulate click events, the smart bar does not appear unless the mouse is first moved to the corresponding position.

Therefore, the simulated click behavior should follow three steps:

1、Move the mouse to the target position (mouseMoved)
2、Press the mouse button (mousePressed)
3、Release the mouse button (mouseReleased)

MouseClick: mouseMoved=>mousePressed=>mouseReleased