### PR TITLE
docs: add HTTP mode and programmatic startup to MCP documentation

### DIFF
--- a/apps/site/docs/en/mcp.mdx
+++ b/apps/site/docs/en/mcp.mdx
@@ -119,3 +119,198 @@ Add the Midscene Android MCP server (`@midscene/android-mcp`) in your MCP client
   }
 }
 ```
+
+## Alternative configuration methods
+
+### Using HTTP mode
+
+The above configurations use MCP's stdio mode (standard input/output), suitable for connecting through MCP clients (like Claude Desktop). If you need to access MCP services through HTTP interface, you can start them in HTTP mode.
+
+All MCP services support HTTP mode, using command-line arguments:
+
+**Web Bridge MCP HTTP service**
+
+```bash
+npx -y @midscene/web-bridge-mcp --mode=http --port=3000 --host=localhost
+```
+
+**iOS MCP HTTP service**
+
+```bash
+npx -y @midscene/ios-mcp --mode=http --port=3001 --host=localhost
+```
+
+**Android MCP HTTP service**
+
+```bash
+npx -y @midscene/android-mcp --mode=http --port=3002 --host=localhost
+```
+
+### Parameter description
+
+- `--mode=http`: Enable HTTP mode (default is `stdio`)
+- `--port=<port_number>`: Specify HTTP service port (default is `3000`)
+- `--host=<host_address>`: Specify HTTP service host address (default is `localhost`)
+
+HTTP mode still requires configuring model-related environment variables, which can be set before the startup command:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="your model service URL" \
+MIDSCENE_MODEL_API_KEY="your API Key" \
+MIDSCENE_MODEL_NAME="your model name" \
+MIDSCENE_MODEL_FAMILY="your model family" \
+npx -y @midscene/web-bridge-mcp --mode=http --port=3000
+```
+
+After starting in HTTP mode, the MCP service will be available at:
+
+```
+http://{host}:{port}/mcp
+```
+
+For example, with default configuration, the access URL is:
+
+```
+http://localhost:3000/mcp
+```
+
+### Notes
+
+1. **Port conflict**: Ensure the specified port is not already in use
+2. **Permission restrictions**: Using ports below 1024 requires administrator privileges
+3. **Session management**: HTTP mode supports multiple concurrent sessions, each managing state independently
+4. **Timeout settings**: Inactive sessions are automatically cleaned up after 30 minutes
+5. **Security**: Defaults to binding `localhost`; configure `--host` parameter carefully for external access
+
+### Using programmatic startup
+
+In addition to configuring through MCP clients or starting via command line, you can also start MCP services programmatically in your own Node.js applications. This is suitable for scenarios like:
+
+- **Service integration**: Embed MCP services into existing applications or microservices
+- **Custom startup logic**: Execute additional initialization or cleanup before/after service startup
+- **Dynamic configuration**: Dynamically choose startup mode based on runtime conditions
+- **Testing environment**: Start MCP services in test code for integration testing
+
+All MCP service packages export corresponding server classes that support both stdio and HTTP modes:
+
+**Web Bridge MCP**
+
+```typescript
+import { WebMCPServer } from '@midscene/web-bridge-mcp/server';
+
+// Create server instance
+const server = new WebMCPServer();
+
+// Option 1: Start stdio mode (for MCP client communication via standard I/O)
+await server.launch();
+
+// Option 2: Start HTTP mode (for HTTP client access)
+await server.launchHttp({
+  port: 3000,
+  host: 'localhost'
+});
+```
+
+**iOS MCP**
+
+```typescript
+import { IOSMCPServer } from '@midscene/ios-mcp/server';
+
+const server = new IOSMCPServer();
+
+// stdio mode
+await server.launch();
+
+// HTTP mode
+await server.launchHttp({
+  port: 3001,
+  host: 'localhost'
+});
+```
+
+**Android MCP**
+
+```typescript
+import { AndroidMCPServer } from '@midscene/android-mcp/server';
+
+const server = new AndroidMCPServer();
+
+// stdio mode
+await server.launch();
+
+// HTTP mode
+await server.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+```
+
+**Environment variable configuration**
+
+When starting programmatically, you need to set environment variables in your code:
+
+```typescript
+// Set environment variables before starting the service
+process.env.MIDSCENE_MODEL_BASE_URL = 'your model service URL';
+process.env.MIDSCENE_MODEL_API_KEY = 'your API Key';
+process.env.MIDSCENE_MODEL_NAME = 'your model name';
+process.env.MIDSCENE_MODEL_FAMILY = 'your model family';
+
+const server = new AndroidMCPServer();
+await server.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+```
+
+**Express application integration example**
+
+The following example shows how to integrate MCP services into an existing Express application:
+
+```typescript
+import express from 'express';
+import { AndroidMCPServer } from '@midscene/android-mcp/server';
+
+// Configure environment variables
+process.env.MIDSCENE_MODEL_BASE_URL = 'your model service URL';
+process.env.MIDSCENE_MODEL_API_KEY = 'your API Key';
+process.env.MIDSCENE_MODEL_NAME = 'your model name';
+process.env.MIDSCENE_MODEL_FAMILY = 'your model family';
+
+const app = express();
+
+// Business routes
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// Start business service
+app.listen(8080, () => {
+  console.log('Business service running at http://localhost:8080');
+});
+
+// Start MCP service (HTTP mode)
+const mcpServer = new AndroidMCPServer();
+await mcpServer.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+
+console.log('MCP service running at http://localhost:3002/mcp');
+```
+
+**API description**
+
+All MCP server classes inherit from `BaseMCPServer` and provide the following methods:
+
+**`launch(): Promise<void>`**
+
+Start the MCP service in stdio mode, suitable for communication with MCP clients through standard input/output.
+
+**`launchHttp(options: HttpLaunchOptions): Promise<void>`**
+
+Start the MCP service in HTTP mode.
+
+Parameters:
+- `options.port`: HTTP service port (required, range 1-65535)
+- `options.host`: HTTP service host address (optional, defaults to `localhost`)

--- a/apps/site/docs/zh/mcp.mdx
+++ b/apps/site/docs/zh/mcp.mdx
@@ -120,3 +120,198 @@ open report_file_name.html
 }
 ```
 
+## 其他配置方式
+
+### 使用 HTTP 模式
+
+以上配置使用的是 MCP 的 stdio 模式(标准输入输出),适合通过 MCP 客户端(如 Claude Desktop)连接。如果你需要通过 HTTP 接口访问 MCP 服务,可以使用 HTTP 模式启动。
+
+所有 MCP 服务都支持 HTTP 模式,使用命令行参数启动:
+
+**浏览器桥接模式 HTTP 服务**
+
+```bash
+npx -y @midscene/web-bridge-mcp --mode=http --port=3000 --host=localhost
+```
+
+**iOS MCP HTTP 服务**
+
+```bash
+npx -y @midscene/ios-mcp --mode=http --port=3001 --host=localhost
+```
+
+**Android MCP HTTP 服务**
+
+```bash
+npx -y @midscene/android-mcp --mode=http --port=3002 --host=localhost
+```
+
+### 参数说明
+
+- `--mode=http`: 启用 HTTP 模式(默认为 `stdio`)
+- `--port=<端口号>`: 指定 HTTP 服务端口(默认为 `3000`)
+- `--host=<主机地址>`: 指定 HTTP 服务主机地址(默认为 `localhost`)
+
+HTTP 模式下仍需要配置模型相关的环境变量,可以在启动命令前设置:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="你的模型服务地址" \
+MIDSCENE_MODEL_API_KEY="你的 API Key" \
+MIDSCENE_MODEL_NAME="你的模型名称" \
+MIDSCENE_MODEL_FAMILY="你的模型系列" \
+npx -y @midscene/web-bridge-mcp --mode=http --port=3000
+```
+
+HTTP 模式启动后,MCP 服务将在以下地址提供服务:
+
+```
+http://{host}:{port}/mcp
+```
+
+例如,使用默认配置时的访问地址为:
+
+```
+http://localhost:3000/mcp
+```
+
+### 注意事项
+
+1. **端口占用**:确保指定的端口未被其他服务占用
+2. **权限限制**:使用 1024 以下的端口需要管理员权限
+3. **会话管理**:HTTP 模式支持多个并发会话,每个会话独立管理状态
+4. **超时设置**:非活动会话将在 30 分钟后自动清理
+5. **安全性**:默认绑定 `localhost` ,如需外部访问请谨慎配置 `--host` 参数
+
+### 使用编程方式启动
+
+除了通过 MCP 客户端配置或命令行启动,你还可以在自己的 Node.js 应用中编程方式启动 MCP 服务。这适用于以下场景:
+
+- **服务集成**: 将 MCP 服务嵌入到现有的应用或微服务中
+- **自定义启动逻辑**: 在服务启动前后执行额外的初始化或清理
+- **动态配置**: 根据运行时条件动态选择启动模式
+- **测试环境**: 在测试代码中启动 MCP 服务进行集成测试
+
+所有 MCP 服务包都导出了对应的服务器类,支持 stdio 和 HTTP 两种模式:
+
+**Web Bridge MCP**
+
+```typescript
+import { WebMCPServer } from '@midscene/web-bridge-mcp/server';
+
+// 创建服务器实例
+const server = new WebMCPServer();
+
+// 方式一:启动 stdio 模式(用于 MCP 客户端通过标准输入输出通信)
+await server.launch();
+
+// 方式二:启动 HTTP 模式(用于 HTTP 客户端访问)
+await server.launchHttp({
+  port: 3000,
+  host: 'localhost'
+});
+```
+
+**iOS MCP**
+
+```typescript
+import { IOSMCPServer } from '@midscene/ios-mcp/server';
+
+const server = new IOSMCPServer();
+
+// stdio 模式
+await server.launch();
+
+// HTTP 模式
+await server.launchHttp({
+  port: 3001,
+  host: 'localhost'
+});
+```
+
+**Android MCP**
+
+```typescript
+import { AndroidMCPServer } from '@midscene/android-mcp/server';
+
+const server = new AndroidMCPServer();
+
+// stdio 模式
+await server.launch();
+
+// HTTP 模式
+await server.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+```
+
+**环境变量配置**
+
+编程方式启动时,需要在代码中设置环境变量:
+
+```typescript
+// 在启动服务前设置环境变量
+process.env.MIDSCENE_MODEL_BASE_URL = '你的模型服务地址';
+process.env.MIDSCENE_MODEL_API_KEY = '你的 API Key';
+process.env.MIDSCENE_MODEL_NAME = '你的模型名称';
+process.env.MIDSCENE_MODEL_FAMILY = '你的模型系列';
+
+const server = new AndroidMCPServer();
+await server.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+```
+
+**集成到 Express 应用示例**
+
+以下示例展示如何将 MCP 服务集成到现有的 Express 应用中:
+
+```typescript
+import express from 'express';
+import { AndroidMCPServer } from '@midscene/android-mcp/server';
+
+// 配置环境变量
+process.env.MIDSCENE_MODEL_BASE_URL = '你的模型服务地址';
+process.env.MIDSCENE_MODEL_API_KEY = '你的 API Key';
+process.env.MIDSCENE_MODEL_NAME = '你的模型名称';
+process.env.MIDSCENE_MODEL_FAMILY = '你的模型系列';
+
+const app = express();
+
+// 业务路由
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// 启动业务服务
+app.listen(8080, () => {
+  console.log('业务服务运行在 http://localhost:8080');
+});
+
+// 启动 MCP 服务(HTTP 模式)
+const mcpServer = new AndroidMCPServer();
+await mcpServer.launchHttp({
+  port: 3002,
+  host: 'localhost'
+});
+
+console.log('MCP 服务运行在 http://localhost:3002/mcp');
+```
+
+**API 说明**
+
+所有 MCP 服务器类都继承自 `BaseMCPServer`,提供以下方法:
+
+**`launch(): Promise<void>`**
+
+启动 stdio 模式的 MCP 服务,适用于通过标准输入输出与 MCP 客户端通信。
+
+**`launchHttp(options: HttpLaunchOptions): Promise<void>`**
+
+启动 HTTP 模式的 MCP 服务。
+
+参数:
+- `options.port`: HTTP 服务端口(必需,范围 1-65535)
+- `options.host`: HTTP 服务主机地址(可选,默认 `localhost`)
+


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for alternative MCP server configuration methods, enhancing the flexibility of MCP service deployment.

### Changes

- **HTTP Mode Configuration**: Added documentation for running MCP servers in HTTP mode with command-line parameters (`--mode=http`, `--port`, `--host`)
- **Programmatic Startup**: Added TypeScript examples showing how to programmatically launch MCP servers using `WebMCPServer`, `IOSMCPServer`, and `AndroidMCPServer` classes
- **Environment Variable Configuration**: Documented how to configure environment variables in both HTTP and programmatic modes
- **Integration Examples**: Added complete Express.js integration example
- **API Reference**: Documented `launch()` and `launchHttp()` methods with parameter details

### Documentation Updated

- `apps/site/docs/en/mcp.mdx` - English documentation
- `apps/site/docs/zh/mcp.mdx` - Chinese documentation

### Use Cases Covered

1. **Service Integration**: Embedding MCP services into existing Node.js applications
2. **Custom Startup Logic**: Executing additional initialization before/after service startup
3. **Dynamic Configuration**: Choosing startup mode based on runtime conditions
4. **Testing Environment**: Starting MCP services in test code for integration testing

All documentation follows the same structure in both languages and maintains consistency with existing content.