### PR TITLE
fix(android): bump scrcpy-server to v3.3.4

### DIFF
--- a/packages/android/scripts/download-scrcpy-server.mjs
+++ b/packages/android/scripts/download-scrcpy-server.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { fetchVersion } from 'gh-release-fetch';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCRCPY_VERSION = 'v3.1';
+const SCRCPY_VERSION = 'v3.3.4';
 
 async function main() {
   const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary
- bump the pinned scrcpy-server download version from v3.1 to v3.3.4 for `@midscene/android`
- keep the Android package aligned with the current scrcpy server release used by the repo

## Validation
- pnpm run lint
- pnpm exec nx test @midscene/android