### PR TITLE
feat(android): add aiImgTap command

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -1,0 +1,415 @@
+import type {
+  AIUsageInfo,
+  BaseElement,
+  ElementTreeNode,
+  MidsceneYamlFlowItem,
+  PlanningAction,
+  PlanningActionParamInputOrKeyPress,
+  PlanningActionParamScroll,
+  PlanningActionParamSleep,
+  PlanningActionParamImgTap,
+  Rect,
+  Size,
+} from '@/types';
+import { assert } from '@midscene/shared/utils';
+
+import type {
+  ChatCompletionSystemMessageParam,
+  ChatCompletionUserMessageParam,
+} from 'openai/resources';
+import {
+  callToGetJSONObject,
+  checkAIConfig,
+  getModelName,
+} from './service-caller/index';
+
+import type { PlanningLocateParam } from '@/types';
+import { NodeType } from '@midscene/shared/constants';
+import { vlLocateMode } from '@midscene/shared/env';
+import { treeToList } from '@midscene/shared/extractor';
+import { compositeElementInfoImg } from '@midscene/shared/img';
+import { getDebug } from '@midscene/shared/logger';
+
+export type AIArgs = [
+  ChatCompletionSystemMessageParam,
+  ChatCompletionUserMessageParam,
+];
+
+export enum AIActionType {
+  ASSERT = 0,
+  INSPECT_ELEMENT = 1,
+  EXTRACT_DATA = 2,
+  PLAN = 3,
+  DESCRIBE_ELEMENT = 4,
+}
+
+export async function callAiFn<T>(
+  msgs: AIArgs,
+  AIActionTypeValue: AIActionType,
+): Promise<{ content: T; usage?: AIUsageInfo }> {
+  assert(
+    checkAIConfig(),
+    'Cannot find config for AI model service. If you are using a self-hosted model without validating the API key, please set `OPENAI_API_KEY` to any non-null value. https://midscenejs.com/model-provider.html',
+  );
+
+  const { content, usage } = await callToGetJSONObject<T>(
+    msgs,
+    AIActionTypeValue,
+  );
+  return { content, usage };
+}
+
+const defaultBboxSize = 20; // must be even number
+const debugInspectUtils = getDebug('ai:common');
+
+// transform the param of locate from qwen mode
+export function fillBboxParam(
+  locate: PlanningLocateParam,
+  width: number,
+  height: number,
+) {
+  // The Qwen model might have hallucinations of naming bbox as bbox_2d.
+  if ((locate as any).bbox_2d && !locate?.bbox) {
+    locate.bbox = (locate as any).bbox_2d;
+    // biome-ignore lint/performance/noDelete: <explanation>
+    delete (locate as any).bbox_2d;
+  }
+
+  if (locate?.bbox) {
+    locate.bbox = adaptBbox(locate.bbox, width, height);
+  }
+
+  return locate;
+}
+
+export function adaptQwenBbox(
+  bbox: number[],
+): [number, number, number, number] {
+  if (bbox.length < 2) {
+    const msg = `invalid bbox data for qwen-vl mode: ${JSON.stringify(bbox)} `;
+    throw new Error(msg);
+  }
+
+  const result: [number, number, number, number] = [
+    Math.round(bbox[0]),
+    Math.round(bbox[1]),
+    typeof bbox[2] === 'number'
+      ? Math.round(bbox[2])
+      : Math.round(bbox[0] + defaultBboxSize),
+    typeof bbox[3] === 'number'
+      ? Math.round(bbox[3])
+      : Math.round(bbox[1] + defaultBboxSize),
+  ];
+  return result;
+}
+
+export function adaptDoubaoBbox(
+  bbox: string[] | number[] | string,
+  width: number,
+  height: number,
+): [number, number, number, number] {
+  assert(
+    width > 0 && height > 0,
+    'width and height must be greater than 0 in doubao mode',
+  );
+
+  if (typeof bbox === 'string') {
+    assert(
+      /^(\d+)\s(\d+)\s(\d+)\s(\d+)$/.test(bbox.trim()),
+      `invalid bbox data string for doubao-vision mode: ${bbox}`,
+    );
+    const splitted = bbox.split(' ');
+    if (splitted.length === 4) {
+      return [
+        Math.round((Number(splitted[0]) * width) / 1000),
+        Math.round((Number(splitted[1]) * height) / 1000),
+        Math.round((Number(splitted[2]) * width) / 1000),
+        Math.round((Number(splitted[3]) * height) / 1000),
+      ];
+    }
+    throw new Error(`invalid bbox data string for doubao-vision mode: ${bbox}`);
+  }
+
+  if (Array.isArray(bbox) && Array.isArray(bbox[0])) {
+    bbox = bbox[0];
+  }
+
+  let bboxList: number[] = [];
+  if (Array.isArray(bbox) && typeof bbox[0] === 'string') {
+    bbox.forEach((item) => {
+      if (typeof item === 'string' && item.includes(',')) {
+        const [x, y] = item.split(',');
+        bboxList.push(Number(x.trim()), Number(y.trim()));
+      } else if (typeof item === 'string' && item.includes(' ')) {
+        const [x, y] = item.split(' ');
+        bboxList.push(Number(x.trim()), Number(y.trim()));
+      } else {
+        bboxList.push(Number(item));
+      }
+    });
+  } else {
+    bboxList = bbox as any;
+  }
+
+  if (bboxList.length === 4 || bboxList.length === 5) {
+    return [
+      Math.round((bboxList[0] * width) / 1000),
+      Math.round((bboxList[1] * height) / 1000),
+      Math.round((bboxList[2] * width) / 1000),
+      Math.round((bboxList[3] * height) / 1000),
+    ];
+  }
+
+  // treat the bbox as a center point
+  if (
+    bboxList.length === 6 ||
+    bboxList.length === 2 ||
+    bboxList.length === 3 ||
+    bboxList.length === 7
+  ) {
+    return [
+      Math.max(
+        0,
+        Math.round((bboxList[0] * width) / 1000) - defaultBboxSize / 2,
+      ),
+      Math.max(
+        0,
+        Math.round((bboxList[1] * height) / 1000) - defaultBboxSize / 2,
+      ),
+      Math.min(
+        width,
+        Math.round((bboxList[0] * width) / 1000) + defaultBboxSize / 2,
+      ),
+      Math.min(
+        height,
+        Math.round((bboxList[1] * height) / 1000) + defaultBboxSize / 2,
+      ),
+    ];
+  }
+
+  if (bbox.length === 8) {
+    return [
+      Math.round((bboxList[0] * width) / 1000),
+      Math.round((bboxList[1] * height) / 1000),
+      Math.round((bboxList[4] * width) / 1000),
+      Math.round((bboxList[5] * height) / 1000),
+    ];
+  }
+
+  const msg = `invalid bbox data for doubao-vision mode: ${JSON.stringify(bbox)} `;
+  throw new Error(msg);
+}
+
+export function adaptBbox(
+  bbox: number[],
+  width: number,
+  height: number,
+): [number, number, number, number] {
+  if (vlLocateMode() === 'doubao-vision' || vlLocateMode() === 'vlm-ui-tars') {
+    return adaptDoubaoBbox(bbox, width, height);
+  }
+
+  if (vlLocateMode() === 'gemini') {
+    return adaptGeminiBbox(bbox, width, height);
+  }
+
+  return adaptQwenBbox(bbox);
+}
+
+export function adaptGeminiBbox(
+  bbox: number[],
+  width: number,
+  height: number,
+): [number, number, number, number] {
+  const left = Math.round((bbox[1] * width) / 1000);
+  const top = Math.round((bbox[0] * height) / 1000);
+  const right = Math.round((bbox[3] * width) / 1000);
+  const bottom = Math.round((bbox[2] * height) / 1000);
+  return [left, top, right, bottom];
+}
+
+export function adaptBboxToRect(
+  bbox: number[],
+  width: number,
+  height: number,
+  offsetX = 0,
+  offsetY = 0,
+): Rect {
+  debugInspectUtils('adaptBboxToRect', bbox, width, height, offsetX, offsetY);
+  const [left, top, right, bottom] = adaptBbox(bbox, width, height);
+  const rect = {
+    left: left + offsetX,
+    top: top + offsetY,
+    width: right - left,
+    height: bottom - top,
+  };
+  debugInspectUtils('adaptBboxToRect, result=', rect);
+  return rect;
+}
+
+let warned = false;
+export function warnGPT4oSizeLimit(size: Size) {
+  if (warned) return;
+  if (getModelName()?.toLowerCase().includes('gpt-4o')) {
+    const warningMsg = `GPT-4o has a maximum image input size of 2000x768 or 768x2000, but got ${size.width}x${size.height}. Please set your page to a smaller resolution. Otherwise, the result may be inaccurate.`;
+
+    if (
+      Math.max(size.width, size.height) > 2000 ||
+      Math.min(size.width, size.height) > 768
+    ) {
+      console.warn(warningMsg);
+      warned = true;
+    }
+  } else if (size.width > 1800 || size.height > 1800) {
+    console.warn(
+      `The image size seems too large (${size.width}x${size.height}). It may lead to more token usage, slower response, and inaccurate result.`,
+    );
+    warned = true;
+  }
+}
+
+export function mergeRects(rects: Rect[]) {
+  const minLeft = Math.min(...rects.map((r) => r.left));
+  const minTop = Math.min(...rects.map((r) => r.top));
+  const maxRight = Math.max(...rects.map((r) => r.left + r.width));
+  const maxBottom = Math.max(...rects.map((r) => r.top + r.height));
+  return {
+    left: minLeft,
+    top: minTop,
+    width: maxRight - minLeft,
+    height: maxBottom - minTop,
+  };
+}
+
+// expand the search area to at least 300 x 300, or add a default padding
+export function expandSearchArea(rect: Rect, screenSize: Size) {
+  const minEdgeSize = 300;
+  const defaultPadding = 160;
+
+  const paddingSizeHorizontal =
+    rect.width < minEdgeSize
+      ? Math.ceil((minEdgeSize - rect.width) / 2)
+      : defaultPadding;
+  const paddingSizeVertical =
+    rect.height < minEdgeSize
+      ? Math.ceil((minEdgeSize - rect.height) / 2)
+      : defaultPadding;
+  rect.left = Math.max(0, rect.left - paddingSizeHorizontal);
+  rect.width = Math.min(
+    rect.width + paddingSizeHorizontal * 2,
+    screenSize.width - rect.left,
+  );
+  rect.top = Math.max(0, rect.top - paddingSizeVertical);
+  rect.height = Math.min(
+    rect.height + paddingSizeVertical * 2,
+    screenSize.height - rect.top,
+  );
+  return rect;
+}
+
+export async function markupImageForLLM(
+  screenshotBase64: string,
+  tree: ElementTreeNode<BaseElement>,
+  size: Size,
+) {
+  const elementsInfo = treeToList(tree);
+  const elementsPositionInfoWithoutText = elementsInfo!.filter(
+    (elementInfo) => {
+      if (elementInfo.attributes.nodeType === NodeType.TEXT) {
+        return false;
+      }
+      return true;
+    },
+  );
+
+  const imagePayload = await compositeElementInfoImg({
+    inputImgBase64: screenshotBase64,
+    elementsPositionInfo: elementsPositionInfoWithoutText,
+    size,
+  });
+  return imagePayload;
+}
+
+export function buildYamlFlowFromPlans(
+  plans: PlanningAction[],
+  sleep?: number,
+): MidsceneYamlFlowItem[] {
+  const flow: MidsceneYamlFlowItem[] = [];
+
+  for (const plan of plans) {
+    const type = plan.type;
+    const locate = plan.locate?.prompt!; // TODO: check if locate is null
+
+    if (type === 'Tap') {
+      flow.push({
+        aiTap: locate!,
+      });
+    } else if (type === 'ImgTap') {
+      const param = plan.param as PlanningActionParamImgTap;
+      flow.push({
+        aiImgTap: param.templateImage,
+        threshold: param.threshold,
+      });
+    } else if (type === 'Hover') {
+      flow.push({
+        aiHover: locate!,
+      });
+    } else if (type === 'Input') {
+      const param = plan.param as PlanningActionParamInputOrKeyPress;
+      flow.push({
+        aiInput: param.value,
+        locate,
+      });
+    } else if (type === 'KeyboardPress') {
+      const param = plan.param as PlanningActionParamInputOrKeyPress;
+      flow.push({
+        aiKeyboardPress: param.value,
+        locate,
+      });
+    } else if (type === 'Scroll') {
+      const param = plan.param as PlanningActionParamScroll;
+      flow.push({
+        aiScroll: null,
+        locate,
+        direction: param.direction,
+        scrollType: param.scrollType,
+        distance: param.distance,
+      });
+    } else if (type === 'Sleep') {
+      const param = plan.param as PlanningActionParamSleep;
+      flow.push({
+        sleep: param.timeMs,
+      });
+    } else if (type === 'Locate') {
+      // Locate actions are typically used internally and don't need YAML representation
+      // They are usually followed by other actions that do the actual interaction
+      // Skip this action type as it's not a user-facing action
+    } else if (
+      type === 'AndroidBackButton' ||
+      type === 'AndroidHomeButton' ||
+      type === 'AndroidRecentAppsButton'
+    ) {
+      // not implemented in yaml yet
+    } else if (
+      type === 'Error' ||
+      type === 'ExpectedFalsyCondition' ||
+      type === 'Assert' ||
+      type === 'AssertWithoutThrow' ||
+      type === 'Finished'
+    ) {
+      // do nothing
+    } else {
+      console.warn(
+        `Cannot convert action ${type} to yaml flow. This should be a bug of Midscene.`,
+      );
+    }
+  }
+
+  if (sleep) {
+    flow.push({
+      sleep: sleep,
+    });
+  }
+
+  return flow;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,4 +20,5 @@ export type {
   MidsceneYamlTask,
   MidsceneYamlFlowItem,
   MidsceneYamlFlowItemAIRightClick,
+  MidsceneYamlFlowItemAIImgTap,
 } from './yaml';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -255,6 +255,7 @@ export interface PlanningAction<ParamType = any> {
   type:
     | 'Locate'
     | 'Tap'
+    | 'ImgTap'
     | 'RightClick'
     | 'Hover'
     | 'Drag'
@@ -294,6 +295,10 @@ export interface PlanningAIResponse {
 // export type PlanningActionParamPlan = PlanningFurtherPlan;
 
 export type PlanningActionParamTap = null;
+export interface PlanningActionParamImgTap {
+  templateImage: string; // Image file path
+  threshold?: number; // Optional confidence threshold (0-1), defaults to 0.8
+}
 export type PlanningActionParamHover = null;
 export type PlanningActionParamRightClick = null;
 export interface PlanningActionParamInputOrKeyPress {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -135,6 +135,11 @@ export interface MidsceneYamlFlowItemAITap extends LocateOption {
   aiTap: string;
 }
 
+export interface MidsceneYamlFlowItemAIImgTap {
+  aiImgTap: string; // Image file path
+  threshold?: number; // Optional confidence threshold (0-1), defaults to 0.8
+}
+
 export interface MidsceneYamlFlowItemAIRightClick extends LocateOption {
   aiRightClick: string;
 }
@@ -180,6 +185,7 @@ export type MidsceneYamlFlowItem =
   | MidsceneYamlFlowItemAIQuery
   | MidsceneYamlFlowItemAIWaitFor
   | MidsceneYamlFlowItemAITap
+  | MidsceneYamlFlowItemAIImgTap
   | MidsceneYamlFlowItemAIRightClick
   | MidsceneYamlFlowItemAIHover
   | MidsceneYamlFlowItemAIInput

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -20,3 +20,10 @@ export {
 } from './transform';
 export { processImageElementInfo, compositeElementInfoImg } from './box-select';
 export { drawBoxOnImage, savePositionImg } from './draw-box';
+export {
+  matchTemplate,
+  findBestMatch,
+  templateExists,
+  type TemplateMatchResult,
+  type TemplateMatchOptions,
+} from './template-matching';

--- a/packages/shared/src/img/template-matching.ts
+++ b/packages/shared/src/img/template-matching.ts
@@ -1,0 +1,318 @@
+/**
+ * Template matching functionality similar to OpenCV's cv2.matchTemplate
+ * Implements normalized cross-correlation template matching for image comparison
+ */
+
+import { imageInfoOfBase64, bufferFromBase64 } from './info';
+import { jimpFromBase64 } from './transform';
+import getJimp from './get-jimp';
+
+// Debug flag for template matching - only enable when explicitly requested
+const TEMPLATE_MATCHING_DEBUG = process.env.MIDSCENE_TEMPLATE_DEBUG === 'true';
+
+export interface TemplateMatchResult {
+  x: number;
+  y: number;
+  confidence: number;
+  width: number;
+  height: number;
+}
+
+export interface TemplateMatchOptions {
+  method?: 'TM_CCOEFF_NORMED' | 'TM_CCORR_NORMED' | 'TM_SQDIFF_NORMED';
+  threshold?: number; // Minimum confidence threshold (0-1)
+  maxResults?: number; // Maximum number of results to return
+}
+
+/**
+ * Convert image to grayscale using luminance formula
+ */
+function rgbToGray(r: number, g: number, b: number): number {
+  return Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+}
+
+/**
+ * Extract grayscale image data from Jimp image
+ */
+async function extractGrayscaleData(image: any): Promise<{
+  data: number[];
+  width: number;
+  height: number;
+}> {
+  const { width, height } = image.bitmap;
+  const data: number[] = new Array(width * height);
+  
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const r = image.bitmap.data[idx];
+      const g = image.bitmap.data[idx + 1];
+      const b = image.bitmap.data[idx + 2];
+      data[y * width + x] = rgbToGray(r, g, b);
+    }
+  }
+  
+  return { data, width, height };
+}
+
+/**
+ * Compute normalized cross-correlation coefficient (similar to TM_CCOEFF_NORMED)
+ */
+function computeNormalizedCrossCorrelation(
+  image: { data: number[]; width: number; height: number },
+  template: { data: number[]; width: number; height: number },
+  startX: number,
+  startY: number
+): number {
+  const { width: imgWidth } = image;
+  const { width: tplWidth, height: tplHeight, data: tplData } = template;
+  
+  // Calculate means
+  let imageMean = 0;
+  let templateMean = 0;
+  const numPixels = tplWidth * tplHeight;
+  
+  for (let ty = 0; ty < tplHeight; ty++) {
+    for (let tx = 0; tx < tplWidth; tx++) {
+      const imgIdx = (startY + ty) * imgWidth + (startX + tx);
+      const tplIdx = ty * tplWidth + tx;
+      imageMean += image.data[imgIdx];
+      templateMean += tplData[tplIdx];
+    }
+  }
+  
+  imageMean /= numPixels;
+  templateMean /= numPixels;
+  
+  // Calculate correlation coefficient
+  let numerator = 0;
+  let imageVariance = 0;
+  let templateVariance = 0;
+  
+  for (let ty = 0; ty < tplHeight; ty++) {
+    for (let tx = 0; tx < tplWidth; tx++) {
+      const imgIdx = (startY + ty) * imgWidth + (startX + tx);
+      const tplIdx = ty * tplWidth + tx;
+      
+      const imgDiff = image.data[imgIdx] - imageMean;
+      const tplDiff = tplData[tplIdx] - templateMean;
+      
+      numerator += imgDiff * tplDiff;
+      imageVariance += imgDiff * imgDiff;
+      templateVariance += tplDiff * tplDiff;
+    }
+  }
+  
+  const denominator = Math.sqrt(imageVariance * templateVariance);
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+/**
+ * Compute squared difference normalized (similar to TM_SQDIFF_NORMED)
+ */
+function computeSquaredDifferenceNormalized(
+  image: { data: number[]; width: number; height: number },
+  template: { data: number[]; width: number; height: number },
+  startX: number,
+  startY: number
+): number {
+  const { width: imgWidth } = image;
+  const { width: tplWidth, height: tplHeight, data: tplData } = template;
+  
+  let sumSquaredDiff = 0;
+  let imageSum = 0;
+  let templateSum = 0;
+  const numPixels = tplWidth * tplHeight;
+  
+  for (let ty = 0; ty < tplHeight; ty++) {
+    for (let tx = 0; tx < tplWidth; tx++) {
+      const imgIdx = (startY + ty) * imgWidth + (startX + tx);
+      const tplIdx = ty * tplWidth + tx;
+      
+      const imgVal = image.data[imgIdx];
+      const tplVal = tplData[tplIdx];
+      const diff = imgVal - tplVal;
+      
+      sumSquaredDiff += diff * diff;
+      imageSum += imgVal * imgVal;
+      templateSum += tplVal * tplVal;
+    }
+  }
+  
+  const normalizationFactor = Math.sqrt(imageSum * templateSum);
+  return normalizationFactor === 0 ? 1 : sumSquaredDiff / normalizationFactor;
+}
+
+/**
+ * Compute correlation coefficient normalized (similar to TM_CCORR_NORMED)
+ */
+function computeCorrelationCoefficientNormalized(
+  image: { data: number[]; width: number; height: number },
+  template: { data: number[]; width: number; height: number },
+  startX: number,
+  startY: number
+): number {
+  const { width: imgWidth } = image;
+  const { width: tplWidth, height: tplHeight, data: tplData } = template;
+  
+  let correlation = 0;
+  let imageSum = 0;
+  let templateSum = 0;
+  
+  for (let ty = 0; ty < tplHeight; ty++) {
+    for (let tx = 0; tx < tplWidth; tx++) {
+      const imgIdx = (startY + ty) * imgWidth + (startX + tx);
+      const tplIdx = ty * tplWidth + tx;
+      
+      const imgVal = image.data[imgIdx];
+      const tplVal = tplData[tplIdx];
+      
+      correlation += imgVal * tplVal;
+      imageSum += imgVal * imgVal;
+      templateSum += tplVal * tplVal;
+    }
+  }
+  
+  const normalizationFactor = Math.sqrt(imageSum * templateSum);
+  return normalizationFactor === 0 ? 0 : correlation / normalizationFactor;
+}
+
+/**
+ * Perform template matching on two base64-encoded images
+ * Replicates OpenCV's cv2.matchTemplate functionality
+ * 
+ * @param sourceImageBase64 - Base64 encoded source image to search in
+ * @param templateImageBase64 - Base64 encoded template image to search for
+ * @param options - Template matching options
+ * @returns Array of match results sorted by confidence (highest first)
+ */
+export async function matchTemplate(
+  sourceImageBase64: string,
+  templateImageBase64: string,
+  options: TemplateMatchOptions = {}
+): Promise<TemplateMatchResult[]> {
+  const {
+    method = 'TM_CCOEFF_NORMED',
+    threshold = 0.5,
+    maxResults = 10
+  } = options;
+  
+  const Jimp = await getJimp();
+  
+  // Load and process images
+  const sourceJimp = await jimpFromBase64(sourceImageBase64);
+  const templateJimp = await jimpFromBase64(templateImageBase64);
+  
+  // Extract grayscale data
+  const sourceGray = await extractGrayscaleData(sourceJimp);
+  const templateGray = await extractGrayscaleData(templateJimp);
+  
+  // Validate template size
+  if (templateGray.width > sourceGray.width || templateGray.height > sourceGray.height) {
+    throw new Error('Template image must be smaller than source image');
+  }
+  
+  const results: TemplateMatchResult[] = [];
+  
+  // Slide template across source image
+  for (let y = 0; y <= sourceGray.height - templateGray.height; y++) {
+    for (let x = 0; x <= sourceGray.width - templateGray.width; x++) {
+      let confidence: number;
+      
+      switch (method) {
+        case 'TM_CCOEFF_NORMED':
+          confidence = computeNormalizedCrossCorrelation(sourceGray, templateGray, x, y);
+          break;
+        case 'TM_CCORR_NORMED':
+          confidence = computeCorrelationCoefficientNormalized(sourceGray, templateGray, x, y);
+          break;
+        case 'TM_SQDIFF_NORMED':
+          // For squared difference, lower values are better, so invert
+          confidence = 1 - computeSquaredDifferenceNormalized(sourceGray, templateGray, x, y);
+          break;
+        default:
+          throw new Error(`Unsupported template matching method: ${method}`);
+      }
+      
+      // Only include results above threshold
+      if (confidence >= threshold) {
+        const matchResult = {
+          x,
+          y,
+          confidence,
+          width: templateGray.width,
+          height: templateGray.height
+        };
+        results.push(matchResult);
+        
+        // Debug output for each valid match found
+        if (TEMPLATE_MATCHING_DEBUG && results.length <= 3) { // Only log first 3 matches to avoid spam
+          console.log(`🎯 Match #${results.length}: (${x}, ${y}) confidence=${(confidence * 100).toFixed(2)}%`);
+        }
+      }
+    }
+  }
+  
+  // Sort by confidence (highest first) and limit results
+  results.sort((a, b) => b.confidence - a.confidence);
+  
+  if (TEMPLATE_MATCHING_DEBUG) {
+    console.log(`📈 Template matching completed: found ${results.length} matches above threshold ${threshold}`);
+  }
+  
+  return results.slice(0, maxResults);
+}
+
+/**
+ * Find the best match for a template in a source image
+ * Returns the match with highest confidence, or null if no match above threshold
+ */
+export async function findBestMatch(
+  sourceImageBase64: string,
+  templateImageBase64: string,
+  options: TemplateMatchOptions = {}
+): Promise<TemplateMatchResult | null> {
+  const {
+    threshold = 0.5,
+    method = 'TM_CCOEFF_NORMED'
+  } = options;
+  
+  if (TEMPLATE_MATCHING_DEBUG) {
+    console.log('🔍 Template Matching Debug:');
+    console.log(`📊 Method: ${method}, Threshold: ${threshold}`);
+  }
+  
+  const results = await matchTemplate(sourceImageBase64, templateImageBase64, {
+    ...options,
+    maxResults: 1
+  });
+  
+  if (results.length > 0) {
+    const bestMatch = results[0];
+    if (TEMPLATE_MATCHING_DEBUG) {
+      console.log(`✅ Best Match Found: confidence=${(bestMatch.confidence * 100).toFixed(2)}%, position=(${bestMatch.x}, ${bestMatch.y}), size=${bestMatch.width}x${bestMatch.height}`);
+    }
+    return bestMatch;
+  } else {
+    if (TEMPLATE_MATCHING_DEBUG) {
+      console.log(`❌ No match found above threshold ${threshold}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Check if template exists in source image with given confidence threshold
+ */
+export async function templateExists(
+  sourceImageBase64: string,
+  templateImageBase64: string,
+  threshold: number = 0.8
+): Promise<boolean> {
+  const result = await findBestMatch(sourceImageBase64, templateImageBase64, {
+    threshold,
+    maxResults: 1
+  });
+  
+  return result !== null;
+}

--- a/packages/web-integration/src/common/agent.ts
+++ b/packages/web-integration/src/common/agent.ts
@@ -280,6 +280,22 @@ export class PageAgent<PageType extends WebPage = WebPage> {
     return output;
   }
 
+  async aiImgTap(templateImagePath: string, threshold = 0.8) {
+    assert(templateImagePath, 'missing template image path for image tap');
+    assert(threshold >= 0 && threshold <= 1, 'threshold must be between 0 and 1');
+    
+    const plans = buildPlans('ImgTap', undefined, {
+      templateImage: templateImagePath,
+      threshold,
+    });
+    const { executor, output } = await this.taskExecutor.runPlans(
+      taskTitleStr('ImgTap', `path: ${templateImagePath}, threshold: ${threshold}`),
+      plans,
+    );
+    this.afterTaskRunning(executor);
+    return output;
+  }
+
   async aiRightClick(locatePrompt: string, opt?: LocateOption) {
     const detailedLocateParam = this.buildDetailedLocateParam(
       locatePrompt,

--- a/packages/web-integration/src/common/plan-builder.ts
+++ b/packages/web-integration/src/common/plan-builder.ts
@@ -6,6 +6,7 @@ import type {
   PlanningActionParamScroll,
   PlanningActionParamSleep,
   PlanningActionParamTap,
+  PlanningActionParamImgTap,
   PlanningLocateParam,
 } from '@midscene/core';
 import { getDebug } from '@midscene/shared/logger';
@@ -19,7 +20,8 @@ export function buildPlans(
   param?:
     | PlanningActionParamInputOrKeyPress
     | PlanningActionParamScroll
-    | PlanningActionParamSleep,
+    | PlanningActionParamSleep
+    | PlanningActionParamImgTap,
 ): PlanningAction[] {
   let returnPlans: PlanningAction[] = [];
   const locatePlan: PlanningAction<PlanningLocateParam> | null = locateParam
@@ -41,6 +43,34 @@ export function buildPlans(
     };
 
     returnPlans = [locatePlan, tapPlan];
+  }
+  
+  if (type === 'ImgTap') {
+    assert(param, `missing param for action "${type}"`);
+    
+    // Create a locate param for template image
+    const imgTapParam = param as PlanningActionParamImgTap;
+    const templateLocateParam: DetailedLocateParam = {
+      prompt: `Template image: ${imgTapParam.templateImage}`,
+    };
+    
+    // Create Locate plan for template matching
+    const locatePlan: PlanningAction<PlanningLocateParam> = {
+      type: 'Locate',
+      locate: templateLocateParam,
+      param: templateLocateParam,
+      thought: '',
+    };
+    
+    // Create ImgTap plan
+    const imgTapPlan: PlanningAction<PlanningActionParamImgTap> = {
+      type,
+      param: imgTapParam,
+      thought: '',
+      locate: templateLocateParam,
+    };
+    
+    returnPlans = [locatePlan, imgTapPlan];
   }
   if (type === 'Input' || type === 'KeyboardPress') {
     if (type === 'Input') {

--- a/packages/web-integration/src/common/ui-utils.ts
+++ b/packages/web-integration/src/common/ui-utils.ts
@@ -65,6 +65,7 @@ export function taskTitleStr(
     | 'RightClick'
     | 'KeyboardPress'
     | 'Scroll'
+    | 'ImgTap'
     | 'Action'
     | 'Query'
     | 'Assert'

--- a/packages/web-integration/src/yaml/player.ts
+++ b/packages/web-integration/src/yaml/player.ts
@@ -10,6 +10,7 @@ import type {
   MidsceneYamlFlowItemAIAssert,
   MidsceneYamlFlowItemAIBoolean,
   MidsceneYamlFlowItemAIHover,
+  MidsceneYamlFlowItemAIImgTap,
   MidsceneYamlFlowItemAIInput,
   MidsceneYamlFlowItemAIKeyboardPress,
   MidsceneYamlFlowItemAILocate,
@@ -284,6 +285,9 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
       } else if ('aiTap' in (flowItem as MidsceneYamlFlowItemAITap)) {
         const tapTask = flowItem as MidsceneYamlFlowItemAITap;
         await agent.aiTap(tapTask.aiTap, tapTask);
+      } else if ('aiImgTap' in (flowItem as MidsceneYamlFlowItemAIImgTap)) {
+        const imgTapTask = flowItem as MidsceneYamlFlowItemAIImgTap;
+        await agent.aiImgTap(imgTapTask.aiImgTap, imgTapTask.threshold);
       } else if (
         'aiRightClick' in (flowItem as MidsceneYamlFlowItemAIRightClick)
       ) {


### PR DESCRIPTION
Added aiImgTap command (only tested on Android), which can perform template matching operations on icon buttons on the current screen. It is a bit strange that threshold is only about 0.5x, but it can easily reach 0.8~0.9 on Python.
example yaml:
`android:
deviceId: xxx

tasks:

name: to cs page
flow:
aiImgTap: '/private/tmp/cs.png'
threshold: 0.5
sleep: 6000
aiAssert: 'AI'`