### PR TITLE
fix(chrome-extension): add awaitPromise: true to evaluateJavaScript

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -336,6 +336,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   public async evaluateJavaScript(script: string) {
     return this.sendCommandToDebugger('Runtime.evaluate', {
       expression: script,
+      awaitPromise: true,
     });
   }
 


### PR DESCRIPTION
## Summary

This PR adds `awaitPromise: true` parameter to Chrome Extension's `evaluateJavaScript` method to properly wait for Promise resolution.

## Problem

Currently, Chrome Extension's `evaluateJavaScript` uses CDP's `Runtime.evaluate` without the `awaitPromise` parameter. This causes async scripts to return unresolved Promise objects instead of their resolved values.

## Solution

Add `awaitPromise: true` to the `Runtime.evaluate` call.

## Changes

**File: `packages/web-integration/src/chrome-extension/page.ts`**

```typescript
public async evaluateJavaScript(script: string) {
  return this.sendCommandToDebugger('Runtime.evaluate', {
    expression: script,
    awaitPromise: true,  // ← Added this line
  });
}
```

## Benefits

- ✅ Async scripts now properly wait for Promise resolution
- ✅ Behavior aligns with Puppeteer and Playwright (which use `awaitPromise: true` internally)
- ✅ Backward compatible - sync scripts work as before
- ✅ Minimal change - only one line added

## Documentation Reference

According to [CDP Runtime.evaluate documentation](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate):

> **awaitPromise** (boolean): Whether execution should await for resulting value and return once awaited promise is resolved.

Both Puppeteer and Playwright set this parameter to `true` by default in their internal implementations.

## Testing

Manual testing confirms that async scripts now correctly resolve:

```typescript
// Before: Would return unresolved Promise object
// After: Correctly returns 42
await page.evaluateJavaScript('Promise.resolve(42)');
```