### PR TITLE
docs: clarify file execution order in YAML scripts documentation

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -438,7 +438,7 @@ midscene './scripts/**/*.yaml'
 
 The command-line tool provides several options to control the execution behavior of your scripts.
 
-- `--files <file1> <file2> ...`: Specifies a list of script files to execute, which will be run in order. Supports glob patterns, following the syntax supported by [glob](https://www.npmjs.com/package/glob).
+- `--files <file1> <file2> ...`: Specifies a list of script files to execute. Files will be executed in the specified order, sequentially by default (when `--concurrent` is `1`), and can be executed concurrently by setting the `--concurrent` parameter. Supports glob patterns, following the syntax supported by [glob](https://www.npmjs.com/package/glob).
 - `--concurrent <number>`: Sets the number of concurrent executions. Defaults to `1`.
 - `--continue-on-error`: If this flag is set, it will continue to run the remaining scripts even if one fails. Defaults to off.
 - `--share-browser-context`: Shares the same browser context (e.g., Cookies and `localStorage`) across all scripts. This is very useful for sequential tests that require a login state. Defaults to off.
@@ -457,7 +457,7 @@ The command-line tool provides several options to control the execution behavior
 
 Examples:
 
-Use the `--files` argument to specify the file order and run in parallel.
+Use the `--files` argument to specify the file execution order.
 
 ```bash
 midscene --files ./login.yaml ./buy/*.yaml ./checkout.yaml

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -443,7 +443,7 @@ midscene './scripts/**/*.yaml'
 
 命令行工具提供了一些选项来控制脚本的执行行为。
 
-- `--files <file1> <file2> ...`: 指定要执行的脚本文件列表，文件将按顺序执行。支持通配符模式，遵循 [glob](https://www.npmjs.com/package/glob) 支持的语法。
+- `--files <file1> <file2> ...`: 指定要执行的脚本文件列表。文件将按指定的顺序执行，默认情况下依次顺序执行(当 `--concurrent` 为 `1` 时)，可通过设置 `--concurrent` 参数实现并发执行。支持通配符模式，遵循 [glob](https://www.npmjs.com/package/glob) 支持的语法。
 - `--concurrent <number>`: 设置并发执行的数量。默认为 `1`。
 - `--continue-on-error`: 如果设置了此选项，即使有脚本文件执行失败，也会继续运行余下的脚本文件。默认关闭。
 - `--share-browser-context`: 在所有脚本之间共享同一个浏览器上下文（例如 Cookies 和 `localStorage`）。这对于需要登录状态的连续测试非常有用，默认关闭。
@@ -462,7 +462,7 @@ midscene './scripts/**/*.yaml'
 
 举例：
 
-使用 `--files` 参数来指定文件顺序，并行执行
+使用 `--files` 参数来指定文件执行顺序
 
 ```bash
 midscene --files ./login.yaml ./buy/*.yaml ./checkout.yaml


### PR DESCRIPTION
## Summary

Fixed ambiguous descriptions about sequential vs parallel execution in the YAML scripts documentation (both English and Chinese versions).

### Changes Made

1. **Updated `--files` parameter description** (line ~441/446):
   - Clarified that files execute in the specified order
   - Explicitly stated sequential execution by default (when `--concurrent=1`)
   - Explained that parallel execution requires the `--concurrent` parameter

2. **Fixed misleading example description** (line ~460/465):
   - Removed "run in parallel" / "并行执行" from the example that doesn't use `--concurrent`
   - Changed to simply describe it as "specify file execution order"

### Problem

The documentation had conflicting information:
- Line 446/441 said files "execute in order", suggesting sequential execution
- Line 465/460 said "run in parallel", but the example didn't use `--concurrent`
- This created confusion about whether `--files` alone enables parallel execution

### Solution

The documentation now clearly states:
- Files execute in the specified order
- Default behavior is sequential (`--concurrent=1`)
- Parallel execution requires explicitly setting `--concurrent > 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)