### PR TITLE
chore(workflow): add AGENTS.md and .agents to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,9 +125,12 @@ packages/computer-playground/static/
 packages/playground/static/
 .cursor
 CLAUDE.md
+AGENTS.md
 .claude
 **/.claude
+**/.agents
 **/CLAUDE.md
+**/AGENTS.md
 
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` and `**/AGENTS.md` to `.gitignore` to prevent agent instruction files from being committed
- Add `**/.agents` to `.gitignore` to ignore agent workspace directories

## Test plan
- [x] Verify `.gitignore` patterns correctly match the intended files