### PR TITLE
fix(core): fix double nesting of prompt objects in locate parameters

### DIFF
--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -73,7 +73,21 @@ export function buildDetailedLocateParam(
   opt?: LocateOption,
 ): DetailedLocateParam | undefined {
   debugUtils('will call buildDetailedLocateParam', locatePrompt, opt);
-  let prompt = locatePrompt || opt?.prompt || (opt as any)?.locate; // as a shortcut
+  // Normalize object-form TUserPrompt: when the object only contains a
+  // `prompt` string (no multimodal fields like `images`), unwrap it to
+  // avoid double nesting like { prompt: { prompt: '...' } }.
+  let normalizedLocatePrompt: TUserPrompt = locatePrompt;
+  if (
+    typeof locatePrompt === 'object' &&
+    locatePrompt !== null &&
+    'prompt' in locatePrompt
+  ) {
+    const { prompt: innerPrompt, ...rest } = locatePrompt;
+    const hasMultimodalFields = Object.keys(rest).length > 0;
+    normalizedLocatePrompt = hasMultimodalFields ? locatePrompt : innerPrompt;
+  }
+
+  let prompt = normalizedLocatePrompt || opt?.prompt || (opt as any)?.locate; // as a shortcut
   let deepLocate = false;
   let cacheable = true;
   let xpath = undefined;

--- a/packages/core/tests/unit-test/agent-scroll-compat.test.ts
+++ b/packages/core/tests/unit-test/agent-scroll-compat.test.ts
@@ -77,9 +77,7 @@ describe('Agent aiScroll legacy scrollType compatibility', () => {
       'Scroll',
       expect.objectContaining({
         locate: expect.objectContaining({
-          prompt: {
-            prompt: '计数器',
-          },
+          prompt: '计数器',
         }),
       }),
     );


### PR DESCRIPTION
## Summary
Fixed an issue where prompt objects were being double-nested when passed to `buildDetailedLocateParam`, resulting in structures like `{ prompt: { prompt: '...' } }` instead of the expected `{ prompt: '...' }`.

## Key Changes
- Added normalization logic in `buildDetailedLocateParam` to unwrap single-property prompt objects that only contain a `prompt` string field
- The normalization checks if the object has multimodal fields (like `images`) and only unwraps when no such fields are present
- Updated corresponding test expectations to reflect the corrected prompt structure

## Implementation Details
The fix detects when `locatePrompt` is an object containing only a `prompt` property (no multimodal fields) and extracts the inner prompt string to prevent double nesting. This ensures consistent prompt handling whether the input is a string or an object-form prompt.

https://claude.ai/code/session_013RyokPM5Wp71ZETv2YbShu