### PR TITLE
feat(report): add custom log entry tip in execution sidebar

### DIFF
--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -317,6 +317,34 @@
       overflow-y: auto;
       overflow-x: hidden;
       min-height: 0;
+
+      .executions-tip {
+        padding: 12px 20px;
+        font-size: 12px;
+        color: #8c8c8c;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+
+        .tip-icon {
+          color: #8c8c8c;
+          font-weight: 500;
+          flex-shrink: 0;
+        }
+
+        .tip-text {
+          line-height: 1.5;
+
+          a {
+            color: #1890ff;
+            text-decoration: none;
+
+            &:hover {
+              text-decoration: underline;
+            }
+          }
+        }
+      }
     }
   }
 

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -343,6 +343,19 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
             </div>
           );
         })}
+        <div className="executions-tip">
+          <span className="tip-icon">?</span>
+          <span className="tip-text">
+            How to insert a custom log entry ?{' '}
+            <a
+              href="https://midscenejs.com/api#agentlogscreenshot"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more
+            </a>
+          </span>
+        </div>
       </div>
     </div>
   ) : null;


### PR DESCRIPTION
## Summary
- Add a helpful tip at the end of the executions list in the report sidebar
- Guide users on how to insert custom log entries
- Include a link to the API documentation

## Changes
- Added tip component after all execution items in the sidebar
- Styled as plain text with minimal visual emphasis (gray color, no background)
- Links to https://midscenejs.com/api#agentlogscreenshot

## Screenshots
The tip appears at the bottom of the execution list:
> ? How to insert a custom log entry ? [Learn more](https://midscenejs.com/api#agentlogscreenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)