### PR TITLE
fix(core): image dump in prompts

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -561,6 +561,19 @@ export const ifMidsceneLocatorField = (field: any): boolean => {
   return false;
 };
 
+const formatPromptWithImages = (promptObj: any): string => {
+  let promptString = promptObj.prompt;
+  if (
+    promptObj.images &&
+    Array.isArray(promptObj.images) &&
+    promptObj.images.length > 0
+  ) {
+    const imageCount = promptObj.images.length;
+    promptString += ` (with ${imageCount} image${imageCount > 1 ? 's' : ''})`;
+  }
+  return promptString;
+};
+
 export const dumpMidsceneLocatorField = (field: any): string => {
   assert(
     ifMidsceneLocatorField(field),
@@ -580,7 +593,7 @@ export const dumpMidsceneLocatorField = (field: any): string => {
     }
     // If prompt is a TUserPrompt object, extract the prompt string
     if (typeof field.prompt === 'object' && field.prompt.prompt) {
-      return field.prompt.prompt; // TODO: dump images if necessary
+      return formatPromptWithImages(field.prompt);
     }
   }
 
@@ -648,7 +661,7 @@ export const dumpActionParam = (
             fieldValue.prompt.prompt
           ) {
             // If prompt is a TUserPrompt object, extract the prompt string
-            result[fieldName] = fieldValue.prompt.prompt;
+            result[fieldName] = formatPromptWithImages(fieldValue.prompt);
           }
         }
       }

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -561,13 +561,11 @@ export const ifMidsceneLocatorField = (field: any): boolean => {
   return false;
 };
 
-const formatPromptWithImages = (promptObj: any): string => {
+const formatPromptWithImages = (
+  promptObj: Exclude<TUserPrompt, string>,
+): string => {
   let promptString = promptObj.prompt;
-  if (
-    promptObj.images &&
-    Array.isArray(promptObj.images) &&
-    promptObj.images.length > 0
-  ) {
+  if (Array.isArray(promptObj.images) && promptObj.images.length > 0) {
     const imageCount = promptObj.images.length;
     promptString += ` (with ${imageCount} image${imageCount > 1 ? 's' : ''})`;
   }

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -758,6 +758,25 @@ describe('dumpActionParam', () => {
         "locator": "find the text (with 1 image)",
       }
     `);
+
+    const inputWithEmptyImages = {
+      locator: {
+        midscene_location_field_flag: true,
+        prompt: {
+          prompt: 'find the link',
+          images: [],
+        },
+        center: [100, 200],
+        rect: { left: 50, top: 100, width: 100, height: 50 },
+      },
+    };
+
+    const resultWithEmptyImages = dumpActionParam(inputWithEmptyImages, schema);
+    expect(resultWithEmptyImages).toMatchInlineSnapshot(`
+      {
+        "locator": "find the link",
+      }
+    `);
   });
 
   it('should handle edge cases and invalid inputs', () => {

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -713,6 +713,53 @@ describe('dumpActionParam', () => {
     `);
   });
 
+  it('should format locator fields that have image arrays', () => {
+    const schema = z.object({
+      locator: getMidsceneLocationSchema(),
+    });
+
+    const inputWithImages = {
+      locator: {
+        midscene_location_field_flag: true,
+        prompt: {
+          prompt: 'find the button',
+          images: [
+            { name: 'button1.png', url: 'data:image/png;base64,xyz' },
+            { name: 'button2.png', url: 'https://example.com/img.png' },
+          ],
+        },
+        center: [100, 200],
+        rect: { left: 50, top: 100, width: 100, height: 50 },
+      },
+    };
+
+    const resultWithImages = dumpActionParam(inputWithImages, schema);
+    expect(resultWithImages).toMatchInlineSnapshot(`
+      {
+        "locator": "find the button (with 2 images)",
+      }
+    `);
+
+    const inputWithOneImage = {
+      locator: {
+        midscene_location_field_flag: true,
+        prompt: {
+          prompt: 'find the text',
+          images: [{ name: 'text.png', url: 'data:image/png;base64,abc' }],
+        },
+        center: [100, 200],
+        rect: { left: 50, top: 100, width: 100, height: 50 },
+      },
+    };
+
+    const resultWithOneImage = dumpActionParam(inputWithOneImage, schema);
+    expect(resultWithOneImage).toMatchInlineSnapshot(`
+      {
+        "locator": "find the text (with 1 image)",
+      }
+    `);
+  });
+
   it('should handle edge cases and invalid inputs', () => {
     const schema = z.object({
       foo: z.string(),


### PR DESCRIPTION
 **What:** Adds support for dumping images when they are included in prompts by appending a summary string with the image count. Extracted logic to a helper function.
 **Why:** To improve code health and maintainability by resolving a TODO to serialize image data properly, without bloating console logs.
**Verification:** Ran test suite, explicitly verified changes to `dumpActionParam` in `utils.test.ts`. Tests run successfully.
 **Result:** Clean serialization of prompts that contain image attachments.