### PR TITLE
Inject package version into build and improve model-family validation messages

### DIFF
--- a/packages/shared/rslib.config.ts
+++ b/packages/shared/rslib.config.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from '@rslib/core';
+import { version } from './package.json';
 
 const scriptStr = fs.readFileSync(
   path.resolve(__dirname, './dist-inspect/htmlElement.js'),
@@ -34,6 +35,7 @@ export default defineConfig({
   source: {
     define: {
       __HTML_ELEMENT_SCRIPT__: JSON.stringify(scriptStr),
+      __VERSION__: JSON.stringify(version),
     },
   },
 });

--- a/packages/shared/src/env/parse-model-config.ts
+++ b/packages/shared/src/env/parse-model-config.ts
@@ -24,9 +24,29 @@ import {
 } from './types';
 
 import { getDebug } from '../logger';
+
 import { assert } from '../utils';
 import { maskConfig, parseJson } from './helper';
 import { initDebugConfig } from './init-debug';
+
+declare const __VERSION__: string | undefined;
+
+const MODEL_CONFIG_DOC_URL = 'https://midscenejs.com/model-common-config.html';
+
+const getCurrentVersion = (): string => {
+  if (typeof __VERSION__ !== 'undefined' && __VERSION__) {
+    return __VERSION__;
+  }
+
+  if (typeof process !== 'undefined' && process.env?.npm_package_version) {
+    return process.env.npm_package_version;
+  }
+
+  return 'unknown';
+};
+
+const getInvalidModelFamilyMessage = (modelFamily: TModelFamily): string =>
+  `Invalid MIDSCENE_MODEL_FAMILY value: ${modelFamily}. Current version v${getCurrentVersion()} accepts the following model families: ${MODEL_FAMILY_VALUES.join(', ')}. You can also visit ${MODEL_CONFIG_DOC_URL} for the latest configuration information.`;
 
 type TModelConfigKeys =
   | typeof INSIGHT_MODEL_CONFIG_KEYS
@@ -70,7 +90,7 @@ export const getUITarsModelVersion = (
  */
 export const validateModelFamily = (modelFamily?: TModelFamily): void => {
   if (modelFamily && !MODEL_FAMILY_VALUES.includes(modelFamily as any)) {
-    throw new Error(`Invalid MIDSCENE_MODEL_FAMILY value: ${modelFamily}`);
+    throw new Error(getInvalidModelFamilyMessage(modelFamily));
   }
 };
 

--- a/packages/shared/src/env/parse-model-config.ts
+++ b/packages/shared/src/env/parse-model-config.ts
@@ -38,10 +38,6 @@ const getCurrentVersion = (): string => {
     return __VERSION__;
   }
 
-  if (typeof process !== 'undefined' && process.env?.npm_package_version) {
-    return process.env.npm_package_version;
-  }
-
   return 'unknown';
 };
 

--- a/packages/shared/tests/unit-test/env/parse.test.ts
+++ b/packages/shared/tests/unit-test/env/parse.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { version } from '../../../package.json';
 import {
   getUITarsModelVersion,
   legacyConfigToModelFamily,
@@ -11,6 +12,7 @@ import {
   MIDSCENE_USE_QWEN3_VL,
   MIDSCENE_USE_QWEN_VL,
   MIDSCENE_USE_VLM_UI_TARS,
+  MODEL_FAMILY_VALUES,
 } from '../../../src/env/types';
 
 describe('getUITarsModelVersion', () => {
@@ -51,7 +53,16 @@ describe('validateModelFamily', () => {
 
   it('should throw on invalid value', () => {
     expect(() => validateModelFamily('invalid' as any)).toThrow(
-      'Invalid MIDSCENE_MODEL_FAMILY value: invalid',
+      /Invalid MIDSCENE_MODEL_FAMILY value: invalid/,
+    );
+    expect(() => validateModelFamily('invalid' as any)).toThrow(
+      `Current version v${version}`,
+    );
+    expect(() => validateModelFamily('invalid' as any)).toThrow(
+      MODEL_FAMILY_VALUES.join(', '),
+    );
+    expect(() => validateModelFamily('invalid' as any)).toThrow(
+      'https://midscenejs.com/model-common-config.html',
     );
   });
 });

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import dotenv from 'dotenv';
 import { defineConfig } from 'vitest/config';
+import { version } from './package.json';
 
 /**
  * Read environment variables from file.
@@ -21,6 +22,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
+  },
+  define: {
+    __VERSION__: JSON.stringify(version),
   },
   ssr: {
     external: ['@silvia-odwyer/photon'],


### PR DESCRIPTION
### Motivation

- Make the package version available at runtime so validation errors can include the current library version for clearer diagnostics.
- Improve the `MIDSCENE_MODEL_FAMILY` validation message to list accepted values and point to documentation for easier troubleshooting.

### Description

- Add `version` from `package.json` into the rslib build `define` as `__VERSION__` in `packages/shared/rslib.config.ts` and expose it to Vitest via `packages/shared/vitest.config.ts` with `define.__VERSION__`.
- Introduce `getCurrentVersion` and `getInvalidModelFamilyMessage` in `packages/shared/src/env/parse-model-config.ts`, declare `__VERSION__`, and update `validateModelFamily` to throw the enhanced message listing `MODEL_FAMILY_VALUES` and a documentation URL.
- Update unit tests in `packages/shared/tests/unit-test/env/parse.test.ts` to import `version`, assert the new error includes the version, allowed model families, and the docs URL, and adjust the original error expectation to a regex.

### Testing

- Ran the shared package unit tests with Vitest (via the monorepo test command), and the updated `parse.test.ts` assertions passed.
- The modified tests assert the enhanced validation message content and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbeec2b348832497f32af19f3b3946)