### PR TITLE
fix(ios): use WebDriver Clear API for dynamic input fields

### DIFF
--- a/packages/android/tests/ai/ebay.test.ts
+++ b/packages/android/tests/ai/ebay.test.ts
@@ -27,7 +27,9 @@ describe('Test todo list', () => {
     'search headphones',
     async () => {
       // 👀 type keywords, perform a search
-      await agent.aiAction('type "Headphones" in search box, hit Enter');
+      await agent.aiAction(
+        'type "Headphones" in search box, click search button',
+      );
 
       // 👀 wait for the loading
       await agent.aiWaitFor('there is at least one headphone item on page');

--- a/packages/cli/tests/multi_yaml_android_scripts/search-headphone-on-ebay.yaml
+++ b/packages/cli/tests/multi_yaml_android_scripts/search-headphone-on-ebay.yaml
@@ -8,7 +8,7 @@ tasks:
   - name: search headphones
     flow:
       - aiAction: open browser and navigate to ebay.com
-      - aiAction: type 'Headphones' in ebay search box, hit Enter
+      - aiAction: type 'Headphones' in ebay search box, click the search button
       - sleep: 5000
       - aiAction: scroll down the page for 800px
 

--- a/packages/cli/tests/multi_yaml_ios_scripts/search-headphone-on-ebay.yaml
+++ b/packages/cli/tests/multi_yaml_ios_scripts/search-headphone-on-ebay.yaml
@@ -7,7 +7,7 @@ tasks:
   - name: search headphones
     flow:
       - aiAction: open browser and navigate to ebay.com
-      - aiAction: type 'Headphones' in ebay search box, hit Enter
+      - aiAction: type 'Headphones' in ebay search box, click the search button
       - sleep: 5000
       - aiAction: scroll down the page for 800px
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -402,24 +402,17 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     await this.tap(element.center[0], element.center[1]);
     await sleep(100);
 
-    // For iOS, we need to use different methods to clear text
-    try {
-      // Method 1: Triple tap to select all, then delete
-      await this.tripleTap(element.center[0], element.center[1]);
-      await sleep(200); // Wait for selection to appear
-
-      // Type empty string to replace selected text
-      await this.wdaBackend.typeText(BackspaceChar);
-    } catch (error2) {
-      debugDevice(`Method 1 failed, trying method 2: ${error2}`);
-      try {
-        // Method 2: Send multiple backspace characters
-        const backspaces = Array(100).fill(BackspaceChar).join(''); // Unicode backspace
-        await this.wdaBackend.typeText(backspaces);
-      } catch (error3) {
-        debugDevice(`All clear methods failed: ${error3}`);
-        // Continue anyway, maybe there was no text to clear
-      }
+    // For iOS, use WebDriver's standard clear API
+    // This gets the currently focused element and clears it using the /element/{id}/clear endpoint
+    // Works reliably with dynamic input fields and doesn't trigger unwanted events
+    debugDevice('Attempting to clear input with WebDriver Clear API');
+    const cleared = await this.wdaBackend.clearActiveElement();
+    if (cleared) {
+      debugDevice('Successfully cleared input with WebDriver Clear API');
+    } else {
+      debugDevice(
+        'WebDriver Clear API returned false (no active element or clear failed)',
+      );
     }
   }
 

--- a/packages/ios/tests/ai/ebay.test.ts
+++ b/packages/ios/tests/ai/ebay.test.ts
@@ -42,7 +42,7 @@ describe('Test eBay search', () => {
 
       // 👀 type keywords, perform a search
       await agent.aiAction(
-        'type "Headphones" in search box, tap search button',
+        'type "Headphones" in search box, click search button',
       );
 
       // 👀 wait for the loading


### PR DESCRIPTION
## Problem

The previous `clearInput` implementation used `tripleTap` on element coordinates, which failed with **dynamic input fields** like eBay's search box that shows a new input overlay when clicked. 

**Root cause**: When `aiInput` was called after the dynamic input appeared:
1. AI located the original search box coordinates (stale)
2. `clearInput` used `tripleTap` on those stale coordinates
3. The tap hit the wrong element, breaking focus on the dynamic input field
4. Text input failed

## Solution

Replaced the coordinate-based clearing approach with **WebDriver's standard Clear API**:

```typescript
// New approach:
1. Get currently focused element using /element/active endpoint
2. Clear it using /element/{id}/clear endpoint
```

## Benefits

✅ **Works with dynamic input fields** - Uses element references instead of coordinates  
✅ **No unwanted events** - WebDriver's clear is an atomic operation  
✅ **W3C standard** - Uses official WebDriver protocol  
✅ **Simpler code** - Removed tripleTap and backspace fallbacks

## Changes

### `packages/ios/src/ios-webdriver-client.ts`
Added three new methods:
- `getActiveElement()` - Get WebDriver ID of focused element
- `clearElement(elementId)` - Clear element by ID
- `clearActiveElement()` - Combined method for easy use

### `packages/ios/src/device.ts`
Simplified `clearInput()` to use `clearActiveElement()`

### Test files
Updated test files across platforms to use consistent search action descriptions

## Testing

Tested with eBay's dynamic search box which previously failed consistently.

---

**Note**: This PR cherry-picks the changes from PR #1403 (merged to 1.0 branch) to the main branch.