### PR TITLE
chore(core): rename session-related APIs to execution-related terminology

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -52,7 +52,7 @@ import {
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { AbstractInterface } from '@/device';
-import { exportSessionReport } from '@/execution-report';
+import { exportExecutionReport } from '@/execution-report';
 import { ExecutionStore } from '@/execution-store';
 import type { TaskRunner } from '@/task-runner';
 import {
@@ -214,9 +214,9 @@ export class Agent<
    */
   private hasWarnedNonVLModel = false;
 
-  private executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
+  private executionDumpIndexByRunnerId = new Map<number, number>();
 
-  private sessionExecutionOrders: number[] = [];
+  private executionOrders: number[] = [];
 
   private fullActionSpace: DeviceAction[];
 
@@ -360,7 +360,7 @@ export class Agent<
     // Every agent always has a sessionId - auto-generate from reportFileName if not provided
     this.sessionId = this.opts.sessionId || this.reportFileName!;
 
-    this.syncSessionMetadata();
+    this.syncExecutionMetadata();
   }
 
   async getActionSpace(): Promise<DeviceAction[]> {
@@ -416,14 +416,14 @@ export class Agent<
       modelBriefs: [],
       deviceType: this.interface.interfaceType,
     });
-    this.executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
+    this.executionDumpIndexByRunnerId = new Map<number, number>();
 
     return this.dump;
   }
 
-  private syncSessionMetadata(): void {
-    this.executionStore.ensureSession({
-      sessionId: this.sessionId,
+  private syncExecutionMetadata(): void {
+    this.executionStore.ensureExecution({
+      executionId: this.sessionId,
       platform: this.interface.interfaceType,
       groupName: this.opts.groupName,
       groupDescription: this.opts.groupDescription,
@@ -433,14 +433,14 @@ export class Agent<
     });
   }
 
-  private persistSessionDump(
+  private persistExecutionDump(
     execution: ExecutionDump,
     executionIndex: number,
   ): void {
-    let order = this.sessionExecutionOrders[executionIndex];
+    let order = this.executionOrders[executionIndex];
     if (order === undefined) {
       order = this.executionStore.appendExecution(this.sessionId, execution);
-      this.sessionExecutionOrders[executionIndex] = order;
+      this.executionOrders[executionIndex] = order;
       return;
     }
 
@@ -451,24 +451,23 @@ export class Agent<
     const currentDump = this.dump;
     let executionIndex: number;
     if (runner) {
-      const existingIndex = this.executionDumpIndexByRunner.get(runner);
+      const existingIndex = this.executionDumpIndexByRunnerId.get(
+        runner.runnerId,
+      );
       if (existingIndex !== undefined) {
         currentDump.executions[existingIndex] = execution;
         executionIndex = existingIndex;
       } else {
         currentDump.executions.push(execution);
-        this.executionDumpIndexByRunner.set(
-          runner,
-          currentDump.executions.length - 1,
-        );
         executionIndex = currentDump.executions.length - 1;
+        this.executionDumpIndexByRunnerId.set(runner.runnerId, executionIndex);
       }
     } else {
       currentDump.executions.push(execution);
       executionIndex = currentDump.executions.length - 1;
     }
 
-    this.persistSessionDump(
+    this.persistExecutionDump(
       currentDump.executions[executionIndex],
       executionIndex,
     );
@@ -492,8 +491,8 @@ export class Agent<
   }
 
   writeOutActionDumps() {
-    // No-op: persistence is handled by ExecutionStore in persistSessionDump().
-    // Report is generated at destroy() time via exportSessionReport().
+    // No-op: persistence is handled by ExecutionStore in persistExecutionDump().
+    // Report is generated at destroy() time via exportExecutionReport().
   }
 
   private async callbackOnTaskStartTip(task: ExecutionTask) {
@@ -1301,15 +1300,15 @@ export class Agent<
       return;
     }
 
-    // Generate final report from session data
+    // Generate final report from execution data
     if (this.opts.generateReport !== false) {
       try {
-        this.reportFile = exportSessionReport(
+        this.reportFile = exportExecutionReport(
           this.sessionId,
           this.executionStore,
         );
       } catch (error) {
-        debug('Failed to generate session report:', error);
+        debug('Failed to generate execution report:', error);
       }
     }
 
@@ -1360,7 +1359,7 @@ export class Agent<
       description: opt?.content || '',
       tasks: [task],
     });
-    // 5. append to execution dump (also persists to session)
+    // 5. append to execution dump (also persists to execution store)
     this.appendExecutionDump(executionDump);
 
     // Call all registered dump update listeners

--- a/packages/core/src/execution-report.ts
+++ b/packages/core/src/execution-report.ts
@@ -7,15 +7,15 @@ import { logMsg } from '@midscene/shared/utils';
 import { ExecutionStore } from './execution-store';
 import { reportHTMLContent } from './utils';
 
-export function exportSessionReport(
-  sessionId: string,
+export function exportExecutionReport(
+  executionId: string,
   store: ExecutionStore = new ExecutionStore(),
 ): string {
-  const dump = store.buildGroupedDump(sessionId);
-  const reportPath = join(store.reportDir(sessionId), 'index.html');
+  const dump = store.buildGroupedDump(executionId);
+  const reportPath = join(store.reportDir(executionId), 'index.html');
 
   reportHTMLContent(JSON.stringify(dump), reportPath, false);
-  store.markReportGenerated(sessionId, reportPath);
+  store.markReportGenerated(executionId, reportPath);
 
   if (!globalConfigManager.getEnvConfigInBoolean(MIDSCENE_REPORT_QUIET)) {
     logMsg(`Midscene - report generated: ${reportPath}`);

--- a/packages/core/src/execution-store.ts
+++ b/packages/core/src/execution-store.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
-import type { AgentOpt, IExecutionDump, IGroupedActionDump } from './types';
+import type { IExecutionDump, IGroupedActionDump } from './types';
 import { ExecutionDump } from './types';
 
 const lockRetryDelayMs = 20;
@@ -18,8 +18,8 @@ const lockTimeoutMs = 30_000;
 const lockStaleMs = 5 * 60_000;
 const lockSleepArray = new Int32Array(new SharedArrayBuffer(4));
 
-export interface SessionRecord {
-  sessionId: string;
+export interface ExecutionRecord {
+  executionId: string;
   platform: string;
   groupName: string;
   groupDescription?: string;
@@ -32,8 +32,8 @@ export interface SessionRecord {
   reportFilePath?: string;
 }
 
-export interface EnsureSessionRecordInput {
-  sessionId: string;
+export interface EnsureExecutionRecordInput {
+  executionId: string;
   platform: string;
   groupName?: string;
   groupDescription?: string;
@@ -42,30 +42,29 @@ export interface EnsureSessionRecordInput {
   deviceType?: string;
 }
 
-function defaultGroupName(platform: string, sessionId: string): string {
-  return `Midscene ${platform} session ${sessionId}`;
+function defaultGroupName(platform: string, executionId: string): string {
+  return `Midscene ${platform} execution ${executionId}`;
 }
 
-function normalizeSessionRecord(
-  session: Partial<SessionRecord> & {
-    sessionId: string;
+function normalizeExecutionRecord(
+  record: Partial<ExecutionRecord> & {
+    executionId: string;
     platform: string;
   },
-): SessionRecord {
+): ExecutionRecord {
   return {
-    sessionId: session.sessionId,
-    platform: session.platform,
+    executionId: record.executionId,
+    platform: record.platform,
     groupName:
-      session.groupName ??
-      defaultGroupName(session.platform, session.sessionId),
-    groupDescription: session.groupDescription,
-    sdkVersion: session.sdkVersion ?? '',
-    modelBriefs: session.modelBriefs ?? [],
-    deviceType: session.deviceType ?? session.platform,
-    createdAt: session.createdAt ?? Date.now(),
-    updatedAt: session.updatedAt ?? Date.now(),
-    executionCount: session.executionCount ?? 0,
-    reportFilePath: session.reportFilePath,
+      record.groupName ?? defaultGroupName(record.platform, record.executionId),
+    groupDescription: record.groupDescription,
+    sdkVersion: record.sdkVersion ?? '',
+    modelBriefs: record.modelBriefs ?? [],
+    deviceType: record.deviceType ?? record.platform,
+    createdAt: record.createdAt ?? Date.now(),
+    updatedAt: record.updatedAt ?? Date.now(),
+    executionCount: record.executionCount ?? 0,
+    reportFilePath: record.reportFilePath,
   };
 }
 
@@ -85,24 +84,24 @@ function sleepSync(ms: number): void {
   Atomics.wait(lockSleepArray, 0, 0, ms);
 }
 
-function validateSessionId(sessionId: string): void {
+function validateExecutionId(executionId: string): void {
   if (
-    !sessionId ||
-    /[/\\]/.test(sessionId) ||
-    sessionId === '.' ||
-    sessionId === '..'
+    !executionId ||
+    /[/\\]/.test(executionId) ||
+    executionId === '.' ||
+    executionId === '..'
   ) {
-    throw new Error(`Invalid sessionId: ${sessionId}`);
+    throw new Error(`Invalid executionId: ${executionId}`);
   }
 }
 
-function sessionDirPath(sessionId: string): string {
-  validateSessionId(sessionId);
-  return join(getMidsceneRunSubDir('session'), sessionId);
+function executionDirPath(executionId: string): string {
+  validateExecutionId(executionId);
+  return join(getMidsceneRunSubDir('execution'), executionId);
 }
 
-function sessionLockDir(sessionId: string): string {
-  return join(sessionDirPath(sessionId), '.lock');
+function executionLockDir(executionId: string): string {
+  return join(executionDirPath(executionId), '.lock');
 }
 
 function isAlreadyExistsError(error: unknown): error is NodeJS.ErrnoException {
@@ -114,9 +113,9 @@ function isAlreadyExistsError(error: unknown): error is NodeJS.ErrnoException {
   );
 }
 
-function withLock<T>(sessionId: string, fn: () => T): T {
-  const dir = sessionDirPath(sessionId);
-  const lockDir = sessionLockDir(sessionId);
+function withLock<T>(executionId: string, fn: () => T): T {
+  const dir = executionDirPath(executionId);
+  const lockDir = executionLockDir(executionId);
   const lockDeadline = Date.now() + lockTimeoutMs;
 
   mkdirSync(dir, { recursive: true });
@@ -140,7 +139,7 @@ function withLock<T>(sessionId: string, fn: () => T): T {
       }
 
       if (Date.now() >= lockDeadline) {
-        throw new Error(`Timed out waiting for session lock: ${sessionId}`);
+        throw new Error(`Timed out waiting for execution lock: ${executionId}`);
       }
 
       sleepSync(lockRetryDelayMs);
@@ -161,70 +160,70 @@ function writeTextFileAtomic(filePath: string, content: string): void {
 }
 
 /**
- * Persists agent execution dumps to the filesystem, grouped by session ID.
+ * Persists agent execution dumps to the filesystem, grouped by execution ID.
  * Each agent should own its own instance.
  */
 export class ExecutionStore {
   rootDir(): string {
-    return getMidsceneRunSubDir('session');
+    return getMidsceneRunSubDir('execution');
   }
 
-  sessionDir(sessionId: string): string {
-    return sessionDirPath(sessionId);
+  executionDir(executionId: string): string {
+    return executionDirPath(executionId);
   }
 
-  agentFilePath(sessionId: string): string {
-    return join(this.sessionDir(sessionId), 'agent.json');
+  agentFilePath(executionId: string): string {
+    return join(this.executionDir(executionId), 'agent.json');
   }
 
-  executionBasePath(sessionId: string, order: number): string {
-    return join(this.sessionDir(sessionId), `${order}.json`);
+  executionBasePath(executionId: string, order: number): string {
+    return join(this.executionDir(executionId), `${order}.json`);
   }
 
-  reportDir(sessionId: string): string {
-    const dir = join(this.sessionDir(sessionId), 'report');
+  reportDir(executionId: string): string {
+    const dir = join(this.executionDir(executionId), 'report');
     mkdirSync(dir, { recursive: true });
     return dir;
   }
 
-  load(sessionId: string): SessionRecord {
-    const filePath = this.agentFilePath(sessionId);
+  load(executionId: string): ExecutionRecord {
+    const filePath = this.agentFilePath(executionId);
 
     if (!existsSync(filePath)) {
-      throw new Error(`Session not found: ${sessionId}`);
+      throw new Error(`Execution not found: ${executionId}`);
     }
 
-    return normalizeSessionRecord(
-      JSON.parse(readFileSync(filePath, 'utf-8')) as SessionRecord,
+    return normalizeExecutionRecord(
+      JSON.parse(readFileSync(filePath, 'utf-8')) as ExecutionRecord,
     );
   }
 
-  save(session: SessionRecord): SessionRecord {
-    mkdirSync(this.sessionDir(session.sessionId), { recursive: true });
-    const normalized = normalizeSessionRecord(session);
+  save(record: ExecutionRecord): ExecutionRecord {
+    mkdirSync(this.executionDir(record.executionId), { recursive: true });
+    const normalized = normalizeExecutionRecord(record);
     writeTextFileAtomic(
-      this.agentFilePath(normalized.sessionId),
+      this.agentFilePath(normalized.executionId),
       JSON.stringify(normalized, null, 2),
     );
     return normalized;
   }
 
-  ensureSession(input: EnsureSessionRecordInput): SessionRecord {
-    return withLock(input.sessionId, () => {
+  ensureExecution(input: EnsureExecutionRecordInput): ExecutionRecord {
+    return withLock(input.executionId, () => {
       const now = Date.now();
-      const filePath = this.agentFilePath(input.sessionId);
+      const filePath = this.agentFilePath(input.executionId);
 
       if (existsSync(filePath)) {
-        const existing = this.load(input.sessionId);
+        const existing = this.load(input.executionId);
         const mergedModelBriefs = new Set(existing.modelBriefs);
         input.modelBriefs?.forEach((brief) => mergedModelBriefs.add(brief));
-        const next: SessionRecord = {
+        const next: ExecutionRecord = {
           ...existing,
           platform: input.platform ?? existing.platform,
           groupName:
             input.groupName ??
             existing.groupName ??
-            defaultGroupName(input.platform, input.sessionId),
+            defaultGroupName(input.platform, input.executionId),
           groupDescription: input.groupDescription ?? existing.groupDescription,
           sdkVersion: input.sdkVersion ?? existing.sdkVersion,
           modelBriefs: [...mergedModelBriefs],
@@ -236,10 +235,11 @@ export class ExecutionStore {
       }
 
       return this.save({
-        sessionId: input.sessionId,
+        executionId: input.executionId,
         platform: input.platform,
         groupName:
-          input.groupName ?? defaultGroupName(input.platform, input.sessionId),
+          input.groupName ??
+          defaultGroupName(input.platform, input.executionId),
         groupDescription: input.groupDescription,
         sdkVersion: input.sdkVersion ?? '',
         modelBriefs: input.modelBriefs ?? [],
@@ -252,29 +252,29 @@ export class ExecutionStore {
   }
 
   markReportGenerated(
-    sessionId: string,
+    executionId: string,
     reportFilePath: string,
-  ): SessionRecord {
-    return withLock(sessionId, () => {
-      const session = this.load(sessionId);
+  ): ExecutionRecord {
+    return withLock(executionId, () => {
+      const record = this.load(executionId);
       return this.save({
-        ...session,
+        ...record,
         reportFilePath,
         updatedAt: Date.now(),
       });
     });
   }
 
-  appendExecution(sessionId: string, execution: ExecutionDump): number {
-    return withLock(sessionId, () => {
-      const session = this.load(sessionId);
-      const order = session.executionCount + 1;
-      const basePath = this.executionBasePath(sessionId, order);
+  appendExecution(executionId: string, execution: ExecutionDump): number {
+    return withLock(executionId, () => {
+      const record = this.load(executionId);
+      const order = record.executionCount + 1;
+      const basePath = this.executionBasePath(executionId, order);
 
       ExecutionDump.cleanupFiles(basePath);
       execution.serializeToFiles(basePath);
       this.save({
-        ...session,
+        ...record,
         executionCount: order,
         updatedAt: Date.now(),
       });
@@ -284,68 +284,50 @@ export class ExecutionStore {
   }
 
   updateExecution(
-    sessionId: string,
+    executionId: string,
     order: number,
     execution: ExecutionDump,
   ): void {
-    withLock(sessionId, () => {
-      const session = this.load(sessionId);
-      const basePath = this.executionBasePath(sessionId, order);
+    withLock(executionId, () => {
+      const record = this.load(executionId);
+      const basePath = this.executionBasePath(executionId, order);
 
       ExecutionDump.cleanupFiles(basePath);
       execution.serializeToFiles(basePath);
       this.save({
-        ...session,
-        executionCount: Math.max(session.executionCount, order),
+        ...record,
+        executionCount: Math.max(record.executionCount, order),
         updatedAt: Date.now(),
       });
     });
   }
 
-  buildGroupedDump(sessionId: string): IGroupedActionDump {
-    return withLock(sessionId, () => {
-      const session = this.load(sessionId);
+  buildGroupedDump(executionId: string): IGroupedActionDump {
+    return withLock(executionId, () => {
+      const record = this.load(executionId);
       const rootExecutionFiles = orderedRootExecutionFiles(
-        this.sessionDir(sessionId),
+        this.executionDir(executionId),
       );
 
       if (!rootExecutionFiles.length) {
-        throw new Error(`Session ${sessionId} has no persisted executions`);
+        throw new Error(`Execution ${executionId} has no persisted executions`);
       }
 
       const executions: IExecutionDump[] = [];
       for (const fileName of rootExecutionFiles) {
-        const basePath = join(this.sessionDir(sessionId), fileName);
+        const basePath = join(this.executionDir(executionId), fileName);
         const inlineJson = ExecutionDump.fromFilesAsInlineJson(basePath);
         executions.push(JSON.parse(inlineJson) as IExecutionDump);
       }
 
       return {
-        sdkVersion: session.sdkVersion,
-        groupName: session.groupName,
-        groupDescription: session.groupDescription,
-        modelBriefs: session.modelBriefs,
+        sdkVersion: record.sdkVersion,
+        groupName: record.groupName,
+        groupDescription: record.groupDescription,
+        modelBriefs: record.modelBriefs,
         executions,
-        deviceType: session.deviceType ?? session.platform,
+        deviceType: record.deviceType ?? record.platform,
       };
     });
   }
-}
-
-export function createSessionAgentOptions(input: {
-  sessionId?: string;
-  platform: string;
-  groupName?: string;
-  groupDescription?: string;
-}): Partial<AgentOpt> {
-  if (!input.sessionId) {
-    return {};
-  }
-
-  return {
-    sessionId: input.sessionId,
-    groupName:
-      input.groupName ?? defaultGroupName(input.platform, input.sessionId),
-    groupDescription: input.groupDescription,
-  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,10 +66,10 @@ export {
 // Execution persistence & report
 export { ExecutionStore } from './execution-store';
 export type {
-  SessionRecord,
-  EnsureSessionRecordInput,
+  ExecutionRecord,
+  EnsureExecutionRecordInput,
 } from './execution-store';
-export { exportSessionReport } from './execution-report';
+export { exportExecutionReport } from './execution-report';
 
 // ScreenshotItem
 export { ScreenshotItem } from './screenshot-item';

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -31,7 +31,15 @@ type TaskRunnerOperationOptions = {
   allowWhenError?: boolean;
 };
 
+let nextRunnerId = 1;
+
 export class TaskRunner {
+  /**
+   * Auto-increment id unique to each TaskRunner instance within the process.
+   * Used by Agent to track execution dump indices without WeakMap lookups.
+   */
+  readonly runnerId: number;
+
   name: string;
 
   tasks: ExecutionTask[];
@@ -52,6 +60,7 @@ export class TaskRunner {
     uiContextBuilder: () => Promise<UIContext>,
     options?: TaskRunnerInitOptions,
   ) {
+    this.runnerId = nextRunnerId++;
     this.status =
       options?.tasks && options.tasks.length > 0 ? 'pending' : 'init';
     this.name = name;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1133,7 +1133,7 @@ export interface AgentOpt {
   // @deprecated
   cacheId?: string; // Keep backward compatibility, but marked as deprecated
   /**
-   * Persistent session ID used to stitch together executions across
+   * Persistent execution ID used to stitch together executions across
    * separate Agent instances and CLI processes.
    */
   sessionId?: string;

--- a/packages/core/tests/unit-test/session-report.test.ts
+++ b/packages/core/tests/unit-test/session-report.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { Agent } from '@/agent/agent';
 import type { AbstractInterface } from '@/device';
 import { parseDumpScript } from '@/dump/html-utils';
-import { exportSessionReport } from '@/execution-report';
+import { exportExecutionReport } from '@/execution-report';
 import { ExecutionStore } from '@/execution-store';
 import { ScreenshotItem } from '@/screenshot-item';
 import {
@@ -63,12 +63,12 @@ function createMockInterface(): AbstractInterface {
   } as unknown as AbstractInterface;
 }
 
-describe('ExecutionStore + exportSessionReport', () => {
+describe('ExecutionStore + exportExecutionReport', () => {
   let runDir: string;
   let store: ExecutionStore;
 
   beforeEach(() => {
-    runDir = join(tmpdir(), `midscene-session-test-${Date.now()}`);
+    runDir = join(tmpdir(), `midscene-execution-test-${Date.now()}`);
     vi.stubEnv(MIDSCENE_RUN_DIR, runDir);
     store = new ExecutionStore();
   });
@@ -79,19 +79,19 @@ describe('ExecutionStore + exportSessionReport', () => {
   });
 
   it('overwrites the same order slot without growing execution count', () => {
-    const sessionId = 'session-upsert';
+    const executionId = 'execution-upsert';
 
-    store.ensureSession({
-      sessionId,
+    store.ensureExecution({
+      executionId,
       platform: 'web',
-      groupName: 'Session Upsert',
+      groupName: 'Execution Upsert',
       sdkVersion: '1.0.0-test',
       modelBriefs: ['planner/model-a'],
       deviceType: 'web',
     });
 
     const order = store.appendExecution(
-      sessionId,
+      executionId,
       createExecutionDump({
         executionName: 'first-version',
         prompt: 'first prompt',
@@ -100,7 +100,7 @@ describe('ExecutionStore + exportSessionReport', () => {
 
     // Overwrite same order slot with updated execution
     store.updateExecution(
-      sessionId,
+      executionId,
       order,
       createExecutionDump({
         executionName: 'updated-version',
@@ -108,38 +108,38 @@ describe('ExecutionStore + exportSessionReport', () => {
       }),
     );
 
-    const session = store.load(sessionId);
-    const dump = store.buildGroupedDump(sessionId);
+    const record = store.load(executionId);
+    const dump = store.buildGroupedDump(executionId);
 
-    expect(session.executionCount).toBe(1);
+    expect(record.executionCount).toBe(1);
     expect(dump.executions).toHaveLength(1);
     expect(dump.executions[0].name).toBe('updated-version');
   });
 
   it('persists agent metadata when Agent is created with sessionId', () => {
-    const sessionId = 'agent-constructor-session';
+    const sessionId = 'agent-constructor-execution';
     new Agent(createMockInterface(), {
       sessionId,
       generateReport: false,
       modelConfig: mockedModelConfig,
     });
 
-    const persistedSession = store.load(sessionId);
+    const persistedRecord = store.load(sessionId);
 
-    expect(existsSync(join(runDir, 'session', sessionId, 'agent.json'))).toBe(
+    expect(existsSync(join(runDir, 'execution', sessionId, 'agent.json'))).toBe(
       true,
     );
-    expect(persistedSession.groupName).toBe('Midscene Report');
-    expect(persistedSession.platform).toBe('puppeteer');
+    expect(persistedRecord.groupName).toBe('Midscene Report');
+    expect(persistedRecord.platform).toBe('puppeteer');
   });
 
-  it('exports a merged report from persisted session shards', () => {
-    const sessionId = 'session-export';
+  it('exports a merged report from persisted execution shards', () => {
+    const executionId = 'execution-export';
 
-    store.ensureSession({
-      sessionId,
+    store.ensureExecution({
+      executionId,
       platform: 'web',
-      groupName: 'Merged Session',
+      groupName: 'Merged Execution',
       groupDescription: 'export test',
       sdkVersion: '1.0.0-test',
       modelBriefs: ['planner/model-a', 'action/model-b'],
@@ -147,7 +147,7 @@ describe('ExecutionStore + exportSessionReport', () => {
     });
 
     store.appendExecution(
-      sessionId,
+      executionId,
       createExecutionDump({
         executionName: 'first execution',
         prompt: 'open page',
@@ -155,18 +155,18 @@ describe('ExecutionStore + exportSessionReport', () => {
     );
 
     store.appendExecution(
-      sessionId,
+      executionId,
       createExecutionDump({
         executionName: 'second execution',
         prompt: 'click button',
       }),
     );
 
-    const reportPath = exportSessionReport(sessionId, store);
+    const reportPath = exportExecutionReport(executionId, store);
     const html = readFileSync(reportPath, 'utf-8');
     const dump = JSON.parse(parseDumpScript(html)) as IGroupedActionDump;
 
-    expect(dump.groupName).toBe('Merged Session');
+    expect(dump.groupName).toBe('Merged Execution');
     expect(dump.executions).toHaveLength(2);
     expect(dump.modelBriefs).toEqual(
       expect.arrayContaining(['planner/model-a', 'action/model-b']),
@@ -178,11 +178,15 @@ describe('ExecutionStore + exportSessionReport', () => {
         }
       ).screenshot?.base64,
     ).toContain('data:image/png;base64,');
-    expect(store.load(sessionId).reportFilePath).toBe(reportPath);
-    expect(existsSync(join(runDir, 'session', sessionId, 'agent.json'))).toBe(
+    expect(store.load(executionId).reportFilePath).toBe(reportPath);
+    expect(
+      existsSync(join(runDir, 'execution', executionId, 'agent.json')),
+    ).toBe(true);
+    expect(existsSync(join(runDir, 'execution', executionId, '1.json'))).toBe(
       true,
     );
-    expect(existsSync(join(runDir, 'session', sessionId, '1.json'))).toBe(true);
-    expect(existsSync(join(runDir, 'session', sessionId, '2.json'))).toBe(true);
+    expect(existsSync(join(runDir, 'execution', executionId, '2.json'))).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use "execution" terminology instead of "session" for persistence and reporting APIs. This change improves semantic clarity by distinguishing between execution tracking (what the code does) and session management (a higher-level concept).

## Key Changes

- **Interface Renames:**
  - `SessionRecord` → `ExecutionRecord`
  - `EnsureSessionRecordInput` → `EnsureExecutionRecordInput`
  - `exportSessionReport()` → `exportExecutionReport()`

- **ExecutionStore Method Renames:**
  - `sessionDir()` → `executionDir()`
  - `ensureSession()` → `ensureExecution()`
  - Internal helper functions updated: `sessionDirPath()` → `executionDirPath()`, `sessionLockDir()` → `executionLockDir()`, `validateSessionId()` → `validateExecutionId()`

- **Directory Structure:**
  - Storage directory changed from `session/` to `execution/` subdirectory
  - File paths and lock mechanisms updated accordingly

- **Agent Class Improvements:**
  - Replaced `WeakMap<TaskRunner, number>` with `Map<number, number>` for tracking execution dump indices
  - Added `runnerId` field to `TaskRunner` class for stable identification without WeakMap lookups
  - Renamed internal methods: `syncSessionMetadata()` → `syncExecutionMetadata()`, `persistSessionDump()` → `persistExecutionDump()`
  - Updated internal state tracking: `sessionExecutionOrders` → `executionOrders`, `executionDumpIndexByRunner` → `executionDumpIndexByRunnerId`

- **Removed:**
  - `createSessionAgentOptions()` helper function (no longer needed)

- **Tests & Documentation:**
  - Updated test descriptions and variable names to reflect execution terminology
  - Updated comments and error messages throughout

## Implementation Details

The refactoring maintains backward compatibility at the Agent constructor level (still accepts `sessionId` parameter) while updating all internal persistence APIs. The change from WeakMap to Map with explicit runner IDs improves debuggability and eliminates potential garbage collection timing issues.

https://claude.ai/code/session_01EeJW3hstKoNAwtXKt3gSnF