### PR TITLE
fix(core): preserve uiContext and log in _unstableLogContent method

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1277,24 +1277,10 @@ export class Agent<
 
   _unstableLogContent() {
     const { groupName, groupDescription, executions } = this.dump;
-    const newExecutions = Array.isArray(executions)
-      ? executions.map((execution: any) => {
-          const { tasks, ...restExecution } = execution;
-          let newTasks = tasks;
-          if (Array.isArray(tasks)) {
-            newTasks = tasks.map((task: any) => {
-              // only remove uiContext and log from task
-              const { uiContext, log, ...restTask } = task;
-              return restTask;
-            });
-          }
-          return { ...restExecution, ...(newTasks ? { tasks: newTasks } : {}) };
-        })
-      : [];
     return {
       groupName,
       groupDescription,
-      executions: newExecutions,
+      executions: executions || [],
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed `_unstableLogContent` method to preserve `uiContext` and `log` fields in task objects
- Simplified the method implementation by removing unnecessary data filtering

## Details
Previously, the `_unstableLogContent` method was removing `uiContext` and `log` fields from task objects during serialization. This change preserves all task data including these important fields, which are essential for debugging and logging purposes.

## Changes
- Removed filtering logic that stripped `uiContext` and `log` from tasks
- Simplified the method to return executions directly without modification
- Added null-safety with `executions || []`

## Test Plan
- ✅ Linter passed with no issues
- ✅ Verified the method now returns complete task data

🤖 Generated with [Claude Code](https://claude.com/claude-code)