### PR TITLE
fix(core): prevent [object Object] in progress descriptions

### DIFF
--- a/apps/chrome-extension/rsbuild.config.ts
+++ b/apps/chrome-extension/rsbuild.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
   },
   dev: {
     writeToDisk: true,
+    lazyCompilation: false, // Disable lazy compilation for Chrome extension compatibility
   },
   output: {
     polyfill: 'entry',

--- a/apps/site/theme/i18n/zhCN.ts
+++ b/apps/site/theme/i18n/zhCN.ts
@@ -51,8 +51,7 @@ export const ZH_CN: Record<keyof typeof EN_US, string> = {
   modelGeminiDesc:
     'Gemini 先进的多模态模型，拥有强大的视觉能力和全面的 UI 自动化支持。',
   modelUITARSName: '支持多模型组合（可选）',
-  modelUITARSDesc:
-    '可选：规划/洞察模型搭配视觉定位模型，提升完成率。',
+  modelUITARSDesc: '可选：规划/洞察模型搭配视觉定位模型，提升完成率。',
 
   // Feature Sections - DEBUGGING
   debuggingTitle: '开发体验',

--- a/packages/core/src/agent/ui-utils.ts
+++ b/packages/core/src/agent/ui-utils.ts
@@ -205,7 +205,7 @@ export function paramStr(task: ExecutionTask) {
     }
 
     if (locateStr) {
-      if (value) {
+      if (value && typeof value !== 'object') {
         value = `${locateStr} - ${value}`;
       } else {
         value = locateStr;
@@ -217,9 +217,13 @@ export function paramStr(task: ExecutionTask) {
 
   if (typeof value === 'string') return value;
 
-  if (typeof value === 'object' && locateParamStr(value as any)) {
-    return locateParamStr(value as any);
+  if (typeof value === 'object') {
+    const locateStr = locateParamStr(value as any);
+    if (locateStr) {
+      return locateStr;
+    }
+    return JSON.stringify(value, undefined, 2);
   }
 
-  return JSON.stringify(value, undefined, 2);
+  return String(value);
 }


### PR DESCRIPTION
## Summary
Fixed an issue where progress descriptions in the universal playground would display `[object Object]` when action parameters were objects (e.g., during `aiTap` calls).

## Changes
- Modified `paramStr` function in `packages/core/src/agent/ui-utils.ts` to skip appending object parameters to locate descriptions
- When a locate parameter exists with an object value, only the locate description is shown (e.g., "google 搜索" instead of "google 搜索 - [object Object]")

## Test plan
- Test `aiTap` and other actions with object parameters in the universal playground
- Verify progress descriptions show only the action description without `[object Object]`
- Ensure string parameters still display correctly (e.g., "action - string value")

🤖 Generated with [Claude Code](https://claude.com/claude-code)