### PR TITLE
fix(visualizer): keep actionSpace deep think logic and enable aiAct

### DIFF
--- a/packages/visualizer/src/component/prompt-input/index.tsx
+++ b/packages/visualizer/src/component/prompt-input/index.tsx
@@ -172,6 +172,10 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
   // Check if current method supports deep think option (dynamic based on actionSpace)
   const showDeepThinkOption = useMemo(() => {
+    if (selectedType === 'aiAct') {
+      return true;
+    }
+
     if (selectedType === 'aiLocate') {
       return true;
     }

--- a/packages/visualizer/src/utils/constants.tsx
+++ b/packages/visualizer/src/utils/constants.tsx
@@ -1,16 +1,16 @@
 import type { InfoListItem, PlaygroundResult } from '../types';
 
 // tracking popup tip
-export const trackingTip = 'limit popup to current tab';
+export const trackingTip = 'Limit popup to current tab';
 
 // deep think tip
-export const deepThinkTip = 'deep think';
+export const deepThinkTip = 'Deep Think';
 
 // screenshot included tip
-export const screenshotIncludedTip = 'include screenshot in request';
+export const screenshotIncludedTip = 'Include screenshot in request';
 
 // dom included tip
-export const domIncludedTip = 'include DOM info in request';
+export const domIncludedTip = 'Include DOM info in request';
 
 // Android device options tips
 export const imeStrategyTip = 'IME strategy';


### PR DESCRIPTION
### Motivation
- Preserve the original `actionSpace`-based Deep Think detection instead of replacing it with a hard-coded type set.
- Ensure `aiAct` explicitly exposes the Deep Think toggle even when `actionSpace` logic would not enable it.
- Maintain locate-field detection for actions that declare a locate parameter via `paramSchema`.
- Normalize UI tip label casing for consistency across the visualizer.

### Description
- Add an explicit `if (selectedType === 'aiAct') return true;` early in the `showDeepThinkOption` logic in `packages/visualizer/src/component/prompt-input/index.tsx` so `aiAct` always shows Deep Think.
- Keep `actionSpace`-based detection intact by searching `actionSpace` for a matching action and inspecting its `paramSchema` for locate fields in `showDeepThinkOption`.
- Preserve the special-case that always returns true for `aiLocate` in `showDeepThinkOption`.
- Update tip strings to Title Case in `packages/visualizer/src/utils/constants.tsx` for `trackingTip`, `deepThinkTip`, `screenshotIncludedTip`, and `domIncludedTip`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c83d967083249cc2a85905950196)