### PR TITLE
feat(core): add glm-v model family

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -95,6 +95,19 @@ MIDSCENE_MODEL_NAME="qwen-vl-max-latest"
 MIDSCENE_MODEL_FAMILY="qwen2.5-vl"
 ```
 
+### Zhipu GLM-V {#glm-v}
+
+Using Zhipu AI's GLM-4.6V as an example:
+
+Obtain an API key from [Z.AI (Global)](https://z.ai/manage-apikey/apikey-list) or [BigModel (CN)](https://bigmodel.cn/usercenter/proj-mgmt/apikeys), and set:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://api.z.ai/api/paas/v4" # Or https://open.bigmodel.cn/api/paas/v4
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="glm-4.6v"
+MIDSCENE_MODEL_FAMILY="glm-v"
+```
+
 ### Gemini-3-Pro and Gemini-3-Flash {#gemini-3-pro}
 
 After requesting an API key from [Google Gemini](https://gemini.google.com/), configure. Use your specific Gemini-3-Pro or Gemini-3-Flash release name for `MIDSCENE_MODEL_NAME`:

--- a/apps/site/docs/en/model-strategy.mdx
+++ b/apps/site/docs/en/model-strategy.mdx
@@ -9,6 +9,7 @@ If you want to try Midscene right away, pick a model and follow its configuratio
 * [Qwen3-VL](./model-common-config#qwen3-vl)
 * [Qwen2.5-VL](./model-common-config#qwen25-vl)
 * [Gemini-3-Pro / Gemini-3-Flash](./model-common-config#gemini-3-pro)
+* [Zhipu GLM-V](./model-common-config#glm-v)
 * [UI-TARS](./model-common-config#ui-tars)
 
 :::
@@ -53,6 +54,7 @@ If you are unsure where to start, pick whichever model is easiest to access toda
 | Doubao Seed Model<br />[Quick setup](./model-common-config#doubao-seed-model) | Volcano Engine:<br />[Doubao-Seed-1.6-Vision](https://www.volcengine.com/docs/82379/1799865) | ⭐⭐⭐⭐<br />Strong at UI planning and targeting<br />Slightly slower |
 | Qwen3-VL<br />[Quick setup](./model-common-config#qwen3-vl) | [Alibaba Cloud](https://help.aliyun.com/zh/model-studio/vision)<br/>[OpenRouter](https://openrouter.ai/qwen)<br/>[Ollama (open-source)](https://ollama.com/library/qwen3-vl) | ⭐⭐⭐⭐<br />Assertion in very complex scenes can fluctuate<br />Excellent performance and accuracy<br />Open-source builds available ([HuggingFace](https://huggingface.co/Qwen) / [GitHub](https://github.com/QwenLM/)) |
 | Qwen2.5-VL<br />[Quick setup](./model-common-config#qwen25-vl) | [Alibaba Cloud](https://help.aliyun.com/zh/model-studio/vision)<br/>[OpenRouter](https://openrouter.ai/qwen) | ⭐⭐⭐<br />Overall quality is behind Qwen3-VL |
+| Zhipu GLM-4.6V<br />[Quick setup](./model-common-config#glm-v) | [Z.AI (Global)](https://docs.z.ai/guides/vlm/glm-4.6v)<br/>[BigModel (CN)](https://docs.bigmodel.cn/cn/guide/models/vlm/glm-4.6v) | ⭐⭐⭐<br/>Slightly behind Qwen3-VL, but the cost is lower<br />Weights open-sourced on [HuggingFace](https://huggingface.co/zai-org/GLM-4.6V) |
 | Gemini-3-Pro / Gemini-3-Flash<br />[Quick setup](./model-common-config#gemini-3-pro) | [Google Cloud](https://ai.google.dev/gemini-api/docs/models/gemini) | ⭐⭐⭐<br />Gemini-3-Flash is supported<br />Price is higher than Doubao and Qwen |
 | UI-TARS<br />[Quick setup](./model-common-config#ui-tars) | [Volcano Engine](https://www.volcengine.com/docs/82379/1536429) | ⭐⭐<br />Strong exploratory ability but results vary by scenario<br />Open-source versions available ([HuggingFace](https://huggingface.co/bytedance-research/UI-TARS-72B-SFT) / [GitHub](https://github.com/bytedance/ui-tars)) |
 
@@ -132,13 +134,14 @@ See [Model configuration](./model-config).
 
 ### About the `deepThink` option in `aiAct`
 
-The `deepThink` option controls whether models use deep reasoning during planning. Currently supported for `qwen3-vl` and `doubao-seed-1.6` model families.
+The `deepThink` option controls whether models use deep reasoning during planning. Currently supported for `qwen3-vl`, `doubao-seed-1.6` and `glm-v` model families.
 
 When enabled, you'll see a `Reasoning` section in the report. Planning takes longer but produces more accurate results.
 
 **Default behavior varies by provider:**
 - `qwen3-vl` on Alibaba Cloud: disabled by default (faster, less accurate)
 - `doubao-seed-1.6` on Volcano Engine: enabled by default (slower, more accurate)
+- `glm-v` on Z.AI: enabled by default (slower, more accurate)
 
 You can explicitly set `deepThink: true` or `deepThink: false` to override the provider's default.
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -96,6 +96,19 @@ MIDSCENE_MODEL_NAME="qwen-vl-max-latest"
 MIDSCENE_MODEL_FAMILY="qwen2.5-vl"
 ```
 
+### 智谱 GLM-V {#glm-v}
+
+以智谱的 `GLM-4.6V` 模型为例：
+
+从 [Z.AI（国际）](https://z.ai/manage-apikey/apikey-list)或 [BigModel（国内）](https://bigmodel.cn/usercenter/proj-mgmt/apikeys)获取 API 密钥，然后设置：
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://open.bigmodel.cn/api/paas/v4" # 或 https://api.z.ai/api/paas/v4
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="glm-4.6v"
+MIDSCENE_MODEL_FAMILY="glm-v"
+```
+
 ### Gemini-3-Pro and Gemini-3-Flash {#gemini-3-pro}
 
 在 [Google Gemini](https://gemini.google.com/) 上申请 API 密钥后，可以使用以下配置。`MIDSCENE_MODEL_NAME` 请填写你使用的 Gemini-3-Pro 或 Gemini-3-Flash 具体模型名：

--- a/apps/site/docs/zh/model-strategy.mdx
+++ b/apps/site/docs/zh/model-strategy.mdx
@@ -8,6 +8,7 @@ import TroubleshootingLLMConnectivity from './common/troubleshooting-llm-connect
 * [豆包 Seed 模型](./model-common-config#doubao-seed-model)
 * [千问 Qwen3-VL](./model-common-config#qwen3-vl)
 * [千问 Qwen2.5-VL](./model-common-config#qwen25-vl)
+* [智谱 GLM-V](./model-common-config#glm-v)
 * [Gemini-3-Pro / Gemini-3-Flash](./model-common-config#gemini-3-pro)
 * [UI-TARS](./model-common-config#ui-tars)
 
@@ -53,6 +54,7 @@ DOM 定位方案的稳定性不足预期，它常在 Canvas 元素、CSS backgro
 |豆包 Seed 模型<br />[快速配置](./model-common-config#doubao-seed-model)|火山引擎版本：<br />[Doubao-Seed-1.6-Vision](https://www.volcengine.com/docs/82379/1799865)|⭐⭐⭐⭐<br/>UI 操作规划、定位能力较强<br />速度略慢|
 |千问 Qwen3-VL<br />[快速配置](./model-common-config#qwen3-vl)|[阿里云](https://help.aliyun.com/zh/model-studio/vision)<br/>[OpenRouter](https://openrouter.ai/qwen)<br/>[Ollama(开源)](https://ollama.com/library/qwen3-vl)|⭐⭐⭐⭐<br />复杂场景断言能力不够稳定 <br/>性能超群，操作准确<br />有开源版本（[HuggingFace](https://huggingface.co/Qwen) / [Github](https://github.com/QwenLM/)）|
 |千问 Qwen2.5-VL<br />[快速配置](./model-common-config#qwen25-vl)|[阿里云](https://help.aliyun.com/zh/model-studio/vision)<br/>[OpenRouter](https://openrouter.ai/qwen)|⭐⭐⭐<br/>综合效果不如 Qwen3-VL |
+|智谱 GLM-4.6V<br />[快速配置](./model-common-config#glm-v)|[Z.AI (Global)](https://docs.z.ai/guides/vlm/glm-4.6v)<br/>[BigModel (CN)](https://docs.bigmodel.cn/cn/guide/models/vlm/glm-4.6v)|⭐⭐⭐<br/>略逊于 Qwen3-VL，但成本更低<br />权重开源[HuggingFace](https://huggingface.co/zai-org/GLM-4.6V) |
 |Gemini-3-Pro / Gemini-3-Flash<br />[快速配置](./model-common-config#gemini-3-pro)|[Google Cloud](https://ai.google.dev/gemini-api/docs/models/gemini)|⭐⭐⭐<br />支持 Gemini-3-Flash<br />价格高于豆包和千问|
 |UI-TARS <br />[快速配置](./model-common-config#ui-tars)|[火山引擎](https://www.volcengine.com/docs/82379/1536429)|⭐⭐<br /> 有探索能力，但在不同场景表现可能差异较大<br />有开源版本（[HuggingFace](https://huggingface.co/bytedance-research/UI-TARS-72B-SFT) / [Github](https://github.com/bytedance/ui-tars)） |
 
@@ -131,13 +133,14 @@ Midscene 提供了基于页面理解的数据处理接口，如 AI 断言（`aiA
 
 ### 关于 `aiAct` 方法的 `deepThink` 参数
 
-`deepThink` 参数用于控制模型在规划时是否启用深度思考。目前支持 `qwen3-vl` 和 `doubao-seed-1.6` 系列模型。
+`deepThink` 参数用于控制模型在规划时是否启用深度思考。目前支持 `qwen3-vl`、`doubao-seed-1.6`、`glm-v` 等系列模型。
 
 启用后，你可以在报告中看到 `Reasoning` 栏目。开启后，规划耗时会增加，但结果会更准确。
 
 **不同服务商的默认行为：**
 - `qwen3-vl` 在阿里云：默认关闭（更快，但准确性差）
 - `doubao-seed-1.6` 在火山引擎：默认开启（更慢，但更准确）
+- `glm-v` 在 Z.AI：默认开启（更慢，但更准确）
 
 你可以通过显式设置 `deepThink: true` 或 `deepThink: false` 来覆盖服务商的默认配置。
 

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -526,6 +526,15 @@ export function resolveDeepThinkConfig({
     };
   }
 
+  if (vlMode === 'glm-v') {
+    return {
+      config: {
+        thinking: { type: normalizedDeepThink ? 'enabled' : 'disabled' },
+      },
+      debugMessage: `deepThink mapped to thinking.type=${normalizedDeepThink ? 'enabled' : 'disabled'} for glm-v`,
+    };
+  }
+
   return {
     config: {},
     debugMessage: `deepThink ignored: unsupported model_family "${vlMode ?? 'default'}"`,

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -196,7 +196,7 @@ export function adaptBbox(
     result = adaptDoubaoBbox(normalizedBbox, width, height);
   } else if (vlMode === 'gemini') {
     result = adaptGeminiBbox(normalizedBbox as number[], width, height);
-  } else if (vlMode === 'qwen3-vl') {
+  } else if (vlMode === 'qwen3-vl' || vlMode === 'glm-v') {
     result = normalized01000(normalizedBbox as number[], width, height);
   } else {
     result = adaptQwen2_5Bbox(normalizedBbox as number[]);

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -358,6 +358,28 @@ describe('service-caller', () => {
       expect(result.warningMessage).toBeUndefined();
     });
 
+    it('maps deepThink for glm-v', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: true,
+        vlMode: 'glm-v',
+      });
+
+      expect(result.config).toEqual({ thinking: { type: 'enabled' } });
+      expect(result.debugMessage).toContain('thinking.type=enabled');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('maps deepThink false for glm-v', () => {
+      const result = resolveDeepThinkConfig({
+        deepThink: false,
+        vlMode: 'glm-v',
+      });
+
+      expect(result.config).toEqual({ thinking: { type: 'disabled' } });
+      expect(result.debugMessage).toContain('thinking.type=disabled');
+      expect(result.warningMessage).toBeUndefined();
+    });
+
     it('warns when deepThink is unsupported', () => {
       const result = resolveDeepThinkConfig({
         deepThink: true,

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -238,14 +238,16 @@ export type TVlModeValues =
   | 'gemini'
   | 'vlm-ui-tars'
   | 'vlm-ui-tars-doubao'
-  | 'vlm-ui-tars-doubao-1.5';
+  | 'vlm-ui-tars-doubao-1.5'
+  | 'glm-v';
 
 export type TVlModeTypes =
   | 'qwen2.5-vl'
   | 'qwen3-vl'
   | 'doubao-vision'
   | 'gemini'
-  | 'vlm-ui-tars';
+  | 'vlm-ui-tars'
+  | 'glm-v';
 
 export const VL_MODE_RAW_VALID_VALUES: TVlModeValues[] = [
   'doubao-vision',
@@ -255,6 +257,7 @@ export const VL_MODE_RAW_VALID_VALUES: TVlModeValues[] = [
   'vlm-ui-tars',
   'vlm-ui-tars-doubao',
   'vlm-ui-tars-doubao-1.5',
+  'glm-v',
 ];
 
 /**
@@ -317,6 +320,7 @@ export interface IModelConfigForPlanning {
  *   - 'vlm-ui-tars'
  *   - 'vlm-ui-tars-doubao'
  *   - 'vlm-ui-tars-doubao-1.5'
+ *   - 'glm-v'
  */
 export interface IModelConfigForDefault {
   // model name

--- a/packages/shared/tests/unit-test/env/parse.test.ts
+++ b/packages/shared/tests/unit-test/env/parse.test.ts
@@ -46,6 +46,14 @@ describe('modelFamilyToVLConfig', () => {
       vlMode: 'doubao-vision',
       uiTarsVersion: undefined,
     });
+    expect(modelFamilyToVLConfig('gemini')).toEqual({
+      vlMode: 'gemini',
+      uiTarsVersion: undefined,
+    });
+    expect(modelFamilyToVLConfig('glm-v')).toEqual({
+      vlMode: 'glm-v',
+      uiTarsVersion: undefined,
+    });
   });
 
   it('should throw on invalid value', () => {


### PR DESCRIPTION
GLM-V adapts the same grounding technique of Qwen 3 (i.e. `[x1, y1, x2, y2]` normalized in `[0,1000)`), but with a different thinking parameter in API (`thinking.enable=true`). This PR is basically applying the same config of Qwen 3 to GLM-V (except `expandSearchArea`, because I don't know how it works).