### PR TITLE
fix(visualizer): make Deep Think a tri-state control so env reasoningEnabled is respected

### DIFF
--- a/packages/visualizer/src/component/config-selector/index.tsx
+++ b/packages/visualizer/src/component/config-selector/index.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Dropdown, type MenuProps, Radio } from 'antd';
+import { Checkbox, Dropdown, type MenuProps, Radio, Tooltip } from 'antd';
 import type React from 'react';
 import SettingOutlined from '../../icons/setting.svg';
 import { useEnvConfig } from '../../store/store';
@@ -129,14 +129,22 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
     if (showDeepThinkOption) {
       items.push({
         label: (
-          <Checkbox
-            onChange={(e) => {
-              setDeepThink(e.target.checked);
-            }}
-            checked={deepThink}
-          >
-            {deepThinkTip}
-          </Checkbox>
+          <div style={{ padding: '4px 0' }}>
+            <div style={{ marginBottom: '4px', fontSize: '14px' }}>
+              {deepThinkTip}
+            </div>
+            <Radio.Group
+              size="small"
+              value={deepThink}
+              onChange={(e) => setDeepThink(e.target.value)}
+            >
+              <Tooltip title="Controlled by MIDSCENE_MODEL_REASONING_ENABLED env variable">
+                <Radio value={'unset'}>Auto</Radio>
+              </Tooltip>
+              <Radio value={true}>On</Radio>
+              <Radio value={false}>Off</Radio>
+            </Radio.Group>
+          </div>
         ),
         key: 'deep-think-config',
       });

--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -225,7 +225,7 @@ export function usePlaygroundExecution(options: UsePlaygroundExecutionOptions) {
 
         // During deepThink -> deepLocate migration:
         // keep deepThink only for aiAct, and avoid passing it to non-aiAct actions.
-        if (actionType !== 'aiAct' && deepThink) {
+        if (actionType !== 'aiAct' && deepThink === true) {
           console.warn(
             '[Playground] Non-aiAct action will be executed without deepThink. deepThink is only forwarded for aiAct.',
             {
@@ -234,10 +234,15 @@ export function usePlaygroundExecution(options: UsePlaygroundExecutionOptions) {
             },
           );
         }
+        // Only pass deepThink when it's explicitly set (true/false), not when 'unset'
+        // so that model-level reasoningEnabled from env config is respected
+        const resolvedDeepThink = deepThink === 'unset' ? undefined : deepThink;
         const executionOptions = {
           requestId: thisRunningId.toString(),
           deepLocate,
-          ...(actionType === 'aiAct' ? { deepThink } : {}),
+          ...(actionType === 'aiAct' && resolvedDeepThink !== undefined
+            ? { deepThink: resolvedDeepThink }
+            : {}),
           screenshotIncluded,
           domIncluded,
           deviceOptions: {

--- a/packages/visualizer/src/store/store.tsx
+++ b/packages/visualizer/src/store/store.tsx
@@ -196,8 +196,8 @@ export const useEnvConfig = create<{
   setForceSameTabNavigation: (forceSameTabNavigation: boolean) => void;
   deepLocate: boolean;
   setDeepLocate: (deepLocate: boolean) => void;
-  deepThink: boolean;
-  setDeepThink: (deepThink: boolean) => void;
+  deepThink: boolean | 'unset';
+  setDeepThink: (deepThink: boolean | 'unset') => void;
   screenshotIncluded: boolean;
   setScreenshotIncluded: (screenshotIncluded: boolean) => void;
   domIncluded: boolean | 'visible-only';
@@ -225,7 +225,13 @@ export const useEnvConfig = create<{
   const savedForceSameTabNavigation =
     localStorage.getItem(TRACKING_ACTIVE_TAB_KEY) !== 'false';
   const savedDeepLocate = localStorage.getItem(DEEP_LOCATE_KEY) === 'true';
-  const savedDeepThink = localStorage.getItem(DEEP_THINK_KEY) === 'true';
+  const savedDeepThinkRaw = localStorage.getItem(DEEP_THINK_KEY);
+  const savedDeepThink: boolean | 'unset' =
+    savedDeepThinkRaw === 'true'
+      ? true
+      : savedDeepThinkRaw === 'false'
+        ? false
+        : 'unset';
   const savedScreenshotIncluded =
     localStorage.getItem(SCREENSHOT_INCLUDED_KEY) !== 'false';
   const savedDomIncluded = localStorage.getItem(DOM_INCLUDED_KEY) || 'false';
@@ -279,7 +285,7 @@ export const useEnvConfig = create<{
       localStorage.setItem(DEEP_LOCATE_KEY, deepLocate.toString());
     },
     deepThink: savedDeepThink,
-    setDeepThink: (deepThink: boolean) => {
+    setDeepThink: (deepThink: boolean | 'unset') => {
       set({ deepThink });
       localStorage.setItem(DEEP_THINK_KEY, deepThink.toString());
     },


### PR DESCRIPTION
## Summary
- The Playground Deep Think checkbox previously defaulted to `false`, which **always overrode** `MIDSCENE_MODEL_REASONING_ENABLED` from env config — users who set it to `true` still saw `thinking=false` in logs.
- Changed Deep Think from a binary Checkbox to a **tri-state Radio control** (`Auto` / `On` / `Off`):
  - **Auto** (default): does not pass `deepThink`, so `MIDSCENE_MODEL_REASONING_ENABLED` env variable controls reasoning behavior. A tooltip on "Auto" explains this.
  - **On**: passes `deepThink=true`, force-enables reasoning.
  - **Off**: passes `deepThink=false`, force-disables reasoning.
- Updated store type from `boolean` to `boolean | 'unset'`, with proper localStorage persistence and restoration.

## Test plan
- [ ] Fresh Playground (no localStorage) + `MIDSCENE_MODEL_REASONING_ENABLED=true` → reasoning should be enabled (check `ai-call.log`)
- [ ] Fresh Playground + `MIDSCENE_MODEL_REASONING_ENABLED=false` → reasoning should be disabled
- [ ] Select "On" → reasoning force-enabled regardless of env
- [ ] Select "Off" → reasoning force-disabled regardless of env
- [ ] Select "Auto" → env variable controls reasoning
- [ ] Hover over "Auto" radio → tooltip shows env variable name
- [ ] Toggle flow: Auto → On → Off → Auto, refresh page, verify state persists correctly
- [ ] Non-`aiAct` actions should never forward `deepThink`