### PR TITLE
feat(core): add request_id field to AIUsageInfo

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,7 @@ export type AIUsageInfo = Record<string, any> & {
   model_name: string | undefined;
   model_description: string | undefined;
   intent: string | undefined;
+  request_id: string | undefined;
 };
 
 export type { LocateResultElement };


### PR DESCRIPTION
Add request_id field to track API request identifiers in usage info.
This captures the _request_id from OpenAI API responses for both
streaming and non-streaming calls.

https://claude.ai/code/session_01UFeKAtw3SBm8a2EJtbKoGU