### PR TITLE
feat(web-integration): add timeout parameter to connectNewTabWithUrl and connectCurrentTab methods

### DIFF
--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -40,9 +40,9 @@ export const getBridgePageInCliSide = (options?: {
   server.listen({
     timeout: options?.timeout,
   });
-  const bridgeCaller = (method: string) => {
+  const bridgeCaller = (method: string, timeout?: number) => {
     return async (...args: any[]) => {
-      const response = await server.call(method, args);
+      const response = await server.call(method, args, timeout);
       return response;
     };
   };
@@ -111,11 +111,19 @@ export const getBridgePageInCliSide = (options?: {
       }
 
       // Special handling for methods that support timeout in options
-      if (prop === 'connectNewTabWithUrl' || prop === 'connectCurrentTab') {
+      if (prop === 'connectNewTabWithUrl') {
         return async (url: string, options?: BridgeConnectTabOptions) => {
           const timeout = options?.timeout;
-          const response = await server.call(prop, [url, options], timeout);
-          return response;
+          const caller = bridgeCaller(prop, timeout);
+          return await caller(url, options);
+        };
+      }
+
+      if (prop === 'connectCurrentTab') {
+        return async (options?: BridgeConnectTabOptions) => {
+          const timeout = options?.timeout;
+          const caller = bridgeCaller(prop, timeout);
+          return await caller(options);
         };
       }
 

--- a/packages/web-integration/src/bridge-mode/common.ts
+++ b/packages/web-integration/src/bridge-mode/common.ts
@@ -43,7 +43,7 @@ export interface BridgeConnectTabOptions {
    */
   forceSameTabNavigation?: boolean;
   /**
-   * Custom timeout for this specific operation in milliseconds.
+   * Custom timeout for connecting to the tab in milliseconds.
    * @default 30000 (30 seconds)
    */
   timeout?: number;


### PR DESCRIPTION
## Summary

This PR adds method-level `timeout` parameter to `connectNewTabWithUrl` and `connectCurrentTab` methods, allowing users to configure timeout for each specific operation.

## Problem

Previously, the bridge call timeout was hardcoded to 30 seconds (`BridgeCallTimeout` constant). This caused issues when operations like `connectNewTabWithUrl` took longer than 30 seconds.

Users would see errors like:
```
Error: Bridge call timeout after 30000ms: connectNewTabWithUrl
```

## Solution

Changed approach from global `bridgeCallTimeout` parameter to **method-level `timeout` parameter** for better flexibility. Each method call can now specify its own timeout through the options parameter.

### Changes

- Extended `BridgeConnectTabOptions` interface to include optional `timeout` parameter
- Modified Proxy handler in `getBridgePageInCliSide` to extract timeout from options
- Added special handling for `connectNewTabWithUrl` and `connectCurrentTab` methods
- Pass timeout parameter to `server.call()` for these specific methods

### Usage Example

```typescript
import { AgentOverChromeBridge } from '@midscene/web/bridge-mode';

const agent = new AgentOverChromeBridge({
  allowRemoteAccess: true,
  port: 8083,
});

// Set 5-minute timeout for this specific call
await agent.connectNewTabWithUrl('https://example.com', {
  timeout: 5 * 60 * 1000,  // 5 minutes
});

// Also works for connectCurrentTab
await agent.connectCurrentTab({
  timeout: 5 * 60 * 1000,
});
```

## Benefits Over Global Approach

- **More flexible**: Each method call can have its own timeout
- **Cleaner API**: Timeout is specified where it's used
- **Better defaults**: Can use short timeout for some operations and long timeout for others
- **No breaking changes**: Timeout is optional, falls back to 30s default

## Testing

- All existing unit tests pass
- Tested with 3-second timeout: ✅ Works correctly
- Tested with 5-minute timeout: ✅ Parameter correctly passed
- No breaking changes to existing API (parameter is optional)

## Configuration Parameters

- **`serverListeningTimeout`** (constructor): Controls how long to wait for browser extension to connect to WebSocket server
- **`timeout`** (method options): Controls timeout for individual bridge operations

## Related Issue

Fixes issue where users experienced 30-second timeouts on `connectNewTabWithUrl` even when they needed longer execution time.