### PR TITLE
refactor(core): unify UI context parsing and screenshot handling

### DIFF
--- a/apps/chrome-extension/src/utils/eventOptimizer.ts
+++ b/apps/chrome-extension/src/utils/eventOptimizer.ts
@@ -1,5 +1,6 @@
 import Service from '@midscene/core';
 import type { Rect, UIContext } from '@midscene/core';
+import { ScreenshotItem } from '@midscene/core';
 import type { RecordedEvent } from '@midscene/recorder';
 import { globalModelConfigManager } from '@midscene/shared/env';
 import { compositeElementInfoImg } from '@midscene/shared/img';
@@ -135,8 +136,11 @@ export const generateAIDescription = async (
   const descriptionPromise = (async () => {
     try {
       const mockContext: UIContext = {
-        screenshotBase64: event.screenshotBefore as string,
-        size: { width: event.pageInfo.width, height: event.pageInfo.height },
+        screenshot: ScreenshotItem.create(event.screenshotBefore as string),
+        size: {
+          width: event.pageInfo.width,
+          height: event.pageInfo.height,
+        },
       };
 
       const service = new Service(mockContext);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -210,16 +210,6 @@ export class Agent<
    */
   private hasWarnedNonVLModel = false;
 
-  /**
-   * Screenshot scale factor derived from actual screenshot dimensions
-   */
-  private screenshotScale?: number;
-
-  /**
-   * Internal promise to deduplicate screenshot scale computation
-   */
-  private screenshotScalePromise?: Promise<number>;
-
   private executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
 
   private fullActionSpace: DeviceAction[];
@@ -245,54 +235,6 @@ export class Agent<
     ) {
       this.modelConfigManager.throwErrorIfNonVLModel();
       this.hasWarnedNonVLModel = true;
-    }
-  }
-
-  /**
-   * Lazily compute the ratio between the physical screenshot width and the logical page width
-   */
-  private async getScreenshotScale(context: UIContext): Promise<number> {
-    if (this.screenshotScale !== undefined) {
-      return this.screenshotScale;
-    }
-
-    if (!this.screenshotScalePromise) {
-      this.screenshotScalePromise = (async () => {
-        const pageWidth = context.size?.width;
-        assert(
-          pageWidth && pageWidth > 0,
-          `Invalid page width when computing screenshot scale: ${pageWidth}`,
-        );
-
-        debug('will get image info of base64');
-        const screenshotBase64 = context.screenshot.base64;
-        const { width: screenshotWidth } =
-          await imageInfoOfBase64(screenshotBase64);
-        debug('image info of base64 done');
-
-        assert(
-          Number.isFinite(screenshotWidth) && screenshotWidth > 0,
-          `Invalid screenshot width when computing screenshot scale: ${screenshotWidth}`,
-        );
-
-        const computedScale = screenshotWidth / pageWidth;
-        assert(
-          Number.isFinite(computedScale) && computedScale > 0,
-          `Invalid computed screenshot scale: ${computedScale}`,
-        );
-
-        debug(
-          `Computed screenshot scale ${computedScale} from screenshot width ${screenshotWidth} and page width ${pageWidth}`,
-        );
-        return computedScale;
-      })();
-    }
-
-    try {
-      this.screenshotScale = await this.screenshotScalePromise;
-      return this.screenshotScale;
-    } finally {
-      this.screenshotScalePromise = undefined;
     }
   }
 
@@ -432,38 +374,9 @@ export class Agent<
     }
 
     // Get original context
-    let context: UIContext;
-    if (this.interface.getContext) {
-      debug('Using page.getContext for action:', action);
-      context = await this.interface.getContext();
-    } else {
-      debug('Using commonContextParser');
-      context = await commonContextParser(this.interface, {
-        uploadServerUrl: this.modelConfigManager.getUploadTestServerUrl(),
-      });
-    }
-
-    debug('will get screenshot scale');
-    const computedScreenshotScale = await this.getScreenshotScale(context);
-    debug('computedScreenshotScale', computedScreenshotScale);
-
-    if (computedScreenshotScale !== 1) {
-      const scaleForLog = Number.parseFloat(computedScreenshotScale.toFixed(4));
-      debug(
-        `Applying computed screenshot scale: ${scaleForLog} (resize to logical size)`,
-      );
-      const targetWidth = Math.round(context.size.width);
-      const targetHeight = Math.round(context.size.height);
-      debug(`Resizing screenshot to ${targetWidth}x${targetHeight}`);
-      const currentScreenshotBase64 = context.screenshot.base64;
-      const resizedBase64 = await resizeImgBase64(currentScreenshotBase64, {
-        width: targetWidth,
-        height: targetHeight,
-      });
-      context.screenshot = ScreenshotItem.create(resizedBase64);
-    } else {
-      debug(`screenshot scale=${computedScreenshotScale}`);
-    }
+    const context = await commonContextParser(this.interface, {
+      uploadServerUrl: this.modelConfigManager.getUploadTestServerUrl(),
+    });
 
     return context;
   }

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -53,9 +53,6 @@ export abstract class AbstractInterface {
   // @deprecated do NOT extend this method
   abstract evaluateJavaScript?<T = any>(script: string): Promise<T>;
 
-  // @deprecated do NOT extend this method
-  abstract getContext?(): Promise<UIContext>;
-
   /**
    * Get the current time from the device.
    * Returns the device's current timestamp in milliseconds.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -969,8 +969,6 @@ export interface WebElementInfo extends BaseElement {
   };
 }
 
-export type WebUIContext = UIContext;
-
 /**
  * Agent
  */

--- a/packages/evaluation/tests/util.ts
+++ b/packages/evaluation/tests/util.ts
@@ -1,12 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import type { PlanningAIResponse, Rect } from '@midscene/core';
+import { commonContextParser } from '@midscene/core/agent';
 import {
   annotateRects,
   imageInfoOfBase64,
   localImg2Base64,
 } from '@midscene/shared/img';
-import { WebPageContextParser } from '@midscene/web';
 
 export { annotateRects };
 
@@ -218,6 +218,6 @@ export async function buildContext(pageName: string) {
     },
   };
 
-  const context = await WebPageContextParser(fakePage as any, {});
+  const context = await commonContextParser(fakePage as any, {});
   return context;
 }

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -1,4 +1,4 @@
-import type { DeviceAction, WebUIContext } from '@midscene/core';
+import type { DeviceAction } from '@midscene/core';
 import type { Agent } from '@midscene/core/agent';
 
 export interface PlaygroundAgent extends Agent {
@@ -39,13 +39,6 @@ export interface ExecutionOptions {
   requestId?: string;
   deviceOptions?: DeviceOptions;
 }
-
-// Extended web types for playground
-
-export type PlaygroundWebUIContext = WebUIContext & {
-  screenshotBase64?: string;
-  size: { width: number; height: number; dpr?: number };
-};
 
 // SDK types - execution model based
 export type ExecutionType = 'local-execution' | 'remote-execution';

--- a/packages/visualizer/src/types.ts
+++ b/packages/visualizer/src/types.ts
@@ -222,12 +222,7 @@ export const extractDefaultValue = (field: ZodType): unknown => {
   return undefined;
 };
 
-import type {
-  ExecutionDump,
-  GroupedActionDump,
-  IExecutionDump,
-  WebUIContext,
-} from '@midscene/core';
+import type { ExecutionDump, IExecutionDump } from '@midscene/core';
 import type { ExecutionOptions, PlaygroundAgent } from '@midscene/playground';
 
 // result type
@@ -248,7 +243,7 @@ export interface PlaygroundProps {
 
 // static playground component props type
 export interface StaticPlaygroundProps {
-  context: WebUIContext | null;
+  context: UIContext | null;
 }
 
 // service mode type

--- a/packages/visualizer/src/utils/playground-utils.ts
+++ b/packages/visualizer/src/utils/playground-utils.ts
@@ -1,4 +1,4 @@
-import type { WebUIContext } from '@midscene/core';
+import type { UIContext } from '@midscene/core';
 import { StaticPage, StaticPageAgent } from '@midscene/web/static';
 import type { ZodObjectSchema } from '../types';
 import { isZodObjectSchema, unwrapZodType } from '../types';
@@ -31,7 +31,7 @@ export const actionNameForType = (type: string) => {
 };
 
 // Create static agent from context
-export const staticAgentFromContext = (context: WebUIContext) => {
+export const staticAgentFromContext = (context: UIContext) => {
   const page = new StaticPage(context);
   return new StaticPageAgent(page);
 };

--- a/packages/web-integration/src/bin.ts
+++ b/packages/web-integration/src/bin.ts
@@ -2,13 +2,14 @@ import { PlaygroundServer } from '@midscene/playground';
 import cors from 'cors';
 import { StaticPage, StaticPageAgent } from './static';
 import 'dotenv/config';
+import { ScreenshotItem } from '@midscene/core';
 
 async function startServer() {
   // Create page and agent instances with minimal valid data
   // Use screenshotBase64 field for empty screenshot
   const page = new StaticPage({
     size: { width: 800, height: 600 },
-    screenshotBase64: '',
+    screenshot: ScreenshotItem.create(''),
   });
   const agent = new StaticPageAgent(page);
 

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -64,10 +64,6 @@ export const getBridgePageInCliSide = (options?: {
         };
       }
 
-      if (prop === 'getContext') {
-        return undefined;
-      }
-
       if (prop === 'interfaceType') {
         return BridgePageType;
       }

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -12,7 +12,6 @@ import type {
   Point,
   Rect,
   Size,
-  UIContext,
 } from '@midscene/core';
 import type { AbstractInterface, DeviceAction } from '@midscene/core/device';
 import type { ElementInfo } from '@midscene/shared/extractor';
@@ -28,7 +27,6 @@ import {
   judgeOrderSensitive,
   sanitizeXpaths,
 } from '../common/cache-helper';
-import { WebPageContextParser } from '../web-element';
 import {
   type KeyInput,
   type MouseButton,
@@ -466,10 +464,6 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     }
 
     return content?.tree || { node: null, children: [] };
-  }
-
-  async getContext(): Promise<UIContext> {
-    return await WebPageContextParser(this, {});
   }
 
   async size() {

--- a/packages/web-integration/src/index.ts
+++ b/packages/web-integration/src/index.ts
@@ -1,10 +1,7 @@
 export { PlaywrightAiFixture } from './playwright';
 export type { PlayWrightAiFixtureType } from './playwright';
-export type { WebPage } from './web-element';
-export type { WebUIContext } from '@midscene/core';
 
 export { Agent as PageAgent, type AgentOpt } from '@midscene/core/agent';
 export { PuppeteerAgent } from './puppeteer';
 export { PlaywrightAgent } from './playwright';
 export { StaticPageAgent, StaticPage } from './static';
-export { WebPageContextParser } from './web-element';

--- a/packages/web-integration/src/mcp-tools-puppeteer.ts
+++ b/packages/web-integration/src/mcp-tools-puppeteer.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { z } from '@midscene/core';
+import { ScreenshotItem, z } from '@midscene/core';
 import { BaseMidsceneTools, type ToolDefinition } from '@midscene/shared/mcp';
 import type { Page as PuppeteerPage } from 'puppeteer';
 import puppeteer from 'puppeteer-core';
@@ -156,7 +156,7 @@ const browserManager = {
 export class WebPuppeteerMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
   protected createTemporaryDevice() {
     return new StaticPage({
-      screenshotBase64: '',
+      screenshot: ScreenshotItem.create(''),
       size: { width: 1920, height: 1080 },
     });
   }

--- a/packages/web-integration/src/mcp-tools.ts
+++ b/packages/web-integration/src/mcp-tools.ts
@@ -1,4 +1,4 @@
-import { z } from '@midscene/core';
+import { ScreenshotItem, z } from '@midscene/core';
 import { BaseMidsceneTools, type ToolDefinition } from '@midscene/shared/mcp';
 import { AgentOverChromeBridge } from './bridge-mode';
 import { StaticPage } from './static';
@@ -12,8 +12,8 @@ export class WebMidsceneTools extends BaseMidsceneTools<AgentOverChromeBridge> {
     // StaticPage.actionSpace() returns DeviceAction[] which is compatible at runtime
     // Use screenshotBase64 field to avoid async ScreenshotItem.create()
     return new StaticPage({
-      screenshotBase64: '',
-      size: { width: 1920, height: 1080 },
+      screenshot: ScreenshotItem.create(''),
+      size: { width: 1920, height: 1080, dpr: 1 },
     });
   }
 

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -1,4 +1,4 @@
-import { type WebPageAgentOpt, WebPageContextParser } from '@/web-element';
+import type { WebPageAgentOpt } from '@/web-element';
 import type {
   DeviceAction,
   ElementCacheFeature,
@@ -6,7 +6,6 @@ import type {
   Point,
   Rect,
   Size,
-  UIContext,
 } from '@midscene/core';
 import type { AbstractInterface } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
@@ -560,9 +559,6 @@ export class Page<
 
   async destroy(): Promise<void> {}
 
-  async getContext(): Promise<UIContext> {
-    return await WebPageContextParser(this, {});
-  }
   async swipe(
     from: { x: number; y: number },
     to: { x: number; y: number },

--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -1,6 +1,5 @@
 import type { DeviceAction, Point, UIContext } from '@midscene/core';
 import type { AbstractInterface } from '@midscene/core/device';
-import { ScreenshotItem } from '@midscene/core';
 import {
   defineActionDragAndDrop,
   defineActionHover,
@@ -13,10 +12,6 @@ import {
 } from '@midscene/core/device';
 import { ERROR_CODE_NOT_IMPLEMENTED_AS_DESIGNED } from '@midscene/shared/common';
 
-type WebUIContext = UIContext | {
-  screenshotBase64?: string;
-  size: { width: number; height: number; dpr?: number };
-};
 
 const ThrowNotImplemented = (methodName: string) => {
   throw new Error(
@@ -27,9 +22,9 @@ const ThrowNotImplemented = (methodName: string) => {
 export default class StaticPage implements AbstractInterface {
   interfaceType = 'static';
 
-  private uiContext: WebUIContext;
+  private uiContext: UIContext;
 
-  constructor(uiContext: WebUIContext) {
+  constructor(uiContext: UIContext) {
     this.uiContext = uiContext;
   }
 
@@ -93,23 +88,11 @@ export default class StaticPage implements AbstractInterface {
   }
 
   async screenshotBase64() {
-    // Check if this is a UIContext with screenshot property
-    if ('screenshot' in this.uiContext && this.uiContext.screenshot) {
-      const screenshot = this.uiContext.screenshot;
-      if (typeof screenshot === 'object' && 'base64' in screenshot) {
-        return (screenshot as { base64: string }).base64;
-      }
-      return screenshot as unknown as string;
+    const screenshot = this.uiContext.screenshot;
+    if (typeof screenshot === 'object' && 'base64' in screenshot) {
+      return (screenshot as { base64: string }).base64;
     }
-
-    // Check legacy screenshotBase64 field
-    const legacyContext = this.uiContext as { screenshotBase64?: string };
-    const base64 = legacyContext.screenshotBase64;
-
-    if (!base64) {
-      throw new Error('screenshot base64 is empty');
-    }
-    return base64;
+    return screenshot as unknown as string;
   }
 
   async url() {
@@ -168,24 +151,8 @@ export default class StaticPage implements AbstractInterface {
     //
   }
 
-  async getContext(): Promise<UIContext> {
-    // If the context already has a screenshot property, return it as-is
-    if ('screenshot' in this.uiContext && this.uiContext.screenshot) {
-      return this.uiContext as UIContext;
-    }
 
-    // Otherwise, create a proper UIContext from the legacy format
-    const screenshotBase64 = await this.screenshotBase64();
-    const screenshot = ScreenshotItem.create(screenshotBase64);
-    const size = await this.size();
-
-    return {
-      screenshot,
-      size,
-    };
-  }
-
-  updateContext(newContext: WebUIContext): void {
+  updateContext(newContext: UIContext): void {
     this.uiContext = newContext;
   }
 }

--- a/packages/web-integration/src/web-element.ts
+++ b/packages/web-integration/src/web-element.ts
@@ -2,19 +2,11 @@ import type {
   AgentOpt,
   DeviceAction,
   Rect,
-  UIContext,
   WebElementInfo,
 } from '@midscene/core';
-import type { AbstractInterface } from '@midscene/core/device';
-import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 
-import { commonContextParser } from '@midscene/core/agent';
 import type { NodeType } from '@midscene/shared/constants';
-import type ChromeExtensionProxyPage from './chrome-extension/page';
-import type { PlaywrightWebPage } from './playwright';
-import type { PuppeteerWebPage } from './puppeteer';
-import type { StaticPage } from './static';
 export type { WebElementInfo };
 
 export type WebPageAgentOpt = AgentOpt & WebPageOpt;
@@ -36,12 +28,6 @@ export type WebPageOpt = {
   afterInvokeAction?: () => Promise<void>;
   customActions?: DeviceAction<any>[];
 };
-
-export type WebPage =
-  | PlaywrightWebPage
-  | PuppeteerWebPage
-  | StaticPage
-  | ChromeExtensionProxyPage;
 
 export class WebElementInfoImpl implements WebElementInfo {
   content: string;
@@ -95,36 +81,6 @@ export class WebElementInfoImpl implements WebElementInfo {
     this.xpaths = xpaths;
     this.isVisible = isVisible;
   }
-}
-
-const debug = getDebug('web:parse-context');
-export async function WebPageContextParser(
-  page: AbstractInterface,
-  _opt: { uploadServerUrl?: string },
-): Promise<UIContext> {
-  const basicContext = await commonContextParser(page, {
-    uploadServerUrl: _opt.uploadServerUrl,
-  });
-
-  // debug('will traverse element tree');
-  // const tree = (await page.getElementsNodeTree?.()) || {
-  //   node: null,
-  //   children: [],
-  // };
-  // // const webTree = traverseTree(tree!, (elementInfo) => {
-  // //   const { rect, id, content, attributes, indexId, isVisible } = elementInfo;
-  // //   return new WebElementInfoImpl({
-  // //     rect,
-  // //     id,
-  // //     content,
-  // //     attributes,
-  // //     indexId,
-  // //     isVisible,
-  // //   });
-  // // });
-  // debug('traverse element tree end');
-
-  return basicContext;
 }
 
 export const limitOpenNewTabScript = `

--- a/packages/web-integration/tests/ai/web/static/static-page.test.ts
+++ b/packages/web-integration/tests/ai/web/static/static-page.test.ts
@@ -3,10 +3,13 @@ import { join } from 'node:path';
 import { StaticPageAgent, StaticPage } from '@midscene/web/static';
 import { PlaygroundServer } from '@midscene/playground';
 import { afterEach, describe, expect, it } from 'vitest';
+import { ScreenshotItem } from '@midscene/core';
 
 const dumpFilePath = join(__dirname, '../../fixtures/ui-context.json');
 const context = readFileSync(dumpFilePath, { encoding: 'utf-8' });
 const contextJson = JSON.parse(context);
+
+contextJson.screenshot = contextJson.screenshotBase64;
 
 describe(
   'static page agent',
@@ -37,7 +40,7 @@ describe(
     it('server should work', async () => {
       const page = new StaticPage({
         size: { width: 800, height: 600 },
-        screenshotBase64: '',
+        screenshot: ScreenshotItem.create(''),
       });
       const agent = new StaticPageAgent(page);
       server = new PlaygroundServer(agent);

--- a/packages/web-integration/tests/unit-test/playground-server.test.ts
+++ b/packages/web-integration/tests/unit-test/playground-server.test.ts
@@ -1,3 +1,4 @@
+import { ScreenshotItem } from '@midscene/core';
 import { PlaygroundServer } from '@midscene/playground';
 import { StaticPage, StaticPageAgent } from '@midscene/web/static';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -7,9 +8,8 @@ describe('Playground Server', () => {
   let serverBase: string;
   beforeAll(async () => {
     const page = new StaticPage({
-      tree: { node: null, children: [] },
       size: { width: 800, height: 600 },
-      screenshotBase64: '',
+      screenshot: ScreenshotItem.create(''),
     });
     const agent = new StaticPageAgent(page);
     server = new PlaygroundServer(agent);

--- a/packages/web-integration/tests/unit-test/web-extractor.test.ts
+++ b/packages/web-integration/tests/unit-test/web-extractor.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
-import { WebPageContextParser } from '@/web-element';
 import type { WebElementInfo } from '@/web-element';
+import { commonContextParser } from '@midscene/core/agent';
 import {
   descriptionOfTree,
   traverseTree,
@@ -199,9 +199,9 @@ describe(
     it('profiling', async () => {
       const { page, reset } = await launchPage('https://www.bytedance.com');
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      console.time('total - WebPageContextParser');
-      await WebPageContextParser(page, {});
-      console.timeEnd('total - WebPageContextParser');
+      console.time('total - commonContextParser');
+      await commonContextParser(page, {});
+      console.timeEnd('total - commonContextParser');
       await reset();
     });
 


### PR DESCRIPTION
- Move screenshot scaling logic from Agent to commonContextParser
  - Remove screenshotScale calculation from Agent class
  - Centralize shrink factor computation in commonContextParser
  - Automatically resize screenshots to match logical dimensions

- Remove deprecated getContext method from AbstractInterface
  - Delete getContext implementations across all platforms (web, chrome-extension, puppeteer)
  - Simplify context retrieval to use commonContextParser uniformly

- Standardize screenshot data structure
  - Replace screenshotBase64 field usage with ScreenshotItem.create()
  - Update StaticPage to use screenshot property consistently
  - Remove legacy compatibility layer for screenshotBase64

- Clean up type definitions
  - Remove WebUIContext type alias (use UIContext directly)
  - Delete PlaygroundWebUIContext related types
  - Update imports across packages

- Consolidate context parsers
  - Remove WebPageContextParser (superseded by commonContextParser)
  - Update all usages to use commonContextParser from @midscene/core/agent
  - Simplify evaluation and test utilities

This refactoring unifies UI context handling across all device types, reduces code duplication, and improves maintainability by centralizing screenshot processing logic in a single location.