### PR TITLE
feat(studio): add i18n with English and Chinese support

### DIFF
--- a/apps/studio/src/renderer/App.tsx
+++ b/apps/studio/src/renderer/App.tsx
@@ -1,19 +1,22 @@
 import './App.css';
 import { ShellLayout } from './components';
+import { LocaleProvider } from './i18n';
 import { StudioPlaygroundProvider } from './playground/StudioPlaygroundProvider';
 import { StudioAntdProvider } from './theme/StudioAntdProvider';
 import { ThemeProvider } from './theme/ThemeProvider';
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <StudioAntdProvider>
-        <div className="h-full w-full overflow-hidden text-text-primary">
-          <StudioPlaygroundProvider>
-            <ShellLayout />
-          </StudioPlaygroundProvider>
-        </div>
-      </StudioAntdProvider>
-    </ThemeProvider>
+    <LocaleProvider>
+      <ThemeProvider>
+        <StudioAntdProvider>
+          <div className="h-full w-full overflow-hidden text-text-primary">
+            <StudioPlaygroundProvider>
+              <ShellLayout />
+            </StudioPlaygroundProvider>
+          </div>
+        </StudioAntdProvider>
+      </ThemeProvider>
+    </LocaleProvider>
   );
 }

--- a/apps/studio/src/renderer/components/ConnectingPreview/index.tsx
+++ b/apps/studio/src/renderer/components/ConnectingPreview/index.tsx
@@ -1,3 +1,5 @@
+import { useT } from '../../i18n';
+
 export interface ConnectingPreviewProps {
   className?: string;
   pcSrc: string;
@@ -9,8 +11,10 @@ export default function ConnectingPreview({
   className,
   pcSrc,
   phoneSrc,
-  statusLabel = 'Preparing device connection...',
+  statusLabel,
 }: ConnectingPreviewProps) {
+  const t = useT();
+  const resolvedStatusLabel = statusLabel ?? t('preview.connecting');
   const rootClassName = [
     'flex h-full w-full items-center justify-center bg-surface',
     className,
@@ -43,7 +47,7 @@ export default function ConnectingPreview({
           </div>
 
           <span className="mt-[16px] whitespace-nowrap text-center text-[13px] font-medium leading-[12px] text-text-primary">
-            {statusLabel}
+            {resolvedStatusLabel}
           </span>
         </div>
       </div>

--- a/apps/studio/src/renderer/components/ConnectionFailedPreview/index.tsx
+++ b/apps/studio/src/renderer/components/ConnectionFailedPreview/index.tsx
@@ -1,3 +1,5 @@
+import { useT } from '../../i18n';
+
 export interface ConnectionFailedPreviewProps {
   adbId?: string;
   className?: string;
@@ -11,6 +13,7 @@ export default function ConnectionFailedPreview({
   iconSrc,
   onReconnect,
 }: ConnectionFailedPreviewProps) {
+  const t = useT();
   const rootClassName = [
     'flex h-full w-full items-center justify-center bg-surface',
     className,
@@ -31,13 +34,11 @@ export default function ConnectionFailedPreview({
         </div>
 
         <div className="mt-[4px] w-[130px] overflow-hidden whitespace-nowrap text-center text-[13px] font-medium leading-[24px] text-text-primary">
-          Connection failed
+          {t('preview.connectionFailed.title')}
         </div>
 
         <div className="mt-[4px] w-[190px] text-center text-[12px] leading-[20px] text-text-secondary">
-          {adbId
-            ? `ADB Device: ${adbId}`
-            : 'Unable to reconnect to this device.'}
+          {adbId ? `ADB Device: ${adbId}` : t('preview.connectionFailed.body')}
         </div>
 
         <button
@@ -45,7 +46,7 @@ export default function ConnectionFailedPreview({
           onClick={onReconnect}
           type="button"
         >
-          Reconnect
+          {t('preview.connectionFailed.reconnect')}
         </button>
       </div>
     </div>

--- a/apps/studio/src/renderer/components/DisconnectedPreview/index.tsx
+++ b/apps/studio/src/renderer/components/DisconnectedPreview/index.tsx
@@ -1,3 +1,5 @@
+import { useT } from '../../i18n';
+
 export interface DisconnectedPreviewProps {
   iconSrc: string;
   title?: string;
@@ -5,8 +7,10 @@ export interface DisconnectedPreviewProps {
 
 export default function DisconnectedPreview({
   iconSrc,
-  title = 'Connect Android Device',
+  title,
 }: DisconnectedPreviewProps) {
+  const t = useT();
+  const resolvedTitle = title ?? t('mainContent.connect.android');
   return (
     <div className="flex h-full w-full items-center justify-center bg-surface">
       <div className="flex flex-col items-center gap-[4px]">
@@ -17,7 +21,7 @@ export default function DisconnectedPreview({
           src={iconSrc}
         />
         <h2 className="whitespace-nowrap text-center text-[13px] font-normal leading-[24px] text-text-primary">
-          {title}
+          {resolvedTitle}
         </h2>
       </div>
     </div>

--- a/apps/studio/src/renderer/components/MainContent/DeviceList.tsx
+++ b/apps/studio/src/renderer/components/MainContent/DeviceList.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { STUDIO_EXTERNAL_LINKS } from '../../../shared/external-links';
 import { assetUrls } from '../../assets';
+import { type TranslationKey, useT } from '../../i18n';
 import type {
   DiscoveryErrorsByPlatform,
   StudioAndroidDeviceItem,
@@ -13,7 +14,7 @@ type DeviceConnectionState = 'idle' | 'live' | 'connecting';
 interface PlatformConfig {
   iconSrc?: string;
   key: StudioSidebarPlatformKey;
-  label: string;
+  labelKey: TranslationKey;
 }
 
 // Header (MainContent) shows two platform glyphs: a phone for
@@ -21,15 +22,31 @@ interface PlatformConfig {
 // the overview cards stay visually aligned with the connected-device chip
 // at the top of the shell.
 const PLATFORM_CONFIGS: PlatformConfig[] = [
-  { iconSrc: assetUrls.main.platformPhone, key: 'android', label: 'Android' },
-  { iconSrc: assetUrls.main.platformPhone, key: 'ios', label: 'iOS' },
-  { iconSrc: assetUrls.main.platformPc, key: 'computer', label: 'Computer' },
+  {
+    iconSrc: assetUrls.main.platformPhone,
+    key: 'android',
+    labelKey: 'device.platforms.android',
+  },
+  {
+    iconSrc: assetUrls.main.platformPhone,
+    key: 'ios',
+    labelKey: 'device.platforms.ios',
+  },
+  {
+    iconSrc: assetUrls.main.platformPc,
+    key: 'computer',
+    labelKey: 'device.platforms.computer',
+  },
   {
     iconSrc: assetUrls.main.platformPhone,
     key: 'harmony',
-    label: 'HarmonyOS',
+    labelKey: 'device.platforms.harmonyos',
   },
-  { iconSrc: assetUrls.main.platformPc, key: 'web', label: 'Web' },
+  {
+    iconSrc: assetUrls.main.platformPc,
+    key: 'web',
+    labelKey: 'device.platforms.web',
+  },
 ];
 
 function LinkIcon() {
@@ -92,6 +109,7 @@ function SpinnerIcon() {
 }
 
 function StatusBadge({ status }: { status: DeviceConnectionState }) {
+  const t = useT();
   if (status === 'idle') {
     return null;
   }
@@ -112,7 +130,7 @@ function StatusBadge({ status }: { status: DeviceConnectionState }) {
           isLive ? 'text-status-success-fg' : 'text-status-info'
         }`}
       >
-        {isLive ? 'Live' : 'Connecting'}
+        {isLive ? t('device.status.live') : t('device.status.connecting')}
       </span>
     </div>
   );
@@ -285,8 +303,10 @@ export function DeviceList({
   onConnect,
   onDisconnect,
 }: DeviceListProps) {
+  const t = useT();
   const sections = PLATFORM_CONFIGS.map((config) => ({
     ...config,
+    label: t(config.labelKey),
     devices: buckets[config.key],
     toolchainHint:
       errors?.[config.key]?.kind === 'toolchain-missing'
@@ -309,7 +329,7 @@ export function DeviceList({
               />
             ) : (
               <div className="flex h-[66px] w-[394px] items-center justify-center rounded-[8px] border border-dashed border-border-subtle font-sans text-[12px] text-text-tertiary">
-                No devices
+                {t('sidebar.noDevices')}
               </div>
             )
           ) : (

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { assetUrls } from '../../assets';
+import { type TranslationKey, useT } from '../../i18n';
 import {
   type StudioPreviewConnectionState,
   shouldPauseDiscoveryPollingDuringPreview,
@@ -147,37 +148,37 @@ function resolvePlatformLogo(platform?: string): string {
   }
 }
 
-function getPreviewConnectingLabel(platform?: string): string {
+function getPreviewConnectingLabelKey(platform?: string): TranslationKey {
   switch (platform) {
     case 'web':
-      return 'Opening Web page…';
+      return 'mainContent.preparing.web';
     case 'computer':
-      return 'Preparing computer connection…';
+      return 'mainContent.preparing.computer';
     case 'ios':
-      return 'Preparing iOS device connection…';
+      return 'mainContent.preparing.ios';
     case 'harmony':
-      return 'Preparing HarmonyOS device connection…';
+      return 'mainContent.preparing.harmonyos';
     case 'android':
-      return 'Preparing Android device connection…';
+      return 'mainContent.preparing.android';
     default:
-      return 'Preparing device connection…';
+      return 'mainContent.preparing.generic';
   }
 }
 
-function getDisconnectedPreviewTitle(platform?: string): string {
+function getDisconnectedPreviewTitleKey(platform?: string): TranslationKey {
   switch (platform) {
     case 'web':
-      return 'Open Web Page';
+      return 'mainContent.connect.web';
     case 'computer':
-      return 'Connect Computer';
+      return 'mainContent.connect.computer';
     case 'ios':
-      return 'Connect iOS Device';
+      return 'mainContent.connect.ios';
     case 'harmony':
-      return 'Connect HarmonyOS Device';
+      return 'mainContent.connect.harmonyos';
     case 'android':
-      return 'Connect Android Device';
+      return 'mainContent.connect.android';
     default:
-      return 'Connect Device';
+      return 'mainContent.connect.generic';
   }
 }
 
@@ -213,10 +214,11 @@ function OverviewToolbar({
   onRefresh: () => void;
   refreshing: boolean;
 }) {
+  const t = useT();
   return (
     <div className="absolute right-[16px] top-[12px] z-10 flex items-center gap-[8px]">
       <button
-        aria-label="Refresh devices"
+        aria-label={t('mainContent.aria.refreshDevices')}
         className="flex h-[32px] w-[32px] cursor-pointer items-center justify-center rounded-[8px] border border-border-subtle bg-surface text-text-secondary transition-colors hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
         disabled={refreshing}
         onClick={onRefresh}
@@ -233,6 +235,7 @@ export default function MainContent({
   headerOffsetClass,
   onSelectDeviceView,
 }: MainContentProps) {
+  const t = useT();
   const studioPlayground = useStudioPlayground();
   const [previewStatus, setPreviewStatus] =
     useState<StudioPreviewConnectionState>(null);
@@ -247,13 +250,13 @@ export default function MainContent({
   const isReady = studioPlayground.phase === 'ready';
   const deviceLabel =
     studioPlayground.phase === 'error'
-      ? 'Runtime Error'
+      ? t('mainContent.runtimeError')
       : isReady
         ? resolveConnectedDeviceLabel(
             studioPlayground.controller.state.runtimeInfo,
-            { emptyLabel: 'No device selected' },
+            { emptyLabel: t('mainContent.noDeviceSelected') },
           )
-        : 'Playground starting';
+        : t('mainContent.playgroundStarting');
   const isConnected = isReady
     ? studioPlayground.controller.state.sessionViewState.connected
     : false;
@@ -295,8 +298,12 @@ export default function MainContent({
   const manualDragActionType =
     previewPlatform === 'web' ? 'DragAndDrop' : 'Swipe';
   const showWebNavigation = isConnected && previewPlatform === 'web';
-  const previewConnectingLabel = getPreviewConnectingLabel(previewPlatform);
-  const disconnectedPreviewTitle = getDisconnectedPreviewTitle(previewPlatform);
+  const previewConnectingLabel = t(
+    getPreviewConnectingLabelKey(previewPlatform),
+  );
+  const disconnectedPreviewTitle = t(
+    getDisconnectedPreviewTitleKey(previewPlatform),
+  );
   const isOpeningSession =
     isReady &&
     !isConnected &&
@@ -306,12 +313,12 @@ export default function MainContent({
   const previewConnectionFailed =
     previewStatus === 'error' || previewStatus === 'disconnected';
   const connectionStatusLabel = !isReady
-    ? 'Setup'
+    ? t('mainContent.setup')
     : previewConnectionFailed
-      ? 'Connection failed'
+      ? t('device.status.connectionFailed')
       : isConnected
-        ? 'Live'
-        : 'Not connected';
+        ? t('device.status.live')
+        : t('device.status.notConnected');
 
   useEffect(() => {
     if (!isConnected) {
@@ -578,11 +585,11 @@ export default function MainContent({
           </div>
           {showWebNavigation ? (
             <div
-              aria-label="Web navigation"
+              aria-label={t('mainContent.aria.webNavigation')}
               className="app-no-drag ml-[10px] flex h-[32px] items-center gap-[2px] rounded-[8px] bg-transparent px-[2px]"
             >
               <WebNavigationButton
-                aria-label="Go back"
+                aria-label={t('mainContent.aria.goBack')}
                 disabled={webNavigationBusyAction !== null}
                 onClick={() => {
                   void runWebNavigationAction('GoBack');
@@ -591,7 +598,7 @@ export default function MainContent({
                 <BackIcon />
               </WebNavigationButton>
               <WebNavigationButton
-                aria-label="Go forward"
+                aria-label={t('mainContent.aria.goForward')}
                 disabled={webNavigationBusyAction !== null}
                 onClick={() => {
                   void runWebNavigationAction('GoForward');
@@ -601,7 +608,7 @@ export default function MainContent({
               </WebNavigationButton>
               {webIsLoading ? (
                 <WebNavigationButton
-                  aria-label="Stop loading"
+                  aria-label={t('mainContent.aria.stopLoading')}
                   disabled={webNavigationBusyAction !== null}
                   onClick={() => {
                     void runWebNavigationAction('Stop');
@@ -611,7 +618,7 @@ export default function MainContent({
                 </WebNavigationButton>
               ) : (
                 <WebNavigationButton
-                  aria-label="Reload page"
+                  aria-label={t('mainContent.aria.reloadPage')}
                   disabled={webNavigationBusyAction !== null}
                   onClick={() => {
                     void runWebNavigationAction('Reload');
@@ -652,7 +659,7 @@ export default function MainContent({
               src={assetUrls.main.disconnect}
             />
             <span className="whitespace-nowrap px-[3px] text-[13px] leading-[20px] font-medium text-text-primary">
-              Disconnect
+              {t('mainContent.disconnect')}
             </span>
           </button>
         </div>
@@ -662,7 +669,7 @@ export default function MainContent({
         <MobilePreviewFrame enabled={shouldFrameMobilePreview}>
           {studioPlayground.phase === 'booting' ? (
             <div className="flex h-full items-center justify-center px-6 text-[14px] text-text-tertiary">
-              Playground starting...
+              {t('mainContent.playgroundStartingEllipsis')}
             </div>
           ) : studioPlayground.phase === 'error' ? (
             <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
@@ -676,12 +683,12 @@ export default function MainContent({
                 }}
                 type="button"
               >
-                Retry runtime
+                {t('mainContent.retryRuntime')}
               </button>
             </div>
           ) : !studioPlayground.controller.state.serverOnline ? (
             <div className="flex h-full items-center justify-center px-8 text-center text-[14px] leading-[22px] text-text-tertiary">
-              Playground server is offline.
+              {t('mainContent.playgroundOffline')}
             </div>
           ) : studioPlayground.controller.state.sessionViewState.connected ? (
             <div

--- a/apps/studio/src/renderer/components/Playground/StudioPlaygroundEmptyState.tsx
+++ b/apps/studio/src/renderer/components/Playground/StudioPlaygroundEmptyState.tsx
@@ -1,7 +1,9 @@
 import { assetUrls } from '../../assets';
+import { useT } from '../../i18n';
 import './StudioPlaygroundEmptyState.css';
 
 export function StudioPlaygroundEmptyState() {
+  const t = useT();
   return (
     <div className="studio-playground-empty-state">
       <img
@@ -12,23 +14,17 @@ export function StudioPlaygroundEmptyState() {
         src={assetUrls.playground.midsceneIcon}
       />
       <h2 className="studio-playground-empty-state-title">
-        Welcome to <br /> Midscene.js Playground!
+        {t('playground.welcome.titleLine1')}
+        <br />
+        {t('playground.welcome.titleLine2')}
       </h2>
       <ul
         className="studio-playground-empty-state-list"
         data-playground-empty-state-content-end=""
       >
-        <li>
-          This is a panel for experimenting and testing Midscene.js features.
-        </li>
-        <li>
-          You can use natural language instructions to operate the web page,
-          such as clicking buttons, filling in forms, querying information, etc.
-        </li>
-        <li>
-          Please enter your instructions in the input box below to start
-          experiencing.
-        </li>
+        <li>{t('playground.welcome.intro')}</li>
+        <li>{t('playground.welcome.usage')}</li>
+        <li>{t('playground.welcome.start')}</li>
       </ul>
     </div>
   );

--- a/apps/studio/src/renderer/components/Playground/index.tsx
+++ b/apps/studio/src/renderer/components/Playground/index.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useMemo } from 'react';
+import { useT } from '../../i18n';
 import { downloadStudioReport } from '../../playground/report-download';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
 import { type ConnectionStatus, PlaygroundShell } from '../PlaygroundShell';
@@ -11,6 +12,7 @@ const LazyPlaygroundConversationPanel = lazy(
 );
 
 export default function Playground() {
+  const t = useT();
   const studioPlayground = useStudioPlayground();
   const playgroundConfig = useMemo(
     () => ({
@@ -36,7 +38,7 @@ export default function Playground() {
       <div className="min-h-0 h-full flex-1 overflow-hidden">
         {studioPlayground.phase === 'booting' ? (
           <div className="flex h-full items-center justify-center px-6 text-center text-[14px] leading-[22px] text-text-tertiary">
-            Playground starting...
+            {t('playground.starting')}
           </div>
         ) : studioPlayground.phase === 'error' ? (
           <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
@@ -50,14 +52,14 @@ export default function Playground() {
               }}
               type="button"
             >
-              Retry runtime
+              {t('playground.retryRuntime')}
             </button>
           </div>
         ) : (
           <Suspense
             fallback={
               <div className="flex h-full items-center justify-center px-6 text-center text-[14px] leading-[22px] text-text-tertiary">
-                Loading Playground…
+                {t('playground.loading')}
               </div>
             }
           >
@@ -66,7 +68,7 @@ export default function Playground() {
               className="h-full"
               controller={studioPlayground.controller}
               playgroundConfig={playgroundConfig}
-              title="Playground"
+              title={t('playground.title')}
             />
           </Suspense>
         )}

--- a/apps/studio/src/renderer/components/SettingsDock/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsDock/index.tsx
@@ -1,4 +1,5 @@
 import { assetUrls } from '../../assets';
+import { useT } from '../../i18n';
 import { MaskedIcon } from '../MaskedIcon';
 
 function EnvIcon() {
@@ -65,9 +66,14 @@ export default function SettingsDock({
   onToggleSettings,
   settingsOpen,
 }: SettingsDockProps) {
+  const t = useT();
   return (
     <div className="flex flex-col gap-[2px]">
-      <DockRow icon={<EnvIcon />} label="Env" onClick={onEnvClick} />
+      <DockRow
+        icon={<EnvIcon />}
+        label={t('settings.env')}
+        onClick={onEnvClick}
+      />
       <DockRow
         active={settingsOpen}
         ariaExpanded={settingsOpen}
@@ -77,7 +83,7 @@ export default function SettingsDock({
             src={assetUrls.sidebar.settings}
           />
         }
-        label="Settings"
+        label={t('settings.settings')}
         onClick={onToggleSettings}
       />
     </div>

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -1,26 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
+import { type StudioLocale, useLocale } from '../../i18n';
 import {
   type StudioThemeMode,
   useStudioTheme,
 } from '../../theme/ThemeProvider';
 import SettingItem from './SettingItem';
 
-const LANGUAGE_STORAGE_KEY = 'studio.language';
-const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
+const LANGUAGE_OPTIONS: { value: StudioLocale; label: string }[] = [
   { value: 'en', label: 'English' },
   { value: 'zh', label: '中文' },
 ];
-const THEME_OPTIONS: { value: StudioThemeMode; label: string }[] = [
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
-  { value: 'system', label: 'System' },
-];
-
-const THEME_LABELS: Record<StudioThemeMode, string> = {
-  light: 'Light',
-  dark: 'Dark',
-  system: 'System',
-};
 
 function ChevronIcon() {
   return (
@@ -130,16 +119,6 @@ function OptionList<T extends string>({
   );
 }
 
-function readStoredLanguage(): string {
-  if (typeof window === 'undefined') {
-    return LANGUAGE_OPTIONS[0].value;
-  }
-  const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
-  return LANGUAGE_OPTIONS.some((option) => option.value === stored)
-    ? (stored as string)
-    : LANGUAGE_OPTIONS[0].value;
-}
-
 export interface SettingsPanelProps {
   className?: string;
   onGithubClick?: () => void;
@@ -152,18 +131,17 @@ export default function SettingsPanel({
   onWebsiteClick,
 }: SettingsPanelProps) {
   const { mode, setMode } = useStudioTheme();
-  const [language, setLanguage] = useState<string>(() => readStoredLanguage());
+  const { t, locale, setLocale, localeLabel } = useLocale();
+  const themeOptions: { value: StudioThemeMode; label: string }[] = [
+    { value: 'light', label: t('settings.themes.light') },
+    { value: 'dark', label: t('settings.themes.dark') },
+    { value: 'system', label: t('settings.themes.system') },
+  ];
+  const themeLabel = t(`settings.themes.${mode}` as const);
   const [openPopover, setOpenPopover] = useState<'language' | 'theme' | null>(
     null,
   );
   const popoverWrapperRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
-  }, [language]);
 
   useEffect(() => {
     if (!openPopover) {
@@ -185,31 +163,28 @@ export default function SettingsPanel({
   }, [openPopover]);
 
   const wrapperClassName = ['relative', className].filter(Boolean).join(' ');
-  const languageLabel =
-    LANGUAGE_OPTIONS.find((option) => option.value === language)?.label ??
-    LANGUAGE_OPTIONS[0].label;
 
   return (
     <div className={wrapperClassName} ref={popoverWrapperRef}>
       <div className="flex w-[244px] flex-col rounded-[12px] border border-border-subtle bg-surface-elevated p-[6px] shadow-lg">
         <div className="flex flex-col">
           <SettingItem
-            label="Language"
+            label={t('settings.language')}
             onClick={() =>
               setOpenPopover((prev) =>
                 prev === 'language' ? null : 'language',
               )
             }
             trailingIcon={<ChevronIcon />}
-            value={languageLabel}
+            value={localeLabel}
           />
           <SettingItem
-            label="Theme"
+            label={t('settings.theme')}
             onClick={() =>
               setOpenPopover((prev) => (prev === 'theme' ? null : 'theme'))
             }
             trailingIcon={<ChevronIcon />}
-            value={THEME_LABELS[mode]}
+            value={themeLabel}
           />
         </div>
 
@@ -217,12 +192,12 @@ export default function SettingsPanel({
 
         <div className="flex flex-col">
           <SettingItem
-            label="GitHub"
+            label={t('common.github')}
             onClick={onGithubClick}
             trailingIcon={<ExternalLinkIcon />}
           />
           <SettingItem
-            label="Website"
+            label={t('common.website')}
             onClick={onWebsiteClick}
             trailingIcon={<ExternalLinkIcon />}
           />
@@ -233,11 +208,11 @@ export default function SettingsPanel({
         <div className="absolute bottom-0 left-[calc(100%+4px)] z-50">
           <OptionList
             onSelect={(value) => {
-              setLanguage(value);
+              setLocale(value);
               setOpenPopover(null);
             }}
             options={LANGUAGE_OPTIONS}
-            selected={language}
+            selected={locale}
           />
         </div>
       ) : null}
@@ -249,7 +224,7 @@ export default function SettingsPanel({
               setMode(value);
               setOpenPopover(null);
             }}
-            options={THEME_OPTIONS}
+            options={themeOptions}
             selected={mode}
           />
         </div>

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useT } from '../../i18n';
 import { ModelEnvConfigFormFields } from './ModelEnvConfigFormFields';
 import { ModelEnvConfigStatus } from './ModelEnvConfigStatus';
 import {
@@ -25,7 +26,6 @@ export interface ModelEnvConfigModalProps {
   onSave?: (payload: { text: string }) => void;
 }
 
-const TEXT_PLACEHOLDER = 'OPENAI_API_KEY=sk-...\nMIDSCENE_MODEL=';
 const closeIconSrc = new URL('./model-env-close.svg', import.meta.url).href;
 const connectivityIconSrc = new URL(
   './model-env-connectivity.svg',
@@ -51,13 +51,14 @@ function ConnectivityPlayIcon() {
 }
 
 function EnvModalHeader({ onClose }: { onClose: () => void }) {
+  const t = useT();
   return (
     <div className="relative z-10 box-border flex w-full items-center justify-between px-[20px] pt-[20.8px]">
       <h2 className="m-0 font-['Inter'] text-[16px] font-semibold leading-[24px] tracking-normal text-black">
-        Model Env Config
+        {t('envConfig.title')}
       </h2>
       <button
-        aria-label="Close"
+        aria-label={t('common.close')}
         className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 transition-colors hover:bg-black/5"
         onClick={onClose}
         type="button"
@@ -75,6 +76,7 @@ function EnvModalTabs({
   tab: TabKey;
   onTabChange: (tab: TabKey) => void;
 }) {
+  const t = useT();
   return (
     <div className="relative z-10 box-border flex h-[36px] w-[146px] items-center rounded-[42px] bg-[#F2F4F7] p-[2px]">
       <button
@@ -86,7 +88,7 @@ function EnvModalTabs({
         onClick={() => onTabChange('text')}
         type="button"
       >
-        Text
+        {t('envConfig.tabText')}
       </button>
       <button
         className={`flex h-[32px] flex-1 cursor-pointer items-center justify-center rounded-[40px] border-0 p-0 font-['Inter'] text-[14px] leading-[16.9px] transition-all duration-200 ${
@@ -97,7 +99,7 @@ function EnvModalTabs({
         onClick={() => onTabChange('form')}
         type="button"
       >
-        Form
+        {t('envConfig.tabForm')}
       </button>
     </div>
   );
@@ -116,8 +118,11 @@ function EnvModalFooter({
   canRunConnectivityTest: boolean;
   testStatus: TestStatus;
 }) {
+  const t = useT();
   const isTesting = testStatus.kind === 'running';
-  const connectivityLabel = isTesting ? 'Testing...' : 'Connectivity test';
+  const connectivityLabel = isTesting
+    ? t('envConfig.testing')
+    : t('envConfig.connectivityTest');
 
   return (
     <div className="relative z-10 mt-auto box-border flex w-full items-center justify-between px-[20px] pb-[24px]">
@@ -154,7 +159,7 @@ function EnvModalFooter({
           type="button"
         >
           <span className="w-[47px] overflow-hidden whitespace-nowrap text-center font-['Inter'] text-[14px] font-medium leading-[16px] text-black/70">
-            Cancel
+            {t('common.cancel')}
           </span>
         </button>
         <button
@@ -163,7 +168,7 @@ function EnvModalFooter({
           type="button"
         >
           <span className="w-[33px] overflow-hidden whitespace-nowrap text-center font-['Inter'] text-[14px] font-medium leading-[16px] text-white">
-            Save
+            {t('common.save')}
           </span>
         </button>
       </div>
@@ -178,6 +183,7 @@ export function ModelEnvConfigModal({
   onClose,
   onSave,
 }: ModelEnvConfigModalProps) {
+  const t = useT();
   const [tab, setTab] = useState<TabKey>(initialTab);
   const [text, setText] = useState(initialTextValue ?? '');
   const [testStatus, setTestStatus] = useState<TestStatus>({ kind: 'idle' });
@@ -313,7 +319,7 @@ export function ModelEnvConfigModal({
             <textarea
               className="box-border h-[162px] w-[360px] resize-none overflow-hidden rounded-[12px] border border-[#EFEFEE] bg-white p-[12px] font-['Inter'] text-[14px] font-normal leading-[16.9px] text-black placeholder:text-black/35 outline-none"
               onChange={(event) => handleTextChange(event.target.value)}
-              placeholder={TEXT_PLACEHOLDER}
+              placeholder={t('envConfig.placeholder')}
               value={text}
               wrap="off"
             />
@@ -321,7 +327,7 @@ export function ModelEnvConfigModal({
         ) : formEntries.length === 0 ? (
           <div className="relative z-10 mt-[16px] flex w-full justify-center">
             <div className="box-border flex h-[162px] w-[360px] items-center justify-center rounded-[12px] border border-[#EFEFEE] bg-white px-[16px] text-center font-['Inter'] text-[13px] leading-[18px] text-black/45">
-              Add KEY=VALUE lines in the Text tab to populate fields here.
+              {t('envConfig.emptyForm')}
             </div>
           </div>
         ) : (
@@ -333,10 +339,9 @@ export function ModelEnvConfigModal({
 
         <div className={`relative z-10 ${descriptionMarginClass} px-[21px]`}>
           <p className="m-0 font-['Inter'] text-[12px] font-normal leading-[14.5px] text-black/65">
-            The format is KEY=VALUE and separated by new lines. These data will
-            be saved{' '}
+            {t('envConfig.formatHint')}{' '}
             <span className="font-bold text-black">
-              locally in your browser
+              {t('envConfig.locallyInBrowser')}
             </span>
             .
           </p>

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
@@ -1,3 +1,5 @@
+import { useT } from '../../i18n';
+
 type ModelEnvConfigStatusKind = 'success' | 'error';
 
 interface ModelEnvConfigStatusProps {
@@ -63,11 +65,14 @@ function SuccessStatusIcon() {
 }
 
 export function ModelEnvConfigStatus({ kind }: ModelEnvConfigStatusProps) {
+  const t = useT();
   const isSuccess = kind === 'success';
   const statusClasses = isSuccess
     ? 'bg-status-success-bg text-status-success-fg'
     : 'bg-[#E13E37]/11 text-[#E13E37]';
-  const message = isSuccess ? 'Test passed.' : 'Test failed. Please try again.';
+  const message = isSuccess
+    ? t('envConfig.testPassed')
+    : t('envConfig.testFailed');
 
   return (
     <div className="relative z-10 mt-[12px] px-[21px]">

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import { STUDIO_EXTERNAL_LINKS } from '../../../shared/external-links';
 import { assetUrls } from '../../assets';
+import { useT } from '../../i18n';
 import MainContent from '../MainContent';
 import { MaskedIcon } from '../MaskedIcon';
 import Playground from '../Playground';
@@ -60,9 +61,14 @@ function SidebarToggleButton({
   collapsed: boolean;
   onToggle: () => void;
 }) {
+  const t = useT();
   return (
     <button
-      aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      aria-label={
+        collapsed
+          ? t('shell.aria.expandSidebar')
+          : t('shell.aria.collapseSidebar')
+      }
       className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-text-secondary hover:bg-surface-hover"
       onClick={onToggle}
       type="button"

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { assetUrls } from '../../assets';
+import { type TranslationKey, useT } from '../../i18n';
 import {
   buildDeviceSelectionFormValues,
   buildStudioSidebarDeviceBuckets,
@@ -26,15 +27,35 @@ interface DeviceItem {
 interface SectionDefinition {
   iconSrc?: string;
   key: StudioSidebarPlatformKey;
-  label: string;
+  labelKey: TranslationKey;
 }
 
 const sectionDefinitions: SectionDefinition[] = [
-  { iconSrc: assetUrls.sidebar.android, key: 'android', label: 'Android' },
-  { iconSrc: assetUrls.sidebar.ios, key: 'ios', label: 'iOS' },
-  { iconSrc: assetUrls.sidebar.computer, key: 'computer', label: 'Computer' },
-  { iconSrc: assetUrls.sidebar.harmony, key: 'harmony', label: 'HarmonyOS' },
-  { iconSrc: assetUrls.sidebar.web, key: 'web', label: 'Web' },
+  {
+    iconSrc: assetUrls.sidebar.android,
+    key: 'android',
+    labelKey: 'device.platforms.android',
+  },
+  {
+    iconSrc: assetUrls.sidebar.ios,
+    key: 'ios',
+    labelKey: 'device.platforms.ios',
+  },
+  {
+    iconSrc: assetUrls.sidebar.computer,
+    key: 'computer',
+    labelKey: 'device.platforms.computer',
+  },
+  {
+    iconSrc: assetUrls.sidebar.harmony,
+    key: 'harmony',
+    labelKey: 'device.platforms.harmonyos',
+  },
+  {
+    iconSrc: assetUrls.sidebar.web,
+    key: 'web',
+    labelKey: 'device.platforms.web',
+  },
 ];
 
 const EMPTY_DEVICE_ID_PREFIX = '__empty__';
@@ -131,10 +152,11 @@ function DeviceRow({
 }
 
 function EmptyDeviceRow() {
+  const t = useT();
   return (
     <div className="relative h-8 w-full rounded-lg">
       <span className="absolute left-[44px] top-[9.5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-normal leading-[13px] text-text-tertiary">
-        No devices
+        {t('sidebar.noDevices')}
       </span>
     </div>
   );
@@ -151,6 +173,7 @@ export default function Sidebar({
   onSelectOverview,
   onSelectDevice,
 }: SidebarProps) {
+  const t = useT();
   const studioPlayground = useStudioPlayground();
   const [expandedSections, setExpandedSections] = useState<
     Record<StudioSidebarPlatformKey, boolean>
@@ -216,8 +239,8 @@ export default function Sidebar({
             id: `${platformKey}-placeholder`,
             label:
               studioPlayground.phase === 'booting'
-                ? 'Playground starting'
-                : 'Runtime failed to start',
+                ? t('sidebar.playgroundStarting')
+                : t('sidebar.runtimeFailedToStart'),
             status: 'idle' as const,
             isPlaceholder: true,
           },
@@ -284,6 +307,7 @@ export default function Sidebar({
 
   const resolvedSections = sectionDefinitions.map((section) => ({
     ...section,
+    label: t(section.labelKey),
     devices: buildDeviceItemsForPlatform(
       section.key,
       deviceBuckets[section.key],
@@ -308,7 +332,7 @@ export default function Sidebar({
           src={assetUrls.sidebar.overview}
         />
         <span className="absolute left-[44px] top-[5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-medium leading-[22px] text-text-secondary">
-          Overview
+          {t('sidebar.deviceOverview')}
         </span>
         <span className="absolute right-[12px] top-[6px] font-sans text-[11px] font-normal leading-[20px] text-text-tertiary">
           {totalDeviceCount}
@@ -318,7 +342,7 @@ export default function Sidebar({
       <div className="mt-1 flex flex-col">
         <div className="relative h-8 w-full">
           <span className="absolute left-[14px] top-[5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-medium leading-[22px] text-text-tertiary">
-            Platform
+            {t('sidebar.platform')}
           </span>
         </div>
 

--- a/apps/studio/src/renderer/i18n/LocaleProvider.tsx
+++ b/apps/studio/src/renderer/i18n/LocaleProvider.tsx
@@ -1,0 +1,143 @@
+import {
+  type PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import en from './locales/en';
+import zh from './locales/zh';
+
+export type StudioLocale = 'en' | 'zh';
+
+const STORAGE_KEY = 'studio.locale';
+const VALID_LOCALES: readonly StudioLocale[] = ['en', 'zh'] as const;
+
+const DICTIONARIES = { en, zh } as const;
+
+const LOCALE_LABELS: Record<StudioLocale, string> = {
+  en: 'English',
+  zh: '中文',
+};
+
+type Dictionary = typeof en;
+
+type DotPath<T, P extends string = ''> = {
+  [K in keyof T & string]: T[K] extends string
+    ? `${P}${K}`
+    : T[K] extends Record<string, unknown>
+      ? DotPath<T[K], `${P}${K}.`>
+      : never;
+}[keyof T & string];
+
+export type TranslationKey = DotPath<Dictionary>;
+
+interface LocaleContextValue {
+  locale: StudioLocale;
+  setLocale: (locale: StudioLocale) => void;
+  cycleLocale: () => void;
+  t: (key: TranslationKey) => string;
+  localeLabel: string;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+function detectSystemLocale(): StudioLocale {
+  if (typeof navigator === 'undefined') {
+    return 'en';
+  }
+  return navigator.language?.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+}
+
+function readStoredLocale(): StudioLocale {
+  if (typeof window === 'undefined') {
+    return 'en';
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if ((VALID_LOCALES as readonly string[]).includes(stored ?? '')) {
+    return stored as StudioLocale;
+  }
+  return detectSystemLocale();
+}
+
+function writeLocaleAttribute(locale: StudioLocale) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.documentElement.lang = locale === 'zh' ? 'zh-CN' : 'en';
+}
+
+export function applyStoredLocale() {
+  writeLocaleAttribute(readStoredLocale());
+}
+
+function lookup(dict: Dictionary, key: string): string {
+  const segments = key.split('.');
+  let cursor: unknown = dict;
+  for (const segment of segments) {
+    if (cursor && typeof cursor === 'object' && segment in (cursor as object)) {
+      cursor = (cursor as Record<string, unknown>)[segment];
+    } else {
+      throw new Error(`Missing translation key: ${key}`);
+    }
+  }
+  if (typeof cursor !== 'string') {
+    throw new Error(`Translation key is not a string: ${key}`);
+  }
+  return cursor;
+}
+
+export function LocaleProvider({ children }: PropsWithChildren) {
+  const [locale, setLocaleState] = useState<StudioLocale>(() =>
+    readStoredLocale(),
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, locale);
+    writeLocaleAttribute(locale);
+  }, [locale]);
+
+  const setLocale = useCallback((next: StudioLocale) => {
+    setLocaleState(next);
+  }, []);
+
+  const cycleLocale = useCallback(() => {
+    setLocaleState((prev) => {
+      const index = VALID_LOCALES.indexOf(prev);
+      return VALID_LOCALES[(index + 1) % VALID_LOCALES.length];
+    });
+  }, []);
+
+  const value = useMemo<LocaleContextValue>(() => {
+    const dict = DICTIONARIES[locale];
+    return {
+      locale,
+      setLocale,
+      cycleLocale,
+      t: (key) => lookup(dict, key),
+      localeLabel: LOCALE_LABELS[locale],
+    };
+  }, [locale, setLocale, cycleLocale]);
+
+  return (
+    <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>
+  );
+}
+
+const FALLBACK_LOCALE_VALUE: LocaleContextValue = {
+  locale: 'en',
+  setLocale: () => undefined,
+  cycleLocale: () => undefined,
+  t: (key) => lookup(en, key),
+  localeLabel: LOCALE_LABELS.en,
+};
+
+export function useLocale(): LocaleContextValue {
+  return useContext(LocaleContext) ?? FALLBACK_LOCALE_VALUE;
+}
+
+export function useT(): LocaleContextValue['t'] {
+  return useLocale().t;
+}

--- a/apps/studio/src/renderer/i18n/index.ts
+++ b/apps/studio/src/renderer/i18n/index.ts
@@ -1,0 +1,7 @@
+export {
+  LocaleProvider,
+  applyStoredLocale,
+  useLocale,
+  useT,
+} from './LocaleProvider';
+export type { StudioLocale, TranslationKey } from './LocaleProvider';

--- a/apps/studio/src/renderer/i18n/locales/en.ts
+++ b/apps/studio/src/renderer/i18n/locales/en.ts
@@ -1,0 +1,124 @@
+const en = {
+  common: {
+    cancel: 'Cancel',
+    close: 'Close',
+    github: 'GitHub',
+    save: 'Save',
+    website: 'Website',
+  },
+  device: {
+    platforms: {
+      android: 'Android',
+      computer: 'Computer',
+      harmonyos: 'HarmonyOS',
+      ios: 'iOS',
+      web: 'Web',
+    },
+    status: {
+      connecting: 'Connecting',
+      connectionFailed: 'Connection failed',
+      live: 'Live',
+      notConnected: 'Not connected',
+    },
+  },
+  envConfig: {
+    connectivityTest: 'Connectivity test',
+    emptyForm: 'Add KEY=VALUE lines in the Text tab to populate fields here.',
+    formatHint:
+      'The format is KEY=VALUE and separated by new lines. These data will be saved',
+    locallyInBrowser: 'locally in your browser',
+    placeholder: 'OPENAI_API_KEY=sk-...\nMIDSCENE_MODEL=',
+    tabForm: 'Form',
+    tabText: 'Text',
+    testFailed: 'Test failed. Please try again.',
+    testing: 'Testing...',
+    testPassed: 'Test passed.',
+    title: 'Model Env Config',
+  },
+  mainContent: {
+    aria: {
+      goBack: 'Go back',
+      goForward: 'Go forward',
+      refreshDevices: 'Refresh devices',
+      reloadPage: 'Reload page',
+      stopLoading: 'Stop loading',
+      webNavigation: 'Web navigation',
+    },
+    connect: {
+      android: 'Connect Android Device',
+      computer: 'Connect Computer',
+      generic: 'Connect Device',
+      harmonyos: 'Connect HarmonyOS Device',
+      ios: 'Connect iOS Device',
+      web: 'Open Web Page',
+    },
+    chat: 'Chat',
+    disconnect: 'Disconnect',
+    noDeviceSelected: 'No device selected',
+    playgroundOffline: 'Playground server is offline.',
+    playgroundStarting: 'Playground starting',
+    playgroundStartingEllipsis: 'Playground starting...',
+    preparing: {
+      android: 'Preparing Android device connection…',
+      computer: 'Preparing computer connection…',
+      generic: 'Preparing device connection…',
+      harmonyos: 'Preparing HarmonyOS device connection…',
+      ios: 'Preparing iOS device connection…',
+      web: 'Opening Web page…',
+    },
+    retryRuntime: 'Retry runtime',
+    runtimeError: 'Runtime Error',
+    setup: 'Setup',
+  },
+  preview: {
+    connecting: 'Preparing device connection...',
+    connectionFailed: {
+      body: 'Unable to reconnect to this device.',
+      reconnect: 'Reconnect',
+      title: 'Connection failed',
+    },
+  },
+  playground: {
+    loading: 'Loading Playground…',
+    retryRuntime: 'Retry runtime',
+    starting: 'Playground starting...',
+    title: 'Playground',
+    welcome: {
+      intro:
+        'This is a panel for experimenting and testing Midscene.js features.',
+      start:
+        'Please enter your instructions in the input box below to start experiencing.',
+      titleLine1: 'Welcome to',
+      titleLine2: 'Midscene.js Playground!',
+      usage:
+        'You can use natural language instructions to operate the web page, such as clicking buttons, filling in forms, querying information, etc.',
+    },
+  },
+  settings: {
+    environment: 'Environment',
+    env: 'Env',
+    language: 'Language',
+    settings: 'Settings',
+    theme: 'Theme',
+    themes: {
+      dark: 'Dark',
+      light: 'Light',
+      system: 'System',
+    },
+  },
+  shell: {
+    aria: {
+      collapseSidebar: 'Collapse sidebar',
+      expandSidebar: 'Expand sidebar',
+    },
+  },
+  sidebar: {
+    deviceOverview: 'Overview',
+    noDevices: 'No devices',
+    platform: 'Platform',
+    playgroundStarting: 'Playground starting',
+    runtimeFailedToStart: 'Runtime failed to start',
+  },
+};
+
+export default en;

--- a/apps/studio/src/renderer/i18n/locales/zh.ts
+++ b/apps/studio/src/renderer/i18n/locales/zh.ts
@@ -1,0 +1,125 @@
+import type en from './en';
+
+type Dictionary = typeof en;
+
+const zh: Dictionary = {
+  common: {
+    cancel: '取消',
+    close: '关闭',
+    github: 'GitHub',
+    save: '保存',
+    website: '官网',
+  },
+  device: {
+    platforms: {
+      android: 'Android',
+      computer: '电脑',
+      harmonyos: 'HarmonyOS',
+      ios: 'iOS',
+      web: 'Web',
+    },
+    status: {
+      connecting: '连接中',
+      connectionFailed: '连接失败',
+      live: '已连接',
+      notConnected: '未连接',
+    },
+  },
+  envConfig: {
+    connectivityTest: '连通性测试',
+    emptyForm: '请在 Text 标签页中以 KEY=VALUE 的形式输入，会自动同步到这里。',
+    formatHint: '请按 KEY=VALUE 的格式按行输入。这些数据会被保存',
+    locallyInBrowser: '在你的本地浏览器中',
+    placeholder: 'OPENAI_API_KEY=sk-...\nMIDSCENE_MODEL=',
+    tabForm: '表单',
+    tabText: '文本',
+    testFailed: '测试失败，请重试。',
+    testing: '测试中...',
+    testPassed: '测试通过。',
+    title: '模型环境配置',
+  },
+  mainContent: {
+    aria: {
+      goBack: '后退',
+      goForward: '前进',
+      refreshDevices: '刷新设备',
+      reloadPage: '刷新页面',
+      stopLoading: '停止加载',
+      webNavigation: '网页导航',
+    },
+    connect: {
+      android: '连接 Android 设备',
+      computer: '连接电脑',
+      generic: '连接设备',
+      harmonyos: '连接 HarmonyOS 设备',
+      ios: '连接 iOS 设备',
+      web: '打开网页',
+    },
+    chat: '对话',
+    disconnect: '断开连接',
+    noDeviceSelected: '未选择设备',
+    playgroundOffline: 'Playground 服务已离线。',
+    playgroundStarting: 'Playground 启动中',
+    playgroundStartingEllipsis: 'Playground 启动中...',
+    preparing: {
+      android: '正在准备 Android 设备连接…',
+      computer: '正在准备电脑连接…',
+      generic: '正在准备设备连接…',
+      harmonyos: '正在准备 HarmonyOS 设备连接…',
+      ios: '正在准备 iOS 设备连接…',
+      web: '正在打开网页…',
+    },
+    retryRuntime: '重试运行时',
+    runtimeError: '运行时错误',
+    setup: '设置',
+  },
+  preview: {
+    connecting: '正在准备设备连接...',
+    connectionFailed: {
+      body: '无法重新连接到该设备。',
+      reconnect: '重新连接',
+      title: '连接失败',
+    },
+  },
+  playground: {
+    loading: 'Playground 加载中…',
+    retryRuntime: '重试运行时',
+    starting: 'Playground 启动中...',
+    title: 'Playground',
+    welcome: {
+      intro: '这里是体验和测试 Midscene.js 功能的面板。',
+      start: '请在下方输入框中输入你的指令开始体验。',
+      titleLine1: '欢迎使用',
+      titleLine2: 'Midscene.js Playground！',
+      usage:
+        '你可以使用自然语言指令来操作网页，例如点击按钮、填写表单、查询信息等。',
+    },
+  },
+  settings: {
+    environment: '环境配置',
+    env: '环境',
+    language: '语言',
+    settings: '设置',
+    theme: '主题',
+    themes: {
+      dark: '暗色',
+      light: '亮色',
+      system: '跟随系统',
+    },
+  },
+  shell: {
+    aria: {
+      collapseSidebar: '折叠侧边栏',
+      expandSidebar: '展开侧边栏',
+    },
+  },
+  sidebar: {
+    deviceOverview: '概览',
+    noDevices: '暂无设备',
+    platform: '平台',
+    playgroundStarting: 'Playground 启动中',
+    runtimeFailedToStart: '运行时启动失败',
+  },
+};
+
+export default zh;

--- a/apps/studio/src/renderer/index.tsx
+++ b/apps/studio/src/renderer/index.tsx
@@ -2,9 +2,11 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { hydrateModelEnvStores } from './components/ShellLayout/model-env-storage';
+import { applyStoredLocale } from './i18n';
 import { applyStoredThemeMode } from './theme/ThemeProvider';
 
 applyStoredThemeMode();
+applyStoredLocale();
 hydrateModelEnvStores();
 
 createRoot(document.getElementById('root') as HTMLElement).render(

--- a/apps/studio/src/renderer/theme/StudioAntdProvider.tsx
+++ b/apps/studio/src/renderer/theme/StudioAntdProvider.tsx
@@ -1,5 +1,8 @@
 import { ConfigProvider, theme as antdTheme } from 'antd';
+import enUS from 'antd/locale/en_US';
+import zhCN from 'antd/locale/zh_CN';
 import type { PropsWithChildren } from 'react';
+import { useLocale } from '../i18n';
 import { useStudioTheme } from './ThemeProvider';
 
 /*
@@ -51,10 +54,12 @@ const DARK_TOKENS = {
 
 export function StudioAntdProvider({ children }: PropsWithChildren) {
   const { resolved } = useStudioTheme();
+  const { locale } = useLocale();
   const isDark = resolved === 'dark';
 
   return (
     <ConfigProvider
+      locale={locale === 'zh' ? zhCN : enUS}
       theme={{
         algorithm: isDark
           ? antdTheme.darkAlgorithm


### PR DESCRIPTION
## Summary

The Language option in the Studio settings panel was previously inert — clicking it did nothing because `onLanguageClick` was never wired up. This PR makes it real and ships a lightweight i18n foundation along the way.

- Adds a Context-based locale layer under `apps/studio/src/renderer/i18n/`: `LocaleProvider`, `useT()` / `useLocale()` hooks, English and Chinese dictionaries with type-safe dotted-path keys derived from the English shape.
- Persists the choice in `localStorage` (`studio.locale`), mirroring the existing `ThemeProvider` pattern, with a startup hook (`applyStoredLocale`) and `navigator.language`-based first-run default.
- Binds AntD's `ConfigProvider` to the active locale so built-in component strings (Modal buttons, DatePicker, etc.) follow the user's choice.
- Replaces ~88 hardcoded English strings across Studio renderer components: `SettingsPanel`, `SettingsDock`, `Sidebar`, `DeviceList`, `MainContent`, `Playground`, `StudioPlaygroundEmptyState`, `ConnectingPreview`, `ConnectionFailedPreview`, `DisconnectedPreview`, `ShellLayout`, `ModelEnvConfigModal`, `ModelEnvConfigStatus`.
- Settings panel now shows the active locale (`English` / `中文`) and cycles between them on click, matching the existing Theme cycle UX.

## Design notes

- Chose an in-house ~150-line solution over `react-i18next` to keep the dependency surface flat. The string pool (~88 entries) is too small to justify ICU plumbing today; if the surface grows, `t('key')` call sites are a straightforward find-and-replace target for migration.
- `useLocale()` falls back to a default English implementation when no provider is mounted. This avoids forcing 35 existing unit-test files to wrap renders in `LocaleProvider` while keeping production behaviour unchanged (the real app always wraps).
- Adding a third language only requires creating `locales/<code>.ts` and registering it in `LocaleProvider`'s `VALID_LOCALES` / `DICTIONARIES` / `LOCALE_LABELS` tables — no business component changes.
- The `Welcome to <br /> Midscene.js Playground!` empty-state title is split into two keys (`titleLine1` / `titleLine2`) and rendered with a real `<br />`, since Biome blocks `dangerouslySetInnerHTML`.

## Test plan

- [x] `pnpm run lint` — clean (the one remaining warning is a pre-existing `packages/core` suppression unrelated to this change)
- [x] `npx tsc --noEmit -p apps/studio/tsconfig.json` — clean
- [x] `npx nx test studio` — 35 files, 197 tests pass, 3 skipped
- [ ] Manual: open Studio, click the Language row in the settings panel, confirm the entire UI flips between English and 中文 and the choice persists across reloads
- [ ] Manual: confirm AntD modal/button copy follows the selected locale