### PR TITLE
fix(web-integration): preserve fractional deviceScaleFactor in puppeteer launcher

### DIFF
--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -208,8 +208,8 @@ export async function launchPuppeteerPage(
       typeof target.deviceScaleFactor === 'number',
       'deviceScaleFactor must be a number',
     );
-    dpr = Number.parseInt(target.deviceScaleFactor as unknown as string, 10);
-    assert(dpr >= 0, `deviceScaleFactor must be >= 0, but got ${dpr}`);
+    dpr = target.deviceScaleFactor;
+    assert(dpr > 0, `deviceScaleFactor must be > 0, but got ${dpr}`);
   }
   const viewportConfig = {
     width,

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -71,6 +71,28 @@ describe('launchPuppeteerPage', () => {
     );
   });
 
+  it('preserves fractional deviceScaleFactor without truncating to integer', async () => {
+    await launchPuppeteerPage({
+      url: 'https://example.com',
+      deviceScaleFactor: 1.5,
+    });
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultViewport: expect.objectContaining({ deviceScaleFactor: 1.5 }),
+      }),
+    );
+  });
+
+  it('rejects deviceScaleFactor=0', async () => {
+    await expect(
+      launchPuppeteerPage({
+        url: 'https://example.com',
+        deviceScaleFactor: 0,
+      }),
+    ).rejects.toThrow(/deviceScaleFactor must be > 0/);
+  });
+
   it('passes yaml waitForNetworkIdle settings to the agent for later actions', async () => {
     const { agent } = await puppeteerAgentForTarget({
       url: 'https://example.com',


### PR DESCRIPTION
## Summary

`launchPuppeteerPage` was passing `deviceScaleFactor` through `Number.parseInt(...)` immediately after asserting it was a number. The `parseInt` had no defensive purpose there (the value is already a `number`) and silently truncated valid fractional DPRs — `1.5` → `1`, `2.75` → `2` — before the value was forwarded to Puppeteer / CDP, both of which accept fractional `deviceScaleFactor`.

## Changes

- `packages/web-integration/src/puppeteer/agent-launcher.ts`
  - Drop `Number.parseInt(...)` on `deviceScaleFactor`; use the asserted `number` directly.
  - Tighten the bound from `>= 0` to `> 0`. `deviceScaleFactor: 0` is not a meaningful value — CDP treats `0` as "unset", which silently conflicts with the user explicitly passing it.
- `packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts`
  - Add a test asserting `deviceScaleFactor: 1.5` reaches `puppeteer.launch` unchanged.
  - Add a test asserting `deviceScaleFactor: 0` is rejected.

`viewportWidth` / `viewportHeight` still use `Number.parseInt` — they take a slightly different shape (string-from-YAML inputs) so I left them alone. Happy to follow up if you want a single consistent treatment.