### PR TITLE
fix(core): remove z.preprocess from input mode schema for correct form rendering

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -719,10 +719,14 @@ export class Agent<
     // Convert value to string to ensure consistency
     const stringValue = typeof value === 'number' ? String(value) : value;
 
+    // backward compat: convert deprecated 'append' to 'typeOnly'
+    const mode = opt?.mode === 'append' ? 'typeOnly' : opt?.mode;
+
     return this.callActionInActionSpace('Input', {
       ...(opt || {}),
       value: stringValue,
       locate: detailedLocateParam,
+      mode,
     });
   }
 

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -191,15 +191,12 @@ export const actionInputParamSchema = z.object({
   locate: getMidsceneLocationSchema()
     .describe(inputLocateDescription)
     .optional(),
-  mode: z.preprocess(
-    (val) => (val === 'append' ? 'typeOnly' : val),
-    z
-      .enum(['replace', 'clear', 'typeOnly'])
-      .default('replace')
-      .describe(
-        'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - clear the field without inputting new text.',
-      ),
-  ),
+  mode: z
+    .enum(['replace', 'clear', 'typeOnly'])
+    .default('replace')
+    .describe(
+      'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - clear the field without inputting new text.',
+    ),
 });
 export type ActionInputParam = {
   value: string;
@@ -215,7 +212,13 @@ export const defineActionInput = (
     description: 'Input the value into the element',
     interfaceAlias: 'aiInput',
     paramSchema: actionInputParamSchema,
-    call,
+    call: (param) => {
+      // backward compat: convert deprecated 'append' to 'typeOnly'
+      if ((param.mode as string) === 'append') {
+        param.mode = 'typeOnly';
+      }
+      return call(param);
+    },
   });
 };
 


### PR DESCRIPTION
## Summary
- Remove `z.preprocess()` wrapper from the `mode` field in `actionInputParamSchema`, so the visualizer's `unwrapZodType` can correctly identify it as `ZodDefault<ZodEnum>` instead of opaque `ZodEffects`
- This fixes the playground/chrome-extension UI where the `mode` field was incorrectly rendered as a required plain text input, instead of an optional dropdown defaulting to `replace`
- Move the deprecated `append` → `typeOnly` backward compatibility conversion to `agent.aiInput()` (before schema validation) and `defineActionInput`'s call wrapper (safety net)

## Test plan
- [ ] Verify `aiInput` mode field renders as a dropdown (`replace` / `clear` / `typeOnly`) in the chrome extension playground
- [ ] Verify mode defaults to `replace` when not specified
- [ ] Verify passing `mode: 'append'` via the `aiInput()` API still works (backward compat)
- [ ] Run `npx nx test @midscene/core` to confirm no regressions