### PR TITLE
fix(mcp): fix bundle

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,7 +38,8 @@
     "zod": "3.24.3"
   },
   "dependencies": {
-    "puppeteer": "24.2.0"
+    "puppeteer": "24.2.0",
+    "sharp": "0.33.5"
   },
   "license": "MIT"
 }

--- a/packages/mcp/rslib.config.ts
+++ b/packages/mcp/rslib.config.ts
@@ -41,6 +41,19 @@ export default defineConfig({
   },
   output: {
     copy: [{ from: path.join(__dirname, '../../apps/site/docs/en/api.mdx') }],
+    externals: [
+      (data, cb) => {
+        if (
+          data.context?.includes('/node_modules/ws/lib') &&
+          ['bufferutil', 'utf-8-validate'].includes(data.request as string)
+        ) {
+          cb(undefined, data.request);
+        }
+        cb();
+      },
+      '@silvia-odwyer/photon',
+      '@silvia-odwyer/photon-node',
+    ],
   },
   lib: [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
       puppeteer:
         specifier: 24.2.0
         version: 24.2.0(typescript@5.8.3)
+      sharp:
+        specifier: 0.33.5
+        version: 0.33.5
     devDependencies:
       '@midscene/android':
         specifier: workspace:*
@@ -16510,7 +16513,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.4.3
+      '@emnapi/runtime': 1.4.5
     optional: true
 
   '@img/sharp-win32-ia32@0.33.5':


### PR DESCRIPTION
1. external photon to avoid runtime error `Automatic Public path is not supported in this browser`.
2. add `sharp` into `deps`, which was external by `shared`