### PR TITLE
feat(android): optimize the logic of text input

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -66,17 +66,15 @@ const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 const debugDevice = getDebug('android:device');
 
 /**
- * Escape text for safe use in shell double-quoted strings.
- * This prevents shell injection and handles special characters.
- * Note: For yadb, \\n will be converted back to real newline by yadb itself.
+ * Escape text for safe use in shell single-quoted strings.
+ * In single quotes, all characters are literal except ' itself.
+ * Newlines (0x0A) are converted to literal \n for safe transport;
+ * yadb interprets \n back to a real newline.
  */
 export function escapeForShell(text: string): string {
   return text
-    .replace(/\\/g, '\\\\') // Escape backslashes first
-    .replace(/"/g, '\\"') // Escape double quotes
-    .replace(/`/g, '\\`') // Escape backticks (command substitution)
-    .replace(/\$/g, '\\$') // Escape dollar signs (variable expansion)
-    .replace(/\n/g, '\\n'); // Escape newlines
+    .replace(/'/g, "'\\''") // End quote, escaped quote, start quote: ' → '\''
+    .replace(/\n/g, '\\n'); // 0x0A → literal \n (yadb interprets back to newline)
 }
 
 export class AndroidDevice implements AbstractInterface {
@@ -575,7 +573,7 @@ ${Object.keys(size)
     const adb = await this.getAdb();
 
     await adb.shell(
-      `app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard "${keyboardContent}"`,
+      `app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard '${keyboardContent}'`,
     );
   }
 
@@ -1383,24 +1381,40 @@ ${Object.keys(size)
   }
 
   /**
-   * Check if text contains characters that may cause issues with ADB inputText
-   * This includes:
-   * - Non-ASCII characters (Unicode characters like ö, é, ñ, Chinese, Japanese, etc.)
-   * - Format specifiers that may be interpreted by shell (%, $)
-   * - Special shell characters that need escaping
-   * - Control characters like newlines, tabs, carriage returns
+   * Check if text contains characters that may cause issues with ADB inputText.
+   * appium-adb's inputText has known bugs with certain characters:
+   * - Backslash causes broken shell quoting
+   * - Backtick is not escaped at all
+   * - Text containing both " and ' throws an error
+   * - Dollar sign can cause variable expansion issues
+   *
+   * For these characters, we route through yadb which handles them correctly
+   * via escapeForShell + double-quoted shell context.
    */
   private shouldUseYadbForText(text: string): boolean {
     // Check for any non-ASCII characters (code point >= 128)
     // This covers Latin Unicode characters (ö, é, ñ), Chinese, Japanese, etc.
-    // Using positive match to avoid control character in regex
     const hasNonAscii = /[\x80-\uFFFF]/.test(text);
 
     // Check for format specifiers that may cause issues in shell
     // % can be interpreted as format specifier in some contexts
     const hasFormatSpecifiers = /%[a-zA-Z]/.test(text);
 
-    return hasNonAscii || hasFormatSpecifiers;
+    // Check for shell-special characters that appium-adb's inputText cannot handle correctly:
+    // \ (backslash) - causes broken quoting in inputText
+    // ` (backtick) - not escaped by inputText, causes command substitution
+    // $ (dollar) - can cause variable expansion issues with double escaping
+    const hasShellSpecialChars = /[\\`$]/.test(text);
+
+    // appium-adb throws if text contains both " and '
+    const hasBothQuotes = text.includes('"') && text.includes("'");
+
+    return (
+      hasNonAscii ||
+      hasFormatSpecifiers ||
+      hasShellSpecialChars ||
+      hasBothQuotes
+    );
   }
 
   async keyboardType(
@@ -1409,7 +1423,6 @@ ${Object.keys(size)
   ): Promise<void> {
     if (!text) return;
     const adb = await this.getAdb();
-    const shouldUseYadb = this.shouldUseYadbForText(text);
     const IME_STRATEGY =
       (this.options?.imeStrategy ||
         globalConfigManager.getEnvConfigValue(MIDSCENE_ANDROID_IME_STRATEGY)) ??
@@ -1417,17 +1430,28 @@ ${Object.keys(size)
     const shouldAutoDismissKeyboard =
       options?.autoDismissKeyboard ?? this.options?.autoDismissKeyboard ?? true;
 
-    // Escape text for shell safety
-    const escapedText = escapeForShell(text);
-
-    if (
+    // Decide input path for the entire text, not per-segment.
+    const useYadb =
       IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
-      (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII && shouldUseYadb)
-    ) {
-      await this.execYadb(escapedText);
+      (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
+        this.shouldUseYadbForText(text));
+
+    if (useYadb) {
+      // yadb handles newlines natively: escapeForShell converts \n (0x0A)
+      // to literal \n (two chars), which yadb interprets back as newline.
+      // Single adb call for the entire text.
+      await this.execYadb(escapeForShell(text));
     } else {
-      // for pure ASCII characters, directly use inputText
-      await adb.inputText(escapedText);
+      // inputText cannot handle newlines, so split by \n and press Enter between segments.
+      const segments = text.split('\n');
+      for (let i = 0; i < segments.length; i++) {
+        if (segments[i].length > 0) {
+          await adb.inputText(segments[i]);
+        }
+        if (i < segments.length - 1) {
+          await adb.keyevent(66);
+        }
+      }
     }
 
     if (shouldAutoDismissKeyboard === true) {


### PR DESCRIPTION
## Summary

Fixes the `keyboardType` method in `AndroidDevice` to properly handle text input escaping by:
- Switching the yadb shell command from double-quote to single-quote wrapping for safer escaping
- Fixing a bug where `escapeForShell` was applied to both yadb and inputText paths (causing double-escaping)
- Refactoring to evaluate the entire text for routing instead of splitting by newline first

## Background: Three Android Text Input Methods

### 1. `adb shell input text` — Native Android command

| Capability | Support |
|---|---|
| ASCII letters/numbers | ✓ |
| Non-ASCII (Chinese, emoji, Unicode Latin) | ✗ NullPointerException |
| Spaces | Only via `%s` |
| Newlines | ✗ Not supported |
| `\n` `\t` escape sequences | ✗ Not interpreted |

Character compatibility:

| Character | Double quotes | Single quotes | Unquoted | Notes |
|---|---|---|---|---|
| Plain ASCII | ✓ | ✓ | ✓ | |
| `! @ # , . / - _ : = + ? {} []` | ✓ | ✓ | ✓ | |
| `& \| ; ()` | ✓ | ✓ | ✗ | Interpreted by shell when unquoted |
| `* ~ ^ < >` | ✓ | ✓ | Risky | May glob when unquoted |
| `'` | ✓ | — | — | |
| `"` | — | ✓ | — | |
| `\` | `\\`→`\` | ✓ | ✓ | |
| `` ` `` | `` \` ``→`` ` `` | ✓ | ✗ | |
| `$` | `\$`→`$` | ✓ | Risky | |
| `!` | ✗ Gets `\` prefix | ✗ Gets `\` prefix | ✓ | `input text` adds `\` prefix to `!` inside quotes |
| `%s` | ✗ Becomes space | ✗ Becomes space | ✗ Becomes space | Internal `input text` behavior, **unavoidable** |

### 2. appium-adb `inputText()` — Node.js wrapper

Built on `adb shell input text`, with quoting and escaping logic. Two modes:
- **Array mode** `['input', 'text', text]`: passes args directly when no special chars
- **String mode** `['input text "escaped"']`: passes through shell with quote wrapping for special chars

Test results (direct calls, without escapeForShell):

| Character | Mode | Result |
|---|---|---|
| `hello` `abc123` | array | ✓ |
| `hello world` | string | ✓ `%s` replaces space |
| `hello!` `user@host` `a#b` `a?b` | array | ✓ |
| `a,b.c` `a/b` `a-b_c` `a:b` `a=b+c` | array | ✓ |
| `a{b}c` `a[b]c` `%%` | array | ✓ |
| `a&b` `a\|b` `a;b` `a(b)c` `a<b>c` `a~b` `a^b` `a*b` | string | ✓ |
| `it's` / `say"hi"` | string | ✓ Auto-selects quotes |
| `a$b` `$HOME` | string | ✓ `\$` |
| `a\b` | string | ✓ Works by coincidence |

Failures:

| Character | Result | Reason |
|---|---|---|
| `` a`b `` | ✗ Shell error | `` ` `` not escaped |
| `it's a "test"` | ✗ Throws Error | Contains both `"` and `'` |
| `100%success` | ✗ `100 uccess` | Array mode, `%s` interpreted as space by `input text` |
| Chinese/emoji/café | ✗ NullPointerException | `input text` only supports ASCII |

`\` caveat: appium-adb **does not escape** `\`, relying only on quote wrapping. `a\b` works by coincidence (`\b` is not special in shell double quotes), but `a\\b` (loses `\`), `a\` (trailing, shell error), `a\"b` (quote consumed) all fail.

### 3. yadb — Java clipboard input

Sends commands via `adb.shell()`, with text passed inside **single quotes** in Android shell.
yadb writes text to clipboard then pastes, so it's not limited by `input text`'s ASCII restriction.

Character compatibility — with single-quote wrapping, shell does not interpret any characters; **only `'` itself needs escaping**:

| Character | Direct | Escape method |
|---|---|---|
| `'` | ✗ Ends quote | `'\''` (end quote + escaped quote + start quote) |

**No escaping needed** (all passed literally inside single quotes):

| Character | Result |
|---|---|
| `\` `"` `` ` `` `$` | ✓ Not special inside single quotes |
| Space | ✓ |
| `! @ # & \| ; () {} [] <> ~ ^ * ? = + , . / - _ :` | ✓ |
| `%s` `%d` `%f` | ✓ yadb **does not interpret** percent signs |
| Chinese, Japanese, emoji, Unicode Latin | ✓ |

Newline handling — yadb accepts newlines in **two equivalent ways**:

| Content received by yadb | Source example | yadb behavior |
|---|---|---|
| Literal `\n` (two characters `\` + `n`) | Shell double quotes `"a\nb"` passes as-is | yadb scans and replaces `\n` → newline |
| Real newline 0x0A | Read from file `$(cat file)` embedded in quotes | yadb directly interprets as newline |

**yadb only recognizes `\n` as an escape sequence**. `\t` `\r` `\0` `\a` `\b` are all kept as literals.
`\\n` → `\` + newline (yadb doesn't recognize `\\` as escape, only does simple `\n` scan-replace).

## Comparison

| Feature | `input text` | appium-adb | yadb |
|---|---|---|---|
| Non-ASCII (Chinese/Japanese/emoji) | ✗ Crashes | ✗ Crashes | ✓ |
| Spaces | Only `%s` | ✓ Auto `%s` | ✓ |
| Newlines | ✗ | ✗ | ✓ |
| `%s` literal | ✗ Becomes space | ✗ Becomes space | ✓ |
| `\` backslash | Needs quotes | Has caveats | ✓ |
| `` ` `` backtick | Needs quotes | ✗ Not escaped | ✓ |
| `$` | Needs escaping | ✓ | ✓ |
| `"` + `'` together | Needs mixed quotes | ✗ Throws error | ✓ |
| `!` | Broken inside quotes | ✓ | ✓ |

## Implementation

### Routing strategy — `shouldUseYadbForText`

```
User text
   │
   ├─ Contains any of the following → yadb path
   │   • Non-ASCII (Chinese, emoji, Unicode Latin)
   │   • %[a-zA-Z] (%s would be swallowed by input text)
   │   • \ backslash (appium-adb has caveats)
   │   • ` backtick (appium-adb doesn't escape)
   │   • $ dollar sign
   │   • Contains both " and ' (appium-adb throws error)
   │
   └─ All other pure ASCII → appium-adb inputText path
```

### yadb path: `escapeForShell` + `execYadb`

Uses single-quote wrapping; only need to handle `'` itself + newlines:

```typescript
function escapeForShell(text: string): string {
  return text
    .replace(/'/g, "'\\''")  // ' → '\'' (end quote + escaped quote + start quote)
    .replace(/\n/g, '\\n');  // newline(0x0A) → literal \n, yadb interprets back to newline
}
```

`execYadb` uses single quotes:
```typescript
adb.shell(`... -keyboard '${escapedText}'`);
```

### inputText path: pass original text

appium-adb has its own escaping (`$`→`\$`, spaces→`%s`, quote wrapping). `escapeForShell` should **not** be applied.

### Newline handling

Route decision is made once for the **entire text**, not per-segment:

- **yadb path**: No splitting. `escapeForShell` converts `\n`(0x0A) to literal `\n` (two chars); yadb interprets it back to a newline. Single adb call.
- **inputText path**: `input text` doesn't support newlines. Split by `\n`, insert `keyevent 66` (Enter) between segments.

### Known edge case

Text containing literal `\n` (two characters `\` + `n`, not a newline):
- `shouldUseYadbForText` detects `\` → routes to yadb
- `escapeForShell`: `\` is unchanged inside single quotes → shell passes `\n` to yadb → yadb interprets as newline
- **Cannot input literal `\n` via yadb**, but this is an extremely rare edge case

## Test plan

- [x] Unit tests for `escapeForShell` pure function (single-quote escaping behavior)
- [x] Unit tests for `shouldUseYadbForText` routing logic
- [x] Integration tests for `keyboardType` — inputText path (ASCII, punctuation, operators, quotes)
- [x] Integration tests for `keyboardType` — yadb path (backslash, backtick, dollar, both quotes, non-ASCII, emoji)
- [x] Newline handling tests for both paths (middle, trailing, leading, consecutive, just-newline)
- [x] IME strategy tests (always-yadb, yadb-for-non-ascii)
- [x] All 141 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)