### PR TITLE
fix(shared): close bridge server after CLI command completes

### DIFF
--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -175,7 +175,7 @@ export async function runToolsCLI(
 
   const result = await match.def.handler(parsedArgs);
   outputResult(result);
-  await tools.closeBrowser();
+  await tools.destroy();
   if (result.isError) {
     throw new CLIError('Command failed', 1);
   }

--- a/packages/shared/src/mcp/base-server.ts
+++ b/packages/shared/src/mcp/base-server.ts
@@ -133,7 +133,7 @@ export abstract class BaseMCPServer {
   private performCleanup(): void {
     console.error(`${this.config.name} closing...`);
     this.mcpServer.close();
-    this.toolsManager?.closeBrowser?.().catch(console.error);
+    this.toolsManager?.destroy?.().catch(console.error);
   }
 
   /**

--- a/packages/shared/src/mcp/base-tools.ts
+++ b/packages/shared/src/mcp/base-tools.ts
@@ -120,7 +120,7 @@ export abstract class BaseMidsceneTools<TAgent extends BaseAgent = BaseAgent>
   /**
    * Cleanup method - destroy agent and release resources
    */
-  public async closeBrowser(): Promise<void> {
+  public async destroy(): Promise<void> {
     await this.agent?.destroy?.();
   }
 

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -108,5 +108,5 @@ export interface BaseDevice {
 export interface IMidsceneTools {
   attachToServer(server: McpServer): void;
   initTools(): Promise<void>;
-  closeBrowser?(): Promise<void>;
+  destroy?(): Promise<void>;
 }

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -210,7 +210,7 @@ describe('runToolsCLI', () => {
   ) {
     return {
       initTools: vi.fn().mockResolvedValue(undefined),
-      closeBrowser: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
       getToolDefinitions: vi.fn().mockReturnValue(
         definitions.map((d) => ({
           name: d.name,
@@ -241,7 +241,7 @@ describe('runToolsCLI', () => {
   function createDetailedMockTools() {
     return {
       initTools: vi.fn().mockResolvedValue(undefined),
-      closeBrowser: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
       getToolDefinitions: vi.fn().mockReturnValue([
         {
           name: 'connect',
@@ -364,7 +364,7 @@ describe('runToolsCLI', () => {
     vi.restoreAllMocks();
   });
 
-  it('calls closeBrowser after successful command', async () => {
+  it('calls destroy after successful command', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'done' }],
       isError: false,
@@ -374,11 +374,11 @@ describe('runToolsCLI', () => {
 
     await runToolsCLI(tools, 'test-cli', { argv: ['connect'] });
 
-    expect(tools.closeBrowser).toHaveBeenCalledOnce();
+    expect(tools.destroy).toHaveBeenCalledOnce();
     vi.restoreAllMocks();
   });
 
-  it('calls closeBrowser before throwing on command error', async () => {
+  it('calls destroy before throwing on command error', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Something went wrong' }],
       isError: true,
@@ -393,7 +393,7 @@ describe('runToolsCLI', () => {
       }),
     ).rejects.toThrow(CLIError);
 
-    expect(tools.closeBrowser).toHaveBeenCalledOnce();
+    expect(tools.destroy).toHaveBeenCalledOnce();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary

- Fix bridge mode CLI process hanging for ~2 minutes after command completion (e.g., `npx @midscene/web --bridge take_screenshot`)
- The root cause is that `runToolsCLI()` never calls `tools.closeBrowser()` after command execution, leaving the BridgeServer's HTTP + Socket.IO server alive and blocking Node.js event loop exit
- Add `await tools.closeBrowser()` after outputting the result to properly destroy the agent and close the server

## Test plan

- [ ] Run `time npx @midscene/web --bridge take_screenshot` and verify the process exits immediately after saving the screenshot (instead of hanging for ~2 minutes)
- [ ] Verify other bridge commands (`connect`, `act`, `disconnect`) still work correctly
- [ ] Verify puppeteer mode CLI commands are not affected