### PR TITLE
refactor(report): consolidate PlaygroundSDK creation for report components

### DIFF
--- a/apps/report/src/components/open-in-playground/index.tsx
+++ b/apps/report/src/components/open-in-playground/index.tsx
@@ -1,6 +1,5 @@
 import { PlayCircleOutlined } from '@ant-design/icons';
 import type { UIContext } from '@midscene/core';
-import { PlaygroundSDK } from '@midscene/playground';
 import { staticAgentFromContext, useEnvConfig } from '@midscene/visualizer';
 import type { WebUIContext } from '@midscene/web';
 import {
@@ -12,18 +11,15 @@ import {
   Tooltip,
 } from 'antd';
 import { useEffect, useState } from 'react';
+import { getReportPlaygroundSDK } from '../../utils/report-playground-utils';
 import { StandardPlayground } from '../playground';
-
-declare const __VERSION__: string;
 
 // Create PlaygroundSDK instance for server communication
 const getPlaygroundSDK = () => {
-  return new PlaygroundSDK({
-    type: 'remote-execution',
-  });
+  return getReportPlaygroundSDK('Server');
 };
 
-const errorMessageNoContext = `No context info found. 
+const errorMessageNoContext = `No context info found.
 Try to select another task like 'Locate'
 `;
 

--- a/apps/report/src/components/playground/index.tsx
+++ b/apps/report/src/components/playground/index.tsx
@@ -1,5 +1,5 @@
 import type { DeviceAction, UIContext } from '@midscene/core';
-import { PlaygroundSDK, noReplayAPIs } from '@midscene/playground';
+import { type PlaygroundSDK, noReplayAPIs } from '@midscene/playground';
 import type { ServerResponse } from '@midscene/playground';
 import {
   ContextPreview,
@@ -18,8 +18,10 @@ import type { StaticPageAgent } from '@midscene/web/static';
 import { Form, message } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-
-type ServiceModeType = 'Server' | 'In-Browser' | 'In-Browser-Extension';
+import {
+  type ServiceModeType,
+  getReportPlaygroundSDK,
+} from '../../utils/report-playground-utils';
 
 // Constants
 const PROGRESS_POLL_INTERVAL = 500;
@@ -30,23 +32,6 @@ const blankResult = {
   dump: null,
   reportHTML: null,
   error: null,
-};
-
-// Initialize PlaygroundSDK instances for different service modes
-const getPlaygroundSDK = (serviceMode: ServiceModeType, agent?: any) => {
-  if (serviceMode === 'Server') {
-    return new PlaygroundSDK({
-      type: 'remote-execution',
-    });
-  }
-  // For In-Browser and In-Browser-Extension modes, use local execution
-  if (!agent) {
-    throw new Error('Agent is required for local execution mode');
-  }
-  return new PlaygroundSDK({
-    type: 'local-execution',
-    agent,
-  });
 };
 
 // Utility function to determine if the run button should be enabled
@@ -110,7 +95,9 @@ export function StandardPlayground({
   useEffect(() => {
     if (serviceMode === 'Server') {
       // For server mode, we don't need agent initially
-      playgroundSDK.current = getPlaygroundSDK(serviceMode as ServiceModeType);
+      playgroundSDK.current = getReportPlaygroundSDK(
+        serviceMode as ServiceModeType,
+      );
     }
     // For In-Browser mode, we'll initialize PlaygroundSDK when we actually need it
     // to ensure we use the same agent instance
@@ -121,7 +108,7 @@ export function StandardPlayground({
     (agent: any) => {
       // Only recreate if agent has changed or SDK doesn't exist
       if (!playgroundSDK.current || currentAgent.current !== agent) {
-        playgroundSDK.current = getPlaygroundSDK(
+        playgroundSDK.current = getReportPlaygroundSDK(
           serviceMode as ServiceModeType,
           agent,
         );
@@ -324,6 +311,10 @@ export function StandardPlayground({
         // Use PlaygroundSDK for In-Browser mode as well
         // Use optimized SDK getter to prevent unnecessary recreation
         const sdk = getOrCreatePlaygroundSDK(activeAgent);
+
+        if (!sdk) {
+          throw new Error('Failed to create PlaygroundSDK');
+        }
 
         result.result = await sdk.executeAction(
           actionType,

--- a/apps/report/src/utils/report-playground-utils.ts
+++ b/apps/report/src/utils/report-playground-utils.ts
@@ -1,0 +1,32 @@
+import { PlaygroundSDK } from '@midscene/playground';
+import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
+
+export type ServiceModeType = 'Server' | 'In-Browser' | 'In-Browser-Extension';
+
+/**
+ * Gets a PlaygroundSDK instance based on service mode.
+ * For report components that support both Server and In-Browser modes.
+ *
+ * @param serviceMode - The service mode: 'Server', 'In-Browser', or 'In-Browser-Extension'
+ * @param agent - Required for In-Browser modes, optional for Server mode
+ * @returns Configured PlaygroundSDK instance
+ */
+export function getReportPlaygroundSDK(
+  serviceMode: ServiceModeType,
+  agent?: any,
+): PlaygroundSDK {
+  if (serviceMode === 'Server') {
+    return new PlaygroundSDK({
+      type: 'remote-execution',
+      serverUrl: `http://localhost:${PLAYGROUND_SERVER_PORT}`,
+    });
+  }
+  // For In-Browser and In-Browser-Extension modes, use local execution
+  if (!agent) {
+    throw new Error('Agent is required for local execution mode');
+  }
+  return new PlaygroundSDK({
+    type: 'local-execution',
+    agent,
+  });
+}

--- a/packages/shared/src/env/decide-model-config.ts
+++ b/packages/shared/src/env/decide-model-config.ts
@@ -110,8 +110,7 @@ export const decideOpenaiSdkConfig = ({
 
   if (keys.httpProxy === MIDSCENE_OPENAI_HTTP_PROXY) {
     // Priority: MIDSCENE_MODEL_HTTP_PROXY > MIDSCENE_OPENAI_HTTP_PROXY
-    httpProxy =
-      provider[MIDSCENE_MODEL_HTTP_PROXY] || provider[keys.httpProxy];
+    httpProxy = provider[MIDSCENE_MODEL_HTTP_PROXY] || provider[keys.httpProxy];
   } else {
     httpProxy = provider[keys.httpProxy];
   }


### PR DESCRIPTION
## Summary
This PR consolidates all PlaygroundSDK creation logic for report components into a single shared utility module, reducing code duplication and improving maintainability.

## Changes
- Created `apps/report/src/utils/report-playground-utils.ts` with `getReportPlaygroundSDK(serviceMode, agent?)` function that handles both Server and In-Browser modes
- Removed duplicate `getPlaygroundSDK` implementations from `playground.tsx` and `playground/index.tsx`
- Updated `open-in-playground/index.tsx` to use the shared function
- Removed unnecessary `createReportPlaygroundSDK` wrapper function
- All report components now use `PLAYGROUND_SERVER_PORT` constant from the shared package

## Benefits
- **Single source of truth**: All PlaygroundSDK creation for report components is now centralized in one place
- **Consistent behavior**: Static report files always connect to `localhost:5800` for Server mode
- **Reduced duplication**: Eliminated duplicate code across multiple files
- **Improved maintainability**: Changes to SDK creation logic only need to be made in one place

## Testing
- ✅ All builds pass successfully
- ✅ No TypeScript errors
- ✅ Server mode correctly uses `localhost:5800`
- ✅ In-Browser mode correctly uses local execution with agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)