### PR TITLE
feat(core): make locate parameter optional in defineActionClearInput

### DIFF
--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -394,11 +394,15 @@ export const defineActionSwipe = (
 };
 
 // ClearInput
+const clearInputLocateDescription =
+  'the position of the placeholder or text content in the target input field. If there is no content, locate the center of the input field.';
 export const actionClearInputParamSchema = z.object({
-  locate: getMidsceneLocationSchema().describe('The input field to be cleared'),
+  locate: getMidsceneLocationSchema()
+    .describe(clearInputLocateDescription)
+    .optional(),
 });
 export type ActionClearInputParam = {
-  locate: LocateResultElement;
+  locate?: LocateResultElement;
 };
 
 export const defineActionClearInput = (
@@ -409,7 +413,7 @@ export const defineActionClearInput = (
     ActionClearInputParam
   >({
     name: 'ClearInput',
-    description: inputLocateDescription,
+    description: 'Clear the input field',
     interfaceAlias: 'aiClearInput',
     paramSchema: actionClearInputParamSchema,
     call,

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -201,8 +201,19 @@ export class IOSDevice implements AbstractInterface {
       }),
       defineActionClearInput(async (param) => {
         const element = param.locate;
-        assert(element, 'Element not found, cannot clear input');
-        await this.clearInput(element as unknown as ElementInfo);
+        if (element) {
+          await this.clearInput(element as unknown as ElementInfo);
+        } else {
+          // If no locate provided, use keyboard-only operation
+          // Clear the currently focused element
+          debugDevice('Attempting to clear input without locate, using keyboard');
+          const cleared = await this.wdaBackend.clearActiveElement();
+          if (cleared) {
+            debugDevice('Successfully cleared focused input');
+          } else {
+            debugDevice('Failed to clear input - no active element');
+          }
+        }
       }),
     ];
 

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -624,8 +624,20 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
 
   defineActionClearInput(async (param) => {
     const element = param.locate;
-    assert(element, 'Element not found, cannot clear input');
-    await page.clearInput(element as unknown as ElementInfo);
+    if (element) {
+      await page.clearInput(element as unknown as ElementInfo);
+    } else {
+      // If no locate provided, use keyboard-only operation (like Input)
+      // Select all and delete
+      const isMac = process.platform === 'darwin';
+      const selectAllKeys = isMac
+        ? [{ key: 'Meta' }, { key: 'a' }]
+        : [{ key: 'Control' }, { key: 'a' }];
+
+      await page.keyboard.press(selectAllKeys as any);
+      await sleep(100);
+      await page.keyboard.press([{ key: 'Backspace' }] as any);
+    }
   }),
 
   defineAction({


### PR DESCRIPTION
- Updated defineActionClearInput to make locate parameter optional
- When locate is not provided, use keyboard-only operations instead of mouse actions
- Web: Use Ctrl/Cmd+A and Backspace to clear focused input
- iOS: Use clearActiveElement() to clear currently focused element
- Android: Use keyboard clear commands without mouse click
- This allows ClearInput to work like Input action (keyboard-only mode)