### PR TITLE
docs(yaml): add global agent configuration for aiActionContext

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -188,8 +188,10 @@ agent:
 ```
 
 :::tip aiActionContext configuration
+
 - **Applicable environments**: Web, iOS, and Android environments can all use the global `agent` configuration to set `aiActionContext`
 - **Purpose**: Provides background knowledge to the AI model to help handle popups, login pages, and other common scenarios
+
 :::
 
 #### Usage example

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -174,9 +174,46 @@ web:
 
   # Whether to ignore HTTPS certificate errors, optional, defaults to false.
   acceptInsecureCerts: <boolean>
+```
 
+### Global agent configuration
+
+If you need to use the `aiActionContext` parameter, you can set it through the global `agent` configuration:
+
+```yaml
+# Global AI agent configuration
+agent:
   # Background knowledge to send to the AI model when calling aiAction, optional.
   aiActionContext: <string>
+```
+
+:::tip aiActionContext configuration
+- **Applicable environments**: Web, iOS, and Android environments can all use the global `agent` configuration to set `aiActionContext`
+- **Purpose**: Provides background knowledge to the AI model to help handle popups, login pages, and other common scenarios
+:::
+
+#### Usage example
+
+```yaml
+# Global agent configuration, applies to all environments
+agent:
+  aiActionContext: "If any popup appears, click agree. If login page appears, skip it."
+
+# iOS environment configuration
+ios:
+  launch: https://www.bing.com
+  wdaPort: 8100
+
+# Or Android environment configuration
+android:
+  deviceId: s4ey59
+  launch: https://www.bing.com
+
+tasks:
+  - name: Search for weather
+    flow:
+      - ai: Search for "today's weather"
+      - aiAssert: The results show weather information
 ```
 
 ### The `android` part

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -190,7 +190,7 @@ agent:
 :::tip aiActionContext configuration
 
 - **Applicable environments**: Web, iOS, and Android environments can all use the global `agent` configuration to set `aiActionContext`
-- **Purpose**: Provides background knowledge to the AI model to help handle popups, login pages, and other common scenarios
+- **Purpose**: Provides background knowledge to the AI model, like how to handle popups, business introduction, etc.
 
 :::
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -190,7 +190,7 @@ agent:
 :::tip aiActionContext 配置说明
 
 - **适用环境**：Web、iOS 和 Android 环境都可以通过全局的 `agent` 配置来设置 `aiActionContext`
-- **作用**：为 AI 模型提供背景知识，帮助处理弹窗、登录页面等常见场景
+- **作用**：为 AI 模型提供背景知识，例如处理弹窗、业务介绍等常见场景
 
 :::
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -174,9 +174,46 @@ web:
 
   # 是否忽略 HTTPS 证书错误，可选，默认 false
   acceptInsecureCerts: <boolean>
+```
 
+### 全局 agent 配置
+
+如需使用 `aiActionContext` 参数，可以通过全局的 `agent` 配置来设置：
+
+```yaml
+# 全局 AI agent 配置
+agent:
   # 在调用 aiAction 时发送给 AI 模型的背景知识，可选
   aiActionContext: <string>
+```
+
+:::tip aiActionContext 配置说明
+- **适用环境**：Web、iOS 和 Android 环境都可以通过全局的 `agent` 配置来设置 `aiActionContext`
+- **作用**：为 AI 模型提供背景知识，帮助处理弹窗、登录页面等常见场景
+:::
+
+#### 使用示例
+
+```yaml
+# 全局 agent 配置，适用于所有环境
+agent:
+  aiActionContext: "如果出现弹窗，点击同意。如果出现登录页面，跳过它。"
+
+# iOS 环境配置
+ios:
+  launch: https://www.bing.com
+  wdaPort: 8100
+
+# 或 Android 环境配置
+android:
+  deviceId: s4ey59
+  launch: https://www.bing.com
+
+tasks:
+  - name: 搜索天气
+    flow:
+      - ai: 搜索 "今日天气"
+      - aiAssert: 结果显示天气信息
 ```
 
 ### `android` 部分

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -188,8 +188,10 @@ agent:
 ```
 
 :::tip aiActionContext 配置说明
+
 - **适用环境**：Web、iOS 和 Android 环境都可以通过全局的 `agent` 配置来设置 `aiActionContext`
 - **作用**：为 AI 模型提供背景知识，帮助处理弹窗、登录页面等常见场景
+
 :::
 
 #### 使用示例


### PR DESCRIPTION
- Add global agent configuration section to both EN and ZH docs
- Move aiActionContext from web-specific to global agent config
- Provide unified configuration approach for all environments (Web, iOS, Android)
- Include usage examples with iOS and Android configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)