### PR TITLE
Refactor device time API from environment variable to agent config

### DIFF
--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -33,7 +33,6 @@ You need to set a default model for Midscene; see [Model strategy](./model-strat
 | `MIDSCENE_MODEL_INIT_CONFIG_JSON` | JSON blob that overrides the OpenAI SDK initialization config |
 | `MIDSCENE_RUN_DIR` | Run artifact directory, like report and logs. Defaults to `midscene_run` in the current working directory; accepts absolute or relative paths |
 | `MIDSCENE_PREFERRED_LANGUAGE` | Optional. Preferred response language. Defaults to `Chinese` if timezone is GMT+8, otherwise `English` |
-| `MIDSCENE_USE_DEVICE_TIME` | When set to `true`, Midscene will use the target device's time (Android/iOS) instead of the system time. Useful when the device time differs from the host machine. Default: `false` |
 
 > Note: Control replanning behavior with the agent option `replanningCycleLimit` (defaults to 20, or 40 for `vlm-ui-tars`), not with environment variables.
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -31,7 +31,6 @@ Midscene 默认集成了 OpenAI SDK 调用 AI 服务，它限定了推理服务�
 | `MIDSCENE_MODEL_INIT_CONFIG_JSON` | 覆盖 OpenAI SDK 初始化配置的 JSON |
 | `MIDSCENE_RUN_DIR` | 运行产物目录，默认值为当前工作目录下的 `midscene_run`，支持设置绝对路径或相对路径 |
 | `MIDSCENE_PREFERRED_LANGUAGE` | 可选，模型响应的语言；如果当前系统时区是 GMT+8 则默认是 `Chinese`，否则是 `English` |
-| `MIDSCENE_USE_DEVICE_TIME` | 设置为 `true` 时，Midscene 会使用目标设备（Android/iOS）的时间而非系统时间。当设备时间与主机时间不一致时非常有用。默认值：`false` |
 
 > 提示：通过 Agent 的 `replanningCycleLimit` 入参控制重规划次数（默认 20，`vlm-ui-tars` 为 40），不再使用环境变量。
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1496,7 +1496,7 @@ ${Object.keys(size)
    * Returns the device's current timestamp in milliseconds.
    * This is useful when the system time and device time are not synchronized.
    */
-  async getDeviceTime(): Promise<number> {
+  async getTimestamp(): Promise<number> {
     const adb = await this.getAdb();
     try {
       // Get time in milliseconds using date command

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1769,12 +1769,12 @@ describe('AndroidDevice', () => {
     });
   });
 
-  describe('getDeviceTime', () => {
+  describe('getTimestamp', () => {
     it('should return device timestamp in milliseconds', async () => {
       const mockTimestamp = '1706262645123';
       mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
 
-      const result = await device.getDeviceTime();
+      const result = await device.getTimestamp();
 
       expect(mockAdb.shell).toHaveBeenCalledWith('date +%s%3N');
       expect(result).toBe(1706262645123);
@@ -1784,7 +1784,7 @@ describe('AndroidDevice', () => {
       const mockTimestamp = '  1706262645123  \n';
       mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
 
-      const result = await device.getDeviceTime();
+      const result = await device.getTimestamp();
 
       expect(result).toBe(1706262645123);
     });
@@ -1792,7 +1792,7 @@ describe('AndroidDevice', () => {
     it('should throw error for invalid timestamp format', async () => {
       mockAdb.shell.mockResolvedValueOnce('invalid-timestamp');
 
-      await expect(device.getDeviceTime()).rejects.toThrow(
+      await expect(device.getTimestamp()).rejects.toThrow(
         'Invalid timestamp format',
       );
     });
@@ -1800,7 +1800,7 @@ describe('AndroidDevice', () => {
     it('should throw error when shell command fails', async () => {
       mockAdb.shell.mockRejectedValueOnce(new Error('Shell command failed'));
 
-      await expect(device.getDeviceTime()).rejects.toThrow(
+      await expect(device.getTimestamp()).rejects.toThrow(
         'Failed to get device time',
       );
     });
@@ -1808,7 +1808,7 @@ describe('AndroidDevice', () => {
     it('should throw error for empty response', async () => {
       mockAdb.shell.mockResolvedValueOnce('');
 
-      await expect(device.getDeviceTime()).rejects.toThrow(
+      await expect(device.getTimestamp()).rejects.toThrow(
         'Invalid timestamp format',
       );
     });
@@ -1817,7 +1817,7 @@ describe('AndroidDevice', () => {
       const mockTimestamp = '1893456000000'; // Year 2030
       mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
 
-      const result = await device.getDeviceTime();
+      const result = await device.getTimestamp();
 
       expect(result).toBe(1893456000000);
     });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -392,6 +392,7 @@ export class Agent<
       onTaskStart: this.callbackOnTaskStartTip.bind(this),
       replanningCycleLimit: this.opts.replanningCycleLimit,
       waitAfterAction: this.opts.waitAfterAction,
+      useDeviceTimestamp: this.opts.useDeviceTimestamp,
       actionSpace: this.fullActionSpace,
       hooks: {
         onTaskUpdate: (runner) => {

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -81,6 +81,8 @@ export class TaskExecutor {
 
   waitAfterAction?: number;
 
+  useDeviceTimestamp?: boolean;
+
   // @deprecated use .interface instead
   get page() {
     return this.interface;
@@ -94,6 +96,7 @@ export class TaskExecutor {
       onTaskStart?: ExecutionTaskProgressOptions['onTaskStart'];
       replanningCycleLimit?: number;
       waitAfterAction?: number;
+      useDeviceTimestamp?: boolean;
       hooks?: TaskExecutorHooks;
       actionSpace: DeviceAction[];
     },
@@ -104,6 +107,7 @@ export class TaskExecutor {
     this.onTaskStartCallback = opts?.onTaskStart;
     this.replanningCycleLimit = opts.replanningCycleLimit;
     this.waitAfterAction = opts.waitAfterAction;
+    this.useDeviceTimestamp = opts.useDeviceTimestamp;
     this.hooks = opts.hooks;
     this.conversationHistory = new ConversationHistory();
     this.providedActionSpace = opts.actionSpace;
@@ -137,12 +141,15 @@ export class TaskExecutor {
 
   /**
    * Get a readable time string using device time when configured.
-   * This method respects the MIDSCENE_USE_DEVICE_TIME configuration.
+   * This method respects the useDeviceTimestamp configuration.
    * @param format - Optional format string
    * @returns A formatted time string
    */
   private async getTimeString(format?: string): Promise<string> {
-    const timestamp = await getCurrentTime(this.interface);
+    const timestamp = await getCurrentTime(
+      this.interface,
+      this.useDeviceTimestamp,
+    );
     return getReadableTimeString(format, timestamp);
   }
 

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -61,7 +61,7 @@ export abstract class AbstractInterface {
    * Returns the device's current timestamp in milliseconds.
    * This is useful when the system time and device time are not synchronized.
    */
-  getDeviceTime?(): Promise<number>;
+  getTimestamp?(): Promise<number>;
 }
 
 // Generic function to define actions with proper type inference

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -788,6 +788,13 @@ export interface AgentOpt {
   waitAfterAction?: number;
 
   /**
+   * When set to true, Midscene will use the target device's time (Android/iOS)
+   * instead of the system time. Useful when the device time differs from the
+   * host machine. Default: false
+   */
+  useDeviceTimestamp?: boolean;
+
+  /**
    * Custom OpenAI client factory function
    *
    * If provided, this function will be called to create OpenAI client instances

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -949,9 +949,9 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
    * Returns the device's current timestamp in milliseconds.
    * Uses the Appium XCUITest driver's device time API.
    */
-  async getDeviceTime(): Promise<number> {
+  async getTimestamp(): Promise<number> {
     try {
-      const timestamp = await this.wdaBackend.getDeviceTime();
+      const timestamp = await this.wdaBackend.getTimestamp();
       debugDevice(`Got device time: ${timestamp}`);
       return timestamp;
     } catch (error) {

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -538,7 +538,7 @@ export class IOSWebDriverClient extends WebDriverClient {
    * @param format Optional format string (default: 'YYYY-MM-DDTHH:mm:ssZ')
    * @returns Device time as a timestamp in milliseconds
    */
-  async getDeviceTime(format?: string): Promise<number> {
+  async getTimestamp(format?: string): Promise<number> {
     this.ensureSession();
 
     try {

--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -233,13 +233,13 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
   });
 
-  describe('getDeviceTime()', () => {
+  describe('getTimestamp()', () => {
     it('should return timestamp when appium endpoint succeeds', async () => {
       const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
       const mockTimeString = '2024-01-26T15:30:45+08:00';
       makeRequestSpy.mockResolvedValueOnce({ value: mockTimeString });
 
-      const result = await client.getDeviceTime();
+      const result = await client.getTimestamp();
 
       expect(makeRequestSpy).toHaveBeenCalledTimes(1);
       expect(makeRequestSpy).toHaveBeenCalledWith(
@@ -258,7 +258,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
       // Second call (execute method) succeeds
       makeRequestSpy.mockResolvedValueOnce({ value: mockTimeString });
 
-      const result = await client.getDeviceTime();
+      const result = await client.getTimestamp();
 
       expect(makeRequestSpy).toHaveBeenCalledTimes(2);
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
@@ -284,7 +284,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
       makeRequestSpy.mockRejectedValueOnce(new Error('Appium endpoint failed'));
       makeRequestSpy.mockRejectedValueOnce(new Error('Execute method failed'));
 
-      await expect(client.getDeviceTime()).rejects.toThrow(
+      await expect(client.getTimestamp()).rejects.toThrow(
         'Failed to get device time',
       );
 
@@ -295,7 +295,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
       const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
       makeRequestSpy.mockResolvedValueOnce({ value: 'invalid-time-string' });
 
-      await expect(client.getDeviceTime()).rejects.toThrow(
+      await expect(client.getTimestamp()).rejects.toThrow(
         'Invalid time format received',
       );
     });
@@ -305,7 +305,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
       const mockTimeString = '2024-01-26T15:30:45+08:00';
       makeRequestSpy.mockResolvedValueOnce(mockTimeString);
 
-      const result = await client.getDeviceTime();
+      const result = await client.getTimestamp();
 
       expect(result).toBe(new Date(mockTimeString).getTime());
     });
@@ -317,7 +317,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
       makeRequestSpy.mockRejectedValueOnce(new Error('Endpoint not found'));
       makeRequestSpy.mockResolvedValueOnce({ value: '2024-01-26' });
 
-      await client.getDeviceTime('YYYY-MM-DD');
+      await client.getTimestamp('YYYY-MM-DD');
 
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
         2,

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -64,13 +64,6 @@ export const MIDSCENE_ANDROID_IME_STRATEGY = 'MIDSCENE_ANDROID_IME_STRATEGY';
 export const MIDSCENE_IOS_DEVICE_UDID = 'MIDSCENE_IOS_DEVICE_UDID';
 export const MIDSCENE_IOS_SIMULATOR_UDID = 'MIDSCENE_IOS_SIMULATOR_UDID';
 
-/**
- * Time source configuration for Midscene.
- * When set to 'true', Midscene will use the target device's time instead of the system time.
- * This is useful when the system time and device time are not synchronized.
- */
-export const MIDSCENE_USE_DEVICE_TIME = 'MIDSCENE_USE_DEVICE_TIME';
-
 export const MIDSCENE_CACHE = 'MIDSCENE_CACHE';
 export const MIDSCENE_USE_VLM_UI_TARS = 'MIDSCENE_USE_VLM_UI_TARS';
 export const MIDSCENE_USE_QWEN_VL = 'MIDSCENE_USE_QWEN_VL';
@@ -157,7 +150,6 @@ export const BOOLEAN_ENV_KEYS = [
   MIDSCENE_MCP_ANDROID_MODE,
   MIDSCENE_LANGSMITH_DEBUG,
   MIDSCENE_LANGFUSE_DEBUG,
-  MIDSCENE_USE_DEVICE_TIME,
 ] as const;
 
 export const NUMBER_ENV_KEYS = [

--- a/packages/shared/src/env/utils.ts
+++ b/packages/shared/src/env/utils.ts
@@ -3,7 +3,6 @@ import { ModelConfigManager } from './model-config-manager';
 import {
   type GLOBAL_ENV_KEYS,
   MIDSCENE_PREFERRED_LANGUAGE,
-  MIDSCENE_USE_DEVICE_TIME,
   type MODEL_ENV_KEYS,
 } from './types';
 
@@ -15,17 +14,17 @@ globalConfigManager.registerModelConfigManager(globalModelConfigManager);
 globalModelConfigManager.registerGlobalConfigManager(globalConfigManager);
 
 /**
- * Interface for devices that support getDeviceTime method.
+ * Interface for devices that support getTimestamp method.
  * This is a minimal interface to avoid circular dependencies with @midscene/core.
  */
-export interface DeviceWithTime {
-  getDeviceTime?: () => Promise<number>;
+export interface DeviceWithTimestamp {
+  getTimestamp?: () => Promise<number>;
 }
 
 /**
  * Get the current timestamp, optionally from the target device.
  *
- * When MIDSCENE_USE_DEVICE_TIME is enabled and a device with getDeviceTime is provided,
+ * When useDeviceTimestamp is enabled and a device with getTimestamp is provided,
  * this function will return the device's time. Otherwise, it returns the system time.
  *
  * This is useful when:
@@ -33,7 +32,8 @@ export interface DeviceWithTime {
  * - Debugging time-sensitive features
  * - The system clock and device clock are not synchronized
  *
- * @param device Optional device interface that supports getDeviceTime
+ * @param device Optional device interface that supports getTimestamp
+ * @param useDeviceTimestamp Whether to use device timestamp (from agent config)
  * @returns Timestamp in milliseconds
  *
  * @example
@@ -42,16 +42,15 @@ export interface DeviceWithTime {
  *
  * @example
  * // With device and config enabled - returns device time
- * const deviceTime = await getCurrentTime(androidDevice);
+ * const deviceTime = await getCurrentTime(androidDevice, true);
  */
-export async function getCurrentTime(device?: DeviceWithTime): Promise<number> {
-  const useDeviceTime = globalConfigManager.getEnvConfigInBoolean(
-    MIDSCENE_USE_DEVICE_TIME,
-  );
-
-  if (useDeviceTime && device?.getDeviceTime) {
+export async function getCurrentTime(
+  device?: DeviceWithTimestamp,
+  useDeviceTimestamp?: boolean,
+): Promise<number> {
+  if (useDeviceTimestamp && device?.getTimestamp) {
     try {
-      return await device.getDeviceTime();
+      return await device.getTimestamp();
     } catch (error) {
       // Fall back to system time if device time retrieval fails
       console.warn(


### PR DESCRIPTION
## Summary
This PR refactors the device timestamp retrieval mechanism from using an environment variable (`MIDSCENE_USE_DEVICE_TIME`) to a configuration option passed through the Agent initialization (`useDeviceTimestamp`). Additionally, the method name is standardized across all device implementations from `getDeviceTime()` to `getTimestamp()`.

## Key Changes

- **Removed environment variable**: Deleted `MIDSCENE_USE_DEVICE_TIME` from environment configuration and documentation
- **Added agent configuration option**: Introduced `useDeviceTimestamp?: boolean` to `AgentOpt` interface for explicit control during agent initialization
- **Standardized method naming**: Renamed `getDeviceTime()` to `getTimestamp()` across all device implementations:
  - Android device (`packages/android/src/device.ts`)
  - iOS device (`packages/ios/src/device.ts`)
  - iOS WebDriver client (`packages/ios/src/ios-webdriver-client.ts`)
  - Abstract interface (`packages/core/src/device/index.ts`)
- **Updated API contracts**: Modified `getCurrentTime()` function to accept `useDeviceTimestamp` as a parameter instead of reading from environment
- **Updated documentation**: Removed references to `MIDSCENE_USE_DEVICE_TIME` from both English and Chinese documentation
- **Updated tests**: Refactored all unit tests to use the new method names and parameter-based configuration

## Implementation Details

- The `useDeviceTimestamp` option is now passed from `Agent` to `TaskExecutor` during initialization
- `TaskExecutor.getTimeString()` now passes the configuration to `getCurrentTime()` instead of relying on environment variables
- The change provides better encapsulation and makes the configuration explicit at the agent level rather than implicit through environment variables
- All error handling and fallback behavior remains unchanged - system time is used if device time retrieval fails