### PR TITLE
package Studio release artifacts in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,23 @@ jobs:
   release:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+      is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24.13.0]
+        node-version: [22.11.0]
+    # Force rspack/miette onto the narratable diagnostic path. The graphical
+    # handler in miette 7.6.0 panics on `terminal_size()` edge cases inside
+    # GitHub Actions (no tty + stream multiplexing), which surfaces as a
+    # "Formatting argument out of range" abort at
+    # miette-7.6.0/src/handlers/graphical.rs:1159. Same commit can flake
+    # pass/fail across reruns — setting these env vars makes the build
+    # deterministic until rspack rolls a newer miette.
+    env:
+      COLUMNS: '120'
+      TERM: dumb
+      FORCE_COLOR: '0'
+      NO_COLOR: '1'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -41,7 +54,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24.13.0'
+        node-version: '22.11.0'
         cache: 'pnpm'
 
     - name: Cache Puppeteer
@@ -67,7 +80,12 @@ jobs:
       id: get_version
       run: |
         VERSION=$(cat packages/core/package.json | jq -r '.version')
+        IS_PRERELEASE=false
+        if [[ "$VERSION" == *beta* || "$VERSION" == *alpha* || "$VERSION" == *rc* ]]; then
+          IS_PRERELEASE=true
+        fi
         echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+        echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
         echo "Core package version: v${VERSION}"
         echo "## 🚀 Released v${VERSION}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -75,6 +93,12 @@ jobs:
         echo "- **Type**: \`${{ github.event.inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Branch**: \`${{ github.event.inputs.branch }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **NPM**: [\`@midscene/core@${VERSION}\`](https://www.npmjs.com/package/@midscene/core/v/${VERSION})" >> $GITHUB_STEP_SUMMARY
+        if [[ "$IS_PRERELEASE" == "true" ]]; then
+          echo "- **GitHub Release**: skipped for prerelease builds" >> $GITHUB_STEP_SUMMARY
+          echo "- **Artifacts**: download them from this workflow run" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **GitHub Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> $GITHUB_STEP_SUMMARY
+        fi
       
     - name: Upload output
       uses: actions/upload-artifact@v4
@@ -84,10 +108,12 @@ jobs:
         path: ${{ github.workspace }}/apps/chrome-extension/extension_output
         
     - name: Upload Release Assets
+      if: ${{ steps.get_version.outputs.is_prerelease != 'true' }}
       uses: softprops/action-gh-release@v2
-      if: ${{ !contains(steps.get_version.outputs.version, 'beta') && !contains(steps.get_version.outputs.version, 'alpha') }}
       with:
         tag_name: ${{ steps.get_version.outputs.version }}
+        target_commitish: ${{ github.event.inputs.branch }}
+        prerelease: ${{ contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'rc') }}
         files: |
           ${{ github.workspace }}/apps/chrome-extension/extension_output/**/*.zip
       env:
@@ -127,3 +153,73 @@ jobs:
         echo "Download the packaged extension zip from the GitHub Release page and upload it manually:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "https://github.com/${{ github.repository }}/releases/tag/${{ needs.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
+  package_studio:
+    needs: release
+    if: ${{ needs.release.result == 'success' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+          platform: linux
+          arch: x64
+        - os: windows-latest
+          platform: win32
+          arch: x64
+        - os: macos-15
+          platform: darwin
+          arch: arm64
+    # Same miette-graphical workaround as the `release` job above.
+    env:
+      COLUMNS: '120'
+      TERM: dumb
+      FORCE_COLOR: '0'
+      NO_COLOR: '1'
+    steps:
+    - uses: actions/checkout@v2
+      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
+      with:
+        ref: refs/tags/${{ needs.release.outputs.version }}
+    - uses: actions/checkout@v2
+      if: ${{ needs.release.outputs.is_prerelease == 'true' }}
+      with:
+        ref: ${{ github.event.inputs.branch }}
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 9.3.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.11.0'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Build Studio and Nx dependencies
+      run: npx nx build studio
+
+    - name: Package Midscene Studio
+      run: pnpm --dir apps/studio run package:release -- --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --version=${{ needs.release.outputs.version }}
+
+    - name: Upload packaged Studio artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: studio_${{ matrix.platform }}_${{ matrix.arch }}
+        path: ${{ github.workspace }}/.release/studio/artifacts/*.zip
+
+    - name: Upload Studio asset to GitHub Release
+      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ needs.release.outputs.version }}
+        target_commitish: ${{ github.event.inputs.branch }}
+        prerelease: ${{ contains(needs.release.outputs.version, 'beta') || contains(needs.release.outputs.version, 'alpha') || contains(needs.release.outputs.version, 'rc') }}
+        files: ${{ github.workspace }}/.release/studio/artifacts/*.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,8 @@ jobs:
       NO_COLOR: '1'
     steps:
     - uses: actions/checkout@v2
-      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
       with:
         ref: refs/tags/${{ needs.release.outputs.version }}
-    - uses: actions/checkout@v2
-      if: ${{ needs.release.outputs.is_prerelease == 'true' }}
-      with:
-        ref: ${{ github.event.inputs.branch }}
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:


### PR DESCRIPTION
## Stack
- Stack A 3/3
- Base PR: #2398
- Merge after #2398 lands

## Summary
- package Studio release artifacts in CI on Linux, Windows, and macOS
- pin the release jobs to Node 22 LTS and force non-graphical miette diagnostics for rspack stability in GitHub Actions
- anchor release tagging and Studio packaging to immutable release refs, and skip GitHub Release publication for prerelease versions

## Why
This is the workflow half of PR #2376. Keeping it separate from the local packager makes the CI and release semantics reviewable without the packaging implementation noise.

## Impact
- every release run can build Studio artifacts
- macOS release packaging targets `darwin-arm64`
- prerelease versions publish workflow artifacts without creating mutable GitHub Release assets
- release asset uploads are tied to the computed release ref instead of a moving branch head

## Validation
- `pnpm run lint`
