### PR TITLE
fix(site): use proper closing tag for video element in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ English | [简体中文](./README.zh.md)
 
 autonomously register the GitHub form in a web browser and pass all field validations.
 
-<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github2.mp4" height="300" controls />
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github2.mp4" height="300" controls></video>
 
 Plus these real-world showcases:
 * [iOS Automation - Meituan coffee order](https://midscenejs.com/showcases#ios)

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,7 +40,7 @@
 
 在 Web 浏览器中自主注册 Github 表单，并通过所有字段校验。
 
-<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github2.mp4" height="300" controls />
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github2.mp4" height="300" controls></video>
 
 此外还有这些实战案例：
 * [iOS 自动化 - 美团下单咖啡](https://midscenejs.com/zh/showcases#ios)


### PR DESCRIPTION
## Summary
- Fixed README content being truncated after line 42 on GitHub
- Changed self-closing `<video ... />` tags to proper closing `<video ...></video>` format
- Applied fix to both `README.md` and `README.zh.md`

## Background
GitHub's Markdown renderer does not support self-closing video tags (`<video ... />`). This caused all content after line 42 to not be displayed on the GitHub repository page.

## Test plan
- [ ] Verify README.md displays completely on GitHub after merge
- [ ] Verify README.zh.md displays completely on GitHub after merge