### PR TITLE
feat(site): merge MCP card with Skills on home page

### DIFF
--- a/apps/site/theme/components/FeatureSections.tsx
+++ b/apps/site/theme/components/FeatureSections.tsx
@@ -561,9 +561,9 @@ export function FeatureSections() {
                 </div>
               </TiltCard>
 
-              {/* MCP Server Card */}
+              {/* Skills & MCP Card */}
               <TiltCard
-                href={tUrl(t('featureMCPServerLink'))}
+                href={tUrl(t('featureSkillsMcpLink'))}
                 className="w-full md:w-[381px] md:h-[289px] flex flex-col group cursor-pointer"
               >
                 <div className="flex flex-col gap-[17px] h-full">
@@ -577,7 +577,7 @@ export function FeatureSections() {
                     >
                       <img
                         src="/icon/ai-tap.svg"
-                        alt="MCP Server"
+                        alt="Skills & MCP"
                         className="w-12 h-12 md:w-16 md:h-16"
                       />
                     </div>
@@ -592,16 +592,16 @@ export function FeatureSections() {
                     >
                       <img
                         src="/icon/ai-tap.svg"
-                        alt="MCP Server"
+                        alt="Skills & MCP"
                         className="w-12 h-12 md:w-16 md:h-16"
                       />
                     </div>
                   </div>
                   <p className="font-sans text-xl md:text-2xl font-medium leading-6 text-black dark:text-white">
-                    {t('featureMCPServer')}
+                    {t('featureSkillsMcp')}
                   </p>
                   <div className="font-sans text-sm md:text-base font-normal leading-5 md:leading-6 text-black/70 dark:text-white/70">
-                    {t('featureMCPServerDesc')}
+                    {t('featureSkillsMcpDesc')}
                   </div>
                 </div>
               </TiltCard>

--- a/apps/site/theme/i18n/enUS.ts
+++ b/apps/site/theme/i18n/enUS.ts
@@ -73,9 +73,9 @@ and more`,
   featureRichAPIs: 'Rich APIs',
   featureRichAPIsDesc:
     'Enables both smart automation workflows and fine-grained atomic control.',
-  featureMCPServer: 'MCP Server',
-  featureMCPServerDesc:
-    'Exposes device operations as an MCP Server for collaboration with various models.',
+  featureSkillsMcp: 'Skills & MCP',
+  featureSkillsMcpDesc:
+    'Drop-in Agent Skills for AI coding tools, plus an MCP Server for model collaboration.',
   featureReportsPlayground: 'Reports & Playground',
   featureReportsPlaygroundDesc:
     'Provides intuitive visualization reports to help developers trace back the automation process',
@@ -83,7 +83,7 @@ and more`,
   featureFlexibleIntegrationDesc:
     'Supports using Yaml to write automation flows, supports custom Agent execution strategies',
   featureRichAPIsLink: '/api',
-  featureMCPServerLink: '/mcp',
+  featureSkillsMcpLink: '/skills',
   featureReportsPlaygroundLink: '/quick-experience',
   featureFlexibleIntegrationLink: '/automate-with-scripts-in-yaml',
 

--- a/apps/site/theme/i18n/zhCN.ts
+++ b/apps/site/theme/i18n/zhCN.ts
@@ -69,8 +69,9 @@ export const ZH_CN: Record<keyof typeof EN_US, string> = {
   // Feature Cards
   featureRichAPIs: '丰富的 API',
   featureRichAPIsDesc: '同时支持智能执行流程与原子化精确控制。',
-  featureMCPServer: 'MCP Server',
-  featureMCPServerDesc: '将设备操作暴露为 MCP Server，并可与多种模型协作使用。',
+  featureSkillsMcp: 'Skills 与 MCP',
+  featureSkillsMcpDesc:
+    '为 AI 编程工具提供开箱即用的 Agent Skills，同时支持将设备操作暴露为 MCP Server。',
   featureReportsPlayground: '报告与 Playground',
   featureReportsPlaygroundDesc:
     '提供直观的可视化报告，帮助开发者回溯自动化流程',
@@ -78,7 +79,7 @@ export const ZH_CN: Record<keyof typeof EN_US, string> = {
   featureFlexibleIntegrationDesc:
     '支持使用 Yaml 编写自动化流程，支持自定义 Agent 执行策略',
   featureRichAPIsLink: '/api',
-  featureMCPServerLink: '/mcp',
+  featureSkillsMcpLink: '/skills',
   featureReportsPlaygroundLink: '/quick-experience',
   featureFlexibleIntegrationLink: '/automate-with-scripts-in-yaml',
 


### PR DESCRIPTION
## Summary
- Collapse the standalone **MCP Server** card on the home page into a single **Skills & MCP** card.
- Lead copy with Agent Skills, keep MCP Server as secondary capability.
- Repoint the card link from `/mcp` to `/skills` so Skills is the primary destination.
- Rename the i18n keys `featureMCPServer*` → `featureSkillsMcp*` in both `enUS.ts` and `zhCN.ts`.

## Test plan
- [ ] `pnpm run lint`
- [ ] Run the site dev server locally and verify the home page renders a single **Skills & MCP** / **Skills 与 MCP** card in the "Developer Experience" section for both EN and ZH locales.
- [ ] Confirm the card link navigates to `/skills` (and `/zh/skills` for ZH).