### PR TITLE
fix(core): always crop in describe deepLocate mode

### DIFF
--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -339,28 +339,18 @@ export default class Service {
 
     if (opt?.deepLocate) {
       const searchArea = expandSearchArea(targetRect, shotSize);
-      // Only crop when the search area covers at least 50% of the screen
-      // in both dimensions. Small crops (e.g., 500px on 1920x1080) lose
-      // too much context and cause model hallucinations.
-      const widthRatio = searchArea.width / shotSize.width;
-      const heightRatio = searchArea.height / shotSize.height;
-      if (widthRatio >= 0.5 && heightRatio >= 0.5) {
-        debug('describe: cropping to searchArea', searchArea);
-        const croppedResult = await cropByRect(
-          imagePayload,
-          searchArea,
-          modelFamily === 'qwen2.5-vl',
-        );
-        imagePayload = croppedResult.imageBase64;
-      } else {
-        debug(
-          'describe: skip cropping, search area too small (%dx%d on %dx%d)',
-          searchArea.width,
-          searchArea.height,
-          shotSize.width,
-          shotSize.height,
-        );
-      }
+      // Always crop in describe mode. Unlike locate's deepLocate (where
+      // cropping too small loses context for finding elements), describe's
+      // deepLocate intentionally zooms in so the model produces a more
+      // precise description from a focused view. expandSearchArea already
+      // guarantees a minimum 400x400 area with surrounding context.
+      debug('describe: cropping to searchArea', searchArea);
+      const croppedResult = await cropByRect(
+        imagePayload,
+        searchArea,
+        modelFamily === 'qwen2.5-vl',
+      );
+      imagePayload = croppedResult.imageBase64;
     }
 
     const msgs: AIArgs = [


### PR DESCRIPTION
## Summary

Fix the `element describer - deep think` flaky test by removing the incorrect guard condition in `describe`'s `deepLocate` branch.

## Root cause

The `describe` method had a guard that skipped cropping when `searchArea` was < 50% of screen dimensions in both axes:

```ts
if (widthRatio >= 0.5 && heightRatio >= 0.5) { // ← this guard
  // crop
}
```

This guard was designed for `locate`'s `deepLocate` (where small crops lose context for finding elements), but was incorrectly applied to `describe`'s `deepLocate` as well.

**Numeric walkthrough** (1280×720 viewport, 30×30 element):
- `expandSearchArea` expands 30×30 → ~400×400 (minimum area guarantee)
- `widthRatio = 400/1280 ≈ 0.31` — fails the `>= 0.5` check
- Cropping is **always skipped** at common resolutions
- `deepLocate` behaves identically to non-`deepLocate`
- 5 retries all produce similar descriptions → consistent verification failures

## Fix

Remove the guard in `describe`'s `deepLocate` branch. Always crop to the `expandSearchArea` region, which is guaranteed to be at least 400×400 with surrounding context. This gives the model a focused view for more precise element descriptions.

## Test plan

- [ ] `element describer` test passes (non-deep)
- [ ] `element describer - deep think` test passes (no assertion changes)
- [ ] Run full `@midscene/web:test:ai` suite