### PR TITLE
fix(core): inline screenshots in browser environment for Chrome extension

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -523,10 +523,15 @@ export class Agent<
     // update dump info
     this.dump.groupName = this.opts.groupName!;
     this.dump.groupDescription = this.opts.groupDescription;
+    // In browser environment, use inline screenshots since file system is not available
+    if (ifInBrowser) {
+      return this.dump.serializeWithInlineScreenshots();
+    }
     return this.dump.serialize();
   }
 
   reportHTMLString() {
+    // dumpDataString() handles browser environment with inline screenshots
     return reportHTMLContent(this.dumpDataString());
   }
 

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
-import { logMsg } from '@midscene/shared/utils';
+import { ifInBrowser, logMsg } from '@midscene/shared/utils';
 import {
   generateDumpScriptTag,
   generateImageScriptTag,
@@ -73,6 +73,9 @@ export class ReportGenerator implements IReportGenerator {
     },
   ): IReportGenerator {
     if (opts.generateReport === false) return nullReportGenerator;
+
+    // In browser environment, file system is not available
+    if (ifInBrowser) return nullReportGenerator;
 
     if (opts.outputFormat === 'html-and-external-assets') {
       const outputDir = join(getMidsceneRunSubDir('report'), reportFileName);


### PR DESCRIPTION
## Summary
- Modified `dumpDataString()` to use `serializeWithInlineScreenshots()` in browser environment
- Modified `reportHTMLString()` to use `serializeWithInlineScreenshots()` in browser environment  
- Added `ifInBrowser` check in `ReportGenerator.create()` to return `nullReportGenerator`

## Problem
When using the Chrome extension:
1. Downloaded HTML reports showed CORS errors when trying to load screenshots
2. Chat window playback failed with "existsSync is not a function" and "img is required" errors

## Root Cause
- Report serialization used `{ $screenshot: id }` reference format
- In browser environment, `ReportGenerator` couldn't use Node.js fs API to write screenshots to `<script type="midscene-image">` tags
- Downloaded HTML only had references, not actual base64 data

## Solution
Use `ifInBrowser` environment detection to:
1. Inline screenshots as base64 in `dumpDataString()` for proper playback in chat window
2. Inline screenshots as base64 in `reportHTMLString()` for downloadable reports
3. Skip `ReportGenerator` file operations in browser environment

## Test plan
- [ ] Build Chrome extension
- [ ] Execute an action in the extension
- [ ] Download the HTML report and open it locally - screenshots should display correctly
- [ ] Play the report in the chat window - playback should work without errors