### PR TITLE
Bug fix yaml device

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ English | [简体中文](./README.zh.md)
   <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&color=00a8f0" alt="License" />
   <a href="https://discord.gg/2JyBHxszE4"><img src="https://img.shields.io/discord/1328277792730779648?style=flat-square&color=7289DA&label=Discord&logo=discord&logoColor=white" alt="discord" /></a>
   <a href="https://x.com/midscene_ai"><img src="https://img.shields.io/twitter/follow/midscene_ai?style=flat-square" alt="twitter" /></a>
+  <a href="https://deepwiki.com/web-infra-dev/midscene">
+    <img alt="Ask DeepWiki.com" src="https://devin.ai/assets/deepwiki-badge.png" style="height: 18px; vertical-align: middle;">
+  </a>
 </p>
 
 Midscene.js allows AI to serve as your web and Android operator 🤖. Simply describe what you want to achieve in natural language, and it will assist you in operating the interface, validating content, and extracting data. Whether you seek a quick experience or in-depth development, you'll find it easy to get started.

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,9 @@
   <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&color=00a8f0" alt="License" />
   <a href="https://discord.gg/2JyBHxszE4"><img src="https://img.shields.io/discord/1328277792730779648?style=flat-square&color=7289DA&label=Discord&logo=discord&logoColor=white" alt="discord" /></a>
   <a href="https://x.com/midscene_ai"><img src="https://img.shields.io/twitter/follow/midscene_ai?style=flat-square" alt="twitter" /></a>
+  <a href="https://deepwiki.com/web-infra-dev/midscene">
+    <img alt="Ask DeepWiki.com" src="https://devin.ai/assets/deepwiki-badge.png" style="height: 18px; vertical-align: middle;">
+  </a>
 </p>
 
 Midscene.js 是一个 AI 操作助手，适用于 Web、Android、自动化和测试。只需用自然语言描述你想做什么，它就能帮你操作网页、验证内容，并提取数据。无论你是想快速体验还是深度开发，都可以轻松上手。

--- a/apps/site/docs/en/choose-a-model.mdx
+++ b/apps/site/docs/en/choose-a-model.mdx
@@ -2,7 +2,7 @@
 
 In this article, we will talk about what kind of models are supported by Midscene.js and the features of each model.
 
-## Quick Start for using Midscene.js
+## Quick Config for using Midscene.js
 
 Choose one of the following models, obtain the API key, complete the configuration, and you are ready to go. Choose the model that is easiest to obtain if you are a beginner.
 
@@ -44,6 +44,17 @@ OPENAI_BASE_URL="https://generativelanguage.googleapis.com/v1beta/openai/"
 OPENAI_API_KEY="......"
 MIDSCENE_MODEL_NAME="gemini-2.5-pro-preview-03-25"
 MIDSCENE_USE_GEMINI=1
+```
+
+### Doubao-1.5-thinking-vision-pro on Volcano Engine
+
+You can use the `Doubao-1.5-thinking-vision-pro` model on [Volcano Engine](https://volcengine.com). After obtaining an API key from Volcano Engine, you can use the following configuration:
+
+```bash
+OPENAI_BASE_URL="https://ark.cn-beijing.volces.com/api/v3" 
+OPENAI_API_KEY="...."
+MIDSCENE_MODEL_NAME="ep-..." # Inference endpoint ID from Volcano Engine
+MIDSCENE_USE_DOUBAO_VISION=1
 ```
 
 ### UI-TARS on volcengine.com
@@ -161,6 +172,15 @@ MIDSCENE_USE_GEMINI=1
 
 **Links**
 - [Gemini 2.5 on Google Cloud](https://cloud.google.com/gemini-api/docs/gemini-25-overview)
+
+
+### Doubao-1.5-thinking-vision-pro
+
+Doubao-1.5-thinking-vision-pro is a model provided by Volcano Engine. It works better on visual grounding and assertion.
+
+**Links**
+- [Doubao-1.5-thinking-vision-pro on Volcano Engine](https://www.volcengine.com/docs/82379/1536428)
+
 
 ### UI-TARS
 

--- a/apps/site/docs/en/integrate-with-playwright.mdx
+++ b/apps/site/docs/en/integrate-with-playwright.mdx
@@ -84,7 +84,8 @@ test("search headphone on ebay", async ({
   aiAssert,
   aiInput,
   aiTap,
-  aiScroll 
+  aiScroll,
+  aiWaitFor
 }) => {
   // Use aiInput to enter search keyword
   await aiInput('Headphones', 'search box');

--- a/apps/site/docs/en/model-provider.mdx
+++ b/apps/site/docs/en/model-provider.mdx
@@ -4,6 +4,8 @@ Midscene uses the OpenAI SDK to call AI services. Using this SDK limits the inpu
 
 In this article, we will show you how to config AI service provider and how to choose a different model. You may read [Choose a model](./choose-a-model) first to learn more about how to choose a model.
 
+
+
 ## Configs
 
 ### Common configs
@@ -154,6 +156,19 @@ export OPENAI_API_KEY="sk-..."
 export OPENAI_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
 export MIDSCENE_MODEL_NAME="qwen-vl-max-latest"
 export MIDSCENE_USE_QWEN_VL=1
+```
+
+
+## Example: Using `Doubao-1.5-thinking-vision-pro` from Volcano Engine
+
+Configure the environment variables:
+
+
+```bash
+export OPENAI_BASE_URL="https://ark-cn-beijing.bytedance.net/api/v3"
+export OPENAI_API_KEY="..."
+export MIDSCENE_MODEL_NAME='ep-...'
+export MIDSCENE_USE_DOUBAO_VISION=1
 ```
 
 ## Example: Using `ui-tars-72b-sft` hosted by yourself

--- a/apps/site/docs/zh/choose-a-model.mdx
+++ b/apps/site/docs/zh/choose-a-model.mdx
@@ -2,7 +2,8 @@
 
 在这篇文章中，我们将讨论如何为 Midscene.js 选择 AI 模型，以及这些模型各自的特点。
 
-## 快速开始
+
+## 快速配置
 
 选择一个模型、获取 API 密钥并完成配置，你就可以开始使用 Midscene.js 了。如果你是刚开始使用，选择最容易获得的模型服务即可。
 
@@ -32,6 +33,17 @@ OPENAI_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
 OPENAI_API_KEY="......"
 MIDSCENE_MODEL_NAME="qwen-vl-max-latest"
 MIDSCENE_USE_QWEN_VL=1
+```
+
+### 火山引擎上的 Doubao-1.5-thinking-vision-pro
+
+你可以在[火山引擎](https://volcengine.com)上使用 `Doubao-1.5-thinking-vision-pro` 模型，在火山引擎上申请 API 密钥后，你可以使用以下配置：
+
+```bash
+OPENAI_BASE_URL="https://ark.cn-beijing.volces.com/api/v3" 
+OPENAI_API_KEY="...."
+MIDSCENE_MODEL_NAME="ep-..." # 火山引擎的推理接入点ID
+MIDSCENE_USE_DOUBAO_VISION=1
 ```
 
 ### 火山引擎上的 UI-TARS
@@ -147,6 +159,15 @@ MIDSCENE_USE_QWEN_VL=1 # 别忘了配置这项，用于启用 Qwen 2.5 模式！
 - [Qwen 2.5 on Github](https://github.com/QwenLM/Qwen2.5-VL)
 - [Qwen 2.5 - 阿里云百炼](https://bailian.console.aliyun.com/#/model-market/detail/qwen-vl-max-latest)
 - [Qwen 2.5 - openrouter.ai](https://openrouter.ai/models/Qwen/Qwen2.5-VL-72B-Instruct)
+
+### Doubao-1.5-thinking-vision-pro
+
+Doubao-1.5-thinking-vision-pro 是火山引擎提供的模型。它在视觉定位（Visual Grounding）和断言（Assertion）方面表现较好。
+
+**资源**
+
+- [Doubao-1.5-thinking-vision-pro on Volcano Engine](https://www.volcengine.com/docs/82379/1536428)
+
 
 ### UI-TARS
 

--- a/apps/site/docs/zh/integrate-with-playwright.mdx
+++ b/apps/site/docs/zh/integrate-with-playwright.mdx
@@ -85,7 +85,8 @@ test("search headphone on ebay", async ({
   aiAssert,
   aiInput,
   aiTap,
-  aiScroll 
+  aiScroll,
+  aiWaitFor
 }) => {
   // 使用 aiInput 输入搜索关键词
   await aiInput('Headphones', '搜索框');

--- a/apps/site/docs/zh/model-provider.mdx
+++ b/apps/site/docs/zh/model-provider.mdx
@@ -4,6 +4,9 @@ Midscene 默认集成了 OpenAI SDK 调用 AI 服务。使用这个 SDK 限定�
 
 在本文中，我们将展示如何配置 AI 提供商，以及如何选择不同的模型。你可以先阅读 [选择 AI 模型](./choose-a-model) 来了解如何选择模型。
 
+# 选择 AI 模型
+
+
 ## 配置
 
 ### 通用配置
@@ -157,6 +160,17 @@ export MIDSCENE_MODEL_NAME="qwen-vl-max-latest"
 export MIDSCENE_USE_QWEN_VL=1
 ```
 
+## 示例：使用 Doubao-1.5-thinking-vision-pro 模型
+
+配置环境变量：
+
+```bash
+export OPENAI_BASE_URL="https://ark-cn-beijing.bytedance.net/api/v3"
+export OPENAI_API_KEY="..."
+export MIDSCENE_MODEL_NAME='ep-...'
+export MIDSCENE_USE_DOUBAO_VISION=1
+```
+
 ## 示例：使用 UI-TARS 模型
 
 配置环境变量：
@@ -178,7 +192,6 @@ export MIDSCENE_USE_ANTHROPIC_SDK=1
 export ANTHROPIC_API_KEY="....."
 export MIDSCENE_MODEL_NAME="claude-3-opus-20240229"
 ```
-
 ## 调试 LLM 服务连接问题
 
 如果你想要调试 LLM 服务连接问题，可以使用示例项目中的 `connectivity-test` 目录：[https://github.com/web-infra-dev/midscene-example/tree/main/connectivity-test](https://github.com/web-infra-dev/midscene-example/tree/main/connectivity-test)

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -18,7 +18,11 @@ export function parseYamlScript(
   filePath?: string,
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
-  const interpolatedContent = interpolateEnvVars(content);
+  const processedContent = content.replace(
+    /deviceId:\s*(\d+)/g,
+    (match, deviceId) => `deviceId: '${deviceId}'`,
+  );
+  const interpolatedContent = interpolateEnvVars(processedContent);
   const obj = yaml.load(interpolatedContent, {
     schema: yaml.JSON_SCHEMA,
   }) as MidsceneYamlScript;

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -19,13 +19,10 @@ export function parseYamlScript(
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
   const interpolatedContent = interpolateEnvVars(content);
-  // const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
-  // 使用 schema 选项确保不自动转换类型
   const obj = yaml.load(interpolatedContent, {
-    schema: yaml.JSON_SCHEMA
+    schema: yaml.JSON_SCHEMA,
   }) as MidsceneYamlScript;
 
-  // 确保 deviceId 是字符串类型
   if (obj.android && typeof obj.android.deviceId !== 'undefined') {
     obj.android.deviceId = String(obj.android.deviceId);
   }

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import type { MidsceneYamlScript } from '@midscene/core';
 
 function interpolateEnvVars(content: string): string {
-  return content.replace(/\$\{([^}]+)}/g, (_, envVar) => {
+  return content.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
     const value = process.env[envVar.trim()];
     if (value === undefined) {
       throw new Error(`Environment variable "${envVar.trim()}" is not defined`);

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import type { MidsceneYamlScript } from '@midscene/core';
 
 function interpolateEnvVars(content: string): string {
-  return content.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+  return content.replace(/\$\{([^}]+)}/g, (_, envVar) => {
     const value = process.env[envVar.trim()];
     if (value === undefined) {
       throw new Error(`Environment variable "${envVar.trim()}" is not defined`);
@@ -19,7 +19,16 @@ export function parseYamlScript(
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
   const interpolatedContent = interpolateEnvVars(content);
-  const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
+  // const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
+  // 使用 schema 选项确保不自动转换类型
+  const obj = yaml.load(interpolatedContent, {
+    schema: yaml.JSON_SCHEMA
+  }) as MidsceneYamlScript;
+
+  // 确保 deviceId 是字符串类型
+  if (obj.android && typeof obj.android.deviceId !== 'undefined') {
+    obj.android.deviceId = String(obj.android.deviceId);
+  }
   const pathTip = filePath ? `, failed to load ${filePath}` : '';
   const android =
     typeof obj.android !== 'undefined'


### PR DESCRIPTION
android的yaml模式下，当deviceId为0开头的数据时，会出现运行过程中的deviceId的首位0 丢失，从而导致运行因为找不到对应的设备而失败。
报错信息：
![image](https://github.com/user-attachments/assets/87d49725-3780-4c19-bd19-036de0d9a15f)
实际的设备的deviceId的信息：
![image](https://github.com/user-attachments/assets/3f0eb66d-2b59-467d-8b29-639b253728d9)
修正后的数据：
![image](https://github.com/user-attachments/assets/9330a381-6bad-4153-975d-1de9bb69a43b)

出错的代码demo：
android:
  launch: https://www.joker.pw
  deviceId: 0826337218000060

tasks:
  - name: 打开第一个工具
    flow:
      - ai: 打开浏览器并导航到 https://www.joker.pw
      - ai: 找到第一个工具卡片
      - sleep: 3000
      - aiAssert: 工具页面有正常打开