### PR TITLE
fix(core): resolve circular dependency warnings for Agent and createAgent

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,3 +1,9 @@
+import type { TUserPrompt } from '../ai-model/index';
+import { ScreenshotItem } from '../screenshot-item';
+import Service from '../service/index';
+// Import types and values directly from their source files to avoid circular dependency
+// DO NOT import from '../index' as it creates a circular dependency:
+// index.ts -> agent/index.ts -> agent/agent.ts -> index.ts
 import {
   type ActionParam,
   type ActionReturn,
@@ -7,31 +13,26 @@ import {
   type AgentWaitForOpt,
   type CacheConfig,
   type DeepThinkOption,
-  type DetailedLocateParam,
   type DeviceAction,
   ExecutionDump,
   type ExecutionRecorderItem,
   type ExecutionTask,
   type ExecutionTaskLog,
-  type ExecutionTaskPlanning,
   GroupedActionDump,
   type LocateOption,
   type LocateResultElement,
   type LocateValidatorResult,
   type LocatorValidatorOption,
-  type MidsceneYamlScript,
   type OnTaskStartTip,
   type PlanningAction,
   type Rect,
-  ScreenshotItem,
   type ScrollParam,
-  Service,
   type ServiceAction,
   type ServiceExtractOption,
   type ServiceExtractParam,
-  type TUserPrompt,
   type UIContext,
-} from '../index';
+} from '../types';
+import type { MidsceneYamlScript } from '../yaml';
 export type TestStatus =
   | 'passed'
   | 'failed'

--- a/packages/web-integration/tests/unit-test/circular-dependency.test.ts
+++ b/packages/web-integration/tests/unit-test/circular-dependency.test.ts
@@ -1,0 +1,77 @@
+import { exec } from 'node:child_process';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execAsync = promisify(exec);
+
+describe('circular dependency detection', () => {
+  it('should not have circular dependency warnings when importing the package (CJS)', async () => {
+    const packageRoot = resolve(__dirname, '../..');
+
+    // Test CJS import with --trace-warnings to capture circular dependency warnings
+    const { stdout, stderr } = await execAsync(
+      `node --trace-warnings -e "require('./dist/lib/index.js')"`,
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: '', // Ensure warnings are not suppressed
+        },
+      },
+    ).catch((error) => ({
+      stdout: error.stdout || '',
+      stderr: error.stderr || '',
+    }));
+
+    const output = stdout + stderr;
+
+    // Check for circular dependency warnings
+    const hasCircularDependencyWarning = output.includes('circular dependency');
+
+    if (hasCircularDependencyWarning) {
+      console.log('Detected circular dependency warnings:');
+      console.log(output);
+    }
+
+    expect(hasCircularDependencyWarning).toBe(false);
+  });
+
+  it('should not warn about accessing non-existent Agent property', async () => {
+    const packageRoot = resolve(__dirname, '../..');
+
+    const { stdout, stderr } = await execAsync(
+      `node --trace-warnings -e "require('./dist/lib/index.js'); console.log('done')"`,
+      {
+        cwd: packageRoot,
+      },
+    ).catch((error) => ({
+      stdout: error.stdout || '',
+      stderr: error.stderr || '',
+    }));
+
+    const output = stdout + stderr;
+
+    const hasAgentWarning =
+      output.includes("Accessing non-existent property 'Agent'") ||
+      output.includes("Accessing non-existent property 'createAgent'");
+
+    if (hasAgentWarning) {
+      console.log('Detected Agent/createAgent circular dependency warnings:');
+      console.log(output);
+    }
+
+    expect(hasAgentWarning).toBe(false);
+  });
+
+  it('should properly export all public APIs', async () => {
+    // This test verifies that all expected exports are available
+    const { PlaywrightAgent, PuppeteerAgent, PageAgent, StaticPageAgent } =
+      await import('@midscene/web');
+
+    expect(PlaywrightAgent).toBeDefined();
+    expect(PuppeteerAgent).toBeDefined();
+    expect(PageAgent).toBeDefined();
+    expect(StaticPageAgent).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix circular dependency that caused Node.js warnings when importing `@midscene/web` package
- Add unit tests to detect circular dependency regressions

## Problem
When running e2e tests or importing `@midscene/web`, Node.js emitted the following warnings:
```
Warning: Accessing non-existent property 'Agent' of module exports inside circular dependency
Warning: Accessing non-existent property 'createAgent' of module exports inside circular dependency
```

## Root Cause
The circular dependency was in `packages/core/src/agent/agent.ts` which imported from `../index`, creating a cycle:
```
index.ts → agent/index.ts → agent/agent.ts → index.ts (circular!)
```

## Solution
Import types and values directly from their source files instead of through the barrel export (`../index`):
- Types from `../types`
- `TUserPrompt` from `../ai-model/index`
- `ScreenshotItem` from `../screenshot-item`
- `Service` from `../service/index`
- `MidsceneYamlScript` from `../yaml`

## Test plan
- [x] Verify no circular dependency warnings when importing `@midscene/web`
- [x] All existing unit tests pass (246 tests in web-integration)
- [x] New unit tests detect the regression if fix is reverted
- [x] E2E tests pass without warnings