### PR TITLE
chore(android): use local proxy when downloading binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ packages/all-in-one-playground/static/*
 # rslib
 .rslib
 **/.rslib
+
+# jetbrains
+.idea/

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -64,7 +64,8 @@
     "typescript": "^5.8.3",
     "tsx": "^4.19.2",
     "vitest": "3.0.5",
-    "zod": "^3.25.1"
+    "zod": "^3.25.1",
+    "https-proxy-agent": "7.0.6"
   },
   "license": "MIT"
 }

--- a/packages/android/scripts/download-scrcpy-server.mjs
+++ b/packages/android/scripts/download-scrcpy-server.mjs
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { fetchVersion } from 'gh-release-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(scriptPath);
@@ -12,6 +13,23 @@ export const SCRCPY_SERVER_VERSION_TAG = `v${SCRCPY_PROTOCOL_VERSION}`;
 export const SCRCPY_SERVER_VERSION_FILENAME = 'scrcpy-server.version';
 
 const SCRCPY_VERSION = SCRCPY_SERVER_VERSION_TAG;
+
+const PROXY_URL =
+  process.env.HTTPS_PROXY_URL ||
+  process.env.HTTP_PROXY_URL ||
+  process.env.https_proxy_url ||
+  process.env.http_proxy_url;
+
+function createProxyAgent() {
+  if (!PROXY_URL) {
+    return undefined;
+  }
+
+  console.log(
+    `[scrcpy] Using proxy: ${PROXY_URL.replace(/\/\/.*@/, '//***:***@')}`,
+  );
+  return new HttpsProxyAgent(PROXY_URL);
+}
 
 export function shouldDownloadScrcpyServer(
   existingVersion,
@@ -120,16 +138,20 @@ export async function main() {
   const maxRetries = 3;
   const downloadedFile = path.join(binDir, `scrcpy-server-${SCRCPY_VERSION}`);
   await fs.rm(downloadedFile, { force: true });
+  const agent = createProxyAgent();
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await fetchVersion({
-        repository: 'Genymobile/scrcpy',
-        version: SCRCPY_VERSION,
-        package: `scrcpy-server-${SCRCPY_VERSION}`,
-        destination: binDir,
-        extract: false,
-      });
+      await fetchVersion(
+        {
+          repository: 'Genymobile/scrcpy',
+          version: SCRCPY_VERSION,
+          package: `scrcpy-server-${SCRCPY_VERSION}`,
+          destination: binDir,
+          extract: false,
+        },
+        { agent },
+      );
       break;
     } catch (err) {
       if (attempt === maxRetries) throw err;

--- a/packages/android/scripts/download-yadb.mjs
+++ b/packages/android/scripts/download-yadb.mjs
@@ -3,9 +3,26 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { fetchVersion } from 'gh-release-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const YADB_VERSION = 'v1.1.1';
+const PROXY_URL =
+  process.env.HTTPS_PROXY_URL ||
+  process.env.HTTP_PROXY_URL ||
+  process.env.https_proxy_url ||
+  process.env.http_proxy_url;
+
+function createProxyAgent() {
+  if (!PROXY_URL) {
+    return undefined;
+  }
+
+  console.log(
+    `[yadb] Using proxy: ${PROXY_URL.replace(/\/\/.*@/, '//***:***@')}`,
+  );
+  return new HttpsProxyAgent(PROXY_URL);
+}
 
 async function main() {
   const binDir = path.resolve(__dirname, '../bin');
@@ -36,15 +53,19 @@ async function main() {
   await fs.mkdir(binDir, { recursive: true });
 
   const maxRetries = 3;
+  const agent = createProxyAgent();
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await fetchVersion({
-        repository: 'ysbing/YADB',
-        version: YADB_VERSION,
-        package: 'yadb',
-        destination: binDir,
-        extract: false,
-      });
+      await fetchVersion(
+        {
+          repository: 'ysbing/YADB',
+          version: YADB_VERSION,
+          package: 'yadb',
+          destination: binDir,
+          extract: false,
+        },
+        { agent },
+      );
       break;
     } catch (err) {
       if (attempt === maxRetries) throw err;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       gh-release-fetch:
         specifier: ^4.0.3
         version: 4.0.3
+      https-proxy-agent:
+        specifier: 7.0.6
+        version: 7.0.6
       tsx:
         specifier: ^4.19.2
         version: 4.19.2


### PR DESCRIPTION
# Summary
Add proxy support to the Android prebuild scripts for downloading `scrcpy` and `yadb` binaries. Fix #2347 

# Key Changes
1. Introduced a new dependency: `https-proxy-agent@7.0.6`
2. Updated `packages/android/scripts/download-scrcpy-server.mjs`:
    - Detect proxy configuration from environment variables
    - Apply proxy settings to `fetchVersion` when a proxy is present
3. Updated `packages/android/scripts/download-yadb.mjs`:
    - Detect proxy configuration from environment variables
    - Apply proxy settings to `fetchVersion` when a proxy is present
 
# Testing
- [ ] Set `HTTPS_PROXY` and `HTTP_PROXY`, then run:
```bash
node packages/android/scripts/download-yadb.mjs
node packages/android/scripts/download-scrcpy-server.mjs
```
- [ ] Unset `HTTPS_PROXY` and `HTTP_PROXY`, then run:
```bash
node packages/android/scripts/download-yadb.mjs
node packages/android/scripts/download-scrcpy-server.mjs
```