### PR TITLE
chore(core): update launchParamSchema description text

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1691,7 +1691,7 @@ const launchParamSchema = z.object({
   uri: z
     .string()
     .describe(
-      'Prioritize using the exact package name or URL the user has provided. If none provided, use the accurate app name.',
+      'App name, package name, or URL to launch. Prioritize using the exact package name or URL the user has provided. If none provided, use the accurate app name.',
     ),
 });
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -963,7 +963,7 @@ type RunWdaRequestReturn = Awaited<ReturnType<IOSDevice['runWdaRequest']>>;
 const launchParamSchema = z
   .string()
   .describe(
-    'Prioritize using the exact bundle ID or URL the user has provided. If none provided, use the accurate app name.',
+    'App name, bundle ID, or URL to launch. Prioritize using the exact bundle ID or URL the user has provided. If none provided, use the accurate app name.',
   );
 
 type LaunchParam = z.infer<typeof launchParamSchema>;


### PR DESCRIPTION
…ntifiers

Update launchParamSchema description to emphasize using the exact bundle ID/package name or URL that the user has already provided, rather than inferring. Only use app name when no identifier is provided.