### PR TITLE
feat(android): export ScrcpyDeviceAdapter from package entry

### DIFF
--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -3,3 +3,4 @@ export { AndroidAgent, agentFromAdbDevice } from './agent';
 export type { AndroidAgentOpt } from './agent';
 export { overrideAIConfig } from '@midscene/shared/env';
 export { getConnectedDevices } from './utils';
+export { ScrcpyDeviceAdapter } from './scrcpy-device-adapter';


### PR DESCRIPTION
## Summary
- Export `ScrcpyDeviceAdapter` class from `@midscene/android` package entry point (`index.ts`)
- This allows consumers to directly import `ScrcpyDeviceAdapter` from the package without reaching into internal paths

## Test plan
- [ ] Verify `ScrcpyDeviceAdapter` can be imported from `@midscene/android`
- [ ] Ensure existing exports are unaffected