### PR TITLE
feat(core): improve dropdown selection guidance

### DIFF
--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -393,6 +393,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "type 'hello' in the search box" → ${shouldIncludeSubGoals ? 'Goal accomplished' : 'Instruction fulfilled'} when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → ${shouldIncludeSubGoals ? 'Goal accomplished' : 'Instruction fulfilled'} when selected. Do NOT proceed to checkout.
 
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
 - This rule overrides the general requirement to verify the exact target text from the screenshot.

--- a/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
+++ b/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
@@ -283,6 +283,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
 
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
 - This rule overrides the general requirement to verify the exact target text from the screenshot.
@@ -601,6 +609,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
 
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
 - This rule overrides the general requirement to verify the exact target text from the screenshot.
@@ -891,6 +907,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "click the login button" → Instruction fulfilled once clicked. Do NOT wait for page load or verify login success.
 - "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
+
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
 
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
@@ -1271,6 +1295,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "type 'hello' in the search box" → Goal accomplished when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Goal accomplished when selected. Do NOT proceed to checkout.
 
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
 - This rule overrides the general requirement to verify the exact target text from the screenshot.
@@ -1615,6 +1647,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
 
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
 - This rule overrides the general requirement to verify the exact target text from the screenshot.
@@ -1932,6 +1972,14 @@ The user's instruction defines the EXACT scope of what you must accomplish. You 
 - "click the login button" → Instruction fulfilled once clicked. Do NOT wait for page load or verify login success.
 - "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
 - "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
+
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
 
 **Special case - Text hidden by a narrow input field:**
 - CRITICAL PRIORITY OVERRIDE - Input verification after an input action:

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -319,6 +319,32 @@ describe('system prompts', () => {
     );
   });
 
+  it('planning should include dropdown scrolling guidance', async () => {
+    const prompt = await systemPromptToTaskPlanning({
+      actionSpace: mockActionSpace,
+      modelFamily: undefined,
+      includeBbox: false,
+      includeSubGoals: false,
+    });
+
+    expect(prompt).toContain('Scrollable option lists and dropdowns');
+    expect(prompt).toContain(
+      'When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list',
+    );
+    expect(prompt).toContain(
+      'Once the list is open, interact with the list itself, not the page',
+    );
+    expect(prompt).toContain(
+      'If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown',
+    );
+    expect(prompt).toContain(
+      'prefer small incremental Scroll actions with an explicit distance',
+    );
+    expect(prompt).toContain(
+      'treat the current selection step as fulfilled and continue evaluating the remaining user instruction',
+    );
+  });
+
   it('planning - multi-turn example with includeSubGoals true should have sub-goal tags', async () => {
     const prompt = await systemPromptToTaskPlanning({
       actionSpace: mockActionSpace,

--- a/packages/web-integration/tests/ai/fixtures/select-scroll-bottom.html
+++ b/packages/web-integration/tests/ai/fixtures/select-scroll-bottom.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scrollable Select Test</title>
+  <style>
+    :root {
+      --border: #d9d9d9;
+      --border-active: #1677ff;
+      --bg: #f5f7fb;
+      --card: #ffffff;
+      --text: #1f1f1f;
+      --muted: #6b7280;
+      --hover: #f0f7ff;
+      --selected: #e6f4ff;
+      --shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Arial, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(22, 119, 255, 0.12), transparent 28%),
+        linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+      padding: 48px 24px;
+    }
+
+    .page {
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    .fixture-card {
+      background: var(--card);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      border-radius: 24px;
+      box-shadow: var(--shadow);
+      padding: 32px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 32px;
+      line-height: 1.1;
+    }
+
+    .subtitle {
+      margin: 0 0 24px;
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.6;
+    }
+
+    .field-label {
+      display: block;
+      margin-bottom: 10px;
+      font-size: 15px;
+      font-weight: 700;
+    }
+
+    .custom-select {
+      position: relative;
+      width: 100%;
+    }
+
+    .select-trigger {
+      width: 100%;
+      min-height: 48px;
+      padding: 12px 44px 12px 14px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: #fff;
+      color: var(--text);
+      text-align: left;
+      font-size: 15px;
+      cursor: pointer;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      position: relative;
+    }
+
+    .select-trigger:hover,
+    .select-trigger[aria-expanded="true"] {
+      border-color: var(--border-active);
+      box-shadow: 0 0 0 3px rgba(22, 119, 255, 0.12);
+    }
+
+    .trigger-placeholder {
+      color: var(--muted);
+    }
+
+    .select-arrow {
+      position: absolute;
+      right: 14px;
+      top: 50%;
+      width: 10px;
+      height: 10px;
+      border-right: 2px solid #8c8c8c;
+      border-bottom: 2px solid #8c8c8c;
+      transform: translateY(-60%) rotate(45deg);
+      transition: transform 0.2s ease;
+    }
+
+    .select-trigger[aria-expanded="true"] .select-arrow {
+      transform: translateY(-35%) rotate(-135deg);
+    }
+
+    .select-dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 0;
+      right: 0;
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      z-index: 10;
+    }
+
+    .select-dropdown.open {
+      display: block;
+    }
+
+    .options {
+      max-height: 220px;
+      overflow-y: auto;
+      padding: 8px;
+    }
+
+    .option {
+      width: 100%;
+      border: 0;
+      background: transparent;
+      border-radius: 10px;
+      padding: 11px 12px;
+      text-align: left;
+      font-size: 14px;
+      cursor: pointer;
+      margin-bottom: 4px;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    .option:hover {
+      background: var(--hover);
+    }
+
+    .option.selected {
+      background: var(--selected);
+      color: #0958d9;
+      font-weight: 700;
+    }
+
+    .selection-banner {
+      margin-top: 22px;
+      padding: 16px 18px;
+      border-radius: 16px;
+      background: linear-gradient(135deg, #ecfeff 0%, #f0f9ff 100%);
+      border: 1px solid rgba(34, 197, 94, 0.16);
+    }
+
+    .selection-banner strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 14px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page">
+    <section class="fixture-card">
+      <h1>Scrollable Select Fixture</h1>
+      <p class="subtitle">
+        This page contains one custom Select component with a long dropdown list.
+      </p>
+
+      <label class="field-label" for="delivery-zone-trigger">Choose a delivery zone</label>
+
+      <div class="custom-select" id="delivery-zone-select">
+        <button
+          id="delivery-zone-trigger"
+          class="select-trigger"
+          type="button"
+          aria-expanded="false"
+          aria-controls="delivery-zone-dropdown"
+        >
+          <span id="trigger-text" class="trigger-placeholder">Please select a delivery zone</span>
+          <span class="select-arrow" aria-hidden="true"></span>
+        </button>
+
+        <div id="delivery-zone-dropdown" class="select-dropdown" role="listbox">
+          <div id="options-panel" class="options" aria-label="Delivery zone options"></div>
+        </div>
+      </div>
+
+      <div class="selection-banner">
+        <strong>Selection result</strong>
+        <div id="selection-result">Current selection: none</div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const options = [
+      'Zone 01 - North Harbor',
+      'Zone 02 - East Harbor',
+      'Zone 03 - South Harbor',
+      'Zone 04 - West Harbor',
+      'Zone 05 - Maple Avenue',
+      'Zone 06 - Cedar Avenue',
+      'Zone 07 - Willow Avenue',
+      'Zone 08 - Pine Avenue',
+      'Zone 09 - Granite Hill',
+      'Zone 10 - Silver Hill',
+      'Zone 11 - Amber Hill',
+      'Zone 12 - Quartz Hill',
+      'Zone 13 - River Gate',
+      'Zone 14 - River Plaza',
+      'Zone 15 - River Market',
+      'Zone 16 - River Station',
+      'Zone 17 - Aurora Point',
+      'Zone 18 - Aurora Park',
+      'Zone 19 - Aurora Bay',
+      'Zone 20 - Aurora Ridge',
+      'Zone 21 - Skyline North',
+      'Zone 22 - Skyline East',
+      'Zone 23 - Skyline South',
+      'Zone 24 - Skyline West',
+      'Zone 25 - Garden Court',
+      'Zone 26 - Garden Walk',
+      'Zone 27 - Garden Square',
+      'Zone 28 - Garden Terrace',
+      'Zone 29 - Ocean Terminal',
+      'Zone 30 - Ocean Exchange',
+      'Zone 31 - Ocean Customs',
+      'Zone 32 - Ocean Depot',
+      'Zone 33 - Summit Base',
+      'Zone 34 - Summit Camp',
+      'Zone 35 - Summit Peak',
+      'Zone 36 - Summit Relay',
+      'Zone 37 - Polar Research Base'
+    ];
+
+    const trigger = document.getElementById('delivery-zone-trigger');
+    const dropdown = document.getElementById('delivery-zone-dropdown');
+    const optionsPanel = document.getElementById('options-panel');
+    const triggerText = document.getElementById('trigger-text');
+    const selectionResult = document.getElementById('selection-result');
+
+    let currentSelection = '';
+
+    function renderOptions() {
+      optionsPanel.innerHTML = '';
+
+      for (const optionText of options) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = `option${currentSelection === optionText ? ' selected' : ''}`;
+        button.textContent = optionText;
+        button.dataset.value = optionText;
+        button.addEventListener('click', () => selectOption(optionText));
+        optionsPanel.appendChild(button);
+      }
+    }
+
+    function selectOption(value) {
+      currentSelection = value;
+      triggerText.textContent = value;
+      triggerText.className = '';
+      selectionResult.textContent = `Current selection: ${value}`;
+      closeDropdown();
+      renderOptions();
+    }
+
+    function openDropdown() {
+      dropdown.classList.add('open');
+      trigger.setAttribute('aria-expanded', 'true');
+    }
+
+    function closeDropdown() {
+      dropdown.classList.remove('open');
+      trigger.setAttribute('aria-expanded', 'false');
+    }
+
+    trigger.addEventListener('click', () => {
+      const isOpen = dropdown.classList.contains('open');
+      if (isOpen) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      const selectRoot = document.getElementById('delivery-zone-select');
+      if (!selectRoot.contains(event.target)) {
+        closeDropdown();
+      }
+    });
+
+    renderOptions();
+  </script>
+</body>
+
+</html>

--- a/packages/web-integration/tests/ai/web/puppeteer/select-scroll.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/select-scroll.test.ts
@@ -1,0 +1,65 @@
+import { PuppeteerAgent } from '@/puppeteer';
+import type { Page } from 'puppeteer';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_TEST_TIMEOUT,
+  createTestContext,
+  getFixturePath,
+} from './test-utils';
+import { launchPage } from './utils';
+
+const FIXTURE_URL = `file://${getFixturePath('select-scroll-bottom.html')}`;
+const TARGET_OPTION = 'Zone 12 - Quartz Hill';
+
+async function waitForSelectFixtureReady(originPage: Page) {
+  await originPage.waitForSelector('#delivery-zone-trigger', {
+    timeout: 30 * 1000,
+  });
+  await originPage.waitForSelector('#selection-result', {
+    timeout: 30 * 1000,
+  });
+  await originPage.waitForFunction(
+    () => document.querySelectorAll('#options-panel .option').length > 0,
+    { timeout: 30 * 1000 },
+  );
+}
+
+describe(
+  'Scrollable Select capability',
+  () => {
+    const ctx = createTestContext();
+
+    it('should open the only select and choose Zone 12 - Quartz Hill', async () => {
+      const { originPage, reset } = await launchPage(FIXTURE_URL, {
+        viewport: {
+          width: 1440,
+          height: 1200,
+          deviceScaleFactor: 1,
+        },
+      });
+      ctx.resetFn = reset;
+
+      await waitForSelectFixtureReady(originPage);
+      ctx.agent = new PuppeteerAgent(originPage, {
+        cache: false,
+      });
+
+      await ctx.agent.aiAct(
+        'Open the only select on the page, choose "Zone 12 - Quartz Hill", and return only the selected option text.',
+      );
+
+      const triggerText = await originPage.$eval(
+        '#trigger-text',
+        (element) => element.textContent?.trim() || '',
+      );
+      const selectionResult = await originPage.$eval(
+        '#selection-result',
+        (element) => element.textContent?.trim() || '',
+      );
+
+      expect(triggerText).toBe(TARGET_OPTION);
+      expect(selectionResult).toContain(TARGET_OPTION);
+    });
+  },
+  DEFAULT_TEST_TIMEOUT,
+);


### PR DESCRIPTION

## Summary

This PR improves `aiAct` planning for scrollable select/dropdown/listbox interactions.

Before this change, when the target option was not visible in an opened dropdown, the planner could keep replanning, interact with the page outside the opened list, or scroll with too large/default distances and skip relevant options. This made `select-scroll` unstable across model configs.

The fix adds general planning guidance for scrollable option lists:

- Open the select/dropdown first if it is closed.
- Once the list is open, keep interacting with the opened list itself, not the surrounding page.
- If the target option is visible, tap it immediately.
- If the target option is not visible, search by scrolling the opened list/dropdown.
- Use small explicit scroll distances while searching, so intermediate options are not skipped.
- Finish once the selected value is visible in the trigger/result text.

This is intentionally implemented as model/planning guidance instead of DOM-specific logic, so it remains aligned with Midscene’s multi-platform interaction model.

## Test Coverage

- Added a web integration fixture with a custom scrollable select whose target option is below the initially visible range.
- Added `select-scroll.test.ts` to cover opening the select and selecting `Zone 12 - Quartz Hill`.
- Added prompt unit coverage to ensure the planning system prompt includes the generic dropdown scrolling guidance.
- Updated planning prompt snapshots.

## Validation

AI regression runs for `select-scroll.test.ts`:

| Model / Config | Before | After |
|---|---:|---:|
| qwen3 | 2/10 | 10/10 |
| doubao | 5/10 | 10/10 |
| doubao low reasoning | - | 10/10 |

