### PR TITLE
fix(core): adjust Doubao/Qwen thinking behavior

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -131,6 +131,7 @@ function aiAct(
   options?: {
     cacheable?: boolean;
     qwen3_vl_enable_thinking?: boolean;
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
 ): Promise<void>;
 function ai(prompt: string): Promise<void>; // shorthand form
@@ -141,7 +142,8 @@ function ai(prompt: string): Promise<void>; // shorthand form
   - `prompt: string` - A natural language description of the UI steps.
   - `options?: Object` - Optional, a configuration object containing:
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
-    - `qwen3_vl_enable_thinking?: boolean` - Whether to enable the thinking feature when using Qwen3-VL models. Defaults to false.
+    - `qwen3_vl_enable_thinking?: boolean` - Whether to enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
+    - `doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto'` - Whether to enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
 
 - Return Value:
 

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -380,13 +380,15 @@ tasks:
       # Perform an interaction. `ai` is a shorthand for `aiAct`.
       - ai: <prompt>
         cacheable: <boolean> # Optional, whether to cache the result of this API call when the [caching feature](./caching.mdx) is enabled. Defaults to True.
-        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. Defaults to false.
+        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
+        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # Optional, enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
 
       # This usage is the same as `ai`.
       # Note: In earlier versions, this was also written as `aiAction`. The current version supports both names.
       - aiAct: <prompt>
         cacheable: <boolean> # Optional, whether to cache the result of this API call when the [caching feature](./caching.mdx) is enabled. Defaults to True.
-        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. Defaults to false.
+        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
+        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # Optional, enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
 
       # Instant Action (.aiTap, .aiHover, .aiInput, .aiKeyboardPress, .aiScroll)
       # ----------------

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -133,6 +133,7 @@ function aiAct(
   options?: {
     cacheable?: boolean;
     qwen3_vl_enable_thinking?: boolean;
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
 ): Promise<void>;
 function ai(prompt: string): Promise<void>; // 简写形式
@@ -143,7 +144,8 @@ function ai(prompt: string): Promise<void>; // 简写形式
   - `prompt: string` - 用自然语言描述的操作内容
   - `options?: Object` - 可选，一个配置对象，包含：
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
-    - `qwen3_vl_enable_thinking?: boolean` - 是否在 qwen3-vl 模型下打开 thinking（思考）特性，默认值为 false
+    - `qwen3_vl_enable_thinking?: boolean` - 是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+    - `doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto'` - 是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
 
 - 返回值：
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -384,13 +384,15 @@ tasks:
       # 执行一个交互，`ai` 是 `aiAct` 的简写方式
       - ai: <prompt>
         cacheable: <boolean> # 可选，当启用 [缓存功能](./caching.mdx) 时,是否允许缓存当前 API 调用结果。默认值为 True
-        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性，默认值为 False
+        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # 可选，是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
 
       # 这种用法与 `ai` 相同
       # 注意：在之前版本中也被写作 `aiAction`，当前版本兼容两种写法
       - aiAct: <prompt>
         cacheable: <boolean> # 可选，当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 True
-        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性，默认值为 False
+        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # 可选，是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
 
       # 即时操作(Instant Action, .aiTap, .aiHover, .aiInput, .aiKeyboardPress, .aiScroll)
       # ----------------

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -139,6 +139,7 @@ const defaultVlmUiTarsReplanningCycleLimit = 40;
 export type AiActOptions = {
   cacheable?: boolean;
   qwen3_vl_enable_thinking?: boolean;
+  doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
 };
 
 export class Agent<
@@ -859,7 +860,8 @@ export class Agent<
     debug('setting includeBboxInPlanning to', includeBboxInPlanning);
 
     const cacheable = opt?.cacheable;
-    const qwen3_vl_enable_thinking = opt?.qwen3_vl_enable_thinking ?? false;
+    const qwen3_vl_enable_thinking = opt?.qwen3_vl_enable_thinking;
+    const doubao_enable_thinking = opt?.doubao_enable_thinking;
     const replanningCycleLimit = this.resolveReplanningCycleLimit(
       modelConfigForPlanning,
     );
@@ -902,6 +904,7 @@ export class Agent<
       replanningCycleLimit,
       imagesIncludeCount,
       qwen3_vl_enable_thinking,
+      doubao_enable_thinking,
     );
 
     // update cache

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -209,6 +209,7 @@ export class TaskExecutor {
     replanningCycleLimitOverride?: number,
     imagesIncludeCount?: number,
     qwen3_vl_enable_thinking?: boolean,
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto',
   ): Promise<
     ExecutionResult<
       | {
@@ -280,8 +281,14 @@ export class TaskExecutor {
               includeBbox: includeBboxInPlanning,
               imagesIncludeCount,
               qwen3_vl_enable_thinking:
-                modelConfigForPlanning.vlMode === 'qwen3-vl' &&
-                qwen3_vl_enable_thinking,
+                modelConfigForPlanning.vlMode === 'qwen3-vl'
+                  ? qwen3_vl_enable_thinking
+                  : undefined,
+              doubao_enable_thinking:
+                modelConfigForPlanning.vlMode === 'doubao-vision' ||
+                modelConfigForPlanning.vlMode === 'vlm-ui-tars'
+                  ? doubao_enable_thinking
+                  : undefined,
             });
             debug('planResult', JSON.stringify(planResult, null, 2));
 

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -34,6 +34,7 @@ export async function plan(
     includeBbox: boolean;
     imagesIncludeCount?: number;
     qwen3_vl_enable_thinking?: boolean;
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
 ): Promise<PlanningAIResponse> {
   const { context, modelConfig, conversationHistory } = opts;
@@ -135,6 +136,7 @@ export async function plan(
     modelConfig,
     {
       qwen3_vl_enable_thinking: opts.qwen3_vl_enable_thinking,
+      doubao_enable_thinking: opts.doubao_enable_thinking,
     },
   );
 

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -206,6 +206,7 @@ export async function callAI(
     stream?: boolean;
     onChunk?: StreamingCallback;
     qwen3_vl_enable_thinking?: boolean;
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
 ): Promise<{ content: string; usage?: AIUsageInfo; isStreamed: boolean }> {
   const { completion, modelName, modelDescription, uiTarsVersion, vlMode } =
@@ -258,7 +259,13 @@ export async function callAI(
           vl_high_resolution_images: true,
         }
       : {}),
-    ...(options?.qwen3_vl_enable_thinking ? { enable_thinking: true } : {}),
+    ...(options?.qwen3_vl_enable_thinking !== undefined
+      ? { enable_thinking: options.qwen3_vl_enable_thinking }
+      : {}),
+    ...((vlMode === 'doubao-vision' || vlMode === 'vlm-ui-tars') &&
+    options?.doubao_enable_thinking
+      ? { thinking: { type: options.doubao_enable_thinking } }
+      : {}),
   };
 
   try {
@@ -398,10 +405,12 @@ export async function callAIWithObjectResponse<T>(
   modelConfig: IModelConfig,
   options?: {
     qwen3_vl_enable_thinking?: boolean;
+    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
 ): Promise<{ content: T; contentString: string; usage?: AIUsageInfo }> {
   const response = await callAI(messages, AIActionTypeValue, modelConfig, {
     qwen3_vl_enable_thinking: options?.qwen3_vl_enable_thinking,
+    doubao_enable_thinking: options?.doubao_enable_thinking,
   });
   assert(response, 'empty response');
   const vlMode = modelConfig.vlMode;


### PR DESCRIPTION
### Motivation
- Map Doubao thinking option to the provider payload shape (`thinking.type`) per service-caller requirements.  
- Avoid forcing a default `false` for Qwen3 thinking so that omitting the option defers to the model provider's default.  
- Expose a typed `doubao_enable_thinking` option to the `aiAct` API to allow `'enabled' | 'disabled' | 'auto'` values.  
- Clarify EN/ZH and YAML docs that leaving the thinking option unset uses the provider default.

### Description
- Added `doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto'` to `AiActOptions` and threaded the option through `aiAct` -> `TaskExecutor.action` -> `plan` -> AI call layer.  
- In `packages/core/src/ai-model/service-caller/index.ts` only send `enable_thinking` for Qwen when the option is explicitly defined and map Doubao to `thinking: { type: ... }` for `doubao-vision` and `vlm-ui-tars` VL modes.  
- Updated conditional propagation so `qwen3_vl_enable_thinking` is `undefined` unless explicitly set and `doubao_enable_thinking` is only included for relevant VL modes.  
- Updated EN/ZH API and YAML docs to note that omitting the thinking options uses the provider's default behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e41c123c83249284cd5b7a19a2d2)