### PR TITLE
docs(cache): add write-only cache strategy documentation

### DIFF
--- a/apps/site/docs/en/caching.mdx
+++ b/apps/site/docs/en/caching.mdx
@@ -106,6 +106,27 @@ agent:
     strategy: "read-only"
 ```
 
+### Write-only mode
+
+Configuration: `cache: { strategy: "write-only", id: "my-cache-id" }`
+
+Only write to cache, do not read existing cache contents. Always call AI model for each execution and write results to cache file. Suitable for initially building cache or updating cache.
+
+```javascript
+// Direct Agent creation
+const agent = new PuppeteerAgent(page, {
+  cache: { strategy: "write-only", id: "my-cache-id" },
+});
+```
+
+```yaml
+# YAML configuration
+agent:
+  cache:
+    id: "my-cache-test"
+    strategy: "write-only"
+```
+
 ### Compatibility mode (not recommended)
 
 Configuration via `MIDSCENE_CACHE=1` environment variable with cacheId, equivalent to read-write mode.
@@ -190,6 +211,19 @@ test('manual cache flush', async ({ agentForPage, page, aiTap, aiWaitFor }) => {
   await agent.flushCache();
 });
 ```
+
+### Write-only mode
+
+```typescript
+// fixture.ts in sample code
+export const test = base.extend<PlayWrightAiFixtureType>(
+  PlaywrightAiFixture({
+    cache: { strategy: "write-only", id: "write-only-cache" },
+  }),
+);
+```
+
+In write-only mode, each test will call the AI model and automatically write results to cache file without reading existing cache.
 
 ## FAQ
 

--- a/apps/site/docs/zh/caching.mdx
+++ b/apps/site/docs/zh/caching.mdx
@@ -109,6 +109,27 @@ agent:
     strategy: "read-only"
 ```
 
+### 只写模式
+
+配置方式：`cache: { strategy: "write-only", id: "my-cache-id" }`
+
+只写入缓存，不读取已有缓存内容。每次执行时都会调用 AI 模型，并将结果写入缓存文件。适合初次建立缓存或更新缓存时使用。
+
+```javascript
+// 直接创建 Agent
+const agent = new PuppeteerAgent(page, {
+  cache: { strategy: "write-only", id: "my-cache-id" },
+});
+```
+
+```yaml
+# YAML 配置
+agent:
+  cache:
+    id: "my-cache-test"
+    strategy: "write-only"
+```
+
 ### 兼容方式（不推荐）
 
 通过环境变量 `MIDSCENE_CACHE=1` 配合 cacheId 配置，等同于读写模式。
@@ -193,6 +214,19 @@ test('manual cache flush', async ({ agentForPage, page, aiTap, aiWaitFor }) => {
   await agent.flushCache();
 });
 ```
+
+### 只写模式
+
+```typescript
+// 对应样例代码中的 fixture.ts
+export const test = base.extend<PlayWrightAiFixtureType>(
+  PlaywrightAiFixture({
+    cache: { strategy: "write-only", id: "write-only-cache" },
+  }),
+);
+```
+
+在只写模式下，每次测试都会调用 AI 模型，并将结果自动写入缓存文件，不会读取已有缓存。
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `write-only` cache strategy in both Chinese and English caching documentation.

## Changes

### Documentation Updates

- **Chinese documentation** (`apps/site/docs/zh/caching.mdx`):
  - Added "只写模式" section explaining the write-only strategy
  - Included JavaScript/TypeScript and YAML configuration examples
  - Added write-only mode configuration for Playwright AI Fixture
  
- **English documentation** (`apps/site/docs/en/caching.mdx`):
  - Added "Write-only mode" section explaining the write-only strategy
  - Included JavaScript/TypeScript and YAML configuration examples
  - Added write-only mode configuration for Playwright AI Fixture

### Write-only Strategy Features

- Only writes to cache, does not read existing cache contents
- Always calls the AI model for each execution
- Automatically writes results to cache file
- Suitable for initially building cache or updating cache
- Configuration: `cache: { strategy: "write-only", id: "my-cache-id" }`

## Documentation Coverage

The documentation now comprehensively covers all three cache strategies:

1. **read-write** (default): Read existing cache and auto-update
2. **read-only**: Read cache, manual write via `flushCache()`
3. **write-only**: Always call AI, auto-write without reading

## Testing

- ✅ All changes passed linter check
- ✅ Verified both Chinese and English documentation formatting
- ✅ Confirmed consistency between both language versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)