### PR TITLE
Add batch locate support to aiLocate method

### DIFF
--- a/packages/core/src/ai-model/index.ts
+++ b/packages/core/src/ai-model/index.ts
@@ -18,9 +18,12 @@ export type { ChatCompletionMessageParam } from 'openai/resources/index';
 
 export {
   AiLocateElement,
+  AiLocateElements,
   AiExtractElementInfo,
   AiLocateSection,
   AiJudgeOrderSensitive,
+  type AiBatchLocateElementResult,
+  type AIBatchElementResponse,
 } from './inspect';
 
 export { plan } from './llm-planning';

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -36,6 +36,11 @@ import {
   systemPromptToLocateElement,
 } from './prompt/llm-locator';
 import {
+  type BatchLocateTarget,
+  findElementsPrompt,
+  systemPromptToLocateElements,
+} from './prompt/llm-locator-batch';
+import {
   sectionLocatorInstruction,
   systemPromptToLocateSection,
 } from './prompt/llm-section-locator';
@@ -369,6 +374,249 @@ export async function AiLocateElement(options: {
       elements: matchedElements as LocateResultElement[],
       errors: errors as string[],
     },
+    rawResponse,
+    usage: res.usage,
+    reasoning_content: res.reasoning_content,
+  };
+}
+
+export interface AiBatchLocateElementResult {
+  id: string;
+  element: LocateResultElement | null;
+  rect?: Rect;
+  error?: string;
+}
+
+export interface AIBatchElementResponse {
+  elements: Array<{
+    id: string;
+    bbox: [number, number, number, number] | [];
+    error?: string;
+  }>;
+}
+
+export async function AiLocateElements(options: {
+  context: UIContext;
+  targetDescriptions: Array<{ id: string; description: TUserPrompt }>;
+  callAIFn: typeof callAIWithObjectResponse<AIBatchElementResponse>;
+  modelConfig: IModelConfig;
+}): Promise<{
+  results: AiBatchLocateElementResult[];
+  rawResponse: string;
+  usage?: AIUsageInfo;
+  reasoning_content?: string;
+}> {
+  const { context, targetDescriptions, callAIFn, modelConfig } = options;
+  const { modelFamily } = modelConfig;
+  const screenshotBase64 = context.screenshot.base64;
+
+  assert(
+    targetDescriptions.length > 0,
+    'targetDescriptions must have at least one element',
+  );
+
+  // For AutoGLM, fall back to sequential single-element calls
+  if (isAutoGLM(modelFamily)) {
+    const results: AiBatchLocateElementResult[] = [];
+    let totalUsage: AIUsageInfo | undefined;
+    const rawResponses: string[] = [];
+
+    for (const target of targetDescriptions) {
+      const singleResult = await AiLocateElement({
+        context,
+        targetElementDescription: target.description,
+        callAIFn: callAIWithObjectResponse as typeof callAIWithObjectResponse<
+          AIElementResponse | [number, number]
+        >,
+        modelConfig,
+      });
+
+      rawResponses.push(singleResult.rawResponse);
+
+      if (singleResult.usage) {
+        if (!totalUsage) {
+          totalUsage = { ...singleResult.usage };
+        } else {
+          totalUsage.prompt_tokens =
+            (totalUsage.prompt_tokens || 0) +
+            (singleResult.usage.prompt_tokens || 0);
+          totalUsage.completion_tokens =
+            (totalUsage.completion_tokens || 0) +
+            (singleResult.usage.completion_tokens || 0);
+          totalUsage.total_tokens =
+            (totalUsage.total_tokens || 0) +
+            (singleResult.usage.total_tokens || 0);
+        }
+      }
+
+      const element = singleResult.parseResult.elements[0] || null;
+      const error = singleResult.parseResult.errors?.[0];
+
+      results.push({
+        id: target.id,
+        element,
+        rect: singleResult.rect,
+        error,
+      });
+    }
+
+    return {
+      results,
+      rawResponse: JSON.stringify(rawResponses),
+      usage: totalUsage,
+    };
+  }
+
+  const targets: BatchLocateTarget[] = targetDescriptions.map((t) => ({
+    id: t.id,
+    description: extraTextFromUserPrompt(t.description),
+  }));
+
+  let imagePayload = screenshotBase64;
+  let imageWidth = context.size.width;
+  let imageHeight = context.size.height;
+
+  if (modelFamily === 'qwen2.5-vl') {
+    const paddedResult = await paddingToMatchBlockByBase64(imagePayload);
+    imageWidth = paddedResult.width;
+    imageHeight = paddedResult.height;
+    imagePayload = paddedResult.imageBase64;
+  }
+
+  const systemPrompt = systemPromptToLocateElements(modelFamily);
+  const userPrompt = findElementsPrompt(targets);
+
+  const msgs: AIArgs = [
+    { role: 'system', content: systemPrompt },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'image_url',
+          image_url: {
+            url: imagePayload,
+            detail: 'high',
+          },
+        },
+        {
+          type: 'text',
+          text: userPrompt,
+        },
+      ],
+    },
+  ];
+
+  let res: Awaited<ReturnType<typeof callAIFn>>;
+  try {
+    res = await callAIFn(msgs, modelConfig);
+  } catch (callError) {
+    const errorMessage =
+      callError instanceof Error ? callError.message : String(callError);
+    const rawResponse =
+      callError instanceof AIResponseParseError
+        ? callError.rawResponse
+        : errorMessage;
+    const usage =
+      callError instanceof AIResponseParseError ? callError.usage : undefined;
+
+    // Return error for all targets
+    const results: AiBatchLocateElementResult[] = targetDescriptions.map(
+      (t) => ({
+        id: t.id,
+        element: null,
+        error: `AI call error: ${errorMessage}`,
+      }),
+    );
+
+    return {
+      results,
+      rawResponse,
+      usage,
+    };
+  }
+
+  const rawResponse = JSON.stringify(res.content);
+  const responseElements = res.content.elements || [];
+
+  // Create a map for quick lookup
+  const responseMap = new Map<
+    string,
+    { bbox: [number, number, number, number] | []; error?: string }
+  >();
+  for (const elem of responseElements) {
+    responseMap.set(elem.id, { bbox: elem.bbox, error: elem.error });
+  }
+
+  // Build results in the same order as input
+  const results: AiBatchLocateElementResult[] = targetDescriptions.map(
+    (target) => {
+      const response = responseMap.get(target.id);
+
+      if (!response) {
+        return {
+          id: target.id,
+          element: null,
+          error: `No response for element ${target.id}`,
+        };
+      }
+
+      if (
+        response.error ||
+        !response.bbox ||
+        !Array.isArray(response.bbox) ||
+        response.bbox.length < 4
+      ) {
+        return {
+          id: target.id,
+          element: null,
+          error: response.error || 'Element not found',
+        };
+      }
+
+      try {
+        const resRect = adaptBboxToRect(
+          response.bbox,
+          imageWidth,
+          imageHeight,
+          undefined,
+          undefined,
+          context.size.width,
+          context.size.height,
+          modelFamily,
+        );
+
+        const rectCenter = {
+          x: resRect.left + resRect.width / 2,
+          y: resRect.top + resRect.height / 2,
+        };
+
+        const descriptionText = extraTextFromUserPrompt(target.description);
+        const element: LocateResultElement = generateElementByPosition(
+          rectCenter,
+          descriptionText,
+        );
+
+        return {
+          id: target.id,
+          element,
+          rect: resRect,
+        };
+      } catch (e) {
+        const msg =
+          e instanceof Error
+            ? `Failed to parse bbox: ${e.message}`
+            : 'unknown error in batch locate';
+        return {
+          id: target.id,
+          element: null,
+          error: msg,
+        };
+      }
+    },
+  );
+
+  return {
+    results,
     rawResponse,
     usage: res.usage,
     reasoning_content: res.reasoning_content,

--- a/packages/core/src/ai-model/prompt/llm-locator-batch.ts
+++ b/packages/core/src/ai-model/prompt/llm-locator-batch.ts
@@ -1,0 +1,70 @@
+import type { TModelFamily } from '@midscene/shared/env';
+import { getPreferredLanguage } from '@midscene/shared/env';
+import { bboxDescription } from './common';
+
+export function systemPromptToLocateElements(
+  modelFamily: TModelFamily | undefined,
+) {
+  const preferredLanguage = getPreferredLanguage();
+  const bboxComment = bboxDescription(modelFamily);
+  return `
+## Role:
+You are an AI assistant that helps identify UI elements.
+
+## Objective:
+- Identify multiple elements in screenshots that match the user's descriptions.
+- Provide the coordinates of each element that matches the corresponding description.
+- Return results in the same order as the input descriptions.
+
+## Output Format:
+\`\`\`json
+{
+  "elements": [
+    {
+      "id": string,  // The ID from the input
+      "bbox": [number, number, number, number],  // ${bboxComment}
+      "error"?: string  // Error message if element not found
+    }
+  ]
+}
+\`\`\`
+
+Fields:
+* \`elements\` is an array of results, one for each input description, in the same order
+* \`id\` is the identifier from the input, used to match results with requests
+* \`bbox\` is the bounding box of the element that matches the description
+* \`error\` is an optional error message when the element cannot be found
+
+For example, when all elements are found:
+\`\`\`json
+{
+  "elements": [
+    { "id": "0", "bbox": [100, 100, 200, 200] },
+    { "id": "1", "bbox": [300, 300, 400, 400] }
+  ]
+}
+\`\`\`
+
+When some elements are not found:
+\`\`\`json
+{
+  "elements": [
+    { "id": "0", "bbox": [100, 100, 200, 200] },
+    { "id": "1", "bbox": [], "error": "Element not found. Use ${preferredLanguage}." }
+  ]
+}
+\`\`\`
+`;
+}
+
+export interface BatchLocateTarget {
+  id: string;
+  description: string;
+}
+
+export const findElementsPrompt = (targets: BatchLocateTarget[]) => {
+  const targetList = targets
+    .map((t) => `- ID "${t.id}": ${t.description}`)
+    .join('\n');
+  return `Find the following elements:\n${targetList}`;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ import { getVersion } from './utils';
 export {
   plan,
   AiLocateElement,
+  AiLocateElements,
+  type AiBatchLocateElementResult,
   getMidsceneLocationSchema,
   type MidsceneLocationResultType,
   PointSchema,


### PR DESCRIPTION
## Summary
Enhanced the `aiLocate` method to support locating multiple UI elements in a single operation, improving performance when dealing with multiple element queries. The method now accepts either a single prompt or an array of prompts and returns results accordingly.

## Key Changes

- **Method Overloading**: Added TypeScript overloads to `aiLocate` to support both single prompt and array of prompts with appropriate return types
- **Batch Locate Implementation**: 
  - Single prompt: Uses existing single-element locate logic
  - Multiple prompts: Uses new `AiLocateElements` function for batch processing
- **New Batch Locate Function**: Implemented `AiLocateElements` in `inspect.ts` that:
  - Processes multiple element descriptions in a single AI call
  - Falls back to sequential calls for AutoGLM models
  - Returns results in the same order as input with optional error messages per element
- **Batch Prompt Templates**: Added `llm-locator-batch.ts` with system and user prompt templates optimized for batch element location
- **Service Layer**: Added `locateMultiple` method to Service class to handle batch locate queries with proper result transformation
- **Exports**: Updated public API exports to include new batch locate types and functions

## Implementation Details

- Batch locate leverages the existing `callAIWithObjectResponse` infrastructure
- Results maintain order correspondence with input queries
- Each result includes optional `error` field for individual element failures
- Image padding for Qwen models is applied once for all queries
- DPR (device pixel ratio) is included in all results
- Graceful fallback to sequential processing for models that don't support batch operations

https://claude.ai/code/session_01X5yjQA28e1jnQXix6ZuZEj