### PR TITLE
feat(android): add runAdbCommand method to AndroidAgent

### DIFF
--- a/apps/site/docs/en/integrate-with-android.mdx
+++ b/apps/site/docs/en/integrate-with-android.mdx
@@ -164,6 +164,37 @@ await agent.launch('com.android.settings'); // open a native page
 await agent.launch('com.android.settings/.Settings'); // open a native page
 ```
 
+#### `agent.runAdbCommand()`
+
+Execute an adb shell command.
+
+- Type
+
+```typescript
+function runAdbCommand(command: string): Promise<string>;
+```
+
+- Parameters:
+
+  - `command: string` - The adb shell command to execute.
+
+- Return Value:
+
+  - `Promise<string>` - Returns a Promise that resolves to the command output.
+
+- Examples:
+
+```typescript
+import { AndroidAgent, AndroidDevice } from '@midscene/android';
+
+const device = new AndroidDevice('s4ey59');
+const agent = new AndroidAgent(device);
+await device.connect();
+
+const result = await agent.runAdbCommand('dumpsys battery');
+console.log(result);
+```
+
 #### `agentFromAdbDevice()`
 
 Create a AndroidAgent from a connected adb device.

--- a/apps/site/docs/en/integrate-with-android.mdx
+++ b/apps/site/docs/en/integrate-with-android.mdx
@@ -164,14 +164,16 @@ await agent.launch('com.android.settings'); // open a native page
 await agent.launch('com.android.settings/.Settings'); // open a native page
 ```
 
-#### `agent.runAdbCommand()`
+#### `agent.runAdbShell()`
 
-Execute an adb shell command.
+Execute a command through `adb shell` on the connected device.
+
+> Note: This method wraps `adb shell` and forwards the command directly to the device.
 
 - Type
 
 ```typescript
-function runAdbCommand(command: string): Promise<string>;
+function runAdbShell(command: string): Promise<string>;
 ```
 
 - Parameters:
@@ -191,7 +193,8 @@ const device = new AndroidDevice('s4ey59');
 const agent = new AndroidAgent(device);
 await device.connect();
 
-const result = await agent.runAdbCommand('dumpsys battery');
+const result = await agent.runAdbShell('dumpsys battery');
+// Equivalent to running `adb shell dumpsys battery`
 console.log(result);
 ```
 

--- a/apps/site/docs/zh/integrate-with-android.mdx
+++ b/apps/site/docs/zh/integrate-with-android.mdx
@@ -163,14 +163,16 @@ await agent.launch('com.android.settings'); // 打开系统设置 app(package na
 await agent.launch('com.android.settings/.Settings'); // 打开系统设置 app(package name) 的 .Settings(activity name) 页面
 ```
 
-#### `agent.runAdbCommand()`
+#### `agent.runAdbShell()`
 
-执行 adb shell 命令。
+执行 `adb shell` 命令。
+
+> 注意：该方法本质上是调用 `adb shell` 执行传入的命令。
 
 - 类型
 
 ```typescript
-function runAdbCommand(command: string): Promise<string>;
+function runAdbShell(command: string): Promise<string>;
 ```
 
 - 参数：
@@ -190,7 +192,8 @@ const page = new AndroidDevice('s4ey59');
 const agent = new AndroidAgent(page);
 await page.connect();
 
-const result = await agent.runAdbCommand('dumpsys battery');
+const result = await agent.runAdbShell('dumpsys battery');
+// 等同于执行 `adb shell dumpsys battery`
 console.log(result);
 ```
 

--- a/apps/site/docs/zh/integrate-with-android.mdx
+++ b/apps/site/docs/zh/integrate-with-android.mdx
@@ -163,6 +163,37 @@ await agent.launch('com.android.settings'); // 打开系统设置 app(package na
 await agent.launch('com.android.settings/.Settings'); // 打开系统设置 app(package name) 的 .Settings(activity name) 页面
 ```
 
+#### `agent.runAdbCommand()`
+
+执行 adb shell 命令。
+
+- 类型
+
+```typescript
+function runAdbCommand(command: string): Promise<string>;
+```
+
+- 参数：
+
+  - `command: string` - 要执行的 adb shell 命令
+
+- 返回值:
+
+  - `Promise<string>` - 命令执行的输出结果
+
+- 示例:
+
+```typescript
+import { AndroidAgent, AndroidDevice } from '@midscene/android';
+
+const page = new AndroidDevice('s4ey59');
+const agent = new AndroidAgent(page);
+await page.connect();
+
+const result = await agent.runAdbCommand('dumpsys battery');
+console.log(result);
+```
+
 #### `agentFromAdbDevice()`
 
 从已连接的 adb 设备中，创建一个 AndroidAgent。

--- a/packages/android/src/agent.ts
+++ b/packages/android/src/agent.ts
@@ -12,6 +12,11 @@ export class AndroidAgent extends PageAgent<AndroidDevice> {
     const device = this.page;
     await device.launch(uri);
   }
+
+  async runAdbCommand(command: string): Promise<string> {
+    const adb = await this.page.getAdb();
+    return await adb.shell(command);
+  }
 }
 
 export async function agentFromAdbDevice(

--- a/packages/android/src/agent.ts
+++ b/packages/android/src/agent.ts
@@ -13,7 +13,7 @@ export class AndroidAgent extends PageAgent<AndroidDevice> {
     await device.launch(uri);
   }
 
-  async runAdbCommand(command: string): Promise<string> {
+  async runAdbShell(command: string): Promise<string> {
     const adb = await this.page.getAdb();
     return await adb.shell(command);
   }


### PR DESCRIPTION
## Summary
- Add `runAdbCommand` method to `AndroidAgent` class that wraps `adb.shell()` calls
- Update documentation (both English and Chinese) with the new API

## Changes
- Added `runAdbCommand(command: string): Promise<string>` method to `AndroidAgent`
- Updated `/apps/site/docs/en/integrate-with-android.mdx` with API documentation
- Updated `/apps/site/docs/zh/integrate-with-android.mdx` with API documentation

This method allows users to execute custom adb shell commands directly through the AndroidAgent interface, providing more flexibility for advanced use cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)