### PR TITLE
feat(core): propagate `deepThink` to extraction calls and update YAML/player/docs

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1136,6 +1136,7 @@ export class Agent<
       screenshotIncluded:
         opt?.screenshotIncluded ??
         defaultServiceExtractOption.screenshotIncluded,
+      ...(opt?.deepThink !== undefined ? { deepThink: opt.deepThink } : {}),
     };
 
     const { textPrompt, multimodalPrompt } = parsePrompt(assertion);

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -438,6 +438,9 @@ export async function AiExtractElementInfo<T>(options: {
     msgs,
     AIActionType.EXTRACT_DATA,
     modelConfig,
+    extractOption?.deepThink !== undefined
+      ? { deepThink: extractOption.deepThink }
+      : undefined,
   );
   return {
     parseResult: result.content,

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -14,6 +14,7 @@ export interface LocateOption {
 export interface ServiceExtractOption {
   domIncluded?: boolean | 'visible-only';
   screenshotIncluded?: boolean;
+  deepThink?: boolean;
   [key: string]: unknown;
 }
 

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -282,15 +282,16 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         await agent.aiAct(prompt, actionOptions);
       } else if ('aiAssert' in (flowItem as MidsceneYamlFlowItemAIAssert)) {
         const assertTask = flowItem as MidsceneYamlFlowItemAIAssert;
-        const prompt = assertTask.aiAssert;
-        const msg = assertTask.errorMessage;
+        const { aiAssert: prompt, errorMessage: msg, name, ...assertOptions } =
+          assertTask;
         assert(prompt, 'missing prompt for aiAssert');
         const { pass, thought, message } =
           (await agent.aiAssert(prompt, msg, {
             keepRawResponse: true,
+            ...assertOptions,
           })) || {};
 
-        this.setResult(assertTask.name, {
+        this.setResult(name, {
           pass,
           thought,
           message,

--- a/packages/shared/src/constants/example-code.ts
+++ b/packages/shared/src/constants/example-code.ts
@@ -19,9 +19,11 @@ aiScroll(locate: string | undefined, options: {
   xpath?: string,
   cacheable?: boolean
 }): Promise<void>
-aiAssert(assertion: string, options?: { errorMessage?: string }): Promise<void>
+aiAssert(assertion: string, options?: { errorMessage?: string, deepThink?: boolean, domIncluded?: boolean | 'visible-only', screenshotIncluded?: boolean }): Promise<void>
 aiWaitFor(prompt: string, options?: { timeout?: number }): Promise<void>
-aiQuery<T>(queryObject: Record<string, string>): Promise<T> // Extracts data from page based on descriptions
+aiQuery<T>(queryObject: Record<string, string>, options?: { deepThink?: boolean, domIncluded?: boolean | 'visible-only', screenshotIncluded?: boolean }): Promise<T> // Extracts data from page based on descriptions
+aiString(prompt: string, options?: { deepThink?: boolean, domIncluded?: boolean | 'visible-only', screenshotIncluded?: boolean }): Promise<string>
+aiAsk(prompt: string, options?: { deepThink?: boolean, domIncluded?: boolean | 'visible-only', screenshotIncluded?: boolean }): Promise<string>
 
 // examples:
 // Reference the following code to generate Midscene test cases
@@ -186,6 +188,7 @@ tasks:
       # Perform a query that returns a JSON object.
       - aiQuery: <prompt> # Remember to describe the format of the result in the prompt.
         name: <name> # The key for the query result in the JSON output.
+        deepThink: <boolean> # Optional, whether to enable deepThink for this query. Defaults to False.
 
       # More APIs
       # ----------------
@@ -197,6 +200,7 @@ tasks:
       # Perform an assertion.
       - aiAssert: <prompt>
         errorMessage: <error-message> # Optional, the error message to print if the assertion fails.
+        deepThink: <boolean> # Optional, whether to enable deepThink for this assertion. Defaults to False.
 
       # Wait for a specified amount of time.
       - sleep: <ms>


### PR DESCRIPTION
### Motivation

- Ensure the `deepThink` flag is available and correctly propagated so callers can opt into deeper visual reasoning for extraction/assertion flows.
- Remove misleading documentation that `deepThink` is only available in VL models to avoid confusion.
- Make YAML player forward AI assertion options to the agent so script-specified flags are respected.
- Update example code signatures and YAML docs to document the new `deepThink` / extraction options.

### Description

- Removed the "only available in vl model" remark and added `deepThink?: boolean` to `ServiceExtractOption` and kept `deepThink` on `LocateOption` in `packages/core/src/yaml.ts`.
- Propagated `deepThink` into `aiAssert` by including it in `serviceOpt` in `packages/core/src/agent/agent.ts` so the agent forwards the flag to execution calls.
- Passed `extractOption?.deepThink` into `callAIWithObjectResponse` in `packages/core/src/ai-model/inspect.ts` so extraction requests include `deepThink` configuration.
- Updated the YAML player to destructure and forward assert options to `agent.aiAssert`, adjust result naming, and updated example signatures in `packages/shared/src/constants/example-code.ts` to include `deepThink`, `domIncluded`, and `screenshotIncluded` as applicable and added `aiString`/`aiAsk` signatures.

### Testing

- No automated tests were executed as part of this change set.
- Lint and type checks were not run locally in this rollout and should be validated by CI.
- The change was committed locally; CI is expected to run build and unit tests after merge.
- Manual verification was limited to ensuring the trivial comment and option forwarding code changes applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a413e9b08324b5ce6558b5637b9d)