### PR TITLE
fix(studio): notarize prerelease builds when notary credentials are present

### DIFF
--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -255,7 +255,13 @@ export const resolveMacPackagedAppSecurity = ({
           ...(appleApiIssuer ? { appleApiIssuer } : {}),
         }
       : undefined;
-  const shouldNotarize = requireNotarization && Boolean(notarizeOptions);
+  // Always notarize when both Developer ID signing and notarization
+  // credentials are available, regardless of the require flag. Otherwise
+  // a prerelease ends up Developer-ID signed but unnotarized, which
+  // Gatekeeper rejects on download with "Apple cannot verify..." even
+  // though the signature itself is valid. The require flag only governs
+  // whether missing credentials should fail the build (handled below).
+  const shouldNotarize = shouldDeveloperIdSign && Boolean(notarizeOptions);
 
   if (requireCodesign && !shouldDeveloperIdSign) {
     throw new Error(

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -190,6 +190,49 @@ describe('package-electron helpers', () => {
     });
   });
 
+  it('notarizes prerelease builds whenever Developer ID + notary credentials are present', () => {
+    // Prereleases set MIDSCENE_REQUIRE_MAC_NOTARIZATION=false so missing
+    // credentials don't fail the build, but when credentials ARE present
+    // we must still notarize. Otherwise the .app gets Developer-ID
+    // signed but stays unnotarized, and Gatekeeper rejects it on
+    // download with "Apple cannot verify...".
+    expect(
+      resolveMacPackagedAppSecurity({
+        env: {
+          APPLE_API_KEY_ID: 'ABC123XYZ9',
+          APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123XYZ9.p8',
+          APPLE_API_ISSUER_ID: 'issuer-uuid',
+          APPLE_CODESIGN_IDENTITY:
+            'Developer ID Application: YIBING LIN (62S977T8M3)',
+          APPLE_TEAM_ID: '62S977T8M3',
+          MIDSCENE_REQUIRE_MAC_CODESIGN: 'false',
+          MIDSCENE_REQUIRE_MAC_NOTARIZATION: 'false',
+        },
+        platform: 'darwin',
+      }),
+    ).toMatchObject({
+      shouldDeveloperIdSign: true,
+      shouldNotarize: true,
+      requireNotarization: false,
+    });
+  });
+
+  it('skips notarization when notary credentials are absent even with a Developer ID identity', () => {
+    expect(
+      resolveMacPackagedAppSecurity({
+        env: {
+          APPLE_CODESIGN_IDENTITY:
+            'Developer ID Application: YIBING LIN (62S977T8M3)',
+          APPLE_TEAM_ID: '62S977T8M3',
+        },
+        platform: 'darwin',
+      }),
+    ).toMatchObject({
+      shouldDeveloperIdSign: true,
+      shouldNotarize: false,
+    });
+  });
+
   it('rejects release mac packaging when codesign is required but no identity is configured', () => {
     expect(() =>
       resolveMacPackagedAppSecurity({


### PR DESCRIPTION
## Summary

Prerelease (prepatch / beta / alpha / rc) Studio macOS artifacts produced by CI were Developer-ID signed but never notarized, so Gatekeeper rejected them on download with the dialog:

> Apple could not verify "Midscene Studio.app" is free of malware that may harm your Mac or compromise your privacy.

### Root cause

`release.yml` sets `MIDSCENE_REQUIRE_MAC_NOTARIZATION=false` for prereleases so a CI run will not fail when secrets are missing. The packaging script was using the **same** flag to decide whether to actually run notarization:

```js
const shouldNotarize = requireNotarization && Boolean(notarizeOptions);
```

As a result, a prerelease run on a machine where every Apple secret IS configured still skipped `notarize()` + `xcrun stapler`, leaving the .app signed but unstapled. CI logs from a recent prepatch run confirm this — the codesign step ran end-to-end, but `Submitting ... for notarization.` and `xcrun stapler validate` never appeared.

### Fix

Decouple execution from enforcement. Notarize whenever the .app is Developer-ID signed AND notarization credentials are configured:

```js
const shouldNotarize = shouldDeveloperIdSign && Boolean(notarizeOptions);
```

The `MIDSCENE_REQUIRE_*` flags now purely govern whether missing credentials should fail the build (the existing throw blocks below already handle that case). Behavior matrix after the fix:

| Scenario | Before | After |
| --- | --- | --- |
| Formal release + secrets present | sign + notarize ✅ | sign + notarize ✅ |
| Prerelease + secrets present | sign, **skip notarize** ❌ | sign + notarize ✅ |
| Prerelease + secrets missing | ad-hoc fallback | ad-hoc fallback (unchanged) |
| Formal release + secrets missing | error (unchanged) | error (unchanged) |

### Tests

Added two regression tests that pin the new behavior:

- prerelease env (`require=false`) + full credentials → `shouldNotarize: true`
- Developer ID identity present without notary credentials → `shouldNotarize: false`

## Test plan

- [x] `pnpm exec vitest run tests/package-electron.test.mjs` (38/38 passed)
- [x] `pnpm run lint` (clean — only a pre-existing unrelated warning in `packages/core`)
- [ ] After merge: trigger a prepatch and verify the new artifact passes `spctl -a -vvv -t exec` with `source=Notarized Developer ID`, and that CI logs show `Submitting Midscene Studio.app for notarization.` followed by `xcrun stapler validate`.