### PR TITLE
perf(studio): fix Node event-loop stalls during agent execution

### DIFF
--- a/apps/studio/scripts/launch-electron-dev.mjs
+++ b/apps/studio/scripts/launch-electron-dev.mjs
@@ -14,18 +14,24 @@ const rootDir = path.resolve(
   '..',
 );
 
-const child = spawn(
-  electronBinary,
-  [path.join(rootDir, 'dist/main/main.cjs')],
-  {
-    env: buildStudioRuntimeEnv({
-      baseEnv: process.env,
-      overrides: { MIDSCENE_STUDIO_RENDERER_URL: rendererDevUrl },
-      studioRootDir: rootDir,
-    }),
-    stdio: 'inherit',
-  },
-);
+// Enable Node inspector on the Electron main process in dev so external
+// profilers (chrome://inspect, CDP clients) can attach for a V8 CPU
+// profile. Set MIDSCENE_STUDIO_MAIN_INSPECT=0 to disable, or a custom port
+// like `9230` to override; default 9229 matches Node's own default.
+const inspectSetting = process.env.MIDSCENE_STUDIO_MAIN_INSPECT ?? '9229';
+const electronArgs = [path.join(rootDir, 'dist/main/main.cjs')];
+if (inspectSetting !== '0' && inspectSetting !== 'false') {
+  electronArgs.unshift(`--inspect=${inspectSetting}`);
+}
+
+const child = spawn(electronBinary, electronArgs, {
+  env: buildStudioRuntimeEnv({
+    baseEnv: process.env,
+    overrides: { MIDSCENE_STUDIO_RENDERER_URL: rendererDevUrl },
+    studioRootDir: rootDir,
+  }),
+  stdio: 'inherit',
+});
 
 const forwardSignal = (signal) => {
   if (!child.killed) child.kill(signal);

--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -24,6 +24,18 @@ let mainWindow: BrowserWindow | null = null;
 let cachedAppIcon: NativeImage | null = null;
 const androidPlaygroundRuntime = createAndroidPlaygroundRuntimeService();
 
+// Expose the Chromium DevTools Protocol on a fixed port in dev so external
+// profilers (e.g. chrome-devtools-mcp at http://localhost:9224) can attach to
+// the renderer without the user keeping DevTools open. Production builds never
+// set this — it would be a liability. The port can be overridden with the
+// MIDSCENE_STUDIO_CDP_PORT env var when multiple dev instances are running.
+if (!app.isPackaged) {
+  const cdpPort = process.env.MIDSCENE_STUDIO_CDP_PORT ?? '9224';
+  app.commandLine.appendSwitch('remote-debugging-port', cdpPort);
+  // Bind to loopback so the debug endpoint isn't reachable from the network.
+  app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1');
+}
+
 const getRendererEntryPath = () =>
   path.join(__dirname, '../renderer/index.html');
 

--- a/packages/core/src/agent/ui-utils.ts
+++ b/packages/core/src/agent/ui-utils.ts
@@ -224,7 +224,26 @@ export function paramStr(task: ExecutionTask) {
     if (locateStr) {
       return locateStr;
     }
-    return JSON.stringify(value, undefined, 2);
+    // Flatten `{key: "raw value"}` into `key: raw value` instead of emitting
+    // a pretty-printed JSON string. JSON.stringify would escape every inner
+    // quote as `\"`, and the UI renders the result as plain text — so a
+    // command like `grep -E "version"` ends up shown with the literal
+    // backslashes, which is both noisy and confusing for users.
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      return '';
+    }
+    const formatValue = (v: unknown): string => {
+      if (typeof v === 'string') return v;
+      if (v === null || v === undefined) return String(v);
+      if (typeof v === 'object') return JSON.stringify(v);
+      return String(v);
+    };
+    if (entries.length === 1) {
+      const [key, v] = entries[0];
+      return `${key}: ${formatValue(v)}`;
+    }
+    return entries.map(([key, v]) => `${key}: ${formatValue(v)}`).join(', ');
   }
 
   return String(value);

--- a/packages/core/src/dump/screenshot-store.ts
+++ b/packages/core/src/dump/screenshot-store.ts
@@ -1,10 +1,5 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { writeFile as writeFileAsync } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
 import type { ScreenshotItem } from '../screenshot-item';
 import { extractImageByIdSync } from './html-utils';
@@ -130,7 +125,10 @@ export class ScreenshotStore {
   private readonly mode: 'inline' | 'directory';
   private readonly reportPath: string;
   private readonly screenshotsDir?: string;
-  private readonly writeInlineImage?: (id: string, base64: string) => void;
+  private readonly writeInlineImage?: (
+    id: string,
+    base64: string,
+  ) => void | Promise<void>;
   private readonly alsoWriteFileCopy: boolean;
   private readonly writtenInlineIds = new Set<string>();
   private readonly writtenFileIds = new Set<string>();
@@ -139,7 +137,7 @@ export class ScreenshotStore {
     mode: 'inline' | 'directory';
     reportPath: string;
     screenshotsDir?: string;
-    writeInlineImage?: (id: string, base64: string) => void;
+    writeInlineImage?: (id: string, base64: string) => void | Promise<void>;
     alsoWriteFileCopy?: boolean;
     /** @deprecated Use alsoWriteFileCopy instead. */
     ensureFileCopy?: boolean;
@@ -152,11 +150,11 @@ export class ScreenshotStore {
       options.alsoWriteFileCopy ?? options.ensureFileCopy ?? false;
   }
 
-  persist(screenshot: ScreenshotItem): ScreenshotRef {
+  async persist(screenshot: ScreenshotItem): Promise<ScreenshotRef> {
     const shouldWriteFileCopy =
       this.mode === 'directory' || this.alsoWriteFileCopy;
     const fileRef = shouldWriteFileCopy
-      ? this.persistToSharedFileIfNeeded(screenshot, {
+      ? await this.persistToSharedFileIfNeeded(screenshot, {
           markAsPersisted: this.mode === 'directory',
         })
       : null;
@@ -168,7 +166,7 @@ export class ScreenshotStore {
         );
       }
       if (!this.writtenInlineIds.has(screenshot.id)) {
-        this.writeInlineImage(screenshot.id, screenshot.base64);
+        await this.writeInlineImage(screenshot.id, screenshot.base64);
         this.writtenInlineIds.add(screenshot.id);
       }
       return screenshot.markPersistedInline(this.reportPath);
@@ -182,12 +180,12 @@ export class ScreenshotStore {
     return fileRef;
   }
 
-  private persistToSharedFileIfNeeded(
+  private async persistToSharedFileIfNeeded(
     screenshot: ScreenshotItem,
     options: {
       markAsPersisted: boolean;
     },
-  ): ScreenshotRef {
+  ): Promise<ScreenshotRef> {
     const screenshotsDir = this.screenshotsDir;
     if (!screenshotsDir) {
       throw new Error(
@@ -206,7 +204,7 @@ export class ScreenshotStore {
 
     if (!this.writtenFileIds.has(screenshot.id)) {
       const buffer = Buffer.from(screenshot.rawBase64, 'base64');
-      writeFileSync(absolutePath, buffer);
+      await writeFileAsync(absolutePath, buffer);
       this.writtenFileIds.add(screenshot.id);
     }
 

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -1,4 +1,8 @@
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import {
+  appendFile as appendFileAsync,
+  writeFile as writeFileAsync,
+} from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import {
@@ -18,7 +22,7 @@ import {
   type ReportAttributes,
   type ReportMeta,
 } from './types';
-import { appendFileSync, getReportTpl } from './utils';
+import { getReportTpl } from './utils';
 
 export interface IReportGenerator {
   /**
@@ -111,8 +115,8 @@ export class ReportGenerator implements IReportGenerator {
       mode: this.screenshotMode === 'inline' ? 'inline' : 'directory',
       reportPath: this.reportPath,
       screenshotsDir: join(dirname(this.reportPath), 'screenshots'),
-      writeInlineImage: (id, base64) => {
-        appendFileSync(
+      writeInlineImage: async (id, base64) => {
+        await appendFileAsync(
           this.reportPath,
           `\n${generateImageScriptTag(id, base64)}`,
         );
@@ -164,9 +168,9 @@ export class ReportGenerator implements IReportGenerator {
     this.lastExecution = execution;
     this.lastReportMeta = reportMeta;
     this.mergeReportAttributes(attributes);
-    this.writeQueue = this.writeQueue.then(() => {
+    this.writeQueue = this.writeQueue.then(async () => {
       if (this.destroyed) return;
-      this.doWriteExecution(execution, reportMeta);
+      await this.doWriteExecution(execution, reportMeta);
     });
   }
 
@@ -209,20 +213,20 @@ export class ReportGenerator implements IReportGenerator {
     }
   }
 
-  private doWriteExecution(
+  private async doWriteExecution(
     execution: ExecutionDump,
     reportMeta: ReportMeta,
-  ): void {
+  ): Promise<void> {
     const singleDump = this.wrapAsReportDump(execution, reportMeta);
 
     if (this.screenshotMode === 'inline') {
-      this.writeInlineExecution(execution, singleDump);
+      await this.writeInlineExecution(execution, singleDump);
     } else {
-      this.writeDirectoryExecution(execution, singleDump);
+      await this.writeDirectoryExecution(execution, singleDump);
     }
 
     if (this.shouldPersistExecutionDump) {
-      this.persistExecutionDumpToFile(execution, singleDump);
+      await this.persistExecutionDumpToFile(execution, singleDump);
     }
 
     if (!this.firstWriteDone) {
@@ -299,11 +303,16 @@ export class ReportGenerator implements IReportGenerator {
    * Append-only inline mode: write new screenshots and a dump tag on every call.
    * The frontend deduplicates executions with the same id/name (keeps last).
    * Duplicate dump JSON is acceptable; only screenshots are deduplicated.
+   *
+   * All writes go through `fs/promises` so they run on libuv's thread pool
+   * rather than blocking the Node event loop. A long agent run previously
+   * appended multi-MB dumps (screenshots + serialized tasks) per progress
+   * tick on the main thread, starving IPC and UI for >10s per stall.
    */
-  private writeInlineExecution(
+  private async writeInlineExecution(
     execution: ExecutionDump,
     singleDump: ReportActionDump,
-  ): void {
+  ): Promise<void> {
     const dir = dirname(this.reportPath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
@@ -311,48 +320,48 @@ export class ReportGenerator implements IReportGenerator {
 
     // Initialize: write HTML template once
     if (!this.initialized) {
-      writeFileSync(this.reportPath, getReportTpl());
+      await writeFileAsync(this.reportPath, getReportTpl());
       this.initialized = true;
     }
 
     // Append new screenshots (skip already-written ones)
     for (const screenshot of execution.collectScreenshots()) {
-      this.screenshotStore.persist(screenshot);
+      await this.screenshotStore.persist(screenshot);
     }
 
     // Append dump tag (always — frontend keeps only last per execution id)
     const serialized = singleDump.serialize();
-    appendFileSync(
+    await appendFileAsync(
       this.reportPath,
       `\n${generateDumpScriptTag(serialized, this.getDumpScriptAttributes())}`,
     );
   }
 
-  private writeDirectoryExecution(
+  private async writeDirectoryExecution(
     execution: ExecutionDump,
     singleDump: ReportActionDump,
-  ): void {
+  ): Promise<void> {
     const dir = dirname(this.reportPath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
 
     for (const screenshot of execution.collectScreenshots()) {
-      this.screenshotStore.persist(screenshot);
+      await this.screenshotStore.persist(screenshot);
     }
 
     // 2. Append dump tag (always — frontend keeps only last per execution id)
     const serialized = singleDump.serialize();
 
     if (!this.initialized) {
-      writeFileSync(
+      await writeFileAsync(
         this.reportPath,
         `${getReportTpl()}${getBaseUrlFixScript()}`,
       );
       this.initialized = true;
     }
 
-    appendFileSync(
+    await appendFileAsync(
       this.reportPath,
       `\n${generateDumpScriptTag(serialized, this.getDumpScriptAttributes())}`,
     );
@@ -367,10 +376,10 @@ export class ReportGenerator implements IReportGenerator {
     return `id:${execution.id}`;
   }
 
-  private persistExecutionDumpToFile(
+  private async persistExecutionDumpToFile(
     execution: ExecutionDump,
     singleDump: ReportActionDump,
-  ): void {
+  ): Promise<void> {
     const dir = dirname(this.reportPath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
@@ -387,7 +396,7 @@ export class ReportGenerator implements IReportGenerator {
 
     const fileName = `${fileIndex}.execution.json`;
     const filePath = join(dirname(this.reportPath), fileName);
-    writeFileSync(filePath, singleDump.serialize(2), 'utf-8');
+    await writeFileAsync(filePath, singleDump.serialize(2), 'utf-8');
   }
 }
 

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -1,3 +1,12 @@
+/*
+ * PERF INVARIANT — DO NOT reintroduce sync fs APIs (writeFileSync /
+ * appendFileSync) in this file's write paths. `ReportGenerator` runs on
+ * the Electron main event loop during agent execution, and a single
+ * progress tick appends a multi-MB ExecutionDump payload. Sync I/O here
+ * blocked the loop for 20+ seconds per run, freezing IPC, scrcpy and
+ * every renderer round-trip. Always use `fs/promises`. See commit
+ * 6a25e05c and `report-generator-async-contract.test.ts`.
+ */
 import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import {
   appendFile as appendFileAsync,

--- a/packages/core/tests/unit-test/report-generator-async-contract.test.ts
+++ b/packages/core/tests/unit-test/report-generator-async-contract.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression guard for the perf fix in commit 6a25e05c.
+ *
+ * The Electron main event loop was being blocked for 20+ seconds per
+ * agent run because `ReportGenerator` was calling `fs.writeFileSync` /
+ * `fs.appendFileSync` on every progress tick (multi-MB dump payload
+ * written synchronously). Switching the hot write paths to `fs/promises`
+ * moved the I/O onto libuv's thread pool and freed the main thread.
+ *
+ * This test pins the API shape: the methods in the hot path MUST remain
+ * declared `async`. If anyone reintroduces sync fs APIs or accidentally
+ * drops the `async` keyword, this test fails with a loud message
+ * pointing at the offending method and the original fix commit.
+ *
+ * It does NOT try to measure blocking time — wall-clock perf tests are
+ * flaky on shared CI. This structural check is cheap, reliable, and
+ * catches the 90% regression path (someone typing `Sync` back in).
+ */
+import { describe, expect, it } from 'vitest';
+import { ScreenshotStore } from '../../src/dump/screenshot-store';
+import { ReportGenerator } from '../../src/report-generator';
+
+// Derive the AsyncFunction constructor reliably at runtime. Core compiles to
+// ES2018, which preserves `async` natively — no downleveling.
+// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional noop to access ctor
+const AsyncFunction = (async () => {}).constructor;
+
+function assertAsync(method: unknown, label: string): void {
+  expect(
+    method,
+    `${label} must remain an async function. Sync fs APIs in this path block the Electron main event loop during agent execution (see commit 6a25e05c). If you changed this on purpose, update the regression guard together with the change.`,
+  ).toBeInstanceOf(AsyncFunction);
+}
+
+describe('ReportGenerator — async fs contract (perf guard)', () => {
+  it('keeps the hot write path async so the Node event loop is not blocked', () => {
+    const proto = ReportGenerator.prototype as unknown as Record<
+      string,
+      unknown
+    >;
+    assertAsync(proto.doWriteExecution, 'ReportGenerator.doWriteExecution');
+    assertAsync(
+      proto.writeInlineExecution,
+      'ReportGenerator.writeInlineExecution',
+    );
+    assertAsync(
+      proto.writeDirectoryExecution,
+      'ReportGenerator.writeDirectoryExecution',
+    );
+    assertAsync(
+      proto.persistExecutionDumpToFile,
+      'ReportGenerator.persistExecutionDumpToFile',
+    );
+    assertAsync(proto.flush, 'ReportGenerator.flush');
+    assertAsync(proto.finalize, 'ReportGenerator.finalize');
+  });
+
+  it('ScreenshotStore persist path stays async (inline + file writes)', () => {
+    const proto = ScreenshotStore.prototype as unknown as Record<
+      string,
+      unknown
+    >;
+    assertAsync(proto.persist, 'ScreenshotStore.persist');
+    assertAsync(
+      proto.persistToSharedFileIfNeeded,
+      'ScreenshotStore.persistToSharedFileIfNeeded',
+    );
+  });
+});

--- a/packages/core/tests/unit-test/screenshot-store.test.ts
+++ b/packages/core/tests/unit-test/screenshot-store.test.ts
@@ -27,7 +27,7 @@ describe('ScreenshotStore', () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('releases memory after persist and supports recovery in directory mode', () => {
+  it('releases memory after persist and supports recovery in directory mode', async () => {
     const reportPath = join(tmpRoot, 'index.html');
     const screenshotsDir = join(tmpRoot, 'screenshots');
     const item = ScreenshotItem.create(pngBase64, 100);
@@ -37,14 +37,14 @@ describe('ScreenshotStore', () => {
       screenshotsDir,
     });
 
-    const ref = store.persist(item);
+    const ref = await store.persist(item);
     expect(item.hasBase64()).toBe(false);
     expect(ref.storage).toBe('file');
     expect(existsSync(join(screenshotsDir, `${item.id}.png`))).toBe(true);
     expect(store.loadBase64(ref)).toContain('data:image/png;base64,');
   });
 
-  it('deduplicates same screenshot persistence by id', () => {
+  it('deduplicates same screenshot persistence by id', async () => {
     const reportPath = join(tmpRoot, 'index.html');
     const screenshotsDir = join(tmpRoot, 'screenshots');
     const item = ScreenshotItem.create(pngBase64, 100);
@@ -54,9 +54,9 @@ describe('ScreenshotStore', () => {
       screenshotsDir,
     });
 
-    const first = store.persist(item);
+    const first = await store.persist(item);
     writeFileSync(join(screenshotsDir, `${item.id}.png`), 'marker');
-    const second = store.persist(item);
+    const second = await store.persist(item);
 
     expect(first.id).toBe(second.id);
     expect(readFileSync(join(screenshotsDir, `${item.id}.png`), 'utf-8')).toBe(
@@ -64,7 +64,7 @@ describe('ScreenshotStore', () => {
     );
   });
 
-  it('supports inline mode persistence + lazy restore', () => {
+  it('supports inline mode persistence + lazy restore', async () => {
     const reportPath = join(tmpRoot, 'inline.html');
     const appendInline = vi.fn((id: string, base64: string) => {
       writeFileSync(
@@ -79,13 +79,13 @@ describe('ScreenshotStore', () => {
     });
     const item = ScreenshotItem.create(pngBase64, 100);
 
-    const ref = store.persist(item);
+    const ref = await store.persist(item);
     expect(item.hasBase64()).toBe(false);
     expect(appendInline).toHaveBeenCalledTimes(1);
     expect(store.loadBase64(ref)).toBe(pngBase64);
   });
 
-  it('can ensure shared file copy while preserving inline mode semantics', () => {
+  it('can ensure shared file copy while preserving inline mode semantics', async () => {
     const reportPath = join(tmpRoot, 'inline-with-file-copy.html');
     const screenshotsDir = join(tmpRoot, 'screenshots');
     const appendInline = vi.fn((id: string, base64: string) => {
@@ -103,7 +103,7 @@ describe('ScreenshotStore', () => {
     });
     const item = ScreenshotItem.create(pngBase64, 100);
 
-    const ref = store.persist(item);
+    const ref = await store.persist(item);
     expect(ref.storage).toBe('inline');
     expect(item.toSerializable().storage).toBe('inline');
     expect(appendInline).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ describe('ScreenshotStore', () => {
     expect(store.loadBase64(ref)).toBe(pngBase64);
   });
 
-  it('keeps supporting ensureFileCopy as a deprecated alias', () => {
+  it('keeps supporting ensureFileCopy as a deprecated alias', async () => {
     const reportPath = join(tmpRoot, 'inline-with-deprecated-file-copy.html');
     const screenshotsDir = join(tmpRoot, 'screenshots');
     const appendInline = vi.fn((id: string, base64: string) => {
@@ -131,7 +131,7 @@ describe('ScreenshotStore', () => {
     });
     const item = ScreenshotItem.create(pngBase64, 100);
 
-    const ref = store.persist(item);
+    const ref = await store.persist(item);
     expect(ref.storage).toBe('inline');
     expect(existsSync(join(screenshotsDir, `${item.id}.png`))).toBe(true);
   });

--- a/packages/visualizer/src/component/universal-playground/index.tsx
+++ b/packages/visualizer/src/component/universal-playground/index.tsx
@@ -270,6 +270,18 @@ export function UniversalPlayground({
     return { firstInProgressGroup: firstIds, visibleInfoList: visible };
   }, [collapsedProgressGroups, collapsibleProgressGroup, infoList]);
 
+  // Precompute the id of the latest progress item once so each renderItem
+  // can do a single string compare instead of re-scanning `infoList` with
+  // `findIndex` + `slice` on every render. On long agent runs that scan was
+  // the dominant cost — O(n) per progress item × N items = O(n²) per state
+  // update, visibly stuttering the UI at 15+ steps.
+  const latestProgressId = useMemo(() => {
+    for (let i = infoList.length - 1; i >= 0; i--) {
+      if (infoList[i].type === 'progress') return infoList[i].id;
+    }
+    return null;
+  }, [infoList]);
+
   return (
     <div className={`playground-container ${layout}-mode ${className}`.trim()}>
       <Form form={form} onFinish={handleFormRun} className="command-form">
@@ -337,13 +349,7 @@ export function UniversalPlayground({
                         const action = parts[0]?.trim();
                         const description = parts.slice(1).join(' - ').trim();
 
-                        const currentIndex = infoList.findIndex(
-                          (listItem) => listItem.id === item.id,
-                        );
-                        const laterProgressExists = infoList
-                          .slice(currentIndex + 1)
-                          .some((listItem) => listItem.type === 'progress');
-                        const isLatestProgress = !laterProgressExists;
+                        const isLatestProgress = item.id === latestProgressId;
                         const shouldShowLoading = loading && isLatestProgress;
 
                         return (


### PR DESCRIPTION
## Summary

Studio's Android agent felt laggy during long runs. CDP-traced the renderer and Node CPU-profiled the Electron main process; the main event loop had 21.6s + 17.4s single-task blocks, all inside `ReportGenerator` doing synchronous filesystem writes. The renderer also had an O(n²) scan on every progress item. Both are fixed here, with a regression guard pinning the async contract.

## Impact

| Metric | Before | After |
|---|---|---|
| Electron main event loop longest block | 21,604 ms | no >6 ms single-task block |
| CrBrowserMain active time (40s window) | ~15,000 ms | ~1,600 ms (**-89%**) |
| `writeInlineExecution` / `writeFileUtf8` self | 11,236 / 11,235 ms | not in top 25 (off main thread) |
| Renderer O(n²) scan on 15-step run | visible stutter | ~0 ms per render |

## Changes

**Critical perf fix**
- \`packages/core/src/report-generator.ts\`, \`packages/core/src/dump/screenshot-store.ts\` — switch the hot write path to \`node:fs/promises\` so each progress tick lets libuv do the I/O on a worker thread instead of parking the Node event loop during a multi-MB append. Public API is unchanged (\`flush()\` / \`finalize()\` still return Promises; callers always awaited them).
- \`packages/visualizer/src/component/universal-playground/index.tsx\` — precompute \`latestProgressId\` once via \`useMemo\` and replace the per-renderItem \`findIndex + slice\` pair (O(n²) total) with a single string equality compare.
- \`packages/core/src/agent/ui-utils.ts\` \`paramStr\` — flatten \`{key: value}\` objects into \`"key: value"\` instead of \`JSON.stringify(..., null, 2)\`, so descriptions with inner quotes (\`RunAdbShell { command: 'grep -E \"version\"' }\`) render cleanly without literal backslashes.

**Regression guard**
- \`packages/core/tests/unit-test/report-generator-async-contract.test.ts\` — structural test asserting the hot methods on \`ReportGenerator\` and \`ScreenshotStore\` remain \`async\`. Cheap and reliable; catches the 90% regression path (someone typing \`Sync\` back in).
- PERF INVARIANT comment at the top of \`report-generator.ts\` pointing at the test + this PR.

**Profiling infrastructure (dev-only)**
- \`apps/studio/rsbuild.config.ts\` already had CDP on port 9224; \`apps/studio/src/main/index.ts\` now registers the switch at runtime when \`!app.isPackaged\`, bound to 127.0.0.1. Production builds never set it.
- \`apps/studio/scripts/launch-electron-dev.mjs\` enables Node's inspector on port 9229 in dev so external CPU profilers can attach to the main process. Port overridable via \`MIDSCENE_STUDIO_MAIN_INSPECT\`; set \`0\` or \`false\` to disable.

## Test plan

- [x] \`pnpm run lint\`
- [x] \`npx nx test @midscene/core\` — 786 tests + 8 skipped (incl. new async-contract guard)
- [x] \`npx nx test @midscene/visualizer\`
- [x] Captured two back-to-back CPU profiles (baseline vs. this PR) against the same agent run: the 21s CrBrowserMain block is gone and main-thread active time drops by ~9×.