### PR TITLE
ci(workflow): bump release workflow Node to 24.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.11.0]
+        node-version: [24.13.0]
     # Force rspack/miette onto the narratable diagnostic path. The graphical
     # handler in miette 7.6.0 panics on `terminal_size()` edge cases inside
     # GitHub Actions (no tty + stream multiplexing), which surfaces as a
@@ -54,7 +54,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '22.11.0'
+        node-version: '24.13.0'
         cache: 'pnpm'
 
     - name: Cache Puppeteer


### PR DESCRIPTION
## Summary
- Align the `release` job in `.github/workflows/release.yml` with every other CI workflow by bumping Node from `22.11.0` to `24.13.0`.
- The `package_studio` job is intentionally left on `22.11.0` because it covers Electron packaging and was not affected.

## Why
Failing run: https://github.com/web-infra-dev/midscene/actions/runs/25145382152/job/73703974098

The release job runs `pnpm test`. On Node `22.11.0`, vitest crashes with an unhandled error:

```
Error: require() of ES Module .../@exodus+bytes@1.15.0/.../encoding-lite.js
from .../html-encoding-sniffer@6.0.0/lib/html-encoding-sniffer.js not supported.
Serialized Error: { code: 'ERR_REQUIRE_ESM' }
```

Chain of causation:
- `apps/studio` depends on `jsdom@29.0.2` (used by some `@vitest-environment jsdom` tests across `packages/shared`, `apps/studio`, `apps/chrome-extension`).
- `jsdom@29` pulls in `html-encoding-sniffer@6.0.0` (CJS) which `require()`s `@exodus/bytes/encoding-lite.js` (ESM-only).
- Node `<22.12` does not allow `require()` of ESM by default, so the test process throws.
- Node `22.12+` enables this transparently, which is why the rest of CI (already on `24.13.0`) does not see this error.

That is also the answer to "why didn't other PR CIs hit it" — `ci.yml`, `lint.yml`, `ai.yml`, `ai-unit-test.yml`, `headless-linux.yml`, etc. all run on `24.13.0`. Only `release.yml` was still pinned to `22.11.0`, so the failure was unique to the release workflow.

## Test plan
- [ ] Re-trigger the Release workflow (`workflow_dispatch` with `version=patch`) and verify `pnpm test` passes inside the release job.
- [ ] Confirm `package_studio` job still runs on Node `22.11.0` and produces Studio artifacts as before.