### PR TITLE
feat(web-integration): add data-group-id to Playwright reporter dump tags

### DIFF
--- a/packages/web-integration/src/playwright/reporter/index.ts
+++ b/packages/web-integration/src/playwright/reporter/index.ts
@@ -192,19 +192,28 @@ class MidsceneReporter implements Reporter {
       }
 
       // Parse the dump string and generate dump script tag
-      let dumpScript = `<script type="midscene_web_dump">\n${escapeScriptTag(testData.dumpString)}\n</script>`;
+      // Build attributes array — always include data-group-id for per-execution model alignment
+      const allAttributes: string[] = [];
 
-      // Add attributes to the dump script if this is merged report
-      if (this.mode === 'merged' && testData.attributes) {
-        const attributesArr = Object.keys(testData.attributes).map((key) => {
-          return `${key}="${encodeURIComponent(testData.attributes![key])}"`;
-        });
-        // Add attributes to the script tag
-        dumpScript = dumpScript.replace(
-          '<script type="midscene_web_dump"',
-          `<script type="midscene_web_dump" ${attributesArr.join(' ')}`,
+      // Add data-group-id for viewer merging support
+      if (testData.attributes?.playwright_test_title) {
+        allAttributes.push(
+          `data-group-id="${encodeURIComponent(testData.attributes.playwright_test_title)}"`,
         );
       }
+
+      // Add playwright attributes for merged report
+      if (this.mode === 'merged' && testData.attributes) {
+        for (const key of Object.keys(testData.attributes)) {
+          allAttributes.push(
+            `${key}="${encodeURIComponent(testData.attributes[key])}"`,
+          );
+        }
+      }
+
+      const attrString =
+        allAttributes.length > 0 ? ` ${allAttributes.join(' ')}` : '';
+      const dumpScript = `<script type="midscene_web_dump"${attrString}>\n${escapeScriptTag(testData.dumpString)}\n</script>`;
 
       // Write or append to file
       if (this.mode === 'merged') {


### PR DESCRIPTION
## Summary

- Add `data-group-id` attribute to dump script tags in `MidsceneReporter`, using the test title as group identifier
- Aligns Playwright reporter output with the per-execution append model from #2153
- The viewer uses `data-group-id` to merge related dump tags into a single logical group

**Depends on:** #2153

## Test plan

- [x] `pnpm run lint` passes
- [ ] Playwright merged report: verify dump tags contain `data-group-id`
- [ ] Playwright separate report: unaffected
- [ ] Multi-browser (multi-project) report: correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)