### PR TITLE
fix(ios): remove lowercase device override alias

### DIFF
--- a/apps/site/docs/en/ios-api-reference.mdx
+++ b/apps/site/docs/en/ios-api-reference.mdx
@@ -43,7 +43,7 @@ const device = new IOSDevice({
 
 - `wdaPort?: number` &mdash; WebDriverAgent port. Default `8100`.
 - `wdaHost?: string` &mdash; WebDriverAgent host. Default `'localhost'`.
-- `iOSDeviceClassOverride?: string` / `iosDeviceClassOverride?: string` &mdash; Optional npm module path that replaces the default `IOSDevice` when using `agentFromWebDriverAgent()` or iOS Playground. The module must export an `IOSDevice` class or a default class.
+- `iOSDeviceClassOverride?: string` &mdash; Optional npm module path that replaces the default `IOSDevice` when using `agentFromWebDriverAgent()` or iOS Playground. The module must export an `IOSDevice` class or a default class.
 - `autoDismissKeyboard?: boolean` &mdash; Hide the keyboard after text input. Default `true`.
 - `customActions?: DeviceAction<any>[]` &mdash; Additional device actions exposed to the agent.
 

--- a/apps/site/docs/zh/ios-api-reference.mdx
+++ b/apps/site/docs/zh/ios-api-reference.mdx
@@ -43,7 +43,7 @@ const device = new IOSDevice({
 
 - `wdaPort?: number` —— WebDriverAgent 端口，默认 `8100`。
 - `wdaHost?: string` —— WebDriverAgent host，默认 `'localhost'`。
-- `iOSDeviceClassOverride?: string` / `iosDeviceClassOverride?: string` —— 使用 `agentFromWebDriverAgent()` 或 iOS Playground 时替换默认 `IOSDevice` 的 npm module path。目标模块必须导出 `IOSDevice` class 或 default class。
+- `iOSDeviceClassOverride?: string` —— 使用 `agentFromWebDriverAgent()` 或 iOS Playground 时替换默认 `IOSDevice` 的 npm module path。目标模块必须导出 `IOSDevice` class 或 default class。
 - `autoDismissKeyboard?: boolean` —— 文本输入后自动隐藏键盘，默认 `true`。
 - `customActions?: DeviceAction<any>[]` —— 向 Agent 暴露的额外设备动作。
 

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -120,8 +120,6 @@ export type IOSDeviceOpt = {
    * The target module must export an `IOSDevice` class (or default export) compatible with Midscene's iOS device interface.
    */
   iOSDeviceClassOverride?: string;
-  /** Alias of `iOSDeviceClassOverride` for lower-case acronym style. */
-  iosDeviceClassOverride?: string;
   /** Custom device actions to register */
   customActions?: DeviceAction<any>[];
   /** WebDriverAgent port (default: 8100) */

--- a/packages/core/tests/unit-test/device-options.test.ts
+++ b/packages/core/tests/unit-test/device-options.test.ts
@@ -53,7 +53,7 @@ describe('Device Options Type Definitions', () => {
     test('should include all required iOS device options', () => {
       const options: IOSDeviceOpt = {
         deviceId: '00008110-000123456789ABCD',
-        iosDeviceClassOverride: '@private-package/ios',
+        iOSDeviceClassOverride: '@private-package/ios',
         wdaPort: 8100,
         wdaHost: 'localhost',
         useWDA: true,
@@ -127,7 +127,7 @@ describe('Device Options Type Definitions', () => {
       const yamlConfig: MidsceneYamlScriptIOSEnv = {
         // From IOSDeviceOpt
         deviceId: '00008110-000123456789ABCD',
-        iosDeviceClassOverride: '@private-package/ios',
+        iOSDeviceClassOverride: '@private-package/ios',
         wdaPort: 8100,
         wdaHost: 'localhost',
         useWDA: true,

--- a/packages/ios/src/agent.ts
+++ b/packages/ios/src/agent.ts
@@ -114,7 +114,6 @@ export async function agentFromWebDriverAgent(
 
   const overrideModule =
     opts?.iOSDeviceClassOverride?.trim() ||
-    opts?.iosDeviceClassOverride?.trim() ||
     process.env[MIDSCENE_IOS_DEVICE_CLASS_OVERRIDE]?.trim();
 
   let DeviceClass: IOSDeviceClass = IOSDevice;

--- a/packages/ios/tests/unit-test/agent.test.ts
+++ b/packages/ios/tests/unit-test/agent.test.ts
@@ -231,33 +231,6 @@ describe('IOSAgent', () => {
       vi.doUnmock(moduleName);
     });
 
-    it('should load override device class from lower-case option alias', async () => {
-      const connectSpy = vi.fn().mockResolvedValue(undefined);
-      const actionSpaceSpy = vi.fn().mockReturnValue([]);
-      const setAppNameMappingSpy = vi.fn();
-      const moduleName = 'test-ios-device-override-alias';
-
-      vi.doMock(
-        moduleName,
-        () => ({
-          IOSDevice: class {
-            connect = connectSpy;
-            actionSpace = actionSpaceSpy;
-            setAppNameMapping = setAppNameMappingSpy;
-          },
-        }),
-        { virtual: true },
-      );
-
-      await agentFromWebDriverAgent({
-        modelConfig: mockedModelConfig,
-        iosDeviceClassOverride: moduleName,
-      });
-
-      expect(connectSpy).toHaveBeenCalledTimes(1);
-      vi.doUnmock(moduleName);
-    });
-
     it('should load override device class from env', async () => {
       const connectSpy = vi.fn().mockResolvedValue(undefined);
       const actionSpaceSpy = vi.fn().mockReturnValue([]);
@@ -287,7 +260,7 @@ describe('IOSAgent', () => {
       await expect(
         agentFromWebDriverAgent({
           modelConfig: mockedModelConfig,
-          iosDeviceClassOverride: 'missing-ios-device-override-package',
+          iOSDeviceClassOverride: 'missing-ios-device-override-package',
         }),
       ).rejects.toThrow('Failed to load iOS device class override');
     });


### PR DESCRIPTION
### Motivation

- Remove an unnecessary lowercase alias `iosDeviceClassOverride` from the iOS device options to avoid supporting duplicate option names.
- Simplify runtime override resolution so only the documented `iOSDeviceClassOverride` and the `MIDSCENE_IOS_DEVICE_CLASS_OVERRIDE` env var are considered.
- Keep public API and docs consistent and update tests to reflect the single canonical option name.

### Description

- Removed the `iosDeviceClassOverride?: string` alias from `IOSDeviceOpt` in `packages/core/src/device/device-options.ts`.
- Stopped checking `opts?.iosDeviceClassOverride` in `agentFromWebDriverAgent()` so override resolution uses only `iOSDeviceClassOverride` and the env var in `packages/ios/src/agent.ts`.
- Updated unit tests to use `iOSDeviceClassOverride` and removed the test that asserted behavior for the lowercase alias in `packages/core/tests/unit-test/device-options.test.ts` and `packages/ios/tests/unit-test/agent.test.ts`.
- Removed the alias from the English and Chinese iOS API docs in `apps/site/docs/en/ios-api-reference.mdx` and `apps/site/docs/zh/ios-api-reference.mdx`.

### Testing

- Ran `npx nx test @midscene/core -- tests/unit-test/device-options.test.ts` and it passed (15 tests passed).
- Built shared and core with `npx nx build @midscene/shared && npx nx build @midscene/core` and the builds succeeded.
- Built `@midscene/webdriver` with `npx nx build @midscene/webdriver` and the build succeeded.
- Ran `npx nx test @midscene/ios -- tests/unit-test/agent.test.ts` after building dependencies and it passed (13 tests passed).
- Built `@midscene/ios` with `npx nx build @midscene/ios` and the build succeeded.
- Ran linter with `pnpm run lint`; after cleaning `.pnpm-store` the lint run completed with no errors and one informational warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaa57934c8324b9d834c3402f40f5)