### PR TITLE
fix(aiNumber):To ensure proper matching with the structure returned by the AI

### DIFF
--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -594,6 +594,7 @@ export class TaskExecutor {
             [keyOfResult]: booleanPrompt,
           };
         } else if (ifTypeRestricted) {
+          keyOfResult = type;
           demandInput = {
             [keyOfResult]: `${type}, ${demand}`,
           };


### PR DESCRIPTION
issues: https://github.com/web-infra-dev/midscene/issues/2179

Root cause: The code uses a fixed keyOfResult='result 'to read the return result, but the key name in the actual result returned by AI is Number/String/Boolean (consistent with the type parameter), resulting in the read result being undefined and throwing a "No result in query data" error, but in reality, AI has correctly extracted the value.

Fix: When setting up a query request for Number/String/Boolean types, also set the keyOfResult to the same value as the type to ensure proper matching with the structure returned by the AI.
