### PR TITLE
fix(android-playground): enable remote access and fix screenshot polling

### DIFF
--- a/apps/android-playground/src/App.tsx
+++ b/apps/android-playground/src/App.tsx
@@ -1,8 +1,5 @@
 import './App.less';
-import {
-  PLAYGROUND_SERVER_PORT,
-  SCRCPY_SERVER_PORT,
-} from '@midscene/shared/constants';
+import { SCRCPY_SERVER_PORT } from '@midscene/shared/constants';
 import {
   ScreenshotViewer,
   globalThemeConfig,
@@ -34,7 +31,7 @@ export default function App() {
   const [connectToDevice, setConnectToDevice] = useState(false);
   const [messageApi, contextHolder] = message.useMessage();
   const [serverUrl, setServerUrl] = useState(
-    `http://localhost:${SCRCPY_SERVER_PORT}`,
+    `http://${window.location.hostname}:${SCRCPY_SERVER_PORT}`,
   );
   const [isNarrowScreen, setIsNarrowScreen] = useState(false);
   const [usePollingMode, setUsePollingMode] = useState(false);
@@ -51,7 +48,7 @@ export default function App() {
   useEffect(() => {
     const scrcpyPort = (window as any).SCRCPY_PORT;
     if (scrcpyPort) {
-      setServerUrl(`http://localhost:${scrcpyPort}`);
+      setServerUrl(`http://${window.location.hostname}:${scrcpyPort}`);
     }
   }, []);
 
@@ -183,14 +180,10 @@ export default function App() {
                 ) : (
                   <ScreenshotViewer
                     getScreenshot={() =>
-                      fetch(
-                        `http://localhost:${PLAYGROUND_SERVER_PORT}/screenshot`,
-                      ).then((r) => r.json())
+                      fetch('/screenshot').then((r) => r.json())
                     }
                     getInterfaceInfo={() =>
-                      fetch(
-                        `http://localhost:${PLAYGROUND_SERVER_PORT}/interface-info`,
-                      ).then((r) => r.json())
+                      fetch('/interface-info').then((r) => r.json())
                     }
                     serverOnline={true}
                     isUserOperating={false}

--- a/packages/android-playground/src/bin.ts
+++ b/packages/android-playground/src/bin.ts
@@ -13,6 +13,7 @@ import {
   SCRCPY_SERVER_PORT,
 } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
+import cors from 'cors';
 import ScrcpyServer from './scrcpy-server';
 
 const promiseExec = promisify(exec);
@@ -93,6 +94,15 @@ const main = async () => {
 
     // Set the selected device in scrcpy server
     scrcpyServer.currentDeviceId = selectedDeviceId;
+
+    // Add CORS middleware to playground server for remote access
+    playgroundServer.app.use(
+      cors({
+        origin: true,
+        credentials: true,
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      }),
+    );
 
     console.log('🚀 Starting servers...');
 

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -32,10 +32,7 @@ export default class ScrcpyServer {
     this.httpServer = createServer(this.app);
     this.io = new Server(this.httpServer, {
       cors: {
-        origin: [
-          /^http:\/\/localhost(:\d+)?$/,
-          /^http:\/\/127\.0\.0\.1(:\d+)?$/,
-        ],
+        origin: true,
         methods: ['GET', 'POST'],
         credentials: true,
       },


### PR DESCRIPTION
## Summary

- Enable Android Playground to be accessed from non-localhost addresses (e.g., via IP)
- Fix ScreenshotViewer polling mode not working due to incorrect API URLs

## Changes

- **Frontend (App.tsx)**: Use `window.location.hostname` instead of hardcoded `localhost` for scrcpy server URL, allowing access from any IP address
- **Frontend (App.tsx)**: Use relative paths (`/screenshot`, `/interface-info`) instead of absolute URLs with hardcoded port for ScreenshotViewer API calls
- **Backend (bin.ts)**: Add CORS middleware to playground server to allow cross-origin requests from remote clients
- **Backend (scrcpy-server.ts)**: Update Socket.IO CORS config to use `origin: true` instead of restricting to localhost only

## Test plan

- [ ] Start Android Playground with a connected device
- [ ] Access from localhost - verify scrcpy stream works
- [ ] Access from another machine via IP address (e.g., `http://192.168.x.x:5800`) - verify scrcpy stream works
- [ ] Connect a remote Android device (via `adb connect IP:PORT`) - verify ScreenshotViewer polling mode displays screenshots correctly