### PR TITLE
feat(core): add monitor detection to device health check

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -485,6 +485,21 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
       `[HealthCheck] Mouse restored to (${startPos.x}, ${startPos.y})`,
     );
 
+    // Step 3: List available monitors
+    console.log('[HealthCheck] Listing monitors...');
+    const displays = await ComputerDevice.listDisplays();
+    if (displays.length > 0) {
+      console.log(`[HealthCheck] Found ${displays.length} monitor(s):`);
+      for (const display of displays) {
+        const primaryTag = display.primary ? ' (primary)' : '';
+        console.log(
+          `[HealthCheck]   - id=${display.id}, name=${display.name}${primaryTag}`,
+        );
+      }
+    } else {
+      console.log('[HealthCheck] No monitors detected');
+    }
+
     console.log('[HealthCheck] Health check passed');
   }
 


### PR DESCRIPTION
## Summary
Enhanced the device health check functionality to include monitor/display detection and reporting.

## Key Changes
- Added Step 3 to the health check process that lists all available monitors
- Displays monitor count, ID, name, and primary status for each detected display
- Provides user-friendly console output indicating when no monitors are detected
- Integrates with existing `ComputerDevice.listDisplays()` method

## Implementation Details
- Uses the existing `ComputerDevice.listDisplays()` API to retrieve display information
- Iterates through detected displays and logs relevant metadata including:
  - Display ID and name
  - Primary monitor indicator tag
- Maintains consistent `[HealthCheck]` logging prefix for easy filtering and debugging
- Gracefully handles the case where no monitors are detected

https://claude.ai/code/session_01Pwkj9dSMs34pns7y3NskhP