### PR TITLE
fix(report): fix screenshot not displaying when recorder is empty

### DIFF
--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -166,16 +166,16 @@ const DetailPanel = (): JSX.Element => {
       ) : null;
 
     // screenshot view
-    if (activeTask.recorder?.length) {
-      const screenshotFromContext = activeTask.uiContext?.screenshotBase64;
-      if (screenshotFromContext) {
-        screenshotItems.push({
-          timestamp: activeTask.timing?.start ?? undefined,
-          screenshot: screenshotFromContext,
-          timing: 'before-calling',
-        });
-      }
+    const screenshotFromContext = activeTask.uiContext?.screenshotBase64;
+    if (screenshotFromContext) {
+      screenshotItems.push({
+        timestamp: activeTask.timing?.start ?? undefined,
+        screenshot: screenshotFromContext,
+        timing: 'before-calling',
+      });
+    }
 
+    if (activeTask.recorder?.length) {
       for (const item of activeTask.recorder) {
         if (item.screenshot) {
           screenshotItems.push({
@@ -206,7 +206,7 @@ const DetailPanel = (): JSX.Element => {
         </div>
       );
     } else {
-      content = <div>no screenshot</div>;
+      content = <div>No screenshot</div>;
     }
   }
 


### PR DESCRIPTION
## Summary
Fixed an issue where screenshots from `uiContext.screenshotBase64` were not displayed when `activeTask.recorder` was empty or undefined.

## Problem
Previously, the screenshot extraction logic in `detail-panel/index.tsx` had the `uiContext.screenshotBase64` check nested inside the `recorder?.length` condition. This caused screenshots to not be shown when there were no recorder entries, even if `uiContext.screenshotBase64` existed.

## Solution
Separated the `uiContext.screenshotBase64` logic from the `recorder` check, so that:
1. First, check and add screenshot from `uiContext.screenshotBase64` if it exists
2. Then, process screenshots from `recorder` if it has entries

## Test Plan
- Verify that screenshots from `uiContext.screenshotBase64` are displayed even when `recorder` is empty
- Verify that recorder screenshots are still displayed correctly when they exist
- Verify that both sources of screenshots work together when both are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)