### PR TITLE
docs(site): add second Java SDK (by @alstafeev) to awesome list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Community projects that extend Midscene.js capabilities:
 
 * [midscene-ios](https://github.com/lhuanyu/midscene-ios) - iOS automation support for Midscene
 * [Midscene-Python](https://github.com/Python51888/Midscene-Python) - Python SDK for Midscene automation
-* [midscene-java](https://github.com/Master-Frank/midscene-java) - Java SDK that brings Midscene automation features to JVM projects
-* [midscene-java](https://github.com/alstafeev/midscene-java) - Java SDK for Midscene automation
+* [midscene-java](https://github.com/Master-Frank/midscene-java) by @Master-Frank - Java SDK that brings Midscene automation features to JVM projects
+* [midscene-java](https://github.com/alstafeev/midscene-java) by @alstafeev - Java SDK for Midscene automation
 
 
 ## 📝 Credits

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,8 +133,8 @@ for (const record of recordList) {
 
 * [midscene-ios](https://github.com/lhuanyu/midscene-ios) - iOS 设备自动化工具
 * [Midscene-Python](https://github.com/Python51888/Midscene-Python) - Python 版本的 Midscene SDK
-* [midscene-java](https://github.com/Master-Frank/midscene-java) - Java 版本的 Midscene SDK，便于在 JVM 项目中使用自动化能力
-* [midscene-java](https://github.com/alstafeev/midscene-java) - Java SDK,用于 Midscene 自动化
+* [midscene-java](https://github.com/Master-Frank/midscene-java) by @Master-Frank - Java 版本的 Midscene SDK，便于在 JVM 项目中使用自动化能力
+* [midscene-java](https://github.com/alstafeev/midscene-java) by @alstafeev - Java SDK,用于 Midscene 自动化
 
 ## 📝 致谢
 

--- a/apps/site/docs/en/awesome-midscene.md
+++ b/apps/site/docs/en/awesome-midscene.md
@@ -15,10 +15,10 @@ A curated list of community projects that extend Midscene.js capabilities across
   - Allows integration with existing Python testing and automation workflows
 
 ### Java SDK
-- **[midscene-java](https://github.com/Master-Frank/midscene-java)** - Java SDK for Midscene automation
+- **[midscene-java](https://github.com/Master-Frank/midscene-java)** by @Master-Frank - Java SDK for Midscene automation
   - Offers a JVM-friendly way to script Midscene experiences similar to the Python SDK
   - Fits easily into existing Java automation or testing pipelines
-- **[midscene-java](https://github.com/alstafeev/midscene-java)** - Java SDK for Midscene automation
+- **[midscene-java](https://github.com/alstafeev/midscene-java)** by @alstafeev - Java SDK for Midscene automation
   - Provides a JVM-native interface for scripting Midscene
   - Integrates seamlessly into established Java testing frameworks and automation workflows
 

--- a/apps/site/docs/zh/awesome-midscene.md
+++ b/apps/site/docs/zh/awesome-midscene.md
@@ -15,10 +15,10 @@
   - 支持与现有 Python 测试和自动化工作流程的集成
 
 ### Java SDK
-- **[midscene-java](https://github.com/Master-Frank/midscene-java)** - Java 版本的 Midscene SDK
+- **[midscene-java](https://github.com/Master-Frank/midscene-java)** by @Master-Frank - Java 版本的 Midscene SDK
   - 提供与 Python 版本类似的体验，适配 JVM 生态
   - 易于整合到现有的 Java 自动化或测试流程
-- **[midscene-java](https://github.com/alstafeev/midscene-java)** - Java 版本的 Midscene SDK
+- **[midscene-java](https://github.com/alstafeev/midscene-java)** by @alstafeev - Java 版本的 Midscene SDK
   - 提供用于脚本化 Midscene 的 JVM 原生接口
   - 无缝整合至现有的 Java 测试框架与自动化工作流程
 


### PR DESCRIPTION
Add second community-maintained midscene-java SDK to Awesome Midscene list.

## Changes

- Add @alstafeev's Java SDK to README.md and README.zh.md
- Add SDK introduction to awesome-midscene documentation (English and Chinese)
- Convert Traditional Chinese descriptions to Simplified Chinese

## Original Author

Original contribution from @alstafeev (PR #1519)

- Original commit: c04067d7 by Alexey Stafeev <a.stafeev@clickadu.com>
- Maven repository: https://mvnrepository.com/artifact/io.github.alstafeev/midscene-web

## Related Links

- Original PR: #1519
- Java SDK repository: https://github.com/alstafeev/midscene-java

Co-authored-by: Alexey Stafeev <a.stafeev@clickadu.com>