### PR TITLE
fix(report): prevent time column overflow with status text

### DIFF
--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -222,13 +222,17 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
 
     groupedDump.executions.forEach((execution) => {
       execution.tasks.forEach((task) => {
-        // Time cost length (e.g., "1.23s", "123ms")
+        // Time cost length (e.g., "1.23s", "123ms") or status text
         if (typeof task.timing?.cost === 'number') {
           const timeStr =
             task.timing.cost < 1000
               ? `${task.timing.cost}ms`
               : `${(task.timing.cost / 1000).toFixed(2)}s`;
           maxTimeLength = Math.max(maxTimeLength, timeStr.length);
+        } else {
+          // Measure status text length when no timing cost
+          const statusText = task.status || '';
+          maxTimeLength = Math.max(maxTimeLength, statusText.length);
         }
 
         // Intent length

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -801,10 +801,7 @@ export class Agent<
     });
   }
 
-  async aiAct(
-    taskPrompt: string,
-    opt?: AiActOptions,
-  ) {
+  async aiAct(taskPrompt: string, opt?: AiActOptions) {
     const modelConfigForPlanning =
       this.modelConfigManager.getModelConfig('planning');
     const defaultIntentModelConfig =
@@ -903,10 +900,7 @@ export class Agent<
   /**
    * @deprecated Use {@link Agent.aiAct} instead.
    */
-  async aiAction(
-    taskPrompt: string,
-    opt?: AiActOptions,
-  ) {
+  async aiAction(taskPrompt: string, opt?: AiActOptions) {
     return this.aiAct(taskPrompt, opt);
   }
 


### PR DESCRIPTION
## Summary

Fixed the Time column in the sidebar table overflowing when displaying status text (e.g., "running", "pending", "cancelled") by adding status text length measurement to the dynamic width calculation.

## Problem

The Time column would overflow when displaying status text like "running" (7 chars) or "cancelled" (9 chars), especially when the column width was calculated based on short time strings like "1s" (2 chars).

## Root Cause

The dynamic width calculation in `dynamicWidths` (line 225-232) only measured numeric time strings (e.g., "1.23s", "123ms") but completely ignored status text strings that could also be displayed in the same column.

## Solution

Added an `else` branch to measure status text length when no timing cost is available, following the same pattern already used by the Intent and Model columns:

\`\`\`typescript
} else {
  // Measure status text length when no timing cost
  const statusText = task.status || '';
  maxTimeLength = Math.max(maxTimeLength, statusText.length);
}
\`\`\`

## Status Values Covered

- \`pending\` (7 chars)
- \`running\` (7 chars)
- \`finished\` (8 chars)
- \`failed\` (6 chars)
- \`cancelled\` (9 chars)

## Files Changed

- \`apps/report/src/components/sidebar/index.tsx\` - Added status text length measurement
- \`packages/core/src/agent/agent.ts\` - Linter auto-fix formatting

## Testing

The fix ensures the column width accommodates whichever is longer (time string or status text), preventing overflow in all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)