### PR TITLE
fix(core): compute bbox center from original coordinates to avoid rounding drift

### DIFF
--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -142,19 +142,23 @@ export function matchElementFromPlan(
     return undefined;
   }
 
+  const promptText =
+    typeof planLocateParam.prompt === 'string'
+      ? planLocateParam.prompt
+      : planLocateParam.prompt?.prompt || '';
+
+  // Prefer pre-computed precise center (avoids rounding error from independent corner rounding)
+  if (planLocateParam.bboxCenter) {
+    return generateElementByPosition(planLocateParam.bboxCenter, promptText);
+  }
+
+  // Fallback: compute center from already-rounded bbox
   if (planLocateParam.bbox) {
     const centerPosition = {
       x: Math.floor((planLocateParam.bbox[0] + planLocateParam.bbox[2]) / 2),
       y: Math.floor((planLocateParam.bbox[1] + planLocateParam.bbox[3]) / 2),
     };
-
-    const element = generateElementByPosition(
-      centerPosition,
-      typeof planLocateParam.prompt === 'string'
-        ? planLocateParam.prompt
-        : planLocateParam.prompt?.prompt || '',
-    );
-    return element;
+    return generateElementByPosition(centerPosition, promptText);
   }
 
   return undefined;

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -22,7 +22,12 @@ import type {
   ChatCompletionUserMessageParam,
 } from 'openai/resources/index';
 import type { TMultimodalPrompt, TUserPrompt } from '../common';
-import { adaptBboxToRect, expandSearchArea, mergeRects } from '../common';
+import {
+  adaptBboxToRect,
+  computeBboxCenter,
+  expandSearchArea,
+  mergeRects,
+} from '../common';
 import { parseAutoGLMLocateResponse } from './auto-glm/parser';
 import { getAutoGLMLocatePrompt } from './auto-glm/prompt';
 import { isAutoGLM } from './auto-glm/util';
@@ -336,10 +341,14 @@ export async function AiLocateElement(options: {
 
       debugInspect('resRect', resRect);
 
-      const rectCenter = {
-        x: resRect.left + resRect.width / 2,
-        y: resRect.top + resRect.height / 2,
-      };
+      const rectCenter = computeBboxCenter(
+        res.content.bbox,
+        imageWidth,
+        imageHeight,
+        options.searchConfig?.rect?.left,
+        options.searchConfig?.rect?.top,
+        modelFamily,
+      );
 
       const element: LocateResultElement = generateElementByPosition(
         rectCenter,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -227,6 +227,7 @@ export interface AgentAssertOpt {
 
 export interface PlanningLocateParam extends DetailedLocateParam {
   bbox?: [number, number, number, number];
+  bboxCenter?: { x: number; y: number };
 }
 
 export interface PlanningAction<ParamType = any> {

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -74,6 +74,7 @@ describe('llm planning - doubao', () => {
       id: 'test',
       prompt: 'test',
       bbox: [923, 123, 123, 123],
+      bboxCenter: { x: 523, y: 123 },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix coordinate precision issue where independently rounding each bbox corner before computing the center point caused up to 1px drift, potentially placing clicks outside target element boundaries.
- Introduce `computeBboxCenter()` that computes the center directly from original normalized coordinates with a single `Math.round`, eliminating accumulated rounding error.
- Apply the fix to both the AI Locate path (`inspect.ts`) and Plan-hit path (`matchElementFromPlan` via `fillBboxParam`).

### Root Cause

```
Original bbox: [934, 93, 951, 118], image 1280×860

Before (with error):
  left  = Math.round(934 × 1.28) = 1196
  right = Math.round(951 × 1.28) = 1217
  width = 21 (odd → center .5)
  center_x = 1196 + 10.5 = 1206.5 → Math.round = 1207 ← outside button

After (precise):
  center_x = ((934+951)/2) × 1.28 = 1206.4 → Math.round = 1206 ← correct
```

### Changes

| File | Change |
|------|--------|
| `packages/core/src/common.ts` | Add `parseBboxToNumbers` and `computeBboxCenter`; pre-compute `bboxCenter` in `fillBboxParam` |
| `packages/core/src/types.ts` | Add `bboxCenter` field to `PlanningLocateParam` |
| `packages/core/src/ai-model/inspect.ts` | Use `computeBboxCenter` in standard bbox locate path |
| `packages/core/src/agent/utils.ts` | Prefer pre-computed `bboxCenter` in `matchElementFromPlan` with fallback |
| `packages/core/tests/unit-test/utils.test.ts` | Add 13 test cases for `parseBboxToNumbers` and `computeBboxCenter` |
| `packages/core/tests/unit-test/llm-planning.test.ts` | Update `fill locate param` expectation to include `bboxCenter` |

### Unaffected paths
- AutoGLM (returns single point, even-sized rect)
- UI-TARS (independent path)
- XPath-hit / Cache-hit (rect from browser, no normalization)

## Test plan

- [x] Unit tests for `computeBboxCenter` covering: original bug case, even-width bbox, gemini format, qwen2.5-vl pixel/point format, doubao point format, offset scenarios, 3-element point format
- [x] Unit tests for `parseBboxToNumbers` covering: number arrays, string arrays (comma/space separated), plain strings, nested arrays
- [x] `npx nx test @midscene/core` — all related tests pass