### PR TITLE
refine Studio frontend UX on top of startup plumbing

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -1,19 +1,35 @@
 import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { IPC_CHANNELS } from '@shared/electron-contract';
+import {
+  type DiscoverDevicesRequest,
+  IPC_CHANNELS,
+  type WriteReportFileRequest,
+} from '@shared/electron-contract';
 import { resolveExternalUrl } from '@shared/external-links';
 import {
   BrowserWindow,
   type NativeImage,
   app,
+  dialog,
   ipcMain,
   nativeImage,
   shell,
 } from 'electron';
 import type { TitleBarOverlay } from 'electron';
-import { runConnectivityTest } from './playground/connectivity-test';
-import { discoverAllDevices } from './playground/device-discovery';
-import { createMultiPlatformRuntimeService } from './playground/multi-platform-runtime';
+import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
+import type { PlaygroundRuntimeService } from './playground/types';
+import { configureStudioShellEnvHydration } from './shell-env';
+import { registerWindowRevealHandlers } from './window-reveal';
+
+// macOS GUI launches (Finder, Dock) skip the user's login shell, so
+// `ANDROID_HOME`, `PATH` additions for adb/hdc/xcrun, etc. never reach
+// `process.env`. Configure the hydrator once here, but only run it lazily
+// from the device-specific paths that actually need those binaries.
+configureStudioShellEnvHydration({
+  isPackaged: app.isPackaged,
+  log: (message, error) => console.warn(`[studio:shell-env] ${message}`, error),
+});
 
 /**
  * Main process owns native shell concerns only.
@@ -23,7 +39,10 @@ import { createMultiPlatformRuntimeService } from './playground/multi-platform-r
 
 let mainWindow: BrowserWindow | null = null;
 let cachedAppIcon: NativeImage | null = null;
-const playgroundRuntime = createMultiPlatformRuntimeService();
+let playgroundRuntimePromise: Promise<PlaygroundRuntimeService> | null = null;
+let deviceDiscoveryServicePromise: Promise<
+  import('./playground/device-discovery').DeviceDiscoveryService
+> | null = null;
 
 // Expose the Chromium DevTools Protocol on a fixed port in dev so external
 // profilers (e.g. chrome-devtools-mcp at http://localhost:9224) can attach to
@@ -87,8 +106,63 @@ const getTitleBarOverlay = (): TitleBarOverlay => ({
   symbolColor: '#17212b',
 });
 
+const DEFAULT_REPORT_FILE_NAME = 'midscene_report.html';
+
+const ensureHtmlFileName = (value: string) =>
+  value.toLowerCase().endsWith('.html') ? value : `${value}.html`;
+
+const resolveDefaultReportSavePath = (defaultFileName?: string) => {
+  const safeFileName = path.basename(
+    ensureHtmlFileName(defaultFileName?.trim() || DEFAULT_REPORT_FILE_NAME),
+  );
+  return path.join(app.getPath('downloads'), safeFileName);
+};
+
+const getPlaygroundRuntime = async (): Promise<PlaygroundRuntimeService> => {
+  if (!playgroundRuntimePromise) {
+    playgroundRuntimePromise = import('./playground/multi-platform-runtime')
+      .then(({ createMultiPlatformRuntimeService }) =>
+        createMultiPlatformRuntimeService({
+          deviceDiscoveryService: getDeviceDiscoveryService(),
+        }),
+      )
+      .catch((error) => {
+        playgroundRuntimePromise = null;
+        throw error;
+      });
+  }
+
+  return playgroundRuntimePromise;
+};
+
+const closePlaygroundRuntime = async (): Promise<void> => {
+  if (!playgroundRuntimePromise) {
+    return;
+  }
+
+  const runtime = await playgroundRuntimePromise;
+  await runtime.close();
+};
+
+const getDeviceDiscoveryService = async () => {
+  if (!deviceDiscoveryServicePromise) {
+    deviceDiscoveryServicePromise = import('./playground/device-discovery')
+      .then(({ createDeviceDiscoveryService }) =>
+        createDeviceDiscoveryService(),
+      )
+      .catch((error) => {
+        deviceDiscoveryServicePromise = null;
+        throw error;
+      });
+  }
+
+  return deviceDiscoveryServicePromise;
+};
+
 const createMainWindow = () => {
   const rendererDevUrl = process.env.MIDSCENE_STUDIO_RENDERER_URL;
+  const rendererEntryPath = getRendererEntryPath();
+  const preloadEntryPath = getPreloadEntryPath();
   const appIcon = getAppIcon();
   const window = new BrowserWindow({
     width: 1440,
@@ -111,19 +185,27 @@ const createMainWindow = () => {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      preload: getPreloadEntryPath(),
+      preload: preloadEntryPath,
       sandbox: false,
     },
   });
 
-  window.once('ready-to-show', () => {
-    window.show();
+  registerWindowRevealHandlers({
+    isDestroyed: () => window.isDestroyed(),
+    onDidFailLoad: (listener) =>
+      window.webContents.once('did-fail-load', listener),
+    onDidFinishLoad: (listener) =>
+      window.webContents.once('did-finish-load', listener),
+    onReadyToShow: (listener) => window.once('ready-to-show', listener),
+    show: () => window.show(),
   });
 
   if (rendererDevUrl) {
     window.loadURL(rendererDevUrl);
   } else {
-    window.loadFile(getRendererEntryPath());
+    void window.loadFile(rendererEntryPath).catch((error) => {
+      console.error('Failed to load Midscene Studio renderer:', error);
+    });
   }
 
   mainWindow = window;
@@ -136,6 +218,30 @@ const registerIpcHandlers = () => {
   ipcMain.handle(IPC_CHANNELS.openExternalUrl, async (_event, url: string) => {
     await shell.openExternal(resolveExternalUrl(url));
   });
+  ipcMain.handle(
+    IPC_CHANNELS.chooseReportSavePath,
+    async (_event, defaultFileName?: string) => {
+      const dialogOptions = {
+        title: 'Save Midscene Report',
+        defaultPath: resolveDefaultReportSavePath(defaultFileName),
+        filters: [
+          {
+            name: 'HTML Report',
+            extensions: ['html'],
+          },
+        ],
+      };
+      const result = mainWindow
+        ? await dialog.showSaveDialog(mainWindow, dialogOptions)
+        : await dialog.showSaveDialog(dialogOptions);
+
+      if (result.canceled || !result.filePath) {
+        return null;
+      }
+
+      return ensureHtmlFileName(result.filePath);
+    },
+  );
   ipcMain.handle(IPC_CHANNELS.toggleMaximizeWindow, () => {
     if (!mainWindow) return;
     if (mainWindow.isMaximized()) {
@@ -147,22 +253,55 @@ const registerIpcHandlers = () => {
   ipcMain.handle(IPC_CHANNELS.closeWindow, () => {
     mainWindow?.close();
   });
+  ipcMain.handle(
+    IPC_CHANNELS.writeReportFile,
+    async (_event, request: WriteReportFileRequest) => {
+      const targetPath = request?.path?.trim();
+      if (!targetPath) {
+        throw new Error('writeReportFile: path is required');
+      }
+      if (typeof request.content !== 'string') {
+        throw new Error('writeReportFile: content must be a string');
+      }
+
+      await writeFile(ensureHtmlFileName(targetPath), request.content, 'utf-8');
+    },
+  );
   // Multi-platform playground — a single server for Android, iOS,
   // HarmonyOS, and Computer. Legacy channel names (getAndroidPlayground*)
   // are aliased to the same strings in IPC_CHANNELS, so the old
   // renderer code keeps working transparently.
-  ipcMain.handle(IPC_CHANNELS.getPlaygroundBootstrap, () =>
-    playgroundRuntime.getBootstrap(),
-  );
+  ipcMain.handle(IPC_CHANNELS.getPlaygroundBootstrap, async () => {
+    const runtime = await getPlaygroundRuntime();
+    return requestPlaygroundBootstrap(runtime, (error) => {
+      console.error(
+        'Failed to start Midscene Studio playground runtime:',
+        error,
+      );
+    });
+  });
   ipcMain.handle(IPC_CHANNELS.restartPlayground, async () =>
-    playgroundRuntime.restart(),
+    (await getPlaygroundRuntime()).restart(),
   );
-  ipcMain.handle(IPC_CHANNELS.discoverDevices, async () =>
-    discoverAllDevices(),
+  ipcMain.handle(
+    IPC_CHANNELS.discoverDevices,
+    async (_event, request?: DiscoverDevicesRequest) =>
+      (await getDeviceDiscoveryService()).getSnapshot({
+        forceRefresh: request?.forceRefresh,
+      }),
   );
-  ipcMain.handle(IPC_CHANNELS.runConnectivityTest, async (_event, request) =>
-    runConnectivityTest(request),
+  ipcMain.handle(
+    IPC_CHANNELS.setDiscoveryPollingPaused,
+    async (_event, paused: boolean) => {
+      (await getDeviceDiscoveryService()).setPollingPaused(Boolean(paused));
+    },
   );
+  ipcMain.handle(IPC_CHANNELS.runConnectivityTest, async (_event, request) => {
+    const { runConnectivityTest } = await import(
+      './playground/connectivity-test'
+    );
+    return runConnectivityTest(request);
+  });
 };
 
 app.whenReady().then(() => {
@@ -170,8 +309,24 @@ app.whenReady().then(() => {
     app.dock.setIcon(getAppIcon());
   }
 
+  void getDeviceDiscoveryService()
+    .then((service) =>
+      service.subscribe((devices) => {
+        if (!mainWindow || mainWindow.isDestroyed()) {
+          return;
+        }
+
+        mainWindow.webContents.send(
+          IPC_CHANNELS.discoveredDevicesUpdated,
+          devices,
+        );
+      }),
+    )
+    .catch((error) => {
+      console.error('Failed to initialize device discovery service:', error);
+    });
+
   registerIpcHandlers();
-  void playgroundRuntime.start();
   createMainWindow();
 
   app.on('activate', () => {
@@ -188,5 +343,12 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
-  void playgroundRuntime.close();
+  void closePlaygroundRuntime();
+  void getDeviceDiscoveryService()
+    .then((service) => {
+      service.close();
+    })
+    .catch(() => {
+      // ignore cleanup failures during shutdown
+    });
 });

--- a/apps/studio/src/main/playground/bootstrap-request.ts
+++ b/apps/studio/src/main/playground/bootstrap-request.ts
@@ -1,0 +1,10 @@
+import type { PlaygroundBootstrap } from '@shared/electron-contract';
+import type { PlaygroundRuntimeService } from './types';
+
+export function requestPlaygroundBootstrap(
+  runtime: PlaygroundRuntimeService,
+  onStartError: (error: unknown) => void,
+): PlaygroundBootstrap {
+  void runtime.start().catch(onStartError);
+  return runtime.getBootstrap();
+}

--- a/apps/studio/src/main/playground/device-discovery.ts
+++ b/apps/studio/src/main/playground/device-discovery.ts
@@ -1,10 +1,31 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import { getDebug } from '@midscene/shared/logger';
-import type { DiscoveredDevice } from '@shared/electron-contract';
+import type {
+  DiscoverDevicesResult,
+  DiscoveredDevice,
+} from '@shared/electron-contract';
+import { ensureStudioShellEnvHydrated } from '../shell-env';
 
 const debugLog = getDebug('studio:device-discovery', { console: true });
 const IOS_WDA_DISCOVERY_HOST = 'localhost';
 const IOS_WDA_DISCOVERY_TIMEOUT_MS = 1000;
+export const DEVICE_DISCOVERY_POLL_INTERVAL_MS = 5000;
+
+export interface DeviceDiscoveryService {
+  close(): void;
+  getSnapshot(options?: {
+    forceRefresh?: boolean;
+  }): Promise<DiscoverDevicesResult>;
+  setPollingPaused(paused: boolean): void;
+  subscribe(listener: (devices: DiscoverDevicesResult) => void): () => void;
+}
+
+interface CreateDeviceDiscoveryServiceOptions {
+  clearIntervalFn?: typeof globalThis.clearInterval;
+  discoverDevices?: () => Promise<DiscoverDevicesResult>;
+  intervalMs?: number;
+  setIntervalFn?: typeof globalThis.setInterval;
+}
 
 interface WDAStatusResponse {
   value?: {
@@ -41,6 +62,126 @@ function buildIOSDiscoveryDescription(
   return details.join(' · ');
 }
 
+export function createDeviceDiscoveryService({
+  clearIntervalFn = globalThis.clearInterval,
+  discoverDevices = discoverAllDevices,
+  intervalMs = DEVICE_DISCOVERY_POLL_INTERVAL_MS,
+  setIntervalFn = globalThis.setInterval,
+}: CreateDeviceDiscoveryServiceOptions = {}): DeviceDiscoveryService {
+  let currentSnapshot: DiscoverDevicesResult = [];
+  let currentSignature = JSON.stringify(currentSnapshot);
+  let hasSnapshot = false;
+  let intervalId: ReturnType<typeof globalThis.setInterval> | null = null;
+  let paused = false;
+  let refreshPromise: Promise<DiscoverDevicesResult> | null = null;
+  let started = false;
+  const listeners = new Set<(devices: DiscoverDevicesResult) => void>();
+
+  const stopPolling = () => {
+    if (intervalId !== null) {
+      clearIntervalFn(intervalId);
+      intervalId = null;
+    }
+  };
+
+  const notifyListeners = (devices: DiscoverDevicesResult) => {
+    listeners.forEach((listener) => {
+      try {
+        listener(devices);
+      } catch (error) {
+        debugLog('device discovery listener failed:', error);
+      }
+    });
+  };
+
+  const refreshSnapshot = async (): Promise<DiscoverDevicesResult> => {
+    if (refreshPromise) {
+      return refreshPromise;
+    }
+
+    refreshPromise = (async () => {
+      const nextSnapshot = await discoverDevices();
+      const nextSignature = JSON.stringify(nextSnapshot);
+      currentSnapshot = nextSnapshot;
+      hasSnapshot = true;
+      if (nextSignature !== currentSignature) {
+        currentSignature = nextSignature;
+        notifyListeners(nextSnapshot);
+      }
+      return nextSnapshot;
+    })().finally(() => {
+      refreshPromise = null;
+    });
+
+    return refreshPromise;
+  };
+
+  const ensurePolling = () => {
+    if (paused || intervalId !== null) {
+      return;
+    }
+
+    intervalId = setIntervalFn(() => {
+      void refreshSnapshot().catch((error) => {
+        debugLog('device discovery refresh failed:', error);
+      });
+    }, intervalMs);
+  };
+
+  const ensureStarted = () => {
+    if (started) {
+      return;
+    }
+
+    started = true;
+    void refreshSnapshot().catch((error) => {
+      debugLog('initial device discovery refresh failed:', error);
+    });
+    ensurePolling();
+  };
+
+  return {
+    close() {
+      stopPolling();
+      listeners.clear();
+    },
+    async getSnapshot(options) {
+      ensureStarted();
+      if (options?.forceRefresh || !hasSnapshot) {
+        return refreshSnapshot();
+      }
+      return currentSnapshot;
+    },
+    setPollingPaused(nextPaused) {
+      ensureStarted();
+      if (paused === nextPaused) {
+        return;
+      }
+
+      paused = nextPaused;
+      if (paused) {
+        stopPolling();
+        return;
+      }
+
+      void refreshSnapshot().catch((error) => {
+        debugLog('device discovery resume refresh failed:', error);
+      });
+      ensurePolling();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      ensureStarted();
+      if (hasSnapshot) {
+        listener(currentSnapshot);
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
 /**
  * Scan all platforms for connected devices. Each platform's scan is
  * independent — a failure on one platform (e.g. `hdc` not installed)
@@ -72,6 +213,7 @@ export async function discoverAllDevices(): Promise<DiscoveredDevice[]> {
 
 async function scanAndroidDevices(): Promise<DiscoveredDevice[]> {
   try {
+    ensureStudioShellEnvHydrated();
     const { getConnectedDevicesWithDetails } = await import(
       '@midscene/android'
     );
@@ -81,6 +223,7 @@ async function scanAndroidDevices(): Promise<DiscoveredDevice[]> {
       id: device.udid,
       label: (device as { label?: string }).label || device.udid,
       description: `ADB: ${device.udid}`,
+      status: device.state,
       sessionValues: {
         deviceId: device.udid,
       },
@@ -127,6 +270,7 @@ async function scanIOSDevices(): Promise<DiscoveredDevice[]> {
           DEFAULT_WDA_PORT,
           status,
         ),
+        status: 'device',
         sessionValues: {
           host: IOS_WDA_DISCOVERY_HOST,
           port: DEFAULT_WDA_PORT,
@@ -143,6 +287,7 @@ async function scanIOSDevices(): Promise<DiscoveredDevice[]> {
 
 async function scanHarmonyDevices(): Promise<DiscoveredDevice[]> {
   try {
+    ensureStudioShellEnvHydrated();
     const { getConnectedDevices } = await import('@midscene/harmony');
     const devices = await getConnectedDevices();
     return devices.map((device) => ({
@@ -150,6 +295,7 @@ async function scanHarmonyDevices(): Promise<DiscoveredDevice[]> {
       id: device.deviceId,
       label: device.deviceId,
       description: `HDC: ${device.deviceId}`,
+      status: 'device',
       sessionValues: {
         deviceId: device.deviceId,
       },
@@ -169,6 +315,7 @@ async function scanComputerDisplays(): Promise<DiscoveredDevice[]> {
       id: String(display.id),
       label: display.name || `Display ${display.id}`,
       description: display.primary ? 'Primary display' : undefined,
+      status: 'device',
       sessionValues: {
         displayId: String(display.id),
       },

--- a/apps/studio/src/main/playground/multi-platform-runtime.ts
+++ b/apps/studio/src/main/playground/multi-platform-runtime.ts
@@ -1,21 +1,15 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import {
-  ScrcpyServer,
-  androidPlaygroundPlatform,
-} from '@midscene/android-playground';
-import { computerPlaygroundPlatform } from '@midscene/computer-playground';
-import { harmonyPlaygroundPlatform } from '@midscene/harmony';
-import { iosPlaygroundPlatform } from '@midscene/ios';
-import {
-  type LaunchPlaygroundResult,
-  type PreparedPlaygroundPlatform,
-  type RegisteredPlaygroundPlatform,
-  launchPreparedPlaygroundPlatform,
-  prepareMultiPlatformPlayground,
+import type {
+  LaunchPlaygroundResult,
+  PreparedPlaygroundPlatform,
+  RegisteredPlaygroundPlatform,
 } from '@midscene/playground';
+import type { DiscoveredDevice } from '@shared/electron-contract';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
+import { ensureStudioShellEnvHydrated } from '../shell-env';
 import { createStudioCorsOptions } from './cors';
+import type { DeviceDiscoveryService } from './device-discovery';
 import type { PlaygroundRuntimeService } from './types';
 
 const require = createRequire(__filename);
@@ -26,9 +20,125 @@ function getErrorMessage(error: unknown): string {
     : 'Unknown playground runtime error';
 }
 
-function resolveStaticDir(packageName: string): string {
-  const packageJsonPath = require.resolve(`${packageName}/package.json`);
-  return path.join(path.dirname(packageJsonPath), 'static');
+type PlaygroundCoreModules = Pick<
+  MultiPlatformRuntimeModules,
+  'launchPreparedPlaygroundPlatform' | 'prepareMultiPlatformPlayground'
+>;
+
+type AndroidPlaygroundModule = typeof import('@midscene/android-playground');
+type ComputerPlaygroundModule = typeof import('@midscene/computer-playground');
+type HarmonyPlaygroundModule = typeof import('@midscene/harmony');
+type IosPlaygroundModule = typeof import('@midscene/ios');
+type PlaygroundModule = typeof import('@midscene/playground');
+
+type MultiPlatformRuntimeModules = {
+  ScrcpyServer: AndroidPlaygroundModule['ScrcpyServer'];
+  androidPlaygroundPlatform: AndroidPlaygroundModule['androidPlaygroundPlatform'];
+  computerPlaygroundPlatform: ComputerPlaygroundModule['computerPlaygroundPlatform'];
+  harmonyPlaygroundPlatform: HarmonyPlaygroundModule['harmonyPlaygroundPlatform'];
+  iosPlaygroundPlatform: IosPlaygroundModule['iosPlaygroundPlatform'];
+  launchPreparedPlaygroundPlatform: PlaygroundModule['launchPreparedPlaygroundPlatform'];
+  prepareMultiPlatformPlayground: PlaygroundModule['prepareMultiPlatformPlayground'];
+};
+
+type StudioDeviceDiscoveryService =
+  | DeviceDiscoveryService
+  | Promise<DeviceDiscoveryService>;
+
+const resolvePackageRootDir = (packageName: string): string =>
+  path.resolve(path.dirname(require.resolve(packageName)), '..', '..');
+
+const requirePackageModule = <ModuleType>(
+  packageName: string,
+  relativeModulePath: string,
+): ModuleType =>
+  require(path.join(resolvePackageRootDir(packageName), relativeModulePath));
+
+export async function loadPlaygroundCoreModules(): Promise<PlaygroundCoreModules> {
+  const multiPlatformModule = requirePackageModule<
+    Pick<
+      typeof import('@midscene/playground'),
+      'prepareMultiPlatformPlayground'
+    >
+  >('@midscene/playground', 'dist/lib/multi-platform.js');
+  const platformLauncherModule = requirePackageModule<
+    Pick<
+      typeof import('@midscene/playground'),
+      'launchPreparedPlaygroundPlatform'
+    >
+  >('@midscene/playground', 'dist/lib/platform-launcher.js');
+
+  return {
+    prepareMultiPlatformPlayground:
+      multiPlatformModule.prepareMultiPlatformPlayground,
+    launchPreparedPlaygroundPlatform:
+      platformLauncherModule.launchPreparedPlaygroundPlatform,
+  };
+}
+
+export async function loadAndroidPlaygroundModule(): Promise<
+  Pick<
+    MultiPlatformRuntimeModules,
+    'ScrcpyServer' | 'androidPlaygroundPlatform'
+  >
+> {
+  ensureStudioShellEnvHydrated();
+  return require('@midscene/android-playground');
+}
+
+export async function loadComputerPlaygroundModule(): Promise<
+  Pick<MultiPlatformRuntimeModules, 'computerPlaygroundPlatform'>
+> {
+  return require('@midscene/computer-playground');
+}
+
+export async function loadHarmonyPlaygroundModule(): Promise<
+  Pick<MultiPlatformRuntimeModules, 'harmonyPlaygroundPlatform'>
+> {
+  ensureStudioShellEnvHydrated();
+  return require('@midscene/harmony');
+}
+
+export async function loadIosPlaygroundModule(): Promise<
+  Pick<MultiPlatformRuntimeModules, 'iosPlaygroundPlatform'>
+> {
+  ensureStudioShellEnvHydrated();
+  return require('@midscene/ios');
+}
+
+export async function loadMultiPlatformRuntimeModules(): Promise<MultiPlatformRuntimeModules> {
+  const [
+    androidPlaygroundModule,
+    computerPlaygroundModule,
+    harmonyPlaygroundModule,
+    iosPlaygroundModule,
+    playgroundCoreModules,
+  ] = await Promise.all([
+    loadAndroidPlaygroundModule(),
+    loadComputerPlaygroundModule(),
+    loadHarmonyPlaygroundModule(),
+    loadIosPlaygroundModule(),
+    loadPlaygroundCoreModules(),
+  ]);
+
+  return {
+    ScrcpyServer: androidPlaygroundModule.ScrcpyServer,
+    androidPlaygroundPlatform:
+      androidPlaygroundModule.androidPlaygroundPlatform,
+    computerPlaygroundPlatform:
+      computerPlaygroundModule.computerPlaygroundPlatform,
+    harmonyPlaygroundPlatform:
+      harmonyPlaygroundModule.harmonyPlaygroundPlatform,
+    iosPlaygroundPlatform: iosPlaygroundModule.iosPlaygroundPlatform,
+    launchPreparedPlaygroundPlatform:
+      playgroundCoreModules.launchPreparedPlaygroundPlatform,
+    prepareMultiPlatformPlayground:
+      playgroundCoreModules.prepareMultiPlatformPlayground,
+  };
+}
+
+export function resolveStaticDir(packageName: string): string {
+  return path.join(resolvePackageRootDir(packageName), 'static');
 }
 
 interface StudioPlatformSpec {
@@ -39,31 +149,90 @@ interface StudioPlatformSpec {
   prepare: (staticDir: string) => Promise<PreparedPlaygroundPlatform>;
 }
 
-const studioPlatformSpecs: StudioPlatformSpec[] = [
+function toScrcpyDeviceList(devices: DiscoveredDevice[]) {
+  return devices
+    .filter((device) => device.platformId === 'android')
+    .map((device) => ({
+      id: device.id,
+      name: device.label,
+      status: device.status || 'device',
+    }));
+}
+
+async function createScrcpyDeviceListSource(
+  deviceDiscoveryService: StudioDeviceDiscoveryService,
+) {
+  const resolvedService = await deviceDiscoveryService;
+  return {
+    async getDevices() {
+      return toScrcpyDeviceList(await resolvedService.getSnapshot());
+    },
+    subscribe(
+      listener: (devices: ReturnType<typeof toScrcpyDeviceList>) => void,
+    ) {
+      return resolvedService.subscribe((devices) => {
+        listener(toScrcpyDeviceList(devices));
+      });
+    },
+  };
+}
+
+const createStudioPlatformSpecs = ({
+  loadAndroidModule = loadAndroidPlaygroundModule,
+  loadComputerModule = loadComputerPlaygroundModule,
+  deviceDiscoveryService,
+  loadHarmonyModule = loadHarmonyPlaygroundModule,
+  loadIosModule = loadIosPlaygroundModule,
+}: {
+  loadAndroidModule?: typeof loadAndroidPlaygroundModule;
+  loadComputerModule?: typeof loadComputerPlaygroundModule;
+  deviceDiscoveryService?: StudioDeviceDiscoveryService;
+  loadHarmonyModule?: typeof loadHarmonyPlaygroundModule;
+  loadIosModule?: typeof loadIosPlaygroundModule;
+} = {}): StudioPlatformSpec[] => [
   {
     id: 'android',
     label: 'Android',
     description: 'Connect to an Android device via ADB',
     staticDirPackage: '@midscene/android-playground',
-    prepare: (staticDir) =>
-      androidPlaygroundPlatform.prepare({
+    prepare: async (staticDir) => {
+      const androidModule = await loadAndroidModule();
+      return androidModule.androidPlaygroundPlatform.prepare({
         staticDir,
-        scrcpyServer: new ScrcpyServer(),
-      }),
+        scrcpyServer: new androidModule.ScrcpyServer(
+          deviceDiscoveryService
+            ? {
+                deviceListSource: await createScrcpyDeviceListSource(
+                  deviceDiscoveryService,
+                ),
+              }
+            : undefined,
+        ),
+      });
+    },
   },
   {
     id: 'ios',
     label: 'iOS',
     description: 'Connect to an iOS device via WebDriverAgent',
     staticDirPackage: '@midscene/ios',
-    prepare: (staticDir) => iosPlaygroundPlatform.prepare({ staticDir }),
+    prepare: async (staticDir) => {
+      const iosModule = await loadIosModule();
+      return iosModule.iosPlaygroundPlatform.prepare({ staticDir });
+    },
   },
   {
     id: 'harmony',
     label: 'HarmonyOS',
     description: 'Connect to a HarmonyOS device via HDC',
     staticDirPackage: '@midscene/harmony',
-    prepare: (staticDir) => harmonyPlaygroundPlatform.prepare({ staticDir }),
+    prepare: async (staticDir) => {
+      const harmonyModule = await loadHarmonyModule();
+      return harmonyModule.harmonyPlaygroundPlatform.prepare({
+        staticDir,
+        deferConnection: true,
+      });
+    },
   },
   {
     id: 'computer',
@@ -74,17 +243,22 @@ const studioPlatformSpecs: StudioPlatformSpec[] = [
     // without a window controller, it just won't auto-minimize Studio
     // during task execution. A follow-up can provide an Electron-native
     // adapter that calls mainWindow.minimize()/restore().
-    prepare: (staticDir) =>
-      computerPlaygroundPlatform.prepare({
+    prepare: async (staticDir) => {
+      const computerModule = await loadComputerModule();
+      return computerModule.computerPlaygroundPlatform.prepare({
         staticDir,
         getWindowController: () => null,
-      }),
+      });
+    },
   },
 ];
 
-function buildRegisteredPlatforms(): RegisteredPlaygroundPlatform[] {
+function buildRegisteredPlatforms(
+  studioPlatformSpecs: StudioPlatformSpec[],
+  resolvePackageStaticDir: (packageName: string) => string,
+): RegisteredPlaygroundPlatform[] {
   return studioPlatformSpecs.map((spec) => {
-    const staticDir = resolveStaticDir(spec.staticDirPackage);
+    const staticDir = resolvePackageStaticDir(spec.staticDirPackage);
     return {
       id: spec.id,
       label: spec.label,
@@ -102,7 +276,25 @@ function buildRegisteredPlatforms(): RegisteredPlaygroundPlatform[] {
  * server. The renderer talks to this one server; the platform selector
  * on the setup form routes to the correct backend.
  */
-export function createMultiPlatformRuntimeService(): PlaygroundRuntimeService {
+export function createMultiPlatformRuntimeService({
+  deviceDiscoveryService,
+  loadModules,
+  loadPlaygroundCore = loadPlaygroundCoreModules,
+  loadAndroidModule = loadAndroidPlaygroundModule,
+  loadComputerModule = loadComputerPlaygroundModule,
+  loadHarmonyModule = loadHarmonyPlaygroundModule,
+  loadIosModule = loadIosPlaygroundModule,
+  resolvePackageStaticDir = resolveStaticDir,
+}: {
+  deviceDiscoveryService?: StudioDeviceDiscoveryService;
+  loadModules?: () => Promise<MultiPlatformRuntimeModules>;
+  loadPlaygroundCore?: () => Promise<PlaygroundCoreModules>;
+  loadAndroidModule?: typeof loadAndroidPlaygroundModule;
+  loadComputerModule?: typeof loadComputerPlaygroundModule;
+  loadHarmonyModule?: typeof loadHarmonyPlaygroundModule;
+  loadIosModule?: typeof loadIosPlaygroundModule;
+  resolvePackageStaticDir?: (packageName: string) => string;
+} = {}): PlaygroundRuntimeService {
   let bootstrap: PlaygroundBootstrap = {
     status: 'starting',
     serverUrl: null,
@@ -138,23 +330,96 @@ export function createMultiPlatformRuntimeService(): PlaygroundRuntimeService {
 
     startPromise = (async () => {
       try {
-        const platforms = buildRegisteredPlatforms();
-        const prepared = await prepareMultiPlatformPlayground(platforms, {
-          title: 'Midscene Studio',
-          description: 'Multi-platform playground',
-          selectorFieldKey: 'platformId',
-          selectorVariant: 'cards',
-        });
-
-        const nextLaunchResult = await launchPreparedPlaygroundPlatform(
-          prepared,
-          {
-            corsOptions: createStudioCorsOptions(),
-            enableCors: true,
-            openBrowser: false,
-            verbose: false,
-          },
+        const runtimeModules = loadModules ? await loadModules() : null;
+        const playgroundCoreModules =
+          runtimeModules ??
+          ({
+            ...(await loadPlaygroundCore()),
+          } as PlaygroundCoreModules);
+        const platforms = buildRegisteredPlatforms(
+          runtimeModules
+            ? [
+                {
+                  id: 'android',
+                  label: 'Android',
+                  description: 'Connect to an Android device via ADB',
+                  staticDirPackage: '@midscene/android-playground',
+                  prepare: async (staticDir) =>
+                    runtimeModules.androidPlaygroundPlatform.prepare({
+                      staticDir,
+                      scrcpyServer: new runtimeModules.ScrcpyServer(
+                        deviceDiscoveryService
+                          ? {
+                              deviceListSource:
+                                await createScrcpyDeviceListSource(
+                                  deviceDiscoveryService,
+                                ),
+                            }
+                          : undefined,
+                      ),
+                    }),
+                },
+                {
+                  id: 'ios',
+                  label: 'iOS',
+                  description: 'Connect to an iOS device via WebDriverAgent',
+                  staticDirPackage: '@midscene/ios',
+                  prepare: (staticDir) =>
+                    runtimeModules.iosPlaygroundPlatform.prepare({ staticDir }),
+                },
+                {
+                  id: 'harmony',
+                  label: 'HarmonyOS',
+                  description: 'Connect to a HarmonyOS device via HDC',
+                  staticDirPackage: '@midscene/harmony',
+                  prepare: (staticDir) =>
+                    runtimeModules.harmonyPlaygroundPlatform.prepare({
+                      staticDir,
+                      deferConnection: true,
+                    }),
+                },
+                {
+                  id: 'computer',
+                  label: 'Computer',
+                  description: 'Control the local desktop',
+                  staticDirPackage: '@midscene/computer-playground',
+                  prepare: (staticDir) =>
+                    runtimeModules.computerPlaygroundPlatform.prepare({
+                      staticDir,
+                      getWindowController: () => null,
+                    }),
+                },
+              ]
+            : createStudioPlatformSpecs({
+                deviceDiscoveryService,
+                loadAndroidModule,
+                loadComputerModule,
+                loadHarmonyModule,
+                loadIosModule,
+              }),
+          resolvePackageStaticDir,
         );
+        const prepared =
+          await playgroundCoreModules.prepareMultiPlatformPlayground(
+            platforms,
+            {
+              title: 'Midscene Studio',
+              description: 'Multi-platform playground',
+              selectorFieldKey: 'platformId',
+              selectorVariant: 'cards',
+            },
+          );
+
+        const nextLaunchResult =
+          await playgroundCoreModules.launchPreparedPlaygroundPlatform(
+            prepared,
+            {
+              corsOptions: createStudioCorsOptions(),
+              enableCors: true,
+              openBrowser: false,
+              verbose: false,
+            },
+          );
 
         launchResult = nextLaunchResult;
         bootstrap = {

--- a/apps/studio/src/main/shell-env.ts
+++ b/apps/studio/src/main/shell-env.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from 'node:child_process';
+
+// Needs to out-wait a slow interactive login shell: real-world .zshrc
+// setups (pyenv, fnm, Oh My Zsh plugins, corp shims) routinely take
+// 8-12s on first run in a packaged app, where we can't benefit from
+// terminal warm-up caching. 5s used to time out before
+// ANDROID_HOME / PATH made it into process.env, which then surfaced as
+// "Android device discovery failed" on first click. Blocks the first
+// device-discovery call by at most this long, once per app launch.
+const SHELL_TIMEOUT_MS = 20000;
+const ENV_MARKER = '___MIDSCENE_SHELL_ENV___';
+
+const KEYS_FORCE_OVERRIDE = new Set(['PATH']);
+
+interface HydrateOptions {
+  runShell?: (shell: string) => string;
+  platform?: NodeJS.Platform;
+  isPackaged?: boolean;
+  env?: NodeJS.ProcessEnv;
+  log?: (message: string, error?: unknown) => void;
+}
+
+interface HydrateResult {
+  applied: boolean;
+  reason?: string;
+  mutatedKeys: string[];
+}
+
+let configuredStudioHydrateOptions: HydrateOptions | null = null;
+let cachedStudioHydrateResult: HydrateResult | null = null;
+
+function resolveShell(env: NodeJS.ProcessEnv, platform: NodeJS.Platform) {
+  if (env.SHELL) {
+    return env.SHELL;
+  }
+  return platform === 'darwin' ? '/bin/zsh' : '/bin/bash';
+}
+
+function parseEnvPayload(payload: string): Record<string, string> {
+  const startIdx = payload.indexOf(ENV_MARKER);
+  if (startIdx < 0) {
+    return {};
+  }
+  const body = payload.slice(startIdx + ENV_MARKER.length);
+  const result: Record<string, string> = {};
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    result[key] = line.slice(eq + 1);
+  }
+  return result;
+}
+
+function runLoginShell(shell: string): string {
+  // Emit a marker before `env` so we can skip any rc-file noise on stdout.
+  // `command env` avoids alias interference. `-ilc` -> interactive login,
+  // which is the only way `.zshrc`/`.zprofile`/`.bashrc` reliably load on macOS.
+  const script = `printf '%s\\n' '${ENV_MARKER}'; command env`;
+  return execFileSync(shell, ['-ilc', script], {
+    encoding: 'utf8',
+    timeout: SHELL_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    windowsHide: true,
+  });
+}
+
+/**
+ * Extracts the user's login-shell environment and merges select keys into
+ * `process.env`. Necessary because packaged macOS apps launched from
+ * Finder/Dock inherit only a minimal environment — no `ANDROID_HOME`,
+ * no user `PATH` additions — so native CLIs like `adb`, `hdc`, `xcrun`
+ * aren't discoverable.
+ *
+ * Keys already present in `process.env` are preserved, with one exception:
+ * `PATH` is replaced with the login-shell value when available, so device
+ * tools installed outside the default system paths become reachable.
+ *
+ * No-ops on Windows (GUI launches inherit user env there) and in dev
+ * (where Electron was started from a shell that already exported env).
+ */
+export function hydrateLoginShellEnv(
+  options: HydrateOptions = {},
+): HydrateResult {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const isPackaged = options.isPackaged ?? false;
+  const log = options.log ?? (() => {});
+
+  if (platform === 'win32') {
+    return { applied: false, reason: 'windows', mutatedKeys: [] };
+  }
+  if (!isPackaged) {
+    return { applied: false, reason: 'not-packaged', mutatedKeys: [] };
+  }
+
+  const shell = resolveShell(env, platform);
+  let payload: string;
+  try {
+    payload = options.runShell ? options.runShell(shell) : runLoginShell(shell);
+  } catch (error) {
+    log('login shell env extraction failed', error);
+    return { applied: false, reason: 'shell-failed', mutatedKeys: [] };
+  }
+
+  const parsed = parseEnvPayload(payload);
+  const mutated: string[] = [];
+  for (const [key, value] of Object.entries(parsed)) {
+    if (env[key] !== undefined && !KEYS_FORCE_OVERRIDE.has(key)) {
+      continue;
+    }
+    if (env[key] === value) continue;
+    env[key] = value;
+    mutated.push(key);
+  }
+
+  return { applied: true, mutatedKeys: mutated };
+}
+
+export function configureStudioShellEnvHydration(
+  options: HydrateOptions,
+): void {
+  configuredStudioHydrateOptions = options;
+  cachedStudioHydrateResult = null;
+}
+
+export function ensureStudioShellEnvHydrated(): HydrateResult {
+  if (cachedStudioHydrateResult) {
+    return cachedStudioHydrateResult;
+  }
+  if (!configuredStudioHydrateOptions) {
+    throw new Error(
+      'Studio shell env hydration was used before it was configured.',
+    );
+  }
+  cachedStudioHydrateResult = hydrateLoginShellEnv(
+    configuredStudioHydrateOptions,
+  );
+  return cachedStudioHydrateResult;
+}
+
+export function resetStudioShellEnvHydrationForTests(): void {
+  configuredStudioHydrateOptions = null;
+  cachedStudioHydrateResult = null;
+}

--- a/apps/studio/src/main/window-reveal.ts
+++ b/apps/studio/src/main/window-reveal.ts
@@ -1,0 +1,41 @@
+interface RevealableWindow {
+  isDestroyed?: () => boolean;
+  onDidFailLoad: (listener: (...args: unknown[]) => void) => void;
+  onDidFinishLoad: (listener: (...args: unknown[]) => void) => void;
+  onReadyToShow: (listener: () => void) => void;
+  show: () => void;
+}
+
+const windowRevealFallbackDelayMs = 2000;
+
+/**
+ * Some packaged macOS builds never emit `ready-to-show` for the transparent
+ * Studio shell, which leaves the app running without a visible window. Reveal
+ * the window on the first reliable renderer lifecycle event instead.
+ */
+export function registerWindowRevealHandlers(window: RevealableWindow): void {
+  let revealed = false;
+  let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const reveal = () => {
+    if (revealed) {
+      return;
+    }
+    if (window.isDestroyed?.()) {
+      return;
+    }
+
+    revealed = true;
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer);
+    }
+    window.show();
+  };
+
+  fallbackTimer = setTimeout(reveal, windowRevealFallbackDelayMs);
+  fallbackTimer.unref?.();
+
+  window.onReadyToShow(reveal);
+  window.onDidFinishLoad(reveal);
+  window.onDidFailLoad(reveal);
+}

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -15,15 +15,34 @@ const electronShellApi: ElectronShellApi = {
   minimizeWindow: () => ipcRenderer.invoke(IPC_CHANNELS.minimizeWindow),
   openExternalUrl: (url) =>
     ipcRenderer.invoke(IPC_CHANNELS.openExternalUrl, url),
+  chooseReportSavePath: (defaultFileName) =>
+    ipcRenderer.invoke(IPC_CHANNELS.chooseReportSavePath, defaultFileName),
   toggleMaximizeWindow: () =>
     ipcRenderer.invoke(IPC_CHANNELS.toggleMaximizeWindow),
+  writeReportFile: (request) =>
+    ipcRenderer.invoke(IPC_CHANNELS.writeReportFile, request),
 };
 
 const studioRuntimeApi: StudioRuntimeApi = {
   getPlaygroundBootstrap: () =>
     ipcRenderer.invoke(IPC_CHANNELS.getPlaygroundBootstrap),
   restartPlayground: () => ipcRenderer.invoke(IPC_CHANNELS.restartPlayground),
-  discoverDevices: () => ipcRenderer.invoke(IPC_CHANNELS.discoverDevices),
+  discoverDevices: (request) =>
+    ipcRenderer.invoke(IPC_CHANNELS.discoverDevices, request),
+  onDiscoveredDevicesChanged: (listener) => {
+    const handler = (_event: unknown, devices: unknown) => {
+      listener(devices as Parameters<typeof listener>[0]);
+    };
+    ipcRenderer.on(IPC_CHANNELS.discoveredDevicesUpdated, handler);
+    return () => {
+      ipcRenderer.removeListener(
+        IPC_CHANNELS.discoveredDevicesUpdated,
+        handler,
+      );
+    };
+  },
+  setDiscoveryPollingPaused: (paused) =>
+    ipcRenderer.invoke(IPC_CHANNELS.setDiscoveryPollingPaused, paused),
   runConnectivityTest: (request) =>
     ipcRenderer.invoke(IPC_CHANNELS.runConnectivityTest, request),
 };

--- a/apps/studio/src/renderer/components/MainContent/LazyPlaygroundPreview.tsx
+++ b/apps/studio/src/renderer/components/MainContent/LazyPlaygroundPreview.tsx
@@ -1,0 +1,8 @@
+import {
+  PlaygroundPreview,
+  type PlaygroundPreviewProps,
+} from '@midscene/playground-app';
+
+export default function LazyPlaygroundPreview(props: PlaygroundPreviewProps) {
+  return <PlaygroundPreview {...props} />;
+}

--- a/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
+++ b/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
@@ -1,0 +1,93 @@
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { fitMobilePreviewViewport } from './preview-layout';
+
+interface MobilePreviewFrameProps extends PropsWithChildren {
+  enabled: boolean;
+}
+
+export function MobilePreviewFrame({
+  children,
+  enabled,
+}: MobilePreviewFrameProps) {
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!enabled) {
+      setViewportSize({ width: 0, height: 0 });
+      return;
+    }
+
+    const stage = stageRef.current;
+    if (!stage) {
+      return;
+    }
+
+    const updateViewportSize = () => {
+      setViewportSize(
+        fitMobilePreviewViewport(stage.clientWidth, stage.clientHeight),
+      );
+    };
+
+    updateViewportSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateViewportSize);
+      return () => {
+        window.removeEventListener('resize', updateViewportSize);
+      };
+    }
+
+    const observer = new ResizeObserver(() => {
+      updateViewportSize();
+    });
+    observer.observe(stage);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled]);
+
+  const rootClassName = [
+    'h-full w-full min-h-0',
+    enabled &&
+      'flex items-center justify-center bg-surface px-4 py-5 md:px-6 md:py-6',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const shellClassName = [
+    'h-full w-full min-h-0',
+    enabled && 'flex max-h-full max-w-[392px] items-center justify-center',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const stageClassName = [
+    'h-full w-full min-h-0',
+    enabled && 'flex items-center justify-center overflow-hidden',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const viewportClassName = enabled
+    ? 'shrink-0 overflow-hidden rounded-[34px]'
+    : 'h-full w-full min-h-0 overflow-hidden';
+  const viewportStyle = enabled
+    ? viewportSize.width > 0 && viewportSize.height > 0
+      ? {
+          width: `${viewportSize.width}px`,
+          height: `${viewportSize.height}px`,
+        }
+      : undefined
+    : undefined;
+
+  return (
+    <div className={rootClassName}>
+      <div className={shellClassName}>
+        <div className={stageClassName} ref={stageRef}>
+          <div className={viewportClassName} style={viewportStyle}>
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -1,5 +1,4 @@
-import { PlaygroundPreview } from '@midscene/playground-app';
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { assetUrls } from '../../assets';
 import {
   type StudioPreviewConnectionState,
@@ -19,6 +18,10 @@ import ConnectionFailedPreview from '../ConnectionFailedPreview';
 import DisconnectedPreview from '../DisconnectedPreview';
 import type { ShellActiveView } from '../ShellLayout/types';
 import { DeviceList } from './DeviceList';
+import { MobilePreviewFrame } from './MobilePreviewFrame';
+import { shouldEnableMobilePreviewFrame } from './preview-layout';
+
+const LazyPlaygroundPreview = lazy(() => import('./LazyPlaygroundPreview'));
 
 export interface MainContentProps {
   activeView: ShellActiveView;
@@ -140,6 +143,20 @@ export default function MainContent({
     ? resolveSelectedDeviceId(studioPlayground.controller.state.formValues)
     : undefined;
   const previewDeviceId = connectedDeviceId ?? selectedDeviceId;
+  const runtimeInfo =
+    studioPlayground.phase === 'ready'
+      ? studioPlayground.controller.state.runtimeInfo
+      : null;
+  const previewFormValues: Record<string, unknown> =
+    studioPlayground.phase === 'ready'
+      ? studioPlayground.controller.state.formValues
+      : {};
+  const shouldFrameMobilePreview = shouldEnableMobilePreviewFrame(
+    runtimeInfo,
+    previewFormValues,
+    isConnected,
+    previewStatus,
+  );
   const disconnectDisabled =
     !isReady || !studioPlayground.controller.state.sessionViewState.connected;
   const previewConnectionFailed =
@@ -159,10 +176,6 @@ export default function MainContent({
     }
   }, [isConnected]);
 
-  const runtimeInfo =
-    studioPlayground.phase === 'ready'
-      ? studioPlayground.controller.state.runtimeInfo
-      : null;
   const pauseDiscoveryPolling = shouldPauseDiscoveryPollingDuringPreview({
     previewStatus,
     runtimeInfo,
@@ -380,64 +393,93 @@ export default function MainContent({
       </div>
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-surface">
-        {studioPlayground.phase === 'booting' ? (
-          <div className="flex h-full items-center justify-center px-6 text-[14px] text-text-tertiary">
-            Playground starting...
-          </div>
-        ) : studioPlayground.phase === 'error' ? (
-          <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
-            <div className="max-w-[420px] text-[14px] leading-[22px] text-text-secondary">
-              {studioPlayground.error}
+        <MobilePreviewFrame enabled={shouldFrameMobilePreview}>
+          {studioPlayground.phase === 'booting' ? (
+            <div className="flex h-full items-center justify-center px-6 text-[14px] text-text-tertiary">
+              Playground starting...
             </div>
-            <button
-              className="rounded-lg border border-border-subtle px-4 py-2 text-[13px] font-medium text-text-primary"
-              onClick={() => {
-                void studioPlayground.restartPlayground();
-              }}
-              type="button"
-            >
-              Retry runtime
-            </button>
-          </div>
-        ) : !studioPlayground.controller.state.serverOnline ? (
-          <div className="flex h-full items-center justify-center px-8 text-center text-[14px] leading-[22px] text-text-tertiary">
-            Playground server is offline.
-          </div>
-        ) : studioPlayground.controller.state.sessionViewState.connected ? (
-          <div className="h-full w-full">
-            <PlaygroundPreview
-              connectingOverlay={
-                <ConnectingPreview
-                  pcSrc={assetUrls.main.pc}
-                  phoneSrc={assetUrls.main.phone}
-                  statusLabel={
-                    previewStatusText || 'Preparing Android device connection…'
+          ) : studioPlayground.phase === 'error' ? (
+            <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
+              <div className="max-w-[420px] text-[14px] leading-[22px] text-text-secondary">
+                {studioPlayground.error}
+              </div>
+              <button
+                className="rounded-lg border border-border-subtle px-4 py-2 text-[13px] font-medium text-text-primary"
+                onClick={() => {
+                  void studioPlayground.restartPlayground();
+                }}
+                type="button"
+              >
+                Retry runtime
+              </button>
+            </div>
+          ) : !studioPlayground.controller.state.serverOnline ? (
+            <div className="flex h-full items-center justify-center px-8 text-center text-[14px] leading-[22px] text-text-tertiary">
+              Playground server is offline.
+            </div>
+          ) : studioPlayground.controller.state.sessionViewState.connected ? (
+            <div className="h-full w-full">
+              <Suspense
+                fallback={
+                  <ConnectingPreview
+                    pcSrc={assetUrls.main.pc}
+                    phoneSrc={assetUrls.main.phone}
+                    statusLabel={
+                      previewStatusText ||
+                      'Preparing Android device connection…'
+                    }
+                  />
+                }
+              >
+                <LazyPlaygroundPreview
+                  connectingOverlay={
+                    <ConnectingPreview
+                      pcSrc={assetUrls.main.pc}
+                      phoneSrc={assetUrls.main.phone}
+                      statusLabel={
+                        previewStatusText ||
+                        'Preparing Android device connection…'
+                      }
+                    />
+                  }
+                  onScrcpyStatusChange={(status, statusText) => {
+                    setPreviewStatus(status);
+                    setPreviewStatusText(statusText);
+                  }}
+                  renderErrorOverlay={({ retry }) => (
+                    <ConnectionFailedPreview
+                      adbId={previewDeviceId}
+                      iconSrc={assetUrls.main.connectionFailed}
+                      onReconnect={retry}
+                    />
+                  )}
+                  playgroundSDK={
+                    studioPlayground.controller.state.playgroundSDK
+                  }
+                  screenshotViewerMode={
+                    shouldFrameMobilePreview ? 'screen-only' : undefined
+                  }
+                  scrcpyViewportStyle={
+                    shouldFrameMobilePreview
+                      ? {
+                          background: 'transparent',
+                          borderRadius: 0,
+                        }
+                      : undefined
+                  }
+                  runtimeInfo={studioPlayground.controller.state.runtimeInfo}
+                  serverUrl={studioPlayground.serverUrl}
+                  serverOnline={studioPlayground.controller.state.serverOnline}
+                  isUserOperating={
+                    studioPlayground.controller.state.isUserOperating
                   }
                 />
-              }
-              onScrcpyStatusChange={(status, statusText) => {
-                setPreviewStatus(status);
-                setPreviewStatusText(statusText);
-              }}
-              renderErrorOverlay={({ retry }) => (
-                <ConnectionFailedPreview
-                  adbId={previewDeviceId}
-                  iconSrc={assetUrls.main.connectionFailed}
-                  onReconnect={retry}
-                />
-              )}
-              playgroundSDK={studioPlayground.controller.state.playgroundSDK}
-              runtimeInfo={studioPlayground.controller.state.runtimeInfo}
-              serverUrl={studioPlayground.serverUrl}
-              serverOnline={studioPlayground.controller.state.serverOnline}
-              isUserOperating={
-                studioPlayground.controller.state.isUserOperating
-              }
-            />
-          </div>
-        ) : (
-          <DisconnectedPreview iconSrc={assetUrls.main.connectionClosed} />
-        )}
+              </Suspense>
+            </div>
+          ) : (
+            <DisconnectedPreview iconSrc={assetUrls.main.connectionClosed} />
+          )}
+        </MobilePreviewFrame>
       </div>
     </div>
   );

--- a/apps/studio/src/renderer/components/MainContent/preview-layout.ts
+++ b/apps/studio/src/renderer/components/MainContent/preview-layout.ts
@@ -1,48 +1,20 @@
 import type { PlaygroundRuntimeInfo } from '@midscene/playground';
+import type { StudioPlatformId } from '@shared/electron-contract';
 import type { StudioPreviewConnectionState } from '../../playground/preview-discovery';
-
-type PreviewPlatform = 'android' | 'ios' | 'harmony' | 'computer' | 'web';
+import { normalizeStudioPlatformId } from '../../playground/selectors';
 
 const MOBILE_PREVIEW_ASPECT_RATIO = 9 / 19.5;
 const MOBILE_PREVIEW_HORIZONTAL_GUTTER_PX = 24;
 const MOBILE_PREVIEW_VERTICAL_GUTTER_PX = 56;
 
-function normalizePreviewPlatform(value: unknown): PreviewPlatform | undefined {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    return undefined;
-  }
-
-  switch (value.trim().toLowerCase()) {
-    case 'android':
-      return 'android';
-    case 'ios':
-      return 'ios';
-    case 'harmony':
-    case 'harmonyos':
-    case 'harmony-os':
-      return 'harmony';
-    case 'computer':
-    case 'desktop':
-    case 'macos':
-    case 'windows':
-    case 'linux':
-      return 'computer';
-    case 'web':
-    case 'browser':
-      return 'web';
-    default:
-      return undefined;
-  }
-}
-
 export function resolveStudioPreviewPlatform(
   runtimeInfo: PlaygroundRuntimeInfo | null,
   formValues: Record<string, unknown>,
-): PreviewPlatform | undefined {
+): StudioPlatformId | undefined {
   return (
-    normalizePreviewPlatform(runtimeInfo?.platformId) ||
-    normalizePreviewPlatform(runtimeInfo?.interface?.type) ||
-    normalizePreviewPlatform(formValues.platformId)
+    normalizeStudioPlatformId(runtimeInfo?.platformId) ||
+    normalizeStudioPlatformId(runtimeInfo?.interface?.type) ||
+    normalizeStudioPlatformId(formValues.platformId)
   );
 }
 

--- a/apps/studio/src/renderer/components/MainContent/preview-layout.ts
+++ b/apps/studio/src/renderer/components/MainContent/preview-layout.ts
@@ -1,0 +1,108 @@
+import type { PlaygroundRuntimeInfo } from '@midscene/playground';
+import type { StudioPreviewConnectionState } from '../../playground/preview-discovery';
+
+type PreviewPlatform = 'android' | 'ios' | 'harmony' | 'computer' | 'web';
+
+const MOBILE_PREVIEW_ASPECT_RATIO = 9 / 19.5;
+const MOBILE_PREVIEW_HORIZONTAL_GUTTER_PX = 24;
+const MOBILE_PREVIEW_VERTICAL_GUTTER_PX = 56;
+
+function normalizePreviewPlatform(value: unknown): PreviewPlatform | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+
+  switch (value.trim().toLowerCase()) {
+    case 'android':
+      return 'android';
+    case 'ios':
+      return 'ios';
+    case 'harmony':
+    case 'harmonyos':
+    case 'harmony-os':
+      return 'harmony';
+    case 'computer':
+    case 'desktop':
+    case 'macos':
+    case 'windows':
+    case 'linux':
+      return 'computer';
+    case 'web':
+    case 'browser':
+      return 'web';
+    default:
+      return undefined;
+  }
+}
+
+export function resolveStudioPreviewPlatform(
+  runtimeInfo: PlaygroundRuntimeInfo | null,
+  formValues: Record<string, unknown>,
+): PreviewPlatform | undefined {
+  return (
+    normalizePreviewPlatform(runtimeInfo?.platformId) ||
+    normalizePreviewPlatform(runtimeInfo?.interface?.type) ||
+    normalizePreviewPlatform(formValues.platformId)
+  );
+}
+
+export function shouldUseMobilePreviewFrame(
+  runtimeInfo: PlaygroundRuntimeInfo | null,
+  formValues: Record<string, unknown>,
+): boolean {
+  const platform = resolveStudioPreviewPlatform(runtimeInfo, formValues);
+  return platform === 'android' || platform === 'ios' || platform === 'harmony';
+}
+
+export function shouldEnableMobilePreviewFrame(
+  runtimeInfo: PlaygroundRuntimeInfo | null,
+  formValues: Record<string, unknown>,
+  sessionConnected: boolean,
+  previewStatus: StudioPreviewConnectionState,
+): boolean {
+  if (
+    !sessionConnected ||
+    !shouldUseMobilePreviewFrame(runtimeInfo, formValues)
+  ) {
+    return false;
+  }
+
+  const previewKind = runtimeInfo?.preview.kind;
+  if (!previewKind || previewKind === 'none' || previewKind === 'custom') {
+    return false;
+  }
+
+  return previewKind !== 'scrcpy' || previewStatus === 'connected';
+}
+
+export function fitMobilePreviewViewport(
+  stageWidth: number,
+  stageHeight: number,
+): {
+  width: number;
+  height: number;
+} {
+  const availableWidth = Math.max(
+    0,
+    stageWidth - MOBILE_PREVIEW_HORIZONTAL_GUTTER_PX,
+  );
+  const availableHeight = Math.max(
+    0,
+    stageHeight - MOBILE_PREVIEW_VERTICAL_GUTTER_PX,
+  );
+
+  if (availableWidth === 0 || availableHeight === 0) {
+    return {
+      width: 0,
+      height: 0,
+    };
+  }
+
+  const heightLimitedWidth = availableHeight * MOBILE_PREVIEW_ASPECT_RATIO;
+  const width = Math.min(availableWidth, heightLimitedWidth);
+
+  return {
+    width,
+    height: width / MOBILE_PREVIEW_ASPECT_RATIO,
+  };
+}

--- a/apps/studio/src/renderer/components/Playground/LazyPlaygroundConversationPanel.tsx
+++ b/apps/studio/src/renderer/components/Playground/LazyPlaygroundConversationPanel.tsx
@@ -1,0 +1,10 @@
+import {
+  PlaygroundConversationPanel,
+  type PlaygroundConversationPanelProps,
+} from '@midscene/playground-app';
+
+export default function LazyPlaygroundConversationPanel(
+  props: PlaygroundConversationPanelProps,
+) {
+  return <PlaygroundConversationPanel {...props} />;
+}

--- a/apps/studio/src/renderer/components/Playground/index.tsx
+++ b/apps/studio/src/renderer/components/Playground/index.tsx
@@ -1,11 +1,22 @@
-import { PlaygroundConversationPanel } from '@midscene/playground-app';
+import { Suspense, lazy, useMemo } from 'react';
+import { downloadStudioReport } from '../../playground/report-download';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
 import { PlaygroundShell } from '../PlaygroundShell';
 
 declare const __APP_VERSION__: string;
 
+const LazyPlaygroundConversationPanel = lazy(
+  () => import('./LazyPlaygroundConversationPanel'),
+);
+
 export default function Playground() {
   const studioPlayground = useStudioPlayground();
+  const playgroundConfig = useMemo(
+    () => ({
+      onDownloadReport: downloadStudioReport,
+    }),
+    [],
+  );
 
   return (
     <PlaygroundShell>
@@ -30,12 +41,21 @@ export default function Playground() {
             </button>
           </div>
         ) : (
-          <PlaygroundConversationPanel
-            appVersion={__APP_VERSION__}
-            className="h-full"
-            controller={studioPlayground.controller}
-            title="Playground"
-          />
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center px-6 text-center text-[14px] leading-[22px] text-text-tertiary">
+                Loading Playground…
+              </div>
+            }
+          >
+            <LazyPlaygroundConversationPanel
+              appVersion={__APP_VERSION__}
+              className="h-full"
+              controller={studioPlayground.controller}
+              playgroundConfig={playgroundConfig}
+              title="Playground"
+            />
+          </Suspense>
         )}
       </div>
     </PlaygroundShell>

--- a/apps/studio/src/renderer/components/ShellLayout/model-env-storage.ts
+++ b/apps/studio/src/renderer/components/ShellLayout/model-env-storage.ts
@@ -1,6 +1,24 @@
+import { useEnvConfig } from '@midscene/visualizer';
 import { parseEnvText, resolveModelConnection } from './connectivity-env';
 
 const STORAGE_KEY = 'studio:model-env-text';
+
+// The Studio shell and the Playground panel read model env from two
+// separate stores. The shell modal owns the raw text (for round-tripping
+// in the UI) and uses it directly for the Connectivity Test IPC call.
+// The Playground reads `useEnvConfig` from @midscene/visualizer to build
+// its `overrideConfig` payload. If those stay out of sync, the server
+// never learns about MIDSCENE_MODEL_NAME and agent creation throws.
+// We mirror every shell save into `useEnvConfig` so both surfaces see
+// the same values.
+function mirrorToVisualizerStore(text: string): void {
+  try {
+    useEnvConfig.getState().loadConfig(text);
+  } catch {
+    // Visualizer store should always be available in the renderer, but
+    // never take down the shell if a zustand internal change breaks this.
+  }
+}
 
 export function loadModelEnvText(): string {
   if (typeof localStorage === 'undefined') {
@@ -14,6 +32,17 @@ export function saveModelEnvText(text: string): void {
     return;
   }
   localStorage.setItem(STORAGE_KEY, text);
+  mirrorToVisualizerStore(text);
+}
+
+// Called once on renderer boot so any pre-existing shell text is also
+// reflected into the visualizer store before the Playground reads it.
+export function hydrateModelEnvStores(): void {
+  const text = loadModelEnvText();
+  if (!text) {
+    return;
+  }
+  mirrorToVisualizerStore(text);
 }
 
 export function isModelEnvConfigured(text: string): boolean {

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -228,33 +228,6 @@ export default function Sidebar({
       return [];
     }
 
-    // iOS discovery needs WebDriverAgent running, which is a manual
-    // setup step; surface a hint row instead of an empty section so
-    // users know it isn't a bug.
-    if (platformKey === 'ios' && devices.length === 0) {
-      return [
-        {
-          id: 'ios-setup-hint',
-          label: 'Set up iOS via the playground form',
-          status: 'idle' as const,
-          isPlaceholder: true,
-          onClick: async () => {
-            if (studioPlayground.phase !== 'ready') {
-              return;
-            }
-            const { actions, state } = studioPlayground.controller;
-            const nextValues = {
-              ...state.form.getFieldsValue(true),
-              platformId: 'ios',
-            };
-            state.form.setFieldsValue(nextValues);
-            onSelectDevice();
-            await actions.refreshSessionSetup(nextValues);
-          },
-        },
-      ];
-    }
-
     return devices.map((item) => ({
       id: item.id,
       label: item.label,

--- a/apps/studio/src/renderer/index.tsx
+++ b/apps/studio/src/renderer/index.tsx
@@ -1,9 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { hydrateModelEnvStores } from './components/ShellLayout/model-env-storage';
 import { applyStoredThemeMode } from './theme/ThemeProvider';
 
 applyStoredThemeMode();
+hydrateModelEnvStores();
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>

--- a/apps/studio/src/renderer/playground/StudioPlaygroundProvider.tsx
+++ b/apps/studio/src/renderer/playground/StudioPlaygroundProvider.tsx
@@ -1,16 +1,23 @@
-import {
-  PlaygroundThemeProvider,
-  usePlaygroundController,
-} from '@midscene/playground-app';
 import type {
+  DiscoverDevicesResult,
   PlaygroundBootstrap,
-  StudioPlatformId,
 } from '@shared/electron-contract';
 import type { PropsWithChildren } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { bucketDiscoveredDevices } from './selectors';
 import type { DiscoveredDevicesByPlatform } from './types';
 import { StudioPlaygroundContext } from './useStudioPlayground';
+
+const ReadyStudioPlaygroundProvider = lazy(
+  () => import('./StudioPlaygroundReadyProvider'),
+);
 
 function getMissingBridgeError() {
   return 'Studio preload bridge is unavailable. Restart the Electron app.';
@@ -19,59 +26,6 @@ function getMissingBridgeError() {
 function normalizeBootstrapError(bootstrap: PlaygroundBootstrap): string {
   return bootstrap.error || 'Failed to start playground runtime.';
 }
-
-// Default platform for Studio — pre-selected so the first session-setup
-// poll already has a `platformId` and immediately returns Android
-// targets, instead of the generic "Choose a platform" setup.
-const DEFAULT_PLATFORM_ID: StudioPlatformId = 'android';
-
-function ReadyStudioPlaygroundProvider({
-  children,
-  discoveredDevices,
-  refreshDiscoveredDevices,
-  restartPlayground,
-  setDiscoveryPollingPaused,
-  serverUrl,
-}: PropsWithChildren<{
-  discoveredDevices?: DiscoveredDevicesByPlatform;
-  refreshDiscoveredDevices: () => Promise<void>;
-  restartPlayground: () => Promise<void>;
-  setDiscoveryPollingPaused: (paused: boolean) => void;
-  serverUrl: string;
-}>) {
-  const controller = usePlaygroundController({
-    serverUrl,
-    initialFormValues: { platformId: DEFAULT_PLATFORM_ID },
-  });
-
-  const contextValue = useMemo(
-    () => ({
-      phase: 'ready' as const,
-      serverUrl,
-      controller,
-      restartPlayground,
-      refreshDiscoveredDevices,
-      setDiscoveryPollingPaused,
-      discoveredDevices,
-    }),
-    [
-      controller,
-      discoveredDevices,
-      refreshDiscoveredDevices,
-      restartPlayground,
-      setDiscoveryPollingPaused,
-      serverUrl,
-    ],
-  );
-
-  return (
-    <StudioPlaygroundContext.Provider value={contextValue}>
-      {children}
-    </StudioPlaygroundContext.Provider>
-  );
-}
-
-const DISCOVERY_POLL_INTERVAL_MS = 5000;
 
 export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
   const [bootstrap, setBootstrap] = useState<
@@ -88,11 +42,15 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
   const [discoveredDevices, setDiscoveredDevices] = useState<
     DiscoveredDevicesByPlatform | undefined
   >();
-  const [discoveryPollingPaused, setDiscoveryPollingPaused] = useState(false);
-  const refreshDiscoveredDevicesRef = useRef<Promise<void> | null>(null);
+  const applyDiscoveredDevices = useCallback(
+    (devices: DiscoverDevicesResult) => {
+      setDiscoveredDevices(bucketDiscoveredDevices(devices));
+    },
+    [],
+  );
 
   const setDiscoveryPollingPausedValue = useCallback((paused: boolean) => {
-    setDiscoveryPollingPaused(paused);
+    void window.studioRuntime?.setDiscoveryPollingPaused(paused);
   }, []);
 
   // Imperative scan — safe to call from anywhere (user-initiated refresh,
@@ -103,38 +61,50 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
       return;
     }
 
-    if (refreshDiscoveredDevicesRef.current) {
-      return refreshDiscoveredDevicesRef.current;
+    try {
+      const devices = await studioRuntime.discoverDevices({
+        forceRefresh: true,
+      });
+      applyDiscoveredDevices(devices);
+    } catch (err) {
+      console.warn('[studio] device discovery failed:', err);
     }
+  }, [applyDiscoveredDevices]);
 
-    const pendingRefresh = (async () => {
-      try {
-        const devices = await studioRuntime.discoverDevices();
-        setDiscoveredDevices(bucketDiscoveredDevices(devices));
-      } catch (err) {
-        console.warn('[studio] device discovery failed:', err);
-      } finally {
-        refreshDiscoveredDevicesRef.current = null;
-      }
-    })();
-
-    refreshDiscoveredDevicesRef.current = pendingRefresh;
-    return pendingRefresh;
-  }, []);
-
-  const pollingActive = bootstrap.phase === 'ready' && !discoveryPollingPaused;
   useEffect(() => {
-    if (!pollingActive) {
+    if (bootstrap.phase !== 'ready') {
       return;
     }
-    void refreshDiscoveredDevices();
-    const id = window.setInterval(() => {
-      void refreshDiscoveredDevices();
-    }, DISCOVERY_POLL_INTERVAL_MS);
+
+    const studioRuntime = window.studioRuntime;
+    if (!studioRuntime) {
+      return;
+    }
+
+    let cancelled = false;
+    const unsubscribe = studioRuntime.onDiscoveredDevicesChanged((devices) => {
+      if (cancelled) {
+        return;
+      }
+      applyDiscoveredDevices(devices);
+    });
+
+    void studioRuntime
+      .discoverDevices()
+      .then((devices) => {
+        if (!cancelled) {
+          applyDiscoveredDevices(devices);
+        }
+      })
+      .catch((err) => {
+        console.warn('[studio] initial device discovery failed:', err);
+      });
+
     return () => {
-      window.clearInterval(id);
+      cancelled = true;
+      unsubscribe();
     };
-  }, [pollingActive, refreshDiscoveredDevices]);
+  }, [applyDiscoveredDevices, bootstrap.phase]);
 
   const readBootstrap = useCallback(async () => {
     if (!window.studioRuntime) {
@@ -248,23 +218,43 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
     setDiscoveryPollingPausedValue,
   ]);
 
-  return (
-    <PlaygroundThemeProvider>
-      {bootstrap.phase === 'ready' ? (
-        <ReadyStudioPlaygroundProvider
-          discoveredDevices={discoveredDevices}
-          refreshDiscoveredDevices={refreshDiscoveredDevices}
-          restartPlayground={restartPlayground}
-          setDiscoveryPollingPaused={setDiscoveryPollingPausedValue}
-          serverUrl={bootstrap.serverUrl}
-        >
-          {children}
-        </ReadyStudioPlaygroundProvider>
-      ) : (
-        <StudioPlaygroundContext.Provider value={contextValue}>
+  const bootingContextValue = useMemo(
+    () => ({
+      phase: 'booting' as const,
+      restartPlayground,
+      refreshDiscoveredDevices,
+      setDiscoveryPollingPaused: setDiscoveryPollingPausedValue,
+      discoveredDevices,
+    }),
+    [
+      discoveredDevices,
+      refreshDiscoveredDevices,
+      restartPlayground,
+      setDiscoveryPollingPausedValue,
+    ],
+  );
+
+  return bootstrap.phase === 'ready' ? (
+    <Suspense
+      fallback={
+        <StudioPlaygroundContext.Provider value={bootingContextValue}>
           {children}
         </StudioPlaygroundContext.Provider>
-      )}
-    </PlaygroundThemeProvider>
+      }
+    >
+      <ReadyStudioPlaygroundProvider
+        discoveredDevices={discoveredDevices}
+        refreshDiscoveredDevices={refreshDiscoveredDevices}
+        restartPlayground={restartPlayground}
+        setDiscoveryPollingPaused={setDiscoveryPollingPausedValue}
+        serverUrl={bootstrap.serverUrl}
+      >
+        {children}
+      </ReadyStudioPlaygroundProvider>
+    </Suspense>
+  ) : (
+    <StudioPlaygroundContext.Provider value={contextValue}>
+      {children}
+    </StudioPlaygroundContext.Provider>
   );
 }

--- a/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
+++ b/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
@@ -2,10 +2,13 @@ import {
   PlaygroundThemeProvider,
   usePlaygroundController,
 } from '@midscene/playground-app';
+import type { StudioPlatformId } from '@shared/electron-contract';
 import type { PropsWithChildren } from 'react';
 import { useMemo } from 'react';
 import type { DiscoveredDevicesByPlatform } from './types';
 import { StudioPlaygroundContext } from './useStudioPlayground';
+
+const DEFAULT_PLATFORM_ID: StudioPlatformId = 'android';
 
 interface StudioPlaygroundReadyProviderProps {
   discoveredDevices?: DiscoveredDevicesByPlatform;
@@ -24,6 +27,7 @@ export default function StudioPlaygroundReadyProvider({
   serverUrl,
 }: PropsWithChildren<StudioPlaygroundReadyProviderProps>) {
   const controller = usePlaygroundController({
+    initialFormValues: { platformId: DEFAULT_PLATFORM_ID },
     serverUrl,
   });
 

--- a/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
+++ b/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
@@ -1,0 +1,57 @@
+import {
+  PlaygroundThemeProvider,
+  usePlaygroundController,
+} from '@midscene/playground-app';
+import type { PropsWithChildren } from 'react';
+import { useMemo } from 'react';
+import type { DiscoveredDevicesByPlatform } from './types';
+import { StudioPlaygroundContext } from './useStudioPlayground';
+
+interface StudioPlaygroundReadyProviderProps {
+  discoveredDevices?: DiscoveredDevicesByPlatform;
+  refreshDiscoveredDevices: () => Promise<void>;
+  restartPlayground: () => Promise<void>;
+  setDiscoveryPollingPaused: (paused: boolean) => void;
+  serverUrl: string;
+}
+
+export default function StudioPlaygroundReadyProvider({
+  children,
+  discoveredDevices,
+  refreshDiscoveredDevices,
+  restartPlayground,
+  setDiscoveryPollingPaused,
+  serverUrl,
+}: PropsWithChildren<StudioPlaygroundReadyProviderProps>) {
+  const controller = usePlaygroundController({
+    serverUrl,
+  });
+
+  const contextValue = useMemo(
+    () => ({
+      phase: 'ready' as const,
+      serverUrl,
+      controller,
+      restartPlayground,
+      refreshDiscoveredDevices,
+      setDiscoveryPollingPaused,
+      discoveredDevices,
+    }),
+    [
+      controller,
+      discoveredDevices,
+      refreshDiscoveredDevices,
+      restartPlayground,
+      setDiscoveryPollingPaused,
+      serverUrl,
+    ],
+  );
+
+  return (
+    <PlaygroundThemeProvider>
+      <StudioPlaygroundContext.Provider value={contextValue}>
+        {children}
+      </StudioPlaygroundContext.Provider>
+    </PlaygroundThemeProvider>
+  );
+}

--- a/apps/studio/src/renderer/playground/report-download.ts
+++ b/apps/studio/src/renderer/playground/report-download.ts
@@ -1,0 +1,44 @@
+import type {
+  ReportDownloadHandler,
+  ReportDownloadRequest,
+} from '@midscene/visualizer';
+import type { ElectronShellApi } from '../../shared/electron-contract';
+
+type StudioReportShell = Pick<
+  ElectronShellApi,
+  'chooseReportSavePath' | 'writeReportFile'
+>;
+
+export async function saveReportWithElectronShell(
+  request: ReportDownloadRequest,
+  shell?: Partial<StudioReportShell>,
+): Promise<void> {
+  const activeShell =
+    shell ??
+    ((globalThis.window as Window | undefined)?.electronShell as
+      | Partial<StudioReportShell>
+      | undefined);
+
+  if (!activeShell?.chooseReportSavePath || !activeShell?.writeReportFile) {
+    throw new Error('Studio report download is unavailable.');
+  }
+
+  const filePath = await activeShell.chooseReportSavePath(
+    request.defaultFileName,
+  );
+
+  if (!filePath) {
+    return;
+  }
+
+  await activeShell.writeReportFile({
+    path: filePath,
+    content: request.content,
+  });
+}
+
+export const downloadStudioReport: ReportDownloadHandler = async (
+  request: ReportDownloadRequest,
+) => {
+  await saveReportWithElectronShell(request);
+};

--- a/apps/studio/src/renderer/playground/selectors.ts
+++ b/apps/studio/src/renderer/playground/selectors.ts
@@ -45,7 +45,12 @@ function buildHostPortId(host: string, port: number): string {
   return `${host}:${port}`;
 }
 
-function normalizeSidebarPlatformKey(
+/**
+ * Map any incoming platform string (runtime metadata, form values, desktop
+ * OS aliases like `macos`) to the canonical `StudioPlatformId`. Exported so
+ * other studio renderer modules don't need to keep their own alias tables.
+ */
+export function normalizeStudioPlatformId(
   value: unknown,
 ): StudioSidebarPlatformKey | undefined {
   if (!isString(value)) {
@@ -64,8 +69,6 @@ function normalizeSidebarPlatformKey(
     case 'linux':
       return 'computer';
     case 'harmony':
-    case 'harmonyos':
-    case 'harmony-os':
       return 'harmony';
     case 'web':
     case 'browser':
@@ -206,7 +209,7 @@ export function resolveSelectedAndroidDeviceId(
 export function resolveSelectedDeviceId(
   formValues: Record<string, unknown>,
 ): string | undefined {
-  const selectedPlatform = normalizeSidebarPlatformKey(formValues.platformId);
+  const selectedPlatform = normalizeStudioPlatformId(formValues.platformId);
 
   if (selectedPlatform === 'ios') {
     const host = isString(formValues['ios.host'])
@@ -341,7 +344,7 @@ export function buildStudioSidebarDeviceBuckets({
   targets: PlaygroundSessionTarget[];
 }): StudioSidebarDeviceBuckets {
   const deviceBuckets = createEmptySidebarDeviceBuckets();
-  const runtimePlatformKey = normalizeSidebarPlatformKey(
+  const runtimePlatformKey = normalizeStudioPlatformId(
     runtimeInfo?.platformId ?? runtimeInfo?.interface?.type,
   );
 

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -7,7 +7,9 @@ export const IPC_CHANNELS = {
   closeWindow: 'shell:close-window',
   minimizeWindow: 'shell:minimize-window',
   openExternalUrl: 'shell:open-external-url',
+  chooseReportSavePath: 'shell:choose-report-save-path',
   toggleMaximizeWindow: 'shell:toggle-maximize-window',
+  writeReportFile: 'shell:write-report-file',
   // Multi-platform playground runtime (Android, iOS, HarmonyOS, Computer).
   getPlaygroundBootstrap: 'studio:get-playground-bootstrap',
   restartPlayground: 'studio:restart-playground',
@@ -15,6 +17,8 @@ export const IPC_CHANNELS = {
   // at once (Android via ADB, Harmony via HDC, Computer via display
   // enumeration). Independent of session manager.
   discoverDevices: 'studio:discover-devices',
+  discoveredDevicesUpdated: 'studio:discovered-devices-updated',
+  setDiscoveryPollingPaused: 'studio:set-discovery-polling-paused',
   runConnectivityTest: 'studio:run-connectivity-test',
 } as const;
 
@@ -22,6 +26,11 @@ export interface ConnectivityTestRequest {
   apiKey: string;
   baseUrl: string;
   model: string;
+}
+
+export interface WriteReportFileRequest {
+  path: string;
+  content: string;
 }
 
 export type ConnectivityTestResult =
@@ -59,6 +68,8 @@ export interface DiscoveredDevice {
   id: string;
   label: string;
   description?: string;
+  /** Optional platform-native availability state, e.g. `device` or `offline`. */
+  status?: string;
   /**
    * Session-setup field values for this discovered target, before Studio
    * prefixes them with `{platformId}.`.
@@ -68,6 +79,10 @@ export interface DiscoveredDevice {
 
 /** Result of the cross-platform device discovery scan. */
 export type DiscoverDevicesResult = DiscoveredDevice[];
+
+export interface DiscoverDevicesRequest {
+  forceRefresh?: boolean;
+}
 
 /**
  * Public API exposed on `window.electronShell` by the preload bridge.
@@ -83,18 +98,28 @@ export interface ElectronShellApi {
   minimizeWindow: () => Promise<void>;
   /** Open an external HTTP(S) link in the system browser. */
   openExternalUrl: (url: string) => Promise<void>;
+  /** Ask the main process for a target path for a report HTML export. */
+  chooseReportSavePath: (defaultFileName?: string) => Promise<string | null>;
   /**
    * Toggle maximize/unmaximize on the current shell window. No-op if the
    * window is not available (e.g. during teardown).
    */
   toggleMaximizeWindow: () => Promise<void>;
+  /** Persist a report HTML file using the native shell process. */
+  writeReportFile: (request: WriteReportFileRequest) => Promise<void>;
 }
 
 export interface StudioRuntimeApi {
   getPlaygroundBootstrap: () => Promise<PlaygroundBootstrap>;
   restartPlayground: () => Promise<PlaygroundBootstrap>;
   /** Scan ALL platforms for connected devices (ADB, HDC, displays). */
-  discoverDevices: () => Promise<DiscoverDevicesResult>;
+  discoverDevices: (
+    request?: DiscoverDevicesRequest,
+  ) => Promise<DiscoverDevicesResult>;
+  onDiscoveredDevicesChanged: (
+    listener: (devices: DiscoverDevicesResult) => void,
+  ) => () => void;
+  setDiscoveryPollingPaused: (paused: boolean) => Promise<void>;
   runConnectivityTest: (
     request: ConnectivityTestRequest,
   ) => Promise<ConnectivityTestResult>;

--- a/apps/studio/tests/android-runtime.test.ts
+++ b/apps/studio/tests/android-runtime.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createStudioCorsOptions,
   isAllowedStudioOrigin,
 } from '../src/main/playground/cors';
+import { createMultiPlatformRuntimeService } from '../src/main/playground/multi-platform-runtime';
 
 describe('android runtime CORS policy', () => {
   it('allows Studio origins used by Electron and local renderer dev', () => {
@@ -38,5 +39,171 @@ describe('android runtime CORS policy', () => {
     expect(allowedResult).toBe(true);
     expect(blockedResult).toBe(false);
     expect(corsOptions.credentials).toBe(true);
+  });
+});
+
+describe('playground runtime bootstrap', () => {
+  it('reports dependency load failures through the bootstrap state', async () => {
+    const runtime = createMultiPlatformRuntimeService({
+      loadModules: async () => {
+        throw new Error('Synthetic dependency resolution failure');
+      },
+    });
+
+    await expect(runtime.start()).resolves.toEqual({
+      status: 'error',
+      serverUrl: null,
+      port: null,
+      error: 'Synthetic dependency resolution failure',
+    });
+
+    expect(runtime.getBootstrap()).toEqual({
+      status: 'error',
+      serverUrl: null,
+      port: null,
+      error: 'Synthetic dependency resolution failure',
+    });
+  });
+
+  it('defers platform module loading until a platform is actually prepared', async () => {
+    let androidLoadCount = 0;
+    let computerLoadCount = 0;
+    let harmonyLoadCount = 0;
+    let iosLoadCount = 0;
+    let capturedPlatforms:
+      | import('@midscene/playground').RegisteredPlaygroundPlatform[]
+      | undefined;
+
+    const runtime = createMultiPlatformRuntimeService({
+      loadPlaygroundCore: async () => ({
+        launchPreparedPlaygroundPlatform: async () => ({
+          close: async () => undefined,
+          host: '127.0.0.1',
+          port: 5800,
+          server: {
+            setPreparedPlatform: () => undefined,
+          },
+        }),
+        prepareMultiPlatformPlayground: async (platforms) => {
+          capturedPlatforms = platforms;
+          return {
+            platformId: 'multi-platform',
+            title: 'Midscene Studio',
+            description: 'Multi-platform playground',
+            metadata: {},
+            sessionManager: {
+              createSession: async () => {
+                throw new Error('not needed for bootstrap');
+              },
+            },
+          };
+        },
+      }),
+      loadAndroidModule: async () => {
+        androidLoadCount += 1;
+        throw new Error('android should stay lazy');
+      },
+      loadComputerModule: async () => {
+        computerLoadCount += 1;
+        throw new Error('computer should stay lazy');
+      },
+      loadHarmonyModule: async () => {
+        harmonyLoadCount += 1;
+        throw new Error('harmony should stay lazy');
+      },
+      loadIosModule: async () => {
+        iosLoadCount += 1;
+        throw new Error('ios should stay lazy');
+      },
+    });
+
+    await expect(runtime.start()).resolves.toEqual({
+      status: 'ready',
+      serverUrl: 'http://127.0.0.1:5800',
+      port: 5800,
+      error: null,
+    });
+
+    expect(capturedPlatforms?.map((platform) => platform.id)).toEqual([
+      'android',
+      'ios',
+      'harmony',
+      'computer',
+    ]);
+    expect(androidLoadCount).toBe(0);
+    expect(computerLoadCount).toBe(0);
+    expect(harmonyLoadCount).toBe(0);
+    expect(iosLoadCount).toBe(0);
+
+    await expect(capturedPlatforms?.[0]?.prepare()).rejects.toThrow(
+      'android should stay lazy',
+    );
+    expect(androidLoadCount).toBe(1);
+  });
+
+  it('prepares Harmony in deferred mode so Studio never exits on device selection', async () => {
+    const harmonyPrepare = vi.fn(async () => ({
+      platformId: 'harmony',
+      title: 'Midscene HarmonyOS Playground',
+      metadata: {
+        sessionConnected: false,
+        setupState: 'required',
+      },
+      sessionManager: {
+        createSession: async () => ({
+          displayName: 'unused',
+        }),
+      },
+    }));
+    let capturedPlatforms:
+      | import('@midscene/playground').RegisteredPlaygroundPlatform[]
+      | undefined;
+
+    const runtime = createMultiPlatformRuntimeService({
+      loadPlaygroundCore: async () => ({
+        launchPreparedPlaygroundPlatform: async () => ({
+          close: async () => undefined,
+          host: '127.0.0.1',
+          port: 5800,
+          server: {
+            setPreparedPlatform: () => undefined,
+          },
+        }),
+        prepareMultiPlatformPlayground: async (platforms) => {
+          capturedPlatforms = platforms;
+          return {
+            platformId: 'multi-platform',
+            title: 'Midscene Studio',
+            description: 'Multi-platform playground',
+            metadata: {},
+            sessionManager: {
+              createSession: async () => {
+                throw new Error('not needed for bootstrap');
+              },
+            },
+          };
+        },
+      }),
+      loadHarmonyModule: async () => ({
+        harmonyPlaygroundPlatform: {
+          prepare: harmonyPrepare,
+        },
+      }),
+      resolvePackageStaticDir: (packageName) => `/virtual/${packageName}`,
+    });
+
+    await expect(runtime.start()).resolves.toEqual({
+      status: 'ready',
+      serverUrl: 'http://127.0.0.1:5800',
+      port: 5800,
+      error: null,
+    });
+
+    await capturedPlatforms?.[2]?.prepare();
+
+    expect(harmonyPrepare).toHaveBeenCalledWith({
+      staticDir: '/virtual/@midscene/harmony',
+      deferConnection: true,
+    });
   });
 });

--- a/apps/studio/tests/device-discovery-service.test.ts
+++ b/apps/studio/tests/device-discovery-service.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEVICE_DISCOVERY_POLL_INTERVAL_MS,
+  createDeviceDiscoveryService,
+} from '../src/main/playground/device-discovery';
+
+describe('createDeviceDiscoveryService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('refreshes immediately and publishes changed snapshots to listeners', async () => {
+    vi.useFakeTimers();
+
+    const discoverDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          platformId: 'android',
+          id: 'device-1',
+          label: 'Pixel 9',
+          status: 'device',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          platformId: 'android',
+          id: 'device-2',
+          label: 'Pixel 10',
+          status: 'device',
+        },
+      ]);
+
+    const service = createDeviceDiscoveryService({
+      discoverDevices,
+      intervalMs: DEVICE_DISCOVERY_POLL_INTERVAL_MS,
+    });
+    const listener = vi.fn();
+    const unsubscribe = service.subscribe(listener);
+
+    await service.getSnapshot();
+
+    expect(discoverDevices).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith([
+      {
+        platformId: 'android',
+        id: 'device-1',
+        label: 'Pixel 9',
+        status: 'device',
+      },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(DEVICE_DISCOVERY_POLL_INTERVAL_MS);
+
+    expect(discoverDevices).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith([
+      {
+        platformId: 'android',
+        id: 'device-2',
+        label: 'Pixel 10',
+        status: 'device',
+      },
+    ]);
+
+    unsubscribe();
+    service.close();
+  });
+
+  it('pauses background polling while still allowing forced refreshes', async () => {
+    vi.useFakeTimers();
+
+    const discoverDevices = vi.fn().mockResolvedValue([
+      {
+        platformId: 'android',
+        id: 'device-1',
+        label: 'Pixel 9',
+        status: 'device',
+      },
+    ]);
+
+    const service = createDeviceDiscoveryService({
+      discoverDevices,
+      intervalMs: DEVICE_DISCOVERY_POLL_INTERVAL_MS,
+    });
+
+    await service.getSnapshot();
+    expect(discoverDevices).toHaveBeenCalledTimes(1);
+
+    service.setPollingPaused(true);
+    await vi.advanceTimersByTimeAsync(DEVICE_DISCOVERY_POLL_INTERVAL_MS * 2);
+    expect(discoverDevices).toHaveBeenCalledTimes(1);
+
+    await service.getSnapshot({ forceRefresh: true });
+    expect(discoverDevices).toHaveBeenCalledTimes(2);
+
+    service.setPollingPaused(false);
+    await vi.advanceTimersByTimeAsync(DEVICE_DISCOVERY_POLL_INTERVAL_MS);
+    expect(discoverDevices).toHaveBeenCalledTimes(4);
+
+    service.close();
+  });
+});

--- a/apps/studio/tests/electron-contract.test.ts
+++ b/apps/studio/tests/electron-contract.test.ts
@@ -4,10 +4,20 @@ import { IPC_CHANNELS } from '../src/shared/electron-contract';
 describe('IPC_CHANNELS', () => {
   it('includes shell and playground bridge channels', () => {
     expect(IPC_CHANNELS.openExternalUrl).toBe('shell:open-external-url');
+    expect(IPC_CHANNELS.chooseReportSavePath).toBe(
+      'shell:choose-report-save-path',
+    );
+    expect(IPC_CHANNELS.writeReportFile).toBe('shell:write-report-file');
     expect(IPC_CHANNELS.getPlaygroundBootstrap).toBe(
       'studio:get-playground-bootstrap',
     );
     expect(IPC_CHANNELS.restartPlayground).toBe('studio:restart-playground');
     expect(IPC_CHANNELS.discoverDevices).toBe('studio:discover-devices');
+    expect(IPC_CHANNELS.discoveredDevicesUpdated).toBe(
+      'studio:discovered-devices-updated',
+    );
+    expect(IPC_CHANNELS.setDiscoveryPollingPaused).toBe(
+      'studio:set-discovery-polling-paused',
+    );
   });
 });

--- a/apps/studio/tests/main-content-preview-layout.test.ts
+++ b/apps/studio/tests/main-content-preview-layout.test.ts
@@ -1,0 +1,151 @@
+import type { PlaygroundRuntimeInfo } from '@midscene/playground';
+import { describe, expect, it } from 'vitest';
+import {
+  fitMobilePreviewViewport,
+  resolveStudioPreviewPlatform,
+  shouldEnableMobilePreviewFrame,
+  shouldUseMobilePreviewFrame,
+} from '../src/renderer/components/MainContent/preview-layout';
+
+function createRuntimeInfo(
+  platformId: PlaygroundRuntimeInfo['platformId'],
+  interfaceType?: string,
+): PlaygroundRuntimeInfo {
+  return {
+    platformId,
+    interface: {
+      type: interfaceType ?? platformId,
+    },
+    metadata: {},
+    executionUxHints: [],
+    preview: {
+      kind: 'none',
+      capabilities: [],
+    },
+  };
+}
+
+describe('resolveStudioPreviewPlatform', () => {
+  it('prefers the runtime platform when a session is already connected', () => {
+    expect(
+      resolveStudioPreviewPlatform(createRuntimeInfo('ios'), {
+        platformId: 'computer',
+      }),
+    ).toBe('ios');
+  });
+
+  it('falls back to the selected form platform before connection starts', () => {
+    expect(
+      resolveStudioPreviewPlatform(null, { platformId: 'harmonyos' }),
+    ).toBe('harmony');
+  });
+
+  it('normalizes desktop aliases to computer', () => {
+    expect(
+      resolveStudioPreviewPlatform(createRuntimeInfo('computer', 'macos'), {}),
+    ).toBe('computer');
+  });
+});
+
+describe('shouldUseMobilePreviewFrame', () => {
+  it('enables the framed preview for mobile platforms', () => {
+    expect(shouldUseMobilePreviewFrame(createRuntimeInfo('android'), {})).toBe(
+      true,
+    );
+    expect(
+      shouldUseMobilePreviewFrame(createRuntimeInfo('ios'), {
+        platformId: 'computer',
+      }),
+    ).toBe(true);
+    expect(shouldUseMobilePreviewFrame(null, { platformId: 'harmony' })).toBe(
+      true,
+    );
+  });
+
+  it('keeps the desktop layout for computer and web previews', () => {
+    expect(shouldUseMobilePreviewFrame(createRuntimeInfo('computer'), {})).toBe(
+      false,
+    );
+    expect(shouldUseMobilePreviewFrame(createRuntimeInfo('web'), {})).toBe(
+      false,
+    );
+  });
+});
+
+describe('shouldEnableMobilePreviewFrame', () => {
+  it('keeps scrcpy connecting overlays full width until the stream is live', () => {
+    expect(
+      shouldEnableMobilePreviewFrame(
+        {
+          ...createRuntimeInfo('android'),
+          preview: {
+            kind: 'scrcpy',
+            capabilities: [{ kind: 'scrcpy' }],
+          },
+        },
+        {},
+        true,
+        'connecting',
+      ),
+    ).toBe(false);
+    expect(
+      shouldEnableMobilePreviewFrame(
+        {
+          ...createRuntimeInfo('android'),
+          preview: {
+            kind: 'scrcpy',
+            capabilities: [{ kind: 'scrcpy' }],
+          },
+        },
+        {},
+        true,
+        'connected',
+      ),
+    ).toBe(true);
+  });
+
+  it('enables the mobile frame for connected non-scrcpy previews', () => {
+    expect(
+      shouldEnableMobilePreviewFrame(
+        {
+          ...createRuntimeInfo('ios'),
+          preview: {
+            kind: 'mjpeg',
+            mjpegPath: '/mjpeg',
+            capabilities: [{ kind: 'mjpeg' }],
+          },
+        },
+        {},
+        true,
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it('disables the mobile frame when no session is connected', () => {
+    expect(
+      shouldEnableMobilePreviewFrame(
+        createRuntimeInfo('android'),
+        {},
+        false,
+        null,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('fitMobilePreviewViewport', () => {
+  it('preserves vertical gutter when height is the limiting factor', () => {
+    const viewport = fitMobilePreviewViewport(380, 820);
+
+    expect(viewport.height).toBeLessThan(820);
+    expect(820 - viewport.height).toBeGreaterThanOrEqual(56);
+  });
+
+  it('caps the viewport by width when the stage is narrow', () => {
+    const viewport = fitMobilePreviewViewport(280, 820);
+
+    expect(viewport.width).toBeLessThan(280);
+    expect(viewport.height).toBeLessThan(820);
+  });
+});

--- a/apps/studio/tests/main-content-preview-layout.test.ts
+++ b/apps/studio/tests/main-content-preview-layout.test.ts
@@ -35,9 +35,9 @@ describe('resolveStudioPreviewPlatform', () => {
   });
 
   it('falls back to the selected form platform before connection starts', () => {
-    expect(
-      resolveStudioPreviewPlatform(null, { platformId: 'harmonyos' }),
-    ).toBe('harmony');
+    expect(resolveStudioPreviewPlatform(null, { platformId: 'harmony' })).toBe(
+      'harmony',
+    );
   });
 
   it('normalizes desktop aliases to computer', () => {

--- a/apps/studio/tests/model-env-storage.test.ts
+++ b/apps/studio/tests/model-env-storage.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadConfigMock = vi.fn<(text: string) => void>();
+let memoryStore: Record<string, string> = {};
+
+vi.mock('@midscene/visualizer', () => ({
+  useEnvConfig: {
+    getState: () => ({
+      loadConfig: loadConfigMock,
+    }),
+  },
+}));
+
+beforeEach(() => {
+  memoryStore = {};
+  (globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (key: string) => memoryStore[key] ?? null,
+    setItem: (key: string, value: string) => {
+      memoryStore[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete memoryStore[key];
+    },
+    clear: () => {
+      memoryStore = {};
+    },
+    key: () => null,
+    length: 0,
+  } as Storage;
+  loadConfigMock.mockReset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  (globalThis as { localStorage?: Storage }).localStorage = undefined;
+});
+
+describe('saveModelEnvText', () => {
+  it('persists the raw text and mirrors it into the visualizer env store', async () => {
+    const { saveModelEnvText } = await import(
+      '../src/renderer/components/ShellLayout/model-env-storage'
+    );
+    const text = 'MIDSCENE_MODEL_NAME=gpt-4o\nOPENAI_API_KEY=sk-example';
+
+    saveModelEnvText(text);
+
+    expect(memoryStore['studio:model-env-text']).toBe(text);
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(loadConfigMock).toHaveBeenCalledWith(text);
+  });
+});
+
+describe('hydrateModelEnvStores', () => {
+  it('is a no-op when no shell text has been saved', async () => {
+    const { hydrateModelEnvStores } = await import(
+      '../src/renderer/components/ShellLayout/model-env-storage'
+    );
+
+    hydrateModelEnvStores();
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('seeds the visualizer store from pre-existing shell text on boot', async () => {
+    memoryStore['studio:model-env-text'] = 'MIDSCENE_MODEL_NAME=claude';
+    const { hydrateModelEnvStores } = await import(
+      '../src/renderer/components/ShellLayout/model-env-storage'
+    );
+
+    hydrateModelEnvStores();
+
+    expect(loadConfigMock).toHaveBeenCalledWith('MIDSCENE_MODEL_NAME=claude');
+  });
+});

--- a/apps/studio/tests/playground-bootstrap-request.test.ts
+++ b/apps/studio/tests/playground-bootstrap-request.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requestPlaygroundBootstrap } from '../src/main/playground/bootstrap-request';
+import type { PlaygroundRuntimeService } from '../src/main/playground/types';
+
+function createRuntimeMock(
+  overrides: Partial<PlaygroundRuntimeService> = {},
+): PlaygroundRuntimeService {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    getBootstrap: vi.fn().mockReturnValue({
+      status: 'starting',
+      serverUrl: null,
+      port: null,
+      error: null,
+    }),
+    restart: vi.fn(),
+    start: vi.fn().mockResolvedValue({
+      status: 'ready',
+      serverUrl: 'http://127.0.0.1:3000',
+      port: 3000,
+      error: null,
+    }),
+    ...overrides,
+  };
+}
+
+describe('requestPlaygroundBootstrap', () => {
+  it('returns the current bootstrap immediately while starting in background', () => {
+    const runtime = createRuntimeMock();
+    const onStartError = vi.fn();
+
+    const bootstrap = requestPlaygroundBootstrap(runtime, onStartError);
+
+    expect(runtime.start).toHaveBeenCalledTimes(1);
+    expect(runtime.getBootstrap).toHaveBeenCalledTimes(1);
+    expect(onStartError).not.toHaveBeenCalled();
+    expect(bootstrap).toEqual({
+      status: 'starting',
+      serverUrl: null,
+      port: null,
+      error: null,
+    });
+  });
+
+  it('reports asynchronous start failures without throwing synchronously', async () => {
+    const failure = new Error('runtime failed');
+    const runtime = createRuntimeMock({
+      start: vi.fn().mockRejectedValue(failure),
+    });
+    const onStartError = vi.fn();
+
+    const bootstrap = requestPlaygroundBootstrap(runtime, onStartError);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(bootstrap.status).toBe('starting');
+    expect(onStartError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/apps/studio/tests/playground-selectors.test.ts
+++ b/apps/studio/tests/playground-selectors.test.ts
@@ -152,9 +152,9 @@ describe('buildStudioSidebarDeviceBuckets', () => {
     const buckets = buildStudioSidebarDeviceBuckets({
       formValues: {},
       runtimeInfo: {
-        platformId: 'harmonyos',
+        platformId: 'harmony',
         title: 'Harmony Playground',
-        interface: { type: 'harmonyos' },
+        interface: { type: 'harmony' },
         preview: { kind: 'none', capabilities: [] },
         executionUxHints: [],
         metadata: {

--- a/apps/studio/tests/report-download.test.ts
+++ b/apps/studio/tests/report-download.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { saveReportWithElectronShell } from '../src/renderer/playground/report-download';
+
+describe('saveReportWithElectronShell', () => {
+  it('writes the selected report file after the user confirms the save dialog', async () => {
+    const shell = {
+      chooseReportSavePath: vi
+        .fn()
+        .mockResolvedValue('/tmp/midscene-report.html'),
+      writeReportFile: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await saveReportWithElectronShell(
+      {
+        content: '<html>report</html>',
+        defaultFileName: 'midscene_report.html',
+      },
+      shell,
+    );
+
+    expect(shell.chooseReportSavePath).toHaveBeenCalledWith(
+      'midscene_report.html',
+    );
+    expect(shell.writeReportFile).toHaveBeenCalledWith({
+      path: '/tmp/midscene-report.html',
+      content: '<html>report</html>',
+    });
+  });
+
+  it('does not write a file when the user cancels the save dialog', async () => {
+    const shell = {
+      chooseReportSavePath: vi.fn().mockResolvedValue(null),
+      writeReportFile: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await saveReportWithElectronShell(
+      {
+        content: '<html>report</html>',
+        defaultFileName: 'midscene_report.html',
+      },
+      shell,
+    );
+
+    expect(shell.writeReportFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the Electron shell bridge is unavailable', async () => {
+    await expect(
+      saveReportWithElectronShell({
+        content: '<html>report</html>',
+        defaultFileName: 'midscene_report.html',
+      }),
+    ).rejects.toThrow('Studio report download is unavailable.');
+  });
+});

--- a/apps/studio/tests/shell-env.test.ts
+++ b/apps/studio/tests/shell-env.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureStudioShellEnvHydration,
+  ensureStudioShellEnvHydrated,
+  hydrateLoginShellEnv,
+  resetStudioShellEnvHydrationForTests,
+} from '../src/main/shell-env';
+
+const MARKER = '___MIDSCENE_SHELL_ENV___';
+
+function fakeShellOutput(entries: Record<string, string>, noise = ''): string {
+  const body = Object.entries(entries)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+  return `${noise}${MARKER}\n${body}\n`;
+}
+
+afterEach(() => {
+  resetStudioShellEnvHydrationForTests();
+});
+
+describe('hydrateLoginShellEnv', () => {
+  it('skips non-packaged runs (dev already inherits shell env)', () => {
+    const env: NodeJS.ProcessEnv = {};
+    const runShell = vi.fn();
+    const result = hydrateLoginShellEnv({
+      isPackaged: false,
+      platform: 'darwin',
+      env,
+      runShell,
+    });
+    expect(result).toEqual({
+      applied: false,
+      reason: 'not-packaged',
+      mutatedKeys: [],
+    });
+    expect(runShell).not.toHaveBeenCalled();
+  });
+
+  it('skips Windows (GUI launches inherit env there)', () => {
+    const runShell = vi.fn();
+    const result = hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'win32',
+      env: {},
+      runShell,
+    });
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe('windows');
+    expect(runShell).not.toHaveBeenCalled();
+  });
+
+  it('merges missing keys like ANDROID_HOME into process.env', () => {
+    const env: NodeJS.ProcessEnv = { HOME: '/Users/test', PATH: '/usr/bin' };
+    const result = hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () =>
+        fakeShellOutput({
+          ANDROID_HOME: '/Users/test/Library/Android/sdk',
+          ANDROID_SDK_ROOT: '/Users/test/Library/Android/sdk',
+          PATH: '/Users/test/Library/Android/sdk/platform-tools:/usr/bin',
+        }),
+    });
+    expect(result.applied).toBe(true);
+    expect(env.ANDROID_HOME).toBe('/Users/test/Library/Android/sdk');
+    expect(env.ANDROID_SDK_ROOT).toBe('/Users/test/Library/Android/sdk');
+    expect(result.mutatedKeys).toEqual(
+      expect.arrayContaining(['ANDROID_HOME', 'ANDROID_SDK_ROOT', 'PATH']),
+    );
+  });
+
+  it('force-overrides PATH so adb/hdc become discoverable', () => {
+    const env: NodeJS.ProcessEnv = { PATH: '/usr/bin:/bin' };
+    hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () =>
+        fakeShellOutput({ PATH: '/opt/homebrew/bin:/usr/bin:/bin' }),
+    });
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin:/bin');
+  });
+
+  it('preserves non-PATH keys that already exist (system/Electron wins)', () => {
+    const env: NodeJS.ProcessEnv = {
+      HOME: '/Users/real',
+      ANDROID_HOME: '/explicit/override',
+    };
+    hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () =>
+        fakeShellOutput({
+          HOME: '/Users/ignored',
+          ANDROID_HOME: '/Users/ignored/sdk',
+        }),
+    });
+    expect(env.HOME).toBe('/Users/real');
+    expect(env.ANDROID_HOME).toBe('/explicit/override');
+  });
+
+  it('ignores rc-file stdout noise preceding the marker', () => {
+    const env: NodeJS.ProcessEnv = {};
+    hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () =>
+        fakeShellOutput(
+          { ANDROID_HOME: '/sdk' },
+          'welcome banner\nsome=thing that should not leak\n',
+        ),
+    });
+    expect(env.ANDROID_HOME).toBe('/sdk');
+    expect(env.some).toBeUndefined();
+  });
+
+  it('reports shell-failed without throwing when the spawn rejects', () => {
+    const log = vi.fn();
+    const env: NodeJS.ProcessEnv = {};
+    const result = hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () => {
+        throw new Error('shell missing');
+      },
+      log,
+    });
+    expect(result).toEqual({
+      applied: false,
+      reason: 'shell-failed',
+      mutatedKeys: [],
+    });
+    expect(log).toHaveBeenCalledWith(
+      'login shell env extraction failed',
+      expect.any(Error),
+    );
+  });
+
+  it('skips malformed lines without a valid identifier', () => {
+    const env: NodeJS.ProcessEnv = {};
+    hydrateLoginShellEnv({
+      isPackaged: true,
+      platform: 'darwin',
+      env,
+      runShell: () => `${MARKER}\n=nokey\n9FOO=bad\nBAD KEY=x\nGOOD=yes\n`,
+    });
+    expect(env.GOOD).toBe('yes');
+    expect(env['']).toBeUndefined();
+    expect(env['9FOO']).toBeUndefined();
+    expect(env['BAD KEY']).toBeUndefined();
+  });
+});
+
+describe('ensureStudioShellEnvHydrated', () => {
+  it('throws until studio hydration is configured', () => {
+    expect(() => ensureStudioShellEnvHydrated()).toThrow(
+      'Studio shell env hydration was used before it was configured.',
+    );
+  });
+
+  it('hydrates at most once after configuration', () => {
+    const runShell = vi.fn(() =>
+      fakeShellOutput({
+        PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+        ANDROID_HOME: '/sdk',
+      }),
+    );
+
+    configureStudioShellEnvHydration({
+      env: { PATH: '/usr/bin:/bin' },
+      isPackaged: true,
+      platform: 'darwin',
+      runShell,
+    });
+
+    const first = ensureStudioShellEnvHydrated();
+    const second = ensureStudioShellEnvHydrated();
+
+    expect(runShell).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(first.mutatedKeys).toEqual(
+      expect.arrayContaining(['PATH', 'ANDROID_HOME']),
+    );
+  });
+});

--- a/apps/studio/tests/sidebar-device-list.test.ts
+++ b/apps/studio/tests/sidebar-device-list.test.ts
@@ -1,0 +1,66 @@
+import type { PlaygroundControllerResult } from '@midscene/playground-app';
+import type { StudioPlaygroundContextValue } from '@renderer/playground/types';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import Sidebar from '../src/renderer/components/Sidebar';
+import { StudioPlaygroundContext } from '../src/renderer/playground/useStudioPlayground';
+
+function createReadyContextValue(): StudioPlaygroundContextValue {
+  return {
+    phase: 'ready',
+    serverUrl: 'http://127.0.0.1:5800',
+    controller: {
+      state: {
+        form: {
+          getFieldsValue: () => ({}),
+          setFieldsValue: () => undefined,
+        },
+        formValues: {},
+        runtimeInfo: null,
+        sessionSetup: {
+          fields: [],
+          targets: [],
+        },
+        sessionViewState: {
+          connected: false,
+          setupState: 'idle',
+        },
+      },
+      actions: {
+        refreshSessionSetup: vi.fn(async () => undefined),
+        createSession: vi.fn(async () => false),
+        destroySession: vi.fn(async () => undefined),
+      },
+    } as unknown as PlaygroundControllerResult,
+    discoveredDevices: {
+      android: [],
+      ios: [],
+      computer: [],
+      harmony: [],
+      web: [],
+    },
+    refreshDiscoveredDevices: vi.fn(async () => undefined),
+    restartPlayground: vi.fn(async () => undefined),
+    setDiscoveryPollingPaused: vi.fn(),
+  };
+}
+
+describe('Sidebar device list', () => {
+  it('shows empty platform rows instead of an iOS setup hint when no devices exist', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundContext.Provider,
+        { value: createReadyContextValue() },
+        createElement(Sidebar, {
+          activeView: 'overview',
+          onSelectDevice: () => undefined,
+          onSelectOverview: () => undefined,
+        }),
+      ),
+    );
+
+    expect(html).not.toContain('Set up iOS via the playground form');
+    expect(html.match(/No devices/g)).toHaveLength(5);
+  });
+});

--- a/apps/studio/tests/studio-playground-ready-provider.test.ts
+++ b/apps/studio/tests/studio-playground-ready-provider.test.ts
@@ -1,0 +1,42 @@
+import type { PlaygroundControllerResult } from '@midscene/playground-app';
+import { type ReactNode, createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import StudioPlaygroundReadyProvider from '../src/renderer/playground/StudioPlaygroundReadyProvider';
+
+const { usePlaygroundControllerMock } = vi.hoisted(() => ({
+  usePlaygroundControllerMock: vi.fn(
+    () =>
+      ({
+        actions: {},
+        state: {},
+      }) as unknown as PlaygroundControllerResult,
+  ),
+}));
+
+vi.mock('@midscene/playground-app', () => ({
+  PlaygroundThemeProvider: ({ children }: { children: ReactNode }) => children,
+  usePlaygroundController: usePlaygroundControllerMock,
+}));
+
+describe('StudioPlaygroundReadyProvider', () => {
+  it('seeds the controller with the default Android platform', () => {
+    renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundReadyProvider,
+        {
+          refreshDiscoveredDevices: async () => undefined,
+          restartPlayground: async () => undefined,
+          setDiscoveryPollingPaused: () => undefined,
+          serverUrl: 'http://127.0.0.1:5800',
+        },
+        createElement('div', null, 'child'),
+      ),
+    );
+
+    expect(usePlaygroundControllerMock).toHaveBeenCalledWith({
+      initialFormValues: { platformId: 'android' },
+      serverUrl: 'http://127.0.0.1:5800',
+    });
+  });
+});

--- a/apps/studio/tests/window-reveal.test.ts
+++ b/apps/studio/tests/window-reveal.test.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerWindowRevealHandlers } from '../src/main/window-reveal';
+
+class FakeWindow extends EventEmitter {
+  destroyed = false;
+  showCalls = 0;
+  webContents = new EventEmitter();
+
+  isDestroyed() {
+    return this.destroyed;
+  }
+
+  show() {
+    this.showCalls += 1;
+  }
+}
+
+function register(window: FakeWindow) {
+  registerWindowRevealHandlers({
+    isDestroyed: () => window.isDestroyed(),
+    onDidFailLoad: (listener) =>
+      window.webContents.once('did-fail-load', listener),
+    onDidFinishLoad: (listener) =>
+      window.webContents.once('did-finish-load', listener),
+    onReadyToShow: (listener) => window.once('ready-to-show', listener),
+    show: () => window.show(),
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('window reveal handlers', () => {
+  it('shows the window when ready-to-show fires', () => {
+    const window = new FakeWindow();
+
+    register(window);
+    window.emit('ready-to-show');
+
+    expect(window.showCalls).toBe(1);
+  });
+
+  it('falls back to did-finish-load when ready-to-show never arrives', () => {
+    const window = new FakeWindow();
+
+    register(window);
+    window.webContents.emit('did-finish-load');
+
+    expect(window.showCalls).toBe(1);
+  });
+
+  it('shows the window on load failure so the user can see the error state', () => {
+    const window = new FakeWindow();
+
+    register(window);
+    window.webContents.emit('did-fail-load');
+
+    expect(window.showCalls).toBe(1);
+  });
+
+  it('does not try to show a destroyed window', () => {
+    const window = new FakeWindow();
+    window.destroyed = true;
+
+    register(window);
+    window.emit('ready-to-show');
+    window.webContents.emit('did-finish-load');
+
+    expect(window.showCalls).toBe(0);
+  });
+
+  it('reveals the window only once even if multiple events fire', () => {
+    const window = new FakeWindow();
+
+    register(window);
+    window.webContents.emit('did-finish-load');
+    window.emit('ready-to-show');
+    window.webContents.emit('did-fail-load');
+
+    expect(window.showCalls).toBe(1);
+  });
+
+  it('falls back to a timeout when lifecycle events never arrive', () => {
+    vi.useFakeTimers();
+    const window = new FakeWindow();
+
+    register(window);
+    vi.advanceTimersByTime(2000);
+
+    expect(window.showCalls).toBe(1);
+  });
+});

--- a/packages/android-playground/src/platform.ts
+++ b/packages/android-playground/src/platform.ts
@@ -38,6 +38,22 @@ async function getAdbTargets(): Promise<PlaygroundSessionTarget[]> {
     }));
 }
 
+interface AdbTargetsResult {
+  targets: PlaygroundSessionTarget[];
+  error?: string;
+}
+
+async function getAdbTargetsSafe(): Promise<AdbTargetsResult> {
+  try {
+    return { targets: await getAdbTargets() };
+  } catch (error) {
+    return {
+      targets: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export const androidPlaygroundPlatform = definePlaygroundPlatform<
   AndroidPlatformOptions | undefined
 >({
@@ -68,13 +84,20 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
 
     const sessionManager: PlaygroundSessionManager = {
       async getSetupSchema() {
-        const targets = await getAdbTargets();
+        const { targets, error } = await getAdbTargetsSafe();
         return {
           title: 'Welcome to\nMidscene.js Playground!',
           description:
             'Select an available ADB device to create the current Android Agent',
           primaryActionLabel: 'Create Agent',
           autoSubmitWhenReady: targets.length === 1,
+          notice: error
+            ? {
+                type: 'warning',
+                message: 'Android device discovery failed',
+                description: error,
+              }
+            : undefined,
           fields: [
             {
               key: 'deviceId',
@@ -93,7 +116,7 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
           targets,
         };
       },
-      listTargets: getAdbTargets,
+      listTargets: async () => (await getAdbTargetsSafe()).targets,
       async createSession(input) {
         const targets = await getAdbTargets();
         const deviceId =

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -58,6 +58,21 @@ export interface ScrcpyConnectDeviceRequest {
   maxSize?: number;
 }
 
+export interface ScrcpyListedDevice {
+  id: string;
+  name: string;
+  status: string;
+}
+
+export interface ScrcpyDeviceListSource {
+  getDevices(): Promise<ScrcpyListedDevice[]>;
+  subscribe(listener: (devices: ScrcpyListedDevice[]) => void): () => void;
+}
+
+export interface ScrcpyServerOptions {
+  deviceListSource?: ScrcpyDeviceListSource;
+}
+
 export function resolveRequestedDeviceId(
   options: ScrcpyConnectDeviceRequest | undefined,
   currentDeviceId: string | null,
@@ -76,9 +91,12 @@ export default class ScrcpyServer {
   adbClient: AdbServerClient | null = null;
   currentDeviceId: string | null = null;
   devicePollInterval: NodeJS.Timeout | null = null;
+  private deviceListSource?: ScrcpyDeviceListSource;
+  private deviceListSourceUnsubscribe?: () => void;
   lastDeviceList = ''; // use for comparing changes
 
-  constructor() {
+  constructor(options: ScrcpyServerOptions = {}) {
+    this.deviceListSource = options.deviceListSource;
     this.app = express();
     this.httpServer = createServer(this.app);
     this.io = new Server(this.httpServer, {
@@ -124,6 +142,10 @@ export default class ScrcpyServer {
 
   // get devices list
   private async getDevicesList() {
+    if (this.deviceListSource) {
+      return this.deviceListSource.getDevices();
+    }
+
     try {
       debugPage('start to get devices list');
       const client = await this.getAdbClient();
@@ -162,6 +184,39 @@ export default class ScrcpyServer {
       console.error('failed to get devices list:', error);
       return [];
     }
+  }
+
+  private broadcastDevicesList(devices: ScrcpyListedDevice[]) {
+    const currentDevicesJson = JSON.stringify(devices);
+
+    if (this.lastDeviceList === currentDevicesJson) {
+      return;
+    }
+
+    debugPage('devices list changed, push to all connected clients');
+    this.lastDeviceList = currentDevicesJson;
+
+    if (
+      this.currentDeviceId &&
+      !devices.some((device) => device.id === this.currentDeviceId)
+    ) {
+      this.currentDeviceId = null;
+    }
+
+    if (!this.currentDeviceId && devices.length > 0) {
+      const onlineDevices = devices.filter(
+        (device) => device.status.toLowerCase() === 'device',
+      );
+      if (onlineDevices.length > 0) {
+        this.currentDeviceId = onlineDevices[0].id;
+        debugPage('auto select the first online device:', this.currentDeviceId);
+      }
+    }
+
+    this.io.emit('devices-list', {
+      devices,
+      currentDeviceId: this.currentDeviceId,
+    });
   }
 
   // get adb client
@@ -617,37 +672,28 @@ export default class ScrcpyServer {
 
   // start device monitoring
   private startDeviceMonitoring() {
+    if (this.deviceListSource) {
+      this.deviceListSourceUnsubscribe = this.deviceListSource.subscribe(
+        (devices) => {
+          this.broadcastDevicesList(devices);
+        },
+      );
+
+      void this.getDevicesList()
+        .then((devices) => {
+          this.broadcastDevicesList(devices);
+        })
+        .catch((error) => {
+          console.error('device monitoring error:', error);
+        });
+      return;
+    }
+
     // check devices list every 3 seconds
     this.devicePollInterval = setInterval(async () => {
       try {
         const devices = await this.getDevicesList();
-        const currentDevicesJson = JSON.stringify(devices);
-
-        // if devices list changed, push to all connected clients
-        if (this.lastDeviceList !== currentDevicesJson) {
-          debugPage('devices list changed, push to all connected clients');
-          this.lastDeviceList = currentDevicesJson;
-
-          // if there is no selected device and there are available devices, auto select the first device
-          if (!this.currentDeviceId && devices.length > 0) {
-            const onlineDevices = devices.filter(
-              (device) => device.status.toLowerCase() === 'device',
-            );
-            if (onlineDevices.length > 0) {
-              this.currentDeviceId = onlineDevices[0].id;
-              debugPage(
-                'auto select the first online device:',
-                this.currentDeviceId,
-              );
-            }
-          }
-
-          // push updated devices list to all connected clients
-          this.io.emit('devices-list', {
-            devices,
-            currentDeviceId: this.currentDeviceId,
-          });
-        }
+        this.broadcastDevicesList(devices);
       } catch (error) {
         console.error('device monitoring error:', error);
       }
@@ -661,8 +707,12 @@ export default class ScrcpyServer {
       clearInterval(this.devicePollInterval);
       this.devicePollInterval = null;
     }
+    if (this.deviceListSourceUnsubscribe) {
+      this.deviceListSourceUnsubscribe();
+      this.deviceListSourceUnsubscribe = undefined;
+    }
 
-    if (this.httpServer) {
+    if (this.httpServer?.listening) {
       return this.httpServer.close();
     }
   }

--- a/packages/android-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/android-playground/tests/unit/platform-session-manager.test.ts
@@ -76,7 +76,7 @@ describe('androidPlaygroundPlatform session manager', () => {
     expect(connectMock).toHaveBeenCalled();
   });
 
-  test('surfaces adb discovery failures instead of returning empty targets', async () => {
+  test('keeps the setup schema usable when adb discovery fails', async () => {
     getConnectedDevicesWithDetailsMock
       .mockRejectedValueOnce(new Error('adb executable not found'))
       .mockRejectedValueOnce(new Error('adb executable not found'));
@@ -84,10 +84,26 @@ describe('androidPlaygroundPlatform session manager', () => {
     const { androidPlaygroundPlatform } = await import('../../src/platform');
     const prepared = await androidPlaygroundPlatform.prepare();
 
-    await expect(prepared.sessionManager?.getSetupSchema()).rejects.toThrow(
-      'adb executable not found',
+    const setup = await prepared.sessionManager?.getSetupSchema();
+    expect(setup?.targets).toEqual([]);
+    expect(setup?.autoSubmitWhenReady).toBe(false);
+    expect(setup?.notice).toMatchObject({
+      type: 'warning',
+      description: expect.stringContaining('adb executable not found'),
+    });
+
+    await expect(prepared.sessionManager?.listTargets?.()).resolves.toEqual([]);
+  });
+
+  test('bubbles adb discovery failures out of createSession so the user sees the root cause', async () => {
+    getConnectedDevicesWithDetailsMock.mockRejectedValueOnce(
+      new Error('adb executable not found'),
     );
-    await expect(prepared.sessionManager?.listTargets?.()).rejects.toThrow(
+
+    const { androidPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await androidPlaygroundPlatform.prepare();
+
+    await expect(prepared.sessionManager?.createSession({})).rejects.toThrow(
       'adb executable not found',
     );
   });

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -35,9 +35,13 @@ vi.mock('@yume-chan/scrcpy', () => ({
   DefaultServerPath: '/mocked/scrcpy-server.jar',
 }));
 
-vi.mock('node:fs', () => ({
-  createReadStream: mockCreateReadStream,
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    createReadStream: mockCreateReadStream,
+  };
+});
 
 describe('ScrcpyServer', () => {
   it('prefers the explicit device from the preview handshake', () => {
@@ -85,5 +89,53 @@ describe('ScrcpyServer', () => {
       'pushing-server',
       'starting-service',
     ]);
+  });
+
+  it('can consume device list updates from an external discovery source', async () => {
+    const unsubscribe = vi.fn();
+    const getDevices = vi.fn().mockResolvedValue([
+      {
+        id: 'device-1',
+        name: 'Pixel 9',
+        status: 'device',
+      },
+    ]);
+    const subscribe = vi.fn((listener: (devices: any[]) => void) => {
+      listener([
+        {
+          id: 'device-2',
+          name: 'Pixel 10',
+          status: 'device',
+        },
+      ]);
+      return unsubscribe;
+    });
+
+    const server = new ScrcpyServer({
+      deviceListSource: {
+        getDevices,
+        subscribe,
+      },
+    });
+    const emitSpy = vi.spyOn(server.io, 'emit');
+
+    (server as any).startDeviceMonitoring();
+    await Promise.resolve();
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(getDevices).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith('devices-list', {
+      devices: [
+        {
+          id: 'device-2',
+          name: 'Pixel 10',
+          status: 'device',
+        },
+      ],
+      currentDeviceId: 'device-2',
+    });
+
+    server.close();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -2147,6 +2147,8 @@ const createPlatformActions = (
       description: 'Terminate (force-stop) an Android app by package name',
       interfaceAlias: 'terminate',
       paramSchema: terminateParamSchema,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async (param) => {
         if (!param.uri || param.uri.trim() === '') {
           throw new Error('Terminate requires a non-empty uri parameter');
@@ -2157,6 +2159,8 @@ const createPlatformActions = (
     AndroidBackButton: defineAction({
       name: 'AndroidBackButton',
       description: 'Trigger the system "back" operation on Android devices',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async () => {
         await device.back();
       },
@@ -2164,6 +2168,8 @@ const createPlatformActions = (
     AndroidHomeButton: defineAction({
       name: 'AndroidHomeButton',
       description: 'Trigger the system "home" operation on Android devices',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async () => {
         await device.home();
       },

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -253,6 +253,7 @@ export class TaskBuilder {
         });
 
         setTimingFieldOnce(timing, 'beforeInvokeActionHookStart');
+        const delayBeforeRunner = action.delayBeforeRunner ?? 200;
         try {
           await Promise.all([
             (async () => {
@@ -266,7 +267,9 @@ export class TaskBuilder {
                 );
               }
             })(),
-            sleep(200),
+            delayBeforeRunner > 0
+              ? sleep(delayBeforeRunner)
+              : Promise.resolve(),
           ]);
         } catch (originalError: any) {
           const originalMessage =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1004,6 +1004,7 @@ export interface DeviceAction<TParam = any, TReturn = any> {
   interfaceAlias?: string;
   paramSchema?: z.ZodType<TParam>;
   call: (param: TParam, context: ExecutorContext) => Promise<TReturn> | TReturn;
+  delayBeforeRunner?: number;
   delayAfterRunner?: number;
   /**
    * An example param object for this action.

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -3,7 +3,7 @@ import { getMidsceneLocationSchema } from '@/ai-model';
 import { AbstractInterface, defineActionSleep } from '@/device';
 import type Service from '@/insight';
 import type { DeviceAction, PlanningAction } from '@/types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 class MockInterface extends AbstractInterface {
@@ -27,6 +27,10 @@ class MockInterface extends AbstractInterface {
 }
 
 describe('TaskBuilder', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('dispatches plans using handler registry', async () => {
     const actionSchema = z.object({
       locate: getMidsceneLocationSchema().describe('element to locate'),
@@ -85,5 +89,96 @@ describe('TaskBuilder', () => {
       ['Planning', 'Locate'],
       ['Action Space', 'Tap'],
     ]);
+  });
+
+  it('supports fast-path action delays for system actions', async () => {
+    vi.useFakeTimers();
+
+    const defaultBeforeHook = vi.fn(async () => undefined);
+    const defaultAfterHook = vi.fn(async () => undefined);
+    const defaultActionCall = vi.fn(async () => undefined);
+    const defaultAction: DeviceAction = {
+      name: 'DefaultExit',
+      description: 'default exit action',
+      call: defaultActionCall,
+    };
+
+    const defaultInterface = new MockInterface([defaultAction]);
+    defaultInterface.beforeInvokeAction = defaultBeforeHook;
+    defaultInterface.afterInvokeAction = defaultAfterHook;
+
+    const fastBeforeHook = vi.fn(async () => undefined);
+    const fastAfterHook = vi.fn(async () => undefined);
+    const fastActionCall = vi.fn(async () => undefined);
+    const fastAction: DeviceAction = {
+      name: 'FastExit',
+      description: 'fast exit action',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+      call: fastActionCall,
+    };
+
+    const fastInterface = new MockInterface([fastAction]);
+    fastInterface.beforeInvokeAction = fastBeforeHook;
+    fastInterface.afterInvokeAction = fastAfterHook;
+
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate: vi.fn(),
+    } as unknown as Service;
+
+    const defaultTaskBuilder = new TaskBuilder({
+      interfaceInstance: defaultInterface,
+      service: insightService,
+      actionSpace: defaultInterface.actionSpace(),
+    });
+
+    const fastTaskBuilder = new TaskBuilder({
+      interfaceInstance: fastInterface,
+      service: insightService,
+      actionSpace: fastInterface.actionSpace(),
+    });
+
+    const { tasks: defaultTasks } = await defaultTaskBuilder.build(
+      [{ type: 'DefaultExit', thought: '', param: {} }],
+      {} as any,
+      {} as any,
+    );
+    const { tasks: fastTasks } = await fastTaskBuilder.build(
+      [{ type: 'FastExit', thought: '', param: {} }],
+      {} as any,
+      {} as any,
+    );
+
+    const defaultTask = defaultTasks[0];
+    const fastTask = fastTasks[0];
+    const taskContext = {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1 },
+    } as any;
+
+    const defaultPromise = defaultTask.executor(defaultTask.param, taskContext);
+
+    await vi.advanceTimersByTimeAsync(199);
+    expect(defaultBeforeHook).toHaveBeenCalledTimes(1);
+    expect(defaultActionCall).not.toHaveBeenCalled();
+    expect(defaultAfterHook).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(defaultActionCall).toHaveBeenCalledTimes(1);
+    expect(defaultAfterHook).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(299);
+    expect(defaultAfterHook).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(defaultPromise).resolves.toEqual({ output: undefined });
+    expect(defaultAfterHook).toHaveBeenCalledTimes(1);
+
+    const fastPromise = fastTask.executor(fastTask.param, taskContext);
+    await expect(fastPromise).resolves.toEqual({ output: undefined });
+    expect(fastBeforeHook).toHaveBeenCalledTimes(1);
+    expect(fastActionCall).toHaveBeenCalledTimes(1);
+    expect(fastAfterHook).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -843,6 +843,8 @@ const createPlatformActions = (
         'Terminate (force-stop) a HarmonyOS app by bundle name or mapped app name',
       interfaceAlias: 'terminate',
       paramSchema: terminateParamSchema,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async (param) => {
         if (!param.uri || param.uri.trim() === '') {
           throw new Error('Terminate requires a non-empty uri parameter');
@@ -853,6 +855,8 @@ const createPlatformActions = (
     HarmonyBackButton: defineAction({
       name: 'HarmonyBackButton',
       description: 'Trigger the system "back" operation on HarmonyOS devices',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async () => {
         await device.back();
       },
@@ -860,6 +864,8 @@ const createPlatformActions = (
     HarmonyHomeButton: defineAction({
       name: 'HarmonyHomeButton',
       description: 'Trigger the system "home" operation on HarmonyOS devices',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async () => {
         await device.home();
       },

--- a/packages/harmony/src/platform.ts
+++ b/packages/harmony/src/platform.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { select } from '@inquirer/prompts';
 import {
+  type PlaygroundSessionManager,
+  type PlaygroundSessionTarget,
   createScreenshotPreviewDescriptor,
   definePlaygroundPlatform,
 } from '@midscene/playground';
@@ -11,33 +13,66 @@ import { HarmonyDevice } from './device';
 import { getConnectedDevices } from './utils';
 
 export interface HarmonyPlatformOptions {
+  deferConnection?: boolean;
   deviceId?: string;
   staticDir?: string;
 }
 
+const HARMONY_NO_DEVICE_MESSAGE =
+  'No HarmonyOS devices found. Connect a device via USB, ensure HDC is configured, and run `hdc list targets` to verify.';
+
+function createNoDeviceError(): Error {
+  return new Error(HARMONY_NO_DEVICE_MESSAGE);
+}
+
+async function getHdcTargets(): Promise<PlaygroundSessionTarget[]> {
+  const devices = await getConnectedDevices();
+  return devices.map((device, index) => ({
+    id: device.deviceId,
+    label: device.deviceId,
+    isDefault: index === 0,
+    status: 'device',
+  }));
+}
+
+interface HdcTargetsResult {
+  targets: PlaygroundSessionTarget[];
+  error?: string;
+}
+
+async function getHdcTargetsSafe(): Promise<HdcTargetsResult> {
+  try {
+    const targets = await getHdcTargets();
+    return {
+      targets,
+      ...(targets.length === 0 ? { error: HARMONY_NO_DEVICE_MESSAGE } : {}),
+    };
+  } catch (error) {
+    return {
+      targets: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 async function selectDevice(): Promise<string> {
   console.log('🔍 Scanning for HarmonyOS devices...');
-  const devices = await getConnectedDevices();
+  const targets = await getHdcTargets();
 
-  if (devices.length === 0) {
-    console.error('❌ No HarmonyOS devices found!');
-    console.log('📱 Please ensure:');
-    console.log('  • Your device is connected via USB');
-    console.log('  • HDC is properly configured');
-    console.log('  • Run `hdc list targets` to verify');
-    process.exit(1);
+  if (targets.length === 0) {
+    throw createNoDeviceError();
   }
 
-  if (devices.length === 1) {
-    console.log(`📱 Found device: ${devices[0].deviceId}`);
-    return devices[0].deviceId;
+  if (targets.length === 1) {
+    console.log(`📱 Found device: ${targets[0].id}`);
+    return targets[0].id;
   }
 
   return select({
     message: '📱 Multiple devices found. Please select one:',
-    choices: devices.map((device) => ({
-      name: device.deviceId,
-      value: device.deviceId,
+    choices: targets.map((target) => ({
+      name: target.label,
+      value: target.id,
     })),
   });
 }
@@ -49,7 +84,6 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
   title: 'Midscene HarmonyOS Playground',
   description: 'HarmonyOS playground platform descriptor',
   async prepare(options) {
-    const selectedDeviceId = options?.deviceId || (await selectDevice());
     const staticDir =
       options?.staticDir || path.join(__dirname, '../../static');
     const availablePort = await findAvailablePort(PLAYGROUND_SERVER_PORT);
@@ -59,6 +93,135 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
         `⚠️  Port ${PLAYGROUND_SERVER_PORT} is busy, using port ${availablePort} instead`,
       );
     }
+
+    const createSessionManager = (): PlaygroundSessionManager => ({
+      async getSetupSchema() {
+        const explicitDeviceId = options?.deviceId;
+        const discovery = explicitDeviceId
+          ? {
+              targets: [
+                {
+                  id: explicitDeviceId,
+                  label: explicitDeviceId,
+                  isDefault: true,
+                  status: 'device',
+                },
+              ] satisfies PlaygroundSessionTarget[],
+            }
+          : await getHdcTargetsSafe();
+        const { error, targets } = discovery;
+
+        return {
+          title: 'Welcome to\nMidscene.js Playground!',
+          description:
+            'Select an available HDC device to create the current HarmonyOS Agent',
+          primaryActionLabel: 'Create Agent',
+          autoSubmitWhenReady: targets.length === 1,
+          notice: error
+            ? {
+                type: 'warning',
+                message: 'HarmonyOS device discovery failed',
+                description: error,
+              }
+            : undefined,
+          fields: [
+            {
+              key: 'deviceId',
+              label: 'HDC device',
+              type: 'select',
+              required: true,
+              options: targets.map((target) => ({
+                label: target.label,
+                value: target.id,
+                description: target.description,
+              })),
+              defaultValue: targets.find((target) => target.isDefault)?.id,
+              placeholder: 'Select a connected HarmonyOS device',
+            },
+          ],
+          targets,
+        };
+      },
+      async listTargets() {
+        if (options?.deviceId) {
+          return [
+            {
+              id: options.deviceId,
+              label: options.deviceId,
+              isDefault: true,
+              status: 'device',
+            },
+          ];
+        }
+
+        return (await getHdcTargetsSafe()).targets;
+      },
+      async createSession(input) {
+        const targets = options?.deviceId
+          ? [
+              {
+                id: options.deviceId,
+                label: options.deviceId,
+                isDefault: true,
+                status: 'device',
+              },
+            ]
+          : await getHdcTargets();
+        const deviceId =
+          options?.deviceId ||
+          (typeof input?.deviceId === 'string' && input.deviceId
+            ? input.deviceId
+            : targets.find((target) => target.isDefault)?.id);
+
+        if (!deviceId) {
+          throw createNoDeviceError();
+        }
+
+        const connectAgent = async () => {
+          const device = new HarmonyDevice(deviceId);
+          await device.connect();
+          return new HarmonyAgent(device);
+        };
+
+        const agent = await connectAgent();
+
+        return {
+          agent,
+          agentFactory: connectAgent,
+          preview: createScreenshotPreviewDescriptor({
+            title: 'HarmonyOS device preview',
+          }),
+          displayName: deviceId,
+          metadata: {
+            deviceId,
+          },
+        };
+      },
+    });
+
+    if (options?.deferConnection) {
+      return {
+        platformId: 'harmony',
+        title: 'Midscene HarmonyOS Playground',
+        sessionManager: createSessionManager(),
+        launchOptions: {
+          port: availablePort,
+          openBrowser: false,
+          verbose: false,
+          staticPath: staticDir,
+        },
+        preview: createScreenshotPreviewDescriptor({
+          title: 'HarmonyOS device preview',
+        }),
+        metadata: {
+          ...(options.deviceId ? { deviceId: options.deviceId } : {}),
+          sessionConnected: false,
+          setupState: 'required',
+        },
+      };
+    }
+
+    const selectedDeviceId = options?.deviceId || (await selectDevice());
 
     return {
       platformId: 'harmony',

--- a/packages/harmony/tests/unit-test/platform.test.ts
+++ b/packages/harmony/tests/unit-test/platform.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const connectMock = vi.fn();
+const getConnectedDevicesMock = vi.fn();
+const findAvailablePortMock = vi.fn(async () => 5810);
 
 vi.mock('@midscene/playground', () => ({
   createScreenshotPreviewDescriptor: (overrides = {}) => ({
@@ -10,13 +14,40 @@ vi.mock('@midscene/playground', () => ({
 }));
 
 vi.mock('@midscene/shared/node', () => ({
-  findAvailablePort: vi.fn().mockResolvedValue(5810),
+  findAvailablePort: findAvailablePortMock,
 }));
 
-import { harmonyPlaygroundPlatform } from '../../src/platform';
+vi.mock('../../src/agent', () => ({
+  HarmonyAgent: vi.fn().mockImplementation((device) => ({
+    device,
+    interface: {
+      interfaceType: 'harmony',
+      actionSpace: () => [],
+      describe: () => 'Mock Harmony device',
+    },
+  })),
+}));
+
+vi.mock('../../src/device', () => ({
+  HarmonyDevice: vi.fn().mockImplementation(() => ({
+    connect: connectMock,
+  })),
+}));
+
+vi.mock('../../src/utils', () => ({
+  getConnectedDevices: getConnectedDevicesMock,
+}));
 
 describe('harmonyPlaygroundPlatform', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConnectedDevicesMock.mockResolvedValue([{ deviceId: 'SERIAL123' }]);
+    connectMock.mockResolvedValue(undefined);
+    findAvailablePortMock.mockResolvedValue(5810);
+  });
+
   test('prepare returns typed launch options when a device id is provided', async () => {
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
     const prepared = await harmonyPlaygroundPlatform.prepare({
       deviceId: 'SERIAL123',
       staticDir: '/tmp/harmony-static',
@@ -26,6 +57,7 @@ describe('harmonyPlaygroundPlatform', () => {
     expect(prepared.metadata).toMatchObject({
       deviceId: 'SERIAL123',
     });
+    expect(prepared.sessionManager).toBeUndefined();
     expect(prepared.launchOptions).toMatchObject({
       port: 5810,
       staticPath: '/tmp/harmony-static',
@@ -35,5 +67,67 @@ describe('harmonyPlaygroundPlatform', () => {
     expect(prepared.preview).toMatchObject({
       kind: 'screenshot',
     });
+  });
+
+  test('deferred mode returns setup fields and creates a connected session', async () => {
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await harmonyPlaygroundPlatform.prepare({
+      staticDir: '/tmp/harmony-static',
+      deferConnection: true,
+    });
+    const setup = await prepared.sessionManager?.getSetupSchema();
+
+    expect(prepared.metadata).toMatchObject({
+      sessionConnected: false,
+      setupState: 'required',
+    });
+    expect(setup?.fields[0]).toMatchObject({
+      key: 'deviceId',
+      type: 'select',
+      defaultValue: 'SERIAL123',
+    });
+    expect(setup?.autoSubmitWhenReady).toBe(true);
+
+    const created = await prepared.sessionManager?.createSession({
+      deviceId: 'SERIAL123',
+    });
+
+    expect(created?.displayName).toBe('SERIAL123');
+    expect(created?.metadata).toMatchObject({
+      deviceId: 'SERIAL123',
+    });
+    expect(connectMock).toHaveBeenCalled();
+  });
+
+  test('keeps deferred setup usable when no HarmonyOS devices are connected', async () => {
+    getConnectedDevicesMock.mockResolvedValue([]);
+
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await harmonyPlaygroundPlatform.prepare({
+      deferConnection: true,
+    });
+
+    const setup = await prepared.sessionManager?.getSetupSchema();
+
+    expect(setup?.targets).toEqual([]);
+    expect(setup?.autoSubmitWhenReady).toBe(false);
+    expect(setup?.notice).toMatchObject({
+      type: 'warning',
+      description: expect.stringContaining('No HarmonyOS devices found'),
+    });
+    await expect(prepared.sessionManager?.listTargets?.()).resolves.toEqual([]);
+    await expect(prepared.sessionManager?.createSession({})).rejects.toThrow(
+      'No HarmonyOS devices found',
+    );
+  });
+
+  test('throws a normal error instead of exiting when direct mode has no devices', async () => {
+    getConnectedDevicesMock.mockResolvedValue([]);
+
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
+
+    await expect(harmonyPlaygroundPlatform.prepare()).rejects.toThrow(
+      'No HarmonyOS devices found',
+    );
   });
 });

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -1091,6 +1091,8 @@ const createPlatformActions = (device: IOSDevice) => {
       sample: {
         uri: 'com.apple.Preferences',
       },
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async (param) => {
         if (!param.uri || param.uri.trim() === '') {
           throw new Error('Terminate requires a non-empty uri parameter');
@@ -1101,6 +1103,8 @@ const createPlatformActions = (device: IOSDevice) => {
     IOSHomeButton: defineAction({
       name: 'IOSHomeButton',
       description: 'Trigger the system "home" operation on iOS devices',
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
       call: async () => {
         await device.home();
       },

--- a/packages/playground-app/src/PlaygroundPreview.tsx
+++ b/packages/playground-app/src/PlaygroundPreview.tsx
@@ -2,7 +2,8 @@ import type {
   PlaygroundRuntimeInfo,
   PlaygroundSDK,
 } from '@midscene/playground';
-import type { ReactNode } from 'react';
+import type { ScreenshotViewerMode } from '@midscene/visualizer';
+import type { CSSProperties, ReactNode } from 'react';
 import { PreviewRenderer } from './PreviewRenderer';
 import type { ScrcpyErrorOverlayRenderer } from './ScrcpyPanel';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
@@ -14,6 +15,8 @@ export interface PlaygroundPreviewProps {
     statusText: string,
   ) => void;
   renderErrorOverlay?: ScrcpyErrorOverlayRenderer;
+  scrcpyViewportStyle?: CSSProperties;
+  screenshotViewerMode?: ScreenshotViewerMode;
   playgroundSDK: PlaygroundSDK;
   runtimeInfo: PlaygroundRuntimeInfo | null;
   serverUrl: string;

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -2,10 +2,13 @@ import type {
   PlaygroundRuntimeInfo,
   PlaygroundSDK,
 } from '@midscene/playground';
-import { ScreenshotViewer } from '@midscene/visualizer';
+import {
+  ScreenshotViewer,
+  type ScreenshotViewerMode,
+} from '@midscene/visualizer';
 import { WebCodecsVideoDecoder } from '@yume-chan/scrcpy-decoder-webcodecs';
 import { Alert, Popover } from 'antd';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { type ScrcpyErrorOverlayRenderer, ScrcpyPanel } from './ScrcpyPanel';
 import { resolvePreviewConnectionInfo } from './runtime-info';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
@@ -17,6 +20,8 @@ interface PreviewRendererProps {
     statusText: string,
   ) => void;
   renderErrorOverlay?: ScrcpyErrorOverlayRenderer;
+  scrcpyViewportStyle?: CSSProperties;
+  screenshotViewerMode?: ScreenshotViewerMode;
   playgroundSDK: PlaygroundSDK;
   runtimeInfo: PlaygroundRuntimeInfo | null;
   serverUrl: string;
@@ -40,6 +45,8 @@ export function PreviewRenderer({
   connectingOverlay,
   onScrcpyStatusChange,
   renderErrorOverlay,
+  scrcpyViewportStyle,
+  screenshotViewerMode,
   playgroundSDK,
   runtimeInfo,
   serverUrl,
@@ -148,6 +155,7 @@ export function PreviewRenderer({
           onStatusChange={onScrcpyStatusChange}
           renderErrorOverlay={renderErrorOverlay}
           serverUrl={previewConnection.scrcpyUrl}
+          viewportStyle={scrcpyViewportStyle}
         />
       ) : (
         <ScreenshotViewer
@@ -160,6 +168,7 @@ export function PreviewRenderer({
           serverOnline={serverOnline}
           isUserOperating={isUserOperating}
           mjpegUrl={previewConnection.mjpegUrl}
+          mode={screenshotViewerMode}
         />
       )}
     </div>

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -11,6 +11,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from 'react';
 import type { Socket } from 'socket.io-client';
@@ -47,6 +48,7 @@ interface ScrcpyPanelProps {
   serverUrl?: string;
   metadataTimeoutMs?: number;
   reconnectInterval?: number;
+  viewportStyle?: CSSProperties;
 }
 
 interface VideoMetadata {
@@ -63,6 +65,7 @@ export function ScrcpyPanel({
   serverUrl,
   metadataTimeoutMs = SCRCPY_METADATA_TIMEOUT_MS,
   reconnectInterval = 3000,
+  viewportStyle,
 }: ScrcpyPanelProps) {
   const canvasStageRef = useRef<HTMLDivElement | null>(null);
   const socketRef = useRef<Socket | null>(null);
@@ -356,6 +359,7 @@ export function ScrcpyPanel({
           background: '#111827',
           borderRadius: 8,
           overflow: 'hidden',
+          ...viewportStyle,
         }}
       >
         <div

--- a/packages/playground-app/src/SessionSetupPanel.tsx
+++ b/packages/playground-app/src/SessionSetupPanel.tsx
@@ -173,6 +173,15 @@ export function SessionSetupPanel({
             className="session-setup-alert"
           />
         ) : null}
+        {sessionSetup?.notice ? (
+          <Alert
+            type={sessionSetup.notice.type}
+            showIcon
+            message={sessionSetup.notice.message}
+            description={sessionSetup.notice.description}
+            className="session-setup-alert"
+          />
+        ) : null}
 
         <Form
           form={form}

--- a/packages/playground-app/tests/scrcpy-panel.test.ts
+++ b/packages/playground-app/tests/scrcpy-panel.test.ts
@@ -19,4 +19,19 @@ describe('ScrcpyPanel', () => {
     expect(html).toContain('custom-connecting-overlay');
     expect(html).not.toContain('Connecting to scrcpy preview server');
   });
+
+  it('applies custom viewport styles when provided', () => {
+    const html = renderToStaticMarkup(
+      createElement(ScrcpyPanel, {
+        serverUrl: 'http://127.0.0.1:9234',
+        viewportStyle: {
+          background: 'transparent',
+          borderRadius: 0,
+        },
+      }),
+    );
+
+    expect(html).toContain('background:transparent');
+    expect(html).toContain('border-radius:0');
+  });
 });

--- a/packages/playground/src/multi-platform.ts
+++ b/packages/playground/src/multi-platform.ts
@@ -264,6 +264,7 @@ export async function prepareMultiPlatformPlayground(
           fieldKey: selectorFieldKey,
           variant: options.selectorVariant || 'cards',
         },
+        notice: childSetup?.notice,
       };
     },
     async createSession(input?: Record<string, unknown>) {

--- a/packages/playground/src/platform.ts
+++ b/packages/playground/src/platform.ts
@@ -64,6 +64,12 @@ export interface PlaygroundSessionField {
   description?: string;
 }
 
+export interface PlaygroundSessionNotice {
+  type: 'info' | 'warning' | 'error';
+  message: string;
+  description?: string;
+}
+
 export interface PlaygroundSessionSetup {
   title?: string;
   description?: string;
@@ -73,6 +79,7 @@ export interface PlaygroundSessionSetup {
   targets?: PlaygroundSessionTarget[];
   platformRegistry?: PlaygroundPlatformRegistration[];
   platformSelector?: PlaygroundPlatformSelectorConfig;
+  notice?: PlaygroundSessionNotice;
 }
 
 export interface PlaygroundExecutionHooks {

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -15,26 +15,15 @@ import { Dropdown, Spin, Switch, Tooltip, message } from 'antd';
 import GlobalPerspectiveIcon from '../../icons/global-perspective.svg';
 import PlayerSettingIcon from '../../icons/player-setting.svg';
 import { type PlaybackSpeedType, useGlobalPreference } from '../../store/store';
+import type { ReportDownloadHandler } from '../../types';
 import type { AnimationScript } from '../../utils/replay-scripts';
+import { triggerReportDownload } from './report-download';
 import { StepsTimeline } from './scenes/StepScene';
 import { exportBrandedVideo } from './scenes/export-branded-video';
 import { calculateFrameMap } from './scenes/frame-calculator';
 import type { FrameMap, ScriptFrame } from './scenes/frame-calculator';
 import { getPlaybackFrameState } from './scenes/playback-frame';
 import { useFramePlayer } from './use-frame-player';
-
-const downloadReport = (content: string): void => {
-  const blob = new Blob([content], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'midscene_report.html';
-  a.style.display = 'none';
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  setTimeout(() => URL.revokeObjectURL(url), 0);
-};
 
 function deriveTaskId(
   scriptFrames: ScriptFrame[],
@@ -70,6 +59,7 @@ export function Player(props?: {
   fitMode?: 'width' | 'height';
   autoZoom?: boolean;
   canDownloadReport?: boolean;
+  onDownloadReport?: ReportDownloadHandler;
   onTaskChange?: (taskId: string | null) => void;
 }) {
   const {
@@ -162,6 +152,23 @@ export function Player(props?: {
     if (!frameMap) return null;
     return getPlaybackFrameState(frameMap, player.currentFrame);
   }, [frameMap, player.currentFrame]);
+
+  const handleDownloadReport = useCallback(async () => {
+    if (!props?.reportFileContent) {
+      return;
+    }
+
+    try {
+      await triggerReportDownload({
+        content: props.reportFileContent,
+        onDownloadReport: props.onDownloadReport,
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      message.error(`Failed to download report: ${errorMessage}`);
+    }
+  }, [props?.onDownloadReport, props?.reportFileContent]);
 
   const subtitle = useMemo(() => {
     if (!currentFrameState) return null;
@@ -452,7 +459,9 @@ export function Player(props?: {
               <Tooltip title="Download Report">
                 <div
                   className="status-icon"
-                  onClick={() => downloadReport(props.reportFileContent!)}
+                  onClick={() => {
+                    void handleDownloadReport();
+                  }}
                 >
                   <DownloadOutlined />
                 </div>

--- a/packages/visualizer/src/component/player/report-download.ts
+++ b/packages/visualizer/src/component/player/report-download.ts
@@ -1,0 +1,91 @@
+import type { ReportDownloadHandler } from '../../types';
+
+export const DEFAULT_REPORT_FILE_NAME = 'midscene_report.html';
+
+interface AnchorLike {
+  href: string;
+  download: string;
+  style: {
+    display: string;
+  };
+  click: () => void;
+}
+
+interface DocumentLike {
+  body: {
+    appendChild: (node: AnchorLike) => void;
+    removeChild: (node: AnchorLike) => void;
+  };
+  createElement: (tagName: string) => AnchorLike;
+}
+
+interface UrlLike {
+  createObjectURL: (blob: Blob) => string;
+  revokeObjectURL: (url: string) => void;
+}
+
+interface TriggerReportDownloadOptions {
+  content: string;
+  defaultFileName?: string;
+  onDownloadReport?: ReportDownloadHandler;
+  documentRef?: DocumentLike;
+  urlRef?: UrlLike;
+  blobFactory?: (parts: BlobPart[], options: BlobPropertyBag) => Blob;
+  scheduleRevoke?: (callback: () => void) => void;
+}
+
+export async function triggerReportDownload(
+  options: TriggerReportDownloadOptions,
+): Promise<void> {
+  const {
+    content,
+    defaultFileName = DEFAULT_REPORT_FILE_NAME,
+    onDownloadReport,
+    documentRef,
+    urlRef,
+    blobFactory,
+    scheduleRevoke,
+  } = options;
+
+  if (onDownloadReport) {
+    await onDownloadReport({
+      content,
+      defaultFileName,
+    });
+    return;
+  }
+
+  const activeDocument = (documentRef ?? (globalThis.document as unknown)) as
+    | DocumentLike
+    | undefined;
+  if (!activeDocument) {
+    throw new Error('Report download requires a document context.');
+  }
+
+  const activeUrl = (urlRef ?? (globalThis.URL as unknown)) as
+    | UrlLike
+    | undefined;
+  if (!activeUrl?.createObjectURL || !activeUrl?.revokeObjectURL) {
+    throw new Error('Report download requires URL.createObjectURL support.');
+  }
+
+  const createBlob =
+    blobFactory ?? ((parts, blobOptions) => new Blob(parts, blobOptions));
+  const blob = createBlob([content], { type: 'text/html' });
+  const url = activeUrl.createObjectURL(blob);
+  const anchor = activeDocument.createElement('a');
+
+  anchor.href = url;
+  anchor.download = defaultFileName;
+  anchor.style.display = 'none';
+  activeDocument.body.appendChild(anchor);
+
+  try {
+    anchor.click();
+  } finally {
+    activeDocument.body.removeChild(anchor);
+    (scheduleRevoke ?? ((callback) => setTimeout(callback, 0)))(() => {
+      activeUrl.revokeObjectURL(url);
+    });
+  }
+}

--- a/packages/visualizer/src/component/playground-result/index.tsx
+++ b/packages/visualizer/src/component/playground-result/index.tsx
@@ -2,8 +2,11 @@ import { LoadingOutlined } from '@ant-design/icons';
 import { noReplayAPIs } from '@midscene/playground';
 import { Spin } from 'antd';
 import type React from 'react';
-import type { PlaygroundResult as PlaygroundResultType } from '../../types';
-import type { ServiceModeType } from '../../types';
+import type {
+  PlaygroundResult as PlaygroundResultType,
+  ReportDownloadHandler,
+  ServiceModeType,
+} from '../../types';
 import type { ReplayScriptsInfo } from '../../utils/replay-scripts';
 import { emptyResultTip, serverLaunchTip } from '../misc';
 import { Player } from '../player';
@@ -24,6 +27,7 @@ interface PlaygroundResultProps {
   autoZoom?: boolean;
   actionType?: string; // The action type that was executed
   canDownloadReport?: boolean;
+  onDownloadReport?: ReportDownloadHandler;
 }
 
 export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
@@ -40,6 +44,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
   autoZoom,
   actionType,
   canDownloadReport,
+  onDownloadReport,
 }) => {
   let resultWrapperClassName = 'result-wrapper';
   if (verticalMode) {
@@ -99,6 +104,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
                 canDownloadReport={
                   canDownloadReport ?? serviceMode !== 'In-Browser'
                 }
+                onDownloadReport={onDownloadReport}
               />
             </div>
           </div>
@@ -142,6 +148,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
               canDownloadReport={
                 canDownloadReport ?? serviceMode !== 'In-Browser'
               }
+              onDownloadReport={onDownloadReport}
             />
           </div>
         </div>
@@ -161,6 +168,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
         fitMode={fitMode}
         autoZoom={autoZoom}
         canDownloadReport={canDownloadReport ?? serviceMode !== 'In-Browser'}
+        onDownloadReport={onDownloadReport}
       />
     );
   } else if (
@@ -193,6 +201,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
               canDownloadReport={
                 canDownloadReport ?? serviceMode !== 'In-Browser'
               }
+              onDownloadReport={onDownloadReport}
             />
           </div>
         </div>
@@ -215,6 +224,7 @@ export const PlaygroundResultView: React.FC<PlaygroundResultProps> = ({
         fitMode={fitMode}
         autoZoom={autoZoom}
         canDownloadReport={canDownloadReport ?? serviceMode !== 'In-Browser'}
+        onDownloadReport={onDownloadReport}
       />
     );
   } else if (result?.result !== undefined) {

--- a/packages/visualizer/src/component/screenshot-viewer/index.less
+++ b/packages/visualizer/src/component/screenshot-viewer/index.less
@@ -4,6 +4,23 @@
   flex-direction: column;
   height: 100%;
 
+  &.screen-only {
+    min-height: 0;
+
+    > .screenshot-content {
+      flex: 1;
+      min-height: 0;
+
+      .screenshot-image {
+        width: 100%;
+        height: 100%;
+        max-width: none;
+        max-height: none;
+        border-radius: 0;
+      }
+    }
+  }
+
   &.offline,
   &.loading,
   &.error {

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -1,7 +1,9 @@
 import { InfoCircleOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Button, Spin, Tooltip } from 'antd';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './index.less';
+
+export type ScreenshotViewerMode = 'default' | 'screen-only';
 
 interface ScreenshotViewerProps {
   getScreenshot: () => Promise<{
@@ -15,6 +17,7 @@ interface ScreenshotViewerProps {
   serverOnline: boolean;
   isUserOperating?: boolean; // Whether user is currently operating
   mjpegUrl?: string; // When provided, use MJPEG live stream instead of polling
+  mode?: ScreenshotViewerMode;
 }
 
 export default function ScreenshotViewer({
@@ -23,6 +26,7 @@ export default function ScreenshotViewer({
   serverOnline,
   isUserOperating = false,
   mjpegUrl,
+  mode = 'default',
 }: ScreenshotViewerProps) {
   const [screenshot, setScreenshot] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -33,6 +37,13 @@ export default function ScreenshotViewer({
     description?: string;
   } | null>(null);
   const isMjpeg = Boolean(mjpegUrl && serverOnline);
+  const showChrome = mode !== 'screen-only';
+  const rootClassName = [
+    'screenshot-viewer',
+    mode === 'screen-only' && 'screen-only',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   // Refs for managing polling
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -193,7 +204,7 @@ export default function ScreenshotViewer({
 
   if (!serverOnline) {
     return (
-      <div className="screenshot-viewer offline">
+      <div className={`${rootClassName} offline`}>
         <div className="screenshot-placeholder">
           <h3>📱 Screen Preview</h3>
           <p>Start the playground server to see real-time screenshots</p>
@@ -204,7 +215,7 @@ export default function ScreenshotViewer({
 
   if (!isMjpeg && loading && !screenshot) {
     return (
-      <div className="screenshot-viewer loading">
+      <div className={`${rootClassName} loading`}>
         <Spin size="large" />
         <p>Loading screenshot...</p>
       </div>
@@ -213,7 +224,7 @@ export default function ScreenshotViewer({
 
   if (!isMjpeg && error && !screenshot) {
     return (
-      <div className="screenshot-viewer error">
+      <div className={`${rootClassName} error`}>
         <div className="screenshot-placeholder">
           <h3>📱 Screen Preview</h3>
           <p className="error-message">{error}</p>
@@ -232,8 +243,47 @@ export default function ScreenshotViewer({
     return new Date(timestamp).toLocaleTimeString();
   };
 
+  const screenshotContent = (
+    <div className="screenshot-content">
+      {isMjpeg ? (
+        <img
+          src={mjpegUrl}
+          alt="Device Live Stream"
+          className="screenshot-image"
+        />
+      ) : screenshot ? (
+        <img
+          src={
+            screenshot.startsWith('data:image/')
+              ? screenshot
+              : `data:image/png;base64,${screenshot}`
+          }
+          alt="Device Screenshot"
+          className="screenshot-image"
+          onLoad={() => console.log('Screenshot image loaded successfully')}
+          onError={(e) => {
+            console.error('Screenshot image load error:', e);
+            console.error(
+              'Screenshot data preview:',
+              screenshot.substring(0, 100),
+            );
+            setError('Failed to load screenshot image');
+          }}
+        />
+      ) : (
+        <div className="screenshot-placeholder">
+          <p>No screenshot available</p>
+        </div>
+      )}
+    </div>
+  );
+
+  if (!showChrome) {
+    return <div className={rootClassName}>{screenshotContent}</div>;
+  }
+
   return (
-    <div className="screenshot-viewer">
+    <div className={rootClassName}>
       <div className="screenshot-header">
         <div className="screenshot-title">
           <h3>{interfaceInfo?.type ? interfaceInfo.type : 'Device Name'}</h3>
@@ -270,38 +320,7 @@ export default function ScreenshotViewer({
             </div>
           )}
         </div>
-        <div className="screenshot-content">
-          {isMjpeg ? (
-            <img
-              src={mjpegUrl}
-              alt="Device Live Stream"
-              className="screenshot-image"
-            />
-          ) : screenshot ? (
-            <img
-              src={
-                screenshot.startsWith('data:image/')
-                  ? screenshot
-                  : `data:image/png;base64,${screenshot}`
-              }
-              alt="Device Screenshot"
-              className="screenshot-image"
-              onLoad={() => console.log('Screenshot image loaded successfully')}
-              onError={(e) => {
-                console.error('Screenshot image load error:', e);
-                console.error(
-                  'Screenshot data preview:',
-                  screenshot.substring(0, 100),
-                );
-                setError('Failed to load screenshot image');
-              }}
-            />
-          ) : (
-            <div className="screenshot-placeholder">
-              <p>No screenshot available</p>
-            </div>
-          )}
-        </div>
+        {screenshotContent}
       </div>
     </div>
   );

--- a/packages/visualizer/src/component/universal-playground/index.tsx
+++ b/packages/visualizer/src/component/universal-playground/index.tsx
@@ -441,6 +441,9 @@ export function UniversalPlayground({
                               verticalMode={item.verticalMode || false}
                               fitMode="width"
                               actionType={item.actionType}
+                              onDownloadReport={
+                                componentConfig.onDownloadReport
+                              }
                             />
                           ) : (
                             <>

--- a/packages/visualizer/src/index.tsx
+++ b/packages/visualizer/src/index.tsx
@@ -36,6 +36,7 @@ export { PromptInput } from './component/prompt-input';
 export { Player } from './component/player';
 export { Blackboard } from './component/blackboard';
 export { default as ScreenshotViewer } from './component/screenshot-viewer';
+export type { ScreenshotViewerMode } from './component/screenshot-viewer';
 
 // Export playground utilities
 export {
@@ -68,6 +69,8 @@ export type {
   ExecutionUxHint,
   ExecutionUxConfig,
   PromptInputChromeConfig,
+  ReportDownloadHandler,
+  ReportDownloadRequest,
 } from './types';
 
 // Export storage providers (both legacy and new)

--- a/packages/visualizer/src/types.ts
+++ b/packages/visualizer/src/types.ts
@@ -384,6 +384,15 @@ export interface InfoListItem {
   actionKind?: string;
 }
 
+export interface ReportDownloadRequest {
+  content: string;
+  defaultFileName: string;
+}
+
+export type ReportDownloadHandler = (
+  request: ReportDownloadRequest,
+) => void | Promise<void>;
+
 // main component config interface
 export interface UniversalPlaygroundConfig {
   showContextPreview?: boolean;
@@ -415,6 +424,11 @@ export interface UniversalPlaygroundConfig {
    * grouping, no connector) so existing hosts keep their behaviour.
    */
   executionFlow?: ExecutionFlowConfig;
+  /**
+   * Optional host-provided report download hook.
+   * Defaults to the browser Blob download flow when omitted.
+   */
+  onDownloadReport?: ReportDownloadHandler;
 }
 
 export interface ExecutionFlowConfig {

--- a/packages/visualizer/tests/report-download.test.ts
+++ b/packages/visualizer/tests/report-download.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_REPORT_FILE_NAME,
+  triggerReportDownload,
+} from '../src/component/player/report-download';
+
+describe('triggerReportDownload', () => {
+  it('delegates to the host-provided download handler when present', async () => {
+    const onDownloadReport = vi.fn().mockResolvedValue(undefined);
+
+    await triggerReportDownload({
+      content: '<html>report</html>',
+      onDownloadReport,
+    });
+
+    expect(onDownloadReport).toHaveBeenCalledWith({
+      content: '<html>report</html>',
+      defaultFileName: DEFAULT_REPORT_FILE_NAME,
+    });
+  });
+
+  it('falls back to browser blob download when no handler is provided', async () => {
+    const anchor = {
+      href: '',
+      download: '',
+      style: { display: '' },
+      click: vi.fn(),
+    };
+    const documentRef = {
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      createElement: vi.fn(() => anchor),
+    };
+    const urlRef = {
+      createObjectURL: vi.fn(() => 'blob:report'),
+      revokeObjectURL: vi.fn(),
+    };
+    const blobFactory = vi.fn(() => ({}) as Blob);
+
+    await triggerReportDownload({
+      content: '<html>blob-report</html>',
+      defaultFileName: 'custom-report.html',
+      documentRef,
+      urlRef,
+      blobFactory,
+      scheduleRevoke: (callback) => callback(),
+    });
+
+    expect(blobFactory).toHaveBeenCalledWith(['<html>blob-report</html>'], {
+      type: 'text/html',
+    });
+    expect(documentRef.createElement).toHaveBeenCalledWith('a');
+    expect(anchor.href).toBe('blob:report');
+    expect(anchor.download).toBe('custom-report.html');
+    expect(anchor.style.display).toBe('none');
+    expect(documentRef.body.appendChild).toHaveBeenCalledWith(anchor);
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+    expect(documentRef.body.removeChild).toHaveBeenCalledWith(anchor);
+    expect(urlRef.revokeObjectURL).toHaveBeenCalledWith('blob:report');
+  });
+});

--- a/packages/visualizer/tests/screenshot-viewer.test.ts
+++ b/packages/visualizer/tests/screenshot-viewer.test.ts
@@ -1,0 +1,35 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import ScreenshotViewer from '../src/component/screenshot-viewer';
+
+describe('ScreenshotViewer', () => {
+  it('renders a screen-only variant without viewer chrome', () => {
+    const html = renderToStaticMarkup(
+      createElement(ScreenshotViewer, {
+        getScreenshot: async () => null,
+        serverOnline: true,
+        mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+        mode: 'screen-only',
+      }),
+    );
+
+    expect(html).toContain('screenshot-viewer screen-only');
+    expect(html).toContain('screenshot-content');
+    expect(html).not.toContain('screenshot-header');
+    expect(html).not.toContain('device-name-overlay');
+  });
+
+  it('keeps the default viewer chrome when no mode override is provided', () => {
+    const html = renderToStaticMarkup(
+      createElement(ScreenshotViewer, {
+        getScreenshot: async () => null,
+        serverOnline: true,
+        mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+      }),
+    );
+
+    expect(html).toContain('screenshot-header');
+    expect(html).toContain('device-name-overlay');
+  });
+});


### PR DESCRIPTION
## Stack
- Stack B 2/2
- Base PR: #2400
- Merge after #2400 lands

## Summary
- lazy-load heavier Studio playground surfaces and refine the main mobile preview layout
- surface model env state and native report-download actions through the renderer and visualizer UI
- update playground-app, visualizer, and per-platform setup panels so the deferred startup flow from the base branch has a complete UX

## Why
This is the user-facing frontend half of PR #2376. It sits on top of the startup/discovery plumbing branch so reviewers can focus on renderer behavior and layout without re-reading Electron boot-path code.

## Impact
- Studio setup reaches a cleaner, faster first-render experience
- the mobile preview and screenshot viewer layout is more usable
- report downloads and environment-driven UI state are visible in the renderer and visualizer surfaces
- platform setup panels better reflect deferred and no-device states

## Validation
- `pnpm run lint`
- `pnpm --dir apps/studio exec vitest run tests/main-content-preview-layout.test.ts tests/model-env-storage.test.ts tests/report-download.test.ts tests/sidebar-device-list.test.ts`
- `node_modules/.pnpm/node_modules/.bin/vitest run packages/android-playground/tests/unit/platform-session-manager.test.ts packages/playground-app/tests/scrcpy-panel.test.ts packages/visualizer/tests/report-download.test.ts packages/visualizer/tests/screenshot-viewer.test.ts`
- `pnpm exec nx build studio --skip-nx-cache`
