### PR TITLE
refactor(core): extract resolveDeepThinkConfig and add unit tests

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -130,8 +130,7 @@ function aiAct(
   prompt: string,
   options?: {
     cacheable?: boolean;
-    qwen3_vl_enable_thinking?: boolean;
-    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
+    deepThink?: boolean;
   },
 ): Promise<void>;
 function ai(prompt: string): Promise<void>; // shorthand form
@@ -142,8 +141,7 @@ function ai(prompt: string): Promise<void>; // shorthand form
   - `prompt: string` - A natural language description of the UI steps.
   - `options?: Object` - Optional, a configuration object containing:
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
-    - `qwen3_vl_enable_thinking?: boolean` - Whether to enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
-    - `doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto'` - Whether to enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
+    - `deepThink?: boolean` - Whether to enable deep thinking during planning when the model family supports it.
 
 - Return Value:
 

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -380,15 +380,13 @@ tasks:
       # Perform an interaction. `ai` is a shorthand for `aiAct`.
       - ai: <prompt>
         cacheable: <boolean> # Optional, whether to cache the result of this API call when the [caching feature](./caching.mdx) is enabled. Defaults to True.
-        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
-        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # Optional, enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
+        deepThink: <boolean> # Optional, enable deep thinking for planning when supported by the model family.
 
       # This usage is the same as `ai`.
       # Note: In earlier versions, this was also written as `aiAction`. The current version supports both names.
       - aiAct: <prompt>
         cacheable: <boolean> # Optional, whether to cache the result of this API call when the [caching feature](./caching.mdx) is enabled. Defaults to True.
-        qwen3_vl_enable_thinking: <boolean> # Optional, enable the thinking feature when using Qwen3-VL models. If omitted, the provider's default applies (see the model provider documentation).
-        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # Optional, enable the thinking feature for Doubao models. If omitted, the provider's default applies (see the model provider documentation).
+        deepThink: <boolean> # Optional, enable deep thinking for planning when supported by the model family.
 
       # Instant Action (.aiTap, .aiHover, .aiInput, .aiKeyboardPress, .aiScroll)
       # ----------------

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -132,8 +132,7 @@ function aiAct(
   prompt: string,
   options?: {
     cacheable?: boolean;
-    qwen3_vl_enable_thinking?: boolean;
-    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
+    deepThink?: boolean;
   },
 ): Promise<void>;
 function ai(prompt: string): Promise<void>; // 简写形式
@@ -144,8 +143,7 @@ function ai(prompt: string): Promise<void>; // 简写形式
   - `prompt: string` - 用自然语言描述的操作内容
   - `options?: Object` - 可选，一个配置对象，包含：
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
-    - `qwen3_vl_enable_thinking?: boolean` - 是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
-    - `doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto'` - 是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+    - `deepThink?: boolean` - 当模型家族支持时，是否开启规划阶段的深度思考能力。
 
 - 返回值：
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -384,15 +384,13 @@ tasks:
       # 执行一个交互，`ai` 是 `aiAct` 的简写方式
       - ai: <prompt>
         cacheable: <boolean> # 可选，当启用 [缓存功能](./caching.mdx) 时,是否允许缓存当前 API 调用结果。默认值为 True
-        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
-        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # 可选，是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+        deepThink: <boolean> # 可选，当模型家族支持时，开启规划阶段的深度思考能力。
 
       # 这种用法与 `ai` 相同
       # 注意：在之前版本中也被写作 `aiAction`，当前版本兼容两种写法
       - aiAct: <prompt>
         cacheable: <boolean> # 可选，当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 True
-        qwen3_vl_enable_thinking: <boolean> # 可选，是否在 qwen3-vl 模型下打开 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
-        doubao_enable_thinking: <'enabled' | 'disabled' | 'auto'> # 可选，是否在豆包模型下开启 thinking（思考）特性。未传则使用对应模型服务商的默认配置（详见对应模型文档）。
+        deepThink: <boolean> # 可选，当模型家族支持时，开启规划阶段的深度思考能力。
 
       # 即时操作(Instant Action, .aiTap, .aiHover, .aiInput, .aiKeyboardPress, .aiScroll)
       # ----------------

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -138,8 +138,7 @@ const defaultVlmUiTarsReplanningCycleLimit = 40;
 
 export type AiActOptions = {
   cacheable?: boolean;
-  qwen3_vl_enable_thinking?: boolean;
-  doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
+  deepThink?: boolean;
 };
 
 export class Agent<
@@ -860,8 +859,7 @@ export class Agent<
     debug('setting includeBboxInPlanning to', includeBboxInPlanning);
 
     const cacheable = opt?.cacheable;
-    const qwen3_vl_enable_thinking = opt?.qwen3_vl_enable_thinking;
-    const doubao_enable_thinking = opt?.doubao_enable_thinking;
+    const deepThink = opt?.deepThink;
     const replanningCycleLimit = this.resolveReplanningCycleLimit(
       modelConfigForPlanning,
     );
@@ -903,8 +901,7 @@ export class Agent<
       cacheable,
       replanningCycleLimit,
       imagesIncludeCount,
-      qwen3_vl_enable_thinking,
-      doubao_enable_thinking,
+      deepThink,
     );
 
     // update cache

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -208,8 +208,7 @@ export class TaskExecutor {
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
     imagesIncludeCount?: number,
-    qwen3_vl_enable_thinking?: boolean,
-    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto',
+    deepThink?: boolean,
   ): Promise<
     ExecutionResult<
       | {
@@ -280,15 +279,7 @@ export class TaskExecutor {
               conversationHistory: this.conversationHistory,
               includeBbox: includeBboxInPlanning,
               imagesIncludeCount,
-              qwen3_vl_enable_thinking:
-                modelConfigForPlanning.vlMode === 'qwen3-vl'
-                  ? qwen3_vl_enable_thinking
-                  : undefined,
-              doubao_enable_thinking:
-                modelConfigForPlanning.vlMode === 'doubao-vision' ||
-                modelConfigForPlanning.vlMode === 'vlm-ui-tars'
-                  ? doubao_enable_thinking
-                  : undefined,
+              deepThink,
             });
             debug('planResult', JSON.stringify(planResult, null, 2));
 

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -33,8 +33,7 @@ export async function plan(
     conversationHistory: ConversationHistory;
     includeBbox: boolean;
     imagesIncludeCount?: number;
-    qwen3_vl_enable_thinking?: boolean;
-    doubao_enable_thinking?: 'enabled' | 'disabled' | 'auto';
+    deepThink?: boolean;
   },
 ): Promise<PlanningAIResponse> {
   const { context, modelConfig, conversationHistory } = opts;
@@ -136,8 +135,7 @@ export async function plan(
     AIActionType.PLAN,
     modelConfig,
     {
-      qwen3_vl_enable_thinking: opts.qwen3_vl_enable_thinking,
-      doubao_enable_thinking: opts.doubao_enable_thinking,
+      deepThink: opts.deepThink,
     },
   );
 

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -1,4 +1,4 @@
-import { safeParseJson } from '@/ai-model/service-caller';
+import { resolveDeepThinkConfig, safeParseJson } from '@/ai-model/service-caller';
 import type { IModelConfig } from '@midscene/shared/env';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -310,6 +310,50 @@ describe('service-caller', () => {
 
       expect(result.type).toBe('Tap');
       expect(result.param.prompt).toBe('Click');
+    });
+  });
+
+  describe('resolveDeepThinkConfig', () => {
+    it('returns empty config when deepThink is disabled', () => {
+      expect(
+        resolveDeepThinkConfig({ deepThink: false, vlMode: 'qwen3-vl' }),
+      ).toMatchObject({
+        config: {},
+        debugMessage: undefined,
+      });
+    });
+
+    it('maps deepThink for qwen3-vl', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: true,
+        vlMode: 'qwen3-vl',
+      });
+
+      expect(result.config).toEqual({ enable_thinking: true });
+      expect(result.debugMessage).toContain('enable_thinking');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('maps deepThink for doubao-vision', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: true,
+        vlMode: 'doubao-vision',
+      });
+
+      expect(result.config).toEqual({ thinking: { type: 'enabled' } });
+      expect(result.debugMessage).toContain('thinking.type=enabled');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('warns when deepThink is unsupported', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: true,
+        vlMode: 'vlm-ui-tars',
+      });
+
+      expect(result.config).toEqual({});
+      expect(result.debugMessage).toContain('deepThink ignored');
+      expect(result.warningMessage).toContain('not supported');
     });
   });
 });

--- a/packages/web-integration/tests/ai/web/puppeteer/e2e.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/e2e.test.ts
@@ -71,8 +71,7 @@ describe(
           // '在当前页面里完成这个任务：用户名填入 abc，密码填入 123 , 点击 email 字段。断言：界面上有抛错',
           '按住“dragMe”元素，往右拖动300像素',
           {
-            doubao_enable_thinking: 'enabled',
-            qwen3_vl_enable_thinking: true,
+            deepThink: true,
           },
         );
       },


### PR DESCRIPTION
### Motivation

- Centralize provider-specific mapping for the `deepThink` option so mapping logic is isolated and easier to maintain.  
- Make mapping decisions observable via debug and warning messages so callers can see when `deepThink` is applied or ignored.  
- Enable focused unit testing and future optimization by extracting mapping into a single function.  

### Description

- Added `resolveDeepThinkConfig` in `packages/core/src/ai-model/service-caller/index.ts` to return provider-specific config, debug message, and optional warning.  
- Updated `callAI` (streaming and non-streaming paths) to apply the resolved `deepThink` config and emit debug/warning messages.  
- Adjusted `callAIWithObjectResponse` to forward the unified `deepThink` option.  
- Added unit tests for `resolveDeepThinkConfig` in `packages/core/tests/unit-test/service-caller.test.ts`.  

### Testing

- Added unit tests covering `resolveDeepThinkConfig` behavior for `qwen3-vl`, `doubao-vision`, disabled, and unsupported modes.  
- Tests were added to `packages/core/tests/unit-test/service-caller.test.ts` and assert mapping, debug messages, and warning presence.  
- No automated test suite was executed as part of this change.  
- CI (if configured) will run the test suite after push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69548f6d9f6c8324a323db0bfb17a232)