### PR TITLE
feat(report): add timeline collapse toggle and change time unit to seconds

### DIFF
--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -50,6 +50,7 @@ function Visualizer(props: VisualizerProps): JSX.Element {
   const [mainLayoutChangeFlag, setMainLayoutChangeFlag] = useState(0);
   const mainLayoutChangedRef = useRef(false);
   const dump = useExecutionDump((store) => store.dump);
+  const [timelineCollapsed, setTimelineCollapsed] = useState(false);
   const {
     modelCallDetailsEnabled: proModeEnabled,
     setModelCallDetailsEnabled: setProModeEnabled,
@@ -177,8 +178,27 @@ function Visualizer(props: VisualizerProps): JSX.Element {
         />
         <Panel defaultSize={75} maxSize={95}>
           <div className="main-right">
-            <div className="main-right-header">Record</div>
-            <Timeline key={mainLayoutChangeFlag} />
+            <div
+              className="main-right-header"
+              onClick={() => setTimelineCollapsed(!timelineCollapsed)}
+              style={{ cursor: 'pointer', userSelect: 'none' }}
+            >
+              <span
+                className="timeline-collapse-icon"
+                style={{
+                  display: 'inline-block',
+                  marginRight: 8,
+                  transition: 'transform 0.2s',
+                  transform: timelineCollapsed
+                    ? 'rotate(-90deg)'
+                    : 'rotate(0deg)',
+                }}
+              >
+                ▼
+              </span>
+              Record
+            </div>
+            {!timelineCollapsed && <Timeline key={mainLayoutChangeFlag} />}
             <div className="main-content">{content}</div>
           </div>
         </Panel>

--- a/apps/report/src/components/timeline/index.tsx
+++ b/apps/report/src/components/timeline/index.tsx
@@ -195,7 +195,9 @@ const TimelineWidget = (props: {
       domRef.current.replaceChildren(app.canvas);
 
       const pixiTextForNumber = (num: number) => {
-        const textContent = `${num}ms`;
+        const seconds = num / 1000;
+        const textContent =
+          seconds % 1 === 0 ? `${seconds}s` : `${seconds.toFixed(1)}s`;
         const text = new PIXI.Text(`${textContent}`, {
           fontSize: timeContentFontSize,
           fill: gridTextColor,


### PR DESCRIPTION
## Summary
- Add collapsible Record timeline section to save vertical space on smaller screens (e.g., 13-inch laptops)
- Change time display unit from milliseconds (ms) to seconds (s) for better readability

## Changes
- **Timeline collapse**: Click on the "Record" header to toggle timeline visibility. A rotating arrow icon (▼) indicates the collapse state.
- **Time unit**: Timeline markers now display in seconds (e.g., `1s`, `2.5s`) instead of milliseconds (`1000ms`, `2500ms`).

## Test plan
- [ ] Open the report viewer and verify the timeline can be collapsed/expanded by clicking "Record"
- [ ] Verify the collapse arrow rotates when toggling
- [ ] Verify time markers display in seconds format