### PR TITLE
fix: disable deepThink by default for act tool in MCP/CLI runner

### DIFF
--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -407,7 +407,7 @@ export function generateCommonTools(
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
-          const result = await agent.aiAction(prompt, { deepThink: true });
+          const result = await agent.aiAction(prompt, { deepThink: false });
           const screenshotResult = await captureScreenshotResult(agent, 'act');
           if (result) {
             const message =


### PR DESCRIPTION
The `act` command handler in generateCommonTools() was hardcoded with `deepThink: true`, causing every `act --prompt "..."` invocation to always enable deep thinking mode. Change the default to `false`.

https://claude.ai/code/session_016zLfWbTcSBkRehKJveNAHh