### PR TITLE
feat(bridge): 增加可选参数以获取浏览器标签列表

### DIFF
--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -5,6 +5,7 @@ import type { KeyboardAction, MouseAction } from '../web-page';
 import {
   type BridgeConnectTabOptions,
   BridgeEvent,
+  type BridgeGetBrowserTabListOptions,
   BridgePageType,
   DefaultBridgeServerPort,
   KeyboardEvent,
@@ -150,8 +151,8 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
     await this.setDestroyOptionsAfterConnect();
   }
 
-  async getBrowserTabList() {
-    return await this.page.getBrowserTabList();
+  async getBrowserTabList(options?: BridgeGetBrowserTabListOptions) {
+    return await this.page.getBrowserTabList(options);
   }
 
   async setActiveTabId(tabId: string) {

--- a/packages/web-integration/src/bridge-mode/common.ts
+++ b/packages/web-integration/src/bridge-mode/common.ts
@@ -69,3 +69,7 @@ export interface BridgeCallResponse {
 export interface BridgeConnectedEventPayload {
   version: string;
 }
+
+export interface BridgeGetBrowserTabListOptions {
+  currentWindow?: boolean;
+}

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -75,10 +75,12 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
    * Get a list of current tabs
    * @returns {Promise<Array<{id: number, title: string, url: string}>>}
    */
-  public async getBrowserTabList(): Promise<
+  public async getBrowserTabList(
+    option: { currentWindow?: boolean } = { currentWindow: true },
+  ): Promise<
     { id: string; title: string; url: string; currentActiveTab: boolean }[]
   > {
-    const tabs = await chrome.tabs.query({ currentWindow: true });
+    const tabs = await chrome.tabs.query(option);
     return tabs
       .map((tab) => ({
         id: `${tab.id}`,


### PR DESCRIPTION
- 在 `getBrowserTabList` 方法中添加 `options` 参数，允许用户指定是否仅获取当前窗口的标签。
- 新增 `BridgeGetBrowserTabListOptions` 接口以定义选项结构。