### PR TITLE
fix(core): Fix ConversationHistory.reset() to clear memories and subGoals

### DIFF
--- a/packages/core/src/ai-model/conversation-history.ts
+++ b/packages/core/src/ai-model/conversation-history.ts
@@ -38,6 +38,8 @@ export class ConversationHistory {
 
   reset() {
     this.messages.length = 0;
+    this.memories.length = 0;
+    this.subGoals.length = 0;
   }
 
   /**

--- a/packages/core/tests/unit-test/conversation-history.test.ts
+++ b/packages/core/tests/unit-test/conversation-history.test.ts
@@ -40,6 +40,26 @@ describe('ConversationHistory', () => {
     expect(history.length).toBe(2);
   });
 
+  it('reset clears messages, memories, and subGoals', () => {
+    const history = new ConversationHistory();
+    history.append(userMessage('msg1'));
+    history.append(assistantMessage('msg2'));
+    history.appendMemory('Memory from task 1');
+    history.appendMemory('Another memory');
+    history.setSubGoals([
+      { index: 1, status: 'pending', description: 'Sub-goal 1' },
+      { index: 2, status: 'pending', description: 'Sub-goal 2' },
+    ]);
+
+    history.reset();
+
+    expect(history.length).toBe(0);
+    expect(history.snapshot()).toEqual([]);
+    expect(history.getMemories()).toEqual([]);
+    expect(history.memoriesToText()).toBe('');
+    expect(history.subGoalsToText()).toBe('');
+  });
+
   it('clears pending feedback message only when set', () => {
     const history = new ConversationHistory();
 


### PR DESCRIPTION
## Summary
Fixed the `ConversationHistory.reset()` method to properly clear all internal state, including memories and subGoals in addition to messages.

## Changes
- **ConversationHistory.reset()**: Added clearing of `memories` and `subGoals` arrays to ensure complete state reset
- **Unit tests**: Added comprehensive test case to verify that `reset()` clears messages, memories, and subGoals

## Details
Previously, the `reset()` method only cleared the messages array, leaving memories and subGoals in a stale state. This could cause issues when reusing a ConversationHistory instance across multiple conversations or tasks. The fix ensures all three collections are properly cleared when reset is called.

The new test validates that after calling `reset()`:
- Message history is empty
- Memory history is empty
- SubGoals are cleared
- Text representations return empty strings

https://claude.ai/code/session_01LfiNcU6BXtsmRKJUGx54yj