### PR TITLE
fix(shared): prevent MCP stdio server from becoming orphan with 100% CPU

### DIFF
--- a/packages/shared/src/mcp/base-server.ts
+++ b/packages/shared/src/mcp/base-server.ts
@@ -165,11 +165,24 @@ export abstract class BaseMCPServer {
       throw new Error(`Failed to initialize MCP stdio transport: ${message}`);
     }
 
+    // Setup signal handlers for graceful shutdown
+    let isShuttingDown = false;
+    const cleanup = () => {
+      if (isShuttingDown) return;
+      isShuttingDown = true;
+      console.error(`${this.config.name} shutting down...`);
+      this.performCleanup().finally(() => process.exit(0));
+    };
+
     // Setup process-level error handlers to prevent crashes
-    process.on('uncaughtException', (error: Error) => {
+    process.on('uncaughtException', (error: Error & { code?: string }) => {
+      // Exit on pipe errors — parent process is gone
+      if (error.code === 'EPIPE' || error.code === 'ERR_STREAM_DESTROYED') {
+        cleanup();
+        return;
+      }
       console.error(`[${this.config.name}] Uncaught Exception:`, error);
       console.error('Stack:', error.stack);
-      // Don't exit - try to recover
     });
 
     process.on('unhandledRejection', (reason: unknown) => {
@@ -177,22 +190,18 @@ export abstract class BaseMCPServer {
       if (reason instanceof Error) {
         console.error('Stack:', reason.stack);
       }
-      // Don't exit - try to recover
     });
 
-    // Setup cleanup handlers
-    process.stdin.on('close', () => {
-      this.performCleanup().finally(() => process.exit(0));
-    });
+    // Exit when stdin closes (parent process gone) or reaches EOF
+    process.stdin.on('close', cleanup);
+    process.stdin.on('end', cleanup);
 
-    // Setup signal handlers for graceful shutdown
-    const cleanup = () => {
-      console.error(`${this.config.name} shutting down...`);
-      this.performCleanup().finally(() => process.exit(0));
-    };
+    // Exit when stdout/stderr pipe breaks (parent process gone)
+    process.stdout.on('error', cleanup);
 
     process.once('SIGINT', cleanup);
     process.once('SIGTERM', cleanup);
+    process.once('SIGHUP', cleanup);
 
     return {
       close: async () => {


### PR DESCRIPTION
## Summary

- Fix MCP stdio server processes becoming orphaned with 100% CPU usage when the MCP client exits unexpectedly
- Add multiple fallback exit triggers (`stdin end`, `stdout error`, `SIGHUP`) and a shutdown guard to ensure clean process termination

## Root cause

When an MCP client (e.g. Claude Code) spawns an MCP server via `npm exec`, the process tree is:

```
MCP Client → npm exec → node mcp-server
```

When the MCP client exits/crashes:

1. `npm exec` (the wrapper) receives EPIPE on its stdout pipe and **crashes without gracefully closing the pipe to the child**
2. The child `node mcp-server` process's `stdin.on('close')` **never fires** because the pipe wasn't cleanly closed
3. The MCP server continues running, and its periodic stdout writes (MCP protocol) each throw EPIPE
4. `uncaughtException` handler catches every EPIPE with `"Don't exit - try to recover"` → **infinite busy loop at 100% CPU**
5. The process becomes an orphan (PPID=1) and runs indefinitely

## Reproduction results

Simulated the real scenario: parent spawns a wrapper (like `npm exec`) which spawns the MCP server, then parent closes pipes abruptly.

**Before fix (old logic):**
```
Client: destroying pipes (simulating client exit)...
mcp-server: uncaught: EPIPE write EPIPE
mcp-server: uncaught: EPIPE write EPIPE
mcp-server: uncaught: EPIPE write EPIPE
mcp-server: uncaught: EPIPE write EPIPE
... (repeats indefinitely, 100% CPU)

❌ BUG CONFIRMED: Child still alive after 8s (orphan / CPU spin)
```

**After fix (new logic):**
```
Client: destroying pipes (simulating client exit)...
mcp-server: shutting down

✅ wrapper exited
```

The fix detects the first EPIPE and exits immediately instead of swallowing it.

## Changes

| Change | Why |
|--------|-----|
| Detect `EPIPE` / `ERR_STREAM_DESTROYED` in `uncaughtException` and call `cleanup()` | Root cause fix — stop the busy loop |
| Add `stdin.on('end', cleanup)` | Fallback: some platforms emit `end` but not `close` |
| Add `process.stdout.on('error', cleanup)` | Fallback: catch stdout pipe break directly |
| Add `process.once('SIGHUP', cleanup)` | Handle terminal close scenarios |
| Add `isShuttingDown` guard | Prevent duplicate cleanup from multiple events firing |

## Test plan

- [x] Reproduced the bug with old logic — confirmed 100% CPU orphan
- [x] Verified fix — process exits cleanly on first EPIPE
- [x] Verified simple stdin close scenario still works
- [ ] Manual test: start MCP server via Claude Code, kill Claude Code, verify MCP server exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)