### PR TITLE
chore(workflow): Make dev work normally

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.23.4",
   "scripts": {
-    "dev": "nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose",
+    "dev": "nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose --parallel=8",
     "build": "nx run-many --target=build --exclude=doc --verbose",
     "build:skip-cache": "nx run-many --target=build --exclude=doc --verbose --skip-nx-cache",
     "test": "nx run-many --target=test --projects=@midscene/core,@midscene/shared,@midscene/visualizer,@midscene/web,@midscene/cli,@midscene/android --verbose",

--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -13,7 +13,7 @@
     "dev": "modern dev",
     "dev:server": "npm run build && ./bin/playground",
     "build": "modern build -c ./modern.config.ts",
-    "build:watch": "modern build -w -c ./modern.config.ts"
+    "build:watch": "modern build -w -c ./modern.config.ts --no-clear"
   },
   "dependencies": {
     "@midscene/android": "workspace:*",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "modern build -c ./modern.config.ts",
-    "build:watch": "modern build -w -c ./modern.config.ts",
+    "build:watch": "modern build -w -c ./modern.config.ts --no-clear",
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AI_TEST_TYPE=android npm run test",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "modern build",
-    "build:watch": "modern build -w",
+    "build:watch": "modern build -w --no-clear",
     "new": "modern new",
     "upgrade": "modern upgrade",
     "test": "vitest --run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "modern build",
-    "build:watch": "modern build -w",
+    "build:watch": "modern build -w --no-clear",
     "new": "modern new",
     "upgrade": "modern upgrade",
     "test": "vitest --run",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     "build": "npm run build:pkg && npm run build:script",
     "build:pkg": "modern build -c ./modern.config.ts",
     "build:script": "modern build -c ./modern.inspect.config.ts",
-    "build:watch": "modern build -w",
+    "build:watch": "modern build -w --no-clear",
     "reset": "rimraf ./**/node_modules",
     "lint": "modern lint",
     "bump": "modern bump",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "npm run build && npx npm-watch",
     "build": "modern build ",
-    "build:watch": "modern build -w",
+    "build:watch": "modern build -w --no-clear",
     "serve": "http-server ./dist/ -p 3000",
     "new": "modern new",
     "upgrade": "modern upgrade"

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -117,7 +117,7 @@
     "dev:server": "npm run build && ./bin/midscene-playground",
     "build": "modern build -c ./modern.config.ts",
     "postbuild": "node scripts/check-exports.js",
-    "build:watch": "modern build -w -c ./modern.config.ts",
+    "build:watch": "modern build -w -c ./modern.config.ts --no-clear",
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AI_TEST_TYPE=web npm run test",


### PR DESCRIPTION
1. Add Nx cli config `--parallel=8` (default value is 3) to ensure all package be watched concurrently.
2. Add Modern.js cli config `--no-clear` to avoid clean dist when dev, which will leading module not found error in dev.