### PR TITLE
docs(site): add agent self-verification example and use cases to skills page

### DIFF
--- a/apps/site/docs/en/skills.mdx
+++ b/apps/site/docs/en/skills.mdx
@@ -52,6 +52,32 @@ In your AI chat assistant, you can use the following command to use skills:
 Open photo app, see what is the first photo in the album.
 ```
 
+## Example: Coding Agent self-verifies after writing code
+
+In this example, we ask Claude Code to develop an Electron Todo app, and after writing the code, it uses the `desktop-computer-automation` Skill to launch the app, interact with the UI, and take screenshots to verify the feature works as expected — no manual intervention or test scripts needed.
+
+**Prompt:**
+
+```
+Build an Electron Todo app with add, toggle, and delete functionality.
+After development, launch the app and verify with desktop automation: add 3 todos, check one off, delete one, and take a screenshot to confirm the final state is correct.
+```
+
+The coding agent autonomously completes the entire workflow: write the Todo component → launch the Electron app → connect to the desktop → take screenshots to understand the UI → interact via natural language → take screenshots to verify results. The developer only describes the intent, and Skills give the agent the ability to "see the screen and move the mouse", letting it verify its own code just like a human would.
+
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/computer-skill.mp4" height="300" controls />
+
+## More use cases
+
+Skills go beyond local desktop testing. By combining different Skills, you can cover a wide range of automation scenarios:
+
+- **Desktop app testing** — Verify functionality of Electron, Qt, WPF and other desktop applications
+- **Remote computer control** — Operate applications on remote machines via remote desktop connections for remote ops and debugging
+- **Mobile app testing** — Use `@midscene/android` and `@midscene/ios` Skills to test mobile apps on real devices or simulators
+- **Cross-app workflows** — Chain operations across multiple apps, e.g. fetch data from browser → paste into Excel → take screenshot and send to Slack
+- **CI/CD integration** — Run desktop automation in headless mode on Linux CI via Xvfb, no physical display needed
+- **Daily task automation** — Batch form filling, scheduled screenshot monitoring, automatic file organization, etc.
+
 ## More
 
 Please refer to the [Skills Repository](https://github.com/web-infra-dev/midscene-skills) for more details.

--- a/apps/site/docs/zh/skills.mdx
+++ b/apps/site/docs/zh/skills.mdx
@@ -52,6 +52,32 @@ MIDSCENE_MODEL_FAMILY="family-identifier"
 Open photo app, see what is the first photo in the album.
 ```
 
+## 案例：编码 Agent 写完代码后自行验证功能
+
+以下示例中，我们让 Claude Code 开发一个 Electron Todo 应用，并在写完代码后通过 `desktop-computer-automation` Skill 自行启动应用、操作 UI、截图验证功能是否符合预期 —— 全程无需人工介入，也无需编写测试脚本。
+
+**Prompt：**
+
+```
+开发一个 Electron Todo 应用，包含添加、勾选、删除功能。
+开发完成后，启动应用并用桌面自动化验证：添加 3 个 todo、勾选其中 1 个、删除 1 个，截图确认最终状态正确。
+```
+
+编码 Agent 会自主完成以下工作：编写 Todo 组件 → 启动 Electron 应用 → 连接桌面 → 截图识别 UI → 通过自然语言操作界面 → 截图验证结果。开发者只需描述意图，Skill 赋予 Agent "看屏幕、动鼠标" 的能力，让它像人一样验证自己写的代码。
+
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/computer-skill.mp4" height="300" controls />
+
+## 更多应用场景
+
+Skills 不仅限于本地桌面测试，通过组合不同 Skill 可以覆盖更多场景：
+
+- **桌面应用自动化测试** — 验证 Electron、Qt、WPF 等桌面应用的功能流程
+- **远程控制电脑** — 通过远程桌面连接操控远程机器上的应用，实现远程运维和调试
+- **移动端应用测试** — 使用 `@midscene/android` 和 `@midscene/ios` Skill 在真机或模拟器上验证移动应用
+- **跨应用工作流** — 串联多个应用操作，如从浏览器取数据 → 粘贴到 Excel → 截图发送到 Slack
+- **CI/CD 集成** — 在 Linux CI 中通过 Xvfb 无头模式运行，无需物理显示器
+- **日常任务自动化** — 批量填写表单、定时截图监控、自动整理文件等
+
 ## 更多
 
 请参考 [Skills 仓库](https://github.com/web-infra-dev/midscene-skills) 获取更多详情。


### PR DESCRIPTION
## Summary

- Add a new "Coding Agent self-verifies after writing code" example section showing how Claude Code can develop an Electron Todo app and autonomously verify functionality using the `desktop-computer-automation` Skill
- Add a "More use cases" section covering desktop app testing, remote computer control, mobile app testing, cross-app workflows, CI/CD integration, and daily task automation
- Both English and Chinese versions updated

## Test plan

- [ ] Verify the documentation site builds correctly
- [ ] Check that the embedded video renders properly
- [ ] Review both EN and ZH content for accuracy