### PR TITLE
feat(web): add navigator support for chrome extension

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -445,6 +445,27 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     return url || '';
   }
 
+  async navigate(url: string): Promise<void> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    await chrome.tabs.update(tabId, { url });
+    // Wait for navigation to complete
+    await this.waitUntilNetworkIdle();
+  }
+
+  async reload(): Promise<void> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    await chrome.tabs.reload(tabId);
+    // Wait for reload to complete
+    await this.waitUntilNetworkIdle();
+  }
+
+  async goBack(): Promise<void> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    await chrome.tabs.goBack(tabId);
+    // Wait for navigation to complete
+    await this.waitUntilNetworkIdle();
+  }
+
   async scrollUntilTop(startingPoint?: Point) {
     if (startingPoint) {
       await this.mouse.move(startingPoint.left, startingPoint.top);


### PR DESCRIPTION
## Summary

This PR adds navigation method support to `ChromeExtensionProxyPage`, completing the navigator actions feature for all web page types.

### New Methods Added

- **navigate(url)**: Navigate to a specified URL using `chrome.tabs.update`
- **reload()**: Reload the current page using `chrome.tabs.reload`
- **goBack()**: Navigate back in history using `chrome.tabs.goBack`

All methods automatically wait for network idle after the operation completes.

### Context

This completes the navigator actions feature started in #1479 by adding support for:

- ✅ Puppeteer (completed in #1479)
- ✅ Playwright (completed in #1479)
- ✅ **Chrome Extension** (this PR)

### Implementation Details

The Chrome Extension implementation uses the Chrome Tabs API:
- `chrome.tabs.update(tabId, { url })` for navigation
- `chrome.tabs.reload(tabId)` for page reload
- `chrome.tabs.goBack(tabId)` for browser back

Each method reuses the existing `getTabIdOrConnectToCurrentTab()` and `waitUntilNetworkIdle()` methods for consistency.

### Files Changed

- `packages/web-integration/src/chrome-extension/page.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)