### PR TITLE
fix(visualizer): highlight active playback speed with color

### DIFF
--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -262,6 +262,10 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
+.player-speed-option.active {
+  color: #1677ff;
+}
+
 [data-theme='dark'] {
   .player-settings-dropdown {
     background-color: #1f1f1f;

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -1226,11 +1226,10 @@ export function Player(props?: {
                         lineHeight: '32px',
                         padding: '0 8px 0 24px',
                         fontSize: '12px',
-                        fontWeight: playbackSpeed === speed ? 600 : 'normal',
                         cursor: 'pointer',
                         borderRadius: '4px',
                       }}
-                      className="player-speed-option"
+                      className={`player-speed-option${playbackSpeed === speed ? ' active' : ''}`}
                     >
                       {speed}x
                     </div>


### PR DESCRIPTION
## Summary

- Replace bold font-weight with blue highlight color (#1677ff) for active playback speed option
- Provides clearer visual feedback for the currently selected speed

## Test plan

- Open a report with playback functionality
- Click settings icon to open the dropdown
- Verify the currently selected playback speed is highlighted in blue
- Select different speeds and verify the highlight updates correctly