### PR TITLE
docs(site): fix volcengine version USE_VLM_UI_TARS value and modify 火山云 to 火山引擎

### DIFF
--- a/apps/site/docs/en/choose-a-model.md
+++ b/apps/site/docs/en/choose-a-model.md
@@ -188,7 +188,20 @@ Except for the regular config, you need to include the `MIDSCENE_USE_VLM_UI_TARS
 OPENAI_BASE_URL="....."
 OPENAI_API_KEY="......" 
 MIDSCENE_MODEL_NAME="ui-tars-72b-sft"
-MIDSCENE_USE_VLM_UI_TARS=DOUBAO # remember to include this for UI-TARS mode !
+MIDSCENE_USE_VLM_UI_TARS=1 # remember to include this for UI-TARS mode !
+```
+
+**Use the version provided by Volcengine**
+
+On the Volcengine, there is a `doubao-1.5-ui-tars` model that has been deployed. Developers can access the model directly via API calls and pay based on usage. Docs link: https://www.volcengine.com/docs/82379/1536429
+
+When using the Volcengine version of the model, you need to create an inference access point(like `ep-2025...`). After collecting the API Key and inference access point ID, configure should look like this:
+
+```bash
+OPENAI_BASE_URL="https://ark.cn-beijing.volces.com/api/v3" 
+OPENAI_API_KEY="...."
+MIDSCENE_MODEL_NAME="ep-2025..."
+MIDSCENE_USE_VLM_UI_TARS=DOUBAO
 ```
 
 Links:

--- a/apps/site/docs/zh/choose-a-model.md
+++ b/apps/site/docs/zh/choose-a-model.md
@@ -36,12 +36,12 @@ MIDSCENE_USE_QWEN_VL=1
 
 ### 火山引擎上的 UI-TARS
 
-你可以在 [火山引擎](https://volcengine.com)上使用 `doubao-1.5-ui-tars` 模型，在火山引擎上申请 API 密钥后，你可以使用以下配置：
+你可以在[火山引擎](https://volcengine.com)上使用 `doubao-1.5-ui-tars` 模型，在火山引擎上申请 API 密钥后，你可以使用以下配置：
 
 ```bash
 OPENAI_BASE_URL="https://ark.cn-beijing.volces.com/api/v3" 
 OPENAI_API_KEY="...."
-MIDSCENE_MODEL_NAME="ep-2025..." # 火山引擎的推理点名称
+MIDSCENE_MODEL_NAME="ep-2025..." # 火山引擎的推理接入点ID
 MIDSCENE_USE_VLM_UI_TARS=DOUBAO
 ```
 
@@ -157,7 +157,7 @@ UI-TARS 是一个专为 UI 自动化设计的开源模型。它仅以截图作�
 **特性**
 
 - **适用于探索性场景**：UI-TARS 在开放性任务场景中表现出色，例如 “帮我发一条微博”，它能多次进行尝试，直到找到正确的操作步骤。
-- **速度**：以火山云部署的 `doubao-1.5-ui-tars` 作为基准，它的返回速度快于其他模型。
+- **速度**：以火山引擎部署的 `doubao-1.5-ui-tars` 作为基准，它的返回速度快于其他模型。
 - **原生图像识别**：UI-TARS 有视觉定位（Visual Grounding）的能力，和 Qwen-2.5-VL 一样，在使用 UI-TARS 时， Midscene.js 不需要发送 DOM 树。
 - **开源**：UI-TARS 是一个开源模型，因此你可以选择部署到你自己的服务器上，你的数据将不再发送到云端。
 
@@ -168,27 +168,27 @@ UI-TARS 是一个专为 UI 自动化设计的开源模型。它仅以截图作�
 
 **配置**
 
-除了常规配置，你还需要包含 `MIDSCENE_USE_VLM_UI_TARS` 参数来指定 UI-TARS 版本，支持的值为 `1.0` `1.5` `DOUBAO`（火山云版本）。否则，你会遇到一些 JSON 解析错误。
+除了常规配置，你还需要包含 `MIDSCENE_USE_VLM_UI_TARS` 参数来指定 UI-TARS 版本，支持的值为 `1.0` `1.5` `DOUBAO`（火山引擎版本）。否则，你会遇到一些 JSON 解析错误。
 
 ```bash
 OPENAI_BASE_URL="....."
 OPENAI_API_KEY="......" 
-MIDSCENE_MODEL_NAME="ui-tars-7b-sft"
-MIDSCENE_USE_VLM_UI_TARS=DOUBAO # 别忘了配置这项用于 UI-TARS 模式！
+MIDSCENE_MODEL_NAME="ui-tars-72b-sft"
+MIDSCENE_USE_VLM_UI_TARS=1 # 别忘了配置这项用于 UI-TARS 模式！
 ```
 
-**使用火山云提供的版本**
+**使用火山引擎提供的版本**
 
-在火山云平台上，有一个已经部署完成的 `doubao-1.5-ui-tars` 模型，开发者可以通过 API 调用、按使用量付费。模型文档帮助： https://www.volcengine.com/docs/82379/1536429
+在火山引擎平台上，有一个已经部署完成的 `doubao-1.5-ui-tars` 模型，开发者可以通过 API 调用、按使用量付费。模型文档帮助：https://www.volcengine.com/docs/82379/1536429
 
-在使用火山云版本模型时，需要创建推理点（形如 `ep-2025...`）。集齐 API Key 和推理点信息后，配置文件类似如下：
+在使用火山引擎版本模型时，需要创建推理接入点（形如 `ep-2025...`）。集齐 API Key 和推理点信息后，配置文件类似如下：
 
 ```bash
 # 注意 URL 最后填写到 /v3 结束即可
 OPENAI_BASE_URL="https://ark.cn-beijing.volces.com/api/v3" 
 OPENAI_API_KEY="...."
 MIDSCENE_MODEL_NAME="ep-2025..."
-MIDSCENE_USE_VLM_UI_TARS=1
+MIDSCENE_USE_VLM_UI_TARS=DOUBAO
 ```
 
 **资源**

--- a/apps/site/docs/zh/model-provider.md
+++ b/apps/site/docs/zh/model-provider.md
@@ -28,7 +28,7 @@ Midscene 默认集成了 OpenAI SDK 调用 AI 服务。使用这个 SDK 限定�
 
 | 名称 | 描述 |
 |------|-------------|
-| `MIDSCENE_USE_VLM_UI_TARS` | 指定 UI-TARS 版本，支持的值为 `1.0` `1.5` `DOUBAO`（火山云版本） |
+| `MIDSCENE_USE_VLM_UI_TARS` | 指定 UI-TARS 版本，支持的值为 `1.0` `1.5` `DOUBAO`（火山引擎版本） |
 
 使用 `Gemini 2.5 Pro` 模型的额外配置：
 


### PR DESCRIPTION
火山引擎版本MIDSCENE_USE_VLM_UI_TARS值和开源版本写反了
文案统一：火山云统一叫火山引擎