### PR TITLE
Improve screenshot output message clarity in do command

### DIFF
--- a/packages/cli/src/commands/do.ts
+++ b/packages/cli/src/commands/do.ts
@@ -193,7 +193,7 @@ function printResult(result: DoResult): void {
     console.log(result.message);
   }
   if (result.screenshot) {
-    console.log(`Screenshot: ${result.screenshot}`);
+    console.log(`Screenshot after running: ${result.screenshot}`);
   }
   if (result.error) {
     console.error(`Error: ${result.error}`);


### PR DESCRIPTION
## Summary
Updated the screenshot output message in the `do` command to provide clearer context about when the screenshot was captured.

## Changes
- Modified the screenshot console output message from `"Screenshot: "` to `"Screenshot after running: "` to better indicate that the screenshot was taken after the command execution completed

## Details
This is a minor UX improvement that makes the output message more descriptive and helps users understand the timing of the screenshot capture relative to the command execution.

https://claude.ai/code/session_01CTmr9ZyWyYzKQ5iobcqt8n