### PR TITLE
fix(computer): build linux rdp-helper during release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,16 @@ jobs:
     - name: Install Puppeteer browser
       run: cd packages/web-integration && npx puppeteer browsers install chrome
 
+    - name: Install @midscene/computer native build deps (linux/x64)
+      # The prepublishOnly hook of @midscene/computer compiles
+      # bin/linux/rdp-helper on the publishing runner so the linux helper
+      # ships in the published tarball. The build needs cmake, pkg-config
+      # and FreeRDP 3 development headers. cmake/pkg-config are usually
+      # preinstalled on ubuntu-latest, but we install them defensively.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake pkg-config libfreerdp3-dev
+
     - name: release
       run: node ./scripts/release.js --version=${{ github.event.inputs.version }}
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,13 @@ jobs:
       # The prepublishOnly hook of @midscene/computer compiles
       # bin/linux/rdp-helper on the publishing runner so the linux helper
       # ships in the published tarball. The build needs cmake, pkg-config
-      # and FreeRDP 3 development headers. cmake/pkg-config are usually
-      # preinstalled on ubuntu-latest, but we install them defensively.
+      # and the FreeRDP 3 development headers. On Ubuntu 24.04 the dev
+      # metapackage is `freerdp3-dev` (universe) — note this is the
+      # FreeRDP source-package name, not `libfreerdp3-dev` (which does
+      # not exist on noble).
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake pkg-config libfreerdp3-dev
+        sudo apt-get install -y cmake pkg-config freerdp3-dev
 
     - name: release
       run: node ./scripts/release.js --version=${{ github.event.inputs.version }}

--- a/packages/computer/native/rdp/CMakeLists.txt
+++ b/packages/computer/native/rdp/CMakeLists.txt
@@ -26,7 +26,11 @@ if(WIN32)
   set(FREERDP_LIBRARIES ${FREERDP_CLIENT_LIBRARY} ${FREERDP_LIBRARY} ${WINPR_LIBRARY})
 else()
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(FREERDP REQUIRED IMPORTED_TARGET freerdp3 freerdp-client3)
+  # winpr3 is listed in Requires.private of freerdp3.pc, so on linux with
+  # the default --as-needed linker behavior pkg-config won't emit -lwinpr3
+  # unless we ask for it explicitly. session.cpp directly references WinPR
+  # symbols (e.g. WaitForMultipleObjects), so request it as a public dep.
+  pkg_check_modules(FREERDP REQUIRED IMPORTED_TARGET freerdp3 freerdp-client3 winpr3)
   set(FREERDP_INCLUDE_DIRS "")
   set(FREERDP_LIBRARIES PkgConfig::FREERDP)
 endif()

--- a/packages/computer/scripts/prepublish-native.mjs
+++ b/packages/computer/scripts/prepublish-native.mjs
@@ -6,13 +6,11 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, '..');
 
-if (process.env.CI) {
-  console.log(
-    '[prepublishOnly] Skipping native helper rebuild in CI. Published artifacts use the checked-in binaries under packages/computer/bin and include native sources for local rebuilds.',
-  );
-  process.exit(0);
-}
-
+// Build the native helpers for whichever platform we're publishing from.
+// build-native.mjs already skips targets that don't apply to the current
+// platform (e.g. phased-scroll only builds on darwin), so on a linux CI
+// runner this produces bin/linux/rdp-helper without touching the
+// checked-in darwin artifacts.
 const result = spawnSync('pnpm', ['run', 'build:native'], {
   cwd: packageRoot,
   stdio: 'inherit',


### PR DESCRIPTION
## Summary

- Published `@midscene/computer` tarballs previously only carried the darwin `rdp-helper`. Any linux consumer (e.g. FaaS deploys depending on `@midscene/computer` for protocol-level RDP) hit `RDP helper binary not found for linux. Run \`pnpm --filter @midscene/computer run build:native\` first.` at runtime and had to compile the helper out-of-band.
- This was confirmed against `1.7.5-beta-20260422015927.0` and is reproducible on every release through `1.7.9`: only `bin/darwin/rdp-helper` has ever been checked in, and the existing `prepublishOnly` hook short-circuits on CI (`if (process.env.CI) process.exit(0)`), so the linux helper is never produced at publish time.
- Drop that CI early-exit in `prepublish-native.mjs` and install `cmake` / `pkg-config` / `libfreerdp3-dev` on the release runner. `build-native.mjs` already gates each target on `process.platform`, so the linux runner only rebuilds `bin/linux/rdp-helper` and leaves the checked-in `bin/darwin/*` artifacts untouched. The `"files": ["bin", ...]` field then ships the freshly built helper in the npm tarball.
- After this lands, `npm i @midscene/computer` on linux/x64 will receive a working `rdp-helper` without any post-install build step.

## Out of scope

- windows and linux-arm64 still require local `pnpm --filter @midscene/computer run build:native`. A multi-OS matrix that uploads/aggregates per-platform helpers (mirroring `package_studio`) is the natural follow-up.
- Already-published versions (including `1.7.5-beta-20260422015927.0` and `1.7.9`) cannot be retroactively fixed; consumers must upgrade to a release built after this PR.

## Test plan

- [ ] Manually trigger `release.yml` with `version=prepatch` from this branch, then confirm the published `@midscene/computer` tarball contains `bin/linux/rdp-helper` (e.g. `npm pack @midscene/computer@<beta> && tar -tf *.tgz | grep linux`).
- [ ] On a clean linux/x64 host, install the resulting beta and run an RDP scenario to confirm `getRdpHelperBinaryPath()` resolves without throwing.
- [ ] Re-run an existing darwin-based smoke test to verify the checked-in `bin/darwin/rdp-helper` is unaffected.

## Validation commands run

- `pnpm run lint`