### PR TITLE
docs(site): update Android and iOS CLI examples to native app scenarios

### DIFF
--- a/apps/site/docs/en/command-line-tools.mdx
+++ b/apps/site/docs/en/command-line-tools.mdx
@@ -83,32 +83,31 @@ Drive an Android device connected over adb:
 
 ```yaml
 android:
-  # launch: https://www.bing.com
   deviceId: s4ey59 # find the device id with `adb devices`
 
 tasks:
-  - name: Search for weather
+  - name: Maps Navigation
     flow:
-      - ai: Open the browser and navigate to bing.com
-      - ai: Search for "today's weather"
-      - sleep: 3000
-      - aiAssert: The results show weather information
+      - ai: Open the Maps app
+      - ai: Input 'West Lake, Hangzhou' in the search bar, and click the search button
+      - ai: Click the first search result, enter the details page
+      - ai: Click "Directions" button, enter the route planning page
+      - ai: Click "Start" button to start navigation
 ```
 
 Or drive an iOS device with WebDriverAgent configured:
 
 ```yaml
 ios:
-  # launch: com.apple.mobilesafari
   wdaPort: 8100
 
 tasks:
-  - name: Search for weather
+  - name: Change System Settings
     flow:
-      - ai: Open the browser and navigate to bing.com
-      - ai: Search for "today's weather"
-      - sleep: 3000
-      - aiAssert: The results show weather information
+      - ai: Open the Settings app
+      - ai: Tap "Display & Brightness"
+      - ai: Turn on "Dark Mode"
+      - aiAssert: Dark Mode is enabled
 ```
 
 ### Run the script

--- a/apps/site/docs/zh/command-line-tools.mdx
+++ b/apps/site/docs/zh/command-line-tools.mdx
@@ -82,36 +82,35 @@ tasks:
       - aiAssert: 结果显示天气信息
 ```
 
-驱动 已连接 adb 的 Android 设备：
+驱动已连接 adb 的 Android 设备：
 
 ```yaml
 android:
-  # launch: https://www.bing.com
   deviceId: s4ey59 # device id 可以在 adb 命令行中通过 `adb devices` 命令获取
 
 tasks:
-  - name: 搜索天气
+  - name: 地图导航
     flow:
-      - ai: 打开浏览器并访问 bing.com
-      - ai: 搜索 "今日天气"
-      - sleep: 3000
-      - aiAssert: 结果显示天气信息
+      - ai: 打开地图应用
+      - ai: 在搜索栏输入 "杭州西湖"，然后点击搜索按钮
+      - ai: 点击第一个搜索结果，进入详情页
+      - ai: 点击 "路线" 按钮，进入路线规划页面
+      - ai: 点击 "开始" 按钮开始导航
 ```
 
 或者驱动配置好 WebDriverAgent 的 iOS 设备：
 
 ```yaml
 ios:
-  # launch: com.apple.mobilesafari
   wdaPort: 8100
 
 tasks:
-  - name: 搜索天气
+  - name: 修改系统设置
     flow:
-      - ai: 打开浏览器并访问 bing.com
-      - ai: 搜索 "今日天气"
-      - sleep: 3000
-      - aiAssert: 结果显示天气信息
+      - ai: 打开设置应用
+      - ai: 点击 "显示与亮度"
+      - ai: 开启 "深色模式"
+      - aiAssert: 深色模式已开启
 ```
 
 ### 运行脚本


### PR DESCRIPTION
## Summary
- Replace browser-based examples (Bing search) with native app operation examples in CLI tools documentation
- Android example: Maps navigation to "West Lake, Hangzhou"
- iOS example: System Settings to toggle Dark Mode
- Updated both English and Chinese documentation

## Test plan
- [ ] Verify the YAML examples render correctly on the documentation site
- [ ] Confirm the examples are valid YAML syntax