### PR TITLE
fix(build): switch from nano-staged to lint-staged for proper auto-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "check-spell": "npx cspell"
   },
   "simple-git-hooks": {
-    "pre-commit": "npx nano-staged"
+    "pre-commit": "npx lint-staged"
   },
-  "nano-staged": {
-    "*.{md,mdx,json,css,less,scss}": "npx biome check . --diagnostic-level=info --no-errors-on-unmatched --fix --verbose",
-    "*.{js,jsx,ts,tsx,mjs,cjs,json}": [
-      "npx biome check . --diagnostic-level=info --no-errors-on-unmatched --fix --verbose"
+  "lint-staged": {
+    "*.{md,mdx,json,css,less,scss}": [
+      "npx biome check --diagnostic-level=info --fix"
+    ],
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "npx biome check --diagnostic-level=info --fix"
     ],
     "package.json": "pnpm run check-dependency-version"
   },


### PR DESCRIPTION
## Problem

The previous nano-staged configuration had two critical issues:

1. **Checked entire project instead of staged files**: Used `biome check .` which scanned the whole project, causing pre-commit hook to fail when any file in the project had linting errors
2. **Failed to re-stage fixed files**: nano-staged doesn't automatically add fixed files back to staging area, resulting in commits containing unfixed code

## Solution

Switched from nano-staged to lint-staged, which provides:

- ✅ Automatic file filtering - only passes staged files to biome
- ✅ Auto re-staging - files are automatically re-staged after fixes
- ✅ Better stability - more mature and widely adopted in the community

## Changes

- Replaced `nano-staged` with `lint-staged` in pre-commit hook configuration
- Updated biome command to remove project-wide scan (removed `.` parameter)
- Added `lint-staged@16.2.6` as dev dependency
- Updated `.git/hooks/pre-commit` to use lint-staged

## Testing

Verified the fix works correctly:
1. Created test file with intentional formatting errors (double semicolons, bad spacing)
2. Staged the file and ran lint-staged
3. Confirmed files were automatically fixed and re-staged
4. Verified commit contains fixed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)