### PR TITLE
fix(core): include parse error details in safeParseJson error message

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -514,19 +514,32 @@ export function safeParseJson(input: string, vlMode: TVlModeTypes | undefined) {
   }
 
   let parsed: any;
+  let lastError: unknown;
   try {
     parsed = JSON.parse(cleanJsonString);
     return normalizeJsonObject(parsed);
-  } catch {}
+  } catch (error) {
+    lastError = error;
+  }
   try {
     parsed = JSON.parse(jsonrepair(cleanJsonString));
     return normalizeJsonObject(parsed);
-  } catch (e) {}
+  } catch (error) {
+    lastError = error;
+  }
 
   if (vlMode === 'doubao-vision' || vlMode === 'vlm-ui-tars') {
     const jsonString = preprocessDoubaoBboxJson(cleanJsonString);
-    parsed = JSON.parse(jsonrepair(jsonString));
-    return normalizeJsonObject(parsed);
+    try {
+      parsed = JSON.parse(jsonrepair(jsonString));
+      return normalizeJsonObject(parsed);
+    } catch (error) {
+      lastError = error;
+    }
   }
-  throw Error(`failed to parse json response: ${input}`);
+  throw Error(
+    `failed to parse LLM response into JSON. Error - ${String(
+      lastError ?? 'unknown error',
+    )}. Response - \n ${input}`,
+  );
 }


### PR DESCRIPTION
### Motivation
- Improve error diagnostics when JSON parsing of LLM responses fails in `safeParseJson`.
- Ensure the thrown error matches the requested format: `failed to parse LLM response into JSON. Error - ${}. Response - \n ${response}`.
- Capture underlying parser errors so operators can see the root cause instead of a generic message.
- Target the JSON extraction/repair flow for vision-specific modes as well.

### Description
- Added a `lastError` variable in `packages/core/src/ai-model/service-caller/index.ts` to record parse failures across attempts.
- Wrapped the initial `JSON.parse` and `jsonrepair` parse attempts in `try/catch` blocks to populate `lastError` on failure.
- Added a `try/catch` around the `vlMode` (`doubao-vision` / `vlm-ui-tars`) reparsing path to capture its errors as well.
- Replaced the previous generic thrown error with the new formatted message that includes the stringified `lastError` and the original response.

### Testing
- No automated tests were run for this change during the rollout.
- Existing unit tests reference `safeParseJson` and should cover normalization behavior, but were not executed here.
- Commit-time hooks were respected during development and did not block the change.
- Recommend running the core unit test suite (e.g. the tests under `packages/core/tests`) after merge to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4656a8c08324b020dd3e5b43cf7c)