### PR TITLE
feat(core): add Skill CLI support for custom interfaces

### DIFF
--- a/apps/site/docs/en/integrate-with-any-interface.mdx
+++ b/apps/site/docs/en/integrate-with-any-interface.mdx
@@ -198,7 +198,7 @@ Add a CLI entry file to your npm package (e.g., `./src/cli.ts`):
 
 ```ts
 #!/usr/bin/env node
-import { runSkillCLI } from '@midscene/core/mcp';
+import { runSkillCLI } from '@midscene/core/skill';
 import { SampleDevice } from './sample-device';
 
 runSkillCLI({

--- a/apps/site/docs/zh/integrate-with-any-interface.mdx
+++ b/apps/site/docs/zh/integrate-with-any-interface.mdx
@@ -197,7 +197,7 @@ console.log('Playground 已关闭！');
 
 ```ts
 #!/usr/bin/env node
-import { runSkillCLI } from '@midscene/core/mcp';
+import { runSkillCLI } from '@midscene/core/skill';
 import { SampleDevice } from './sample-device';
 
 runSkillCLI({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,10 +49,10 @@
       "import": "./dist/es/report.mjs",
       "require": "./dist/lib/report.js"
     },
-    "./mcp": {
-      "types": "./dist/types/mcp/index.d.ts",
-      "import": "./dist/es/mcp/index.mjs",
-      "require": "./dist/lib/mcp/index.js"
+    "./skill": {
+      "types": "./dist/types/skill/index.d.ts",
+      "import": "./dist/es/skill/index.mjs",
+      "require": "./dist/lib/skill/index.js"
     }
   },
   "typesVersions": {
@@ -64,7 +64,7 @@
       "device": ["./dist/types/device.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
-      "mcp": ["./dist/types/mcp/index.d.ts"]
+      "mcp": ["./dist/types/skill/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/core/src/skill/index.ts
+++ b/packages/core/src/skill/index.ts
@@ -41,7 +41,7 @@ export interface SkillCLIOptions {
  * @example
  * ```typescript
  * #!/usr/bin/env node
- * import { runSkillCLI } from '@midscene/core/mcp';
+ * import { runSkillCLI } from '@midscene/core/skill';
  * import { SampleDevice } from './sample-device';
  *
  * runSkillCLI({

--- a/packages/core/tests/unit-test/mcp.test.ts
+++ b/packages/core/tests/unit-test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { runSkillCLI } from '@/mcp/index';
+import { runSkillCLI } from '@/skill/index';
 import { describe, expect, it } from 'vitest';
 
 describe('runSkillCLI', () => {


### PR DESCRIPTION
## Summary

- Add `@midscene/core/mcp` sub-path export with `runSkillCLI` API
- Custom `AbstractInterface` implementations can now create Agent Skill CLIs with minimal code:
  ```typescript
  runSkillCLI({ DeviceClass: SampleDevice, scriptName: 'my-device' });
  ```
- Replace "still in progress" placeholder in docs with Step 4 (Skill support, optional)
- Add reference to [midscene-skills](https://github.com/web-infra-dev/midscene-skills) repository for Skill authoring guidelines

## Test plan

- [x] 2 unit tests pass (`packages/core/tests/unit-test/mcp.test.ts`)
- [x] Build succeeds with new `./mcp` export path
- [x] Lint passes (biome check)
- [ ] Verify docs render correctly on site