### PR TITLE
fix(report): show merge non-passed/failed cases as Other

### DIFF
--- a/apps/report/src/components/playwright-case-selector/index.less
+++ b/apps/report/src/components/playwright-case-selector/index.less
@@ -4,7 +4,7 @@
   flex-shrink: 0;
 
   .selector-header {
-    padding: 0 12px;
+    padding: 6px 12px;
     background: #f2f4f7;
     border-radius: 8px;
     border: 1px solid transparent;
@@ -14,6 +14,7 @@
     justify-content: space-between;
     transition: all 0.2s ease;
     min-height: 36px;
+    line-height: 1.4;
 
     &:hover {
       background: #f6f8fa;
@@ -147,14 +148,14 @@
 
       .option-item {
         width: 100%;
-        padding-left: 8px;
-        padding-right: 8px;
+        padding: 6px 8px;
         display: flex;
         align-items: center;
         gap: 8px;
         cursor: pointer;
         transition: background-color 0.2s ease;
-        line-height: 32px;
+        min-height: 32px;
+        line-height: 1.4;
         white-space: normal;
         overflow: visible;
 

--- a/apps/report/src/components/playwright-case-selector/index.tsx
+++ b/apps/report/src/components/playwright-case-selector/index.tsx
@@ -24,6 +24,14 @@ interface PlaywrightCaseSelectorProps {
   onSelect?: (dump: GroupedActionDump) => void;
 }
 
+const STATUS_DISPLAY_LABEL: Partial<
+  Record<PlaywrightTaskAttributes['playwright_test_status'], string>
+> = {
+  timedOut: 'timed out',
+  interrupted: 'interrupted',
+  skipped: 'skipped',
+};
+
 function PlaywrightCaseTitle(props: {
   attributes: Pick<
     PlaywrightTaskAttributes,
@@ -36,10 +44,13 @@ function PlaywrightCaseTitle(props: {
   const { attributes } = props;
   const status = iconForStatus(attributes.playwright_test_status);
   const costStr = attributes.playwright_test_duration;
+  const extraStatusLabel =
+    STATUS_DISPLAY_LABEL[attributes.playwright_test_status];
   const cost = costStr ? (
     <span className="cost-str">
       {' '}
-      ({timeCostStrElement(Number(costStr) || 0)})
+      ({timeCostStrElement(Number(costStr) || 0)}
+      {extraStatusLabel ? `, ${extraStatusLabel}` : ''})
     </span>
   ) : null;
 

--- a/apps/report/src/components/report-overview/index.less
+++ b/apps/report/src/components/report-overview/index.less
@@ -41,7 +41,7 @@
           color: #e40303;
         }
 
-        &.stats-timedout {
+        &.stats-other {
           color: #ff8c00;
         }
       }
@@ -73,7 +73,7 @@
             color: #ff4d4f;
           }
 
-          &.stats-timedout {
+          &.stats-other {
             color: #ffa940;
           }
         }

--- a/apps/report/src/components/report-overview/index.tsx
+++ b/apps/report/src/components/report-overview/index.tsx
@@ -1,10 +1,15 @@
 import { Tooltip } from 'antd';
 import { useMemo } from 'react';
-import type { PlaywrightTasks } from '../../types';
+import type { PlaywrightTaskAttributes, PlaywrightTasks } from '../../types';
 import { PlaywrightCaseSelector } from '../playwright-case-selector';
 
 import './index.less';
 import { iconForStatus } from '@midscene/visualizer';
+
+type OtherTestEntry = {
+  name: string;
+  status: PlaywrightTaskAttributes['playwright_test_status'];
+};
 
 const ReportOverview = (props: {
   title: string;
@@ -13,31 +18,19 @@ const ReportOverview = (props: {
   dumps?: PlaywrightTasks[];
 }): JSX.Element => {
   const testStats = useMemo(() => {
-    if (!props.dumps || props.dumps.length === 0) {
-      return {
-        total: 0,
-        passed: 0,
-        failed: 0,
-        skipped: 0,
-        timedOut: 0,
-        passedTests: [],
-        failedTests: [],
-        skippedTests: [],
-        timedOutTests: [],
-      };
-    }
-
     const stats = {
       total: 0,
       passed: 0,
       failed: 0,
-      skipped: 0,
-      timedOut: 0,
+      other: 0,
       passedTests: [] as string[],
       failedTests: [] as string[],
-      skippedTests: [] as string[],
-      timedOutTests: [] as string[],
+      otherTests: [] as OtherTestEntry[],
     };
+
+    if (!props.dumps || props.dumps.length === 0) {
+      return stats;
+    }
 
     props.dumps.forEach((dump) => {
       stats.total++;
@@ -53,12 +46,9 @@ const ReportOverview = (props: {
       } else if (status === 'failed') {
         stats.failed++;
         stats.failedTests.push(testName);
-      } else if (status === 'skipped') {
-        stats.skipped++;
-        stats.skippedTests.push(testName);
-      } else if (status === 'timedOut' || status === 'interrupted') {
-        stats.timedOut++;
-        stats.timedOutTests.push(testName);
+      } else {
+        stats.other++;
+        stats.otherTests.push({ name: testName, status });
       }
     });
 
@@ -112,11 +102,11 @@ const ReportOverview = (props: {
         </Tooltip>
         <Tooltip
           title={
-            testStats.timedOutTests.length > 0 ? (
+            testStats.otherTests.length > 0 ? (
               <div>
-                {testStats.timedOutTests.map((testName, index) => (
+                {testStats.otherTests.map((entry, index) => (
                   <div key={index}>
-                    {iconForStatus('timedOut')} {testName}
+                    {iconForStatus(entry.status)} {entry.name}
                   </div>
                 ))}
               </div>
@@ -124,10 +114,8 @@ const ReportOverview = (props: {
           }
         >
           <div className="stats-card">
-            <div className="stats-value stats-timedout">
-              {testStats.timedOut}
-            </div>
-            <div className="stats-label">Timeout</div>
+            <div className="stats-value stats-other">{testStats.other}</div>
+            <div className="stats-label">Other</div>
           </div>
         </Tooltip>
       </div>


### PR DESCRIPTION
## Summary
- Rename the merge report stats card from `Timeout` to `Other` so it accurately reflects every non-passed/non-failed test instead of pretending the bucket is timeout-only.
- Include all non-passed/non-failed Playwright statuses (`timedOut`, `interrupted`, `skipped`, …) in the `Other` bucket; the previous logic silently dropped `skipped` and lumped `timedOut`/`interrupted` together with a misleading label.
- Render each case's actual status icon inside the `Other` tooltip, instead of a hard-coded `timedOut` icon for every entry.
- Append the concrete status next to the duration in the case-selector list (e.g. `(37.00s, interrupted)`, `(12.00s, timed out)`, `(5.00s, skipped)`) so the outcome is visible at a glance, while passed/failed rows keep the original `(<duration>)` format.
- Rename the corresponding LESS class `.stats-timedout` → `.stats-other` (color treatment unchanged).

## Test plan
- [x] `pnpm run lint`
- [ ] Open a merged Playwright report containing `interrupted`/`timedOut`/`skipped` cases and verify the `Other` card count, tooltip icons, and per-row status suffix.