### PR TITLE
fix(core): map deepThink when explicitly set

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -506,22 +506,22 @@ export function resolveDeepThinkConfig({
   debugMessage?: string;
   warningMessage?: string;
 } {
-  if (!deepThink) {
+  if (deepThink === undefined) {
     return { config: {}, debugMessage: undefined };
   }
 
   if (vlMode === 'qwen3-vl') {
     return {
-      config: { enable_thinking: true },
-      debugMessage: 'deepThink enabled: mapped to enable_thinking for qwen3-vl',
+      config: { enable_thinking: deepThink },
+      debugMessage: `deepThink mapped to enable_thinking=${deepThink} for qwen3-vl`,
     };
   }
 
   if (vlMode === 'doubao-vision') {
     return {
-      config: { thinking: { type: 'enabled' } },
+      config: { thinking: { type: deepThink ? 'enabled' : 'disabled' } },
       debugMessage:
-        'deepThink enabled: mapped to thinking.type=enabled for doubao-vision',
+        `deepThink mapped to thinking.type=${deepThink ? 'enabled' : 'disabled'} for doubao-vision`,
     };
   }
 

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -317,12 +317,11 @@ describe('service-caller', () => {
   });
 
   describe('resolveDeepThinkConfig', () => {
-    it('returns empty config when deepThink is disabled', () => {
+    it('maps deepThink false for qwen3-vl', () => {
       expect(
         resolveDeepThinkConfig({ deepThink: false, vlMode: 'qwen3-vl' }),
       ).toMatchObject({
-        config: {},
-        debugMessage: undefined,
+        config: { enable_thinking: false },
       });
     });
 
@@ -345,6 +344,17 @@ describe('service-caller', () => {
 
       expect(result.config).toEqual({ thinking: { type: 'enabled' } });
       expect(result.debugMessage).toContain('thinking.type=enabled');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('maps deepThink false for doubao-vision', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: false,
+        vlMode: 'doubao-vision',
+      });
+
+      expect(result.config).toEqual({ thinking: { type: 'disabled' } });
+      expect(result.debugMessage).toContain('thinking.type=disabled');
       expect(result.warningMessage).toBeUndefined();
     });
 


### PR DESCRIPTION
### Motivation
- `deepThink` should be passed explicitly to VL model configs when the caller sets it (not only when truthy).
- The previous logic ignored explicit `false` and only acted when `deepThink` was truthy, causing incorrect model config for `qwen3-vl` and `doubao-vision`.
- Improve debug messaging so it reflects whether `deepThink` was mapped to enabled or disabled.

### Description
- Change `resolveDeepThinkConfig` to treat `deepThink === undefined` as “no opinion” and only map when `deepThink` is explicitly provided.
- For `qwen3-vl` map to `enable_thinking: <boolean>` (pass through the explicit boolean) and update the debug message to include the boolean.
- For `doubao-vision` map to `thinking.type: 'enabled' | 'disabled'` based on the explicit boolean and update the debug message accordingly.
- Updated unit tests in `packages/core/tests/unit-test/service-caller.test.ts` to cover explicit `false` mappings; changed `packages/core/src/ai-model/service-caller/index.ts` accordingly.

### Testing
- Added unit assertions in `packages/core/tests/unit-test/service-caller.test.ts` to verify `deepThink: false` behavior for both `qwen3-vl` and `doubao-vision`.
- No automated test suite was executed as part of this change in the workspace. 
- CI should run the full test matrix and is expected to validate these updated expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549bea9ba08324911674eb0529014e)