### PR TITLE
chore(workflow): improve dev workflow to eliminate build:skip-cache dependency

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,7 +24,8 @@
       "outputs": ["{projectRoot}/dist"]
     },
     "build:watch": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "continuous": true
     },
     "test": {
       "cache": false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.3.1",
   "scripts": {
-    "dev": "nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose --parallel=6",
+    "dev": "node scripts/dev-prepare.js && nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose --parallel=6",
     "build": "nx run-many --target=build --exclude=doc --verbose",
     "build:skip-cache": "npm run clean && nx run-many --target=build --exclude=doc --verbose --skip-nx-cache",
     "test": "nx run-many --target=test --projects=@midscene/core,@midscene/shared,@midscene/visualizer,@midscene/web,@midscene/cli,@midscene/android,@midscene/ios,@midscene/computer,@midscene/android-mcp,@midscene/ios-mcp,@midscene/web-bridge-mcp,@midscene/playground  --verbose",
@@ -20,7 +20,7 @@
     "format": "pretty-quick --staged",
     "commit": "cz",
     "check-spell": "npx cspell",
-    "clean": "rm -rf .nx packages/*/dist packages/*/node_modules/.cache apps/*/dist apps/*/node_modules/.cache"
+    "clean": "rm -rf .nx packages/*/dist packages/*/node_modules/.cache apps/*/dist apps/*/node_modules/.cache packages/playground/static packages/ios/static"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -50,10 +50,10 @@
     "@midscene/shared": "workspace:*",
     "@midscene/webdriver": "workspace:*",
     "@inquirer/prompts": "^7.8.6",
+    "@midscene/playground": "workspace:*",
     "open": "10.1.0"
   },
   "devDependencies": {
-    "@midscene/playground": "workspace:*",
     "@rslib/core": "^0.18.3",
     "@types/node": "^18.0.0",
     "dotenv": "^16.4.5",

--- a/packages/shared/src/build/copy-static.ts
+++ b/packages/shared/src/build/copy-static.ts
@@ -23,6 +23,12 @@ export const createCopyStaticPlugin = (options: CopyStaticOptions) => ({
     api.onAfterBuild(async () => {
       const { srcDir, destDir, faviconPath } = options;
 
+      // Remove symlink left by dev mode before copying
+      const stat = await fs.promises.lstat(destDir).catch(() => null);
+      if (stat?.isSymbolicLink()) {
+        await fs.promises.unlink(destDir);
+      }
+
       await fs.promises.mkdir(destDir, { recursive: true });
 
       // Copy directory contents recursively

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,6 +1065,9 @@ importers:
       '@midscene/core':
         specifier: workspace:*
         version: link:../core
+      '@midscene/playground':
+        specifier: workspace:*
+        version: link:../playground
       '@midscene/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1075,9 +1078,6 @@ importers:
         specifier: 10.1.0
         version: 10.1.0
     devDependencies:
-      '@midscene/playground':
-        specifier: workspace:*
-        version: link:../playground
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.118))(typescript@5.8.3)

--- a/scripts/dev-prepare.js
+++ b/scripts/dev-prepare.js
@@ -1,0 +1,43 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+
+// 1. Build report if dist doesn't exist (needed by core's USE_DEV_REPORT)
+const reportHtml = path.join(root, 'apps/report/dist/index.html');
+if (!fs.existsSync(reportHtml)) {
+  console.log('[dev-prepare] Building report...');
+  execSync('npx nx build @midscene/report', { cwd: root, stdio: 'inherit' });
+}
+
+// 2. Build playground if dist doesn't exist
+const playgroundDist = path.join(root, 'apps/playground/dist/index.html');
+if (!fs.existsSync(playgroundDist)) {
+  console.log('[dev-prepare] Building playground...');
+  execSync('npx nx build playground', { cwd: root, stdio: 'inherit' });
+}
+
+// 3. Symlink playground static dirs → apps/playground/dist
+const symlinks = [
+  {
+    link: path.join(root, 'packages/playground/static'),
+    target: '../../apps/playground/dist',
+  },
+  {
+    link: path.join(root, 'packages/ios/static'),
+    target: '../../apps/playground/dist',
+  },
+];
+
+for (const { link, target } of symlinks) {
+  const stat = fs.lstatSync(link, { throwIfNoEntry: false });
+  if (stat?.isSymbolicLink()) continue; // already set up
+  if (stat) fs.rmSync(link, { recursive: true });
+  fs.symlinkSync(target, link);
+  console.log(
+    `[dev-prepare] Symlinked ${path.relative(root, link)} → ${target}`,
+  );
+}
+
+console.log('[dev-prepare] Ready.');


### PR DESCRIPTION
## Summary

- Add `scripts/dev-prepare.js` that runs before `pnpm run dev` to auto-build report/playground (if dist missing) and create symlinks from `packages/playground/static` and `packages/ios/static` to `apps/playground/dist`
- Add `continuous: true` for `build:watch` target in `nx.json` so Nx treats watch tasks as long-running processes instead of blocking downstream tasks
- Handle dev-mode symlinks in `createCopyStaticPlugin` by removing them before copying, preventing `fs.cp()` errors when src and dest resolve to the same path
- Clean up static artifact directories in the `clean` script
- Fix pre-existing `@midscene/ios` build failure by moving `@midscene/playground` from `devDependencies` to `dependencies` (it is imported at runtime in `bin.ts`)

## Test plan

- [ ] Run `pnpm run clean && pnpm run dev` — should auto-prepare and start all watch tasks without hanging
- [ ] Modify a file in `packages/core/src` — watch should auto-rebuild
- [ ] Run `pnpm run build` after dev — should succeed (symlinks cleaned before copy)
- [ ] Run `npx nx build @midscene/ios --skip-nx-cache` — should succeed without `Module not found` error