### PR TITLE
fix(visualizer): reset player to first frame after autoplay completes

### DIFF
--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -124,7 +124,21 @@ export function Player(props?: {
     playbackRate: playbackSpeed,
   });
 
-  // Track frame for taskId callback (only while playing)
+  // When playback stops, seek to the last frame with a taskId (skip the End card)
+  useEffect(() => {
+    if (!frameMap || player.playing) return;
+    const { scriptFrames, totalDurationInFrames } = frameMap;
+    if (player.currentFrame < totalDurationInFrames - 1) return;
+    for (let i = scriptFrames.length - 1; i >= 0; i--) {
+      const sf = scriptFrames[i];
+      if (sf.taskId) {
+        player.seekTo(sf.startFrame + sf.durationInFrames - 1);
+        break;
+      }
+    }
+  }, [frameMap, player.playing]);
+
+  // Sync taskId to parent: report current task while playing, clear on stop
   useEffect(() => {
     if (!frameMap || !props?.onTaskChange) return;
     if (!player.playing) {
@@ -357,7 +371,7 @@ export function Player(props?: {
                   >
                     <StepsTimeline
                       frameMap={frameMap}
-                      autoZoom={autoZoom}
+                      autoZoom={autoZoom && player.playing}
                       frame={player.currentFrame}
                       width={compositionWidth}
                       height={compositionHeight}

--- a/packages/visualizer/src/component/player/use-frame-player.ts
+++ b/packages/visualizer/src/component/player/use-frame-player.ts
@@ -57,8 +57,8 @@ export function useFramePlayer(options: UseFramePlayerOptions): FramePlayer {
               frameRef.current = 0;
               setCurrentFrame(0);
             } else {
-              frameRef.current = 0;
-              setCurrentFrame(0);
+              frameRef.current = durationRef.current - 1;
+              setCurrentFrame(durationRef.current - 1);
               setPlaying(false);
               return;
             }
@@ -76,11 +76,15 @@ export function useFramePlayer(options: UseFramePlayerOptions): FramePlayer {
     return () => cancelAnimationFrame(rafId);
   }, [playing]);
 
-  const play = useCallback(() => {
+  const resetIfAtEnd = () => {
     if (frameRef.current >= durationRef.current - 1) {
       frameRef.current = 0;
       setCurrentFrame(0);
     }
+  };
+
+  const play = useCallback(() => {
+    resetIfAtEnd();
     setPlaying(true);
   }, []);
 
@@ -90,10 +94,7 @@ export function useFramePlayer(options: UseFramePlayerOptions): FramePlayer {
     if (playingRef.current) {
       setPlaying(false);
     } else {
-      if (frameRef.current >= durationRef.current - 1) {
-        frameRef.current = 0;
-        setCurrentFrame(0);
-      }
+      resetIfAtEnd();
       setPlaying(true);
     }
   }, []);


### PR DESCRIPTION
## Summary
- Reset `currentFrame` to 0 instead of staying at the last frame when autoplay finishes, restoring the first frame's subtitle and full-screen (unzoomed) view.
- Clear `playingTaskId` when the player is not playing, so the sidebar shimmer animation highlight is removed when playback is stopped.

## Test plan
- [ ] Open a report with replay data, let autoplay complete, and verify the view returns to the first frame with correct subtitle and no zoom.
- [ ] Verify the sidebar task row does not show the shimmer animation after playback stops.
- [ ] Verify clicking play again restarts from the beginning correctly.