### PR TITLE
fix(visualizer): add null check for playgroundSDK in getSDKId function

### DIFF
--- a/packages/visualizer/src/component/universal-playground/index.tsx
+++ b/packages/visualizer/src/component/universal-playground/index.tsx
@@ -26,6 +26,10 @@ const { Text } = Typography;
 
 // Function to get stable ID for SDK (adapter-driven)
 function getSDKId(sdk: any): string {
+  // Handle null/undefined SDK
+  if (!sdk) {
+    return 'playground-default';
+  }
   // Primary: Use adapter ID if available (works for both remote and local)
   if (sdk.id && typeof sdk.id === 'string') {
     return `agent-${sdk.id}`;


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of null (reading 'id')` error in the Chrome extension playground component.

## Root Cause

The `getSDKId` function at line 109 in `index.tsx` was being called with `playgroundSDK` which can be `null` (as defined in `UniversalPlaygroundProps`), but the function attempted to access `sdk.id` without checking for null first.

## Changes

- Added null/undefined check at the beginning of `getSDKId` function
- Returns `'playground-default'` when SDK is null/undefined
- Aligns with null-safe patterns used elsewhere in the component (lines 74, 161, 189)

## Test Plan

- [x] Ran `npm run lint` - all checks passed
- [x] Built `@midscene/visualizer` package successfully
- [x] Built Chrome extension successfully with the fix included

## Impact

This fix prevents the crash when the playground component is initialized with a null SDK, allowing the component to gracefully fall back to the default namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)