### PR TITLE
feat(agent): add setAIActContext alias and deprecate setAIActionContext

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -782,7 +782,7 @@ For more information about YAML scripts, please refer to [Automate with Scripts 
 
 :::
 
-### `agent.setAIActionContext()`
+### `agent.setAIActContext()`
 
 Set the background knowledge that should be sent to the AI model when calling `agent.aiAct()` or `agent.ai()`. This will override the previous setting.
 
@@ -791,7 +791,7 @@ For instant action type APIs, like `aiTap()`, this setting will not take effect.
 - Type
 
 ```typescript
-function setAIActionContext(actionContext: string): void;
+function setAIActContext(actionContext: string): void;
 ```
 
 - Parameters:
@@ -801,10 +801,14 @@ function setAIActionContext(actionContext: string): void;
 - Example:
 
 ```typescript
-await agent.setAIActionContext(
-  'Close the cookie consent dialog first if it exists',
-);
+await agent.setAIActContext('Close the cookie consent dialog first if it exists');
 ```
+
+:::note
+
+`agent.setAIActionContext()` is deprecated. Please use `agent.setAIActContext()` instead. The deprecated method remains as an alias for compatibility.
+
+:::
 
 ### `agent.evaluateJavaScript()`
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -774,7 +774,7 @@ console.log(result);
 
 :::
 
-### `agent.setAIActionContext()`
+### `agent.setAIActContext()`
 
 设置在调用 `agent.aiAct()` 或 `agent.ai()` 时，发送给 AI 模型的背景知识。这个设置会覆盖之前的设置。
 
@@ -783,7 +783,7 @@ console.log(result);
 - 类型
 
 ```typescript
-function setAIActionContext(actionContext: string): void;
+function setAIActContext(actionContext: string): void;
 ```
 
 - 参数：
@@ -793,8 +793,14 @@ function setAIActionContext(actionContext: string): void;
 - 示例：
 
 ```typescript
-await agent.setAIActionContext('如果 “使用cookie” 对话框存在，先关闭它');
+await agent.setAIActContext('如果 “使用cookie” 对话框存在，先关闭它');
 ```
+
+:::note
+
+`agent.setAIActionContext()` 已被弃用，请改用 `agent.setAIActContext()`。弃用的方法仍作为兼容别名保留。
+
+:::
 
 ### `agent.evaluateJavaScript()`
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -423,7 +423,14 @@ export class Agent<
     return await this.getUIContext('locate');
   }
 
+  /**
+   * @deprecated Use {@link setAIActContext} instead.
+   */
   async setAIActionContext(prompt: string) {
+    await this.setAIActContext(prompt);
+  }
+
+  async setAIActContext(prompt: string) {
     if (this.opts.aiActionContext) {
       console.warn(
         'aiActionContext is already set, and it is called again, will override the previous setting',


### PR DESCRIPTION
## Summary
- add setAIActContext method mirroring the previous AI action context setter and deprecate setAIActionContext
- document the new API and deprecation in both English and Chinese API references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a903ce6988324a856c8ebe7b44e5d)