### PR TITLE
fix: resolve MIDSCENE_MODEL_MAX_TOKENS environment variable not working

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -220,8 +220,8 @@ export async function callAI(
     });
 
   const maxTokens =
-    globalConfigManager.getEnvConfigValue(MIDSCENE_MODEL_MAX_TOKENS) ??
-    globalConfigManager.getEnvConfigValue(OPENAI_MAX_TOKENS);
+    globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS) ??
+    globalConfigManager.getEnvConfigValueAsNumber(OPENAI_MAX_TOKENS);
   const debugCall = getDebug('ai:call');
   const debugProfileStats = getDebug('ai:profile:stats');
   const debugProfileDetail = getDebug('ai:profile:detail');
@@ -258,7 +258,7 @@ export async function callAI(
   const commonConfig = {
     temperature,
     stream: !!isStreaming,
-    max_tokens: typeof maxTokens === 'number' ? maxTokens : undefined,
+    max_tokens: maxTokens,
     ...(vlMode === 'qwen2.5-vl' // qwen vl v2 specific config
       ? {
           vl_high_resolution_images: true,

--- a/packages/shared/src/env/global-config-manager.ts
+++ b/packages/shared/src/env/global-config-manager.ts
@@ -118,6 +118,20 @@ export class GlobalConfigManager {
     return !!value.trim();
   }
 
+  /**
+   * Read string environment variable value and convert it to number.
+   * Returns undefined if the value is not set or cannot be converted to a valid number.
+   * This is useful for environment variables that store numeric values but are defined as string keys.
+   */
+  getEnvConfigValueAsNumber(key: (typeof STRING_ENV_KEYS)[number]): number | undefined {
+    const stringValue = this.getEnvConfigValue(key);
+    if (!stringValue) {
+      return undefined;
+    }
+    const numValue = Number(stringValue);
+    return Number.isNaN(numValue) ? undefined : numValue;
+  }
+
   registerModelConfigManager(globalModelConfigManager: ModelConfigManager) {
     this.globalModelConfigManager = globalModelConfigManager;
   }

--- a/packages/shared/tests/unit-test/env/global-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/global-config-manager.test.ts
@@ -301,6 +301,151 @@ describe('overrideAIConfig', () => {
   });
 });
 
+describe('getEnvConfigValueAsNumber', () => {
+  beforeEach(() => {
+    vi.stubEnv(MIDSCENE_ADB_PATH, '<test-adb-path>');
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
+    vi.stubEnv(MIDSCENE_CACHE, '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return number for valid numeric string values', () => {
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(100);
+  });
+
+  it('should return undefined for non-numeric string values', () => {
+    vi.stubEnv(MIDSCENE_ADB_PATH, 'not-a-number');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_ADB_PATH),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for unset environment variables', () => {
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_PREFERRED_LANGUAGE),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for empty string values', () => {
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('should handle decimal values', () => {
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '123.45');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(123.45);
+  });
+
+  it('should handle zero values', () => {
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '0');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(0);
+  });
+
+  it('should handle negative values', () => {
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '-100');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(-100);
+  });
+
+  it('should trim whitespace before conversion', () => {
+    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '  100  ');
+
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(100);
+  });
+
+  it('should work with override config', () => {
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    // Initially not set
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(100); // from beforeEach
+
+    // Override with new value
+    globalConfigManager.overrideAIConfig({
+      [MIDSCENE_CACHE_MAX_FILENAME_LENGTH]: '200',
+    });
+
+    expect(
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
+      ),
+    ).toBe(200);
+  });
+
+  it('should throw if key is not in STRING_ENV_KEYS', () => {
+    const globalConfigManager = new GlobalConfigManager();
+    globalConfigManager.registerModelConfigManager(new ModelConfigManager());
+
+    expect(() =>
+      globalConfigManager.getEnvConfigValueAsNumber(
+        // @ts-expect-error MIDSCENE_CACHE is truly not a valid string key (it's boolean)
+        MIDSCENE_CACHE,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Error: getEnvConfigValue with key MIDSCENE_CACHE is not supported.]',
+    );
+  });
+});
+
 describe('getEnvConfigValue', () => {
   beforeEach(() => {
     vi.stubEnv(MIDSCENE_MODEL_NAME, '<test-model>');


### PR DESCRIPTION
The environment variable MIDSCENE_MODEL_MAX_TOKENS was not being applied because getEnvConfigValue() returns string | undefined, but the code checked `typeof maxTokens === 'number'` which would never be true.

Changed to convert the string value to number using Number().

Fix #1748