### PR TITLE
refactor: rename API methods for improved clarity

### DIFF
--- a/packages/core/tests/unit-test/proxy-integration.test.ts
+++ b/packages/core/tests/unit-test/proxy-integration.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { IModelConfig } from '@midscene/shared/env';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the dependencies before importing the module under test
 vi.mock('openai', () => {

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -1,7 +1,7 @@
 import { AIActionType } from '@/ai-model';
 import { getResponseFormat } from '@/ai-model/service-caller';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { IModelConfig } from '@midscene/shared/env';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('service-caller', () => {
   describe('getResponseFormat', () => {

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -238,6 +238,21 @@ export interface IModelConfigForVQA {
   [MIDSCENE_VQA_VL_MODE]?: TVlModeValues;
 }
 
+/**
+ * Model configuration for Planning intent.
+ *
+ * IMPORTANT: Planning MUST use a vision language model (VL mode).
+ * DOM-based planning is not supported.
+ *
+ * Required: MIDSCENE_PLANNING_VL_MODE must be set to one of:
+ *   - 'qwen-vl'
+ *   - 'qwen3-vl'
+ *   - 'gemini'
+ *   - 'doubao-vision'
+ *   - 'vlm-ui-tars'
+ *   - 'vlm-ui-tars-doubao'
+ *   - 'vlm-ui-tars-doubao-1.5'
+ */
 export interface IModelConfigForPlanning {
   // model name
   [MIDSCENE_PLANNING_MODEL_NAME]: string;


### PR DESCRIPTION
## Summary

This PR refactors the Midscene API by renaming key methods for improved clarity and consistency:

- `aiAction()` → `aiAct()` - More concise and clear naming
- `logScreenshot()` → `recordToReport()` - Better reflects the method's purpose

## Breaking Changes

⚠️ **Breaking Change**: The following methods have been renamed:
- `aiAction()` is now `aiAct()`
- `logScreenshot()` is now `recordToReport()`

**Backward Compatibility**: The old `aiAction()` method is kept as a deprecated wrapper to maintain backward compatibility. Users should migrate to `aiAct()` when convenient.

## Changes

### Core Changes
- ✨ Renamed `aiAction()` to `aiAct()` in `packages/core/src/agent/agent.ts`
- ✨ Renamed `logScreenshot()` to `recordToReport()` in agent implementation
- 🔄 Added deprecation wrapper for `aiAction()` with JSDoc warning
- 🧪 Updated all test files to use new method names

### Web Integration
- 🔧 Updated Playwright fixture to support new method names
- 🔧 Added `aiAct` and `recordToReport` fixture types
- 🧪 Updated integration tests

### Documentation
- 📝 Updated all English documentation (15 files)
- 📝 Updated all Chinese documentation (16 files)
- 📝 Updated README.md and README.zh.md with new examples
- 📝 Updated code examples in blog posts and guides

## Migration Guide

**Before:**
```javascript
await aiAction('click the submit button');
await logScreenshot('After submission');
```

**After:**
```javascript
await aiAct('click the submit button');
await recordToReport('After submission');
```

## Impact

- **Users**: Need to update method names in their code (or continue using deprecated `aiAction()`)
- **Documentation**: All examples now use the new naming convention
- **Tests**: All passing with new method names

## Test Plan

- ✅ All existing unit tests pass
- ✅ All integration tests updated and passing
- ✅ Documentation examples verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)