### PR TITLE
fix(core): use gemini thinkingLevel for deepThink

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -524,6 +524,13 @@ export function resolveDeepThinkConfig({
     };
   }
 
+  if (vlMode === 'gemini') {
+    return {
+      config: { thinkingLevel: deepThink ? 'high' : 'low' },
+      debugMessage: `deepThink mapped to thinkingLevel=${deepThink ? 'high' : 'low'} for gemini`,
+    };
+  }
+
   return {
     config: {},
     debugMessage: `deepThink ignored: unsupported model_family "${vlMode ?? 'default'}"`,

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -358,6 +358,28 @@ describe('service-caller', () => {
       expect(result.warningMessage).toBeUndefined();
     });
 
+    it('maps deepThink true for gemini', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: true,
+        vlMode: 'gemini',
+      });
+
+      expect(result.config).toEqual({ thinkingLevel: 'high' });
+      expect(result.debugMessage).toContain('thinkingLevel=high');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('maps deepThink false for gemini', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: false,
+        vlMode: 'gemini',
+      });
+
+      expect(result.config).toEqual({ thinkingLevel: 'low' });
+      expect(result.debugMessage).toContain('thinkingLevel=low');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
     it('warns when deepThink is unsupported', () => {
       const result = resolveDeepThinkConfig({
         deepThink: true,


### PR DESCRIPTION
### Motivation
- Ensure `deepThink` mapping follows `vlMode`-only logic and uses the documented Gemini parameter name. 
- Avoid relying on `modelName` to determine mapping behavior and prevent inventing unsupported parameters. 
- Preserve existing behavior for other VL model families while aligning Gemini mapping with docs.

### Description
- Removed passing/inspection of `modelName` in `resolveDeepThinkConfig` and now resolve mappings solely from `vlMode`.
- For `vlMode === 'gemini'`, map `deepThink` to `thinkingLevel: 'high' | 'low'` and update the debug message accordingly. 
- Left `qwen3-vl` mapping to `enable_thinking` and `doubao-vision` mapping to `thinking.type` unchanged. 
- Updated unit tests in `packages/core/tests/unit-test/service-caller.test.ts` to expect `thinkingLevel` for Gemini.

### Testing
- Unit tests were added/updated in `packages/core/tests/unit-test/service-caller.test.ts` to cover the new Gemini mapping. 
- No automated test suite (unit or CI) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959cc4205d483248f160ab1d50fa5a3)