### PR TITLE
fix(web-integration): add browser UI height offset for headed mode window size

### DIFF
--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -225,9 +225,13 @@ export async function launchPuppeteerPage(
 
   // Build Chrome arguments using the shared helper
   // Only pass windowSize in headed mode; in headless mode, defaultViewport takes precedence
+  // Add 100px to height to account for browser UI (address bar, tabs, etc.)
+  const browserUIHeight = 100;
   const args = buildChromeArgs({
     userAgent: ua,
-    windowSize: headed ? { width, height } : undefined,
+    windowSize: headed
+      ? { width, height: height + browserUIHeight }
+      : undefined,
     chromeArgs: target.chromeArgs,
   });
 


### PR DESCRIPTION
## Summary
- Add 100px to window height in headed mode to account for browser UI (address bar, tabs, etc.)
- This ensures the viewport matches the expected size when running Puppeteer in headed mode

## Test plan
- [x] Unit tests pass: `npx nx test @midscene/web -- tests/unit-test/puppeteer/agent-launcher.test.ts`