### PR TITLE
feat(core): expose agent.aiLongPress() and agent.aiClearInput()

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -604,7 +604,7 @@ function aiLongPress(
 
   - `locate: string | Object` - A natural language description of the element to long-press on, or [prompting with images](#prompting-with-images).
   - `opt?: Object` - Optional, a configuration object containing:
-    - `duration?: number` - How long the press is held, in milliseconds. Defaults vary by platform (Android / Web use `2000`, iOS uses `1000`).
+    - `duration?: number` - How long the press is held, in milliseconds. When omitted, each platform applies its own default (Android `2000`, iOS `1000`, Web `500`).
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
     - `xpath?: string` - The xpath of the element to operate. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -122,7 +122,7 @@ Below are the main APIs available for the various Agents in Midscene.
 In Midscene, you can choose to use either auto planning or instant action.
 
 - `agent.ai()` is for Auto Planning: Midscene will automatically plan the steps and execute them. It's more smart and looks like more fashionable style for AI agents. But it may be slower and heavily rely on the quality of the AI model.
-- `agent.aiTap()`, `agent.aiHover()`, `agent.aiInput()`, `agent.aiKeyboardPress()`, `agent.aiScroll()`, `agent.aiPinch()`, `agent.aiDoubleClick()`, `agent.aiRightClick()` are for Instant Action: Midscene will directly perform the specified action, while the AI model is responsible for basic tasks such as locating elements. It's faster and more reliable if you are certain about the action you want to perform.
+- `agent.aiTap()`, `agent.aiHover()`, `agent.aiInput()`, `agent.aiClearInput()`, `agent.aiKeyboardPress()`, `agent.aiScroll()`, `agent.aiPinch()`, `agent.aiLongPress()`, `agent.aiDoubleClick()`, `agent.aiRightClick()` are for Instant Action: Midscene will directly perform the specified action, while the AI model is responsible for basic tasks such as locating elements. It's faster and more reliable if you are certain about the action you want to perform.
 
 :::
 
@@ -346,6 +346,52 @@ We recently updated the `aiInput` API signature to put the locate prompt as the 
 
 :::
 
+### `agent.aiClearInput()`
+
+Clear the content of an input field. Useful as a standalone step before typing, or when you need to remove existing text without immediately inputting a new value.
+
+- Type
+
+```typescript
+function aiClearInput(
+  locate: string | Object,
+  opt?: {
+    deepLocate?: boolean;
+    xpath?: string;
+    cacheable?: boolean;
+  },
+): Promise<void>;
+```
+
+- Parameters:
+
+  - `locate: string | Object` - A natural language description of the input field to clear, or [prompting with images](#prompting-with-images).
+  - `opt?: Object` - Optional, a configuration object containing:
+    - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
+    - `xpath?: string` - The xpath of the element to operate. Empty by default.
+    - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
+
+- Return Value:
+
+  - Returns a `Promise<void>`
+
+- Examples:
+
+```typescript
+// Clear the search box
+await agent.aiClearInput('the search input field');
+
+// Clear and then type a new value
+await agent.aiClearInput('the email input');
+await agent.aiInput('the email input', { value: 'user@example.com' });
+```
+
+:::tip When to use `aiClearInput` vs `aiInput`
+
+`aiInput(locate, { value: '...' })` already clears the field by default (via `mode: 'replace'`). Reach for `aiClearInput` when you need clearing as an independent step — for example, to test empty-state validation, or when you want to control clearing and typing as separate actions.
+
+:::
+
 ### `agent.aiKeyboardPress()`
 
 Press a keyboard key.
@@ -533,6 +579,53 @@ await agent.aiPinch('the image', { direction: 'out', distance: 300, duration: 10
 - **iOS** &mdash; Implemented via W3C Actions API with dual touch pointers.
 - **Web** &mdash; Implemented via CDP touch events. For Puppeteer/Playwright, requires `enableTouchEventsInActionSpace: true`. Playwright only supports Chromium-based browsers.
 - **HarmonyOS** &mdash; Not supported. The `uitest` framework does not provide multi-touch APIs.
+
+:::
+
+### `agent.aiLongPress()`
+
+Long-press (or click-and-hold) an element. Useful for opening context menus, selecting items, or triggering long-press gestures.
+
+- Type
+
+```typescript
+function aiLongPress(
+  locate: string | Object,
+  opt?: {
+    duration?: number;
+    deepLocate?: boolean;
+    xpath?: string;
+    cacheable?: boolean;
+  },
+): Promise<void>;
+```
+
+- Parameters:
+
+  - `locate: string | Object` - A natural language description of the element to long-press on, or [prompting with images](#prompting-with-images).
+  - `opt?: Object` - Optional, a configuration object containing:
+    - `duration?: number` - How long the press is held, in milliseconds. Defaults vary by platform (Android / Web use `2000`, iOS uses `1000`).
+    - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
+    - `xpath?: string` - The xpath of the element to operate. Empty by default.
+    - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
+
+- Return Value:
+
+  - Returns a `Promise<void>`
+
+- Examples:
+
+```typescript
+// Long-press an article to open the context menu
+await agent.aiLongPress('the first article on the homepage');
+
+// Long-press with a custom duration
+await agent.aiLongPress('the message bubble', { duration: 2000 });
+```
+
+:::info Platform Support
+
+- **Android**, **iOS**, **HarmonyOS**, **Web** (Chromium-based browsers via touch events). On HarmonyOS the `duration` option is ignored because the underlying `uitest` API does not expose a custom hold time.
 
 :::
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -597,7 +597,7 @@ function aiLongPress(
 
   - `locate: string | Object` - 要长按的元素的自然语言描述，或[通过图像提示](#通过图像提示)。
   - `opt?: Object` - 可选配置对象：
-    - `duration?: number` - 按住时长（毫秒），默认值随平台而异（Android / Web 默认 `2000`，iOS 默认 `1000`）。
+    - `duration?: number` - 按住时长（毫秒）。未传时各平台使用各自默认值：Android `2000`，iOS `1000`，Web `500`。
     - `deepLocate?: boolean` - 是否启用[深度定位](#深度定位deeplocate)，默认 `false`。
     - `xpath?: string` - 要操作元素的 xpath，默认空。
     - `cacheable?: boolean` - 启用[缓存功能](./caching.mdx)时是否缓存，默认 `true`。

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -124,7 +124,7 @@ const agent = new PuppeteerAgent(page, {
 在 Midscene 中，你可以选择使用自动规划（Auto Planning）或即时操作（Instant Action）。
 
 - `agent.ai()` 是自动规划（Auto Planning）：Midscene 会自动规划操作步骤并执行。它更智能，更像流行的 AI Agent 风格，但可能较慢，且效果依赖于 AI 模型的质量。
-- `agent.aiTap()`, `agent.aiHover()`, `agent.aiInput()`, `agent.aiKeyboardPress()`, `agent.aiScroll()`, `agent.aiPinch()`, `agent.aiDoubleClick()`, `agent.aiRightClick()` 是即时操作（Instant Action）：Midscene 会直接执行指定的操作，而 AI 模型只负责底层任务，如定位元素等。这种接口形式更快、更可靠。当你完全确定自己想要执行的操作时，推荐使用这种接口形式。
+- `agent.aiTap()`, `agent.aiHover()`, `agent.aiInput()`, `agent.aiClearInput()`, `agent.aiKeyboardPress()`, `agent.aiScroll()`, `agent.aiPinch()`, `agent.aiLongPress()`, `agent.aiDoubleClick()`, `agent.aiRightClick()` 是即时操作（Instant Action）：Midscene 会直接执行指定的操作，而 AI 模型只负责底层任务，如定位元素等。这种接口形式更快、更可靠。当你完全确定自己想要执行的操作时，推荐使用这种接口形式。
 
 :::
 
@@ -339,6 +339,52 @@ await agent.aiInput('Hello World', '搜索框');
 
 :::
 
+### `agent.aiClearInput()`
+
+清空输入框内容。适合作为一个独立步骤使用：在输入前先清空，或只需删除现有文本而暂时不输入新内容。
+
+- 类型
+
+```typescript
+function aiClearInput(
+  locate: string | Object,
+  opt?: {
+    deepLocate?: boolean;
+    xpath?: string;
+    cacheable?: boolean;
+  },
+): Promise<void>;
+```
+
+- 参数：
+
+  - `locate: string | Object` - 要清空的输入框的自然语言描述，或[通过图像提示](#通过图像提示)。
+  - `opt?: Object` - 可选配置对象：
+    - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认 `false`。
+    - `xpath?: string` - 要操作元素的 xpath，默认空。
+    - `cacheable?: boolean` - 启用[缓存功能](./caching.mdx)时是否缓存，默认 `true`。
+
+- 返回值：
+
+  - 返回 `Promise<void>`
+
+- 示例：
+
+```typescript
+// 清空搜索框
+await agent.aiClearInput('搜索框');
+
+// 先清空再输入新值
+await agent.aiClearInput('邮箱输入框');
+await agent.aiInput('邮箱输入框', { value: 'user@example.com' });
+```
+
+:::tip `aiClearInput` 与 `aiInput` 的取舍
+
+`aiInput(locate, { value: '...' })` 默认会先清空输入框（`mode: 'replace'`）。只有在需要把清空当成独立一步时（例如测试空值校验，或想把清空和输入拆成两步分别控制）才使用 `aiClearInput`。
+
+:::
+
 ### `agent.aiKeyboardPress()`
 
 按下键盘上的某个键。
@@ -526,6 +572,53 @@ await agent.aiPinch('图片', { direction: 'out', distance: 300, duration: 1000 
 - **iOS** —— 通过 W3C Actions API 双触摸指针实现。
 - **Web** —— 通过 CDP 触摸事件实现。Puppeteer/Playwright 需设置 `enableTouchEventsInActionSpace: true`。Playwright 仅支持 Chromium 内核浏览器。
 - **HarmonyOS** —— 不支持。`uitest` 框架未提供多触点 API。
+
+:::
+
+### `agent.aiLongPress()`
+
+长按（按住不放）某个元素，常用于唤起右键/上下文菜单、触发选中模式或其他长按手势。
+
+- 类型
+
+```typescript
+function aiLongPress(
+  locate: string | Object,
+  opt?: {
+    duration?: number;
+    deepLocate?: boolean;
+    xpath?: string;
+    cacheable?: boolean;
+  },
+): Promise<void>;
+```
+
+- 参数：
+
+  - `locate: string | Object` - 要长按的元素的自然语言描述，或[通过图像提示](#通过图像提示)。
+  - `opt?: Object` - 可选配置对象：
+    - `duration?: number` - 按住时长（毫秒），默认值随平台而异（Android / Web 默认 `2000`，iOS 默认 `1000`）。
+    - `deepLocate?: boolean` - 是否启用[深度定位](#深度定位deeplocate)，默认 `false`。
+    - `xpath?: string` - 要操作元素的 xpath，默认空。
+    - `cacheable?: boolean` - 启用[缓存功能](./caching.mdx)时是否缓存，默认 `true`。
+
+- 返回值：
+
+  - 返回 `Promise<void>`
+
+- 示例：
+
+```typescript
+// 长按首页的第一篇文章以唤起菜单
+await agent.aiLongPress('首页的第一篇文章');
+
+// 自定义长按时长
+await agent.aiLongPress('消息气泡', { duration: 2000 });
+```
+
+:::info 平台支持
+
+- **Android**、**iOS**、**HarmonyOS**、**Web**（基于 Chromium 的浏览器，通过触摸事件实现）。HarmonyOS 会忽略 `duration` 选项，因为底层 `uitest` API 不支持自定义按住时长。
 
 :::
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -23,6 +23,7 @@ import {
   defineActionDoubleClick,
   defineActionDragAndDrop,
   defineActionKeyboardPress,
+  defineActionLongPress,
   defineActionPinch,
   defineActionScroll,
   defineActionSwipe,
@@ -256,38 +257,13 @@ export class AndroidDevice implements AbstractInterface {
           await sleep(100);
         }
       }),
-      defineAction<
-        z.ZodObject<{
-          duration: z.ZodOptional<z.ZodNumber>;
-          locate: ReturnType<typeof getMidsceneLocationSchema>;
-        }>,
-        {
-          duration?: number;
-          locate: LocateResultElement;
+      defineActionLongPress(async (param) => {
+        const element = param.locate;
+        if (!element) {
+          throw new Error('LongPress requires an element to be located');
         }
-      >({
-        name: 'LongPress',
-        description: 'Trigger a long press on the screen at specified element',
-        paramSchema: z.object({
-          duration: z
-            .number()
-            .optional()
-            .describe('The duration of the long press in milliseconds'),
-          locate: getMidsceneLocationSchema().describe(
-            'The element to be long pressed',
-          ),
-        }),
-        sample: {
-          locate: { prompt: 'the message bubble' },
-        },
-        call: async (param) => {
-          const element = param.locate;
-          if (!element) {
-            throw new Error('LongPress requires an element to be located');
-          }
-          const [x, y] = element.center;
-          await this.longPress(x, y, param?.duration);
-        },
+        const [x, y] = element.center;
+        await this.longPress(x, y, param?.duration);
       }),
       defineAction<
         z.ZodObject<{

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -860,6 +860,30 @@ export class Agent<
     });
   }
 
+  async aiLongPress(
+    locatePrompt: TUserPrompt,
+    opt?: LocateOption & { duration?: number },
+  ) {
+    assert(locatePrompt, 'missing locate prompt for long press');
+
+    const detailedLocateParam = buildDetailedLocateParam(locatePrompt, opt);
+
+    return this.callActionInActionSpace('LongPress', {
+      ...(opt || {}),
+      locate: detailedLocateParam,
+    });
+  }
+
+  async aiClearInput(locatePrompt: TUserPrompt, opt?: LocateOption) {
+    assert(locatePrompt, 'missing locate prompt for clear input');
+
+    const detailedLocateParam = buildDetailedLocateParam(locatePrompt, opt);
+
+    return this.callActionInActionSpace('ClearInput', {
+      locate: detailedLocateParam,
+    });
+  }
+
   async aiAct(
     taskPrompt: string,
     opt?: AiActOptions,

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -374,6 +374,7 @@ export const defineActionLongPress = (
   return defineAction<typeof ActionLongPressParamSchema, ActionLongPressParam>({
     name: 'LongPress',
     description: 'Long press the element',
+    interfaceAlias: 'aiLongPress',
     paramSchema: ActionLongPressParamSchema,
     sample: {
       locate: { prompt: 'the message bubble' },

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -359,7 +359,6 @@ export const ActionLongPressParamSchema = z.object({
   ),
   duration: z
     .number()
-    .default(500)
     .optional()
     .describe('Long press duration in milliseconds'),
 });

--- a/packages/core/tests/unit-test/action-clear-input.test.ts
+++ b/packages/core/tests/unit-test/action-clear-input.test.ts
@@ -1,0 +1,91 @@
+import { Agent } from '@/agent';
+import { parseActionParam } from '@/ai-model';
+import { actionClearInputParamSchema, defineActionClearInput } from '@/device';
+import { describe, expect, it, vi } from 'vitest';
+
+const createAgentStub = () => {
+  const agent = Object.create(Agent.prototype) as Agent<any>;
+  (agent as any).callActionInActionSpace = vi.fn(async () => undefined);
+  return agent;
+};
+
+describe('ClearInput Action', () => {
+  describe('defineActionClearInput', () => {
+    it('should create an action with correct name and alias', () => {
+      const callFn = vi.fn();
+      const action = defineActionClearInput(callFn);
+
+      expect(action.name).toBe('ClearInput');
+      expect(action.interfaceAlias).toBe('aiClearInput');
+      expect(action.paramSchema).toBeDefined();
+      expect(action.sample).toEqual({
+        locate: { prompt: 'the search input field' },
+      });
+    });
+  });
+
+  describe('actionClearInputParamSchema', () => {
+    it('should accept locate with prompt', () => {
+      const parsed = parseActionParam(
+        { locate: { prompt: 'the search input field' } },
+        actionClearInputParamSchema,
+      );
+      expect(parsed.locate).toEqual({ prompt: 'the search input field' });
+    });
+
+    it('should allow missing locate (optional)', () => {
+      const parsed = parseActionParam({}, actionClearInputParamSchema);
+      expect(parsed.locate).toBeUndefined();
+    });
+  });
+
+  describe('Agent.aiClearInput', () => {
+    it('dispatches the ClearInput action with locate prompt', async () => {
+      const agent = createAgentStub();
+      const callActionSpy = (agent as any)
+        .callActionInActionSpace as ReturnType<typeof vi.fn>;
+
+      await agent.aiClearInput('the search input field');
+
+      expect(callActionSpy).toHaveBeenCalledTimes(1);
+      expect(callActionSpy).toHaveBeenCalledWith(
+        'ClearInput',
+        expect.objectContaining({
+          locate: expect.objectContaining({
+            prompt: 'the search input field',
+          }),
+        }),
+      );
+    });
+
+    it('forwards locate options such as deepLocate and xpath', async () => {
+      const agent = createAgentStub();
+      const callActionSpy = (agent as any)
+        .callActionInActionSpace as ReturnType<typeof vi.fn>;
+
+      await agent.aiClearInput('the search input field', {
+        deepLocate: true,
+        xpath: '//input[@id="q"]',
+      });
+
+      expect(callActionSpy).toHaveBeenCalledTimes(1);
+      const [actionName, payload] = callActionSpy.mock.calls[0] as [
+        string,
+        any,
+      ];
+      expect(actionName).toBe('ClearInput');
+      expect(payload.locate).toMatchObject({
+        prompt: 'the search input field',
+        deepLocate: true,
+        xpath: '//input[@id="q"]',
+      });
+    });
+
+    it('throws when locate prompt is missing', async () => {
+      const agent = createAgentStub();
+      await expect(agent.aiClearInput('' as any)).rejects.toThrow(
+        /missing locate prompt/,
+      );
+    });
+  });
+});

--- a/packages/core/tests/unit-test/action-long-press.test.ts
+++ b/packages/core/tests/unit-test/action-long-press.test.ts
@@ -1,0 +1,86 @@
+import { Agent } from '@/agent';
+import { parseActionParam } from '@/ai-model';
+import { ActionLongPressParamSchema, defineActionLongPress } from '@/device';
+import { describe, expect, it, vi } from 'vitest';
+
+const createAgentStub = () => {
+  const agent = Object.create(Agent.prototype) as Agent<any>;
+  (agent as any).callActionInActionSpace = vi.fn(async () => undefined);
+  return agent;
+};
+
+describe('LongPress Action', () => {
+  describe('defineActionLongPress', () => {
+    it('should create an action with correct name and alias', () => {
+      const callFn = vi.fn();
+      const action = defineActionLongPress(callFn);
+
+      expect(action.name).toBe('LongPress');
+      expect(action.interfaceAlias).toBe('aiLongPress');
+      expect(action.paramSchema).toBeDefined();
+      expect(action.sample).toEqual({
+        locate: { prompt: 'the message bubble' },
+      });
+    });
+  });
+
+  describe('ActionLongPressParamSchema', () => {
+    it('should accept locate with prompt', () => {
+      const parsed = parseActionParam(
+        { locate: { prompt: 'the message bubble' } },
+        ActionLongPressParamSchema,
+      );
+      expect(parsed.locate).toEqual({ prompt: 'the message bubble' });
+    });
+
+    it('should accept custom duration', () => {
+      const parsed = parseActionParam(
+        { locate: { prompt: 'the message bubble' }, duration: 2000 },
+        ActionLongPressParamSchema,
+      );
+      expect(parsed.duration).toBe(2000);
+    });
+  });
+
+  describe('Agent.aiLongPress', () => {
+    it('dispatches the LongPress action with locate prompt', async () => {
+      const agent = createAgentStub();
+      const callActionSpy = (agent as any)
+        .callActionInActionSpace as ReturnType<typeof vi.fn>;
+
+      await agent.aiLongPress('首页任意一篇文章');
+
+      expect(callActionSpy).toHaveBeenCalledTimes(1);
+      expect(callActionSpy).toHaveBeenCalledWith(
+        'LongPress',
+        expect.objectContaining({
+          locate: expect.objectContaining({ prompt: '首页任意一篇文章' }),
+        }),
+      );
+    });
+
+    it('forwards duration to the LongPress action', async () => {
+      const agent = createAgentStub();
+      const callActionSpy = (agent as any)
+        .callActionInActionSpace as ReturnType<typeof vi.fn>;
+
+      await agent.aiLongPress('首页任意一篇文章', { duration: 2000 });
+
+      expect(callActionSpy).toHaveBeenCalledTimes(1);
+      expect(callActionSpy).toHaveBeenCalledWith(
+        'LongPress',
+        expect.objectContaining({
+          duration: 2000,
+          locate: expect.objectContaining({ prompt: '首页任意一篇文章' }),
+        }),
+      );
+    });
+
+    it('throws when locate prompt is missing', async () => {
+      const agent = createAgentStub();
+      await expect(agent.aiLongPress('' as any)).rejects.toThrow(
+        /missing locate prompt/,
+      );
+    });
+  });
+});

--- a/packages/core/tests/unit-test/action-long-press.test.ts
+++ b/packages/core/tests/unit-test/action-long-press.test.ts
@@ -40,6 +40,14 @@ describe('LongPress Action', () => {
       );
       expect(parsed.duration).toBe(2000);
     });
+
+    it('should leave duration undefined when omitted so each device can apply its own default', () => {
+      const parsed = parseActionParam(
+        { locate: { prompt: 'the message bubble' } },
+        ActionLongPressParamSchema,
+      );
+      expect(parsed.duration).toBeUndefined();
+    });
   });
 
   describe('Agent.aiLongPress', () => {

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -19,6 +19,7 @@ import {
   defineActionDoubleClick,
   defineActionDragAndDrop,
   defineActionKeyboardPress,
+  defineActionLongPress,
   defineActionScroll,
   defineActionSwipe,
   defineActionTap,
@@ -237,37 +238,12 @@ export class HarmonyDevice implements AbstractInterface {
           await sleep(100);
         }
       }),
-      defineAction<
-        z.ZodObject<{
-          duration: z.ZodOptional<z.ZodNumber>;
-          locate: ReturnType<typeof getMidsceneLocationSchema>;
-        }>,
-        {
-          duration?: number;
-          locate: LocateResultElement;
+      defineActionLongPress(async (param) => {
+        const element = param.locate;
+        if (!element) {
+          throw new Error('LongPress requires an element to be located');
         }
-      >({
-        name: 'LongPress',
-        description: 'Trigger a long press on the screen at specified element',
-        paramSchema: z.object({
-          duration: z
-            .number()
-            .optional()
-            .describe('The duration of the long press in milliseconds'),
-          locate: getMidsceneLocationSchema().describe(
-            'The element to be long pressed',
-          ),
-        }),
-        sample: {
-          locate: { prompt: 'the message bubble' },
-        },
-        call: async (param) => {
-          const element = param.locate;
-          if (!element) {
-            throw new Error('LongPress requires an element to be located');
-          }
-          await this.longPress(element.center[0], element.center[1]);
-        },
+        await this.longPress(element.center[0], element.center[1]);
       }),
       defineActionClearInput(async (param) => {
         await this.clearInput(param.locate as ElementInfo | undefined);

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -19,6 +19,7 @@ import {
   defineActionDoubleClick,
   defineActionDragAndDrop,
   defineActionKeyboardPress,
+  defineActionLongPress,
   defineActionPinch,
   defineActionScroll,
   defineActionSwipe,
@@ -217,36 +218,11 @@ export class IOSDevice implements AbstractInterface {
           await sleep(100);
         }
       }),
-      defineAction<
-        z.ZodObject<{
-          duration: z.ZodOptional<z.ZodNumber>;
-          locate: ReturnType<typeof getMidsceneLocationSchema>;
-        }>,
-        {
-          duration?: number;
-          locate: LocateResultElement;
-        }
-      >({
-        name: 'LongPress',
-        description: 'Trigger a long press on the screen at specified element',
-        paramSchema: z.object({
-          duration: z
-            .number()
-            .optional()
-            .describe('The duration of the long press in milliseconds'),
-          locate: getMidsceneLocationSchema().describe(
-            'The element to be long pressed',
-          ),
-        }),
-        sample: {
-          locate: { prompt: 'the message bubble' },
-        },
-        call: async (param) => {
-          const element = param.locate;
-          assert(element, 'LongPress requires an element to be located');
-          const [x, y] = element.center;
-          await this.longPress(x, y, param?.duration);
-        },
+      defineActionLongPress(async (param) => {
+        const element = param.locate;
+        assert(element, 'LongPress requires an element to be located');
+        const [x, y] = element.center;
+        await this.longPress(x, y, param?.duration);
       }),
       defineActionPinch(async (param) => {
         const { centerX, centerY, startDistance, endDistance, duration } =


### PR DESCRIPTION
## Summary

- Add two first-class `ai*` methods on `Agent` for actions that were previously only reachable through `agent.callActionInActionSpace()`:
  - `agent.aiLongPress(locate, { duration? })`
  - `agent.aiClearInput(locate)`
- Wire `interfaceAlias: 'aiLongPress'` on the shared `defineActionLongPress()` helper so cross-platform action metadata is consistent (`aiClearInput` was already wired).
- Refactor the Android / iOS / HarmonyOS device implementations to use `defineActionLongPress()` instead of hand-rolling the schema, keeping the three platforms aligned with the core definition. HarmonyOS still ignores `duration` because the underlying `uitest` API does not expose a custom hold time.

## Motivation

Users have asked us to open up dedicated interfaces for the remaining instant actions instead of driving them through the generic `callActionInActionSpace('LongPress' | 'ClearInput', ...)` API:

- `aiLongPress` is a common gesture on mobile (context menus, selection mode, etc.) and was effectively hidden.
- `aiClearInput` is useful as an independent step (e.g. asserting empty-state validation) or when you want to decouple clearing from typing. It complements `aiInput({ mode: 'replace' })` rather than replacing it.

The `aiAct` planner path is still available for natural-language flows; this PR is about giving users an equally ergonomic entry point for the deterministic path.

## API

```ts
// New
await agent.aiLongPress('the first article on the homepage');
await agent.aiLongPress('the message bubble', { duration: 2000 });

await agent.aiClearInput('the search input field');
await agent.aiClearInput('the email input', { deepLocate: true });
```

Both methods accept the usual `LocateOption` (`deepLocate`, `xpath`, `cacheable`, image prompts).

## Docs

- `apps/site/docs/en/api.mdx` and `apps/site/docs/zh/api.mdx` gain dedicated `agent.aiLongPress()` and `agent.aiClearInput()` sections, and the Instant Action intro list now mentions both methods.
- A short tip clarifies when to reach for `aiClearInput` vs. the default clearing behaviour of `aiInput({ mode: 'replace' })`.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx test core` — 806 passed (including the two new suites)
- [x] `pnpm exec vitest run tests/unit-test/action-long-press.test.ts tests/unit-test/action-clear-input.test.ts` (inside `packages/core`) — 12 passed
- [x] `npx nx test android` — 264 passed
- [x] `npx nx test ios` — 110 passed
- [x] `npx nx test harmony` — 117 passed

Pre-existing failures outside the scope of this PR (verified reproducible on `main`):
- `packages/web-integration/tests/unit-test/playground-server.test.ts` — `EADDRINUSE` on port 5800 in the local sandbox.
- `packages/web-integration/tests/unit-test/yaml/player.test.ts > flush output even if assertion failed` — e2e test timing out on network idle.