### PR TITLE
fix(docs): unexpected link style

### DIFF
--- a/apps/site/docs/en/model-provider.mdx
+++ b/apps/site/docs/en/model-provider.mdx
@@ -43,7 +43,7 @@ Some advanced configs are also supported. Usually you don't need to use them.
 |------|-------------|
 | `OPENAI_USE_AZURE` | Optional. Set to "true" to use Azure OpenAI Service. See more details in the following section. |
 | `MIDSCENE_OPENAI_INIT_CONFIG_JSON` | Optional. Custom JSON config for OpenAI SDK initialization |
-| `MIDSCENE_OPENAI_HTTP_PROXY` | Optional. HTTP/HTTPS proxy configuration (e.g. "http://127.0.0.1:8080" or "https://proxy.example.com:8080"). This option has higher priority than `MIDSCENE_OPENAI_SOCKS_PROXY` |
+| `MIDSCENE_OPENAI_HTTP_PROXY` | Optional. HTTP/HTTPS proxy configuration (e.g. `http://127.0.0.1:8080` or `https://proxy.example.com:8080`). This option has higher priority than `MIDSCENE_OPENAI_SOCKS_PROXY` |
 | `MIDSCENE_OPENAI_SOCKS_PROXY` | Optional. SOCKS proxy configuration (e.g. "socks5://127.0.0.1:1080") |
 | `MIDSCENE_PREFERRED_LANGUAGE` | Optional. The preferred language for the model response. The default is `Chinese` if the current timezone is GMT+8 and `English` otherwise. |
 | `OPENAI_MAX_TOKENS` | Optional. Maximum tokens for model response |

--- a/apps/site/docs/zh/model-provider.mdx
+++ b/apps/site/docs/zh/model-provider.mdx
@@ -46,7 +46,7 @@ Midscene 默认集成了 OpenAI SDK 调用 AI 服务。使用这个 SDK 限定�
 |------|-------------|
 | `OPENAI_USE_AZURE` | 可选。设置为 "true" 以使用 Azure OpenAI Service。更多详情请参阅后文 |
 | `MIDSCENE_OPENAI_INIT_CONFIG_JSON` | 可选。OpenAI SDK 的初始化配置 JSON |
-| `MIDSCENE_OPENAI_HTTP_PROXY` | 可选。HTTP/HTTPS 代理配置 (如 "http://127.0.0.1:8080" 或 "https://proxy.example.com:8080")。这个选项优先级高于 `MIDSCENE_OPENAI_SOCKS_PROXY` |
+| `MIDSCENE_OPENAI_HTTP_PROXY` | 可选。HTTP/HTTPS 代理配置 (如 `http://127.0.0.1:8080` 或 `https://proxy.example.com:8080`)。这个选项优先级高于 `MIDSCENE_OPENAI_SOCKS_PROXY` |
 | `MIDSCENE_OPENAI_SOCKS_PROXY` | 可选。SOCKS 代理配置 (如 "socks5://127.0.0.1:1080") |
 | `MIDSCENE_PREFERRED_LANGUAGE` | 可选。模型响应的语言。如果当前时区是 GMT+8 则默认是 `Chinese`，否则是 `English` |
 | `OPENAI_MAX_TOKENS` | 可选。模型响应的 max_tokens 数 |


### PR DESCRIPTION
before:
<img width="1806" height="1102" alt="image" src="https://github.com/user-attachments/assets/4d27ef15-421f-4f23-aa1d-0a1b139a4029" />

after:
<img width="1768" height="1096" alt="image" src="https://github.com/user-attachments/assets/05803d9a-bd69-4dc7-ba5e-a43775282753" />

The text '这个选项优先级高于' should not be displayed with http link style, maybe a bug of Rspress.