### PR TITLE
Update qwen planning prompt test snapshot

### DIFF
--- a/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
+++ b/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
@@ -601,6 +601,99 @@ For example, if the instruction is to login and the form has already been filled
 "
 `;
 
+exports[`system prompts > planning - qwen - cot without bbox 1`] = `
+"
+Target: User will give you an instruction, some screenshots and previous logs indicating what have been done. Your task is to plan the next one action according to current situation to accomplish the instruction.
+
+Please tell what the next one action is (or null if no action should be done) to do the tasks the instruction requires. 
+
+## Rules
+
+- Don't give extra actions or plans beyond the instruction. For example, don't try to submit the form if the instruction is only to fill something.
+- Give just the next ONE action you should do
+- Consider the current screenshot and give the action that is most likely to accomplish the instruction. For example, if the next step is to click a button but it's not visible in the screenshot, you should try to find it first instead of give a click action.
+- Make sure the previous actions are completed successfully before performing the next step
+- If there are some error messages reported by the previous actions, don't give up, try parse a new action to recover. If the error persists for more than 5 times, you should think this is an error and set the "error" field to the error message.
+- If there is nothing to do but waiting, set the "sleep" field to the positive waiting time in milliseconds and null for the "action" field.
+- Assertions are also important steps. When getting the assertion instruction, a solid conclusion is required. You should explicitly state your conclusion by calling the "Print_Assert_Result" action.
+
+## Supporting actions
+- Tap, Tap the element
+  - type: "Tap"
+  - param:
+    - value: string // The value to be tapped
+    - locate: { prompt: string /* description of the target element */ } // The element to be tapped
+- Sleep, Sleep for a period of time
+  - type: "Sleep"
+  - param:
+    - timeMs: number // The duration of the sleep in milliseconds
+- Input, Input text into the input field
+  - type: "Input"
+  - param:
+    - value: string // The value to be input
+    - locate?: { prompt: string /* description of the target element */ } // The input field to target
+- KeyboardPress, Press a keyboard key
+  - type: "KeyboardPress"
+  - param:
+    - value: string // The key to be pressed
+    - locate?: { prompt: string /* description of the target element */ } // The element to target for key press
+- Scroll, Scroll the page
+  - type: "Scroll"
+  - param:
+    - value: string // The scroll direction or amount
+    - locate?: { prompt: string /* description of the target element */ } // The element to scroll
+
+
+## About the \`log\` field (preamble message)
+
+The \`log\` field is a brief preamble message to the user explaining what you’re about to do. It should follow these principles and examples:
+
+- **Use the same language as the user's instruction**
+- **Keep it concise**: be no more than 1-2 sentences, focused on immediate, tangible next steps. (8–12 words or Chinese characters for quick updates).
+- **Build on prior context**: if this is not the first action to be done, use the preamble message to connect the dots with what’s been done so far and create a sense of momentum and clarity for the user to understand your next actions.
+- **Keep your tone light, friendly and curious**: add small touches of personality in preambles feel collaborative and engaging.
+
+**Examples:**
+- "Click the login button"
+- "Scroll to find the 'Yes' button in popup"
+- "Previous actions failed to find the 'Yes' button, i will try again"
+- "Go back to find the login button"
+
+
+## Return format
+
+Return in JSON format:
+{
+  "log": string, // a brief preamble to the user explaining what you’re about to do
+  "error"?: string, // Error messages about unexpected situations, if any. Only think it is an error when the situation is not foreseeable according to the instruction. Use the same language as the user's instruction.
+  "more_actions_needed_by_instruction": boolean, // Consider if there is still more action(s) to do after the action in "Log" is done, according to the instruction. If so, set this field to true. Otherwise, set it to false.
+  "action": 
+    {
+      "type": string, // the type of the action
+      "param"?: { // The parameter of the action, if any
+         // k-v style parameter fields
+      }, 
+    } | null,
+  ,
+  "sleep"?: number, // The sleep time after the action, in milliseconds.
+}
+
+For example, if the instruction is to login and the form has already been filled, this is a valid return value:
+
+{
+  "log": "Click the login button",
+  "more_actions_needed_by_instruction": false,
+  "action": {
+    "type": "Tap",
+    "param": {
+      "locate": { 
+        "prompt": "The login button"
+      }
+    }
+  }
+"
+`;
+
 exports[`system prompts > section locator - gemini 1`] = `
 "
 ## Role:

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -139,6 +139,16 @@ describe('system prompts', () => {
     expect(prompt).toMatchSnapshot();
   });
 
+  it('planning - qwen - cot without bbox', async () => {
+    const prompt = await systemPromptToTaskPlanning({
+      actionSpace: mockActionSpace,
+      vlMode: 'qwen2.5-vl',
+      includeBbox: false,
+    });
+
+    expect(prompt).toMatchSnapshot();
+  });
+
   it('planning - gemini', async () => {
     const prompt = await systemPromptToTaskPlanning({
       actionSpace: mockActionSpace,


### PR DESCRIPTION
## Summary
- switch the qwen planning prompt test without bbox to use a snapshot assertion
- record the corresponding snapshot to capture bbox omission behavior

## Testing
- pnpm --filter @midscene/core exec vitest run tests/unit-test/prompt/prompt.test.ts -u

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943cb808f3c832480bafb790996ffaf)