### PR TITLE
Allow YAML AI steps to forward arbitrary options

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -93,6 +93,12 @@ const defaultServiceExtractOption: ServiceExtractOption = {
   screenshotIncluded: true,
 };
 
+type AiActOpt = {
+  cacheable?: boolean;
+  _deepThink?: boolean;
+  [key: string]: unknown;
+};
+
 type CacheStrategy = NonNullable<CacheConfig['strategy']>;
 
 const CACHE_STRATEGIES: readonly CacheStrategy[] = [
@@ -789,10 +795,7 @@ export class Agent<
 
   async aiAct(
     taskPrompt: string,
-    opt?: {
-      cacheable?: boolean;
-      _deepThink?: boolean;
-    },
+    opt?: AiActOpt,
   ) {
     const modelConfigForPlanning =
       this.modelConfigManager.getModelConfig('planning');
@@ -876,9 +879,7 @@ export class Agent<
    */
   async aiAction(
     taskPrompt: string,
-    opt?: {
-      cacheable?: boolean;
-    },
+    opt?: AiActOpt,
   ) {
     return this.aiAct(taskPrompt, opt);
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -224,6 +224,7 @@ export type OnTaskStartTip = (tip: string) => Promise<void> | void;
 export interface AgentWaitForOpt {
   checkIntervalMs?: number;
   timeoutMs?: number;
+  [key: string]: unknown;
 }
 
 export interface AgentAssertOpt {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -14,6 +14,7 @@ export interface LocateOption {
 export interface ServiceExtractOption {
   domIncluded?: boolean | 'visible-only';
   screenshotIncluded?: boolean;
+  [key: string]: unknown;
 }
 
 export interface ReferenceImage {
@@ -133,12 +134,14 @@ export interface MidsceneYamlFlowItemAIAction {
   aiActionProgressTips?: string[];
   cacheable?: boolean;
   _deepThink?: boolean;
+  [key: string]: unknown;
 }
 
 export interface MidsceneYamlFlowItemAIAssert {
   aiAssert: string;
   errorMessage?: string;
   name?: string;
+  [key: string]: unknown;
 }
 
 export interface MidsceneYamlFlowItemAIQuery extends ServiceExtractOption {
@@ -174,6 +177,7 @@ export interface MidsceneYamlFlowItemAILocate extends LocateOption {
 export interface MidsceneYamlFlowItemAIWaitFor {
   aiWaitFor: string;
   timeout?: number;
+  [key: string]: unknown;
 }
 
 export interface MidsceneYamlFlowItemEvaluateJavaScript {

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -253,12 +253,10 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         'ai' in (flowItem as MidsceneYamlFlowItemAIAction)
       ) {
         const actionTask = flowItem as MidsceneYamlFlowItemAIAction;
-        const prompt = actionTask.aiAct || actionTask.aiAction || actionTask.ai;
+        const { aiAct, aiAction, ai, ...actionOptions } = actionTask;
+        const prompt = aiAct || aiAction || ai;
         assert(prompt, 'missing prompt for ai (aiAct)');
-        await agent.aiAct(prompt, {
-          cacheable: actionTask.cacheable,
-          _deepThink: actionTask._deepThink,
-        });
+        await agent.aiAct(prompt, actionOptions);
       } else if ('aiAssert' in (flowItem as MidsceneYamlFlowItemAIAssert)) {
         const assertTask = flowItem as MidsceneYamlFlowItemAIAssert;
         const prompt = assertTask.aiAssert;
@@ -280,50 +278,39 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         }
       } else if ('aiQuery' in (flowItem as MidsceneYamlFlowItemAIQuery)) {
         const queryTask = flowItem as MidsceneYamlFlowItemAIQuery;
-        const prompt = queryTask.aiQuery;
-        const options = {
-          domIncluded: queryTask.domIncluded,
-          screenshotIncluded: queryTask.screenshotIncluded,
-        };
+        const { aiQuery, name, ...options } = queryTask;
+        const prompt = aiQuery;
         assert(prompt, 'missing prompt for aiQuery');
         const queryResult = await agent.aiQuery(prompt, options);
-        this.setResult(queryTask.name, queryResult);
+        this.setResult(name, queryResult);
       } else if ('aiNumber' in (flowItem as MidsceneYamlFlowItemAINumber)) {
         const numberTask = flowItem as MidsceneYamlFlowItemAINumber;
-        const prompt = numberTask.aiNumber;
-        const options = {
-          domIncluded: numberTask.domIncluded,
-          screenshotIncluded: numberTask.screenshotIncluded,
-        };
+        const { aiNumber, name, ...options } = numberTask;
+        const prompt = aiNumber;
         assert(prompt, 'missing prompt for aiNumber');
         const numberResult = await agent.aiNumber(prompt, options);
-        this.setResult(numberTask.name, numberResult);
+        this.setResult(name, numberResult);
       } else if ('aiString' in (flowItem as MidsceneYamlFlowItemAIString)) {
         const stringTask = flowItem as MidsceneYamlFlowItemAIString;
-        const prompt = stringTask.aiString;
-        const options = {
-          domIncluded: stringTask.domIncluded,
-          screenshotIncluded: stringTask.screenshotIncluded,
-        };
+        const { aiString, name, ...options } = stringTask;
+        const prompt = aiString;
         assert(prompt, 'missing prompt for aiString');
         const stringResult = await agent.aiString(prompt, options);
-        this.setResult(stringTask.name, stringResult);
+        this.setResult(name, stringResult);
       } else if ('aiBoolean' in (flowItem as MidsceneYamlFlowItemAIBoolean)) {
         const booleanTask = flowItem as MidsceneYamlFlowItemAIBoolean;
-        const prompt = booleanTask.aiBoolean;
-        const options = {
-          domIncluded: booleanTask.domIncluded,
-          screenshotIncluded: booleanTask.screenshotIncluded,
-        };
+        const { aiBoolean, name, ...options } = booleanTask;
+        const prompt = aiBoolean;
         assert(prompt, 'missing prompt for aiBoolean');
         const booleanResult = await agent.aiBoolean(prompt, options);
-        this.setResult(booleanTask.name, booleanResult);
+        this.setResult(name, booleanResult);
       } else if ('aiAsk' in (flowItem as MidsceneYamlFlowItemAIAsk)) {
         const askTask = flowItem as MidsceneYamlFlowItemAIAsk;
-        const prompt = askTask.aiAsk;
+        const { aiAsk, name, ...options } = askTask;
+        const prompt = aiAsk;
         assert(prompt, 'missing prompt for aiAsk');
-        const askResult = await agent.aiAsk(prompt);
-        this.setResult(askTask.name, askResult);
+        const askResult = await agent.aiAsk(prompt, options);
+        this.setResult(name, askResult);
       } else if ('aiLocate' in (flowItem as MidsceneYamlFlowItemAILocate)) {
         const locateTask = flowItem as MidsceneYamlFlowItemAILocate;
         const prompt = locateTask.aiLocate;
@@ -332,10 +319,16 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         this.setResult(locateTask.name, locateResult);
       } else if ('aiWaitFor' in (flowItem as MidsceneYamlFlowItemAIWaitFor)) {
         const waitForTask = flowItem as MidsceneYamlFlowItemAIWaitFor;
-        const prompt = waitForTask.aiWaitFor;
+        const { aiWaitFor, timeout, ...restWaitForOpts } = waitForTask;
+        const prompt = aiWaitFor;
         assert(prompt, 'missing prompt for aiWaitFor');
-        const timeout = waitForTask.timeout;
-        await agent.aiWaitFor(prompt, { timeoutMs: timeout });
+        const waitForOptions = {
+          ...restWaitForOpts,
+          ...(timeout !== undefined
+            ? { timeout, timeoutMs: timeout }
+            : {}),
+        };
+        await agent.aiWaitFor(prompt, waitForOptions);
       } else if ('sleep' in (flowItem as MidsceneYamlFlowItemSleep)) {
         const sleepTask = flowItem as MidsceneYamlFlowItemSleep;
         const ms = sleepTask.sleep;


### PR DESCRIPTION
## Summary
- allow YAML ai* steps to forward any additional parameters to the agent as options
- loosen option typing for aiAct/aiQuery and related flows to accept future parameters without code changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930599c8ccc8324a43a57533b1fa64c)