### PR TITLE
docs(core): Clarify `aiScroll` direction semantics and update schema/docs

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -328,8 +328,8 @@ function aiScroll(
 - Parameters:
 
   - `scrollParam: PlanningActionParamScroll` - The scroll parameter
-    - `direction?: 'down' | 'up' | 'right' | 'left'` - The direction to scroll. Defaults to `down`. Whether it is Android or Web, the scrolling direction here all refers to which direction of the page's content will appear on the screen. For example, when the scrolling direction is `down`, the hidden content at the bottom of the page will gradually reveal itself from the bottom of the screen upwards.
     - `scrollType?: 'singleAction' | 'scrollToBottom' | 'scrollToTop' | 'scrollToRight' | 'scrollToLeft'` - The scroll behavior. Defaults to `singleAction`.
+    - `direction?: 'down' | 'up' | 'right' | 'left'` - The direction to scroll. Defaults to `down`. Only effective when `scrollType` is `singleAction`. Whether it is Android or Web, the scrolling direction here all refers to which direction of the page's content will appear on the screen. For example, when the scrolling direction is `down`, the hidden content at the bottom of the page will gradually reveal itself from the bottom of the screen upwards.
     - `distance?: number | null` - Optional, the distance to scroll in px. Use `null` to allow Midscene to decide automatically.
   - `locate?: string | Object` - Optional, a natural language description of the element to scroll on, or [prompting with images](#prompting-with-images). If not provided, Midscene will perform scroll on the current mouse position.
   - `options?: Object` - Optional, a configuration object containing:
@@ -345,7 +345,7 @@ function aiScroll(
 
 ```typescript
 await agent.aiScroll(
-  { direction: 'up', distance: 100, scrollType: 'singleAction' },
+  { scrollType: 'singleAction', direction: 'up', distance: 100 },
   'The form panel',
 );
 ```

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -417,8 +417,8 @@ tasks:
 
       # Scroll globally or on an element described by a prompt.
       - aiScroll:
-        direction: 'down' # or 'up' | 'left' | 'right'. Defaults to 'down'.
         scrollType: 'singleAction' # or 'scrollToBottom' | 'scrollToTop' | 'scrollToRight' | 'scrollToLeft'. Defaults to 'singleAction'.
+        direction: 'down' # or 'up' | 'left' | 'right'. Defaults to 'down'. Only effective when scrollType is singleAction.
         distance: <number> # Optional, the scroll distance in pixels. Use null to let Midscene decide automatically.
         locate: <prompt> # Optional, the element to scroll on.
         deepThink: <boolean> # Optional, whether to use deepThink to precisely locate the element. Defaults to False.

--- a/apps/site/docs/en/integrate-with-playwright.mdx
+++ b/apps/site/docs/en/integrate-with-playwright.mdx
@@ -217,7 +217,6 @@ test('search headphone on ebay', async ({
   // Use aiScroll to scroll to bottom
   await aiScroll(
     {
-      direction: 'down',
       scrollType: 'untilBottom',
     },
     'search results list',

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -322,8 +322,8 @@ function aiScroll(
 - 参数：
 
   - `scrollParam: PlanningActionParamScroll` - 滚动参数
-    - `direction?: 'down' | 'up' | 'left' | 'right'` - 滚动方向，默认值为 `down`。不论是 Android 还是 Web，这里的滚动方向都是指页面哪个方向的内容会进入屏幕。比如当滚动方向是 `down` 时，页面下方被隐藏的内容会从屏幕底部开始逐渐向上露出。
     - `scrollType?: 'singleAction' | 'scrollToBottom' | 'scrollToTop' | 'scrollToRight' | 'scrollToLeft'` - 滚动类型，默认值为 `singleAction`。
+    - `direction?: 'down' | 'up' | 'left' | 'right'` - 滚动方向，默认值为 `down`。仅在 `scrollType` 为 `singleAction` 时生效。不论是 Android 还是 Web，这里的滚动方向都是指页面哪个方向的内容会进入屏幕。比如当滚动方向是 `down` 时，页面下方被隐藏的内容会从屏幕底部开始逐渐向上露出。
     - `distance?: number | null` - 滚动距离，单位为像素。设置为 `null` 表示由 Midscene 自动决定。
   - `locate?: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。如果未传入，Midscene 会在当前鼠标位置滚动。
   - `options?: Object` - 可选，一个配置对象，包含：
@@ -339,7 +339,7 @@ function aiScroll(
 
 ```typescript
 await agent.aiScroll(
-  { direction: 'up', distance: 100, scrollType: 'singleAction' },
+  { scrollType: 'singleAction', direction: 'up', distance: 100 },
   '表单区域',
 );
 ```

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -423,8 +423,8 @@ tasks:
 
       # 全局滚动，或滚动 prompt 描述的元素
       - aiScroll:
-        direction: 'down' # 或 'up' | 'left' | 'right'，默认值为 'down'
         scrollType: 'singleAction' # 或 'scrollToBottom' | 'scrollToTop' | 'scrollToRight' | 'scrollToLeft'，默认值为 'singleAction'
+        direction: 'down' # 或 'up' | 'left' | 'right'，默认值为 'down'。仅在 scrollType 为 singleAction 时生效
         distance: <number> # 可选，滚动距离，单位为像素。设置为 null 表示由 Midscene 自动决定。
         locate: <prompt> # 可选，执行滚动的元素
         deepThink: <boolean> # 可选，是否使用深度思考（deepThink）来精确定位元素。默认值为 False

--- a/apps/site/docs/zh/integrate-with-playwright.mdx
+++ b/apps/site/docs/zh/integrate-with-playwright.mdx
@@ -217,7 +217,6 @@ test('search headphone on ebay', async ({
   // 使用 aiScroll 滚动到页面底部
   await aiScroll(
     {
-      direction: 'down',
       scrollType: 'untilBottom',
     },
     '搜索结果列表',

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -236,10 +236,6 @@ export const defineActionKeyboardPress = (
 
 // Scroll
 export const actionScrollParamSchema = z.object({
-  direction: z
-    .enum(['down', 'up', 'right', 'left'])
-    .default('down')
-    .describe('The direction to scroll'),
   scrollType: z
     .enum([
       'singleAction',
@@ -251,6 +247,12 @@ export const actionScrollParamSchema = z.object({
     .default('singleAction')
     .describe(
       'The scroll behavior: "singleAction" for a single scroll action, "scrollToBottom" for scrolling to the bottom, "scrollToTop" for scrolling to the top, "scrollToRight" for scrolling to the right, "scrollToLeft" for scrolling to the left',
+    ),
+  direction: z
+    .enum(['down', 'up', 'right', 'left'])
+    .default('down')
+    .describe(
+      'The direction to scroll. Only effective when scrollType is "singleAction".',
     ),
   distance: z
     .number()


### PR DESCRIPTION
### Motivation
- Make `direction` behavior explicit: it should only affect single-step scrolls and not multi-step `scrollType` modes.
- Ensure API schema and user docs are consistent about the `direction` semantics.
- Improve examples to avoid passing `direction` when using `scrollType` modes like `scrollToBottom`.

### Description
- Reordered the fields in the `actionScrollParamSchema` so `scrollType` appears before `direction` and updated `direction` description to: `The direction to scroll. Only effective when scrollType is "singleAction".` in `packages/core/src/device/index.ts`.
- Updated API docs (`apps/site/docs/en/api.mdx` and `apps/site/docs/zh/api.mdx`) to state that `direction` is only effective when `scrollType` is `singleAction` and adjusted example parameter ordering to `scrollType` first.
- Updated YAML/docs (`apps/site/docs/en/automate-with-scripts-in-yaml.mdx`, `apps/site/docs/zh/automate-with-scripts-in-yaml.mdx`) to mention the constraint and adjusted `integrate-with-playwright` examples to omit `direction` when using `scrollType: 'untilBottom'`.

### Testing
- No automated tests were executed for this change because it only updates schema descriptions and documentation.
- Changes are limited to `packages/core` schema and docs under `apps/site/docs/*` and should not affect runtime behavior except for improved documentation.
- A commit was created with the message `docs(core): clarify aiScroll direction behavior`.
- Manual verification: updated examples compile as plain Markdown/MDX changes and the TypeScript schema change is a non-breaking reordering and description update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695287f0ab5883249c56d5c70c16baf2)