### PR TITLE
fix(core): add error handling for xpath fallback to AI locate

### DIFF
--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -400,9 +400,14 @@ export class TaskBuilder {
         // from xpath
         let rectFromXpath: Rect | undefined;
         if (param.xpath && this.interface.rectMatchesCacheFeature) {
-          rectFromXpath = await this.interface.rectMatchesCacheFeature({
-            xpaths: [param.xpath],
-          });
+          try {
+            rectFromXpath = await this.interface.rectMatchesCacheFeature({
+              xpaths: [param.xpath],
+            });
+          } catch (error) {
+            // xpath locate failed, allow fallback to cache or AI locate
+            rectFromXpath = undefined;
+          }
         }
         const elementFromXpath = rectFromXpath
           ? generateElementByPosition(


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where xpath-based element location failures would throw errors directly instead of falling back to cache or AI locate methods.

## Problem

In `packages/core/src/agent/task-builder.ts:402-406`, when `rectMatchesCacheFeature` throws an error during xpath locate (e.g., from `base-page.ts:277`), the program would crash immediately without attempting the fallback mechanisms.

## Solution

Added try-catch error handling around the `rectMatchesCacheFeature` call to allow graceful fallback to:
1. Cache-based element location
2. AI-powered re-location

This aligns with the error handling pattern already used in `utils.ts:184-204` for the same method call.

## Changes

- Added try-catch block in `task-builder.ts` for xpath locate error handling
- Set `rectFromXpath = undefined` on error to trigger fallback logic
- Added inline comment explaining the fallback behavior

## Testing

- ✅ Biome lint check passed
- ✅ TypeScript type checking passed
- ✅ Build successful for @midscene/core package

## Impact

This fix ensures that temporary xpath locate failures (e.g., element moved, DOM changed) won't break the entire automation flow, improving robustness of the element location system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)