### PR TITLE
feat(studio): manual mouse/touch control of Android, iOS, Harmony device previews

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -73,6 +73,9 @@ const getAppIconPath = () => {
     path.resolve(process.resourcesPath, 'assets/midscene-icon.png'),
     path.resolve(app.getAppPath(), 'assets/midscene-icon.png'),
     path.resolve(__dirname, '../assets/midscene-icon.png'),
+    // Dev mode: rsbuild dev does not run sync-static-assets, so fall back to
+    // the source assets directory next to the package.json.
+    path.resolve(__dirname, '../../assets/midscene-icon.png'),
   ];
 
   const iconPath = candidatePaths.find((candidatePath) =>

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -20,6 +20,7 @@ import type { ShellActiveView } from '../ShellLayout/types';
 import { DeviceList } from './DeviceList';
 import { MobilePreviewFrame } from './MobilePreviewFrame';
 import {
+  resolveStudioPreviewPlatform,
   shouldEnableMobilePreviewFrame,
   shouldUseComputerPreviewPadding,
 } from './preview-layout';
@@ -131,6 +132,15 @@ export default function MainContent({
     runtimeInfo,
     previewFormValues,
   );
+  const previewPlatform = resolveStudioPreviewPlatform(
+    runtimeInfo,
+    previewFormValues,
+  );
+  const manualControlEnabled =
+    isConnected &&
+    (previewPlatform === 'android' ||
+      previewPlatform === 'ios' ||
+      previewPlatform === 'harmony');
   const disconnectDisabled =
     !isReady || !studioPlayground.controller.state.sessionViewState.connected;
   const previewConnectionFailed =
@@ -438,6 +448,7 @@ export default function MainContent({
                   isUserOperating={
                     studioPlayground.controller.state.isUserOperating
                   }
+                  manualControlEnabled={manualControlEnabled}
                 />
               </Suspense>
             </div>

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -1,0 +1,208 @@
+import { type CSSProperties, useCallback, useEffect, useRef } from 'react';
+
+export interface DeviceSize {
+  width: number;
+  height: number;
+}
+
+export interface DeviceInteractionLayerProps {
+  enabled: boolean;
+  deviceSize?: DeviceSize | null;
+  onTap?: (point: { x: number; y: number }) => void;
+  onSwipe?: (
+    start: { x: number; y: number },
+    end: { x: number; y: number },
+    duration: number,
+  ) => void;
+  /**
+   * Tap classification thresholds. Pointer movement below this distance and
+   * total duration below this delay is reported as a Tap; anything else is a
+   * Swipe.
+   */
+  tapMaxDistance?: number;
+  tapMaxDurationMs?: number;
+  style?: CSSProperties;
+}
+
+interface ActivePointer {
+  startX: number;
+  startY: number;
+  startTime: number;
+  lastX: number;
+  lastY: number;
+  contentRect: { left: number; top: number; width: number; height: number };
+}
+
+export function inscribedContentRect(
+  panel: { left: number; top: number; width: number; height: number },
+  deviceSize: DeviceSize,
+) {
+  const aspect = deviceSize.width / deviceSize.height;
+  if (panel.height <= 0 || panel.width <= 0) return panel;
+  if (panel.width / panel.height > aspect) {
+    const renderedWidth = panel.height * aspect;
+    return {
+      left: panel.left + (panel.width - renderedWidth) / 2,
+      top: panel.top,
+      width: renderedWidth,
+      height: panel.height,
+    };
+  }
+  const renderedHeight = panel.width / aspect;
+  return {
+    left: panel.left,
+    top: panel.top + (panel.height - renderedHeight) / 2,
+    width: panel.width,
+    height: renderedHeight,
+  };
+}
+
+export function DeviceInteractionLayer({
+  enabled,
+  deviceSize,
+  onTap,
+  onSwipe,
+  tapMaxDistance = 8,
+  tapMaxDurationMs = 250,
+  style,
+}: DeviceInteractionLayerProps) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const activePointer = useRef<ActivePointer | null>(null);
+
+  const projectToDevice = useCallback(
+    (
+      clientX: number,
+      clientY: number,
+      contentRect: { left: number; top: number; width: number; height: number },
+    ) => {
+      if (!deviceSize) return null;
+      const ratioX = (clientX - contentRect.left) / contentRect.width;
+      const ratioY = (clientY - contentRect.top) / contentRect.height;
+      const x = Math.max(
+        0,
+        Math.min(deviceSize.width - 1, Math.round(ratioX * deviceSize.width)),
+      );
+      const y = Math.max(
+        0,
+        Math.min(deviceSize.height - 1, Math.round(ratioY * deviceSize.height)),
+      );
+      return { x, y };
+    },
+    [deviceSize],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!enabled || !deviceSize || !overlayRef.current) return;
+      if (event.button !== 0 && event.pointerType === 'mouse') return;
+      const panelRect = overlayRef.current.getBoundingClientRect();
+      const contentRect = inscribedContentRect(panelRect, deviceSize);
+      if (
+        event.clientX < contentRect.left ||
+        event.clientX > contentRect.left + contentRect.width ||
+        event.clientY < contentRect.top ||
+        event.clientY > contentRect.top + contentRect.height
+      ) {
+        return;
+      }
+      overlayRef.current.setPointerCapture(event.pointerId);
+      activePointer.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        startTime: performance.now(),
+        lastX: event.clientX,
+        lastY: event.clientY,
+        contentRect,
+      };
+      event.preventDefault();
+    },
+    [enabled, deviceSize],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const active = activePointer.current;
+      if (!active) return;
+      active.lastX = event.clientX;
+      active.lastY = event.clientY;
+    },
+    [],
+  );
+
+  const finishPointer = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>, cancelled: boolean) => {
+      const active = activePointer.current;
+      activePointer.current = null;
+      if (!active) return;
+      try {
+        overlayRef.current?.releasePointerCapture(event.pointerId);
+      } catch {
+        /* ignore */
+      }
+      if (cancelled) return;
+
+      const dx = event.clientX - active.startX;
+      const dy = event.clientY - active.startY;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      const duration = Math.max(0, performance.now() - active.startTime);
+
+      const startPoint = projectToDevice(
+        active.startX,
+        active.startY,
+        active.contentRect,
+      );
+      const endPoint = projectToDevice(
+        event.clientX,
+        event.clientY,
+        active.contentRect,
+      );
+      if (!startPoint || !endPoint) return;
+
+      if (distance <= tapMaxDistance && duration <= tapMaxDurationMs) {
+        onTap?.(startPoint);
+      } else {
+        onSwipe?.(startPoint, endPoint, Math.round(duration));
+      }
+    },
+    [onTap, onSwipe, projectToDevice, tapMaxDistance, tapMaxDurationMs],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => finishPointer(event, false),
+    [finishPointer],
+  );
+  const handlePointerCancel = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => finishPointer(event, true),
+    [finishPointer],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      activePointer.current = null;
+    }
+  }, [enabled]);
+
+  if (!enabled || !deviceSize) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onContextMenu={(e) => e.preventDefault()}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 5,
+        cursor: 'crosshair',
+        touchAction: 'none',
+        userSelect: 'none',
+        ...style,
+      }}
+    />
+  );
+}

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -28,8 +28,6 @@ interface ActivePointer {
   startX: number;
   startY: number;
   startTime: number;
-  lastX: number;
-  lastY: number;
   contentRect: { left: number; top: number; width: number; height: number };
 }
 
@@ -110,23 +108,11 @@ export function DeviceInteractionLayer({
         startX: event.clientX,
         startY: event.clientY,
         startTime: performance.now(),
-        lastX: event.clientX,
-        lastY: event.clientY,
         contentRect,
       };
       event.preventDefault();
     },
     [enabled, deviceSize],
-  );
-
-  const handlePointerMove = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      const active = activePointer.current;
-      if (!active) return;
-      active.lastX = event.clientX;
-      active.lastY = event.clientY;
-    },
-    [],
   );
 
   const finishPointer = useCallback(
@@ -190,7 +176,6 @@ export function DeviceInteractionLayer({
     <div
       ref={overlayRef}
       onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerCancel}
       onContextMenu={(e) => e.preventDefault()}

--- a/packages/playground-app/src/PlaygroundPreview.tsx
+++ b/packages/playground-app/src/PlaygroundPreview.tsx
@@ -22,6 +22,7 @@ export interface PlaygroundPreviewProps {
   serverUrl: string;
   serverOnline: boolean;
   isUserOperating: boolean;
+  manualControlEnabled?: boolean;
 }
 
 export function PlaygroundPreview(props: PlaygroundPreviewProps) {

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -7,8 +7,18 @@ import {
   type ScreenshotViewerMode,
 } from '@midscene/visualizer';
 import { WebCodecsVideoDecoder } from '@yume-chan/scrcpy-decoder-webcodecs';
-import { Alert, Popover } from 'antd';
-import type { CSSProperties, ReactNode } from 'react';
+import { Alert, Popover, message } from 'antd';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  DeviceInteractionLayer,
+  type DeviceSize,
+} from './DeviceInteractionLayer';
 import { type ScrcpyErrorOverlayRenderer, ScrcpyPanel } from './ScrcpyPanel';
 import { resolvePreviewConnectionInfo } from './runtime-info';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
@@ -27,6 +37,12 @@ interface PreviewRendererProps {
   serverUrl: string;
   serverOnline: boolean;
   isUserOperating: boolean;
+  /**
+   * When true, the preview accepts mouse/touch input and forwards it to the
+   * connected device (Android tap/swipe via ADB, iOS via WDA). Currently
+   * supported for Android and iOS only.
+   */
+  manualControlEnabled?: boolean;
 }
 
 function isNonLocalhostHttp(): boolean {
@@ -52,10 +68,81 @@ export function PreviewRenderer({
   serverUrl,
   serverOnline,
   isUserOperating,
+  manualControlEnabled = false,
 }: PreviewRendererProps) {
   const previewConnection = resolvePreviewConnectionInfo(
     runtimeInfo,
     serverUrl,
+  );
+
+  const [deviceSize, setDeviceSize] = useState<DeviceSize | null>(null);
+
+  // Pull device size from /screenshot once a session is online so the
+  // interaction layer can map display coords to device pixels. Refresh
+  // periodically (orientation changes, hot-swapped devices).
+  useEffect(() => {
+    if (!manualControlEnabled || !serverOnline) {
+      setDeviceSize(null);
+      return;
+    }
+    let cancelled = false;
+    const fetchSize = async () => {
+      const result = await playgroundSDK.getScreenshot();
+      if (cancelled) return;
+      if (result?.size?.width && result.size.height) {
+        setDeviceSize((current) => {
+          if (
+            current &&
+            current.width === result.size!.width &&
+            current.height === result.size!.height
+          ) {
+            return current;
+          }
+          return { width: result.size!.width, height: result.size!.height };
+        });
+      }
+    };
+    fetchSize();
+    const timer = setInterval(fetchSize, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [manualControlEnabled, playgroundSDK, serverOnline]);
+
+  const handleTap = useCallback(
+    async (point: { x: number; y: number }) => {
+      const res = await playgroundSDK.interact({
+        actionType: 'Tap',
+        x: point.x,
+        y: point.y,
+      });
+      if (!res.ok) {
+        message.error(res.error || 'Tap failed');
+      }
+    },
+    [playgroundSDK],
+  );
+
+  const handleSwipe = useCallback(
+    async (
+      start: { x: number; y: number },
+      end: { x: number; y: number },
+      duration: number,
+    ) => {
+      const res = await playgroundSDK.interact({
+        actionType: 'Swipe',
+        x: start.x,
+        y: start.y,
+        endX: end.x,
+        endY: end.y,
+        duration,
+      });
+      if (!res.ok) {
+        message.error(res.error || 'Swipe failed');
+      }
+    },
+    [playgroundSDK],
   );
 
   // Fall back to screenshot polling when WebCodecs is unavailable
@@ -171,6 +258,16 @@ export function PreviewRenderer({
           mode={screenshotViewerMode}
         />
       )}
+      <DeviceInteractionLayer
+        enabled={
+          manualControlEnabled &&
+          serverOnline &&
+          previewConnection.type !== 'none'
+        }
+        deviceSize={deviceSize}
+        onTap={handleTap}
+        onSwipe={handleSwipe}
+      />
     </div>
   );
 }

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -39,8 +39,7 @@ interface PreviewRendererProps {
   isUserOperating: boolean;
   /**
    * When true, the preview accepts mouse/touch input and forwards it to the
-   * connected device (Android tap/swipe via ADB, iOS via WDA). Currently
-   * supported for Android and iOS only.
+   * connected device (Android via ADB, iOS via WDA, Harmony via HDC).
    */
   manualControlEnabled?: boolean;
 }
@@ -77,9 +76,9 @@ export function PreviewRenderer({
 
   const [deviceSize, setDeviceSize] = useState<DeviceSize | null>(null);
 
-  // Pull device size from /screenshot once a session is online so the
-  // interaction layer can map display coords to device pixels. Refresh
-  // periodically (orientation changes, hot-swapped devices).
+  // Pull device size from lightweight interface metadata so the interaction
+  // layer can map display coords to device pixels. Refresh periodically
+  // (orientation changes, hot-swapped devices).
   useEffect(() => {
     if (!manualControlEnabled || !serverOnline) {
       setDeviceSize(null);
@@ -87,18 +86,19 @@ export function PreviewRenderer({
     }
     let cancelled = false;
     const fetchSize = async () => {
-      const result = await playgroundSDK.getScreenshot();
+      const result = await playgroundSDK.getInterfaceInfo();
       if (cancelled) return;
       if (result?.size?.width && result.size.height) {
+        const { size } = result;
         setDeviceSize((current) => {
           if (
             current &&
-            current.width === result.size!.width &&
-            current.height === result.size!.height
+            current.width === size.width &&
+            current.height === size.height
           ) {
             return current;
           }
-          return { width: result.size!.width, height: result.size!.height };
+          return { width: size.width, height: size.height };
         });
       }
     };
@@ -110,6 +110,17 @@ export function PreviewRenderer({
     };
   }, [manualControlEnabled, playgroundSDK, serverOnline]);
 
+  const showManualControlError = useCallback(
+    (fallback: string, error?: string) => {
+      message.open({
+        type: 'error',
+        content: error || fallback,
+        key: 'manual-control-error',
+      });
+    },
+    [],
+  );
+
   const handleTap = useCallback(
     async (point: { x: number; y: number }) => {
       const res = await playgroundSDK.interact({
@@ -118,10 +129,10 @@ export function PreviewRenderer({
         y: point.y,
       });
       if (!res.ok) {
-        message.error(res.error || 'Tap failed');
+        showManualControlError('Tap failed', res.error);
       }
     },
-    [playgroundSDK],
+    [playgroundSDK, showManualControlError],
   );
 
   const handleSwipe = useCallback(
@@ -139,10 +150,10 @@ export function PreviewRenderer({
         duration,
       });
       if (!res.ok) {
-        message.error(res.error || 'Swipe failed');
+        showManualControlError('Swipe failed', res.error);
       }
     },
-    [playgroundSDK],
+    [playgroundSDK, showManualControlError],
   );
 
   // Fall back to screenshot polling when WebCodecs is unavailable

--- a/packages/playground-app/src/index.ts
+++ b/packages/playground-app/src/index.ts
@@ -1,6 +1,11 @@
 export { PlaygroundApp } from './PlaygroundApp';
 export { PlaygroundPreview } from './PlaygroundPreview';
 export { PlaygroundThemeProvider } from './PlaygroundThemeProvider';
+export { DeviceInteractionLayer } from './DeviceInteractionLayer';
+export type {
+  DeviceInteractionLayerProps,
+  DeviceSize,
+} from './DeviceInteractionLayer';
 export { PlaygroundConversationPanel } from './panels/PlaygroundConversationPanel';
 export type { PlaygroundAppProps } from './PlaygroundApp';
 export type { PlaygroundPreviewProps } from './PlaygroundPreview';

--- a/packages/playground-app/src/runtime-info.ts
+++ b/packages/playground-app/src/runtime-info.ts
@@ -64,6 +64,7 @@ export function buildFallbackRuntimeInfo(
 export interface RuntimeInterfaceInfo {
   type: string;
   description?: string;
+  size?: { width: number; height: number };
 }
 
 export function filterValidExecutionUxHints(

--- a/packages/playground-app/tests/device-interaction-layer.test.ts
+++ b/packages/playground-app/tests/device-interaction-layer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { inscribedContentRect } from '../src/DeviceInteractionLayer';
+
+describe('inscribedContentRect', () => {
+  it('letter-boxes horizontally when the panel is wider than device aspect', () => {
+    // Panel: 1000x500 (2:1) – Device: 100x200 (portrait, 1:2)
+    // Content should be a 250x500 rect centered horizontally.
+    const rect = inscribedContentRect(
+      { left: 0, top: 0, width: 1000, height: 500 },
+      { width: 100, height: 200 },
+    );
+    expect(rect.height).toBe(500);
+    expect(rect.width).toBe(250);
+    expect(rect.left).toBe(375);
+    expect(rect.top).toBe(0);
+  });
+
+  it('letter-boxes vertically when the panel is taller than device aspect', () => {
+    // Panel: 500x1000 (1:2) – Device: 200x100 (landscape, 2:1)
+    // Content should be a 500x250 rect centered vertically.
+    const rect = inscribedContentRect(
+      { left: 0, top: 0, width: 500, height: 1000 },
+      { width: 200, height: 100 },
+    );
+    expect(rect.width).toBe(500);
+    expect(rect.height).toBe(250);
+    expect(rect.left).toBe(0);
+    expect(rect.top).toBe(375);
+  });
+
+  it('preserves panel rect when aspect ratios match exactly', () => {
+    const panel = { left: 10, top: 20, width: 300, height: 600 };
+    const rect = inscribedContentRect(panel, { width: 100, height: 200 });
+    expect(rect).toEqual(panel);
+  });
+
+  it('returns the panel unchanged when dimensions are zero or negative', () => {
+    const panel = { left: 5, top: 5, width: 0, height: 100 };
+    expect(inscribedContentRect(panel, { width: 9, height: 19 })).toEqual(
+      panel,
+    );
+  });
+});

--- a/packages/playground/src/adapters/local-execution.ts
+++ b/packages/playground/src/adapters/local-execution.ts
@@ -422,6 +422,7 @@ export class LocalExecutionAdapter extends BasePlaygroundAdapter {
   async getInterfaceInfo(): Promise<{
     type: string;
     description?: string;
+    size?: { width: number; height: number };
   } | null> {
     if (!this.agent?.interface) {
       return null;
@@ -430,10 +431,15 @@ export class LocalExecutionAdapter extends BasePlaygroundAdapter {
     try {
       const type = this.agent.interface.interfaceType || 'Unknown';
       const description = this.agent.interface.describe?.() || undefined;
+      const size =
+        typeof this.agent.interface.size === 'function'
+          ? await this.agent.interface.size()
+          : undefined;
 
       return {
         type,
         description,
+        ...(size ? { size } : {}),
       };
     } catch (error: unknown) {
       console.error('Failed to get interface info:', error);

--- a/packages/playground/src/adapters/remote-execution.ts
+++ b/packages/playground/src/adapters/remote-execution.ts
@@ -437,6 +437,7 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
   async getScreenshot(): Promise<{
     screenshot: string;
     timestamp: number;
+    size?: { width: number; height: number };
   } | null> {
     if (!this.serverUrl) {
       return null;
@@ -456,6 +457,43 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
     } catch (error) {
       console.error('Failed to get screenshot:', error);
       return null;
+    }
+  }
+
+  // Direct device manipulation – invokes a named action on the connected
+  // device without going through AI planning.
+  async interact(
+    payload: { actionType: string } & Record<string, unknown>,
+  ): Promise<{ ok: boolean; error?: string }> {
+    if (!this.serverUrl) {
+      return { ok: false, error: 'No server URL configured' };
+    }
+
+    try {
+      const response = await fetch(`${this.serverUrl}/interact`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const data = (await response.json().catch(() => null)) as {
+        ok?: boolean;
+        error?: string;
+      } | null;
+
+      if (!response.ok || !data?.ok) {
+        return {
+          ok: false,
+          error: data?.error || `Interact request failed (${response.status})`,
+        };
+      }
+
+      return { ok: true };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
     }
   }
 

--- a/packages/playground/src/adapters/remote-execution.ts
+++ b/packages/playground/src/adapters/remote-execution.ts
@@ -437,7 +437,6 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
   async getScreenshot(): Promise<{
     screenshot: string;
     timestamp: number;
-    size?: { width: number; height: number };
   } | null> {
     if (!this.serverUrl) {
       return null;
@@ -477,11 +476,10 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
       });
 
       const data = (await response.json().catch(() => null)) as {
-        ok?: boolean;
         error?: string;
       } | null;
 
-      if (!response.ok || !data?.ok) {
+      if (!response.ok) {
         return {
           ok: false,
           error: data?.error || `Interact request failed (${response.status})`,
@@ -501,6 +499,7 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
   async getInterfaceInfo(): Promise<{
     type: string;
     description?: string;
+    size?: { width: number; height: number };
   } | null> {
     if (!this.serverUrl) {
       return null;

--- a/packages/playground/src/sdk/index.ts
+++ b/packages/playground/src/sdk/index.ts
@@ -226,11 +226,22 @@ export class PlaygroundSDK {
   async getScreenshot(): Promise<{
     screenshot: string;
     timestamp: number;
+    size?: { width: number; height: number };
   } | null> {
     if (this.adapter instanceof RemoteExecutionAdapter) {
       return this.adapter.getScreenshot();
     }
     return null; // For local execution, not supported yet
+  }
+
+  // Direct device manipulation – mouse/keyboard input from UI overlays.
+  async interact(
+    payload: { actionType: string } & Record<string, unknown>,
+  ): Promise<{ ok: boolean; error?: string }> {
+    if (this.adapter instanceof RemoteExecutionAdapter) {
+      return this.adapter.interact(payload);
+    }
+    return { ok: false, error: 'Direct interaction requires remote execution' };
   }
 
   // Get interface information (type and description)

--- a/packages/playground/src/sdk/index.ts
+++ b/packages/playground/src/sdk/index.ts
@@ -226,7 +226,6 @@ export class PlaygroundSDK {
   async getScreenshot(): Promise<{
     screenshot: string;
     timestamp: number;
-    size?: { width: number; height: number };
   } | null> {
     if (this.adapter instanceof RemoteExecutionAdapter) {
       return this.adapter.getScreenshot();
@@ -248,6 +247,7 @@ export class PlaygroundSDK {
   async getInterfaceInfo(): Promise<{
     type: string;
     description?: string;
+    size?: { width: number; height: number };
   } | null> {
     const adapter = this.runtimeMetadataAdapter();
     if (!adapter) {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -12,6 +12,7 @@ import {
   globalModelConfigManager,
   overrideAIConfig,
 } from '@midscene/shared/env';
+import type { LocateResultElement } from '@midscene/shared/types';
 import { uuid } from '@midscene/shared/utils';
 import express, { type Request, type Response } from 'express';
 import { executeAction, formatErrorMessage } from './common';
@@ -113,6 +114,91 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const STATIC_PATH = join(__dirname, '..', '..', 'static');
 
+export function pointToLocateResult(
+  x: unknown,
+  y: unknown,
+  description: string,
+): LocateResultElement {
+  if (typeof x !== 'number' || typeof y !== 'number') {
+    throw new Error('x and y must be numbers');
+  }
+  const cx = Math.round(x);
+  const cy = Math.round(y);
+  return {
+    description,
+    center: [cx, cy] as [number, number],
+    rect: {
+      left: Math.max(cx - 4, 0),
+      top: Math.max(cy - 4, 0),
+      width: 8,
+      height: 8,
+    },
+  };
+}
+
+export function buildInteractParams(
+  actionType: string,
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  switch (actionType) {
+    case 'Tap':
+    case 'DoubleClick':
+    case 'RightClick':
+    case 'Hover':
+    case 'LongPress': {
+      const params: Record<string, unknown> = {
+        locate: pointToLocateResult(body.x, body.y, `manual ${actionType}`),
+      };
+      if (typeof body.duration === 'number') {
+        params.duration = body.duration;
+      }
+      return params;
+    }
+    case 'Swipe': {
+      const start = pointToLocateResult(body.x, body.y, 'manual swipe start');
+      const end = pointToLocateResult(body.endX, body.endY, 'manual swipe end');
+      const params: Record<string, unknown> = { start, end };
+      if (typeof body.duration === 'number') params.duration = body.duration;
+      if (typeof body.repeat === 'number') params.repeat = body.repeat;
+      return params;
+    }
+    case 'DragAndDrop': {
+      return {
+        from: pointToLocateResult(body.x, body.y, 'manual drag from'),
+        to: pointToLocateResult(body.endX, body.endY, 'manual drag to'),
+      };
+    }
+    case 'KeyboardPress': {
+      if (typeof body.keyName !== 'string') {
+        throw new Error('keyName is required for KeyboardPress');
+      }
+      return { keyName: body.keyName };
+    }
+    case 'Input': {
+      if (typeof body.value !== 'string') {
+        throw new Error('value is required for Input');
+      }
+      const params: Record<string, unknown> = { value: body.value };
+      if (typeof body.x === 'number' && typeof body.y === 'number') {
+        params.locate = pointToLocateResult(body.x, body.y, 'manual input');
+      }
+      if (typeof body.mode === 'string') params.mode = body.mode;
+      if (typeof body.autoDismissKeyboard === 'boolean') {
+        params.autoDismissKeyboard = body.autoDismissKeyboard;
+      }
+      return params;
+    }
+    default: {
+      // Fallback: pass-through any caller-provided params for less common actions.
+      const { actionType: _omit, ...passthrough } = body as Record<
+        string,
+        unknown
+      >;
+      return passthrough;
+    }
+  }
+}
+
 const errorHandler = (
   err: unknown,
   req: Request,
@@ -161,8 +247,12 @@ class PlaygroundServer {
 
   private _initialized = false;
 
-  // Native MJPEG stream probe: null = not tested, true/false = result
+  // Native MJPEG stream probe: null = not tested, true/false = result.
+  // The negative cache expires after MJPEG_NEGATIVE_CACHE_MS so the server
+  // recovers automatically when WDA / iproxy comes online after startup.
   private _nativeMjpegAvailable: boolean | null = null;
+  private _nativeMjpegFailedAt: number | null = null;
+  private static readonly MJPEG_NEGATIVE_CACHE_MS = 10_000;
 
   private sessionManager?: PlaygroundSessionManager;
   private sessionSetupState: 'required' | 'ready' | 'blocked' = 'ready';
@@ -1162,10 +1252,19 @@ class PlaygroundServer {
         }
 
         const base64Screenshot = await agent.interface.screenshotBase64();
+        let size: { width: number; height: number } | undefined;
+        if (typeof agent.interface.size === 'function') {
+          try {
+            size = await agent.interface.size();
+          } catch {
+            size = undefined;
+          }
+        }
 
         res.json({
           screenshot: base64Screenshot,
           timestamp: Date.now(),
+          ...(size ? { size } : {}),
         });
       } catch (error: unknown) {
         const errorMessage =
@@ -1193,7 +1292,12 @@ class PlaygroundServer {
 
       const nativeUrl = agent.interface?.mjpegStreamUrl;
 
-      if (nativeUrl && this._nativeMjpegAvailable !== false) {
+      const recentlyFailed =
+        this._nativeMjpegAvailable === false &&
+        this._nativeMjpegFailedAt !== null &&
+        Date.now() - this._nativeMjpegFailedAt <
+          PlaygroundServer.MJPEG_NEGATIVE_CACHE_MS;
+      if (nativeUrl && !recentlyFailed) {
         const proxyOk = await this.probeAndProxyNativeMjpeg(
           nativeUrl,
           req,
@@ -1227,6 +1331,60 @@ class PlaygroundServer {
         res.status(500).json({
           error: `Failed to get interface info: ${errorMessage}`,
         });
+      }
+    });
+
+    // Direct manipulation API – invokes a named action immediately, bypassing
+    // AI planning, the task lock, and dump bookkeeping. Designed for UI-driven
+    // pointer/keyboard input on Android/iOS device previews.
+    this._app.post('/interact', async (req: Request, res: Response) => {
+      let agent: PageAgent;
+      try {
+        agent = this.getActiveAgentOrThrow();
+      } catch (error) {
+        return res.status(409).json({
+          ok: false,
+          error: error instanceof Error ? error.message : 'No active session',
+        });
+      }
+
+      const { actionType } = req.body ?? {};
+      if (typeof actionType !== 'string' || !actionType) {
+        return res.status(400).json({
+          ok: false,
+          error: 'actionType is required',
+        });
+      }
+
+      const action = agent.interface
+        .actionSpace()
+        .find((entry: { name: string }) => entry.name === actionType);
+      if (!action || typeof action.call !== 'function') {
+        return res.status(404).json({
+          ok: false,
+          error: `Action "${actionType}" is not available on the current device`,
+        });
+      }
+
+      try {
+        const params = buildInteractParams(actionType, req.body ?? {});
+        const actionFn = (
+          action.call as unknown as (
+            param: unknown,
+            context: unknown,
+          ) => Promise<unknown> | unknown
+        ).bind(agent.interface);
+        // ExecutorContext shape is required by the type but every device
+        // action used here ignores it; pass a minimal stub.
+        await actionFn(params, { task: { type: 'Action' } });
+        res.json({ ok: true });
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        console.error(
+          `Failed to run interact action "${actionType}": ${errorMessage}`,
+        );
+        res.status(500).json({ ok: false, error: errorMessage });
       }
     });
 
@@ -1342,6 +1500,7 @@ class PlaygroundServer {
       console.log(`MJPEG: trying native stream from ${nativeUrl}`);
       const proxyReq = http.get(nativeUrl, (proxyRes) => {
         this._nativeMjpegAvailable = true;
+        this._nativeMjpegFailedAt = null;
         console.log('MJPEG: streaming via native WDA MJPEG server');
         const contentType = proxyRes.headers['content-type'];
         if (contentType) {
@@ -1355,11 +1514,32 @@ class PlaygroundServer {
       });
       proxyReq.on('error', (err) => {
         this._nativeMjpegAvailable = false;
+        this._nativeMjpegFailedAt = Date.now();
         console.warn(
           `MJPEG: native stream unavailable (${err.message}), using polling mode`,
         );
         resolve(false);
       });
+    });
+  }
+
+  /**
+   * Quick liveness check for the native MJPEG endpoint without consuming a
+   * full streaming response. Used while we are in polling fallback so we can
+   * upgrade back to the native stream as soon as WDA / iproxy comes online.
+   */
+  private probeNativeMjpegLiveness(nativeUrl: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const probe = http.get(nativeUrl, (probeRes) => {
+        const reachable = (probeRes.statusCode ?? 0) < 500;
+        probeRes.destroy();
+        resolve(reachable);
+      });
+      probe.setTimeout(1000, () => {
+        probe.destroy();
+        resolve(false);
+      });
+      probe.on('error', () => resolve(false));
     });
   }
 
@@ -1374,6 +1554,7 @@ class PlaygroundServer {
     const maxMjpegFps = 30;
     const maxErrorBackoffMs = 3000;
     const errorLogThreshold = 3;
+    const nativeProbeIntervalMs = 3000;
 
     const parsedFps = Number(req.query.fps);
     const fps = Math.min(
@@ -1395,6 +1576,37 @@ class PlaygroundServer {
     let consecutiveErrors = 0;
     req.on('close', () => {
       stopped = true;
+    });
+
+    // While we are in polling mode, periodically probe the native MJPEG URL.
+    // As soon as it becomes reachable, end this response so the client's
+    // <img> MJPEG connection retries and lands on the native stream.
+    const nativeUrl = this._activeConnection.agent?.interface?.mjpegStreamUrl;
+    let probeTimer: ReturnType<typeof setInterval> | undefined;
+    if (nativeUrl) {
+      probeTimer = setInterval(async () => {
+        if (stopped) return;
+        const reachable = await this.probeNativeMjpegLiveness(nativeUrl);
+        if (reachable && !stopped) {
+          console.log(
+            'MJPEG: native stream came online, ending polling so client reconnects',
+          );
+          this._nativeMjpegAvailable = true;
+          this._nativeMjpegFailedAt = null;
+          stopped = true;
+          // Destroy the socket so the client's <img> fires onError and
+          // reconnects; res.end() leaves multipart streams visually frozen
+          // on the last frame in some browsers.
+          try {
+            res.destroy();
+          } catch {
+            /* socket already closed */
+          }
+        }
+      }, nativeProbeIntervalMs);
+    }
+    req.on('close', () => {
+      if (probeTimer) clearInterval(probeTimer);
     });
 
     while (!stopped) {
@@ -1440,6 +1652,7 @@ class PlaygroundServer {
         await new Promise((r) => setTimeout(r, remaining));
       }
     }
+    if (probeTimer) clearInterval(probeTimer);
   }
 
   /**

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -3,7 +3,12 @@ import http from 'node:http';
 import type { Server } from 'node:http';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ExecutionDump } from '@midscene/core';
+import type {
+  DeviceAction,
+  ExecutionDump,
+  ExecutionTask,
+  ExecutorContext,
+} from '@midscene/core';
 import { ReportActionDump, runConnectivityTest } from '@midscene/core';
 import type { Agent as PageAgent } from '@midscene/core/agent';
 import { getTmpDir } from '@midscene/core/utils';
@@ -12,7 +17,8 @@ import {
   globalModelConfigManager,
   overrideAIConfig,
 } from '@midscene/shared/env';
-import type { LocateResultElement } from '@midscene/shared/types';
+import { generateElementByPoint } from '@midscene/shared/extractor';
+import { getDebug } from '@midscene/shared/logger';
 import { uuid } from '@midscene/shared/utils';
 import express, { type Request, type Response } from 'express';
 import { executeAction, formatErrorMessage } from './common';
@@ -114,89 +120,136 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const STATIC_PATH = join(__dirname, '..', '..', 'static');
 
-export function pointToLocateResult(
+const debugScreenshot = getDebug('playground:screenshot', { console: true });
+const debugMjpeg = getDebug('playground:mjpeg', { console: true });
+
+/**
+ * Thrown when a caller supplies an /interact body that fails validation
+ * (missing x/y, missing keyName for KeyboardPress, etc.). Distinct from a
+ * downstream device failure so the route handler can map this to HTTP 400.
+ */
+export class InteractParamsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InteractParamsValidationError';
+  }
+}
+
+function requireNumber(value: unknown, field: string): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new InteractParamsValidationError(
+      `${field} must be a number for this action`,
+    );
+  }
+  return value;
+}
+
+function locateFromPoint(
   x: unknown,
   y: unknown,
+  fieldX: string,
+  fieldY: string,
   description: string,
-): LocateResultElement {
-  if (typeof x !== 'number' || typeof y !== 'number') {
-    throw new Error('x and y must be numbers');
-  }
-  const cx = Math.round(x);
-  const cy = Math.round(y);
-  return {
+) {
+  return generateElementByPoint(
+    [
+      Math.round(requireNumber(x, fieldX)),
+      Math.round(requireNumber(y, fieldY)),
+    ],
     description,
-    center: [cx, cy] as [number, number],
-    rect: {
-      left: Math.max(cx - 4, 0),
-      top: Math.max(cy - 4, 0),
-      width: 8,
-      height: 8,
-    },
-  };
+  );
 }
+
+type InteractParamBuilder = (
+  body: Record<string, unknown>,
+  actionType: string,
+) => Record<string, unknown>;
+
+const buildLocateActionParams: InteractParamBuilder = (body, actionType) => {
+  const params: Record<string, unknown> = {
+    locate: locateFromPoint(body.x, body.y, 'x', 'y', `manual ${actionType}`),
+  };
+  if (typeof body.duration === 'number') {
+    params.duration = body.duration;
+  }
+  return params;
+};
+
+const manualInteractParamBuilders: Record<string, InteractParamBuilder> = {
+  Tap: buildLocateActionParams,
+  DoubleClick: buildLocateActionParams,
+  RightClick: buildLocateActionParams,
+  Hover: buildLocateActionParams,
+  LongPress: buildLocateActionParams,
+  Swipe: (body) => {
+    const params: Record<string, unknown> = {
+      start: locateFromPoint(body.x, body.y, 'x', 'y', 'manual swipe start'),
+      end: locateFromPoint(
+        body.endX,
+        body.endY,
+        'endX',
+        'endY',
+        'manual swipe end',
+      ),
+    };
+    if (typeof body.duration === 'number') params.duration = body.duration;
+    if (typeof body.repeat === 'number') params.repeat = body.repeat;
+    return params;
+  },
+  DragAndDrop: (body) => ({
+    from: locateFromPoint(body.x, body.y, 'x', 'y', 'manual drag from'),
+    to: locateFromPoint(body.endX, body.endY, 'endX', 'endY', 'manual drag to'),
+  }),
+  KeyboardPress: (body) => {
+    if (typeof body.keyName !== 'string') {
+      throw new InteractParamsValidationError(
+        'keyName is required for KeyboardPress',
+      );
+    }
+    return { keyName: body.keyName };
+  },
+  Input: (body) => {
+    if (typeof body.value !== 'string') {
+      throw new InteractParamsValidationError('value is required for Input');
+    }
+    const params: Record<string, unknown> = { value: body.value };
+    if (typeof body.x === 'number' && typeof body.y === 'number') {
+      params.locate = locateFromPoint(body.x, body.y, 'x', 'y', 'manual input');
+    }
+    if (typeof body.mode === 'string') params.mode = body.mode;
+    if (typeof body.autoDismissKeyboard === 'boolean') {
+      params.autoDismissKeyboard = body.autoDismissKeyboard;
+    }
+    return params;
+  },
+};
 
 export function buildInteractParams(
   actionType: string,
   body: Record<string, unknown>,
 ): Record<string, unknown> {
-  switch (actionType) {
-    case 'Tap':
-    case 'DoubleClick':
-    case 'RightClick':
-    case 'Hover':
-    case 'LongPress': {
-      const params: Record<string, unknown> = {
-        locate: pointToLocateResult(body.x, body.y, `manual ${actionType}`),
-      };
-      if (typeof body.duration === 'number') {
-        params.duration = body.duration;
-      }
-      return params;
-    }
-    case 'Swipe': {
-      const start = pointToLocateResult(body.x, body.y, 'manual swipe start');
-      const end = pointToLocateResult(body.endX, body.endY, 'manual swipe end');
-      const params: Record<string, unknown> = { start, end };
-      if (typeof body.duration === 'number') params.duration = body.duration;
-      if (typeof body.repeat === 'number') params.repeat = body.repeat;
-      return params;
-    }
-    case 'DragAndDrop': {
-      return {
-        from: pointToLocateResult(body.x, body.y, 'manual drag from'),
-        to: pointToLocateResult(body.endX, body.endY, 'manual drag to'),
-      };
-    }
-    case 'KeyboardPress': {
-      if (typeof body.keyName !== 'string') {
-        throw new Error('keyName is required for KeyboardPress');
-      }
-      return { keyName: body.keyName };
-    }
-    case 'Input': {
-      if (typeof body.value !== 'string') {
-        throw new Error('value is required for Input');
-      }
-      const params: Record<string, unknown> = { value: body.value };
-      if (typeof body.x === 'number' && typeof body.y === 'number') {
-        params.locate = pointToLocateResult(body.x, body.y, 'manual input');
-      }
-      if (typeof body.mode === 'string') params.mode = body.mode;
-      if (typeof body.autoDismissKeyboard === 'boolean') {
-        params.autoDismissKeyboard = body.autoDismissKeyboard;
-      }
-      return params;
-    }
-    default: {
-      // Fallback: pass-through any caller-provided params for less common actions.
-      const { actionType: _omit, ...passthrough } = body as Record<
-        string,
-        unknown
-      >;
-      return passthrough;
-    }
+  const builder = manualInteractParamBuilders[actionType];
+  if (builder) {
+    return builder(body, actionType);
   }
+  // Fallback: pass-through any caller-provided params for less common actions.
+  const { actionType: _omit, ...passthrough } = body as Record<string, unknown>;
+  return passthrough;
+}
+
+export function createManualExecutorContext(
+  actionType: string,
+  param: unknown,
+): ExecutorContext {
+  const task: ExecutionTask = {
+    type: 'Action Space',
+    subType: actionType,
+    param,
+    executor: async () => undefined,
+    taskId: `manual-${uuid()}`,
+    status: 'running',
+  };
+  return { task };
 }
 
 const errorHandler = (
@@ -1251,20 +1304,9 @@ class PlaygroundServer {
           });
         }
 
-        const base64Screenshot = await agent.interface.screenshotBase64();
-        let size: { width: number; height: number } | undefined;
-        if (typeof agent.interface.size === 'function') {
-          try {
-            size = await agent.interface.size();
-          } catch {
-            size = undefined;
-          }
-        }
-
         res.json({
-          screenshot: base64Screenshot,
+          screenshot: await agent.interface.screenshotBase64(),
           timestamp: Date.now(),
-          ...(size ? { size } : {}),
         });
       } catch (error: unknown) {
         const errorMessage =
@@ -1319,10 +1361,20 @@ class PlaygroundServer {
     this._app.get('/interface-info', async (_req: Request, res: Response) => {
       try {
         const runtimeInfo = this.getRuntimeInfo();
+        const agent = this._activeConnection.agent;
+        let size: { width: number; height: number } | undefined;
+        if (typeof agent?.interface?.size === 'function') {
+          try {
+            size = await agent.interface.size();
+          } catch (error) {
+            debugScreenshot('interface size() failed:', error);
+          }
+        }
 
         res.json({
           type: runtimeInfo.interface.type,
           description: runtimeInfo.interface.description,
+          ...(size ? { size } : {}),
         });
       } catch (error: unknown) {
         const errorMessage =
@@ -1336,14 +1388,13 @@ class PlaygroundServer {
 
     // Direct manipulation API – invokes a named action immediately, bypassing
     // AI planning, the task lock, and dump bookkeeping. Designed for UI-driven
-    // pointer/keyboard input on Android/iOS device previews.
+    // pointer/keyboard input on Android/iOS/Harmony device previews.
     this._app.post('/interact', async (req: Request, res: Response) => {
       let agent: PageAgent;
       try {
         agent = this.getActiveAgentOrThrow();
       } catch (error) {
         return res.status(409).json({
-          ok: false,
           error: error instanceof Error ? error.message : 'No active session',
         });
       }
@@ -1351,40 +1402,47 @@ class PlaygroundServer {
       const { actionType } = req.body ?? {};
       if (typeof actionType !== 'string' || !actionType) {
         return res.status(400).json({
-          ok: false,
           error: 'actionType is required',
         });
       }
 
-      const action = agent.interface
-        .actionSpace()
-        .find((entry: { name: string }) => entry.name === actionType);
+      const action = (
+        agent.interface.actionSpace() as DeviceAction<unknown>[]
+      ).find((entry) => entry.name === actionType);
       if (!action || typeof action.call !== 'function') {
         return res.status(404).json({
-          ok: false,
           error: `Action "${actionType}" is not available on the current device`,
         });
       }
 
+      let params: Record<string, unknown>;
       try {
-        const params = buildInteractParams(actionType, req.body ?? {});
-        const actionFn = (
-          action.call as unknown as (
-            param: unknown,
-            context: unknown,
-          ) => Promise<unknown> | unknown
-        ).bind(agent.interface);
-        // ExecutorContext shape is required by the type but every device
-        // action used here ignores it; pass a minimal stub.
-        await actionFn(params, { task: { type: 'Action' } });
-        res.json({ ok: true });
+        params = buildInteractParams(actionType, req.body ?? {});
+      } catch (error: unknown) {
+        if (error instanceof InteractParamsValidationError) {
+          return res.status(400).json({ error: error.message });
+        }
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        console.error(
+          `Failed to build interact params for "${actionType}": ${errorMessage}`,
+        );
+        return res.status(500).json({ error: errorMessage });
+      }
+
+      try {
+        await action.call(
+          params,
+          createManualExecutorContext(actionType, params),
+        );
+        res.json({});
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error';
         console.error(
           `Failed to run interact action "${actionType}": ${errorMessage}`,
         );
-        res.status(500).json({ ok: false, error: errorMessage });
+        res.status(500).json({ error: errorMessage });
       }
     });
 
@@ -1489,7 +1547,7 @@ class PlaygroundServer {
 
   /**
    * Probe and proxy a native MJPEG stream (e.g. WDA MJPEG server).
-   * Result is cached so we only probe once per server lifetime.
+   * Failed probes are cached briefly so WDA / iproxy can come online later.
    */
   private probeAndProxyNativeMjpeg(
     nativeUrl: string,
@@ -1499,6 +1557,17 @@ class PlaygroundServer {
     return new Promise<boolean>((resolve) => {
       console.log(`MJPEG: trying native stream from ${nativeUrl}`);
       const proxyReq = http.get(nativeUrl, (proxyRes) => {
+        const statusCode = proxyRes.statusCode ?? 0;
+        if (statusCode >= 400) {
+          this._nativeMjpegAvailable = false;
+          this._nativeMjpegFailedAt = Date.now();
+          proxyRes.resume();
+          debugMjpeg(
+            `native stream returned HTTP ${statusCode}, using polling mode`,
+          );
+          resolve(false);
+          return;
+        }
         this._nativeMjpegAvailable = true;
         this._nativeMjpegFailedAt = null;
         console.log('MJPEG: streaming via native WDA MJPEG server');
@@ -1515,7 +1584,7 @@ class PlaygroundServer {
       proxyReq.on('error', (err) => {
         this._nativeMjpegAvailable = false;
         this._nativeMjpegFailedAt = Date.now();
-        console.warn(
+        debugMjpeg(
           `MJPEG: native stream unavailable (${err.message}), using polling mode`,
         );
         resolve(false);
@@ -1531,7 +1600,8 @@ class PlaygroundServer {
   private probeNativeMjpegLiveness(nativeUrl: string): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const probe = http.get(nativeUrl, (probeRes) => {
-        const reachable = (probeRes.statusCode ?? 0) < 500;
+        const statusCode = probeRes.statusCode ?? 0;
+        const reachable = statusCode >= 200 && statusCode < 400;
         probeRes.destroy();
         resolve(reachable);
       });
@@ -1574,9 +1644,6 @@ class PlaygroundServer {
 
     let stopped = false;
     let consecutiveErrors = 0;
-    req.on('close', () => {
-      stopped = true;
-    });
 
     // While we are in polling mode, periodically probe the native MJPEG URL.
     // As soon as it becomes reachable, end this response so the client's
@@ -1606,6 +1673,7 @@ class PlaygroundServer {
       }, nativeProbeIntervalMs);
     }
     req.on('close', () => {
+      stopped = true;
       if (probeTimer) clearInterval(probeTimer);
     });
 

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -175,60 +175,79 @@ const buildLocateActionParams: InteractParamBuilder = (body, actionType) => {
   return params;
 };
 
-const manualInteractParamBuilders: Record<string, InteractParamBuilder> = {
-  Tap: buildLocateActionParams,
-  DoubleClick: buildLocateActionParams,
-  RightClick: buildLocateActionParams,
-  Hover: buildLocateActionParams,
-  LongPress: buildLocateActionParams,
-  Swipe: (body) => {
-    const params: Record<string, unknown> = {
-      start: locateFromPoint(body.x, body.y, 'x', 'y', 'manual swipe start'),
-      end: locateFromPoint(
-        body.endX,
-        body.endY,
-        'endX',
-        'endY',
-        'manual swipe end',
-      ),
-    };
-    if (typeof body.duration === 'number') params.duration = body.duration;
-    if (typeof body.repeat === 'number') params.repeat = body.repeat;
-    return params;
-  },
-  DragAndDrop: (body) => ({
-    from: locateFromPoint(body.x, body.y, 'x', 'y', 'manual drag from'),
-    to: locateFromPoint(body.endX, body.endY, 'endX', 'endY', 'manual drag to'),
-  }),
-  KeyboardPress: (body) => {
-    if (typeof body.keyName !== 'string') {
-      throw new InteractParamsValidationError(
-        'keyName is required for KeyboardPress',
-      );
-    }
-    return { keyName: body.keyName };
-  },
-  Input: (body) => {
-    if (typeof body.value !== 'string') {
-      throw new InteractParamsValidationError('value is required for Input');
-    }
-    const params: Record<string, unknown> = { value: body.value };
-    if (typeof body.x === 'number' && typeof body.y === 'number') {
-      params.locate = locateFromPoint(body.x, body.y, 'x', 'y', 'manual input');
-    }
-    if (typeof body.mode === 'string') params.mode = body.mode;
-    if (typeof body.autoDismissKeyboard === 'boolean') {
-      params.autoDismissKeyboard = body.autoDismissKeyboard;
-    }
-    return params;
-  },
+const buildSwipeParams: InteractParamBuilder = (body) => {
+  const params: Record<string, unknown> = {
+    start: locateFromPoint(body.x, body.y, 'x', 'y', 'manual swipe start'),
+    end: locateFromPoint(
+      body.endX,
+      body.endY,
+      'endX',
+      'endY',
+      'manual swipe end',
+    ),
+  };
+  if (typeof body.duration === 'number') params.duration = body.duration;
+  if (typeof body.repeat === 'number') params.repeat = body.repeat;
+  return params;
 };
+
+const buildDragAndDropParams: InteractParamBuilder = (body) => ({
+  from: locateFromPoint(body.x, body.y, 'x', 'y', 'manual drag from'),
+  to: locateFromPoint(body.endX, body.endY, 'endX', 'endY', 'manual drag to'),
+});
+
+const buildKeyboardPressParams: InteractParamBuilder = (body) => {
+  if (typeof body.keyName !== 'string') {
+    throw new InteractParamsValidationError(
+      'keyName is required for KeyboardPress',
+    );
+  }
+  return { keyName: body.keyName };
+};
+
+const buildInputParams: InteractParamBuilder = (body) => {
+  if (typeof body.value !== 'string') {
+    throw new InteractParamsValidationError('value is required for Input');
+  }
+  const params: Record<string, unknown> = { value: body.value };
+  if (typeof body.x === 'number' && typeof body.y === 'number') {
+    params.locate = locateFromPoint(body.x, body.y, 'x', 'y', 'manual input');
+  }
+  if (typeof body.mode === 'string') params.mode = body.mode;
+  if (typeof body.autoDismissKeyboard === 'boolean') {
+    params.autoDismissKeyboard = body.autoDismissKeyboard;
+  }
+  return params;
+};
+
+function getManualInteractParamBuilder(
+  actionType: string,
+): InteractParamBuilder | undefined {
+  switch (actionType) {
+    case 'Tap':
+    case 'DoubleClick':
+    case 'RightClick':
+    case 'Hover':
+    case 'LongPress':
+      return buildLocateActionParams;
+    case 'Swipe':
+      return buildSwipeParams;
+    case 'DragAndDrop':
+      return buildDragAndDropParams;
+    case 'KeyboardPress':
+      return buildKeyboardPressParams;
+    case 'Input':
+      return buildInputParams;
+    default:
+      return undefined;
+  }
+}
 
 export function buildInteractParams(
   actionType: string,
   body: Record<string, unknown>,
 ): Record<string, unknown> {
-  const builder = manualInteractParamBuilders[actionType];
+  const builder = getManualInteractParamBuilder(actionType);
   if (builder) {
     return builder(body, actionType);
   }
@@ -251,7 +270,6 @@ export function createManualExecutorContext(
   };
   return { task };
 }
-
 const errorHandler = (
   err: unknown,
   req: Request,

--- a/packages/playground/tests/unit/build-interact-params.test.ts
+++ b/packages/playground/tests/unit/build-interact-params.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { buildInteractParams, pointToLocateResult } from '../../src/server';
+
+describe('pointToLocateResult', () => {
+  it('rounds and clamps coordinates and produces a small rect', () => {
+    const result = pointToLocateResult(123.4, 456.6, 'manual');
+    expect(result.center).toEqual([123, 457]);
+    expect(result.description).toBe('manual');
+    expect(result.rect.width).toBe(8);
+    expect(result.rect.height).toBe(8);
+    expect(result.rect.left).toBeGreaterThanOrEqual(0);
+    expect(result.rect.top).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps a near-zero point to a non-negative rect origin', () => {
+    const result = pointToLocateResult(2, 1, 'edge');
+    expect(result.rect.left).toBe(0);
+    expect(result.rect.top).toBe(0);
+  });
+
+  it('throws when x or y is missing or non-numeric', () => {
+    expect(() => pointToLocateResult(undefined, 5, 'x')).toThrow();
+    expect(() => pointToLocateResult(5, undefined, 'x')).toThrow();
+    expect(() => pointToLocateResult('5', 5, 'x' as string)).toThrow();
+  });
+});
+
+describe('buildInteractParams', () => {
+  it('Tap wraps {x,y} into a locate element', () => {
+    const params = buildInteractParams('Tap', { x: 100, y: 200 });
+    expect(params.locate).toMatchObject({ center: [100, 200] });
+  });
+
+  it.each(['Tap', 'DoubleClick', 'RightClick', 'Hover', 'LongPress'])(
+    '%s uses {x,y} as locate and forwards optional duration',
+    (actionType) => {
+      const params = buildInteractParams(actionType, {
+        x: 10,
+        y: 20,
+        duration: 350,
+      });
+      expect(params.locate).toMatchObject({ center: [10, 20] });
+      expect(params.duration).toBe(350);
+    },
+  );
+
+  it('Swipe builds start/end locate elements and forwards duration & repeat', () => {
+    const params = buildInteractParams('Swipe', {
+      x: 10,
+      y: 20,
+      endX: 110,
+      endY: 220,
+      duration: 500,
+      repeat: 2,
+    });
+    expect(params).toMatchObject({
+      start: { center: [10, 20] },
+      end: { center: [110, 220] },
+      duration: 500,
+      repeat: 2,
+    });
+  });
+
+  it('DragAndDrop maps to {from,to} pair', () => {
+    const params = buildInteractParams('DragAndDrop', {
+      x: 1,
+      y: 2,
+      endX: 3,
+      endY: 4,
+    });
+    expect(params).toMatchObject({
+      from: { center: [1, 2] },
+      to: { center: [3, 4] },
+    });
+  });
+
+  it('KeyboardPress requires keyName and passes it through', () => {
+    expect(buildInteractParams('KeyboardPress', { keyName: 'Enter' })).toEqual({
+      keyName: 'Enter',
+    });
+    expect(() => buildInteractParams('KeyboardPress', {})).toThrow();
+  });
+
+  it('Input requires value and accepts optional locate / mode flags', () => {
+    expect(
+      buildInteractParams('Input', {
+        value: 'hello',
+        x: 50,
+        y: 60,
+        mode: 'replace',
+        autoDismissKeyboard: true,
+      }),
+    ).toMatchObject({
+      value: 'hello',
+      locate: { center: [50, 60] },
+      mode: 'replace',
+      autoDismissKeyboard: true,
+    });
+    expect(() => buildInteractParams('Input', {})).toThrow();
+  });
+
+  it('falls back to pass-through (minus actionType) for unknown actions', () => {
+    const params = buildInteractParams('CustomThing', {
+      foo: 1,
+      bar: 'baz',
+    });
+    expect(params).toEqual({ foo: 1, bar: 'baz' });
+    expect(params).not.toHaveProperty('actionType');
+  });
+});

--- a/packages/playground/tests/unit/build-interact-params.test.ts
+++ b/packages/playground/tests/unit/build-interact-params.test.ts
@@ -127,4 +127,9 @@ describe('buildInteractParams', () => {
     expect(params).toEqual({ foo: 1, bar: 'baz' });
     expect(params).not.toHaveProperty('actionType');
   });
+
+  it('does not dispatch prototype property names as builders', () => {
+    expect(buildInteractParams('constructor', { foo: 1 })).toEqual({ foo: 1 });
+    expect(buildInteractParams('__proto__', { foo: 1 })).toEqual({ foo: 1 });
+  });
 });

--- a/packages/playground/tests/unit/build-interact-params.test.ts
+++ b/packages/playground/tests/unit/build-interact-params.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { buildInteractParams, pointToLocateResult } from '../../src/server';
+import {
+  InteractParamsValidationError,
+  buildInteractParams,
+} from '../../src/server';
 
-describe('pointToLocateResult', () => {
+describe('manual interaction locate params', () => {
   it('rounds and clamps coordinates and produces a small rect', () => {
-    const result = pointToLocateResult(123.4, 456.6, 'manual');
+    const params = buildInteractParams('Tap', { x: 123.4, y: 456.6 });
+    const result = params.locate as {
+      center: [number, number];
+      description: string;
+      rect: { left: number; top: number; width: number; height: number };
+    };
     expect(result.center).toEqual([123, 457]);
-    expect(result.description).toBe('manual');
+    expect(result.description).toBe('manual Tap');
     expect(result.rect.width).toBe(8);
     expect(result.rect.height).toBe(8);
     expect(result.rect.left).toBeGreaterThanOrEqual(0);
@@ -13,15 +21,27 @@ describe('pointToLocateResult', () => {
   });
 
   it('clamps a near-zero point to a non-negative rect origin', () => {
-    const result = pointToLocateResult(2, 1, 'edge');
+    const params = buildInteractParams('Tap', { x: 2, y: 1 });
+    const result = params.locate as {
+      rect: { left: number; top: number };
+    };
     expect(result.rect.left).toBe(0);
     expect(result.rect.top).toBe(0);
   });
 
   it('throws when x or y is missing or non-numeric', () => {
-    expect(() => pointToLocateResult(undefined, 5, 'x')).toThrow();
-    expect(() => pointToLocateResult(5, undefined, 'x')).toThrow();
-    expect(() => pointToLocateResult('5', 5, 'x' as string)).toThrow();
+    expect(() => buildInteractParams('Tap', { y: 5 })).toThrow(
+      InteractParamsValidationError,
+    );
+    expect(() => buildInteractParams('Tap', { x: 5 })).toThrow(
+      InteractParamsValidationError,
+    );
+    expect(() => buildInteractParams('Tap', { x: '5', y: 5 })).toThrow(
+      InteractParamsValidationError,
+    );
+    expect(() => buildInteractParams('Tap', { x: Number.NaN, y: 5 })).toThrow(
+      InteractParamsValidationError,
+    );
   });
 });
 

--- a/packages/playground/tests/unit/remote-execution-adapter.test.ts
+++ b/packages/playground/tests/unit/remote-execution-adapter.test.ts
@@ -642,4 +642,58 @@ describe('RemoteExecutionAdapter', () => {
       consoleWarnSpy.mockRestore();
     });
   });
+
+  describe('interact', () => {
+    it('POSTs JSON to /interact and returns ok', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+
+      const result = await adapter.interact({
+        actionType: 'Tap',
+        x: 100,
+        y: 200,
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(mockFetch).toHaveBeenCalledWith(`${mockServerUrl}/interact`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ actionType: 'Tap', x: 100, y: 200 }),
+      });
+    });
+
+    it('surfaces server-provided error message on non-ok responses', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({
+          ok: false,
+          error: 'Action "Foo" is not available',
+        }),
+      });
+
+      const result = await adapter.interact({ actionType: 'Foo' });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('not available');
+    });
+
+    it('returns ok:false with a generic error when fetch rejects', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const result = await adapter.interact({ actionType: 'Tap', x: 0, y: 0 });
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('network down');
+    });
+
+    it('refuses without serverUrl', async () => {
+      const noUrlAdapter = new RemoteExecutionAdapter();
+      // @ts-expect-error – simulate the fallback resolution returning empty
+      noUrlAdapter.serverUrl = undefined;
+      const result = await noUrlAdapter.interact({ actionType: 'Tap' });
+      expect(result.ok).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/playground/tests/unit/remote-execution-adapter.test.ts
+++ b/packages/playground/tests/unit/remote-execution-adapter.test.ts
@@ -648,7 +648,7 @@ describe('RemoteExecutionAdapter', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ ok: true }),
+        json: async () => ({}),
       });
 
       const result = await adapter.interact({
@@ -670,7 +670,6 @@ describe('RemoteExecutionAdapter', () => {
         ok: false,
         status: 404,
         json: async () => ({
-          ok: false,
           error: 'Action "Foo" is not available',
         }),
       });
@@ -688,9 +687,7 @@ describe('RemoteExecutionAdapter', () => {
     });
 
     it('refuses without serverUrl', async () => {
-      const noUrlAdapter = new RemoteExecutionAdapter();
-      // @ts-expect-error – simulate the fallback resolution returning empty
-      noUrlAdapter.serverUrl = undefined;
+      const noUrlAdapter = new RemoteExecutionAdapter('');
       const result = await noUrlAdapter.interact({ actionType: 'Tap' });
       expect(result.ok).toBe(false);
       expect(mockFetch).not.toHaveBeenCalled();

--- a/packages/playground/tests/unit/server-interact.test.ts
+++ b/packages/playground/tests/unit/server-interact.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, vi } from 'vitest';
+import { PlaygroundServer } from '../../src/server';
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function getRouteHandler(
+  server: PlaygroundServer,
+  method: 'get' | 'post',
+  route: string,
+) {
+  const calls = (server.app[method] as any).mock.calls as Array<[string, any]>;
+  return calls.find(([registeredRoute]) => registeredRoute === route)?.[1];
+}
+
+describe('PlaygroundServer manual interaction APIs', () => {
+  test('POST /interact invokes the selected action with manual params', async () => {
+    const tapCall = vi.fn();
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'android',
+        describe: () => 'Android device',
+        actionSpace: () => [{ name: 'Tap', description: 'tap', call: tapCall }],
+        screenshotBase64: async () => 'base64-image',
+        size: async () => ({ width: 1080, height: 1920 }),
+      },
+    } as any);
+
+    await server.launch(6110);
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    expect(interactHandler).toBeTypeOf('function');
+
+    const response = createMockResponse();
+    await interactHandler(
+      { body: { actionType: 'Tap', x: 10, y: 20 } },
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({});
+    expect(tapCall).toHaveBeenCalledWith(
+      {
+        locate: expect.objectContaining({
+          center: [10, 20],
+          description: 'manual Tap',
+        }),
+      },
+      {
+        task: expect.objectContaining({
+          type: 'Action Space',
+          subType: 'Tap',
+        }),
+      },
+    );
+  });
+
+  test('POST /interact returns 400 for invalid manual params', async () => {
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'android',
+        actionSpace: () => [{ name: 'Tap', description: 'tap', call: vi.fn() }],
+      },
+    } as any);
+
+    await server.launch(6111);
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    const response = createMockResponse();
+    await interactHandler({ body: { actionType: 'Tap', y: 20 } }, response);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'x must be a number for this action',
+    });
+  });
+
+  test('POST /interact returns 404 when the current device lacks the action', async () => {
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'android',
+        actionSpace: () => [],
+      },
+    } as any);
+
+    await server.launch(6112);
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    const response = createMockResponse();
+    await interactHandler(
+      { body: { actionType: 'Tap', x: 10, y: 20 } },
+      response,
+    );
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toMatchObject({
+      error: 'Action "Tap" is not available on the current device',
+    });
+  });
+
+  test('GET /interface-info includes device size without fetching a screenshot', async () => {
+    const screenshotBase64 = vi.fn(async () => 'base64-image');
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'ios',
+        describe: () => 'iPhone',
+        actionSpace: () => [],
+        screenshotBase64,
+        size: async () => ({ width: 390, height: 844 }),
+      },
+    } as any);
+
+    await server.launch(6113);
+    const interfaceInfoHandler = getRouteHandler(
+      server,
+      'get',
+      '/interface-info',
+    );
+    const response = createMockResponse();
+    await interfaceInfoHandler({}, response);
+
+    expect(response.body).toMatchObject({
+      type: 'ios',
+      description: 'iPhone',
+      size: { width: 390, height: 844 },
+    });
+    expect(screenshotBase64).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/extractor/index.ts
+++ b/packages/shared/src/extractor/index.ts
@@ -43,6 +43,6 @@ export {
   getElementXpath,
 } from './locator';
 
-export { generateElementByRect } from './dom-util';
+export { generateElementByPoint, generateElementByRect } from './dom-util';
 
 export { isNotContainerElement } from './dom-util';

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -36,6 +36,10 @@ export default function ScreenshotViewer({
     type: string;
     description?: string;
   } | null>(null);
+  // Bumping mjpegEpoch forces the <img> to remount so the multipart connection
+  // is reopened. Used both for natural retries on stream errors and for the
+  // server-driven upgrade from polling fallback to native MJPEG.
+  const [mjpegEpoch, setMjpegEpoch] = useState(0);
   const isMjpeg = Boolean(mjpegUrl && serverOnline);
   const showChrome = mode !== 'screen-only';
   const rootClassName = [
@@ -247,9 +251,21 @@ export default function ScreenshotViewer({
     <div className="screenshot-content">
       {isMjpeg ? (
         <img
-          src={mjpegUrl}
+          key={mjpegEpoch}
+          src={
+            mjpegEpoch === 0
+              ? mjpegUrl
+              : `${mjpegUrl}${mjpegUrl?.includes('?') ? '&' : '?'}t=${mjpegEpoch}`
+          }
           alt="Device Live Stream"
           className="screenshot-image"
+          onError={() => {
+            // Server may have closed the polling fallback because the native
+            // MJPEG stream just came online; reconnect so the next /mjpeg
+            // request lands on the native (faster) path. Also covers
+            // transient network blips.
+            window.setTimeout(() => setMjpegEpoch((epoch) => epoch + 1), 500);
+          }}
         />
       ) : screenshot ? (
         <img

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -13,6 +13,7 @@ interface ScreenshotViewerProps {
   getInterfaceInfo?: () => Promise<{
     type: string;
     description?: string;
+    size?: { width: number; height: number };
   } | null>;
   serverOnline: boolean;
   isUserOperating?: boolean; // Whether user is currently operating
@@ -35,11 +36,12 @@ export default function ScreenshotViewer({
   const [interfaceInfo, setInterfaceInfo] = useState<{
     type: string;
     description?: string;
+    size?: { width: number; height: number };
   } | null>(null);
-  // Bumping mjpegEpoch forces the <img> to remount so the multipart connection
+  // Changing mjpegRetryToken forces the <img> to remount so the multipart connection
   // is reopened. Used both for natural retries on stream errors and for the
   // server-driven upgrade from polling fallback to native MJPEG.
-  const [mjpegEpoch, setMjpegEpoch] = useState(0);
+  const [mjpegRetryToken, setMjpegRetryToken] = useState('');
   const isMjpeg = Boolean(mjpegUrl && serverOnline);
   const showChrome = mode !== 'screen-only';
   const rootClassName = [
@@ -251,11 +253,11 @@ export default function ScreenshotViewer({
     <div className="screenshot-content">
       {isMjpeg ? (
         <img
-          key={mjpegEpoch}
+          key={mjpegRetryToken || 'initial'}
           src={
-            mjpegEpoch === 0
+            !mjpegRetryToken
               ? mjpegUrl
-              : `${mjpegUrl}${mjpegUrl?.includes('?') ? '&' : '?'}t=${mjpegEpoch}`
+              : `${mjpegUrl}${mjpegUrl?.includes('?') ? '&' : '?'}_mjpegRetry=${encodeURIComponent(mjpegRetryToken)}`
           }
           alt="Device Live Stream"
           className="screenshot-image"
@@ -264,7 +266,10 @@ export default function ScreenshotViewer({
             // MJPEG stream just came online; reconnect so the next /mjpeg
             // request lands on the native (faster) path. Also covers
             // transient network blips.
-            window.setTimeout(() => setMjpegEpoch((epoch) => epoch + 1), 500);
+            window.setTimeout(
+              () => setMjpegRetryToken(String(Date.now())),
+              500,
+            );
           }}
         />
       ) : screenshot ? (


### PR DESCRIPTION
## Summary

- Studio's left-pane device preview (Android via scrcpy, iOS / Harmony via MJPEG or screenshot) becomes interactive: clicking taps the device, dragging sends a swipe. Backed by a lightweight `POST /interact` endpoint that bypasses AI planning, the task lock, and dump bookkeeping so it can run alongside (or in between) AI tasks.
- iOS MJPEG self-heals: if WDA / `iproxy 9100` comes online after Studio started, the playground server probes mid-stream, ends the polling fallback, and the `<img>` re-mounts onto the native stream without a Studio restart.
- Dev-mode startup fix: `pnpm run dev` no longer crashes on a missing app icon; `getAppIconPath()` now falls back to the source `apps/studio/assets` directory.
- Review hardening: manual point params now reuse shared `generateElementByPoint`, `/interact` uses status-code-driven responses and returns 400 for bad payloads, MJPEG probes reject 4xx native responses, and device size metadata moved from `/screenshot` to lightweight `/interface-info`.

## Architecture

```
Studio overlay  →  PlaygroundSDK.interact({actionType, x, y, ...})
                →  POST /interact
                →  agent.interface.actionSpace().find(name).call(params, manualContext)
                →  Android ADB / iOS WDA / Harmony HDC tap/swipe
```

- **Server** (`packages/playground/src/server.ts`): `POST /interact` with body `{actionType, x, y, endX?, endY?, duration?, value?, keyName?}`. It uses data-driven manual param builders and shared `generateElementByPoint` for locate fields. Bad manual payloads return HTTP 400; missing actions return HTTP 404. `/interface-info` returns optional `{size}` for client-side coordinate mapping. `/mjpeg` uses a TTL-bounded negative cache and a 3s background probe that destroys the polling response when native MJPEG comes online.
- **SDK / adapter**: new `interact(payload)` on `PlaygroundSDK` and `RemoteExecutionAdapter`.
- **UI** (`packages/playground-app/src/DeviceInteractionLayer.tsx`): absolute overlay listens to `pointerdown/up`, classifies tap vs swipe (≤8px AND ≤250ms = tap), and maps display coords to device pixels via `inscribedContentRect`, honoring `object-fit: contain` letter-boxing. Clicks outside the inscribed content are ignored.
- **Visualizer**: MJPEG `<img>` now remounts with a retry token on `onError` so the stream reconnects when the server closes the polling fallback.
- **Studio integration**: `MainContent` enables `manualControlEnabled` only when the connected platform is `android | ios | harmony`. Web and Computer previews are unchanged.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx build @midscene/shared`
- [x] `npx nx run @midscene/playground:type-check`
- [x] `npx nx run @midscene/visualizer:build`
- [x] `npx nx run-many --target=build --projects=@midscene/playground,@midscene/playground-app`
- [x] `npx nx run @midscene/playground:test` — 202 passed
- [x] `npx nx run @midscene/playground-app:test` — 37 passed
- [x] `npx nx run studio:test` — 163 passed / 2 skipped
- [x] Manual: connected an iPhone with WDA + `iproxy 8100/9100`, verified `MJPEG: streaming via native WDA MJPEG server` and end-to-end tap/swipe via `/interact`
- [x] Manual: confirmed studio dev no longer crashes on the missing icon
- [ ] Recommended follow-up: end-to-end manual test on Android (scrcpy) and a Harmony device, since this PR was only spot-checked on iOS at runtime

## Notes / non-goals

- KeyboardPress / Input actions are exposed in the SDK but no UI keyboard input is wired yet.
- iOS `waitForIdleTimeout: 0` / `animationCoolOffTimeout: 0` performance tuning is intentionally not included here; that should be a separate change.