### PR TITLE
fix(visualizer): prevent long reportHTML from being displayed in playground output

### DIFF
--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -206,7 +206,8 @@ export function usePlaygroundExecution(
           if (resultObj.error) result.error = formatError(resultObj.error);
 
           // If result was wrapped, extract the actual result
-          if (resultObj.result !== undefined) {
+          // Handle both defined values and undefined (e.g., from aiWaitFor)
+          if ('result' in resultObj) {
             result.result = resultObj.result;
           }
         }


### PR DESCRIPTION
## Summary

Fixed an issue where `aiWaitFor` (and other APIs returning `undefined`) would display the entire `reportHTML` content in the playground output section, causing very long and unreadable text to appear.

## Root Cause

The problem occurred in `usePlaygroundExecution.ts` where the result extraction logic used:
```typescript
if (resultObj.result !== undefined) {
  result.result = resultObj.result;
}
```

This condition failed to handle cases where `resultObj.result` is `undefined`, causing:
1. `local-execution.ts` wraps the result as: `{ result: undefined, dump: {...}, reportHTML: "long HTML string" }`
2. The extraction logic didn't update `result.result` because `undefined !== undefined` is `false`
3. The entire wrapped object (including the long `reportHTML`) remained in `result.result`
4. UI components displayed this via `JSON.stringify(result.result)`, showing the entire HTML string

## Solution

Changed the condition to use the `in` operator:
```typescript
if ('result' in resultObj) {
  result.result = resultObj.result;
}
```

This properly handles `undefined` values by checking for property existence rather than value comparison, ensuring `result.result` is correctly set to `undefined` instead of the wrapped response object.

## Test Plan

- [x] Lint checks pass
- [x] Build successful
- [x] Verified the fix handles `undefined` values correctly

## Screenshots

Before: Long HTML/JavaScript text displayed in output
After: Clean output with only the actual result displayed