### PR TITLE
fix(core): add missing left_double and right_single action handlers for UI-TARS

### DIFF
--- a/packages/core/src/ai-model/ui-tars-planning.ts
+++ b/packages/core/src/ai-model/ui-tars-planning.ts
@@ -16,6 +16,8 @@ import { getSummary, getUiTarsPlanningPrompt } from './prompt/ui-tars-planning';
 import { callAIWithStringResponse } from './service-caller/index';
 type ActionType =
   | 'click'
+  | 'left_double'
+  | 'right_single'
   | 'drag'
   | 'type'
   | 'hotkey'
@@ -100,6 +102,7 @@ export async function uiTarsPlanning(
   );
 
   const transformActions: PlanningAction[] = [];
+  const unhandledActions: Array<{ type: string; thought: string }> = [];
   let shouldContinue = true;
   parsed.forEach((action) => {
     const actionType = (action.action_type || '').toLowerCase();
@@ -118,6 +121,40 @@ export async function uiTarsPlanning(
             ),
           },
         },
+      });
+    } else if (actionType === 'left_double') {
+      assert(action.action_inputs.start_box, 'start_box is required');
+      const point = getPoint(action.action_inputs.start_box, size);
+      transformActions.push({
+        type: 'DoubleClick',
+        param: {
+          locate: {
+            prompt: action.thought || '',
+            bbox: pointToBbox(
+              { x: point[0], y: point[1] },
+              size.width,
+              size.height,
+            ),
+          },
+        },
+        thought: action.thought || '',
+      });
+    } else if (actionType === 'right_single') {
+      assert(action.action_inputs.start_box, 'start_box is required');
+      const point = getPoint(action.action_inputs.start_box, size);
+      transformActions.push({
+        type: 'RightClick',
+        param: {
+          locate: {
+            prompt: action.thought || '',
+            bbox: pointToBbox(
+              { x: point[0], y: point[1] },
+              size.width,
+              size.height,
+            ),
+          },
+        },
+        thought: action.thought || '',
       });
     } else if (actionType === 'drag') {
       assert(action.action_inputs.start_box, 'start_box is required');
@@ -193,14 +230,54 @@ export async function uiTarsPlanning(
         },
         thought: action.thought || '',
       });
+    } else if (actionType) {
+      // Track unhandled action types
+      unhandledActions.push({
+        type: actionType,
+        thought: action.thought || '',
+      });
+      debug('Unhandled action type:', actionType, 'thought:', action.thought);
     }
   });
 
   if (transformActions.length === 0) {
-    throw new Error(`No actions found, response: ${res.content}`, {
+    const errorDetails: string[] = [];
+
+    // Check if parsing failed
+    if (parsed.length === 0) {
+      errorDetails.push('Action parser returned no actions');
+
+      // Check if response has Thought but no Action
+      if (
+        res.content.includes('Thought:') &&
+        !res.content.includes('Action:')
+      ) {
+        errorDetails.push(
+          'Response contains "Thought:" but missing "Action:" line',
+        );
+      } else {
+        errorDetails.push('Response may be malformed or empty');
+      }
+    }
+
+    // Check if we have unhandled action types
+    if (unhandledActions.length > 0) {
+      const types = unhandledActions.map((a) => a.type).join(', ');
+      errorDetails.push(`Unhandled action types: ${types}`);
+    }
+
+    const errorMessage = [
+      'No actions found in UI-TARS response.',
+      ...errorDetails,
+      `\nRaw response: ${res.content}`,
+    ].join('\n');
+
+    throw new Error(errorMessage, {
       cause: {
         prediction: res.content,
         parsed,
+        unhandledActions,
+        convertedText,
       },
     });
   }
@@ -291,6 +368,20 @@ interface WaitAction extends BaseAction {
   };
 }
 
+interface LeftDoubleAction extends BaseAction {
+  action_type: 'left_double';
+  action_inputs: {
+    start_box: string; // JSON string of [x, y] coordinates
+  };
+}
+
+interface RightSingleAction extends BaseAction {
+  action_type: 'right_single';
+  action_inputs: {
+    start_box: string; // JSON string of [x, y] coordinates
+  };
+}
+
 interface TypeAction extends BaseAction {
   action_type: 'type';
   action_inputs: {
@@ -319,6 +410,8 @@ interface FinishedAction extends BaseAction {
 
 export type Action =
   | ClickAction
+  | LeftDoubleAction
+  | RightSingleAction
   | DragAction
   | TypeAction
   | HotkeyAction

--- a/packages/core/tests/ai/parse-action.test.ts
+++ b/packages/core/tests/ai/parse-action.test.ts
@@ -116,6 +116,34 @@ Action: finished()`;
     expect(parsed[0].action_type).toBe('finished');
     expect(parsed[0].action_inputs).toEqual({});
   });
+
+  it('should parse left_double action', () => {
+    const text = `Thought: Double-click the search button
+Action: left_double(start_box='(460,452)')`;
+
+    const { parsed } = actionParser({
+      prediction: text,
+      factor: 1000,
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].action_type).toBe('left_double');
+    expect(parsed[0].action_inputs.start_box).toBeDefined();
+    expect(parsed[0].thought).toBe('Double-click the search button');
+  });
+
+  it('should parse right_single action', () => {
+    const text = `Thought: Right-click to open context menu
+Action: right_single(start_box='(300,200)')`;
+
+    const { parsed } = actionParser({
+      prediction: text,
+      factor: 1000,
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].action_type).toBe('right_single');
+    expect(parsed[0].action_inputs.start_box).toBeDefined();
+    expect(parsed[0].thought).toBe('Right-click to open context menu');
+  });
 });
 
 describe('getSummary', () => {


### PR DESCRIPTION
## Summary

Fixes the "No actions found" error when UI-TARS model returns `left_double` (double-click) or `right_single` (right-click) actions. These action types were defined in the UI-TARS prompt but missing from the transformation logic, causing the error when the model attempted to use them.

## Root Cause

The UI-TARS planning prompt (`prompt/ui-tars-planning.ts`) declares `left_double` and `right_single` as valid action types, but the transformation code in `ui-tars-planning.ts` only handled: `click`, `drag`, `type`, `hotkey`, `scroll`, `wait`, and `finished`. When the model returned these undeclared actions, they were silently ignored, resulting in an empty `transformActions` array and triggering the "No actions found" error.

## Changes

### Type System Updates
- Added `'left_double'` and `'right_single'` to `ActionType` union (line 17-26)
- Implemented `LeftDoubleAction` and `RightSingleAction` interfaces (line 296-308)
- Updated `Action` union type to include new action types (line 336-345)

### Transformation Logic
- Added `left_double` handler that maps to `DoubleClick` action (line 124-140)
- Added `right_single` handler that maps to `RightClick` action (line 141-157)
- Both use the same coordinate transformation logic as `click`

### Error Diagnostics Enhancement
- Track unhandled action types during transformation (line 105, 233-240)
- Distinguish between different failure scenarios:
  - Missing Action line in response (has `Thought:` but no `Action:`)
  - Unhandled action types
  - Other parsing failures
- Provide detailed error messages with raw response for debugging (line 243-283)

### Testing
- Added test case for `left_double` action parsing
- Added test case for `right_single` action parsing
- All 10 tests in `parse-action.test.ts` pass

## Technical Notes

- The device layer already fully supports `DoubleClick` and `RightClick` actions (defined in `device/index.ts:131-144` and `device/index.ts:106-119`)
- This fix only required updating the UI-TARS planning module to properly map the action types
- No breaking changes to the API or existing functionality

## Test Results

```bash
✓ tests/ai/parse-action.test.ts (10 tests) 11ms
  Test Files  1 passed (1)
  Tests  10 passed (10)
```

## Files Changed

- `packages/core/src/ai-model/ui-tars-planning.ts` - Core fix
- `packages/core/tests/ai/parse-action.test.ts` - Test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)