### PR TITLE
fix(report): properly stringify array output in detail view

### DIFF
--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -865,7 +865,11 @@ const DetailSide = (): JSX.Element => {
             onMouseEnter={noop}
             onMouseLeave={noop}
             title="output"
-            content={<pre>{String(data)}</pre>}
+            content={
+              <pre className="description-content">
+                {JSON.stringify(data, undefined, 2)}
+              </pre>
+            }
           />,
         );
       }


### PR DESCRIPTION
## Summary
Fixed an issue where array outputs in the report detail view were displaying as `[object Object], [object Object], ...` instead of properly formatted JSON.

## Problem
When Query/Insight tasks return array results (e.g., extracting a list of articles), the output was being converted to a string using `String(data)`, which caused JavaScript to call the default `toString()` method on objects, resulting in the unhelpful `[object Object]` representation.

## Solution
Replaced `String(data)` with `JSON.stringify(data, undefined, 2)` to properly serialize arrays and objects into formatted JSON with 2-space indentation.

## Changes
- **File**: `apps/report/src/components/detail-side/index.tsx`
- **Line**: 868
- **Change**: Updated output rendering to use `JSON.stringify` instead of `String`

## Before
```tsx
content={<pre>{String(data)}</pre>}
```

## After
```tsx
content={
  <pre className="description-content">
    {JSON.stringify(data, undefined, 2)}
  </pre>
}
```

## Testing
- ✅ Lint check passed
- ✅ Follows the same pattern used for Assert task output (line 640)
- ✅ Properly displays array outputs with formatted JSON

## Impact
This fix ensures that Query/Insight task outputs that return arrays (like data extraction results) are properly displayed in the report viewer instead of showing `[object Object]` strings.