### PR TITLE
fix(visualizer): respect focus on cursor setting in exported video

### DIFF
--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -262,8 +262,12 @@ export function Player(props?: {
     setIsExporting(true);
     setExportProgress(0);
     try {
-      await exportBrandedVideo(frameMap, (pct) =>
-        setExportProgress(Math.round(pct * 100)),
+      await exportBrandedVideo(
+        frameMap,
+        {
+          autoZoom,
+        },
+        (pct) => setExportProgress(Math.round(pct * 100)),
       );
       message.success('Video exported');
     } catch (e) {
@@ -273,7 +277,7 @@ export function Player(props?: {
       setIsExporting(false);
       setExportProgress(0);
     }
-  }, [frameMap, isExporting]);
+  }, [autoZoom, frameMap, isExporting]);
 
   // Compute chapter markers
   const chapterMarkers = useMemo(() => {

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -20,6 +20,27 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
 }
 
+export function resolveExportCamera(
+  prevCamera: { left: number; top: number; width: number },
+  camera: { left: number; top: number; width: number },
+  imageWidth: number,
+  progress: number,
+  autoZoom: boolean,
+) {
+  if (!autoZoom) {
+    return {
+      camLeft: 0,
+      camTop: 0,
+      camWidth: imageWidth,
+    };
+  }
+  return {
+    camLeft: lerp(prevCamera.left, camera.left, progress),
+    camTop: lerp(prevCamera.top, camera.top, progress),
+    camWidth: lerp(prevCamera.width, camera.width, progress),
+  };
+}
+
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -123,6 +144,7 @@ function drawSteps(
   imgCache: Map<string, HTMLImageElement>,
   cursorImg: HTMLImageElement | null,
   spinnerImg: HTMLImageElement | null,
+  autoZoom: boolean,
 ) {
   const { scriptFrames, imageWidth: baseW, imageHeight: baseH, fps } = frameMap;
   const st = deriveFrameState(scriptFrames, stepsFrame, baseW, baseH, fps);
@@ -153,9 +175,11 @@ function drawSteps(
       : Math.min((rawProgress - POINTER_PHASE) / (1 - POINTER_PHASE), 1)
     : rawProgress;
 
-  const camL = lerp(prevCamera.left, camera.left, cT);
-  const camT2 = lerp(prevCamera.top, camera.top, cT);
-  const camW = lerp(prevCamera.width, camera.width, cT);
+  const {
+    camLeft: camL,
+    camTop: camT2,
+    camWidth: camW,
+  } = resolveExportCamera(prevCamera, camera, imgW, cT, autoZoom);
   const ptrX = lerp(prevCamera.pointerLeft, camera.pointerLeft, pT);
   const ptrY = lerp(prevCamera.pointerTop, camera.pointerTop, pT);
 
@@ -222,9 +246,13 @@ function drawSteps(
 
 export async function exportBrandedVideo(
   frameMap: FrameMap,
+  options?: {
+    autoZoom?: boolean;
+  },
   onProgress?: (pct: number) => void,
 ): Promise<void> {
   const { totalDurationInFrames: total, fps } = frameMap;
+  const autoZoom = options?.autoZoom ?? true;
 
   // 1. pre-load all images
   const imgSrcs = new Set<string>();
@@ -302,7 +330,15 @@ export async function exportBrandedVideo(
       if (targetFrame > lastFrame) {
         lastFrame = targetFrame;
         ctx.clearRect(0, 0, W, H);
-        drawSteps(ctx, targetFrame, frameMap, imgCache, cursorImg, spinnerImg);
+        drawSteps(
+          ctx,
+          targetFrame,
+          frameMap,
+          imgCache,
+          cursorImg,
+          spinnerImg,
+          autoZoom,
+        );
         onProgress?.((targetFrame + 1) / total);
       }
 

--- a/packages/visualizer/tests/playback-composition.test.ts
+++ b/packages/visualizer/tests/playback-composition.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { resolveExportCamera } from '../src/component/player/scenes/export-branded-video';
 import { calculateFrameMap } from '../src/component/player/scenes/frame-calculator';
 import { getPlaybackFrameState } from '../src/component/player/scenes/playback-frame';
 import { getPlaybackViewport } from '../src/component/player/scenes/playback-layout';
@@ -65,5 +66,27 @@ describe('playback composition sizing', () => {
     expect(viewport.contentWidth).toBeCloseTo(303.75, 5);
     expect(viewport.offsetX).toBeCloseTo(328.125, 5);
     expect(viewport.offsetY).toBe(0);
+  });
+
+  it('disables camera zoom for export when focus on cursor is off', () => {
+    const prevCamera = { left: 120, top: 80, width: 640 };
+    const camera = { left: 320, top: 200, width: 360 };
+    const progress = 0.5;
+
+    expect(
+      resolveExportCamera(prevCamera, camera, 1280, progress, false),
+    ).toEqual({
+      camLeft: 0,
+      camTop: 0,
+      camWidth: 1280,
+    });
+
+    expect(
+      resolveExportCamera(prevCamera, camera, 1280, progress, true),
+    ).toEqual({
+      camLeft: 220,
+      camTop: 140,
+      camWidth: 500,
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Exports always used the camera zoom/pan behavior even when the visualizer's "Focus on cursor" (`autoZoom`) toggle was off, producing exported video that did not match what the user sees during playback.

### Description
- Pass the current `autoZoom` preference from `Player` into the export path by calling `exportBrandedVideo(frameMap, { autoZoom }, ...)` in `packages/visualizer/src/component/player/index.tsx`.
- Add an `options` parameter to `exportBrandedVideo` and thread `autoZoom` through the export renderer in `packages/visualizer/src/component/player/scenes/export-branded-video.ts` so export respects the toggle.
- Introduce `resolveExportCamera(...)` to centralize camera decision logic and disable camera zoom/pan (use full-frame) when `autoZoom` is false; update `drawSteps` to accept `autoZoom` and use `resolveExportCamera`.
- Add a unit test in `packages/visualizer/tests/playback-composition.test.ts` to verify camera resolution for both `autoZoom: false` and `autoZoom: true`.
- Modified files: `packages/visualizer/src/component/player/index.tsx`, `packages/visualizer/src/component/player/scenes/export-branded-video.ts`, and `packages/visualizer/tests/playback-composition.test.ts`.

### Testing
- Ran unit tests for the visualizer with `npx nx test @midscene/visualizer`, and all tests passed (`54 passed`).
- Ran `pnpm run lint`; the linter failed in this environment due to large files under `./.pnpm-store` exceeding Biome's `files.maxSize` limit, which is unrelated to the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef065eb4d88324898be036677c7d20)