### PR TITLE
fix(computer): prevent shell and AppleScript injection in sendKeyViaA…

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-09 - Shell and AppleScript Injection in `packages/computer`
+**Vulnerability:** Shell command injection via `execSync` combined with unsanitized user input in an AppleScript generated for keystrokes in `packages/computer/src/device.ts` (`sendKeyViaAppleScript`).
+**Learning:** Interpolating user-provided inputs directly into a shell command (`osascript -e '...'`) can lead to arbitrary command execution on the host machine. The lack of escaping inside the AppleScript string further allows AppleScript injection.
+**Prevention:** Avoid shell evaluation completely by using `execFileSync` (or `spawnSync`) and passing arguments as an array instead of a single string. When dynamically generating AppleScript containing user input, always escape backslashes and quotes (`"`) explicitly.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-04-09 - Shell and AppleScript Injection in `packages/computer`
-**Vulnerability:** Shell command injection via `execSync` combined with unsanitized user input in an AppleScript generated for keystrokes in `packages/computer/src/device.ts` (`sendKeyViaAppleScript`).
-**Learning:** Interpolating user-provided inputs directly into a shell command (`osascript -e '...'`) can lead to arbitrary command execution on the host machine. The lack of escaping inside the AppleScript string further allows AppleScript injection.
-**Prevention:** Avoid shell evaluation completely by using `execFileSync` (or `spawnSync`) and passing arguments as an array instead of a single string. When dynamically generating AppleScript containing user input, always escape backslashes and quotes (`"`) explicitly.

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import {
   type DeviceAction,
@@ -158,16 +158,13 @@ function sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
   if (keyCode !== undefined) {
     // Use key code for special keys
     script = `tell application "System Events" to key code ${keyCode}${modifierStr}`;
-  } else if (lowerKey.length === 1) {
-    // Use keystroke for single characters (letters, numbers, symbols)
-    script = `tell application "System Events" to keystroke "${key}"${modifierStr}`;
   } else {
-    // Fallback: try as keystroke
-    script = `tell application "System Events" to keystroke "${key}"${modifierStr}`;
+    const escapedKey = key.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    script = `tell application "System Events" to keystroke "${escapedKey}"${modifierStr}`;
   }
 
   debugDevice('sendKeyViaAppleScript', { key, modifiers, script });
-  execSync(`osascript -e '${script}'`);
+  execFileSync('osascript', ['-e', script]);
 }
 
 // Lazy load libnut with fallback

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockState = vi.hoisted(() => {
+  const execSync = vi.fn();
+  const execFileSync = vi.fn();
+
+  const screenshot = vi.fn(async () => Buffer.from('png')) as ReturnType<
+    typeof vi.fn
+  > & {
+    listDisplays: ReturnType<typeof vi.fn>;
+  };
+  screenshot.listDisplays = vi.fn(async () => [
+    { id: 1, name: 'Display 1', primary: true },
+  ]);
+
+  let mousePos = { x: 10, y: 20 };
+  const libnut = {
+    getScreenSize: vi.fn(() => ({ width: 800, height: 600 })),
+    getMousePos: vi.fn(() => ({ ...mousePos })),
+    moveMouse: vi.fn((x: number, y: number) => {
+      mousePos = { x, y };
+    }),
+    mouseClick: vi.fn(),
+    mouseToggle: vi.fn(),
+    scrollMouse: vi.fn(),
+    keyTap: vi.fn(),
+    typeString: vi.fn(),
+  };
+
+  const createRequire = vi.fn(() =>
+    vi.fn(() => ({
+      libnut,
+    })),
+  );
+
+  const reset = () => {
+    mousePos = { x: 10, y: 20 };
+    execSync.mockReset();
+    execFileSync.mockReset();
+    screenshot.mockClear();
+    screenshot.listDisplays.mockClear();
+    libnut.getScreenSize.mockClear();
+    libnut.getMousePos.mockClear();
+    libnut.moveMouse.mockClear();
+    libnut.mouseClick.mockClear();
+    libnut.mouseToggle.mockClear();
+    libnut.scrollMouse.mockClear();
+    libnut.keyTap.mockClear();
+    libnut.typeString.mockClear();
+    createRequire.mockClear();
+  };
+
+  return {
+    execSync,
+    execFileSync,
+    screenshot,
+    libnut,
+    createRequire,
+    reset,
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  execSync: mockState.execSync,
+  execFileSync: mockState.execFileSync,
+}));
+
+vi.mock('screenshot-desktop', () => ({
+  default: mockState.screenshot,
+}));
+
+vi.mock('node:module', () => ({
+  createRequire: mockState.createRequire,
+}));
+
+const originalPlatform = process.platform;
+
+beforeEach(() => {
+  mockState.reset();
+  Object.defineProperty(process, 'platform', { value: 'darwin' });
+});
+
+afterEach(() => {
+  vi.resetModules();
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+async function runKeyboardPress(keyName: string): Promise<void> {
+  const { ComputerDevice } = await import('../../src/device');
+  const device = new ComputerDevice({});
+  await device.connect();
+
+  const keyboardPress = device
+    .actionSpace()
+    .find((action) => action.name === 'KeyboardPress');
+
+  expect(keyboardPress).toBeDefined();
+  await keyboardPress!.call({ keyName });
+}
+
+describe('ComputerDevice AppleScript security', () => {
+  it('uses execFileSync to avoid shell interpolation when sending keys', async () => {
+    const payload = `'; touch /tmp/midscene-shell-injection-proof; echo '`;
+
+    await runKeyboardPress(payload);
+
+    expect(mockState.execSync).not.toHaveBeenCalled();
+    expect(mockState.execFileSync).toHaveBeenCalledWith('osascript', [
+      '-e',
+      expect.any(String),
+    ]);
+  });
+
+  it('escapes quotes and backslashes in keystroke payloads', async () => {
+    await runKeyboardPress('a"\\b');
+
+    expect(mockState.execSync).not.toHaveBeenCalled();
+    expect(mockState.execFileSync).toHaveBeenCalledWith('osascript', [
+      '-e',
+      'tell application "System Events" to keystroke "a\\"\\\\b"',
+    ]);
+  });
+});


### PR DESCRIPTION

- Refactor `sendKeyViaAppleScript` to use `execFileSync` instead of `execSync` to avoid shell layer interpolation.
- Ensure strings are properly escaped to prevent AppleScript injection breaking out of the `keystroke` command string.