### PR TITLE
Export AiActOptions type for agent integration

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -136,7 +136,7 @@ const normalizeScrollType = (
 const defaultReplanningCycleLimit = 20;
 const defaultVlmUiTarsReplanningCycleLimit = 40;
 
-type AiActOptions = {
+export type AiActOptions = {
   cacheable?: boolean;
   planningStrategy?: 'fast' | 'standard' | 'max';
 };

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -20,3 +20,4 @@ export { TaskExecutor } from './tasks';
 export { getCurrentExecutionFile } from './utils';
 
 export type { AgentOpt } from '../types';
+export type { AiActOptions } from './agent';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,4 +45,4 @@ export type {
   DetailedLocateParam,
 } from './yaml';
 
-export { Agent, type AgentOpt, createAgent } from './agent';
+export { Agent, type AgentOpt, type AiActOptions, createAgent } from './agent';


### PR DESCRIPTION
## Summary
- export the AiActOptions type from the agent module
- re-export AiActOptions through agent and core package entry points for consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943a26500dc8324bfb414ec6832e7ac)