### PR TITLE
fix(core): handle ZodEffects and ZodUnion in schema parsing

### DIFF
--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -57,6 +57,14 @@ export const descriptionForAction = (
           return unwrapField(f._def.innerType);
         }
 
+        // Handle ZodEffects (transformations, refinements, preprocessors)
+        if (typeName === 'ZodEffects') {
+          // For ZodEffects, unwrap the schema field which contains the underlying type
+          if (f._def.schema) {
+            return unwrapField(f._def.schema);
+          }
+        }
+
         return f;
       };
 
@@ -82,6 +90,16 @@ export const descriptionForAction = (
 
         return `enum(${values})`;
       }
+      // Handle ZodUnion by taking the first option (for display purposes)
+      if (fieldTypeName === 'ZodUnion') {
+        const options = actualField._def?.options as any[] | undefined;
+        if (options && options.length > 0) {
+          // For unions, list all types
+          const types = options.map((opt: any) => getTypeName(opt));
+          return types.join(' | ');
+        }
+        return 'union';
+      }
 
       console.warn(
         'failed to parse Zod type. This may lead to wrong params from the LLM.\n',
@@ -105,6 +123,14 @@ export const descriptionForAction = (
           typeName === 'ZodDefault'
         ) {
           return unwrapField(f._def.innerType);
+        }
+
+        // Handle ZodEffects (transformations, refinements, preprocessors)
+        if (typeName === 'ZodEffects') {
+          // For ZodEffects, unwrap the schema field which contains the underlying type
+          if (f._def.schema) {
+            return unwrapField(f._def.schema);
+          }
         }
 
         return f;


### PR DESCRIPTION
## Problem Description

When caching is enabled, the warning "failed to parse Zod type" appears on first execution but not on subsequent executions.

```
failed to parse Zod type. This may lead to wrong params from the LLM.
 {
  errorMap: [Function: customMap],
  description: 'The text to input. Provide the final content for replace/append modes, or an empty string when using clear mode to remove existing text.',
  schema: ZodUnion { ... },
  typeName: 'ZodEffects',
  effect: { type: 'transform', transform: [Function (anonymous)] }
}
```

## Root Cause

The `getTypeName` and `getDescription` functions in `packages/core/src/ai-model/prompt/llm-planning.ts` didn't handle two important Zod types:
- **`ZodEffects`** - Used for transformations (e.g., `.transform()`)
- **`ZodUnion`** - Used for union types (e.g., `z.union([z.string(), z.number()])`)

The `value` field in `actionInputParamSchema` uses `z.union([z.string(), z.number()]).transform(val => String(val))`, creating a nested `ZodEffects(ZodUnion)` structure that couldn't be parsed correctly.

## Solution

1. **Handle `ZodEffects`**: Recursively unwrap `_def.schema` to extract the underlying type before transformation
2. **Handle `ZodUnion`**: Iterate through `_def.options` and display types as `type1 | type2` format
3. Apply this unwrapping logic consistently in both `getTypeName` and `getDescription` helper functions

## Changes

- Added `ZodEffects` handling in both `getTypeName` and `getDescription` functions
- Added `ZodUnion` handling to properly display union types
- Warning no longer appears regardless of cache state

## Test Results

After the fix, running the CLI command produces clean output without warnings:

```bash
./bin/midscene --config tests/multi_yaml_scripts/index.yaml
# No "failed to parse Zod type" warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)