### PR TITLE
fix(visualizer): prevent uncaught frame cancel errors in export video

### DIFF
--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -80,7 +80,8 @@ const frameKit = (): {
       }
       requestAnimationFrame(() => {
         if (cancelFlag) {
-          throw new Error(ERROR_FRAME_CANCEL);
+          // Don't throw in requestAnimationFrame callback - just return silently
+          return;
         }
         callback(performance.now());
       });
@@ -91,7 +92,8 @@ const frameKit = (): {
       }
       setTimeout(() => {
         if (cancelFlag) {
-          throw new Error(ERROR_FRAME_CANCEL);
+          // Don't throw in setTimeout callback - just return silently
+          return;
         }
         callback();
       }, ms);


### PR DESCRIPTION
## Summary

Fixed uncaught exception errors that occurred when exporting video in the Player component. The issue manifested as multiple "frame cancel (this is an error on purpose)" errors in the console when the export video feature was triggered.

## Problem

The `frameKit`'s `timeout` function was throwing errors inside `setTimeout` callbacks when the animation was canceled. Since these callbacks execute asynchronously, the thrown errors could not be caught by the Promise's catch handler, resulting in uncaught exceptions flooding the console.

## Solution

Modified the `timeout` function in `frameKit` to return silently instead of throwing an error when `cancelFlag` is set during the `setTimeout` callback execution. This allows the animation cleanup to happen gracefully without generating console errors.

## Changes

- `packages/visualizer/src/component/player/index.tsx:88-98` - Changed error throwing to silent return in setTimeout callback

## Test Plan

1. Open the Player component with replay scripts
2. Click "Export Video" button
3. Verify that the video export completes successfully without console errors
4. Check that the exported video file is generated correctly

## Related Issues

Resolves the export video error reported in the console.