### PR TITLE
fix(web-integration): add retry mechanism for screenshot to handle transient CDP errors

### DIFF
--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -338,6 +338,7 @@ export class Page<
     const maxRetries = 3;
     const baseDelay = 500;
     let lastError: Error | undefined;
+    let actualAttempts = 0;
 
     // Errors that indicate the page/session is permanently gone - no point retrying
     const unrecoverableErrors = [
@@ -355,6 +356,7 @@ export class Page<
     };
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      actualAttempts = attempt;
       try {
         let base64: string;
         if (this.interfaceType === 'puppeteer') {
@@ -417,7 +419,7 @@ export class Page<
     // All retries exhausted or unrecoverable error, throw the last error
     const endTime = Date.now();
     debugPage(
-      `screenshotBase64 failed after ${maxRetries} attempts, cost: ${endTime - startTime}ms`,
+      `screenshotBase64 failed after ${actualAttempts} attempt(s), cost: ${endTime - startTime}ms`,
     );
     throw lastError || new Error('Screenshot failed after all retries');
   }

--- a/packages/web-integration/tests/unit-test/puppeteer/screenshot-retry.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/screenshot-retry.test.ts
@@ -1,5 +1,5 @@
 import { Page } from '@/puppeteer/base-page';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the sleep function to speed up tests
 const { mockSleep } = vi.hoisted(() => ({
@@ -23,6 +23,10 @@ describe('screenshotBase64 retry mechanism', () => {
     vi.clearAllMocks();
     mockSleep.mockClear();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   const createMockPuppeteerPage = (screenshotFn: () => Promise<string>) => ({


### PR DESCRIPTION
## Summary

- Add retry mechanism (3 attempts with exponential backoff: 500ms, 1000ms, 2000ms) for `screenshotBase64` method to handle transient CDP errors
- Skip retries for unrecoverable errors (Target closed, Session closed, Page closed, etc.)
- Improve reliability when browser state is temporarily unstable during screenshot capture
- Add warning logs for failed screenshot attempts to aid debugging

## Background

The Puppeteer screenshot API can occasionally fail with CDP "Internal error" when the browser state is temporarily unstable. This change adds automatic retry logic with exponential backoff to improve reliability.

## Changes

- Wrap screenshot logic in a retry loop with max retries (3) and exponential backoff (500ms base delay)
- Skip retries for unrecoverable errors (Target/Session/Page closed, browser disconnected, execution context destroyed)
- Add console warning for each failed attempt
- Preserve debug logging for retry events with accurate attempt count
- Throw the last error if all retries are exhausted or unrecoverable error encountered

## Test plan

- [x] Existing tests should pass
- [x] Unit tests for retry mechanism added
- [ ] Manual testing with scenarios that trigger CDP errors