### PR TITLE
fix(puppeteer): prevent screenshot hang on inactive tabs

### DIFF
--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -339,25 +339,11 @@ export class Page<
       // Inactive tabs in Chrome don't produce frames, causing screenshot to hang.
       // See: https://github.com/puppeteer/puppeteer/issues/12712
       await (this.underlyingPage as PuppeteerPage).bringToFront();
-      const screenshotTimeout = 10 * 1000;
-      const result = await Promise.race([
-        (this.underlyingPage as PuppeteerPage).screenshot({
-          type: imgType,
-          quality,
-          encoding: 'base64',
-        }),
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  `Puppeteer screenshot timed out after ${screenshotTimeout}ms`,
-                ),
-              ),
-            screenshotTimeout,
-          ),
-        ),
-      ]);
+      const result = await (this.underlyingPage as PuppeteerPage).screenshot({
+        type: imgType,
+        quality,
+        encoding: 'base64',
+      });
       base64 = createImgBase64ByFormat(imgType, result);
     } else if (this.interfaceType === 'playwright') {
       const buffer = await (this.underlyingPage as PlaywrightPage).screenshot({


### PR DESCRIPTION
## Summary
- Add `page.bringToFront()` before Puppeteer screenshot to ensure the tab is actively rendering frames (root cause fix for inactive tab hang)
- Add 10s timeout via `Promise.race` as a safety fallback, matching Playwright's built-in screenshot timeout behavior

## Background
Chrome doesn't render frames for inactive tabs, which causes `Page.captureScreenshot` CDP command to hang indefinitely. This is especially problematic in CI environments where new tabs are opened (e.g., `target="_blank"` links) and the original tab becomes inactive.

Puppeteer's own `screenshot()` does call `bringToFront()` internally, but race conditions with tab creation/closing can prevent it from working reliably. An explicit call before the screenshot ensures the tab is in the foreground.

Reference: https://github.com/puppeteer/puppeteer/issues/12712

## Test plan
- [ ] Verify tab-navigation test passes in CI (previously hung on screenshot)
- [ ] Verify existing Puppeteer screenshot tests still pass