### PR TITLE
docs(site): move Qwen3-VL into Other Models in common model config docs

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -90,19 +90,6 @@ MIDSCENE_MODEL_REASONING_ENABLED="false"
 
 To enable thinking mode, set `MIDSCENE_MODEL_REASONING_ENABLED="true"` and add `MIDSCENE_MODEL_REASONING_BUDGET="500"` to control thinking cost.
 
-### Qwen3-VL {#qwen3-vl}
-
-Using Alibaba Cloud's `qwen3-vl-plus` as an example:
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
-MIDSCENE_MODEL_API_KEY="......"
-MIDSCENE_MODEL_NAME="qwen3-vl-plus"
-MIDSCENE_MODEL_FAMILY="qwen3-vl"
-```
-
-You can also use Qwen3-VL from [OpenRouter](https://openrouter.ai/qwen).
-
 ### Zhipu GLM-V Series {#glm-v}
 
 Zhipu GLM-V is a vision understanding model from Zhipu AI. The latest versions include `GLM-4.6V` (open-source) and `GLM-5V-Turbo`.
@@ -186,6 +173,19 @@ MIDSCENE_MODEL_FAMILY="gpt-5"
 :::
 
 ## Other Models
+
+### Qwen3-VL {#qwen3-vl}
+
+Using Alibaba Cloud's `qwen3-vl-plus` as an example:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="qwen3-vl-plus"
+MIDSCENE_MODEL_FAMILY="qwen3-vl"
+```
+
+You can also use Qwen3-VL from [OpenRouter](https://openrouter.ai/qwen).
 
 ### Qwen2.5-VL (Not recommended) {#qwen25-vl}
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -94,17 +94,6 @@ MIDSCENE_MODEL_REASONING_ENABLED="false"
 
 如果需要开启思考模式，可以配置 `MIDSCENE_MODEL_REASONING_ENABLED="true"` 并增加 `MIDSCENE_MODEL_REASONING_BUDGET="500"` 配置以控制思考耗时。
 
-### 千问 Qwen3-VL {#qwen3-vl}
-
-以[阿里云](https://www.aliyun.com/)的 `qwen3-vl-plus` 模型为例，它的环境变量配置如下：
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
-MIDSCENE_MODEL_API_KEY="......"
-MIDSCENE_MODEL_NAME="qwen3-vl-plus"
-MIDSCENE_MODEL_FAMILY="qwen3-vl"
-```
-
 ### 智谱 GLM-V 系列 {#glm-v}
 
 智谱 GLM-V 是智谱 AI 推出的视觉理解模型。最新版本有 `GLM-4.6V`（开源）、`GLM-5V-Turbo`。
@@ -189,6 +178,17 @@ MIDSCENE_MODEL_FAMILY="gpt-5"
 :::
 
 ## 其他模型
+
+### 千问 Qwen3-VL {#qwen3-vl}
+
+以[阿里云](https://www.aliyun.com/)的 `qwen3-vl-plus` 模型为例，它的环境变量配置如下：
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="qwen3-vl-plus"
+MIDSCENE_MODEL_FAMILY="qwen3-vl"
+```
 
 ### 千问 Qwen2.5-VL（不推荐） {#qwen25-vl}
 


### PR DESCRIPTION
### Motivation
- Qwen3-VL was being shown in the main recommended/common model list but should be categorized under "Other Models" to reflect its non-recommended status.

### Description
- Moved the `Qwen3-VL` subsection from the primary model list into the `## Other Models` section in `apps/site/docs/en/model-common-config.mdx` and `apps/site/docs/zh/model-common-config.mdx`.
- Preserved the existing `#qwen3-vl` anchor and the configuration example content so existing links and examples continue to work.
- Applied the same change to both English and Chinese files to keep i18n parity.

### Testing
- Ran `pnpm run lint`, which was executed but failed in this environment due to repo-level Biome issues involving oversized files in `./.pnpm-store` and broken symlinks under `packages/ios/static` and `packages/playground/static`.
- No unit or integration tests were required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05c82d41083249e4209e489051435)