### PR TITLE
fix(visualizer): add delay before stopping video recorder to capture final frames

### DIFF
--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -871,6 +871,8 @@ export function Player(props?: {
         }
 
         if (recorderSessionRef.current) {
+          // Add delay to capture final frames before stopping the recorder
+          await sleep(1200);
           recorderSessionRef.current.stop();
           recorderSessionRef.current = null;
           setIsRecording(false);


### PR DESCRIPTION
## Summary
- Fixed video export issue where the last operation was immediately cut off
- Added 1200ms delay before stopping the MediaRecorder to ensure final frames are captured

## Problem
When exporting a video, the last operation's result was not visible because:
1. The last animation script had `duration: 0` 
2. `RecordingSession.stop()` was called immediately after animation completed
3. MediaRecorder didn't have time to capture the final state frames

## Solution
Added a 1200ms delay (via `await sleep(1200)`) before stopping the recorder in the `play()` function. This ensures viewers can see the complete effect of the last operation in the exported video.

## Test plan
- [ ] Export a video with multiple operations
- [ ] Verify the last operation's result is visible for ~1.2 seconds before the video ends
- [ ] Check that the video quality and timing of other operations remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)