### PR TITLE
chore(core): log full error response when an error occurs at calling OpenAI

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -131,6 +131,29 @@ async function createChatClient({
         [MIDSCENE_API_TYPE]: AIActionTypeValue.toString(),
       },
       dangerouslyAllowBrowser: true,
+      /**
+       * By default, OpenAI uses the built-in fetch function of Node.js as the implementation of fetch.
+       * However, the built-in error handling logic of OpenAI does not throw out all the text in the HTTP response.
+       * This will prevent users from seeing the most crucial error messages, especially when using third-party models.
+       */
+      fetch: async (...args) => {
+        const result = await fetch(...args);
+        if (!result.ok) {
+          const clone = result.clone();
+          try {
+            const text = await clone.text();
+            console.log(
+              `call AI model service error with status code ${result.status} and response text: ${text}`,
+            );
+          } catch (e) {
+            console.log(
+              `call AI model service error with status code ${result.status} but get response text failed.`,
+              e,
+            );
+          }
+        }
+        return result;
+      },
     });
   }
 
@@ -468,7 +491,7 @@ export async function callAI(
       isStreamed: !!isStreaming,
     };
   } catch (e: any) {
-    console.error(' call AI error', e);
+    console.error('call AI model service error', e);
     const newError = new Error(
       `failed to call ${isStreaming ? 'streaming ' : ''}AI model service: ${e.message}. Trouble shooting: https://midscenejs.com/model-provider.html`,
       {


### PR DESCRIPTION
For such an HTTP error

```js
const http = require('node:http');

const server = http.createServer((req, res) => {
  res.writeHead(400, { 'Content-Type': 'text/json' });
  res.end(JSON.stringify({ data: 'A very important error message' }));
});

const port = 3000;
const host = '127.0.0.1';

server.listen(port, host, () => {
  console.log(`Server running at http://${host}:${port}/`);
});

```

Before log:

```text
call AI model service error BadRequestError: 400 status code (no body)
```

After log:

```text
call AI model service error with status code 400 and response text: {"data":"A very important error message"}
call AI model service error BadRequestError: 400 status code (no body)
```