### PR TITLE
Expose _reportHTMLContent in core exports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,3 +46,6 @@ export type {
 } from './yaml';
 
 export { Agent, type AgentOpt, createAgent } from './agent';
+
+// Internal utilities
+export { reportHTMLContent as _reportHTMLContent } from './utils';


### PR DESCRIPTION
## Summary
- add _reportHTMLContent named export from the core package entrypoint for HTML report generation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69425d43eb448324b38ab3ea910c3b7a)