### PR TITLE
feat(chrome-extension): persist popup mode selection in localStorage

### DIFF
--- a/apps/chrome-extension/src/extension/popup/index.tsx
+++ b/apps/chrome-extension/src/extension/popup/index.tsx
@@ -28,13 +28,23 @@ const extensionAgentForTab = (forceSameTabNavigation = true) => {
   return new ChromeExtensionProxyPageAgent(page);
 };
 
+const STORAGE_KEY = 'midscene-popup-mode';
+
 export function PlaygroundPopup() {
   const { setPopupTab } = useEnvConfig();
   const [currentMode, setCurrentMode] = useState<
     'playground' | 'bridge' | 'recorder'
-  >('playground');
+  >(() => {
+    const savedMode = localStorage.getItem(STORAGE_KEY);
+    return (savedMode as 'playground' | 'bridge' | 'recorder') || 'playground';
+  });
 
   const { config } = useEnvConfig();
+
+  // Sync popupTab with saved mode on mount
+  useEffect(() => {
+    setPopupTab(currentMode);
+  }, []);
 
   // Override AI configuration
   useEffect(() => {
@@ -54,6 +64,7 @@ export function PlaygroundPopup() {
       onClick: () => {
         setCurrentMode('playground');
         setPopupTab('playground');
+        localStorage.setItem(STORAGE_KEY, 'playground');
       },
     },
     {
@@ -63,6 +74,7 @@ export function PlaygroundPopup() {
       onClick: () => {
         setCurrentMode('recorder');
         setPopupTab('recorder');
+        localStorage.setItem(STORAGE_KEY, 'recorder');
       },
     },
     {
@@ -72,6 +84,7 @@ export function PlaygroundPopup() {
       onClick: () => {
         setCurrentMode('bridge');
         setPopupTab('bridge');
+        localStorage.setItem(STORAGE_KEY, 'bridge');
       },
     },
   ];


### PR DESCRIPTION
## Summary
- Remember last selected mode (playground/bridge/recorder) in localStorage
- Auto-restore mode when popup opens
- Improves user experience by maintaining mode preference across sessions

## Changes
- Added `STORAGE_KEY` constant for localStorage key
- Modified `useState` initialization to read from localStorage
- Added `useEffect` to sync popupTab with saved mode on mount
- Updated all menu item onClick handlers to save mode to localStorage

## Test plan
- [ ] Open Chrome extension popup
- [ ] Switch between different modes (playground/bridge/recorder)
- [ ] Close and reopen the popup
- [ ] Verify the last selected mode is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)