### PR TITLE
feat(shared): add moonshot model family support

### DIFF
--- a/packages/shared/src/env/parse-model-config.ts
+++ b/packages/shared/src/env/parse-model-config.ts
@@ -12,6 +12,7 @@ import {
   MIDSCENE_OPENAI_SOCKS_PROXY,
   MIDSCENE_USE_DOUBAO_VISION,
   MIDSCENE_USE_GEMINI,
+  MIDSCENE_USE_MOONSHOT,
   MIDSCENE_USE_QWEN3_VL,
   MIDSCENE_USE_QWEN_VL,
   MIDSCENE_USE_VLM_UI_TARS,
@@ -87,6 +88,7 @@ export const legacyConfigToModelFamily = (
   const isQwen3 = provider[MIDSCENE_USE_QWEN3_VL];
   const isUiTars = provider[MIDSCENE_USE_VLM_UI_TARS];
   const isGemini = provider[MIDSCENE_USE_GEMINI];
+  const isMoonshot = provider[MIDSCENE_USE_MOONSHOT];
 
   const enabledModes = [
     isDoubao && MIDSCENE_USE_DOUBAO_VISION,
@@ -94,6 +96,7 @@ export const legacyConfigToModelFamily = (
     isQwen3 && MIDSCENE_USE_QWEN3_VL,
     isUiTars && MIDSCENE_USE_VLM_UI_TARS,
     isGemini && MIDSCENE_USE_GEMINI,
+    isMoonshot && MIDSCENE_USE_MOONSHOT,
   ].filter(Boolean);
 
   if (enabledModes.length > 1) {
@@ -107,6 +110,7 @@ export const legacyConfigToModelFamily = (
   if (isQwen) return 'qwen2.5-vl';
   if (isDoubao) return 'doubao-vision';
   if (isGemini) return 'gemini';
+  if (isMoonshot) return 'moonshot';
 
   // UI-TARS with version detection
   if (isUiTars) {

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -76,6 +76,7 @@ export const MIDSCENE_USE_QWEN_VL = 'MIDSCENE_USE_QWEN_VL';
 export const MIDSCENE_USE_QWEN3_VL = 'MIDSCENE_USE_QWEN3_VL';
 export const MIDSCENE_USE_DOUBAO_VISION = 'MIDSCENE_USE_DOUBAO_VISION';
 export const MIDSCENE_USE_GEMINI = 'MIDSCENE_USE_GEMINI';
+export const MIDSCENE_USE_MOONSHOT = 'MIDSCENE_USE_MOONSHOT';
 export const MIDSCENE_USE_VL_MODEL = 'MIDSCENE_USE_VL_MODEL';
 export const MATCH_BY_POSITION = 'MATCH_BY_POSITION';
 export const MIDSCENE_REPORT_TAG_NAME = 'MIDSCENE_REPORT_TAG_NAME';
@@ -234,6 +235,7 @@ export const MODEL_ENV_KEYS = [
   MIDSCENE_USE_QWEN3_VL,
   MIDSCENE_USE_DOUBAO_VISION,
   MIDSCENE_USE_GEMINI,
+  MIDSCENE_USE_MOONSHOT,
   MIDSCENE_USE_VL_MODEL,
   // model default legacy
   OPENAI_API_KEY,
@@ -297,6 +299,7 @@ export type TModelFamily =
   | 'doubao-vision'
   | 'doubao-seed'
   | 'gemini'
+  | 'moonshot'
   | 'vlm-ui-tars'
   | 'vlm-ui-tars-doubao'
   | 'vlm-ui-tars-doubao-1.5'
@@ -309,6 +312,7 @@ export const MODEL_FAMILY_VALUES: TModelFamily[] = [
   'doubao-vision',
   'doubao-seed',
   'gemini',
+  'moonshot',
   'qwen2.5-vl',
   'qwen3-vl',
   'qwen3.5',

--- a/packages/shared/tests/unit-test/env/parse.test.ts
+++ b/packages/shared/tests/unit-test/env/parse.test.ts
@@ -8,6 +8,7 @@ import { UITarsModelVersion } from '../../../src/env/types';
 import {
   MIDSCENE_USE_DOUBAO_VISION,
   MIDSCENE_USE_GEMINI,
+  MIDSCENE_USE_MOONSHOT,
   MIDSCENE_USE_QWEN3_VL,
   MIDSCENE_USE_QWEN_VL,
   MIDSCENE_USE_VLM_UI_TARS,
@@ -32,6 +33,7 @@ describe('getUITarsModelVersion', () => {
     expect(getUITarsModelVersion('qwen3-vl')).toBeUndefined();
     expect(getUITarsModelVersion('doubao-vision')).toBeUndefined();
     expect(getUITarsModelVersion('gemini')).toBeUndefined();
+    expect(getUITarsModelVersion('moonshot')).toBeUndefined();
     expect(getUITarsModelVersion('glm-v')).toBeUndefined();
     expect(getUITarsModelVersion('gpt-5')).toBeUndefined();
   });
@@ -43,6 +45,7 @@ describe('validateModelFamily', () => {
     expect(() => validateModelFamily('qwen3.6')).not.toThrow();
     expect(() => validateModelFamily('doubao-vision')).not.toThrow();
     expect(() => validateModelFamily('gemini')).not.toThrow();
+    expect(() => validateModelFamily('moonshot')).not.toThrow();
     expect(() => validateModelFamily('glm-v')).not.toThrow();
     expect(() => validateModelFamily('gpt-5')).not.toThrow();
     expect(() => validateModelFamily('vlm-ui-tars')).not.toThrow();
@@ -73,6 +76,9 @@ describe('legacyConfigToModelFamily', () => {
     ).toBe('doubao-vision');
     expect(legacyConfigToModelFamily({ [MIDSCENE_USE_GEMINI]: '1' })).toBe(
       'gemini',
+    );
+    expect(legacyConfigToModelFamily({ [MIDSCENE_USE_MOONSHOT]: '1' })).toBe(
+      'moonshot',
     );
   });
 


### PR DESCRIPTION
## Summary

Add support for Moonshot AI (Kimi) vision models in Midscene.js.

## Changes

- Add `moonshot` to `TModelFamily` type and `MODEL_FAMILY_VALUES` array
- Add `MIDSCENE_USE_MOONSHOT` legacy environment variable for quick configuration
- Add `moonshot` mapping in `legacyConfigToModelFamily`
- Add unit tests for model family validation and legacy config parsing

## Why

Moonshot API is fully OpenAI-compatible, so it can reuse Midscene's existing VLM calling chain. However, registering it as a first-class `modelFamily` ensures:

1. **Planning prompt includes bbox**: When `modelFamily` is set, the planning prompt correctly describes the `locate` param as `{bbox: [xmin, ymin, xmax, ymax], prompt: string}`, allowing the model to return coordinates directly in the planning phase.
2. **Avoids extra locate API call**: Without a model family, the planning prompt only asks for `{prompt: string}`, forcing a separate locate call afterward.
3. **Clean user configuration**: Users can explicitly set `MIDSCENE_MODEL_FAMILY=moonshot` or `MIDSCENE_USE_MOONSHOT=1`.

## Usage

```bash
export MIDSCENE_MODEL_FAMILY="moonshot"
export MIDSCENE_MODEL_NAME="kimi-k2.5"
export MIDSCENE_MODEL_BASE_URL="https://api.moonshot.cn/v1"
export MIDSCENE_MODEL_API_KEY="your-api-key"
```

Or via legacy flag:

```bash
export MIDSCENE_USE_MOONSHOT=1
export MIDSCENE_MODEL_NAME="kimi-k2.5"
export MIDSCENE_MODEL_BASE_URL="https://api.moonshot.cn/v1"
export MIDSCENE_MODEL_API_KEY="your-api-key"
```

## Validation

- `pnpm run lint`
- `npx nx test @midscene/shared` (325 passed)
- `npx nx test @midscene/core` (817 passed)