### PR TITLE
fix(visualizer): add subType check for Planning task filtering in animation scripts

### DIFF
--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -298,7 +298,11 @@ export const generateAnimationScripts = (
     }
 
     for (let i = startIndex; i < execution.tasks.length; i++) {
-      if (i > startIndex && execution.tasks[i].type === 'Planning') {
+      if (
+        i > startIndex &&
+        execution.tasks[i].type === 'Planning' &&
+        execution.tasks[i].subType === 'Plan'
+      ) {
         break;
       }
 


### PR DESCRIPTION
## Summary

This PR fixes the Planning task filtering logic in the animation scripts generation to be more precise by adding a `subType` check.

## Changes

- Added `subType === 'Plan'` condition to the Planning task filter in `generateAnimationScripts` function
- This ensures that only Planning tasks with the 'Plan' subType will trigger the break in the loop, avoiding false positives from other Planning task subtypes

## Impact

This improves the accuracy of task filtering during animation script generation in the visualizer, preventing premature breaks when encountering Planning tasks that don't have the 'Plan' subType.

## Test Plan

- Existing unit tests should continue to pass
- The animation generation logic should now correctly handle different Planning task subtypes