### PR TITLE
fix(core): reset pendingFeedbackMessage in ConversationHistory.reset()

### DIFF
--- a/packages/core/src/ai-model/conversation-history.ts
+++ b/packages/core/src/ai-model/conversation-history.ts
@@ -42,6 +42,7 @@ export class ConversationHistory {
     this.memories.length = 0;
     this.subGoals.length = 0;
     this.historicalLogs.length = 0;
+    this.pendingFeedbackMessage = '';
   }
 
   /**

--- a/packages/core/tests/unit-test/conversation-history.test.ts
+++ b/packages/core/tests/unit-test/conversation-history.test.ts
@@ -54,6 +54,8 @@ describe('ConversationHistory', () => {
     history.appendHistoricalLog('Step 1');
     history.appendHistoricalLog('Step 2');
 
+    history.pendingFeedbackMessage = 'Current time: 2026-03-02T16:04:00';
+
     history.reset();
 
     expect(history.length).toBe(0);
@@ -62,6 +64,7 @@ describe('ConversationHistory', () => {
     expect(history.memoriesToText()).toBe('');
     expect(history.subGoalsToText()).toBe('');
     expect(history.historicalLogsToText()).toBe('');
+    expect(history.pendingFeedbackMessage).toBe('');
   });
 
   it('clears pending feedback message only when set', () => {


### PR DESCRIPTION
## Summary

- Fix a bug where `ConversationHistory.reset()` did not clear `pendingFeedbackMessage`, causing stale context from previous MCP tool calls to leak into new planning sessions.
- This made the planning model incorrectly interpret the first turn as a continuation (seeing "The previous action has been executed"), leading it to return `<complete>` without performing any action.
- The issue manifested as MCP `Tap`/`locate` calls failing on the first attempt but succeeding on retry.

## Root Cause

Each `execute()` (triggered by MCP tool calls like `Tap { locate: { prompt: "..." } }`) calls `this.conversationHistory.reset()` to start a fresh planning session. However, `reset()` only cleared `messages`, `memories`, `subGoals`, and `historicalLogs` — it did **not** clear `pendingFeedbackMessage`.

After a previous `execute()` completes, `pendingFeedbackMessage` is left with a value like `"Current time: ..."`. On the next `execute()`, this stale value triggers the planning prompt to include `"... The previous action has been executed, here is the latest screenshot."`, which misleads the model into thinking the current instruction was already fulfilled.

## Test plan

- [x] Updated existing `conversation-history.test.ts` to verify `reset()` clears `pendingFeedbackMessage`
- [x] All 626 unit tests pass