### PR TITLE
refactor(env): use getEnvConfigValueAsNumber

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -312,13 +312,10 @@ export class Agent<
   constructor(interfaceInstance: InterfaceType, opts?: AgentOpt) {
     this.interface = interfaceInstance;
 
-    const envConfig = globalConfigManager.getAllEnvConfig();
-    const envReplanningCycleLimitRaw =
-      envConfig[MIDSCENE_REPLANNING_CYCLE_LIMIT];
     const envReplanningCycleLimit =
-      envReplanningCycleLimitRaw !== undefined
-        ? Number(envReplanningCycleLimitRaw)
-        : undefined;
+      globalConfigManager.getEnvConfigValueAsNumber(
+        MIDSCENE_REPLANNING_CYCLE_LIMIT,
+      );
 
     this.opts = Object.assign(
       {

--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -74,9 +74,9 @@ export class TaskCache {
     assert(cacheId, 'cacheId is required');
     let safeCacheId = replaceIllegalPathCharsAndSpace(cacheId);
     const cacheMaxFilenameLength =
-      globalConfigManager.getEnvConfigInNumber(
+      globalConfigManager.getEnvConfigValueAsNumber(
         MIDSCENE_CACHE_MAX_FILENAME_LENGTH,
-      ) || DEFAULT_CACHE_MAX_FILENAME_LENGTH;
+      ) ?? DEFAULT_CACHE_MAX_FILENAME_LENGTH;
     if (Buffer.byteLength(safeCacheId, 'utf8') > cacheMaxFilenameLength) {
       const prefix = safeCacheId.slice(0, 32);
       const hash = generateHashId(undefined, safeCacheId);

--- a/packages/shared/src/env/global-config-manager.ts
+++ b/packages/shared/src/env/global-config-manager.ts
@@ -80,20 +80,6 @@ export class GlobalConfigManager {
   }
 
   /**
-   * read number only from process.env
-   */
-  getEnvConfigInNumber(key: (typeof NUMBER_ENV_KEYS)[number]): number {
-    const allConfig = this.getAllEnvConfig();
-
-    if (!NUMBER_ENV_KEYS.includes(key)) {
-      throw new Error(`getEnvConfigInNumber with key ${key} is not supported`);
-    }
-    const value = allConfig[key];
-    this.keysHaveBeenRead[key] = true;
-    return Number(value || '');
-  }
-
-  /**
    * read boolean only from process.env
    */
   getEnvConfigInBoolean(key: (typeof BOOLEAN_ENV_KEYS)[number]): boolean {
@@ -119,16 +105,30 @@ export class GlobalConfigManager {
   }
 
   /**
-   * Read string environment variable value and convert it to number.
+   * Read environment variable value and convert it to number.
    * Returns undefined if the value is not set or cannot be converted to a valid number.
-   * This is useful for environment variables that store numeric values but are defined as string keys.
    */
-  getEnvConfigValueAsNumber(key: (typeof STRING_ENV_KEYS)[number]): number | undefined {
-    const stringValue = this.getEnvConfigValue(key);
-    if (!stringValue) {
+  getEnvConfigValueAsNumber(
+    key: (typeof STRING_ENV_KEYS)[number] | (typeof NUMBER_ENV_KEYS)[number],
+  ): number | undefined {
+    if (!STRING_ENV_KEYS.includes(key) && !NUMBER_ENV_KEYS.includes(key)) {
+      throw new Error(
+        `getEnvConfigValueAsNumber with key ${key} is not supported.`,
+      );
+    }
+
+    const allConfig = this.getAllEnvConfig();
+    const value = allConfig[key];
+    this.keysHaveBeenRead[key] = true;
+
+    if (typeof value !== 'string') {
       return undefined;
     }
-    const numValue = Number(stringValue);
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const numValue = Number(trimmed);
     return Number.isNaN(numValue) ? undefined : numValue;
   }
 

--- a/packages/shared/tests/unit-test/env/global-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/global-config-manager.test.ts
@@ -143,7 +143,7 @@ describe('overrideAIConfig', () => {
     );
     // Should return original env values for non-overridden keys
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
     ).toBe(100);
   });
 
@@ -194,7 +194,7 @@ describe('overrideAIConfig', () => {
       '/second/override',
     );
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
     ).toBe(300);
     // Previous override should be lost in non-extend mode
     expect(globalConfigManager.getEnvConfigInBoolean(MIDSCENE_CACHE)).toBe(
@@ -239,7 +239,7 @@ describe('overrideAIConfig', () => {
       '/second/override',
     );
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
     ).toBe(300);
     // Previous override should be preserved in extend mode
     expect(globalConfigManager.getEnvConfigInBoolean(MIDSCENE_CACHE)).toBe(
@@ -411,7 +411,7 @@ describe('getEnvConfigValueAsNumber', () => {
     ).toBe(200);
   });
 
-  it('should throw if key is not in STRING_ENV_KEYS', () => {
+  it('should throw if key is not a supported numeric key', () => {
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
@@ -421,7 +421,7 @@ describe('getEnvConfigValueAsNumber', () => {
         MIDSCENE_CACHE,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      '[Error: getEnvConfigValue with key MIDSCENE_CACHE is not supported.]',
+      '[Error: getEnvConfigValueAsNumber with key MIDSCENE_CACHE is not supported.]',
     );
   });
 });
@@ -453,12 +453,12 @@ describe('getEnvConfigValue', () => {
     );
 
     expect(() =>
-      globalConfigManager.getEnvConfigInNumber(
+      globalConfigManager.getEnvConfigValueAsNumber(
         // @ts-expect-error MIDSCENE_MODEL_NAME is truly not a valid key
         MIDSCENE_MODEL_NAME,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      '[Error: getEnvConfigInNumber with key MIDSCENE_MODEL_NAME is not supported]',
+      '[Error: getEnvConfigValueAsNumber with key MIDSCENE_MODEL_NAME is not supported.]',
     );
 
     expect(() =>
@@ -484,7 +484,7 @@ describe('getEnvConfigValue', () => {
     );
 
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
     ).toBe(100);
 
     expect(globalConfigManager.getEnvConfigInBoolean(MIDSCENE_CACHE)).toBe(
@@ -500,8 +500,8 @@ describe('getEnvConfigValue', () => {
     ).toBeUndefined();
 
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
-    ).toBe(0);
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
+    ).toBeUndefined();
 
     expect(globalConfigManager.getEnvConfigInBoolean(MIDSCENE_CACHE)).toBe(
       false,
@@ -518,7 +518,7 @@ describe('getEnvConfigValue', () => {
     );
 
     expect(
-      globalConfigManager.getEnvConfigInNumber(MIDSCENE_MODEL_MAX_TOKENS),
+      globalConfigManager.getEnvConfigValueAsNumber(MIDSCENE_MODEL_MAX_TOKENS),
     ).toBe(100);
 
     expect(globalConfigManager.getEnvConfigInBoolean(MIDSCENE_CACHE)).toBe(


### PR DESCRIPTION
### Motivation

- Unify numeric env parsing into a single helper to handle both string and numeric env keys consistently.
- Remove the brittle `getEnvConfigInNumber` that only read raw `process.env` without trimming/validation.
- Switch callers that rely on numeric environment values to use the new helper for safer parsing.
- Keep tests aligned with the new behavior and error messages.

### Description

- Replaced `getEnvConfigInNumber` with `getEnvConfigValueAsNumber` in `packages/shared/src/env/global-config-manager.ts` and expanded it to accept keys from both `STRING_ENV_KEYS` and `NUMBER_ENV_KEYS` with validation and trimming.
- Updated callers to use the new API: `MIDSCENE_CACHE_MAX_FILENAME_LENGTH` in `packages/core/src/agent/task-cache.ts` and `MIDSCENE_REPLANNING_CYCLE_LIMIT` in `packages/core/src/agent/agent.ts` now call `getEnvConfigValueAsNumber`.
- Adjusted logic to use `??`/`||` appropriately when falling back to defaults (`DEFAULT_CACHE_MAX_FILENAME_LENGTH`) and to treat unset/invalid values as `undefined` rather than `0`.
- Updated unit tests in `packages/shared/tests/unit-test/env/global-config-manager.test.ts` to reflect the new function name, validations, return values, and error messages.

### Testing

- Unit tests in `packages/shared` were updated to reflect the new API but no test suite was executed as part of this change.
- No automated test runs (CI) were triggered during this local refactor.
- Commit hooks (conventional commit lint) were satisfied and the change was committed as `refactor(env): use getEnvConfigValueAsNumber`.
- Recommend running the full test suite (`pnpm test` or project CI) after merging to validate behavior across packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ae1460088324b005d2ce3c263c74)