### PR TITLE
Improve page loading detection in LLM planning prompts

### DIFF
--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -344,7 +344,7 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 
 **Special case - Assertion instructions:**
 - If the user's instruction includes an assertion (e.g., "verify that...", "check that...", "assert..."), and you observe from the screenshot that the assertion condition is NOT satisfied and cannot be satisfied, mark ${shouldIncludeSubGoals ? 'the goal' : 'it'} as failed (success="false").
-- If the page is still loading (e.g., you see a loading spinner, skeleton screen, or progress bar), do NOT assert yet. Wait for the page to finish loading before evaluating the assertion.
+- If the page is still loading (e.g., you see a loading spinner, skeleton screen, or progress bar), do NOT assert yet. Use a \`Sleep\` action (1000ms) to wait for the page to finish loading before evaluating the assertion. If the page still has not finished loading after 5 consecutive waits, consider the task as failed (success="false").
 ${
   !shouldIncludeSubGoals
     ? `
@@ -372,6 +372,7 @@ ONLY if the task is not complete: Think what the next action is according to the
 - Make sure the previous actions are completed successfully. Otherwise, retry or do something else to recover.
 - Give just the next ONE action you should do (if any)
 - If there are some error messages reported by the previous actions, don't give up, try parse a new action to recover. If the error persists for more than 3 times, you should think this is an error and set the "error" field to the error message.
+- **Page loading detection**: If the page is still loading (e.g., you see a loading spinner, skeleton screen, progress bar, or the page content is incomplete/not fully rendered), you MUST use a \`Sleep\` action (1000ms) to wait for the page to finish loading before continuing with subsequent actions or assertions. Do NOT interact with or assert on a page that is still loading. However, if you have already waited 5 or more times for the same page loading and it still has not completed, consider the task as failed and output \`<complete success="false">Page loading timeout: the page failed to finish loading after multiple attempts</complete>\`.
 
 ### Supporting actions list
 


### PR DESCRIPTION
## Summary
Enhanced the LLM planning prompt instructions to provide more robust guidance on handling page loading states during task execution. The changes add explicit instructions for using Sleep actions to wait for page loads and define failure conditions when pages fail to load after multiple attempts.

## Key Changes
- **Updated assertion instruction**: Modified the special case guidance for assertion instructions to explicitly recommend using a `Sleep` action (1000ms) when the page is still loading, with a failure condition if the page hasn't loaded after 5 consecutive waits.

- **Added page loading detection guidance**: Introduced a new detailed instruction in the action planning section that:
  - Requires using `Sleep` actions (1000ms) when detecting loading indicators (spinners, skeleton screens, progress bars, incomplete content)
  - Prohibits interactions or assertions on pages that are still loading
  - Defines a timeout failure condition: if 5+ waits have occurred for the same page load without completion, the task should be marked as failed with a specific error message

## Implementation Details
These changes improve the reliability of AI-driven task execution by:
- Providing explicit, measurable guidance (1000ms sleep intervals, 5-attempt threshold)
- Preventing premature assertions or interactions on incompletely loaded pages
- Establishing clear failure criteria to avoid infinite waiting loops
- Ensuring consistent behavior across different loading scenarios

https://claude.ai/code/session_013R6UiSRRXHpMaLUccdvxF7