### PR TITLE
fix(core): support nested locate format in aiTap YAML parsing

### DIFF
--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -452,18 +452,23 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
 
         let locatePrompt: TUserPrompt;
         let opts = tapOptions;
+        // Support both formats:
+        // 1. { aiTap: null, locate: { prompt, images, ... } }  (locate as sibling key)
+        // 2. { aiTap: { locate: { prompt, images, ... } } }    (locate nested in aiTap)
+        const locateObj = locate
+          ?? (typeof aiTap === 'object' && aiTap !== null ? aiTap.locate : undefined);
 
         if (typeof aiTap === 'string' && aiTap) {
           // User YAML: aiTap: 'search input box'
           locatePrompt = aiTap;
-        } else if (typeof locate === 'object' && locate?.prompt) {
+        } else if (typeof locateObj === 'object' && locateObj?.prompt) {
           // buildYamlFlowFromPlans: { aiTap: '', locate: { prompt, deepLocate, cacheable } }
-          const { prompt: lp, ...locateOpts } = locate;
+          const { prompt: lp, ...locateOpts } = locateObj;
           locatePrompt = lp;
           opts = { ...locateOpts, ...tapOptions };
         } else {
           // User YAML: aiTap: { prompt: '...' } or aiTap: null + prompt: '...'
-          locatePrompt = aiTap?.prompt || prompt || locate;
+          locatePrompt = aiTap?.prompt || prompt || locateObj;
         }
 
         assert(locatePrompt, 'missing prompt for aiTap');

--- a/packages/web-integration/tests/unit-test/yaml/player.test.ts
+++ b/packages/web-integration/tests/unit-test/yaml/player.test.ts
@@ -533,6 +533,78 @@ tasks:
     `);
   });
 
+  test('aiTap with locate containing image prompts (sibling and nested formats)', async () => {
+    const yamlString = `
+target:
+  url: "https://example.com"
+tasks:
+  - name: test_aiTap_image_prompt
+    flow:
+      - aiTap:
+        locate:
+          prompt: the area contains the image.
+          images:
+            - name: target image
+              url: https://example.com/image.png
+          convertHttpImage2Base64: true
+      - aiTap:
+          locate:
+            prompt: the area contains the image.
+            images:
+              - name: target image
+                url: https://example.com/image.png
+            convertHttpImage2Base64: true
+`;
+
+    const script = parseYamlScript(yamlString);
+    const mockAgent = await getMockAgent();
+    const player = new ScriptPlayer<MidsceneYamlScriptWebEnv>(
+      script,
+      async () => mockAgent,
+    );
+
+    await player.run();
+
+    expect(player.errorInSetup).toBeUndefined();
+    expect(player.taskStatusList[0].error).toBeUndefined();
+    expect(player.status).toBe('done');
+
+    // Both formats should produce the same aiTap calls
+    const aiTapCalls = (mockAgent.agent.aiTap as MockedFunction<any>).mock
+      .calls;
+    expect(aiTapCalls).toHaveLength(2);
+    // Both calls should have the same arguments regardless of YAML nesting style
+    expect(aiTapCalls[0]).toEqual(aiTapCalls[1]);
+    expect(aiTapCalls).toMatchInlineSnapshot(`
+      [
+        [
+          "the area contains the image.",
+          {
+            "convertHttpImage2Base64": true,
+            "images": [
+              {
+                "name": "target image",
+                "url": "https://example.com/image.png",
+              },
+            ],
+          },
+        ],
+        [
+          "the area contains the image.",
+          {
+            "convertHttpImage2Base64": true,
+            "images": [
+              {
+                "name": "target image",
+                "url": "https://example.com/image.png",
+              },
+            ],
+          },
+        ],
+      ]
+    `);
+  });
+
   test('aiInput, aiScroll, aiKeyboardPress , different style', async () => {
     const yamlString = `
 target:


### PR DESCRIPTION
## Summary

- Fix `aiTap` YAML parsing to support nested `locate` format (`aiTap: { locate: { prompt, images } }`), which is documented but was not handled
- Add unit test covering both sibling and nested `locate` formats with image prompts
- Clean cherry-pick of the core fix from #2081, without unrelated Android changes

### Background

PR #2081 identified the correct bug but included unrelated Android changes (`runAdbShell` schema change, screenshot logic modifications). This PR isolates only the `aiTap` fix with proper test coverage.

### Supported YAML formats

```yaml
# Format 1: locate as sibling key (already worked)
- aiTap:
  locate:
    prompt: the area contains the image.
    images:
      - name: target image
        url: https://example.com/image.png

# Format 2: locate nested in aiTap (was broken, now fixed)
- aiTap:
    locate:
      prompt: the area contains the image.
      images:
        - name: target image
          url: https://example.com/image.png
```

## Test plan

- [x] New unit test `aiTap with locate containing image prompts (sibling and nested formats)` passes
- [x] All 28 existing player tests pass
- [ ] CI passes