### PR TITLE
fix(core): prevent duplicate retries in service caller

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -168,6 +168,9 @@ async function createChatClient({
     // Note: Type assertion needed due to undici version mismatch between dependencies
     ...(proxyAgent ? { fetchOptions: { dispatcher: proxyAgent as any } } : {}),
     ...openaiExtraConfig,
+    // Midscene already handles retries in callAI(), so disable SDK-level retries
+    // to avoid duplicate attempts and duplicated backoff latency.
+    maxRetries: 0,
     // When disabled (timeoutMs === null) fall through to the SDK default so
     // only the caller-provided abortSignal can cancel the request.
     ...(effectiveTimeoutMs !== null ? { timeout: effectiveTimeoutMs } : {}),

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -154,6 +154,7 @@ describe('service-caller request timeout', () => {
     >;
     const lastCallOptions = OpenAI.mock.calls.at(-1)?.[0];
     expect(lastCallOptions?.timeout).toBe(180_000);
+    expect(lastCallOptions?.maxRetries).toBe(0);
   });
 
   it('retries after a hard timeout and returns the next successful response', async () => {


### PR DESCRIPTION
### Motivation
- Prevent duplicate, overlapping retry attempts by disabling SDK-level retries when constructing the OpenAI client because `service-caller` already implements an explicit retry loop; the OpenAI Node SDK exposes a `maxRetries` option (documented in the openai-node README). 

### Description
- Add `maxRetries: 0` (with a clarifying comment) to the OpenAI init options in `packages/core/src/ai-model/service-caller/index.ts` and add an assertion in `packages/core/tests/unit-test/service-caller-timeout.test.ts` to verify the constructor received `maxRetries: 0`.

### Testing
- Ran `npx nx build @midscene/shared` which completed successfully. 
- Ran the focused unit test for the timeout suite with `pnpm --filter @midscene/core exec vitest --run tests/unit-test/service-caller-timeout.test.ts` and `npx nx test @midscene/core tests/unit-test/service-caller-timeout.test.ts`, and the targeted tests passed. 
- Ran `pnpm run lint` (failed in this environment due to Biome scanning large files under `.pnpm-store`), and a full `npx nx test @midscene/core` initially failed until `@midscene/shared` was built (this is an environment/ordering issue, not a regression from the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08072a268832481628ff8d1cd20e7)