### PR TITLE
chore(mcp): bundle mcp as cjs

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,29 +1,17 @@
 {
   "name": "@midscene/mcp",
   "version": "0.26.4",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
-  },
-  "bin": "dist/index.cjs",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "bin": "dist/index.js",
   "files": ["dist"],
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
     "build:watch": "npm run dev",
     "test": "vitest run",
-    "inspect": "node scripts/inspect.mjs",
-    "inspect2": "mcp-inspector node ./dist/test2.cjs"
+    "inspect": "node scripts/inspect.mjs"
   },
   "devDependencies": {
-    "@modelcontextprotocol/inspector": "0.14.1",
+    "@modelcontextprotocol/inspector": "^0.16.3",
     "@rslib/core": "^0.11.2",
     "@types/node": "^18.0.0",
     "typescript": "^5.8.3",
@@ -35,10 +23,10 @@
     "@midscene/shared": "workspace:*",
     "@midscene/android": "workspace:*",
     "@modelcontextprotocol/sdk": "1.10.2",
+    "puppeteer-core": "24.2.0",
     "zod": "3.24.3"
   },
   "dependencies": {
-    "puppeteer-core": "24.2.0",
     "sharp": "^0.34.3"
   },
   "license": "MIT"

--- a/packages/mcp/rslib.config.ts
+++ b/packages/mcp/rslib.config.ts
@@ -1,34 +1,6 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from '@rslib/core';
 import { version } from './package.json';
-
-const copyReportTemplate = () => ({
-  name: 'copy-report-template',
-  setup(api) {
-    api.onAfterBuild(() => {
-      const shebang = '#!/usr/bin/env node\n';
-
-      // Add shebang to index.cjs
-      const cjsPath = path.join(__dirname, 'dist', 'index.cjs');
-      if (fs.existsSync(cjsPath)) {
-        const content = fs.readFileSync(cjsPath, 'utf-8');
-        if (!content.startsWith(shebang)) {
-          fs.writeFileSync(cjsPath, shebang + content);
-        }
-      }
-
-      // Add shebang to index.js
-      const jsPath = path.join(__dirname, 'dist', 'index.js');
-      if (fs.existsSync(jsPath)) {
-        const content = fs.readFileSync(jsPath, 'utf-8');
-        if (!content.startsWith(shebang)) {
-          fs.writeFileSync(jsPath, shebang + content);
-        }
-      }
-    });
-  },
-});
 
 export default defineConfig({
   source: {
@@ -57,19 +29,13 @@ export default defineConfig({
   },
   lib: [
     {
-      format: 'esm',
+      format: 'cjs',
       syntax: 'es2021',
-      dts: true,
-      shims: {
-        esm: {
-          __dirname: true,
+      output: {
+        distPath: {
+          root: 'dist',
         },
       },
     },
-    {
-      format: 'cjs',
-      syntax: 'es2021',
-    },
   ],
-  plugins: [copyReportTemplate()],
 });

--- a/packages/mcp/scripts/inspect.mjs
+++ b/packages/mcp/scripts/inspect.mjs
@@ -44,7 +44,7 @@ console.log(envOverrides);
 const args = [
   'mcp-inspector',
   'node',
-  path.resolve(__dirname, '..', 'dist', 'index.cjs'), // Use resolved path for robustness
+  path.resolve(__dirname, '..', 'dist', 'index.js'), // Use resolved path for robustness
   ...Object.entries(envOverrides).map(([key, value]) => `-e ${key}=${value}`),
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,9 +648,6 @@ importers:
 
   packages/mcp:
     dependencies:
-      puppeteer-core:
-        specifier: 24.2.0
-        version: 24.2.0
       sharp:
         specifier: ^0.34.3
         version: 0.34.3
@@ -671,8 +668,8 @@ importers:
         specifier: workspace:*
         version: link:../web-integration
       '@modelcontextprotocol/inspector':
-        specifier: 0.14.1
-        version: 0.14.1(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)
+        specifier: ^0.16.3
+        version: 0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)
       '@modelcontextprotocol/sdk':
         specifier: 1.10.2
         version: 1.10.2
@@ -685,6 +682,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      puppeteer-core:
+        specifier: 24.2.0
+        version: 24.2.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2359,28 +2359,29 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@modelcontextprotocol/inspector-cli@0.14.3':
-    resolution: {integrity: sha512-cAjCfwJUfN1WHc/sGgY/yAQ7K02WOKIso+LzVoKzEr50Nf4R+WKEuq6lhnLfG3f61sU823V8TxRscc8NTYTgww==}
+  '@modelcontextprotocol/inspector-cli@0.16.3':
+    resolution: {integrity: sha512-6Hbh+QVRsEDel7hA9qiRklwWEoW4dQXHw4Ltr8JdsU1ziqem4/ERgGxthg/d+qrmbVwW9shOqPIaGoRFaZ264g==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector-client@0.14.3':
-    resolution: {integrity: sha512-kbpUYzImbB3VOolyzASfmz08m6kDQvFC0iYv4bF/ZZiwJHaqAPi/i/BIZSrpfRGbAnH+ECqjeRsxRjD6S8pr+g==}
+  '@modelcontextprotocol/inspector-client@0.16.3':
+    resolution: {integrity: sha512-BbFyNUesmZrl9FcM+TeogAo2DM6lA1+NJSSszd9+xtuumdX8WxEynv4quBgfxW/R+nHv6+D5h/ftQ3x9hwgskQ==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector-server@0.14.3':
-    resolution: {integrity: sha512-nstKV26OUHj0Dh4S+M44JsU8UGfCrxfChmczR3GZ1658t6cBLBvw2EeqUgQa4BJ0X/KbDdIgZMX0oYKEE1hYcA==}
+  '@modelcontextprotocol/inspector-server@0.16.3':
+    resolution: {integrity: sha512-7chp1jSSzM/7YswfQXA0CoBoWwEzUyKBe9s4H3e8DOBJPho6IxYgouHccHHmghWkd7e2W6ir3xwQBkLRnkt2nQ==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector@0.14.1':
-    resolution: {integrity: sha512-F9Xd/06eCfeuHkFR+6sNGhGrKAfgXFmf9VDzw+hMMoeJM3ltOUSJh/fqCvvM6tGrxvb49uAF7dr/o5Dz+rVKxw==}
+  '@modelcontextprotocol/inspector@0.16.3':
+    resolution: {integrity: sha512-9zOf8piPYNz/8vLEMHzmp8kBYQ/FZ1WP1Ao7fXHqkNcSbyw6d7CfTgZvI2Uj1Cb5VFxZ2jWvCD7J80q8G4okjg==}
+    engines: {node: '>=22.7.5'}
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.10.2':
     resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
     engines: {node: '>=18'}
 
-  '@modelcontextprotocol/sdk@1.15.1':
-    resolution: {integrity: sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==}
+  '@modelcontextprotocol/sdk@1.17.2':
+    resolution: {integrity: sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==}
     engines: {node: '>=18'}
 
   '@module-federation/error-codes@0.14.0':
@@ -6712,10 +6713,10 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lucide-react@0.447.0:
-    resolution: {integrity: sha512-SZ//hQmvi+kDKrNepArVkYK7/jfeZ5uFNEnYmd45RKZcbGD78KLnrcNXmgeg6m+xNHFvTG+CblszXCy4n6DN4w==}
+  lucide-react@0.523.0:
+    resolution: {integrity: sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -7262,6 +7263,10 @@ packages:
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
+    engines: {node: '>=18'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
   open@8.4.2:
@@ -9609,6 +9614,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
 
@@ -11408,17 +11417,17 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@modelcontextprotocol/inspector-cli@0.14.3':
+  '@modelcontextprotocol/inspector-cli@0.16.3':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.15.1
+      '@modelcontextprotocol/sdk': 1.17.2
       commander: 13.1.0
       spawn-rx: 5.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/inspector-client@0.14.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)':
+  '@modelcontextprotocol/inspector-client@0.16.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.15.1
+      '@modelcontextprotocol/sdk': 1.17.2
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)
@@ -11433,7 +11442,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      lucide-react: 0.447.0(react@18.3.1)
+      lucide-react: 0.523.0(react@18.3.1)
       pkce-challenge: 4.1.0
       prismjs: 1.30.0
       react: 18.3.1
@@ -11442,37 +11451,37 @@ snapshots:
       serve-handler: 6.1.6
       tailwind-merge: 2.6.0
       tailwindcss-animate: 1.0.7
-      zod: 3.24.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
       - supports-color
       - tailwindcss
 
-  '@modelcontextprotocol/inspector-server@0.14.3':
+  '@modelcontextprotocol/inspector-server@0.16.3':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.15.1
+      '@modelcontextprotocol/sdk': 1.17.2
       cors: 2.8.5
       express: 5.1.0
       ws: 8.18.3
-      zod: 3.24.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.14.1(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)':
+  '@modelcontextprotocol/inspector@0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)':
     dependencies:
-      '@modelcontextprotocol/inspector-cli': 0.14.3
-      '@modelcontextprotocol/inspector-client': 0.14.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)
-      '@modelcontextprotocol/inspector-server': 0.14.3
-      '@modelcontextprotocol/sdk': 1.15.1
+      '@modelcontextprotocol/inspector-cli': 0.16.3
+      '@modelcontextprotocol/inspector-client': 0.16.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)
+      '@modelcontextprotocol/inspector-server': 0.16.3
+      '@modelcontextprotocol/sdk': 1.17.2
       concurrently: 9.2.0
-      open: 10.1.0
+      open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
       ts-node: 10.9.2(@types/node@18.19.62)(typescript@5.8.3)
-      zod: 3.24.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -11500,7 +11509,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.15.1':
+  '@modelcontextprotocol/sdk@1.17.2':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -16707,7 +16716,7 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react@0.447.0(react@18.3.1):
+  lucide-react@0.523.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 
@@ -17527,6 +17536,13 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.2.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   open@8.4.2:
     dependencies:
@@ -20314,6 +20330,10 @@ snapshots:
 
   ws@8.18.3: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.0
+
   xhr@2.6.0:
     dependencies:
       global: 4.4.0
@@ -20437,8 +20457,7 @@ snapshots:
 
   zod@3.24.3: {}
 
-  zod@3.25.76:
-    optional: true
+  zod@3.25.76: {}
 
   zustand@4.5.2(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
1. MCP cli only need cjs.
2. bundle puppeteer-core to decrease installed deps.