### PR TITLE
fix(web-integration): derive Playwright reportFileName from readable test title

### DIFF
--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -137,7 +137,11 @@ export const PlaywrightAiFixture = (options?: PlaywrightAiFixtureOptions) => {
       (page as any)[midsceneAgentKeyId] = idForPage;
       const { file, title } = groupAndCaseForTest(testInfo);
       const cacheConfig = processTestCacheConfig(testInfo);
-      const reportTag = `playwright-${title}-${idForPage}`;
+      // `replaceIllegalPathCharsAndSpace` intentionally preserves `/` and `\`
+      // so groupName/groupDescription can still carry hierarchy. But
+      // ReportGenerator rejects path separators in the file name, so strip
+      // them here for the report tag only.
+      const reportTag = `playwright-${title.replace(/[\\/]/g, '-')}-${idForPage}`;
 
       const agent = new PlaywrightAgent(page, {
         testId: reportTag,

--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -135,13 +135,13 @@ export const PlaywrightAiFixture = (options?: PlaywrightAiFixtureOptions) => {
     if (!idForPage) {
       idForPage = uuid();
       (page as any)[midsceneAgentKeyId] = idForPage;
-      const { testId } = testInfo;
       const { file, title } = groupAndCaseForTest(testInfo);
       const cacheConfig = processTestCacheConfig(testInfo);
+      const reportTag = `playwright-${title}-${idForPage}`;
 
       const agent = new PlaywrightAgent(page, {
-        testId: `playwright-${testId}-${idForPage}`,
-        reportFileName: `playwright-${testId}-${idForPage}`,
+        testId: reportTag,
+        reportFileName: reportTag,
         forceSameTabNavigation,
         cache: cacheConfig,
         groupName: title,

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
@@ -123,7 +123,7 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
     expect(a.reportFileName).not.toBe(b.reportFileName);
   });
 
-  it('sanitizes filename-hostile characters but preserves path separators', async () => {
+  it('sanitizes filename-hostile characters so the result passes ReportGenerator validation', async () => {
     const opts = await runAi({
       testId: 'uuid',
       titlePath: ['auth.spec.ts', 'can I click "Submit" on #home?'],
@@ -138,5 +138,27 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
     // Readable words still come through.
     expect(opts.reportFileName).toContain('Submit');
     expect(opts.reportFileName).toContain('home');
+  });
+
+  it('strips path separators from the title so ReportGenerator.create does not throw', async () => {
+    const opts = await runAi({
+      testId: 'uuid',
+      titlePath: ['auth.spec.ts', 'login / sign\\up flow'],
+      annotations: [],
+      retry: 0,
+    });
+
+    // ReportGenerator's validateReportFileName rejects `/` and `\`. The
+    // fixture must strip them even though replaceIllegalPathCharsAndSpace
+    // intentionally leaves path separators alone for groupName.
+    expect(opts.reportFileName).not.toContain('/');
+    expect(opts.reportFileName).not.toContain('\\');
+    // Surrounding words still survive so the filename stays recognizable.
+    expect(opts.reportFileName).toContain('login');
+    expect(opts.reportFileName).toContain('sign');
+    expect(opts.reportFileName).toContain('up');
+    // groupName keeps the original hierarchy-carrying separators.
+    expect(opts.groupName).toContain('/');
+    expect(opts.groupName).toContain('\\');
   });
 });

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Repro + regression tests for PlaywrightAiFixture report filename derivation.
+ *
+ * Background
+ * ----------
+ * PlaywrightAiFixture used to forward Playwright's internal `testInfo.testId`
+ * (a UUID string) directly as the Agent's `reportFileName`, producing
+ * intermediate report files like:
+ *   playwright-01e1ae2eda378fcdc79a-5b19ff8659b54d79108c-<pageUuid>.html
+ *
+ * That name carries no information about which spec/case the report belongs to,
+ * making on-disk triage and custom report-parsing scripts impossible.
+ *
+ * The fix routes `reportFileName` through `groupAndCaseForTest`'s already
+ * path-safe, retry-aware `title` field. These tests pin that behavior so it
+ * cannot silently regress again.
+ *
+ * How it reproduces
+ * -----------------
+ * We mock `PlaywrightAgent` to capture the constructor options the fixture
+ * synthesizes, then invoke `fixture.ai({page}, ...)` which is the cheapest
+ * code path that runs `createOrReuseAgentForPage`.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockState = vi.hoisted(() => ({
+  ctorOpts: [] as any[],
+}));
+
+vi.mock('@/playwright/index', () => {
+  class MockPlaywrightAgent {
+    reportFile?: string;
+
+    constructor(_page: any, opts: any) {
+      mockState.ctorOpts.push(opts);
+    }
+
+    async destroy() {}
+  }
+
+  return { PlaywrightAgent: MockPlaywrightAgent };
+});
+
+import { PlaywrightAiFixture } from '@/playwright/ai-fixture';
+
+const createPage = () =>
+  ({
+    on: vi.fn(),
+  }) as any;
+
+const runAi = async (testInfo: any) => {
+  const fixture = PlaywrightAiFixture();
+  await fixture.ai({ page: createPage() }, async () => {}, testInfo);
+  return mockState.ctorOpts[0];
+};
+
+describe('PlaywrightAiFixture reportFileName derivation', () => {
+  beforeEach(() => {
+    mockState.ctorOpts.length = 0;
+  });
+
+  it('uses the human-readable test title and drops the Playwright UUID testId', async () => {
+    const opts = await runAi({
+      testId: '01e1ae2eda378fcdc79a-5b19ff8659b54d79108c',
+      titlePath: [
+        'repayment.spec.ts',
+        'repay within 7 days with 108 coupon [smoke]',
+      ],
+      annotations: [],
+      retry: 0,
+    });
+
+    expect(opts.reportFileName).toContain('repay');
+    expect(opts.reportFileName).toContain('108-coupon');
+    expect(opts.reportFileName).not.toContain('01e1ae2eda378fcdc79a');
+    expect(opts.reportFileName).not.toContain('5b19ff8659b54d79108c');
+    // Kept in lockstep with reportFileName so the deprecated testId fallback
+    // in @midscene/core Agent does not reintroduce a UUID-based filename if
+    // reportFileName is ever dropped.
+    expect(opts.testId).toBe(opts.reportFileName);
+  });
+
+  it('embeds a retry marker so reruns do not overwrite the first attempt', async () => {
+    const opts = await runAi({
+      testId: 'does-not-matter',
+      titlePath: ['flow.spec.ts', 'login case'],
+      annotations: [],
+      retry: 2,
+    });
+
+    // replaceIllegalPathCharsAndSpace turns ' ' and '#' into '-', so the
+    // retry marker surfaces as "(retry--2)" on disk.
+    expect(opts.reportFileName).toContain('login-case(retry--2)');
+  });
+
+  it('preserves the page-level uuid suffix so multiple pages in one test do not clash', async () => {
+    const fixture = PlaywrightAiFixture();
+    const pageA = createPage();
+    const pageB = createPage();
+    const testInfo = {
+      testId: 'uuid',
+      titlePath: ['shop.spec.ts', 'checkout'],
+      annotations: [],
+      retry: 0,
+    } as any;
+
+    let getAgent: any;
+    await fixture.agentForPage(
+      { page: pageA },
+      async (fn: any) => {
+        getAgent = fn;
+      },
+      testInfo,
+    );
+
+    await getAgent(pageA);
+    await getAgent(pageB);
+
+    expect(mockState.ctorOpts).toHaveLength(2);
+    const [a, b] = mockState.ctorOpts;
+    expect(a.reportFileName).toContain('checkout');
+    expect(b.reportFileName).toContain('checkout');
+    expect(a.reportFileName).not.toBe(b.reportFileName);
+  });
+
+  it('sanitizes filename-hostile characters but preserves path separators', async () => {
+    const opts = await runAi({
+      testId: 'uuid',
+      titlePath: ['auth.spec.ts', 'can I click "Submit" on #home?'],
+      annotations: [],
+      retry: 0,
+    });
+
+    // replaceIllegalPathCharsAndSpace scrubs these filename-hostile chars.
+    for (const forbidden of [':', '*', '?', '"', '<', '>', '|', '#']) {
+      expect(opts.reportFileName.includes(forbidden)).toBe(false);
+    }
+    // Readable words still come through.
+    expect(opts.reportFileName).toContain('Submit');
+    expect(opts.reportFileName).toContain('home');
+  });
+});


### PR DESCRIPTION
## Summary

- `PlaywrightAiFixture` was forwarding Playwright's internal `testInfo.testId` (a UUID) as the Agent's `reportFileName`, producing intermediate report files named `playwright-<uuid>-<uuid>.html` that carry no information about which spec or case produced them — impossible to triage on disk, and it breaks downstream parsing scripts that expect a readable `playwright-<title>-<date>-<shortUuid>.html` pattern.
- Route `reportFileName` through the already path-safe, retry-aware `title` returned by `groupAndCaseForTest`. Keep the Agent `testId` option in lockstep with `reportFileName` so the deprecated `testId` fallback in `@midscene/core` cannot silently reintroduce a UUID-based filename if `reportFileName` is ever dropped.
- Reproduced via the new unit test file. Before: `reportFileName = playwright-<playwright-testId-uuid>-<page-uuid>`. After: `reportFileName = playwright-<readable-title-with-retry>-<page-uuid>`.

## Root cause

`packages/web-integration/src/playwright/ai-fixture.ts` destructured `testInfo.testId` (Playwright's internal UUID) and used it to build the Agent's `reportFileName`, ignoring the human-readable `title` / `id` fields that `groupAndCaseForTest` was already computing right beside it. The Agent then wrote that UUID directly to disk because `ReportGenerator.create()` treats an explicit `reportFileName` as the final filename (no date/shortUuid wrapping).

Behavior regressed in two steps: `#2264` switched the field from `testId` to `reportFileName` (now used verbatim), and `#2328` kept both fields carrying the UUID.

## Test plan

- [x] New repro/regression file `packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts` (4 cases):
  - Readable title replaces UUID `testId`; `testId` option stays in lockstep with `reportFileName`.
  - Retry marker `(retry--N)` is embedded so reruns do not clobber the first attempt.
  - Multi-page agents in one test do not collide (page-level uuid suffix preserved).
  - Filename-hostile characters (`:*?"<>|#` and space) are scrubbed; path separators `/\` are preserved (matches `replaceIllegalPathCharsAndSpace`).
- [x] `npx vitest run packages/web-integration/tests/unit-test/playwright-ai-fixture-*.test.ts` — 21/21 passing.
- [x] `pnpm run lint` — clean (only one pre-existing unrelated warning in `packages/core`).