### PR TITLE
test(computer): fix RDP test import paths

### DIFF
--- a/packages/computer/tests/ai/rdp/login-form.test.ts
+++ b/packages/computer/tests/ai/rdp/login-form.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { ComputerAgent, RDPDevice } from '@/index';
+import type { Rect, Size } from '@midscene/core';
+import { describe, expect, it } from 'vitest';
+import { ComputerAgent, RDPDevice } from '../../../src';
 import type {
   RDPBackendClient,
   RDPConnectionConfig,
@@ -8,9 +10,7 @@ import type {
   RDPMouseButton,
   RDPMouseButtonAction,
   RDPScrollDirection,
-} from '@/index';
-import type { Rect, Size } from '@midscene/core';
-import { describe, expect, it } from 'vitest';
+} from '../../../src';
 
 interface FixtureTreeNode {
   node?: {

--- a/packages/computer/tests/ai/rdp/real-session-protocol.test.ts
+++ b/packages/computer/tests/ai/rdp/real-session-protocol.test.ts
@@ -1,5 +1,5 @@
-import { ComputerAgent, RDPDevice } from '@/index';
 import { describe, expect, it } from 'vitest';
+import { ComputerAgent, RDPDevice } from '../../../src';
 
 const realRdpEnv = {
   enabled: process.env.MIDSCENE_RDP_REAL_TEST === '1',

--- a/packages/computer/tests/unit-test/rdp/agent.test.ts
+++ b/packages/computer/tests/unit-test/rdp/agent.test.ts
@@ -1,4 +1,5 @@
-import { ComputerAgent, RDPDevice, agentFromComputer } from '@/index';
+import type { Size } from '@midscene/core';
+import { ComputerAgent, RDPDevice, agentFromComputer } from '../../../src';
 import type {
   RDPBackendClient,
   RDPConnectionConfig,
@@ -6,8 +7,7 @@ import type {
   RDPMouseButton,
   RDPMouseButtonAction,
   RDPScrollDirection,
-} from '@/index';
-import type { Size } from '@midscene/core';
+} from '../../../src';
 
 class FakeRDPBackend implements RDPBackendClient {
   calls: Array<{ name: string; args: unknown[] }> = [];

--- a/packages/computer/tests/unit-test/rdp/backend-client.test.ts
+++ b/packages/computer/tests/unit-test/rdp/backend-client.test.ts
@@ -4,7 +4,7 @@ import {
   HelperProcessRDPBackendClient,
   type RDPHelperRequest,
   type RDPHelperResponse,
-} from '@/index';
+} from '../../../src';
 
 class FakeChildProcess extends EventEmitter {
   stdout = new PassThrough();


### PR DESCRIPTION
## Summary

This PR fixes the newly moved RDP test files under `@midscene/computer` to use the package's existing relative-import convention instead of the Vitest-only `@/` alias.

## Why

After merging the RDP runtime into `@midscene/computer`, the moved test files still imported from `@/index`. That worked in Vitest because the alias is configured there, but TypeScript and editors reported `Cannot find module '@/index'` because `packages/computer/tsconfig.json` does not include test files in its alias-aware compile scope.

## What changed

- Replaced `@/index` imports with relative imports in the RDP test files under `packages/computer/tests/**/rdp`
- Kept runtime code unchanged
- Preserved the existing `packages/computer` test import style so IDE and test runner behavior stay aligned

## Impact

- Removes false TypeScript editor errors in the moved RDP tests
- Keeps the `@midscene/computer` package layout unchanged
- Avoids widening the package tsconfig scope just to support a small set of tests

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/computer exec vitest --run tests/unit-test/rdp/agent.test.ts tests/unit-test/rdp/backend-client.test.ts`
