### PR TITLE
feat(core): fail planning when Finalize carries falsy-assert flag

### DIFF
--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -144,6 +144,14 @@ export async function plan(
   const actions = planFromAI.action ? [planFromAI.action] : [];
   let shouldContinuePlanning = true;
   if (actions[0]?.type === finalizeActionName) {
+    const ifContainsFalsyAssert = Boolean(
+      actions[0]?.param?.ifContainsFalsyAssert,
+    );
+    if (ifContainsFalsyAssert) {
+      throw new Error(
+        'Task finalized with a falsy assert result from the previous step.',
+      );
+    }
     debug('finalize action planned, stop planning');
     shouldContinuePlanning = false;
   }

--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -240,6 +240,7 @@ Please tell what the next one action is (or null if no action should be done) to
 - If there are some error messages reported by the previous actions, don't give up, try parse a new action to recover. If the error persists for more than 5 times, you should think this is an error and set the "error" field to the error message.
 - Assertions are also important steps. When getting the assertion instruction, a solid conclusion is required. You should explicitly state your conclusion by calling the "Print_Assert_Result" action.
 - Call the "Finalize" action when the task is completed and no more actions should be done.
+- If the previous action is "Print_Assert_Result" and its result is false, set "action.param.ifContainsFalsyAssert" to true when calling "Finalize".
 
 ## Supporting actions
 ${actionList}

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -498,9 +498,16 @@ export const actionFinalizeParamSchema = z.object({
     .describe(
       'The conclusion, data, or return value that the user needs. This message will be provided to the user when the task is finalized.',
     ),
+  ifContainsFalsyAssert: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true when the previous task is Print_Assert_Result and the assertion result is false.',
+    ),
 });
 export type ActionFinalizeParam = {
   message?: string;
+  ifContainsFalsyAssert?: boolean;
 };
 
 export const defineActionFinalize = (): DeviceAction<ActionFinalizeParam> => {


### PR DESCRIPTION
### Motivation
- Make a failed assertion explicit in planning termination so the planner treats a finalized task that follows a falsy assertion as an overall task failure.

### Description
- Add optional `ifContainsFalsyAssert?: boolean` to `Finalize` action params and schema with a description indicating it should be set when the previous action was `Print_Assert_Result` with `result: false` (`packages/core/src/device/index.ts`).
- In LLM planning (`plan`) detect `Finalize` actions carrying `ifContainsFalsyAssert: true` and immediately throw an error to mark the task as failed, otherwise continue the existing finalize flow (`packages/core/src/ai-model/llm-planning.ts`).
- Update the LLM planning prompt to instruct the model to set `action.param.ifContainsFalsyAssert` when the previous action is `Print_Assert_Result` and its result is false (`packages/core/src/ai-model/prompt/llm-planning.ts`).

### Testing
- Ran the focused planning unit tests with `pnpm -C packages/core exec vitest --run tests/unit-test/llm-planning.test.ts`, which passed (`20 tests` passed).
- Ran the broader core test run with `pnpm nx test @midscene/core --skip-nx-cache`; many tests executed and several unrelated proxy-configuration tests reported expected errors in that environment, but the planning-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b116c81b483249b23e4e859e3c7d0)