### PR TITLE
Support multiple executions per report with stable execution IDs

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1326,6 +1326,7 @@ export class Agent<
     };
     // 4. build ExecutionDump
     const executionDump = new ExecutionDump({
+      id: uuid(),
       logTime: now,
       name: `Log - ${title || 'untitled'}`,
       description: opt?.content || '',

--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -220,6 +220,98 @@ export function extractLastDumpScriptSync(filePath: string): string {
   return lastContent;
 }
 
+/**
+ * Extract ALL dump script contents from an HTML file using streaming.
+ * Each entry includes the full opening tag (for attribute extraction) and the content.
+ *
+ * @param filePath - Absolute path to the HTML file
+ * @returns Array of { openTag, content } for each dump script found
+ */
+export function extractAllDumpScriptsSync(
+  filePath: string,
+): { openTag: string; content: string }[] {
+  const openTagPrefix = '<script type="midscene_web_dump"';
+  const closeTag = '</script>';
+
+  const results: { openTag: string; content: string }[] = [];
+
+  const fd = openSync(filePath, 'r');
+  const fileSize = statSync(filePath).size;
+  const buffer = Buffer.alloc(STREAMING_CHUNK_SIZE);
+
+  let position = 0;
+  let leftover = '';
+  let capturing = false;
+  let currentContent = '';
+  let currentOpenTag = '';
+
+  try {
+    while (position < fileSize) {
+      const bytesRead = readSync(fd, buffer, 0, STREAMING_CHUNK_SIZE, position);
+      const chunk = leftover + buffer.toString('utf-8', 0, bytesRead);
+      position += bytesRead;
+
+      let searchStart = 0;
+
+      while (searchStart < chunk.length) {
+        if (!capturing) {
+          const startIdx = chunk.indexOf(openTagPrefix, searchStart);
+          if (startIdx !== -1) {
+            const tagEndIdx = chunk.indexOf('>', startIdx);
+            if (tagEndIdx !== -1) {
+              capturing = true;
+              currentOpenTag = chunk.slice(startIdx, tagEndIdx + 1);
+              currentContent = chunk.slice(tagEndIdx + 1);
+              const endIdx = currentContent.indexOf(closeTag);
+              if (endIdx !== -1) {
+                results.push({
+                  openTag: currentOpenTag,
+                  content: currentContent.slice(0, endIdx).trim(),
+                });
+                capturing = false;
+                currentContent = '';
+                currentOpenTag = '';
+                searchStart = tagEndIdx + 1 + endIdx + closeTag.length;
+              } else {
+                leftover = currentContent.slice(-closeTag.length);
+                currentContent = currentContent.slice(0, -closeTag.length);
+                break;
+              }
+            } else {
+              leftover = chunk.slice(startIdx);
+              break;
+            }
+          } else {
+            leftover = chunk.slice(-openTagPrefix.length);
+            break;
+          }
+        } else {
+          const endIdx = chunk.indexOf(closeTag, searchStart);
+          if (endIdx !== -1) {
+            currentContent += chunk.slice(searchStart, endIdx);
+            results.push({
+              openTag: currentOpenTag,
+              content: currentContent.trim(),
+            });
+            capturing = false;
+            currentContent = '';
+            currentOpenTag = '';
+            searchStart = endIdx + closeTag.length;
+          } else {
+            currentContent += chunk.slice(searchStart, -closeTag.length);
+            leftover = chunk.slice(-closeTag.length);
+            break;
+          }
+        }
+      }
+    }
+  } finally {
+    closeSync(fd);
+  }
+
+  return results;
+}
+
 export function parseImageScripts(html: string): Record<string, string> {
   const imageMap: Record<string, string> = {};
   const regex =

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -66,8 +66,8 @@ export class ReportGenerator implements IReportGenerator {
   // Tracks screenshots in the FROZEN region (already written and won't be truncated)
   private frozenScreenshots = new Set<string>();
 
-  // per-execution tracking for inline mode
-  private activeExecName?: string;
+  // per-execution tracking for inline mode (keyed by execution.id or execution.name)
+  private activeExecKey?: string;
   private activeExecStartOffset = 0;
   // ScreenshotItem references for active execution (needed for markPersistedInline on freeze)
   private activeScreenshotRefs: ScreenshotItem[] = [];
@@ -226,15 +226,16 @@ export class ReportGenerator implements IReportGenerator {
     }
 
     // 1. Check if this is a new execution or an update to the active one
-    if (this.activeExecName !== execution.name) {
-      if (this.activeExecName !== undefined) {
+    const execKey = execution.id || execution.name;
+    if (this.activeExecKey !== execKey) {
+      if (this.activeExecKey !== undefined) {
         // Freeze previous active execution's screenshots (move to frozen set)
         this.freezeActiveExecution();
       }
 
       // The current file end becomes the new frozen baseline
       this.activeExecStartOffset = statSync(this.reportPath).size;
-      this.activeExecName = execution.name;
+      this.activeExecKey = execKey;
     }
 
     // 2. Truncate: remove active exec's screenshots and dump tag, keep frozen region
@@ -301,9 +302,10 @@ export class ReportGenerator implements IReportGenerator {
       }
     }
 
-    // 2. Track execution name
-    if (this.activeExecName !== execution.name) {
-      this.activeExecName = execution.name;
+    // 2. Track execution key
+    const execKey = execution.id || execution.name;
+    if (this.activeExecKey !== execKey) {
+      this.activeExecKey = execKey;
     }
 
     if (!this.initialized) {
@@ -320,7 +322,7 @@ export class ReportGenerator implements IReportGenerator {
     if (!this.directoryDumpCache) {
       this.directoryDumpCache = new Map();
     }
-    this.directoryDumpCache.set(execution.name, {
+    this.directoryDumpCache.set(execKey, {
       serialized,
       attributes: dumpAttributes,
     });

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -9,13 +9,15 @@ import {
 } from 'node:fs';
 import * as path from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
-import { logMsg } from '@midscene/shared/utils';
+import { antiEscapeScriptTag, logMsg } from '@midscene/shared/utils';
 import { getReportFileName } from './agent';
 import {
+  extractAllDumpScriptsSync,
   extractLastDumpScriptSync,
   getBaseUrlFixScript,
   streamImageScriptsToFile,
 } from './dump/html-utils';
+import { GroupedActionDump } from './types';
 import type { ReportFileWithAttributes } from './types';
 import { getReportTpl, reportHTMLContent } from './utils';
 
@@ -38,6 +40,28 @@ export class ReportMergingTool {
       path.basename(reportFilePath) === 'index.html' &&
       existsSync(path.join(reportDir, 'screenshots'))
     );
+  }
+
+  /**
+   * Merge multiple dump script contents (from the same source report)
+   * into a single serialized GroupedActionDump string.
+   * If there's only one dump, return it as-is. If multiple, merge
+   * all executions into the first dump's group structure.
+   */
+  private mergeDumpScripts(contents: string[]): string {
+    const unescaped = contents
+      .map((c) => antiEscapeScriptTag(c))
+      .filter((c) => c.length > 0);
+    if (unescaped.length === 0) return '';
+    if (unescaped.length === 1) return unescaped[0];
+
+    // Parse the first dump as base, then merge executions from the rest
+    const base = GroupedActionDump.fromSerializedString(unescaped[0]);
+    for (let i = 1; i < unescaped.length; i++) {
+      const other = GroupedActionDump.fromSerializedString(unescaped[i]);
+      base.executions.push(...other.executions);
+    }
+    return base.serialize();
   }
 
   public mergeReports(
@@ -125,7 +149,19 @@ export class ReportMergingTool {
           streamImageScriptsToFile(reportInfo.reportFilePath, outputFilePath);
         }
 
-        const dumpString = extractLastDumpScriptSync(reportInfo.reportFilePath);
+        // Extract all dump scripts from the source report.
+        // After the per-execution append refactor, a single source report
+        // may contain multiple <script type="midscene_web_dump"> tags
+        // (one per execution). We merge them into a single GroupedActionDump.
+        // Filter by data-group-id to exclude false matches from the template's
+        // bundled JS code, which also references the midscene_web_dump type string.
+        const allDumps = extractAllDumpScriptsSync(
+          reportInfo.reportFilePath,
+        ).filter((d) => d.openTag.includes('data-group-id'));
+        const dumpString =
+          allDumps.length > 0
+            ? this.mergeDumpScripts(allDumps.map((d) => d.content))
+            : extractLastDumpScriptSync(reportInfo.reportFilePath);
         const { reportAttributes } = reportInfo;
 
         const reportHtmlStr = `${reportHTMLContent(

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -32,6 +32,7 @@ type TaskRunnerOperationOptions = {
 };
 
 export class TaskRunner {
+  readonly id: string;
   name: string;
 
   tasks: ExecutionTask[];
@@ -52,6 +53,7 @@ export class TaskRunner {
     uiContextBuilder: () => Promise<UIContext>,
     options?: TaskRunnerInitOptions,
   ) {
+    this.id = uuid();
     this.status =
       options?.tasks && options.tasks.length > 0 ? 'pending' : 'init';
     this.name = name;
@@ -380,6 +382,7 @@ export class TaskRunner {
 
   dump(): ExecutionDump {
     return new ExecutionDump({
+      id: this.id,
       logTime: Date.now(),
       name: this.name,
       tasks: this.tasks,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -436,6 +436,8 @@ export type ExecutionTask<
   };
 
 export interface IExecutionDump extends DumpMeta {
+  /** Stable unique identifier for this execution run */
+  id?: string;
   name: string;
   description?: string;
   tasks: ExecutionTask[];
@@ -495,6 +497,7 @@ function reviverForDumpDeserialization(key: string, value: any): any {
  * ExecutionDump class for serializing and deserializing execution dumps
  */
 export class ExecutionDump implements IExecutionDump {
+  id?: string;
   logTime: number;
   name: string;
   description?: string;
@@ -502,6 +505,7 @@ export class ExecutionDump implements IExecutionDump {
   aiActContext?: string;
 
   constructor(data: IExecutionDump) {
+    this.id = data.id;
     this.logTime = data.logTime;
     this.name = data.name;
     this.description = data.description;
@@ -521,6 +525,7 @@ export class ExecutionDump implements IExecutionDump {
    */
   toJSON(): IExecutionDump {
     return {
+      id: this.id,
       logTime: this.logTime,
       name: this.name,
       description: this.description,

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -41,9 +41,12 @@ const defaultGroupMeta: GroupMeta = {
 /**
  * Create an ExecutionDump with the given screenshots in uiContext.
  */
+let execCounter = 0;
+
 function createExecution(
   screenshots: ScreenshotItem[],
   name = 'test-execution',
+  id?: string,
 ): ExecutionDump {
   const tasks = screenshots.map((s, i) => ({
     taskId: `task-${i}`,
@@ -61,6 +64,7 @@ function createExecution(
   }));
 
   return new ExecutionDump({
+    id: id ?? `exec-id-${++execCounter}`,
     logTime: Date.now(),
     name,
     tasks,
@@ -241,11 +245,16 @@ describe('ReportGenerator — per-execution append model', () => {
       const screenshot2 = ScreenshotItem.create(fakeBase64(200), Date.now());
 
       // Round 1: one screenshot
-      const exec1 = createExecution([screenshot1]);
+      const sharedId = 'same-exec-id';
+      const exec1 = createExecution([screenshot1], 'test-execution', sharedId);
       generator.onExecutionUpdate(exec1, defaultGroupMeta);
 
-      // Round 2: two screenshots (same execution name = update)
-      const exec2 = createExecution([screenshot1, screenshot2]);
+      // Round 2: two screenshots (same execution id = update)
+      const exec2 = createExecution(
+        [screenshot1, screenshot2],
+        'test-execution',
+        sharedId,
+      );
       generator.onExecutionUpdate(exec2, defaultGroupMeta);
       await generator.flush();
 
@@ -309,6 +318,33 @@ describe('ReportGenerator — per-execution append model', () => {
         const parsed = JSON.parse(dumpJson);
         expect(parsed.executions).toHaveLength(1);
       }
+    });
+
+    it('should preserve separate dump tags for executions with same name but different ids', async () => {
+      const reportPath = join(tmpDir, 'same-name-exec-test.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'inline',
+        autoPrint: false,
+      });
+
+      const s1 = ScreenshotItem.create(fakeBase64(100), Date.now());
+      const s2 = ScreenshotItem.create(fakeBase64(100), Date.now());
+
+      // Two executions with the same name but different ids (simulating
+      // repeated aiAct calls with the same prompt)
+      const exec1 = createExecution([s1], 'Act - click login', 'unique-id-1');
+      generator.onExecutionUpdate(exec1, defaultGroupMeta);
+      await generator.flush();
+
+      const exec2 = createExecution([s2], 'Act - click login', 'unique-id-2');
+      generator.onExecutionUpdate(exec2, defaultGroupMeta);
+      await generator.flush();
+
+      const html = readFileSync(reportPath, 'utf-8');
+
+      // Should have 2 separate dump tags despite same execution name
+      expect(countUserDumpTags(html)).toBe(2);
     });
   });
 
@@ -543,6 +579,30 @@ describe('ReportGenerator — per-execution append model', () => {
       await generator.flush();
 
       const exec2 = createExecution([s2], 'exec-2');
+      generator.onExecutionUpdate(exec2, defaultGroupMeta);
+      await generator.flush();
+
+      const html = readFileSync(reportPath, 'utf-8');
+      expect(countUserDumpTags(html)).toBe(2);
+    });
+
+    it('should preserve separate dump tags for same-name executions in directory mode', async () => {
+      const reportDir = join(tmpDir, 'dir-same-name-test');
+      const reportPath = join(reportDir, 'index.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'directory',
+        autoPrint: false,
+      });
+
+      const s1 = ScreenshotItem.create(fakeBase64(100), Date.now());
+      const s2 = ScreenshotItem.create(fakeBase64(100), Date.now());
+
+      const exec1 = createExecution([s1], 'Act - click login', 'dir-id-1');
+      generator.onExecutionUpdate(exec1, defaultGroupMeta);
+      await generator.flush();
+
+      const exec2 = createExecution([s2], 'Act - click login', 'dir-id-2');
       generator.onExecutionUpdate(exec2, defaultGroupMeta);
       await generator.flush();
 

--- a/packages/core/tests/unit-test/report-merge-count.test.ts
+++ b/packages/core/tests/unit-test/report-merge-count.test.ts
@@ -379,6 +379,90 @@ describe('ReportMergingTool merged dump count verification', () => {
   });
 
   /**
+   * Merging source reports that contain multiple executions (per-execution append model)
+   * should preserve all executions from each source.
+   */
+  it('merging source reports with multiple executions preserves all', async () => {
+    const tool = new ReportMergingTool();
+    const n = 3;
+    const execsPerReport = 2;
+
+    for (let i = 0; i < n; i++) {
+      const gen = ReportGenerator.create(`merge-multi-exec-${i}`, {
+        generateReport: true,
+        outputFormat: 'single-html',
+        autoPrintReportMsg: false,
+      }) as ReportGenerator;
+
+      // Write multiple executions to the same report
+      const groupMeta: GroupMeta = {
+        groupName: `multi-group-${i}`,
+        sdkVersion: '1.0.0-test',
+        modelBriefs: ['test-model'],
+      };
+      for (let e = 0; e < execsPerReport; e++) {
+        const exec = new ExecutionDump({
+          id: `report-${i}-exec-${e}`,
+          logTime: Date.now(),
+          name: `exec-${e}`,
+          tasks: [
+            {
+              type: 'Insight' as const,
+              subType: 'Locate',
+              param: { prompt: `task-${i}-${e}` },
+              taskId: `task-${i}-${e}`,
+              uiContext: {
+                screenshot: fakeScreenshot(),
+                shotSize: { width: 1920, height: 1080 },
+                shrunkShotToLogicalRatio: 1,
+              } as unknown as UIContext,
+              executor: async () => undefined,
+              recorder: [],
+              status: 'finished' as const,
+            } as any,
+          ],
+        });
+        gen.onExecutionUpdate(exec, groupMeta);
+      }
+      await gen.finalize();
+
+      tool.append({
+        reportFilePath: gen.getReportPath()!,
+        reportAttributes: {
+          testDescription: `Multi-exec test ${i}`,
+          testDuration: 1000 + i,
+          testId: `multi-exec-${i}`,
+          testStatus: 'passed' as TestStatus,
+          testTitle: `Multi-exec Test ${i}`,
+        },
+      });
+    }
+
+    const mergedPath = tool.mergeReports('merge-multi-exec-merged', {
+      overwrite: true,
+    });
+    expect(mergedPath).toBeTruthy();
+
+    const html = readFileSync(mergedPath!, 'utf-8');
+    const dumps = extractAllDumps(html);
+
+    // Each source report's dump should be merged into one dump script
+    expect(dumps.length).toBe(n);
+
+    // Each merged dump should contain all executions from the source report
+    for (let i = 0; i < n; i++) {
+      const content = html.match(
+        new RegExp(
+          `<script type="midscene_web_dump"[^>]*playwright_test_id="${encodeURIComponent(`multi-exec-${i}`)}"[^>]*>([\\s\\S]*?)</script>`,
+        ),
+      );
+      expect(content).toBeTruthy();
+      const parsed = JSON.parse(antiEscapeScriptTag(content![1]));
+      expect(parsed.executions).toHaveLength(execsPerReport);
+    }
+  });
+
+  /**
    * extractLastDumpScriptSync should return the last dump from a merged file.
    */
   it('extractLastDumpScriptSync returns the last dump from merged file', async () => {


### PR DESCRIPTION
## Summary
This PR refactors the report generation system to properly handle multiple executions within a single report by introducing stable execution IDs. Previously, executions were tracked by name alone, which caused issues when the same operation was repeated. Now each execution has a unique ID that persists across updates, enabling proper tracking and merging of multiple executions.

## Key Changes

- **Added execution ID tracking**: `ExecutionDump` and `TaskRunner` now include an `id` field (UUID) to uniquely identify each execution run, separate from the execution name
- **Updated execution tracking logic**: `ReportGenerator` now uses `execution.id || execution.name` as the key for tracking active executions, allowing multiple executions with the same name to be treated as separate entries
- **Implemented multi-dump extraction**: Added `extractAllDumpScriptsSync()` function to extract all dump script tags from an HTML file (not just the last one), with support for streaming large files
- **Enhanced report merging**: `ReportMergingTool.mergeReports()` now extracts and merges all dump scripts from source reports into a single `GroupedActionDump`, preserving all executions from multi-execution source reports
- **Added comprehensive tests**: New test cases verify that:
  - Multiple executions with the same name but different IDs are preserved as separate dump tags
  - Merging source reports with multiple executions preserves all executions
  - Both inline and directory screenshot modes handle same-name executions correctly

## Implementation Details

- The execution ID is generated using UUID in `TaskRunner` and `Agent` classes
- Report merging filters dump scripts by `data-group-id` attribute to exclude false matches from bundled JS code
- The `mergeDumpScripts()` method parses and combines multiple `GroupedActionDump` objects by merging their execution arrays
- Backward compatibility is maintained: if no ID is present, the execution name is used as the fallback key

https://claude.ai/code/session_01RCJ8MJNcbfXw7DVcn4ez3K