### PR TITLE
refactor(core): remove deprecated onDumpUpdate from IReportGenerator

### DIFF
--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -33,11 +33,6 @@ export interface IReportGenerator {
   onExecutionUpdate(execution: ExecutionDump, groupMeta: GroupMeta): void;
 
   /**
-   * @deprecated Use onExecutionUpdate instead. Kept for backward compatibility.
-   */
-  onDumpUpdate?(dump: GroupedActionDump): void;
-
-  /**
    * Wait for all queued write operations to complete.
    */
   flush(): Promise<void>;


### PR DESCRIPTION
## Summary

- Remove the deprecated `onDumpUpdate?` optional method from the `IReportGenerator` interface
- All callers now use `onExecutionUpdate` exclusively

**Depends on:** #2153, #2155

## Test plan

- [x] `pnpm run lint` passes
- [x] `vitest report-generator` — 25 tests pass
- [x] `vitest report-merge-count` — 8 tests pass
- [x] `vitest report` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)