### PR TITLE
fix(core): normalize JSON whitespace in LLM responses

### DIFF
--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -1,5 +1,5 @@
 import { AIActionType } from '@/ai-model';
-import { getResponseFormat } from '@/ai-model/service-caller';
+import { getResponseFormat, safeParseJson } from '@/ai-model/service-caller';
 import type { IModelConfig } from '@midscene/shared/env';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -335,6 +335,147 @@ describe('service-caller', () => {
       // Config should still be valid
       expect(mockModelConfig.modelName).toBe('gpt-4o');
       expect(mockModelConfig.openaiApiKey).toBe('test-key');
+    });
+  });
+
+  describe('safeParseJson - JSON normalization', () => {
+    it('should trim leading and trailing spaces from object keys', () => {
+      const input =
+        '{"  type  ": "Tap", "param": {"  prompt  ": "Login button"}}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result).toEqual({
+        type: 'Tap',
+        param: {
+          prompt: 'Login button',
+        },
+      });
+      expect(Object.keys(result)).toEqual(['type', 'param']);
+      expect(Object.keys(result.param)).toEqual(['prompt']);
+    });
+
+    it('should trim leading and trailing spaces from type field values', () => {
+      const input = '{"type": "  Tap  ", "param": {}}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.type).toBe('Tap');
+    });
+
+    it('should trim leading and trailing spaces from prompt field values', () => {
+      const input = '{"param": {"prompt": "  Click the button  "}}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.param.prompt).toBe('Click the button');
+    });
+
+    it('should handle the original error case with leading spaces', () => {
+      // This is the actual error case from the issue
+      // Note: extractJSONFromCodeBlock extracts the first object from an array string
+      const input =
+        '[{"type":" Tap","param":{"locate":{"bbox":[574,308,865,352]," prompt ":"The \'Login\' button"}}}]';
+      const result = safeParseJson(input, undefined);
+
+      // The result is the first object (array wrapper is removed by extractJSONFromCodeBlock)
+      expect(result).toEqual({
+        type: 'Tap',
+        param: {
+          locate: {
+            bbox: [574, 308, 865, 352],
+            prompt: "The 'Login' button",
+          },
+        },
+      });
+    });
+
+    it('should handle nested objects and arrays', () => {
+      const input = JSON.stringify({
+        ' type ': '  Tap  ',
+        ' items ': [{ '  name  ': '  item1  ' }, { '  name  ': '  item2  ' }],
+      });
+      const result = safeParseJson(input, undefined);
+
+      expect(result).toEqual({
+        type: 'Tap',
+        items: [
+          { name: 'item1' }, // All string values are trimmed
+          { name: 'item2' },
+        ],
+      });
+    });
+
+    it('should trim all string values including descriptions', () => {
+      const input =
+        '{"type": "  Tap  ", "description": "  Some text with spaces  "}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.type).toBe('Tap');
+      expect(result.description).toBe('Some text with spaces'); // All strings are trimmed
+    });
+
+    it('should handle null and undefined values', () => {
+      const input = '{"type": "Tap", "value": null, "param": {}}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.type).toBe('Tap');
+      expect(result.value).toBeNull();
+    });
+
+    it('should work with malformed JSON that jsonrepair can fix', () => {
+      // jsonrepair can fix missing quotes, trailing commas, etc.
+      const input = '{type: " Tap ", param: {" prompt ": "Login"}}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.type).toBe('Tap');
+      expect(result.param.prompt).toBe('Login');
+    });
+
+    it('should handle deeply nested structures', () => {
+      const input = JSON.stringify({
+        ' type ': '  Action  ',
+        ' nested ': {
+          '  level1  ': {
+            '  level2  ': {
+              '  prompt  ': '  deep value  ',
+            },
+          },
+        },
+      });
+      const result = safeParseJson(input, undefined);
+
+      expect(result.type).toBe('Action');
+      expect(result.nested.level1.level2.prompt).toBe('deep value');
+    });
+
+    it('should trim id field values', () => {
+      const input = '{"id": "  element-123  ", "type": "  Tap  "}';
+      const result = safeParseJson(input, undefined);
+
+      expect(result.id).toBe('element-123');
+      expect(result.type).toBe('Tap');
+    });
+
+    it('should handle arrays of actions with spaces', () => {
+      const input = '[{"  type  ": "  Tap  "}, {"  type  ": "  Hover  "}]';
+      const result = safeParseJson(input, undefined);
+
+      expect(result).toEqual([{ type: 'Tap' }, { type: 'Hover' }]);
+    });
+
+    it('should handle coordinate tuples without breaking them', () => {
+      const input = '(100,200)';
+      const result = safeParseJson(input, undefined);
+
+      // This should match coordinates pattern and return array
+      expect(result).toEqual([100, 200]);
+    });
+
+    it('should work with doubao-vision mode and trim spaces', () => {
+      // Test that normalization works correctly even when vlMode is set
+      const input = '{"  type  ": "  Tap  ", "param": {"  prompt  ": "Click"}}';
+      const result = safeParseJson(input, 'doubao-vision');
+
+      expect(result.type).toBe('Tap');
+      expect(result.param.prompt).toBe('Click');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the issue where LLM-generated action plans fail with 
"Action type not found" errors due to leading/trailing whitespace in JSON keys and values.

Fixes #1435

## Problem

LLM responses sometimes contain malformed JSON with unintentional whitespace:
- Object keys with spaces: `" prompt "` instead of `"prompt"`
- Action type values with spaces: `" Tap"` instead of `"Tap"`

Example error case:
```json
[{"type":" Tap","param":{"locate":{"bbox":[574,308,865,352]," prompt ":"Login"}}}]
```

This causes action type lookup to fail because `" Tap"` doesn't match `"Tap"` 
in the action space registry.

## Solution

Added a `normalizeJsonObject()` function in `safeParseJson()` that:
- ✅ Recursively trims all object keys (e.g., `" prompt "` → `"prompt"`)
- ✅ Recursively trims all string values (e.g., `" Tap"` → `"Tap"`)
- ✅ Handles nested objects and arrays
- ✅ Works with all vlMode types (doubao-vision, vlm-ui-tars, etc.)
- ✅ Preserves null/undefined values

The normalization happens after `jsonrepair` but before returning the parsed object.

## Changes

**Modified Files:**
- `packages/core/src/ai-model/service-caller/index.ts` 
  - Added `normalizeJsonObject()` function (~40 lines)
  - Integrated into `safeParseJson()` pipeline
- `packages/core/tests/unit-test/service-caller.test.ts` 
  - Added 13 comprehensive test cases

## Test Coverage

All 29 tests pass, including new tests for:
- ✅ Original error case with leading/trailing spaces
- ✅ Object key normalization
- ✅ String value normalization
- ✅ Nested structures
- ✅ Arrays of objects
- ✅ Malformed JSON via jsonrepair
- ✅ Coordinate tuples
- ✅ doubao-vision mode compatibility
- ✅ Null/undefined handling

## Verification

Before:
```javascript
const parsed = JSON.parse('[{"type":" Tap","param":{" prompt ":"Login"}}]');
// parsed[0].type === " Tap" ❌ (lookup fails)
```

After:
```javascript
const parsed = safeParseJson('[{"type":" Tap","param":{" prompt ":"Login"}}]');
// parsed.type === "Tap" ✅ (lookup succeeds)
// parsed.param.prompt === "Login" ✅
```

## Breaking Changes

None. This change is backward compatible and only affects JSON with 
leading/trailing whitespace (which is already causing errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)