### PR TITLE
fix(android): use device-local time for planning

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1844,27 +1844,38 @@ ${Object.keys(size)
   }
 
   /**
-   * Get the current time from the Android device.
-   * Returns the device's current timestamp in milliseconds.
-   * This is useful when the system time and device time are not synchronized.
+   * Get the current device-local time as a formatted string.
+   * This avoids formatting an Android epoch timestamp in the host machine's
+   * timezone, which can disagree with the device status bar.
    */
-  async getTimestamp(): Promise<number> {
+  async getDeviceLocalTimeString(
+    format = 'YYYY-MM-DD HH:mm:ss',
+  ): Promise<string> {
     const adb = await this.getAdb();
     try {
-      // Get time in milliseconds using date command
-      // %s gives seconds since epoch, %3N gives milliseconds
-      const stdout = await adb.shell('date +%s%3N');
-      const timestamp = Number.parseInt(stdout.trim(), 10);
+      const stdout = await adb.shell('date +%Y-%m-%dT%H:%M:%S');
+      const match = stdout
+        .trim()
+        .match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
 
-      if (Number.isNaN(timestamp)) {
-        throw new Error(`Invalid timestamp format: ${stdout}`);
+      if (!match) {
+        throw new Error(`Invalid device time format: ${stdout}`);
       }
 
-      debugDevice(`Got device time: ${timestamp}`);
-      return timestamp;
+      const [, year, month, day, hours, minutes, seconds] = match;
+      const timeString = format
+        .replace('YYYY', year)
+        .replace('MM', month)
+        .replace('DD', day)
+        .replace('HH', hours)
+        .replace('mm', minutes)
+        .replace('ss', seconds);
+
+      debugDevice(`Got device local time: ${timeString}`);
+      return `${timeString} (${format})`;
     } catch (error) {
-      debugDevice(`Failed to get device time: ${error}`);
-      throw new Error(`Failed to get device time: ${error}`);
+      debugDevice(`Failed to get device local time: ${error}`);
+      throw new Error(`Failed to get device local time: ${error}`);
     }
   }
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -2347,57 +2347,30 @@ describe('AndroidDevice', () => {
     });
   });
 
-  describe('getTimestamp', () => {
-    it('should return device timestamp in milliseconds', async () => {
-      const mockTimestamp = '1706262645123';
-      mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
+  describe('getDeviceLocalTimeString', () => {
+    it('should return device-local time with the default format', async () => {
+      mockAdb.shell.mockResolvedValueOnce('2023-10-15T15:37:02\n');
 
-      const result = await device.getTimestamp();
+      const result = await device.getDeviceLocalTimeString();
 
-      expect(mockAdb.shell).toHaveBeenCalledWith('date +%s%3N');
-      expect(result).toBe(1706262645123);
+      expect(mockAdb.shell).toHaveBeenCalledWith('date +%Y-%m-%dT%H:%M:%S');
+      expect(result).toBe('2023-10-15 15:37:02 (YYYY-MM-DD HH:mm:ss)');
     });
 
-    it('should handle timestamp with whitespace', async () => {
-      const mockTimestamp = '  1706262645123  \n';
-      mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
+    it('should apply custom format tokens to device-local time', async () => {
+      mockAdb.shell.mockResolvedValueOnce('2023-10-15T15:37:02');
 
-      const result = await device.getTimestamp();
+      const result = await device.getDeviceLocalTimeString('HH:mm');
 
-      expect(result).toBe(1706262645123);
+      expect(result).toBe('15:37 (HH:mm)');
     });
 
-    it('should throw error for invalid timestamp format', async () => {
-      mockAdb.shell.mockResolvedValueOnce('invalid-timestamp');
+    it('should throw error for invalid device-local time format', async () => {
+      mockAdb.shell.mockResolvedValueOnce('invalid-time');
 
-      await expect(device.getTimestamp()).rejects.toThrow(
-        'Invalid timestamp format',
+      await expect(device.getDeviceLocalTimeString()).rejects.toThrow(
+        'Invalid device time format',
       );
-    });
-
-    it('should throw error when shell command fails', async () => {
-      mockAdb.shell.mockRejectedValueOnce(new Error('Shell command failed'));
-
-      await expect(device.getTimestamp()).rejects.toThrow(
-        'Failed to get device time',
-      );
-    });
-
-    it('should throw error for empty response', async () => {
-      mockAdb.shell.mockResolvedValueOnce('');
-
-      await expect(device.getTimestamp()).rejects.toThrow(
-        'Invalid timestamp format',
-      );
-    });
-
-    it('should handle large timestamp values', async () => {
-      const mockTimestamp = '1893456000000'; // Year 2030
-      mockAdb.shell.mockResolvedValueOnce(mockTimestamp);
-
-      const result = await device.getTimestamp();
-
-      expect(result).toBe(1893456000000);
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -326,7 +326,7 @@ export class Agent<
       onTaskStart: this.callbackOnTaskStartTip.bind(this),
       replanningCycleLimit: this.opts.replanningCycleLimit,
       waitAfterAction: this.opts.waitAfterAction,
-      useDeviceTimestamp: this.opts.useDeviceTimestamp,
+      useDeviceTime: this.opts.useDeviceTime,
       actionSpace: this.fullActionSpace,
       hooks: {
         onTaskUpdate: async (runner) => {

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -32,7 +32,7 @@ import type {
   ServiceExtractParam,
 } from '@/types';
 import { ServiceError } from '@/types';
-import { type IModelConfig, getCurrentTime } from '@midscene/shared/env';
+import type { IModelConfig } from '@midscene/shared/env';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import { ExecutionSession } from './execution-session';
@@ -58,6 +58,7 @@ interface TaskExecutorHooks {
 }
 
 const debug = getDebug('device-task-executor');
+const warnLog = getDebug('device-task-executor', { console: true });
 const maxErrorCountAllowedInOnePlanningLoop = 5;
 
 export { TaskExecutionError };
@@ -81,7 +82,7 @@ export class TaskExecutor {
 
   waitAfterAction?: number;
 
-  useDeviceTimestamp?: boolean;
+  useDeviceTime?: boolean;
 
   // @deprecated use .interface instead
   get page() {
@@ -96,7 +97,7 @@ export class TaskExecutor {
       onTaskStart?: ExecutionTaskProgressOptions['onTaskStart'];
       replanningCycleLimit?: number;
       waitAfterAction?: number;
-      useDeviceTimestamp?: boolean;
+      useDeviceTime?: boolean;
       hooks?: TaskExecutorHooks;
       actionSpace: DeviceAction[];
     },
@@ -107,7 +108,7 @@ export class TaskExecutor {
     this.onTaskStartCallback = opts?.onTaskStart;
     this.replanningCycleLimit = opts.replanningCycleLimit;
     this.waitAfterAction = opts.waitAfterAction;
-    this.useDeviceTimestamp = opts.useDeviceTimestamp;
+    this.useDeviceTime = opts.useDeviceTime;
     this.hooks = opts.hooks;
     this.providedActionSpace = opts.actionSpace;
     this.taskBuilder = new TaskBuilder({
@@ -139,17 +140,30 @@ export class TaskExecutor {
   }
 
   /**
-   * Get a readable time string using device time when configured.
-   * This method respects the useDeviceTimestamp configuration.
+   * Get a readable time string. When device time is enabled, use the
+   * device-formatted wall-clock time directly so host timezone formatting does
+   * not reinterpret a device timestamp.
    * @param format - Optional format string
    * @returns A formatted time string
    */
   private async getTimeString(format?: string): Promise<string> {
-    const timestamp = await getCurrentTime(
-      this.interface,
-      this.useDeviceTimestamp,
-    );
-    return getReadableTimeString(format, timestamp);
+    if (this.useDeviceTime) {
+      if (this.interface.getDeviceLocalTimeString) {
+        try {
+          return await this.interface.getDeviceLocalTimeString(format);
+        } catch (error) {
+          warnLog(
+            `Failed to get device time string, falling back to runtime time: ${error}`,
+          );
+        }
+      } else {
+        warnLog(
+          'useDeviceTime is enabled but getDeviceLocalTimeString is not implemented, falling back to runtime time.',
+        );
+      }
+    }
+
+    return getReadableTimeString(format);
   }
 
   public async convertPlanToExecutable(

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -54,11 +54,11 @@ export abstract class AbstractInterface {
   abstract evaluateJavaScript?<T = any>(script: string): Promise<T>;
 
   /**
-   * Get the current time from the device.
-   * Returns the device's current timestamp in milliseconds.
-   * This is useful when the system time and device time are not synchronized.
+   * Get the current device-local time as a formatted string.
+   * Prefer this for user-visible time because timestamps alone do not preserve
+   * the target device's timezone when formatted on the host machine.
    */
-  getTimestamp?(): Promise<number>;
+  getDeviceLocalTimeString?(format?: string): Promise<string>;
 
   /** URL of native MJPEG stream for real-time screen preview (e.g. WDA MJPEG server) */
   mjpegStreamUrl?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1107,11 +1107,12 @@ export interface AgentOpt {
   waitAfterAction?: number;
 
   /**
-   * When set to true, Midscene will use the target device's time (Android/iOS)
-   * instead of the system time. Useful when the device time differs from the
-   * host machine. Default: false
+   * When set to true, Midscene will use the target device's formatted local
+   * time instead of the runtime system time. The target interface must implement
+   * getDeviceLocalTimeString to provide device-local wall-clock time.
+   * Default: false
    */
-  useDeviceTimestamp?: boolean;
+  useDeviceTime?: boolean;
 
   /**
    * Custom screenshot shrink factor to reduce AI token usage.

--- a/packages/core/tests/unit-test/task-executor-concurrency.test.ts
+++ b/packages/core/tests/unit-test/task-executor-concurrency.test.ts
@@ -59,6 +59,7 @@ describe('TaskExecutor concurrency isolation', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('should isolate conversation history between concurrent action calls', async () => {
@@ -107,5 +108,124 @@ describe('TaskExecutor concurrency isolation', () => {
 
     releasePlans.resolve();
     await Promise.all([actionPromiseA, actionPromiseB]);
+  });
+
+  it('should use device-local formatted time for replanning feedback', async () => {
+    const seenPendingFeedback: string[] = [];
+    mockInterface.getDeviceLocalTimeString = vi
+      .fn()
+      .mockResolvedValue('2023-10-15 15:37:00 (YYYY-MM-DD HH:mm:ss)');
+    taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [],
+      useDeviceTime: true,
+    });
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable').mockResolvedValue({
+      tasks: [],
+      yamlFlow: [],
+    } as any);
+
+    vi.mocked(plan)
+      .mockImplementationOnce(async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        opts.conversationHistory.resetPendingFeedbackMessageIfExists();
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: true,
+          log: 'first plan',
+          rawResponse: '',
+        };
+      })
+      .mockImplementationOnce(async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        opts.conversationHistory.resetPendingFeedbackMessageIfExists();
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: false,
+          log: '',
+          rawResponse: '',
+          finalizeSuccess: true,
+          finalizeMessage: 'done',
+        };
+      });
+
+    await taskExecutor.action(
+      'prompt',
+      { modelName: 'planning-model' } as any,
+      { modelName: 'default-model' } as any,
+      true,
+    );
+
+    expect(mockInterface.getDeviceLocalTimeString).toHaveBeenCalledWith(
+      undefined,
+    );
+    expect(seenPendingFeedback).toEqual([
+      '',
+      'Current time: 2023-10-15 15:37:00 (YYYY-MM-DD HH:mm:ss)',
+    ]);
+  });
+
+  it('should fall back to runtime time instead of device timestamp when device-local time is unavailable', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2023, 9, 15, 8, 30, 0));
+
+    const seenPendingFeedback: string[] = [];
+    taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [],
+      useDeviceTime: true,
+    });
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable').mockResolvedValue({
+      tasks: [],
+      yamlFlow: [],
+    } as any);
+
+    vi.mocked(plan)
+      .mockImplementationOnce(async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        opts.conversationHistory.resetPendingFeedbackMessageIfExists();
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: true,
+          log: 'first plan',
+          rawResponse: '',
+        };
+      })
+      .mockImplementationOnce(async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        opts.conversationHistory.resetPendingFeedbackMessageIfExists();
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: false,
+          log: '',
+          rawResponse: '',
+          finalizeSuccess: true,
+          finalizeMessage: 'done',
+        };
+      });
+
+    await taskExecutor.action(
+      'prompt',
+      { modelName: 'planning-model' } as any,
+      { modelName: 'default-model' } as any,
+      true,
+    );
+
+    expect(seenPendingFeedback).toEqual([
+      '',
+      'Current time: 2023-10-15 08:30:00 (YYYY-MM-DD HH:mm:ss)',
+    ]);
   });
 });

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -733,21 +733,38 @@ export class HarmonyDevice implements AbstractInterface {
     await hdc.keyEvent('Back');
   }
 
-  async getTimestamp(): Promise<number> {
+  /**
+   * Get the current device-local time as a formatted string.
+   * This avoids formatting a device timestamp in the host machine's timezone.
+   */
+  async getDeviceLocalTimeString(
+    format = 'YYYY-MM-DD HH:mm:ss',
+  ): Promise<string> {
     const hdc = await this.getHdc();
     try {
-      const stdout = await hdc.shell('date +%s%3N');
-      const timestamp = Number.parseInt(stdout.trim(), 10);
+      const stdout = await hdc.shell('date +%Y-%m-%dT%H:%M:%S');
+      const match = stdout
+        .trim()
+        .match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
 
-      if (Number.isNaN(timestamp)) {
-        throw new Error(`Invalid timestamp format: ${stdout}`);
+      if (!match) {
+        throw new Error(`Invalid device time format: ${stdout}`);
       }
 
-      debugDevice(`Got device time: ${timestamp}`);
-      return timestamp;
+      const [, year, month, day, hours, minutes, seconds] = match;
+      const timeString = format
+        .replace('YYYY', year)
+        .replace('MM', month)
+        .replace('DD', day)
+        .replace('HH', hours)
+        .replace('mm', minutes)
+        .replace('ss', seconds);
+
+      debugDevice(`Got device local time: ${timeString}`);
+      return `${timeString} (${format})`;
     } catch (error) {
-      debugDevice(`Failed to get device time: ${error}`);
-      throw new Error(`Failed to get device time: ${error}`);
+      debugDevice(`Failed to get device local time: ${error}`);
+      throw new Error(`Failed to get device local time: ${error}`);
     }
   }
 

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -614,29 +614,33 @@ describe('HarmonyDevice', () => {
     });
   });
 
-  describe('getTimestamp', () => {
+  describe('getDeviceLocalTimeString', () => {
     beforeEach(async () => {
       await device.connect();
     });
 
-    it('should parse timestamp from device', async () => {
-      mockHdc.shell.mockResolvedValueOnce('1709078400000\n');
-      const ts = await device.getTimestamp();
-      expect(ts).toBe(1709078400000);
-      expect(mockHdc.shell).toHaveBeenCalledWith('date +%s%3N');
+    it('should return device-local time with the default format', async () => {
+      mockHdc.shell.mockResolvedValueOnce('2023-10-15T15:37:02\n');
+
+      const result = await device.getDeviceLocalTimeString();
+
+      expect(mockHdc.shell).toHaveBeenCalledWith('date +%Y-%m-%dT%H:%M:%S');
+      expect(result).toBe('2023-10-15 15:37:02 (YYYY-MM-DD HH:mm:ss)');
     });
 
-    it('should throw on invalid timestamp', async () => {
-      mockHdc.shell.mockResolvedValueOnce('not-a-number\n');
-      await expect(device.getTimestamp()).rejects.toThrow(
-        'Failed to get device time',
-      );
+    it('should apply custom format tokens to device-local time', async () => {
+      mockHdc.shell.mockResolvedValueOnce('2023-10-15T15:37:02');
+
+      const result = await device.getDeviceLocalTimeString('HH:mm');
+
+      expect(result).toBe('15:37 (HH:mm)');
     });
 
-    it('should throw on shell error', async () => {
-      mockHdc.shell.mockRejectedValueOnce(new Error('device offline'));
-      await expect(device.getTimestamp()).rejects.toThrow(
-        'Failed to get device time',
+    it('should throw on invalid device-local time format', async () => {
+      mockHdc.shell.mockResolvedValueOnce('not-a-time\n');
+
+      await expect(device.getDeviceLocalTimeString()).rejects.toThrow(
+        'Failed to get device local time',
       );
     });
   });

--- a/packages/shared/src/env/utils.ts
+++ b/packages/shared/src/env/utils.ts
@@ -13,56 +13,6 @@ export const globalConfigManager = new GlobalConfigManager();
 globalConfigManager.registerModelConfigManager(globalModelConfigManager);
 globalModelConfigManager.registerGlobalConfigManager(globalConfigManager);
 
-/**
- * Interface for devices that support getTimestamp method.
- * This is a minimal interface to avoid circular dependencies with @midscene/core.
- */
-export interface DeviceWithTimestamp {
-  getTimestamp?: () => Promise<number>;
-}
-
-/**
- * Get the current timestamp, optionally from the target device.
- *
- * When useDeviceTimestamp is enabled and a device with getTimestamp is provided,
- * this function will return the device's time. Otherwise, it returns the system time.
- *
- * This is useful when:
- * - Testing on devices with different time zones
- * - Debugging time-sensitive features
- * - The system clock and device clock are not synchronized
- *
- * @param device Optional device interface that supports getTimestamp
- * @param useDeviceTimestamp Whether to use device timestamp (from agent config)
- * @returns Timestamp in milliseconds
- *
- * @example
- * // Without device - always returns system time
- * const systemTime = await getCurrentTime();
- *
- * @example
- * // With device and config enabled - returns device time
- * const deviceTime = await getCurrentTime(androidDevice, true);
- */
-export async function getCurrentTime(
-  device?: DeviceWithTimestamp,
-  useDeviceTimestamp?: boolean,
-): Promise<number> {
-  if (useDeviceTimestamp && device?.getTimestamp) {
-    try {
-      return await device.getTimestamp();
-    } catch (error) {
-      // Fall back to system time if device time retrieval fails
-      console.warn(
-        `Failed to get device time, falling back to system time: ${error}`,
-      );
-      return Date.now();
-    }
-  }
-
-  return Date.now();
-}
-
 export const getPreferredLanguage = () => {
   const prefer = globalConfigManager.getEnvConfigValue(
     MIDSCENE_PREFERRED_LANGUAGE,

--- a/packages/shared/tests/unit-test/env/utils.test.ts
+++ b/packages/shared/tests/unit-test/env/utils.test.ts
@@ -1,10 +1,6 @@
 import { getBasicEnvValue } from 'src/env/basic';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  type DeviceWithTimestamp,
-  MIDSCENE_RUN_DIR,
-  getCurrentTime,
-} from '../../../src/env';
+import { MIDSCENE_RUN_DIR } from '../../../src/env';
 
 describe('getBasicEnvValue', () => {
   afterEach(() => {
@@ -22,77 +18,5 @@ describe('getBasicEnvValue', () => {
     ).toThrowErrorMatchingInlineSnapshot(
       '[Error: getBasicEnvValue with key NOT_EXIST_KEY is not supported.]',
     );
-  });
-});
-
-describe('getCurrentTime', () => {
-  it('should return system time when useDeviceTimestamp is not set', async () => {
-    const before = Date.now();
-    const result = await getCurrentTime();
-    const after = Date.now();
-
-    expect(result).toBeGreaterThanOrEqual(before);
-    expect(result).toBeLessThanOrEqual(after);
-  });
-
-  it('should return system time when useDeviceTimestamp is false', async () => {
-    const before = Date.now();
-    const result = await getCurrentTime(undefined, false);
-    const after = Date.now();
-
-    expect(result).toBeGreaterThanOrEqual(before);
-    expect(result).toBeLessThanOrEqual(after);
-  });
-
-  it('should return system time when device is not provided', async () => {
-    const before = Date.now();
-    const result = await getCurrentTime(undefined, true);
-    const after = Date.now();
-
-    expect(result).toBeGreaterThanOrEqual(before);
-    expect(result).toBeLessThanOrEqual(after);
-  });
-
-  it('should return system time when device does not have getTimestamp method', async () => {
-    const deviceWithoutTime: DeviceWithTimestamp = {};
-
-    const before = Date.now();
-    const result = await getCurrentTime(deviceWithoutTime, true);
-    const after = Date.now();
-
-    expect(result).toBeGreaterThanOrEqual(before);
-    expect(result).toBeLessThanOrEqual(after);
-  });
-
-  it('should return device time when useDeviceTimestamp is true and device has getTimestamp', async () => {
-    const mockDeviceTime = 1700000000000;
-    const deviceWithTime: DeviceWithTimestamp = {
-      getTimestamp: vi.fn().mockResolvedValue(mockDeviceTime),
-    };
-
-    const result = await getCurrentTime(deviceWithTime, true);
-
-    expect(result).toBe(mockDeviceTime);
-    expect(deviceWithTime.getTimestamp).toHaveBeenCalledOnce();
-  });
-
-  it('should fall back to system time when getTimestamp throws an error', async () => {
-    const deviceWithError: DeviceWithTimestamp = {
-      getTimestamp: vi.fn().mockRejectedValue(new Error('Device error')),
-    };
-
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const before = Date.now();
-    const result = await getCurrentTime(deviceWithError, true);
-    const after = Date.now();
-
-    expect(result).toBeGreaterThanOrEqual(before);
-    expect(result).toBeLessThanOrEqual(after);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to get device time'),
-    );
-
-    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Replace timestamp-based device time handling with `useDeviceTime`, which consumes device-local formatted time directly.
- Add `getDeviceLocalTimeString(format)` support for Android and Harmony.
- Remove the legacy `getTimestamp` path to avoid host timezone formatting mismatches in planning feedback.
- Fix time-sensitive planning cases where Midscene’s `Current time` could differ from the device UI.

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/f04b00ca-3d9e-4401-88d9-58b63de02ef5" />
