### PR TITLE
Refactor ReportGenerator to use onExecutionUpdate and finalize separately

### DIFF
--- a/packages/core/tests/unit-test/merge-browser-parse.test.ts
+++ b/packages/core/tests/unit-test/merge-browser-parse.test.ts
@@ -16,7 +16,12 @@ import { extractLastDumpScriptSync } from '@/dump/html-utils';
 import { ReportMergingTool } from '@/report';
 import { ReportGenerator } from '@/report-generator';
 import { ScreenshotItem } from '@/screenshot-item';
-import { ExecutionDump, GroupedActionDump, type UIContext } from '@/types';
+import {
+  ExecutionDump,
+  type GroupMeta,
+  GroupedActionDump,
+  type UIContext,
+} from '@/types';
 import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -78,7 +83,16 @@ describe('browser parse simulation for merged directory-mode reports', () => {
 
     const screenshot = ScreenshotItem.create(fakeBase64(500), Date.now());
     const dump = createDump([screenshot]);
-    await generator.finalize(dump);
+    const groupMeta: GroupMeta = {
+      sdkVersion: dump.sdkVersion,
+      groupName: dump.groupName,
+      groupDescription: dump.groupDescription,
+      modelBriefs: dump.modelBriefs,
+    };
+    for (const exec of dump.executions) {
+      generator.onExecutionUpdate(exec, groupMeta);
+    }
+    await generator.finalize();
 
     // Read the HTML and extract dump the same way mergeReports does
     const dumpString = extractLastDumpScriptSync(reportPath);
@@ -111,7 +125,16 @@ describe('browser parse simulation for merged directory-mode reports', () => {
         ScreenshotItem.create(fakeBase64(400 + r * 50), Date.now()),
       ];
       const dump = createDump(screenshots);
-      await generator.finalize(dump);
+      const groupMeta: GroupMeta = {
+        sdkVersion: dump.sdkVersion,
+        groupName: dump.groupName,
+        groupDescription: dump.groupDescription,
+        modelBriefs: dump.modelBriefs,
+      };
+      for (const exec of dump.executions) {
+        generator.onExecutionUpdate(exec, groupMeta);
+      }
+      await generator.finalize();
 
       tool.append({
         reportFilePath: reportPath,
@@ -186,7 +209,16 @@ describe('browser parse simulation for merged directory-mode reports', () => {
 
     const screenshot = ScreenshotItem.create(fakeBase64(300), Date.now());
     const dump = createDump([screenshot]);
-    await generator.finalize(dump);
+    const groupMeta: GroupMeta = {
+      sdkVersion: dump.sdkVersion,
+      groupName: dump.groupName,
+      groupDescription: dump.groupDescription,
+      modelBriefs: dump.modelBriefs,
+    };
+    for (const exec of dump.executions) {
+      generator.onExecutionUpdate(exec, groupMeta);
+    }
+    await generator.finalize();
 
     // Step 1: extract (what mergeReports does)
     const extracted = extractLastDumpScriptSync(reportPath);


### PR DESCRIPTION
## Summary
This PR refactors the `ReportGenerator` API to decouple execution updates from finalization. Instead of passing the entire dump to `finalize()`, executions are now processed incrementally via `onExecutionUpdate()` with group metadata, and `finalize()` is called without arguments.

## Key Changes
- Updated import to include `GroupMeta` type from `@/types`
- Replaced `generator.finalize(dump)` calls with a two-step process:
  - Extract group metadata (`GroupMeta`) from the dump object
  - Iterate through dump executions and call `generator.onExecutionUpdate(exec, groupMeta)` for each
  - Call `generator.finalize()` without arguments
- Applied this pattern consistently across three test cases in the merge-browser-parse test suite

## Implementation Details
The `GroupMeta` object is constructed from the dump's top-level properties:
- `sdkVersion`
- `groupName`
- `groupDescription`
- `modelBriefs`

This refactoring enables more granular control over report generation and allows executions to be processed as they become available rather than all at once during finalization.

https://claude.ai/code/session_01K2rbJ6DYeiZBf8sVQJmGSm