### PR TITLE
Create convenience for users' bundles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -94,6 +94,7 @@ shrinkwrap.json
 
 # Build outputs
 dist
+dist-inspect
 lib
 
 # Prettier reformats code blocks inside Markdown, which affects rendered output

--- a/apps/chrome-extension/rsbuild.config.ts
+++ b/apps/chrome-extension/rsbuild.config.ts
@@ -55,10 +55,7 @@ export default defineConfig({
     copy: [
       { from: './static', to: './' },
       {
-        from: path.resolve(
-          __dirname,
-          '../../packages/web-integration/iife-script',
-        ),
+        from: path.resolve(__dirname, '../../packages/shared/dist-inspect'),
         to: 'scripts',
       },
       {

--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,7 @@
       "test-data/**",
       "**/inject-tp.js",
       "dist",
+      "dist-inspect",
       "__ai_responses__",
       "ai-data/**",
       "**/doc_build",

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -1,0 +1,1 @@
+/dist-inspect

--- a/packages/shared/modern.config.ts
+++ b/packages/shared/modern.config.ts
@@ -1,4 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { defineConfig, moduleTools } from '@modern-js/module-tools';
+
+const scriptStr = fs.readFileSync(
+  path.resolve(__dirname, './dist-inspect/htmlElement.js'),
+  'utf-8',
+);
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -21,6 +29,9 @@ export default defineConfig({
     target: 'es2020',
     dts: {
       respectExternal: true,
+    },
+    define: {
+      __HTML_ELEMENT_SCRIPT__: scriptStr,
     },
   },
 });

--- a/packages/shared/modern.inspect.config.ts
+++ b/packages/shared/modern.inspect.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       htmlElementDebug: 'src/extractor/debug.ts',
     },
     autoExternal: false,
-    outDir: 'dist/script',
+    outDir: 'dist-inspect',
     esbuildOptions: (options) => {
       options.globalName = 'midscene_element_inspector';
       return options;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -39,10 +39,10 @@
   "files": ["dist", "src", "README.md"],
   "scripts": {
     "dev": "npm run build:watch",
-    "build": "npm run build:pkg && npm run build:script",
+    "build": "npm run build:script && npm run build:pkg",
     "build:pkg": "modern build -c ./modern.config.ts",
     "build:script": "modern build -c ./modern.inspect.config.ts",
-    "build:watch": "modern build -w --no-clear",
+    "build:watch": "npm run build:script && modern build -w --no-clear",
     "reset": "rimraf ./**/node_modules",
     "lint": "modern lint",
     "bump": "modern bump",

--- a/packages/shared/src/node/fs.ts
+++ b/packages/shared/src/node/fs.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import path from 'node:path';
-import { assert, ifInBrowser } from '../utils';
+import { ifInBrowser } from '../utils';
+
+declare const __HTML_ELEMENT_SCRIPT__: string;
 
 interface PkgInfo {
   name: string;
@@ -61,14 +62,12 @@ export function findNearestPackageJson(dir: string): string | null {
 }
 
 export function getElementInfosScriptContent() {
-  // Get __dirname equivalent in Node.js environment
-  const currentFilePath = __filename;
-  const pathDir = findNearestPackageJson(dirname(currentFilePath));
-  assert(pathDir, `can't find pathDir, with ${dirname}`);
-  const scriptPath = path.join(pathDir, './dist/script/htmlElement.js');
-  const elementInfosScriptContent = readFileSync(scriptPath, 'utf-8');
+  const htmlElementScript = __HTML_ELEMENT_SCRIPT__;
 
-  return elementInfosScriptContent;
+  if (!htmlElementScript) {
+    throw new Error('HTML_ELEMENT_SCRIPT inject failed.');
+  }
+  return htmlElementScript;
 }
 
 export async function getExtraReturnLogic(tree = false) {

--- a/packages/web-integration/modern.config.ts
+++ b/packages/web-integration/modern.config.ts
@@ -1,27 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { defineConfig, moduleTools } from '@modern-js/module-tools';
 import { version } from './package.json';
-
-// Create directories and copy files
-// The file copying functionality in modern.js is not operating correctly.
-const files = [
-  [
-    'node_modules/@midscene/shared/dist/script/htmlElement.js',
-    'iife-script/htmlElement.js',
-  ],
-  [
-    'node_modules/@midscene/shared/dist/script/htmlElementDebug.js',
-    'iife-script/htmlElementDebug.js',
-  ],
-];
-files.forEach(([src, dest]) => {
-  // Create parent directory if it doesn't exist
-  const destDir = path.dirname(path.join(__dirname, dest));
-  fs.mkdirSync(destDir, { recursive: true });
-  // Copy file
-  fs.copyFileSync(path.join(__dirname, src), path.join(__dirname, dest));
-});
 
 export default defineConfig({
   plugins: [moduleTools()],


### PR DESCRIPTION
1. Inject `htmlElement.js` content as string into `fs.js` to avoid read relative file at runtime.
2. Remove useless copy `htmlElement.js` in `web-intergration`.
3. Let `chrome-extension` copy `htmlElement.js` from `shared` directlly.