### PR TITLE
refactor(core): centralize screenshot shrink coordinate transforms in service

### DIFF
--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -27,9 +27,6 @@ import {
   ifPlanLocateParamIsBbox,
   matchElementFromCache,
   matchElementFromPlan,
-  transformLogicalElementToScreenshot,
-  transformLogicalRectToScreenshotRect,
-  transformScreenshotElementToLogical,
 } from './utils';
 
 const debug = getDebug('agent:task-builder');
@@ -283,31 +280,14 @@ export class TaskBuilder {
           }
         }
 
-        // Transform coordinates from screenshot space to logical space if needed
-        // This is necessary when shrunkShotToLogicalRatio !== 1
-        const { shrunkShotToLogicalRatio } = uiContext;
-        if (shrunkShotToLogicalRatio === undefined) {
-          throw new Error(
-            'shrunkShotToLogicalRatio is not defined in Action task',
-          );
-        }
-        if (shrunkShotToLogicalRatio !== 1) {
-          debug(
-            `Transforming coordinates for action ${action.name} with shrunkShotToLogicalRatio=${shrunkShotToLogicalRatio}`,
-          );
-
-          for (const field of locateFields) {
-            if (param[field] && typeof param[field] === 'object') {
-              const element = param[field] as LocateResultElement;
-              if (element.center && element.rect) {
-                param[field] = transformScreenshotElementToLogical(
-                  element,
-                  shrunkShotToLogicalRatio,
-                );
-                debug(
-                  `Transformed ${field}: center ${element.center} -> ${param[field].center}`,
-                );
-              }
+        for (const field of locateFields) {
+          if (param[field] && typeof param[field] === 'object') {
+            const element = param[field] as LocateResultElement;
+            if (element.center && element.rect) {
+              param[field] = this.service.screenshotElementToLogical(
+                element,
+                uiContext,
+              );
             }
           }
         }
@@ -400,13 +380,6 @@ export class TaskBuilder {
 
         assert(uiContext, 'uiContext is required for Service task');
 
-        const { shrunkShotToLogicalRatio } = uiContext;
-
-        if (shrunkShotToLogicalRatio === undefined) {
-          throw new Error(
-            'shrunkShotToLogicalRatio is not defined in locate task',
-          );
-        }
 
         let locateDump: ServiceDump | undefined;
         let locateResult: LocateResultWithDump | undefined;
@@ -454,10 +427,7 @@ export class TaskBuilder {
         const elementFromXpath = rectFromXpath
           ? generateElementByRect(
               // rectFromXpath is in logical coordinates, which should be transformed to screenshot coordinates;
-              transformLogicalRectToScreenshotRect(
-                rectFromXpath,
-                shrunkShotToLogicalRatio,
-              ),
+              this.service.logicalRectToScreenshot(rectFromXpath, uiContext),
               typeof param.prompt === 'string'
                 ? param.prompt
                 : param.prompt?.prompt || '',
@@ -485,9 +455,9 @@ export class TaskBuilder {
 
         // elementFromCacheResult is in logical coordinates, which should be transformed to screenshot coordinates;
         const elementFromCache = elementFromCacheResult
-          ? transformLogicalElementToScreenshot(
+          ? this.service.logicalElementToScreenshot(
               elementFromCacheResult,
-              shrunkShotToLogicalRatio,
+              uiContext,
             )
           : undefined;
 
@@ -545,17 +515,10 @@ export class TaskBuilder {
               // When element comes from AI (isPlanHit or elementFromAiLocate), coordinates are in screenshot space
               // When element comes from xpath, coordinates are already in logical space
               let pointForCache: [number, number] = element.center;
-              if (shrunkShotToLogicalRatio !== 1) {
-                pointForCache = [
-                  Math.round(element.center[0] / shrunkShotToLogicalRatio),
-                  Math.round(element.center[1] / shrunkShotToLogicalRatio),
-                ];
-                debug(
-                  'Transformed coordinates for cacheFeatureForPoint: %o -> %o',
-                  element.center,
-                  pointForCache,
-                );
-              }
+              pointForCache = this.service.screenshotElementToLogical(
+                element,
+                uiContext,
+              ).center;
 
               const feature = await this.interface.cacheFeatureForPoint(
                 pointForCache,

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -12,6 +12,7 @@ import type {
   AIDescribeElementResponse,
   AIUsageInfo,
   DetailedLocateParam,
+  LocateResultElement,
   LocateResultWithDump,
   PartialServiceDumpFromSDK,
   Rect,
@@ -201,6 +202,68 @@ export default class Service {
       element: null,
       rect,
       dump,
+    };
+  }
+
+  screenshotElementToLogical(
+    element: LocateResultElement,
+    context: UIContext,
+  ): LocateResultElement {
+    const ratio = context.shrunkShotToLogicalRatio;
+    if (ratio === 1) {
+      return element;
+    }
+
+    return {
+      ...element,
+      center: [
+        Math.round(element.center[0] / ratio),
+        Math.round(element.center[1] / ratio),
+      ],
+      rect: {
+        left: Math.round(element.rect.left / ratio),
+        top: Math.round(element.rect.top / ratio),
+        width: Math.round(element.rect.width / ratio),
+        height: Math.round(element.rect.height / ratio),
+      },
+    };
+  }
+
+  logicalElementToScreenshot(
+    element: LocateResultElement,
+    context: UIContext,
+  ): LocateResultElement {
+    const ratio = context.shrunkShotToLogicalRatio;
+    if (ratio === 1) {
+      return element;
+    }
+
+    return {
+      ...element,
+      center: [
+        Math.round(element.center[0] * ratio),
+        Math.round(element.center[1] * ratio),
+      ],
+      rect: {
+        left: Math.round(element.rect.left * ratio),
+        top: Math.round(element.rect.top * ratio),
+        width: Math.round(element.rect.width * ratio),
+        height: Math.round(element.rect.height * ratio),
+      },
+    };
+  }
+
+  logicalRectToScreenshot(rect: Rect, context: UIContext): Rect {
+    const ratio = context.shrunkShotToLogicalRatio;
+    if (ratio === 1) {
+      return rect;
+    }
+
+    return {
+      left: Math.round(rect.left * ratio),
+      top: Math.round(rect.top * ratio),
+      width: Math.round(rect.width * ratio),
+      height: Math.round(rect.height * ratio),
     };
   }
 


### PR DESCRIPTION
### Motivation

- Ensure the screenshot compression strategy (the `screenshotShrinkFactor` that controls model-facing image shrinking) is consumed at the service/AI-model layer rather than scattered in task orchestration code.
- Move coordinate conversion logic out of `TaskBuilder` so task-building focuses on orchestration and `core/service` owns mapping between shrunk screenshots and logical coordinates.

### Description

- Added three conversion helpers on `Service`: `screenshotElementToLogical`, `logicalElementToScreenshot`, and `logicalRectToScreenshot` to centralize shrunk<->logical coordinate transforms in `packages/core/src/service/index.ts`.
- Replaced direct uses of transform helpers in `packages/core/src/agent/task-builder.ts` with calls to `this.service.screenshotElementToLogical`, `this.service.logicalElementToScreenshot`, and `this.service.logicalRectToScreenshot` so `TaskBuilder` no longer performs shrink-ratio math itself.
- Removed direct imports of transform utilities from `task-builder.ts` and updated usages that convert action params, xpath results, cache results, and `cacheFeatureForPoint` coordinates to use the `Service` methods.
- Did not change the location of the `screenshotShrinkFactor` option (it remains an `AgentOpt` option); this change centralizes how that shrink factor is consumed (mapping logic now lives in `Service`).

### Testing

- Ran `pnpm -C packages/core build`, which completed successfully.
- Ran `pnpm -C packages/core test -- tests/unit-test/task-runner/index.test.ts`, which passed (all tests in that file passed).
- Ran `pnpm -C packages/core test -- tests/unit-test/utils.test.ts`, where most tests passed but one heavy case timed out in this environment (test timed out at 30s); this timeout appears due to a large-case test and not specific to the coordinate-transform refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6b76a09c83248180aa273bec9676)