### PR TITLE
fix(android): use z.string() schema for RunAdbShell and Launch actions

### DIFF
--- a/packages/android/src/agent.ts
+++ b/packages/android/src/agent.ts
@@ -89,7 +89,7 @@ export class AndroidAgent extends PageAgent<AndroidDevice> {
    */
   async launch(uri: string): Promise<void> {
     const action = this.wrapActionInActionSpace<DeviceActionLaunch>('Launch');
-    return action({ uri });
+    return action(uri);
   }
 
   /**
@@ -99,7 +99,7 @@ export class AndroidAgent extends PageAgent<AndroidDevice> {
   async runAdbShell(command: string): Promise<string> {
     const action =
       this.wrapActionInActionSpace<DeviceActionRunAdbShell>('RunAdbShell');
-    return action({ command });
+    return action(command);
   }
 
   private createActionWrapper<T extends DeviceAction>(

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1834,17 +1834,15 @@ ${Object.keys(size)
  * Platform-specific action definitions for Android
  * Single source of truth for both runtime behavior and type definitions
  */
-const runAdbShellParamSchema = z.object({
-  command: z.string().describe('ADB shell command to execute'),
-});
+const runAdbShellParamSchema = z
+  .string()
+  .describe('ADB shell command to execute');
 
-const launchParamSchema = z.object({
-  uri: z
-    .string()
-    .describe(
-      'App name, package name, or URL to launch. Prioritize using the exact package name or URL the user has provided. If none provided, use the accurate app name.',
-    ),
-});
+const launchParamSchema = z
+  .string()
+  .describe(
+    'App name, package name, or URL to launch. Prioritize using the exact package name or URL the user has provided. If none provided, use the accurate app name.',
+  );
 
 type RunAdbShellParam = z.infer<typeof runAdbShellParamSchema>;
 type LaunchParam = z.infer<typeof launchParamSchema>;
@@ -1867,12 +1865,12 @@ const createPlatformActions = (
       description: 'Execute ADB shell command on Android device',
       interfaceAlias: 'runAdbShell',
       paramSchema: runAdbShellParamSchema,
-      call: async (param) => {
-        if (!param.command || param.command.trim() === '') {
+      call: async (command: string) => {
+        if (!command || command.trim() === '') {
           throw new Error('RunAdbShell requires a non-empty command parameter');
         }
         const adb = await device.getAdb();
-        return await adb.shell(param.command);
+        return await adb.shell(command);
       },
     }),
     Launch: defineAction({
@@ -1880,11 +1878,11 @@ const createPlatformActions = (
       description: 'Launch an Android app or URL',
       interfaceAlias: 'launch',
       paramSchema: launchParamSchema,
-      call: async (param) => {
-        if (!param.uri || param.uri.trim() === '') {
+      call: async (uri: string) => {
+        if (!uri || uri.trim() === '') {
           throw new Error('Launch requires a non-empty uri parameter');
         }
-        await device.launch(param.uri);
+        await device.launch(uri);
       },
     }),
     AndroidBackButton: defineAction({

--- a/packages/android/tests/unit-test/agent.test.ts
+++ b/packages/android/tests/unit-test/agent.test.ts
@@ -107,8 +107,8 @@ describe('AndroidAgent', () => {
 
       await agent.launch(uri);
 
-      // agent.launch(uri) converts string to { uri } object before calling device action
-      expect(launchSpy).toHaveBeenCalledWith({ uri });
+      // agent.launch(uri) passes string directly to device action
+      expect(launchSpy).toHaveBeenCalledWith(uri);
     });
   });
 

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -545,40 +545,6 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
           if (result !== undefined) {
             this.setResult(resultName, result);
           }
-        } else if (
-          typeof actionParamForMatchedAction === 'string' &&
-          (matchedAction.name === 'Launch' ||
-            matchedAction.interfaceAlias === 'launch') &&
-          typeof (agent as any).launch === 'function'
-        ) {
-          // Call agent.launch directly for Launch action with string param
-          debug(`Calling agent.launch with: ${actionParamForMatchedAction}`);
-          const result = await (agent as any).launch(
-            actionParamForMatchedAction,
-          );
-
-          const resultName = (flowItem as any).name;
-          if (result !== undefined) {
-            this.setResult(resultName, result);
-          }
-        } else if (
-          typeof actionParamForMatchedAction === 'string' &&
-          (matchedAction.name === 'RunAdbShell' ||
-            matchedAction.interfaceAlias === 'runAdbShell') &&
-          typeof (agent as any).runAdbShell === 'function'
-        ) {
-          // Call agent.runAdbShell directly for RunAdbShell action with string param
-          debug(
-            `Calling agent.runAdbShell with: ${actionParamForMatchedAction}`,
-          );
-          const result = await (agent as any).runAdbShell(
-            actionParamForMatchedAction,
-          );
-
-          const resultName = (flowItem as any).name;
-          if (result !== undefined) {
-            this.setResult(resultName, result);
-          }
         } else {
           // Determine the source for parameter extraction:
           // - If we have a locatePromptShortcut, use the flowItem (for actions like aiTap with prompt)


### PR DESCRIPTION
## Summary
- Replace `z.object({ command: z.string() })` and `z.object({ uri: z.string() })` with `z.string()` for `RunAdbShell` and `Launch` action schemas
- Remove hardcoded special cases for `Launch` and `RunAdbShell` in YAML player (`player.ts`), letting the generic `isStringParamSchema` → `callActionInActionSpace` path handle them automatically
- Update agent method calls to pass string directly instead of wrapping in object

## Test plan
- [x] `npx nx test @midscene/core` — 548 tests passed
- [x] `npx nx test @midscene/android` — 160 tests passed (including `yaml-runAdbShell.test.ts`)
- [x] Biome lint — no issues