### PR TITLE
fix(core): disable thinking for locate calls

### DIFF
--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -237,6 +237,7 @@ export async function AiLocateElement(options: {
     const { content: rawResponseContent, usage } =
       await callAIWithStringResponse(msgs, modelConfig, {
         abortSignal: options.abortSignal,
+        deepThink: false,
       });
 
     debugInspect('auto-glm rawResponse:', rawResponseContent);
@@ -307,7 +308,7 @@ export async function AiLocateElement(options: {
     res = await callAIWithObjectResponse<AIElementResponse | [number, number]>(
       msgs,
       modelConfig,
-      { abortSignal: options.abortSignal },
+      { abortSignal: options.abortSignal, deepThink: false },
     );
   } catch (callError) {
     // Return error with usage and rawResponse if available
@@ -447,7 +448,7 @@ export async function AiLocateSection(options: {
     result = await callAIWithObjectResponse<AISectionLocatorResponse>(
       msgs,
       modelConfig,
-      { abortSignal: options.abortSignal },
+      { abortSignal: options.abortSignal, deepThink: false },
     );
   } catch (callError) {
     // Return error with usage and rawResponse if available

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -643,10 +643,12 @@ export async function callAIWithStringResponse(
   msgs: AIArgs,
   modelConfig: IModelConfig,
   options?: {
+    deepThink?: DeepThinkOption;
     abortSignal?: AbortSignal;
   },
 ): Promise<{ content: string; usage?: AIUsageInfo }> {
   const { content, usage } = await callAI(msgs, modelConfig, {
+    deepThink: options?.deepThink,
     abortSignal: options?.abortSignal,
   });
   return { content, usage };

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -29,6 +29,7 @@ import { assert, ifInBrowser } from '@midscene/shared/utils';
 import { jsonrepair } from 'jsonrepair';
 import OpenAI from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
+
 import type { Stream } from 'openai/streaming';
 import type { AIArgs } from '../../common';
 import { isAutoGLM, isUITars } from '../auto-glm/util';
@@ -42,6 +43,13 @@ import {
   isHardTimeoutError,
   resolveEffectiveTimeoutMs,
 } from './request-timeout';
+
+export interface CallAIOptions {
+  stream?: boolean;
+  onChunk?: StreamingCallback;
+  deepThink?: DeepThinkOption;
+  abortSignal?: AbortSignal;
+}
 
 async function createChatClient({
   modelConfig,
@@ -231,12 +239,7 @@ async function createChatClient({
 export async function callAI(
   messages: ChatCompletionMessageParam[],
   modelConfig: IModelConfig,
-  options?: {
-    stream?: boolean;
-    onChunk?: StreamingCallback;
-    deepThink?: DeepThinkOption;
-    abortSignal?: AbortSignal;
-  },
+  options?: CallAIOptions,
 ): Promise<{
   content: string;
   reasoning_content?: string;
@@ -607,20 +610,14 @@ export async function callAI(
 export async function callAIWithObjectResponse<T>(
   messages: ChatCompletionMessageParam[],
   modelConfig: IModelConfig,
-  options?: {
-    deepThink?: DeepThinkOption;
-    abortSignal?: AbortSignal;
-  },
+  options?: CallAIOptions,
 ): Promise<{
   content: T;
   contentString: string;
   usage?: AIUsageInfo;
   reasoning_content?: string;
 }> {
-  const response = await callAI(messages, modelConfig, {
-    deepThink: options?.deepThink,
-    abortSignal: options?.abortSignal,
-  });
+  const response = await callAI(messages, modelConfig, options);
   assert(response, 'empty response');
   const modelFamily = modelConfig.modelFamily;
   const jsonContent = safeParseJson(response.content, modelFamily);
@@ -642,15 +639,9 @@ export async function callAIWithObjectResponse<T>(
 export async function callAIWithStringResponse(
   msgs: AIArgs,
   modelConfig: IModelConfig,
-  options?: {
-    deepThink?: DeepThinkOption;
-    abortSignal?: AbortSignal;
-  },
+  options?: CallAIOptions,
 ): Promise<{ content: string; usage?: AIUsageInfo }> {
-  const { content, usage } = await callAI(msgs, modelConfig, {
-    deepThink: options?.deepThink,
-    abortSignal: options?.abortSignal,
-  });
+  const { content, usage } = await callAI(msgs, modelConfig, options);
   return { content, usage };
 }
 

--- a/packages/core/tests/unit-test/locate-thinking.test.ts
+++ b/packages/core/tests/unit-test/locate-thinking.test.ts
@@ -1,0 +1,77 @@
+import { AiLocateElement, AiLocateSection } from '@/ai-model/inspect';
+import { callAIWithObjectResponse } from '@/ai-model/service-caller/index';
+import type { IModelConfig } from '@midscene/shared/env';
+import { createFakeContext } from 'tests/utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ai-model/service-caller/index', () => ({
+  AIResponseParseError: class AIResponseParseError extends Error {
+    rawResponse: string;
+    usage: unknown;
+
+    constructor(message: string, rawResponse: string, usage?: unknown) {
+      super(message);
+      this.rawResponse = rawResponse;
+      this.usage = usage;
+    }
+  },
+  callAI: vi.fn(),
+  callAIWithObjectResponse: vi.fn(),
+  callAIWithStringResponse: vi.fn(),
+}));
+
+describe('locate model calls thinking defaults', () => {
+  const modelConfig: IModelConfig = {
+    modelFamily: 'qwen3-vl',
+    modelName: 'test-model',
+    modelDescription: 'test model',
+    intent: 'default',
+    reasoningEnabled: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forces deepThink=false for element locate calls', async () => {
+    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+      content: { bbox: [100, 100, 200, 200] },
+      contentString: '{"bbox":[100,100,200,200]}',
+      usage: undefined,
+      reasoning_content: undefined,
+    });
+
+    await AiLocateElement({
+      context: createFakeContext(),
+      targetElementDescription: 'submit button',
+      modelConfig,
+    });
+
+    expect(callAIWithObjectResponse).toHaveBeenCalledWith(
+      expect.any(Array),
+      modelConfig,
+      { abortSignal: undefined, deepThink: false },
+    );
+  });
+
+  it('forces deepThink=false for deepLocate section calls', async () => {
+    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+      content: { error: 'not found' },
+      contentString: '{"error":"not found"}',
+      usage: undefined,
+      reasoning_content: undefined,
+    });
+
+    await AiLocateSection({
+      context: createFakeContext(),
+      sectionDescription: 'toolbar area',
+      modelConfig,
+    });
+
+    expect(callAIWithObjectResponse).toHaveBeenCalledWith(
+      expect.any(Array),
+      modelConfig,
+      { abortSignal: undefined, deepThink: false },
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Users observed that `aiTap(..., { deepLocate: true })` would still allow model "thinking" to run because locate calls did not explicitly override reasoning; the locate flow should default to no thinking for speed and determinism.

### Description

- Force `deepThink: false` for locate-related model calls by passing the flag into `AiLocateElement`'s AutoGLM string branch and its object-response branch via `callAIWithObjectResponse` and `callAIWithStringResponse`.
- Force `deepThink: false` when running `AiLocateSection` for deepLocate section lookup so the section-detection phase also disables model thinking by default.
- Extend `callAIWithStringResponse` signature to accept a `deepThink` option so string-response calls can receive the same override as object-response calls.
- Add unit tests in `packages/core/tests/unit-test/locate-thinking.test.ts` to assert that element locate and deepLocate section calls pass `{ deepThink: false }` even when `modelConfig.reasoningEnabled` is true.

### Testing

- Ran linter: `pnpm run lint` which completed successfully after cleanup and fixes.
- Ran the focused unit tests: `pnpm --filter @midscene/core test -- tests/unit-test/locate-thinking.test.ts tests/unit-test/service-locate-deeplocate.test.ts` and both suites passed.
- Built the core package: `npx nx build @midscene/core` which succeeded and produced expected `dist` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0137d8e36c83249b943612129378f0)