### PR TITLE
feat(core): yaml inter-step variable interpolation

### DIFF
--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -53,6 +53,29 @@ import {
 } from './utils';
 
 const debug = getDebug('yaml-player');
+
+const VARIABLE_FULL_MATCH_RE = /^\$([a-zA-Z_][a-zA-Z0-9_]*)$/;
+const VARIABLE_EMBEDDED_RE = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+
+function deepTransform(
+  value: unknown,
+  transform: (val: unknown) => unknown,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => deepTransform(item, transform));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = deepTransform(val, transform);
+    }
+    return result;
+  }
+
+  return transform(value);
+}
+
 const aiTaskHandlerMap = {
   aiQuery: 'aiQuery',
   aiNumber: 'aiNumber',
@@ -277,6 +300,33 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
     }
   }
 
+  private resolveVariables(value: unknown): unknown {
+    return deepTransform(value, (val) => {
+      if (typeof val !== 'string') {
+        return val;
+      }
+
+      const fullMatch = val.match(VARIABLE_FULL_MATCH_RE);
+      if (fullMatch) {
+        const varName = fullMatch[1];
+        if (!(varName in this.result)) {
+          throw new Error(`Variable "${varName}" is not defined`);
+        }
+        return this.result[varName];
+      }
+
+      return val.replace(VARIABLE_EMBEDDED_RE, (_, varName) => {
+        if (!(varName in this.result)) {
+          throw new Error(`Variable "${varName}" is not defined`);
+        }
+        const replacement = this.result[varName];
+        return typeof replacement === 'string'
+          ? replacement
+          : JSON.stringify(replacement);
+      });
+    });
+  }
+
   async playTask(taskStatus: ScriptPlayerTaskStatus, agent: Agent) {
     const { flow } = taskStatus;
     assert(flow, 'missing flow in task');
@@ -284,7 +334,10 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
     for (const flowItemIndex in flow) {
       const currentStep = Number.parseInt(flowItemIndex, 10);
       taskStatus.currentStep = currentStep;
-      const flowItem = flow[flowItemIndex];
+      const flowItem = this.resolveVariables(flow[flowItemIndex]) as Record<
+        string,
+        unknown
+      >;
 
       // Skip Finalize action from cache - it's a planning-only marker
       if ('Finalize' in flowItem) {

--- a/packages/core/tests/unit-test/player-action-dispatch.test.ts
+++ b/packages/core/tests/unit-test/player-action-dispatch.test.ts
@@ -289,6 +289,114 @@ describe('player action dispatch ordering', () => {
     });
   });
 
+  describe('player variable interpolation', () => {
+    it('should replace $var with stored result value', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent();
+      player.result.product_id = '110';
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiInput: 'search box', value: '$product_id' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.callActionInActionSpace).toHaveBeenCalledWith(
+        'Input',
+        expect.objectContaining({ value: '110' }),
+      );
+    });
+
+    it('should preserve non-string types for $var replacement', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent();
+      player.result.count = 42;
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiInput: 'qty field', value: '$count' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.callActionInActionSpace).toHaveBeenCalledWith(
+        'Input',
+        expect.objectContaining({ value: '42' }),
+      );
+    });
+
+    it('should interpolate ${var} inside strings', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent({
+        aiQuery: vi.fn().mockResolvedValue('query-result'),
+      });
+      player.result.product_id = '110';
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiQuery: 'search for product-${product_id}', name: 'result' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.aiQuery).toHaveBeenCalledWith(
+        'search for product-110',
+        expect.anything(),
+      );
+    });
+
+    it('should throw when referencing undefined variable', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent();
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiInput: 'search box', value: '$undefined_var' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await expect(player.playTask(taskStatus, agent)).rejects.toThrow(
+        'Variable "undefined_var" is not defined',
+      );
+    });
+
+    it('should replace variables in nested objects', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent({
+        aiTap: vi.fn().mockResolvedValue('tap-result'),
+      });
+      player.result.prompt_text = 'search box';
+
+      const taskStatus = {
+        name: 'test',
+        flow: [
+          {
+            aiTap: { prompt: '$prompt_text' },
+          },
+        ],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.aiTap).toHaveBeenCalledWith('search box', expect.anything());
+    });
+  });
+
   it('round-trip: cached plan → buildYamlFlowFromPlans → player dispatches with correct param', async () => {
     // Regression for the cache-replay bug: a Terminate plan was serialized as
     // { terminate: '', uri: '...' }, then replayed as agent.terminate('').


### PR DESCRIPTION
## Summary

This PR implements inter-step variable passing in YAML scripts (closes #2428).

Users can now reference results from previous steps using `$variableName` or `${variableName}` syntax within any flow item field.

### Syntax

- `$name` — full replacement, preserves the original type from `result`.
- `${name}` — embedded interpolation inside a larger string. Non-string values are JSON-stringified.

### Example

```yaml
- aiQuery: 提取第一个商品条目的商品ID，输出为字符串
  name: tc001_product_id

- aiInput: 商品名称搜索输入框
  value: $tc001_product_id

- aiQuery: 搜索商品编号为 ${tc001_product_id} 的详情
  name: detail
```

### Implementation

- Added `deepTransform(value, transform)` utility to recursively walk arrays/objects and apply a callback to leaf nodes.
- Added `resolveVariables` in `ScriptPlayer` to substitute `$var` / `${var}` references from `this.result` before dispatching each flow item.
- Throws a clear error when referencing an undefined variable.

### Validation

- `pnpm run lint`
- `npx nx test @midscene/core` — 822 tests passed