### PR TITLE
fix(chrome-extension): adjust scroll-to-bottom button position

### DIFF
--- a/apps/chrome-extension/src/extension/bridge/index.less
+++ b/apps/chrome-extension/src/extension/bridge/index.less
@@ -367,7 +367,7 @@
 
   .scroll-to-bottom-button {
     position: fixed;
-    bottom: 10px;
+    bottom: 100px;
     right: 10px;
     z-index: 1001;
     background: #fff;


### PR DESCRIPTION
## Summary
Adjusted the scroll-to-bottom button position in bridge mode to improve visibility and prevent overlap with other UI elements.

## Changes
- Increased bottom offset from `10px` to `100px` for the scroll-to-bottom button

## Test plan
- [ ] Open Chrome extension in bridge mode
- [ ] Verify scroll-to-bottom button is positioned correctly
- [ ] Confirm no overlap with other UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)