### PR TITLE
Bug fix yaml device id joker

### DIFF
--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -18,7 +18,11 @@ export function parseYamlScript(
   filePath?: string,
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
-  const interpolatedContent = interpolateEnvVars(content);
+  const processedContent = content.replace(
+    /deviceId:\s*(\d+)/g,
+    (match, deviceId) => `deviceId: '${deviceId}'`,
+  );
+  const interpolatedContent = interpolateEnvVars(processedContent);
   const obj = yaml.load(interpolatedContent, {
     schema: yaml.JSON_SCHEMA,
   }) as MidsceneYamlScript;

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -19,13 +19,10 @@ export function parseYamlScript(
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
   const interpolatedContent = interpolateEnvVars(content);
-  // const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
-  // 使用 schema 选项确保不自动转换类型
   const obj = yaml.load(interpolatedContent, {
-    schema: yaml.JSON_SCHEMA
+    schema: yaml.JSON_SCHEMA,
   }) as MidsceneYamlScript;
 
-  // 确保 deviceId 是字符串类型
   if (obj.android && typeof obj.android.deviceId !== 'undefined') {
     obj.android.deviceId = String(obj.android.deviceId);
   }

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import type { MidsceneYamlScript } from '@midscene/core';
 
 function interpolateEnvVars(content: string): string {
-  return content.replace(/\$\{([^}]+)}/g, (_, envVar) => {
+  return content.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
     const value = process.env[envVar.trim()];
     if (value === undefined) {
       throw new Error(`Environment variable "${envVar.trim()}" is not defined`);

--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import type { MidsceneYamlScript } from '@midscene/core';
 
 function interpolateEnvVars(content: string): string {
-  return content.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+  return content.replace(/\$\{([^}]+)}/g, (_, envVar) => {
     const value = process.env[envVar.trim()];
     if (value === undefined) {
       throw new Error(`Environment variable "${envVar.trim()}" is not defined`);
@@ -19,7 +19,16 @@ export function parseYamlScript(
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
   const interpolatedContent = interpolateEnvVars(content);
-  const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
+  // const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
+  // 使用 schema 选项确保不自动转换类型
+  const obj = yaml.load(interpolatedContent, {
+    schema: yaml.JSON_SCHEMA
+  }) as MidsceneYamlScript;
+
+  // 确保 deviceId 是字符串类型
+  if (obj.android && typeof obj.android.deviceId !== 'undefined') {
+    obj.android.deviceId = String(obj.android.deviceId);
+  }
   const pathTip = filePath ? `, failed to load ${filePath}` : '';
   const android =
     typeof obj.android !== 'undefined'


### PR DESCRIPTION
android的yaml模式下，当deviceId为0开头的数据时，会出现运行过程中的deviceId的首位0 丢失，从而导致运行因为找不到对应的设备而失败。
对应的issue：https://github.com/web-infra-dev/midscene/issues/734

出错的代码demo：
android:
launch: https://www.joker.pw/
deviceId: 0826337218000060

tasks:

name: 打开第一个工具
flow:
ai: 打开浏览器并导航到 https://www.joker.pw/
ai: 找到第一个工具卡片
sleep: 3000
aiAssert: 工具页面有正常打开