### PR TITLE
fix(web-integration): declare semver as a runtime dependency

### DIFF
--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -120,6 +120,7 @@
     "dotenv": "^16.4.5",
     "http-server": "14.1.1",
     "puppeteer-core": "24.6.0",
+    "semver": "7.5.2",
     "socket.io": "^4.8.1",
     "socket.io-client": "4.8.1",
     "ws": "^8.18.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1766,6 +1766,9 @@ importers:
       puppeteer-core:
         specifier: 24.6.0
         version: 24.6.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      semver:
+        specifier: 7.5.2
+        version: 7.5.2
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1(bufferutil@4.0.9)(utf-8-validate@6.0.5)
@@ -2275,19 +2278,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':
@@ -10658,11 +10658,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
     engines: {node: '>=10'}
@@ -16727,7 +16722,7 @@ snapshots:
       ini: 5.0.0
       lodash: 4.17.21
       lru-cache: 10.4.3
-      semver: 7.3.7
+      semver: 7.5.2
       source-map-support: 0.5.21
       teen_process: 2.3.1
     transitivePeerDependencies:
@@ -22873,10 +22868,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.3.7:
-    dependencies:
-      lru-cache: 6.0.0
-
   semver@7.5.2:
     dependencies:
       lru-cache: 6.0.0
@@ -23026,7 +23017,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.4
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.3
       '@img/sharp-darwin-x64': 0.34.3


### PR DESCRIPTION
## Summary

- `packages/web-integration/src/puppeteer/index.ts` and `playwright/index.ts` import `semver` for peer-version checks.
- `semver` was only declared transitively (via `@types/semver` devDependency); the monorepo masked the gap through hoisting.
- Installing the published package in a non-workspace consumer (e.g. `npx -p @midscene/web@<version> midscene-web ...` or any `npm i @midscene/web` outside the repo) fails immediately with `Error: Cannot find module 'semver'` when either entry point loads.
- This adds `semver: 7.5.2` to the runtime dependencies (matching the pin already used by `@midscene/core`).

## Repro on the published package

```
npx -y -p @midscene/web@1.7.6 midscene-web --help
# Error: Cannot find module 'semver'
#   at @midscene/web/dist/lib/puppeteer/index.js
```

After this change, the same invocation resolves `semver` from `@midscene/web/node_modules`.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx build @midscene/web`
- [x] Manual: ran `npx -p @midscene/cli@<beta> -p semver midscene <yaml>` from `/tmp` to confirm puppeteer mode loads with `semver` present (full e2e succeeds end-to-end).
- [ ] CI

## Notes

- The lockfile picks up two unrelated, idempotent re-syncs alongside the new `semver` entry: pnpm dedupes the duplicate `semver@7.3.7` (an `appium`-only resolution) onto `7.5.2`, and bumps a `sharp` transitive `semver: 7.7.2 → 7.7.3`. No source changes needed.