### PR TITLE
fix(visualizer): prevent structured params form from horizontal overflow

### DIFF
--- a/packages/visualizer/src/component/prompt-input/index.less
+++ b/packages/visualizer/src/component/prompt-input/index.less
@@ -328,8 +328,13 @@
   .structured-params-container {
     padding: 16px;
     padding-bottom: 56px;
+    overflow: hidden;
+    box-sizing: border-box;
 
     .structured-params {
+      width: 100%;
+      min-width: 0; // Prevent flex item from overflowing
+
       .ant-form-item {
         // Force vertical layout - label above input
         display: flex;


### PR DESCRIPTION
## Summary
- Fix horizontal overflow issue in structured params form on certain systems
- Add `overflow: hidden` and `box-sizing: border-box` to `.structured-params-container`
- Set `width: 100%` and `min-width: 0` on `.structured-params` to prevent flex items from overflowing

## Test plan
- [ ] Verify the Mode input field in the Input form no longer overflows horizontally
- [ ] Test on different screen sizes and systems to ensure the fix works consistently