### PR TITLE
docs(site): clarify splitReportFile output in consume-report-file docs

### DIFF
--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -81,6 +81,13 @@ const markdownResult = await reportFileToMarkdown({
 console.log(markdownResult.markdownFiles);
 ```
 
+`splitReportFile` and `reportFileToMarkdown` serve different outputs:
+
+- `splitReportFile` generates JSON files for the original structured objects (one `*.execution.json` per execution). The JSON keeps the raw `ReportActionDump`-style data and exports screenshots alongside it. The returned `executionJsonFiles` and `screenshotFiles` are lists of generated file paths.
+- `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
+
+Use `splitReportFile` when you want the most complete, programmatic raw data. Use `reportFileToMarkdown` when you want readable content for summarization or downstream content generation.
+
 ## About Fields In JSON And Markdown
 
 The parsed JSON and Markdown structures may change as Midscene evolves. Use the actual conversion result as the source of truth.

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -81,6 +81,13 @@ const markdownResult = await reportFileToMarkdown({
 console.log(markdownResult.markdownFiles);
 ```
 
+`splitReportFile` 和 `reportFileToMarkdown` 的用途不同：
+
+- `splitReportFile` 会产出“原始对象”对应的 JSON 文件（每个 execution 一个 `*.execution.json`），内容是 `ReportActionDump` 的原始结构化数据，同时会导出截图文件。返回值中的 `executionJsonFiles` 和 `screenshotFiles` 都是生成后的文件路径列表。
+- `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
+
+如果你想保留最完整、可编程处理的数据，优先使用 `splitReportFile`；如果你想直接阅读、总结，或用于二次生成（例如生成视频脚本），优先使用 `reportFileToMarkdown`。
+
 ## 关于 JSON 和 Markdown 的内容字段
 
 解析得到的 JSON 和 Markdown 数据结构可能会随着 Midscene 版本演进而变化，请以实际转换结果为准。


### PR DESCRIPTION
### Motivation
- Clarify the difference between `splitReportFile` and `reportFileToMarkdown` in the consume-report-file documentation so readers understand that `splitReportFile` produces raw `ReportActionDump`-style JSON per execution plus exported screenshots while `reportFileToMarkdown` produces human-readable Markdown and its referenced screenshots.

### Description
- Updated both English and Chinese `apps/site/docs/*/consume-report-file.md` to add an explicit explanation of the distinct outputs (`*.execution.json` + screenshots vs Markdown + screenshots) and recommend when to use each function.

### Testing
- Ran `pnpm run lint` (failed in this environment due to `biome` scanning large files under `./.pnpm-store` and hitting the configured `files.maxSize`), and ran `npx biome check apps/site/docs/en/consume-report-file.md apps/site/docs/zh/consume-report-file.md --diagnostic-level=info --no-errors-on-unmatched` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef216c854883249b3e60eb5fed0dfb)