### PR TITLE
fix(web-integration): 处理androi模式的yaml格式情况下，deviceId首位为0被去除的问题.

### DIFF
--- a/packages/web-integration/src/yaml/utils.ts
+++ b/packages/web-integration/src/yaml/utils.ts
@@ -18,8 +18,18 @@ export function parseYamlScript(
   filePath?: string,
   ignoreCheckingTarget?: boolean,
 ): MidsceneYamlScript {
-  const interpolatedContent = interpolateEnvVars(content);
-  const obj = yaml.load(interpolatedContent) as MidsceneYamlScript;
+  const processedContent = content.replace(
+    /deviceId:\s*(\d+)/g,
+    (match, deviceId) => `deviceId: '${deviceId}'`,
+  );
+  const interpolatedContent = interpolateEnvVars(processedContent);
+  const obj = yaml.load(interpolatedContent, {
+    schema: yaml.JSON_SCHEMA,
+  }) as MidsceneYamlScript;
+
+  if (obj.android && typeof obj.android.deviceId !== 'undefined') {
+    obj.android.deviceId = String(obj.android.deviceId);
+  }
   const pathTip = filePath ? `, failed to load ${filePath}` : '';
   const android =
     typeof obj.android !== 'undefined'


### PR DESCRIPTION
解决android的yaml模式下，deviceId首位0丢失的问题，现象如图：
![image](https://github.com/user-attachments/assets/5e825c35-2045-4533-adef-a6b80386330f)
