### PR TITLE
fix(playground): inline screenshots in playground server responses

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -519,20 +519,20 @@ export class Agent<
     currentDump.executions.push(execution);
   }
 
-  dumpDataString() {
+  dumpDataString(opt?: { inlineScreenshots?: boolean }) {
     // update dump info
     this.dump.groupName = this.opts.groupName!;
     this.dump.groupDescription = this.opts.groupDescription;
     // In browser environment, use inline screenshots since file system is not available
-    if (ifInBrowser) {
+    if (ifInBrowser || opt?.inlineScreenshots) {
       return this.dump.serializeWithInlineScreenshots();
     }
     return this.dump.serialize();
   }
 
-  reportHTMLString() {
+  reportHTMLString(opt?: { inlineScreenshots?: boolean }) {
     // dumpDataString() handles browser environment with inline screenshots
-    return reportHTMLContent(this.dumpDataString());
+    return reportHTMLContent(this.dumpDataString(opt));
   }
 
   writeOutActionDumps() {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -452,7 +452,9 @@ class PlaygroundServer {
       }
 
       try {
-        const dumpString = this.agent.dumpDataString();
+        const dumpString = this.agent.dumpDataString({
+          inlineScreenshots: true,
+        });
         if (dumpString) {
           const groupedDump =
             GroupedActionDump.fromSerializedString(dumpString);
@@ -461,7 +463,8 @@ class PlaygroundServer {
         } else {
           response.dump = null;
         }
-        response.reportHTML = this.agent.reportHTMLString() || null;
+        response.reportHTML =
+          this.agent.reportHTMLString({ inlineScreenshots: true }) || null;
 
         this.agent.writeOutActionDumps();
         this.agent.resetDump();
@@ -523,7 +526,9 @@ class PlaygroundServer {
           let reportHTML: string | null = null;
 
           try {
-            const dumpString = this.agent.dumpDataString?.();
+            const dumpString = this.agent.dumpDataString?.({
+              inlineScreenshots: true,
+            });
             if (dumpString) {
               const groupedDump =
                 GroupedActionDump.fromSerializedString(dumpString);
@@ -531,7 +536,9 @@ class PlaygroundServer {
               dump = groupedDump.executions?.[0] || null;
             }
 
-            reportHTML = this.agent.reportHTMLString?.() || null;
+            reportHTML =
+              this.agent.reportHTMLString?.({ inlineScreenshots: true }) ||
+              null;
           } catch (error: unknown) {
             console.warn('Failed to get execution data before cancel:', error);
           }


### PR DESCRIPTION
## Summary
- Add optional `{ inlineScreenshots?: boolean }` parameter to `Agent.dumpDataString()` and `Agent.reportHTMLString()` so callers can explicitly request base64-inlined screenshots
- Use `inlineScreenshots: true` in the playground server's `/execute` and `/cancel` endpoints, ensuring Android/iOS playground clients receive self-contained reports with embedded screenshots instead of file-path references they cannot resolve

## Test plan
- [x] `npx nx build @midscene/core` — passes
- [x] `npx nx build @midscene/playground` — passes
- [x] `npx nx test @midscene/core` — 548 tests passed
- [x] `npx nx test @midscene/playground` — 129 tests passed