### PR TITLE
fix(core): handle structured output in callAI responses

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -336,7 +336,16 @@ export async function callAI(
           result.choices,
           `invalid response from LLM service: ${JSON.stringify(result)}`,
         );
-        content = result.choices[0].message.content!;
+        const rawContent = result.choices[0].message.content!;
+
+        // Handle structured output: if content is an object, stringify it
+        if (typeof rawContent === 'object' && rawContent !== null) {
+          console.warn('rawContent is an object, stringifying:', rawContent);
+          content = JSON.stringify(rawContent);
+        } else {
+          content = rawContent;
+        }
+
         usage = result.usage;
       }
 
@@ -432,7 +441,15 @@ export async function callAI(
           ...commonConfig,
         } as any);
         timeCost = Date.now() - startTime;
-        content = (result as any).content[0].text as string;
+
+        const rawContent = (result as any).content[0].text;
+        // Handle structured output: ensure content is a string
+        if (typeof rawContent === 'object' && rawContent !== null) {
+          content = JSON.stringify(rawContent);
+        } else {
+          content = rawContent;
+        }
+
         usage = result.usage;
       }
 
@@ -583,6 +600,7 @@ export function preprocessDoubaoBboxJson(input: string) {
 
 export function safeParseJson(input: string, vlMode: TVlModeTypes | undefined) {
   const cleanJsonString = extractJSONFromCodeBlock(input);
+
   // match the point
   if (cleanJsonString?.match(/\((\d+),(\d+)\)/)) {
     return cleanJsonString


### PR DESCRIPTION
## Summary
Fix handling of structured output in `callAI` responses by properly converting object responses to JSON strings.

## Problem
When AI model responses contain structured objects instead of plain text strings, the system wasn't handling them correctly, which could lead to unexpected behavior or errors.

## Solution
Added checks in both the OpenAI-compatible and Anthropic response handlers to:
- Detect when response content is an object rather than a string
- Automatically stringify object responses using `JSON.stringify()`
- Log a warning when this conversion occurs for debugging purposes

## Changes
- Modified `packages/core/src/ai-model/service-caller/index.ts`:
  - Added object type checking for OpenAI-compatible responses
  - Added object type checking for Anthropic responses
  - Added warning logs for structured output detection

## Test plan
- [ ] Test with responses that return structured objects
- [ ] Verify JSON stringification works correctly
- [ ] Ensure backward compatibility with string responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)