### PR TITLE
fix(web-integration): remove unnecessary 100px height adjustment in headed mode

### DIFF
--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -228,7 +228,7 @@ export async function launchPuppeteerPage(
     userAgent: ua,
     windowSize: {
       width,
-      height: height + (headed ? 100 : 0), // add 100px for the address bar in headed mode
+      height,
     },
     chromeArgs: target.chromeArgs,
   });


### PR DESCRIPTION
## Summary
- Remove the hardcoded 100px height offset for address bar compensation in headed mode
- This adjustment was unreliable across different browsers, systems, and scaling factors
- Since headed mode already uses `defaultViewport: null` to auto-fit the viewport, this adjustment is unnecessary

## Related
- Related to PR #1908 which copies this logic - if merged, that PR should also remove this adjustment