### PR TITLE
fix(core): merge sub-goal updates to avoid blank description overwrite

### DIFF
--- a/packages/core/src/ai-model/conversation-history.ts
+++ b/packages/core/src/ai-model/conversation-history.ts
@@ -110,6 +110,48 @@ export class ConversationHistory {
   }
 
   /**
+   * Merge sub-goals from update-plan-content.
+   * Preserves existing descriptions when incoming description is empty.
+   *
+   * This handles compact XML updates like:
+   * <sub-goal index="1" status="finished" />
+   */
+  mergeSubGoals(subGoals: SubGoal[]): void {
+    if (this.subGoals.length === 0) {
+      this.setSubGoals(subGoals);
+      return;
+    }
+
+    const existingByIndex = new Map(
+      this.subGoals.map((goal) => [goal.index, goal] as const),
+    );
+
+    const mergedSubGoals = subGoals.map((goal) => {
+      const existingGoal = existingByIndex.get(goal.index);
+      const hasNonEmptyDescription = goal.description.trim().length > 0;
+
+       if (!existingGoal && !hasNonEmptyDescription) {
+        return null;
+      }
+
+      return {
+        ...goal,
+        description:
+          hasNonEmptyDescription || !existingGoal
+            ? goal.description
+            : existingGoal.description,
+      };
+    });
+
+    const validSubGoals = mergedSubGoals.filter((goal) => goal !== null);
+    if (validSubGoals.length === 0) {
+      return;
+    }
+
+    this.setSubGoals(validSubGoals);
+  }
+
+  /**
    * Update a single sub-goal by index.
    * Clears logs if status or description actually changes.
    * @returns true if the sub-goal was found and updated, false otherwise

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -304,7 +304,7 @@ export async function plan(
     // Update sub-goals in conversation history based on response (only when deepThink is enabled)
     if (includeSubGoals) {
       if (planFromAI.updateSubGoals?.length) {
-        conversationHistory.setSubGoals(planFromAI.updateSubGoals);
+        conversationHistory.mergeSubGoals(planFromAI.updateSubGoals);
       }
       if (planFromAI.markFinishedIndexes?.length) {
         for (const index of planFromAI.markFinishedIndexes) {

--- a/packages/core/tests/unit-test/conversation-history.test.ts
+++ b/packages/core/tests/unit-test/conversation-history.test.ts
@@ -196,6 +196,50 @@ describe('ConversationHistory', () => {
     `);
   });
 
+  it('preserves descriptions when mergeSubGoals receives empty descriptions', () => {
+    const history = new ConversationHistory();
+    history.setSubGoals([
+      { index: 1, status: 'pending', description: 'Log in to the system' },
+      { index: 2, status: 'pending', description: 'Open reimbursement page' },
+      {
+        index: 3,
+        status: 'pending',
+        description: 'Fill and submit reimbursement form',
+      },
+    ]);
+
+    history.mergeSubGoals([
+      { index: 1, status: 'finished', description: '' },
+      { index: 2, status: 'pending', description: '' },
+      { index: 3, status: 'pending', description: '' },
+    ]);
+
+    expect(history.subGoalsToText()).toMatchInlineSnapshot(`
+      "Sub-goals:
+      1. Log in to the system (finished)
+      2. Open reimbursement page (running)
+      3. Fill and submit reimbursement form (pending)
+      Current sub-goal is: Open reimbursement page"
+    `);
+  });
+
+  it('ignores newly introduced goals with empty descriptions in mergeSubGoals', () => {
+    const history = new ConversationHistory();
+    history.setSubGoals([
+      { index: 1, status: 'pending', description: 'Existing goal' },
+    ]);
+
+    history.mergeSubGoals([
+      { index: 1, status: 'finished', description: '' },
+      { index: 2, status: 'pending', description: '' },
+    ]);
+
+    expect(history.subGoalsToText()).toMatchInlineSnapshot(`
+      "Sub-goals:
+      1. Existing goal (finished)"
+    `);
+  });
+
   it('updates a single sub-goal by index', () => {
     const history = new ConversationHistory();
     history.setSubGoals([


### PR DESCRIPTION
- replace wholesale sub-goal replacement with index-based merge in planning flow
- preserve existing descriptions when update-plan-content uses self-closing sub-goal entries
- ignore newly introduced sub-goals with empty descriptions to avoid blank context lines
- add unit tests for both regression cases (preserve existing descriptions, ignore empty new goals)