### PR TITLE
chore(workflow): update version to 0.30.10 and release configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - "v1"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release Version(minor,patch,preminor,prepatch)'
+        description: 'Release Version(major,minor,patch,preminor,prepatch)'
         required: true
         default: 'prepatch'
       branch:

--- a/apps/recorder-form/package.json
+++ b/apps/recorder-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recorder-form",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midscene",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.30.10",
   "scripts": {
     "dev": "nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose --parallel=6",
     "build": "nx run-many --target=build --exclude=doc --verbose",

--- a/packages/android-mcp/package.json
+++ b/packages/android-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android-mcp",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Midscene MCP Server for Android automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android-playground",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Android playground for Midscene",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Android automation library for Midscene",
   "keywords": [
     "Android UI automation",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midscene/cli",
   "description": "An AI-powered automation SDK can control the page, perform assertions, and extract data in JSON format using natural language. See https://midscenejs.com/ for details.",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midscene/core",
   "description": "Automate browser actions, extract data, and perform assertions using AI. It offers JavaScript SDK, Chrome extension, and support for scripting in YAML. See https://midscenejs.com/ for details.",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -39,5 +39,5 @@
     "registry": "https://registry.npmjs.org"
   },
   "license": "MIT",
-  "version": "0.30.6"
+  "version": "0.30.10"
 }

--- a/packages/ios-mcp/package.json
+++ b/packages/ios-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios-mcp",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Midscene MCP Server for iOS automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/ios-playground/package.json
+++ b/packages/ios-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios-playground",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "iOS playground for Midscene",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "iOS automation library for Midscene",
   "keywords": [
     "iOS UI automation",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/mcp",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Deprecated - Use @midscene/web-bridge-mcp, @midscene/android-mcp, or @midscene/ios-mcp",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/playground",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Midscene playground utilities for web integration",
   "author": "midscene team",
   "license": "MIT",

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/recorder",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/shared",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "types": "./dist/types/index.d.ts",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/visualizer",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "types": "./dist/types/index.d.ts",

--- a/packages/web-bridge-mcp/package.json
+++ b/packages/web-bridge-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/web-bridge-mcp",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "Midscene MCP Server for Web automation (Bridge mode)",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -8,7 +8,7 @@
     "Browser use",
     "Android use"
   ],
-  "version": "1.0.0",
+  "version": "0.30.10",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/webdriver",
-  "version": "1.0.0",
+  "version": "0.30.10",
   "description": "WebDriver protocol implementation for Midscene automation",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.mjs",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -222,11 +222,11 @@ async function publish(version) {
       releaseTag = 'rc';
     }
 
-    // Validate version: do not allow publishing 1.x stable releases (latest tag)
-    // Only allow beta versions (prepatch) for 1.x
+    // Validate version: do not allow publishing 2.x stable releases (latest tag)
+    // Only allow beta versions (prepatch) for 2.x
     const majorVersion = semver.major(version);
-    if (majorVersion === 1 && releaseTag === 'latest') {
-      const errorMsg = `Publishing 1.x stable releases (latest tag) is not allowed. Current version: ${version}. Only beta versions (prepatch) are allowed for 1.x.`;
+    if (majorVersion === 2 && releaseTag === 'latest') {
+      const errorMsg = `Publishing 2.x stable releases (latest tag) is not allowed. Current version: ${version}. Only beta versions (prepatch) are allowed for 2.x.`;
       console.error(chalk.red(errorMsg));
       throw new Error(errorMsg);
     }


### PR DESCRIPTION
## Summary
- Update root package.json version from 1.0.0 to 0.30.10
- Synchronize all package versions to maintain consistency  
- Modify release.js validation to restrict 2.x stable releases instead of 1.x
- Update CI/CD workflow configurations

## Test Plan
- [ ] Verify linting passes: `pnpm run lint`
- [ ] Ensure build completes successfully: `pnpm run build`
- [ ] Check package version consistency across the monorepo
- [ ] Review release script validation logic changes