### PR TITLE
feat(core): add configurable QWEN high resolution images support

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -225,7 +225,7 @@ export async function callAI(
         : Number.parseInt(maxTokens || '2048', 10),
     ...(vlMode === 'qwen-vl' || vlMode === 'qwen3-vl' // qwen specific config
       ? {
-          vl_high_resolution_images: true,
+          ...(modelConfig.qwenHighResolution === false ? {} : { vl_high_resolution_images: true }),
         }
       : {}),
   };

--- a/packages/core/tests/unit-test/qwen-high-res-service-caller.test.ts
+++ b/packages/core/tests/unit-test/qwen-high-res-service-caller.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock photon packages to prevent resolution issues
+vi.mock('@silvia-odwyer/photon', () => ({}));
+vi.mock('@silvia-odwyer/photon-node', () => ({}));
+vi.mock('@midscene/shared/img', () => ({}));
+vi.mock('@midscene/shared/src/img/get-photon', () => ({}));
+
+vi.mock('openai', () => ({
+  default: vi.fn()
+}));
+vi.mock('@midscene/shared/env', () => ({
+  globalConfigManager: {
+    getEnvConfigValue: vi.fn(),
+    getEnvConfigInBoolean: vi.fn(),
+  },
+  globalModelConfigManager: {
+    getModelConfig: vi.fn(),
+  },
+  OPENAI_MAX_TOKENS: 'OPENAI_MAX_TOKENS',
+  MIDSCENE_LANGSMITH_DEBUG: 'MIDSCENE_LANGSMITH_DEBUG',
+  MIDSCENE_API_TYPE: 'MIDSCENE_API_TYPE',
+}));
+
+import { callAI } from '../../src/ai-model/service-caller/index';
+import { AIActionType } from '../../src/ai-model/common';
+import type { IModelConfig } from '@midscene/shared/env';
+import { globalConfigManager, globalModelConfigManager } from '@midscene/shared/env';
+
+describe('QWEN High Resolution Service Caller Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(globalConfigManager.getEnvConfigValue).mockReturnValue(undefined);
+    vi.mocked(globalConfigManager.getEnvConfigInBoolean).mockReturnValue(false);
+  });
+
+  it('should include vl_high_resolution_images when QWEN model and flag enabled', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen-vl-max',
+      vlMode: 'qwen-vl',
+      qwenHighResolution: true,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).toHaveProperty('vl_high_resolution_images', true);
+  });
+
+  it('should include vl_high_resolution_images when QWEN3 model and flag enabled', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen3-vl-max',
+      vlMode: 'qwen3-vl',
+      qwenHighResolution: true,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).toHaveProperty('vl_high_resolution_images', true);
+  });
+
+  it('should not include vl_high_resolution_images when QWEN model and flag disabled', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen-vl-max',
+      vlMode: 'qwen-vl',
+      qwenHighResolution: false,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).not.toHaveProperty('vl_high_resolution_images');
+  });
+
+  it('should default to enabled when QWEN model and flag unspecified', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen-vl-max',
+      vlMode: 'qwen-vl',
+      qwenHighResolution: undefined,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).toHaveProperty('vl_high_resolution_images', true);
+  });
+
+  it('should ignore flag for non-QWEN models even when enabled', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'gpt-4o',
+      vlMode: 'gemini',
+      qwenHighResolution: true,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).not.toHaveProperty('vl_high_resolution_images');
+  });
+
+  it('should not include vl_high_resolution_images when QWEN3 model and flag disabled', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen3-vl-max',
+      vlMode: 'qwen3-vl',
+      qwenHighResolution: false,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).not.toHaveProperty('vl_high_resolution_images');
+  });
+
+  it('should default to enabled when QWEN3 model and flag unspecified', async () => {
+    const mockConfig: IModelConfig = {
+      modelName: 'qwen3-vl-max',
+      vlMode: 'qwen3-vl',
+      qwenHighResolution: undefined,
+      openaiApiKey: 'test-key',
+      openaiBaseURL: 'https://api.openai.com/v1',
+      modelDescription: 'test model',
+      from: 'env',
+      intent: 'default',
+    };
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: 'test response' } }],
+            usage: { total_tokens: 100 },
+          }),
+        },
+      },
+    };
+
+    const { default: OpenAI } = await import('openai');
+    vi.mocked(OpenAI).mockReturnValue(mockOpenAI as any);
+
+    await callAI(
+      [{ role: 'user', content: 'test message' }],
+      AIActionType.INSPECT_ELEMENT,
+      mockConfig
+    );
+
+    const createCall = mockOpenAI.chat.completions.create.mock.calls[0][0];
+    expect(createCall).toHaveProperty('vl_high_resolution_images', true);
+  });
+});

--- a/packages/shared/src/env/decide-model-config.ts
+++ b/packages/shared/src/env/decide-model-config.ts
@@ -19,6 +19,7 @@ import { createAssert, maskConfig, parseJson } from './helper';
 import { initDebugConfig } from './init-debug';
 import {
   parseVlModeAndUiTarsFromGlobalConfig,
+  parseQwenHighResolution,
   parseVlModeAndUiTarsModelVersionFromRawValue,
 } from './parse';
 
@@ -219,6 +220,7 @@ export const decideModelConfigFromIntentConfig = (
   const { vlMode, uiTarsVersion } =
     parseVlModeAndUiTarsModelVersionFromRawValue(result.vlModeRaw);
 
+  const qwenHighResolution = undefined;
   const modelDescription = getModelDescription(vlMode, uiTarsVersion);
 
   const finalResult: IModelConfig = {
@@ -226,6 +228,7 @@ export const decideModelConfigFromIntentConfig = (
     modelName: intentConfig[chosenKeys.modelName]!,
     vlMode,
     uiTarsModelVersion: uiTarsVersion,
+    qwenHighResolution,
     modelDescription,
     from: 'modelConfig',
     intent,
@@ -263,6 +266,7 @@ export const decideModelConfigFromEnv = (
 
     const { vlMode, uiTarsVersion } =
       parseVlModeAndUiTarsModelVersionFromRawValue(result.vlModeRaw);
+    const qwenHighResolution = parseQwenHighResolution(allEnvConfig);
     const modelDescription = getModelDescription(vlMode, uiTarsVersion);
 
     const finalResult: IModelConfig = {
@@ -270,6 +274,7 @@ export const decideModelConfigFromEnv = (
       modelName,
       vlMode,
       uiTarsModelVersion: uiTarsVersion,
+      qwenHighResolution,
       modelDescription,
       from: 'env',
       intent,
@@ -296,6 +301,7 @@ export const decideModelConfigFromEnv = (
 
   const { vlMode, uiTarsVersion } =
     parseVlModeAndUiTarsFromGlobalConfig(allEnvConfig);
+  const qwenHighResolution = parseQwenHighResolution(allEnvConfig);
 
   const modelDescription = getModelDescription(vlMode, uiTarsVersion);
 
@@ -306,6 +312,7 @@ export const decideModelConfigFromEnv = (
       allEnvConfig[DEFAULT_MODEL_CONFIG_KEYS_LEGACY.modelName] || 'gpt-4o',
     vlMode,
     uiTarsModelVersion: uiTarsVersion,
+    qwenHighResolution,
     modelDescription,
     from: 'legacy-env',
     intent,

--- a/packages/shared/src/env/parse.ts
+++ b/packages/shared/src/env/parse.ts
@@ -3,6 +3,7 @@ import {
   MIDSCENE_USE_GEMINI,
   MIDSCENE_USE_QWEN3_VL,
   MIDSCENE_USE_QWEN_VL,
+  MIDSCENE_USE_QWEN_HIGH_RES,
   MIDSCENE_USE_VLM_UI_TARS,
   type TVlModeTypes,
   type TVlModeValues,
@@ -129,3 +130,27 @@ export const parseVlModeAndUiTarsFromGlobalConfig = (
     uiTarsVersion: undefined,
   };
 };
+
+export const parseQwenHighResolution = (
+  provider: Record<string, string | undefined>,
+): boolean | undefined => {
+  const qwenHighResFlag = provider[MIDSCENE_USE_QWEN_HIGH_RES];
+  if (qwenHighResFlag === undefined) return undefined;
+  
+  const normalizedFlag = qwenHighResFlag.toLowerCase().trim();
+  return ['true', '1', 'yes', 'on'].includes(normalizedFlag) && normalizedFlag !== '';
+};
+
+export const parseModelProvider = (
+  provider: Record<string, string | undefined>,
+): {
+  vlMode: TVlModeTypes | undefined;
+  qwenHighResolution: boolean | undefined;
+} => {
+  const { vlMode } = parseVlModeAndUiTarsFromGlobalConfig(provider);
+  const qwenHighResolution = parseQwenHighResolution(provider);
+  
+  return { vlMode, qwenHighResolution };
+};
+
+export { MIDSCENE_USE_QWEN_HIGH_RES };

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -33,6 +33,7 @@ export const MIDSCENE_CACHE = 'MIDSCENE_CACHE';
 export const MIDSCENE_USE_VLM_UI_TARS = 'MIDSCENE_USE_VLM_UI_TARS';
 export const MIDSCENE_USE_QWEN_VL = 'MIDSCENE_USE_QWEN_VL';
 export const MIDSCENE_USE_QWEN3_VL = 'MIDSCENE_USE_QWEN3_VL';
+export const MIDSCENE_USE_QWEN_HIGH_RES = 'MIDSCENE_USE_QWEN_HIGH_RES';
 export const MIDSCENE_USE_DOUBAO_VISION = 'MIDSCENE_USE_DOUBAO_VISION';
 export const MIDSCENE_USE_GEMINI = 'MIDSCENE_USE_GEMINI';
 export const MIDSCENE_USE_VL_MODEL = 'MIDSCENE_USE_VL_MODEL';
@@ -249,6 +250,7 @@ export const MODEL_ENV_KEYS = [
   MIDSCENE_USE_VLM_UI_TARS,
   MIDSCENE_USE_QWEN_VL,
   MIDSCENE_USE_QWEN3_VL,
+  MIDSCENE_USE_QWEN_HIGH_RES,
   MIDSCENE_USE_DOUBAO_VISION,
   MIDSCENE_USE_GEMINI,
   MIDSCENE_USE_VL_MODEL,
@@ -551,6 +553,7 @@ export interface IModelConfig {
   vlModeRaw?: string;
   vlMode?: TVlModeTypes;
   uiTarsModelVersion?: UITarsModelVersion;
+  qwenHighResolution?: boolean;
   modelDescription: string;
   /**
    * for debug

--- a/packages/shared/tests/unit-test/env/qwen-high-res-config.test.ts
+++ b/packages/shared/tests/unit-test/env/qwen-high-res-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { parseModelProvider } from '../../../src/env/parse';
+
+describe('QWEN High Resolution Configuration', () => {
+  it('should parse QWEN high resolution flag when enabled', () => {
+    const provider = {
+      MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus',
+      MIDSCENE_USE_QWEN_HIGH_RES: 'true',
+    };
+
+    const result = parseModelProvider(provider);
+    expect(result.vlMode).toBe('qwen-vl');
+    expect(result.qwenHighResolution).toBe(true);
+  });
+
+  it('should parse QWEN high resolution flag when disabled', () => {
+    const provider = {
+      MIDSCENE_USE_QWEN3_VL: 'qwen3-vl-plus',
+      MIDSCENE_USE_QWEN_HIGH_RES: 'false',
+    };
+
+    const result = parseModelProvider(provider);
+    expect(result.vlMode).toBe('qwen3-vl');
+    expect(result.qwenHighResolution).toBe(false);
+  });
+
+  it('should default to undefined when QWEN high resolution flag not specified', () => {
+    const provider = {
+      MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus',
+    };
+
+    const result = parseModelProvider(provider);
+    expect(result.vlMode).toBe('qwen-vl');
+    expect(result.qwenHighResolution).toBeUndefined();
+  });
+
+  it('should handle QWEN high resolution flag with non-QWEN models', () => {
+    const provider = {
+      MIDSCENE_USE_GEMINI: 'gemini-pro',
+      MIDSCENE_USE_QWEN_HIGH_RES: 'true',
+    };
+
+    const result = parseModelProvider(provider);
+    expect(result.qwenHighResolution).toBe(true);
+  });
+
+  it('should handle various truthy values for QWEN high resolution flag', () => {
+    const truthyValues = ['true', '1', 'yes', 'on', 'TRUE', 'True'];
+    
+    for (const value of truthyValues) {
+      const provider = {
+        MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus',
+        MIDSCENE_USE_QWEN_HIGH_RES: value,
+      };
+
+      const result = parseModelProvider(provider);
+      expect(result.qwenHighResolution).toBe(true);
+    }
+  });
+
+  it('should handle various falsy values for QWEN high resolution flag', () => {
+    const falsyValues = ['false', '0', 'no', 'off', 'FALSE', 'False', ''];
+    
+    for (const value of falsyValues) {
+      const provider = {
+        MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus',
+        MIDSCENE_USE_QWEN_HIGH_RES: value,
+      };
+
+      const result = parseModelProvider(provider);
+      expect(result.qwenHighResolution).toBe(false);
+    }
+  });
+
+  it('should integrate env parsing with model config for end-to-end flow', () => {
+    // Test that environment variable parsing flows through to model configuration
+    const envWithEnabled = {
+      MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus',
+      MIDSCENE_USE_QWEN_HIGH_RES: 'true',
+    };
+
+    const envWithDisabled = {
+      MIDSCENE_USE_QWEN_VL: 'qwen-vl-plus', 
+      MIDSCENE_USE_QWEN_HIGH_RES: 'false',
+    };
+
+    const enabledResult = parseModelProvider(envWithEnabled);
+    const disabledResult = parseModelProvider(envWithDisabled);
+
+    // Verify that parsed values would correctly influence service caller behavior
+    expect(enabledResult.qwenHighResolution).toBe(true);
+    expect(disabledResult.qwenHighResolution).toBe(false);
+    expect(enabledResult.vlMode).toBe('qwen-vl');
+    expect(disabledResult.vlMode).toBe('qwen-vl');
+  });
+});


### PR DESCRIPTION
- Add MIDSCENE_USE_QWEN_HIGH_RES environment variable for controlling vl_high_resolution_images parameter
- Support three states: enabled (true), disabled (false), unspecified (defaults to enabled)
- Only affects QWEN models (qwen-vl, qwen3-vl), ignored for other model types
- Add comprehensive test coverage for all configuration scenarios
- Implement case-insensitive parsing for extended truthy/falsy values