### PR TITLE
fix(core): optimize report merging for large inline reports

### DIFF
--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -1,4 +1,10 @@
-import { closeSync, openSync, readSync, statSync } from 'node:fs';
+import {
+  appendFileSync,
+  closeSync,
+  openSync,
+  readSync,
+  statSync,
+} from 'node:fs';
 import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
 
 export const escapeContent = escapeScriptTag;
@@ -127,15 +133,43 @@ export function streamImageScriptsToFile(
   srcFilePath: string,
   destFilePath: string,
 ): void {
-  const { appendFileSync } = require('node:fs');
-  const openTag = '<script type="midscene-image"';
-  const closeTag = '</script>';
-
-  streamScanTags(srcFilePath, openTag, closeTag, (content) => {
-    // Write complete tag immediately to destination, don't accumulate
-    appendFileSync(destFilePath, `${openTag}${content}${closeTag}\n`);
-    return false; // Continue scanning for more tags
+  streamInlineReportArtifactsSync(srcFilePath, (tag) => {
+    appendFileSync(destFilePath, tag);
   });
+}
+
+/**
+ * Stream inline report image tags and capture the LAST dump script content
+ * in a single scan. This avoids rescanning large report files during merge.
+ *
+ * @param filePath - Absolute path to the HTML file
+ * @param onImageScript - Called for each complete image script tag
+ * @returns The dump script content (trimmed), or empty string if not found
+ */
+export function streamInlineReportArtifactsSync(
+  filePath: string,
+  onImageScript?: (imageScriptTag: string) => void,
+): string {
+  const openTagPrefix = '<script type="midscene';
+  const closeTag = '</script>';
+  let lastContent = '';
+  streamScanTags(filePath, openTagPrefix, closeTag, (content) => {
+    if (content.startsWith('-image"')) {
+      onImageScript?.(`${openTagPrefix}${content}${closeTag}\n`);
+      return false;
+    }
+
+    if (content.startsWith('_web_dump"')) {
+      const tagEndIdx = content.indexOf('>');
+      if (tagEndIdx !== -1) {
+        lastContent = content.slice(tagEndIdx + 1).trim();
+      }
+    }
+
+    return false;
+  });
+
+  return lastContent;
 }
 
 /**
@@ -146,78 +180,7 @@ export function streamImageScriptsToFile(
  * @returns The dump script content (trimmed), or empty string if not found
  */
 export function extractLastDumpScriptSync(filePath: string): string {
-  const openTagPrefix = '<script type="midscene_web_dump"';
-  const closeTag = '</script>';
-
-  let lastContent = '';
-
-  // Custom streaming to handle the special case where open tag has variable attributes
-  const fd = openSync(filePath, 'r');
-  const fileSize = statSync(filePath).size;
-  const buffer = Buffer.alloc(STREAMING_CHUNK_SIZE);
-
-  let position = 0;
-  let leftover = '';
-  let capturing = false;
-  let currentContent = '';
-
-  try {
-    while (position < fileSize) {
-      const bytesRead = readSync(fd, buffer, 0, STREAMING_CHUNK_SIZE, position);
-      const chunk = leftover + buffer.toString('utf-8', 0, bytesRead);
-      position += bytesRead;
-
-      let searchStart = 0;
-
-      while (searchStart < chunk.length) {
-        if (!capturing) {
-          const startIdx = chunk.indexOf(openTagPrefix, searchStart);
-          if (startIdx !== -1) {
-            // Find the end of the opening tag (the '>' character)
-            const tagEndIdx = chunk.indexOf('>', startIdx);
-            if (tagEndIdx !== -1) {
-              capturing = true;
-              currentContent = chunk.slice(tagEndIdx + 1);
-              const endIdx = currentContent.indexOf(closeTag);
-              if (endIdx !== -1) {
-                lastContent = currentContent.slice(0, endIdx).trim();
-                capturing = false;
-                currentContent = '';
-                searchStart = tagEndIdx + 1 + endIdx + closeTag.length;
-              } else {
-                leftover = currentContent.slice(-closeTag.length);
-                currentContent = currentContent.slice(0, -closeTag.length);
-                break;
-              }
-            } else {
-              leftover = chunk.slice(startIdx);
-              break;
-            }
-          } else {
-            leftover = chunk.slice(-openTagPrefix.length);
-            break;
-          }
-        } else {
-          const endIdx = chunk.indexOf(closeTag, searchStart);
-          if (endIdx !== -1) {
-            currentContent += chunk.slice(searchStart, endIdx);
-            lastContent = currentContent.trim();
-            capturing = false;
-            currentContent = '';
-            searchStart = endIdx + closeTag.length;
-          } else {
-            currentContent += chunk.slice(searchStart, -closeTag.length);
-            leftover = chunk.slice(-closeTag.length);
-            break;
-          }
-        }
-      }
-    }
-  } finally {
-    closeSync(fd);
-  }
-
-  return lastContent;
+  return streamInlineReportArtifactsSync(filePath);
 }
 
 export function parseImageScripts(html: string): Record<string, string> {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,11 +1,13 @@
 import {
-  appendFileSync,
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  openSync,
   readdirSync,
   rmSync,
   unlinkSync,
+  writeSync,
 } from 'node:fs';
 import * as path from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
@@ -14,7 +16,7 @@ import { getReportFileName } from './agent';
 import {
   extractLastDumpScriptSync,
   getBaseUrlFixScript,
-  streamImageScriptsToFile,
+  streamInlineReportArtifactsSync,
 } from './dump/html-utils';
 import type { ReportFileWithAttributes } from './types';
 import { getReportTpl, reportHTMLContent } from './utils';
@@ -84,21 +86,22 @@ export class ReportMergingTool {
       }
     }
 
-    if (hasDirectoryModeReport) {
-      mkdirSync(path.dirname(outputFilePath), { recursive: true });
-    }
-
     logMsg(
       `Start merging ${this.reportInfos.length} reports...\nCreating template file...`,
     );
 
+    let outputFd: number | null = null;
+
     try {
+      mkdirSync(path.dirname(outputFilePath), { recursive: true });
+      outputFd = openSync(outputFilePath, 'w');
+
       // Write template
-      appendFileSync(outputFilePath, getReportTpl());
+      writeSync(outputFd, getReportTpl());
 
       // For directory-mode output, inject base URL fix script
       if (hasDirectoryModeReport) {
-        appendFileSync(outputFilePath, getBaseUrlFixScript());
+        writeSync(outputFd, getBaseUrlFixScript());
       }
 
       // Process all reports one by one
@@ -106,6 +109,7 @@ export class ReportMergingTool {
         const reportInfo = this.reportInfos[i];
         logMsg(`Processing report ${i + 1}/${this.reportInfos.length}`);
 
+        let dumpString = '';
         if (this.isDirectoryModeReport(reportInfo.reportFilePath)) {
           // Directory mode: copy external screenshot files
           const reportDir = path.dirname(reportInfo.reportFilePath);
@@ -120,12 +124,17 @@ export class ReportMergingTool {
             const dest = path.join(mergedScreenshotsDir, file);
             copyFileSync(src, dest);
           }
+          dumpString = extractLastDumpScriptSync(reportInfo.reportFilePath);
         } else {
-          // Inline mode: stream image scripts to output file
-          streamImageScriptsToFile(reportInfo.reportFilePath, outputFilePath);
+          // Inline mode: copy image scripts and extract dump in a single scan
+          dumpString = streamInlineReportArtifactsSync(
+            reportInfo.reportFilePath,
+            (imageScriptTag) => {
+              writeSync(outputFd!, imageScriptTag);
+            },
+          );
         }
 
-        const dumpString = extractLastDumpScriptSync(reportInfo.reportFilePath);
         const { reportAttributes } = reportInfo;
 
         const reportHtmlStr = `${reportHTMLContent(
@@ -144,7 +153,7 @@ export class ReportMergingTool {
           false,
         )}\n`;
 
-        appendFileSync(outputFilePath, reportHtmlStr);
+        writeSync(outputFd!, reportHtmlStr);
       }
 
       logMsg(`Successfully merged new report: ${outputFilePath}`);
@@ -170,6 +179,10 @@ export class ReportMergingTool {
     } catch (error) {
       logMsg(`Error in mergeReports: ${error}`);
       throw error;
+    } finally {
+      if (outputFd !== null) {
+        closeSync(outputFd);
+      }
     }
   }
 }

--- a/packages/core/tests/unit-test/report-merge-performance.test.ts
+++ b/packages/core/tests/unit-test/report-merge-performance.test.ts
@@ -1,0 +1,109 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('report merge performance regression', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `midscene-report-merge-perf-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.doUnmock('node:fs');
+    vi.resetModules();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should scan each inline report only once while merging', async () => {
+    const openSyncCalls = vi.fn();
+
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+
+      return {
+        ...actual,
+        openSync: vi.fn((...args: Parameters<typeof actual.openSync>) => {
+          openSyncCalls(...args);
+          return actual.openSync(...args);
+        }),
+      };
+    });
+
+    const { ReportMergingTool } = await import('../../src/report');
+    const { generateDumpScriptTag, generateImageScriptTag } = await import(
+      '../../src/dump/html-utils'
+    );
+
+    const tool = new ReportMergingTool();
+    const reportPaths: string[] = [];
+    const reportsToMerge = 2;
+    const imagesPerReport = 30;
+
+    for (let reportIndex = 0; reportIndex < reportsToMerge; reportIndex++) {
+      const reportPath = join(tmpDir, `inline-report-${reportIndex}.html`);
+      const imageScripts = Array.from(
+        { length: imagesPerReport },
+        (_, imageIndex) =>
+          generateImageScriptTag(
+            `img-${reportIndex}-${imageIndex}`,
+            `data:image/png;base64,${'A'.repeat(8 * 1024)}`,
+          ),
+      ).join('\n');
+      const dumpScript = generateDumpScriptTag(
+        JSON.stringify({
+          groupName: `group-${reportIndex}`,
+          executions: [],
+        }),
+      );
+
+      writeFileSync(
+        reportPath,
+        `<!doctype html>\n${imageScripts}\n${dumpScript}`,
+      );
+      reportPaths.push(reportPath);
+
+      tool.append({
+        reportFilePath: reportPath,
+        reportAttributes: {
+          testDescription: `desc-${reportIndex}`,
+          testDuration: 1000,
+          testId: `id-${reportIndex}`,
+          testStatus: 'passed',
+          testTitle: `title-${reportIndex}`,
+        },
+      });
+    }
+
+    const mergedPath = tool.mergeReports('inline-report-single-pass-scan', {
+      overwrite: true,
+    });
+
+    expect(existsSync(mergedPath!)).toBe(true);
+
+    const mergedContent = readFileSync(mergedPath!, 'utf-8');
+    expect(mergedContent).toContain('data-id="img-0-0"');
+    expect(mergedContent).toContain('data-id="img-1-29"');
+    expect(mergedContent).toContain('playwright_test_title="title-0"');
+    expect(mergedContent).toContain('playwright_test_title="title-1"');
+
+    const openCountsBySource = new Map(
+      reportPaths.map((reportPath) => [
+        reportPath,
+        openSyncCalls.mock.calls.filter(([filePath]) => filePath === reportPath)
+          .length,
+      ]),
+    );
+
+    expect(openCountsBySource.get(reportPaths[0])).toBe(1);
+    expect(openCountsBySource.get(reportPaths[1])).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- merge inline report image scripts and dump extraction in a single streaming pass
- keep one output file descriptor open during merge to avoid repeated destination reopen overhead
- add a regression test that verifies each inline source report is scanned only once

## Problem
Merging many large inline HTML reports became noticeably slower after the first several files because each source report was scanned twice and every copied image script reopened the merged output file.

## Validation
- `pnpm run lint`
- `npx nx build @midscene/core`
- `pnpm --dir packages/core exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir packages/core exec vitest run tests/unit-test/report-merge-performance.test.ts`
- `pnpm --dir packages/core exec vitest run tests/unit-test/merge-browser-parse.test.ts -t "step 2: verify merged report preserves directory mode with screenshots"`
- `pnpm --dir packages/core exec vitest run tests/unit-test/report.test.ts -t "should merge 3 mocked reports|should merge directory mode reports and copy screenshots"`
- `pnpm --dir packages/core exec vitest run tests/unit-test/report.test.ts -t "should use constant memory when merging reports with large inline images"`

## Notes
This change is intended to be safe for a prepatch release if you want to cut one after review.
