### PR TITLE
chore(mcp): replace puppeteer with puppeteer-core

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,7 +38,7 @@
     "zod": "3.24.3"
   },
   "dependencies": {
-    "puppeteer": "24.2.0",
+    "puppeteer-core": "24.2.0",
     "sharp": "0.33.5"
   },
   "license": "MIT"

--- a/packages/mcp/src/puppeteer.ts
+++ b/packages/mcp/src/puppeteer.ts
@@ -1,9 +1,9 @@
 // fork from https://github.com/modelcontextprotocol/servers/blob/f93737dbb098f8c078365c63c94908598f7db157/src/puppeteer/index.ts
 
 import { PuppeteerAgent } from '@midscene/web/puppeteer';
-import type { Browser, LaunchOptions } from 'puppeteer';
-import type { Page } from 'puppeteer';
-import puppeteer from 'puppeteer';
+import type { Browser, LaunchOptions } from 'puppeteer-core';
+import type { Page } from 'puppeteer-core';
+import puppeteer from 'puppeteer-core';
 import { deepMerge } from './utils';
 
 // Global state
@@ -120,6 +120,7 @@ export class PuppeteerBrowserAgent extends PuppeteerAgent {
   private browser: Browser;
 
   constructor(browser: Browser, page: Page) {
+    // @ts-expect-error The `Page` type in Puppeteer and Puppeteer-core is the same, but it is in different files. They all have a `#private` declare, which causes a TypeScript error.
     super(page);
     this.browser = browser;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,9 +630,9 @@ importers:
 
   packages/mcp:
     dependencies:
-      puppeteer:
+      puppeteer-core:
         specifier: 24.2.0
-        version: 24.2.0(typescript@5.8.3)
+        version: 24.2.0
       sharp:
         specifier: 0.33.5
         version: 0.33.5
@@ -13480,18 +13480,6 @@ packages:
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -27040,7 +27028,7 @@ snapshots:
       debug: 4.4.0(supports-color@5.5.0)
       devtools-protocol: 0.0.1402036
       typed-query-selector: 2.12.0
-      ws: 8.18.0
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -30030,8 +30018,6 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.17.1: {}
-
-  ws@8.18.0: {}
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
1. The number of installed dependencies has decreased from 96 to 79 🎉 .
2. Saved the time for downloading Chrome during the installation process. 🚀. 