### PR TITLE
feat(core): validate dumps are from Playwright tests in report overview

### DIFF
--- a/apps/report/src/components/report-overview/index.tsx
+++ b/apps/report/src/components/report-overview/index.tsx
@@ -59,7 +59,9 @@ const ReportOverview = (props: {
   }, [props.dumps]);
 
   const testStatsEl =
-    props.dumps && props.dumps.length > 0 ? (
+    props.dumps &&
+    props.dumps.length > 0 &&
+    props.dumps.every((dump) => dump.attributes?.playwright_test_id) ? (
       <div className="test-case-stats">
         <div className="stats-card">
           <div className="stats-value">{testStats.total}</div>


### PR DESCRIPTION
## Summary
- Add validation to ensure report overview only displays when all dumps contain Playwright test IDs
- This ensures the report data comes from Playwright test execution before showing statistics

## Test plan
- [ ] Verify report overview shows when dumps have valid Playwright test IDs
- [ ] Verify report overview is hidden when dumps lack Playwright test IDs
- [ ] Test with mixed dump data to ensure validation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)