### PR TITLE
docs(site): remove stray quote in aiAssert tip examples

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -757,7 +757,7 @@ For example, you might replace the above code with:
 
 ```typescript
 const items = await agent.aiQuery(
-  '"{name: string, price: number}[], return product names and prices',
+  '{name: string, price: number}[], return product names and prices',
 );
 const onesieItem = items.find((item) => item.name === 'Sauce Labs Onesie');
 expect(onesieItem).toBeTruthy();

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -752,7 +752,7 @@ await agent.aiAssert('"Sauce Labs Onesie" 的价格是 7.99');
 
 ```typescript
 const items = await agent.aiQuery(
-  '"{name: string, price: number}[], 返回商品名称和价格列表',
+  '{name: string, price: number}[], 返回商品名称和价格列表',
 );
 const onesieItem = items.find((item) => item.name === 'Sauce Labs Onesie');
 expect(onesieItem).toBeTruthy();


### PR DESCRIPTION
### Motivation
- Fix a stray leading double-quote in the `aiAssert` tip example in the API reference and keep English/Chinese docs consistent.

### Description
- Removed the extra leading `"` from the `agent.aiQuery` example under `agent.aiAssert()` in `apps/site/docs/zh/api.mdx` and applied the same fix to `apps/site/docs/en/api.mdx`.

### Testing
- Ran `pnpm run lint` (failed due to unrelated Biome errors elsewhere in the repo). 
- Ran `pnpm exec biome check apps/site/docs/en/api.mdx apps/site/docs/zh/api.mdx --diagnostic-level=info --no-errors-on-unmatched`, which completed but reported "Checked 0 files" in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0acdf502c8324850ad4bde42e59c0)