### PR TITLE
docs: add WebDriverAgent version requirement (>= 7.0.0) to iOS preparation guide

### DIFF
--- a/apps/site/docs/en/common/prepare-ios.mdx
+++ b/apps/site/docs/en/common/prepare-ios.mdx
@@ -20,7 +20,15 @@ Before getting started, you need to set up the iOS development environment:
 
 #### Environment Configuration
 
-Before using Midscene iOS, you need to prepare the WebDriverAgent service. Please refer to the official documentation for setup:
+Before using Midscene iOS, you need to prepare the WebDriverAgent service.
+
+:::note Version Requirement
+
+WebDriverAgent version must be **>= 7.0.0**
+
+:::
+
+Please refer to the official documentation for setup:
 
 - **Simulator Configuration**: [Run Prebuilt WDA](https://appium.github.io/appium-xcuitest-driver/5.12/run-prebuilt-wda/)
 - **Real Device Configuration**: [Real Device Configuration](https://appium.github.io/appium-xcuitest-driver/5.12/real-device-config/)

--- a/apps/site/docs/zh/common/prepare-ios.mdx
+++ b/apps/site/docs/zh/common/prepare-ios.mdx
@@ -20,7 +20,15 @@
 
 #### 配置环境
 
-在使用 Midscene iOS 之前，需要先准备 WebDriverAgent 服务。请参考官方文档进行设置：
+在使用 Midscene iOS 之前，需要先准备 WebDriverAgent 服务。
+
+:::note 版本要求
+
+WebDriverAgent 版本需要 **>= 7.0.0**
+
+:::
+
+请参考官方文档进行设置：
 
 - **模拟器配置**：[Run Prebuilt WDA](https://appium.github.io/appium-xcuitest-driver/5.12/run-prebuilt-wda/)
 - **真机配置**：[Real Device Configuration](https://appium.github.io/appium-xcuitest-driver/5.12/real-device-config/)


### PR DESCRIPTION
## Summary

- Added WebDriverAgent version requirement notice (>= 7.0.0) in both English and Chinese iOS preparation documentation
- Updated `apps/site/docs/en/common/prepare-ios.mdx` to include version requirement
- Updated `apps/site/docs/zh/common/prepare-ios.mdx` to include version requirement

## Changes

Added a clear notice block in the "Environment Configuration" section of the iOS preparation guide to inform users that WebDriverAgent version 7.0.0 or higher is required for using Midscene iOS.

The notice is displayed in a formatted note box for better visibility.

## Test plan

- [ ] Verify the documentation renders correctly in both English and Chinese versions
- [ ] Confirm the version requirement notice is clearly visible
- [ ] Check that all links and references remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)