### PR TITLE
docs(core): update GitHub stars count from 11k to 12k in banner

### DIFF
--- a/apps/site/theme/components/Banner.tsx
+++ b/apps/site/theme/components/Banner.tsx
@@ -44,7 +44,7 @@ export function Banner() {
           <div className="mt-8 md:mt-12 flex flex-row gap-x-8 md:gap-x-16">
             <div className="flex flex-col gap-1 md:gap-1.5">
               <div className="font-sans text-[28px] md:text-[40px] font-semibold leading-[32px] md:leading-[48px] tracking-[-1px] md:tracking-[-1.6px] text-black dark:text-white">
-                11k+
+                12k+
               </div>
               <div className="font-sans text-sm md:text-base font-normal leading-5 md:leading-6 text-black/50 dark:text-white/50">
                 {t('githubStars')}


### PR DESCRIPTION
## Summary
Updates the GitHub stars milestone displayed in the site banner from 11k to 12k.

## Changes
- Updated the GitHub stars count in the Banner component from `11k+` to `12k+`

## Details
This is a simple content update to reflect the project's growing GitHub community. The change updates the static text displayed in the banner's statistics section without any functional or styling modifications.

https://claude.ai/code/session_01GP1CDmSHFNx6sDvvkhP8bH