### PR TITLE
fix(cli): allow --files to override config entries

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,8 +45,14 @@ Promise.resolve(
     let config;
 
     if (configFile) {
-      config = await createConfig(configFile, configOptions);
-      console.log(`   Config file: ${configFile}`);
+      if (cmdFiles && cmdFiles.length > 0) {
+        config = await createConfig(configFile, configOptions, cmdFiles);
+        console.log(`   Config file: ${configFile}`);
+        console.log('   Executing YAML files from --files argument...');
+      } else {
+        config = await createConfig(configFile, configOptions);
+        console.log(`   Config file: ${configFile}`);
+      }
     } else if (cmdFiles && cmdFiles.length > 0) {
       console.log('   Executing YAML files from --files argument...');
       config = await createFilesConfig(cmdFiles, configOptions);

--- a/packages/cli/tests/unit-test/config-factory.test.ts
+++ b/packages/cli/tests/unit-test/config-factory.test.ts
@@ -255,6 +255,39 @@ concurrent: 2
       expect(result.summary).toBe('from-cmd.json');
       expect(result.globalConfig).toEqual(expectedGlobalConfig);
     });
+
+    test('should override config file patterns with --files patterns', async () => {
+      const mockYamlContent = `
+files:
+  - from-config.yml
+concurrent: 2
+`;
+      const mockParsedYaml = {
+        files: ['from-config.yml'],
+        concurrent: 2,
+        continueOnError: false,
+        headed: false,
+        keepWindow: false,
+        dotenvOverride: false,
+        dotenvDebug: false,
+        summary: 'parsed.json',
+        shareBrowserContext: false,
+      };
+      vi.mocked(readFileSync).mockReturnValue(mockYamlContent);
+      vi.mocked(yamlLoad).mockReturnValue(mockParsedYaml);
+      vi.mocked(matchYamlFiles)
+        .mockResolvedValueOnce(['from-config.yml'])
+        .mockResolvedValueOnce(['override.yml']);
+
+      const result = await createConfig('/test/index.yml', undefined, [
+        'override.yml',
+      ]);
+
+      expect(result.files).toEqual(['override.yml']);
+      expect(matchYamlFiles).toHaveBeenCalledWith('override.yml', {
+        cwd: process.cwd(),
+      });
+    });
   });
 
   describe('createFilesConfig', async () => {


### PR DESCRIPTION
### Motivation

- The CLI previously ignored `--files` when `--config` was supplied, causing user-supplied file lists to be overridden by the config file.
- Users expect command-line `--files` to take precedence over the `files` array in a config YAML.
- Pattern expansion for overrides should be resolved from the current working directory to match `--files` semantics.

### Description

- Add an optional `overrideFiles` parameter to `createConfig` and use `expandFilePatterns(overrideFiles, cwd())` to expand `--files` when provided alongside `--config`.
- Throw a clear error when overridden patterns do not match any files: `No YAML files found matching the patterns in "--files"`.
- Update `packages/cli/src/index.ts` to pass `cmdFiles` into `createConfig` when both `--config` and `--files` are provided and print an informational message.
- Add a unit test to `packages/cli/tests/unit-test/config-factory.test.ts` that verifies `--files` overrides config patterns and that `matchYamlFiles` is called with `cwd()`.

### Testing

- Ran `pnpm --filter @midscene/cli test` to execute the package unit tests.
- All unit tests passed: 103 tests passed (including the new override test).
- The new test verifies the override behavior and that patterns are expanded from `process.cwd()`.
- No regressions were observed in existing test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bf3e50f883249e93cf02246f4260)