### PR TITLE
fix(puppeteer): page-level cookie API is deprecated. Use Browser.setC…

### DIFF
--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -136,7 +136,7 @@ export async function launchPuppeteerPage(
 
   if (target.cookie) {
     const cookieFileContent = readFileSync(target.cookie, 'utf-8');
-    await page.setCookie(...JSON.parse(cookieFileContent));
+    await browser.setCookie(...JSON.parse(cookieFileContent));
   }
 
   const waitForNetworkIdleTimeout =


### PR DESCRIPTION
page-level cookie API is deprecated. Use Browser.setCookie() instead.

FYI : https://pptr.dev/api/puppeteer.page.setcookie