### PR TITLE
ci(workflow): remove push trigger from AI test workflows

### DIFF
--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -1,8 +1,5 @@
 name: AI unit test
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -1,8 +1,5 @@
 name: AI - Playwright e2e
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Remove push trigger on main branch for `ai-unit-test.yml` and `ai.yml` workflows
- These workflows will now only run on pull requests and manual `workflow_dispatch` events
- This prevents duplicate workflow runs after merging PRs to main

## Test plan
- [x] Verify workflows still trigger on pull requests
- [x] Verify workflows can still be triggered manually via workflow_dispatch