### PR TITLE
fix(shared): disable chunk splitting for IIFE build to fix window.midscene_element_inspector

### DIFF
--- a/packages/shared/rslib.inspect.config.ts
+++ b/packages/shared/rslib.inspect.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
               name: 'midscene_element_inspector',
             },
           },
+          optimization: {
+            runtimeChunk: false,
+            splitChunks: false,
+          },
         },
         bundlerChain: (chain, { CHAIN_ID }) => {
           chain.optimization.minimizer(CHAIN_ID.MINIMIZER.JS).tap((options) => {


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Cannot read properties of undefined (reading 'webExtractNodeTree')` error caused by the @rslib/core upgrade from 0.11.2 to 0.18.2.

## Root Cause

The @rslib/core upgrade introduced webpack's chunk optimization mechanism (`__webpack_require__.O()`) by default for IIFE bundles. This caused:

1. Module loading to be deferred into a queue
2. `__webpack_exports__` to be `undefined` at the time of assignment
3. `window.midscene_element_inspector` being set to `undefined`

## Changes

Added explicit optimization configuration to `packages/shared/rslib.inspect.config.ts`:

```typescript
optimization: {
  runtimeChunk: false,
  splitChunks: false,
}
```

This ensures the IIFE bundle remains self-contained without deferred chunk loading, allowing `window.midscene_element_inspector` to be properly set.

## Testing

- ✅ All 13 tests in `web-extractor.test.ts` now pass
- ✅ Verified `window.midscene_element_inspector` is properly set with all expected exports
- ✅ Bundle size: 65.5 kB (was previously using chunk splitting)

## Related Issue

Resolves the issue reported in commit 2ff7492b where the rslib upgrade broke the IIFE script injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)