### PR TITLE
fix(report): set explicit assetPrefix to avoid runtime publicPath error

### DIFF
--- a/apps/report/rsbuild.config.ts
+++ b/apps/report/rsbuild.config.ts
@@ -154,6 +154,7 @@ export default defineConfig({
     },
   },
   output: {
+    assetPrefix: './',
     inlineScripts: true,
     injectStyles: true,
   },

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -29,7 +29,7 @@ import {
   ReportActionDump,
 } from './types';
 import type { ReportFileWithAttributes } from './types';
-import { getReportTpl, reportHTMLContent } from './utils';
+import { getReportTpl, getVersion, reportHTMLContent } from './utils';
 
 /**
  * Check if a report is in directory mode (html-and-external-assets).
@@ -58,6 +58,24 @@ export function dedupeExecutionsKeepLatest<T extends Pick<ExecutionDump, 'id'>>(
   }
   return Array.from(deduped.values());
 }
+/**
+ * Peek at the first `sdkVersion` field embedded in a midscene_web_dump
+ * script tag inside the given report file. Returns undefined if no
+ * recognizable tag or sdkVersion is present.
+ */
+function peekReportSdkVersion(reportFilePath: string): string | undefined {
+  try {
+    const dump = extractLastDumpScriptSync(reportFilePath);
+    if (!dump) return undefined;
+    const match = dump.match(/"sdkVersion"\s*:\s*"([^"]+)"/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+const warnedMismatchedVersions = new Set<string>();
+
 export class ReportMergingTool {
   private reportInfos: ReportFileWithAttributes[] = [];
 
@@ -72,6 +90,21 @@ export class ReportMergingTool {
   }
 
   public append(reportInfo: ReportFileWithAttributes) {
+    if (reportInfo.reportFilePath) {
+      const sourceVersion = peekReportSdkVersion(reportInfo.reportFilePath);
+      const currentVersion = getVersion();
+      if (
+        sourceVersion &&
+        currentVersion &&
+        sourceVersion !== currentVersion &&
+        !warnedMismatchedVersions.has(sourceVersion)
+      ) {
+        warnedMismatchedVersions.add(sourceVersion);
+        logMsg(
+          `[@midscene/core] ReportMergingTool version mismatch: source report was written by @midscene/core@${sourceVersion} but the merger is @midscene/core@${currentVersion}. This commonly means @midscene/core and the device package (e.g. @midscene/android) resolve to different versions in node_modules. Merged output may silently drop intermediate steps. Align the versions and reinstall (rm -rf node_modules package-lock.json && npm install).`,
+        );
+      }
+    }
     this.reportInfos.push(reportInfo);
   }
   public clear() {


### PR DESCRIPTION
## Summary

- The bundled report JS was throwing `Uncaught Error: Automatic publicPath is not supported in this browser` when the report HTML was opened from `file://` or an http static server in some browsers. This regressed between 1.5.1 and 1.7.x after reports started using the `html-and-external-assets` layout (externalized `screenshots/` directory).
- Root cause: `apps/report/rsbuild.config.ts` did not set `output.assetPrefix`, so rsbuild defaulted to `'auto'`. At runtime rspack tries to derive `publicPath` from `document.currentScript.src`, but because the bundle is also emitted with `inlineScripts: true`, `currentScript.src` is empty and the auto-detection path throws.
- Fix: set `output.assetPrefix: './'` so rspack emits relative asset paths and skips the runtime auto-detection entirely. This keeps the inline-script + externalized-screenshots layout working in all browsers.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx build report` — confirmed the string `Automatic publicPath is not supported` no longer appears in the built `dist/index.html`.
- [x] Generated a fresh Android report via `@midscene/android` with `outputFormat: 'html-and-external-assets'`, served it over `http://`, and verified no `publicPath` runtime error in the browser console. Screenshots under `screenshots/*.jpeg` loaded correctly.