### PR TITLE
fix(chrome-extension): restore bridge start/stop controls in status bar

### DIFF
--- a/apps/chrome-extension/src/extension/bridge/index.less
+++ b/apps/chrome-extension/src/extension/bridge/index.less
@@ -281,6 +281,46 @@
       margin-left: 16px;
     }
 
+    .bottom-status-btn {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      margin-left: 12px;
+
+      .status-action-button {
+        border: none;
+        box-shadow: none;
+        background: transparent;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 4px 8px;
+        height: auto;
+
+        &:hover,
+        &:focus,
+        &:active {
+          background: none;
+          border: none;
+          box-shadow: none;
+        }
+      }
+
+      .stop-button {
+        gap: 8px;
+
+        &::before {
+          content: '';
+          display: inline-block;
+          width: 10px;
+          height: 10px;
+          background-color: #000;
+          border-radius: 2px;
+        }
+      }
+    }
+
     .status-loading-icon {
       display: flex;
       align-items: center;

--- a/apps/chrome-extension/src/extension/bridge/index.tsx
+++ b/apps/chrome-extension/src/extension/bridge/index.tsx
@@ -218,6 +218,55 @@ export default function Bridge() {
     });
   };
 
+  const handleStartBridge = () => {
+    const serverEndpoint =
+      serverUrl && serverUrl !== DEFAULT_SERVER_URL ? serverUrl : undefined;
+    connectionStatusMessageId.current = null;
+
+    chrome.runtime.sendMessage(
+      {
+        type: workerMessageTypes.BRIDGE_START,
+        payload: { serverEndpoint },
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          appendBridgeMessage(
+            `Failed to start bridge: ${chrome.runtime.lastError.message}`,
+          );
+          return;
+        }
+        if (!response?.success) {
+          appendBridgeMessage(
+            `Failed to start bridge: ${response?.error || 'Unknown error'}`,
+          );
+          return;
+        }
+        setBridgeStatus(response.status || 'closed');
+      },
+    );
+  };
+
+  const handleStopBridge = () => {
+    chrome.runtime.sendMessage(
+      { type: workerMessageTypes.BRIDGE_STOP },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          appendBridgeMessage(
+            `Failed to stop bridge: ${chrome.runtime.lastError.message}`,
+          );
+          return;
+        }
+        if (!response?.success) {
+          appendBridgeMessage(
+            `Failed to stop bridge: ${response?.error || 'Unknown error'}`,
+          );
+          return;
+        }
+        setBridgeStatus(response.status || 'closed');
+      },
+    );
+  };
+
   // check if scrolled to bottom
   const checkIfScrolledToBottom = () => {
     if (messageListRef.current) {
@@ -271,11 +320,20 @@ export default function Bridge() {
 
   let statusIcon;
   let statusTip: string;
-  if (
-    bridgeStatus === 'listening' ||
-    bridgeStatus === 'disconnected' ||
-    bridgeStatus === 'closed'
-  ) {
+  let statusActionButton: JSX.Element | null = null;
+  if (bridgeStatus === 'closed') {
+    statusIcon = iconForStatus('closed');
+    statusTip = 'Closed';
+    statusActionButton = (
+      <Button
+        className="status-action-button"
+        type="text"
+        onClick={handleStartBridge}
+      >
+        Start
+      </Button>
+    );
+  } else if (bridgeStatus === 'listening' || bridgeStatus === 'disconnected') {
     statusIcon = (
       <Spin
         className="status-loading-icon"
@@ -284,9 +342,27 @@ export default function Bridge() {
       />
     );
     statusTip = 'Listening for connection';
+    statusActionButton = (
+      <Button
+        className="status-action-button stop-button"
+        type="text"
+        onClick={handleStopBridge}
+      >
+        Stop
+      </Button>
+    );
   } else if (bridgeStatus === 'connected') {
     statusIcon = iconForStatus('connected');
     statusTip = 'Connected';
+    statusActionButton = (
+      <Button
+        className="status-action-button stop-button"
+        type="text"
+        onClick={handleStopBridge}
+      >
+        Stop
+      </Button>
+    );
   } else {
     statusIcon = iconForStatus('failed');
     statusTip = `Unknown Status - ${bridgeStatus}`;
@@ -422,6 +498,12 @@ export default function Bridge() {
             <span className="bottom-status-icon">{statusIcon}</span>
             <span className="bottom-status-tip">{statusTip}</span>
           </div>
+          {statusActionButton && (
+            <>
+              <div className="bottom-status-divider" />
+              <div className="bottom-status-btn">{statusActionButton}</div>
+            </>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 背景 / 用户可见问题
- 在 Chrome Extension 的 Bridge Mode 中，进入页面后会显示 `Listening for connection`，但底部没有可操作的退出按钮，用户无法在 UI 上主动停止监听。
- 这导致 Bridge 看起来“只能进不能退”，和历史交互预期不一致。
- 且导致 bridge server url 不能修改 

### 根因分析（为什么 Stop Listen 消失）
- 该行为主要来自一次有意的产品改动：为 MCP 引入 Background Bridge（后台监听）。
- 在该改动中，Bridge UI 从“前端直接控制连接”调整为“仅订阅 worker 状态”，并移除了底部 Start/Stop 操作按钮。
- 同时，`closed` 状态在 UI 上被归并展示为 `Listening for connection`，进一步放大了“无法退出”的感知。
- 结论：这是“需求牵引（默认后台监听）”触发的 UI 能力回退，而不是随机回归。

### 本次修复内容
- 恢复 Bridge 底部状态栏的控制能力：
- `closed` 状态显示 `Closed`，提供 `Start` 按钮。
- `listening` / `disconnected` / `connected` 状态提供 `Stop` 按钮。
- 点击 `Start/Stop` 分别发送 `BRIDGE_START` / `BRIDGE_STOP` 给 worker，复用现有后台消息处理逻辑。
- 恢复底部状态栏右侧 action 区样式（分隔线 + 按钮区域）。

### 变更文件
- `apps/chrome-extension/src/extension/bridge/index.tsx`
- `apps/chrome-extension/src/extension/bridge/index.less`

### 影响范围与非目标
- 影响范围：仅 Bridge Mode UI 交互层，不改动 recorder/playground。
- 非目标：本 PR 不调整 worker 的“启动后自动监听”策略；因此在扩展/worker 重启后，仍可能再次自动进入监听。

### 验证证据
- 已完成代码路径核对：UI 操作已接入 `BRIDGE_START/BRIDGE_STOP` 消息通道。
- 已经手动测试使用自定url remote bridge, 能恢复使用
