### PR TITLE
fix(android): use logger warning helper for warning notices

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -68,6 +68,7 @@ const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 
 const debugDevice = getDebug('android:device');
+const warnDevice = getDebug('android:device', { console: true });
 
 /**
  * Escape text for safe use in shell single-quoted strings.
@@ -396,7 +397,7 @@ export class AndroidDevice implements AbstractInterface {
         );
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        console.warn(
+        warnDevice(
           `[midscene] Scrcpy unavailable, using ADB fallback (device: ${this.deviceId}): ${msg}`,
         );
       }
@@ -1089,7 +1090,7 @@ ${Object.keys(size)
       right: 'right edge',
     };
 
-    console.warn(
+    warnDevice(
       `[midscene] Android ADB swipe coordinates must stay within the screen bounds. The requested scroll distance (${requestedDistance}px) exceeds the maximum single swipe distance (${appliedDistance}px) from the current start point, so it will be clamped. If you want to scroll to the ${edgeLabel[direction]}, use ${scrollToSuggestion[direction]} instead.`,
     );
   }
@@ -2080,7 +2081,7 @@ ${Object.keys(size)
       );
     }
 
-    console.warn(
+    warnDevice(
       'Warning: Failed to hide the software keyboard after trying both ESC and BACK keys',
     );
     return false;

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1262,6 +1262,7 @@ describe('AndroidDevice', () => {
 
         // Verify warning was logged
         expect(warnSpy).toHaveBeenCalledWith(
+          '[Midscene]',
           'Warning: Failed to hide the software keyboard after trying both ESC and BACK keys',
         );
 
@@ -1395,6 +1396,7 @@ describe('AndroidDevice', () => {
         await device.scrollDown(9999999);
 
         expect(console.warn).toHaveBeenCalledWith(
+          '[Midscene]',
           '[midscene] Android ADB swipe coordinates must stay within the screen bounds. The requested scroll distance (9999999px) exceeds the maximum single swipe distance (480px) from the current start point, so it will be clamped. If you want to scroll to the bottom, use scrollToBottom instead.',
         );
       });
@@ -1833,6 +1835,7 @@ describe('AndroidDevice', () => {
         await device.scrollDown(500, startPoint);
 
         expect(console.warn).toHaveBeenCalledWith(
+          '[Midscene]',
           '[midscene] Android ADB swipe coordinates must stay within the screen bounds. The requested scroll distance (500px) exceeds the maximum single swipe distance (100px) from the current start point, so it will be clamped. If you want to scroll to the bottom, use scrollToBottom instead.',
         );
       });


### PR DESCRIPTION
### Motivation
- Standardize warning output to the repository logging flow instead of using raw `console.warn` so warnings include the shared logger prefix and file logging behavior.
- Prevent fragile test assertions against raw `console.warn` text by routing warnings through the existing `getDebug(..., { console: true })` helper.

### Description
- Add `warnDevice = getDebug('android:device', { console: true })` in `packages/android/src/device.ts` and replace three `console.warn` calls with `warnDevice(...)` (scrcpy fallback, scroll clamp notice, and keyboard-hide failure).
- Update `packages/android/tests/unit-test/page.test.ts` assertions that inspected `console.warn` to match the logger-emitted output which includes the `"[Midscene]"` prefix.
- No behavioral changes beyond how warnings are emitted; runtime logic and messages remain the same.

### Testing
- Ran linter with `pnpm run lint` and the check completed successfully after automatic fixes were applied.
- Ran Android unit tests with `npx nx test @midscene/android` which succeeded (package `@midscene/android` tests passed).
- Attempted focused build with `npx nx run-many -t build -p @midscene/shared @midscene/core @midscene/android` which failed during `@midscene/android:build` prebuild due to an external scrcpy server download failure (network/download error), not related to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e091c32ea0832498098d97c2ff556e)