### PR TITLE
refactor(core): remove deprecated getContext from AbstractInterface

### DIFF
--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -53,9 +53,6 @@ export abstract class AbstractInterface {
   // @deprecated do NOT extend this method
   abstract evaluateJavaScript?<T = any>(script: string): Promise<T>;
 
-  // @deprecated do NOT extend this method
-  abstract getContext?(): Promise<UIContext>;
-
   /**
    * Get the current time from the device.
    * Returns the device's current timestamp in milliseconds.

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -64,10 +64,6 @@ export const getBridgePageInCliSide = (options?: {
         };
       }
 
-      if (prop === 'getContext') {
-        return undefined;
-      }
-
       if (prop === 'interfaceType') {
         return BridgePageType;
       }


### PR DESCRIPTION
## Summary

- Remove `getContext?()` declaration from `AbstractInterface` in `packages/core/src/device/index.ts`
- Remove dead `getContext` proxy interception in `packages/web-integration/src/bridge-mode/agent-cli-side.ts`

## Context

After the `screenshotShrinkFactor` refactor in #1961, `Agent.getUIContext()` no longer calls `this.interface.getContext()` — it always uses `commonContextParser` directly. All three implementations (ChromeExtension, Puppeteer, StaticPage) were already removed in #1961, but the interface declaration and bridge-mode proxy interception remained as dead code.

Verified that no platform (Android, iOS, Computer, MCP) ever implemented `getContext()`.

## Test plan

- [ ] Existing tests should pass without modification since `getContext` was already unused