### PR TITLE
docs(site): add Electron demo tip for headless Linux in computer docs

### DIFF
--- a/apps/site/docs/en/computer-api-reference.mdx
+++ b/apps/site/docs/en/computer-api-reference.mdx
@@ -32,6 +32,10 @@ interface ComputerAgentOpt {
 - `headless` (optional, Linux only): Set to `true` to start a virtual display via [Xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml), enabling desktop automation on headless Linux servers and CI environments without a physical display. Can also be set via the `MIDSCENE_COMPUTER_HEADLESS_LINUX=true` environment variable.
 - `xvfbResolution` (optional): Resolution for the Xvfb virtual display. Defaults to `'1920x1080x24'`.
 
+:::tip Example: Testing Electron Apps on Headless Linux CI
+A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+:::
+
 **Example:**
 
 ```typescript

--- a/apps/site/docs/en/computer-getting-started.mdx
+++ b/apps/site/docs/en/computer-getting-started.mdx
@@ -46,6 +46,10 @@ const agent = await agentFromComputer({ headless: true });
 
 Xvfb creates a virtual display so that mouse, keyboard, and screenshot operations work without a physical monitor. See [API Reference](./computer-api-reference) for details.
 
+:::tip Example: Testing Electron Apps on Headless Linux CI
+A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+:::
+
 ## Try Playground (no code)
 
 Playground is the fastest way to validate the connection and observe AI-driven steps without writing code. It shares the same core as `@midscene/computer`, so anything that works here will behave the same once scripted.

--- a/apps/site/docs/zh/computer-api-reference.mdx
+++ b/apps/site/docs/zh/computer-api-reference.mdx
@@ -32,6 +32,10 @@ interface ComputerAgentOpt {
 - `headless`（可选，仅 Linux）：设为 `true` 时通过 [Xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml) 启动虚拟显示器，使桌面自动化能在无物理显示器的 Linux 服务器和 CI 环境中运行。也可通过环境变量 `MIDSCENE_COMPUTER_HEADLESS_LINUX=true` 设置。
 - `xvfbResolution`（可选）：Xvfb 虚拟显示器的分辨率，默认为 `'1920x1080x24'`。
 
+:::tip 示例：在无头 Linux CI 中测试 Electron 应用
+使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+:::
+
 **示例：**
 
 ```typescript

--- a/apps/site/docs/zh/computer-getting-started.mdx
+++ b/apps/site/docs/zh/computer-getting-started.mdx
@@ -46,6 +46,10 @@ const agent = await agentFromComputer({ headless: true });
 
 Xvfb 会创建一个虚拟显示器，使鼠标、键盘和截图操作在没有物理显示器的情况下正常工作。详见 [API 参考](./computer-api-reference)。
 
+:::tip 示例：在无头 Linux CI 中测试 Electron 应用
+使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+:::
+
 ## 试用 Playground（零代码）
 
 Playground 是验证连接、观察 AI Agent 的最快方式，无需编写代码。它与 `@midscene/computer` 共享相同的代码实现，因此在 Playground 上验证通过的流程，用脚本运行时也完全一致。


### PR DESCRIPTION
## Summary

- Add a `:::tip` callout linking to the [Electron demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo) (testing [Obsidian](https://obsidian.md/) on headless Linux CI) in the headless Linux sections of:
  - `computer-getting-started.mdx` (en/zh)
  - `computer-api-reference.mdx` (en/zh)

## Test plan

- [ ] Verify the tip renders correctly on the docs site