### PR TITLE
fix(core): add hard 180s timeout to AI HTTP calls

### DIFF
--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -39,7 +39,7 @@ Notes:
 
 | Name | Description |
 |------|-------------|
-| `MIDSCENE_MODEL_TIMEOUT` | Hard timeout for AI API calls in milliseconds (default intent). Defaults to `180000` (180s). Set to `0` to disable the hard timeout and let the request run indefinitely (only a caller-provided `AbortSignal` will cancel it). Note: the OpenAI SDK's built-in timeout only covers response-header arrival, not body reading, so Midscene installs an additional end-to-end `AbortSignal` to prevent stalled body reads from hanging the process |
+| `MIDSCENE_MODEL_TIMEOUT` | Hard timeout for AI API calls in milliseconds (default intent). Defaults to `180000` (180s). Set to `0` to disable the hard timeout and let the request run indefinitely (only a caller-provided `AbortSignal` will cancel it). Note: Midscene controls the full request lifetime, not just the time until the first response header arrives, so stalled body reads can still be terminated cleanly |
 | `MIDSCENE_MODEL_TEMPERATURE` | Sampling temperature for model responses |
 | `MIDSCENE_MODEL_MAX_TOKENS` | `max_tokens` for responses, default 2048 |
 | `MIDSCENE_MODEL_RETRY_COUNT` | Number of retries when AI call fails, default 1 (i.e., retry once after failure) |

--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -39,7 +39,7 @@ Notes:
 
 | Name | Description |
 |------|-------------|
-| `MIDSCENE_MODEL_TIMEOUT` | Timeout for AI API calls in milliseconds (default intent). Defaults to OpenAI SDK default (10 minutes) |
+| `MIDSCENE_MODEL_TIMEOUT` | Hard timeout for AI API calls in milliseconds (default intent). Defaults to `180000` (180s). Set to `0` to disable the hard timeout and let the request run indefinitely (only a caller-provided `AbortSignal` will cancel it). Note: the OpenAI SDK's built-in timeout only covers response-header arrival, not body reading, so Midscene installs an additional end-to-end `AbortSignal` to prevent stalled body reads from hanging the process |
 | `MIDSCENE_MODEL_TEMPERATURE` | Sampling temperature for model responses |
 | `MIDSCENE_MODEL_MAX_TOKENS` | `max_tokens` for responses, default 2048 |
 | `MIDSCENE_MODEL_RETRY_COUNT` | Number of retries when AI call fails, default 1 (i.e., retry once after failure) |

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -37,7 +37,7 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 
 | 名称 | 描述 |
 |------|-------------|
-| `MIDSCENE_MODEL_TIMEOUT` | AI 接口调用硬超时（毫秒，默认意图），默认 `180000`（180 秒）。设为 `0` 可禁用硬超时，只有调用方传入的 `AbortSignal` 能取消请求。说明：OpenAI SDK 自带的超时仅覆盖响应头到达阶段，不覆盖响应体读取；因此 Midscene 额外注入了端到端的 `AbortSignal`，避免读响应体时挂起导致进程卡死 |
+| `MIDSCENE_MODEL_TIMEOUT` | AI 接口调用硬超时（毫秒，默认意图），默认 `180000`（180 秒）。设为 `0` 可禁用硬超时，只有调用方传入的 `AbortSignal` 能取消请求。说明：Midscene 控制的是完整请求生命周期，而不只是首个响应 header 返回的时间，因此即使响应体读取阶段卡住，也能被及时终止 |
 | `MIDSCENE_MODEL_TEMPERATURE` | 模型采样温度 |
 | `MIDSCENE_MODEL_MAX_TOKENS` | 模型响应的 max_tokens 数配置，默认是 2048 |
 | `MIDSCENE_MODEL_RETRY_COUNT` | AI 调用失败时的重试次数，默认 1（即失败后重试 1 次）|

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -37,7 +37,7 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 
 | 名称 | 描述 |
 |------|-------------|
-| `MIDSCENE_MODEL_TIMEOUT` | AI 接口调用超时时间（毫秒，默认意图），默认使用 OpenAI SDK 默认值（10 分钟）|
+| `MIDSCENE_MODEL_TIMEOUT` | AI 接口调用硬超时（毫秒，默认意图），默认 `180000`（180 秒）。设为 `0` 可禁用硬超时，只有调用方传入的 `AbortSignal` 能取消请求。说明：OpenAI SDK 自带的超时仅覆盖响应头到达阶段，不覆盖响应体读取；因此 Midscene 额外注入了端到端的 `AbortSignal`，避免读响应体时挂起导致进程卡死 |
 | `MIDSCENE_MODEL_TEMPERATURE` | 模型采样温度 |
 | `MIDSCENE_MODEL_MAX_TOKENS` | 模型响应的 max_tokens 数配置，默认是 2048 |
 | `MIDSCENE_MODEL_RETRY_COUNT` | AI 调用失败时的重试次数，默认 1（即失败后重试 1 次）|

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -38,18 +38,40 @@ import {
 } from './codex-app-server';
 import { shouldForceOriginalImageDetail } from './image-detail';
 
-// Hard default to prevent AI HTTP calls from hanging indefinitely when the
-// underlying socket stalls (the OpenAI SDK's request-level timeout has been
-// observed to miss those cases). Users can still override per-intent via
-// MIDSCENE_MODEL_TIMEOUT / MIDSCENE_INSIGHT_MODEL_TIMEOUT /
-// MIDSCENE_PLANNING_MODEL_TIMEOUT.
+/**
+ * Default hard timeout (ms) applied to every AI HTTP call.
+ *
+ * Behavior change: prior to this default the OpenAI SDK's built-in 600s
+ * request timeout was the only guard, and it has been observed to miss
+ * stalled-socket scenarios (requests hung for >30 minutes in production).
+ *
+ * Override per intent via `MIDSCENE_MODEL_TIMEOUT`,
+ * `MIDSCENE_INSIGHT_MODEL_TIMEOUT`, or `MIDSCENE_PLANNING_MODEL_TIMEOUT`.
+ * Set the env var (or `modelConfig.timeout`) to `0` to disable the hard
+ * timeout entirely — only a caller-provided `abortSignal` will cancel the
+ * request.
+ */
 export const DEFAULT_AI_CALL_TIMEOUT_MS = 180_000;
+
+/**
+ * Resolve the hard request timeout for an AI call.
+ * Returns `null` when the user explicitly opted out (`timeout === 0`).
+ */
+export function resolveEffectiveTimeoutMs(
+  modelConfig: Pick<IModelConfig, 'timeout'>,
+): number | null {
+  const { timeout } = modelConfig;
+  if (typeof timeout !== 'number') return DEFAULT_AI_CALL_TIMEOUT_MS;
+  if (timeout <= 0) return null;
+  return timeout;
+}
 
 // Wires a hard timeout into the abort signal passed to fetch so the request
 // is actually cancelled even if the SDK-level timeout fails to fire. Honours
-// any abortSignal supplied by the caller.
+// any abortSignal supplied by the caller. Passing `null` for `timeoutMs`
+// disables the hard timeout and only forwards the user signal.
 function buildRequestAbortSignal(
-  timeoutMs: number,
+  timeoutMs: number | null,
   userSignal?: AbortSignal,
 ): { signal: AbortSignal; cleanup: () => void } {
   const controller = new AbortController();
@@ -59,24 +81,31 @@ function buildRequestAbortSignal(
     return { signal: controller.signal, cleanup: () => {} };
   }
 
-  const timer = setTimeout(() => {
-    controller.abort(new Error(`AI call timed out after ${timeoutMs}ms`));
-  }, timeoutMs);
-  // Allow the process to exit even if the timer is still pending.
-  if (typeof (timer as { unref?: () => void }).unref === 'function') {
-    (timer as { unref: () => void }).unref();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (timeoutMs !== null) {
+    timer = setTimeout(() => {
+      controller.abort(new Error(`AI call timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    // Allow the process to exit even if the timer is still pending.
+    if (typeof (timer as { unref?: () => void }).unref === 'function') {
+      (timer as { unref: () => void }).unref();
+    }
   }
 
-  const onUserAbort = () => {
-    controller.abort(userSignal?.reason);
-  };
-  userSignal?.addEventListener('abort', onUserAbort, { once: true });
+  const onUserAbort = userSignal
+    ? () => controller.abort(userSignal.reason)
+    : undefined;
+  if (userSignal && onUserAbort) {
+    userSignal.addEventListener('abort', onUserAbort, { once: true });
+  }
 
   return {
     signal: controller.signal,
     cleanup: () => {
-      clearTimeout(timer);
-      userSignal?.removeEventListener('abort', onUserAbort);
+      if (timer) clearTimeout(timer);
+      if (userSignal && onUserAbort) {
+        userSignal.removeEventListener('abort', onUserAbort);
+      }
     },
   };
 }
@@ -91,7 +120,6 @@ async function createChatClient({
   modelDescription: string;
   uiTarsModelVersion?: UITarsModelVersion;
   modelFamily: TModelFamily | undefined;
-  effectiveTimeoutMs: number;
 }> {
   const {
     socksProxy,
@@ -199,6 +227,7 @@ async function createChatClient({
     }
   }
 
+  const effectiveTimeoutMs = resolveEffectiveTimeoutMs({ timeout });
   const openAIOptions = {
     baseURL: openaiBaseURL,
     apiKey: openaiApiKey,
@@ -206,7 +235,9 @@ async function createChatClient({
     // Note: Type assertion needed due to undici version mismatch between dependencies
     ...(proxyAgent ? { fetchOptions: { dispatcher: proxyAgent as any } } : {}),
     ...openaiExtraConfig,
-    timeout: typeof timeout === 'number' ? timeout : DEFAULT_AI_CALL_TIMEOUT_MS,
+    // When disabled (timeoutMs === null) fall through to the SDK default so
+    // only the caller-provided abortSignal can cancel the request.
+    ...(effectiveTimeoutMs !== null ? { timeout: effectiveTimeoutMs } : {}),
     dangerouslyAllowBrowser: true,
   };
 
@@ -258,8 +289,6 @@ async function createChatClient({
     modelDescription,
     uiTarsModelVersion,
     modelFamily,
-    effectiveTimeoutMs:
-      typeof timeout === 'number' ? timeout : DEFAULT_AI_CALL_TIMEOUT_MS,
   };
 }
 
@@ -288,10 +317,10 @@ export async function callAI(
     modelDescription,
     uiTarsModelVersion,
     modelFamily,
-    effectiveTimeoutMs,
   } = await createChatClient({
     modelConfig,
   });
+  const effectiveTimeoutMs = resolveEffectiveTimeoutMs(modelConfig);
 
   const extraBody = modelConfig.extraBody;
 
@@ -433,11 +462,8 @@ export async function callAI(
     if (isStreaming) {
       const { signal: streamSignal, cleanup: cleanupStreamSignal } =
         buildRequestAbortSignal(effectiveTimeoutMs, options?.abortSignal);
-      let stream: Stream<OpenAI.Chat.Completions.ChatCompletionChunk> & {
-        _request_id?: string | null;
-      };
       try {
-        stream = (await completion.create(
+        const stream = (await completion.create(
           {
             model: modelName,
             messages: messagesWithImageDetail,
@@ -452,67 +478,65 @@ export async function callAI(
         )) as Stream<OpenAI.Chat.Completions.ChatCompletionChunk> & {
           _request_id?: string | null;
         };
-      } catch (err) {
-        cleanupStreamSignal();
-        throw err;
-      }
 
-      requestId = stream._request_id;
+        requestId = stream._request_id;
 
-      for await (const chunk of stream) {
-        const content = chunk.choices?.[0]?.delta?.content || '';
-        const reasoning_content =
-          (chunk.choices?.[0]?.delta as any)?.reasoning_content || '';
+        for await (const chunk of stream) {
+          const content = chunk.choices?.[0]?.delta?.content || '';
+          const reasoning_content =
+            (chunk.choices?.[0]?.delta as any)?.reasoning_content || '';
 
-        // Check for usage info in any chunk (OpenAI provides usage in separate chunks)
-        if (chunk.usage) {
-          usage = chunk.usage;
-        }
-
-        if (content || reasoning_content) {
-          accumulated += content;
-          accumulatedReasoning += reasoning_content;
-          const chunkData: CodeGenerationChunk = {
-            content,
-            reasoning_content,
-            accumulated,
-            isComplete: false,
-            usage: undefined,
-          };
-          options.onChunk!(chunkData);
-        }
-
-        // Check if stream is complete
-        if (chunk.choices?.[0]?.finish_reason) {
-          timeCost = Date.now() - startTime;
-
-          // If usage is not available from the stream, provide a basic usage info
-          if (!usage) {
-            // Estimate token counts based on content length (rough approximation)
-            const estimatedTokens = Math.max(
-              1,
-              Math.floor(accumulated.length / 4),
-            );
-            usage = {
-              prompt_tokens: estimatedTokens,
-              completion_tokens: estimatedTokens,
-              total_tokens: estimatedTokens * 2,
-            };
+          // Check for usage info in any chunk (OpenAI provides usage in separate chunks)
+          if (chunk.usage) {
+            usage = chunk.usage;
           }
 
-          // Send final chunk
-          const finalChunk: CodeGenerationChunk = {
-            content: '',
-            accumulated,
-            reasoning_content: '',
-            isComplete: true,
-            usage: buildUsageInfo(usage, requestId),
-          };
-          options.onChunk!(finalChunk);
-          break;
+          if (content || reasoning_content) {
+            accumulated += content;
+            accumulatedReasoning += reasoning_content;
+            const chunkData: CodeGenerationChunk = {
+              content,
+              reasoning_content,
+              accumulated,
+              isComplete: false,
+              usage: undefined,
+            };
+            options.onChunk!(chunkData);
+          }
+
+          // Check if stream is complete
+          if (chunk.choices?.[0]?.finish_reason) {
+            timeCost = Date.now() - startTime;
+
+            // If usage is not available from the stream, provide a basic usage info
+            if (!usage) {
+              // Estimate token counts based on content length (rough approximation)
+              const estimatedTokens = Math.max(
+                1,
+                Math.floor(accumulated.length / 4),
+              );
+              usage = {
+                prompt_tokens: estimatedTokens,
+                completion_tokens: estimatedTokens,
+                total_tokens: estimatedTokens * 2,
+              };
+            }
+
+            // Send final chunk
+            const finalChunk: CodeGenerationChunk = {
+              content: '',
+              accumulated,
+              reasoning_content: '',
+              isComplete: true,
+              usage: buildUsageInfo(usage, requestId),
+            };
+            options.onChunk!(finalChunk);
+            break;
+          }
         }
+      } finally {
+        cleanupStreamSignal();
       }
-      cleanupStreamSignal();
       content = accumulated;
       debugProfileStats(
         `streaming model, ${modelName}, mode, ${modelFamily || 'default'}, cost-ms, ${timeCost}, temperature, ${temperature ?? ''}`,

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -41,9 +41,18 @@ import { shouldForceOriginalImageDetail } from './image-detail';
 /**
  * Default hard timeout (ms) applied to every AI HTTP call.
  *
- * Behavior change: prior to this default the OpenAI SDK's built-in 600s
- * request timeout was the only guard, and it has been observed to miss
- * stalled-socket scenarios (requests hung for >30 minutes in production).
+ * Why we need our own timeout on top of the SDK one:
+ * The openai SDK (>= v4) implements `timeout` inside `fetchWithTimeout` via
+ * `setTimeout(controller.abort, ms)` that is cleared in a `finally` block as
+ * soon as `await fetch()` resolves. `fetch` resolves when response headers
+ * arrive, NOT when the body has been fully read. The JSON body is only
+ * consumed later via `await response.json()`, which has no timer attached.
+ * So if a server returns `200 OK` fast but then stalls while streaming the
+ * body, the SDK-level timeout is already cleared and the read hangs
+ * indefinitely (observed: 37 minutes on doubao-seed in production).
+ *
+ * Our `buildRequestAbortSignal` installs an end-to-end AbortSignal that
+ * aborts the underlying ReadableStream, covering the body-read phase.
  *
  * Override per intent via `MIDSCENE_MODEL_TIMEOUT`,
  * `MIDSCENE_INSIGHT_MODEL_TIMEOUT`, or `MIDSCENE_PLANNING_MODEL_TIMEOUT`.
@@ -52,6 +61,9 @@ import { shouldForceOriginalImageDetail } from './image-detail';
  * request.
  */
 export const DEFAULT_AI_CALL_TIMEOUT_MS = 180_000;
+
+/** Identifying code set on the AbortError raised by our hard timeout. */
+export const AI_CALL_HARD_TIMEOUT_CODE = 'AI_CALL_HARD_TIMEOUT';
 
 /**
  * Resolve the hard request timeout for an AI call.
@@ -64,6 +76,26 @@ export function resolveEffectiveTimeoutMs(
   if (typeof timeout !== 'number') return DEFAULT_AI_CALL_TIMEOUT_MS;
   if (timeout <= 0) return null;
   return timeout;
+}
+
+/**
+ * True if the error was raised by our hard-timeout AbortSignal (vs any other
+ * abort/network/HTTP error). Used to drive observability without having to
+ * string-match the message.
+ */
+export function isHardTimeoutError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === AI_CALL_HARD_TIMEOUT_CODE) return true;
+  const cause = (err as { cause?: unknown }).cause;
+  if (
+    cause &&
+    typeof cause === 'object' &&
+    (cause as { code?: unknown }).code === AI_CALL_HARD_TIMEOUT_CODE
+  ) {
+    return true;
+  }
+  return false;
 }
 
 // Wires a hard timeout into the abort signal passed to fetch so the request
@@ -84,7 +116,11 @@ function buildRequestAbortSignal(
   let timer: ReturnType<typeof setTimeout> | undefined;
   if (timeoutMs !== null) {
     timer = setTimeout(() => {
-      controller.abort(new Error(`AI call timed out after ${timeoutMs}ms`));
+      const err = new Error(
+        `AI call hard timeout after ${timeoutMs}ms (SDK body-read has no native timer, see DEFAULT_AI_CALL_TIMEOUT_MS)`,
+      ) as Error & { code?: string };
+      err.code = AI_CALL_HARD_TIMEOUT_CODE;
+      controller.abort(err);
     }, timeoutMs);
     // Allow the process to exit even if the timer is still pending.
     if (typeof (timer as { unref?: () => void }).unref === 'function') {
@@ -602,6 +638,12 @@ export async function callAI(
           break; // Success, exit retry loop
         } catch (error) {
           lastError = error as Error;
+          const wasHardTimeout = isHardTimeoutError(lastError);
+          if (wasHardTimeout) {
+            warnCall(
+              `AI call hit hard timeout (${effectiveTimeoutMs}ms, attempt ${attempt}/${maxAttempts}, model ${modelName}, intent ${modelConfig.intent})`,
+            );
+          }
           // Do not retry if the request was aborted by the caller
           if (options?.abortSignal?.aborted) {
             break;

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -38,6 +38,49 @@ import {
 } from './codex-app-server';
 import { shouldForceOriginalImageDetail } from './image-detail';
 
+// Hard default to prevent AI HTTP calls from hanging indefinitely when the
+// underlying socket stalls (the OpenAI SDK's request-level timeout has been
+// observed to miss those cases). Users can still override per-intent via
+// MIDSCENE_MODEL_TIMEOUT / MIDSCENE_INSIGHT_MODEL_TIMEOUT /
+// MIDSCENE_PLANNING_MODEL_TIMEOUT.
+export const DEFAULT_AI_CALL_TIMEOUT_MS = 180_000;
+
+// Wires a hard timeout into the abort signal passed to fetch so the request
+// is actually cancelled even if the SDK-level timeout fails to fire. Honours
+// any abortSignal supplied by the caller.
+function buildRequestAbortSignal(
+  timeoutMs: number,
+  userSignal?: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+
+  if (userSignal?.aborted) {
+    controller.abort(userSignal.reason);
+    return { signal: controller.signal, cleanup: () => {} };
+  }
+
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`AI call timed out after ${timeoutMs}ms`));
+  }, timeoutMs);
+  // Allow the process to exit even if the timer is still pending.
+  if (typeof (timer as { unref?: () => void }).unref === 'function') {
+    (timer as { unref: () => void }).unref();
+  }
+
+  const onUserAbort = () => {
+    controller.abort(userSignal?.reason);
+  };
+  userSignal?.addEventListener('abort', onUserAbort, { once: true });
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      userSignal?.removeEventListener('abort', onUserAbort);
+    },
+  };
+}
+
 async function createChatClient({
   modelConfig,
 }: {
@@ -48,6 +91,7 @@ async function createChatClient({
   modelDescription: string;
   uiTarsModelVersion?: UITarsModelVersion;
   modelFamily: TModelFamily | undefined;
+  effectiveTimeoutMs: number;
 }> {
   const {
     socksProxy,
@@ -162,7 +206,7 @@ async function createChatClient({
     // Note: Type assertion needed due to undici version mismatch between dependencies
     ...(proxyAgent ? { fetchOptions: { dispatcher: proxyAgent as any } } : {}),
     ...openaiExtraConfig,
-    ...(typeof timeout === 'number' ? { timeout } : {}),
+    timeout: typeof timeout === 'number' ? timeout : DEFAULT_AI_CALL_TIMEOUT_MS,
     dangerouslyAllowBrowser: true,
   };
 
@@ -214,6 +258,8 @@ async function createChatClient({
     modelDescription,
     uiTarsModelVersion,
     modelFamily,
+    effectiveTimeoutMs:
+      typeof timeout === 'number' ? timeout : DEFAULT_AI_CALL_TIMEOUT_MS,
   };
 }
 
@@ -242,6 +288,7 @@ export async function callAI(
     modelDescription,
     uiTarsModelVersion,
     modelFamily,
+    effectiveTimeoutMs,
   } = await createChatClient({
     modelConfig,
   });
@@ -384,21 +431,31 @@ export async function callAI(
     );
 
     if (isStreaming) {
-      const stream = (await completion.create(
-        {
-          model: modelName,
-          messages: messagesWithImageDetail,
-          ...commonConfig,
-          ...reasoningEffortConfig,
-          ...extraBody,
-        },
-        {
-          stream: true,
-          ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
-        },
-      )) as Stream<OpenAI.Chat.Completions.ChatCompletionChunk> & {
+      const { signal: streamSignal, cleanup: cleanupStreamSignal } =
+        buildRequestAbortSignal(effectiveTimeoutMs, options?.abortSignal);
+      let stream: Stream<OpenAI.Chat.Completions.ChatCompletionChunk> & {
         _request_id?: string | null;
       };
+      try {
+        stream = (await completion.create(
+          {
+            model: modelName,
+            messages: messagesWithImageDetail,
+            ...commonConfig,
+            ...reasoningEffortConfig,
+            ...extraBody,
+          },
+          {
+            stream: true,
+            signal: streamSignal,
+          },
+        )) as Stream<OpenAI.Chat.Completions.ChatCompletionChunk> & {
+          _request_id?: string | null;
+        };
+      } catch (err) {
+        cleanupStreamSignal();
+        throw err;
+      }
 
       requestId = stream._request_id;
 
@@ -455,6 +512,7 @@ export async function callAI(
           break;
         }
       }
+      cleanupStreamSignal();
       content = accumulated;
       debugProfileStats(
         `streaming model, ${modelName}, mode, ${modelFamily || 'default'}, cost-ms, ${timeCost}, temperature, ${temperature ?? ''}`,
@@ -468,6 +526,8 @@ export async function callAI(
       let lastError: Error | undefined;
 
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const { signal: attemptSignal, cleanup: cleanupAttemptSignal } =
+          buildRequestAbortSignal(effectiveTimeoutMs, options?.abortSignal);
         try {
           const result = await completion.create(
             {
@@ -477,7 +537,7 @@ export async function callAI(
               ...reasoningEffortConfig,
               ...extraBody,
             } as any,
-            options?.abortSignal ? { signal: options.abortSignal } : undefined,
+            { signal: attemptSignal },
           );
 
           timeCost = Date.now() - startTime;
@@ -528,6 +588,8 @@ export async function callAI(
             );
             await new Promise((resolve) => setTimeout(resolve, retryInterval));
           }
+        } finally {
+          cleanupAttemptSignal();
         }
       }
 

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -37,114 +37,11 @@ import {
   isCodexAppServerProvider,
 } from './codex-app-server';
 import { shouldForceOriginalImageDetail } from './image-detail';
-
-/**
- * Default hard timeout (ms) applied to every AI HTTP call.
- *
- * Why we need our own timeout on top of the SDK one:
- * The openai SDK (>= v4) implements `timeout` inside `fetchWithTimeout` via
- * `setTimeout(controller.abort, ms)` that is cleared in a `finally` block as
- * soon as `await fetch()` resolves. `fetch` resolves when response headers
- * arrive, NOT when the body has been fully read. The JSON body is only
- * consumed later via `await response.json()`, which has no timer attached.
- * So if a server returns `200 OK` fast but then stalls while streaming the
- * body, the SDK-level timeout is already cleared and the read hangs
- * indefinitely (observed: 37 minutes on doubao-seed in production).
- *
- * Our `buildRequestAbortSignal` installs an end-to-end AbortSignal that
- * aborts the underlying ReadableStream, covering the body-read phase.
- *
- * Override per intent via `MIDSCENE_MODEL_TIMEOUT`,
- * `MIDSCENE_INSIGHT_MODEL_TIMEOUT`, or `MIDSCENE_PLANNING_MODEL_TIMEOUT`.
- * Set the env var (or `modelConfig.timeout`) to `0` to disable the hard
- * timeout entirely — only a caller-provided `abortSignal` will cancel the
- * request.
- */
-export const DEFAULT_AI_CALL_TIMEOUT_MS = 180_000;
-
-/** Identifying code set on the AbortError raised by our hard timeout. */
-export const AI_CALL_HARD_TIMEOUT_CODE = 'AI_CALL_HARD_TIMEOUT';
-
-/**
- * Resolve the hard request timeout for an AI call.
- * Returns `null` when the user explicitly opted out (`timeout === 0`).
- */
-export function resolveEffectiveTimeoutMs(
-  modelConfig: Pick<IModelConfig, 'timeout'>,
-): number | null {
-  const { timeout } = modelConfig;
-  if (typeof timeout !== 'number') return DEFAULT_AI_CALL_TIMEOUT_MS;
-  if (timeout <= 0) return null;
-  return timeout;
-}
-
-/**
- * True if the error was raised by our hard-timeout AbortSignal (vs any other
- * abort/network/HTTP error). Used to drive observability without having to
- * string-match the message.
- */
-export function isHardTimeoutError(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as { code?: unknown }).code;
-  if (code === AI_CALL_HARD_TIMEOUT_CODE) return true;
-  const cause = (err as { cause?: unknown }).cause;
-  if (
-    cause &&
-    typeof cause === 'object' &&
-    (cause as { code?: unknown }).code === AI_CALL_HARD_TIMEOUT_CODE
-  ) {
-    return true;
-  }
-  return false;
-}
-
-// Wires a hard timeout into the abort signal passed to fetch so the request
-// is actually cancelled even if the SDK-level timeout fails to fire. Honours
-// any abortSignal supplied by the caller. Passing `null` for `timeoutMs`
-// disables the hard timeout and only forwards the user signal.
-function buildRequestAbortSignal(
-  timeoutMs: number | null,
-  userSignal?: AbortSignal,
-): { signal: AbortSignal; cleanup: () => void } {
-  const controller = new AbortController();
-
-  if (userSignal?.aborted) {
-    controller.abort(userSignal.reason);
-    return { signal: controller.signal, cleanup: () => {} };
-  }
-
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  if (timeoutMs !== null) {
-    timer = setTimeout(() => {
-      const err = new Error(
-        `AI call hard timeout after ${timeoutMs}ms (SDK body-read has no native timer, see DEFAULT_AI_CALL_TIMEOUT_MS)`,
-      ) as Error & { code?: string };
-      err.code = AI_CALL_HARD_TIMEOUT_CODE;
-      controller.abort(err);
-    }, timeoutMs);
-    // Allow the process to exit even if the timer is still pending.
-    if (typeof (timer as { unref?: () => void }).unref === 'function') {
-      (timer as { unref: () => void }).unref();
-    }
-  }
-
-  const onUserAbort = userSignal
-    ? () => controller.abort(userSignal.reason)
-    : undefined;
-  if (userSignal && onUserAbort) {
-    userSignal.addEventListener('abort', onUserAbort, { once: true });
-  }
-
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      if (timer) clearTimeout(timer);
-      if (userSignal && onUserAbort) {
-        userSignal.removeEventListener('abort', onUserAbort);
-      }
-    },
-  };
-}
+import {
+  buildRequestAbortSignal,
+  isHardTimeoutError,
+  resolveEffectiveTimeoutMs,
+} from './request-timeout';
 
 async function createChatClient({
   modelConfig,

--- a/packages/core/src/ai-model/service-caller/request-timeout.ts
+++ b/packages/core/src/ai-model/service-caller/request-timeout.ts
@@ -1,0 +1,100 @@
+import type { IModelConfig } from '@midscene/shared/env';
+
+/**
+ * Default hard timeout (ms) applied to every AI HTTP call.
+ *
+ * We need an end-to-end timeout for the whole request lifecycle, not just the
+ * time until response headers arrive. Some providers can return headers
+ * quickly and then stall while the body is still being read.
+ *
+ * Override per intent via `MIDSCENE_MODEL_TIMEOUT`,
+ * `MIDSCENE_INSIGHT_MODEL_TIMEOUT`, or `MIDSCENE_PLANNING_MODEL_TIMEOUT`.
+ * Set the env var (or `modelConfig.timeout`) to `0` to disable the hard
+ * timeout entirely; only a caller-provided `abortSignal` will cancel the
+ * request in that case.
+ */
+export const DEFAULT_AI_CALL_TIMEOUT_MS = 180_000;
+
+/** Identifying code set on the AbortError raised by our hard timeout. */
+export const AI_CALL_HARD_TIMEOUT_CODE = 'AI_CALL_HARD_TIMEOUT';
+
+/**
+ * Resolve the hard request timeout for an AI call.
+ * Returns `null` when the user explicitly opted out (`timeout === 0`).
+ */
+export function resolveEffectiveTimeoutMs(
+  modelConfig: Pick<IModelConfig, 'timeout'>,
+): number | null {
+  const { timeout } = modelConfig;
+  if (typeof timeout !== 'number') return DEFAULT_AI_CALL_TIMEOUT_MS;
+  if (timeout <= 0) return null;
+  return timeout;
+}
+
+/**
+ * True if the error was raised by our hard-timeout AbortSignal (vs any other
+ * abort/network/HTTP error). Used to drive observability without having to
+ * string-match the message.
+ */
+export function isHardTimeoutError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === AI_CALL_HARD_TIMEOUT_CODE) return true;
+  const cause = (err as { cause?: unknown }).cause;
+  if (
+    cause &&
+    typeof cause === 'object' &&
+    (cause as { code?: unknown }).code === AI_CALL_HARD_TIMEOUT_CODE
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// Wires a hard timeout into the abort signal passed to fetch so the request
+// is actually cancelled even if the provider/client timeout only covers part
+// of the request. Honours any abortSignal supplied by the caller. Passing
+// `null` for `timeoutMs` disables the hard timeout and only forwards the user
+// signal.
+export function buildRequestAbortSignal(
+  timeoutMs: number | null,
+  userSignal?: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+
+  if (userSignal?.aborted) {
+    controller.abort(userSignal.reason);
+    return { signal: controller.signal, cleanup: () => {} };
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (timeoutMs !== null) {
+    timer = setTimeout(() => {
+      const err = new Error(
+        `AI call hard timeout after ${timeoutMs}ms (full request time exceeded)`,
+      ) as Error & { code?: string };
+      err.code = AI_CALL_HARD_TIMEOUT_CODE;
+      controller.abort(err);
+    }, timeoutMs);
+    if (typeof (timer as { unref?: () => void }).unref === 'function') {
+      (timer as { unref: () => void }).unref();
+    }
+  }
+
+  const onUserAbort = userSignal
+    ? () => controller.abort(userSignal.reason)
+    : undefined;
+  if (userSignal && onUserAbort) {
+    userSignal.addEventListener('abort', onUserAbort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timer) clearTimeout(timer);
+      if (userSignal && onUserAbort) {
+        userSignal.removeEventListener('abort', onUserAbort);
+      }
+    },
+  };
+}

--- a/packages/core/tests/unit-test/gpt-image-detail.test.ts
+++ b/packages/core/tests/unit-test/gpt-image-detail.test.ts
@@ -101,7 +101,7 @@ describe('GPT image detail handling', () => {
           },
         ],
       }),
-      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
@@ -132,7 +132,7 @@ describe('GPT image detail handling', () => {
           },
         ],
       }),
-      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 });

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -30,6 +30,60 @@ describe('service-caller request timeout', () => {
     vi.clearAllMocks();
   });
 
+  it('resolves default, custom and disabled timeout values', async () => {
+    const { DEFAULT_AI_CALL_TIMEOUT_MS, resolveEffectiveTimeoutMs } =
+      await import('@/ai-model/service-caller/request-timeout');
+
+    expect(DEFAULT_AI_CALL_TIMEOUT_MS).toBe(180_000);
+    expect(resolveEffectiveTimeoutMs({})).toBe(180_000);
+    expect(resolveEffectiveTimeoutMs({ timeout: 12_345 })).toBe(12_345);
+    expect(resolveEffectiveTimeoutMs({ timeout: 0 })).toBeNull();
+    expect(resolveEffectiveTimeoutMs({ timeout: -1 })).toBeNull();
+  });
+
+  it('identifies hard-timeout errors both directly and through cause chains', async () => {
+    const { AI_CALL_HARD_TIMEOUT_CODE, isHardTimeoutError } = await import(
+      '@/ai-model/service-caller/request-timeout'
+    );
+
+    const direct = Object.assign(new Error('timeout'), {
+      code: AI_CALL_HARD_TIMEOUT_CODE,
+    });
+    const wrapped = new Error('wrapped', { cause: direct });
+
+    expect(isHardTimeoutError(direct)).toBe(true);
+    expect(isHardTimeoutError(wrapped)).toBe(true);
+    expect(isHardTimeoutError(new Error('other'))).toBe(false);
+  });
+
+  it('cleans up the injected timer so it does not auto-abort after success', async () => {
+    const { buildRequestAbortSignal } = await import(
+      '@/ai-model/service-caller/request-timeout'
+    );
+
+    const { signal, cleanup } = buildRequestAbortSignal(20);
+
+    cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('forwards an already-aborted caller signal immediately', async () => {
+    const { buildRequestAbortSignal } = await import(
+      '@/ai-model/service-caller/request-timeout'
+    );
+
+    const controller = new AbortController();
+    const reason = new Error('caller already cancelled');
+    controller.abort(reason);
+
+    const { signal } = buildRequestAbortSignal(60_000, controller.signal);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(reason);
+  });
+
   it('aborts a hung request via the injected AbortSignal once timeout elapses', async () => {
     const { callAI } = await import('@/ai-model/service-caller');
 
@@ -54,8 +108,10 @@ describe('service-caller request timeout', () => {
   });
 
   it('tags the timeout error with AI_CALL_HARD_TIMEOUT so callers can branch on it', async () => {
-    const { callAI, isHardTimeoutError, AI_CALL_HARD_TIMEOUT_CODE } =
-      await import('@/ai-model/service-caller');
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { AI_CALL_HARD_TIMEOUT_CODE, isHardTimeoutError } = await import(
+      '@/ai-model/service-caller/request-timeout'
+    );
 
     expect(AI_CALL_HARD_TIMEOUT_CODE).toBe('AI_CALL_HARD_TIMEOUT');
 
@@ -78,8 +134,9 @@ describe('service-caller request timeout', () => {
   });
 
   it('uses the 180s default timeout when none is configured', async () => {
-    const { callAI, DEFAULT_AI_CALL_TIMEOUT_MS } = await import(
-      '@/ai-model/service-caller'
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { DEFAULT_AI_CALL_TIMEOUT_MS } = await import(
+      '@/ai-model/service-caller/request-timeout'
     );
 
     expect(DEFAULT_AI_CALL_TIMEOUT_MS).toBe(180_000);
@@ -127,8 +184,9 @@ describe('service-caller request timeout', () => {
   });
 
   it('disables the hard timeout when modelConfig.timeout is 0', async () => {
-    const { callAI, resolveEffectiveTimeoutMs } = await import(
-      '@/ai-model/service-caller'
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { resolveEffectiveTimeoutMs } = await import(
+      '@/ai-model/service-caller/request-timeout'
     );
 
     expect(resolveEffectiveTimeoutMs({ timeout: 0 })).toBeNull();

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -75,6 +75,64 @@ describe('service-caller request timeout', () => {
     expect(lastCallOptions?.timeout).toBe(180_000);
   });
 
+  it('retries after a hard timeout and returns the next successful response', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+
+    mockCreate
+      .mockImplementationOnce((_body, opts) => {
+        const signal = opts?.signal as AbortSignal | undefined;
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            reject(signal.reason ?? new Error('aborted'));
+          });
+        });
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'recovered' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        _request_id: 'req_retry_ok',
+      });
+
+    const result = await callAI(
+      [{ role: 'user', content: 'hello' }],
+      baseConfig({ timeout: 30, retryCount: 1, retryInterval: 0 }),
+    );
+
+    expect(result.content).toBe('recovered');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('disables the hard timeout when modelConfig.timeout is 0', async () => {
+    const { callAI, resolveEffectiveTimeoutMs } = await import(
+      '@/ai-model/service-caller'
+    );
+
+    expect(resolveEffectiveTimeoutMs({ timeout: 0 })).toBeNull();
+
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      _request_id: 'req_no_timeout',
+    });
+
+    await callAI(
+      [{ role: 'user', content: 'hello' }],
+      baseConfig({ timeout: 0 }),
+    );
+
+    const OpenAI = (await import('openai')).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const lastCallOptions = OpenAI.mock.calls.at(-1)?.[0];
+    // When timeout is disabled we should NOT forward a timeout to the SDK.
+    expect(lastCallOptions?.timeout).toBeUndefined();
+
+    // And the signal we injected should not auto-abort.
+    const lastCreateOpts = mockCreate.mock.calls.at(-1)?.[1];
+    const signal = lastCreateOpts?.signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+  });
+
   it('honours the caller abortSignal even before the timeout fires', async () => {
     const { callAI } = await import('@/ai-model/service-caller');
 

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -1,0 +1,101 @@
+import type { IModelConfig } from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreate = vi.fn();
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: mockCreate,
+      },
+    },
+  })),
+}));
+
+const baseConfig = (overrides: Partial<IModelConfig> = {}): IModelConfig =>
+  ({
+    modelName: 'gpt-4o',
+    openaiApiKey: 'test-key',
+    openaiBaseURL: 'https://api.openai.com/v1',
+    modelDescription: 'test model',
+    intent: 'default',
+    from: 'modelConfig',
+    retryCount: 0,
+    ...overrides,
+  }) as IModelConfig;
+
+describe('service-caller request timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('aborts a hung request via the injected AbortSignal once timeout elapses', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+
+    let observedSignal: AbortSignal | undefined;
+    mockCreate.mockImplementation((_body, opts) => {
+      observedSignal = opts?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        observedSignal?.addEventListener('abort', () => {
+          reject(observedSignal?.reason ?? new Error('aborted'));
+        });
+      });
+    });
+
+    const promise = callAI(
+      [{ role: 'user', content: 'hello' }],
+      baseConfig({ timeout: 50 }),
+    );
+
+    await expect(promise).rejects.toThrow(/timed out after 50ms/);
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
+  it('uses the 180s default timeout when none is configured', async () => {
+    const { callAI, DEFAULT_AI_CALL_TIMEOUT_MS } = await import(
+      '@/ai-model/service-caller'
+    );
+
+    expect(DEFAULT_AI_CALL_TIMEOUT_MS).toBe(180_000);
+
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      _request_id: 'req_default_timeout',
+    });
+
+    await callAI([{ role: 'user', content: 'hello' }], baseConfig());
+
+    const OpenAI = (await import('openai')).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const lastCallOptions = OpenAI.mock.calls.at(-1)?.[0];
+    expect(lastCallOptions?.timeout).toBe(180_000);
+  });
+
+  it('honours the caller abortSignal even before the timeout fires', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+
+    mockCreate.mockImplementation((_body, opts) => {
+      const signal = opts?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(signal.reason ?? new Error('aborted'));
+        });
+      });
+    });
+
+    const controller = new AbortController();
+    const promise = callAI(
+      [{ role: 'user', content: 'hello' }],
+      baseConfig({ timeout: 60_000 }),
+      { abortSignal: controller.signal },
+    );
+
+    setTimeout(() => controller.abort(new Error('user cancelled')), 10);
+
+    await expect(promise).rejects.toThrow(/user cancelled/);
+  });
+});

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -48,9 +48,33 @@ describe('service-caller request timeout', () => {
       baseConfig({ timeout: 50 }),
     );
 
-    await expect(promise).rejects.toThrow(/timed out after 50ms/);
+    await expect(promise).rejects.toThrow(/hard timeout after 50ms/);
     expect(observedSignal).toBeDefined();
     expect(observedSignal?.aborted).toBe(true);
+  });
+
+  it('tags the timeout error with AI_CALL_HARD_TIMEOUT so callers can branch on it', async () => {
+    const { callAI, isHardTimeoutError, AI_CALL_HARD_TIMEOUT_CODE } =
+      await import('@/ai-model/service-caller');
+
+    expect(AI_CALL_HARD_TIMEOUT_CODE).toBe('AI_CALL_HARD_TIMEOUT');
+
+    mockCreate.mockImplementation((_body, opts) => {
+      const signal = opts?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+    try {
+      await callAI(
+        [{ role: 'user', content: 'hello' }],
+        baseConfig({ timeout: 30 }),
+      );
+      throw new Error('should have timed out');
+    } catch (err) {
+      expect(isHardTimeoutError(err)).toBe(true);
+    }
   });
 
   it('uses the 180s default timeout when none is configured', async () => {


### PR DESCRIPTION
## Summary

`aiAct` was observed hanging on the final planning step for ~37 minutes in production (doubao-seed-2-0-lite) with no error, no retry, and no abort. Root cause turned out to be **a latent bug in the `openai` Node SDK, not a Midscene bug** — but Midscene has to defend against it because upgrading the SDK does not fix it.

### Root cause — openai SDK (open source, Apache-2.0, https://github.com/openai/openai-node)

`openai/client.mjs` → `fetchWithTimeout` (verified identical in 6.3.0, our current pinned version, and 6.34.0, the latest on npm at the time of this PR):

```js
async fetchWithTimeout(url, init, ms, controller) {
  ...
  const timeout = setTimeout(abort, ms);           // start the request timer
  try {
    return await this.fetch.call(undefined, url, fetchOptions); // resolves at *headers*
  } finally {
    clearTimeout(timeout);                          // ← cancelled as soon as headers arrive
  }
}
```

The `timeout` option only covers the TTFB (response-header arrival) phase. The JSON body is read later via `await response.json()` **with no timer attached**. If a server returns `200 OK` fast and then stalls while streaming the body — which is what doubao-seed did for 37 minutes — the SDK sits there forever and the caller has no signal of failure.

We filed this as an upstream concern; in the meantime Midscene has to apply its own cover.

### Fix

`packages/core/src/ai-model/service-caller/index.ts`

- New helper `buildRequestAbortSignal(timeoutMs, userSignal?)` that composes the caller's `abortSignal` with a hard-timeout `AbortController`, and forwards it as `signal` on both `completion.create` calls (streaming + non-streaming). The SDK forwards this signal into the underlying `ReadableStream`, so it actually covers the body-read phase the SDK timer misses.
- Default hard timeout `DEFAULT_AI_CALL_TIMEOUT_MS = 180_000`. Overridable per intent via `MIDSCENE_MODEL_TIMEOUT`, `MIDSCENE_INSIGHT_MODEL_TIMEOUT`, `MIDSCENE_PLANNING_MODEL_TIMEOUT`, or `modelConfig.timeout`. Setting `timeout: 0` disables the hard timeout (only `abortSignal` can cancel).
- `resolveEffectiveTimeoutMs()` factored out so `createChatClient` (SDK-level `timeout` option) and `callAI` (our injected `AbortSignal`) share one source of truth.
- Streaming branch now uses `try/finally` so the timer + abort listener are always cleaned up even if the SSE iterator throws mid-stream.
- On non-streaming, the existing `retryCount` loop naturally converts a hard timeout into a retry — so a single stalled body read no longer terminates the whole task.

### Observability

- Exported `AI_CALL_HARD_TIMEOUT_CODE = 'AI_CALL_HARD_TIMEOUT'`. The AbortError raised by our timer carries this `code`, distinguishing it from caller aborts / network errors / 5xx retries.
- Exported `isHardTimeoutError(err)` so monitors / tests can branch without string-matching the message.
- On timeout trip, `warnCall` logs `AI call hit hard timeout (${ms}ms, attempt X/Y, model Z, intent W)` so production can count how often the safety net actually fires.

### Behavior change (read before merging)

Prior default: OpenAI SDK's 10-minute header timeout (ineffective against body-read stalls).
New default: **180 s end-to-end hard timeout**. Users running models with single-call latency > 180 s must raise `MIDSCENE_MODEL_TIMEOUT` or set it to `0` to opt out. Documented in `apps/site/docs/{en,zh}/model-config.mdx`.

### Docs

`apps/site/docs/en/model-config.mdx` and `apps/site/docs/zh/model-config.mdx` — rewrote the `MIDSCENE_MODEL_TIMEOUT` row to state the new default, the `0` opt-out, and a brief explanation of why the hard timeout exists.

## Test plan

- [x] `npx vitest --run tests/unit-test/service-caller tests/unit-test/gpt-image-detail` — 47/47 pass. New cases:
  - reproduces the original hang by mocking `completion.create` to never resolve and asserts the call rejects with the hard-timeout error
  - asserts the `DEFAULT_AI_CALL_TIMEOUT_MS = 180_000` is applied to the OpenAI client when not configured
  - asserts a caller-supplied `abortSignal` still cancels the request before the timeout fires
  - retries after a hard timeout and returns the next successful response (verifies timeout participates in retry path)
  - asserts `timeout: 0` disables the hard timeout (no SDK `timeout`, no auto-abort)
  - asserts the raised error is tagged with `AI_CALL_HARD_TIMEOUT` (`isHardTimeoutError()` returns `true`)
- [x] `pnpm run lint`
- [x] Published a prepatch (`1.7.3-beta-20260415071518.0`) for downstream smoke-testing.