### PR TITLE
docs(site): fix custom interface links

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -9,7 +9,7 @@ Midscene ships multiple agents tuned for specific automation environments. Every
 - In Bridge Mode, use [AgentOverChromeBridge](./web-api-reference#chrome-bridge-agent)
 - On Android, use [Android API reference](./android-api-reference)
 - On iOS, use [iOS API reference](./ios-api-reference)
-- For GUI agents integrating with your own interface, refer to [Custom Interface Agent](#custom-interface-agent)
+- For GUI agents integrating with your own interface, refer to [Custom Interface Agent](./integrate-with-any-interface.mdx)
 
 ### Parameters
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -11,7 +11,7 @@ Midscene 针对每个不同环境都有对应的 Agent。每个 Agent 的构造�
 - 在桥接模式（Bridge Mode）中，使用 [AgentOverChromeBridge](./web-api-reference#chrome-bridge-agent)
 - 在 Android 中，使用 [Android API 参考](./android-api-reference)
 - 在 iOS 中，使用 [iOS API 参考](./ios-api-reference)
-- 如果你要把 GUI Agent 集成到自己的界面，请参考 [自定义界面 Agent](#custom-interface-agent)
+- 如果你要把 GUI Agent 集成到自己的界面，请参考 [自定义界面 Agent](./integrate-with-any-interface.mdx)
 
 ### 参数
 


### PR DESCRIPTION
### Motivation

- The API reference linked to a local anchor that does not point to the dedicated custom interface guide, causing navigation to fail.
- Users expect the API docs to link directly to the full guide page for integrating GUI agents into custom interfaces.

### Description

- Replaced the broken anchor link with a relative link to `./integrate-with-any-interface.mdx` in the English API doc at `apps/site/docs/en/api.mdx`.
- Applied the same fix to the Chinese API doc at `apps/site/docs/zh/api.mdx`.
- Commit message set to `docs(site): fix custom interface links` to follow project commit conventions.

### Testing

- Commit hooks (commitlint/husky) ran and initially failed due to commit format, and then passed after updating the commit message.
- No unit or integration tests were executed because this is a docs-only change.
- A PR was prepared using the repository's PR helper script to bundle the change for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ee7987e08324ab167c9b1a82781e)