### PR TITLE
feat(visualizer): display both output and report for data extraction APIs

### DIFF
--- a/packages/playground/src/adapters/local-execution.ts
+++ b/packages/playground/src/adapters/local-execution.ts
@@ -189,6 +189,7 @@ export class LocalExecutionAdapter extends BasePlaygroundAdapter {
           }
         }
 
+        // Always generate reportHTML for all APIs (including noReplayAPIs)
         if (this.agent.reportHTMLString) {
           response.reportHTML = this.agent.reportHTMLString() || null;
         }

--- a/packages/visualizer/src/component/playground-result/index.tsx
+++ b/packages/visualizer/src/component/playground-result/index.tsx
@@ -1,4 +1,5 @@
 import { LoadingOutlined } from '@ant-design/icons';
+import { noReplayAPIs } from '@midscene/playground';
 import { Spin } from 'antd';
 import type React from 'react';
 import type { PlaygroundResult as PlaygroundResultType } from '../../types';
@@ -21,6 +22,7 @@ interface PlaygroundResultProps {
   notReadyMessage?: React.ReactNode | string;
   fitMode?: 'width' | 'height';
   autoZoom?: boolean;
+  actionType?: string; // The action type that was executed
 }
 
 export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
@@ -35,6 +37,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
   notReadyMessage,
   fitMode,
   autoZoom,
+  actionType,
 }) => {
   let resultWrapperClassName = 'result-wrapper';
   if (verticalMode) {
@@ -45,6 +48,10 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
   }
 
   let resultDataToShow: React.ReactNode = emptyResultTip;
+
+  // Determine if this is a data extraction API that should prioritize result output
+  const shouldPrioritizeResult =
+    actionType && noReplayAPIs.includes(actionType);
 
   if (!serverValid && serviceMode === 'Server') {
     resultDataToShow = serverLaunchTip(notReadyMessage);
@@ -57,8 +64,57 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
         </div>
       </div>
     );
+  } else if (result?.error) {
+    // Show errors first
+    resultDataToShow = <pre>{result?.error}</pre>;
+  } else if (
+    shouldPrioritizeResult &&
+    result?.result !== undefined &&
+    replayScriptsInfo
+  ) {
+    // For data extraction APIs: show both result output and replay/report
+    const resultOutput =
+      typeof result?.result === 'string' ? (
+        <pre>{result?.result}</pre>
+      ) : (
+        <pre>{JSON.stringify(result?.result, null, 2)}</pre>
+      );
+
+    const reportContent =
+      (serviceMode === 'In-Browser-Extension' || serviceMode === 'Server') &&
+      result?.reportHTML
+        ? result?.reportHTML
+        : null;
+
+    resultDataToShow = (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          height: '100%',
+        }}
+      >
+        <div style={{ flex: '0 0 auto' }}>
+          <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Output:</div>
+          {resultOutput}
+        </div>
+        <div style={{ flex: '1 1 auto', minHeight: 0 }}>
+          <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Report:</div>
+          <Player
+            key={replayCounter}
+            replayScripts={replayScriptsInfo.scripts}
+            imageWidth={replayScriptsInfo.width}
+            imageHeight={replayScriptsInfo.height}
+            reportFileContent={reportContent}
+            fitMode={fitMode}
+            autoZoom={autoZoom}
+          />
+        </div>
+      </div>
+    );
   } else if (replayScriptsInfo) {
-    // Has replay scripts - show Player with replay and report
+    // Has replay scripts (non-noReplayAPI) - show Player with replay and report
     const reportContent =
       (serviceMode === 'In-Browser-Extension' || serviceMode === 'Server') &&
       result?.reportHTML
@@ -77,9 +133,51 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
       />
     );
   } else if (
-    result?.reportHTML &&
-    (serviceMode === 'In-Browser-Extension' || serviceMode === 'Server')
+    shouldPrioritizeResult &&
+    result?.result !== undefined &&
+    result?.reportHTML
   ) {
+    // For data extraction APIs: show both result output and reportHTML
+    const resultOutput =
+      typeof result?.result === 'string' ? (
+        <pre>{result?.result}</pre>
+      ) : (
+        <pre>{JSON.stringify(result?.result, null, 2)}</pre>
+      );
+
+    resultDataToShow = (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          height: '100%',
+        }}
+      >
+        <div style={{ flex: '0 0 auto' }}>
+          <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Output:</div>
+          {resultOutput}
+        </div>
+        <div style={{ flex: '1 1 auto', minHeight: 0 }}>
+          <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Report:</div>
+          <Player
+            key={replayCounter}
+            reportFileContent={result.reportHTML}
+            fitMode={fitMode}
+            autoZoom={autoZoom}
+          />
+        </div>
+      </div>
+    );
+  } else if (shouldPrioritizeResult && result?.result !== undefined) {
+    // For data extraction APIs without reportHTML: show result output only
+    resultDataToShow =
+      typeof result?.result === 'string' ? (
+        <pre>{result?.result}</pre>
+      ) : (
+        <pre>{JSON.stringify(result?.result, null, 2)}</pre>
+      );
+  } else if (result?.reportHTML) {
     // No replay scripts but has report - show Player with report only
     resultDataToShow = (
       <Player
@@ -89,9 +187,8 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
         autoZoom={autoZoom}
       />
     );
-  } else if (result?.error) {
-    resultDataToShow = <pre>{result?.error}</pre>;
   } else if (result?.result !== undefined) {
+    // Fallback: show result output
     resultDataToShow =
       typeof result?.result === 'string' ? (
         <pre>{result?.result}</pre>

--- a/packages/visualizer/src/component/universal-playground/index.tsx
+++ b/packages/visualizer/src/component/universal-playground/index.tsx
@@ -338,6 +338,7 @@ export function UniversalPlayground({
                               }
                               verticalMode={item.verticalMode || false}
                               fitMode="width"
+                              actionType={item.actionType}
                             />
                           ) : (
                             <>

--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -217,8 +217,9 @@ export function usePlaygroundExecution(
       let replayInfo = null;
       let counter = replayCounter;
 
-      // Generate replay info for interaction APIs
-      if (result?.dump && !noReplayAPIs.includes(actionType)) {
+      // Generate replay info for all APIs (including noReplayAPIs)
+      // This allows noReplayAPIs to display both output and report
+      if (result?.dump) {
         if (result.dump.tasks && Array.isArray(result.dump.tasks)) {
           const groupedDump = wrapExecutionDumpForReplay(result.dump);
           const info = allScriptsFromDump(groupedDump);
@@ -254,6 +255,7 @@ export function usePlaygroundExecution(
         replayCounter: counter,
         loadingProgressText: '',
         verticalMode: verticalMode,
+        actionType: actionType, // Save actionType for display logic
       };
 
       setInfoList((prev) => [...prev, resultItem]);

--- a/packages/visualizer/src/types.ts
+++ b/packages/visualizer/src/types.ts
@@ -349,6 +349,7 @@ export interface InfoListItem {
   replayCounter?: number;
   loadingProgressText?: string;
   verticalMode?: boolean;
+  actionType?: string; // Track which action type was executed
 }
 
 // main component config interface


### PR DESCRIPTION
## Summary

This PR enhances the playground visualization for data extraction APIs (noReplayAPIs) by displaying both the output result and the execution report simultaneously.

### Changes

**Data extraction APIs affected:**
- `aiQuery`
- `aiBoolean`
- `aiNumber`
- `aiString`
- `aiAsk`
- `aiAssert`
- `aiWaitFor`

### What's New

For the above APIs, the playground now shows:

1. **Output** (top section): The direct result of the query/extraction
2. **Report** (bottom section): Full execution report with screenshots and step details

This provides users with both the immediate result and the complete execution context for better debugging and understanding.

### Technical Details

- **Generate replay scripts for all APIs**: Removed the filter that prevented `noReplayAPIs` from generating `replayScriptsInfo`
- **Track action type**: Added `actionType` field to `InfoListItem` to identify which API was executed
- **Adjusted display logic**: Modified `PlaygroundResultView` to show both output and report when the action type is a data extraction API
- **Component chain updates**: Pass `actionType` through the visualization components

### Files Modified

- `packages/visualizer/src/types.ts`: Added `actionType` field to `InfoListItem`
- `packages/visualizer/src/hooks/usePlaygroundExecution.ts`: Generate replay info for all APIs
- `packages/visualizer/src/component/playground-result/index.tsx`: Adjust display logic for dual view
- `packages/visualizer/src/component/universal-playground/index.tsx`: Pass actionType to result view
- `packages/playground/src/adapters/local-execution.ts`: Add clarifying comment

### Testing

Manually tested with:
- `aiQuery`: Shows extracted data + report ✅
- `aiAct`: Shows report only (as before) ✅
- Other `noReplayAPIs`: Show output + report ✅