### PR TITLE
fix(computer-mcp): add @computer-use/libnut as runtime dependency

### DIFF
--- a/packages/computer-mcp/package.json
+++ b/packages/computer-mcp/package.json
@@ -34,6 +34,7 @@
     "vitest": "3.0.5"
   },
   "dependencies": {
+    "@computer-use/libnut": "^4.2.0",
     "@silvia-odwyer/photon": "0.3.3",
     "@silvia-odwyer/photon-node": "0.3.3",
     "bufferutil": "4.0.9",

--- a/packages/computer-mcp/rslib.config.ts
+++ b/packages/computer-mcp/rslib.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         }
         cb();
       },
+      '@computer-use/libnut',
       '@silvia-odwyer/photon',
       '@silvia-odwyer/photon-node',
       '@modelcontextprotocol/sdk',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,6 +915,9 @@ importers:
 
   packages/computer-mcp:
     dependencies:
+      '@computer-use/libnut':
+        specifier: ^4.2.0
+        version: 4.2.0(@computer-use/nut-js@4.2.0)
       '@silvia-odwyer/photon':
         specifier: 0.3.3
         version: 0.3.3


### PR DESCRIPTION
## Summary
- Add `@computer-use/libnut` to `dependencies` in `@midscene/computer-mcp` package
- Add `@computer-use/libnut` to `externals` in rslib config to prevent bundling the native module

## Problem
When `@midscene/computer-mcp` is installed via npx, the `@computer-use/libnut` native module is missing at runtime, causing the error:
```
Error: Cannot find module '@computer-use/libnut/dist/import_libnut'
```

This happens because `@computer-use/libnut` is a dependency of `@midscene/computer` (which gets bundled into computer-mcp's dist), but as a native C++ addon it cannot be bundled — the `require()` call remains in the output. Since it was not declared as a dependency of `computer-mcp`, npm/npx never installs it.

## Fix
1. **`package.json`**: Added `"@computer-use/libnut": "^4.2.0"` to `dependencies` so it gets installed at runtime
2. **`rslib.config.ts`**: Added `'@computer-use/libnut'` to `externals` to explicitly mark it as an external module during bundling

## Test plan
- [ ] Run `npx @midscene/computer-mcp` and verify `computer_connect` no longer throws the missing module error
- [ ] Verify the build output still works correctly with `pnpm run build`