### PR TITLE
fix(visualizer): four player/playground polish bugs

### DIFF
--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -11,6 +11,7 @@
 @control-gap: 8px;
 @status-icon-size: 28px;
 @status-icon-glyph-size: 16px;
+@seek-knob-width: 8px;
 @right-control-gap: 2px;
 
 .player-container {
@@ -156,7 +157,7 @@
     .seek-bar-knob {
       position: absolute;
       top: 50%;
-      width: 8px;
+      width: @seek-knob-width;
       height: 16px;
       background: #fff;
       border-radius: 10px;
@@ -216,6 +217,7 @@
     align-items: center;
     justify-content: center;
     gap: @right-control-gap;
+    margin-left: (@seek-knob-width / 2);
     min-width: (@status-icon-size * 2 + @right-control-gap);
 
     .ant-spin {

--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -11,6 +11,7 @@
 @control-gap: 8px;
 @status-icon-size: 28px;
 @status-icon-glyph-size: 16px;
+@right-control-gap: 2px;
 
 .player-container {
   width: 100%;
@@ -214,8 +215,8 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    gap: @control-gap;
-    min-width: (@status-icon-size * 2 + @control-gap);
+    gap: @right-control-gap;
+    min-width: (@status-icon-size * 2 + @right-control-gap);
 
     .ant-spin {
       color: #fff;

--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -217,6 +217,23 @@
       color: #fff;
     }
   }
+
+  &.player-container-empty {
+    align-items: center;
+    justify-content: center;
+
+    .player-empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+      color: #6b7280;
+
+      .player-empty-text {
+        font-size: 14px;
+      }
+    }
+  }
 }
 
 // Chapter marker tooltip

--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -294,6 +294,12 @@
   margin: 4px 0;
 }
 
+.player-export-label {
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum';
+}
+
 .player-speed-option:hover,
 .player-settings-item:hover {
   background: rgba(0, 0, 0, 0.04);

--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -8,6 +8,9 @@
 @timeline-height: 4px;
 @tools-height: 42px;
 @tools-margin: 15px;
+@control-gap: 8px;
+@status-icon-size: 28px;
+@status-icon-glyph-size: 16px;
 
 .player-container {
   width: 100%;
@@ -110,7 +113,7 @@
     right: 0;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: @control-gap;
     padding: 8px 12px;
     background: linear-gradient(transparent, rgba(0, 0, 0, 0.6));
     transition: opacity 0.3s;
@@ -184,8 +187,8 @@
 
   .status-icon {
     transition: 0.2s;
-    width: 28px;
-    height: 28px;
+    width: @status-icon-size;
+    height: @status-icon-size;
     border-radius: 4px;
     display: flex;
     align-items: center;
@@ -197,7 +200,7 @@
 
     svg {
       color: #fff;
-      font-size: 16px;
+      font-size: @status-icon-glyph-size;
     }
 
     &:hover {
@@ -211,8 +214,8 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-    min-width: 64px;
+    gap: @control-gap;
+    min-width: (@status-icon-size * 2 + @control-gap);
 
     .ant-spin {
       color: #fff;

--- a/packages/visualizer/src/component/player/index.less
+++ b/packages/visualizer/src/component/player/index.less
@@ -210,8 +210,9 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: center;
     gap: 8px;
-    margin-right: 8px;
+    min-width: 64px;
 
     .ant-spin {
       color: #fff;

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -17,6 +17,7 @@ import PlayerSettingIcon from '../../icons/player-setting.svg';
 import { type PlaybackSpeedType, useGlobalPreference } from '../../store/store';
 import type { ReportDownloadHandler } from '../../types';
 import type { AnimationScript } from '../../utils/replay-scripts';
+import { shouldRestartPlaybackFromBeginning } from './playback-controls';
 import { triggerReportDownload } from './report-download';
 import { StepsTimeline } from './scenes/StepScene';
 import { exportBrandedVideo } from './scenes/export-branded-video';
@@ -129,12 +130,39 @@ export function Player(props?: {
     return Math.max(0, frameMap.totalDurationInFrames - 1);
   }, [frameMap]);
 
+  const handlePlaybackToggle = useCallback(() => {
+    if (player.playing) {
+      player.pause();
+      return;
+    }
+
+    if (
+      shouldRestartPlaybackFromBeginning(player.currentFrame, effectiveEndFrame)
+    ) {
+      player.seekTo(0);
+    }
+    player.play();
+  }, [
+    effectiveEndFrame,
+    player.currentFrame,
+    player.pause,
+    player.play,
+    player.playing,
+    player.seekTo,
+  ]);
+
   // When playback stops, seek to the last frame with a taskId (skip the End card)
   useEffect(() => {
     if (!frameMap || player.playing) return;
     if (player.currentFrame < frameMap.totalDurationInFrames - 1) return;
     if (effectiveEndFrame > 0) player.seekTo(effectiveEndFrame);
-  }, [frameMap, player.playing, effectiveEndFrame]);
+  }, [
+    effectiveEndFrame,
+    frameMap,
+    player.currentFrame,
+    player.playing,
+    player.seekTo,
+  ]);
 
   // Sync taskId to parent: report current task while playing, clear on stop
   useEffect(() => {
@@ -228,12 +256,12 @@ export function Player(props?: {
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       if (e.code === 'Space') {
         e.preventDefault();
-        player.toggle();
+        handlePlaybackToggle();
       }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [player]);
+  }, [handlePlaybackToggle]);
 
   // Seek bar drag
   const seekBarRef = useRef<HTMLDivElement>(null);
@@ -398,7 +426,7 @@ export function Player(props?: {
               height: '100%',
               overflow: 'hidden',
             }}
-            onClick={player.toggle}
+            onClick={handlePlaybackToggle}
           >
             {(() => {
               const scale =
@@ -458,7 +486,7 @@ export function Player(props?: {
           className={`control-bar ${controlsVisible ? '' : 'hidden'}`}
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="status-icon" onClick={player.toggle}>
+          <div className="status-icon" onClick={handlePlaybackToggle}>
             {player.playing ? <PauseOutlined /> : <CaretRightOutlined />}
           </div>
 

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -327,19 +327,22 @@ export function Player(props?: {
     return markers;
   }, [frameMap, effectiveEndFrame]);
 
+  const reportFileContent = props?.reportFileContent ?? null;
+  const canDownloadReport = props?.canDownloadReport !== false;
+  const handleDownloadReport = useCallback(() => {
+    if (reportFileContent) downloadReport(reportFileContent);
+  }, [reportFileContent]);
+
   // If no scripts, fall back to a Download-report empty state when a report is
   // available (e.g. Stop was pressed before any task finished). Otherwise hide
   // the Player entirely instead of rendering an empty bordered box.
   if (!scripts || scripts.length === 0 || !frameMap) {
-    if (props?.reportFileContent && props?.canDownloadReport !== false) {
+    if (reportFileContent && canDownloadReport) {
       return (
         <div className="player-container player-container-empty">
           <div className="player-empty-state">
             <span className="player-empty-text">No replay available</span>
-            <Button
-              icon={<DownloadOutlined />}
-              onClick={() => downloadReport(props.reportFileContent!)}
-            >
+            <Button icon={<DownloadOutlined />} onClick={handleDownloadReport}>
               Download report
             </Button>
           </div>
@@ -491,12 +494,9 @@ export function Player(props?: {
 
           {/* Custom controls */}
           <div className="player-custom-controls">
-            {props?.reportFileContent && props?.canDownloadReport !== false ? (
+            {reportFileContent && canDownloadReport ? (
               <Tooltip title="Download Report">
-                <div
-                  className="status-icon"
-                  onClick={() => downloadReport(props.reportFileContent!)}
-                >
+                <div className="status-icon" onClick={handleDownloadReport}>
                   <DownloadOutlined />
                 </div>
               </Tooltip>

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -218,6 +218,7 @@ export function Player(props?: {
   // pointer-events:none, and the dropdown closes mid-export).
   const [isExporting, setIsExporting] = useState(false);
   const [exportProgress, setExportProgress] = useState(0);
+  const exportInFlightRef = useRef(false);
 
   // Controls auto-hide
   const [controlsVisible, setControlsVisible] = useState(true);
@@ -313,7 +314,8 @@ export function Player(props?: {
 
   // Export video
   const handleExportVideo = useCallback(async () => {
-    if (!frameMap || isExporting) return;
+    if (!frameMap || exportInFlightRef.current) return;
+    exportInFlightRef.current = true;
     setIsExporting(true);
     setExportProgress(0);
     try {
@@ -327,12 +329,14 @@ export function Player(props?: {
       message.success('Video exported');
     } catch (e) {
       console.error('Export failed:', e);
-      message.error('Export failed');
+      const errorMessage = e instanceof Error ? e.message : 'Export failed';
+      message.error(errorMessage);
     } finally {
+      exportInFlightRef.current = false;
       setIsExporting(false);
       setExportProgress(0);
     }
-  }, [autoZoom, frameMap, isExporting]);
+  }, [autoZoom, frameMap]);
 
   // Compute chapter markers
   const chapterMarkers = useMemo(() => {

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -177,6 +177,13 @@ export function Player(props?: {
     };
   }, [currentFrameState]);
 
+  // Export video state (declared up here so the controls auto-hide logic can
+  // see it and keep the control bar visible while an export is in progress —
+  // otherwise the bar fades out, the settings dropdown trigger goes
+  // pointer-events:none, and the dropdown closes mid-export).
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportProgress, setExportProgress] = useState(0);
+
   // Controls auto-hide
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -184,8 +191,9 @@ export function Player(props?: {
   const showControls = useCallback(() => {
     setControlsVisible(true);
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    if (isExporting) return;
     hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
-  }, []);
+  }, [isExporting]);
 
   const onMouseEnter = useCallback(() => {
     setControlsVisible(true);
@@ -194,8 +202,18 @@ export function Player(props?: {
 
   const onMouseLeave = useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    if (isExporting) return;
     hideTimerRef.current = setTimeout(() => setControlsVisible(false), 1000);
-  }, []);
+  }, [isExporting]);
+
+  useEffect(() => {
+    if (!isExporting) return;
+    setControlsVisible(true);
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, [isExporting]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -259,9 +277,6 @@ export function Player(props?: {
   }, []);
 
   // Export video
-  const [isExporting, setIsExporting] = useState(false);
-  const [exportProgress, setExportProgress] = useState(0);
-
   const handleExportVideo = useCallback(async () => {
     if (!frameMap || isExporting) return;
     setIsExporting(true);

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -11,7 +11,7 @@ import {
   PauseOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
-import { Dropdown, Spin, Switch, Tooltip, message } from 'antd';
+import { Button, Dropdown, Progress, Switch, Tooltip, message } from 'antd';
 import GlobalPerspectiveIcon from '../../icons/global-perspective.svg';
 import PlayerSettingIcon from '../../icons/player-setting.svg';
 import { type PlaybackSpeedType, useGlobalPreference } from '../../store/store';
@@ -127,19 +127,24 @@ export function Player(props?: {
     playbackRate: playbackSpeed,
   });
 
+  // The last frame that contains real content (skip the trailing End card).
+  // Used as the denominator for the seek bar so the knob can reach 100% when
+  // playback finishes — otherwise it parks at ~80–90% inside the End card.
+  const effectiveEndFrame = useMemo(() => {
+    if (!frameMap) return 0;
+    for (let i = frameMap.scriptFrames.length - 1; i >= 0; i--) {
+      const sf = frameMap.scriptFrames[i];
+      if (sf.taskId) return sf.startFrame + sf.durationInFrames - 1;
+    }
+    return Math.max(0, frameMap.totalDurationInFrames - 1);
+  }, [frameMap]);
+
   // When playback stops, seek to the last frame with a taskId (skip the End card)
   useEffect(() => {
     if (!frameMap || player.playing) return;
-    const { scriptFrames, totalDurationInFrames } = frameMap;
-    if (player.currentFrame < totalDurationInFrames - 1) return;
-    for (let i = scriptFrames.length - 1; i >= 0; i--) {
-      const sf = scriptFrames[i];
-      if (sf.taskId) {
-        player.seekTo(sf.startFrame + sf.durationInFrames - 1);
-        break;
-      }
-    }
-  }, [frameMap, player.playing]);
+    if (player.currentFrame < frameMap.totalDurationInFrames - 1) return;
+    if (effectiveEndFrame > 0) player.seekTo(effectiveEndFrame);
+  }, [frameMap, player.playing, effectiveEndFrame]);
 
   // Sync taskId to parent: report current task while playing, clear on stop
   useEffect(() => {
@@ -219,7 +224,7 @@ export function Player(props?: {
           0,
           Math.min(1, (clientX - rect.left) / rect.width),
         );
-        player.seekTo(Math.round(ratio * (frameMap.totalDurationInFrames - 1)));
+        player.seekTo(Math.round(ratio * effectiveEndFrame));
       };
 
       seek(e.clientX);
@@ -232,7 +237,7 @@ export function Player(props?: {
       bar.addEventListener('pointermove', onMove);
       bar.addEventListener('pointerup', onUp);
     },
-    [frameMap, player],
+    [frameMap, player, effectiveEndFrame],
   );
 
   // Fullscreen
@@ -281,19 +286,17 @@ export function Player(props?: {
 
   // Compute chapter markers
   const chapterMarkers = useMemo(() => {
-    if (!frameMap) return [];
-    const { scriptFrames, totalDurationInFrames } = frameMap;
-    if (totalDurationInFrames === 0) return [];
+    if (!frameMap || effectiveEndFrame <= 0) return [];
 
     const markers: { percent: number; title: string; frame: number }[] = [];
-    for (const sf of scriptFrames) {
+    for (const sf of frameMap.scriptFrames) {
       if (
         (sf.type !== 'img' && sf.type !== 'insight') ||
         sf.durationInFrames === 0
       )
         continue;
       const globalFrame = sf.startFrame;
-      const percent = (globalFrame / totalDurationInFrames) * 100;
+      const percent = (globalFrame / effectiveEndFrame) * 100;
       if (percent > 1 && percent < 99) {
         const parts = [sf.title, sf.subTitle].filter(Boolean);
         markers.push({
@@ -307,11 +310,28 @@ export function Player(props?: {
       }
     }
     return markers;
-  }, [frameMap]);
+  }, [frameMap, effectiveEndFrame]);
 
-  // If no scripts, show empty
+  // If no scripts, fall back to a Download-report empty state when a report is
+  // available (e.g. Stop was pressed before any task finished). Otherwise hide
+  // the Player entirely instead of rendering an empty bordered box.
   if (!scripts || scripts.length === 0 || !frameMap) {
-    return <div className="player-container" />;
+    if (props?.reportFileContent && props?.canDownloadReport !== false) {
+      return (
+        <div className="player-container player-container-empty">
+          <div className="player-empty-state">
+            <span className="player-empty-text">No replay available</span>
+            <Button
+              icon={<DownloadOutlined />}
+              onClick={() => downloadReport(props.reportFileContent!)}
+            >
+              Download report
+            </Button>
+          </div>
+        </div>
+      );
+    }
+    return null;
   }
 
   const compositionWidth = currentFrameState?.imageWidth || frameMap.imageWidth;
@@ -319,9 +339,10 @@ export function Player(props?: {
     currentFrameState?.imageHeight || frameMap.imageHeight;
   const isPortraitCanvas = compositionHeight > compositionWidth;
 
-  const totalFrames = frameMap.totalDurationInFrames;
   const seekPercent =
-    totalFrames > 1 ? (player.currentFrame / (totalFrames - 1)) * 100 : 0;
+    effectiveEndFrame > 0
+      ? Math.min(100, (player.currentFrame / effectiveEndFrame) * 100)
+      : 0;
 
   return (
     <div className="player-container" data-fit-mode={props?.fitMode}>
@@ -415,8 +436,11 @@ export function Player(props?: {
           </div>
 
           <span className="time-display">
-            {formatTime(player.currentFrame, frameMap.fps)} /{' '}
-            {formatTime(totalFrames, frameMap.fps)}
+            {formatTime(
+              Math.min(player.currentFrame, effectiveEndFrame),
+              frameMap.fps,
+            )}{' '}
+            / {formatTime(effectiveEndFrame + 1, frameMap.fps)}
           </span>
 
           <div
@@ -484,13 +508,32 @@ export function Player(props?: {
                     }}
                     onClick={isExporting ? undefined : handleExportVideo}
                   >
-                    {isExporting ? (
-                      <Spin size="small" />
-                    ) : (
-                      <ExportOutlined
-                        style={{ width: '16px', height: '16px' }}
-                      />
-                    )}
+                    <span
+                      style={{
+                        width: 16,
+                        height: 16,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {isExporting ? (
+                        <Progress
+                          type="circle"
+                          percent={exportProgress}
+                          size={16}
+                          strokeWidth={14}
+                          showInfo={false}
+                          strokeColor="#1677ff"
+                          trailColor="rgba(0, 0, 0, 0.12)"
+                        />
+                      ) : (
+                        <ExportOutlined
+                          style={{ width: '16px', height: '16px' }}
+                        />
+                      )}
+                    </span>
                     <span style={{ fontSize: '14px' }}>
                       {isExporting
                         ? `Exporting ${exportProgress}%`
@@ -590,7 +633,7 @@ export function Player(props?: {
                       style={{
                         height: '32px',
                         lineHeight: '32px',
-                        padding: '0 8px 0 24px',
+                        padding: '0 8px 0 28px',
                         fontSize: '14px',
                         cursor: 'pointer',
                         borderRadius: '4px',

--- a/packages/visualizer/src/component/player/index.tsx
+++ b/packages/visualizer/src/component/player/index.tsx
@@ -595,7 +595,7 @@ export function Player(props?: {
                         />
                       )}
                     </span>
-                    <span style={{ fontSize: '14px' }}>
+                    <span className="player-export-label">
                       {isExporting
                         ? `Exporting ${exportProgress}%`
                         : 'Export video'}

--- a/packages/visualizer/src/component/player/playback-controls.ts
+++ b/packages/visualizer/src/component/player/playback-controls.ts
@@ -1,0 +1,6 @@
+export function shouldRestartPlaybackFromBeginning(
+  currentFrame: number,
+  effectiveEndFrame: number,
+): boolean {
+  return effectiveEndFrame > 0 && currentFrame >= effectiveEndFrame;
+}

--- a/packages/visualizer/src/component/player/scenes/StepScene.tsx
+++ b/packages/visualizer/src/component/player/scenes/StepScene.tsx
@@ -58,9 +58,14 @@ export const StepsTimeline: React.FC<{
   } = state;
 
   // ── Camera interpolation ──
-  const pT = pointerMoved
-    ? Math.min(rawProgress / POINTER_PHASE, 1)
-    : rawProgress;
+  // When focus on cursor is OFF, snap the cursor to its target instead of
+  // animating it from the previous default center; otherwise the cursor visibly
+  // slides across the un-zoomed frame and looks like it is in the wrong place.
+  const pT = !autoZoom
+    ? 1
+    : pointerMoved
+      ? Math.min(rawProgress / POINTER_PHASE, 1)
+      : rawProgress;
   const cT = pointerMoved
     ? rawProgress <= POINTER_PHASE
       ? 0

--- a/packages/visualizer/src/component/player/scenes/StepScene.tsx
+++ b/packages/visualizer/src/component/player/scenes/StepScene.tsx
@@ -4,7 +4,7 @@ import { getCenterHighlightBox } from '../../../utils/highlight-element';
 import { deriveFrameState } from './derive-frame-state';
 import type { FrameMap } from './frame-calculator';
 import { getPlaybackViewport } from './playback-layout';
-import { resolvePointerLayout } from './pointer-layout';
+import { resolvePointerLayout, resolveSpinnerLayout } from './pointer-layout';
 
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
@@ -112,6 +112,7 @@ export const StepsTimeline: React.FC<{
 
   // Scale overlays proportionally so they stay visible at any resolution.
   const pointerLayout = resolvePointerLayout(imgW);
+  const spinnerLayout = resolveSpinnerLayout(pointerLayout);
   const resScale = pointerLayout.scale;
 
   const crossfadeAlpha = imageChanged
@@ -248,10 +249,10 @@ export const StepsTimeline: React.FC<{
           src={mouseLoading}
           style={{
             position: 'absolute',
-            left: ptrX - pointerLayout.centerOffsetX,
-            top: ptrY - pointerLayout.centerOffsetY,
-            width: pointerLayout.width,
-            height: pointerLayout.height,
+            left: ptrX - spinnerLayout.centerOffset,
+            top: ptrY - spinnerLayout.centerOffset,
+            width: spinnerLayout.size,
+            height: spinnerLayout.size,
             transform: `rotate(${spinRotation}rad)`,
             transformOrigin: 'center center',
             filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))',

--- a/packages/visualizer/src/component/player/scenes/StepScene.tsx
+++ b/packages/visualizer/src/component/player/scenes/StepScene.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { mouseLoading } from '../../../utils';
 import { getCenterHighlightBox } from '../../../utils/highlight-element';
-import { deriveFrameState } from './derive-frame-state';
+import { deriveFrameState, shouldRenderCursor } from './derive-frame-state';
 import type { FrameMap } from './frame-calculator';
 import { getPlaybackViewport } from './playback-layout';
 import { resolvePointerLayout, resolveSpinnerLayout } from './pointer-layout';
@@ -50,6 +50,7 @@ export const StepsTimeline: React.FC<{
     spinning: spinningPointer,
     spinningElapsedMs,
     currentPointerImg,
+    pointerVisible,
     title,
     subTitle,
     frameInScript,
@@ -104,11 +105,13 @@ export const StepsTimeline: React.FC<{
   const camH = cameraWidth * (imgH / imgW);
   const ptrX = ((pointerLeft - cameraLeft) / cameraWidth) * contentWidth;
   const ptrY = ((pointerTop - cameraTop) / camH) * contentHeight;
-  const showCursor =
-    camera.pointerLeft !== Math.round(imgW / 2) ||
-    camera.pointerTop !== Math.round(imgH / 2) ||
-    prevCamera.pointerLeft !== Math.round(imgW / 2) ||
-    prevCamera.pointerTop !== Math.round(imgH / 2);
+  const showCursor = shouldRenderCursor(
+    pointerVisible,
+    camera,
+    prevCamera,
+    imgW,
+    imgH,
+  );
 
   // Scale overlays proportionally so they stay visible at any resolution.
   const pointerLayout = resolvePointerLayout(imgW);

--- a/packages/visualizer/src/component/player/scenes/StepScene.tsx
+++ b/packages/visualizer/src/component/player/scenes/StepScene.tsx
@@ -4,6 +4,7 @@ import { getCenterHighlightBox } from '../../../utils/highlight-element';
 import { deriveFrameState } from './derive-frame-state';
 import type { FrameMap } from './frame-calculator';
 import { getPlaybackViewport } from './playback-layout';
+import { resolvePointerLayout } from './pointer-layout';
 
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
@@ -109,8 +110,9 @@ export const StepsTimeline: React.FC<{
     prevCamera.pointerLeft !== Math.round(imgW / 2) ||
     prevCamera.pointerTop !== Math.round(imgH / 2);
 
-  // Scale overlays proportionally so they stay visible at any resolution
-  const resScale = Math.max(1, Math.sqrt(imgW / 1920));
+  // Scale overlays proportionally so they stay visible at any resolution.
+  const pointerLayout = resolvePointerLayout(imgW);
+  const resScale = pointerLayout.scale;
 
   const crossfadeAlpha = imageChanged
     ? Math.min(frameInScript / CROSSFADE_FRAMES, 1)
@@ -246,10 +248,10 @@ export const StepsTimeline: React.FC<{
           src={mouseLoading}
           style={{
             position: 'absolute',
-            left: ptrX - 22 * resScale,
-            top: ptrY - 28 * resScale,
-            width: 44 * resScale,
-            height: 56 * resScale,
+            left: ptrX - pointerLayout.centerOffsetX,
+            top: ptrY - pointerLayout.centerOffsetY,
+            width: pointerLayout.width,
+            height: pointerLayout.height,
             transform: `rotate(${spinRotation}rad)`,
             transformOrigin: 'center center',
             filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))',
@@ -263,10 +265,10 @@ export const StepsTimeline: React.FC<{
           src={currentPointerImg}
           style={{
             position: 'absolute',
-            left: ptrX - 6 * resScale,
-            top: ptrY - 4 * resScale,
-            width: 44 * resScale,
-            height: 56 * resScale,
+            left: ptrX - pointerLayout.hotspotX,
+            top: ptrY - pointerLayout.hotspotY,
+            width: pointerLayout.width,
+            height: pointerLayout.height,
             filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))',
           }}
         />

--- a/packages/visualizer/src/component/player/scenes/derive-frame-state.ts
+++ b/packages/visualizer/src/component/player/scenes/derive-frame-state.ts
@@ -31,6 +31,7 @@ export interface FrameState {
   spinning: boolean;
   spinningElapsedMs: number;
   currentPointerImg: string;
+  pointerVisible: boolean;
   title: string;
   subTitle: string;
   taskId: string | undefined;
@@ -53,6 +54,7 @@ interface Acc {
   spinning: boolean;
   spinningElapsedMs: number;
   pointerImg: string;
+  pointerVisible: boolean;
   title: string;
   subTitle: string;
   taskId: string | undefined;
@@ -109,6 +111,24 @@ function checkPointerMoved(prev: CameraState, cur: CameraState): boolean {
   return (
     Math.abs(prev.pointerLeft - cur.pointerLeft) > 1 ||
     Math.abs(prev.pointerTop - cur.pointerTop) > 1
+  );
+}
+
+export function shouldRenderCursor(
+  pointerVisible: boolean,
+  camera: CameraState,
+  prevCamera: CameraState,
+  imageWidth: number,
+  imageHeight: number,
+): boolean {
+  const centerX = Math.round(imageWidth / 2);
+  const centerY = Math.round(imageHeight / 2);
+  return (
+    pointerVisible ||
+    Math.abs(camera.pointerLeft - centerX) > 1 ||
+    Math.abs(camera.pointerTop - centerY) > 1 ||
+    Math.abs(prevCamera.pointerLeft - centerX) > 1 ||
+    Math.abs(prevCamera.pointerTop - centerY) > 1
   );
 }
 
@@ -205,6 +225,7 @@ export function deriveFrameState(
     spinning: false,
     spinningElapsedMs: 0,
     pointerImg: mousePointer,
+    pointerVisible: false,
     title: '',
     subTitle: '',
     taskId: undefined,
@@ -223,6 +244,7 @@ export function deriveFrameState(
       if (sf.startFrame <= frame) {
         if (sf.type === 'pointer' && sf.pointerImg) {
           acc.pointerImg = sf.pointerImg;
+          acc.pointerVisible = true;
         }
         acc.title = sf.title || acc.title;
         acc.subTitle = sf.subTitle || acc.subTitle;
@@ -291,6 +313,7 @@ export function deriveFrameState(
     spinning: acc.spinning,
     spinningElapsedMs: acc.spinningElapsedMs,
     currentPointerImg: acc.pointerImg,
+    pointerVisible: acc.pointerVisible,
     title: acc.title,
     subTitle: acc.subTitle,
     taskId: acc.taskId,

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -9,6 +9,10 @@ const W = 960;
 const H = 540;
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
+const POINTER_WIDTH = 44;
+const POINTER_HEIGHT = 56;
+const POINTER_HOTSPOT_X = 6;
+const POINTER_HOTSPOT_Y = 4;
 
 // ── helpers ──
 
@@ -124,6 +128,7 @@ function drawSpinningPointer(
   img: HTMLImageElement,
   x: number,
   y: number,
+  scale: number,
   elapsedMs: number,
 ) {
   const progress = (Math.sin(elapsedMs / 500 - Math.PI / 2) + 1) / 2;
@@ -131,8 +136,31 @@ function drawSpinningPointer(
   ctx.save();
   ctx.translate(x, y);
   ctx.rotate(rotation);
-  ctx.drawImage(img, -11, -14, 22, 28);
+  ctx.drawImage(
+    img,
+    -(POINTER_WIDTH * scale) / 2,
+    -(POINTER_HEIGHT * scale) / 2,
+    POINTER_WIDTH * scale,
+    POINTER_HEIGHT * scale,
+  );
   ctx.restore();
+}
+
+export function resolveExportPointerLayout(
+  imageWidth: number,
+  contentWidth: number,
+) {
+  const resScale = Math.max(1, Math.sqrt(imageWidth / 1920));
+  const exportScale = (contentWidth / imageWidth) * resScale;
+
+  return {
+    width: POINTER_WIDTH * exportScale,
+    height: POINTER_HEIGHT * exportScale,
+    hotspotX: POINTER_HOTSPOT_X * exportScale,
+    hotspotY: POINTER_HOTSPOT_Y * exportScale,
+    centerOffsetX: (POINTER_WIDTH * exportScale) / 2,
+    centerOffsetY: (POINTER_HEIGHT * exportScale) / 2,
+  };
 }
 
 // ── Steps rendering ──
@@ -232,6 +260,7 @@ function drawSteps(
   const camH = camW * (imgH / imgW);
   const sX = offsetX + ((ptrX - camL) / camW) * contentWidth;
   const sY = offsetY + ((ptrY - camT2) / camH) * contentHeight;
+  const pointerLayout = resolveExportPointerLayout(imgW, contentWidth);
 
   const hasPtrData =
     Math.abs(camera.pointerLeft - Math.round(imgW / 2)) > 1 ||
@@ -240,11 +269,24 @@ function drawSteps(
     Math.abs(prevCamera.pointerTop - Math.round(imgH / 2)) > 1;
 
   if (spinning && spinnerImg) {
-    drawSpinningPointer(ctx, spinnerImg, sX, sY, spinningElapsedMs);
+    drawSpinningPointer(
+      ctx,
+      spinnerImg,
+      sX,
+      sY,
+      pointerLayout.width / POINTER_WIDTH,
+      spinningElapsedMs,
+    );
   }
 
   if (!spinning && hasPtrData && cursorImg) {
-    ctx.drawImage(cursorImg, sX - 3, sY - 2, 22, 28);
+    ctx.drawImage(
+      cursorImg,
+      sX - pointerLayout.hotspotX,
+      sY - pointerLayout.hotspotY,
+      pointerLayout.width,
+      pointerLayout.height,
+    );
   }
 }
 

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -1,3 +1,4 @@
+import type { Rect } from '@midscene/core';
 import { mouseLoading, mousePointer } from '../../../utils';
 import { getCenterHighlightBox } from '../../../utils/highlight-element';
 import { deriveFrameState } from './derive-frame-state';
@@ -7,12 +8,22 @@ import { getPlaybackViewport } from './playback-layout';
 import {
   type PointerLayout,
   resolveExportPointerLayout,
+  resolveSpinnerLayout,
 } from './pointer-layout';
 
 const W = 960;
 const H = 540;
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
+
+interface ExportOverlayViewport {
+  offsetX: number;
+  offsetY: number;
+  contentWidth: number;
+  contentHeight: number;
+  imageWidth: number;
+  imageHeight: number;
+}
 
 // ── helpers ──
 
@@ -57,13 +68,42 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 
 // ── Insight overlay drawing ──
 
+export function projectNativeRectToExportViewport(
+  rect: Rect,
+  cameraTransform: { zoom: number; tx: number; ty: number },
+  viewport: ExportOverlayViewport,
+): Rect {
+  const scaleX = viewport.contentWidth / viewport.imageWidth;
+  const scaleY = viewport.contentHeight / viewport.imageHeight;
+
+  return {
+    left:
+      viewport.offsetX +
+      (rect.left * scaleX + cameraTransform.tx) * cameraTransform.zoom,
+    top:
+      viewport.offsetY +
+      (rect.top * scaleY + cameraTransform.ty) * cameraTransform.zoom,
+    width: rect.width * scaleX * cameraTransform.zoom,
+    height: rect.height * scaleY * cameraTransform.zoom,
+  };
+}
+
 function drawInsightOverlays(
   ctx: CanvasRenderingContext2D,
   insights: InsightOverlay[],
   cameraTransform: { zoom: number; tx: number; ty: number },
-  bx: number,
-  contentY: number,
+  viewport: ExportOverlayViewport,
 ) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(
+    viewport.offsetX,
+    viewport.offsetY,
+    viewport.contentWidth,
+    viewport.contentHeight,
+  );
+  ctx.clip();
+
   for (const insight of insights) {
     if (insight.alpha <= 0) continue;
     ctx.save();
@@ -71,54 +111,70 @@ function drawInsightOverlays(
 
     if (insight.highlightElement) {
       const highlightBox = getCenterHighlightBox(insight.highlightElement);
-      const rx =
-        bx +
-        (highlightBox.left * cameraTransform.zoom +
-          cameraTransform.tx * cameraTransform.zoom);
-      const ry =
-        contentY +
-        (highlightBox.top * cameraTransform.zoom +
-          cameraTransform.ty * cameraTransform.zoom);
-      const highlightWidth = highlightBox.width * cameraTransform.zoom;
-      const highlightHeight = highlightBox.height * cameraTransform.zoom;
+      const projected = projectNativeRectToExportViewport(
+        highlightBox,
+        cameraTransform,
+        viewport,
+      );
 
       ctx.fillStyle = 'rgba(253, 89, 7, 0.4)';
-      ctx.fillRect(rx, ry, highlightWidth, highlightHeight);
+      ctx.fillRect(
+        projected.left,
+        projected.top,
+        projected.width,
+        projected.height,
+      );
       ctx.strokeStyle = '#fd5907';
       ctx.lineWidth = 1;
-      ctx.strokeRect(rx, ry, highlightWidth, highlightHeight);
+      ctx.strokeRect(
+        projected.left,
+        projected.top,
+        projected.width,
+        projected.height,
+      );
       ctx.shadowColor = 'rgba(51, 51, 51, 0.4)';
       ctx.shadowBlur = 2;
       ctx.shadowOffsetX = 4;
       ctx.shadowOffsetY = 4;
-      ctx.strokeRect(rx, ry, highlightWidth, highlightHeight);
+      ctx.strokeRect(
+        projected.left,
+        projected.top,
+        projected.width,
+        projected.height,
+      );
       ctx.shadowBlur = 0;
       ctx.shadowOffsetX = 0;
       ctx.shadowOffsetY = 0;
     }
 
     if (insight.searchArea) {
-      const r = insight.searchArea;
-      const rx =
-        bx +
-        (r.left * cameraTransform.zoom +
-          cameraTransform.tx * cameraTransform.zoom);
-      const ry =
-        contentY +
-        (r.top * cameraTransform.zoom +
-          cameraTransform.ty * cameraTransform.zoom);
-      const rw = r.width * cameraTransform.zoom;
-      const rh = r.height * cameraTransform.zoom;
+      const projected = projectNativeRectToExportViewport(
+        insight.searchArea,
+        cameraTransform,
+        viewport,
+      );
 
       ctx.fillStyle = 'rgba(2, 131, 145, 0.4)';
-      ctx.fillRect(rx, ry, rw, rh);
+      ctx.fillRect(
+        projected.left,
+        projected.top,
+        projected.width,
+        projected.height,
+      );
       ctx.strokeStyle = '#028391';
       ctx.lineWidth = 1;
-      ctx.strokeRect(rx, ry, rw, rh);
+      ctx.strokeRect(
+        projected.left,
+        projected.top,
+        projected.width,
+        projected.height,
+      );
     }
 
     ctx.restore();
   }
+
+  ctx.restore();
 }
 
 // ── Spinning pointer Canvas drawing ──
@@ -237,13 +293,26 @@ function drawSteps(
   drawImg(img, imageChanged ? crossAlpha : 1);
 
   if (insights.length > 0) {
-    drawInsightOverlays(ctx, insights, { zoom, tx, ty }, offsetX, offsetY);
+    drawInsightOverlays(
+      ctx,
+      insights,
+      { zoom, tx, ty },
+      {
+        offsetX,
+        offsetY,
+        contentWidth,
+        contentHeight,
+        imageWidth: imgW,
+        imageHeight: imgH,
+      },
+    );
   }
 
   const camH = camW * (imgH / imgW);
   const sX = offsetX + ((ptrX - camL) / camW) * contentWidth;
   const sY = offsetY + ((ptrY - camT2) / camH) * contentHeight;
   const pointerLayout = resolveExportPointerLayout(imgW, contentWidth);
+  const spinnerLayout = resolveSpinnerLayout(pointerLayout);
 
   const hasPtrData =
     Math.abs(camera.pointerLeft - Math.round(imgW / 2)) > 1 ||
@@ -257,7 +326,13 @@ function drawSteps(
       spinnerImg,
       sX,
       sY,
-      pointerLayout,
+      {
+        ...pointerLayout,
+        width: spinnerLayout.size,
+        height: spinnerLayout.size,
+        centerOffsetX: spinnerLayout.centerOffset,
+        centerOffsetY: spinnerLayout.centerOffset,
+      },
       spinningElapsedMs,
     );
   }

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -4,15 +4,15 @@ import { deriveFrameState } from './derive-frame-state';
 import type { InsightOverlay } from './derive-frame-state';
 import type { FrameMap } from './frame-calculator';
 import { getPlaybackViewport } from './playback-layout';
+import {
+  type PointerLayout,
+  resolveExportPointerLayout,
+} from './pointer-layout';
 
 const W = 960;
 const H = 540;
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
-const POINTER_WIDTH = 44;
-const POINTER_HEIGHT = 56;
-const POINTER_HOTSPOT_X = 6;
-const POINTER_HOTSPOT_Y = 4;
 
 // ── helpers ──
 
@@ -128,7 +128,7 @@ function drawSpinningPointer(
   img: HTMLImageElement,
   x: number,
   y: number,
-  scale: number,
+  layout: PointerLayout,
   elapsedMs: number,
 ) {
   const progress = (Math.sin(elapsedMs / 500 - Math.PI / 2) + 1) / 2;
@@ -138,29 +138,12 @@ function drawSpinningPointer(
   ctx.rotate(rotation);
   ctx.drawImage(
     img,
-    -(POINTER_WIDTH * scale) / 2,
-    -(POINTER_HEIGHT * scale) / 2,
-    POINTER_WIDTH * scale,
-    POINTER_HEIGHT * scale,
+    -layout.centerOffsetX,
+    -layout.centerOffsetY,
+    layout.width,
+    layout.height,
   );
   ctx.restore();
-}
-
-export function resolveExportPointerLayout(
-  imageWidth: number,
-  contentWidth: number,
-) {
-  const resScale = Math.max(1, Math.sqrt(imageWidth / 1920));
-  const exportScale = (contentWidth / imageWidth) * resScale;
-
-  return {
-    width: POINTER_WIDTH * exportScale,
-    height: POINTER_HEIGHT * exportScale,
-    hotspotX: POINTER_HOTSPOT_X * exportScale,
-    hotspotY: POINTER_HOTSPOT_Y * exportScale,
-    centerOffsetX: (POINTER_WIDTH * exportScale) / 2,
-    centerOffsetY: (POINTER_HEIGHT * exportScale) / 2,
-  };
 }
 
 // ── Steps rendering ──
@@ -274,7 +257,7 @@ function drawSteps(
       spinnerImg,
       sX,
       sY,
-      pointerLayout.width / POINTER_WIDTH,
+      pointerLayout,
       spinningElapsedMs,
     );
   }

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -166,9 +166,15 @@ function drawSteps(
     insights,
   } = st;
 
-  const pT = pointerMoved
-    ? Math.min(rawProgress / POINTER_PHASE, 1)
-    : rawProgress;
+  // When focus on cursor is OFF, the camera does not zoom into the click point,
+  // so the cursor "slide-in" animation (interpolating from the previous default
+  // center to the new click target) is visually distracting and looks like the
+  // cursor is in the wrong place. Snap straight to the target instead.
+  const pT = !autoZoom
+    ? 1
+    : pointerMoved
+      ? Math.min(rawProgress / POINTER_PHASE, 1)
+      : rawProgress;
   const cT = pointerMoved
     ? rawProgress <= POINTER_PHASE
       ? 0

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -1,7 +1,7 @@
 import type { Rect } from '@midscene/core';
 import { mouseLoading, mousePointer } from '../../../utils';
 import { getCenterHighlightBox } from '../../../utils/highlight-element';
-import { deriveFrameState } from './derive-frame-state';
+import { deriveFrameState, shouldRenderCursor } from './derive-frame-state';
 import type { InsightOverlay } from './derive-frame-state';
 import type { FrameMap } from './frame-calculator';
 import { getPlaybackViewport } from './playback-layout';
@@ -15,6 +15,10 @@ const W = 960;
 const H = 540;
 const POINTER_PHASE = 0.375;
 const CROSSFADE_FRAMES = 10;
+const EXPORT_STALL_GRACE_MS = 2000;
+const EXPORT_STALL_GRACE_FRAMES = 10;
+
+let activeExport = false;
 
 interface ExportOverlayViewport {
   offsetX: number;
@@ -33,6 +37,16 @@ function clamp(v: number, lo: number, hi: number): number {
 
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
+}
+
+export function isExportRenderStalled(
+  elapsedSinceLastFrameMs: number,
+  frameDurationMs: number,
+): boolean {
+  return (
+    elapsedSinceLastFrameMs >
+    Math.max(EXPORT_STALL_GRACE_MS, frameDurationMs * EXPORT_STALL_GRACE_FRAMES)
+  );
 }
 
 export function resolveExportCamera(
@@ -209,7 +223,7 @@ function drawSteps(
   stepsFrame: number,
   frameMap: FrameMap,
   imgCache: Map<string, HTMLImageElement>,
-  cursorImg: HTMLImageElement | null,
+  pointerCache: Map<string, HTMLImageElement>,
   spinnerImg: HTMLImageElement | null,
   autoZoom: boolean,
 ) {
@@ -230,6 +244,8 @@ function drawSteps(
     frameInScript: fInScript,
     spinning,
     spinningElapsedMs,
+    currentPointerImg,
+    pointerVisible,
     insights,
   } = st;
 
@@ -313,12 +329,15 @@ function drawSteps(
   const sY = offsetY + ((ptrY - camT2) / camH) * contentHeight;
   const pointerLayout = resolveExportPointerLayout(imgW, contentWidth);
   const spinnerLayout = resolveSpinnerLayout(pointerLayout);
-
-  const hasPtrData =
-    Math.abs(camera.pointerLeft - Math.round(imgW / 2)) > 1 ||
-    Math.abs(camera.pointerTop - Math.round(imgH / 2)) > 1 ||
-    Math.abs(prevCamera.pointerLeft - Math.round(imgW / 2)) > 1 ||
-    Math.abs(prevCamera.pointerTop - Math.round(imgH / 2)) > 1;
+  const cursorImg =
+    pointerCache.get(currentPointerImg) ?? pointerCache.get(mousePointer);
+  const showCursor = shouldRenderCursor(
+    pointerVisible,
+    camera,
+    prevCamera,
+    imgW,
+    imgH,
+  );
 
   if (spinning && spinnerImg) {
     drawSpinningPointer(
@@ -337,7 +356,7 @@ function drawSteps(
     );
   }
 
-  if (!spinning && hasPtrData && cursorImg) {
+  if (!spinning && showCursor && cursorImg) {
     ctx.drawImage(
       cursorImg,
       sX - pointerLayout.hotspotX,
@@ -351,6 +370,24 @@ function drawSteps(
 // ── main export function ──
 
 export async function exportBrandedVideo(
+  frameMap: FrameMap,
+  options?: {
+    autoZoom?: boolean;
+  },
+  onProgress?: (pct: number) => void,
+): Promise<void> {
+  if (activeExport) {
+    throw new Error('Video export is already in progress');
+  }
+  activeExport = true;
+  try {
+    await runExportBrandedVideo(frameMap, options, onProgress);
+  } finally {
+    activeExport = false;
+  }
+}
+
+async function runExportBrandedVideo(
   frameMap: FrameMap,
   options?: {
     autoZoom?: boolean;
@@ -376,13 +413,23 @@ export async function exportBrandedVideo(
     }),
   );
 
-  let cursorImg: HTMLImageElement | null = null;
-  let spinnerImg: HTMLImageElement | null = null;
-  try {
-    cursorImg = await loadImage(mousePointer);
-  } catch {
-    /* optional */
+  const pointerSrcs = new Set<string>([mousePointer]);
+  for (const sf of frameMap.scriptFrames) {
+    if (sf.pointerImg) pointerSrcs.add(sf.pointerImg);
   }
+
+  const pointerCache = new Map<string, HTMLImageElement>();
+  await Promise.all(
+    [...pointerSrcs].map(async (src) => {
+      try {
+        pointerCache.set(src, await loadImage(src));
+      } catch {
+        /* optional */
+      }
+    }),
+  );
+
+  let spinnerImg: HTMLImageElement | null = null;
   try {
     spinnerImg = await loadImage(mouseLoading);
   } catch {
@@ -404,8 +451,55 @@ export async function exportBrandedVideo(
 
   // 3. render loop
   return new Promise<void>((resolve, reject) => {
-    recorder.onerror = () => reject(new Error('MediaRecorder error'));
+    let stoppedByError: Error | null = null;
+    let settled = false;
+    let nextFrame = 0;
+    let nextFrameDueAt = performance.now();
+    let lastFrameAt = nextFrameDueAt;
+    let stopTimer: ReturnType<typeof setTimeout> | null = null;
+    let renderTimer: ReturnType<typeof setTimeout> | null = null;
+    const frameDuration = 1000 / fps;
+
+    const cleanup = () => {
+      if (stopTimer) clearTimeout(stopTimer);
+      if (renderTimer) clearTimeout(renderTimer);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      stream.getTracks().forEach((track) => track.stop());
+    };
+
+    const finishWithError = (error: Error) => {
+      if (settled || stoppedByError) return;
+      stoppedByError = error;
+      if (recorder.state !== 'inactive') {
+        recorder.stop();
+      } else {
+        cleanup();
+        settled = true;
+        reject(error);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        finishWithError(
+          new Error(
+            'Video export was interrupted because the report tab was hidden',
+          ),
+        );
+      }
+    };
+
+    recorder.onerror = () => {
+      finishWithError(new Error('MediaRecorder error'));
+    };
     recorder.onstop = () => {
+      cleanup();
+      if (settled) return;
+      settled = true;
+      if (stoppedByError) {
+        reject(stoppedByError);
+        return;
+      }
       if (chunks.length === 0) {
         reject(new Error('No video data'));
         return;
@@ -416,45 +510,60 @@ export async function exportBrandedVideo(
       a.href = url;
       a.download = 'midscene_replay.webm';
       a.click();
-      stream.getTracks().forEach((track) => track.stop());
       setTimeout(() => URL.revokeObjectURL(url), 1000);
       resolve();
     };
 
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     recorder.start();
-    const frameDuration = 1000 / fps;
-    const startTime = performance.now();
-    let lastFrame = -1;
 
-    const tick = () => {
-      const elapsed = performance.now() - startTime;
-      const targetFrame = Math.min(
-        Math.floor(elapsed / frameDuration),
-        total - 1,
-      );
+    const scheduleNextFrame = () => {
+      const delay = Math.max(0, nextFrameDueAt - performance.now());
+      renderTimer = setTimeout(() => {
+        requestAnimationFrame(renderFrame);
+      }, delay);
+    };
 
-      if (targetFrame > lastFrame) {
-        lastFrame = targetFrame;
-        ctx.clearRect(0, 0, W, H);
-        drawSteps(
-          ctx,
-          targetFrame,
-          frameMap,
-          imgCache,
-          cursorImg,
-          spinnerImg,
-          autoZoom,
+    const renderFrame = (timestamp: number) => {
+      if (settled || recorder.state === 'inactive') return;
+      if (
+        nextFrame > 0 &&
+        isExportRenderStalled(timestamp - lastFrameAt, frameDuration)
+      ) {
+        finishWithError(
+          new Error('Video export was interrupted because rendering stalled'),
         );
-        onProgress?.((targetFrame + 1) / total);
+        return;
       }
 
-      if (targetFrame < total - 1) {
-        requestAnimationFrame(tick);
+      lastFrameAt = timestamp;
+      ctx.clearRect(0, 0, W, H);
+      drawSteps(
+        ctx,
+        nextFrame,
+        frameMap,
+        imgCache,
+        pointerCache,
+        spinnerImg,
+        autoZoom,
+      );
+      onProgress?.((nextFrame + 1) / total);
+
+      nextFrame += 1;
+      if (nextFrame < total) {
+        nextFrameDueAt += frameDuration;
+        scheduleNextFrame();
       } else {
-        setTimeout(() => recorder.stop(), frameDuration * 2);
+        stopTimer = setTimeout(() => {
+          if (recorder.state !== 'inactive') recorder.stop();
+        }, frameDuration * 2);
       }
     };
 
-    requestAnimationFrame(tick);
+    requestAnimationFrame((timestamp) => {
+      lastFrameAt = timestamp;
+      nextFrameDueAt = timestamp;
+      renderFrame(timestamp);
+    });
   });
 }

--- a/packages/visualizer/src/component/player/scenes/pointer-layout.ts
+++ b/packages/visualizer/src/component/player/scenes/pointer-layout.ts
@@ -1,0 +1,52 @@
+const POINTER_REFERENCE_IMAGE_WIDTH = 1920;
+
+export const POINTER_WIDTH = 44;
+export const POINTER_HEIGHT = 56;
+export const POINTER_HOTSPOT_X = 6;
+export const POINTER_HOTSPOT_Y = 4;
+
+export interface PointerLayout {
+  scale: number;
+  width: number;
+  height: number;
+  hotspotX: number;
+  hotspotY: number;
+  centerOffsetX: number;
+  centerOffsetY: number;
+}
+
+function assertPositiveFinite(value: number, name: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive finite number`);
+  }
+}
+
+function buildPointerLayout(scale: number): PointerLayout {
+  return {
+    scale,
+    width: POINTER_WIDTH * scale,
+    height: POINTER_HEIGHT * scale,
+    hotspotX: POINTER_HOTSPOT_X * scale,
+    hotspotY: POINTER_HOTSPOT_Y * scale,
+    centerOffsetX: (POINTER_WIDTH * scale) / 2,
+    centerOffsetY: (POINTER_HEIGHT * scale) / 2,
+  };
+}
+
+export function resolvePointerLayout(imageWidth: number): PointerLayout {
+  assertPositiveFinite(imageWidth, 'imageWidth');
+
+  return buildPointerLayout(
+    Math.max(1, Math.sqrt(imageWidth / POINTER_REFERENCE_IMAGE_WIDTH)),
+  );
+}
+
+export function resolveExportPointerLayout(
+  imageWidth: number,
+  contentWidth: number,
+): PointerLayout {
+  assertPositiveFinite(contentWidth, 'contentWidth');
+
+  const liveLayout = resolvePointerLayout(imageWidth);
+  return buildPointerLayout(liveLayout.scale * (contentWidth / imageWidth));
+}

--- a/packages/visualizer/src/component/player/scenes/pointer-layout.ts
+++ b/packages/visualizer/src/component/player/scenes/pointer-layout.ts
@@ -15,6 +15,11 @@ export interface PointerLayout {
   centerOffsetY: number;
 }
 
+export interface SpinnerLayout {
+  size: number;
+  centerOffset: number;
+}
+
 function assertPositiveFinite(value: number, name: string): void {
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(`${name} must be a positive finite number`);
@@ -49,4 +54,14 @@ export function resolveExportPointerLayout(
 
   const liveLayout = resolvePointerLayout(imageWidth);
   return buildPointerLayout(liveLayout.scale * (contentWidth / imageWidth));
+}
+
+export function resolveSpinnerLayout(
+  pointerLayout: PointerLayout,
+): SpinnerLayout {
+  const size = pointerLayout.height;
+  return {
+    size,
+    centerOffset: size / 2,
+  };
 }

--- a/packages/visualizer/tests/playback-composition.test.ts
+++ b/packages/visualizer/tests/playback-composition.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { shouldRestartPlaybackFromBeginning } from '../src/component/player/playback-controls';
 import {
+  deriveFrameState,
+  shouldRenderCursor,
+} from '../src/component/player/scenes/derive-frame-state';
+import {
+  isExportRenderStalled,
   projectNativeRectToExportViewport,
   resolveExportCamera,
 } from '../src/component/player/scenes/export-branded-video';
@@ -185,5 +190,71 @@ describe('playback composition sizing', () => {
     expect(shouldRestartPlaybackFromBeginning(120, 120)).toBe(true);
     expect(shouldRestartPlaybackFromBeginning(121, 120)).toBe(true);
     expect(shouldRestartPlaybackFromBeginning(119, 120)).toBe(false);
+  });
+
+  it('keeps the cursor visible after an explicit pointer frame', () => {
+    const frameMap = calculateFrameMap([
+      {
+        type: 'img',
+        img: 'frame',
+        duration: 500,
+        imageWidth: 1280,
+        imageHeight: 720,
+      },
+      {
+        type: 'pointer',
+        img: 'cursor',
+        duration: 0,
+      },
+      {
+        type: 'img',
+        img: 'frame-after-action',
+        duration: 500,
+        imageWidth: 1280,
+        imageHeight: 720,
+      },
+    ]);
+
+    const beforePointer = deriveFrameState(
+      frameMap.scriptFrames,
+      0,
+      frameMap.imageWidth,
+      frameMap.imageHeight,
+      frameMap.fps,
+    );
+    const afterPointer = deriveFrameState(
+      frameMap.scriptFrames,
+      16,
+      frameMap.imageWidth,
+      frameMap.imageHeight,
+      frameMap.fps,
+    );
+
+    expect(
+      shouldRenderCursor(
+        beforePointer.pointerVisible,
+        beforePointer.camera,
+        beforePointer.prevCamera,
+        beforePointer.imageWidth,
+        beforePointer.imageHeight,
+      ),
+    ).toBe(false);
+    expect(afterPointer.currentPointerImg).toBe('cursor');
+    expect(
+      shouldRenderCursor(
+        afterPointer.pointerVisible,
+        afterPointer.camera,
+        afterPointer.prevCamera,
+        afterPointer.imageWidth,
+        afterPointer.imageHeight,
+      ),
+    ).toBe(true);
+  });
+
+  it('treats long export render gaps as stalled recordings', () => {
+    const frameDuration = 1000 / 30;
+
+    expect(isExportRenderStalled(500, frameDuration)).toBe(false);
+    expect(isExportRenderStalled(2500, frameDuration)).toBe(true);
   });
 });

--- a/packages/visualizer/tests/playback-composition.test.ts
+++ b/packages/visualizer/tests/playback-composition.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import {
-  resolveExportCamera,
-  resolveExportPointerLayout,
-} from '../src/component/player/scenes/export-branded-video';
+import { resolveExportCamera } from '../src/component/player/scenes/export-branded-video';
 import { calculateFrameMap } from '../src/component/player/scenes/frame-calculator';
 import { getPlaybackFrameState } from '../src/component/player/scenes/playback-frame';
 import { getPlaybackViewport } from '../src/component/player/scenes/playback-layout';
+import {
+  resolveExportPointerLayout,
+  resolvePointerLayout,
+} from '../src/component/player/scenes/pointer-layout';
 import type { AnimationScript } from '../src/utils/replay-scripts';
 
 describe('playback composition sizing', () => {
@@ -93,23 +94,36 @@ describe('playback composition sizing', () => {
     });
   });
 
-  it('scales exported pointer to match live playback at the export viewport size', () => {
-    expect(resolveExportPointerLayout(1280, 960)).toEqual({
-      width: 33,
-      height: 42,
-      hotspotX: 4.5,
-      hotspotY: 3,
-      centerOffsetX: 16.5,
-      centerOffsetY: 21,
-    });
+  it('projects the live pointer layout into the export viewport', () => {
+    const imageWidth = 1400;
+    const contentWidth = 960;
+    const liveLayout = resolvePointerLayout(imageWidth);
+    const exportLayout = resolveExportPointerLayout(imageWidth, contentWidth);
+    const exportScale = contentWidth / imageWidth;
 
-    expect(resolveExportPointerLayout(1920, 960)).toEqual({
-      width: 22,
-      height: 28,
-      hotspotX: 3,
-      hotspotY: 2,
-      centerOffsetX: 11,
-      centerOffsetY: 14,
-    });
+    expect(exportLayout.scale).toBeCloseTo(liveLayout.scale * exportScale, 5);
+    expect(exportLayout.width).toBeCloseTo(liveLayout.width * exportScale, 5);
+    expect(exportLayout.height).toBeCloseTo(liveLayout.height * exportScale, 5);
+    expect(exportLayout.hotspotX).toBeCloseTo(
+      liveLayout.hotspotX * exportScale,
+      5,
+    );
+    expect(exportLayout.hotspotY).toBeCloseTo(
+      liveLayout.hotspotY * exportScale,
+      5,
+    );
+  });
+
+  it('uses the same resolution scale for live and exported high-res pointers', () => {
+    const imageWidth = 2560;
+    const contentWidth = 960;
+    const liveLayout = resolvePointerLayout(imageWidth);
+    const exportLayout = resolveExportPointerLayout(imageWidth, contentWidth);
+
+    expect(liveLayout.scale).toBeGreaterThan(1);
+    expect(exportLayout.scale).toBeCloseTo(
+      liveLayout.scale * (contentWidth / imageWidth),
+      5,
+    );
   });
 });

--- a/packages/visualizer/tests/playback-composition.test.ts
+++ b/packages/visualizer/tests/playback-composition.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveExportCamera } from '../src/component/player/scenes/export-branded-video';
+import {
+  resolveExportCamera,
+  resolveExportPointerLayout,
+} from '../src/component/player/scenes/export-branded-video';
 import { calculateFrameMap } from '../src/component/player/scenes/frame-calculator';
 import { getPlaybackFrameState } from '../src/component/player/scenes/playback-frame';
 import { getPlaybackViewport } from '../src/component/player/scenes/playback-layout';
@@ -87,6 +90,26 @@ describe('playback composition sizing', () => {
       camLeft: 220,
       camTop: 140,
       camWidth: 500,
+    });
+  });
+
+  it('scales exported pointer to match live playback at the export viewport size', () => {
+    expect(resolveExportPointerLayout(1280, 960)).toEqual({
+      width: 33,
+      height: 42,
+      hotspotX: 4.5,
+      hotspotY: 3,
+      centerOffsetX: 16.5,
+      centerOffsetY: 21,
+    });
+
+    expect(resolveExportPointerLayout(1920, 960)).toEqual({
+      width: 22,
+      height: 28,
+      hotspotX: 3,
+      hotspotY: 2,
+      centerOffsetX: 11,
+      centerOffsetY: 14,
     });
   });
 });

--- a/packages/visualizer/tests/playback-composition.test.ts
+++ b/packages/visualizer/tests/playback-composition.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { resolveExportCamera } from '../src/component/player/scenes/export-branded-video';
+import { shouldRestartPlaybackFromBeginning } from '../src/component/player/playback-controls';
+import {
+  projectNativeRectToExportViewport,
+  resolveExportCamera,
+} from '../src/component/player/scenes/export-branded-video';
 import { calculateFrameMap } from '../src/component/player/scenes/frame-calculator';
 import { getPlaybackFrameState } from '../src/component/player/scenes/playback-frame';
 import { getPlaybackViewport } from '../src/component/player/scenes/playback-layout';
 import {
   resolveExportPointerLayout,
   resolvePointerLayout,
+  resolveSpinnerLayout,
 } from '../src/component/player/scenes/pointer-layout';
 import type { AnimationScript } from '../src/utils/replay-scripts';
 
@@ -125,5 +130,60 @@ describe('playback composition sizing', () => {
       liveLayout.scale * (contentWidth / imageWidth),
       5,
     );
+  });
+
+  it('projects native screenshot overlays into the export viewport', () => {
+    const projected = projectNativeRectToExportViewport(
+      { left: 256, top: 108, width: 768, height: 28 },
+      { zoom: 1, tx: 0, ty: 0 },
+      {
+        offsetX: 0,
+        offsetY: 0,
+        contentWidth: 960,
+        contentHeight: 540,
+        imageWidth: 1280,
+        imageHeight: 720,
+      },
+    );
+
+    expect(projected.left).toBeCloseTo(192, 5);
+    expect(projected.top).toBeCloseTo(81, 5);
+    expect(projected.width).toBeCloseTo(576, 5);
+    expect(projected.height).toBeCloseTo(21, 5);
+  });
+
+  it('keeps native overlays aligned while export camera zooms', () => {
+    const projected = projectNativeRectToExportViewport(
+      { left: 256, top: 108, width: 768, height: 28 },
+      { zoom: 2, tx: -96, ty: -54 },
+      {
+        offsetX: 0,
+        offsetY: 0,
+        contentWidth: 960,
+        contentHeight: 540,
+        imageWidth: 1280,
+        imageHeight: 720,
+      },
+    );
+
+    expect(projected.left).toBeCloseTo(192, 5);
+    expect(projected.top).toBeCloseTo(54, 5);
+    expect(projected.width).toBeCloseTo(1152, 5);
+    expect(projected.height).toBeCloseTo(42, 5);
+  });
+
+  it('draws the loading pointer with a square box so it stays circular', () => {
+    const pointerLayout = resolveExportPointerLayout(1280, 960);
+    const spinnerLayout = resolveSpinnerLayout(pointerLayout);
+
+    expect(spinnerLayout.size).toBeCloseTo(pointerLayout.height, 5);
+    expect(spinnerLayout.size).toBeGreaterThan(pointerLayout.width);
+    expect(spinnerLayout.centerOffset).toBeCloseTo(spinnerLayout.size / 2, 5);
+  });
+
+  it('restarts from the beginning at the effective end frame', () => {
+    expect(shouldRestartPlaybackFromBeginning(120, 120)).toBe(true);
+    expect(shouldRestartPlaybackFromBeginning(121, 120)).toBe(true);
+    expect(shouldRestartPlaybackFromBeginning(119, 120)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Single-PR fix for the visualizer player/playground issues reported during review:

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 2.1 | Speed options (`0.5x` …) misaligned with menu items above | Speed item left padding `24px` vs `padding 8 + icon 16 + gap 4 = 28px` for items above | Bump speed-item left padding to `28px` |
| 2.2 | Seek-bar knob parks at ~80–90% when playback ends | Denominator was `totalDurationInFrames - 1` but playback auto-seeks back to the last task frame (skipping the End card) | Compute `effectiveEndFrame` from the last task-bearing script frame; use it for `seekPercent`, `time-display`, drag seek and chapter-marker percentages |
| 2.3 | "Export video" text jitters when switching to "Exporting NN%" | `<Spin size="small">` (~14px) replaces 16px export icon, so width changes | Wrap indicator in fixed 16x16 slot |
| 2.4 | Want a circular progress instead of a bare spinner during export | The export dropdown had no visible numeric/proportional icon progress | Replace `<Spin>` with `<Progress type="circle">` showing the actual percentage |
| 3 | Cursor in exported video appears in the wrong place when Focus on cursor is OFF | Pointer interpolates from default frame center to click target every step; with autoZoom on, the camera moves with it so it looks fine, but with autoZoom off the slide is exposed | When `autoZoom` is false, snap `pT = 1` (no slide) in both live `StepScene` and `export-branded-video` |
| 4 | Playground replay area becomes an empty bordered box after Stop | `Player` returned an empty `.player-container` when `scripts` was empty, even when a partial `reportHTML` was available | Render a "No replay available" empty state with a Download-report button when a report exists; otherwise return `null` |
| 5 | Clicking the lower-left Play button after playback finishes does not restart from the beginning | The player intentionally stops on `effectiveEndFrame` to skip the End card, but `useFramePlayer` only reset when it was on `totalDurationInFrames - 1` | Route canvas click, play button, and Space key through a toggle handler that restarts at frame 0 when `currentFrame >= effectiveEndFrame` |
| 6 | Exported video overlay position is wrong in 1280x720 reports, and the loading circle looks stretched | Export draws to a 960x540 canvas but overlay rectangles were still drawn in native screenshot coordinates; the loading spinner reused the 44x56 pointer layout | Project native rects into the export viewport before applying camera zoom, clip overlays to the viewport, and render the loading spinner in a square layout |
| 7 | The right-side settings/fullscreen controls are not centered in their side area | The right control group had only content width plus `margin-right`, so the two icons were visually offset | Give the control group a 64px minimum width and center its contents |

## Test plan

- [x] `pnpm exec nx test visualizer` (64/64 passed)
- [x] `pnpm exec nx build visualizer`
- [x] `pnpm exec nx build @midscene/report`
- [x] `pnpm run lint` (exit 0; existing warning in `packages/core/tests/unit-test/report-generator-async-contract.test.ts`)
- [ ] **Manual UI verification**:
  - Open the report player, let playback finish, then click the lower-left Play button and press Space; playback should restart at frame 0.
  - Export `/Users/bytedance/Downloads/playwright-Enhanced-Cache-Functionality__should-handle-cache-with-performance-considerations-5aba707f-727d-44e0-af71-8dfb5ee97fd3.html`; the highlight/search overlays should align with the 1280x720 screenshot after downscaling, and the loading circle should stay circular.
  - Check the right-side settings/fullscreen icons are centered in the right control segment.

## Notes

- No backwards-compat shims needed — pure visualizer UI/export fixes.
- Touches only `packages/visualizer/src/component/player/**` and the nearest visualizer unit test.
