### PR TITLE
fix(core): add image detail override support for GPT-5 models

### DIFF
--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -52,11 +52,13 @@ type CodexTextInput = {
 type CodexImageInput = {
   type: 'image';
   url: string;
+  detail?: string;
 };
 
 type CodexLocalImageInput = {
   type: 'localImage';
   path: string;
+  detail?: string;
 };
 
 type CodexTurnInput = CodexTextInput | CodexImageInput | CodexLocalImageInput;
@@ -206,6 +208,7 @@ const extractTextFromMessage = (
 
 const extractImageInputs = (
   message: ChatCompletionMessageParam,
+  imageDetailOverride?: string,
 ): Array<CodexImageInput | CodexLocalImageInput> => {
   const content = (message as any).content;
   if (!Array.isArray(content)) return [];
@@ -224,6 +227,12 @@ const extractImageInputs = (
 
     if (!imageUrl) continue;
 
+    // Resolve detail: use override if provided, otherwise extract from the original message part
+    const detail =
+      imageDetailOverride ||
+      toNonEmptyString(part.image_url?.detail) ||
+      toNonEmptyString(part.detail);
+
     if (
       imageUrl.startsWith('/') ||
       imageUrl.startsWith('./') ||
@@ -237,6 +246,7 @@ const extractImageInputs = (
       inputs.push({
         type: 'localImage',
         path,
+        ...(detail ? { detail } : {}),
       });
       continue;
     }
@@ -244,6 +254,7 @@ const extractImageInputs = (
     inputs.push({
       type: 'image',
       url: imageUrl,
+      ...(detail ? { detail } : {}),
     });
   }
 
@@ -278,6 +289,7 @@ export const resolveCodexReasoningEffort = ({
 
 export const buildCodexTurnPayloadFromMessages = (
   messages: ChatCompletionMessageParam[],
+  options?: { imageDetailOverride?: string },
 ): {
   developerInstructions?: string;
   input: CodexTurnInput[];
@@ -303,7 +315,9 @@ export const buildCodexTurnPayloadFromMessages = (
     }
 
     if (role === 'user') {
-      imageInputs.push(...extractImageInputs(message));
+      imageInputs.push(
+        ...extractImageInputs(message, options?.imageDetailOverride),
+      );
     }
   }
 
@@ -404,8 +418,13 @@ class CodexAppServerConnection {
     const deadlineAt = Date.now() + timeoutMs;
     const isStreaming = !!(stream && onChunk);
 
-    const { developerInstructions, input } =
-      buildCodexTurnPayloadFromMessages(messages);
+    // For GPT-5 models, use "detail": "original" for image inputs to get original resolution
+    const imageDetailOverride =
+      modelConfig.modelFamily === 'gpt-5' ? 'original' : undefined;
+    const { developerInstructions, input } = buildCodexTurnPayloadFromMessages(
+      messages,
+      { imageDetailOverride },
+    );
     const effort = resolveCodexReasoningEffort({ deepThink, modelConfig });
 
     let threadId: string | undefined;

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -151,6 +151,66 @@ describe('codex app-server provider helper', () => {
     });
   });
 
+  it('passes detail override to image inputs when provided', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/shot.png' },
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'file:///tmp/local.png' },
+          },
+        ],
+      },
+    ];
+
+    const payload = buildCodexTurnPayloadFromMessages(messages, {
+      imageDetailOverride: 'original',
+    });
+
+    expect(payload.input).toContainEqual({
+      type: 'image',
+      url: 'https://example.com/shot.png',
+      detail: 'original',
+    });
+    expect(payload.input).toContainEqual({
+      type: 'localImage',
+      path: '/tmp/local.png',
+      detail: 'original',
+    });
+  });
+
+  it('preserves detail from original message part when no override', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this.' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/img.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ];
+
+    const payload = buildCodexTurnPayloadFromMessages(messages);
+
+    expect(payload.input).toContainEqual({
+      type: 'image',
+      url: 'https://example.com/img.png',
+      detail: 'high',
+    });
+  });
+
   it('keeps the newest transcript context when truncating long turns', () => {
     const oldContent = `old-prefix-${'a'.repeat(270_000)}`;
     const latestRequest = 'latest user request should survive truncation';


### PR DESCRIPTION
## Summary
This PR adds support for overriding image detail levels when building Codex turn payloads, with automatic application for GPT-5 models to use original resolution images.

## Key Changes
- **Image detail parameter support**: Added optional `detail` field to `CodexImageInput` and `CodexLocalImageInput` types to preserve or override image detail levels
- **Detail override mechanism**: Introduced `imageDetailOverride` option to `buildCodexTurnPayloadFromMessages()` function that allows callers to specify a detail level for all image inputs
- **GPT-5 automatic optimization**: Automatically sets `detail: "original"` for GPT-5 models to ensure they receive images at their original resolution
- **Fallback logic**: When no override is provided, the function preserves the detail level from the original message part (if present)

## Implementation Details
- The detail resolution follows a priority order: override > original message detail > undefined
- Detail values are only included in the payload when explicitly set (using spread operator to avoid empty fields)
- The feature is backward compatible - existing code without the override option continues to work as before
- Tests verify both the override behavior and the preservation of original detail values

https://claude.ai/code/session_01GbfoowkkPMMmdJkN5rqQdH