### PR TITLE
fix(core): prevent empty-uri crash on yaml cache replay

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -456,10 +456,30 @@ export function buildYamlFlowFromPlans(
       ? dumpActionParam(plan.param || {}, action.paramSchema)
       : {};
 
-    const flowItem: MidsceneYamlFlowItem = {
-      [flowKey]: '',
-      ...flowParam,
-    };
+    // For actions whose param is a single string field (e.g. Launch/Terminate's
+    // `uri`, RunAdbShell's `command`), inline the value on the flowKey. Writing
+    // `{ terminate: '', uri: '...' }` makes the YAML player treat the empty
+    // string as the param and drop the sibling `uri`, so cache replay would
+    // call the action with an empty argument.
+    const shortcutField =
+      action.name === 'Launch' || action.interfaceAlias === 'launch'
+        ? 'uri'
+        : action.name === 'Terminate' || action.interfaceAlias === 'terminate'
+          ? 'uri'
+          : action.name === 'RunAdbShell' ||
+              action.interfaceAlias === 'runAdbShell'
+            ? 'command'
+            : undefined;
+    const shortcutKeys = shortcutField ? Object.keys(flowParam) : [];
+    const canInlineShortcut =
+      shortcutField &&
+      shortcutKeys.length === 1 &&
+      shortcutKeys[0] === shortcutField &&
+      typeof flowParam[shortcutField] === 'string';
+
+    const flowItem: MidsceneYamlFlowItem = canInlineShortcut
+      ? { [flowKey]: flowParam[shortcutField as string] }
+      : { [flowKey]: '', ...flowParam };
 
     flow.push(flowItem);
   }

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -565,57 +565,7 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
                 actionParamForMatchedAction,
               )
             : undefined;
-        if (
-          typeof actionParamForMatchedAction === 'string' &&
-          (matchedAction.name === 'Launch' ||
-            matchedAction.interfaceAlias === 'launch') &&
-          typeof (agent as any).launch === 'function'
-        ) {
-          // Call agent.launch directly for Launch action with string param
-          debug(`Calling agent.launch with: ${actionParamForMatchedAction}`);
-          const result = await (agent as any).launch(
-            actionParamForMatchedAction,
-          );
-
-          const resultName = (flowItem as any).name;
-          if (result !== undefined) {
-            this.setResult(resultName, result);
-          }
-        } else if (
-          typeof actionParamForMatchedAction === 'string' &&
-          (matchedAction.name === 'Terminate' ||
-            matchedAction.interfaceAlias === 'terminate') &&
-          typeof (agent as any).terminate === 'function'
-        ) {
-          // Call agent.terminate directly for Terminate action with string param
-          debug(`Calling agent.terminate with: ${actionParamForMatchedAction}`);
-          const result = await (agent as any).terminate(
-            actionParamForMatchedAction,
-          );
-
-          const resultName = (flowItem as any).name;
-          if (result !== undefined) {
-            this.setResult(resultName, result);
-          }
-        } else if (
-          typeof actionParamForMatchedAction === 'string' &&
-          (matchedAction.name === 'RunAdbShell' ||
-            matchedAction.interfaceAlias === 'runAdbShell') &&
-          typeof (agent as any).runAdbShell === 'function'
-        ) {
-          // Call agent.runAdbShell directly for RunAdbShell action with string param
-          debug(
-            `Calling agent.runAdbShell with: ${actionParamForMatchedAction}`,
-          );
-          const result = await (agent as any).runAdbShell(
-            actionParamForMatchedAction,
-          );
-
-          const resultName = (flowItem as any).name;
-          if (result !== undefined) {
-            this.setResult(resultName, result);
-          }
-        } else if (specialActionParamToCall) {
+        if (specialActionParamToCall) {
           debug(
             `matchedAction: ${matchedAction.name}`,
             `flowParams: ${JSON.stringify(specialActionParamToCall)}`,

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -376,6 +376,33 @@ describe('llm planning - build yaml flow', () => {
       { runAdbShell: 'input keyevent 3' },
     ]);
   });
+
+  it('fallback to expanded format when shortcut action carries extra fields', () => {
+    // If a future schema adds a second field (e.g. Terminate.force), we must
+    // NOT inline; the player's string-param path would drop the extras.
+    const flow = buildYamlFlowFromPlans(
+      [
+        {
+          type: 'Terminate',
+          param: { uri: 'com.mi.car.mobile', force: true } as any,
+        },
+      ],
+      [
+        {
+          name: 'Terminate',
+          interfaceAlias: 'terminate',
+          paramSchema: z.object({
+            uri: z.string(),
+            force: z.boolean().optional(),
+          }),
+          call: async () => {},
+        },
+      ],
+    );
+    expect(flow).toEqual([
+      { terminate: '', uri: 'com.mi.car.mobile', force: true },
+    ]);
+  });
 });
 
 describe('llm planning - descriptionForAction with ZodEffects and ZodUnion', () => {

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -341,6 +341,41 @@ describe('llm planning - build yaml flow', () => {
       },
     ]);
   });
+
+  it('inline single-string shortcut for Terminate/Launch/RunAdbShell', () => {
+    const flow = buildYamlFlowFromPlans(
+      [
+        { type: 'Terminate', param: { uri: 'com.mi.car.mobile' } },
+        { type: 'Launch', param: { uri: 'com.mi.car.mobile' } },
+        { type: 'RunAdbShell', param: { command: 'input keyevent 3' } },
+      ],
+      [
+        {
+          name: 'Terminate',
+          interfaceAlias: 'terminate',
+          paramSchema: z.object({ uri: z.string() }),
+          call: async () => {},
+        },
+        {
+          name: 'Launch',
+          interfaceAlias: 'launch',
+          paramSchema: z.object({ uri: z.string() }),
+          call: async () => {},
+        },
+        {
+          name: 'RunAdbShell',
+          interfaceAlias: 'runAdbShell',
+          paramSchema: z.object({ command: z.string() }),
+          call: async () => {},
+        },
+      ],
+    );
+    expect(flow).toEqual([
+      { terminate: 'com.mi.car.mobile' },
+      { launch: 'com.mi.car.mobile' },
+      { runAdbShell: 'input keyevent 3' },
+    ]);
+  });
 });
 
 describe('llm planning - descriptionForAction with ZodEffects and ZodUnion', () => {

--- a/packages/core/tests/unit-test/player-action-dispatch.test.ts
+++ b/packages/core/tests/unit-test/player-action-dispatch.test.ts
@@ -1,3 +1,4 @@
+import { buildYamlFlowFromPlans } from '@/common';
 import { ScriptPlayer } from '@/yaml/player';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -286,5 +287,64 @@ describe('player action dispatch ordering', () => {
     expect(agent.callActionInActionSpace).toHaveBeenCalledWith('RunAdbShell', {
       command: 'ls /sdcard',
     });
+  });
+
+  it('round-trip: cached plan → buildYamlFlowFromPlans → player dispatches with correct param', async () => {
+    // Regression for the cache-replay bug: a Terminate plan was serialized as
+    // { terminate: '', uri: '...' }, then replayed as agent.terminate('').
+    const actionSpaceDefs = [
+      {
+        name: 'Terminate',
+        interfaceAlias: 'terminate',
+        paramSchema: terminateParamSchema,
+      },
+      {
+        name: 'Launch',
+        interfaceAlias: 'launch',
+        paramSchema: launchParamSchema,
+      },
+      {
+        name: 'RunAdbShell',
+        interfaceAlias: 'runAdbShell',
+        paramSchema: runAdbShellParamSchema,
+      },
+    ];
+
+    const flow = buildYamlFlowFromPlans(
+      [
+        { type: 'Terminate', param: { uri: 'com.mi.car.mobile' } },
+        { type: 'Launch', param: { uri: 'com.mi.car.mobile' } },
+        { type: 'RunAdbShell', param: { command: 'input keyevent 3' } },
+      ],
+      actionSpaceDefs.map((def) => ({ ...def, call: async () => {} })),
+    );
+
+    const player = createPlayerWithActionSpace(actionSpaceDefs);
+    const agent = createMockAgent();
+
+    await player.playTask(
+      {
+        name: 'test',
+        flow,
+        index: 0,
+        status: 'running' as const,
+        totalSteps: flow.length,
+      },
+      agent,
+    );
+
+    expect(agent.callActionInActionSpace).toHaveBeenNthCalledWith(
+      1,
+      'Terminate',
+      { uri: 'com.mi.car.mobile' },
+    );
+    expect(agent.callActionInActionSpace).toHaveBeenNthCalledWith(2, 'Launch', {
+      uri: 'com.mi.car.mobile',
+    });
+    expect(agent.callActionInActionSpace).toHaveBeenNthCalledWith(
+      3,
+      'RunAdbShell',
+      { command: 'input keyevent 3' },
+    );
   });
 });

--- a/packages/core/tests/unit-test/player-action-dispatch.test.ts
+++ b/packages/core/tests/unit-test/player-action-dispatch.test.ts
@@ -41,7 +41,7 @@ function createMockAgent(overrides: Record<string, any> = {}) {
 }
 
 describe('player action dispatch ordering', () => {
-  it('should call agent.runAdbShell directly for RunAdbShell action', async () => {
+  it('should dispatch RunAdbShell string param via callActionInActionSpace', async () => {
     const actionSpace = [
       {
         name: 'RunAdbShell',
@@ -62,12 +62,13 @@ describe('player action dispatch ordering', () => {
 
     await player.playTask(taskStatus, agent);
 
-    // Should call agent.runAdbShell directly, NOT callActionInActionSpace
-    expect(agent.runAdbShell).toHaveBeenCalledWith('input tap 100 200');
-    expect(agent.callActionInActionSpace).not.toHaveBeenCalled();
+    expect(agent.callActionInActionSpace).toHaveBeenCalledWith('RunAdbShell', {
+      command: 'input tap 100 200',
+    });
+    expect(agent.runAdbShell).not.toHaveBeenCalled();
   });
 
-  it('should call agent.launch directly for Launch action', async () => {
+  it('should dispatch Launch string param via callActionInActionSpace', async () => {
     const actionSpace = [
       {
         name: 'Launch',
@@ -88,11 +89,13 @@ describe('player action dispatch ordering', () => {
 
     await player.playTask(taskStatus, agent);
 
-    expect(agent.launch).toHaveBeenCalledWith('com.example.app');
-    expect(agent.callActionInActionSpace).not.toHaveBeenCalled();
+    expect(agent.callActionInActionSpace).toHaveBeenCalledWith('Launch', {
+      uri: 'com.example.app',
+    });
+    expect(agent.launch).not.toHaveBeenCalled();
   });
 
-  it('should call agent.terminate directly for Terminate action', async () => {
+  it('should dispatch Terminate string param via callActionInActionSpace', async () => {
     const actionSpace = [
       {
         name: 'Terminate',
@@ -113,8 +116,10 @@ describe('player action dispatch ordering', () => {
 
     await player.playTask(taskStatus, agent);
 
-    expect(agent.terminate).toHaveBeenCalledWith('com.example.app');
-    expect(agent.callActionInActionSpace).not.toHaveBeenCalled();
+    expect(agent.callActionInActionSpace).toHaveBeenCalledWith('Terminate', {
+      uri: 'com.example.app',
+    });
+    expect(agent.terminate).not.toHaveBeenCalled();
   });
 
   it('should call callActionInActionSpace for generic string param action with paramSchema', async () => {
@@ -239,7 +244,7 @@ describe('player action dispatch ordering', () => {
     ];
     const player = createPlayerWithActionSpace(actionSpace);
     const agent = createMockAgent({
-      runAdbShell: vi.fn().mockResolvedValue('shell output'),
+      callActionInActionSpace: vi.fn().mockResolvedValue('shell output'),
     });
 
     const taskStatus = {


### PR DESCRIPTION
## Summary

- Second-run YAML execution (cache hit) crashed with `Terminate requires a non-empty uri parameter` when the original plan included a `Terminate` / `Launch` / `RunAdbShell` action.
- Root cause: `buildYamlFlowFromPlans` emitted `{ terminate: '', uri: 'com.xxx' }`; the YAML player's string-param fast path treated the empty flowKey value as the argument and dropped the sibling `uri`, calling `agent.terminate('')`.
- Fix: inline the single string field onto the flowKey during cache serialization (matches hand-written YAML like `terminate: com.xxx`), and drop the three redundant direct-call branches in the player — the existing `specialActionParamToCall` path already wraps `{ uri | command }` and dispatches via `callActionInActionSpace`.
- Net: ~50 fewer lines in `player.ts`, unified dispatch path, crash eliminated.

## Test plan

- [x] `npx vitest run tests/unit-test/llm-planning.test.ts` — new case covers inlined serialization for `Terminate` / `Launch` / `RunAdbShell` (51 tests green).
- [x] `npx vitest run tests/unit-test/player-action-dispatch.test.ts` — rewritten to assert dispatch goes through `callActionInActionSpace` with `{ uri | command }` (9 tests green).
- [x] `npx vitest run tests/unit-test/` — full core unit suite green (784 passed, 8 skipped).
- [x] `pnpm run lint` — clean.
- [ ] Manual: re-run the user's failing YAML (with `cache.strategy: read-write`) twice; second run should no longer throw.