### PR TITLE
fix(android): allow ffmpeg fallback when @ffmpeg-installer/ffmpeg is missing

### DIFF
--- a/packages/android-mcp/rslib.config.ts
+++ b/packages/android-mcp/rslib.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
       '@silvia-odwyer/photon',
       '@silvia-odwyer/photon-node',
       '@modelcontextprotocol/sdk',
+      // Keep as external so try-catch can handle missing optional dependency
+      '@ffmpeg-installer/ffmpeg',
     ],
   },
   plugins: [injectReportHtmlFromCore(__dirname)],

--- a/packages/android/rslib.config.ts
+++ b/packages/android/rslib.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
+  output: {
+    // Keep @ffmpeg-installer/ffmpeg as external so it's loaded at runtime
+    // This allows try-catch to properly handle missing optional dependency
+    externals: ['@ffmpeg-installer/ffmpeg'],
+  },
   lib: [
     {
       output: {

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -232,7 +232,10 @@ export class ScrcpyScreenshotManager {
   private getFfmpegPath(): string {
     try {
       // Try npm-installed ffmpeg first
-      const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
+      // Use createRequire to dynamically load optional dependency
+      // This ensures the require happens at runtime, not bundle time
+      const dynamicRequire = createRequire(import.meta.url);
+      const ffmpegInstaller = dynamicRequire('@ffmpeg-installer/ffmpeg');
       debugScrcpy(`Using ffmpeg from npm package: ${ffmpegInstaller.path}`);
       return ffmpegInstaller.path;
     } catch (error) {


### PR DESCRIPTION
## Summary

- Fix bundler hoisting `require('@ffmpeg-installer/ffmpeg')` to top level, which caused module load errors when ffmpeg binaries were not found
- Use `createRequire()` for dynamic module loading at runtime
- Add `@ffmpeg-installer/ffmpeg` to externals in both android and android-mcp packages

This allows the try-catch fallback to system ffmpeg to work properly when the npm package is unavailable.

## Test plan

- [x] All 160 unit tests pass
- [ ] Test with `npx @midscene/android-mcp` without `@ffmpeg-installer/ffmpeg` installed
- [ ] Verify fallback to system ffmpeg works correctly