### PR TITLE
chore(workflow): integrate rsbuild-plugin-workspace-dev and improve watch mode

### DIFF
--- a/apps/android-playground/rsbuild.config.ts
+++ b/apps/android-playground/rsbuild.config.ts
@@ -9,6 +9,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginWorkspaceDev } from 'rsbuild-plugin-workspace-dev';
 import { version as playgroundVersion } from '../../packages/playground/package.json';
 
 export default defineConfig({
@@ -69,5 +70,12 @@ export default defineConfig({
       path.join(__dirname, 'src', 'favicon.ico'),
     ),
     pluginTypeCheck(),
+    pluginWorkspaceDev({
+      projects: {
+        '@midscene/report': {
+          skip: true,
+        },
+      },
+    }),
   ],
 });

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -46,6 +46,7 @@
     "concurrently": "^8.2.0",
     "less": "^4.2.0",
     "openai": "6.3.0",
+    "rsbuild-plugin-workspace-dev": "0.0.1",
     "tailwindcss": "4.1.11",
     "typescript": "^5.8.3",
     "web-ext": "9.0.0"

--- a/apps/chrome-extension/rsbuild.config.ts
+++ b/apps/chrome-extension/rsbuild.config.ts
@@ -6,6 +6,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginWorkspaceDev } from 'rsbuild-plugin-workspace-dev';
 import { version } from '../../packages/visualizer/package.json';
 
 export default defineConfig({
@@ -103,5 +104,12 @@ export default defineConfig({
     pluginLess(),
     pluginSvgr(),
     pluginTypeCheck(),
+    pluginWorkspaceDev({
+      projects: {
+        '@midscene/report': {
+          skip: true,
+        },
+      },
+    }),
   ],
 });

--- a/apps/playground/rsbuild.config.ts
+++ b/apps/playground/rsbuild.config.ts
@@ -9,6 +9,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginWorkspaceDev } from 'rsbuild-plugin-workspace-dev';
 import { version as playgroundVersion } from '../../packages/playground/package.json';
 
 export default defineConfig({
@@ -35,6 +36,13 @@ export default defineConfig({
       path.join(__dirname, 'src', 'favicon.ico'),
     ),
     pluginTypeCheck(),
+    pluginWorkspaceDev({
+      projects: {
+        '@midscene/report': {
+          skip: true,
+        },
+      },
+    }),
   ],
   resolve: {
     alias: {

--- a/apps/recorder-form/package.json
+++ b/apps/recorder-form/package.json
@@ -9,19 +9,21 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
+    "@midscene/recorder": "workspace:*",
     "antd": "^5.21.6",
     "dayjs": "^1.11.11",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "@midscene/recorder": "workspace:*"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@rsbuild/plugin-node-polyfill": "1.4.2",
-    "@rsbuild/plugin-type-check": "1.2.4",
+    "@midscene/shared": "workspace:*",
     "@rsbuild/core": "^1.5.17",
+    "@rsbuild/plugin-node-polyfill": "1.4.2",
     "@rsbuild/plugin-react": "^1.4.1",
+    "@rsbuild/plugin-type-check": "1.2.4",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "rsbuild-plugin-workspace-dev": "0.0.1",
     "typescript": "^5.8.3"
   }
 }

--- a/apps/recorder-form/rsbuild.config.ts
+++ b/apps/recorder-form/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginWorkspaceDev } from 'rsbuild-plugin-workspace-dev';
 
 export default defineConfig({
   tools: {
@@ -13,5 +14,16 @@ export default defineConfig({
   server: {
     port: 3001,
   },
-  plugins: [pluginReact(), pluginNodePolyfill(), pluginTypeCheck()],
+  plugins: [
+    pluginReact(),
+    pluginNodePolyfill(),
+    pluginTypeCheck(),
+    pluginWorkspaceDev({
+      projects: {
+        '@midscene/report': {
+          skip: true,
+        },
+      },
+    }),
+  ],
 });

--- a/apps/report/package.json
+++ b/apps/report/package.json
@@ -17,7 +17,6 @@
     "@midscene/shared": "workspace:*",
     "@midscene/visualizer": "workspace:*",
     "@midscene/web": "workspace:*",
-
     "@rsbuild/core": "^1.5.17",
     "@rsbuild/plugin-less": "^1.5.0",
     "@rsbuild/plugin-react": "^1.4.1",

--- a/apps/report/rsbuild.config.ts
+++ b/apps/report/rsbuild.config.ts
@@ -8,6 +8,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginWorkspaceDev } from 'rsbuild-plugin-workspace-dev';
 
 // Read all JSON files from test-data directory
 const testDataDir = path.join(__dirname, 'test-data');
@@ -28,7 +29,9 @@ const allTestData = jsonFiles.map((file) => {
 // ERROR: This repository uses pkg in bundler mode. It is necessary to declare @midscene/report in the dependency; otherwise, it may cause packaging order issues and thus lead to the failure of report injection
 const copyReportTemplate = () => ({
   name: 'copy-report-template',
-  setup(api) {
+  setup(api: {
+    onAfterBuild: (arg0: ({ compiler }: { compiler: any }) => void) => void;
+  }) {
     api.onAfterBuild(({ compiler }) => {
       const magicString = 'REPLACE_ME_WITH_REPORT_HTML';
       const replacedMark = '/*REPORT_HTML_REPLACED*/';
@@ -161,5 +164,12 @@ export default defineConfig({
     pluginSvgr(),
     copyReportTemplate(),
     pluginTypeCheck(),
+    pluginWorkspaceDev({
+      projects: {
+        '@midscene/report': {
+          skip: true,
+        },
+      },
+    }),
   ],
 });

--- a/packages/android-mcp/package.json
+++ b/packages/android-mcp/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "npm run build:watch",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "mcp-playground": "npx @modelcontextprotocol/inspector node ./dist/index.js",
     "test": "vitest run",
     "inspect": "node scripts/inspect.mjs"

--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -14,7 +14,7 @@
     "dev": "npm run build:watch",
     "dev:server": "npm run build && ./bin/playground",
     "build": "rslib build",
-    "build:watch": "rslib build --watch"
+    "build:watch": "rslib build --watch --no-clean"
   },
   "dependencies": {
     "@midscene/android": "workspace:*",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
     "test": "vitest --run",
     "test:u": "vitest --run -u",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "test": "vitest --run",
     "test:ai": "AITEST=true vitest --run",
     "test:ai:temp": "AITEST=true BRIDGE_MODE=true vitest tests/bridge.test.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "USE_DEV_REPORT=1 rslib build --watch",
+    "build:watch": "USE_DEV_REPORT=1 rslib build --watch --no-clean",
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AITEST=true npm run test",

--- a/packages/ios-mcp/package.json
+++ b/packages/ios-mcp/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "npm run build:watch",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "mcp-playground": "npx @modelcontextprotocol/inspector node ./dist/index.js",
     "test": "vitest run",
     "inspect": "node scripts/inspect.mjs"

--- a/packages/ios-playground/package.json
+++ b/packages/ios-playground/package.json
@@ -14,7 +14,7 @@
     "dev": "npm run build:watch",
     "dev:server": "npm run build && ./bin/ios-playground",
     "build": "rslib build",
-    "build:watch": "rslib build --watch"
+    "build:watch": "rslib build --watch --no-clean"
   },
   "dependencies": {
     "@midscene/ios": "workspace:*"

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
     "test": "vitest --run",
     "test:u": "vitest --run -u",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "npm run build:watch",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "mcp-playground": "npx @modelcontextprotocol/inspector node ./dist/index.js",
     "inspect": "node scripts/inspect.mjs"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -18,7 +18,7 @@
   "files": ["dist", "static"],
   "scripts": {
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "dev": "npm run build:watch",
     "test": "vitest --run",
     "test:watch": "vitest",

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "npm run build:watch",
-    "build:watch": "rslib build --watch"
+    "build:watch": "rslib build --watch --no-clean"
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.4.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -79,7 +79,7 @@
     "build": "npm run build:script && npm run build:pkg",
     "build:pkg": "rslib build",
     "build:script": "rslib build -c ./rslib.inspect.config.ts",
-    "build:watch": "npm run build:script && rslib build --watch",
+    "build:watch": "npm run build:script && rslib build --watch --no-clean",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest --run",
     "test:u": "vitest --run -u"

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "serve": "http-server ./dist/ -p 3000"
   },
   "peerDependencies": {

--- a/packages/web-bridge-mcp/package.json
+++ b/packages/web-bridge-mcp/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "npm run build:watch",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "mcp-playground": "npx @modelcontextprotocol/inspector node ./dist/index.js",
     "test": "vitest run",
     "inspect": "node scripts/inspect.mjs"

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -90,7 +90,7 @@
     "dev": "npm run build:watch",
     "dev:server": "npm run build && ./bin/midscene-playground",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
     "test": "vitest --run",
     "test:u": "vitest --run -u",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "npm run build:watch",
     "build": "rslib build",
-    "build:watch": "rslib build --watch",
+    "build:watch": "rslib build --watch --no-clean",
     "test": "vitest",
     "lint": "biome check .",
     "lint:fix": "biome check . --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       openai:
         specifier: 6.3.0
         version: 6.3.0(ws@8.18.3)(zod@3.25.76)
+      rsbuild-plugin-workspace-dev:
+        specifier: 0.0.1
+        version: 0.0.1(@rsbuild/core@1.6.9)
       tailwindcss:
         specifier: 4.1.11
         version: 4.1.11
@@ -354,6 +357,9 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@midscene/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@rsbuild/core':
         specifier: ^1.5.17
         version: 1.6.9
@@ -372,6 +378,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.7(@types/react@18.3.23)
+      rsbuild-plugin-workspace-dev:
+        specifier: 0.0.1
+        version: 0.0.1(@rsbuild/core@1.6.9)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2822,8 +2831,20 @@ packages:
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
+  '@manypkg/find-root@3.1.0':
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
+
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@manypkg/get-packages@3.1.0':
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/tools@2.1.0':
+    resolution: {integrity: sha512-0FOIepYR4ugPYaHwK7hDeHDkfPOBVvayt9QpvRbi2LT/h2b0GaE/gM9Gag7fsnyYyNaTZ2IGyOuVg07IYepvYQ==}
+    engines: {node: '>=20.0.0'}
 
   '@mdn/browser-compat-data@7.1.7':
     resolution: {integrity: sha512-bpWZ7hidvjrwNWcMngZ8nTMTxn8WhnQntsGqEYgPr1vjy66kfwfDVizwXg6PvsgoANZ7nhuRBmvzjpCMk4ITDw==}
@@ -6591,6 +6612,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -9261,6 +9285,14 @@ packages:
       '@typescript/native-preview':
         optional: true
       typescript:
+        optional: true
+
+  rsbuild-plugin-workspace-dev@0.0.1:
+    resolution: {integrity: sha512-anYvqSf5KMfkGPgD8wvC1+hiZQ94MUEqJdRogdrTpUNfrf/tP71PnrZ0ARdVsJI9cMGzeTpFw3TzmI0DCXM+4w==}
+    peerDependencies:
+      '@rsbuild/core': 1.x
+    peerDependenciesMeta:
+      '@rsbuild/core':
         optional: true
 
   rslog@1.2.3:
@@ -12553,6 +12585,10 @@ snapshots:
       find-up: 4.1.0
       fs-extra: 8.1.0
 
+  '@manypkg/find-root@3.1.0':
+    dependencies:
+      '@manypkg/tools': 2.1.0
+
   '@manypkg/get-packages@1.1.3':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -12561,6 +12597,17 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@manypkg/get-packages@3.1.0':
+    dependencies:
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.0
+
+  '@manypkg/tools@2.1.0':
+    dependencies:
+      jju: 1.4.0
+      js-yaml: 4.1.0
+      tinyglobby: 0.2.15
 
   '@mdn/browser-compat-data@7.1.7': {}
 
@@ -17431,6 +17478,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.17.21
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -18135,8 +18186,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jju@1.4.0:
-    optional: true
+  jju@1.4.0: {}
 
   jose@5.9.6: {}
 
@@ -20666,6 +20716,17 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.10(@types/node@24.10.2)
       typescript: 5.8.3
+
+  rsbuild-plugin-workspace-dev@0.0.1(@rsbuild/core@1.6.9):
+    dependencies:
+      '@manypkg/get-packages': 3.1.0
+      chalk: 5.6.2
+      fast-glob: 3.3.3
+      graphlib: 2.1.8
+      json5: 2.2.3
+      yaml: 2.8.2
+    optionalDependencies:
+      '@rsbuild/core': 1.6.9
 
   rslog@1.2.3: {}
 


### PR DESCRIPTION
- Add rsbuild-plugin-workspace-dev plugin to all Rsbuild configurations
- Configure plugin to skip @midscene/report in workspace dev mode
- Add --no-clean flag to all build:watch scripts for better incremental builds
- Update dependencies in affected packages