### PR TITLE
Extract input action schemas to module level

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -53,6 +53,24 @@ interface ScreenshotDisplay {
   primary?: boolean;
 }
 
+// Input action schema for computer
+const computerInputParamSchema = z.object({
+  value: z.string().describe('The text to input'),
+  mode: z
+    .enum(['replace', 'clear', 'append'])
+    .default('replace')
+    .optional()
+    .describe('Input mode: replace, clear, or append'),
+  locate: getMidsceneLocationSchema()
+    .describe('The input field to be filled')
+    .optional(),
+});
+type ComputerInputParam = {
+  value: string;
+  mode?: 'replace' | 'clear' | 'append';
+  locate?: LocateResultElement;
+};
+
 // Constants
 const SMOOTH_MOVE_STEPS_TAP = 8;
 const SMOOTH_MOVE_STEPS_MOUSE_MOVE = 10;
@@ -652,21 +670,14 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
       }),
 
       // Input
-      defineAction({
+      defineAction<
+        typeof computerInputParamSchema,
+        ComputerInputParam
+      >({
         name: 'Input',
         description: 'Input text into the input field',
         interfaceAlias: 'aiInput',
-        paramSchema: z.object({
-          value: z.string().describe('The text to input'),
-          mode: z
-            .enum(['replace', 'clear', 'append'])
-            .default('replace')
-            .optional()
-            .describe('Input mode: replace, clear, or append'),
-          locate: getMidsceneLocationSchema()
-            .describe('The input field to be filled')
-            .optional(),
-        }),
+        paramSchema: computerInputParamSchema,
         sample: {
           value: 'test@example.com',
           locate: { prompt: 'the email input field' },

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -33,6 +33,33 @@ import { HdcClient } from './hdc';
 
 export type { HarmonyDeviceOpt } from '@midscene/core/device';
 
+// Input action schema for Harmony
+const harmonyInputParamSchema = z.object({
+  value: z
+    .string()
+    .describe(
+      'The text to input. Provide the final content for replace/append modes, or an empty string when using clear mode to remove existing text.',
+    ),
+  mode: z.preprocess(
+    (val) => (val === 'append' ? 'typeOnly' : val),
+    z
+      .enum(['replace', 'clear', 'typeOnly'])
+      .default('replace')
+      .optional()
+      .describe(
+        'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - attempt to clear the field (limited support on HarmonyOS).',
+      ),
+  ),
+  locate: getMidsceneLocationSchema()
+    .describe('The input field to be filled')
+    .optional(),
+});
+type HarmonyInputParam = {
+  value: string;
+  mode?: 'replace' | 'clear' | 'typeOnly';
+  locate?: LocateResultElement;
+};
+
 const defaultScrollUntilTimes = 10;
 const defaultSwipeSpeed = 600;
 const defaultFastSwipeSpeed = 2000;
@@ -102,30 +129,11 @@ export class HarmonyDevice implements AbstractInterface {
         assert(element, 'Element not found, cannot double click');
         await this.doubleTap(element.center[0], element.center[1]);
       }),
-      defineAction({
+      defineAction<typeof harmonyInputParamSchema, HarmonyInputParam>({
         name: 'Input',
         description: 'Input text into the input field',
         interfaceAlias: 'aiInput',
-        paramSchema: z.object({
-          value: z
-            .string()
-            .describe(
-              'The text to input. Provide the final content for replace/append modes, or an empty string when using clear mode to remove existing text.',
-            ),
-          mode: z.preprocess(
-            (val) => (val === 'append' ? 'typeOnly' : val),
-            z
-              .enum(['replace', 'clear', 'typeOnly'])
-              .default('replace')
-              .optional()
-              .describe(
-                'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - attempt to clear the field (limited support on HarmonyOS).',
-              ),
-          ),
-          locate: getMidsceneLocationSchema()
-            .describe('The input field to be filled')
-            .optional(),
-        }),
+        paramSchema: harmonyInputParamSchema,
         sample: {
           value: 'test@example.com',
           locate: { prompt: 'the email input field' },
@@ -761,7 +769,7 @@ const createPlatformActions = (
   HarmonyRecentAppsButton: DeviceActionHarmonyRecentAppsButton;
 } => {
   return {
-    RunHdcShell: defineAction({
+    RunHdcShell: defineAction<typeof runHdcShellParamSchema, RunHdcShellParam, string>({
       name: 'RunHdcShell',
       description: 'Execute HDC shell command on HarmonyOS device',
       interfaceAlias: 'runHdcShell',
@@ -777,7 +785,7 @@ const createPlatformActions = (
         return await hdc.shell(param.command);
       },
     }),
-    Launch: defineAction({
+    Launch: defineAction<typeof launchParamSchema, LaunchParam, void>({
       name: 'Launch',
       description: 'Launch a HarmonyOS app or URL',
       interfaceAlias: 'launch',

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -38,6 +38,40 @@ export type { IOSDeviceOpt, IOSDeviceInputOpt } from '@midscene/core/device';
 
 const debugDevice = getDebug('ios:device');
 
+// Input action schema for iOS
+const iosInputParamSchema = z.object({
+  value: z
+    .string()
+    .describe(
+      'The text to input. Provide the final content for replace/append modes, or an empty string when using clear mode to remove existing text.',
+    ),
+  autoDismissKeyboard: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to dismiss the keyboard after input. Defaults to true if not specified. Set to false to keep the keyboard visible after input.',
+    ),
+  mode: z.preprocess(
+    (val) => (val === 'append' ? 'typeOnly' : val),
+    z
+      .enum(['replace', 'clear', 'typeOnly'])
+      .default('replace')
+      .optional()
+      .describe(
+        'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - clear the field without inputting new text.',
+      ),
+  ),
+  locate: getMidsceneLocationSchema()
+    .describe('The input field to be filled')
+    .optional(),
+});
+type IOSInputParam = {
+  value: string;
+  autoDismissKeyboard?: boolean;
+  mode?: 'replace' | 'clear' | 'typeOnly';
+  locate?: LocateResultElement;
+};
+
 /**
  * HTTP methods supported by WebDriverAgent API
  */
@@ -74,36 +108,11 @@ export class IOSDevice implements AbstractInterface {
         assert(element, 'Element not found, cannot double click');
         await this.doubleTap(element.center[0], element.center[1]);
       }),
-      defineAction({
+      defineAction<typeof iosInputParamSchema, IOSInputParam>({
         name: 'Input',
         description: 'Input text into the input field',
         interfaceAlias: 'aiInput',
-        paramSchema: z.object({
-          value: z
-            .string()
-            .describe(
-              'The text to input. Provide the final content for replace/append modes, or an empty string when using clear mode to remove existing text.',
-            ),
-          autoDismissKeyboard: z
-            .boolean()
-            .optional()
-            .describe(
-              'Whether to dismiss the keyboard after input. Defaults to true if not specified. Set to false to keep the keyboard visible after input.',
-            ),
-          mode: z.preprocess(
-            (val) => (val === 'append' ? 'typeOnly' : val),
-            z
-              .enum(['replace', 'clear', 'typeOnly'])
-              .default('replace')
-              .optional()
-              .describe(
-                'Input mode: "replace" (default) - clear the field and input the value; "typeOnly" - type the value directly without clearing the field first; "clear" - clear the field without inputting new text.',
-              ),
-          ),
-          locate: getMidsceneLocationSchema()
-            .describe('The input field to be filled')
-            .optional(),
-        }),
+        paramSchema: iosInputParamSchema,
         sample: {
           value: 'test@example.com',
           locate: { prompt: 'the email input field' },
@@ -1044,9 +1053,6 @@ const createPlatformActions = (device: IOSDevice) => {
       description: 'Launch an iOS app or URL',
       interfaceAlias: 'launch',
       paramSchema: launchParamSchema,
-      sample: {
-        param: 'com.apple.mobilesafari',
-      },
       call: async (param) => {
         await device.launch(param);
       },

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -26,6 +26,14 @@ import { transformHotkeyInput } from '@midscene/shared/us-keyboard-layout';
 
 const debug = getDebug('web:page');
 
+const navigateParamSchema = z.object({
+  url: z
+    .string()
+    .describe(
+      'The URL to navigate to. Must start with https://, file://, or a similar protocol.',
+    ),
+});
+
 function normalizeKeyInputs(value: string | string[]): string[] {
   const inputs = Array.isArray(value) ? value : [value];
   const result: string[] = [];
@@ -640,17 +648,11 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
     await page.clearInput(param.locate as ElementInfo | undefined);
   }),
 
-  defineAction({
+  defineAction<typeof navigateParamSchema, { url: string }>({
     name: 'Navigate',
     description:
       'Navigate the browser to a specified URL. Opens the URL in the current tab.',
-    paramSchema: z.object({
-      url: z
-        .string()
-        .describe(
-          'The URL to navigate to. Must start with https://, file://, or a similar protocol.',
-        ),
-    }),
+    paramSchema: navigateParamSchema,
     sample: {
       url: 'https://www.example.com',
     },


### PR DESCRIPTION
## Summary
Refactored input action parameter schemas across multiple device implementations (iOS, Harmony, and Computer) by extracting them from inline definitions to module-level constants. This improves code organization, reusability, and maintainability while adding proper TypeScript generic typing to action definitions.

## Key Changes
- **iOS Device**: Extracted `iosInputParamSchema` and `IOSInputParam` type to module level; added generic type parameters to `defineAction` call; removed unused `sample` property from Launch action
- **Harmony Device**: Extracted `harmonyInputParamSchema` and `HarmonyInputParam` type to module level; added generic type parameters to `defineAction` calls for Input, RunHdcShell, and Launch actions
- **Computer Device**: Extracted `computerInputParamSchema` and `ComputerInputParam` type to module level; added generic type parameters to `defineAction` call
- **Web Integration**: Extracted `navigateParamSchema` to module level; added generic type parameters to Navigate action's `defineAction` call

## Implementation Details
- All extracted schemas maintain their original validation logic and descriptions
- TypeScript generics are now properly applied to `defineAction` calls, providing better type safety and IDE support
- The refactoring follows a consistent pattern across all device implementations
- No functional changes to the actual input handling or validation behavior

https://claude.ai/code/session_01AnpHjZWrpR3XHh8dB7y4Z8