### PR TITLE
feat(core,shared): enforce VL mode requirement for Planning

### DIFF
--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -375,6 +375,21 @@ export interface IModelConfigForVQA {
   [MIDSCENE_VQA_VL_MODE]?: TVlModeValues;
 }
 
+/**
+ * Model configuration for Planning intent.
+ *
+ * IMPORTANT: Planning MUST use a vision language model (VL mode).
+ * DOM-based planning is not supported.
+ *
+ * Required: MIDSCENE_PLANNING_VL_MODE must be set to one of:
+ *   - 'qwen-vl'
+ *   - 'qwen3-vl'
+ *   - 'gemini'
+ *   - 'doubao-vision'
+ *   - 'vlm-ui-tars'
+ *   - 'vlm-ui-tars-doubao'
+ *   - 'vlm-ui-tars-doubao-1.5'
+ */
 export interface IModelConfigForPlanning {
   // model name
   [MIDSCENE_PLANNING_MODEL_NAME]: string;

--- a/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
@@ -13,6 +13,7 @@ import {
   MIDSCENE_PLANNING_MODEL_NAME,
   MIDSCENE_PLANNING_OPENAI_API_KEY,
   MIDSCENE_PLANNING_OPENAI_BASE_URL,
+  MIDSCENE_PLANNING_VL_MODE,
   MIDSCENE_VQA_MODEL_NAME,
   MIDSCENE_VQA_OPENAI_API_KEY,
   MIDSCENE_VQA_OPENAI_BASE_URL,
@@ -48,9 +49,10 @@ describe('ModelConfigManager', () => {
             };
           case 'planning':
             return {
-              [MIDSCENE_PLANNING_MODEL_NAME]: 'gpt-4',
+              [MIDSCENE_PLANNING_MODEL_NAME]: 'qwen-vl-plus',
               [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-planning-key',
               [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+              [MIDSCENE_PLANNING_VL_MODE]: 'qwen-vl' as const,
             };
           case 'grounding':
             return {
@@ -105,9 +107,10 @@ describe('ModelConfigManager', () => {
             };
           case 'planning':
             return {
-              [MIDSCENE_PLANNING_MODEL_NAME]: 'gpt-4',
+              [MIDSCENE_PLANNING_MODEL_NAME]: 'qwen-vl-plus',
               [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-planning-key',
               [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+              [MIDSCENE_PLANNING_VL_MODE]: 'qwen-vl',
             };
           case 'grounding':
             return {
@@ -131,10 +134,11 @@ describe('ModelConfigManager', () => {
       expect(vqaConfig.from).toBe('modelConfig');
 
       const planningConfig = manager.getModelConfig('planning');
-      expect(planningConfig.modelName).toBe('gpt-4');
+      expect(planningConfig.modelName).toBe('qwen-vl-plus');
       expect(planningConfig.openaiApiKey).toBe('test-planning-key');
       expect(planningConfig.intent).toBe('planning');
       expect(planningConfig.from).toBe('modelConfig');
+      expect(planningConfig.vlMode).toBe('qwen-vl');
 
       const groundingConfig = manager.getModelConfig('grounding');
       expect(groundingConfig.modelName).toBe('gpt-4-vision');
@@ -261,6 +265,156 @@ describe('ModelConfigManager', () => {
       expect(config.modelName).toBe('gpt-4');
       expect(config.openaiApiKey).toBe('isolated-key');
       expect(config.openaiBaseURL).toBe('https://isolated.openai.com/v1');
+    });
+  });
+
+  describe('Planning VL mode validation', () => {
+    it('should throw error when planning has no vlMode in isolated mode', () => {
+      const modelConfigFn: TModelConfigFn = ({ intent }) => {
+        if (intent === 'planning') {
+          // Missing VL mode for planning
+          return {
+            [MIDSCENE_PLANNING_MODEL_NAME]: 'gpt-4',
+            [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-key',
+            [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+          };
+        }
+        return {
+          [MIDSCENE_MODEL_NAME]: 'gpt-4',
+          [MIDSCENE_OPENAI_API_KEY]: 'test-key',
+          [MIDSCENE_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+        };
+      };
+
+      const manager = new ModelConfigManager(modelConfigFn);
+
+      expect(() => manager.getModelConfig('planning')).toThrow(
+        'Planning requires a vision language model (VL model). DOM-based planning is not supported.',
+      );
+    });
+
+    it('should succeed when planning has valid vlMode in isolated mode', () => {
+      const modelConfigFn: TModelConfigFn = ({ intent }) => {
+        if (intent === 'planning') {
+          return {
+            [MIDSCENE_PLANNING_MODEL_NAME]: 'qwen-vl-plus',
+            [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-key',
+            [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+            [MIDSCENE_PLANNING_VL_MODE]: 'qwen-vl' as const,
+          };
+        }
+        return {
+          [MIDSCENE_MODEL_NAME]: 'gpt-4',
+          [MIDSCENE_OPENAI_API_KEY]: 'test-key',
+          [MIDSCENE_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+        };
+      };
+
+      const manager = new ModelConfigManager(modelConfigFn);
+      const config = manager.getModelConfig('planning');
+
+      expect(config.vlMode).toBe('qwen-vl');
+      expect(config.modelName).toBe('qwen-vl-plus');
+    });
+
+    it('should throw error when planning has no vlMode in normal mode', () => {
+      vi.stubEnv(MIDSCENE_PLANNING_MODEL_NAME, 'gpt-4');
+      vi.stubEnv(MIDSCENE_PLANNING_OPENAI_API_KEY, 'test-key');
+      vi.stubEnv(MIDSCENE_PLANNING_OPENAI_BASE_URL, 'https://api.openai.com/v1');
+      // Intentionally not setting MIDSCENE_PLANNING_VL_MODE
+
+      const manager = new ModelConfigManager();
+      manager.registerGlobalConfigManager(new GlobalConfigManager());
+
+      expect(() => manager.getModelConfig('planning')).toThrow(
+        'Planning requires a vision language model (VL model). DOM-based planning is not supported.',
+      );
+    });
+
+    it('should succeed when planning has valid vlMode in normal mode', () => {
+      vi.stubEnv(MIDSCENE_PLANNING_MODEL_NAME, 'qwen-vl-plus');
+      vi.stubEnv(MIDSCENE_PLANNING_OPENAI_API_KEY, 'test-key');
+      vi.stubEnv(MIDSCENE_PLANNING_OPENAI_BASE_URL, 'https://api.openai.com/v1');
+      vi.stubEnv(MIDSCENE_PLANNING_VL_MODE, 'qwen-vl');
+
+      const manager = new ModelConfigManager();
+      manager.registerGlobalConfigManager(new GlobalConfigManager());
+
+      const config = manager.getModelConfig('planning');
+
+      expect(config.vlMode).toBe('qwen-vl');
+      expect(config.modelName).toBe('qwen-vl-plus');
+      expect(config.intent).toBe('planning');
+    });
+
+    it('should not affect other intents when planning validation fails', () => {
+      const modelConfigFn: TModelConfigFn = ({ intent }) => {
+        if (intent === 'planning') {
+          // Missing VL mode for planning - should fail
+          return {
+            [MIDSCENE_PLANNING_MODEL_NAME]: 'gpt-4',
+            [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-key',
+            [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+          };
+        }
+        // Other intents should work fine
+        return {
+          [MIDSCENE_MODEL_NAME]: 'gpt-4',
+          [MIDSCENE_OPENAI_API_KEY]: 'test-key',
+          [MIDSCENE_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+        };
+      };
+
+      const manager = new ModelConfigManager(modelConfigFn);
+
+      // Planning should fail
+      expect(() => manager.getModelConfig('planning')).toThrow(
+        'Planning requires a vision language model',
+      );
+
+      // Other intents should succeed
+      expect(() => manager.getModelConfig('default')).not.toThrow();
+      expect(() => manager.getModelConfig('VQA')).not.toThrow();
+      expect(() => manager.getModelConfig('grounding')).not.toThrow();
+    });
+
+    it('should accept all valid VL modes for planning', () => {
+      const vlModeTestCases: Array<{
+        raw: 'qwen-vl' | 'qwen3-vl' | 'gemini' | 'doubao-vision' | 'vlm-ui-tars' | 'vlm-ui-tars-doubao' | 'vlm-ui-tars-doubao-1.5';
+        expected: string;
+      }> = [
+        { raw: 'qwen-vl', expected: 'qwen-vl' },
+        { raw: 'qwen3-vl', expected: 'qwen3-vl' },
+        { raw: 'gemini', expected: 'gemini' },
+        { raw: 'doubao-vision', expected: 'doubao-vision' },
+        // UI-TARS variants all normalize to 'vlm-ui-tars'
+        { raw: 'vlm-ui-tars', expected: 'vlm-ui-tars' },
+        { raw: 'vlm-ui-tars-doubao', expected: 'vlm-ui-tars' },
+        { raw: 'vlm-ui-tars-doubao-1.5', expected: 'vlm-ui-tars' },
+      ];
+
+      for (const { raw, expected } of vlModeTestCases) {
+        const modelConfigFn: TModelConfigFn = ({ intent }) => {
+          if (intent === 'planning') {
+            return {
+              [MIDSCENE_PLANNING_MODEL_NAME]: 'test-model',
+              [MIDSCENE_PLANNING_OPENAI_API_KEY]: 'test-key',
+              [MIDSCENE_PLANNING_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+              [MIDSCENE_PLANNING_VL_MODE]: raw,
+            };
+          }
+          return {
+            [MIDSCENE_MODEL_NAME]: 'gpt-4',
+            [MIDSCENE_OPENAI_API_KEY]: 'test-key',
+            [MIDSCENE_OPENAI_BASE_URL]: 'https://api.openai.com/v1',
+          };
+        };
+
+        const manager = new ModelConfigManager(modelConfigFn);
+        const config = manager.getModelConfig('planning');
+
+        expect(config.vlMode).toBe(expected);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR enforces that Planning functionality only supports vision language models (VL mode) 
and removes DOM-based planning support. This change ensures better consistency and performance 
by requiring visual models for planning operations.

## Changes

### Core Changes
- **ModelConfigManager Validation** (`packages/shared/src/env/model-config-manager.ts`)
  - Added validation in `getModelConfig()` to enforce VL mode for Planning intent
  - Provides clear error message with all supported VL modes and configuration examples
  - References documentation link for users to learn more

- **Planning Implementation Simplification** (`packages/core/src/ai-model/llm-planning.ts`)
  - Removed DOM mode support (`describeUserPage`, `markupImageForLLM`)
  - Simplified image processing logic to only support VL mode paths
  - Added assertion to ensure VL mode is configured
  - Removed conditional DOM description in message construction

- **Type Documentation** (`packages/shared/src/env/types.ts`)
  - Added comprehensive JSDoc comments to `IModelConfigForPlanning`
  - Clearly documents VL mode requirement and lists all supported modes

### Test Coverage
- Added 6 new unit tests for Planning VL mode validation:
  1. Isolated mode - should throw error when planning has no VL mode
  2. Isolated mode - should succeed when planning has valid VL mode
  3. Normal mode - should throw error when planning has no VL mode  
  4. Normal mode - should succeed when planning has valid VL mode
  5. Planning validation failure doesn't affect other intents
  6. Should accept all valid VL modes (tests all 7 VL mode values)

- Fixed existing tests to provide VL mode for Planning intent

### Supported VL Modes
- `qwen-vl`
- `qwen3-vl`
- `gemini`
- `doubao-vision`
- `vlm-ui-tars`
- `vlm-ui-tars-doubao`
- `vlm-ui-tars-doubao-1.5`

## Breaking Change ⚠️

**Planning without VL mode configured will now throw an error.**

Before this change, Planning could work with DOM-based mode. After this change, 
users must configure a VL mode for Planning intent.

Error message example:
```
Planning requires a vision language model (VL model). DOM-based planning is not supported.

Please configure one of the following VL modes:
  - doubao-vision
  - gemini
  - qwen-vl
  - qwen3-vl
  - vlm-ui-tars
  - vlm-ui-tars-doubao
  - vlm-ui-tars-doubao-1.5
  
Configuration examples:
  - Environment variable: MIDSCENE_PLANNING_VL_MODE=qwen-vl
  - Or use modelConfig function with planning intent
  
Learn more: https://midscenejs.com/choose-a-model
```

## Migration Guide

Users need to configure VL mode for Planning in one of two ways:

**Option 1: Environment Variable**
```bash
export MIDSCENE_PLANNING_VL_MODE=qwen-vl
export MIDSCENE_PLANNING_MODEL_NAME=qwen-vl-plus
export MIDSCENE_PLANNING_OPENAI_API_KEY=your-api-key
```

**Option 2: modelConfig Function**
```typescript
const agent = new Agent({
  modelConfig: ({ intent }) => {
    if (intent === 'planning') {
      return {
        MIDSCENE_PLANNING_MODEL_NAME: 'qwen-vl-plus',
        MIDSCENE_PLANNING_OPENAI_API_KEY: 'your-api-key',
        MIDSCENE_PLANNING_VL_MODE: 'qwen-vl',
      };
    }
    // ... other intents
  },
});
```

## Test Results

✅ All tests passing (17/17)
✅ Build successful
✅ TypeScript compilation clean

## Impact Analysis

- **VQA not affected**: VQA's `domIncluded` parameter functionality remains unchanged
- **Other intents not affected**: Planning validation only applies to Planning intent
- **Configuration-level validation**: Fails fast with clear error messages at initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)