### PR TITLE
[codex] Fix typed query fallback for malformed String responses

### DIFF
--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -6,6 +6,7 @@ import {
   uiTarsPlanning,
 } from '@/ai-model';
 import { isAutoGLM, isUITars } from '@/ai-model/auto-glm/util';
+import { extractXMLTag } from '@/ai-model/prompt/util';
 import {
   type TMultimodalPrompt,
   type TUserPrompt,
@@ -61,6 +62,42 @@ const debug = getDebug('device-task-executor');
 const maxErrorCountAllowedInOnePlanningLoop = 5;
 
 export { TaskExecutionError };
+
+function looksLikeStructuredJsonLiteral(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith('{') ||
+    trimmed.startsWith('[') ||
+    trimmed.startsWith('"') ||
+    trimmed === 'null' ||
+    trimmed === 'true' ||
+    trimmed === 'false' ||
+    /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(trimmed)
+  );
+}
+
+function fallbackStringResultFromRawResponse(
+  rawResponse?: string,
+): string | undefined {
+  if (!rawResponse) {
+    return undefined;
+  }
+
+  const rawDataJson = extractXMLTag(rawResponse, 'data-json')?.trim();
+  if (!rawDataJson || looksLikeStructuredJsonLiteral(rawDataJson)) {
+    return undefined;
+  }
+
+  return rawDataJson;
+}
+
+function looksLikeNumericLiteral(value: string): boolean {
+  return /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value.trim());
+}
 
 export class TaskExecutor {
   interface: AbstractInterface;
@@ -628,11 +665,32 @@ export class TaskExecutor {
 
         const { data, thought, dump } = extractResult;
         applyDump(dump);
+        const rawResponse = dump.taskInfo?.rawResponse;
 
         let outputResult = data;
         if (ifTypeRestricted) {
-          // If AI returned a plain string instead of structured format, use it directly
           if (typeof data === 'string') {
+            const trimmedData = data.trim();
+            if (type === 'Number' && looksLikeNumericLiteral(trimmedData)) {
+              outputResult = Number(trimmedData);
+            } else if (
+              (type === 'Boolean' || type === 'Assert' || type === 'WaitFor') &&
+              /^(true|false)$/i.test(trimmedData)
+            ) {
+              outputResult = trimmedData.toLowerCase() === 'true';
+            } else {
+              outputResult = data;
+            }
+          } else if (type === 'String' && typeof data === 'number') {
+            outputResult = String(data);
+          } else if (type === 'String' && typeof data === 'boolean') {
+            outputResult = String(data);
+          } else if (type === 'Number' && typeof data === 'number') {
+            outputResult = data;
+          } else if (
+            (type === 'Boolean' || type === 'Assert' || type === 'WaitFor') &&
+            typeof data === 'boolean'
+          ) {
             outputResult = data;
           } else if (type === 'WaitFor') {
             if (data === null || data === undefined) {
@@ -648,6 +706,14 @@ export class TaskExecutor {
               outputResult = (data as any)[keyOfResult];
             } else if (data?.result !== undefined) {
               outputResult = (data as any).result;
+            } else if (type === 'String') {
+              const fallbackString =
+                fallbackStringResultFromRawResponse(rawResponse);
+              if (fallbackString !== undefined) {
+                outputResult = fallbackString;
+              } else {
+                assert(false, 'No result in query data');
+              }
             } else {
               assert(false, 'No result in query data');
             }

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -28,6 +28,7 @@ const createMockDump = (
   data: any,
   thought?: string,
   usage?: { totalTokens: number },
+  rawResponse?: string,
 ): ServiceDump => ({
   type: 'extract',
   logId: 'mock-log-id',
@@ -36,7 +37,7 @@ const createMockDump = (
   data,
   taskInfo: {
     durationMs: 100,
-    rawResponse: JSON.stringify(data),
+    rawResponse: rawResponse ?? JSON.stringify(data),
     usage: usage ? { inputTokens: 0, outputTokens: 0, ...usage } : undefined,
     reasoning_content: thought,
   },
@@ -219,7 +220,7 @@ describe('TaskExecutor - Null Data Handling', () => {
       expect(result.thought).toBe('Condition is met');
     });
 
-    it('should handle string data for WaitFor operation', async () => {
+    it('should coerce string boolean data for WaitFor operation', async () => {
       const mockInsight = {
         contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
         extract: vi.fn(async () => ({
@@ -255,8 +256,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         uiContext: await createEmptyUIContext(),
       } as any);
 
-      // When AI returns a plain string, it should be used directly
-      expect(result.output).toBe('true');
+      expect(result.output).toBe(true);
     });
 
     it('should handle null data for Query operation', async () => {
@@ -388,6 +388,149 @@ describe('TaskExecutor - Null Data Handling', () => {
       );
       expect(result.output).toBe(42);
       expect(result.thought).toBe('Extracted the numeric value successfully');
+    });
+
+    it('should handle primitive number data for Number type query', async () => {
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: 42,
+          usage: { totalTokens: 100 },
+          thought: 'Extracted the numeric value directly',
+          dump: createMockDump(42, 'Extracted the numeric value directly', {
+            totalTokens: 100,
+          }),
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'Number',
+        'Extract the price',
+        mockModelConfig,
+        {},
+      );
+
+      const result = await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      expect(result.output).toBe(42);
+      expect(result.thought).toBe('Extracted the numeric value directly');
+    });
+
+    it('should coerce numeric string data for Number type query', async () => {
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: '42',
+          usage: { totalTokens: 100 },
+          thought: 'Extracted the numeric value as a string',
+          dump: createMockDump(
+            '42',
+            'Extracted the numeric value as a string',
+            {
+              totalTokens: 100,
+            },
+          ),
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'Number',
+        'Extract the price',
+        mockModelConfig,
+        {},
+      );
+
+      const result = await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      expect(result.output).toBe(42);
+      expect(result.thought).toBe('Extracted the numeric value as a string');
+    });
+
+    it('should fall back to raw data-json text for malformed String query results', async () => {
+      const rawDataJson = `
+页面1：知识问答搜索输入页面
+1.1 属于模块：Mind AI新对话的知识问答功能模块
+1.2 页面详细解释说明：当前搜索输入框内已输入内容 @ecom，下拉搜索结果显示暂无搜索结果。
+1.3 使用组件：文本搜索输入框、搜索结果下拉弹窗、模式下拉选择按钮、发送提交按钮
+      `.trim();
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: [
+            '页面1：知识问答搜索输入页面',
+            1.1,
+            '属于模块：Mind AI新对话的知识问答功能模块',
+          ],
+          usage: { totalTokens: 100 },
+          thought: 'jsonrepair repaired the prose into an array',
+          dump: createMockDump(
+            [
+              '页面1：知识问答搜索输入页面',
+              1.1,
+              '属于模块：Mind AI新对话的知识问答功能模块',
+            ],
+            'jsonrepair repaired the prose into an array',
+            { totalTokens: 100 },
+            `<thought>jsonrepair repaired the prose into an array</thought><data-json>${rawDataJson}</data-json>`,
+          ),
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'String',
+        'Summarize the Figma screenshot',
+        mockModelConfig,
+        {},
+      );
+
+      const result = await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      expect(result.output).toBe(rawDataJson);
+      expect(result.thought).toBe(
+        'jsonrepair repaired the prose into an array',
+      );
     });
 
     it('should preserve domIncluded on Insight task params for report rendering', async () => {


### PR DESCRIPTION
## What changed

- harden typed query result normalization in `packages/core/src/agent/tasks.ts`
- coerce primitive string/number/boolean outputs for typed queries instead of assuming object-shaped data only
- add a String-query fallback that reads the raw `<data-json>` payload when malformed prose was incorrectly repaired into an array
- add focused regression tests covering boolean string coercion, numeric string coercion, primitive numeric results, and the malformed `aiString` case

## Why this changed

A user report still hit `No result in query data` after upgrading. The failing `aiString` call was not actually missing a model answer: the model returned prose inside `<data-json>`, and `jsonrepair` transformed that prose into an array because the content contained numbered items like `1.1` and `1.2`.

The typed query executor only accepted three shapes before this change:

- `{ String: ... }`
- `{ result: ... }`
- a plain primitive in a few limited cases

Once the malformed prose had been repaired into an array, the executor treated it as structured data, could not find the expected key, and threw `No result in query data`.

## User impact

- `aiString` no longer fails on this malformed-but-recoverable response shape
- typed queries are more tolerant of primitive model outputs such as `"true"`, `"42"`, `42`, or `true`
- the failure mode is preserved for genuinely invalid structured responses that still cannot be recovered safely

## Validation

- `pnpm run lint`
- `pnpm test -- tests/unit-test/tasks-null-data.test.ts tests/unit-test/extraction.test.ts tests/unit-test/service-caller.test.ts`
- `npx nx test @midscene/core`