### PR TITLE
fix(core): guard test info upload when server url missing

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -346,6 +346,8 @@ export function uploadTestInfoToServer({
   testUrl,
   serverUrl,
 }: { testUrl: string; serverUrl?: string }) {
+  if (!serverUrl) return;
+
   let repoUrl = '';
   let userEmail = '';
 
@@ -361,10 +363,7 @@ export function uploadTestInfoToServer({
   // 2. Either:
   //    - We have a repo URL that's different from last reported one (to avoid duplicate reports)
   //    - OR we don't have a repo URL but have a test URL (for non-git environments)
-  if (
-    serverUrl &&
-    ((repoUrl && repoUrl !== lastReportedRepoUrl) || (!repoUrl && testUrl))
-  ) {
+  if (repoUrl ? repoUrl !== lastReportedRepoUrl : !!testUrl) {
     debugLog('Uploading test info to server', {
       serverUrl,
       repoUrl,


### PR DESCRIPTION
## Summary
- avoid running git commands when no test info server URL is provided
- keep upload conditionals working based on last reported repository URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427c4c43c48324961e349650182840)