### PR TITLE
feat(core): filter Finalize action from plan cache

### DIFF
--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -265,6 +265,12 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
       const currentStep = Number.parseInt(flowItemIndex, 10);
       taskStatus.currentStep = currentStep;
       const flowItem = flow[flowItemIndex];
+
+      // Skip Finalize action from cache - it's a planning-only marker
+      if ('Finalize' in flowItem) {
+        continue;
+      }
+
       debug(
         `playing step ${flowItemIndex}, flowItem=${JSON.stringify(flowItem)}`,
       );


### PR DESCRIPTION
## Summary
- Filter out `Finalize` actions from yamlWorkflow when reading/writing plan cache
- Skip cache entries if all actions are filtered out (only contains Finalize)
- Prevents Finalize action from being cached and replayed

## Test plan
- [x] Build passes
- [x] Existing cache tests pass