### PR TITLE
fix(visualizer): fix report download not working in Playground

### DIFF
--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -29,7 +29,10 @@ const downloadReport = (content: string): void => {
   const a = document.createElement('a');
   a.href = url;
   a.download = 'midscene_report.html';
+  a.style.display = 'none';
+  document.body.appendChild(a);
   a.click();
+  document.body.removeChild(a);
   setTimeout(() => URL.revokeObjectURL(url), 0);
 };
 


### PR DESCRIPTION
## Summary
- Fix the "Download Report" button in PC Desktop Playground (and other browser contexts) having no effect when clicked
- The root cause is that the dynamically created `<a>` element was not appended to the DOM before calling `.click()`, which some browser environments (e.g. Puppeteer `--app` mode) require for triggering downloads
- The fix appends the anchor to `document.body`, triggers the click, then removes it

## Test plan
- [ ] Open Computer Playground (`midscene-computer-playground`)
- [ ] Run an action to generate a report
- [ ] Click the "Download Report" button and verify the HTML file downloads successfully