### PR TITLE
fix(web): remove bringToFront call from puppeteer screenshot

### DIFF
--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -335,10 +335,6 @@ export class Page<
 
     let base64: string;
     if (this.interfaceType === 'puppeteer') {
-      // Bring tab to front to ensure it's actively rendering frames.
-      // Inactive tabs in Chrome don't produce frames, causing screenshot to hang.
-      // See: https://github.com/puppeteer/puppeteer/issues/12712
-      await (this.underlyingPage as PuppeteerPage).bringToFront();
       const result = await (this.underlyingPage as PuppeteerPage).screenshot({
         type: imgType,
         quality,


### PR DESCRIPTION
## Summary
- Remove the `bringToFront()` call before taking screenshots in puppeteer mode
- This was causing unexpected tab switching behavior during automation

## Test plan
- [ ] Verify screenshots still work correctly without bringToFront
- [ ] Test multi-tab scenarios to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)