### PR TITLE
feat(workflow): sign Studio mac release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,18 @@ jobs:
       COLUMNS: '120'
       TERM: dumb
       FORCE_COLOR: '0'
+      MIDSCENE_REQUIRE_MAC_CODESIGN: ${{ needs.release.outputs.is_prerelease != 'true' }}
+      MIDSCENE_REQUIRE_MAC_NOTARIZATION: ${{ needs.release.outputs.is_prerelease != 'true' }}
       NO_COLOR: '1'
     steps:
     - uses: actions/checkout@v2
+      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
       with:
         ref: refs/tags/${{ needs.release.outputs.version }}
+    - uses: actions/checkout@v2
+      if: ${{ needs.release.outputs.is_prerelease == 'true' }}
+      with:
+        ref: ${{ github.event.inputs.branch }}
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
@@ -191,6 +198,51 @@ jobs:
       with:
         node-version: '22.11.0'
         cache: 'pnpm'
+
+    - name: Prepare macOS codesigning keychain
+      if: ${{ matrix.platform == 'darwin' && secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_CODESIGN_IDENTITY != '' }}
+      env:
+        APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+        APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
+        KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
+        KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+
+        printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
+
+        echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
+        echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+        if [ -n "${APPLE_TEAM_ID:-}" ]; then
+          echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
+        fi
+
+    - name: Prepare macOS notarization credentials
+      if: ${{ matrix.platform == 'darwin' && secrets.APPLE_API_KEY_P8_BASE64 != '' && secrets.APPLE_API_KEY_ID != '' }}
+      env:
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+      run: |
+        API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+        printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$API_KEY_PATH"
+
+        echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
+        echo "APPLE_API_KEY_PATH=$API_KEY_PATH" >> "$GITHUB_ENV"
+        if [ -n "${APPLE_API_ISSUER_ID:-}" ]; then
+          echo "APPLE_API_ISSUER_ID=$APPLE_API_ISSUER_ID" >> "$GITHUB_ENV"
+        fi
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,13 +200,17 @@ jobs:
         cache: 'pnpm'
 
     - name: Prepare macOS codesigning keychain
-      if: ${{ matrix.platform == 'darwin' && secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_CODESIGN_IDENTITY != '' }}
+      if: ${{ matrix.platform == 'darwin' }}
       env:
         APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
         APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
+        : "${APPLE_CERT_P12_BASE64:?APPLE_CERT_P12_BASE64 is required for macOS release packaging}"
+        : "${APPLE_CERT_PASSWORD:?APPLE_CERT_PASSWORD is required for macOS release packaging}"
+        : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS release packaging}"
+
         CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
         KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
         KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
@@ -229,12 +233,15 @@ jobs:
         fi
 
     - name: Prepare macOS notarization credentials
-      if: ${{ matrix.platform == 'darwin' && secrets.APPLE_API_KEY_P8_BASE64 != '' && secrets.APPLE_API_KEY_ID != '' }}
+      if: ${{ matrix.platform == 'darwin' }}
       env:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
         APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
       run: |
+        : "${APPLE_API_KEY_P8_BASE64:?APPLE_API_KEY_P8_BASE64 is required for macOS release packaging}"
+        : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required for macOS release packaging}"
+
         API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
         printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$API_KEY_PATH"
 

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -1,0 +1,112 @@
+name: Studio Package Validation
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to package'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  package_studio:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+          - os: windows-latest
+            platform: win32
+            arch: x64
+          - os: macos-15
+            platform: darwin
+            arch: arm64
+    env:
+      COLUMNS: '120'
+      TERM: dumb
+      FORCE_COLOR: '0'
+      MIDSCENE_REQUIRE_MAC_CODESIGN: ${{ matrix.platform == 'darwin' }}
+      MIDSCENE_REQUIRE_MAC_NOTARIZATION: ${{ matrix.platform == 'darwin' }}
+      NO_COLOR: '1'
+      STUDIO_PACKAGE_VALIDATION_VERSION: v0.0.0-validation.${{ github.run_number }}.${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0'
+          cache: 'pnpm'
+
+      - name: Prepare macOS codesigning keychain
+        if: ${{ matrix.platform == 'darwin' && secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_CODESIGN_IDENTITY != '' }}
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+
+          printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
+
+          echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
+          echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          if [ -n "${APPLE_TEAM_ID:-}" ]; then
+            echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
+          fi
+
+      - name: Prepare macOS notarization credentials
+        if: ${{ matrix.platform == 'darwin' && secrets.APPLE_API_KEY_P8_BASE64 != '' && secrets.APPLE_API_KEY_ID != '' }}
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$API_KEY_PATH"
+
+          echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY_PATH=$API_KEY_PATH" >> "$GITHUB_ENV"
+          if [ -n "${APPLE_API_ISSUER_ID:-}" ]; then
+            echo "APPLE_API_ISSUER_ID=$APPLE_API_ISSUER_ID" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build Studio and Nx dependencies
+        run: npx nx build studio
+
+      - name: Package Midscene Studio
+        run: pnpm --dir apps/studio run package:release -- --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --version=${{ env.STUDIO_PACKAGE_VALIDATION_VERSION }}
+
+      - name: Upload packaged Studio artifact
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: studio_validation_${{ matrix.platform }}_${{ matrix.arch }}
+          path: ${{ github.workspace }}/.release/studio/artifacts/*.zip

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -33,7 +33,7 @@ jobs:
       MIDSCENE_REQUIRE_MAC_CODESIGN: ${{ matrix.platform == 'darwin' }}
       MIDSCENE_REQUIRE_MAC_NOTARIZATION: ${{ matrix.platform == 'darwin' }}
       NO_COLOR: '1'
-      STUDIO_PACKAGE_VALIDATION_VERSION: v0.0.0-validation.${{ github.run_number }}.${{ github.run_attempt }}
+      STUDIO_PACKAGE_VALIDATION_VERSION: v0.0.${{ github.run_number }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -51,13 +51,17 @@ jobs:
           cache: 'pnpm'
 
       - name: Prepare macOS codesigning keychain
-        if: ${{ matrix.platform == 'darwin' && secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_CODESIGN_IDENTITY != '' }}
+        if: ${{ matrix.platform == 'darwin' }}
         env:
           APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
           APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          : "${APPLE_CERT_P12_BASE64:?APPLE_CERT_P12_BASE64 is required for macOS validation packaging}"
+          : "${APPLE_CERT_PASSWORD:?APPLE_CERT_PASSWORD is required for macOS validation packaging}"
+          : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS validation packaging}"
+
           CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
@@ -80,12 +84,15 @@ jobs:
           fi
 
       - name: Prepare macOS notarization credentials
-        if: ${{ matrix.platform == 'darwin' && secrets.APPLE_API_KEY_P8_BASE64 != '' && secrets.APPLE_API_KEY_ID != '' }}
+        if: ${{ matrix.platform == 'darwin' }}
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
+          : "${APPLE_API_KEY_P8_BASE64:?APPLE_API_KEY_P8_BASE64 is required for macOS validation packaging}"
+          : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required for macOS validation packaging}"
+
           API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
           printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$API_KEY_PATH"
 

--- a/apps/studio/build/entitlements.mac.gpu.plist
+++ b/apps/studio/build/entitlements.mac.gpu.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/studio/build/entitlements.mac.plist
+++ b/apps/studio/build/entitlements.mac.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.print</key>
+    <true/>
+    <key>com.apple.security.device.usb</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/studio/build/entitlements.mac.plugin.plist
+++ b/apps/studio/build/entitlements.mac.plugin.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/studio/build/entitlements.mac.renderer.plist
+++ b/apps/studio/build/entitlements.mac.renderer.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -28,6 +28,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@electron/notarize": "3.1.1",
     "@electron/packager": "19.1.0",
     "@rsbuild/core": "^1.6.15",
     "@rsbuild/plugin-less": "^1.5.0",

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
+import { notarize } from '@electron/notarize';
 import { packager } from '@electron/packager';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -82,6 +83,8 @@ const staticWorkspacePackageSourceConfigs = [
 }));
 
 const supportedPlatforms = new Set(['darwin', 'linux', 'win32']);
+const truthyBooleanTokens = new Set(['1', 'true', 'yes', 'on']);
+const falsyBooleanTokens = new Set(['0', 'false', 'no', 'off']);
 
 export const shouldUseShellForCommand = (
   command,
@@ -111,6 +114,154 @@ const run = (command, args, { cwd = workspaceRootDir, env } = {}) =>
       );
     });
   });
+
+const resolveConfiguredString = (values) => {
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
+};
+
+export const parseBooleanLike = (value, defaultValue = false) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return defaultValue;
+  }
+
+  if (truthyBooleanTokens.has(normalized)) {
+    return true;
+  }
+
+  if (falsyBooleanTokens.has(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Expected a boolean-like value, but received "${value}".`);
+};
+
+export const resolveMacPackagedAppSecurity = ({
+  cliOptions = {},
+  env = process.env,
+  platform = process.platform,
+} = {}) => {
+  const requireCodesign = parseBooleanLike(
+    cliOptions.requireMacCodesign ?? env.MIDSCENE_REQUIRE_MAC_CODESIGN,
+    false,
+  );
+  const requireNotarization = parseBooleanLike(
+    cliOptions.requireMacNotarization ?? env.MIDSCENE_REQUIRE_MAC_NOTARIZATION,
+    false,
+  );
+
+  if (platform !== 'darwin') {
+    return {
+      notarizeOptions: undefined,
+      requireCodesign,
+      requireNotarization,
+      shouldDeveloperIdSign: false,
+      shouldNotarize: false,
+      signIdentity: undefined,
+      signKeychain: undefined,
+      teamId: undefined,
+    };
+  }
+
+  const signIdentity = resolveConfiguredString([
+    cliOptions.macSignIdentity,
+    env.APPLE_CODESIGN_IDENTITY,
+  ]);
+  const signKeychain = resolveConfiguredString([
+    cliOptions.macSignKeychain,
+    env.APPLE_CODESIGN_KEYCHAIN,
+  ]);
+  const teamId = resolveConfiguredString([
+    cliOptions.macTeamId,
+    env.APPLE_TEAM_ID,
+  ]);
+  const appleApiKey = resolveConfiguredString([
+    cliOptions.macNotarizeApiKey,
+    env.APPLE_API_KEY_PATH,
+  ]);
+  const appleApiKeyId = resolveConfiguredString([
+    cliOptions.macNotarizeApiKeyId,
+    env.APPLE_API_KEY_ID,
+  ]);
+  const appleApiIssuer = resolveConfiguredString([
+    cliOptions.macNotarizeApiIssuer,
+    env.APPLE_API_ISSUER_ID,
+  ]);
+  const shouldDeveloperIdSign = Boolean(signIdentity);
+  const notarizeOptions =
+    appleApiKey && appleApiKeyId
+      ? {
+          appleApiKey,
+          appleApiKeyId,
+          ...(appleApiIssuer ? { appleApiIssuer } : {}),
+        }
+      : undefined;
+  const shouldNotarize = requireNotarization && Boolean(notarizeOptions);
+
+  if (requireCodesign && !shouldDeveloperIdSign) {
+    throw new Error(
+      [
+        'macOS release packaging requires a Developer ID signing identity.',
+        'Set APPLE_CODESIGN_IDENTITY or pass --mac-sign-identity=<identity>.',
+      ].join(' '),
+    );
+  }
+
+  if (teamId && signIdentity && !signIdentity.includes(`(${teamId})`)) {
+    throw new Error(
+      `Developer ID identity "${signIdentity}" does not match APPLE_TEAM_ID "${teamId}".`,
+    );
+  }
+
+  if (requireNotarization && !shouldDeveloperIdSign) {
+    throw new Error(
+      [
+        'macOS notarization requires a Developer ID signing identity.',
+        'Set APPLE_CODESIGN_IDENTITY or pass --mac-sign-identity=<identity>.',
+      ].join(' '),
+    );
+  }
+
+  if (requireNotarization && !notarizeOptions) {
+    throw new Error(
+      [
+        'macOS notarization is required, but notarization credentials are missing.',
+        'Set APPLE_API_KEY_PATH and APPLE_API_KEY_ID',
+        '(plus APPLE_API_ISSUER_ID for App Store Connect team keys).',
+      ].join(' '),
+    );
+  }
+
+  return {
+    notarizeOptions,
+    requireCodesign,
+    requireNotarization,
+    shouldDeveloperIdSign,
+    shouldNotarize,
+    signIdentity,
+    signKeychain,
+    teamId,
+  };
+};
 
 export const normalizeReleaseVersion = (version) => {
   const trimmed = version?.trim();
@@ -455,101 +606,39 @@ export const getBuildStatus = async ({ packageDir, sourceTargets }) => {
   };
 };
 
-const captureCommandOutput = (
-  command,
-  args,
-  { platform = process.platform } = {},
-) =>
-  new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      shell: shouldUseShellForCommand(command, platform),
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on('close', (code) => {
-      resolve({ code: code ?? 0, stderr, stdout });
-    });
-    child.on('error', reject);
-  });
-
-export const getLiveDevBuilderProcessQueries = (
-  platform = process.platform,
-) => {
-  if (platform === 'win32') {
-    const command =
-      '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; ' +
-      'Get-CimInstance Win32_Process | ' +
-      "Where-Object { $_.CommandLine -match 'rsbuild(?:\\\\.cmd)?\\\\s+dev' } | " +
-      "ForEach-Object { '{0} {1}' -f $_.ProcessId, $_.CommandLine }";
-    return [
-      {
-        command: 'powershell',
-        args: ['-NoProfile', '-Command', command],
-      },
-      {
-        command: 'pwsh',
-        args: ['-NoProfile', '-Command', command],
-      },
-    ];
-  }
-
-  return [
-    {
-      command: 'pgrep',
-      args: ['-af', 'rsbuild dev'],
-    },
-  ];
-};
-
-export const parseLiveDevBuilderProcessMatches = (stdout) =>
-  stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-export const findLiveDevBuilderProcesses = async ({
-  platform = process.platform,
-  runCapture = captureCommandOutput,
-} = {}) => {
-  const queries = getLiveDevBuilderProcessQueries(platform);
-
-  for (const query of queries) {
-    try {
-      const result = await runCapture(query.command, query.args, { platform });
-      if (platform !== 'win32' && result.code === 1) {
-        return [];
-      }
-      return parseLiveDevBuilderProcessMatches(result.stdout);
-    } catch (error) {
-      if (error?.code === 'ENOENT') {
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  return [];
-};
-
 const assertNoLiveDevBuilders = async () => {
-  const matches = await findLiveDevBuilderProcesses();
-  if (matches.length > 0) {
-    throw new Error(
-      [
-        'Detected live `rsbuild dev` processes while packaging:',
-        ...matches.map((line) => `  ${line}`),
-        'A concurrent dev server keeps overwriting `apps/studio/dist/` with',
-        'a development-mode renderer whose absolute asset URLs break under',
-        '`file://`. Stop `pnpm dev` first, then rerun `pnpm package:release`.',
-      ].join('\n'),
-    );
+  try {
+    const { stdout } = await new Promise((resolve, reject) => {
+      const child = spawn('pgrep', ['-af', 'rsbuild dev'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let buffer = '';
+      child.stdout.on('data', (chunk) => {
+        buffer += chunk.toString();
+      });
+      child.on('close', () => resolve({ stdout: buffer }));
+      child.on('error', reject);
+    });
+    const matches = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (matches.length > 0) {
+      throw new Error(
+        [
+          'Detected live `rsbuild dev` processes while packaging:',
+          ...matches.map((line) => `  ${line}`),
+          'A concurrent dev server keeps overwriting `apps/studio/dist/` with',
+          'a development-mode renderer whose absolute asset URLs break under',
+          '`file://`. Stop `pnpm dev` first, then rerun `pnpm package:release`.',
+        ].join('\n'),
+      );
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return;
+    }
+    throw error;
   }
 };
 
@@ -833,6 +922,13 @@ export const dropAntdEsmBuild = async (nodeModulesDir) => {
   await removeIfExists(esDir);
 };
 
+// gifwrap ships PNG fixtures under test/ that are never used at runtime.
+// Leaving them in the app bundle makes Developer ID signing attempt to
+// timestamp-sign those images as nested resources, which fails.
+export const pruneGifwrapTestFixtures = async (nodeModulesDir) => {
+  await removeIfExists(path.join(nodeModulesDir, 'gifwrap', 'test'));
+};
+
 // Hardlink every file from `sourceDir` into `destDir`, recreating
 // subdirectories. Same filesystem required — safe inside a single
 // node_modules tree.
@@ -898,6 +994,7 @@ export const slimStageNodeModules = async (nodeModulesDir) => {
   await pruneAntdUmdBundles(nodeModulesDir);
   await dropMidsceneEsmBuilds(nodeModulesDir);
   await dropAntdEsmBuild(nodeModulesDir);
+  await pruneGifwrapTestFixtures(nodeModulesDir);
 };
 
 const vendorWorkspacePackages = async ({ workspacePackages, vendorDir }) => {
@@ -1083,6 +1180,48 @@ const buildPackagedAppPayloadCandidates = async (packagedAppPath) => {
   }
 
   return [...new Set(candidates)];
+};
+
+export const resolveMacPackagedAppBundlePath = async (packagedAppPath) => {
+  if (packagedAppPath.endsWith('.app')) {
+    return packagedAppPath;
+  }
+
+  let packagedOutputStats;
+  try {
+    packagedOutputStats = await fs.stat(packagedAppPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        `Packaged macOS output does not exist: ${packagedAppPath}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!packagedOutputStats.isDirectory()) {
+    throw new Error(
+      `Expected a packaged macOS output directory, received ${packagedAppPath}.`,
+    );
+  }
+
+  const packagedOutputEntries = await fs.readdir(packagedAppPath, {
+    withFileTypes: true,
+  });
+  const appBundleEntries = packagedOutputEntries.filter(
+    (entry) => entry.isDirectory() && entry.name.endsWith('.app'),
+  );
+
+  if (appBundleEntries.length !== 1) {
+    throw new Error(
+      [
+        `Expected exactly one .app bundle inside ${packagedAppPath},`,
+        `received ${appBundleEntries.length}.`,
+      ].join(' '),
+    );
+  }
+
+  return path.join(packagedAppPath, appBundleEntries[0].name);
 };
 
 const findPackagedAppPayloadDir = async (packagedAppPath) => {
@@ -1276,10 +1415,96 @@ const archivePackagedApp = async ({
   return artifactPath;
 };
 
+export const signPackagedMacApp = async ({
+  appPath,
+  security = resolveMacPackagedAppSecurity({ platform: 'darwin' }),
+} = {}) => {
+  if (process.platform !== 'darwin') {
+    throw new Error('macOS app signing requires a macOS host runner.');
+  }
+
+  if (security.shouldDeveloperIdSign) {
+    console.log(
+      `Signing ${path.basename(appPath)} with ${security.signIdentity}.`,
+    );
+    const codesignArgs = [
+      '--force',
+      '--deep',
+      '--sign',
+      security.signIdentity,
+      '--options',
+      'runtime',
+      '--timestamp',
+    ];
+    if (security.signKeychain) {
+      codesignArgs.push('--keychain', security.signKeychain);
+    }
+    codesignArgs.push(appPath);
+
+    await run('codesign', codesignArgs);
+    await run('codesign', [
+      '--verify',
+      '--deep',
+      '--strict',
+      '--verbose=2',
+      appPath,
+    ]);
+    return 'developer-id';
+  }
+
+  console.log(
+    [
+      `No Developer ID identity configured for ${path.basename(appPath)}.`,
+      'Applying ad-hoc codesign so the Electron bundle remains runnable after packaging-time mutations.',
+    ].join(' '),
+  );
+  await run('codesign', [
+    '--force',
+    '--deep',
+    '--sign',
+    '-',
+    '--timestamp=none',
+    appPath,
+  ]);
+  await run('codesign', [
+    '--verify',
+    '--deep',
+    '--strict',
+    '--verbose=2',
+    appPath,
+  ]);
+  return 'adhoc';
+};
+
+export const notarizePackagedMacApp = async ({
+  appPath,
+  security = resolveMacPackagedAppSecurity({ platform: 'darwin' }),
+} = {}) => {
+  if (!security.shouldNotarize) {
+    return false;
+  }
+
+  console.log(`Submitting ${path.basename(appPath)} for notarization.`);
+  await notarize({
+    appPath,
+    ...security.notarizeOptions,
+  });
+  await run('xcrun', ['stapler', 'validate', appPath]);
+  return true;
+};
+
 export const packageStudioElectronApp = async ({
   version,
   platform = process.platform,
   arch = process.arch,
+  macNotarizeApiIssuer,
+  macNotarizeApiKey,
+  macNotarizeApiKeyId,
+  macSignIdentity,
+  macSignKeychain,
+  macTeamId,
+  requireMacCodesign,
+  requireMacNotarization,
 } = {}) => {
   const normalizedVersion = normalizeReleaseVersion(version);
   const baseName = buildArtifactBaseName({
@@ -1288,6 +1513,19 @@ export const packageStudioElectronApp = async ({
     arch,
   });
   const stageDir = path.join(packagingWorkspaceDir, baseName);
+  const macSecurity = resolveMacPackagedAppSecurity({
+    cliOptions: {
+      macNotarizeApiIssuer,
+      macNotarizeApiKey,
+      macNotarizeApiKeyId,
+      macSignIdentity,
+      macSignKeychain,
+      macTeamId,
+      requireMacCodesign,
+      requireMacNotarization,
+    },
+    platform,
+  });
 
   await assertNoLiveDevBuilders();
   await createPackagingWorkspace({ stageDir, version: normalizedVersion });
@@ -1319,6 +1557,19 @@ export const packageStudioElectronApp = async ({
     await dedupePlaygroundStatic(path.join(packagedPayloadDir, 'node_modules'));
   }
 
+  if (platform === 'darwin') {
+    const macAppBundlePath =
+      await resolveMacPackagedAppBundlePath(packagedAppPath);
+    await signPackagedMacApp({
+      appPath: macAppBundlePath,
+      security: macSecurity,
+    });
+    await notarizePackagedMacApp({
+      appPath: macAppBundlePath,
+      security: macSecurity,
+    });
+  }
+
   await archivePackagedApp({
     hostPlatform: process.platform,
     sourcePath: packagedAppPath,
@@ -1339,7 +1590,15 @@ if (isDirectInvocation) {
     allowPositionals: false,
     options: {
       arch: { type: 'string' },
+      'mac-notarize-api-issuer': { type: 'string' },
+      'mac-notarize-api-key': { type: 'string' },
+      'mac-notarize-api-key-id': { type: 'string' },
+      'mac-sign-identity': { type: 'string' },
+      'mac-sign-keychain': { type: 'string' },
+      'mac-team-id': { type: 'string' },
       platform: { type: 'string' },
+      'require-mac-codesign': { type: 'string' },
+      'require-mac-notarization': { type: 'string' },
       version: { type: 'string' },
     },
   });
@@ -1352,7 +1611,15 @@ if (isDirectInvocation) {
 
   await packageStudioElectronApp({
     arch: values.arch,
+    macNotarizeApiIssuer: values['mac-notarize-api-issuer'],
+    macNotarizeApiKey: values['mac-notarize-api-key'],
+    macNotarizeApiKeyId: values['mac-notarize-api-key-id'],
+    macSignIdentity: values['mac-sign-identity'],
+    macSignKeychain: values['mac-sign-keychain'],
+    macTeamId: values['mac-team-id'],
     platform: values.platform,
+    requireMacCodesign: values['require-mac-codesign'],
+    requireMacNotarization: values['require-mac-notarization'],
     version,
   });
 }

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -108,7 +108,22 @@ const macNestedCodeBundleExtensions = new Set([
   '.framework',
   '.xpc',
 ]);
-const macStandaloneCodeFileExtensions = new Set(['.dylib', '.node', '.so']);
+const macStandaloneCodeFileExtensions = new Set([
+  '.bare',
+  '.dylib',
+  '.node',
+  '.so',
+]);
+const macMachOMagicHeaders = new Set([
+  'cafebabe',
+  'cafebabf',
+  'bebafeca',
+  'bfbafeca',
+  'cefaedfe',
+  'cffaedfe',
+  'feedface',
+  'feedfacf',
+]);
 
 export const shouldUseShellForCommand = (
   command,
@@ -1540,6 +1555,29 @@ export const resolveMacCodeSignEntitlementsPath = (targetPath) => {
   return defaultMacEntitlementsPath;
 };
 
+const isMacMachOFile = async (filePath) => {
+  const fileHandle = await fs.open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(4);
+    const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0);
+    return (
+      bytesRead === buffer.length &&
+      macMachOMagicHeaders.has(buffer.toString('hex'))
+    );
+  } finally {
+    await fileHandle.close();
+  }
+};
+
+const isMacStandaloneCodeFile = async (filePath) => {
+  const entryExt = path.extname(filePath).toLowerCase();
+  if (macStandaloneCodeFileExtensions.has(entryExt)) {
+    return true;
+  }
+
+  return isMacMachOFile(filePath);
+};
+
 export const collectNestedMacCodeSignTargets = async (appPath) => {
   const nestedBundles = [];
   const standaloneFiles = [];
@@ -1563,10 +1601,7 @@ export const collectNestedMacCodeSignTargets = async (appPath) => {
         continue;
       }
 
-      if (
-        entry.isFile() &&
-        macStandaloneCodeFileExtensions.has(entryExt.toLowerCase())
-      ) {
+      if (entry.isFile() && (await isMacStandaloneCodeFile(entryPath))) {
         standaloneFiles.push(entryPath);
       }
     }

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -12,6 +12,14 @@ const __dirname = path.dirname(__filename);
 const studioRootDir = path.resolve(__dirname, '..');
 const workspaceRootDir = path.resolve(studioRootDir, '..', '..');
 const studioBuildDir = path.join(studioRootDir, 'build');
+const reportRootDir = path.join(workspaceRootDir, 'apps', 'report');
+const coreRootDir = path.join(workspaceRootDir, 'packages', 'core');
+const coreDistDir = path.join(coreRootDir, 'dist');
+const reportTemplatePath = path.join(reportRootDir, 'dist', 'index.html');
+const reportTemplatePlaceholder = 'REPLACE_ME_WITH_REPORT_HTML';
+const unresolvedReportTemplatePattern = new RegExp(
+  String.raw`(?:=|return)\s*(['"])${reportTemplatePlaceholder}\1`,
+);
 
 // Keep release packaging state outside `apps/studio` so local build outputs do
 // not recurse back into the generated Electron payload.
@@ -25,7 +33,19 @@ const packagingWorkspaceDir = path.join(releaseWorkspaceDir, 'workspace');
 const packagedDir = path.join(releaseWorkspaceDir, 'packaged');
 const packagedAppId = 'midscene-studio';
 const packagedProductName = 'Midscene Studio';
-const packagedIgnorePatterns = [/^\/pnpm-lock\.yaml$/, /^\/vendor($|\/)/];
+const packagedIgnorePatterns = [
+  /^\/pnpm-lock\.yaml$/,
+  /^\/vendor($|\/)/,
+  // Documentation / changelog noise from third-party packages.
+  /\/(README|CHANGELOG|HISTORY|CONTRIBUTING|AUTHORS)(\.[a-zA-Z]+)?$/i,
+  // Editor / repo metadata that shipped from upstream `files` globs.
+  /\/\.(github|vscode|idea|circleci|husky)(\/|$)/,
+  /\/(\.npmignore|\.editorconfig|\.gitignore|\.gitattributes|\.prettierrc[^/]*|\.eslintrc[^/]*|\.eslintignore|\.babelrc[^/]*)$/,
+  // TypeScript type definitions are not loaded by the packaged runtime.
+  /\.d\.ts(\.map)?$/,
+  // Source maps duplicate what `pruneSourceMapFiles` already removed.
+  /\.js\.map$/,
+];
 const defaultMacEntitlementsPath = path.join(
   studioBuildDir,
   'entitlements.mac.plist',
@@ -60,6 +80,13 @@ const studioBuildSourceTargets = [
   'project.json',
   'tsconfig.json',
   'postcss.config.mjs',
+  'rsbuild.config.ts',
+];
+const reportBuildSourceTargets = [
+  'src',
+  'template',
+  'package.json',
+  'tsconfig.json',
   'rsbuild.config.ts',
 ];
 const playgroundAppBuildSourceTargets = [
@@ -154,19 +181,12 @@ const run = (command, args, { cwd = workspaceRootDir, env } = {}) =>
     });
   });
 
-const resolveConfiguredString = (values) => {
-  for (const value of values) {
-    if (typeof value !== 'string') {
-      continue;
-    }
-
-    const trimmed = value.trim();
-    if (trimmed) {
-      return trimmed;
-    }
+const resolveTrimmedEnv = (value) => {
+  if (typeof value !== 'string') {
+    return undefined;
   }
-
-  return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
 };
 
 export const parseBooleanLike = (value, defaultValue = false) => {
@@ -195,16 +215,15 @@ export const parseBooleanLike = (value, defaultValue = false) => {
 };
 
 export const resolveMacPackagedAppSecurity = ({
-  cliOptions = {},
   env = process.env,
   platform = process.platform,
 } = {}) => {
   const requireCodesign = parseBooleanLike(
-    cliOptions.requireMacCodesign ?? env.MIDSCENE_REQUIRE_MAC_CODESIGN,
+    env.MIDSCENE_REQUIRE_MAC_CODESIGN,
     false,
   );
   const requireNotarization = parseBooleanLike(
-    cliOptions.requireMacNotarization ?? env.MIDSCENE_REQUIRE_MAC_NOTARIZATION,
+    env.MIDSCENE_REQUIRE_MAC_NOTARIZATION,
     false,
   );
 
@@ -221,30 +240,12 @@ export const resolveMacPackagedAppSecurity = ({
     };
   }
 
-  const signIdentity = resolveConfiguredString([
-    cliOptions.macSignIdentity,
-    env.APPLE_CODESIGN_IDENTITY,
-  ]);
-  const signKeychain = resolveConfiguredString([
-    cliOptions.macSignKeychain,
-    env.APPLE_CODESIGN_KEYCHAIN,
-  ]);
-  const teamId = resolveConfiguredString([
-    cliOptions.macTeamId,
-    env.APPLE_TEAM_ID,
-  ]);
-  const appleApiKey = resolveConfiguredString([
-    cliOptions.macNotarizeApiKey,
-    env.APPLE_API_KEY_PATH,
-  ]);
-  const appleApiKeyId = resolveConfiguredString([
-    cliOptions.macNotarizeApiKeyId,
-    env.APPLE_API_KEY_ID,
-  ]);
-  const appleApiIssuer = resolveConfiguredString([
-    cliOptions.macNotarizeApiIssuer,
-    env.APPLE_API_ISSUER_ID,
-  ]);
+  const signIdentity = resolveTrimmedEnv(env.APPLE_CODESIGN_IDENTITY);
+  const signKeychain = resolveTrimmedEnv(env.APPLE_CODESIGN_KEYCHAIN);
+  const teamId = resolveTrimmedEnv(env.APPLE_TEAM_ID);
+  const appleApiKey = resolveTrimmedEnv(env.APPLE_API_KEY_PATH);
+  const appleApiKeyId = resolveTrimmedEnv(env.APPLE_API_KEY_ID);
+  const appleApiIssuer = resolveTrimmedEnv(env.APPLE_API_ISSUER_ID);
   const shouldDeveloperIdSign = Boolean(signIdentity);
   const notarizeOptions =
     appleApiKey && appleApiKeyId
@@ -258,10 +259,7 @@ export const resolveMacPackagedAppSecurity = ({
 
   if (requireCodesign && !shouldDeveloperIdSign) {
     throw new Error(
-      [
-        'macOS release packaging requires a Developer ID signing identity.',
-        'Set APPLE_CODESIGN_IDENTITY or pass --mac-sign-identity=<identity>.',
-      ].join(' '),
+      'macOS release packaging requires a Developer ID signing identity. Set APPLE_CODESIGN_IDENTITY.',
     );
   }
 
@@ -273,10 +271,7 @@ export const resolveMacPackagedAppSecurity = ({
 
   if (requireNotarization && !shouldDeveloperIdSign) {
     throw new Error(
-      [
-        'macOS notarization requires a Developer ID signing identity.',
-        'Set APPLE_CODESIGN_IDENTITY or pass --mac-sign-identity=<identity>.',
-      ].join(' '),
+      'macOS notarization requires a Developer ID signing identity. Set APPLE_CODESIGN_IDENTITY.',
     );
   }
 
@@ -547,6 +542,44 @@ const collectLatestMtime = async (targetPath) => {
   return latestMtime;
 };
 
+const reportRuntimeOutputExtensions = new Set(['.cjs', '.html', '.js', '.mjs']);
+
+export const pathContainsReportTemplatePlaceholder = async (rootDir) => {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      if (await pathContainsReportTemplatePlaceholder(entryPath)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (
+      !entry.isFile() ||
+      !reportRuntimeOutputExtensions.has(path.extname(entry.name))
+    ) {
+      continue;
+    }
+
+    const content = await fs.readFile(entryPath, 'utf8');
+    if (unresolvedReportTemplatePattern.test(content)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const BUILD_META_FILENAME = '.release-build-meta.json';
 const BUILD_META_SCHEMA_VERSION = 1;
 
@@ -590,7 +623,11 @@ export const writeBuildMeta = async (packageDir, { nodeEnv }) => {
   );
 };
 
-export const getBuildStatus = async ({ packageDir, sourceTargets }) => {
+export const getBuildStatus = async ({
+  packageDir,
+  sourceTargets,
+  additionalSourceTargets = [],
+}) => {
   const distDir = path.join(packageDir, 'dist');
   try {
     const distStats = await fs.stat(distDir);
@@ -625,10 +662,12 @@ export const getBuildStatus = async ({ packageDir, sourceTargets }) => {
     };
   }
 
+  const sourcePaths = [
+    ...sourceTargets.map((target) => path.join(packageDir, target)),
+    ...additionalSourceTargets,
+  ];
   const latestSourceMtime = await Promise.all(
-    sourceTargets.map((target) =>
-      collectLatestMtime(path.join(packageDir, target)),
-    ),
+    sourcePaths.map((targetPath) => collectLatestMtime(targetPath)),
   ).then((mtimes) => Math.max(0, ...mtimes));
   const latestDistMtime = await collectLatestMtime(distDir);
 
@@ -645,47 +684,99 @@ export const getBuildStatus = async ({ packageDir, sourceTargets }) => {
   };
 };
 
-const assertNoLiveDevBuilders = async () => {
-  try {
-    const { stdout } = await new Promise((resolve, reject) => {
-      const child = spawn('pgrep', ['-af', 'rsbuild dev'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      let buffer = '';
-      child.stdout.on('data', (chunk) => {
-        buffer += chunk.toString();
-      });
-      child.on('close', () => resolve({ stdout: buffer }));
-      child.on('error', reject);
-    });
-    const matches = stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
-    if (matches.length > 0) {
-      throw new Error(
-        [
-          'Detected live `rsbuild dev` processes while packaging:',
-          ...matches.map((line) => `  ${line}`),
-          'A concurrent dev server keeps overwriting `apps/studio/dist/` with',
-          'a development-mode renderer whose absolute asset URLs break under',
-          '`file://`. Stop `pnpm dev` first, then rerun `pnpm package:release`.',
-        ].join('\n'),
-      );
-    }
-  } catch (error) {
-    if (error?.code === 'ENOENT') {
-      return;
-    }
-    throw error;
-  }
-};
-
 const buildPackageDir = async (packageDir) => {
   await run(packageManagerCommand, ['--dir', packageDir, 'build'], {
     env: { ...process.env, NODE_ENV: 'production' },
   });
-  await writeBuildMeta(packageDir, { nodeEnv: 'production' });
+  await writeBuildMeta(
+    path.isAbsolute(packageDir)
+      ? packageDir
+      : path.join(workspaceRootDir, packageDir),
+    { nodeEnv: 'production' },
+  );
+};
+
+const ensureReportTemplateReady = async () => {
+  let content;
+  try {
+    content = await fs.readFile(reportTemplatePath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        `Expected report template to exist after build: ${reportTemplatePath}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!content.trim()) {
+    throw new Error(`Report template is empty: ${reportTemplatePath}`);
+  }
+};
+
+const prepareReportBuildOutput = async () => {
+  let status = await getBuildStatus({
+    packageDir: reportRootDir,
+    sourceTargets: reportBuildSourceTargets,
+  });
+
+  if (!status.needsBuild) {
+    try {
+      const templateStats = await fs.stat(reportTemplatePath);
+      if (!templateStats.isFile()) {
+        status = {
+          needsBuild: true,
+          reason: 'report template output is missing',
+        };
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+      status = {
+        needsBuild: true,
+        reason: 'report template output is missing',
+      };
+    }
+  }
+
+  if (status.needsBuild) {
+    console.log(`Building apps/report (${status.reason}).`);
+    await buildPackageDir(path.relative(workspaceRootDir, reportRootDir));
+  } else {
+    console.log(`Skipping apps/report build (${status.reason}).`);
+  }
+
+  await ensureReportTemplateReady();
+};
+
+const ensureCoreReportTemplateInjected = async () => {
+  let status = await getBuildStatus({
+    packageDir: coreRootDir,
+    sourceTargets: packageBuildSourceTargets,
+    additionalSourceTargets: [reportTemplatePath],
+  });
+
+  if (
+    !status.needsBuild &&
+    (await pathContainsReportTemplatePlaceholder(coreDistDir))
+  ) {
+    status = {
+      needsBuild: true,
+      reason: 'report template placeholder remains in build output',
+    };
+  }
+
+  if (status.needsBuild) {
+    console.log(`Building packages/core (${status.reason}).`);
+    await buildPackageDir(path.relative(workspaceRootDir, coreRootDir));
+  }
+
+  if (await pathContainsReportTemplatePlaceholder(coreDistDir)) {
+    throw new Error(
+      `packages/core build still contains ${reportTemplatePlaceholder}; rebuild apps/report before packaging.`,
+    );
+  }
 };
 
 const prepareStudioWorkspacePackages = async (workspacePackages) => {
@@ -707,19 +798,38 @@ const prepareStudioWorkspacePackages = async (workspacePackages) => {
   }
 };
 
-const prepareStudioBuildOutput = async () => {
-  const status = await getBuildStatus({
+const prepareStudioBuildOutput = async ({
+  additionalSourceTargets = [],
+} = {}) => {
+  let status = await getBuildStatus({
     packageDir: studioRootDir,
     sourceTargets: studioBuildSourceTargets,
+    additionalSourceTargets,
   });
 
-  if (!status.needsBuild) {
-    console.log(`Skipping apps/studio build (${status.reason}).`);
-    return;
+  const studioDistDir = path.join(studioRootDir, 'dist');
+  if (
+    !status.needsBuild &&
+    (await pathContainsReportTemplatePlaceholder(studioDistDir))
+  ) {
+    status = {
+      needsBuild: true,
+      reason: 'report template placeholder remains in build output',
+    };
   }
 
-  console.log(`Building apps/studio (${status.reason}).`);
-  await buildPackageDir(path.relative(workspaceRootDir, studioRootDir));
+  if (status.needsBuild) {
+    console.log(`Building apps/studio (${status.reason}).`);
+    await buildPackageDir(path.relative(workspaceRootDir, studioRootDir));
+  } else {
+    console.log(`Skipping apps/studio build (${status.reason}).`);
+  }
+
+  if (await pathContainsReportTemplatePlaceholder(studioDistDir)) {
+    throw new Error(
+      `apps/studio build still contains ${reportTemplatePlaceholder}; rebuild apps/report before packaging.`,
+    );
+  }
 };
 
 const getStaticWorkspacePackageSourceConfig = (packageName) =>
@@ -1368,7 +1478,11 @@ const createPackagingWorkspace = async ({ stageDir, version }) => {
 
   await prepareStaticWorkspacePackageSources(workspacePackages);
   await prepareStudioWorkspacePackages(workspacePackages);
-  await prepareStudioBuildOutput();
+  await prepareReportBuildOutput();
+  await ensureCoreReportTemplateInjected();
+  await prepareStudioBuildOutput({
+    additionalSourceTargets: [reportTemplatePath, coreDistDir],
+  });
   await removeIfExists(stageDir);
   await fs.mkdir(path.dirname(stageDir), { recursive: true });
   await copyStudioBuildOutputToStageDir(stageDir);
@@ -1640,14 +1754,6 @@ export const packageStudioElectronApp = async ({
   version,
   platform = process.platform,
   arch = process.arch,
-  macNotarizeApiIssuer,
-  macNotarizeApiKey,
-  macNotarizeApiKeyId,
-  macSignIdentity,
-  macSignKeychain,
-  macTeamId,
-  requireMacCodesign,
-  requireMacNotarization,
 } = {}) => {
   const normalizedVersion = normalizeReleaseVersion(version);
   const baseName = buildArtifactBaseName({
@@ -1656,21 +1762,8 @@ export const packageStudioElectronApp = async ({
     arch,
   });
   const stageDir = path.join(packagingWorkspaceDir, baseName);
-  const macSecurity = resolveMacPackagedAppSecurity({
-    cliOptions: {
-      macNotarizeApiIssuer,
-      macNotarizeApiKey,
-      macNotarizeApiKeyId,
-      macSignIdentity,
-      macSignKeychain,
-      macTeamId,
-      requireMacCodesign,
-      requireMacNotarization,
-    },
-    platform,
-  });
+  const macSecurity = resolveMacPackagedAppSecurity({ platform });
 
-  await assertNoLiveDevBuilders();
   await createPackagingWorkspace({ stageDir, version: normalizedVersion });
 
   await removeIfExists(packagedDir);
@@ -1733,15 +1826,7 @@ if (isDirectInvocation) {
     allowPositionals: false,
     options: {
       arch: { type: 'string' },
-      'mac-notarize-api-issuer': { type: 'string' },
-      'mac-notarize-api-key': { type: 'string' },
-      'mac-notarize-api-key-id': { type: 'string' },
-      'mac-sign-identity': { type: 'string' },
-      'mac-sign-keychain': { type: 'string' },
-      'mac-team-id': { type: 'string' },
       platform: { type: 'string' },
-      'require-mac-codesign': { type: 'string' },
-      'require-mac-notarization': { type: 'string' },
       version: { type: 'string' },
     },
   });
@@ -1754,15 +1839,7 @@ if (isDirectInvocation) {
 
   await packageStudioElectronApp({
     arch: values.arch,
-    macNotarizeApiIssuer: values['mac-notarize-api-issuer'],
-    macNotarizeApiKey: values['mac-notarize-api-key'],
-    macNotarizeApiKeyId: values['mac-notarize-api-key-id'],
-    macSignIdentity: values['mac-sign-identity'],
-    macSignKeychain: values['mac-sign-keychain'],
-    macTeamId: values['mac-team-id'],
     platform: values.platform,
-    requireMacCodesign: values['require-mac-codesign'],
-    requireMacNotarization: values['require-mac-notarization'],
     version,
   });
 }

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -11,6 +11,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const studioRootDir = path.resolve(__dirname, '..');
 const workspaceRootDir = path.resolve(studioRootDir, '..', '..');
+const studioBuildDir = path.join(studioRootDir, 'build');
 
 // Keep release packaging state outside `apps/studio` so local build outputs do
 // not recurse back into the generated Electron payload.
@@ -25,6 +26,22 @@ const packagedDir = path.join(releaseWorkspaceDir, 'packaged');
 const packagedAppId = 'midscene-studio';
 const packagedProductName = 'Midscene Studio';
 const packagedIgnorePatterns = [/^\/pnpm-lock\.yaml$/, /^\/vendor($|\/)/];
+const defaultMacEntitlementsPath = path.join(
+  studioBuildDir,
+  'entitlements.mac.plist',
+);
+const gpuMacEntitlementsPath = path.join(
+  studioBuildDir,
+  'entitlements.mac.gpu.plist',
+);
+const pluginMacEntitlementsPath = path.join(
+  studioBuildDir,
+  'entitlements.mac.plugin.plist',
+);
+const rendererMacEntitlementsPath = path.join(
+  studioBuildDir,
+  'entitlements.mac.renderer.plist',
+);
 const packageBuildSourceTargets = [
   'src',
   'html',
@@ -85,6 +102,13 @@ const staticWorkspacePackageSourceConfigs = [
 const supportedPlatforms = new Set(['darwin', 'linux', 'win32']);
 const truthyBooleanTokens = new Set(['1', 'true', 'yes', 'on']);
 const falsyBooleanTokens = new Set(['0', 'false', 'no', 'off']);
+const macNestedCodeBundleExtensions = new Set([
+  '.app',
+  '.appex',
+  '.framework',
+  '.xpc',
+]);
+const macStandaloneCodeFileExtensions = new Set(['.dylib', '.node', '.so']);
 
 export const shouldUseShellForCommand = (
   command,
@@ -1427,21 +1451,24 @@ export const signPackagedMacApp = async ({
     console.log(
       `Signing ${path.basename(appPath)} with ${security.signIdentity}.`,
     );
-    const codesignArgs = [
-      '--force',
-      '--deep',
-      '--sign',
-      security.signIdentity,
-      '--options',
-      'runtime',
-      '--timestamp',
-    ];
-    if (security.signKeychain) {
-      codesignArgs.push('--keychain', security.signKeychain);
+    for (const target of await collectNestedMacCodeSignTargets(appPath)) {
+      await run(
+        'codesign',
+        buildDeveloperIdCodesignArgs({
+          entitlementsPath: resolveMacCodeSignEntitlementsPath(target),
+          security,
+          targetPath: target,
+        }),
+      );
     }
-    codesignArgs.push(appPath);
-
-    await run('codesign', codesignArgs);
+    await run(
+      'codesign',
+      buildDeveloperIdCodesignArgs({
+        entitlementsPath: resolveMacCodeSignEntitlementsPath(appPath),
+        security,
+        targetPath: appPath,
+      }),
+    );
     await run('codesign', [
       '--verify',
       '--deep',
@@ -1474,6 +1501,87 @@ export const signPackagedMacApp = async ({
     appPath,
   ]);
   return 'adhoc';
+};
+
+export const buildDeveloperIdCodesignArgs = ({
+  entitlementsPath,
+  security,
+  targetPath,
+  useRuntime = true,
+}) => {
+  const codesignArgs = ['--force', '--sign', security.signIdentity];
+  if (useRuntime) {
+    codesignArgs.push('--options', 'runtime');
+  }
+  codesignArgs.push('--timestamp');
+  if (security.signKeychain) {
+    codesignArgs.push('--keychain', security.signKeychain);
+  }
+  if (entitlementsPath) {
+    codesignArgs.push('--entitlements', entitlementsPath);
+  }
+  codesignArgs.push(targetPath);
+  return codesignArgs;
+};
+
+export const resolveMacCodeSignEntitlementsPath = (targetPath) => {
+  if (targetPath.includes('(Plugin).app')) {
+    return pluginMacEntitlementsPath;
+  }
+
+  if (targetPath.includes('(GPU).app')) {
+    return gpuMacEntitlementsPath;
+  }
+
+  if (targetPath.includes('(Renderer).app')) {
+    return rendererMacEntitlementsPath;
+  }
+
+  return defaultMacEntitlementsPath;
+};
+
+export const collectNestedMacCodeSignTargets = async (appPath) => {
+  const nestedBundles = [];
+  const standaloneFiles = [];
+
+  const visitDirectory = async (dirPath, isRoot = false) => {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+
+      const entryPath = path.join(dirPath, entry.name);
+      const entryExt = path.extname(entry.name);
+
+      if (entry.isDirectory()) {
+        const isNestedBundle = macNestedCodeBundleExtensions.has(entryExt);
+        if (isNestedBundle && !isRoot) {
+          nestedBundles.push(entryPath);
+        }
+        await visitDirectory(entryPath, false);
+        continue;
+      }
+
+      if (
+        entry.isFile() &&
+        macStandaloneCodeFileExtensions.has(entryExt.toLowerCase())
+      ) {
+        standaloneFiles.push(entryPath);
+      }
+    }
+  };
+
+  await visitDirectory(appPath, true);
+
+  const byDescendingDepth = (leftPath, rightPath) =>
+    rightPath.split(path.sep).length - leftPath.split(path.sep).length ||
+    leftPath.localeCompare(rightPath);
+
+  standaloneFiles.sort(byDescendingDepth);
+  nestedBundles.sort(byDescendingDepth);
+
+  return [...standaloneFiles, ...nestedBundles];
 };
 
 export const notarizePackagedMacApp = async ({

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -19,6 +19,7 @@ import {
   getStudioElectronVersion,
   normalizeReleaseVersion,
   parseBooleanLike,
+  pathContainsReportTemplatePlaceholder,
   pruneAntdUmdBundles,
   pruneGifwrapTestFixtures,
   pruneSourceMapFiles,
@@ -829,6 +830,83 @@ describe('package-electron helpers', () => {
       expect(upToDate).toEqual({ needsBuild: false, reason: 'up to date' });
     } finally {
       await fs.rm(packageDir, { recursive: true, force: true });
+    }
+  });
+
+  it('getBuildStatus treats additional build inputs as source dependencies', async () => {
+    const { getBuildStatus, writeBuildMeta } = await import(
+      '../scripts/package-electron.mjs'
+    );
+    const packageDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-build-'),
+    );
+    const src = path.join(packageDir, 'src');
+    const dist = path.join(packageDir, 'dist');
+    const injectedTemplate = path.join(
+      packageDir,
+      '..',
+      `${path.basename(packageDir)}-report.html`,
+    );
+
+    try {
+      await fs.mkdir(src, { recursive: true });
+      await fs.mkdir(dist, { recursive: true });
+      await fs.writeFile(path.join(src, 'a.ts'), 'x');
+      await fs.writeFile(path.join(dist, 'out.js'), 'x');
+      await writeBuildMeta(packageDir, { nodeEnv: 'production' });
+
+      await expect(
+        getBuildStatus({
+          packageDir,
+          sourceTargets: ['src'],
+        }),
+      ).resolves.toEqual({ needsBuild: false, reason: 'up to date' });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await fs.writeFile(injectedTemplate, '<html></html>');
+
+      await expect(
+        getBuildStatus({
+          packageDir,
+          sourceTargets: ['src'],
+          additionalSourceTargets: [injectedTemplate],
+        }),
+      ).resolves.toEqual({
+        needsBuild: true,
+        reason: 'source files are newer than build output',
+      });
+    } finally {
+      await fs.rm(packageDir, { recursive: true, force: true });
+      await fs.rm(injectedTemplate, { force: true });
+    }
+  });
+
+  it('detects unresolved report template placeholders in runtime output only', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-report-'));
+    try {
+      await fs.writeFile(
+        path.join(root, 'guard.js'),
+        "if (html.includes('REPLACE_ME_WITH_REPORT_HTML')) reportHTML = null;",
+      );
+      await fs.writeFile(
+        path.join(root, 'bundle.js.map'),
+        '{"sourcesContent":["const reportTpl = \'REPLACE_ME_WITH_REPORT_HTML\';"]}',
+      );
+
+      await expect(pathContainsReportTemplatePlaceholder(root)).resolves.toBe(
+        false,
+      );
+
+      await fs.writeFile(
+        path.join(root, 'utils.js'),
+        "const reportTpl = 'REPLACE_ME_WITH_REPORT_HTML';",
+      );
+
+      await expect(pathContainsReportTemplatePlaceholder(root)).resolves.toBe(
+        true,
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -265,6 +265,26 @@ describe('package-electron helpers', () => {
       'Libraries',
       'libffmpeg.dylib',
     );
+    const crashpadHandlerPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Frameworks',
+      'Electron Framework.framework',
+      'Versions',
+      'A',
+      'Helpers',
+      'chrome_crashpad_handler',
+    );
+    const shipItPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Frameworks',
+      'Squirrel.framework',
+      'Versions',
+      'A',
+      'Resources',
+      'ShipIt',
+    );
     const helperAppPath = path.join(
       appBundlePath,
       'Contents',
@@ -277,18 +297,48 @@ describe('package-electron helpers', () => {
       'Resources',
       'native-addon.node',
     );
+    const barePath = path.join(
+      appBundlePath,
+      'Contents',
+      'Resources',
+      'app',
+      'node_modules',
+      'bare-url',
+      'prebuilds',
+      'darwin-arm64',
+      'bare-url.bare',
+    );
+    const scriptPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Resources',
+      'node_modules',
+      '.bin',
+      'not-mach-o',
+    );
 
     try {
       await fs.mkdir(path.dirname(libffmpegPath), { recursive: true });
+      await fs.mkdir(path.dirname(crashpadHandlerPath), { recursive: true });
+      await fs.mkdir(path.dirname(shipItPath), { recursive: true });
       await fs.mkdir(helperAppPath, { recursive: true });
       await fs.mkdir(path.dirname(addonPath), { recursive: true });
+      await fs.mkdir(path.dirname(barePath), { recursive: true });
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
       await fs.writeFile(libffmpegPath, '');
+      await fs.writeFile(crashpadHandlerPath, Buffer.from('cffaedfe', 'hex'));
+      await fs.writeFile(shipItPath, Buffer.from('cffaedfe', 'hex'));
       await fs.writeFile(addonPath, '');
+      await fs.writeFile(barePath, '');
+      await fs.writeFile(scriptPath, '#!/bin/sh\n');
 
       await expect(
         collectNestedMacCodeSignTargets(appBundlePath),
       ).resolves.toEqual([
+        barePath,
+        crashpadHandlerPath,
         libffmpegPath,
+        shipItPath,
         addonPath,
         path.join(
           appBundlePath,
@@ -297,6 +347,12 @@ describe('package-electron helpers', () => {
           'Electron Framework.framework',
         ),
         helperAppPath,
+        path.join(
+          appBundlePath,
+          'Contents',
+          'Frameworks',
+          'Squirrel.framework',
+        ),
       ]);
     } finally {
       await fs.rm(tempRootDir, { force: true, recursive: true });

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -10,6 +10,7 @@ import {
   buildPackagerOptions,
   buildVendoredWorkspaceDirName,
   buildVendoredWorkspaceManifest,
+  collectNestedMacCodeSignTargets,
   collectPackagedNodeModuleSymlinkIssues,
   collectWorkspaceDependencyClosure,
   dedupePlaygroundStatic,
@@ -22,6 +23,7 @@ import {
   pruneGifwrapTestFixtures,
   pruneSourceMapFiles,
   releaseWorkspaceDir,
+  resolveMacCodeSignEntitlementsPath,
   resolveMacPackagedAppBundlePath,
   resolveMacPackagedAppSecurity,
   resolvePackagerIconPath,
@@ -246,6 +248,82 @@ describe('package-electron helpers', () => {
     } finally {
       await fs.rm(tempRootDir, { force: true, recursive: true });
     }
+  });
+
+  it('collects nested macOS code-sign targets deepest-first before signing the root app bundle', async () => {
+    const tempRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-studio-codesign-targets-'),
+    );
+    const appBundlePath = path.join(tempRootDir, 'Midscene Studio.app');
+    const libffmpegPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Frameworks',
+      'Electron Framework.framework',
+      'Versions',
+      'A',
+      'Libraries',
+      'libffmpeg.dylib',
+    );
+    const helperAppPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Frameworks',
+      'Midscene Studio Helper.app',
+    );
+    const addonPath = path.join(
+      appBundlePath,
+      'Contents',
+      'Resources',
+      'native-addon.node',
+    );
+
+    try {
+      await fs.mkdir(path.dirname(libffmpegPath), { recursive: true });
+      await fs.mkdir(helperAppPath, { recursive: true });
+      await fs.mkdir(path.dirname(addonPath), { recursive: true });
+      await fs.writeFile(libffmpegPath, '');
+      await fs.writeFile(addonPath, '');
+
+      await expect(
+        collectNestedMacCodeSignTargets(appBundlePath),
+      ).resolves.toEqual([
+        libffmpegPath,
+        addonPath,
+        path.join(
+          appBundlePath,
+          'Contents',
+          'Frameworks',
+          'Electron Framework.framework',
+        ),
+        helperAppPath,
+      ]);
+    } finally {
+      await fs.rm(tempRootDir, { force: true, recursive: true });
+    }
+  });
+
+  it('selects Electron helper entitlements that match the osx-sign defaults', () => {
+    expect(
+      resolveMacCodeSignEntitlementsPath(
+        '/tmp/Midscene Studio.app/Contents/Frameworks/Midscene Studio Helper (Plugin).app',
+      ),
+    ).toMatch(/entitlements\.mac\.plugin\.plist$/);
+    expect(
+      resolveMacCodeSignEntitlementsPath(
+        '/tmp/Midscene Studio.app/Contents/Frameworks/Midscene Studio Helper (GPU).app',
+      ),
+    ).toMatch(/entitlements\.mac\.gpu\.plist$/);
+    expect(
+      resolveMacCodeSignEntitlementsPath(
+        '/tmp/Midscene Studio.app/Contents/Frameworks/Midscene Studio Helper (Renderer).app',
+      ),
+    ).toMatch(/entitlements\.mac\.renderer\.plist$/);
+    expect(
+      resolveMacCodeSignEntitlementsPath(
+        '/tmp/Midscene Studio.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib',
+      ),
+    ).toMatch(/entitlements\.mac\.plist$/);
   });
 
   it('keeps release staging outside the studio package root', () => {

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   assertPortablePackagedNodeModules,
   buildArtifactBaseName,
@@ -15,14 +15,15 @@ import {
   dedupePlaygroundStatic,
   dropAntdEsmBuild,
   dropMidsceneEsmBuilds,
-  findLiveDevBuilderProcesses,
-  getLiveDevBuilderProcessQueries,
   getStudioElectronVersion,
   normalizeReleaseVersion,
-  parseLiveDevBuilderProcessMatches,
+  parseBooleanLike,
   pruneAntdUmdBundles,
+  pruneGifwrapTestFixtures,
   pruneSourceMapFiles,
   releaseWorkspaceDir,
+  resolveMacPackagedAppBundlePath,
+  resolveMacPackagedAppSecurity,
   resolvePackagerIconPath,
   shouldUseShellForCommand,
   slimStageNodeModules,
@@ -126,77 +127,125 @@ describe('package-electron helpers', () => {
     expect(shouldUseShellForCommand('pnpm', 'linux')).toBe(false);
   });
 
-  it('uses a PowerShell-based process query on Windows', () => {
-    expect(getLiveDevBuilderProcessQueries('win32')).toEqual([
-      expect.objectContaining({ command: 'powershell' }),
-      expect.objectContaining({ command: 'pwsh' }),
-    ]);
+  it('parses boolean-like configuration values used by mac packaging flags', () => {
+    expect(parseBooleanLike('true')).toBe(true);
+    expect(parseBooleanLike('1')).toBe(true);
+    expect(parseBooleanLike('false')).toBe(false);
+    expect(parseBooleanLike(undefined, true)).toBe(true);
+    expect(() => parseBooleanLike('definitely')).toThrow(
+      /Expected a boolean-like value/,
+    );
   });
 
-  it('parses process-list output into individual matches', () => {
+  it('resolves default mac packaging security to ad-hoc signing without notarization', () => {
     expect(
-      parseLiveDevBuilderProcessMatches(
-        '123 rsbuild dev\n456 pnpm rsbuild dev\n',
-      ),
-    ).toEqual(['123 rsbuild dev', '456 pnpm rsbuild dev']);
-  });
-
-  it('detects live dev builders on Windows without relying on pgrep', async () => {
-    const runCapture = vi.fn().mockResolvedValue({
-      code: 0,
-      stderr: '',
-      stdout:
-        '4321 C:\\\\Program Files\\\\nodejs\\\\pnpm.cmd rsbuild dev --host 0.0.0.0\n',
-    });
-
-    await expect(
-      findLiveDevBuilderProcesses({
-        platform: 'win32',
-        runCapture,
-      }),
-    ).resolves.toEqual([
-      '4321 C:\\\\Program Files\\\\nodejs\\\\pnpm.cmd rsbuild dev --host 0.0.0.0',
-    ]);
-    expect(runCapture).toHaveBeenCalledWith('powershell', expect.any(Array), {
-      platform: 'win32',
-    });
-  });
-
-  it('falls back to pwsh when powershell is unavailable on Windows', async () => {
-    const powershellMissing = Object.assign(new Error('missing'), {
-      code: 'ENOENT',
-    });
-    const runCapture = vi
-      .fn()
-      .mockRejectedValueOnce(powershellMissing)
-      .mockResolvedValueOnce({
-        code: 0,
-        stderr: '',
-        stdout: '6789 pwsh rsbuild dev\n',
-      });
-
-    await expect(
-      findLiveDevBuilderProcesses({
-        platform: 'win32',
-        runCapture,
-      }),
-    ).resolves.toEqual(['6789 pwsh rsbuild dev']);
-    expect(runCapture.mock.calls[1][0]).toBe('pwsh');
-  });
-
-  it('treats pgrep exit code 1 as no matches on POSIX hosts', async () => {
-    const runCapture = vi.fn().mockResolvedValue({
-      code: 1,
-      stderr: '',
-      stdout: '',
-    });
-
-    await expect(
-      findLiveDevBuilderProcesses({
+      resolveMacPackagedAppSecurity({
+        env: {},
         platform: 'darwin',
-        runCapture,
       }),
-    ).resolves.toEqual([]);
+    ).toEqual({
+      notarizeOptions: undefined,
+      requireCodesign: false,
+      requireNotarization: false,
+      shouldDeveloperIdSign: false,
+      shouldNotarize: false,
+      signIdentity: undefined,
+      signKeychain: undefined,
+      teamId: undefined,
+    });
+  });
+
+  it('resolves Developer ID signing and notarization credentials from env', () => {
+    expect(
+      resolveMacPackagedAppSecurity({
+        env: {
+          APPLE_API_KEY_ID: 'ABC123XYZ9',
+          APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123XYZ9.p8',
+          APPLE_API_ISSUER_ID: 'issuer-uuid',
+          APPLE_CODESIGN_IDENTITY:
+            'Developer ID Application: YIBING LIN (62S977T8M3)',
+          APPLE_CODESIGN_KEYCHAIN: '/tmp/midscene-signing.keychain-db',
+          APPLE_TEAM_ID: '62S977T8M3',
+          MIDSCENE_REQUIRE_MAC_CODESIGN: 'true',
+          MIDSCENE_REQUIRE_MAC_NOTARIZATION: 'true',
+        },
+        platform: 'darwin',
+      }),
+    ).toEqual({
+      notarizeOptions: {
+        appleApiIssuer: 'issuer-uuid',
+        appleApiKey: '/tmp/AuthKey_ABC123XYZ9.p8',
+        appleApiKeyId: 'ABC123XYZ9',
+      },
+      requireCodesign: true,
+      requireNotarization: true,
+      shouldDeveloperIdSign: true,
+      shouldNotarize: true,
+      signIdentity: 'Developer ID Application: YIBING LIN (62S977T8M3)',
+      signKeychain: '/tmp/midscene-signing.keychain-db',
+      teamId: '62S977T8M3',
+    });
+  });
+
+  it('rejects release mac packaging when codesign is required but no identity is configured', () => {
+    expect(() =>
+      resolveMacPackagedAppSecurity({
+        env: {
+          MIDSCENE_REQUIRE_MAC_CODESIGN: 'true',
+        },
+        platform: 'darwin',
+      }),
+    ).toThrow(/requires a Developer ID signing identity/);
+  });
+
+  it('rejects notarization when credentials are missing', () => {
+    expect(() =>
+      resolveMacPackagedAppSecurity({
+        env: {
+          APPLE_CODESIGN_IDENTITY:
+            'Developer ID Application: YIBING LIN (62S977T8M3)',
+          MIDSCENE_REQUIRE_MAC_NOTARIZATION: 'true',
+        },
+        platform: 'darwin',
+      }),
+    ).toThrow(/notarization credentials are missing/);
+  });
+
+  it('rejects team mismatches between the configured identity and team id', () => {
+    expect(() =>
+      resolveMacPackagedAppSecurity({
+        env: {
+          APPLE_CODESIGN_IDENTITY:
+            'Developer ID Application: YIBING LIN (62S977T8M3)',
+          APPLE_TEAM_ID: 'WRONGTEAM1',
+        },
+        platform: 'darwin',
+      }),
+    ).toThrow(/does not match APPLE_TEAM_ID/);
+  });
+
+  it('resolves the nested .app bundle from the macOS packaged output directory', async () => {
+    const tempRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-studio-mac-bundle-'),
+    );
+    const packagedOutputPath = path.join(
+      tempRootDir,
+      'Midscene Studio-darwin-arm64',
+    );
+    const appBundlePath = path.join(packagedOutputPath, 'Midscene Studio.app');
+
+    try {
+      await fs.mkdir(appBundlePath, { recursive: true });
+
+      await expect(
+        resolveMacPackagedAppBundlePath(packagedOutputPath),
+      ).resolves.toBe(appBundlePath);
+      await expect(
+        resolveMacPackagedAppBundlePath(appBundlePath),
+      ).resolves.toBe(appBundlePath);
+    } finally {
+      await fs.rm(tempRootDir, { force: true, recursive: true });
+    }
   });
 
   it('keeps release staging outside the studio package root', () => {
@@ -489,6 +538,35 @@ describe('package-electron helpers', () => {
     }
   });
 
+  it('removes gifwrap test fixtures while preserving the runtime entry point', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-nm-'));
+    try {
+      const gifwrapDir = path.join(root, 'gifwrap');
+      await fs.mkdir(path.join(gifwrapDir, 'test', 'fixtures'), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(gifwrapDir, 'index.js'),
+        'module.exports={}',
+      );
+      await fs.writeFile(
+        path.join(gifwrapDir, 'test', 'fixtures', 'fixture.png'),
+        'png',
+      );
+
+      await pruneGifwrapTestFixtures(root);
+
+      await expect(
+        fs.stat(path.join(gifwrapDir, 'test')),
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(
+        fs.stat(path.join(gifwrapDir, 'index.js')),
+      ).resolves.toBeTruthy();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('hardlinks the ios/harmony playground static trees onto the canonical copy', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-nm-'));
     try {
@@ -620,7 +698,7 @@ describe('package-electron helpers', () => {
     }
   });
 
-  it('slimStageNodeModules chains all four stage-time prunes', async () => {
+  it('slimStageNodeModules chains all five stage-time prunes', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-nm-'));
     try {
       // sourcemap
@@ -636,6 +714,11 @@ describe('package-electron helpers', () => {
       await fs.writeFile(path.join(antdDist, 'antd.js'), 'x');
       await fs.writeFile(path.join(antdEs, 'index.js'), 'x');
       await fs.writeFile(path.join(antdLib, 'index.js'), 'x');
+      // gifwrap test fixtures
+      const gifwrapTestDir = path.join(root, 'gifwrap', 'test', 'fixtures');
+      await fs.mkdir(gifwrapTestDir, { recursive: true });
+      await fs.writeFile(path.join(root, 'gifwrap', 'index.js'), 'x');
+      await fs.writeFile(path.join(gifwrapTestDir, 'fixture.png'), 'png');
       // @midscene dual build
       const mcDist = path.join(root, '@midscene', 'core', 'dist');
       await fs.mkdir(path.join(mcDist, 'es'), { recursive: true });
@@ -652,6 +735,12 @@ describe('package-electron helpers', () => {
       await expect(fs.stat(antdEs)).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(
         fs.stat(path.join(antdLib, 'index.js')),
+      ).resolves.toBeTruthy();
+      await expect(
+        fs.stat(path.join(root, 'gifwrap', 'test')),
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(
+        fs.stat(path.join(root, 'gifwrap', 'index.js')),
       ).resolves.toBeTruthy();
       await expect(fs.stat(path.join(mcDist, 'es'))).rejects.toMatchObject({
         code: 'ENOENT',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,6 +553,9 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@electron/notarize':
+        specifier: 3.1.1
+        version: 3.1.1
       '@electron/packager':
         specifier: 19.1.0
         version: 19.1.0


### PR DESCRIPTION
## Summary
- add Developer ID signing and notarization support to the Studio release packaging workflow
- prepare macOS keychain + notary credentials in GitHub Actions before `package_studio`
- harden the local packager with mac signing/notarization helpers and stage-time pruning for signing-safe payloads

## Validation
- `pnpm run lint`
- `pnpm exec vitest run --config ./vitest.config.ts tests/package-electron.test.mjs tests/electron-contract.test.ts` (from `apps/studio`)
