### PR TITLE
fix(workflow): fetch only current branch during release push retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       run: cd packages/web-integration && npx puppeteer browsers install chrome
 
     - name: release
-      run: node ./scripts/release.js --version=${{ github.event.inputs.version }}
+      run: node ./scripts/release.js --version=${{ github.event.inputs.version }} --branch=${{ github.event.inputs.branch }}
       env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       run: cd packages/web-integration && npx puppeteer browsers install chrome
 
     - name: release
-      run: node ./scripts/release.js --version=${{ github.event.inputs.version }} --branch=${{ github.event.inputs.branch }}
+      run: node ./scripts/release.js --version=${{ github.event.inputs.version }}
       env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -108,6 +108,14 @@ async function main() {
       console.log('No changes to commit.');
     }
 
+    if (!actionPublishCanary && selectVersion) {
+      // Push version bump commit and tag before npm publish.
+      // If push fails (e.g. remote has new commits), nothing is published
+      // yet, so the release can be safely retried.
+      step('\nPushing to GitHub...');
+      await pushToGithub(selectVersion);
+    }
+
     if (selectVersion) {
       step('\nPublishing...');
       await publish(selectVersion.newVersion);
@@ -116,11 +124,6 @@ async function main() {
       await createVersionMarkerFile(selectVersion.newVersion);
     } else {
       console.log('No new version:', selectVersion);
-    }
-
-    if (!actionPublishCanary) {
-      step('\nPushing to GitHub...');
-      await pushToGithub(selectVersion);
     }
   } catch (error) {
     console.error(
@@ -197,26 +200,14 @@ async function bumpVersion() {
   }
 }
 
-async function pushToGithub(selectVersion, maxRetries = 3) {
-  const branch = args.branch || 'main';
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      // Fetch only the current branch to avoid permission errors on other
-      // remote refs created by actions/checkout.
-      await run('git', ['fetch', 'origin', branch]);
-      await run('git', ['rebase', `origin/${branch}`]);
-      await run('git', ['tag', '-f', `v${selectVersion.newVersion}`]);
-      await run('git', ['push']);
-      await run('git', ['push', 'origin', '--tags', '--force']);
-      return;
-    } catch (error) {
-      console.error(chalk.red(`Push attempt ${attempt}/${maxRetries} failed`));
-      if (attempt === maxRetries) {
-        console.error(chalk.red('Error pushing to GitHub'));
-        throw error;
-      }
-      console.log(chalk.yellow('Retrying...'));
-    }
+async function pushToGithub(selectVersion) {
+  try {
+    await run('git', ['tag', `v${selectVersion.newVersion}`]);
+    await run('git', ['push']);
+    await run('git', ['push', 'origin', '--tags']);
+  } catch (error) {
+    console.error(chalk.red('Error pushing to GitHub'));
+    throw error;
   }
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -198,9 +198,13 @@ async function bumpVersion() {
 }
 
 async function pushToGithub(selectVersion, maxRetries = 3) {
+  const branch = args.branch || 'main';
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await run('git', ['pull', '--rebase', '--autostash']);
+      // Fetch only the current branch to avoid permission errors on other
+      // remote refs created by actions/checkout.
+      await run('git', ['fetch', 'origin', branch]);
+      await run('git', ['rebase', `origin/${branch}`]);
       await run('git', ['tag', '-f', `v${selectVersion.newVersion}`]);
       await run('git', ['push']);
       await run('git', ['push', 'origin', '--tags', '--force']);


### PR DESCRIPTION
## Summary
- Move git push **before** npm publish so that if push fails (e.g. remote has new commits), nothing is published yet and the release can be safely retried
- Remove the rebase retry logic (no longer needed since push happens before publish)
- Remove `--branch` arg from workflow (no longer needed)

### New release flow
1. Bump version + commit
2. `git tag` + `git push` — if this fails, no packages are published, safe to re-run
3. `npm publish`
4. Write version marker file

### Previous release flow (broken)
1. Bump version + commit
2. `npm publish`
3. `git push` — if this fails, packages are already published, re-run bumps a duplicate version

## Test plan
- [ ] Trigger release workflow and verify push succeeds before publish
- [ ] Verify that if push fails, no npm packages are published

## Validation
- `pnpm run lint`