### PR TITLE
fix(shared): add YAML indentation rules to prevent LLM generating incorrect format

### DIFF
--- a/packages/shared/src/constants/example-code.ts
+++ b/packages/shared/src/constants/example-code.ts
@@ -113,6 +113,18 @@ tasks:
 - Add deepThink: true for complex interactions
 - Keep task names concise but descriptive
 
+4. CRITICAL - YAML Indentation Rules:
+- For actions with additional parameters (aiScroll, aiInput, aiKeyboardPress), the parameters must be SIBLING keys, NOT nested children
+- Parameters like direction, scrollType, locate must align with the action key, not indented further
+- CORRECT indentation example:
+      - aiScroll:
+        direction: down
+        scrollType: singleAction
+- WRONG indentation (DO NOT do this):
+      - aiScroll:
+          direction: down
+          scrollType: singleAction
+
 
 
 YAML type


### PR DESCRIPTION
## Summary
- Add explicit YAML indentation rules section to `YAML_EXAMPLE_CODE` constant
- Clarify that parameters (direction, scrollType, locate) must be sibling keys aligned with the action key, not nested children
- Include correct and incorrect examples to guide LLM in generating proper YAML format

## Problem
The recorder was generating YAML with incorrect indentation for actions like `aiScroll`. Parameters were being indented 2 extra spaces as nested children instead of being aligned as sibling keys.

**Expected format:**
```yaml
      - aiScroll:
        direction: down
        scrollType: singleAction
```

**Incorrect format being generated:**
```yaml
      - aiScroll:
          direction: down
          scrollType: singleAction
```

## Test plan
- [ ] Verify lint passes
- [ ] Test recorder YAML generation to confirm correct indentation