### PR TITLE
docs(site): sync site title to Vision-Driven UI Automation

### DIFF
--- a/apps/site/docs/en/introduction.mdx
+++ b/apps/site/docs/en/introduction.mdx
@@ -1,4 +1,4 @@
-# Midscene.js - joyful automation by AI
+# Midscene.js - Vision-Driven Automation by AI
 
 Driving all platforms UI automation with vision-based model
 

--- a/apps/site/rspress.config.ts
+++ b/apps/site/rspress.config.ts
@@ -6,7 +6,7 @@ import { pluginSitemap } from '@rspress/plugin-sitemap';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
-  title: 'Midscene - Joyful UI Automation',
+  title: 'Midscene - Vision-Driven UI Automation',
   description: 'Driving all platforms UI automation with vision-based model',
   icon: '/midscene-icon.png',
   logo: {


### PR DESCRIPTION
### Motivation
- Align the site configuration title with the updated introduction heading by replacing the legacy "Joyful" wording with the normalized phrasing "Vision-Driven UI Automation".

### Description
- Updated `apps/site/rspress.config.ts` to change the `title` from `'Midscene - Joyful UI Automation'` to `'Midscene - Vision-Driven UI Automation'`.

### Testing
- The change was committed (`git commit`) and repository hooks completed successfully, and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982afb2f0688324be44d81ac64bc2d0)