### PR TITLE
feat(core): propagate reasoning content to reports

### DIFF
--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -236,6 +236,7 @@ const DetailSide = (): JSX.Element => {
   const task = useExecutionDump((store) => store.activeTask);
   const dump = useExecutionDump((store) => store.insightDump);
   const { matchedElement: elements } = dump || {};
+  const reasoningContent = task?.reasoning_content;
 
   const aiActContextValue = (task as ExecutionTaskPlanningApply)?.param
     ?.aiActContext;
@@ -629,6 +630,17 @@ const DetailSide = (): JSX.Element => {
             content={<pre className="description-content">{thought}</pre>}
           />
         )}
+        {reasoningContent && (
+          <Card
+            liteMode={true}
+            title="reasoning"
+            onMouseEnter={noop}
+            onMouseLeave={noop}
+            content={
+              <pre className="description-content">{reasoningContent}</pre>
+            }
+          />
+        )}
 
         <Card
           liteMode={true}
@@ -674,6 +686,20 @@ const DetailSide = (): JSX.Element => {
               <pre className="description-content">
                 {(task as ExecutionTaskPlanning).output?.log}
               </pre>
+            }
+          />,
+        );
+      }
+      if (reasoningContent) {
+        planItems.push(
+          <Card
+            key="reasoning"
+            liteMode={true}
+            title="reasoning"
+            onMouseEnter={noop}
+            onMouseLeave={noop}
+            content={
+              <pre className="description-content">{reasoningContent}</pre>
             }
           />,
         );
@@ -810,6 +836,18 @@ const DetailSide = (): JSX.Element => {
             onMouseLeave={noop}
             content={<pre>{thought}</pre>}
             title="thought"
+          />,
+        );
+      }
+      if (reasoningContent) {
+        outputItems.push(
+          <Card
+            key="reasoning"
+            liteMode={true}
+            onMouseEnter={noop}
+            onMouseLeave={noop}
+            content={<pre>{reasoningContent}</pre>}
+            title="reasoning"
           />,
         );
       }

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -404,6 +404,9 @@ export class TaskBuilder {
           if (dump.taskInfo?.searchAreaUsage) {
             task.searchAreaUsage = dump.taskInfo.searchAreaUsage;
           }
+          if (dump.taskInfo?.reasoning_content) {
+            task.reasoning_content = dump.taskInfo.reasoning_content;
+          }
         };
 
         // from bbox (plan hit)

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -300,6 +300,7 @@ export class TaskExecutor {
               usage,
               rawResponse,
               sleep,
+              reasoning_content,
             } = planResult;
 
             executorContext.task.log = {
@@ -307,6 +308,7 @@ export class TaskExecutor {
               rawResponse,
             };
             executorContext.task.usage = usage;
+            executorContext.task.reasoning_content = reasoning_content;
             executorContext.task.output = {
               actions: actions || [],
               more_actions_needed_by_instruction,
@@ -501,8 +503,9 @@ export class TaskExecutor {
           throw error;
         }
 
-        const { data, usage, thought, dump } = extractResult;
+        const { data, usage, thought, dump, reasoning_content } = extractResult;
         applyDump(dump);
+        task.reasoning_content = reasoning_content;
 
         let outputResult = data;
         if (ifTypeRestricted) {

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -128,6 +128,7 @@ export async function AiLocateElement(options: {
   rect?: Rect;
   rawResponse: string;
   usage?: AIUsageInfo;
+  reasoning_content?: string;
 }> {
   const { context, targetElementDescription, callAIFn, modelConfig } = options;
   const { vlMode } = modelConfig;
@@ -261,6 +262,7 @@ export async function AiLocateElement(options: {
     },
     rawResponse,
     usage: res.usage,
+    reasoning_content: res.reasoning_content,
   };
 }
 
@@ -440,6 +442,7 @@ export async function AiExtractElementInfo<T>(options: {
   return {
     parseResult: result.content,
     usage: result.usage,
+    reasoning_content: result.reasoning_content,
   };
 }
 

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -130,6 +130,7 @@ export async function plan(
     content: planFromAI,
     contentString: rawResponse,
     usage,
+    reasoning_content,
   } = await callAIWithObjectResponse<RawResponsePlanningAIResponse>(
     msgs,
     AIActionType.PLAN,
@@ -146,6 +147,7 @@ export async function plan(
     actions,
     rawResponse,
     usage,
+    reasoning_content,
     yamlFlow: buildYamlFlowFromPlans(
       actions,
       opts.actionSpace,

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -419,7 +419,12 @@ export async function callAIWithObjectResponse<T>(
     qwen3_vl_enable_thinking?: boolean;
     doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
   },
-): Promise<{ content: T; contentString: string; usage?: AIUsageInfo }> {
+): Promise<{
+  content: T;
+  contentString: string;
+  usage?: AIUsageInfo;
+  reasoning_content?: string;
+}> {
   const response = await callAI(messages, AIActionTypeValue, modelConfig, {
     qwen3_vl_enable_thinking: options?.qwen3_vl_enable_thinking,
     doubao_enable_thinking: options?.doubao_enable_thinking,
@@ -435,6 +440,7 @@ export async function callAIWithObjectResponse<T>(
     content: jsonContent,
     contentString: response.content,
     usage: response.usage,
+    reasoning_content: response.reasoning_content,
   };
 }
 

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -129,7 +129,8 @@ export default class Service {
     }
 
     const startTime = Date.now();
-    const { parseResult, rect, rawResponse, usage } = await AiLocateElement({
+    const { parseResult, rect, rawResponse, usage, reasoning_content } =
+      await AiLocateElement({
       callAIFn: this.aiVendorFn,
       context,
       targetElementDescription: queryPrompt,
@@ -147,6 +148,7 @@ export default class Service {
       searchArea,
       searchAreaRawResponse,
       searchAreaUsage,
+      reasoning_content,
     };
 
     let errorLog: string | undefined;
@@ -219,7 +221,8 @@ export default class Service {
 
     const startTime = Date.now();
 
-    const { parseResult, usage } = await AiExtractElementInfo<T>({
+    const { parseResult, usage, reasoning_content } =
+      await AiExtractElementInfo<T>({
       context,
       dataQuery: dataDemand,
       multimodalPrompt,
@@ -233,6 +236,7 @@ export default class Service {
       ...(this.taskInfo ? this.taskInfo : {}),
       durationMs: timeCost,
       rawResponse: JSON.stringify(parseResult),
+      reasoning_content,
     };
 
     let errorLog: string | undefined;
@@ -267,6 +271,7 @@ export default class Service {
       data,
       thought,
       usage,
+      reasoning_content,
       dump,
     };
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -143,6 +143,7 @@ export interface ServiceTaskInfo {
   searchArea?: Rect;
   searchAreaRawResponse?: string;
   searchAreaUsage?: AIUsageInfo;
+  reasoning_content?: string;
 }
 
 export interface DumpMeta {
@@ -188,6 +189,7 @@ export interface ServiceExtractResult<T> extends ServiceResultBase {
   data: T;
   thought?: string;
   usage?: AIUsageInfo;
+  reasoning_content?: string;
 }
 
 export class ServiceError extends Error {
@@ -261,6 +263,7 @@ export interface PlanningAIResponse
   yamlFlow?: MidsceneYamlFlowItem[];
   yamlString?: string;
   error?: string;
+  reasoning_content?: string;
 }
 
 export interface PlanningActionParamSleep {
@@ -381,6 +384,7 @@ export type ExecutionTask<
     };
     usage?: AIUsageInfo;
     searchAreaUsage?: AIUsageInfo;
+    reasoning_content?: string;
   };
 
 export interface ExecutionDump extends DumpMeta {


### PR DESCRIPTION
### Motivation

- Capture `reasoning_content` produced by AI services and make it available in execution dumps and task metadata for better transparency.
- Surface the model's reasoning alongside `thought`/logs in the report UI so users can inspect step-by-step rationale.
- Ensure type definitions and service flows carry the new metadata end-to-end.

### Description

- Propagate reasoning content from `callAI` into `callAIWithObjectResponse` and return `reasoning_content` from that API. 
- Return and thread `reasoning_content` through `AiLocateElement`, `AiExtractElementInfo`, and the planning flow (`plan` / `PlanningAIResponse`).
- Record `reasoning_content` into `ServiceTaskInfo` / `ServiceExtractResult` and attach it to `ExecutionTask` instances in `task-builder` / `tasks` when available. 
- Render a new `reasoning` card in the report right-side `DetailSide` component alongside existing `thought` and logs; update `types.ts` to include `reasoning_content` fields.

### Testing

- Started the local report dev build (`pnpm --filter @midscene/report dev`) and subprojects built successfully without TypeScript errors.  
- Launched a Playwright script that injected a demo dump with `reasoning_content` and captured a screenshot of the report UI (`artifacts/report-reasoning.png`), confirming UI rendering of the field.  
- No automated unit tests were explicitly run as part of this change in the rollout.  
- Type definitions and builds were validated by the project build/watch processes which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ee376d2c8324a8d739c32bede962)