### PR TITLE
feat(core): remove onExecutionDumpUpdate hook from Agent

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -335,20 +335,6 @@ export class Agent<
             runner,
           );
 
-          if (this.opts.onExecutionDumpUpdate) {
-            try {
-              await this.opts.onExecutionDumpUpdate(
-                this.dump.executions[executionIndex],
-                {
-                  executionIndex,
-                  groupedDump: this.dump,
-                },
-              );
-            } catch (error) {
-              console.error('Error in onExecutionDumpUpdate hook', error);
-            }
-          }
-
           // Call all registered dump update listeners
           const dumpString = this.dumpDataString();
           for (const listener of this.dumpUpdateListeners) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1235,19 +1235,6 @@ export interface AgentOpt {
    * ```
    */
   createOpenAIClient?: CreateOpenAIClientFn;
-
-  /**
-   * Persist the latest snapshot of an execution whenever it updates.
-   * This is primarily used by stateless CLI flows that need to stitch
-   * together executions across separate processes.
-   */
-  onExecutionDumpUpdate?: (
-    execution: ExecutionDump,
-    metadata: {
-      executionIndex: number;
-      groupedDump: GroupedActionDump;
-    },
-  ) => Promise<void> | void;
 }
 
 export type TestStatus =


### PR DESCRIPTION
## Summary
This PR removes the `onExecutionDumpUpdate` callback hook from the Agent class and its type definition. The hook was used to persist execution snapshots during updates, primarily for stateless CLI flows that needed to stitch together executions across separate processes.

## Changes
- Removed the `onExecutionDumpUpdate` callback invocation from the Agent's execution update logic in `agent.ts`
- Removed the `onExecutionDumpUpdate` option definition from the `AgentOpt` interface in `types.ts`
- The dump update listener system remains in place as the replacement mechanism for tracking execution changes

## Notes
The removal of this hook suggests a shift away from the callback-based approach for persisting execution dumps. The existing `dumpUpdateListeners` system continues to provide dump update notifications for consumers that need to track execution state changes.

https://claude.ai/code/session_01JaRzHvgrSXYDL7oeJRhaJp