### PR TITLE
fix(core): make paramSchema optional for actions without parameters

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1636,7 +1636,6 @@ const createPlatformActions = (
     AndroidBackButton: defineAction({
       name: 'AndroidBackButton',
       description: 'Trigger the system "back" operation on Android devices',
-      paramSchema: z.void().describe('No parameters required'),
       call: async () => {
         await device.back();
       },
@@ -1644,7 +1643,6 @@ const createPlatformActions = (
     AndroidHomeButton: defineAction({
       name: 'AndroidHomeButton',
       description: 'Trigger the system "home" operation on Android devices',
-      paramSchema: z.void().describe('No parameters required'),
       call: async () => {
         await device.home();
       },
@@ -1653,7 +1651,6 @@ const createPlatformActions = (
       name: 'AndroidRecentAppsButton',
       description:
         'Trigger the system "recent apps" operation on Android devices',
-      paramSchema: z.void().describe('No parameters required'),
       call: async () => {
         await device.recentApps();
       },
@@ -1661,6 +1658,6 @@ const createPlatformActions = (
   } as const;
 };
 
-export type DeviceActionAndroidBackButton = DeviceAction<void, void>;
-export type DeviceActionAndroidHomeButton = DeviceAction<void, void>;
-export type DeviceActionAndroidRecentAppsButton = DeviceAction<void, void>;
+export type DeviceActionAndroidBackButton = DeviceAction<undefined, void>;
+export type DeviceActionAndroidHomeButton = DeviceAction<undefined, void>;
+export type DeviceActionAndroidRecentAppsButton = DeviceAction<undefined, void>;

--- a/packages/core/src/ai-model/common.ts
+++ b/packages/core/src/ai-model/common.ts
@@ -668,9 +668,14 @@ export const loadActionParam = (
  * so they are intentionally excluded from Zod parsing and use existing validation logic.
  */
 export const parseActionParam = (
-  rawParam: Record<string, any>,
-  zodSchema: z.ZodType<any>,
-): Record<string, any> => {
+  rawParam: Record<string, any> | undefined,
+  zodSchema?: z.ZodType<any>,
+): Record<string, any> | undefined => {
+  // If no schema is provided, return undefined (action takes no parameters)
+  if (!zodSchema) {
+    return undefined;
+  }
+
   // Handle undefined or null rawParam by providing an empty object
   const param = rawParam ?? {};
 

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -47,15 +47,15 @@ export abstract class AbstractInterface {
 // TRuntime allows specifying a different type for the runtime parameter (after location resolution)
 // TReturn allows specifying the return type of the action
 export const defineAction = <
-  TSchema extends z.ZodType,
-  TRuntime = z.infer<TSchema>,
+  TSchema extends z.ZodType | undefined = undefined,
+  TRuntime = TSchema extends z.ZodType ? z.infer<TSchema> : undefined,
   TReturn = any,
 >(
   config: {
     name: string;
     description: string;
     interfaceAlias?: string;
-    paramSchema: TSchema;
+    paramSchema?: TSchema;
     call: (param: TRuntime) => Promise<TReturn> | TReturn;
   } & Partial<
     Omit<

--- a/packages/core/tests/unit-test/action-param-validation.test.ts
+++ b/packages/core/tests/unit-test/action-param-validation.test.ts
@@ -385,4 +385,45 @@ describe('Action Parameter Validation', () => {
       ).toThrow();
     });
   });
+
+  describe('Actions without paramSchema', () => {
+    it('should return undefined when paramSchema is not provided', () => {
+      const result = parseActionParam({ some: 'data' }, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined even when rawParam is undefined', () => {
+      const result = parseActionParam(undefined, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it('should work with defineAction when paramSchema is omitted', () => {
+      const action = defineAction({
+        name: 'AndroidBackButton',
+        description: 'Trigger the system "back" operation',
+        call: async () => {
+          // Mock implementation
+        },
+      });
+
+      // paramSchema should be undefined
+      expect(action.paramSchema).toBeUndefined();
+
+      // parseActionParam should return undefined
+      const parsed = parseActionParam({}, action.paramSchema);
+      expect(parsed).toBeUndefined();
+    });
+
+    it('should work with defineAction and explicit undefined paramSchema', () => {
+      const action = defineAction<undefined, undefined>({
+        name: 'HomeButton',
+        description: 'Go to home',
+        call: async () => {
+          // Mock implementation
+        },
+      });
+
+      expect(action.paramSchema).toBeUndefined();
+    });
+  });
 });

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -977,7 +977,6 @@ const createPlatformActions = (device: IOSDevice) => {
     IOSHomeButton: defineAction({
       name: 'IOSHomeButton',
       description: 'Trigger the system "home" operation on iOS devices',
-      paramSchema: z.void().describe('No parameters required'),
       call: async () => {
         await device.home();
       },
@@ -985,7 +984,6 @@ const createPlatformActions = (device: IOSDevice) => {
     IOSAppSwitcher: defineAction({
       name: 'IOSAppSwitcher',
       description: 'Trigger the system "app switcher" operation on iOS devices',
-      paramSchema: z.void().describe('No parameters required'),
       call: async () => {
         await device.appSwitcher();
       },
@@ -993,5 +991,5 @@ const createPlatformActions = (device: IOSDevice) => {
   } as const;
 };
 
-export type DeviceActionIOSHomeButton = DeviceAction<void, void>;
-export type DeviceActionIOSAppSwitcher = DeviceAction<void, void>;
+export type DeviceActionIOSHomeButton = DeviceAction<undefined, void>;
+export type DeviceActionIOSAppSwitcher = DeviceAction<undefined, void>;


### PR DESCRIPTION
## Summary

This PR fixes a breaking change introduced when Android and iOS navigation actions were changed to use `z.void()` schemas. The issue was that `parseActionParam` converted `undefined` to `{}`, which caused `z.void()` validation to fail at runtime.

## Problem

The Android system navigation actions (`AndroidBackButton`, `AndroidHomeButton`, `AndroidRecentAppsButton`) and iOS navigation actions (`IOSHomeButton`, `IOSAppSwitcher`) were using `z.void()` for their `paramSchema`. However:

1. `parseActionParam` has a line `const param = rawParam ?? {}` that converts `undefined` to `{}`
2. `z.void().parse({})` fails with "Expected void, received object"
3. This made these actions non-functional

## Solution

Make `paramSchema` optional for actions that don't require parameters:

- Updated `defineAction` function to accept optional `paramSchema`
- Removed `paramSchema` from Android and iOS navigation actions
- Updated `parseActionParam` to return `undefined` when no schema is provided
- Updated type definitions to use `DeviceAction<undefined, void>`

## Changes

- **packages/core/src/device/index.ts**: Made `paramSchema` optional in `defineAction`
- **packages/android/src/device.ts**: Removed `z.void()` schemas from navigation actions
- **packages/ios/src/device.ts**: Removed `z.void()` schemas from navigation actions
- **packages/core/src/ai-model/common.ts**: Handle undefined schemas in `parseActionParam`
- **packages/core/tests/unit-test/action-param-validation.test.ts**: Added tests for actions without schemas

## Test plan

- [x] All existing tests pass (251 tests)
- [x] Added 4 new tests for actions without paramSchema
- [x] Project builds successfully without errors
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)