### PR TITLE
feat(ios): Add WebDriverAgent 5.x-7.x compatibility

### DIFF
--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -1,0 +1,291 @@
+import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
+
+describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
+  let client: IOSWebDriverClient;
+
+  beforeEach(() => {
+    client = new IOSWebDriverClient({
+      port: DEFAULT_WDA_PORT,
+      host: 'localhost',
+    });
+    // Mock sessionId to avoid session creation
+    (client as any).sessionId = 'test-session-id';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('tap() fallback logic', () => {
+    it('should use new endpoint when it succeeds', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      makeRequestSpy.mockResolvedValueOnce({ status: 0 });
+
+      await client.tap(100, 200);
+
+      // Should only call new endpoint once
+      expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/session/test-session-id/wda/tap',
+        { x: 100, y: 200 },
+      );
+    });
+
+    it('should fallback to legacy endpoint when new endpoint fails', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+      // First call (new endpoint) fails
+      makeRequestSpy.mockRejectedValueOnce(new Error('New endpoint not found'));
+      // Second call (legacy endpoint) succeeds
+      makeRequestSpy.mockResolvedValueOnce({ status: 0 });
+
+      await client.tap(100, 200);
+
+      // Should call both endpoints
+      expect(makeRequestSpy).toHaveBeenCalledTimes(2);
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        1,
+        'POST',
+        '/session/test-session-id/wda/tap',
+        { x: 100, y: 200 },
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        'POST',
+        '/session/test-session-id/wda/tap/0',
+        { x: 100, y: 200 },
+      );
+    });
+
+    it('should throw error when both endpoints fail', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+      // Both calls fail
+      makeRequestSpy.mockRejectedValueOnce(new Error('New endpoint failed'));
+      makeRequestSpy.mockRejectedValueOnce(new Error('Legacy endpoint failed'));
+
+      await expect(client.tap(100, 200)).rejects.toThrow(
+        'Failed to tap at coordinates',
+      );
+
+      expect(makeRequestSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle different coordinate types', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      makeRequestSpy.mockResolvedValue({ status: 0 });
+
+      await client.tap(0, 0);
+      await client.tap(999.5, 888.7);
+
+      expect(makeRequestSpy).toHaveBeenCalledTimes(2);
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        1,
+        'POST',
+        '/session/test-session-id/wda/tap',
+        { x: 0, y: 0 },
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        'POST',
+        '/session/test-session-id/wda/tap',
+        { x: 999.5, y: 888.7 },
+      );
+    });
+  });
+
+  describe('getScreenScale() fallback logic', () => {
+    it('should return scale when endpoint succeeds with scale value', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      makeRequestSpy.mockResolvedValueOnce({
+        status: 0,
+        value: { scale: 3 },
+      });
+
+      const scale = await client.getScreenScale();
+
+      expect(scale).toBe(3);
+      expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'GET',
+        '/session/test-session-id/wda/screen',
+      );
+    });
+
+    it('should enter fallback logic when endpoint succeeds but has no scale', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+
+      // First call: endpoint succeeds but no scale
+      makeRequestSpy.mockResolvedValueOnce({
+        status: 0,
+        value: {}, // No scale field
+      });
+
+      // Mock fallback methods to verify they are called
+      const mockBase64 = 'data:image/png;base64,mockdata';
+      takeScreenshotSpy.mockResolvedValueOnce(mockBase64);
+      getWindowSizeSpy.mockResolvedValueOnce({
+        width: 414,
+        height: 896,
+      });
+
+      // This will fail at jimpFromBase64, but we verify the fallback is entered
+      await client.getScreenScale();
+
+      // Verify fallback logic was entered
+      expect(takeScreenshotSpy).toHaveBeenCalledTimes(1);
+      expect(getWindowSizeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should enter fallback logic when endpoint fails', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+
+      // First call: endpoint fails
+      makeRequestSpy.mockRejectedValueOnce(new Error('Endpoint not found'));
+
+      // Mock fallback methods
+      const mockBase64 = 'data:image/png;base64,mockdata';
+      takeScreenshotSpy.mockResolvedValueOnce(mockBase64);
+      getWindowSizeSpy.mockResolvedValueOnce({
+        width: 375,
+        height: 667,
+      });
+
+      // This will fail at jimpFromBase64, but we verify the fallback is entered
+      await client.getScreenScale();
+
+      // Verify fallback logic was entered
+      expect(takeScreenshotSpy).toHaveBeenCalledTimes(1);
+      expect(getWindowSizeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return null when both endpoint and calculation fail', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+
+      // First call: endpoint fails
+      makeRequestSpy.mockRejectedValueOnce(new Error('Endpoint failed'));
+
+      // Fallback: screenshot fails
+      takeScreenshotSpy.mockRejectedValueOnce(new Error('Screenshot failed'));
+
+      const scale = await client.getScreenScale();
+
+      expect(scale).toBeNull();
+      expect(takeScreenshotSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle response without value field gracefully', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+
+      // Endpoint returns response without value field
+      makeRequestSpy.mockResolvedValueOnce({
+        status: 0,
+        // No value field at all
+      });
+
+      // Mock fallback
+      const mockBase64 = 'data:image/png;base64,mockdata';
+      takeScreenshotSpy.mockResolvedValueOnce(mockBase64);
+      getWindowSizeSpy.mockResolvedValueOnce({
+        width: 320,
+        height: 568,
+      });
+
+      await client.getScreenScale();
+
+      // Verify fallback was triggered
+      expect(takeScreenshotSpy).toHaveBeenCalled();
+      expect(getWindowSizeSpy).toHaveBeenCalled();
+    });
+
+    it('should handle scale value of 0 as invalid and trigger fallback', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+
+      // Endpoint returns scale: 0 (invalid)
+      makeRequestSpy.mockResolvedValueOnce({
+        status: 0,
+        value: { scale: 0 },
+      });
+
+      const mockBase64 = 'data:image/png;base64,mockdata';
+      takeScreenshotSpy.mockResolvedValueOnce(mockBase64);
+      getWindowSizeSpy.mockResolvedValueOnce({
+        width: 320,
+        height: 568,
+      });
+
+      await client.getScreenScale();
+
+      // scale: 0 should be treated as falsy and trigger fallback
+      expect(takeScreenshotSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Compatibility scenarios', () => {
+    it('should work with WDA 5.x (legacy tap endpoint)', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+      // Simulate WDA 5.x: new endpoint doesn't exist
+      makeRequestSpy.mockRejectedValueOnce(
+        new Error('404 - Endpoint not found'),
+      );
+      // Legacy endpoint works
+      makeRequestSpy.mockResolvedValueOnce({ status: 0 });
+
+      await client.tap(50, 50);
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/session/test-session-id/wda/tap/0',
+        { x: 50, y: 50 },
+      );
+    });
+
+    it('should work with WDA 6.x/7.x (new tap endpoint)', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+      // Simulate WDA 6.x/7.x: new endpoint works
+      makeRequestSpy.mockResolvedValueOnce({ status: 0 });
+
+      await client.tap(50, 50);
+
+      expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/session/test-session-id/wda/tap',
+        { x: 50, y: 50 },
+      );
+    });
+
+    it('should handle WDA versions with different screen endpoint responses', async () => {
+      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+      // Test different scale values
+      const testCases = [1, 2, 3, 4];
+
+      for (const expectedScale of testCases) {
+        makeRequestSpy.mockResolvedValueOnce({
+          status: 0,
+          value: { scale: expectedScale },
+        });
+
+        const scale = await client.getScreenScale();
+        expect(scale).toBe(expectedScale);
+      }
+
+      expect(makeRequestSpy).toHaveBeenCalledTimes(testCases.length);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add backward compatibility support for WebDriverAgent versions 5.x through 7.x in the iOS WebDriver client.

### Key Changes

- **`tap()` method**: Implements fallback from new endpoint (`/wda/tap`) to legacy endpoint (`/wda/tap/0`)
- **`getScreenScale()` method**: Implements fallback from WDA endpoint to calculation-based approach using screenshot dimensions

### Implementation Details

This implementation follows the Python [facebook-wda](https://github.com/openatx/facebook-wda) library's compatibility approach:

1. **Primary attempt**: Try the newer/recommended endpoint
2. **Fallback**: On failure, automatically fall back to alternative methods
3. **No version detection**: Self-adaptive compatibility without needing version checks

### Compatibility Matrix

| Method | WDA 5.x | WDA 6.x | WDA 7.x | Implementation |
|--------|---------|---------|---------|----------------|
| `tap()` | `/wda/tap/0` | `/wda/tap` | `/wda/tap` | Try new, fallback to legacy |
| `getScreenScale()` | `/wda/screen` | `/wda/screen` | `/wda/screen` | Try endpoint, fallback to calculation |

### Test Coverage

Added comprehensive unit tests in `ios-webdriver-client-compatibility.test.ts`:

- ✅ Fallback logic validation for both methods
- ✅ All edge cases (null values, missing fields, errors)
- ✅ Compatibility scenarios for WDA 5.x, 6.x, and 7.x
- ✅ Error handling and graceful degradation

### Breaking Changes

**None** - This change is fully backward compatible. All existing functionality is preserved.

### References

- Python facebook-wda implementation: [wda/__init__.py](https://github.com/openatx/facebook-wda)
- WebDriverAgent 6.0.0 breaking changes: [CHANGELOG.md](https://github.com/appium/WebDriverAgent/blob/master/CHANGELOG.md#600-2024-01-31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)