### PR TITLE
chore(shared): bump version from 1.7.2 to 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midscene",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.7.3",
   "scripts": {
     "dev": "node scripts/dev-prepare.js && nx run-many --target=build:watch --exclude=android-playground,chrome-extension,@midscene/report,doc --verbose --parallel=6",
     "build": "nx run-many --target=build --exclude=doc --verbose",

--- a/packages/android-mcp/package.json
+++ b/packages/android-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene MCP Server for Android automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android-playground",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Android playground for Midscene",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/android",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Android automation library for Midscene",
   "keywords": [
     "Android UI automation",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midscene/cli",
   "description": "An AI-powered automation SDK can control the page, perform assertions, and extract data in JSON format using natural language. See https://midscenejs.com/ for details.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/computer-linux/package.json
+++ b/packages/computer-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer-linux",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene.js Computer Desktop Automation for Linux",
   "license": "MIT",
   "repository": {

--- a/packages/computer-mac/package.json
+++ b/packages/computer-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer-mac",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene.js Computer Desktop Automation for macOS",
   "license": "MIT",
   "repository": {

--- a/packages/computer-mcp/package.json
+++ b/packages/computer-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene MCP Server for Computer desktop automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/computer-playground/package.json
+++ b/packages/computer-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer-playground",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Computer playground for Midscene - PC desktop automation",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/computer-win/package.json
+++ b/packages/computer-win/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer-win",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene.js Computer Desktop Automation for Windows",
   "license": "MIT",
   "repository": {

--- a/packages/computer/package.json
+++ b/packages/computer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/computer",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene.js Computer Desktop Automation",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midscene/core",
   "description": "Automate browser actions, extract data, and perform assertions using AI. It offers JavaScript SDK, Chrome extension, and support for scripting in YAML. See https://midscenejs.com/ for details.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -39,5 +39,5 @@
     "registry": "https://registry.npmjs.org"
   },
   "license": "MIT",
-  "version": "1.7.2"
+  "version": "1.7.3"
 }

--- a/packages/harmony-mcp/package.json
+++ b/packages/harmony-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/harmony-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene MCP Server for HarmonyOS automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/harmony-playground/package.json
+++ b/packages/harmony-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/harmony-playground",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "HarmonyOS playground for Midscene",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/harmony",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "HarmonyOS automation library for Midscene",
   "keywords": [
     "HarmonyOS UI automation",

--- a/packages/ios-mcp/package.json
+++ b/packages/ios-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene MCP Server for iOS automation",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/ios-playground/package.json
+++ b/packages/ios-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios-playground",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "iOS playground for Midscene",
   "main": "./dist/lib/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/ios",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "iOS automation library for Midscene",
   "keywords": [
     "iOS UI automation",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Deprecated - Use @midscene/web-bridge-mcp, @midscene/android-mcp, or @midscene/ios-mcp",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/playground-app/package.json
+++ b/packages/playground-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/playground-app",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Reusable React shell for Midscene playground applications",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/playground",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene playground utilities for web integration",
   "author": "midscene team",
   "license": "MIT",

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/recorder",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/shared",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "types": "./dist/types/index.d.ts",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/visualizer",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "types": "./dist/types/index.d.ts",

--- a/packages/web-bridge-mcp/package.json
+++ b/packages/web-bridge-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/web-bridge-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Midscene MCP Server for Web automation (Bridge mode)",
   "bin": "dist/index.js",
   "files": ["dist"],

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -8,7 +8,7 @@
     "Browser use",
     "Android use"
   ],
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
   "main": "./dist/lib/index.js",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midscene/webdriver",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "WebDriver protocol implementation for Midscene automation",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.mjs",


### PR DESCRIPTION
## Summary
- Bump all package versions from 1.7.2 to 1.7.3 across 28 package.json files

## Validation
- `pnpm run check-dependency-version` passed via pre-commit hook
- `npx biome check` passed via pre-commit hook