### PR TITLE
fix(visualizer): add null check for action.param in replay scripts

### DIFF
--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -325,24 +325,26 @@ export const generateAnimationScripts = (
         if (actions.length > 0) {
           const action = actions[0];
           const knownFields = ['locate', 'start', 'end'];
-          knownFields.forEach((field) => {
-            if (
-              action.param[field] &&
-              typeof action.param[field] === 'object' &&
-              'center' in (action.param[field] || {})
-            ) {
-              locateElements.push(action.param[field] as LocateResultElement);
-            }
-          });
-          for (const key in action.param) {
-            if (knownFields.includes(key)) {
-              continue;
-            }
-            if (
-              typeof action.param[key] === 'object' &&
-              'center' in (action.param[key] || {})
-            ) {
-              locateElements.push(action.param[key] as LocateResultElement);
+          if (action.param) {
+            knownFields.forEach((field) => {
+              if (
+                action.param[field] &&
+                typeof action.param[field] === 'object' &&
+                'center' in (action.param[field] || {})
+              ) {
+                locateElements.push(action.param[field] as LocateResultElement);
+              }
+            });
+            for (const key in action.param) {
+              if (knownFields.includes(key)) {
+                continue;
+              }
+              if (
+                typeof action.param[key] === 'object' &&
+                'center' in (action.param[key] || {})
+              ) {
+                locateElements.push(action.param[key] as LocateResultElement);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Add defensive null check for `action.param` before accessing its properties in replay scripts
- Prevents potential runtime errors when `param` is undefined or null

## Changes
This PR adds a null safety check in `packages/visualizer/src/utils/replay-scripts.ts` to ensure `action.param` exists before iterating over its properties and accessing nested fields.

## Test plan
- [ ] Verify replay scripts work correctly with actions that have valid params
- [ ] Verify no runtime errors occur when actions have null/undefined params
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)