### PR TITLE
fix(web-integration,shared): CDP CLI tab reuse, upstream switch, hang, diagnostics & MCP error formatting

### DIFF
--- a/packages/shared/src/mcp/base-server.ts
+++ b/packages/shared/src/mcp/base-server.ts
@@ -9,6 +9,7 @@ import express, {
   type Request,
   type Response,
 } from 'express';
+import { getErrorMessage } from './error-formatter';
 import type { IMidsceneTools } from './types';
 
 export interface BaseMCPServerConfig {
@@ -119,7 +120,7 @@ export abstract class BaseMCPServer {
     try {
       await this.toolsManager.initTools();
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       console.error(`Failed to initialize tools: ${message}`);
       console.error('Tools will be initialized on first use');
     }
@@ -160,7 +161,7 @@ export abstract class BaseMCPServer {
     try {
       await this.mcpServer.connect(transport);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       console.error(`Failed to connect MCP stdio transport: ${message}`);
       throw new Error(`Failed to initialize MCP stdio transport: ${message}`);
     }
@@ -282,7 +283,7 @@ export abstract class BaseMCPServer {
             .json({ error: 'Invalid session or GET without session' });
         }
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         const duration = Date.now() - startTime;
         console.error(
           `[${new Date().toISOString()}] [${requestId}] MCP request error after ${duration}ms: ${message}`,
@@ -336,8 +337,7 @@ export abstract class BaseMCPServer {
           try {
             await session.transport.close();
           } catch (error: unknown) {
-            const message =
-              error instanceof Error ? error.message : String(error);
+            const message = getErrorMessage(error);
             console.error(
               `Failed to close session ${session.transport.sessionId}: ${message}`,
             );
@@ -390,7 +390,7 @@ export abstract class BaseMCPServer {
     try {
       await this.mcpServer.connect(transport);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       console.error(
         `[${new Date().toISOString()}] Failed to connect MCP transport: ${message}`,
       );
@@ -425,8 +425,7 @@ export abstract class BaseMCPServer {
               `[${new Date().toISOString()}] Session ${sid} cleaned up due to inactivity (remaining: ${sessions.size})`,
             );
           } catch (error: unknown) {
-            const message =
-              error instanceof Error ? error.message : String(error);
+            const message = getErrorMessage(error);
             console.error(
               `[${new Date().toISOString()}] Failed to close session ${sid} during cleanup: ${message}`,
             );
@@ -455,8 +454,7 @@ export abstract class BaseMCPServer {
         try {
           session.transport.close();
         } catch (error: unknown) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = getErrorMessage(error);
           console.error(`Error closing session during shutdown: ${message}`);
         }
       }
@@ -475,7 +473,7 @@ export abstract class BaseMCPServer {
           this.performCleanup().finally(() => process.exit(1));
         }, 5000);
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         console.error(`Error closing HTTP server: ${message}`);
         this.performCleanup().finally(() => process.exit(1));
       }

--- a/packages/shared/src/mcp/error-formatter.ts
+++ b/packages/shared/src/mcp/error-formatter.ts
@@ -1,0 +1,52 @@
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Many SDK/transport layers reject with structured objects (e.g.
+ * `{ code, message }`, `{ error: { message } }`, `{ cause: { message } }`)
+ * rather than `Error` instances. `String(obj)` collapses those to
+ * `"[object Object]"`, which is useless for diagnostics. This helper walks
+ * the common shapes, falls back to `JSON.stringify`, and finally to
+ * `Object.prototype.toString.call` so that callers always get something
+ * actionable in logs and surfaced tool results.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error === null || error === undefined) return String(error);
+  if (typeof error !== 'object') return String(error);
+
+  const candidate = extractStringMessage(error);
+  if (candidate) return candidate;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return Object.prototype.toString.call(error);
+  }
+}
+
+function extractStringMessage(error: object): string | undefined {
+  const anyError = error as {
+    message?: unknown;
+    error?: { message?: unknown };
+    cause?: { message?: unknown };
+  };
+
+  if (typeof anyError.message === 'string' && anyError.message) {
+    return anyError.message;
+  }
+  if (
+    anyError.error &&
+    typeof anyError.error.message === 'string' &&
+    anyError.error.message
+  ) {
+    return anyError.error.message;
+  }
+  if (
+    anyError.cause &&
+    typeof anyError.cause.message === 'string' &&
+    anyError.cause.message
+  ) {
+    return anyError.cause.message;
+  }
+  return undefined;
+}

--- a/packages/shared/src/mcp/index.ts
+++ b/packages/shared/src/mcp/index.ts
@@ -1,5 +1,6 @@
 export * from './base-server';
 export * from './base-tools';
+export * from './error-formatter';
 export * from './tool-generator';
 export * from './types';
 export * from './inject-report-html-plugin';

--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -6,19 +6,13 @@ import {
   isMidsceneLocatorField,
   unwrapZodField,
 } from '../zod-schema-utils';
+import { getErrorMessage } from './error-formatter';
 import type {
   ActionSpaceItem,
   BaseAgent,
   ToolDefinition,
   ToolResult,
 } from './types';
-
-/**
- * Extract error message from unknown error type
- */
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 /**
  * Generate MCP tool description from ActionSpaceItem

--- a/packages/shared/tests/unit-test/error-formatter.test.ts
+++ b/packages/shared/tests/unit-test/error-formatter.test.ts
@@ -1,0 +1,76 @@
+import { getErrorMessage } from '@/mcp/error-formatter';
+import { describe, expect, it } from 'vitest';
+
+describe('getErrorMessage', () => {
+  it('returns the Error.message for Error instances', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+    expect(getErrorMessage(new TypeError('bad type'))).toBe('bad type');
+  });
+
+  it('stringifies null and undefined', () => {
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('stringifies primitives', () => {
+    expect(getErrorMessage('oops')).toBe('oops');
+    expect(getErrorMessage(42)).toBe('42');
+    expect(getErrorMessage(true)).toBe('true');
+  });
+
+  it('extracts message from { message } shape', () => {
+    expect(getErrorMessage({ message: 'connect ECONNREFUSED' })).toBe(
+      'connect ECONNREFUSED',
+    );
+  });
+
+  it('extracts message from { error: { message } } shape', () => {
+    expect(
+      getErrorMessage({ error: { message: 'upstream failed', code: 502 } }),
+    ).toBe('upstream failed');
+  });
+
+  it('extracts message from { cause: { message } } shape', () => {
+    expect(getErrorMessage({ cause: { message: 'root cause' } })).toBe(
+      'root cause',
+    );
+  });
+
+  it('prefers top-level message over nested error/cause', () => {
+    expect(
+      getErrorMessage({
+        message: 'outer',
+        error: { message: 'inner' },
+        cause: { message: 'root' },
+      }),
+    ).toBe('outer');
+  });
+
+  it('skips empty string messages and falls through to JSON', () => {
+    expect(getErrorMessage({ message: '', code: 'EIO' })).toBe(
+      '{"message":"","code":"EIO"}',
+    );
+  });
+
+  it('serializes plain objects without a known message field', () => {
+    expect(getErrorMessage({ status: 500, details: 'x' })).toBe(
+      '{"status":500,"details":"x"}',
+    );
+  });
+
+  it('falls back to Object.prototype.toString for unserializable objects', () => {
+    const circular: Record<string, unknown> = { foo: 'bar' };
+    circular.self = circular;
+    expect(getErrorMessage(circular)).toBe('[object Object]');
+  });
+
+  it('never returns the literal "[object Object]" for plain objects with data', () => {
+    const result = getErrorMessage({ code: 'E_TEST', detail: 'something' });
+    expect(result).not.toBe('[object Object]');
+    expect(result).toContain('E_TEST');
+  });
+
+  it('handles arrays by JSON-stringifying them', () => {
+    expect(getErrorMessage([1, 2, 3])).toBe('[1,2,3]');
+  });
+});

--- a/packages/web-integration/src/cdp-proxy-constants.ts
+++ b/packages/web-integration/src/cdp-proxy-constants.ts
@@ -9,3 +9,7 @@ export const PROXY_ENDPOINT_FILE = join(
   'midscene-cdp-proxy-endpoint',
 );
 export const PROXY_PID_FILE = join(tmpdir(), 'midscene-cdp-proxy-pid');
+export const PROXY_UPSTREAM_FILE = join(
+  tmpdir(),
+  'midscene-cdp-proxy-upstream',
+);

--- a/packages/web-integration/src/cdp-proxy-constants.ts
+++ b/packages/web-integration/src/cdp-proxy-constants.ts
@@ -13,3 +13,4 @@ export const PROXY_UPSTREAM_FILE = join(
   tmpdir(),
   'midscene-cdp-proxy-upstream',
 );
+export const TARGET_ID_FILE = join(tmpdir(), 'midscene-cdp-target-id');

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -1,22 +1,38 @@
 /**
  * CDP WebSocket Proxy — standalone process.
  *
- * Holds a single persistent WebSocket connection to Chrome's CDP endpoint and
- * exposes a local WebSocket server. Midscene CLI processes connect to the proxy
- * instead of Chrome directly, so Chrome's "Allow remote debugging" permission
- * popup only fires once (when the proxy connects).
+ * Holds a persistent WebSocket connection to Chrome's CDP endpoint and
+ * exposes a local WebSocket server. Midscene CLI processes connect to the
+ * proxy instead of Chrome directly, so Chrome's "Allow remote debugging"
+ * permission popup only fires once (when the proxy connects).
+ *
+ * Lifecycle notes:
+ *  - When all downstream clients disconnect the proxy stays running but
+ *    marks the upstream as needing reconnection. The actual reconnect is
+ *    deferred to the moment the next client connects, so Chrome's CDP
+ *    state (notably Target.setDiscoverTargets) is reset and the new
+ *    client receives all targetCreated events.
+ *  - On startup, if another proxy is already alive the new instance
+ *    announces "duplicate proxy detected" on stderr and exits 0 without
+ *    touching the existing metadata files.
  *
  * Exit conditions:
  *  1. Upstream Chrome connection closes or errors.
  *  2. No downstream client message for IDLE_TIMEOUT_MS (default 5 min).
  *  3. SIGTERM / SIGINT.
+ *  4. Duplicate proxy detected on startup (exits 0 with stderr notice).
  *
  * Usage (spawned by mcp-tools-cdp.ts):
  *   node cdp-proxy.js <chrome-ws-endpoint>
  *
  * On startup, prints the proxy endpoint to stdout as a single JSON line:
  *   {"endpoint":"ws://127.0.0.1:<port>/devtools/browser"}
- * and writes the same endpoint to PROXY_ENDPOINT_FILE.
+ * and writes:
+ *   - PROXY_ENDPOINT_FILE — the local proxy URL above
+ *   - PROXY_PID_FILE      — this process's pid
+ *   - PROXY_UPSTREAM_FILE — the Chrome endpoint the proxy is connected to,
+ *                           so callers can detect when the requested
+ *                           upstream has changed and replace the proxy.
  */
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
@@ -67,6 +83,15 @@ function cleanupIfOwned() {
 }
 
 /**
+ * Maximum time to wait for the stderr drain callback before forcing exit.
+ * The callback should normally fire within microseconds, but if the pipe
+ * has been closed by the parent it may never run. 500ms is generous
+ * enough to be effectively unreachable in the happy path while still
+ * keeping the process from hanging if something goes wrong.
+ */
+const STDERR_FLUSH_FALLBACK_MS = 500;
+
+/**
  * Exit after the stderr diagnostic has been flushed.
  *
  * When the proxy's stderr is a pipe (parent uses stdio 'pipe'), Node's
@@ -83,7 +108,7 @@ function exitWithStderr(message: string, code = 0): void {
     exited = true;
     process.exit(code);
   };
-  const fallback = setTimeout(doExit, 500);
+  const fallback = setTimeout(doExit, STDERR_FLUSH_FALLBACK_MS);
   fallback.unref?.();
   try {
     process.stderr.write(message, () => doExit());

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -22,7 +22,11 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import WebSocket, { WebSocketServer } from 'ws';
-import { PROXY_ENDPOINT_FILE, PROXY_PID_FILE } from './cdp-proxy-constants';
+import {
+  PROXY_ENDPOINT_FILE,
+  PROXY_PID_FILE,
+  PROXY_UPSTREAM_FILE,
+} from './cdp-proxy-constants';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -41,17 +45,24 @@ if (!chromeEndpoint) {
 // ---------------------------------------------------------------------------
 
 function cleanupIfOwned() {
+  // Only clean up if the PID file exists and records *our* PID.
+  // If the file is missing (e.g. already deleted by killProxy()) or
+  // unreadable, skip cleanup — another process may have taken over.
   try {
-    if (existsSync(PROXY_PID_FILE)) {
-      const pid = Number(readFileSync(PROXY_PID_FILE, 'utf-8').trim());
-      if (pid !== process.pid) return;
-    }
-  } catch {}
+    if (!existsSync(PROXY_PID_FILE)) return;
+    const pid = Number(readFileSync(PROXY_PID_FILE, 'utf-8').trim());
+    if (pid !== process.pid) return;
+  } catch {
+    return;
+  }
   try {
     if (existsSync(PROXY_ENDPOINT_FILE)) unlinkSync(PROXY_ENDPOINT_FILE);
   } catch {}
   try {
     if (existsSync(PROXY_PID_FILE)) unlinkSync(PROXY_PID_FILE);
+  } catch {}
+  try {
+    if (existsSync(PROXY_UPSTREAM_FILE)) unlinkSync(PROXY_UPSTREAM_FILE);
   } catch {}
 }
 
@@ -159,6 +170,7 @@ upstream.on('open', () => {
 
     writeFileSync(PROXY_ENDPOINT_FILE, proxyEndpoint);
     writeFileSync(PROXY_PID_FILE, String(process.pid));
+    writeFileSync(PROXY_UPSTREAM_FILE, chromeEndpoint);
 
     process.stdout.write(`${JSON.stringify({ endpoint: proxyEndpoint })}\n`);
   });

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -66,10 +66,35 @@ function cleanupIfOwned() {
   } catch {}
 }
 
-function shutdown(reason: string) {
-  process.stderr.write(`[cdp-proxy] shutting down: ${reason}\n`);
+/**
+ * Exit after the stderr diagnostic has been flushed.
+ *
+ * When the proxy's stderr is a pipe (parent uses stdio 'pipe'), Node's
+ * process.stderr.write() is asynchronous on POSIX. Calling process.exit()
+ * immediately afterwards can drop the pending write, which would silently
+ * lose the very diagnostic the caller is relying on. Wait for the drain
+ * callback before exiting, with a short fallback timer in case the
+ * callback never fires (e.g. the pipe is already closed).
+ */
+function exitWithStderr(message: string, code = 0): void {
+  let exited = false;
+  const doExit = () => {
+    if (exited) return;
+    exited = true;
+    process.exit(code);
+  };
+  const fallback = setTimeout(doExit, 500);
+  fallback.unref?.();
+  try {
+    process.stderr.write(message, () => doExit());
+  } catch {
+    doExit();
+  }
+}
+
+function shutdown(reason: string): void {
   cleanupIfOwned();
-  process.exit(0);
+  exitWithStderr(`[cdp-proxy] shutting down: ${reason}\n`, 0);
 }
 
 process.on('SIGTERM', () => shutdown('SIGTERM'));
@@ -132,8 +157,13 @@ function createUpstream(endpoint: string): WebSocket {
     if (!reconnecting) shutdown(`upstream error: ${err.message}`);
   });
 
-  ws.on('close', () => {
-    if (!reconnecting) shutdown('upstream closed');
+  ws.on('close', (code, reasonBuf) => {
+    if (reconnecting) return;
+    const reason = reasonBuf?.toString?.() || '';
+    const detail = reason
+      ? ` (code=${code}, reason=${reason})`
+      : ` (code=${code})`;
+    shutdown(`upstream closed${detail}`);
   });
 
   // Forward upstream messages to all downstream clients
@@ -240,7 +270,15 @@ upstream.once('open', () => {
       if (existingPid !== process.pid) {
         try {
           process.kill(existingPid, 0);
-          process.exit(0); // another proxy is alive
+          // Another proxy is alive — exit without cleanupIfOwned() (we don't
+          // own the metadata files). Announce the reason on stderr so the
+          // parent process can distinguish this path from upstream failures,
+          // then bail out of this open handler so we don't proceed to listen().
+          exitWithStderr(
+            `[cdp-proxy] duplicate proxy detected (existing pid=${existingPid})\n`,
+            0,
+          );
+          return;
         } catch {
           // dead — we take over
         }

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -96,21 +96,77 @@ resetIdleTimer();
 // Upstream: connect to Chrome
 // ---------------------------------------------------------------------------
 
-const upstream = new WebSocket(chromeEndpoint);
 const clients = new Set<WebSocket>();
 
-upstream.on('error', (err) => shutdown(`upstream error: ${err.message}`));
-upstream.on('close', () => shutdown('upstream closed'));
+/**
+ * Whether we are intentionally reconnecting the upstream WebSocket.
+ * When true, the old upstream's close/error events should not trigger shutdown.
+ */
+let reconnecting = false;
 
-// Forward upstream messages to all downstream clients
-upstream.on('message', (data, isBinary) => {
-  resetIdleTimer();
-  for (const client of clients) {
-    if (client.readyState === WebSocket.OPEN) {
-      client.send(data, { binary: isBinary });
+/**
+ * Messages from downstream clients that arrived while the upstream WebSocket
+ * was not yet open (e.g. during a reconnect). Flushed once upstream opens.
+ */
+const pendingUpstreamMessages: {
+  data: WebSocket.RawData;
+  isBinary: boolean;
+}[] = [];
+
+/**
+ * Create a new upstream WebSocket to Chrome and bind its event handlers.
+ * Used for both initial connection and reconnection.
+ */
+function createUpstream(endpoint: string): WebSocket {
+  const ws = new WebSocket(endpoint);
+
+  ws.on('error', (err) => {
+    if (!reconnecting) shutdown(`upstream error: ${err.message}`);
+  });
+
+  ws.on('close', () => {
+    if (!reconnecting) shutdown('upstream closed');
+  });
+
+  // Forward upstream messages to all downstream clients
+  ws.on('message', (data, isBinary) => {
+    resetIdleTimer();
+    for (const client of clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(data, { binary: isBinary });
+      }
     }
-  }
-});
+  });
+
+  // Flush any messages that were buffered while upstream was reconnecting
+  ws.on('open', () => {
+    for (const msg of pendingUpstreamMessages) {
+      ws.send(msg.data, { binary: msg.isBinary });
+    }
+    pendingUpstreamMessages.length = 0;
+  });
+
+  return ws;
+}
+
+let upstream = createUpstream(chromeEndpoint);
+
+/**
+ * Reconnect the upstream WebSocket to Chrome.
+ *
+ * Called when all downstream clients have disconnected. This resets the CDP
+ * protocol state on Chrome's side — critically, the Target.setDiscoverTargets
+ * subscription — so the next client that connects gets a fresh session and
+ * receives all targetCreated events.
+ */
+function reconnectUpstream() {
+  reconnecting = true;
+  upstream.removeAllListeners();
+  upstream.close();
+  upstream = createUpstream(chromeEndpoint);
+  reconnecting = false;
+  resetIdleTimer();
+}
 
 // ---------------------------------------------------------------------------
 // Downstream: local WebSocket server
@@ -127,23 +183,43 @@ wss.on('connection', (clientWs) => {
   clients.add(clientWs);
   resetIdleTimer();
 
-  // Forward downstream messages to upstream
+  // Forward downstream messages to upstream (buffer if upstream is reconnecting)
   clientWs.on('message', (data, isBinary) => {
     resetIdleTimer();
     if (upstream.readyState === WebSocket.OPEN) {
       upstream.send(data, { binary: isBinary });
+    } else {
+      pendingUpstreamMessages.push({ data, isBinary });
     }
   });
 
-  clientWs.on('close', () => clients.delete(clientWs));
-  clientWs.on('error', () => clients.delete(clientWs));
+  const removeClient = () => {
+    clients.delete(clientWs);
+    // When all downstream clients disconnect, reconnect the upstream WebSocket
+    // to reset Chrome's CDP protocol state (Target.setDiscoverTargets, etc.).
+    // This ensures the next client gets fresh targetCreated events.
+    if (clients.size === 0) {
+      // Drop any buffered messages from the now-gone client so they are not
+      // replayed against Chrome after the upstream reconnects.
+      pendingUpstreamMessages.length = 0;
+      if (upstream.readyState === WebSocket.OPEN) {
+        reconnectUpstream();
+      }
+    }
+  };
+
+  clientWs.on('close', removeClient);
+  clientWs.on('error', removeClient);
 });
 
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 
-upstream.on('open', () => {
+// Start the HTTP/WebSocket server once the initial upstream connection opens.
+// This listener is added *after* createUpstream() already bound its own 'open'
+// handler (which flushes pendingUpstreamMessages), so both will fire.
+upstream.once('open', () => {
   // Check for duplicate proxy
   if (existsSync(PROXY_PID_FILE)) {
     try {

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -105,6 +105,14 @@ const clients = new Set<WebSocket>();
 let reconnecting = false;
 
 /**
+ * Whether the upstream WebSocket needs to be reconnected before the next
+ * client can use it.  Set to true when all downstream clients disconnect;
+ * the actual reconnect is deferred until a new client connects so that
+ * Chrome's permission popup only fires when someone actually needs it.
+ */
+let needsUpstreamReconnect = false;
+
+/**
  * Messages from downstream clients that arrived while the upstream WebSocket
  * was not yet open (e.g. during a reconnect). Flushed once upstream opens.
  */
@@ -180,6 +188,14 @@ const httpServer = createServer((_req, res) => {
 const wss = new WebSocketServer({ server: httpServer });
 
 wss.on('connection', (clientWs) => {
+  // Reconnect the upstream WebSocket if the previous session ended.
+  // This resets Chrome's CDP protocol state (Target.setDiscoverTargets, etc.)
+  // so the new client receives all targetCreated events.
+  if (needsUpstreamReconnect && upstream.readyState === WebSocket.OPEN) {
+    reconnectUpstream();
+    needsUpstreamReconnect = false;
+  }
+
   clients.add(clientWs);
   resetIdleTimer();
 
@@ -195,16 +211,13 @@ wss.on('connection', (clientWs) => {
 
   const removeClient = () => {
     clients.delete(clientWs);
-    // When all downstream clients disconnect, reconnect the upstream WebSocket
-    // to reset Chrome's CDP protocol state (Target.setDiscoverTargets, etc.).
-    // This ensures the next client gets fresh targetCreated events.
+    // When all downstream clients disconnect, mark that the upstream needs
+    // reconnecting to reset Chrome's CDP protocol state.  The actual
+    // reconnect is deferred until the next client connects so we don't
+    // trigger Chrome's permission popup while nobody is using the proxy.
     if (clients.size === 0) {
-      // Drop any buffered messages from the now-gone client so they are not
-      // replayed against Chrome after the upstream reconnects.
       pendingUpstreamMessages.length = 0;
-      if (upstream.readyState === WebSocket.OPEN) {
-        reconnectUpstream();
-      }
+      needsUpstreamReconnect = true;
     }
   };
 

--- a/packages/web-integration/src/mcp-tools-cdp.ts
+++ b/packages/web-integration/src/mcp-tools-cdp.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import { join } from 'node:path';
 import { ScreenshotItem, z } from '@midscene/core';
@@ -12,6 +12,7 @@ import {
   PROXY_ENDPOINT_FILE,
   PROXY_PID_FILE,
   PROXY_UPSTREAM_FILE,
+  TARGET_ID_FILE,
 } from './cdp-proxy-constants';
 import { PuppeteerAgent } from './puppeteer';
 import { StaticPage } from './static';
@@ -142,6 +143,39 @@ function killProxy(): void {
   } catch {}
   try {
     if (existsSync(PROXY_UPSTREAM_FILE)) unlinkSync(PROXY_UPSTREAM_FILE);
+  } catch {}
+}
+
+/**
+ * Read the saved targetId from the temporary file.
+ */
+function readSavedTargetId(): string | null {
+  if (!existsSync(TARGET_ID_FILE)) return null;
+  try {
+    return readFileSync(TARGET_ID_FILE, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a targetId to the temporary file for cross-command tab reuse.
+ */
+function saveTargetId(targetId: string): void {
+  try {
+    writeFileSync(TARGET_ID_FILE, targetId, 'utf-8');
+    debug('Saved targetId: %s', targetId);
+  } catch (err) {
+    debug('Failed to save targetId: %s', err);
+  }
+}
+
+/**
+ * Remove the saved targetId file.
+ */
+function cleanupTargetIdFile(): void {
+  try {
+    if (existsSync(TARGET_ID_FILE)) unlinkSync(TARGET_ID_FILE);
   } catch {}
 }
 
@@ -345,9 +379,28 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
         });
       }
     } else {
-      // Reuse the last web page, or any existing page (including about:blank
-      // which may be the user's active tab). Only create a new page as last resort.
-      if (webPages.length > 0) {
+      // Try to find the exact tab from a previous `connect` command via saved targetId.
+      const savedTargetId = readSavedTargetId();
+      let matchedPage: Page | undefined;
+
+      if (savedTargetId && pages.length > 0) {
+        matchedPage = pages.find(
+          (p) => (p.target() as any)._targetId === savedTargetId,
+        );
+        if (matchedPage) {
+          debug('Matched saved targetId %s', savedTargetId);
+        } else {
+          debug(
+            'Saved targetId %s not found among %d pages, falling back',
+            savedTargetId,
+            pages.length,
+          );
+        }
+      }
+
+      if (matchedPage) {
+        page = matchedPage;
+      } else if (webPages.length > 0) {
         page = webPages[webPages.length - 1];
       } else if (pages.length > 0) {
         page = pages[pages.length - 1];
@@ -356,6 +409,12 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
       }
 
       await page.bringToFront();
+    }
+
+    // Persist the targetId so subsequent CLI commands can find this exact tab
+    const targetId = (page.target() as any)._targetId;
+    if (targetId) {
+      saveTargetId(targetId);
     }
 
     this.agent = new PuppeteerAgent(page as unknown as PuppeteerPage);
@@ -427,6 +486,7 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
             this.activeBrowser.disconnect();
             this.activeBrowser = null;
           }
+          cleanupTargetIdFile();
           return this.buildTextResult(
             'Disconnected from web page (browser still running externally)',
           );

--- a/packages/web-integration/src/mcp-tools-cdp.ts
+++ b/packages/web-integration/src/mcp-tools-cdp.ts
@@ -211,6 +211,9 @@ function spawnProxy(chromeEndpoint: string): Promise<string> {
             settled = true;
             clearTimeout(timer);
             proc.stdout!.removeListener('data', onData);
+            // Destroy the stdout pipe so it doesn't keep the parent
+            // process event loop alive after we've read the endpoint.
+            proc.stdout!.destroy();
             resolve(parsed.endpoint);
             return;
           }

--- a/packages/web-integration/src/mcp-tools-cdp.ts
+++ b/packages/web-integration/src/mcp-tools-cdp.ts
@@ -126,7 +126,8 @@ function readProxyUpstream(): string | null {
 }
 
 /**
- * Kill the running proxy process.
+ * Kill the running proxy process and clear all CDP-mode metadata files
+ * (proxy endpoint/pid/upstream and the cross-command targetId).
  */
 function killProxy(): void {
   if (!existsSync(PROXY_PID_FILE)) return;
@@ -134,7 +135,11 @@ function killProxy(): void {
     const pid = Number(readFileSync(PROXY_PID_FILE, 'utf-8').trim());
     process.kill(pid, 'SIGTERM');
     debug('Killed proxy pid: %d', pid);
-  } catch {}
+  } catch (err) {
+    // ESRCH (already dead) is the common case; surface anything else
+    // (e.g. EPERM) via debug so it does not vanish silently.
+    debug('killProxy failed: %s', err);
+  }
   try {
     if (existsSync(PROXY_ENDPOINT_FILE)) unlinkSync(PROXY_ENDPOINT_FILE);
   } catch {}
@@ -144,6 +149,9 @@ function killProxy(): void {
   try {
     if (existsSync(PROXY_UPSTREAM_FILE)) unlinkSync(PROXY_UPSTREAM_FILE);
   } catch {}
+  // The saved targetId points into the now-defunct upstream's tab list,
+  // so it cannot match anything in a fresh Chrome and must be discarded.
+  cleanupTargetIdFile();
 }
 
 /**
@@ -177,6 +185,16 @@ function cleanupTargetIdFile(): void {
   try {
     if (existsSync(TARGET_ID_FILE)) unlinkSync(TARGET_ID_FILE);
   } catch {}
+}
+
+/**
+ * puppeteer-core does not expose a public method for the underlying
+ * CDP target id, so we reach into `_targetId`. Centralised here so that
+ * a future puppeteer release exposing this properly only requires one
+ * change. Callers must treat the result as optional.
+ */
+function getTargetId(page: Page): string | undefined {
+  return (page.target() as unknown as { _targetId?: string })._targetId;
 }
 
 /** Keep at most this many bytes of proxy stderr for diagnostics. */
@@ -414,9 +432,7 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
       let matchedPage: Page | undefined;
 
       if (savedTargetId && pages.length > 0) {
-        matchedPage = pages.find(
-          (p) => (p.target() as any)._targetId === savedTargetId,
-        );
+        matchedPage = pages.find((p) => getTargetId(p) === savedTargetId);
         if (matchedPage) {
           debug('Matched saved targetId %s', savedTargetId);
         } else {
@@ -442,9 +458,16 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
     }
 
     // Persist the targetId so subsequent CLI commands can find this exact tab
-    const targetId = (page.target() as any)._targetId;
+    const targetId = getTargetId(page);
     if (targetId) {
       saveTargetId(targetId);
+    } else {
+      // If puppeteer ever drops the private _targetId field, this branch
+      // makes the regression visible instead of silently disabling the
+      // cross-command tab reuse path.
+      debug(
+        'No targetId on page.target(); cross-command tab reuse disabled until puppeteer integration is updated.',
+      );
     }
 
     this.agent = new PuppeteerAgent(page as unknown as PuppeteerPage);
@@ -525,3 +548,13 @@ export class WebCdpMidsceneTools extends BaseMidsceneTools<PuppeteerAgent> {
     ];
   }
 }
+
+/**
+ * Internal helpers exposed for unit tests. Not part of the public API.
+ */
+export const __test__ = {
+  getProxyEndpoint,
+  killProxy,
+  readProxyUpstream,
+  isProxyAlive,
+};

--- a/packages/web-integration/src/mcp-tools-cdp.ts
+++ b/packages/web-integration/src/mcp-tools-cdp.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import http from 'node:http';
 import { join } from 'node:path';
 import { ScreenshotItem, z } from '@midscene/core';
@@ -8,7 +8,11 @@ import { BaseMidsceneTools, type ToolDefinition } from '@midscene/shared/mcp';
 import type { Page as PuppeteerPage } from 'puppeteer';
 import puppeteer from 'puppeteer-core';
 import type { Browser, Page } from 'puppeteer-core';
-import { PROXY_ENDPOINT_FILE, PROXY_PID_FILE } from './cdp-proxy-constants';
+import {
+  PROXY_ENDPOINT_FILE,
+  PROXY_PID_FILE,
+  PROXY_UPSTREAM_FILE,
+} from './cdp-proxy-constants';
 import { PuppeteerAgent } from './puppeteer';
 import { StaticPage } from './static';
 
@@ -109,6 +113,39 @@ function readProxyEndpoint(): string | null {
 }
 
 /**
+ * Read the Chrome endpoint that the running proxy is connected to.
+ */
+function readProxyUpstream(): string | null {
+  if (!existsSync(PROXY_UPSTREAM_FILE)) return null;
+  try {
+    return readFileSync(PROXY_UPSTREAM_FILE, 'utf-8').trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Kill the running proxy process.
+ */
+function killProxy(): void {
+  if (!existsSync(PROXY_PID_FILE)) return;
+  try {
+    const pid = Number(readFileSync(PROXY_PID_FILE, 'utf-8').trim());
+    process.kill(pid, 'SIGTERM');
+    debug('Killed proxy pid: %d', pid);
+  } catch {}
+  try {
+    if (existsSync(PROXY_ENDPOINT_FILE)) unlinkSync(PROXY_ENDPOINT_FILE);
+  } catch {}
+  try {
+    if (existsSync(PROXY_PID_FILE)) unlinkSync(PROXY_PID_FILE);
+  } catch {}
+  try {
+    if (existsSync(PROXY_UPSTREAM_FILE)) unlinkSync(PROXY_UPSTREAM_FILE);
+  } catch {}
+}
+
+/**
  * Spawn the CDP proxy process and wait for it to print the endpoint.
  */
 function spawnProxy(chromeEndpoint: string): Promise<string> {
@@ -192,10 +229,22 @@ async function getProxyEndpoint(chromeEndpoint: string): Promise<string> {
     }
   }
 
-  // If proxy is alive and endpoint file exists, reuse it
+  // If proxy is alive and connected to the same Chrome, reuse it
   if (isProxyAlive()) {
     const endpoint = readProxyEndpoint();
-    if (endpoint) return endpoint;
+    const savedUpstream = readProxyUpstream();
+    if (endpoint) {
+      if (savedUpstream && savedUpstream !== browserEndpoint) {
+        // Proxy is connected to a different Chrome — kill it and start fresh
+        debug(
+          'Proxy connected to different upstream (%s), killing',
+          savedUpstream,
+        );
+        killProxy();
+      } else {
+        return endpoint;
+      }
+    }
   }
 
   // Spawn a new proxy

--- a/packages/web-integration/src/mcp-tools-cdp.ts
+++ b/packages/web-integration/src/mcp-tools-cdp.ts
@@ -179,24 +179,46 @@ function cleanupTargetIdFile(): void {
   } catch {}
 }
 
+/** Keep at most this many bytes of proxy stderr for diagnostics. */
+const PROXY_STDERR_BUFFER_LIMIT = 8 * 1024;
+
 /**
  * Spawn the CDP proxy process and wait for it to print the endpoint.
+ *
+ * Captures the child's stderr so that when startup fails we can surface
+ * the real reason (upstream closed / duplicate proxy / upstream error)
+ * instead of the generic "exited before ready".
  */
 function spawnProxy(chromeEndpoint: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const proxyScript = join(__dirname, 'cdp-proxy.js');
     const proc = spawn(process.execPath, [proxyScript, chromeEndpoint], {
       detached: true,
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
     proc.unref();
 
     let output = '';
+    let stderrBuf = '';
     let settled = false;
+
+    const appendStderr = (chunk: Buffer) => {
+      stderrBuf += chunk.toString();
+      if (stderrBuf.length > PROXY_STDERR_BUFFER_LIMIT) {
+        stderrBuf = stderrBuf.slice(-PROXY_STDERR_BUFFER_LIMIT);
+      }
+    };
+    proc.stderr!.on('data', appendStderr);
+
+    const formatStderr = () => {
+      const trimmed = stderrBuf.trim();
+      return trimmed ? ` (stderr: ${trimmed})` : '';
+    };
+
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
-        reject(new Error('Proxy startup timeout (10s)'));
+        reject(new Error(`Proxy startup timeout (10s)${formatStderr()}`));
       }
     }, 10000);
 
@@ -211,9 +233,11 @@ function spawnProxy(chromeEndpoint: string): Promise<string> {
             settled = true;
             clearTimeout(timer);
             proc.stdout!.removeListener('data', onData);
-            // Destroy the stdout pipe so it doesn't keep the parent
+            proc.stderr!.removeListener('data', appendStderr);
+            // Destroy the stdio pipes so they don't keep the parent
             // process event loop alive after we've read the endpoint.
             proc.stdout!.destroy();
+            proc.stderr!.destroy();
             resolve(parsed.endpoint);
             return;
           }
@@ -231,11 +255,14 @@ function spawnProxy(chromeEndpoint: string): Promise<string> {
         reject(new Error(`Failed to spawn proxy: ${err.message}`));
       }
     });
-    proc.on('exit', (code) => {
+    proc.on('exit', (code, signal) => {
       if (!settled) {
         settled = true;
         clearTimeout(timer);
-        reject(new Error(`Proxy exited with code ${code} before ready`));
+        const how = signal ? `signal ${signal}` : `code ${code}`;
+        reject(
+          new Error(`Proxy exited with ${how} before ready${formatStderr()}`),
+        );
       }
     });
   });

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -230,6 +230,73 @@ describe('CDP WebSocket Proxy', () => {
     expect(existsSync(PROXY_PID_FILE)).toBe(false);
   });
 
+  it('reconnects upstream when all clients disconnect', async () => {
+    const { proc, proxyEndpoint } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc;
+
+    // First client connects, sends a message, then disconnects
+    const client1 = new WebSocket(proxyEndpoint);
+    await new Promise<void>((r) => client1.on('open', r));
+    const res1 = await new Promise<Record<string, unknown>>((r) => {
+      client1.on('message', (d) => r(JSON.parse(d.toString())));
+      client1.send(JSON.stringify({ id: 1, method: 'test' }));
+    });
+    expect(res1).toHaveProperty('id', 1);
+
+    // Record how many Chrome-side connections exist before client disconnects
+    const connectionsBefore = fakeChrome.clients.size;
+    client1.close();
+
+    // Wait for proxy to reconnect upstream
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Verify Chrome got a new connection (reconnect happened)
+    // The old connection was closed and a new one was established,
+    // so the count should be at least what it was (old one removed, new one added).
+    // In practice the fake Chrome set tracks connections, so we verify
+    // a new one appeared.
+    expect(fakeChrome.clients.size).toBeGreaterThanOrEqual(1);
+
+    // Second client connects through the same proxy and should work
+    const client2 = new WebSocket(proxyEndpoint);
+    await new Promise<void>((r) => client2.on('open', r));
+    const res2 = await new Promise<Record<string, unknown>>((r) => {
+      client2.on('message', (d) => r(JSON.parse(d.toString())));
+      client2.send(JSON.stringify({ id: 2, method: 'test' }));
+    });
+    expect(res2).toHaveProperty('id', 2);
+    client2.close();
+
+    // Proxy should still be alive
+    expect(proc.killed).toBe(false);
+  });
+
+  it('buffers client messages during upstream reconnect', async () => {
+    const { proc, proxyEndpoint } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc;
+
+    // First client connects and disconnects to trigger upstream reconnect
+    const client1 = new WebSocket(proxyEndpoint);
+    await new Promise<void>((r) => client1.on('open', r));
+    client1.close();
+
+    // Immediately connect a second client — upstream may still be reconnecting
+    // Give just a tiny bit of time for the close event to propagate
+    await new Promise((r) => setTimeout(r, 50));
+
+    const client2 = new WebSocket(proxyEndpoint);
+    await new Promise<void>((r) => client2.on('open', r));
+
+    // Send a message that may need to be buffered if upstream isn't ready yet
+    const res = await new Promise<Record<string, unknown>>((resolve) => {
+      client2.on('message', (d) => resolve(JSON.parse(d.toString())));
+      client2.send(JSON.stringify({ id: 42, method: 'buffered.test' }));
+    });
+
+    expect(res).toHaveProperty('id', 42);
+    client2.close();
+  });
+
   it('shuts down when upstream closes', async () => {
     // Create a separate fake Chrome for this test so we can close it
     const isolatedChrome = await createFakeChrome();

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -413,4 +413,68 @@ describe('CDP WebSocket Proxy', () => {
       fakeChrome2.server.close();
     }
   });
+
+  it('getProxyEndpoint replaces a live proxy when upstream changes', async () => {
+    // This test exercises the real getProxyEndpoint() / killProxy() path.
+    // It guards against the bug where an alive proxy connected to Chrome A
+    // would be reused for a request targeting Chrome B (#2354) — including
+    // the timing window where the old proxy has not finished exiting yet
+    // when the new one is spawned.
+    //
+    // The "records different upstream" test above only covers metadata
+    // bookkeeping with manual SIGTERM + cleanupFiles() in between, which
+    // hides whether killProxy()'s synchronous unlinks let the next
+    // spawnProxy() through without tripping its duplicate-proxy guard.
+    const { __test__ } = await import('../../dist/lib/mcp-tools-cdp.js');
+    const { getProxyEndpoint, isProxyAlive, readProxyUpstream } = __test__;
+
+    cleanupFiles();
+    try {
+      if (existsSync(join(tmpdir(), 'midscene-cdp-target-id'))) {
+        unlinkSync(join(tmpdir(), 'midscene-cdp-target-id'));
+      }
+    } catch {}
+
+    const fakeChromeB = await createFakeChrome();
+    let endpointA = '';
+    let endpointB = '';
+    try {
+      endpointA = await getProxyEndpoint(fakeChrome.endpoint);
+      expect(endpointA).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/devtools\/browser$/);
+      expect(readProxyUpstream()).toBe(fakeChrome.endpoint);
+      expect(isProxyAlive()).toBe(true);
+
+      // Switching upstream — should kill the old proxy and start a new one.
+      // We do NOT cleanupFiles() between calls; the killProxy() path inside
+      // getProxyEndpoint() must handle the metadata files itself so that
+      // the new spawn does not see a stale PID file and exit early.
+      endpointB = await getProxyEndpoint(fakeChromeB.endpoint);
+      expect(endpointB).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/devtools\/browser$/);
+      expect(endpointB).not.toBe(endpointA);
+      expect(readProxyUpstream()).toBe(fakeChromeB.endpoint);
+      expect(isProxyAlive()).toBe(true);
+
+      // The new proxy must actually accept downstream connections —
+      // i.e. spawnProxy() did not silently fall back to returning the raw
+      // Chrome endpoint after the duplicate-proxy guard fired.
+      const ws = new WebSocket(endpointB);
+      await new Promise<void>((resolve, reject) => {
+        ws.on('open', resolve);
+        ws.on('error', reject);
+      });
+      ws.close();
+    } finally {
+      // Tear down the live proxy we created via getProxyEndpoint.
+      if (existsSync(PROXY_PID_FILE)) {
+        try {
+          const pid = Number(readFileSync(PROXY_PID_FILE, 'utf-8').trim());
+          process.kill(pid, 'SIGTERM');
+          await new Promise((r) => setTimeout(r, 200));
+        } catch {}
+      }
+      cleanupFiles();
+      fakeChromeB.wss.close();
+      fakeChromeB.server.close();
+    }
+  });
 });

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -350,6 +350,39 @@ describe('CDP WebSocket Proxy', () => {
     expect(existsSync(PROXY_UPSTREAM_FILE)).toBe(false);
   });
 
+  it('announces duplicate-proxy detection on stderr before exiting', async () => {
+    // Start the first proxy normally.
+    const { proc: proc1 } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc1;
+
+    // Spawn a second proxy against the same Chrome while the first is alive.
+    // The second should see the existing pid file and exit 0 with a
+    // diagnostic line on stderr.
+    const second = spawn(
+      process.execPath,
+      [PROXY_SCRIPT, fakeChrome.endpoint],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    let secondStderr = '';
+    second.stderr?.on('data', (c: Buffer) => {
+      secondStderr += c.toString();
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) =>
+      second.on('exit', (code) => resolve(code)),
+    );
+    expect(exitCode).toBe(0);
+    expect(secondStderr).toMatch(/duplicate proxy detected/);
+
+    // The first proxy's metadata must still be intact — the second must
+    // not have wiped the endpoint/pid files on its way out.
+    expect(existsSync(PROXY_PID_FILE)).toBe(true);
+    expect(existsSync(PROXY_ENDPOINT_FILE)).toBe(true);
+  });
+
   it('records different upstream for different Chrome endpoints', async () => {
     // Start proxy for first fake Chrome
     const { proc: proc1 } = await startProxy(fakeChrome.endpoint);

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -8,6 +8,7 @@ import WebSocket, { WebSocketServer } from 'ws';
 
 const PROXY_ENDPOINT_FILE = join(tmpdir(), 'midscene-cdp-proxy-endpoint');
 const PROXY_PID_FILE = join(tmpdir(), 'midscene-cdp-proxy-pid');
+const PROXY_UPSTREAM_FILE = join(tmpdir(), 'midscene-cdp-proxy-upstream');
 const PROXY_SCRIPT = join(__dirname, '../../dist/lib/cdp-proxy.js');
 
 /**
@@ -111,6 +112,9 @@ function cleanupFiles() {
   } catch {}
   try {
     if (existsSync(PROXY_PID_FILE)) unlinkSync(PROXY_PID_FILE);
+  } catch {}
+  try {
+    if (existsSync(PROXY_UPSTREAM_FILE)) unlinkSync(PROXY_UPSTREAM_FILE);
   } catch {}
 }
 
@@ -250,5 +254,59 @@ describe('CDP WebSocket Proxy', () => {
     const exitCode = await exitPromise;
     proxyProc = null;
     expect(exitCode).toBe(0);
+  });
+
+  it('writes upstream endpoint file on startup', async () => {
+    const { proc } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc;
+
+    expect(existsSync(PROXY_UPSTREAM_FILE)).toBe(true);
+    const savedUpstream = readFileSync(PROXY_UPSTREAM_FILE, 'utf-8').trim();
+    expect(savedUpstream).toBe(fakeChrome.endpoint);
+  });
+
+  it('cleans up upstream file on SIGTERM', async () => {
+    const { proc } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc;
+
+    expect(existsSync(PROXY_UPSTREAM_FILE)).toBe(true);
+
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => proc.on('exit', resolve));
+    proxyProc = null;
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(existsSync(PROXY_UPSTREAM_FILE)).toBe(false);
+  });
+
+  it('records different upstream for different Chrome endpoints', async () => {
+    // Start proxy for first fake Chrome
+    const { proc: proc1 } = await startProxy(fakeChrome.endpoint);
+    proxyProc = proc1;
+
+    const upstream1 = readFileSync(PROXY_UPSTREAM_FILE, 'utf-8').trim();
+    expect(upstream1).toBe(fakeChrome.endpoint);
+
+    // Kill first proxy
+    proc1.kill('SIGTERM');
+    await new Promise<void>((resolve) => proc1.on('exit', resolve));
+    proxyProc = null;
+    cleanupFiles();
+
+    // Start a second fake Chrome on a different port
+    const fakeChrome2 = await createFakeChrome();
+
+    try {
+      const { proc: proc2 } = await startProxy(fakeChrome2.endpoint);
+      proxyProc = proc2;
+
+      const upstream2 = readFileSync(PROXY_UPSTREAM_FILE, 'utf-8').trim();
+      expect(upstream2).toBe(fakeChrome2.endpoint);
+      // The upstream should differ since the fake Chromes are on different ports
+      expect(upstream2).not.toBe(upstream1);
+    } finally {
+      fakeChrome2.wss.close();
+      fakeChrome2.server.close();
+    }
   });
 });

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -230,7 +230,7 @@ describe('CDP WebSocket Proxy', () => {
     expect(existsSync(PROXY_PID_FILE)).toBe(false);
   });
 
-  it('reconnects upstream when all clients disconnect', async () => {
+  it('reconnects upstream when next client connects after all disconnect', async () => {
     const { proc, proxyEndpoint } = await startProxy(fakeChrome.endpoint);
     proxyProc = proc;
 
@@ -243,23 +243,25 @@ describe('CDP WebSocket Proxy', () => {
     });
     expect(res1).toHaveProperty('id', 1);
 
-    // Record how many Chrome-side connections exist before client disconnects
-    const connectionsBefore = fakeChrome.clients.size;
     client1.close();
 
-    // Wait for proxy to reconnect upstream
-    await new Promise((r) => setTimeout(r, 500));
+    // Wait for the close event to propagate
+    await new Promise((r) => setTimeout(r, 200));
 
-    // Verify Chrome got a new connection (reconnect happened)
-    // The old connection was closed and a new one was established,
-    // so the count should be at least what it was (old one removed, new one added).
-    // In practice the fake Chrome set tracks connections, so we verify
-    // a new one appeared.
-    expect(fakeChrome.clients.size).toBeGreaterThanOrEqual(1);
+    // Upstream reconnect is deferred — it should NOT have happened yet.
+    // Chrome should still have only 1 connection (the original).
+    expect(fakeChrome.clients.size).toBe(1);
 
-    // Second client connects through the same proxy and should work
+    // Second client connects — this triggers the deferred upstream reconnect
     const client2 = new WebSocket(proxyEndpoint);
     await new Promise<void>((r) => client2.on('open', r));
+
+    // Wait for upstream reconnect to complete
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Verify Chrome got a new connection (reconnect happened on new client)
+    expect(fakeChrome.clients.size).toBeGreaterThanOrEqual(1);
+
     const res2 = await new Promise<Record<string, unknown>>((r) => {
       client2.on('message', (d) => r(JSON.parse(d.toString())));
       client2.send(JSON.stringify({ id: 2, method: 'test' }));
@@ -275,15 +277,17 @@ describe('CDP WebSocket Proxy', () => {
     const { proc, proxyEndpoint } = await startProxy(fakeChrome.endpoint);
     proxyProc = proc;
 
-    // First client connects and disconnects to trigger upstream reconnect
+    // First client connects and disconnects to mark upstream for reconnect
     const client1 = new WebSocket(proxyEndpoint);
     await new Promise<void>((r) => client1.on('open', r));
     client1.close();
 
-    // Immediately connect a second client — upstream may still be reconnecting
-    // Give just a tiny bit of time for the close event to propagate
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait for the close event to propagate so the reconnect flag is set
+    await new Promise((r) => setTimeout(r, 100));
 
+    // Second client connects — triggers deferred upstream reconnect.
+    // The upstream may still be reconnecting when the client sends a message,
+    // so the message should be buffered and flushed once upstream opens.
     const client2 = new WebSocket(proxyEndpoint);
     await new Promise<void>((r) => client2.on('open', r));
 


### PR DESCRIPTION
## Summary

修复 CDP 模式 CLI 下的五个 bug：

1. **跨命令无法复用 Tab**（#2355）：每次 CLI 命令都打开新的 `about:blank`，而非复用上一条 `connect` 命令打开的页面
2. **切换 CDP 端点时 Proxy 复用错误连接**（#2354）：从本地 Chrome 切换到远程 CDP 端点时，proxy 仍然路由到本地浏览器
3. **首次连接后 CLI 进程挂起**（#2368）：Chrome 重启后首次运行 `connect` 命令，任务完成后进程不退出，必须 Ctrl+C
4. **Proxy 启动失败被压扁成同一条模糊日志**（#2369）：任何启动失败（upstream closed / error / duplicate proxy / timeout）都只报 `Proxy exited with code 0 before ready`，无法定位
5. **非 Error 异常在 MCP 错误消息中被压扁成 `[object Object]`**（#2370）：SDK/transport 层抛出 `{code, message}` 之类的结构化对象时，最终呈现给 AI agent 的错误信息完全不可读

前四个问题仅影响 CLI `--cdp` 模式；第 5 个问题影响所有 MCP 工具调用（任何平台任何模式）。

---

## Bug 1: 跨命令无法复用 Tab (#2355)

### 复现

```bash
CDP="ws://127.0.0.1:9222/devtools/browser/xxx"
npx @midscene/web connect --url https://example.com --cdp $CDP   # ✅ 正常导航
npx @midscene/web act --prompt "click button" --cdp $CDP          # ❌ 打开 about:blank
```

### 根因

CDP proxy (`cdp-proxy.ts`) 到 Chrome 的上游 WebSocket 在客户端断开后始终保持。第二个 CLI 命令通过同一 proxy 重连时，Puppeteer 发送 `Target.setDiscoverTargets`，但 Chrome 认为该上游连接已处于 discover 模式，**不重发 `targetCreated` 事件**。导致 `browser.pages()` 返回 0，代码走到 `browser.newPage()` 创建 `about:blank`。

此外，`Target.attachToTarget` 在 stale proxy 连接上同样失败（Chrome 对该 session 的 target 注册表为空），因此单纯持久化 targetId 也无法解决问题。

```
[Client 1] ←WS→ [CDP Proxy] ←WS→ [Chrome]
  disconnect ↑        ↑ 始终保持      ↑ 不重发 targetCreated
[Client 2] ←WS→ [CDP Proxy] ←WS→ [Chrome]  → browser.pages() = 0 ❌
```

### 修复

分两层解决：

**Proxy 上游延迟重连**（修复根因）：
- 当所有下游客户端断开后，proxy 标记需要重连；下一个客户端连入时重建上游 WebSocket，重置 Chrome 的 CDP 协议状态
- 下一个客户端获得干净的 CDP 连接 → `browser.pages()` 正常返回
- 重连期间的下游消息缓冲到 `pendingUpstreamMessages`，上游 open 后 flush
- 所有客户端断开时清空 buffer，避免已断开客户端的命令被重放

**targetId 持久化**（精确定位 Tab）：
- `connect` 成功后将 `page.target()._targetId` 写入临时文件
- 后续命令通过 savedTargetId 精确匹配 tab（例如用户有 14 个 tab 时不会盲选最后一个）
- `disconnect` 命令清理 targetId 文件

两层缺一不可：上游重连保证 CDP 状态干净，targetId 持久化在多 tab 场景下提供精确匹配。

---

## Bug 2: Proxy Upstream 不匹配 (#2354)

### 复现

```bash
# 先连接本地 Chrome
npx @midscene/web connect --url https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/xxx
# 切换到远程 CDP
npx @midscene/web connect --url https://example.com --cdp ws://remote:9222/devtools/browser/yyy
# ❌ 实际仍操作本地浏览器
```

### 根因

`getProxyEndpoint()` 复用 proxy 时仅检查进程是否存活（`isProxyAlive()`），不校验 proxy 连接的是哪个 Chrome 端点。

### 修复

- 新增 `PROXY_UPSTREAM_FILE` 临时文件，proxy 启动时写入连接的 Chrome 端点
- `getProxyEndpoint()` 复用前对比请求端点与已存储的上游端点，不匹配时 kill 旧 proxy 并启动新的
- 修复 `cleanupIfOwned()` 竞态：PID 文件不存在或不可读时跳过清理，防止退出中的旧 proxy 误删新 proxy 的元数据文件

---

## Bug 3: 首次连接后 CLI 进程挂起 (#2368)

### 复现

```bash
# 1. 启动 Chrome（或重启 Chrome）
# 2. 首次运行 connect 命令
node cli.js connect --cdp ws://127.0.0.1:9222/devtools/browser --url https://example.com
# 命令完成（截图已保存），但进程不退出，必须 Ctrl+C
# 3. 后续命令正常退出
```

### 根因

`spawnProxy()` 通过 `stdio: ['ignore', 'pipe', 'ignore']` 创建子进程，读取 endpoint 后移除了 `data` listener，但 **未 destroy stdout pipe stream**。这个 pipe 引用使父进程的 event loop 无法排空，导致进程无法自然退出。后续命令因 proxy 已在运行（`isProxyAlive()` 返回 true）而跳过 `spawnProxy()`，不创建 pipe，因此不受影响。

这是 #2216 引入的历史 bug。

### 修复

`spawnProxy()`：读取 endpoint 后调用 `proc.stdout!.destroy()` 释放 pipe 引用。

---

## Bug 4: Proxy 启动失败可观测性不足 (#2369)

### 现象

任何 proxy 启动失败都只能看到同一条模糊日志，随后 `act` 紧接着又吐出 `[object Object]`（这是另一条独立的历史问题，见 Bug 5 / #2370）：

```
[cdp] proxy failed, falling back to direct connection: Error: Proxy exited with code 0 before ready
Error executing act: [object Object]
```

无法区分是 upstream 被远端关闭、网络抖动、duplicate proxy 竞态、还是 startup timeout。

### 根因

- **`spawnProxy()` 丢弃了子进程 stderr**：`stdio` 用 `['ignore','pipe','ignore']`，而 `cdp-proxy.ts` 的 `shutdown(reason)` 明明把真实原因写到了 stderr，父进程拿不到
- **upstream `close` 回调没带 close code / reason**：`ws.on('close', () => shutdown('upstream closed'))`
- **duplicate-proxy 分支走 `process.exit(0)` 前连 stderr 都没写**，父进程只能看到退出码
- **即便写了 stderr 也会丢**：POSIX 上 stderr-over-pipe 是异步写入，`process.stderr.write(...)` 之后立刻 `process.exit(0)` 会把缓冲数据扔掉——这一层竞态本身也是 bug

### 修复

**父进程侧（`mcp-tools-cdp.ts` `spawnProxy()`）**：
- `stdio` 改为 `['ignore','pipe','pipe']`，维护 8 KB rolling stderr buffer
- 三类失败路径都把 stderr 尾部拼进错误消息：startup timeout / exit-before-ready（区分 code vs signal）/ spawn error
- 成功读到 endpoint 后同时 destroy stdout + stderr pipe（和 Bug 3 一致，避免 pipe 引用卡住 event loop）

**子进程侧（`cdp-proxy.ts`）**：
- upstream `close(code, reason)` 回调带上 close `code` / `reason`
- duplicate-proxy 分支在 exit 前主动写 `[cdp-proxy] duplicate proxy detected (existing pid=N)`
- 新增 `exitWithStderr(message, code)` helper：在 `process.stderr.write` 的 drain 回调里触发 `process.exit`，配 500ms fallback timer 防止回调不 fire，解决 POSIX 异步写入竞态
- `shutdown()` 也走这条 helper

### 效果

修复前：

```
[cdp] proxy failed, falling back to direct connection: Error: Proxy exited with code 0 before ready
```

修复后（示意）：

```
[cdp] proxy failed, falling back to direct connection: Error: Proxy exited with code 0 before ready (stderr: [cdp-proxy] shutting down: upstream closed (code=1006, reason=))
```

可以直接区分四类根因。

---

## Bug 5: 非 Error 异常被压扁成 `[object Object]` (#2370)

### 现象

```
Error executing act: [object Object]
```

任何通过 MCP 工具调用触发的失败，只要底层抛出的是结构化对象（而非 `Error` 实例），最终交到 AI agent / 用户手里的消息都只剩 `[object Object]`，根因信息全部丢失。

### 根因

`packages/shared/src/mcp/` 下 9 处（`tool-generator.ts` 1 处 helper + `base-server.ts` 8 处内联）统一走：

```ts
error instanceof Error ? error.message : String(error)
```

而 `String({code: 'EIO', message: '...'})` 就是 `"[object Object]"`。SDK / transport 层（`@modelcontextprotocol/sdk`、express 中间件、底层 WS 实现等）抛出的 reject 值大多是这种结构化对象，恰好全部命中。

### 修复

- 新增 `packages/shared/src/mcp/error-formatter.ts`，`getErrorMessage()` 实现：
  1. `Error` 实例 → `error.message`
  2. `null` / `undefined` / 原始类型 → `String(error)`
  3. 对象：依次探测 `error.message` / `error.error.message` / `error.cause.message`（都需非空字符串）
  4. 退化到 `JSON.stringify`；循环引用则 fallback 到 `Object.prototype.toString.call`
- `tool-generator.ts` 删除本地 helper，改为 import
- `base-server.ts` 8 处 inline 三元表达式全部替换为 `getErrorMessage()`
- `packages/shared/src/mcp/index.ts` 补充 re-export
- 新增 `packages/shared/tests/unit-test/error-formatter.test.ts`（12 个 case），覆盖 Error、null、undefined、primitive、`{message}`、`{error:{message}}`、`{cause:{message}}`、无已知字段的对象（走 JSON）、循环引用（走 toString）、数组、空字符串消息 fallthrough，并显式断言不再出现 `[object Object]`

---

## 改动文件

| 文件 | 改动 |
|------|------|
| `packages/web-integration/src/cdp-proxy-constants.ts` | 新增 `PROXY_UPSTREAM_FILE`、`TARGET_ID_FILE` 常量 |
| `packages/web-integration/src/cdp-proxy.ts` | 上游 lazy reconnect、消息缓冲、`PROXY_UPSTREAM_FILE` 写入/清理、`cleanupIfOwned()` 竞态修复、upstream close 带 code/reason、duplicate-proxy 写 stderr、`exitWithStderr()` helper 保证 stderr flush |
| `packages/web-integration/src/mcp-tools-cdp.ts` | `readProxyUpstream()`、`killProxy()`、upstream 对比逻辑、targetId 持久化（读/写/清理）、`ensureAgent()` targetId 匹配、`spawnProxy()` stdout+stderr pipe destroy、stderr 捕获 & 尾部拼错误消息 |
| `packages/web-integration/tests/unit-test/cdp-proxy.test.ts` | 新增 6 个测试（上游重连、消息缓冲、upstream 文件写入/清理/多端点、duplicate-proxy stderr 公告），更新重连测试为 lazy reconnect 语义 |
| `packages/shared/src/mcp/error-formatter.ts` | 新增 `getErrorMessage()` shared helper |
| `packages/shared/src/mcp/index.ts` | 导出 `error-formatter` |
| `packages/shared/src/mcp/tool-generator.ts` | 移除本地 helper，改用 shared `getErrorMessage()` |
| `packages/shared/src/mcp/base-server.ts` | 8 处 inline 三元替换为 shared `getErrorMessage()` |
| `packages/shared/tests/unit-test/error-formatter.test.ts` | 新增 12 个 case 的单测 |

## Test plan

- [x] `npx rslib build`（packages/web-integration、packages/shared）构建通过
- [x] `npx vitest run tests/unit-test/cdp-proxy.test.ts` — 11 个测试全部通过
- [x] `npx vitest run tests/unit-test/error-formatter.test.ts` — 12 个测试全部通过
- [x] `npx vitest run`（packages/shared 全量）— 310 个测试全部通过
- [x] duplicate-proxy 回归测试 stress-run 20 次，全部通过（验证 stderr drain 回调时序可靠）
- [x] `npx biome check` 对所有改动文件无错误
- [x] 真实 Chrome 手动验证：`connect` → `act` 跨命令复用 tab 正常
- [x] 真实 Chrome 手动验证：本地 → 远程 CDP 端点切换正常
- [x] 真实 Chrome 手动验证：Chrome 重启后首次 `connect` 进程正常退出

Closes #2354
Closes #2355
Fixes #2368
Closes #2369
Closes #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
