### PR TITLE
feat(web): restore aiAction fixture with deprecation notice

### DIFF
--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -132,6 +132,7 @@ export const PlaywrightAiFixture = (options?: {
     aiActionType:
       | 'ai'
       | 'aiAct'
+      | 'aiAction'
       | 'aiHover'
       | 'aiInput'
       | 'aiKeyboardPress'
@@ -310,6 +311,21 @@ export const PlaywrightAiFixture = (options?: {
         testInfo,
         use,
         aiActionType: 'aiAct',
+      });
+    },
+    /**
+     * @deprecated Use {@link PlaywrightAiFixture.aiAct} instead.
+     */
+    aiAction: async (
+      { page }: { page: OriginPlaywrightPage },
+      use: any,
+      testInfo: TestInfo,
+    ) => {
+      await generateAiFunction({
+        page,
+        testInfo,
+        use,
+        aiActionType: 'aiAction',
       });
     },
     aiTap: async (
@@ -586,6 +602,10 @@ export type PlayWrightAiFixtureType = {
   ) => Promise<PageAgent<PlaywrightWebPage>>;
   ai: <T = any>(prompt: string) => Promise<T>;
   aiAct: (taskPrompt: string) => ReturnType<PageAgent['aiAct']>;
+  /**
+   * @deprecated Use {@link PlayWrightAiFixtureType.aiAct} instead.
+   */
+  aiAction: (taskPrompt: string) => ReturnType<PageAgent['aiAction']>;
   aiTap: (
     ...args: Parameters<PageAgent['aiTap']>
   ) => ReturnType<PageAgent['aiTap']>;


### PR DESCRIPTION
## Summary

This PR restores the `aiAction` fixture for Playwright integration while marking it as deprecated to maintain backward compatibility.

## Changes

- ✅ Add `aiAction` fixture implementation in `PlaywrightAiFixture`
- ✅ Add `aiAction` to `PlayWrightAiFixtureType` type definition
- ✅ Mark `aiAction` as deprecated with JSDoc `@deprecated` comments
- ✅ Point users to use `aiAct` as the recommended alternative

## Motivation

The `aiAction` method was previously available but was removed. This PR restores it to support existing test code that uses this fixture, while guiding users toward the preferred `aiAct` method through deprecation notices.

## Test Plan

- Existing tests using `aiAction` fixture are already in the codebase
- TypeScript deprecation warnings will guide users to migrate to `aiAct`
- No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)