### PR TITLE
fix(harmony): support render resolution screen info parsing

### DIFF
--- a/packages/harmony/src/hdc.ts
+++ b/packages/harmony/src/hdc.ts
@@ -257,6 +257,8 @@ export class HdcClient {
 
   async getScreenInfo(): Promise<{ width: number; height: number }> {
     const stdout = await this.shell('hidumper -s RenderService -a screen');
+    const renderDimensionPattern =
+      'render\\s+(?:size|resolution)\\s*[:=]\\s*(\\d{3,5})x(\\d{3,5})';
 
     // For foldable screens, find which screen is currently powered on
     // via the foldScreenId section, then match its render size.
@@ -266,7 +268,7 @@ export class HdcClient {
     if (activeFoldMatch) {
       const activeId = activeFoldMatch[1];
       const screenRegex = new RegExp(
-        `screen\\[\\d+\\]:\\s*id=${activeId},.*?render size:\\s*(\\d{3,5})x(\\d{3,5})`,
+        `screen\\[\\d+\\]:\\s*id=${activeId},.*?${renderDimensionPattern}`,
       );
       const screenMatch = stdout.match(screenRegex);
       if (screenMatch) {
@@ -280,8 +282,8 @@ export class HdcClient {
       }
     }
 
-    // Non-foldable: use the first render size like "1260x2720"
-    const renderSizeMatch = stdout.match(/render size:\s*(\d{3,5})x(\d{3,5})/);
+    // Non-foldable: use the first render size/resolution like "1260x2720"
+    const renderSizeMatch = stdout.match(new RegExp(renderDimensionPattern));
     if (renderSizeMatch) {
       return {
         width: Number.parseInt(renderSizeMatch[1], 10),

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -147,6 +147,25 @@ describe('HdcClient', () => {
       expect(info).toEqual({ width: 1260, height: 2720 });
     });
 
+    it('should parse screen size from RenderService output with render resolution', async () => {
+      mockExecFile.mockResolvedValue({
+        stdout: `-------------------------------[ability]-------------------------------
+
+
+----------------------------------RenderService----------------------------------
+-- ScreenInfo
+screen[0]: id=0, powerStatus=POWER_STATUS_ON, backlight=11313, screenType=EXTERNAL_TYPE, render resolution=1216x2688, physical resolution=1216x2688, isVirtual=false, skipFrameInterval=1, expectedRefreshRate=-1, skipFrameStrategy=0
+supportedMode[0]: 1216x2688, refreshRate=120
+activeMode: 1216x2688, refreshRate=60`,
+        stderr: '',
+      });
+
+      const hdc = new HdcClient({});
+      const info = await hdc.getScreenInfo();
+
+      expect(info).toEqual({ width: 1216, height: 2688 });
+    });
+
     it('should throw if screen size cannot be parsed', async () => {
       mockExecFile.mockResolvedValue({
         stdout: 'no size info here',


### PR DESCRIPTION
## Summary
- support Harmony screen-size parsing when RenderService reports `render resolution=` instead of only `render size:`
- keep the existing foldable-screen parsing path aligned with the same pattern
- add a unit test covering the newer RenderService output format

## Validation
- pnpm run lint
- npx nx test @midscene/harmony
- npx nx build @midscene/harmony