### PR TITLE
feat(studio): add interactive Web preview streaming

### DIFF
--- a/.github/workflows/studio-headless-linux.yml
+++ b/.github/workflows/studio-headless-linux.yml
@@ -87,6 +87,12 @@ jobs:
       env:
         MIDSCENE_STUDIO_RUN_STARTUP_SMOKE: '1'
 
+    - name: Run Studio Web preview e2e test
+      run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:web-preview
+      timeout-minutes: 10
+      env:
+        MIDSCENE_STUDIO_RUN_WEB_PREVIEW_E2E: '1'
+
     - name: Run Studio Midscene startup test
       run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:ai
       timeout-minutes: 25

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -12,7 +12,8 @@
     "start": "node scripts/sync-static-assets.mjs && node scripts/launch-electron-prod.mjs",
     "test": "vitest run",
     "test:smoke": "vitest run tests/startup-smoke.test.mjs",
-    "test:smoke:ai": "vitest run tests/startup-smoke-ai.test.mjs"
+    "test:smoke:ai": "vitest run tests/startup-smoke-ai.test.mjs",
+    "test:smoke:web-preview": "vitest run tests/web-preview-e2e.test.mjs"
   },
   "dependencies": {
     "@midscene/android": "workspace:*",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "rsbuild build && node scripts/sync-static-assets.mjs",
-    "dev": "pnpm run dev:deps && concurrently -k -n deps,build,app \"nx run-many --target=dev --projects=@midscene/visualizer,@midscene/playground-app,@midscene/android-playground,@midscene/playground --parallel --exclude-task-dependencies\" \"rsbuild dev\" \"node scripts/wait-for-electron-build.mjs && node scripts/launch-electron-dev.mjs\"",
-    "dev:deps": "nx run @midscene/visualizer:build --outputStyle=stream && nx run-many --target=build --projects=@midscene/playground-app,@midscene/android-playground,@midscene/playground --parallel --outputStyle=stream",
+    "dev": "pnpm run dev:deps && concurrently -k -n deps,build,app \"nx run-many --target=dev --projects=@midscene/visualizer,@midscene/playground-app,@midscene/android-playground,@midscene/playground,@midscene/web --parallel --exclude-task-dependencies\" \"rsbuild dev\" \"node scripts/wait-for-electron-build.mjs && node scripts/launch-electron-dev.mjs\"",
+    "dev:deps": "nx run @midscene/visualizer:build --outputStyle=stream && nx run-many --target=build --projects=@midscene/playground-app,@midscene/android-playground,@midscene/playground,@midscene/web --parallel --outputStyle=stream",
     "package:release": "node scripts/package-electron.mjs",
     "preview": "rsbuild preview --environment renderer",
     "start": "node scripts/sync-static-assets.mjs && node scripts/launch-electron-prod.mjs",
@@ -26,7 +26,9 @@
     "@midscene/playground-app": "workspace:*",
     "@midscene/shared": "workspace:*",
     "@midscene/visualizer": "workspace:*",
+    "@midscene/web": "workspace:*",
     "antd": "^5.21.6",
+    "puppeteer": "24.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
@@ -37,6 +39,7 @@
     "@rsbuild/plugin-less": "^1.5.0",
     "@rsbuild/plugin-node-polyfill": "1.4.2",
     "@rsbuild/plugin-react": "^1.4.1",
+    "@rsbuild/plugin-svgr": "^1.2.2",
     "@rsbuild/plugin-type-check": "^1.3.2",
     "@tailwindcss/postcss": "4.1.11",
     "@types/node": "^18.0.0",

--- a/apps/studio/rsbuild.config.ts
+++ b/apps/studio/rsbuild.config.ts
@@ -12,7 +12,10 @@ import {
   rendererDevPort,
 } from './scripts/renderer-dev-config.mjs';
 
-const rendererAssetPrefix = process.env.NODE_ENV === 'development' ? '/' : './';
+// Studio is loaded by Electron through both the dev server and built
+// `file://` HTML. A relative prefix works in both places; an absolute
+// `/static/...` prefix leaves packaged/build smoke runs with a blank renderer.
+const rendererAssetPrefix = './';
 
 export default defineConfig({
   tools: {

--- a/apps/studio/rsbuild.config.ts
+++ b/apps/studio/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 import { commonIgnoreWarnings } from '../../scripts/rsbuild-utils.ts';
 import { version as appVersion } from './package.json';
@@ -28,6 +29,16 @@ export default defineConfig({
   },
   plugins: [
     pluginReact(),
+    pluginSvgr({
+      // Only source-imported workspace components (for example
+      // @midscene/playground-app) rely on default SVG-as-React-component
+      // imports. Studio's own assets use new URL(...).href and should stay
+      // as asset URLs.
+      excludeImporter: /apps[\\/]studio[\\/]src[\\/]/,
+      svgrOptions: {
+        exportType: 'default',
+      },
+    }),
     pluginLess(),
     pluginNodePolyfill(),
     pluginTypeCheck(),
@@ -41,6 +52,37 @@ export default defineConfig({
       'node:async_hooks': path.join(
         __dirname,
         '../../packages/shared/src/polyfills/async-hooks.ts',
+      ),
+      // Renderer lazy chunks import playground-app on demand. Point dev/build
+      // resolution at the workspace source so Rsbuild does not depend on the
+      // package dist entry during rslib watch rebuild windows.
+      '@midscene/playground-app$': path.join(
+        __dirname,
+        '../../packages/playground-app/src/index.ts',
+      ),
+      // Source-imported renderer packages depend on @midscene/playground.
+      // Resolve that package to its browser-safe source entry so lazy chunks
+      // do not depend on dist/es/index.browser.mjs existing during rslib
+      // watch rebuild windows. Keep this exact-match only: the Node-side
+      // server entry remains externalized in the main process build.
+      '@midscene/playground$': path.join(
+        __dirname,
+        '../../packages/playground/src/index.browser.ts',
+      ),
+      // Same reason as playground-app: renderer imports visualizer directly and
+      // via playground-app. Use source entries so rslib watch cannot break lazy
+      // compilation while dist files are being removed and rebuilt.
+      '@midscene/visualizer$': path.join(
+        __dirname,
+        '../../packages/visualizer/src/index.tsx',
+      ),
+      '@midscene/web/static$': path.join(
+        __dirname,
+        '../../packages/web-integration/src/static/index.ts',
+      ),
+      '@/utils$': path.join(
+        __dirname,
+        '../../packages/visualizer/src/utils/index.ts',
       ),
       undici: false,
       'fetch-socks': false,

--- a/apps/studio/scripts/web-preview-e2e.mjs
+++ b/apps/studio/scripts/web-preview-e2e.mjs
@@ -1,0 +1,307 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { buildStudioRuntimeEnv } from './runtime-env.mjs';
+
+const require = createRequire(import.meta.url);
+const electronBinary = require('electron');
+const __filename = fileURLToPath(import.meta.url);
+const studioRootDir = path.resolve(path.dirname(__filename), '..');
+const studioE2EReadyMarker = 'MIDSCENE_STUDIO_E2E_READY';
+const successMarker = 'STUDIO_WEB_PREVIEW_E2E_READY';
+const cdpPort = Number(process.env.MIDSCENE_STUDIO_CDP_PORT || 9234);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForChildOutput(child, marker, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      child.stdout.off('data', onStdout);
+      child.stderr.off('data', onStderr);
+      child.off('exit', onExit);
+      child.off('error', onError);
+    };
+
+    const settle = (callback) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const onStdout = (chunk) => {
+      stdout += chunk.toString();
+      if (stdout.includes(marker)) {
+        settle(resolve);
+      }
+    };
+    const onStderr = (chunk) => {
+      stderr += chunk.toString();
+    };
+    const onExit = (code, signal) => {
+      settle(() => {
+        reject(
+          new Error(
+            `Studio exited before emitting ${marker}. code=${code} signal=${signal}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+      });
+    };
+    const onError = (error) => settle(() => reject(error));
+
+    const timeoutId = setTimeout(() => {
+      settle(() => {
+        reject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for ${marker}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+      });
+    }, timeoutMs);
+
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.on('exit', onExit);
+    child.on('error', onError);
+  });
+}
+
+function forwardChildOutput(child) {
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(chunk);
+  });
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(chunk);
+  });
+}
+
+async function terminateChildProcess(child, timeoutMs) {
+  if (!child || child.exitCode !== null || child.killed) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    const timeoutId = setTimeout(() => {
+      if (child.exitCode === null) {
+        try {
+          process.kill(child.pid, 'SIGKILL');
+        } catch {
+          /* process already exited */
+        }
+      }
+    }, timeoutMs);
+
+    child.once('exit', () => {
+      clearTimeout(timeoutId);
+      resolve();
+    });
+
+    try {
+      process.kill(child.pid, 'SIGTERM');
+    } catch {
+      /* process already exited */
+    }
+  });
+}
+
+async function waitFor(condition, { timeoutMs, intervalMs = 250, label }) {
+  const startedAt = Date.now();
+  let lastError;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const result = await condition();
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${label}${
+      lastError ? `: ${lastError.message}` : ''
+    }`,
+  );
+}
+
+async function connectStudioRenderer() {
+  console.log('Connecting to Studio renderer via CDP...');
+  const browser = await puppeteer.connect({
+    browserURL: `http://127.0.0.1:${cdpPort}`,
+    defaultViewport: null,
+  });
+
+  const page = await waitFor(
+    async () => {
+      const pages = await browser.pages();
+      for (const candidate of pages) {
+        const hasStudioRuntime = await candidate.evaluate(() =>
+          Boolean(window.studioRuntime),
+        );
+        if (hasStudioRuntime) {
+          console.log(`Connected to Studio renderer: ${candidate.url()}`);
+          return candidate;
+        }
+      }
+      return null;
+    },
+    { timeoutMs: 30_000, label: 'Studio renderer target' },
+  );
+
+  await page.waitForFunction(
+    () =>
+      Boolean(window.studioRuntime) &&
+      document.body.innerText.includes('Device overview'),
+    { timeout: 30_000 },
+  );
+
+  return { browser, page };
+}
+
+async function createDefaultWebAgent(page) {
+  console.log('Creating default Web agent through the Studio UI...');
+  await page.waitForSelector('input[value="web"]', { timeout: 30_000 });
+  await page.evaluate(() => {
+    const webInput = document.querySelector('input[value="web"]');
+    if (webInput instanceof HTMLInputElement && !webInput.checked) {
+      webInput.click();
+    }
+  });
+
+  await page.waitForFunction(
+    () =>
+      document.body.innerText.includes('Open Web Page') &&
+      document.body.innerText.includes('Open Page'),
+    { timeout: 30_000 },
+  );
+
+  await page.click('button.session-setup-submit');
+}
+
+async function assertWebPreview(page) {
+  console.log('Waiting for Web preview stream...');
+  await page.waitForFunction(
+    () =>
+      document.body.innerText.includes('Web') &&
+      document.body.innerText.includes('Live') &&
+      document.body.innerText.includes('Disconnect'),
+    { timeout: 60_000 },
+  );
+
+  await page.waitForFunction(
+    () => {
+      const stream = document.querySelector('img[alt="Device Live Stream"]');
+      return (
+        stream instanceof HTMLImageElement &&
+        stream.src.includes('/mjpeg') &&
+        stream.naturalWidth > 0 &&
+        stream.naturalHeight > 0
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  const streamInfo = await page.evaluate(() => {
+    const stream = document.querySelector('img[alt="Device Live Stream"]');
+    return {
+      src: stream?.getAttribute('src') || '',
+      width: stream?.naturalWidth || 0,
+      height: stream?.naturalHeight || 0,
+    };
+  });
+
+  if (!streamInfo.src.includes('/mjpeg')) {
+    throw new Error(`Expected MJPEG preview src, got ${streamInfo.src}`);
+  }
+  console.log(
+    `Web preview stream ready: ${streamInfo.width}x${streamInfo.height}`,
+  );
+}
+
+async function assertPromptApiMenu(page) {
+  console.log('Checking prompt API menu...');
+  await page.waitForSelector('.minimal-action-trigger', { timeout: 20_000 });
+  await page.click('.minimal-action-trigger');
+
+  await page.waitForFunction(
+    () =>
+      Array.from(document.querySelectorAll('.ant-dropdown-menu-item')).some(
+        (item) => item.textContent?.trim() === 'Action',
+      ),
+    { timeout: 10_000 },
+  );
+
+  const menuLabels = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('.ant-dropdown-menu-item'))
+      .map((item) => item.textContent?.trim())
+      .filter(Boolean),
+  );
+
+  if (!menuLabels.includes('Action')) {
+    throw new Error(`Expected API menu to contain Action, got ${menuLabels}`);
+  }
+  console.log(`Prompt API menu labels: ${menuLabels.join(', ')}`);
+}
+
+async function main() {
+  let launchProcess = null;
+  let browser = null;
+
+  try {
+    launchProcess = spawn(
+      electronBinary,
+      [path.join(studioRootDir, 'dist/main/main.cjs')],
+      {
+        cwd: studioRootDir,
+        env: buildStudioRuntimeEnv({
+          baseEnv: process.env,
+          overrides: {
+            CI: process.env.CI ?? '1',
+            MIDSCENE_STUDIO_CDP_PORT: String(cdpPort),
+            MIDSCENE_STUDIO_E2E_TEST: '1',
+          },
+          studioRootDir,
+        }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    forwardChildOutput(launchProcess);
+
+    console.log('Waiting for Studio Electron readiness marker...');
+    await waitForChildOutput(launchProcess, studioE2EReadyMarker, 60_000);
+
+    const connected = await connectStudioRenderer();
+    browser = connected.browser;
+    const { page } = connected;
+
+    await createDefaultWebAgent(page);
+    await assertWebPreview(page);
+    await assertPromptApiMenu(page);
+
+    console.log(successMarker);
+  } finally {
+    if (browser) {
+      await browser.disconnect();
+    }
+    await terminateChildProcess(launchProcess, 10_000);
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('Studio Web preview e2e failed:', error);
+  process.exit(1);
+}

--- a/apps/studio/src/main/playground/multi-platform-runtime.ts
+++ b/apps/studio/src/main/playground/multi-platform-runtime.ts
@@ -1,10 +1,13 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import type { Agent } from '@midscene/core/agent';
 import type {
   LaunchPlaygroundResult,
+  PlaygroundPreviewDescriptor,
   PreparedPlaygroundPlatform,
   RegisteredPlaygroundPlatform,
 } from '@midscene/playground';
+import { getDebug } from '@midscene/shared/logger';
 import type { DiscoveredDevice } from '@shared/electron-contract';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
 import { ensureStudioShellEnvHydrated } from '../shell-env';
@@ -13,6 +16,7 @@ import type { DeviceDiscoveryService } from './device-discovery';
 import type { PlaygroundRuntimeService } from './types';
 
 const require = createRequire(__filename);
+const debugWebRuntime = getDebug('studio:web-runtime', { console: true });
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error
@@ -31,6 +35,25 @@ type HarmonyPlaygroundModule = typeof import('@midscene/harmony');
 type IosPlaygroundModule = typeof import('@midscene/ios');
 type PlaygroundModule = typeof import('@midscene/playground');
 
+type StudioPuppeteerAgentConstructor = new (
+  page: unknown,
+  opts?: { cacheId?: string },
+) => Agent;
+
+type StudioLaunchPuppeteerPage = (
+  target: {
+    url: string;
+    viewportWidth: number;
+    viewportHeight: number;
+  },
+  preference?: {
+    headed?: boolean;
+  },
+) => Promise<{
+  page: unknown;
+  freeFn: StudioWebCleanup[];
+}>;
+
 type MultiPlatformRuntimeModules = {
   ScrcpyServer: AndroidPlaygroundModule['ScrcpyServer'];
   androidPlaygroundPlatform: AndroidPlaygroundModule['androidPlaygroundPlatform'];
@@ -39,6 +62,13 @@ type MultiPlatformRuntimeModules = {
   iosPlaygroundPlatform: IosPlaygroundModule['iosPlaygroundPlatform'];
   launchPreparedPlaygroundPlatform: PlaygroundModule['launchPreparedPlaygroundPlatform'];
   prepareMultiPlatformPlayground: PlaygroundModule['prepareMultiPlatformPlayground'];
+  PuppeteerAgent: StudioPuppeteerAgentConstructor;
+  launchPuppeteerPage: StudioLaunchPuppeteerPage;
+};
+
+type StudioWebCleanup = {
+  name: string;
+  fn: () => void | Promise<void>;
 };
 
 type StudioDeviceDiscoveryService =
@@ -106,6 +136,23 @@ export async function loadIosPlaygroundModule(): Promise<
   return require('@midscene/ios');
 }
 
+export async function loadWebPlaygroundModule(): Promise<
+  Pick<MultiPlatformRuntimeModules, 'PuppeteerAgent' | 'launchPuppeteerPage'>
+> {
+  ensureStudioShellEnvHydrated();
+  const webModule = require('@midscene/web/puppeteer') as {
+    PuppeteerAgent: StudioPuppeteerAgentConstructor;
+  };
+  const launcherModule = require('@midscene/web/puppeteer-agent-launcher') as {
+    launchPuppeteerPage: StudioLaunchPuppeteerPage;
+  };
+
+  return {
+    PuppeteerAgent: webModule.PuppeteerAgent,
+    launchPuppeteerPage: launcherModule.launchPuppeteerPage,
+  };
+}
+
 export async function loadMultiPlatformRuntimeModules(): Promise<MultiPlatformRuntimeModules> {
   const [
     androidPlaygroundModule,
@@ -113,12 +160,14 @@ export async function loadMultiPlatformRuntimeModules(): Promise<MultiPlatformRu
     harmonyPlaygroundModule,
     iosPlaygroundModule,
     playgroundCoreModules,
+    webPlaygroundModule,
   ] = await Promise.all([
     loadAndroidPlaygroundModule(),
     loadComputerPlaygroundModule(),
     loadHarmonyPlaygroundModule(),
     loadIosPlaygroundModule(),
     loadPlaygroundCoreModules(),
+    loadWebPlaygroundModule(),
   ]);
 
   return {
@@ -134,6 +183,8 @@ export async function loadMultiPlatformRuntimeModules(): Promise<MultiPlatformRu
       playgroundCoreModules.launchPreparedPlaygroundPlatform,
     prepareMultiPlatformPlayground:
       playgroundCoreModules.prepareMultiPlatformPlayground,
+    PuppeteerAgent: webPlaygroundModule.PuppeteerAgent,
+    launchPuppeteerPage: webPlaygroundModule.launchPuppeteerPage,
   };
 }
 
@@ -177,19 +228,214 @@ async function createScrcpyDeviceListSource(
   };
 }
 
+const DEFAULT_STUDIO_WEB_URL = 'https://todomvc.com/examples/react/dist/';
+
+function normalizeWebUrl(value: unknown): string {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) {
+    return DEFAULT_STUDIO_WEB_URL;
+  }
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(raw)) {
+    return raw;
+  }
+  if (
+    /^(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(raw)
+  ) {
+    return `http://${raw}`;
+  }
+  return `https://${raw}`;
+}
+
+function normalizeViewportDimension(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(Math.round(value), 100);
+}
+
+async function runWebCleanup(cleanupFns: StudioWebCleanup[] | null) {
+  for (const cleanup of cleanupFns || []) {
+    try {
+      await cleanup.fn();
+    } catch (error) {
+      debugWebRuntime(
+        `cleanup "${cleanup.name}" failed: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+}
+
+function createStudioWebPreviewDescriptor(): PlaygroundPreviewDescriptor {
+  return {
+    kind: 'mjpeg',
+    title: 'Web page preview',
+    screenshotPath: '/screenshot',
+    mjpegPath: '/mjpeg',
+    capabilities: [
+      {
+        kind: 'mjpeg',
+        label: 'MJPEG streaming',
+        live: true,
+      },
+      {
+        kind: 'screenshot',
+        label: 'Screenshot fallback',
+        live: false,
+      },
+    ],
+  };
+}
+
+async function prepareStudioWebPlatform({
+  loadWebModule,
+}: {
+  loadWebModule: typeof loadWebPlaygroundModule;
+}): Promise<PreparedPlaygroundPlatform> {
+  const webModule = await loadWebModule();
+  let currentCleanup: StudioWebCleanup[] | null = null;
+
+  return {
+    platformId: 'web',
+    title: 'Midscene Web Playground',
+    description: 'Open and control a Chromium page',
+    preview: createStudioWebPreviewDescriptor(),
+    metadata: {
+      interfaceType: 'web',
+    },
+    sessionManager: {
+      async getSetupSchema() {
+        return {
+          title: 'Open a web page',
+          description: 'Start a Chromium page and stream it into Studio.',
+          primaryActionLabel: 'Open Page',
+          fields: [
+            {
+              key: 'url',
+              label: 'URL',
+              type: 'text',
+              required: true,
+              defaultValue: DEFAULT_STUDIO_WEB_URL,
+              placeholder: DEFAULT_STUDIO_WEB_URL,
+            },
+            {
+              key: 'viewportWidth',
+              label: 'Viewport width',
+              type: 'number',
+              defaultValue: 1280,
+            },
+            {
+              key: 'viewportHeight',
+              label: 'Viewport height',
+              type: 'number',
+              defaultValue: 768,
+            },
+            {
+              key: 'headed',
+              label: 'Browser window',
+              type: 'select',
+              defaultValue: false,
+              options: [
+                {
+                  label: 'Headless',
+                  value: false,
+                },
+                {
+                  label: 'Visible Chrome window',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        };
+      },
+      async createSession(input) {
+        await runWebCleanup(currentCleanup);
+        currentCleanup = null;
+
+        const url = normalizeWebUrl(input?.url);
+        const viewportWidth = normalizeViewportDimension(
+          input?.viewportWidth,
+          1280,
+        );
+        const viewportHeight = normalizeViewportDimension(
+          input?.viewportHeight,
+          768,
+        );
+        const headed = input?.headed === true;
+
+        const agentFactory = async () => {
+          await runWebCleanup(currentCleanup);
+          currentCleanup = null;
+
+          const { page, freeFn } = await webModule.launchPuppeteerPage(
+            {
+              url,
+              viewportWidth,
+              viewportHeight,
+            },
+            {
+              headed,
+            },
+          );
+          const agent = new webModule.PuppeteerAgent(page, {
+            cacheId: 'studio-web',
+          });
+          currentCleanup = [
+            {
+              name: 'studio_web_agent',
+              fn: () => agent.destroy(),
+            },
+            ...freeFn,
+          ];
+          return agent;
+        };
+
+        return {
+          agentFactory,
+          displayName: url,
+          metadata: {
+            interfaceType: 'web',
+            sessionDisplayName: url,
+            url,
+          },
+          platformId: 'web',
+          preview: createStudioWebPreviewDescriptor(),
+          title: 'Midscene Web Playground',
+        };
+      },
+      async destroySession() {
+        await runWebCleanup(currentCleanup);
+        currentCleanup = null;
+      },
+    },
+  };
+}
+
 const createStudioPlatformSpecs = ({
   loadAndroidModule = loadAndroidPlaygroundModule,
   loadComputerModule = loadComputerPlaygroundModule,
   deviceDiscoveryService,
   loadHarmonyModule = loadHarmonyPlaygroundModule,
   loadIosModule = loadIosPlaygroundModule,
+  loadWebModule = loadWebPlaygroundModule,
 }: {
   loadAndroidModule?: typeof loadAndroidPlaygroundModule;
   loadComputerModule?: typeof loadComputerPlaygroundModule;
   deviceDiscoveryService?: StudioDeviceDiscoveryService;
   loadHarmonyModule?: typeof loadHarmonyPlaygroundModule;
   loadIosModule?: typeof loadIosPlaygroundModule;
+  loadWebModule?: typeof loadWebPlaygroundModule;
 } = {}): StudioPlatformSpec[] => [
+  {
+    id: 'web',
+    label: 'Web',
+    description: 'Open and control a Chromium page',
+    staticDirPackage: '@midscene/web',
+    prepare: async () =>
+      prepareStudioWebPlatform({
+        loadWebModule,
+      }),
+  },
   {
     id: 'android',
     label: 'Android',
@@ -271,7 +517,7 @@ function buildRegisteredPlatforms(
 /**
  * Creates a multi-platform playground runtime service for the Studio
  * Electron main process. On `start()`, it registers all platforms
- * (Android, iOS, HarmonyOS, Computer) with
+ * (Web, Android, iOS, HarmonyOS, Computer) with
  * `prepareMultiPlatformPlayground` and launches a SINGLE unified HTTP
  * server. The renderer talks to this one server; the platform selector
  * on the setup form routes to the correct backend.
@@ -284,6 +530,7 @@ export function createMultiPlatformRuntimeService({
   loadComputerModule = loadComputerPlaygroundModule,
   loadHarmonyModule = loadHarmonyPlaygroundModule,
   loadIosModule = loadIosPlaygroundModule,
+  loadWebModule = loadWebPlaygroundModule,
   resolvePackageStaticDir = resolveStaticDir,
 }: {
   deviceDiscoveryService?: StudioDeviceDiscoveryService;
@@ -293,6 +540,7 @@ export function createMultiPlatformRuntimeService({
   loadComputerModule?: typeof loadComputerPlaygroundModule;
   loadHarmonyModule?: typeof loadHarmonyPlaygroundModule;
   loadIosModule?: typeof loadIosPlaygroundModule;
+  loadWebModule?: typeof loadWebPlaygroundModule;
   resolvePackageStaticDir?: (packageName: string) => string;
 } = {}): PlaygroundRuntimeService {
   let bootstrap: PlaygroundBootstrap = {
@@ -339,6 +587,19 @@ export function createMultiPlatformRuntimeService({
         const platforms = buildRegisteredPlatforms(
           runtimeModules
             ? [
+                {
+                  id: 'web',
+                  label: 'Web',
+                  description: 'Open and control a Chromium page',
+                  staticDirPackage: '@midscene/web',
+                  prepare: async () =>
+                    prepareStudioWebPlatform({
+                      loadWebModule: async () => ({
+                        PuppeteerAgent: runtimeModules.PuppeteerAgent,
+                        launchPuppeteerPage: runtimeModules.launchPuppeteerPage,
+                      }),
+                    }),
+                },
                 {
                   id: 'android',
                   label: 'Android',
@@ -396,6 +657,7 @@ export function createMultiPlatformRuntimeService({
                 loadComputerModule,
                 loadHarmonyModule,
                 loadIosModule,
+                loadWebModule,
               }),
           resolvePackageStaticDir,
         );

--- a/apps/studio/src/renderer/components/DisconnectedPreview/index.tsx
+++ b/apps/studio/src/renderer/components/DisconnectedPreview/index.tsx
@@ -1,9 +1,11 @@
 export interface DisconnectedPreviewProps {
   iconSrc: string;
+  title?: string;
 }
 
 export default function DisconnectedPreview({
   iconSrc,
+  title = 'Connect Android Device',
 }: DisconnectedPreviewProps) {
   return (
     <div className="flex h-full w-full items-center justify-center bg-surface">
@@ -15,7 +17,7 @@ export default function DisconnectedPreview({
           src={iconSrc}
         />
         <h2 className="whitespace-nowrap text-center text-[13px] font-normal leading-[24px] text-text-primary">
-          Connect Android Device
+          {title}
         </h2>
       </div>
     </div>

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -1,4 +1,11 @@
-import { Suspense, lazy, useEffect, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  Suspense,
+  lazy,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { assetUrls } from '../../assets';
 import {
   type StudioPreviewConnectionState,
@@ -22,7 +29,7 @@ import { MobilePreviewFrame } from './MobilePreviewFrame';
 import {
   resolveStudioPreviewPlatform,
   shouldEnableMobilePreviewFrame,
-  shouldUseComputerPreviewPadding,
+  shouldUseDesktopPreviewPadding,
 } from './preview-layout';
 
 const LazyPlaygroundPreview = lazy(() => import('./LazyPlaygroundPreview'));
@@ -60,6 +67,127 @@ function RefreshIcon({ spinning }: { spinning?: boolean }) {
   );
 }
 
+function BackIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="15"
+      viewBox="0 0 16 16"
+      width="15"
+    >
+      <path
+        d="M9.8 3.2 5 8l4.8 4.8"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+function ForwardIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="15"
+      viewBox="0 0 16 16"
+      width="15"
+    >
+      <path
+        d="M6.2 3.2 11 8l-4.8 4.8"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+function StopIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="13"
+      viewBox="0 0 16 16"
+      width="13"
+    >
+      <rect
+        height="8.5"
+        rx="1"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        width="8.5"
+        x="3.75"
+        y="3.75"
+      />
+    </svg>
+  );
+}
+
+function getPreviewConnectingLabel(platform?: string): string {
+  switch (platform) {
+    case 'web':
+      return 'Opening Web page…';
+    case 'computer':
+      return 'Preparing computer connection…';
+    case 'ios':
+      return 'Preparing iOS device connection…';
+    case 'harmony':
+      return 'Preparing HarmonyOS device connection…';
+    case 'android':
+      return 'Preparing Android device connection…';
+    default:
+      return 'Preparing device connection…';
+  }
+}
+
+function getDisconnectedPreviewTitle(platform?: string): string {
+  switch (platform) {
+    case 'web':
+      return 'Open Web Page';
+    case 'computer':
+      return 'Connect Computer';
+    case 'ios':
+      return 'Connect iOS Device';
+    case 'harmony':
+      return 'Connect HarmonyOS Device';
+    case 'android':
+      return 'Connect Android Device';
+    default:
+      return 'Connect Device';
+  }
+}
+
+function WebNavigationButton({
+  'aria-label': ariaLabel,
+  disabled,
+  onClick,
+  children,
+}: {
+  'aria-label': string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      aria-label={ariaLabel}
+      className="app-no-drag flex h-[28px] w-[28px] cursor-pointer appearance-none items-center justify-center rounded-[7px] border-0 bg-transparent p-0 text-text-secondary shadow-none transition-colors hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+      disabled={disabled}
+      onClick={onClick}
+      title={ariaLabel}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
 function OverviewToolbar({
   onRefresh,
   refreshing,
@@ -94,6 +222,10 @@ export default function MainContent({
     null,
   );
   const [overviewRefreshing, setOverviewRefreshing] = useState(false);
+  const [webNavigationBusyAction, setWebNavigationBusyAction] = useState<
+    'GoBack' | 'GoForward' | 'Stop' | 'Reload' | null
+  >(null);
+  const [webIsLoading, setWebIsLoading] = useState(false);
   const isReady = studioPlayground.phase === 'ready';
   const deviceLabel =
     studioPlayground.phase === 'error'
@@ -128,7 +260,7 @@ export default function MainContent({
     isConnected,
     previewStatus,
   );
-  const shouldPadComputerPreview = shouldUseComputerPreviewPadding(
+  const shouldPadDesktopPreview = shouldUseDesktopPreviewPadding(
     runtimeInfo,
     previewFormValues,
   );
@@ -140,7 +272,17 @@ export default function MainContent({
     isConnected &&
     (previewPlatform === 'android' ||
       previewPlatform === 'ios' ||
-      previewPlatform === 'harmony');
+      previewPlatform === 'harmony' ||
+      previewPlatform === 'web');
+  const manualDragActionType =
+    previewPlatform === 'web' ? 'DragAndDrop' : 'Swipe';
+  const showWebNavigation = isConnected && previewPlatform === 'web';
+  const previewConnectingLabel = getPreviewConnectingLabel(previewPlatform);
+  const disconnectedPreviewTitle = getDisconnectedPreviewTitle(previewPlatform);
+  const isOpeningSession =
+    isReady &&
+    !isConnected &&
+    studioPlayground.controller.state.sessionMutating;
   const disconnectDisabled =
     !isReady || !studioPlayground.controller.state.sessionViewState.connected;
   const previewConnectionFailed =
@@ -157,8 +299,82 @@ export default function MainContent({
     if (!isConnected) {
       setPreviewStatus(null);
       setPreviewStatusText(null);
+      setWebNavigationBusyAction(null);
+      setWebIsLoading(false);
     }
   }, [isConnected]);
+
+  useEffect(() => {
+    if (
+      !showWebNavigation ||
+      studioPlayground.phase !== 'ready' ||
+      !studioPlayground.controller.state.serverOnline
+    ) {
+      setWebIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const refreshWebLoadingState = async () => {
+      let info: Awaited<
+        ReturnType<
+          typeof studioPlayground.controller.state.playgroundSDK.getInterfaceInfo
+        >
+      >;
+      try {
+        info =
+          await studioPlayground.controller.state.playgroundSDK.getInterfaceInfo();
+      } catch (error) {
+        if (!cancelled) {
+          console.warn('Failed to refresh web loading state:', error);
+          setWebIsLoading(false);
+        }
+        return;
+      }
+      if (cancelled) return;
+      setWebIsLoading(Boolean(info?.navigationState?.isLoading));
+    };
+
+    void refreshWebLoadingState();
+    const timer = window.setInterval(refreshWebLoadingState, 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [showWebNavigation, studioPlayground]);
+
+  const runWebNavigationAction = async (
+    actionType: 'GoBack' | 'GoForward' | 'Stop' | 'Reload',
+  ) => {
+    if (
+      studioPlayground.phase !== 'ready' ||
+      webNavigationBusyAction !== null ||
+      previewPlatform !== 'web'
+    ) {
+      return;
+    }
+    setWebNavigationBusyAction(actionType);
+    try {
+      if (actionType !== 'Stop') {
+        setWebIsLoading(true);
+      }
+      const result =
+        await studioPlayground.controller.state.playgroundSDK.interact({
+          actionType,
+        });
+      if (!result.ok) {
+        console.error(
+          `Failed to run web navigation action "${actionType}": ${
+            result.error || 'Unknown error'
+          }`,
+        );
+      } else {
+        setWebIsLoading(false);
+      }
+    } finally {
+      setWebNavigationBusyAction(null);
+    }
+  };
 
   const pauseDiscoveryPolling = shouldPauseDiscoveryPollingDuringPreview({
     previewStatus,
@@ -260,11 +476,14 @@ export default function MainContent({
               platform,
               device,
             );
-            state.form.setFieldsValue(selectionValues);
             onSelectDeviceView?.();
-            if (connectedDeviceId === device.id) {
+            if (
+              connectedDeviceId === device.id ||
+              (device.selected && device.status === 'active')
+            ) {
               return;
             }
+            state.form.setFieldsValue(selectionValues);
             if (state.sessionViewState.connected) {
               await actions.destroySession();
             }
@@ -323,6 +542,54 @@ export default function MainContent({
               {connectionStatusLabel}
             </span>
           </div>
+          {showWebNavigation ? (
+            <div
+              aria-label="Web navigation"
+              className="app-no-drag ml-[10px] flex h-[32px] items-center gap-[2px] rounded-[8px] bg-transparent px-[2px]"
+            >
+              <WebNavigationButton
+                aria-label="Go back"
+                disabled={webNavigationBusyAction !== null}
+                onClick={() => {
+                  void runWebNavigationAction('GoBack');
+                }}
+              >
+                <BackIcon />
+              </WebNavigationButton>
+              <WebNavigationButton
+                aria-label="Go forward"
+                disabled={webNavigationBusyAction !== null}
+                onClick={() => {
+                  void runWebNavigationAction('GoForward');
+                }}
+              >
+                <ForwardIcon />
+              </WebNavigationButton>
+              {webIsLoading ? (
+                <WebNavigationButton
+                  aria-label="Stop loading"
+                  disabled={webNavigationBusyAction !== null}
+                  onClick={() => {
+                    void runWebNavigationAction('Stop');
+                  }}
+                >
+                  <StopIcon />
+                </WebNavigationButton>
+              ) : (
+                <WebNavigationButton
+                  aria-label="Reload page"
+                  disabled={webNavigationBusyAction !== null}
+                  onClick={() => {
+                    void runWebNavigationAction('Reload');
+                  }}
+                >
+                  <RefreshIcon
+                    spinning={webNavigationBusyAction === 'Reload'}
+                  />
+                </WebNavigationButton>
+              )}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex flex-1 justify-end gap-[8.04px]">
@@ -392,8 +659,8 @@ export default function MainContent({
             </div>
           ) : studioPlayground.controller.state.sessionViewState.connected ? (
             <div
-              className={`h-full w-full ${
-                shouldPadComputerPreview ? 'px-4' : ''
+              className={`box-border h-full w-full ${
+                shouldPadDesktopPreview ? 'px-6' : ''
               }`}
             >
               <Suspense
@@ -401,10 +668,7 @@ export default function MainContent({
                   <ConnectingPreview
                     pcSrc={assetUrls.main.pc}
                     phoneSrc={assetUrls.main.phone}
-                    statusLabel={
-                      previewStatusText ||
-                      'Preparing Android device connection…'
-                    }
+                    statusLabel={previewStatusText || previewConnectingLabel}
                   />
                 }
               >
@@ -413,10 +677,7 @@ export default function MainContent({
                     <ConnectingPreview
                       pcSrc={assetUrls.main.pc}
                       phoneSrc={assetUrls.main.phone}
-                      statusLabel={
-                        previewStatusText ||
-                        'Preparing Android device connection…'
-                      }
+                      statusLabel={previewStatusText || previewConnectingLabel}
                     />
                   }
                   onScrcpyStatusChange={(status, statusText) => {
@@ -449,11 +710,22 @@ export default function MainContent({
                     studioPlayground.controller.state.isUserOperating
                   }
                   manualControlEnabled={manualControlEnabled}
+                  manualDragActionType={manualDragActionType}
+                  manualKeyboardEnabled={previewPlatform === 'web'}
                 />
               </Suspense>
             </div>
+          ) : isOpeningSession ? (
+            <ConnectingPreview
+              pcSrc={assetUrls.main.pc}
+              phoneSrc={assetUrls.main.phone}
+              statusLabel={previewConnectingLabel}
+            />
           ) : (
-            <DisconnectedPreview iconSrc={assetUrls.main.connectionClosed} />
+            <DisconnectedPreview
+              iconSrc={assetUrls.main.connectionClosed}
+              title={disconnectedPreviewTitle}
+            />
           )}
         </MobilePreviewFrame>
       </div>

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -1,3 +1,4 @@
+import { getDebug } from '@midscene/shared/logger';
 import {
   type ReactNode,
   Suspense,
@@ -31,6 +32,8 @@ import {
   shouldEnableMobilePreviewFrame,
   shouldUseDesktopPreviewPadding,
 } from './preview-layout';
+
+const debugWebNavigation = getDebug('studio:web-navigation', { console: true });
 
 const LazyPlaygroundPreview = lazy(() => import('./LazyPlaygroundPreview'));
 
@@ -304,35 +307,38 @@ export default function MainContent({
     }
   }, [isConnected]);
 
+  // Web navigation toolbar polls /interface-info for `isLoading` so the
+  // reload/stop button reflects the current page state. Depend on the few
+  // primitives we actually read instead of the whole `studioPlayground`
+  // controller object — that object's identity changes on every render and
+  // would tear down/rebuild the interval each frame.
+  const webNavigationServerOnline =
+    studioPlayground.phase === 'ready'
+      ? studioPlayground.controller.state.serverOnline
+      : false;
+  const webNavigationSDK =
+    studioPlayground.phase === 'ready'
+      ? studioPlayground.controller.state.playgroundSDK
+      : null;
+
   useEffect(() => {
-    if (
-      !showWebNavigation ||
-      studioPlayground.phase !== 'ready' ||
-      !studioPlayground.controller.state.serverOnline
-    ) {
+    if (!showWebNavigation || !webNavigationServerOnline || !webNavigationSDK) {
       setWebIsLoading(false);
       return;
     }
 
     let cancelled = false;
     const refreshWebLoadingState = async () => {
-      let info: Awaited<
-        ReturnType<
-          typeof studioPlayground.controller.state.playgroundSDK.getInterfaceInfo
-        >
-      >;
       try {
-        info =
-          await studioPlayground.controller.state.playgroundSDK.getInterfaceInfo();
+        const info = await webNavigationSDK.getInterfaceInfo();
+        if (cancelled) return;
+        setWebIsLoading(Boolean(info?.navigationState?.isLoading));
       } catch (error) {
         if (!cancelled) {
-          console.warn('Failed to refresh web loading state:', error);
+          debugWebNavigation('failed to refresh web loading state: %s', error);
           setWebIsLoading(false);
         }
-        return;
       }
-      if (cancelled) return;
-      setWebIsLoading(Boolean(info?.navigationState?.isLoading));
     };
 
     void refreshWebLoadingState();
@@ -341,7 +347,7 @@ export default function MainContent({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [showWebNavigation, studioPlayground]);
+  }, [showWebNavigation, webNavigationServerOnline, webNavigationSDK]);
 
   const runWebNavigationAction = async (
     actionType: 'GoBack' | 'GoForward' | 'Stop' | 'Reload',
@@ -363,10 +369,10 @@ export default function MainContent({
           actionType,
         });
       if (!result.ok) {
-        console.error(
-          `Failed to run web navigation action "${actionType}": ${
-            result.error || 'Unknown error'
-          }`,
+        debugWebNavigation(
+          'failed to run web navigation action "%s": %s',
+          actionType,
+          result.error || 'Unknown error',
         );
       } else {
         setWebIsLoading(false);

--- a/apps/studio/src/renderer/components/MainContent/preview-layout.ts
+++ b/apps/studio/src/renderer/components/MainContent/preview-layout.ts
@@ -26,11 +26,12 @@ export function shouldUseMobilePreviewFrame(
   return platform === 'android' || platform === 'ios' || platform === 'harmony';
 }
 
-export function shouldUseComputerPreviewPadding(
+export function shouldUseDesktopPreviewPadding(
   runtimeInfo: PlaygroundRuntimeInfo | null,
   formValues: Record<string, unknown>,
 ): boolean {
-  return resolveStudioPreviewPlatform(runtimeInfo, formValues) === 'computer';
+  const platform = resolveStudioPreviewPlatform(runtimeInfo, formValues);
+  return platform === 'computer' || platform === 'web';
 }
 
 export function shouldEnableMobilePreviewFrame(

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -238,6 +238,11 @@ export default function Sidebar({
         }
         const { actions, state } = studioPlayground.controller;
 
+        if (item.selected && item.status === 'active') {
+          onSelectDevice();
+          return;
+        }
+
         // Tell the multi-platform session manager which platform +
         // device to target. Field keys follow the `{platformId}.fieldKey`
         // convention from `prepareMultiPlatformPlayground`.

--- a/apps/studio/tests/android-runtime.test.ts
+++ b/apps/studio/tests/android-runtime.test.ts
@@ -3,7 +3,10 @@ import {
   createStudioCorsOptions,
   isAllowedStudioOrigin,
 } from '../src/main/playground/cors';
-import { createMultiPlatformRuntimeService } from '../src/main/playground/multi-platform-runtime';
+import {
+  createMultiPlatformRuntimeService,
+  type loadWebPlaygroundModule,
+} from '../src/main/playground/multi-platform-runtime';
 
 describe('android runtime CORS policy', () => {
   it('allows Studio origins used by Electron and local renderer dev', () => {
@@ -70,6 +73,7 @@ describe('playground runtime bootstrap', () => {
     let computerLoadCount = 0;
     let harmonyLoadCount = 0;
     let iosLoadCount = 0;
+    let webLoadCount = 0;
     let capturedPlatforms:
       | import('@midscene/playground').RegisteredPlaygroundPlatform[]
       | undefined;
@@ -115,6 +119,10 @@ describe('playground runtime bootstrap', () => {
         iosLoadCount += 1;
         throw new Error('ios should stay lazy');
       },
+      loadWebModule: async () => {
+        webLoadCount += 1;
+        throw new Error('web should stay lazy');
+      },
     });
 
     await expect(runtime.start()).resolves.toEqual({
@@ -125,6 +133,7 @@ describe('playground runtime bootstrap', () => {
     });
 
     expect(capturedPlatforms?.map((platform) => platform.id)).toEqual([
+      'web',
       'android',
       'ios',
       'harmony',
@@ -134,11 +143,140 @@ describe('playground runtime bootstrap', () => {
     expect(computerLoadCount).toBe(0);
     expect(harmonyLoadCount).toBe(0);
     expect(iosLoadCount).toBe(0);
+    expect(webLoadCount).toBe(0);
 
     await expect(capturedPlatforms?.[0]?.prepare()).rejects.toThrow(
+      'web should stay lazy',
+    );
+    expect(webLoadCount).toBe(1);
+
+    await expect(capturedPlatforms?.[1]?.prepare()).rejects.toThrow(
       'android should stay lazy',
     );
     expect(androidLoadCount).toBe(1);
+  });
+
+  it('prepares a Web session with Puppeteer and MJPEG preview metadata', async () => {
+    const cleanupBrowser = vi.fn();
+    const destroyAgent = vi.fn();
+    const launchPuppeteerPage = vi.fn(async () => ({
+      page: { id: 'puppeteer-page' },
+      freeFn: [
+        {
+          name: 'puppeteer_browser',
+          fn: cleanupBrowser,
+        },
+      ],
+    }));
+    class FakePuppeteerAgent {
+      interface = { interfaceType: 'web' };
+
+      constructor(
+        public page: unknown,
+        public opts: unknown,
+      ) {}
+
+      destroy = destroyAgent;
+    }
+    let capturedPlatforms:
+      | import('@midscene/playground').RegisteredPlaygroundPlatform[]
+      | undefined;
+
+    const runtime = createMultiPlatformRuntimeService({
+      loadPlaygroundCore: async () => ({
+        launchPreparedPlaygroundPlatform: async () => ({
+          close: async () => undefined,
+          host: '127.0.0.1',
+          port: 5800,
+          server: {
+            setPreparedPlatform: () => undefined,
+          },
+        }),
+        prepareMultiPlatformPlayground: async (platforms) => {
+          capturedPlatforms = platforms;
+          return {
+            platformId: 'multi-platform',
+            title: 'Midscene Studio',
+            description: 'Multi-platform playground',
+            metadata: {},
+            sessionManager: {
+              createSession: async () => {
+                throw new Error('not needed for bootstrap');
+              },
+            },
+          };
+        },
+      }),
+      loadWebModule: (async () =>
+        ({
+          PuppeteerAgent: FakePuppeteerAgent,
+          launchPuppeteerPage,
+        }) as unknown as Awaited<
+          ReturnType<typeof loadWebPlaygroundModule>
+        >) as typeof loadWebPlaygroundModule,
+    });
+
+    await expect(runtime.start()).resolves.toEqual({
+      status: 'ready',
+      serverUrl: 'http://127.0.0.1:5800',
+      port: 5800,
+      error: null,
+    });
+
+    const webPlatform = capturedPlatforms?.find(
+      (platform) => platform.id === 'web',
+    );
+    const prepared = await webPlatform?.prepare();
+    expect(prepared?.preview?.kind).toBe('mjpeg');
+    expect(prepared?.metadata?.interfaceType).toBe('web');
+
+    const setup = await prepared?.sessionManager?.getSetupSchema?.();
+    expect(setup?.primaryActionLabel).toBe('Open Page');
+    expect(setup?.fields.map((field) => field.key)).toEqual([
+      'url',
+      'viewportWidth',
+      'viewportHeight',
+      'headed',
+    ]);
+    expect(setup?.fields.find((field) => field.key === 'url')).toMatchObject({
+      defaultValue: 'https://todomvc.com/examples/react/dist/',
+      placeholder: 'https://todomvc.com/examples/react/dist/',
+    });
+
+    const defaultSession = await prepared?.sessionManager?.createSession({});
+    expect(defaultSession?.displayName).toBe(
+      'https://todomvc.com/examples/react/dist/',
+    );
+    expect(defaultSession?.metadata?.url).toBe(
+      'https://todomvc.com/examples/react/dist/',
+    );
+
+    const session = await prepared?.sessionManager?.createSession({
+      url: 'localhost:4173',
+      viewportWidth: 900,
+      viewportHeight: 700,
+      headed: true,
+    });
+    const agent = await session?.agentFactory?.();
+
+    expect(launchPuppeteerPage).toHaveBeenCalledWith(
+      {
+        url: 'http://localhost:4173',
+        viewportWidth: 900,
+        viewportHeight: 700,
+      },
+      {
+        headed: true,
+      },
+    );
+    expect(session?.displayName).toBe('http://localhost:4173');
+    expect(session?.metadata?.sessionDisplayName).toBe('http://localhost:4173');
+    expect(session?.preview?.kind).toBe('mjpeg');
+    expect(agent).toBeInstanceOf(FakePuppeteerAgent);
+
+    await prepared?.sessionManager?.destroySession?.();
+    expect(destroyAgent).toHaveBeenCalledTimes(1);
+    expect(cleanupBrowser).toHaveBeenCalledTimes(1);
   });
 
   it('prepares Harmony in deferred mode so Studio never exits on device selection', async () => {
@@ -199,7 +337,7 @@ describe('playground runtime bootstrap', () => {
       error: null,
     });
 
-    await capturedPlatforms?.[2]?.prepare();
+    await capturedPlatforms?.[3]?.prepare();
 
     expect(harmonyPrepare).toHaveBeenCalledWith({
       staticDir: '/virtual/@midscene/harmony',

--- a/apps/studio/tests/connection-state-previews.test.ts
+++ b/apps/studio/tests/connection-state-previews.test.ts
@@ -16,6 +16,19 @@ describe('connection state previews', () => {
     expect(html).toContain('Connect Android Device');
   });
 
+  it('renders custom disconnected copy for non-Android platforms', () => {
+    const html = renderToStaticMarkup(
+      createElement(DisconnectedPreview, {
+        iconSrc: 'connection-closed.svg',
+        title: 'Open Web Page',
+      }),
+    );
+
+    expect(html).toContain('connection-closed.svg');
+    expect(html).toContain('Open Web Page');
+    expect(html).not.toContain('Connect Android Device');
+  });
+
   it('renders the failed preview with the local icon and english copy', () => {
     const html = renderToStaticMarkup(
       createElement(ConnectionFailedPreview, {

--- a/apps/studio/tests/headless-workflow.test.mjs
+++ b/apps/studio/tests/headless-workflow.test.mjs
@@ -21,5 +21,15 @@ describe('Studio headless workflow', () => {
     expect(workflow).toContain(
       `xvfb-run -a ${xvfbScreenArg} pnpm --dir apps/studio run test:smoke:ai`,
     );
+    expect(workflow).toContain(
+      `xvfb-run -a ${xvfbScreenArg} pnpm --dir apps/studio run test:smoke:web-preview`,
+    );
+  });
+
+  it('runs the Web preview e2e test in the Studio headless workflow', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('Run Studio Web preview e2e test');
+    expect(workflow).toContain('MIDSCENE_STUDIO_RUN_WEB_PREVIEW_E2E');
   });
 });

--- a/apps/studio/tests/main-content-overview.test.tsx
+++ b/apps/studio/tests/main-content-overview.test.tsx
@@ -52,6 +52,101 @@ function createReadyContextValue(): StudioPlaygroundContextValue {
   };
 }
 
+function createConnectedWebContextValue(): StudioPlaygroundContextValue {
+  const context = createReadyContextValue();
+  context.controller.state = {
+    ...context.controller.state,
+    serverOnline: true,
+    isUserOperating: false,
+    playgroundSDK: {
+      interact: vi.fn(async () => ({ ok: true })),
+    },
+    runtimeInfo: {
+      platformId: 'web',
+      title: 'Midscene Web Playground',
+      interface: {
+        type: 'puppeteer',
+        description: 'https://example.com',
+      },
+      preview: {
+        kind: 'mjpeg',
+        mjpegPath: '/mjpeg',
+        screenshotPath: '/screenshot',
+        capabilities: [{ kind: 'mjpeg' }],
+      },
+      executionUxHints: [],
+      metadata: {
+        sessionDisplayName: 'https://example.com',
+      },
+    },
+    sessionViewState: {
+      connected: true,
+      setupState: 'ready',
+    },
+  } as unknown as PlaygroundControllerResult['state'];
+  return context;
+}
+
+function createDisconnectedWebContextValue(): StudioPlaygroundContextValue {
+  const context = createReadyContextValue();
+  context.controller.state = {
+    ...context.controller.state,
+    serverOnline: true,
+    formValues: {
+      platformId: 'web',
+    },
+    sessionViewState: {
+      connected: false,
+      setupState: 'ready',
+    },
+  } as unknown as PlaygroundControllerResult['state'];
+  return context;
+}
+
+function createOpeningWebContextValue(): StudioPlaygroundContextValue {
+  const context = createDisconnectedWebContextValue();
+  context.controller.state = {
+    ...context.controller.state,
+    sessionMutating: true,
+  } as unknown as PlaygroundControllerResult['state'];
+  return context;
+}
+
+function createConnectedComputerContextValue(): StudioPlaygroundContextValue {
+  const context = createReadyContextValue();
+  context.controller.state = {
+    ...context.controller.state,
+    serverOnline: true,
+    isUserOperating: false,
+    playgroundSDK: {
+      interact: vi.fn(async () => ({ ok: true })),
+    },
+    runtimeInfo: {
+      platformId: 'computer',
+      title: 'Midscene Computer Playground',
+      interface: {
+        type: 'macos',
+        description: 'DELL U2720Q',
+      },
+      preview: {
+        kind: 'mjpeg',
+        mjpegPath: '/mjpeg',
+        screenshotPath: '/screenshot',
+        capabilities: [{ kind: 'mjpeg' }],
+      },
+      executionUxHints: [],
+      metadata: {
+        sessionDisplayName: 'DELL U2720Q',
+      },
+    },
+    sessionViewState: {
+      connected: true,
+      setupState: 'ready',
+    },
+  } as unknown as PlaygroundControllerResult['state'];
+  return context;
+}
+
 describe('MainContent overview', () => {
   it('renders discovered devices without requiring model env configuration', () => {
     const html = renderToStaticMarkup(
@@ -85,5 +180,73 @@ describe('MainContent overview', () => {
       'app-drag flex h-8 items-center gap-[4.02px] rounded-lg',
     );
     expect(html).toContain('Chat');
+  });
+
+  it('renders browser navigation controls for connected Web sessions', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundContext.Provider,
+        { value: createConnectedWebContextValue() },
+        createElement(MainContent, {
+          activeView: 'device',
+        }),
+      ),
+    );
+
+    expect(html).toContain('aria-label="Web navigation"');
+    expect(html).toContain('aria-label="Go back"');
+    expect(html).toContain('aria-label="Go forward"');
+    expect(html).toContain('aria-label="Reload page"');
+    expect(html).not.toContain(
+      'border border-border-subtle bg-surface px-[2px]',
+    );
+    expect(html).toContain('box-border h-full w-full px-6');
+    expect(html).toContain('Opening Web page…');
+    expect(html).not.toContain('Preparing Android device connection…');
+  });
+
+  it('shows Web-specific empty state copy before opening a Web page', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundContext.Provider,
+        { value: createDisconnectedWebContextValue() },
+        createElement(MainContent, {
+          activeView: 'device',
+        }),
+      ),
+    );
+
+    expect(html).toContain('Open Web Page');
+    expect(html).not.toContain('Connect Android Device');
+  });
+
+  it('shows a loading state while opening a Web page', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundContext.Provider,
+        { value: createOpeningWebContextValue() },
+        createElement(MainContent, {
+          activeView: 'device',
+        }),
+      ),
+    );
+
+    expect(html).toContain('Opening Web page…');
+    expect(html).not.toContain('Open Web Page');
+    expect(html).not.toContain('Connect Android Device');
+  });
+
+  it('adds horizontal gutter around connected computer previews', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StudioPlaygroundContext.Provider,
+        { value: createConnectedComputerContextValue() },
+        createElement(MainContent, {
+          activeView: 'device',
+        }),
+      ),
+    );
+
+    expect(html).toContain('box-border h-full w-full px-6');
   });
 });

--- a/apps/studio/tests/main-content-preview-layout.test.ts
+++ b/apps/studio/tests/main-content-preview-layout.test.ts
@@ -4,7 +4,7 @@ import {
   fitMobilePreviewViewport,
   resolveStudioPreviewPlatform,
   shouldEnableMobilePreviewFrame,
-  shouldUseComputerPreviewPadding,
+  shouldUseDesktopPreviewPadding,
   shouldUseMobilePreviewFrame,
 } from '../src/renderer/components/MainContent/preview-layout';
 
@@ -73,16 +73,19 @@ describe('shouldUseMobilePreviewFrame', () => {
   });
 });
 
-describe('shouldUseComputerPreviewPadding', () => {
-  it('adds horizontal preview padding only for computer sessions', () => {
+describe('shouldUseDesktopPreviewPadding', () => {
+  it('adds horizontal preview padding for computer and web sessions', () => {
     expect(
-      shouldUseComputerPreviewPadding(createRuntimeInfo('computer'), {}),
+      shouldUseDesktopPreviewPadding(createRuntimeInfo('computer'), {}),
     ).toBe(true);
-    expect(shouldUseComputerPreviewPadding(null, { platformId: 'macos' })).toBe(
+    expect(shouldUseDesktopPreviewPadding(null, { platformId: 'macos' })).toBe(
+      true,
+    );
+    expect(shouldUseDesktopPreviewPadding(createRuntimeInfo('web'), {})).toBe(
       true,
     );
     expect(
-      shouldUseComputerPreviewPadding(createRuntimeInfo('android'), {}),
+      shouldUseDesktopPreviewPadding(createRuntimeInfo('android'), {}),
     ).toBe(false);
   });
 });

--- a/apps/studio/tests/main-content-web-navigation.test.tsx
+++ b/apps/studio/tests/main-content-web-navigation.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import type { PlaygroundControllerResult } from '@midscene/playground-app';
+import type { StudioPlaygroundContextValue } from '@renderer/playground/types';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import MainContent from '../src/renderer/components/MainContent';
+import { StudioPlaygroundContext } from '../src/renderer/playground/useStudioPlayground';
+
+vi.mock('../src/renderer/components/MainContent/LazyPlaygroundPreview', () => ({
+  default: () => null,
+}));
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function createConnectedWebContextValue(): StudioPlaygroundContextValue {
+  return {
+    phase: 'ready',
+    serverUrl: 'http://127.0.0.1:5800',
+    controller: {
+      state: {
+        form: {
+          getFieldsValue: () => ({}),
+          setFieldsValue: () => undefined,
+        },
+        formValues: {
+          platformId: 'web',
+        },
+        runtimeInfo: {
+          platformId: 'web',
+          title: 'Midscene Web Playground',
+          interface: {
+            type: 'puppeteer',
+            description: 'https://todomvc.com/examples/react/dist/',
+          },
+          preview: {
+            kind: 'mjpeg',
+            mjpegPath: '/mjpeg',
+            screenshotPath: '/screenshot',
+            capabilities: [{ kind: 'mjpeg' }],
+          },
+          executionUxHints: [],
+          metadata: {
+            sessionDisplayName: 'https://todomvc.com/examples/react/dist/',
+          },
+        },
+        sessionSetup: {
+          fields: [],
+          targets: [],
+        },
+        serverOnline: true,
+        isUserOperating: false,
+        sessionMutating: false,
+        playgroundSDK: {
+          getInterfaceInfo: vi.fn(async () => {
+            throw new Error('server restarting');
+          }),
+          interact: vi.fn(async () => ({ ok: true })),
+        },
+        sessionViewState: {
+          connected: true,
+          setupState: 'ready',
+        },
+      },
+      actions: {
+        refreshSessionSetup: vi.fn(async () => undefined),
+        createSession: vi.fn(async () => false),
+        destroySession: vi.fn(async () => undefined),
+      },
+    } as unknown as PlaygroundControllerResult,
+    discoveredDevices: {
+      android: [],
+      ios: [],
+      computer: [],
+      harmony: [],
+      web: [],
+    },
+    refreshDiscoveredDevices: vi.fn(async () => undefined),
+    restartPlayground: vi.fn(async () => undefined),
+    setDiscoveryPollingPaused: vi.fn(),
+  };
+}
+
+describe('MainContent web navigation', () => {
+  it('handles transient loading-state polling failures without throwing', async () => {
+    const context = createConnectedWebContextValue();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(
+          StudioPlaygroundContext.Provider,
+          { value: context },
+          createElement(MainContent, {
+            activeView: 'device',
+          }),
+        ),
+      );
+    });
+    await flushPromises();
+
+    expect(
+      context.controller.state.playgroundSDK.getInterfaceInfo,
+    ).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to refresh web loading state:',
+      expect.any(Error),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/studio/tests/main-content-web-navigation.test.tsx
+++ b/apps/studio/tests/main-content-web-navigation.test.tsx
@@ -92,36 +92,36 @@ function createConnectedWebContextValue(): StudioPlaygroundContextValue {
 describe('MainContent web navigation', () => {
   it('handles transient loading-state polling failures without throwing', async () => {
     const context = createConnectedWebContextValue();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
+    let renderError: unknown = null;
     await act(async () => {
-      root.render(
-        createElement(
-          StudioPlaygroundContext.Provider,
-          { value: context },
-          createElement(MainContent, {
-            activeView: 'device',
-          }),
-        ),
-      );
+      try {
+        root.render(
+          createElement(
+            StudioPlaygroundContext.Provider,
+            { value: context },
+            createElement(MainContent, {
+              activeView: 'device',
+            }),
+          ),
+        );
+      } catch (error) {
+        renderError = error;
+      }
     });
     await flushPromises();
 
+    expect(renderError).toBeNull();
     expect(
       context.controller.state.playgroundSDK.getInterfaceInfo,
     ).toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Failed to refresh web loading state:',
-      expect.any(Error),
-    );
 
     await act(async () => {
       root.unmount();
     });
     container.remove();
-    warnSpy.mockRestore();
   });
 });

--- a/apps/studio/tests/rsbuild-config.test.ts
+++ b/apps/studio/tests/rsbuild-config.test.ts
@@ -5,4 +5,24 @@ describe('rsbuild config', () => {
   it('uses relative renderer asset paths outside development', () => {
     expect(config.environments?.renderer?.output?.assetPrefix).toBe('./');
   });
+
+  it('resolves renderer workspace packages from source-safe entries', () => {
+    const alias = config.resolve?.alias as Record<string, string | false>;
+
+    expect(alias['@midscene/playground-app$']).toContain(
+      'packages/playground-app/src/index.ts',
+    );
+    expect(alias['@midscene/playground$']).toContain(
+      'packages/playground/src/index.browser.ts',
+    );
+    expect(alias['@midscene/visualizer$']).toContain(
+      'packages/visualizer/src/index.tsx',
+    );
+    expect(alias['@midscene/web/static$']).toContain(
+      'packages/web-integration/src/static/index.ts',
+    );
+    expect(alias['@/utils$']).toContain(
+      'packages/visualizer/src/utils/index.ts',
+    );
+  });
 });

--- a/apps/studio/tests/sidebar-device-list.test.ts
+++ b/apps/studio/tests/sidebar-device-list.test.ts
@@ -1,10 +1,16 @@
+// @vitest-environment jsdom
 import type { PlaygroundControllerResult } from '@midscene/playground-app';
 import type { StudioPlaygroundContextValue } from '@renderer/playground/types';
-import { createElement } from 'react';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import Sidebar from '../src/renderer/components/Sidebar';
 import { StudioPlaygroundContext } from '../src/renderer/playground/useStudioPlayground';
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
 
 function createReadyContextValue(): StudioPlaygroundContextValue {
   return {
@@ -46,6 +52,61 @@ function createReadyContextValue(): StudioPlaygroundContextValue {
   };
 }
 
+function createConnectedWebContextValue() {
+  const destroySession = vi.fn(async () => undefined);
+  const createSession = vi.fn(async () => false);
+  const setFieldsValue = vi.fn();
+  const context = createReadyContextValue();
+
+  context.controller.state = {
+    ...context.controller.state,
+    form: {
+      getFieldsValue: () => ({}),
+      setFieldsValue,
+    },
+    formValues: {
+      platformId: 'web',
+    },
+    runtimeInfo: {
+      platformId: 'web',
+      title: 'Midscene Web Playground',
+      interface: {
+        type: 'puppeteer',
+        description: 'https://example.com',
+      },
+      preview: {
+        kind: 'mjpeg',
+        mjpegPath: '/mjpeg',
+        screenshotPath: '/screenshot',
+        capabilities: [{ kind: 'mjpeg' }],
+      },
+      executionUxHints: [],
+      metadata: {
+        sessionConnected: true,
+        sessionDisplayName: 'https://example.com',
+        setupState: 'ready',
+        url: 'https://example.com',
+      },
+    },
+    sessionViewState: {
+      connected: true,
+      setupState: 'ready',
+    },
+  } as unknown as PlaygroundControllerResult['state'];
+  context.controller.actions = {
+    ...context.controller.actions,
+    createSession,
+    destroySession,
+  } as unknown as PlaygroundControllerResult['actions'];
+
+  return {
+    context,
+    createSession,
+    destroySession,
+    setFieldsValue,
+  };
+}
+
 describe('Sidebar device list', () => {
   it('shows empty platform rows instead of an iOS setup hint when no devices exist', () => {
     const html = renderToStaticMarkup(
@@ -62,5 +123,45 @@ describe('Sidebar device list', () => {
 
     expect(html).not.toContain('Set up iOS via the playground form');
     expect(html.match(/No devices/g)).toHaveLength(5);
+  });
+
+  it('does not disconnect when clicking the active Web session in the sidebar', async () => {
+    const { context, createSession, destroySession, setFieldsValue } =
+      createConnectedWebContextValue();
+    const onSelectDevice = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(
+          StudioPlaygroundContext.Provider,
+          { value: context },
+          createElement(Sidebar, {
+            activeView: 'device',
+            onSelectDevice,
+            onSelectOverview: () => undefined,
+          }),
+        ),
+      );
+    });
+
+    const webButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('https://example.com'),
+    );
+    expect(webButton).toBeTruthy();
+
+    await act(async () => {
+      webButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSelectDevice).toHaveBeenCalledTimes(1);
+    expect(destroySession).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(setFieldsValue).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/apps/studio/tests/sidebar-device-list.test.ts
+++ b/apps/studio/tests/sidebar-device-list.test.ts
@@ -72,7 +72,7 @@ function createConnectedWebContextValue() {
       title: 'Midscene Web Playground',
       interface: {
         type: 'puppeteer',
-        description: 'https://example.com',
+        description: 'Example Web Session',
       },
       preview: {
         kind: 'mjpeg',
@@ -83,9 +83,9 @@ function createConnectedWebContextValue() {
       executionUxHints: [],
       metadata: {
         sessionConnected: true,
-        sessionDisplayName: 'https://example.com',
+        sessionDisplayName: 'Example Web Session',
         setupState: 'ready',
-        url: 'https://example.com',
+        url: 'Example Web Session',
       },
     },
     sessionViewState: {
@@ -147,7 +147,7 @@ describe('Sidebar device list', () => {
     });
 
     const webButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent?.includes('https://example.com'),
+      (button) => button.textContent?.includes('Example Web Session'),
     );
     expect(webButton).toBeTruthy();
 

--- a/apps/studio/tests/web-preview-e2e.test.mjs
+++ b/apps/studio/tests/web-preview-e2e.test.mjs
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const shouldRunWebPreviewE2E =
+  process.env.MIDSCENE_STUDIO_RUN_WEB_PREVIEW_E2E === '1';
+const __filename = fileURLToPath(import.meta.url);
+const studioRootDir = path.resolve(path.dirname(__filename), '..');
+const webPreviewReadyMarker = 'STUDIO_WEB_PREVIEW_E2E_READY';
+
+function runNodeScript(scriptRelativePath, { env, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptRelativePath], {
+      cwd: studioRootDir,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const timeoutId = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill('SIGKILL');
+        }
+      }, 1000).unref();
+
+      settled = true;
+      reject(
+        new Error(
+          `Timed out after ${timeoutMs}ms running ${scriptRelativePath}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+
+      clearTimeout(timeoutId);
+      settled = true;
+      reject(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      if (settled) {
+        return;
+      }
+
+      clearTimeout(timeoutId);
+      settled = true;
+      resolve({ code, signal, stderr, stdout });
+    });
+  });
+}
+
+const describeWebPreviewE2E = shouldRunWebPreviewE2E ? describe : describe.skip;
+
+describeWebPreviewE2E('apps/studio Web preview e2e', () => {
+  it('creates a Web agent, streams its preview, and exposes Action in the API menu', async () => {
+    const result = await runNodeScript('scripts/web-preview-e2e.mjs', {
+      env: {
+        ...process.env,
+        CI: process.env.CI ?? '1',
+      },
+      timeoutMs: 180_000,
+    });
+
+    if (result.code !== 0) {
+      throw new Error(
+        `Studio Web preview e2e exited with code=${result.code} signal=${result.signal}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+    }
+
+    expect(result.code).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      webPreviewReadyMarker,
+    );
+  }, 210_000);
+});

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -15,6 +15,21 @@ export interface FileChooserHandler {
   accept(files: string[]): Promise<void>;
 }
 
+export interface MjpegStreamFrame {
+  data: string;
+  contentType?: string;
+}
+
+export interface MjpegStreamHandle {
+  stop(): void | Promise<void>;
+}
+
+export interface MjpegStreamOptions {
+  signal?: AbortSignal;
+  onFrame(frame: MjpegStreamFrame): void;
+  onError?(error: unknown): void;
+}
+
 export abstract class AbstractInterface {
   abstract interfaceType: string;
 
@@ -62,6 +77,15 @@ export abstract class AbstractInterface {
 
   /** URL of native MJPEG stream for real-time screen preview (e.g. WDA MJPEG server) */
   mjpegStreamUrl?: string;
+
+  /**
+   * Optional in-process MJPEG frame producer. Implementations can push raw
+   * base64 frames here when there is no standalone native MJPEG URL, e.g.
+   * Chromium CDP Page.startScreencast for web previews.
+   */
+  startMjpegStream?(
+    options: MjpegStreamOptions,
+  ): MjpegStreamHandle | undefined | Promise<MjpegStreamHandle | undefined>;
 }
 
 // Generic function to define actions with proper type inference

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -16,6 +16,7 @@ export interface FileChooserHandler {
 }
 
 export interface MjpegStreamFrame {
+  /** Raw base64-encoded image bytes WITHOUT a `data:image/...;base64,` prefix. */
   data: string;
   contentType?: string;
 }
@@ -86,6 +87,20 @@ export abstract class AbstractInterface {
   startMjpegStream?(
     options: MjpegStreamOptions,
   ): MjpegStreamHandle | undefined | Promise<MjpegStreamHandle | undefined>;
+
+  /**
+   * Optional hook used after keyboard-only actions to force a fresh frame on
+   * the active MJPEG stream. Implementations should be a no-op when no stream
+   * is active.
+   */
+  flushPendingVisualUpdate?(): Promise<void>;
+
+  /**
+   * Optional navigation state probe for browser-like interfaces, used to drive
+   * loading indicators in playground UIs. Returning `undefined` means the
+   * interface does not expose this concept.
+   */
+  navigationState?(): Promise<{ isLoading: boolean }>;
 }
 
 // Generic function to define actions with proper type inference

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -72,6 +72,54 @@ function isHostCopyShortcut(
   );
 }
 
+/**
+ * Keys / shortcut combinations that should always reach the surrounding
+ * Electron / browser host instead of being forwarded to the remote device.
+ * The remote device already exposes its own reload / forward / stop buttons
+ * in the navigation toolbar, so we err on the side of letting the host take
+ * the standard window-level shortcuts.
+ */
+function isHostReservedShortcut(
+  event: Pick<
+    KeyboardEvent,
+    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+  >,
+): boolean {
+  // Host-managed function keys.
+  if (event.key === 'F5' || event.key === 'F11' || event.key === 'F12') {
+    return true;
+  }
+
+  const hasPrimaryModifier = event.metaKey || event.ctrlKey;
+  if (!hasPrimaryModifier) return false;
+
+  const lowerKey = event.key.toLowerCase();
+
+  // DevTools / Inspect: Cmd+Opt+I, Ctrl+Shift+I, Ctrl+Shift+J.
+  if (event.altKey && lowerKey === 'i') return true;
+  if (event.shiftKey && (lowerKey === 'i' || lowerKey === 'j')) {
+    return true;
+  }
+
+  // Window / app-level shortcuts that users expect to control Studio itself,
+  // even while a device is armed for keyboard input.
+  const hostReservedKeys = new Set([
+    'r', // reload (also Shift+R = force reload)
+    'q', // quit
+    'w', // close window/tab
+    'm', // minimize
+    'h', // hide (macOS)
+    'n', // new window
+    't', // new tab (rarely used in Studio but standard)
+    '+',
+    '=',
+    '-',
+    '_',
+    '0', // zoom controls
+  ]);
+  return hostReservedKeys.has(lowerKey);
+}
+
 function hasHostSelectionOutsideOverlay(overlay: HTMLElement | null): boolean {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || !overlay) return false;
@@ -280,6 +328,11 @@ export function DeviceInteractionLayer({
         return;
       }
       if (composingRef.current || event.isComposing) {
+        return;
+      }
+      // Let Electron / browser-level shortcuts reach the host so users keep
+      // standard reload / devtools / window-management behavior.
+      if (isHostReservedShortcut(event)) {
         return;
       }
 

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -1,4 +1,14 @@
-import { type CSSProperties, useCallback, useEffect, useRef } from 'react';
+import React, {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+
+// The package-local Vitest setup still uses the classic JSX runtime for this
+// source file, so keep a runtime React binding even though the component code
+// only references React types explicitly.
+void React;
 
 export interface DeviceSize {
   width: number;
@@ -14,6 +24,9 @@ export interface DeviceInteractionLayerProps {
     end: { x: number; y: number },
     duration: number,
   ) => void;
+  keyboardEnabled?: boolean;
+  onTextInput?: (text: string, point?: { x: number; y: number }) => void;
+  onKeyboardPress?: (keyName: string, point?: { x: number; y: number }) => void;
   /**
    * Tap classification thresholds. Pointer movement below this distance and
    * total duration below this delay is reported as a Tap; anything else is a
@@ -29,6 +42,60 @@ interface ActivePointer {
   startY: number;
   startTime: number;
   contentRect: { left: number; top: number; width: number; height: number };
+}
+
+const keyboardControlKeys = new Set([
+  'Backspace',
+  'Delete',
+  'Enter',
+  'Tab',
+  'Escape',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+]);
+
+const pureModifierKeys = new Set(['Alt', 'Control', 'Meta', 'Shift']);
+
+function isHostCopyShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey'>,
+): boolean {
+  return (
+    !event.altKey &&
+    (event.metaKey || event.ctrlKey) &&
+    event.key.toLowerCase() === 'c'
+  );
+}
+
+function hasHostSelectionOutsideOverlay(overlay: HTMLElement | null): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !overlay) return false;
+  const { anchorNode, focusNode } = selection;
+  if (!anchorNode || !focusNode) return false;
+  return !overlay.contains(anchorNode) && !overlay.contains(focusNode);
+}
+
+export function keyNameForKeyboardEvent(
+  event: Pick<
+    React.KeyboardEvent,
+    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+  >,
+): string | null {
+  if (pureModifierKeys.has(event.key)) return null;
+
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push('Control');
+  if (event.metaKey) parts.push('Meta');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey && event.key !== 'Shift') parts.push('Shift');
+
+  parts.push(event.key === ' ' ? 'Space' : event.key);
+  return parts.join('+');
 }
 
 export function inscribedContentRect(
@@ -60,12 +127,38 @@ export function DeviceInteractionLayer({
   deviceSize,
   onTap,
   onSwipe,
+  keyboardEnabled = false,
+  onTextInput,
+  onKeyboardPress,
   tapMaxDistance = 8,
   tapMaxDurationMs = 250,
   style,
 }: DeviceInteractionLayerProps) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const keyboardSinkRef = useRef<HTMLTextAreaElement | null>(null);
   const activePointer = useRef<ActivePointer | null>(null);
+  const composingRef = useRef(false);
+  const keyboardArmedRef = useRef(false);
+  const lastKeyboardPointRef = useRef<{ x: number; y: number } | null>(null);
+
+  const focusKeyboardSink = useCallback(() => {
+    if (keyboardEnabled) {
+      keyboardArmedRef.current = true;
+      keyboardSinkRef.current?.focus({ preventScroll: true });
+    }
+  }, [keyboardEnabled]);
+
+  const positionKeyboardSink = useCallback(
+    (clientX: number, clientY: number) => {
+      const overlay = overlayRef.current;
+      const sink = keyboardSinkRef.current;
+      if (!overlay || !sink) return;
+      const rect = overlay.getBoundingClientRect();
+      sink.style.left = `${Math.max(0, clientX - rect.left)}px`;
+      sink.style.top = `${Math.max(0, clientY - rect.top)}px`;
+    },
+    [],
+  );
 
   const projectToDevice = useCallback(
     (
@@ -101,9 +194,16 @@ export function DeviceInteractionLayer({
         event.clientY < contentRect.top ||
         event.clientY > contentRect.top + contentRect.height
       ) {
+        keyboardArmedRef.current = false;
         return;
       }
-      overlayRef.current.setPointerCapture(event.pointerId);
+      positionKeyboardSink(event.clientX, event.clientY);
+      focusKeyboardSink();
+      try {
+        overlayRef.current.setPointerCapture(event.pointerId);
+      } catch {
+        /* synthetic/devtools pointer events may not have an active pointer */
+      }
       activePointer.current = {
         startX: event.clientX,
         startY: event.clientY,
@@ -112,7 +212,7 @@ export function DeviceInteractionLayer({
       };
       event.preventDefault();
     },
-    [enabled, deviceSize],
+    [enabled, deviceSize, focusKeyboardSink, positionKeyboardSink],
   );
 
   const finishPointer = useCallback(
@@ -143,6 +243,7 @@ export function DeviceInteractionLayer({
         active.contentRect,
       );
       if (!startPoint || !endPoint) return;
+      lastKeyboardPointRef.current = endPoint;
 
       if (distance <= tapMaxDistance && duration <= tapMaxDurationMs) {
         onTap?.(startPoint);
@@ -162,11 +263,138 @@ export function DeviceInteractionLayer({
     [finishPointer],
   );
 
+  const clearLocalEditableText = useCallback(() => {
+    if (keyboardSinkRef.current?.value) {
+      keyboardSinkRef.current.value = '';
+    }
+  }, []);
+
+  const handleKeyboardEvent = useCallback(
+    (event: KeyboardEvent) => {
+      if (!keyboardEnabled || !keyboardArmedRef.current) return;
+      if (
+        isHostCopyShortcut(event) &&
+        hasHostSelectionOutsideOverlay(overlayRef.current)
+      ) {
+        keyboardArmedRef.current = false;
+        return;
+      }
+      if (composingRef.current || event.isComposing) {
+        return;
+      }
+
+      if (
+        keyboardControlKeys.has(event.key) ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey
+      ) {
+        const keyName = keyNameForKeyboardEvent(event);
+        if (!keyName) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onKeyboardPress?.(keyName, lastKeyboardPointRef.current ?? undefined);
+      }
+    },
+    [keyboardEnabled, onKeyboardPress],
+  );
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!keyboardEnabled || !keyboardArmedRef.current) return;
+      const text = event.clipboardData.getData('text');
+      if (!text) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onTextInput?.(text, lastKeyboardPointRef.current ?? undefined);
+    },
+    [keyboardEnabled, onTextInput],
+  );
+
+  const handleEditableInput = useCallback(
+    (event: React.FormEvent<HTMLTextAreaElement>) => {
+      if (!keyboardEnabled || !keyboardArmedRef.current) {
+        if (!composingRef.current) {
+          clearLocalEditableText();
+        }
+        return;
+      }
+      if (composingRef.current) {
+        return;
+      }
+      const nativeEvent = event.nativeEvent as InputEvent;
+      if (nativeEvent.inputType === 'insertLineBreak') {
+        clearLocalEditableText();
+        event.preventDefault();
+        event.stopPropagation();
+        onKeyboardPress?.('Enter', lastKeyboardPointRef.current ?? undefined);
+        return;
+      }
+      if (nativeEvent.inputType === 'deleteContentBackward') {
+        clearLocalEditableText();
+        event.preventDefault();
+        event.stopPropagation();
+        onKeyboardPress?.(
+          'Backspace',
+          lastKeyboardPointRef.current ?? undefined,
+        );
+        return;
+      }
+      if (nativeEvent.inputType === 'deleteContentForward') {
+        clearLocalEditableText();
+        event.preventDefault();
+        event.stopPropagation();
+        onKeyboardPress?.('Delete', lastKeyboardPointRef.current ?? undefined);
+        return;
+      }
+      const text = nativeEvent.data || keyboardSinkRef.current?.value || '';
+      clearLocalEditableText();
+      if (!text) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onTextInput?.(text, lastKeyboardPointRef.current ?? undefined);
+    },
+    [clearLocalEditableText, keyboardEnabled, onKeyboardPress, onTextInput],
+  );
+
   useEffect(() => {
     if (!enabled) {
       activePointer.current = null;
+      composingRef.current = false;
+      keyboardArmedRef.current = false;
+      lastKeyboardPointRef.current = null;
     }
   }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !keyboardEnabled) {
+      keyboardArmedRef.current = false;
+      return;
+    }
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const overlay = overlayRef.current;
+      if (
+        overlay &&
+        event.target instanceof Node &&
+        overlay.contains(event.target)
+      ) {
+        return;
+      }
+      keyboardArmedRef.current = false;
+    };
+
+    window.addEventListener('keydown', handleKeyboardEvent, true);
+    window.addEventListener('pointerdown', handleDocumentPointerDown, true);
+    return () => {
+      window.removeEventListener('keydown', handleKeyboardEvent, true);
+      window.removeEventListener(
+        'pointerdown',
+        handleDocumentPointerDown,
+        true,
+      );
+    };
+  }, [enabled, handleKeyboardEvent, keyboardEnabled]);
 
   if (!enabled || !deviceSize) {
     return null;
@@ -179,15 +407,62 @@ export function DeviceInteractionLayer({
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerCancel}
       onContextMenu={(e) => e.preventDefault()}
+      data-midscene-device-interaction-layer="true"
       style={{
         position: 'absolute',
         inset: 0,
         zIndex: 5,
-        cursor: 'crosshair',
+        cursor: keyboardEnabled ? 'default' : 'crosshair',
+        outline: 'none',
+        color: 'transparent',
+        caretColor: 'transparent',
         touchAction: 'none',
         userSelect: 'none',
         ...style,
       }}
-    />
+    >
+      {keyboardEnabled ? (
+        <textarea
+          ref={keyboardSinkRef}
+          data-midscene-keyboard-sink="true"
+          tabIndex={-1}
+          onPaste={handlePaste}
+          onCompositionStart={() => {
+            keyboardArmedRef.current = true;
+            composingRef.current = true;
+          }}
+          onCompositionEnd={(event) => {
+            if (!keyboardEnabled || !keyboardArmedRef.current) return;
+            composingRef.current = false;
+            const text = event.data || keyboardSinkRef.current?.value || '';
+            clearLocalEditableText();
+            if (text) {
+              onTextInput?.(text, lastKeyboardPointRef.current ?? undefined);
+            }
+          }}
+          onInput={handleEditableInput}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 32,
+            height: 24,
+            opacity: 0.01,
+            pointerEvents: 'none',
+            resize: 'none',
+            border: 0,
+            padding: 0,
+            margin: 0,
+            outline: 'none',
+            background: 'transparent',
+            color: 'transparent',
+            caretColor: 'transparent',
+            fontSize: 16,
+            lineHeight: '20px',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/packages/playground-app/src/PlaygroundPreview.tsx
+++ b/packages/playground-app/src/PlaygroundPreview.tsx
@@ -6,6 +6,7 @@ import type { ScreenshotViewerMode } from '@midscene/visualizer';
 import type { CSSProperties, ReactNode } from 'react';
 import { PreviewRenderer } from './PreviewRenderer';
 import type { ScrcpyErrorOverlayRenderer } from './ScrcpyPanel';
+import type { ManualDragActionType } from './manual-interaction';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
 
 export interface PlaygroundPreviewProps {
@@ -23,6 +24,8 @@ export interface PlaygroundPreviewProps {
   serverOnline: boolean;
   isUserOperating: boolean;
   manualControlEnabled?: boolean;
+  manualDragActionType?: ManualDragActionType;
+  manualKeyboardEnabled?: boolean;
 }
 
 export function PlaygroundPreview(props: PlaygroundPreviewProps) {

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -8,11 +8,12 @@ import {
 } from '@midscene/visualizer';
 import { WebCodecsVideoDecoder } from '@yume-chan/scrcpy-decoder-webcodecs';
 import { Alert, Popover, message } from 'antd';
-import {
+import React, {
   type CSSProperties,
   type ReactNode,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -20,6 +21,10 @@ import {
   type DeviceSize,
 } from './DeviceInteractionLayer';
 import { type ScrcpyErrorOverlayRenderer, ScrcpyPanel } from './ScrcpyPanel';
+import {
+  type ManualDragActionType,
+  buildManualDragInteractPayload,
+} from './manual-interaction';
 import { resolvePreviewConnectionInfo } from './runtime-info';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
 
@@ -42,6 +47,8 @@ interface PreviewRendererProps {
    * connected device (Android via ADB, iOS via WDA, Harmony via HDC).
    */
   manualControlEnabled?: boolean;
+  manualDragActionType?: ManualDragActionType;
+  manualKeyboardEnabled?: boolean;
 }
 
 function isNonLocalhostHttp(): boolean {
@@ -68,6 +75,8 @@ export function PreviewRenderer({
   serverOnline,
   isUserOperating,
   manualControlEnabled = false,
+  manualDragActionType = 'Swipe',
+  manualKeyboardEnabled = false,
 }: PreviewRendererProps) {
   const previewConnection = resolvePreviewConnectionInfo(
     runtimeInfo,
@@ -75,6 +84,16 @@ export function PreviewRenderer({
   );
 
   const [deviceSize, setDeviceSize] = useState<DeviceSize | null>(null);
+  const manualControlQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  const enqueueManualControl = useCallback(
+    <TResult,>(task: () => Promise<TResult>): Promise<TResult> => {
+      const nextTask = manualControlQueueRef.current.then(task, task);
+      manualControlQueueRef.current = nextTask.catch(() => undefined);
+      return nextTask;
+    },
+    [],
+  );
 
   // Pull device size from lightweight interface metadata so the interaction
   // layer can map display coords to device pixels. Refresh periodically
@@ -86,7 +105,12 @@ export function PreviewRenderer({
     }
     let cancelled = false;
     const fetchSize = async () => {
-      const result = await playgroundSDK.getInterfaceInfo();
+      let result: Awaited<ReturnType<typeof playgroundSDK.getInterfaceInfo>>;
+      try {
+        result = await playgroundSDK.getInterfaceInfo();
+      } catch {
+        return;
+      }
       if (cancelled) return;
       if (result?.size?.width && result.size.height) {
         const { size } = result;
@@ -123,16 +147,18 @@ export function PreviewRenderer({
 
   const handleTap = useCallback(
     async (point: { x: number; y: number }) => {
-      const res = await playgroundSDK.interact({
-        actionType: 'Tap',
-        x: point.x,
-        y: point.y,
-      });
+      const res = await enqueueManualControl(() =>
+        playgroundSDK.interact({
+          actionType: 'Tap',
+          x: point.x,
+          y: point.y,
+        }),
+      );
       if (!res.ok) {
         showManualControlError('Tap failed', res.error);
       }
     },
-    [playgroundSDK, showManualControlError],
+    [enqueueManualControl, playgroundSDK, showManualControlError],
   );
 
   const handleSwipe = useCallback(
@@ -141,19 +167,59 @@ export function PreviewRenderer({
       end: { x: number; y: number },
       duration: number,
     ) => {
-      const res = await playgroundSDK.interact({
-        actionType: 'Swipe',
-        x: start.x,
-        y: start.y,
-        endX: end.x,
-        endY: end.y,
-        duration,
-      });
+      const res = await enqueueManualControl(() =>
+        playgroundSDK.interact(
+          buildManualDragInteractPayload(
+            manualDragActionType,
+            start,
+            end,
+            duration,
+          ),
+        ),
+      );
       if (!res.ok) {
-        showManualControlError('Swipe failed', res.error);
+        showManualControlError(`${manualDragActionType} failed`, res.error);
       }
     },
-    [playgroundSDK, showManualControlError],
+    [
+      enqueueManualControl,
+      manualDragActionType,
+      playgroundSDK,
+      showManualControlError,
+    ],
+  );
+
+  const handleTextInput = useCallback(
+    async (text: string) => {
+      if (!text) return;
+      const res = await enqueueManualControl(() =>
+        playgroundSDK.interact({
+          actionType: 'Input',
+          value: text,
+          mode: 'typeOnly',
+        }),
+      );
+      if (!res.ok) {
+        showManualControlError('Input failed', res.error);
+      }
+    },
+    [enqueueManualControl, playgroundSDK, showManualControlError],
+  );
+
+  const handleKeyboardPress = useCallback(
+    async (keyName: string) => {
+      if (!keyName) return;
+      const res = await enqueueManualControl(() =>
+        playgroundSDK.interact({
+          actionType: 'KeyboardPress',
+          keyName,
+        }),
+      );
+      if (!res.ok) {
+        showManualControlError('Keyboard press failed', res.error);
+      }
+    },
+    [enqueueManualControl, playgroundSDK, showManualControlError],
   );
 
   // Fall back to screenshot polling when WebCodecs is unavailable
@@ -278,6 +344,9 @@ export function PreviewRenderer({
         deviceSize={deviceSize}
         onTap={handleTap}
         onSwipe={handleSwipe}
+        keyboardEnabled={manualKeyboardEnabled}
+        onTextInput={handleTextInput}
+        onKeyboardPress={handleKeyboardPress}
       />
     </div>
   );

--- a/packages/playground-app/src/SessionSetupPanel.less
+++ b/packages/playground-app/src/SessionSetupPanel.less
@@ -1,10 +1,15 @@
 .session-setup-panel {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding: 0 56px;
+  padding: 0 56px 32px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   background: var(--midscene-surface, #fff);
 }
 
@@ -14,7 +19,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 96px;
+  flex-shrink: 0;
+  margin-top: clamp(32px, 10vh, 96px);
+  padding-bottom: 32px;
 }
 
 .session-setup-logo {

--- a/packages/playground-app/src/controller/selectors.ts
+++ b/packages/playground-app/src/controller/selectors.ts
@@ -23,7 +23,6 @@ export function buildConversationConfig(
     showSystemMessageHeader: false,
     promptInputChrome: {
       variant: 'minimal',
-      primaryActionLabel: 'Action',
     },
     executionFlow: {
       collapsible: true,

--- a/packages/playground-app/src/index.ts
+++ b/packages/playground-app/src/index.ts
@@ -1,5 +1,6 @@
 export { PlaygroundApp } from './PlaygroundApp';
 export { PlaygroundPreview } from './PlaygroundPreview';
+export type { ManualDragActionType } from './manual-interaction';
 export { PlaygroundThemeProvider } from './PlaygroundThemeProvider';
 export { DeviceInteractionLayer } from './DeviceInteractionLayer';
 export type {

--- a/packages/playground-app/src/manual-interaction.ts
+++ b/packages/playground-app/src/manual-interaction.ts
@@ -1,0 +1,25 @@
+export type ManualDragActionType = 'Swipe' | 'DragAndDrop';
+
+export function buildManualDragInteractPayload(
+  actionType: ManualDragActionType,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  duration: number,
+) {
+  const basePayload = {
+    actionType,
+    x: start.x,
+    y: start.y,
+    endX: end.x,
+    endY: end.y,
+  };
+
+  if (actionType === 'DragAndDrop') {
+    return basePayload;
+  }
+
+  return {
+    ...basePayload,
+    duration,
+  };
+}

--- a/packages/playground-app/tests/controller-selectors.test.ts
+++ b/packages/playground-app/tests/controller-selectors.test.ts
@@ -24,7 +24,6 @@ describe('buildConversationConfig', () => {
       deviceType: 'android',
       promptInputChrome: {
         variant: 'minimal',
-        primaryActionLabel: 'Action',
       },
       executionFlow: {
         collapsible: true,
@@ -42,6 +41,13 @@ describe('buildConversationConfig', () => {
         countdownSeconds: 3,
       }).promptInputChrome,
     ).not.toHaveProperty('placeholder');
+    expect(
+      buildConversationConfig({
+        deviceType: 'android',
+        executionUxHints: [],
+        countdownSeconds: 3,
+      }).promptInputChrome,
+    ).not.toHaveProperty('primaryActionLabel');
   });
 
   it('preserves shared execution flow defaults when hosts add partial overrides', () => {

--- a/packages/playground-app/tests/device-interaction-layer.test.ts
+++ b/packages/playground-app/tests/device-interaction-layer.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest';
-import { inscribedContentRect } from '../src/DeviceInteractionLayer';
+/** @vitest-environment jsdom */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  DeviceInteractionLayer,
+  inscribedContentRect,
+  keyNameForKeyboardEvent,
+} from '../src/DeviceInteractionLayer';
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
 
 describe('inscribedContentRect', () => {
   it('letter-boxes horizontally when the panel is wider than device aspect', () => {
@@ -39,5 +59,325 @@ describe('inscribedContentRect', () => {
     expect(inscribedContentRect(panel, { width: 9, height: 19 })).toEqual(
       panel,
     );
+  });
+});
+
+describe('keyNameForKeyboardEvent', () => {
+  it('builds keyboard shortcut names understood by /interact KeyboardPress', () => {
+    expect(
+      keyNameForKeyboardEvent({
+        altKey: false,
+        ctrlKey: false,
+        key: 'Enter',
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe('Enter');
+    expect(
+      keyNameForKeyboardEvent({
+        altKey: false,
+        ctrlKey: false,
+        key: 'Tab',
+        metaKey: false,
+        shiftKey: true,
+      }),
+    ).toBe('Shift+Tab');
+    expect(
+      keyNameForKeyboardEvent({
+        altKey: false,
+        ctrlKey: false,
+        key: 'a',
+        metaKey: true,
+        shiftKey: false,
+      }),
+    ).toBe('Meta+a');
+    expect(
+      keyNameForKeyboardEvent({
+        altKey: false,
+        ctrlKey: false,
+        key: 'Shift',
+        metaKey: false,
+        shiftKey: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('DeviceInteractionLayer keyboard capture', () => {
+  async function renderKeyboardLayer() {
+    const onTextInput = vi.fn();
+    const onKeyboardPress = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(DeviceInteractionLayer, {
+          enabled: true,
+          deviceSize: { width: 100, height: 100 },
+          keyboardEnabled: true,
+          onTextInput,
+          onKeyboardPress,
+        }),
+      );
+    });
+
+    const overlay = container.querySelector(
+      '[data-midscene-device-interaction-layer="true"]',
+    ) as HTMLDivElement;
+    Object.defineProperty(overlay, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'releasePointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        bottom: 100,
+        height: 100,
+        left: 0,
+        right: 100,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    const keyboardSink = container.querySelector(
+      '[data-midscene-keyboard-sink="true"]',
+    ) as HTMLTextAreaElement;
+
+    return {
+      container,
+      keyboardSink,
+      onKeyboardPress,
+      onTextInput,
+      overlay,
+      root,
+    };
+  }
+
+  it('focuses the overlay on pointer input and forwards typed characters', async () => {
+    const { keyboardSink, onTextInput, overlay, root } =
+      await renderKeyboardLayer();
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+    });
+
+    expect(document.activeElement).toBe(keyboardSink);
+
+    await act(async () => {
+      keyboardSink.value = 'h';
+      keyboardSink.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'h',
+          inputType: 'insertText',
+        }),
+      );
+    });
+
+    expect(onTextInput).toHaveBeenCalledWith('h', { x: 50, y: 50 });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('forwards fallback input events, control keys, paste text, and composed IME text', async () => {
+    const { keyboardSink, onKeyboardPress, onTextInput, overlay, root } =
+      await renderKeyboardLayer();
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+    });
+
+    await act(async () => {
+      keyboardSink.value = 'i';
+      keyboardSink.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'i',
+          inputType: 'insertText',
+        }),
+      );
+    });
+
+    expect(onTextInput).toHaveBeenCalledWith('i', { x: 50, y: 50 });
+
+    await act(async () => {
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'Backspace',
+        }),
+      );
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'Tab',
+          shiftKey: true,
+        }),
+      );
+    });
+
+    expect(onKeyboardPress).toHaveBeenNthCalledWith(1, 'Backspace', {
+      x: 50,
+      y: 50,
+    });
+    expect(onKeyboardPress).toHaveBeenNthCalledWith(2, 'Shift+Tab', {
+      x: 50,
+      y: 50,
+    });
+
+    await act(async () => {
+      keyboardSink.value = '\n';
+      keyboardSink.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: null,
+          inputType: 'insertLineBreak',
+        }),
+      );
+    });
+
+    expect(onKeyboardPress).toHaveBeenNthCalledWith(3, 'Enter', {
+      x: 50,
+      y: 50,
+    });
+
+    await act(async () => {
+      const pasteEvent = new Event('paste', {
+        bubbles: true,
+        cancelable: true,
+      }) as ClipboardEvent;
+      Object.defineProperty(pasteEvent, 'clipboardData', {
+        value: {
+          getData: (type: string) => (type === 'text' ? 'pasted text' : ''),
+        },
+      });
+      keyboardSink.dispatchEvent(pasteEvent);
+    });
+
+    expect(onTextInput).toHaveBeenCalledWith('pasted text', { x: 50, y: 50 });
+
+    await act(async () => {
+      keyboardSink.dispatchEvent(
+        new Event('compositionstart', {
+          bubbles: true,
+        }),
+      );
+      keyboardSink.value = 'zhong';
+      keyboardSink.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'zhong',
+          inputType: 'insertCompositionText',
+        }),
+      );
+    });
+
+    expect(keyboardSink.value).toBe('zhong');
+    expect(onTextInput).not.toHaveBeenCalledWith('zhong', { x: 50, y: 50 });
+
+    await act(async () => {
+      const compositionEvent = new Event('compositionend', {
+        bubbles: true,
+      }) as CompositionEvent;
+      Object.defineProperty(compositionEvent, 'data', {
+        value: '中文',
+      });
+      keyboardSink.dispatchEvent(compositionEvent);
+    });
+
+    expect(onTextInput).toHaveBeenCalledWith('中文', { x: 50, y: 50 });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('lets the host copy command run when Studio text is selected', async () => {
+    const { onKeyboardPress, overlay, root } = await renderKeyboardLayer();
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+    });
+
+    const hostText = document.createElement('span');
+    hostText.textContent = 'copy me';
+    document.body.appendChild(hostText);
+    const range = document.createRange();
+    range.selectNodeContents(hostText);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'c',
+      metaKey: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onKeyboardPress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/packages/playground-app/tests/preview-renderer-manual-drag.test.ts
+++ b/packages/playground-app/tests/preview-renderer-manual-drag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildManualDragInteractPayload } from '../src/manual-interaction';
+
+describe('buildManualDragInteractPayload', () => {
+  it('maps mobile drag gestures to Swipe actions with duration', () => {
+    expect(
+      buildManualDragInteractPayload(
+        'Swipe',
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+        250,
+      ),
+    ).toEqual({
+      actionType: 'Swipe',
+      x: 10,
+      y: 20,
+      endX: 30,
+      endY: 40,
+      duration: 250,
+    });
+  });
+
+  it('maps web drag gestures to DragAndDrop actions without swipe duration', () => {
+    expect(
+      buildManualDragInteractPayload(
+        'DragAndDrop',
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+        250,
+      ),
+    ).toEqual({
+      actionType: 'DragAndDrop',
+      x: 10,
+      y: 20,
+      endX: 30,
+      endY: 40,
+    });
+  });
+});

--- a/packages/playground-app/tests/preview-renderer-manual-input.test.ts
+++ b/packages/playground-app/tests/preview-renderer-manual-input.test.ts
@@ -1,0 +1,230 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { PreviewRenderer } from '../src/PreviewRenderer';
+
+vi.mock('@midscene/visualizer', () => ({
+  ScreenshotViewer: () => null,
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('PreviewRenderer manual web input', () => {
+  it('ignores transient interface-info failures while polling manual control size', async () => {
+    const playgroundSDK = {
+      getInterfaceInfo: vi.fn(async () => {
+        throw new Error('server restarting');
+      }),
+      getScreenshot: vi.fn(async () => null),
+      interact: vi.fn(async () => ({ ok: true })),
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(PreviewRenderer, {
+          playgroundSDK,
+          runtimeInfo: {
+            interface: { type: 'puppeteer' },
+            metadata: {},
+            preview: {
+              kind: 'mjpeg',
+              mjpegPath: '/mjpeg',
+            },
+          },
+          serverOnline: true,
+          serverUrl: 'http://127.0.0.1:5800',
+          isUserOperating: false,
+          manualControlEnabled: true,
+          manualDragActionType: 'DragAndDrop',
+          manualKeyboardEnabled: true,
+          screenshotViewerMode: 'screen-only',
+        } as any),
+      );
+    });
+    await flushPromises();
+
+    expect(playgroundSDK.getInterfaceInfo).toHaveBeenCalled();
+    expect(
+      container.querySelector(
+        '[data-midscene-device-interaction-layer="true"]',
+      ),
+    ).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('queues tap before keyboard input and sends typeOnly text to the active web page', async () => {
+    const interact = vi.fn(async () => ({ ok: true }));
+    const playgroundSDK = {
+      getInterfaceInfo: vi.fn(async () => ({
+        type: 'puppeteer',
+        size: { width: 100, height: 100 },
+      })),
+      getScreenshot: vi.fn(async () => null),
+      interact,
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(PreviewRenderer, {
+          playgroundSDK,
+          runtimeInfo: {
+            interface: { type: 'puppeteer' },
+            metadata: {},
+            preview: {
+              kind: 'mjpeg',
+              mjpegPath: '/mjpeg',
+            },
+          },
+          serverOnline: true,
+          serverUrl: 'http://127.0.0.1:5800',
+          isUserOperating: false,
+          manualControlEnabled: true,
+          manualDragActionType: 'DragAndDrop',
+          manualKeyboardEnabled: true,
+          screenshotViewerMode: 'screen-only',
+        } as any),
+      );
+    });
+    await flushPromises();
+
+    const overlay = container.querySelector(
+      '[data-midscene-device-interaction-layer="true"]',
+    ) as HTMLDivElement;
+    const keyboardSink = container.querySelector(
+      '[data-midscene-keyboard-sink="true"]',
+    ) as HTMLTextAreaElement;
+    expect(overlay).toBeTruthy();
+    expect(keyboardSink).toBeTruthy();
+    Object.defineProperty(overlay, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'releasePointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        bottom: 100,
+        height: 100,
+        left: 0,
+        right: 100,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      keyboardSink.value = 'h';
+      keyboardSink.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'h',
+          inputType: 'insertText',
+        }),
+      );
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'Enter',
+        }),
+      );
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'c',
+          metaKey: true,
+        }),
+      );
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'a',
+          metaKey: true,
+        }),
+      );
+      keyboardSink.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'Backspace',
+        }),
+      );
+    });
+    await flushPromises();
+
+    expect(interact).toHaveBeenNthCalledWith(1, {
+      actionType: 'Tap',
+      x: 50,
+      y: 50,
+    });
+    expect(interact).toHaveBeenNthCalledWith(2, {
+      actionType: 'Input',
+      value: 'h',
+      mode: 'typeOnly',
+    });
+    expect(interact).toHaveBeenNthCalledWith(3, {
+      actionType: 'KeyboardPress',
+      keyName: 'Enter',
+    });
+    expect(interact).toHaveBeenNthCalledWith(4, {
+      actionType: 'KeyboardPress',
+      keyName: 'Meta+c',
+    });
+    expect(interact).toHaveBeenNthCalledWith(5, {
+      actionType: 'KeyboardPress',
+      keyName: 'Meta+a',
+    });
+    expect(interact).toHaveBeenNthCalledWith(6, {
+      actionType: 'KeyboardPress',
+      keyName: 'Backspace',
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/packages/playground-app/tests/session-setup-panel.test.ts
+++ b/packages/playground-app/tests/session-setup-panel.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import type {
   PlaygroundSessionField,
   PlaygroundSessionSetup,
@@ -71,5 +72,20 @@ describe('SessionSetupPanel', () => {
     expect(getPlatformSelectorOptions(adbDeviceField, setup)).toEqual(
       adbDeviceField.options,
     );
+  });
+
+  it('keeps long setup forms reachable inside constrained sidebars', () => {
+    const styles = readFileSync(
+      new URL('../src/SessionSetupPanel.less', import.meta.url),
+      'utf8',
+    );
+    const panelRule =
+      styles.match(/\.session-setup-panel\s*{[^}]+}/)?.[0] ?? '';
+    const cardRule = styles.match(/\.session-setup-card\s*{[^}]+}/)?.[0] ?? '';
+
+    expect(panelRule).toContain('min-height: 0;');
+    expect(panelRule).toContain('overflow-y: auto;');
+    expect(cardRule).toContain('flex-shrink: 0;');
+    expect(cardRule).toContain('padding-bottom: 32px;');
   });
 });

--- a/packages/playground/src/adapters/remote-execution.ts
+++ b/packages/playground/src/adapters/remote-execution.ts
@@ -500,6 +500,7 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
     type: string;
     description?: string;
     size?: { width: number; height: number };
+    navigationState?: { isLoading: boolean };
   } | null> {
     if (!this.serverUrl) {
       return null;

--- a/packages/playground/src/mjpeg-hub.ts
+++ b/packages/playground/src/mjpeg-hub.ts
@@ -1,0 +1,373 @@
+import type { Agent as PageAgent } from '@midscene/core/agent';
+import type {
+  MjpegStreamFrame,
+  MjpegStreamHandle,
+} from '@midscene/core/device';
+import { type DebugFunction, getDebug } from '@midscene/shared/logger';
+import type { Request, Response } from 'express';
+
+const DATA_URL_BASE64_PREFIX = /^data:image\/\w+;base64,/;
+
+const noopDebug: DebugFunction = () => {};
+
+type ActiveInterface = PageAgent['interface'];
+
+type Subscriber = (frame: MjpegStreamFrame) => void;
+
+interface InternalProducer {
+  source: ActiveInterface;
+  controller: AbortController;
+  handle?: MjpegStreamHandle;
+  lastFrame?: MjpegStreamFrame;
+  startupError?: unknown;
+  firstFrameReady: Promise<boolean>;
+  subscribers: Set<Subscriber>;
+  /** Tracks `res` instances per subscriber so the hub can hard-close them. */
+  responses: Map<Subscriber, Response>;
+  stopTimer?: ReturnType<typeof setTimeout>;
+}
+
+export interface InterfaceMjpegHubOptions {
+  /** Time the hub waits for the first producer frame before falling back. */
+  initialFrameTimeoutMs: number;
+  /** Idle window after the last subscriber leaves before tearing the producer down. */
+  idleStopMs: number;
+  /** Optional debug logger for hub internals. Defaults to a no-op. */
+  debug?: DebugFunction;
+}
+
+/**
+ * Recovery hook supplied by the server. When the producer fails to start
+ * because the underlying page session was closed, the hub asks the server to
+ * rebuild the agent and returns the new interface; otherwise the hub gives up
+ * and lets `streamRequest` resolve to false.
+ */
+export type RecoverActiveAgent = (
+  error: unknown,
+) => Promise<ActiveInterface | null>;
+
+/**
+ * Writes one MJPEG part to `res`, preferring backpressure-safe writes.
+ *
+ * Returns `true` when the chunk has been accepted by the socket buffer and
+ * `false` when the kernel buffer is full. Callers SHOULD drop frames or wait
+ * for `drain` instead of pushing more data when this returns `false`.
+ *
+ * `frame.data` may either be raw base64 or a `data:image/...;base64,...` URL;
+ * the function strips the prefix defensively. New producers should already
+ * normalize to bare base64.
+ */
+export function writeMjpegFrame(
+  res: Response,
+  boundary: string,
+  frame: MjpegStreamFrame,
+): boolean {
+  const raw = frame.data.replace(DATA_URL_BASE64_PREFIX, '');
+  const buf = Buffer.from(raw, 'base64');
+
+  // Each `res.write` returns false when the kernel buffer is full. We
+  // surface the worst result so the caller can react to backpressure on the
+  // first chunk that exceeds the high water mark.
+  let writable = res.write(`--${boundary}\r\n`);
+  writable =
+    res.write(`Content-Type: ${frame.contentType || 'image/jpeg'}\r\n`) &&
+    writable;
+  writable = res.write(`Content-Length: ${buf.length}\r\n\r\n`) && writable;
+  writable = res.write(buf) && writable;
+  writable = res.write('\r\n') && writable;
+  return writable;
+}
+
+/**
+ * Owns the lifecycle of an in-process MJPEG frame producer (e.g. Chromium
+ * CDP `Page.startScreencast`) and fans frames out to all currently connected
+ * HTTP MJPEG clients.
+ *
+ * Why this is its own class:
+ * - CDP screencasts are page-scoped, so multiple concurrent producers would
+ *   steal frames from each other. Keeping a single producer + N subscribers
+ *   here prevents the playground server from accidentally racing against
+ *   itself.
+ * - Producer creation, idle teardown, recovery after page-session loss and
+ *   backpressure handling are all naturally co-located with the producer
+ *   state. Moving them out of `PlaygroundServer` keeps that class focused on
+ *   HTTP routing.
+ */
+export class InterfaceMjpegHub {
+  private producer?: InternalProducer;
+  private readonly debug: DebugFunction;
+
+  constructor(private readonly opts: InterfaceMjpegHubOptions) {
+    this.debug = opts.debug ?? noopDebug;
+  }
+
+  /**
+   * Streams the active interface's MJPEG frames to `res`. Returns true once
+   * the response is committed to streaming, false if the interface has no
+   * frame producer or the initial frame never arrived.
+   */
+  async streamRequest(
+    req: Request,
+    res: Response,
+    activeInterface: ActiveInterface,
+    recoverActiveAgent: RecoverActiveAgent,
+  ): Promise<boolean> {
+    return this.streamRequestInternal(
+      req,
+      res,
+      activeInterface,
+      recoverActiveAgent,
+      true,
+    );
+  }
+
+  /**
+   * Tears down the current producer (used when the server replaces an agent
+   * out-of-band, e.g. after a recoverable page-session error during /interact).
+   */
+  stopProducer(): void {
+    this.stopProducerInternal(this.producer);
+  }
+
+  /**
+   * Best-effort shutdown for server.close(). Aborts any active producer and
+   * forcibly closes attached subscriber sockets.
+   */
+  shutdown(): void {
+    const producer = this.producer;
+    if (!producer) return;
+    for (const [subscriber, res] of producer.responses) {
+      producer.subscribers.delete(subscriber);
+      try {
+        res.destroy();
+      } catch {
+        /* socket already closed */
+      }
+    }
+    producer.responses.clear();
+    this.stopProducerInternal(producer);
+  }
+
+  private async streamRequestInternal(
+    req: Request,
+    res: Response,
+    activeInterface: ActiveInterface,
+    recoverActiveAgent: RecoverActiveAgent,
+    allowRecovery: boolean,
+  ): Promise<boolean> {
+    const producer = this.getOrCreateProducer(activeInterface);
+    if (!producer) return false;
+
+    const hasInitialFrame = await producer.firstFrameReady;
+    if (!hasInitialFrame || !producer.lastFrame) {
+      this.debug(
+        'interface frame producer did not emit an initial frame, falling back to polling',
+      );
+      const startupError = producer.startupError;
+      this.stopProducerInternal(producer);
+      if (allowRecovery && startupError) {
+        const recoveredInterface = await recoverActiveAgent(startupError);
+        if (recoveredInterface) {
+          return this.streamRequestInternal(
+            req,
+            res,
+            recoveredInterface,
+            recoverActiveAgent,
+            false,
+          );
+        }
+      }
+      return false;
+    }
+
+    this.attachSubscriber(req, res, producer);
+    return true;
+  }
+
+  private attachSubscriber(
+    req: Request,
+    res: Response,
+    producer: InternalProducer,
+  ): void {
+    const boundary = 'mjpeg-boundary';
+    let closed = false;
+    let dropping = false;
+
+    const closeResponse = () => {
+      if (closed) return;
+      closed = true;
+      this.releaseSubscriber(producer, subscriber);
+    };
+
+    const subscriber: Subscriber = (frame) => {
+      if (closed) return;
+      // Drop frames while the socket buffer is full instead of letting the
+      // node internal buffer balloon. CDP screencasts can run at 60Hz and a
+      // slow client would otherwise OOM the server.
+      if (dropping) return;
+      try {
+        const writable = writeMjpegFrame(res, boundary, frame);
+        if (!writable) {
+          dropping = true;
+          res.once('drain', () => {
+            dropping = false;
+          });
+        }
+      } catch (error) {
+        this.debug('interface frame write failed: %s', error);
+        closeResponse();
+        try {
+          res.destroy();
+        } catch {
+          /* socket already closed */
+        }
+      }
+    };
+
+    producer.subscribers.add(subscriber);
+    producer.responses.set(subscriber, res);
+    if (producer.stopTimer) {
+      clearTimeout(producer.stopTimer);
+      producer.stopTimer = undefined;
+    }
+    req.on('close', closeResponse);
+
+    res.setHeader(
+      'Content-Type',
+      `multipart/x-mixed-replace; boundary=${boundary}`,
+    );
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.setHeader('Connection', 'keep-alive');
+    subscriber(producer.lastFrame as MjpegStreamFrame);
+
+    this.debug('streaming via shared interface frame producer');
+  }
+
+  private getOrCreateProducer(
+    activeInterface: ActiveInterface,
+  ): InternalProducer | null {
+    const startMjpegStream = activeInterface.startMjpegStream;
+    if (typeof startMjpegStream !== 'function') return null;
+
+    if (this.producer?.source === activeInterface) {
+      if (this.producer.stopTimer) {
+        clearTimeout(this.producer.stopTimer);
+        this.producer.stopTimer = undefined;
+      }
+      return this.producer;
+    }
+
+    this.stopProducerInternal(this.producer);
+
+    const controller = new AbortController();
+    let resolveInitialFrame: ((hasFrame: boolean) => void) | undefined;
+    let initialFrameTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const resolveInitialFrameOnce = (hasFrame: boolean) => {
+      if (!resolveInitialFrame) return;
+      if (initialFrameTimer) {
+        clearTimeout(initialFrameTimer);
+        initialFrameTimer = undefined;
+      }
+      resolveInitialFrame(hasFrame);
+      resolveInitialFrame = undefined;
+    };
+
+    const initialFrameReady = new Promise<boolean>((resolve) => {
+      resolveInitialFrame = resolve;
+      initialFrameTimer = setTimeout(() => {
+        resolveInitialFrameOnce(false);
+      }, this.opts.initialFrameTimeoutMs);
+    });
+
+    const producer: InternalProducer = {
+      source: activeInterface,
+      controller,
+      firstFrameReady: initialFrameReady,
+      subscribers: new Set(),
+      responses: new Map(),
+    };
+    this.producer = producer;
+
+    void (async () => {
+      try {
+        producer.handle =
+          (await startMjpegStream.call(activeInterface, {
+            signal: controller.signal,
+            onFrame: (frame) => {
+              if (controller.signal.aborted) return;
+              producer.lastFrame = frame;
+              resolveInitialFrameOnce(true);
+              for (const subscriber of producer.subscribers) {
+                subscriber(frame);
+              }
+            },
+            onError: (error) => {
+              this.debug('interface stream producer error: %s', error);
+            },
+          })) ?? undefined;
+      } catch (error) {
+        this.debug('interface frame producer unavailable: %s', error);
+        producer.startupError = error;
+        resolveInitialFrameOnce(false);
+        this.stopProducerInternal(producer);
+      }
+    })();
+
+    return producer;
+  }
+
+  private stopProducerInternal(producer?: InternalProducer): void {
+    if (!producer) return;
+    if (producer.stopTimer) {
+      clearTimeout(producer.stopTimer);
+      producer.stopTimer = undefined;
+    }
+    // Hard-close any subscriber sockets we still own so the browser <img>
+    // does not hang on a half-open multipart response.
+    for (const [, res] of producer.responses) {
+      try {
+        res.destroy();
+      } catch {
+        /* socket already closed */
+      }
+    }
+    producer.responses.clear();
+    producer.subscribers.clear();
+    producer.controller.abort();
+    Promise.resolve(producer.handle?.stop?.()).catch((error) => {
+      this.debug('interface stream stop failed: %s', error);
+    });
+    if (this.producer === producer) {
+      this.producer = undefined;
+    }
+  }
+
+  private releaseSubscriber(
+    producer: InternalProducer,
+    subscriber: Subscriber,
+  ): void {
+    producer.subscribers.delete(subscriber);
+    producer.responses.delete(subscriber);
+    if (producer.subscribers.size > 0 || producer.stopTimer) return;
+    producer.stopTimer = setTimeout(() => {
+      producer.stopTimer = undefined;
+      if (producer.subscribers.size === 0) {
+        this.stopProducerInternal(producer);
+      }
+    }, this.opts.idleStopMs);
+  }
+}
+
+/**
+ * Convenience constructor that wires up a debug logger derived from the
+ * `web:mjpeg` namespace so server logs are consistent with other modules.
+ */
+export function createInterfaceMjpegHub(
+  opts: Omit<InterfaceMjpegHubOptions, 'debug'> & { debug?: DebugFunction },
+): InterfaceMjpegHub {
+  return new InterfaceMjpegHub({
+    ...opts,
+    debug: opts.debug ?? getDebug('playground:mjpeg-hub'),
+  });
+}

--- a/packages/playground/src/sdk/index.ts
+++ b/packages/playground/src/sdk/index.ts
@@ -248,6 +248,7 @@ export class PlaygroundSDK {
     type: string;
     description?: string;
     size?: { width: number; height: number };
+    navigationState?: { isLoading: boolean };
   } | null> {
     const adapter = this.runtimeMetadataAdapter();
     if (!adapter) {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -170,6 +170,12 @@ type InteractParamBuilder = (
   actionType: string,
 ) => Record<string, unknown>;
 
+type BrowserChromeInteractAction = 'Stop';
+
+type BrowserChromeInterface = {
+  stopLoading?: () => Promise<void>;
+};
+
 const buildLocateActionParams: InteractParamBuilder = (body, actionType) => {
   const params: Record<string, unknown> = {
     locate: locateFromPoint(body.x, body.y, 'x', 'y', `manual ${actionType}`),
@@ -869,11 +875,38 @@ class PlaygroundServer {
     );
   }
 
+  private canRunBrowserChromeInteractAction(
+    agent: PageAgent,
+    actionType: string,
+  ): actionType is BrowserChromeInteractAction {
+    return (
+      actionType === 'Stop' &&
+      typeof (agent.interface as BrowserChromeInterface).stopLoading ===
+        'function'
+    );
+  }
+
+  private async runBrowserChromeInteractAction(
+    agent: PageAgent,
+    actionType: BrowserChromeInteractAction,
+  ): Promise<void> {
+    switch (actionType) {
+      case 'Stop':
+        await (agent.interface as BrowserChromeInterface).stopLoading?.();
+        return;
+    }
+  }
+
   private async runInteractAction(
     agent: PageAgent,
     actionType: string,
     params: Record<string, unknown>,
   ): Promise<void> {
+    if (this.canRunBrowserChromeInteractAction(agent, actionType)) {
+      await this.runBrowserChromeInteractAction(agent, actionType);
+      return;
+    }
+
     const action = this.findInteractAction(agent, actionType);
     if (!action || typeof action.call !== 'function') {
       throw new Error(
@@ -1550,7 +1583,10 @@ class PlaygroundServer {
         });
       }
 
-      if (!this.findInteractAction(agent, actionType)) {
+      if (
+        !this.findInteractAction(agent, actionType) &&
+        !this.canRunBrowserChromeInteractAction(agent, actionType)
+      ) {
         return res.status(404).json({
           error: `Action "${actionType}" is not available on the current device`,
         });

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -11,6 +11,10 @@ import type {
 } from '@midscene/core';
 import { ReportActionDump, runConnectivityTest } from '@midscene/core';
 import type { Agent as PageAgent } from '@midscene/core/agent';
+import type {
+  MjpegStreamFrame,
+  MjpegStreamHandle,
+} from '@midscene/core/device';
 import { getTmpDir } from '@midscene/core/utils';
 import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
 import {
@@ -202,7 +206,17 @@ const buildKeyboardPressParams: InteractParamBuilder = (body) => {
       'keyName is required for KeyboardPress',
     );
   }
-  return { keyName: body.keyName };
+  const params: Record<string, unknown> = { keyName: body.keyName };
+  if (typeof body.x === 'number' && typeof body.y === 'number') {
+    params.locate = locateFromPoint(
+      body.x,
+      body.y,
+      'x',
+      'y',
+      'manual keyboard press',
+    );
+  }
+  return params;
 };
 
 const buildInputParams: InteractParamBuilder = (body) => {
@@ -301,6 +315,27 @@ interface PlaygroundActiveConnection {
   sidecars?: PlaygroundSidecar[];
 }
 
+type InterfaceMjpegSubscriber = (frame: MjpegStreamFrame) => void;
+
+interface InterfaceMjpegProducer {
+  source: unknown;
+  controller: AbortController;
+  handle?: MjpegStreamHandle;
+  lastFrame?: MjpegStreamFrame;
+  startupError?: unknown;
+  firstFrameReady: Promise<boolean>;
+  subscribers: Set<InterfaceMjpegSubscriber>;
+  stopTimer?: ReturnType<typeof setTimeout>;
+}
+
+const RECOVERABLE_PAGE_SESSION_ERROR_PATTERN =
+  /Session closed|page has been closed|target closed|browser has been closed|Target page, context or browser has been closed/i;
+
+function isRecoverablePageSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return RECOVERABLE_PAGE_SESSION_ERROR_PATTERN.test(message);
+}
+
 class PlaygroundServer {
   private _app: express.Application;
   tmpDir: string;
@@ -324,6 +359,9 @@ class PlaygroundServer {
   private _nativeMjpegAvailable: boolean | null = null;
   private _nativeMjpegFailedAt: number | null = null;
   private static readonly MJPEG_NEGATIVE_CACHE_MS = 10_000;
+  private static readonly INTERFACE_MJPEG_INITIAL_FRAME_TIMEOUT_MS = 1500;
+  private static readonly INTERFACE_MJPEG_IDLE_STOP_MS = 2000;
+  private _interfaceMjpegProducer?: InterfaceMjpegProducer;
 
   private sessionManager?: PlaygroundSessionManager;
   private sessionSetupState: 'required' | 'ready' | 'blocked' = 'ready';
@@ -801,6 +839,54 @@ class PlaygroundServer {
         'Agent destroyed but cannot recreate: no factory function provided. Next /execute call will fail.',
       );
     }
+  }
+
+  private async recoverActiveAgentAfterPreviewError(
+    error: unknown,
+    reason: string,
+  ): Promise<PageAgent | null> {
+    if (
+      !this._activeConnection.agentFactory ||
+      !isRecoverablePageSessionError(error)
+    ) {
+      return null;
+    }
+
+    debugMjpeg(`Recovering active agent after ${reason}:`, error);
+    try {
+      this.stopInterfaceMjpegProducer(this._interfaceMjpegProducer);
+      await this.recreateAgent();
+      return this._activeConnection.agent;
+    } catch (recreateError) {
+      debugMjpeg(
+        `Failed to recover active agent after ${reason}:`,
+        recreateError,
+      );
+      return null;
+    }
+  }
+
+  private findInteractAction(
+    agent: PageAgent,
+    actionType: string,
+  ): DeviceAction<unknown> | undefined {
+    return (agent.interface.actionSpace() as DeviceAction<unknown>[]).find(
+      (entry) => entry.name === actionType,
+    );
+  }
+
+  private async runInteractAction(
+    agent: PageAgent,
+    actionType: string,
+    params: Record<string, unknown>,
+  ): Promise<'missing-action' | 'ok'> {
+    const action = this.findInteractAction(agent, actionType);
+    if (!action || typeof action.call !== 'function') {
+      return 'missing-action';
+    }
+
+    await action.call(params, createManualExecutorContext(actionType, params));
+    return 'ok';
   }
 
   /**
@@ -1314,7 +1400,7 @@ class PlaygroundServer {
     // Screenshot API for real-time screenshot polling
     this._app.get('/screenshot', async (_req: Request, res: Response) => {
       try {
-        const agent = this.getActiveAgentOrThrow();
+        let agent = this.getActiveAgentOrThrow();
         // Check if page has screenshotBase64 method
         if (typeof agent.interface.screenshotBase64 !== 'function') {
           return res.status(500).json({
@@ -1322,8 +1408,26 @@ class PlaygroundServer {
           });
         }
 
+        let screenshot: string;
+        try {
+          screenshot = await agent.interface.screenshotBase64();
+        } catch (error) {
+          const recoveredAgent = await this.recoverActiveAgentAfterPreviewError(
+            error,
+            'screenshot capture',
+          );
+          if (
+            !recoveredAgent ||
+            typeof recoveredAgent.interface.screenshotBase64 !== 'function'
+          ) {
+            throw error;
+          }
+          agent = recoveredAgent;
+          screenshot = await agent.interface.screenshotBase64();
+        }
+
         res.json({
-          screenshot: await agent.interface.screenshotBase64(),
+          screenshot,
           timestamp: Date.now(),
         });
       } catch (error: unknown) {
@@ -1366,7 +1470,12 @@ class PlaygroundServer {
         if (proxyOk) return;
       }
 
-      if (typeof agent.interface?.screenshotBase64 !== 'function') {
+      if (await this.startInterfaceMjpegStream(req, res)) {
+        return;
+      }
+
+      const fallbackAgent = this._activeConnection.agent;
+      if (typeof fallbackAgent?.interface?.screenshotBase64 !== 'function') {
         return res.status(500).json({
           error: 'Screenshot method not available on current interface',
         });
@@ -1381,6 +1490,7 @@ class PlaygroundServer {
         const runtimeInfo = this.getRuntimeInfo();
         const agent = this._activeConnection.agent;
         let size: { width: number; height: number } | undefined;
+        let navigationState: { isLoading: boolean } | undefined;
         if (typeof agent?.interface?.size === 'function') {
           try {
             size = await agent.interface.size();
@@ -1388,11 +1498,25 @@ class PlaygroundServer {
             debugScreenshot('interface size() failed:', error);
           }
         }
+        const interfaceWithNavigationState = agent?.interface as unknown as {
+          navigationState?: () => Promise<{ isLoading: boolean }>;
+        };
+        if (
+          typeof interfaceWithNavigationState?.navigationState === 'function'
+        ) {
+          try {
+            navigationState =
+              await interfaceWithNavigationState.navigationState();
+          } catch (error) {
+            debugScreenshot('interface navigationState() failed:', error);
+          }
+        }
 
         res.json({
           type: runtimeInfo.interface.type,
           description: runtimeInfo.interface.description,
           ...(size ? { size } : {}),
+          ...(navigationState ? { navigationState } : {}),
         });
       } catch (error: unknown) {
         const errorMessage =
@@ -1424,10 +1548,7 @@ class PlaygroundServer {
         });
       }
 
-      const action = (
-        agent.interface.actionSpace() as DeviceAction<unknown>[]
-      ).find((entry) => entry.name === actionType);
-      if (!action || typeof action.call !== 'function') {
+      if (!this.findInteractAction(agent, actionType)) {
         return res.status(404).json({
           error: `Action "${actionType}" is not available on the current device`,
         });
@@ -1449,12 +1570,20 @@ class PlaygroundServer {
       }
 
       try {
-        await action.call(
-          params,
-          createManualExecutorContext(actionType, params),
-        );
+        await this.runInteractAction(agent, actionType, params);
         res.json({});
       } catch (error: unknown) {
+        const recoveredAgent = await this.recoverActiveAgentAfterPreviewError(
+          error,
+          `manual interact action "${actionType}"`,
+        );
+        if (recoveredAgent) {
+          return res.status(409).json({
+            error:
+              'The page session was closed and has been recreated. Please retry the action.',
+          });
+        }
+
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error';
         console.error(
@@ -1631,6 +1760,209 @@ class PlaygroundServer {
     });
   }
 
+  private writeMjpegFrame(
+    res: Response,
+    boundary: string,
+    frame: MjpegStreamFrame,
+  ): void {
+    const raw = frame.data.replace(/^data:image\/\w+;base64,/, '');
+    const buf = Buffer.from(raw, 'base64');
+
+    res.write(`--${boundary}\r\n`);
+    res.write(`Content-Type: ${frame.contentType || 'image/jpeg'}\r\n`);
+    res.write(`Content-Length: ${buf.length}\r\n\r\n`);
+    res.write(buf);
+    res.write('\r\n');
+  }
+
+  /**
+   * Starts (or reuses) one in-process frame producer for the active interface.
+   * CDP Page.startScreencast is page-scoped, so multiple concurrent producers
+   * can steal frames from each other. Keep a single producer and fan frames out
+   * to every HTTP MJPEG client instead.
+   */
+  private getOrCreateInterfaceMjpegProducer(
+    activeInterface: PageAgent['interface'],
+  ): InterfaceMjpegProducer | null {
+    const startMjpegStream = activeInterface.startMjpegStream;
+    if (typeof startMjpegStream !== 'function') return null;
+
+    if (this._interfaceMjpegProducer?.source === activeInterface) {
+      if (this._interfaceMjpegProducer.stopTimer) {
+        clearTimeout(this._interfaceMjpegProducer.stopTimer);
+        this._interfaceMjpegProducer.stopTimer = undefined;
+      }
+      return this._interfaceMjpegProducer;
+    }
+
+    this.stopInterfaceMjpegProducer(this._interfaceMjpegProducer);
+
+    const controller = new AbortController();
+    let resolveInitialFrame: ((hasFrame: boolean) => void) | undefined;
+    let initialFrameTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const resolveInitialFrameOnce = (hasFrame: boolean) => {
+      if (!resolveInitialFrame) return;
+      if (initialFrameTimer) {
+        clearTimeout(initialFrameTimer);
+        initialFrameTimer = undefined;
+      }
+      resolveInitialFrame(hasFrame);
+      resolveInitialFrame = undefined;
+    };
+
+    const initialFrameReady = new Promise<boolean>((resolve) => {
+      resolveInitialFrame = resolve;
+      initialFrameTimer = setTimeout(() => {
+        resolveInitialFrameOnce(false);
+      }, PlaygroundServer.INTERFACE_MJPEG_INITIAL_FRAME_TIMEOUT_MS);
+    });
+
+    const producer: InterfaceMjpegProducer = {
+      source: activeInterface,
+      controller,
+      firstFrameReady: initialFrameReady,
+      subscribers: new Set(),
+    };
+    this._interfaceMjpegProducer = producer;
+
+    void (async () => {
+      try {
+        producer.handle =
+          (await startMjpegStream.call(activeInterface, {
+            signal: controller.signal,
+            onFrame: (frame) => {
+              if (controller.signal.aborted) return;
+              producer.lastFrame = frame;
+              resolveInitialFrameOnce(true);
+              for (const subscriber of producer.subscribers) {
+                subscriber(frame);
+              }
+            },
+            onError: (error) => {
+              debugMjpeg('MJPEG interface stream producer error:', error);
+            },
+          })) ?? undefined;
+      } catch (error) {
+        debugMjpeg('MJPEG: interface frame producer unavailable:', error);
+        producer.startupError = error;
+        resolveInitialFrameOnce(false);
+        this.stopInterfaceMjpegProducer(producer);
+      }
+    })();
+
+    return producer;
+  }
+
+  private stopInterfaceMjpegProducer(producer?: InterfaceMjpegProducer): void {
+    if (!producer) return;
+    if (producer.stopTimer) {
+      clearTimeout(producer.stopTimer);
+      producer.stopTimer = undefined;
+    }
+    producer.subscribers.clear();
+    producer.controller.abort();
+    Promise.resolve(producer.handle?.stop?.()).catch((error) => {
+      debugMjpeg('MJPEG interface stream stop failed:', error);
+    });
+    if (this._interfaceMjpegProducer === producer) {
+      this._interfaceMjpegProducer = undefined;
+    }
+  }
+
+  private releaseInterfaceMjpegSubscriber(
+    producer: InterfaceMjpegProducer,
+    subscriber: InterfaceMjpegSubscriber,
+  ): void {
+    producer.subscribers.delete(subscriber);
+    if (producer.subscribers.size > 0 || producer.stopTimer) return;
+    producer.stopTimer = setTimeout(() => {
+      producer.stopTimer = undefined;
+      if (producer.subscribers.size === 0) {
+        this.stopInterfaceMjpegProducer(producer);
+      }
+    }, PlaygroundServer.INTERFACE_MJPEG_IDLE_STOP_MS);
+  }
+
+  /**
+   * Stream MJPEG frames produced in-process by the active interface, e.g.
+   * Chromium CDP Page.startScreencast for Web previews.
+   */
+  private async startInterfaceMjpegStream(
+    req: Request,
+    res: Response,
+    allowRecovery = true,
+  ): Promise<boolean> {
+    const agent = this._activeConnection.agent;
+    if (!agent) return false;
+
+    const producer = this.getOrCreateInterfaceMjpegProducer(agent.interface);
+    if (!producer) return false;
+
+    const hasInitialFrame = await producer.firstFrameReady;
+    if (!hasInitialFrame || !producer.lastFrame) {
+      debugMjpeg(
+        'MJPEG: interface frame producer did not emit an initial frame, using polling mode',
+      );
+      const startupError = producer.startupError;
+      this.stopInterfaceMjpegProducer(producer);
+      if (allowRecovery && startupError) {
+        const recoveredAgent = await this.recoverActiveAgentAfterPreviewError(
+          startupError,
+          'interface MJPEG startup',
+        );
+        if (recoveredAgent) {
+          return this.startInterfaceMjpegStream(req, res, false);
+        }
+      }
+      return false;
+    }
+
+    const boundary = 'mjpeg-boundary';
+    let closed = false;
+    let subscriber: InterfaceMjpegSubscriber = () => undefined;
+
+    const closeResponse = () => {
+      if (closed) return;
+      closed = true;
+      this.releaseInterfaceMjpegSubscriber(producer, subscriber);
+    };
+
+    const writeFrame = (frame: MjpegStreamFrame) => {
+      if (closed) return;
+      try {
+        this.writeMjpegFrame(res, boundary, frame);
+      } catch (error) {
+        debugMjpeg('MJPEG interface frame write failed:', error);
+        closeResponse();
+        try {
+          res.destroy();
+        } catch {
+          /* socket already closed */
+        }
+      }
+    };
+
+    subscriber = writeFrame;
+    producer.subscribers.add(subscriber);
+    if (producer.stopTimer) {
+      clearTimeout(producer.stopTimer);
+      producer.stopTimer = undefined;
+    }
+    req.on('close', closeResponse);
+
+    res.setHeader(
+      'Content-Type',
+      `multipart/x-mixed-replace; boundary=${boundary}`,
+    );
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.setHeader('Connection', 'keep-alive');
+    writeFrame(producer.lastFrame);
+
+    debugMjpeg('MJPEG: streaming via shared interface frame producer');
+    return true;
+  }
+
   /**
    * Stream screenshots as MJPEG by polling screenshotBase64().
    */
@@ -1709,16 +2041,20 @@ class PlaygroundServer {
         if (stopped) break;
         consecutiveErrors = 0;
 
-        const raw = base64.replace(/^data:image\/\w+;base64,/, '');
-        const buf = Buffer.from(raw, 'base64');
-
-        res.write(`--${boundary}\r\n`);
-        res.write('Content-Type: image/jpeg\r\n');
-        res.write(`Content-Length: ${buf.length}\r\n\r\n`);
-        res.write(buf);
-        res.write('\r\n');
+        this.writeMjpegFrame(res, boundary, {
+          data: base64,
+          contentType: 'image/jpeg',
+        });
       } catch (err) {
         if (stopped) break;
+        const recoveredAgent = await this.recoverActiveAgentAfterPreviewError(
+          err,
+          'polling MJPEG frame capture',
+        );
+        if (recoveredAgent) {
+          consecutiveErrors = 0;
+          continue;
+        }
         consecutiveErrors++;
         if (consecutiveErrors <= errorLogThreshold) {
           console.error('MJPEG frame error:', err);

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -11,10 +11,6 @@ import type {
 } from '@midscene/core';
 import { ReportActionDump, runConnectivityTest } from '@midscene/core';
 import type { Agent as PageAgent } from '@midscene/core/agent';
-import type {
-  MjpegStreamFrame,
-  MjpegStreamHandle,
-} from '@midscene/core/device';
 import { getTmpDir } from '@midscene/core/utils';
 import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
 import {
@@ -26,6 +22,11 @@ import { getDebug } from '@midscene/shared/logger';
 import { uuid } from '@midscene/shared/utils';
 import express, { type Request, type Response } from 'express';
 import { executeAction, formatErrorMessage } from './common';
+import {
+  type InterfaceMjpegHub,
+  createInterfaceMjpegHub,
+  writeMjpegFrame,
+} from './mjpeg-hub';
 import type {
   PlaygroundCreatedSession,
   PlaygroundExecutionHooks,
@@ -315,19 +316,6 @@ interface PlaygroundActiveConnection {
   sidecars?: PlaygroundSidecar[];
 }
 
-type InterfaceMjpegSubscriber = (frame: MjpegStreamFrame) => void;
-
-interface InterfaceMjpegProducer {
-  source: unknown;
-  controller: AbortController;
-  handle?: MjpegStreamHandle;
-  lastFrame?: MjpegStreamFrame;
-  startupError?: unknown;
-  firstFrameReady: Promise<boolean>;
-  subscribers: Set<InterfaceMjpegSubscriber>;
-  stopTimer?: ReturnType<typeof setTimeout>;
-}
-
 const RECOVERABLE_PAGE_SESSION_ERROR_PATTERN =
   /Session closed|page has been closed|target closed|browser has been closed|Target page, context or browser has been closed/i;
 
@@ -361,7 +349,13 @@ class PlaygroundServer {
   private static readonly MJPEG_NEGATIVE_CACHE_MS = 10_000;
   private static readonly INTERFACE_MJPEG_INITIAL_FRAME_TIMEOUT_MS = 1500;
   private static readonly INTERFACE_MJPEG_IDLE_STOP_MS = 2000;
-  private _interfaceMjpegProducer?: InterfaceMjpegProducer;
+  private readonly _interfaceMjpegHub: InterfaceMjpegHub =
+    createInterfaceMjpegHub({
+      initialFrameTimeoutMs:
+        PlaygroundServer.INTERFACE_MJPEG_INITIAL_FRAME_TIMEOUT_MS,
+      idleStopMs: PlaygroundServer.INTERFACE_MJPEG_IDLE_STOP_MS,
+      debug: debugMjpeg,
+    });
 
   private sessionManager?: PlaygroundSessionManager;
   private sessionSetupState: 'required' | 'ready' | 'blocked' = 'ready';
@@ -854,7 +848,7 @@ class PlaygroundServer {
 
     debugMjpeg(`Recovering active agent after ${reason}:`, error);
     try {
-      this.stopInterfaceMjpegProducer(this._interfaceMjpegProducer);
+      this._interfaceMjpegHub.stopProducer();
       await this.recreateAgent();
       return this._activeConnection.agent;
     } catch (recreateError) {
@@ -879,14 +873,15 @@ class PlaygroundServer {
     agent: PageAgent,
     actionType: string,
     params: Record<string, unknown>,
-  ): Promise<'missing-action' | 'ok'> {
+  ): Promise<void> {
     const action = this.findInteractAction(agent, actionType);
     if (!action || typeof action.call !== 'function') {
-      return 'missing-action';
+      throw new Error(
+        `Action "${actionType}" is not available on the current device`,
+      );
     }
 
     await action.call(params, createManualExecutorContext(actionType, params));
-    return 'ok';
   }
 
   /**
@@ -1470,7 +1465,20 @@ class PlaygroundServer {
         if (proxyOk) return;
       }
 
-      if (await this.startInterfaceMjpegStream(req, res)) {
+      const interfaceStreamStarted =
+        await this._interfaceMjpegHub.streamRequest(
+          req,
+          res,
+          agent.interface,
+          async (startupError) =>
+            (
+              await this.recoverActiveAgentAfterPreviewError(
+                startupError,
+                'interface MJPEG startup',
+              )
+            )?.interface ?? null,
+        );
+      if (interfaceStreamStarted) {
         return;
       }
 
@@ -1498,15 +1506,9 @@ class PlaygroundServer {
             debugScreenshot('interface size() failed:', error);
           }
         }
-        const interfaceWithNavigationState = agent?.interface as unknown as {
-          navigationState?: () => Promise<{ isLoading: boolean }>;
-        };
-        if (
-          typeof interfaceWithNavigationState?.navigationState === 'function'
-        ) {
+        if (typeof agent?.interface?.navigationState === 'function') {
           try {
-            navigationState =
-              await interfaceWithNavigationState.navigationState();
+            navigationState = await agent.interface.navigationState();
           } catch (error) {
             debugScreenshot('interface navigationState() failed:', error);
           }
@@ -1760,209 +1762,6 @@ class PlaygroundServer {
     });
   }
 
-  private writeMjpegFrame(
-    res: Response,
-    boundary: string,
-    frame: MjpegStreamFrame,
-  ): void {
-    const raw = frame.data.replace(/^data:image\/\w+;base64,/, '');
-    const buf = Buffer.from(raw, 'base64');
-
-    res.write(`--${boundary}\r\n`);
-    res.write(`Content-Type: ${frame.contentType || 'image/jpeg'}\r\n`);
-    res.write(`Content-Length: ${buf.length}\r\n\r\n`);
-    res.write(buf);
-    res.write('\r\n');
-  }
-
-  /**
-   * Starts (or reuses) one in-process frame producer for the active interface.
-   * CDP Page.startScreencast is page-scoped, so multiple concurrent producers
-   * can steal frames from each other. Keep a single producer and fan frames out
-   * to every HTTP MJPEG client instead.
-   */
-  private getOrCreateInterfaceMjpegProducer(
-    activeInterface: PageAgent['interface'],
-  ): InterfaceMjpegProducer | null {
-    const startMjpegStream = activeInterface.startMjpegStream;
-    if (typeof startMjpegStream !== 'function') return null;
-
-    if (this._interfaceMjpegProducer?.source === activeInterface) {
-      if (this._interfaceMjpegProducer.stopTimer) {
-        clearTimeout(this._interfaceMjpegProducer.stopTimer);
-        this._interfaceMjpegProducer.stopTimer = undefined;
-      }
-      return this._interfaceMjpegProducer;
-    }
-
-    this.stopInterfaceMjpegProducer(this._interfaceMjpegProducer);
-
-    const controller = new AbortController();
-    let resolveInitialFrame: ((hasFrame: boolean) => void) | undefined;
-    let initialFrameTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const resolveInitialFrameOnce = (hasFrame: boolean) => {
-      if (!resolveInitialFrame) return;
-      if (initialFrameTimer) {
-        clearTimeout(initialFrameTimer);
-        initialFrameTimer = undefined;
-      }
-      resolveInitialFrame(hasFrame);
-      resolveInitialFrame = undefined;
-    };
-
-    const initialFrameReady = new Promise<boolean>((resolve) => {
-      resolveInitialFrame = resolve;
-      initialFrameTimer = setTimeout(() => {
-        resolveInitialFrameOnce(false);
-      }, PlaygroundServer.INTERFACE_MJPEG_INITIAL_FRAME_TIMEOUT_MS);
-    });
-
-    const producer: InterfaceMjpegProducer = {
-      source: activeInterface,
-      controller,
-      firstFrameReady: initialFrameReady,
-      subscribers: new Set(),
-    };
-    this._interfaceMjpegProducer = producer;
-
-    void (async () => {
-      try {
-        producer.handle =
-          (await startMjpegStream.call(activeInterface, {
-            signal: controller.signal,
-            onFrame: (frame) => {
-              if (controller.signal.aborted) return;
-              producer.lastFrame = frame;
-              resolveInitialFrameOnce(true);
-              for (const subscriber of producer.subscribers) {
-                subscriber(frame);
-              }
-            },
-            onError: (error) => {
-              debugMjpeg('MJPEG interface stream producer error:', error);
-            },
-          })) ?? undefined;
-      } catch (error) {
-        debugMjpeg('MJPEG: interface frame producer unavailable:', error);
-        producer.startupError = error;
-        resolveInitialFrameOnce(false);
-        this.stopInterfaceMjpegProducer(producer);
-      }
-    })();
-
-    return producer;
-  }
-
-  private stopInterfaceMjpegProducer(producer?: InterfaceMjpegProducer): void {
-    if (!producer) return;
-    if (producer.stopTimer) {
-      clearTimeout(producer.stopTimer);
-      producer.stopTimer = undefined;
-    }
-    producer.subscribers.clear();
-    producer.controller.abort();
-    Promise.resolve(producer.handle?.stop?.()).catch((error) => {
-      debugMjpeg('MJPEG interface stream stop failed:', error);
-    });
-    if (this._interfaceMjpegProducer === producer) {
-      this._interfaceMjpegProducer = undefined;
-    }
-  }
-
-  private releaseInterfaceMjpegSubscriber(
-    producer: InterfaceMjpegProducer,
-    subscriber: InterfaceMjpegSubscriber,
-  ): void {
-    producer.subscribers.delete(subscriber);
-    if (producer.subscribers.size > 0 || producer.stopTimer) return;
-    producer.stopTimer = setTimeout(() => {
-      producer.stopTimer = undefined;
-      if (producer.subscribers.size === 0) {
-        this.stopInterfaceMjpegProducer(producer);
-      }
-    }, PlaygroundServer.INTERFACE_MJPEG_IDLE_STOP_MS);
-  }
-
-  /**
-   * Stream MJPEG frames produced in-process by the active interface, e.g.
-   * Chromium CDP Page.startScreencast for Web previews.
-   */
-  private async startInterfaceMjpegStream(
-    req: Request,
-    res: Response,
-    allowRecovery = true,
-  ): Promise<boolean> {
-    const agent = this._activeConnection.agent;
-    if (!agent) return false;
-
-    const producer = this.getOrCreateInterfaceMjpegProducer(agent.interface);
-    if (!producer) return false;
-
-    const hasInitialFrame = await producer.firstFrameReady;
-    if (!hasInitialFrame || !producer.lastFrame) {
-      debugMjpeg(
-        'MJPEG: interface frame producer did not emit an initial frame, using polling mode',
-      );
-      const startupError = producer.startupError;
-      this.stopInterfaceMjpegProducer(producer);
-      if (allowRecovery && startupError) {
-        const recoveredAgent = await this.recoverActiveAgentAfterPreviewError(
-          startupError,
-          'interface MJPEG startup',
-        );
-        if (recoveredAgent) {
-          return this.startInterfaceMjpegStream(req, res, false);
-        }
-      }
-      return false;
-    }
-
-    const boundary = 'mjpeg-boundary';
-    let closed = false;
-    let subscriber: InterfaceMjpegSubscriber = () => undefined;
-
-    const closeResponse = () => {
-      if (closed) return;
-      closed = true;
-      this.releaseInterfaceMjpegSubscriber(producer, subscriber);
-    };
-
-    const writeFrame = (frame: MjpegStreamFrame) => {
-      if (closed) return;
-      try {
-        this.writeMjpegFrame(res, boundary, frame);
-      } catch (error) {
-        debugMjpeg('MJPEG interface frame write failed:', error);
-        closeResponse();
-        try {
-          res.destroy();
-        } catch {
-          /* socket already closed */
-        }
-      }
-    };
-
-    subscriber = writeFrame;
-    producer.subscribers.add(subscriber);
-    if (producer.stopTimer) {
-      clearTimeout(producer.stopTimer);
-      producer.stopTimer = undefined;
-    }
-    req.on('close', closeResponse);
-
-    res.setHeader(
-      'Content-Type',
-      `multipart/x-mixed-replace; boundary=${boundary}`,
-    );
-    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-    res.setHeader('Connection', 'keep-alive');
-    writeFrame(producer.lastFrame);
-
-    debugMjpeg('MJPEG: streaming via shared interface frame producer');
-    return true;
-  }
-
   /**
    * Stream screenshots as MJPEG by polling screenshotBase64().
    */
@@ -2041,7 +1840,7 @@ class PlaygroundServer {
         if (stopped) break;
         consecutiveErrors = 0;
 
-        this.writeMjpegFrame(res, boundary, {
+        writeMjpegFrame(res, boundary, {
           data: base64,
           contentType: 'image/jpeg',
         });

--- a/packages/playground/tests/unit/build-interact-params.test.ts
+++ b/packages/playground/tests/unit/build-interact-params.test.ts
@@ -98,6 +98,12 @@ describe('buildInteractParams', () => {
     expect(buildInteractParams('KeyboardPress', { keyName: 'Enter' })).toEqual({
       keyName: 'Enter',
     });
+    expect(
+      buildInteractParams('KeyboardPress', { keyName: 'Enter', x: 50, y: 60 }),
+    ).toMatchObject({
+      keyName: 'Enter',
+      locate: { center: [50, 60] },
+    });
     expect(() => buildInteractParams('KeyboardPress', {})).toThrow();
   });
 

--- a/packages/playground/tests/unit/server-interact.test.ts
+++ b/packages/playground/tests/unit/server-interact.test.ts
@@ -111,6 +111,26 @@ describe('PlaygroundServer manual interaction APIs', () => {
     });
   });
 
+  test('POST /interact runs web Stop through browser chrome instead of actionSpace', async () => {
+    const stopLoading = vi.fn(async () => undefined);
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        stopLoading,
+      },
+    } as any);
+
+    await server.launch(6115);
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    const response = createMockResponse();
+    await interactHandler({ body: { actionType: 'Stop' } }, response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({});
+    expect(stopLoading).toHaveBeenCalledTimes(1);
+  });
+
   test('POST /interact recreates a factory-backed agent without replaying the failed action', async () => {
     const firstDestroy = vi.fn();
     const firstTapCall = vi.fn(async () => {

--- a/packages/playground/tests/unit/server-interact.test.ts
+++ b/packages/playground/tests/unit/server-interact.test.ts
@@ -111,6 +111,55 @@ describe('PlaygroundServer manual interaction APIs', () => {
     });
   });
 
+  test('POST /interact recreates a factory-backed agent without replaying the failed action', async () => {
+    const firstDestroy = vi.fn();
+    const firstTapCall = vi.fn(async () => {
+      throw new Error(
+        'Protocol error (Input.dispatchMouseEvent): Session closed. Most likely the page has been closed.',
+      );
+    });
+    const secondTapCall = vi.fn();
+    const agentFactory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        destroy: firstDestroy,
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [
+            { name: 'Tap', description: 'tap', call: firstTapCall },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [
+            { name: 'Tap', description: 'tap', call: secondTapCall },
+          ],
+        },
+      });
+
+    const server = new PlaygroundServer(agentFactory as any);
+    await server.launch(6114);
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    const response = createMockResponse();
+
+    await interactHandler(
+      { body: { actionType: 'Tap', x: 10, y: 20 } },
+      response,
+    );
+
+    expect(response.statusCode).toBe(409);
+    expect(response.body).toEqual({
+      error:
+        'The page session was closed and has been recreated. Please retry the action.',
+    });
+    expect(agentFactory).toHaveBeenCalledTimes(2);
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+    expect(firstTapCall).toHaveBeenCalledTimes(1);
+    expect(secondTapCall).not.toHaveBeenCalled();
+  });
+
   test('GET /interface-info includes device size without fetching a screenshot', async () => {
     const screenshotBase64 = vi.fn(async () => 'base64-image');
     const server = new PlaygroundServer({

--- a/packages/playground/tests/unit/server-mjpeg-stream.test.ts
+++ b/packages/playground/tests/unit/server-mjpeg-stream.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, test, vi } from 'vitest';
+import { PlaygroundServer } from '../../src/server';
+
+function createMockStreamResponse() {
+  const headers = new Map<string, string>();
+  const chunks: Array<string | Buffer> = [];
+
+  return {
+    headersSent: false,
+    destroyed: false,
+    headers,
+    chunks,
+    setHeader(key: string, value: string) {
+      headers.set(key, value);
+      return this;
+    },
+    write(chunk: string | Buffer) {
+      this.headersSent = true;
+      chunks.push(chunk);
+      return true;
+    },
+    destroy() {
+      this.destroyed = true;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    statusCode: 200,
+    body: undefined as unknown,
+  };
+}
+
+function createMockRequest() {
+  const listeners = new Map<string, () => void>();
+  return {
+    query: {},
+    listeners,
+    on(event: string, listener: () => void) {
+      listeners.set(event, listener);
+      return this;
+    },
+  };
+}
+
+function getRouteHandler(
+  server: PlaygroundServer,
+  method: 'get' | 'post',
+  route: string,
+) {
+  const calls = (server.app[method] as any).mock.calls as Array<[string, any]>;
+  return calls.find(([registeredRoute]) => registeredRoute === route)?.[1];
+}
+
+describe('PlaygroundServer MJPEG streaming', () => {
+  test('GET /screenshot recreates a factory-backed agent when the page session is closed', async () => {
+    const firstDestroy = vi.fn();
+    const secondDestroy = vi.fn();
+    const agentFactory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        destroy: firstDestroy,
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [],
+          screenshotBase64: async () => {
+            throw new Error(
+              'Protocol error (Page.captureScreenshot): Session closed. Most likely the page has been closed.',
+            );
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        destroy: secondDestroy,
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [],
+          screenshotBase64: async () =>
+            Buffer.from('recovered-screenshot').toString('base64'),
+        },
+      });
+
+    const server = new PlaygroundServer(agentFactory as any);
+    await server.launch(6124);
+    const screenshotHandler = getRouteHandler(server, 'get', '/screenshot');
+    const response = createMockStreamResponse();
+
+    await screenshotHandler(createMockRequest(), response);
+
+    expect(agentFactory).toHaveBeenCalledTimes(2);
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+    expect(response.body).toMatchObject({
+      screenshot: Buffer.from('recovered-screenshot').toString('base64'),
+    });
+  });
+
+  test('GET /mjpeg recreates a factory-backed agent when interface stream startup sees a closed page', async () => {
+    const firstDestroy = vi.fn();
+    const stop = vi.fn();
+    const agentFactory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        destroy: firstDestroy,
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [],
+          screenshotBase64: async () => {
+            throw new Error('polling should not be used after recovery');
+          },
+          startMjpegStream: async () => {
+            throw new Error('Protocol error: Session closed.');
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        interface: {
+          interfaceType: 'web',
+          actionSpace: () => [],
+          screenshotBase64: async () => {
+            throw new Error('polling should not be used');
+          },
+          startMjpegStream: async ({ onFrame }) => {
+            onFrame({
+              data: Buffer.from('recovered-frame').toString('base64'),
+              contentType: 'image/jpeg',
+            });
+            return { stop };
+          },
+        },
+      });
+
+    const server = new PlaygroundServer(agentFactory as any);
+    await server.launch(6125);
+    vi.useFakeTimers();
+    const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+    try {
+      const request = createMockRequest();
+      const response = createMockStreamResponse();
+
+      await mjpegHandler(request, response);
+
+      expect(agentFactory).toHaveBeenCalledTimes(2);
+      expect(firstDestroy).toHaveBeenCalledTimes(1);
+      expect(
+        response.chunks.some((chunk) => chunk.toString() === 'recovered-frame'),
+      ).toBe(true);
+
+      request.listeners.get('close')?.();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('GET /mjpeg streams frames from an interface MJPEG producer', async () => {
+    const stop = vi.fn();
+    let capturedSignal: AbortSignal | undefined;
+    const startMjpegStream = vi.fn(async ({ signal, onFrame }) => {
+      capturedSignal = signal;
+      onFrame({
+        data: Buffer.from('frame-one').toString('base64'),
+        contentType: 'image/jpeg',
+      });
+      return { stop };
+    });
+
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        screenshotBase64: async () => {
+          throw new Error('polling should not be used');
+        },
+        size: async () => ({ width: 800, height: 600 }),
+        startMjpegStream,
+      },
+    } as any);
+
+    await server.launch(6120);
+    vi.useFakeTimers();
+    const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+    try {
+      expect(mjpegHandler).toBeTypeOf('function');
+
+      const request = createMockRequest();
+      const response = createMockStreamResponse();
+      await mjpegHandler(request, response);
+
+      expect(startMjpegStream).toHaveBeenCalledTimes(1);
+      expect(response.headers.get('Content-Type')).toBe(
+        'multipart/x-mixed-replace; boundary=mjpeg-boundary',
+      );
+      expect(response.headers.get('Cache-Control')).toBe(
+        'no-cache, no-store, must-revalidate',
+      );
+      expect(
+        response.chunks.map((chunk) => chunk.toString()).join(''),
+      ).toContain('Content-Type: image/jpeg');
+      expect(
+        response.chunks.some((chunk) => chunk.toString() === 'frame-one'),
+      ).toBe(true);
+
+      request.listeners.get('close')?.();
+      expect(capturedSignal?.aborted).toBe(false);
+      expect(stop).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('GET /mjpeg shares one interface producer across concurrent clients', async () => {
+    const stop = vi.fn();
+    let emitFrame:
+      | ((frame: { data: string; contentType: string }) => void)
+      | undefined;
+    const startMjpegStream = vi.fn(async ({ onFrame }) => {
+      emitFrame = onFrame;
+      onFrame({
+        data: Buffer.from('frame-one').toString('base64'),
+        contentType: 'image/jpeg',
+      });
+      return { stop };
+    });
+
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        screenshotBase64: async () => {
+          throw new Error('polling should not be used');
+        },
+        size: async () => ({ width: 800, height: 600 }),
+        startMjpegStream,
+      },
+    } as any);
+
+    await server.launch(6123);
+    vi.useFakeTimers();
+    try {
+      const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+      const requestOne = createMockRequest();
+      const requestTwo = createMockRequest();
+      const responseOne = createMockStreamResponse();
+      const responseTwo = createMockStreamResponse();
+
+      await mjpegHandler(requestOne, responseOne);
+      await mjpegHandler(requestTwo, responseTwo);
+
+      expect(startMjpegStream).toHaveBeenCalledTimes(1);
+      expect(
+        responseOne.chunks.some((chunk) => chunk.toString() === 'frame-one'),
+      ).toBe(true);
+      expect(
+        responseTwo.chunks.some((chunk) => chunk.toString() === 'frame-one'),
+      ).toBe(true);
+
+      emitFrame?.({
+        data: Buffer.from('frame-two').toString('base64'),
+        contentType: 'image/jpeg',
+      });
+
+      expect(
+        responseOne.chunks.some((chunk) => chunk.toString() === 'frame-two'),
+      ).toBe(true);
+      expect(
+        responseTwo.chunks.some((chunk) => chunk.toString() === 'frame-two'),
+      ).toBe(true);
+
+      requestOne.listeners.get('close')?.();
+      emitFrame?.({
+        data: Buffer.from('frame-three').toString('base64'),
+        contentType: 'image/jpeg',
+      });
+
+      expect(
+        responseOne.chunks.some((chunk) => chunk.toString() === 'frame-three'),
+      ).toBe(false);
+      expect(
+        responseTwo.chunks.some((chunk) => chunk.toString() === 'frame-three'),
+      ).toBe(true);
+
+      requestTwo.listeners.get('close')?.();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('GET /mjpeg falls back to screenshot polling when producer startup fails', async () => {
+    const screenshotBase64 = vi.fn(async () =>
+      Buffer.from('polling-frame').toString('base64'),
+    );
+    const startMjpegStream = vi.fn(async () => {
+      throw new Error('CDP unavailable');
+    });
+
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        screenshotBase64,
+        size: async () => ({ width: 800, height: 600 }),
+        startMjpegStream,
+      },
+    } as any);
+
+    await server.launch(6121);
+    const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+    const request = createMockRequest();
+    const response = createMockStreamResponse();
+
+    const streamPromise = mjpegHandler(request, response);
+    for (let i = 0; i < 10 && screenshotBase64.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(screenshotBase64).toHaveBeenCalled();
+    request.listeners.get('close')?.();
+    await streamPromise;
+
+    expect(startMjpegStream).toHaveBeenCalledTimes(1);
+    expect(response.chunks.map((chunk) => chunk.toString()).join('')).toContain(
+      'polling-frame',
+    );
+  });
+
+  test('GET /mjpeg falls back to screenshot polling when producer emits no initial frame', async () => {
+    const stop = vi.fn();
+    const screenshotBase64 = vi.fn(async () =>
+      Buffer.from('polling-after-empty-stream').toString('base64'),
+    );
+    const startMjpegStream = vi.fn(async () => ({ stop }));
+
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        screenshotBase64,
+        size: async () => ({ width: 800, height: 600 }),
+        startMjpegStream,
+      },
+    } as any);
+
+    await server.launch(6122);
+    vi.useFakeTimers();
+    try {
+      const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+      const request = createMockRequest();
+      const response = createMockStreamResponse();
+
+      const streamPromise = mjpegHandler(request, response);
+      await vi.advanceTimersByTimeAsync(1500);
+      await Promise.resolve();
+
+      expect(startMjpegStream).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalled();
+      expect(screenshotBase64).toHaveBeenCalled();
+      expect(
+        response.chunks.map((chunk) => chunk.toString()).join(''),
+      ).toContain('polling-after-empty-stream');
+
+      request.listeners.get('close')?.();
+      await vi.runOnlyPendingTimersAsync();
+      await streamPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -42,6 +42,7 @@ export default function ScreenshotViewer({
   // is reopened. Used both for natural retries on stream errors and for the
   // server-driven upgrade from polling fallback to native MJPEG.
   const [mjpegRetryToken, setMjpegRetryToken] = useState('');
+  const mjpegImageRef = useRef<HTMLImageElement | null>(null);
   const isMjpeg = Boolean(mjpegUrl && serverOnline);
   const showChrome = mode !== 'screen-only';
   const rootClassName = [
@@ -54,6 +55,18 @@ export default function ScreenshotViewer({
   // Refs for managing polling
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const isPollingPausedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isMjpeg) return;
+    const timer = window.setTimeout(() => {
+      const image = mjpegImageRef.current;
+      if (!image || image.naturalWidth > 0 || image.naturalHeight > 0) {
+        return;
+      }
+      setMjpegRetryToken(String(Date.now()));
+    }, 2500);
+    return () => window.clearTimeout(timer);
+  }, [isMjpeg, mjpegRetryToken, mjpegUrl]);
 
   // Core function to fetch screenshot
   const fetchScreenshot = useCallback(
@@ -183,7 +196,7 @@ export default function ScreenshotViewer({
 
   // Manage user operation status changes
   useEffect(() => {
-    if (!serverOnline) return;
+    if (!serverOnline || isMjpeg) return;
 
     if (isUserOperating) {
       // When user starts operating, pause polling
@@ -199,6 +212,7 @@ export default function ScreenshotViewer({
     resumePolling,
     fetchScreenshot,
     serverOnline,
+    isMjpeg,
   ]);
 
   // Cleanup function
@@ -254,6 +268,7 @@ export default function ScreenshotViewer({
       {isMjpeg ? (
         <img
           key={mjpegRetryToken || 'initial'}
+          ref={mjpegImageRef}
           src={
             !mjpegRetryToken
               ? mjpegUrl

--- a/packages/visualizer/src/utils/action-label.ts
+++ b/packages/visualizer/src/utils/action-label.ts
@@ -1,5 +1,7 @@
 export const actionNameForType = (type: string) => {
   if (!type) return '';
+  if (type === 'aiAct') return 'Action';
+
   // Remove 'ai' prefix and convert camelCase to space-separated words
   const typeWithoutAi = type.startsWith('ai') ? type.slice(2) : type;
 

--- a/packages/visualizer/src/utils/prompt-input-utils.ts
+++ b/packages/visualizer/src/utils/prompt-input-utils.ts
@@ -15,10 +15,9 @@ export interface InlineStructuredFieldConfig {
  * Inclusion rules:
  *   - If `actionSpace` is empty/undefined, fall back to the full metadata set
  *     so dry-mode / offline renderers still show something to pick from.
- *   - `aiAct` is included **only when the current `actionSpace` exposes it**.
- *     It is the universal "natural-language" action and usually lives in every
- *     device's action space, but we intentionally do not force-inject it —
- *     devices that truly cannot run `aiAct` should not see a broken entry.
+ *   - `aiAct` is always included. It is an Agent-level API and is executed via
+ *     Playground's fallback path, so it does not need to appear in the device
+ *     interface's low-level `actionSpace`.
  *   - `extraction` and `validation` APIs are kept even when not in the device's
  *     `actionSpace`: they are executed against the captured UI context rather
  *     than being dispatched to the device, so they apply universally.
@@ -37,14 +36,13 @@ export const getAvailablePromptActionTypes = (
   const availableMethods = actionSpace.map(
     (action) => action.interfaceAlias || action.name,
   );
-  const supportsAiAct = availableMethods.includes('aiAct');
   const finalMethods = new Set<string>();
 
   metadataMethods.forEach((method) => {
     const methodInfo = apiMetadata[method as keyof typeof apiMetadata];
 
     if (method === 'aiAct') {
-      if (supportsAiAct) finalMethods.add(method);
+      finalMethods.add(method);
       return;
     }
 

--- a/packages/visualizer/tests/inline-structured-field-config.test.ts
+++ b/packages/visualizer/tests/inline-structured-field-config.test.ts
@@ -215,7 +215,7 @@ describe('getAvailablePromptActionTypes', () => {
     expect(actions).toContain('aiTap');
   });
 
-  test('omits aiAct when actionSpace does not expose it', () => {
+  test('keeps aiAct when actionSpace does not expose it', () => {
     const actionSpace = [
       { name: 'Tap', interfaceAlias: 'aiTap' },
       { name: 'Swipe', interfaceAlias: 'aiSwipe' },
@@ -223,7 +223,7 @@ describe('getAvailablePromptActionTypes', () => {
 
     const actions = getAvailablePromptActionTypes(actionSpace);
 
-    expect(actions).not.toContain('aiAct');
+    expect(actions).toContain('aiAct');
     expect(actions).toContain('aiTap');
     expect(actions).toContain('aiSwipe');
   });

--- a/packages/visualizer/tests/prompt-input-labels.test.ts
+++ b/packages/visualizer/tests/prompt-input-labels.test.ts
@@ -8,7 +8,7 @@ describe('getPromptInputActionLabel', () => {
   });
 
   test('derives the label from the selected type when no override is given', () => {
-    expect(getPromptInputActionLabel('aiAct')).toBe('Act');
+    expect(getPromptInputActionLabel('aiAct')).toBe('Action');
     expect(getPromptInputActionLabel('aiTap')).toBe('Tap');
   });
 

--- a/packages/visualizer/tests/screenshot-viewer.test.ts
+++ b/packages/visualizer/tests/screenshot-viewer.test.ts
@@ -1,9 +1,23 @@
-import { createElement } from 'react';
+/** @vitest-environment jsdom */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import ScreenshotViewer from '../src/component/screenshot-viewer';
 
 describe('ScreenshotViewer', () => {
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders a screen-only variant without viewer chrome', () => {
     const html = renderToStaticMarkup(
       createElement(ScreenshotViewer, {
@@ -31,5 +45,97 @@ describe('ScreenshotViewer', () => {
 
     expect(html).toContain('screenshot-header');
     expect(html).toContain('device-name-overlay');
+  });
+
+  it('reconnects an MJPEG image when the first frame never loads', async () => {
+    vi.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ScreenshotViewer, {
+          getScreenshot: async () => null,
+          serverOnline: true,
+          mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+          mode: 'screen-only',
+        }),
+      );
+    });
+
+    const initialImage = container.querySelector(
+      'img[alt="Device Live Stream"]',
+    ) as HTMLImageElement | null;
+    expect(initialImage?.src).toBe('http://127.0.0.1:9234/mjpeg');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    const retriedImage = container.querySelector(
+      'img[alt="Device Live Stream"]',
+    ) as HTMLImageElement | null;
+    expect(retriedImage?.src).toContain('_mjpegRetry=');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('does not call the screenshot API while MJPEG preview is active', async () => {
+    vi.useFakeTimers();
+    const getScreenshot = vi.fn(async () => null);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ScreenshotViewer, {
+          getScreenshot,
+          serverOnline: true,
+          isUserOperating: false,
+          mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+          mode: 'screen-only',
+        }),
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    await act(async () => {
+      root.render(
+        createElement(ScreenshotViewer, {
+          getScreenshot,
+          serverOnline: true,
+          isUserOperating: true,
+          mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+          mode: 'screen-only',
+        }),
+      );
+    });
+
+    await act(async () => {
+      root.render(
+        createElement(ScreenshotViewer, {
+          getScreenshot,
+          serverOnline: true,
+          isUserOperating: false,
+          mjpegUrl: 'http://127.0.0.1:9234/mjpeg',
+          mode: 'screen-only',
+        }),
+      );
+    });
+
+    expect(getScreenshot).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -519,6 +519,23 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     await this.waitUntilNetworkIdle();
   }
 
+  async goForward(): Promise<void> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    await chrome.tabs.goForward(tabId);
+    // Wait for navigation to complete
+    await this.waitUntilNetworkIdle();
+  }
+
+  async stopLoading(): Promise<void> {
+    await this.sendCommandToDebugger('Page.stopLoading', {});
+  }
+
+  async navigationState(): Promise<{ isLoading: boolean }> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    const tab = await chrome.tabs.get(tabId);
+    return { isLoading: tab.status === 'loading' };
+  }
+
   async scrollUntilTop(startingPoint?: Point) {
     if (startingPoint) {
       await this.mouse.move(startingPoint.left, startingPoint.top);

--- a/packages/web-integration/src/platform.ts
+++ b/packages/web-integration/src/platform.ts
@@ -4,7 +4,7 @@ import {
   type AgentFactory,
   type LaunchPlaygroundOptions,
   type PlaygroundPreviewDescriptor,
-  createScreenshotPreviewDescriptor,
+  createMjpegPreviewDescriptor,
   definePlaygroundPlatform,
 } from '@midscene/playground';
 import { StaticPage, StaticPageAgent } from './static';
@@ -49,7 +49,7 @@ export const webPlaygroundPlatform = definePlaygroundPlatform<
       launchOptions: options?.launchOptions,
       preview:
         options?.preview ||
-        createScreenshotPreviewDescriptor({
+        createMjpegPreviewDescriptor({
           title: 'Web page preview',
         }),
       metadata: {

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -49,6 +49,12 @@ export const BROWSER_NAVIGATION_ERROR_PATTERN =
   /execution context was destroyed|frame was detached|target closed|page has been closed|context was destroyed|net::ERR_ABORTED/i;
 
 const CDP_SCREENCAST_QUALITY = 70;
+const CDP_SCREENCAST_EVERY_NTH_FRAME = 1;
+// Upper bound for the "wait for browser repaint" promise inside
+// flushPendingVisualUpdate so the call does not hang forever if the page
+// stops scheduling animation frames (e.g. backgrounded tab).
+const FLUSH_VISUAL_UPDATE_TIMEOUT_MS = 50;
+const DATA_URL_BASE64_PREFIX = /^data:image\/\w+;base64,/;
 
 type ScreencastFrameEvent = {
   data: string;
@@ -103,6 +109,7 @@ export class Page<
   private activeMjpegStream?: {
     token: symbol;
     onFrame: MjpegStreamOptions['onFrame'];
+    onError?: MjpegStreamOptions['onError'];
   };
   interfaceType: AgentType;
 
@@ -434,7 +441,7 @@ export class Page<
 
     try {
       await this.evaluate(
-        () =>
+        (timeoutMs: number) =>
           new Promise<void>((resolve) => {
             let done = false;
             const finish = () => {
@@ -442,18 +449,22 @@ export class Page<
               done = true;
               resolve();
             };
-            setTimeout(finish, 50);
+            setTimeout(finish, timeoutMs);
             requestAnimationFrame(() => requestAnimationFrame(finish));
           }),
+        FLUSH_VISUAL_UPDATE_TIMEOUT_MS,
       );
-      const data = await this.screenshotBase64();
+      const dataUrl = await this.screenshotBase64();
       if (this.activeMjpegStream?.token !== activeStream.token) return;
+      // MjpegStreamFrame.data is contractually bare base64; screenshotBase64()
+      // returns a `data:image/...;base64,...` URL, so strip the prefix here.
       activeStream.onFrame({
-        data,
+        data: dataUrl.replace(DATA_URL_BASE64_PREFIX, ''),
         contentType: 'image/jpeg',
       });
     } catch (error) {
       debugPage('screencast visual refresh failed: %s', error);
+      activeStream.onError?.(error);
     }
   }
 
@@ -468,6 +479,14 @@ export class Page<
     let stopped = false;
     const streamToken = Symbol('mjpeg-stream');
 
+    const reportStreamError = (error: unknown) => {
+      try {
+        onError?.(error);
+      } catch (callbackError) {
+        debugPage('mjpeg onError callback threw: %s', callbackError);
+      }
+    };
+
     const handleFrame = (event: ScreencastFrameEvent) => {
       void (async () => {
         if (stopped) return;
@@ -477,7 +496,7 @@ export class Page<
             contentType: 'image/jpeg',
           });
         } catch (error) {
-          onError?.(error);
+          reportStreamError(error);
         }
 
         try {
@@ -486,7 +505,7 @@ export class Page<
           });
         } catch (error) {
           if (!stopped) {
-            onError?.(error);
+            reportStreamError(error);
           }
         }
       })();
@@ -525,6 +544,7 @@ export class Page<
       this.activeMjpegStream = {
         token: streamToken,
         onFrame,
+        onError,
       };
       signal?.addEventListener('abort', abortHandler, { once: true });
 
@@ -543,7 +563,7 @@ export class Page<
       await client.send('Page.startScreencast', {
         format: 'jpeg',
         quality: CDP_SCREENCAST_QUALITY,
-        everyNthFrame: 1,
+        everyNthFrame: CDP_SCREENCAST_EVERY_NTH_FRAME,
       });
 
       return { stop };

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -7,7 +7,11 @@ import type {
   Rect,
   Size,
 } from '@midscene/core';
-import type { AbstractInterface } from '@midscene/core/device';
+import type {
+  AbstractInterface,
+  MjpegStreamHandle,
+  MjpegStreamOptions,
+} from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
 import {
   DEFAULT_WAIT_FOR_NAVIGATION_TIMEOUT,
@@ -44,6 +48,30 @@ const warnPage = getDebug('web:page', { console: true });
 export const BROWSER_NAVIGATION_ERROR_PATTERN =
   /execution context was destroyed|frame was detached|target closed|page has been closed|context was destroyed|net::ERR_ABORTED/i;
 
+const CDP_SCREENCAST_QUALITY = 70;
+
+type ScreencastFrameEvent = {
+  data: string;
+  sessionId: number;
+};
+
+type ScreencastCdpSession = {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  detach(): Promise<void>;
+  on(
+    event: 'Page.screencastFrame',
+    handler: (event: ScreencastFrameEvent) => void,
+  ): void;
+  off?(
+    event: 'Page.screencastFrame',
+    handler: (event: ScreencastFrameEvent) => void,
+  ): void;
+  removeListener?(
+    event: 'Page.screencastFrame',
+    handler: (event: ScreencastFrameEvent) => void,
+  ): void;
+};
+
 function isClosedPageError(error: unknown) {
   if (!(error instanceof Error)) {
     return false;
@@ -72,6 +100,10 @@ export class Page<
     event: Protocol.Page.FileChooserOpenedEvent,
   ) => Promise<void>;
   private playwrightNetworkIdleWarningShown = false;
+  private activeMjpegStream?: {
+    token: symbol;
+    onFrame: MjpegStreamOptions['onFrame'];
+  };
   interfaceType: AgentType;
 
   actionSpace(): DeviceAction[] {
@@ -380,6 +412,147 @@ export class Page<
     }
   }
 
+  private async createScreencastCdpSession(): Promise<ScreencastCdpSession> {
+    if (this.interfaceType === 'puppeteer') {
+      const page = this.underlyingPage as PuppeteerPage;
+      return (await page.target().createCDPSession()) as ScreencastCdpSession;
+    }
+
+    const page = this.underlyingPage as PlaywrightPage;
+    const browserName = page.context().browser()?.browserType().name();
+    if (browserName && browserName !== 'chromium') {
+      throw new Error(
+        `CDP screencast requires Chromium-based browser, but current browser is "${browserName}".`,
+      );
+    }
+    return (await page.context().newCDPSession(page)) as ScreencastCdpSession;
+  }
+
+  async flushPendingVisualUpdate(): Promise<void> {
+    const activeStream = this.activeMjpegStream;
+    if (!activeStream) return;
+
+    try {
+      await this.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            let done = false;
+            const finish = () => {
+              if (done) return;
+              done = true;
+              resolve();
+            };
+            setTimeout(finish, 50);
+            requestAnimationFrame(() => requestAnimationFrame(finish));
+          }),
+      );
+      const data = await this.screenshotBase64();
+      if (this.activeMjpegStream?.token !== activeStream.token) return;
+      activeStream.onFrame({
+        data,
+        contentType: 'image/jpeg',
+      });
+    } catch (error) {
+      debugPage('screencast visual refresh failed: %s', error);
+    }
+  }
+
+  async startMjpegStream(
+    options: MjpegStreamOptions,
+  ): Promise<MjpegStreamHandle> {
+    const { signal, onFrame, onError } = options;
+    if (typeof this.underlyingPage.bringToFront === 'function') {
+      await this.underlyingPage.bringToFront();
+    }
+    const client = await this.createScreencastCdpSession();
+    let stopped = false;
+    const streamToken = Symbol('mjpeg-stream');
+
+    const handleFrame = (event: ScreencastFrameEvent) => {
+      void (async () => {
+        if (stopped) return;
+        try {
+          onFrame({
+            data: event.data,
+            contentType: 'image/jpeg',
+          });
+        } catch (error) {
+          onError?.(error);
+        }
+
+        try {
+          await client.send('Page.screencastFrameAck', {
+            sessionId: event.sessionId,
+          });
+        } catch (error) {
+          if (!stopped) {
+            onError?.(error);
+          }
+        }
+      })();
+    };
+
+    const removeFrameListener = () => {
+      if (client.off) {
+        client.off('Page.screencastFrame', handleFrame);
+      } else if (client.removeListener) {
+        client.removeListener('Page.screencastFrame', handleFrame);
+      }
+    };
+
+    const stop = async () => {
+      if (stopped) return;
+      stopped = true;
+      if (this.activeMjpegStream?.token === streamToken) {
+        this.activeMjpegStream = undefined;
+      }
+      signal?.removeEventListener('abort', abortHandler);
+      removeFrameListener();
+      await client.send('Page.stopScreencast').catch((error) => {
+        debugPage('Page.stopScreencast failed: %s', error);
+      });
+      await client.detach().catch((error) => {
+        debugPage('CDP screencast session detach failed: %s', error);
+      });
+    };
+
+    const abortHandler = () => {
+      void stop();
+    };
+
+    try {
+      client.on('Page.screencastFrame', handleFrame);
+      this.activeMjpegStream = {
+        token: streamToken,
+        onFrame,
+      };
+      signal?.addEventListener('abort', abortHandler, { once: true });
+
+      if (signal?.aborted) {
+        await stop();
+        return { stop };
+      }
+
+      await client.send('Page.enable');
+      try {
+        const { width, height } = await this.size();
+        await client.send('Emulation.setVisibleSize', { width, height });
+      } catch (error) {
+        debugPage('CDP screencast visible size sync failed: %s', error);
+      }
+      await client.send('Page.startScreencast', {
+        format: 'jpeg',
+        quality: CDP_SCREENCAST_QUALITY,
+        everyNthFrame: 1,
+      });
+
+      return { stop };
+    } catch (error) {
+      await stop();
+      throw error;
+    }
+  }
+
   async url(): Promise<string> {
     return this.underlyingPage.url();
   }
@@ -620,6 +793,47 @@ export class Page<
       await (this.underlyingPage as PlaywrightPage).goBack();
     } else {
       throw new Error('Unsupported page type for go back');
+    }
+  }
+
+  async goForward(): Promise<void> {
+    debugPage('go forward');
+    if (this.interfaceType === 'puppeteer') {
+      await (this.underlyingPage as PuppeteerPage).goForward();
+    } else if (this.interfaceType === 'playwright') {
+      await (this.underlyingPage as PlaywrightPage).goForward();
+    } else {
+      throw new Error('Unsupported page type for go forward');
+    }
+  }
+
+  async stopLoading(): Promise<void> {
+    debugPage('stop loading');
+    if (this.interfaceType === 'puppeteer') {
+      const client = await (this.underlyingPage as PuppeteerPage)
+        .target()
+        .createCDPSession();
+      try {
+        await client.send('Page.stopLoading');
+      } finally {
+        await client.detach();
+      }
+    } else if (this.interfaceType === 'playwright') {
+      await (this.underlyingPage as PlaywrightPage).evaluate(() =>
+        window.stop(),
+      );
+    } else {
+      throw new Error('Unsupported page type for stop loading');
+    }
+  }
+
+  async navigationState(): Promise<{ isLoading: boolean }> {
+    try {
+      const readyState = await this.evaluate(() => document.readyState);
+      return { isLoading: readyState !== 'complete' };
+    } catch (error) {
+      debugPage('failed to query navigation state: %s', error);
+      return { isLoading: false };
     }
   }
 

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -387,6 +387,10 @@ export abstract class AbstractWebPage extends AbstractInterface {
   navigate?(url: string): Promise<void>;
   reload?(): Promise<void>;
   goBack?(): Promise<void>;
+  goForward?(): Promise<void>;
+  stopLoading?(): Promise<void>;
+  navigationState?(): Promise<{ isLoading: boolean }>;
+  flushPendingVisualUpdate?(): Promise<void>;
 
   get mouse(): MouseAction {
     return {
@@ -496,6 +500,7 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
 
     // Note: there is another implementation in AndroidDevicePage, which is more complex
     await page.keyboard.type(param.value);
+    await page.flushPendingVisualUpdate?.();
   }),
   defineActionKeyboardPress(async (param) => {
     const element = param.locate;
@@ -507,6 +512,7 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
 
     const keys = getKeyCommands(param.keyName);
     await page.keyboard.press(keys as any); // TODO: fix this type error
+    await page.flushPendingVisualUpdate?.();
   }),
   defineActionCursorMove(async (param) => {
     const arrowKey = param.direction === 'left' ? 'ArrowLeft' : 'ArrowRight';
@@ -701,6 +707,28 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
         throw new Error('GoBack operation is not supported on this page type');
       }
       await page.goBack();
+    },
+  }),
+  defineAction({
+    name: 'GoForward',
+    description: 'Navigate forward in browser history',
+    call: async () => {
+      if (!page.goForward) {
+        throw new Error(
+          'GoForward operation is not supported on this page type',
+        );
+      }
+      await page.goForward();
+    },
+  }),
+  defineAction({
+    name: 'Stop',
+    description: 'Stop loading the current page',
+    call: async () => {
+      if (!page.stopLoading) {
+        throw new Error('Stop operation is not supported on this page type');
+      }
+      await page.stopLoading();
     },
   }),
 ];

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -721,14 +721,4 @@ export const commonWebActionsForWebPage = <T extends AbstractWebPage>(
       await page.goForward();
     },
   }),
-  defineAction({
-    name: 'Stop',
-    description: 'Stop loading the current page',
-    call: async () => {
-      if (!page.stopLoading) {
-        throw new Error('Stop operation is not supported on this page type');
-      }
-      await page.stopLoading();
-    },
-  }),
 ];

--- a/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
@@ -1,0 +1,208 @@
+import { Page } from '@/puppeteer/base-page';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+  logMsg: vi.fn(),
+}));
+
+vi.mock('@midscene/core/utils', async () => {
+  const actual = await vi.importActual('@midscene/core/utils');
+  return {
+    ...actual,
+    sleep: vi.fn(() => Promise.resolve()),
+  };
+});
+
+vi.mock('@midscene/shared/node', () => ({
+  getElementInfosScriptContent: vi.fn(() => ''),
+  getExtraReturnLogic: vi.fn(() => Promise.resolve('() => ({})')),
+}));
+
+vi.mock('@/web-page', () => ({
+  commonWebActionsForWebPage: vi.fn(() => []),
+}));
+
+describe('Page startMjpegStream', () => {
+  it('starts a Puppeteer CDP screencast and ACKs incoming frames', async () => {
+    const handlers = new Map<string, (event: any) => unknown>();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const detach = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      send,
+      detach,
+      on: vi.fn((event: string, handler: (event: any) => unknown) => {
+        handlers.set(event, handler);
+      }),
+      off: vi.fn(),
+    };
+    const mockPage = {
+      bringToFront: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 768 }),
+      url: () => 'http://example.com',
+      target: () => ({
+        createCDPSession: vi.fn().mockResolvedValue(client),
+      }),
+    } as any;
+    const onFrame = vi.fn();
+
+    const page = new Page(mockPage, 'puppeteer');
+    const handle = await page.startMjpegStream({ onFrame });
+
+    expect(mockPage.bringToFront).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('Page.enable');
+    expect(send).toHaveBeenCalledWith('Emulation.setVisibleSize', {
+      width: 1280,
+      height: 768,
+    });
+    expect(send).toHaveBeenCalledWith('Page.startScreencast', {
+      format: 'jpeg',
+      quality: 70,
+      everyNthFrame: 1,
+    });
+
+    await handlers.get('Page.screencastFrame')?.({
+      data: 'ZnJhbWU=',
+      sessionId: 42,
+    });
+
+    expect(onFrame).toHaveBeenCalledWith({
+      data: 'ZnJhbWU=',
+      contentType: 'image/jpeg',
+    });
+    expect(send).toHaveBeenCalledWith('Page.screencastFrameAck', {
+      sessionId: 42,
+    });
+
+    await handle.stop();
+    expect(send).toHaveBeenCalledWith('Page.stopScreencast');
+    expect(detach).toHaveBeenCalledTimes(1);
+    expect(client.off).toHaveBeenCalledWith(
+      'Page.screencastFrame',
+      expect.any(Function),
+    );
+  });
+
+  it('stops the screencast when the abort signal fires', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const detach = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      send,
+      detach,
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    const mockPage = {
+      evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 768 }),
+      url: () => 'http://example.com',
+      context: () => ({
+        browser: () => ({
+          browserType: () => ({
+            name: () => 'chromium',
+          }),
+        }),
+        newCDPSession: vi.fn().mockResolvedValue(client),
+      }),
+    } as any;
+    const controller = new AbortController();
+
+    const page = new Page(mockPage, 'playwright');
+    await page.startMjpegStream({
+      signal: controller.signal,
+      onFrame: vi.fn(),
+    });
+    controller.abort();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(send).toHaveBeenCalledWith('Page.stopScreencast');
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('can push a screenshot frame to refresh keyboard-only visual changes', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const detach = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      send,
+      detach,
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    const mockPage = {
+      bringToFront: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 768 }),
+      screenshot: vi.fn().mockResolvedValue('cmVmcmVzaA=='),
+      url: () => 'http://example.com',
+      target: () => ({
+        createCDPSession: vi.fn().mockResolvedValue(client),
+      }),
+    } as any;
+    const onFrame = vi.fn();
+
+    const page = new Page(mockPage, 'puppeteer');
+    const handle = await page.startMjpegStream({ onFrame });
+
+    await page.flushPendingVisualUpdate();
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith({
+      type: 'jpeg',
+      quality: 90,
+      encoding: 'base64',
+    });
+    expect(onFrame).toHaveBeenCalledWith({
+      data: 'data:image/jpeg;base64,cmVmcmVzaA==',
+      contentType: 'image/jpeg',
+    });
+
+    await handle.stop();
+    mockPage.screenshot.mockClear();
+    await page.flushPendingVisualUpdate();
+    expect(mockPage.screenshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('Page web navigation controls', () => {
+  it('uses page history for forward navigation', async () => {
+    const mockPage = {
+      goForward: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const page = new Page(mockPage, 'puppeteer');
+    await page.goForward();
+
+    expect(mockPage.goForward).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops Puppeteer page loading through CDP', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const detach = vi.fn().mockResolvedValue(undefined);
+    const client = { send, detach };
+    const mockPage = {
+      target: () => ({
+        createCDPSession: vi.fn().mockResolvedValue(client),
+      }),
+    } as any;
+
+    const page = new Page(mockPage, 'puppeteer');
+    await page.stopLoading();
+
+    expect(send).toHaveBeenCalledWith('Page.stopLoading');
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports Puppeteer loading state from document.readyState', async () => {
+    const mockPage = {
+      evaluate: vi.fn().mockResolvedValue('interactive'),
+    } as any;
+
+    const page = new Page(mockPage, 'puppeteer');
+    await expect(page.navigationState()).resolves.toEqual({
+      isLoading: true,
+    });
+
+    mockPage.evaluate.mockResolvedValue('complete');
+    await expect(page.navigationState()).resolves.toEqual({
+      isLoading: false,
+    });
+  });
+});

--- a/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
@@ -149,8 +149,9 @@ describe('Page startMjpegStream', () => {
       quality: 90,
       encoding: 'base64',
     });
+    // Hub contract: MjpegStreamFrame.data is bare base64, never a data URL.
     expect(onFrame).toHaveBeenCalledWith({
-      data: 'data:image/jpeg;base64,cmVmcmVzaA==',
+      data: 'cmVmcmVzaA==',
       contentType: 'image/jpeg',
     });
 

--- a/packages/web-integration/tests/unit-test/platform.test.ts
+++ b/packages/web-integration/tests/unit-test/platform.test.ts
@@ -12,8 +12,9 @@ describe('webPlaygroundPlatform', () => {
     expect(prepared.agentFactory).toBeTypeOf('function');
     expect(createdAgent).toBeInstanceOf(StaticPageAgent);
     expect(prepared.preview).toMatchObject({
-      kind: 'screenshot',
+      kind: 'mjpeg',
       screenshotPath: '/screenshot',
+      mjpegPath: '/mjpeg',
     });
   });
 

--- a/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
+++ b/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { commonWebActionsForWebPage } from '../../src/web-page';
 
 describe('commonWebActionsForWebPage navigation actions', () => {
-  it('exposes forward and stop actions for manual browser chrome controls', async () => {
+  it('exposes forward without exposing stop as an action-space entry', async () => {
     const page = {
       goForward: vi.fn(async () => undefined),
       stopLoading: vi.fn(async () => undefined),
@@ -12,10 +12,10 @@ describe('commonWebActionsForWebPage navigation actions', () => {
     await actions
       .find((action) => action.name === 'GoForward')
       ?.call(undefined);
-    await actions.find((action) => action.name === 'Stop')?.call(undefined);
 
     expect(page.goForward).toHaveBeenCalledTimes(1);
-    expect(page.stopLoading).toHaveBeenCalledTimes(1);
+    expect(actions.find((action) => action.name === 'Stop')).toBeUndefined();
+    expect(page.stopLoading).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
+++ b/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { commonWebActionsForWebPage } from '../../src/web-page';
+
+describe('commonWebActionsForWebPage navigation actions', () => {
+  it('exposes forward and stop actions for manual browser chrome controls', async () => {
+    const page = {
+      goForward: vi.fn(async () => undefined),
+      stopLoading: vi.fn(async () => undefined),
+    };
+    const actions = commonWebActionsForWebPage(page as any);
+
+    await actions
+      .find((action) => action.name === 'GoForward')
+      ?.call(undefined);
+    await actions.find((action) => action.name === 'Stop')?.call(undefined);
+
+    expect(page.goForward).toHaveBeenCalledTimes(1);
+    expect(page.stopLoading).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('commonWebActionsForWebPage visual refresh', () => {
+  it('refreshes the preview after keyboard-only actions', async () => {
+    const page = {
+      keyboard: {
+        press: vi.fn(async () => undefined),
+      },
+      flushPendingVisualUpdate: vi.fn(async () => undefined),
+    };
+    const actions = commonWebActionsForWebPage(page as any);
+
+    await actions
+      .find((action) => action.name === 'KeyboardPress')
+      ?.call({ keyName: 'Meta+A' });
+
+    expect(page.keyboard.press).toHaveBeenCalledTimes(1);
+    expect(page.flushPendingVisualUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the preview after text input actions', async () => {
+    const page = {
+      keyboard: {
+        type: vi.fn(async () => undefined),
+      },
+      flushPendingVisualUpdate: vi.fn(async () => undefined),
+    };
+    const actions = commonWebActionsForWebPage(page as any);
+
+    await actions
+      .find((action) => action.name === 'Input')
+      ?.call({ value: 'hello', mode: 'typeOnly' });
+
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.flushPendingVisualUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,9 +543,15 @@ importers:
       '@midscene/visualizer':
         specifier: workspace:*
         version: link:../../packages/visualizer
+      '@midscene/web':
+        specifier: workspace:*
+        version: link:../../packages/web-integration
       antd:
         specifier: ^5.21.6
         version: 5.21.6(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      puppeteer:
+        specifier: 24.6.0
+        version: 24.6.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.5)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -571,6 +577,9 @@ importers:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
         version: 1.4.6(@rsbuild/core@1.6.15)
+      '@rsbuild/plugin-svgr':
+        specifier: ^1.2.2
+        version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
         version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)


### PR DESCRIPTION
## Summary

- Add an in-process MJPEG preview path backed by Chromium CDP `Page.startScreencast` for Web sessions.
- Route Web pointer, drag, keyboard, text input, and navigation controls through the existing Playground `/interact` path.
- Harden MJPEG recovery and Studio dev resolution so Web preview chunks do not depend on package `dist` rebuild timing.

## Details

- Web previews now advertise MJPEG streaming by default. The Playground server fans out interface-produced frames to MJPEG clients and falls back to screenshot polling when an interface does not provide a stream.
- Studio enables manual control for Web sessions, maps drag gestures to `DragAndDrop`, shows browser-style back/forward/reload/stop controls, and keeps the preview padded like desktop previews.
- Keyboard input is focused by the initial tap only. Follow-up text and `KeyboardPress` actions avoid synthetic clicks, so shortcuts such as Cmd+A then Backspace work. Keyboard-only visual changes trigger a delayed stream refresh frame after browser paint.
- The server can recreate factory-backed agents when screenshot, MJPEG, or interact requests encounter a closed Web page session.

## Validation

- `pnpm run lint`
- `pnpm exec nx run @midscene/web:test -- tests/unit-test/base-page-screencast.test.ts tests/unit-test/web-actions-navigation.test.ts tests/unit-test/platform.test.ts`
- `pnpm exec nx run @midscene/playground-app:test -- tests/device-interaction-layer.test.ts tests/preview-renderer-manual-drag.test.ts tests/preview-renderer-manual-input.test.ts tests/session-setup-panel.test.ts`
- `pnpm exec nx run @midscene/playground:test -- tests/unit/build-interact-params.test.ts tests/unit/server-interact.test.ts tests/unit/server-mjpeg-stream.test.ts`
- `pnpm exec nx run studio:test -- tests/android-runtime.test.ts tests/main-content-overview.test.tsx tests/main-content-web-navigation.test.tsx tests/main-content-preview-layout.test.ts tests/rsbuild-config.test.ts tests/sidebar-device-list.test.ts tests/connection-state-previews.test.ts`
- `pnpm exec nx run-many --target=build --projects=@midscene/web,@midscene/playground,@midscene/playground-app,@midscene/visualizer,studio --parallel`