### PR TITLE
docs: update demo links from Puppeteer+Vitest to Playwright+Vitest (EN/ZH)

### DIFF
--- a/apps/site/docs/en/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/en/integrate-with-puppeteer.mdx
@@ -11,7 +11,7 @@ import { PackageManagerTabs } from '@theme';
 
 you can check the demo project of Puppeteer here: [https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo](https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo)
 
-There is also a demo of Puppeteer with Vitest: [https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo)
+There is also a demo of Playwright with Vitest: [https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo)
 
 :::
 
@@ -207,4 +207,4 @@ Check [Integrate with any interface](./integrate-with-any-interface#define-a-cus
 - For the Puppeteer API reference, see [Puppeteer Agent API](./web-api-reference#puppeteer-agent).
 - Demo projects
   - Puppeteer demo: [https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo](https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo)
-  - Puppeteer + Vitest demo: [https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo)
+  - Playwright + Vitest demo: [https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo)

--- a/apps/site/docs/zh/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/zh/integrate-with-puppeteer.mdx
@@ -11,7 +11,7 @@ import { PackageManagerTabs } from '@theme';
 
 你可以在这里看到向 Puppeteer 集成的样例项目：[https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo](https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo)
 
-这里还有一个 Puppeteer 和 Vitest 结合的样例项目：[https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo)
+这里还有一个 Playwright 和 Vitest 结合的样例项目：[https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo)
 
 :::
 
@@ -207,4 +207,4 @@ await agent.aiAct('点击红色按钮五次');
 - Puppeteer 的 API 文档请参考 [Puppeteer Agent API](./web-api-reference#puppeteer-agent)。
 - 样例项目
   - Puppeteer：[https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo](https://github.com/web-infra-dev/midscene-example/blob/main/puppeteer-demo)
-  - Puppeteer + Vitest：[https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/puppeteer-with-vitest-demo)
+  - Playwright + Vitest：[https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo](https://github.com/web-infra-dev/midscene-example/tree/main/playwright-with-vitest-demo)


### PR DESCRIPTION
### Motivation
- Correct documentation to point to the Playwright+Vitest example project instead of Puppeteer+Vitest in both English and Chinese pages.

### Description
- Updated `apps/site/docs/en/integrate-with-puppeteer.mdx` to replace the Puppeteer+Vitest demo link and label with the Playwright+Vitest demo.
- Updated `apps/site/docs/zh/integrate-with-puppeteer.mdx` to replace the Puppeteer+Vitest demo link and label with the Playwright+Vitest demo.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e390c3f48324958c317d009aa36f)