### PR TITLE
fix(report): prevent sidebar jitter when expanding case selector

### DIFF
--- a/apps/report/src/components/playwright-case-selector/index.less
+++ b/apps/report/src/components/playwright-case-selector/index.less
@@ -7,6 +7,7 @@
     padding: 0 12px;
     background: #F2F4F7;
     border-radius: 8px;
+    border: 1px solid transparent;
     cursor: pointer;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Fixed sidebar shifting 1-2 pixels when clicking to expand the playwright case selector component

## Changes
- Added `border: 1px solid transparent` to the collapsed state of `.selector-header` in `playwright-case-selector/index.less`
- This ensures consistent height across both collapsed and expanded states
- The transparent border is invisible when collapsed, but prevents layout shift when the colored border appears on expansion

## Test plan
- [ ] Open the report page
- [ ] Click on the playwright case selector component
- [ ] Verify that the sidebar no longer shifts/jitters when the dropdown expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)