### PR TITLE
feat(docs): add CDP WebSocket URL guide and integrate into Playwright and Puppeteer documentation

### DIFF
--- a/apps/site/docs/en/common/get-cdp-url.mdx
+++ b/apps/site/docs/en/common/get-cdp-url.mdx
@@ -1,0 +1,8 @@
+### Getting a CDP WebSocket URL
+
+You can get a CDP WebSocket URL from various sources:
+
+- **BrowserBase**: Sign up at https://browserbase.com and get your CDP URL
+- **Browserless**: Use https://browserless.io or run your own instance
+- **Local Chrome**: Run Chrome with `--remote-debugging-port=9222` and use `ws://localhost:9222/devtools/browser/...`
+- **Docker**: Run Chrome in a Docker container with debugging port exposed

--- a/apps/site/docs/en/integrate-with-playwright.mdx
+++ b/apps/site/docs/en/integrate-with-playwright.mdx
@@ -1,4 +1,5 @@
 import SetupEnv from './common/setup-env.mdx';
+import GetCdpUrl from './common/get-cdp-url.mdx';
 import { PackageManagerTabs } from '@theme';
 
 # Integrate with Playwright
@@ -292,6 +293,10 @@ After the command executes successfully, it will output: `Midscene - report file
 
 ## Example: Connect Midscene Agent to a Remote Playwright Browser
 
+:::info Example Project
+You can find an example project of remote Playwright integration here: [https://github.com/web-infra-dev/midscene-example/tree/main/remote-playwright-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-playwright-demo)
+:::
+
 Use this flow when you want to reuse an existing browser that already runs in your own infrastructure (for example, a persistent cloud worker, a vendor-provided browser grid, or an on-premises desktop). Connecting Midscene to that remote Playwright instance lets you keep browsers close to the target environment, reduce startup costs, and centralize resource management while still using the same AI automation APIs.
 
 In practice you manually:
@@ -299,7 +304,13 @@ In practice you manually:
 2. Use Playwright to connect to the remote browser
 3. Create a Midscene agent for AI-driven automation
 
-The corresponding example code is as follows:
+### Prerequisites
+
+<PackageManagerTabs command="install playwright @playwright/test @midscene/web --save-dev" />
+
+<GetCdpUrl />
+
+### Basic Example
 
 ```typescript
 import { chromium } from 'playwright';

--- a/apps/site/docs/en/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/en/integrate-with-puppeteer.mdx
@@ -1,4 +1,5 @@
 import SetupEnv from './common/setup-env.mdx';
+import GetCdpUrl from './common/get-cdp-url.mdx';
 
 # Integrate with Puppeteer
 
@@ -96,6 +97,10 @@ After the above command executes successfully, the console will output: `Midscen
 
 ## Example: Connect Midscene Agent to a Remote Puppeteer Browser
 
+:::info Example Project
+You can find an example project of remote Puppeteer integration here: [https://github.com/web-infra-dev/midscene-example/tree/main/remote-puppeteer-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-puppeteer-demo)
+:::
+
 Use this approach when you want to reuse a browser that already runs inside your own infrastructure—such as a persistent cloud worker, a third-party browser grid, or an on-prem desktop. Wiring Midscene into that remote Puppeteer instance keeps the browser close to the target environment, cuts repeated startup costs, and lets you centralize management while keeping the same AI automation APIs.
 
 In practice you manually:
@@ -106,6 +111,8 @@ In practice you manually:
 ### Prerequisites
 
 <PackageManagerTabs command="install puppeteer @midscene/web --save-dev" />
+
+<GetCdpUrl />
 
 ### Basic Example
 

--- a/apps/site/docs/zh/common/get-cdp-url.mdx
+++ b/apps/site/docs/zh/common/get-cdp-url.mdx
@@ -1,0 +1,8 @@
+### 获取 CDP WebSocket URL
+
+你可以从多种来源获取 CDP WebSocket URL：
+
+- **BrowserBase**：在 https://browserbase.com 注册并获取你的 CDP URL
+- **Browserless**：使用 https://browserless.io 或运行你自己的实例
+- **本地 Chrome**：使用 `--remote-debugging-port=9222` 参数运行 Chrome，然后使用 `ws://localhost:9222/devtools/browser/...`
+- **Docker**：在 Docker 容器中运行 Chrome 并暴露调试端口

--- a/apps/site/docs/zh/integrate-with-playwright.mdx
+++ b/apps/site/docs/zh/integrate-with-playwright.mdx
@@ -1,4 +1,5 @@
 import SetupEnv from './common/setup-env.mdx';
+import GetCdpUrl from './common/get-cdp-url.mdx';
 import { PackageManagerTabs } from '@theme';
 
 # 集成到 Playwright
@@ -291,6 +292,10 @@ npx playwright test ./e2e/ebay-search.spec.ts
 
 ## 示例：连接远程 Playwright 浏览器并接入 Midscene Agent
 
+:::info 示例项目
+你可以在这里找到远程 Playwright 集成的示例项目：[https://github.com/web-infra-dev/midscene-example/tree/main/remote-playwright-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-playwright-demo)
+:::
+
 当你想复用已有的远程浏览器（例如云端常驻的 worker、第三方浏览器服务或本地内网桌面）时，可通过此流程将 Midscene 与远程 Playwright 实例打通。这样可以让浏览器贴近目标环境、降低启动开销，并集中管理浏览器资源，同时保持一致的 AI 自动化能力。
 
 实践中你需要手动：
@@ -298,7 +303,13 @@ npx playwright test ./e2e/ebay-search.spec.ts
 2. 使用 Playwright 连接到远程浏览器
 3. 创建 Midscene 代理进行 AI 驱动的自动化
 
-对应的示例代码如下：
+### 前置依赖
+
+<PackageManagerTabs command="install playwright @playwright/test @midscene/web --save-dev" />
+
+<GetCdpUrl />
+
+### 基础示例
 
 ```typescript
 import { chromium } from 'playwright';

--- a/apps/site/docs/zh/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/zh/integrate-with-puppeteer.mdx
@@ -1,4 +1,5 @@
 import SetupEnv from './common/setup-env.mdx';
+import GetCdpUrl from './common/get-cdp-url.mdx';
 
 # 集成到 Puppeteer
 
@@ -96,6 +97,10 @@ npx tsx demo.ts
 
 ## 示例：连接远程 Puppeteer 浏览器并接入 Midscene Agent
 
+:::info 示例项目
+你可以在这里找到远程 Puppeteer 集成的示例项目：[https://github.com/web-infra-dev/midscene-example/tree/main/remote-puppeteer-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-puppeteer-demo)
+:::
+
 当你想复用已有的远程浏览器（例如云端常驻的 worker、第三方浏览器网格或本地内网桌面）时，可以通过此流程把 Midscene 接到远程 Puppeteer 实例上。这样做能让浏览器靠近目标环境、降低重复启动成本，并统一管理浏览器资源，同时保持一致的 AI 自动化能力。
 
 实践中你需要手动：
@@ -106,6 +111,8 @@ npx tsx demo.ts
 ### 前置依赖
 
 <PackageManagerTabs command="install puppeteer @midscene/web --save-dev" />
+
+<GetCdpUrl />
 
 ### 基础示例
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive CDP WebSocket URL guidance to the Playwright and Puppeteer remote browser integration documentation.

### Changes

- **Created reusable component**: Added `get-cdp-url.mdx` in both English and Chinese versions containing CDP WebSocket URL sources:
  - BrowserBase
  - Browserless
  - Local Chrome with remote debugging
  - Docker containers

- **Enhanced documentation**: Updated all four integration docs (EN/ZH for both Playwright and Puppeteer):
  - Added example project links pointing to `midscene-example` repository
  - Imported and integrated `GetCdpUrl` component in Prerequisites sections
  - Added `@playwright/test` dependency for Playwright integration
  - Maintained 1.0 branch wording for better clarity

### Documentation Files Changed

- `apps/site/docs/en/common/get-cdp-url.mdx` (new)
- `apps/site/docs/zh/common/get-cdp-url.mdx` (new)
- `apps/site/docs/en/integrate-with-playwright.mdx`
- `apps/site/docs/en/integrate-with-puppeteer.mdx`
- `apps/site/docs/zh/integrate-with-playwright.mdx`
- `apps/site/docs/zh/integrate-with-puppeteer.mdx`

### Benefits

1. **Reduced duplication**: CDP URL guidance is now centralized in a reusable component
2. **Better user experience**: Users can easily find example projects and CDP URL sources
3. **Consistency**: Same information presented consistently across all documentation
4. **Maintainability**: Single source of truth for CDP URL guidance

### Related

- Complements the remote browser connection guide added in #1448
- Example projects: 
  - [remote-playwright-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-playwright-demo)
  - [remote-puppeteer-demo](https://github.com/web-infra-dev/midscene-example/tree/main/remote-puppeteer-demo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)