### PR TITLE
Add collapsible reasoning section to detail panel

### DIFF
--- a/apps/report/src/components/detail-side/index.less
+++ b/apps/report/src/components/detail-side/index.less
@@ -236,7 +236,7 @@
 
       .collapse-icon {
         font-size: 10px;
-        margin-right: 6px;
+        margin-left: 6px;
         color: #00000073;
         transition: transform 0.2s;
       }

--- a/apps/report/src/components/detail-side/index.less
+++ b/apps/report/src/components/detail-side/index.less
@@ -228,6 +228,32 @@
       }
     }
 
+    .title-collapsible {
+      cursor: pointer;
+      user-select: none;
+      display: flex;
+      align-items: center;
+
+      .collapse-icon {
+        font-size: 10px;
+        margin-right: 6px;
+        color: #00000073;
+        transition: transform 0.2s;
+      }
+
+      &:hover {
+        color: #1677ff;
+
+        .collapse-icon {
+          color: #1677ff;
+        }
+      }
+    }
+
+    .item-collapsible {
+      margin-bottom: 4px;
+    }
+
     .subtitle {
       padding-left: 20px;
       font-weight: normal;
@@ -386,6 +412,20 @@
 
         .title-tag {
           color: rgba(255, 255, 255, 0.45);
+        }
+      }
+
+      .title-collapsible {
+        .collapse-icon {
+          color: #9599a6;
+        }
+
+        &:hover {
+          color: #4096ff;
+
+          .collapse-icon {
+            color: #4096ff;
+          }
         }
       }
 

--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -106,10 +106,10 @@ const CollapsibleCard = (props: {
         className="title title-collapsible"
         onClick={() => setCollapsed(!collapsed)}
       >
+        {title}
         <span className="collapse-icon">
           {collapsed ? <RightOutlined /> : <DownOutlined />}
         </span>
-        {title}
       </div>
       {!collapsed && (
         <div className="description">

--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -2,7 +2,13 @@
 'use client';
 import './index.less';
 
-import { FileImageOutlined, RadiusSettingOutlined } from '@ant-design/icons';
+import {
+  DownOutlined,
+  FileImageOutlined,
+  RadiusSettingOutlined,
+  RightOutlined,
+} from '@ant-design/icons';
+import { useState } from 'react';
 import type {
   ExecutionTaskAction,
   ExecutionTaskInsightAssertion,
@@ -19,8 +25,6 @@ import {
 import { Tag, Tooltip } from 'antd';
 import { isElementField, useExecutionDump } from '../store';
 
-const noop = () => {};
-
 function isPlainObject(value: unknown): value is Record<string, any> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -30,19 +34,10 @@ const Card = (props: {
   title?: string;
   subtitle?: string;
   characteristic?: string;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
   content: any;
 }) => {
-  const {
-    highlightWithColor,
-    title,
-    subtitle,
-    onMouseEnter,
-    onMouseLeave,
-    content,
-    characteristic,
-  } = props;
+  const { highlightWithColor, title, subtitle, content, characteristic } =
+    props;
   const titleTag = props.characteristic ? (
     <div className="item-extra">
       <div className="title-tag">
@@ -70,8 +65,6 @@ const Card = (props: {
     <div
       className={`item ${modeClass} ${highlightWithColor ? 'item-highlight' : ''}`}
       style={{ ...highlightStyle }}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
     >
       {/* {extraSection} */}
 
@@ -94,6 +87,35 @@ const Card = (props: {
       >
         {content}
       </div>
+    </div>
+  );
+};
+
+// Collapsible card component for reasoning content (collapsed by default)
+const CollapsibleCard = (props: {
+  title: string;
+  content: any;
+  defaultCollapsed?: boolean;
+}) => {
+  const { title, content, defaultCollapsed = true } = props;
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  return (
+    <div className="item item-lite item-collapsible">
+      <div
+        className="title title-collapsible"
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        <span className="collapse-icon">
+          {collapsed ? <RightOutlined /> : <DownOutlined />}
+        </span>
+        {title}
+      </div>
+      {!collapsed && (
+        <div className="description">
+          <pre className="description-content">{content}</pre>
+        </div>
+      )}
     </div>
   );
 };
@@ -677,8 +699,6 @@ const DetailSide = (): JSX.Element => {
       <Card
         liteMode={true}
         title="error"
-        onMouseEnter={noop}
-        onMouseLeave={noop}
         content={
           <pre className="description-content" style={{ color: '#F00' }}>
             {errorText}
@@ -741,8 +761,6 @@ const DetailSide = (): JSX.Element => {
           <Card
             liteMode={true}
             title="thought"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={<pre className="description-content">{thought}</pre>}
           />
         )}
@@ -750,8 +768,6 @@ const DetailSide = (): JSX.Element => {
         <Card
           liteMode={true}
           title="assertion result"
-          onMouseEnter={noop}
-          onMouseLeave={noop}
           content={
             <pre className="description-content">
               {JSON.stringify(output, undefined, 2)}
@@ -759,15 +775,7 @@ const DetailSide = (): JSX.Element => {
           }
         />
         {reasoningContent && (
-          <Card
-            liteMode={true}
-            title="reasoning"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
-            content={
-              <pre className="description-content">{reasoningContent}</pre>
-            }
-          />
+          <CollapsibleCard title="reasoning" content={reasoningContent} />
         )}
       </>
     );
@@ -777,8 +785,6 @@ const DetailSide = (): JSX.Element => {
         <Card
           liteMode={true}
           title=""
-          onMouseEnter={noop}
-          onMouseLeave={noop}
           content={
             <pre className="description-content yaml-content">
               {(task as ExecutionTaskPlanning).output?.yamlString}
@@ -796,8 +802,6 @@ const DetailSide = (): JSX.Element => {
             key="thought"
             liteMode={true}
             title="thought"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={
               <pre className="description-content">
                 {(task as ExecutionTaskPlanning).output?.thought || ''}
@@ -814,8 +818,6 @@ const DetailSide = (): JSX.Element => {
             key="memory"
             liteMode={true}
             title="memory"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={
               <pre className="description-content">
                 {(task as ExecutionTaskPlanning).output?.memory}
@@ -840,8 +842,6 @@ const DetailSide = (): JSX.Element => {
             key="sub-goals"
             liteMode={true}
             title="sub-goals"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={
               <pre className="description-content">{subGoalsContent}</pre>
             }
@@ -858,8 +858,6 @@ const DetailSide = (): JSX.Element => {
             key="mark-finished"
             liteMode={true}
             title="marked finished"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={
               <pre className="description-content">
                 Sub-goal indexes: {markFinishedIndexes.join(', ')}
@@ -928,8 +926,6 @@ const DetailSide = (): JSX.Element => {
                 liteMode={true}
                 title={`${actionType}.${key}`}
                 subtitle={action.thought}
-                onMouseEnter={noop}
-                onMouseLeave={noop}
                 content={content}
               />,
             );
@@ -951,8 +947,6 @@ const DetailSide = (): JSX.Element => {
               liteMode={true}
               title={typeStr(action as any)}
               subtitle={action.thought}
-              onMouseEnter={noop}
-              onMouseLeave={noop}
               content={nonObjectContent}
             />,
           );
@@ -967,8 +961,6 @@ const DetailSide = (): JSX.Element => {
             key="output-message"
             liteMode={true}
             title="output"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={<pre className="description-content">{outputMessage}</pre>}
           />,
         );
@@ -984,8 +976,6 @@ const DetailSide = (): JSX.Element => {
             key="more-actions"
             liteMode={true}
             title="should continue planning"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={
               <pre className="description-content">
                 {(task as ExecutionTaskPlanning).output?.shouldContinuePlanning
@@ -1000,15 +990,10 @@ const DetailSide = (): JSX.Element => {
       // Add reasoning at the end
       if (reasoningContent) {
         planItems.push(
-          <Card
+          <CollapsibleCard
             key="reasoning"
-            liteMode={true}
             title="reasoning"
-            onMouseEnter={noop}
-            onMouseLeave={noop}
-            content={
-              <pre className="description-content">{reasoningContent}</pre>
-            }
+            content={reasoningContent}
           />,
         );
       }
@@ -1035,8 +1020,6 @@ const DetailSide = (): JSX.Element => {
           <Card
             key="thought"
             liteMode={true}
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             content={<pre>{thought}</pre>}
             title="thought"
           />,
@@ -1078,8 +1061,6 @@ const DetailSide = (): JSX.Element => {
             <Card
               key={key}
               liteMode={true}
-              onMouseEnter={noop}
-              onMouseLeave={noop}
               title={key}
               content={content}
             />,
@@ -1091,8 +1072,6 @@ const DetailSide = (): JSX.Element => {
           <Card
             key="output"
             liteMode={true}
-            onMouseEnter={noop}
-            onMouseLeave={noop}
             title="output"
             content={
               <pre className="description-content">
@@ -1106,13 +1085,10 @@ const DetailSide = (): JSX.Element => {
       // Add reasoning at the end
       if (reasoningContent) {
         outputItems.push(
-          <Card
+          <CollapsibleCard
             key="reasoning"
-            liteMode={true}
-            onMouseEnter={noop}
-            onMouseLeave={noop}
-            content={<pre>{reasoningContent}</pre>}
             title="reasoning"
+            content={reasoningContent}
           />,
         );
       }

--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -8,7 +8,6 @@ import {
   RadiusSettingOutlined,
   RightOutlined,
 } from '@ant-design/icons';
-import { useState } from 'react';
 import type {
   ExecutionTaskAction,
   ExecutionTaskInsightAssertion,
@@ -23,6 +22,7 @@ import {
   timeCostStrElement,
 } from '@midscene/visualizer';
 import { Tag, Tooltip } from 'antd';
+import { useState } from 'react';
 import { isElementField, useExecutionDump } from '../store';
 
 function isPlainObject(value: unknown): value is Record<string, any> {
@@ -1058,12 +1058,7 @@ const DetailSide = (): JSX.Element => {
           }
 
           outputItems.push(
-            <Card
-              key={key}
-              liteMode={true}
-              title={key}
-              content={content}
-            />,
+            <Card key={key} liteMode={true} title={key} content={content} />,
           );
         });
       } else {


### PR DESCRIPTION
## Summary
This PR adds a collapsible card component for the reasoning content in the detail side panel, improving the UI by allowing users to expand/collapse the reasoning section on demand. The reasoning section is now collapsed by default to reduce visual clutter.

## Key Changes
- **New CollapsibleCard component**: Created a reusable collapsible card component with expand/collapse icons (RightOutlined/DownOutlined) and smooth transitions
- **Styling updates**: Added `.title-collapsible` and `.item-collapsible` styles with hover effects and dark mode support
- **Removed unused props**: Cleaned up `onMouseEnter` and `onMouseLeave` props from Card component and removed the `noop` function as they were no longer being used
- **Applied to reasoning sections**: Replaced standard Card components with CollapsibleCard for all reasoning content across different task types (Assertion, Planning, Output)
- **Icon imports**: Added DownOutlined and RightOutlined icons from ant-design for collapse/expand indicators

## Implementation Details
- The CollapsibleCard component uses React's `useState` hook to manage collapsed state with a default of `true` (collapsed by default)
- Collapse icon color matches the theme (light mode: #00000073, dark mode: #9599a6) with hover color changes (#1677ff light, #4096ff dark)
- The component maintains consistent styling with existing Card components while adding the collapsible functionality
- All reasoning content across different execution task types now uses the same collapsible pattern for consistency

https://claude.ai/code/session_01KUHFq6fmLk3tJfdAqpNFes