### PR TITLE
chore(workflow): add version summary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,12 @@ jobs:
         VERSION=$(cat packages/core/package.json | jq -r '.version')
         echo "version=v${VERSION}" >> $GITHUB_OUTPUT
         echo "Core package version: v${VERSION}"
+        echo "## 🚀 Released v${VERSION}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: \`v${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Type**: \`${{ github.event.inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Branch**: \`${{ github.event.inputs.branch }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **NPM**: [\`@midscene/core@${VERSION}\`](https://www.npmjs.com/package/@midscene/core/v/${VERSION})" >> $GITHUB_STEP_SUMMARY
       
     - name: Upload output
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Add version information to GitHub Actions job summary in the release workflow
- After a release completes, the version, release type, branch, and NPM link are displayed directly on the workflow run summary page
- This eliminates the need to dig through logs to find the released version number

## Changes

- Modified `.github/workflows/release.yml` to write version details to `$GITHUB_STEP_SUMMARY`

## Test plan

- [ ] Trigger a prepatch release and verify the version summary appears on the workflow run page