### PR TITLE
Docs: surface headless Linux Electron demo and rework Xvfb guidance in EN/ZH getting-started and API pages

### DIFF
--- a/apps/site/docs/en/computer-api-reference.mdx
+++ b/apps/site/docs/en/computer-api-reference.mdx
@@ -66,10 +66,6 @@ interface RDPComputerAgentOpt extends BaseComputerAgentOpt {
 - `securityProtocol`: Choose `'auto'`, `'tls'`, `'nla'`, or `'rdp'`.
 - `desktopWidth` / `desktopHeight`: Request a specific remote desktop resolution.
 
-:::tip Example: Testing Electron Apps on Headless Linux CI
-A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-:::
-
 **Example:**
 
 ```typescript

--- a/apps/site/docs/en/computer-getting-started.mdx
+++ b/apps/site/docs/en/computer-getting-started.mdx
@@ -15,9 +15,7 @@ Integrate Vitest for testing: [https://github.com/web-infra-dev/midscene-example
 
 Control a remote Windows desktop over RDP: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo)
 
-Linux CI (Xvfb) Electron automation demo: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-
-A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`.
+Test [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
 
 :::
 

--- a/apps/site/docs/en/computer-getting-started.mdx
+++ b/apps/site/docs/en/computer-getting-started.mdx
@@ -17,6 +17,8 @@ Control a remote Windows desktop over RDP: [https://github.com/web-infra-dev/mid
 
 Linux CI (Xvfb) Electron automation demo: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
 
+A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`.
+
 :::
 
 <SetupEnv />

--- a/apps/site/docs/en/computer-getting-started.mdx
+++ b/apps/site/docs/en/computer-getting-started.mdx
@@ -48,9 +48,13 @@ const agent = await agentFromComputer({ headless: true });
 
 Xvfb creates a virtual display so that mouse, keyboard, and screenshot operations work without a physical monitor. See [API Reference](./computer-api-reference) for details.
 
-:::tip Example: Testing Electron Apps on Headless Linux CI
-A complete demo of testing [Obsidian](https://obsidian.md/) (an Electron app) on headless Linux CI with `@midscene/computer`: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-:::
+### Linux example: test Electron apps on headless CI
+
+If you want to run desktop app automation directly in CI (for example, Electron apps like Obsidian), use this end-to-end demo project:
+
+- [computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+
+This demo shows how to start a virtual display with Xvfb on Linux CI and execute `@midscene/computer` automation scripts.
 
 ## Try Playground (no code)
 

--- a/apps/site/docs/en/computer-getting-started.mdx
+++ b/apps/site/docs/en/computer-getting-started.mdx
@@ -15,6 +15,8 @@ Integrate Vitest for testing: [https://github.com/web-infra-dev/midscene-example
 
 Control a remote Windows desktop over RDP: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo)
 
+Linux CI (Xvfb) Electron automation demo: [https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+
 :::
 
 <SetupEnv />
@@ -47,14 +49,6 @@ const agent = await agentFromComputer({ headless: true });
 ```
 
 Xvfb creates a virtual display so that mouse, keyboard, and screenshot operations work without a physical monitor. See [API Reference](./computer-api-reference) for details.
-
-### Linux example: test Electron apps on headless CI
-
-If you want to run desktop app automation directly in CI (for example, Electron apps like Obsidian), use this end-to-end demo project:
-
-- [computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-
-This demo shows how to start a virtual display with Xvfb on Linux CI and execute `@midscene/computer` automation scripts.
 
 ## Try Playground (no code)
 

--- a/apps/site/docs/zh/computer-api-reference.mdx
+++ b/apps/site/docs/zh/computer-api-reference.mdx
@@ -66,10 +66,6 @@ interface RDPComputerAgentOpt extends BaseComputerAgentOpt {
 - `securityProtocol`：可选 `'auto'`、`'tls'`、`'nla'` 或 `'rdp'`。
 - `desktopWidth` / `desktopHeight`：请求指定远程桌面分辨率。
 
-:::tip 示例：在无头 Linux CI 中测试 Electron 应用
-使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-:::
-
 **示例：**
 
 ```typescript

--- a/apps/site/docs/zh/computer-getting-started.mdx
+++ b/apps/site/docs/zh/computer-getting-started.mdx
@@ -15,6 +15,8 @@ import { PackageManagerTabs } from '@theme';
 
 通过 RDP 控制远程 Windows 桌面：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo)
 
+Linux CI（Xvfb）Electron 自动化示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+
 :::
 
 <SetupEnv />
@@ -47,14 +49,6 @@ const agent = await agentFromComputer({ headless: true });
 ```
 
 Xvfb 会创建一个虚拟显示器，使鼠标、键盘和截图操作在没有物理显示器的情况下正常工作。详见 [API 参考](./computer-api-reference)。
-
-### Linux 示例：在无头 CI 中测试 Electron 应用
-
-如果你想在 CI 里直接跑桌面应用自动化（例如 Obsidian 这类 Electron 应用），可以参考以下完整示例仓库：
-
-- [computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-
-该示例演示了如何在 Linux CI 中配合 Xvfb 启动虚拟显示，并运行 `@midscene/computer` 自动化脚本。
 
 ## 试用 Playground（零代码）
 

--- a/apps/site/docs/zh/computer-getting-started.mdx
+++ b/apps/site/docs/zh/computer-getting-started.mdx
@@ -17,6 +17,8 @@ import { PackageManagerTabs } from '@theme';
 
 Linux CI（Xvfb）Electron 自动化示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
 
+使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例。
+
 :::
 
 <SetupEnv />

--- a/apps/site/docs/zh/computer-getting-started.mdx
+++ b/apps/site/docs/zh/computer-getting-started.mdx
@@ -15,9 +15,7 @@ import { PackageManagerTabs } from '@theme';
 
 通过 RDP 控制远程 Windows 桌面：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/rdp-demo)
 
-Linux CI（Xvfb）Electron 自动化示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-
-使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例。
+使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
 
 :::
 

--- a/apps/site/docs/zh/computer-getting-started.mdx
+++ b/apps/site/docs/zh/computer-getting-started.mdx
@@ -48,9 +48,13 @@ const agent = await agentFromComputer({ headless: true });
 
 Xvfb 会创建一个虚拟显示器，使鼠标、键盘和截图操作在没有物理显示器的情况下正常工作。详见 [API 参考](./computer-api-reference)。
 
-:::tip 示例：在无头 Linux CI 中测试 Electron 应用
-使用 `@midscene/computer` 在无头 Linux CI 中测试 [Obsidian](https://obsidian.md/)（Electron 应用）的完整示例：[https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
-:::
+### Linux 示例：在无头 CI 中测试 Electron 应用
+
+如果你想在 CI 里直接跑桌面应用自动化（例如 Obsidian 这类 Electron 应用），可以参考以下完整示例仓库：
+
+- [computer/electron-demo](https://github.com/web-infra-dev/midscene-example/tree/main/computer/electron-demo)
+
+该示例演示了如何在 Linux CI 中配合 Xvfb 启动虚拟显示，并运行 `@midscene/computer` 自动化脚本。
 
 ## 试用 Playground（零代码）
 


### PR DESCRIPTION
### Motivation

- Make the headless Linux / Xvfb guidance more discoverable by surfacing the Electron demo as a standalone example instead of a small tip block.  
- Improve clarity and consistency between the English and Chinese docs for running `@midscene/computer` on CI with Xvfb.

### Description

- Replace the small admonition tip in `computer-getting-started.mdx` (EN/ZH) with a dedicated `Linux example` section that prominently links to the `computer/electron-demo` repository.  
- Remove the same tip from `computer-api-reference.mdx` (EN/ZH) to avoid duplication and to centralize the demo reference in the getting-started guide.  
- Minor copy edits to headings and explanatory text to emphasize using Xvfb on CI and how the demo shows end-to-end usage with `@midscene/computer`.

### Testing

- Built the docs site locally with `pnpm build` and verified the updated pages render and the new demo link is present.  
- No automated unit tests were modified and the static site build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1671f611c832480c226208330e3b8)