### PR TITLE
fix(core): align qwen3 thinking option naming across agent, planning and service layers

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -138,6 +138,7 @@ const defaultVlmUiTarsReplanningCycleLimit = 40;
 
 export type AiActOptions = {
   cacheable?: boolean;
+  qwen3_vl_enable_thinking?: boolean;
 };
 
 export class Agent<
@@ -858,6 +859,7 @@ export class Agent<
     debug('setting includeBboxInPlanning to', includeBboxInPlanning);
 
     const cacheable = opt?.cacheable;
+    const qwen3_vl_enable_thinking = opt?.qwen3_vl_enable_thinking ?? false;
     const replanningCycleLimit = this.resolveReplanningCycleLimit(
       modelConfigForPlanning,
     );
@@ -899,6 +901,7 @@ export class Agent<
       cacheable,
       replanningCycleLimit,
       imagesIncludeCount,
+      qwen3_vl_enable_thinking,
     );
 
     // update cache

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -208,6 +208,7 @@ export class TaskExecutor {
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
     imagesIncludeCount?: number,
+    qwen3_vl_enable_thinking?: boolean,
   ): Promise<
     ExecutionResult<
       | {
@@ -278,6 +279,9 @@ export class TaskExecutor {
               conversationHistory: this.conversationHistory,
               includeBbox: includeBboxInPlanning,
               imagesIncludeCount,
+              qwen3_vl_enable_thinking:
+                modelConfigForPlanning.vlMode === 'qwen3-vl' &&
+                qwen3_vl_enable_thinking,
             });
             debug('planResult', JSON.stringify(planResult, null, 2));
 

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -33,6 +33,7 @@ export async function plan(
     conversationHistory: ConversationHistory;
     includeBbox: boolean;
     imagesIncludeCount?: number;
+    qwen3_vl_enable_thinking?: boolean;
   },
 ): Promise<PlanningAIResponse> {
   const { context, modelConfig, conversationHistory } = opts;
@@ -132,6 +133,9 @@ export async function plan(
     msgs,
     AIActionType.PLAN,
     modelConfig,
+    {
+      qwen3_vl_enable_thinking: opts.qwen3_vl_enable_thinking,
+    },
   );
 
   const actions = planFromAI.action ? [planFromAI.action] : [];

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -205,6 +205,7 @@ export async function callAI(
   options?: {
     stream?: boolean;
     onChunk?: StreamingCallback;
+    qwen3_vl_enable_thinking?: boolean;
   },
 ): Promise<{ content: string; usage?: AIUsageInfo; isStreamed: boolean }> {
   const { completion, modelName, modelDescription, uiTarsVersion, vlMode } =
@@ -257,7 +258,7 @@ export async function callAI(
           vl_high_resolution_images: true,
         }
       : {}),
-    // enable_thinking: true,
+    ...(options?.qwen3_vl_enable_thinking ? { enable_thinking: true } : {}),
   };
 
   try {
@@ -395,8 +396,13 @@ export async function callAIWithObjectResponse<T>(
   messages: ChatCompletionMessageParam[],
   AIActionTypeValue: AIActionType,
   modelConfig: IModelConfig,
+  options?: {
+    qwen3_vl_enable_thinking?: boolean;
+  },
 ): Promise<{ content: T; contentString: string; usage?: AIUsageInfo }> {
-  const response = await callAI(messages, AIActionTypeValue, modelConfig);
+  const response = await callAI(messages, AIActionTypeValue, modelConfig, {
+    qwen3_vl_enable_thinking: options?.qwen3_vl_enable_thinking,
+  });
   assert(response, 'empty response');
   const vlMode = modelConfig.vlMode;
   const jsonContent = safeParseJson(response.content, vlMode);


### PR DESCRIPTION
### Motivation
- Ensure the qwen3-vl thinking toggle uses a consistent name across agent, task, and planning layers to avoid confusion and accidental misconfiguration.
- Only translate the internal option to the model request field `enable_thinking` at the service caller layer.
- Prevent non-`qwen3-vl` models from receiving the `enable_thinking` flag by scoping the toggle to `vlMode === 'qwen3-vl'`.

### Description
- Rename and thread `qwen3_vl_enable_thinking` through `AiActOptions`, `Agent.aiAct`, `TaskExecutor.action`, and the `plan` function signature. 
- Update `callAI` and `callAIWithObjectResponse` to accept `qwen3_vl_enable_thinking` and merge `{ enable_thinking: true }` into the outgoing request config when set. 
- Use `opt?.qwen3_vl_enable_thinking ?? false` at call sites to preserve default behavior. 
- Ensure the option is only converted to `enable_thinking` at the request layer and not renamed elsewhere.

### Testing
- No automated tests were executed for this change.
- Changes were committed; no CI or test suite run was triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d63acca48324b71ca30935bc066b)