### PR TITLE
docs(site): simplify launch action syntax in YAML documentation

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -352,13 +352,11 @@ ios:
 tasks:
   - name: Launch Settings app
     flow:
-      - launch:
-          uri: com.apple.Preferences
+      - launch: com.apple.Preferences
 
   - name: Open webpage
     flow:
-      - launch:
-          uri: https://www.example.com
+      - launch: https://www.example.com
 ```
 
 ### The `tasks` part

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -356,13 +356,11 @@ ios:
 tasks:
   - name: 启动设置应用
     flow:
-      - launch:
-          uri: com.apple.Preferences
+      - launch: com.apple.Preferences
 
   - name: 打开网页
     flow:
-      - launch:
-          uri: https://www.example.com
+      - launch: https://www.example.com
 ```
 
 ### `tasks` 部分


### PR DESCRIPTION
## Summary

This PR simplifies the YAML syntax for the `launch` action in the automation script documentation. The change makes the syntax more concise and easier to understand.

**Before:**
```yaml
- launch:
    uri: com.apple.Preferences
```

**After:**
```yaml
- launch: com.apple.Preferences
```

## Changes

- Updated English documentation (`apps/site/docs/en/automate-with-scripts-in-yaml.mdx`)
- Updated Chinese documentation (`apps/site/docs/zh/automate-with-scripts-in-yaml.mdx`)

## Test Plan

- [x] Lint checks passed
- [x] Documentation reviewed for clarity and accuracy
- [x] Both English and Chinese versions updated consistently