### PR TITLE
docs: add midscene-java to awesome midscene lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Community projects that extend Midscene.js capabilities:
 
 * [midscene-ios](https://github.com/lhuanyu/midscene-ios) - iOS automation support for Midscene
 * [Midscene-Python](https://github.com/Python51888/Midscene-Python) - Python SDK for Midscene automation
+* [midscene-java](https://github.com/Master-Frank/midscene-java) - Java SDK that brings Midscene automation features to JVM projects
 
 
 ## 📝 Credits

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,6 +133,7 @@ for (const record of recordList) {
 
 * [midscene-ios](https://github.com/lhuanyu/midscene-ios) - iOS 设备自动化工具
 * [Midscene-Python](https://github.com/Python51888/Midscene-Python) - Python 版本的 Midscene SDK
+* [midscene-java](https://github.com/Master-Frank/midscene-java) - Java 版本的 Midscene SDK，便于在 JVM 项目中使用自动化能力
 
 ## 📝 致谢
 

--- a/apps/site/docs/en/awesome-midscene.md
+++ b/apps/site/docs/en/awesome-midscene.md
@@ -14,6 +14,11 @@ A curated list of community projects that extend Midscene.js capabilities across
   - Brings Midscene's AI-powered automation capabilities to Python developers
   - Allows integration with existing Python testing and automation workflows
 
+### Java SDK
+- **[midscene-java](https://github.com/Master-Frank/midscene-java)** - Java SDK for Midscene automation
+  - Offers a JVM-friendly way to script Midscene experiences similar to the Python SDK
+  - Fits easily into existing Java automation or testing pipelines
+
 ## Contributing
 
 Have you created a project that extends Midscene.js? We'd love to feature it here!

--- a/apps/site/docs/zh/awesome-midscene.md
+++ b/apps/site/docs/zh/awesome-midscene.md
@@ -14,6 +14,11 @@
   - 为 Python 开发者提供 Midscene 的 AI 驱动自动化能力
   - 支持与现有 Python 测试和自动化工作流程的集成
 
+### Java SDK
+- **[midscene-java](https://github.com/Master-Frank/midscene-java)** - Java 版本的 Midscene SDK
+  - 提供与 Python 版本类似的体验，适配 JVM 生态
+  - 易于整合到现有的 Java 自动化或测试流程
+
 ## 如何贡献
 
 创建了扩展 Midscene.js 功能的项目？我们很乐意在这里展示！


### PR DESCRIPTION
## Summary
- feature the community-maintained midscene-java SDK in the Awesome Midscene sections
- highlight the Java SDK alongside the existing Python entry in both English and Chinese docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0ae185ea88324b1e5343aee462515