### PR TITLE
fix(core): improve Assert task error handling

### DIFF
--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -476,6 +476,12 @@ export class TaskExecutor {
           }
         }
 
+        if (type === 'Assert' && !outputResult) {
+          task.usage = usage;
+          task.thought = thought;
+          throw new Error(`Assertion failed: ${thought}`);
+        }
+
         return {
           output: outputResult,
           log: queryDump,

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -121,14 +121,13 @@ describe('TaskExecutor - Null Data Handling', () => {
         {},
       );
 
-      const result = await queryTask.executor({}, {
-        task: queryTask,
-        uiContext: { screenshotBase64: '', size: { width: 0, height: 0 } },
-      } as any);
-
-      // For Assert with null data, output should be null
-      expect(result.output).toBeNull();
-      expect(result.thought).toBe('Could not verify assertion');
+      // For Assert with null data (falsy), should throw error
+      await expect(
+        queryTask.executor({}, {
+          task: queryTask,
+          uiContext: { screenshotBase64: '', size: { width: 0, height: 0 } },
+        } as any),
+      ).rejects.toThrow('Assertion failed: Could not verify assertion');
     });
 
     it('should handle valid data for WaitFor operation', async () => {


### PR DESCRIPTION
## Summary

This PR backports the Assert task error handling improvement from the main branch (commit 4761a6c) to the 1.0 branch.

### Changes
- Add explicit error throwing for failed Assert tasks with detailed assertion failure messages including the AI's thought process
- Update the corresponding unit test to expect error throws instead of null output

### Motivation

Previously, when an Assert task failed (AI returned null/falsy value), it would silently return null. This made it difficult to detect and debug assertion failures. With this change, failed assertions now throw explicit errors with meaningful messages including the AI's reasoning.

### Test Plan

- Updated unit test `tasks-null-data.test.ts` to verify that Assert tasks with null data throw errors
- The test now expects the error message format: `Assertion failed: ${thought}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)