### PR TITLE
docs(android): clarify imeStrategy description

### DIFF
--- a/apps/site/docs/en/integrate-with-android.mdx
+++ b/apps/site/docs/en/integrate-with-android.mdx
@@ -126,7 +126,7 @@ The AndroidDevice constructor supports the following parameters:
   - `androidAdbPath?: string` - Optional, the path to the adb executable.
   - `remoteAdbHost?: string` - Optional, the remote adb host.
   - `remoteAdbPort?: number` - Optional, the remote adb port.
-  - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` - Optional, when should Midscene invoke [yadb](https://github.com/ysbing/YADB) to input texts. (Default: 'yadb-for-non-ascii')
+  - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` - Optional, when should Midscene invoke [yadb](https://github.com/ysbing/YADB) to input texts. `'yadb-for-non-ascii'` uses yadb only when handling non-ASCII words, while `'always-yadb'` forces yadb for every input task. Try switching between these strategies if the default configuration fails to input texts. (Default: 'yadb-for-non-ascii')
   - `displayId?: number` - Optional, the display id to use. (Default: undefined, means use the current display)
 
 ### Additional Android Agent Interfaces

--- a/apps/site/docs/zh/integrate-with-android.mdx
+++ b/apps/site/docs/zh/integrate-with-android.mdx
@@ -125,7 +125,7 @@ AndroidDevice 的构造函数支持以下参数：
   - `androidAdbPath?: string` - 可选参数，用于指定 adb 可执行文件的路径。
   - `remoteAdbHost?: string` - 可选参数，用于指定远程 adb 主机。
   - `remoteAdbPort?: number` - 可选参数，用于指定远程 adb 端口。
-  - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` - 可选参数，控制 Midscene 何时调用 [yadb](https://github.com/ysbing/YADB) 来输入文本。默认值为 'yadb-for-non-ascii'。
+  - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` - 可选参数，控制 Midscene 何时调用 [yadb](https://github.com/ysbing/YADB) 来输入文本。`'yadb-for-non-ascii'` 仅在输入非 ASCII 文本时启用 yadb，而 `'always-yadb'` 会在所有输入任务中都使用 yadb。如果默认配置无法正确输入文本，可尝试在这两种策略之间切换。默认值为 'yadb-for-non-ascii'。
   - `displayId?: number` - 可选参数，用于指定要使用的显示器 ID。默认值为 undefined，表示使用当前显示器。
 
 ### Android Agent 上的更多接口


### PR DESCRIPTION
## Summary
- clarify the documentation for `imeStrategy` to explain both available modes
- note that switching modes can help when input fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e766993d94832497f45bd305b8a313