### PR TITLE
fix(cdp): validate chrome endpoint URL and protocol

### DIFF
--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -36,6 +36,21 @@ if (!chromeEndpoint) {
   process.exit(1);
 }
 
+let parsedEndpoint: URL;
+try {
+  parsedEndpoint = new URL(chromeEndpoint);
+} catch {
+  process.stderr.write(`Invalid CDP endpoint URL: ${chromeEndpoint}\n`);
+  process.exit(1);
+}
+
+if (parsedEndpoint.protocol !== 'ws:' && parsedEndpoint.protocol !== 'wss:') {
+  process.stderr.write(
+    `Invalid CDP endpoint protocol: ${parsedEndpoint.protocol}. Only ws: and wss: are allowed.\n`,
+  );
+  process.exit(1);
+}
+
 // ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Add validation for the `chromeEndpoint` command-line argument in `cdp-proxy.ts`.

## Why
Previously, arbitrary URLs (e.g. `http` / `https`) could be passed to the WebSocket client.

This may allow connections to unintended internal services if the argument is user-controlled.

## Change
- parse the endpoint using the standard `URL` constructor
- reject invalid URLs
- enforce `ws:` or `wss:` protocols only

## Impact
- prevents unintended connections to non-WebSocket endpoints
- improves safety when handling user-provided endpoints
- no changes to external API

## Verification
- tested locally
- verified invalid URLs and non-ws protocols are rejected