### PR TITLE
fix(studio): anchor settings popovers to their rows

### DIFF
--- a/apps/studio/scripts/startup-smoke-ai.mjs
+++ b/apps/studio/scripts/startup-smoke-ai.mjs
@@ -242,7 +242,7 @@ async function main() {
     await sleep(1_500);
 
     await agent.aiAssert(
-      'A settings popup panel is visible and contains the items Language, Theme, GitHub, and Website.',
+      'A settings popup panel is visible and contains the items Theme, GitHub, and Website.',
     );
 
     await agent.destroy();

--- a/apps/studio/scripts/web-preview-e2e.mjs
+++ b/apps/studio/scripts/web-preview-e2e.mjs
@@ -192,10 +192,14 @@ async function createDefaultWebAgent(page) {
 
 async function assertWebPreview(page) {
   console.log('Waiting for Web preview stream...');
+  // The device header dropped the "Live" / "Not connected" chip in favour
+  // of the ConnectionStatusDot icon — connected state is now signalled by
+  // the dot's aria-label ("Device connected"). Disconnect button text is
+  // still rendered.
   await page.waitForFunction(
     () =>
       document.body.innerText.includes('Web') &&
-      document.body.innerText.includes('Live') &&
+      document.querySelector('[aria-label="Device connected"]') !== null &&
       document.body.innerText.includes('Disconnect'),
     { timeout: 60_000 },
   );

--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -108,8 +108,13 @@ const getAppIcon = () => {
   return icon;
 };
 
+// macOS `vibrancy` and Windows `backgroundMaterial: 'acrylic'` only show
+// through when the BrowserWindow's own backgroundColor is fully transparent
+// — any opaque fill paints over the OS material. Linux has no native
+// material, so keep the solid fallback there to avoid flashing the
+// desktop wallpaper before the renderer mounts.
 const getBackgroundColor = () =>
-  process.platform === 'darwin' ? '#f6f6f6' : '#eef1f5';
+  process.platform === 'linux' ? '#eef1f5' : '#00000000';
 
 const getTitleBarOverlay = (): TitleBarOverlay => ({
   color: '#00000000',
@@ -186,8 +191,10 @@ const createMainWindow = () => {
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
     titleBarOverlay:
       process.platform === 'darwin' ? undefined : getTitleBarOverlay(),
+    // Vertical centers of the 12px traffic lights line up with the sidebar
+    // collapse toggle (24px) at window y=30: (24 + 12/2 = 30).
     trafficLightPosition:
-      process.platform === 'darwin' ? { x: 18, y: 18 } : undefined,
+      process.platform === 'darwin' ? { x: 18, y: 24 } : undefined,
     vibrancy: process.platform === 'darwin' ? 'sidebar' : undefined,
     visualEffectState: process.platform === 'darwin' ? 'active' : undefined,
     backgroundMaterial: process.platform === 'win32' ? 'acrylic' : undefined,
@@ -315,7 +322,14 @@ const registerIpcHandlers = () => {
         return;
       }
       const isDark = nativeTheme.shouldUseDarkColors;
-      mainWindow.setBackgroundColor(isDark ? '#171717' : '#f6f6f6');
+      // Keep the window backgroundColor transparent on platforms that rely
+      // on OS material (macOS vibrancy / Windows acrylic); only Linux needs
+      // a solid theme-tinted fallback.
+      if (process.platform === 'linux') {
+        mainWindow.setBackgroundColor(isDark ? '#171717' : '#eef1f5');
+      } else {
+        mainWindow.setBackgroundColor('#00000000');
+      }
       if (process.platform === 'darwin') {
         mainWindow.setVibrancy('sidebar');
       }

--- a/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
+++ b/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
@@ -68,7 +68,7 @@ export function MobilePreviewFrame({
     .filter(Boolean)
     .join(' ');
   const viewportClassName = enabled
-    ? 'shrink-0 translate-y-[-26px] overflow-hidden'
+    ? 'shrink-0 translate-y-[-26px] overflow-hidden rounded-[8px] border border-border-subtle'
     : 'h-full w-full min-h-0 overflow-hidden';
   const viewportStyle = enabled
     ? viewportSize.width > 0 && viewportSize.height > 0

--- a/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
+++ b/apps/studio/src/renderer/components/MainContent/MobilePreviewFrame.tsx
@@ -3,11 +3,19 @@ import { fitMobilePreviewViewport } from './preview-layout';
 
 interface MobilePreviewFrameProps extends PropsWithChildren {
   enabled: boolean;
+  /**
+   * Width-over-height ratio of the connected device's actual screen.
+   * Passed in by MainContent once the playground reports the device
+   * size, so the viewport tracks reality instead of a hardcoded
+   * 9:19.5 assumption. Falls back to the default when undefined.
+   */
+  aspectRatio?: number;
 }
 
 export function MobilePreviewFrame({
   children,
   enabled,
+  aspectRatio,
 }: MobilePreviewFrameProps) {
   const stageRef = useRef<HTMLDivElement | null>(null);
   const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
@@ -25,7 +33,11 @@ export function MobilePreviewFrame({
 
     const updateViewportSize = () => {
       setViewportSize(
-        fitMobilePreviewViewport(stage.clientWidth, stage.clientHeight),
+        fitMobilePreviewViewport(
+          stage.clientWidth,
+          stage.clientHeight,
+          aspectRatio,
+        ),
       );
     };
 
@@ -46,7 +58,7 @@ export function MobilePreviewFrame({
     return () => {
       observer.disconnect();
     };
-  }, [enabled]);
+  }, [aspectRatio, enabled]);
 
   const rootClassName = [
     'h-full w-full min-h-0',

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -25,6 +25,7 @@ import ConnectingPreview from '../ConnectingPreview';
 import ConnectionFailedPreview from '../ConnectionFailedPreview';
 import DisconnectedPreview from '../DisconnectedPreview';
 import { MaskedIcon } from '../MaskedIcon';
+import { type ConnectionStatus, ConnectionStatusDot } from '../PlaygroundShell';
 import type { ShellActiveView } from '../ShellLayout/types';
 import { DeviceList } from './DeviceList';
 import { MobilePreviewFrame } from './MobilePreviewFrame';
@@ -213,11 +214,16 @@ function OverviewToolbar({
   onRefresh: () => void;
   refreshing: boolean;
 }) {
+  // Vertically centered in the 52px drag header strip so the button lines
+  // up with the sidebar collapse toggle on the opposite side. The
+  // surrounding header is `-webkit-app-region: drag`, so the button must
+  // explicitly opt back out via `app-no-drag` or the OS swallows hover
+  // and click events.
   return (
-    <div className="absolute right-[16px] top-[12px] z-10 flex items-center gap-[8px]">
+    <div className="app-no-drag absolute right-[16px] top-[10px] z-10 flex items-center gap-[8px]">
       <button
         aria-label="Refresh devices"
-        className="flex h-[32px] w-[32px] cursor-pointer items-center justify-center rounded-[8px] border border-border-subtle bg-surface text-text-secondary transition-colors hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
+        className="app-no-drag flex h-[32px] w-[32px] cursor-pointer items-center justify-center rounded-[8px] border-0 bg-transparent text-text-secondary transition-colors hover:bg-surface-hover-strong hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
         disabled={refreshing}
         onClick={onRefresh}
         type="button"
@@ -297,13 +303,11 @@ export default function MainContent({
     !isReady || !studioPlayground.controller.state.sessionViewState.connected;
   const previewConnectionFailed =
     previewStatus === 'error' || previewStatus === 'disconnected';
-  const connectionStatusLabel = !isReady
-    ? 'Setup'
-    : previewConnectionFailed
-      ? 'Connection failed'
-      : isConnected
-        ? 'Live'
-        : 'Not connected';
+  const connectionStatus: ConnectionStatus = previewConnectionFailed
+    ? 'failed'
+    : isConnected
+      ? 'connected'
+      : 'disconnected';
 
   useEffect(() => {
     if (!isConnected) {
@@ -538,36 +542,9 @@ export default function MainContent({
           <span className="ml-[8px] max-w-[134px] truncate text-[13px] leading-[22.1px] font-medium text-text-primary">
             {deviceLabel}
           </span>
-          <div
-            className={`ml-[8px] flex h-[28px] items-center gap-[8.04px] rounded-[16.07px] px-[10px] ${
-              previewConnectionFailed
-                ? 'bg-status-error-bg'
-                : isConnected
-                  ? 'bg-status-success-bg'
-                  : 'bg-surface-muted'
-            }`}
-          >
-            <div
-              className={`h-2 w-2 rounded-full border-2 border-transparent ${
-                previewConnectionFailed
-                  ? 'bg-status-error'
-                  : isConnected
-                    ? 'bg-status-success'
-                    : 'bg-status-idle'
-              }`}
-            />
-            <span
-              className={`text-[12.1px] leading-[12.1px] font-medium ${
-                previewConnectionFailed
-                  ? 'text-status-error'
-                  : isConnected
-                    ? 'text-status-success-fg'
-                    : 'text-text-tertiary'
-              }`}
-            >
-              {connectionStatusLabel}
-            </span>
-          </div>
+          <span className="ml-[8px] inline-flex shrink-0 items-center">
+            <ConnectionStatusDot status={connectionStatus} />
+          </span>
           {showWebNavigation ? (
             <div
               aria-label="Web navigation"

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -43,6 +43,7 @@ export interface MainContentProps {
   activeView: ShellActiveView;
   headerOffsetClass?: string;
   onSelectDeviceView?: () => void;
+  onSelectOverview?: () => void;
 }
 
 function RefreshIcon({ spinning }: { spinning?: boolean }) {
@@ -238,6 +239,7 @@ export default function MainContent({
   activeView,
   headerOffsetClass,
   onSelectDeviceView,
+  onSelectOverview,
 }: MainContentProps) {
   const studioPlayground = useStudioPlayground();
   const [previewStatus, setPreviewStatus] =
@@ -613,6 +615,10 @@ export default function MainContent({
               }
 
               void studioPlayground.controller.actions.destroySession();
+              // After tearing down the session, jump back to the
+              // Overview page so the user lands on a meaningful screen
+              // instead of an empty device pane.
+              onSelectOverview?.();
             }}
             type="button"
           >

--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -244,6 +244,20 @@ export default function MainContent({
   const studioPlayground = useStudioPlayground();
   const [previewStatus, setPreviewStatus] =
     useState<StudioPreviewConnectionState>(null);
+  // Connected device's intrinsic screen size, reported by PreviewRenderer
+  // once `/interface-info` lands. We feed its aspect ratio into the
+  // mobile preview frame so the rounded border tightly hugs the canvas
+  // instead of letterboxing with a hardcoded 9:19.5 assumption.
+  const [previewDeviceSize, setPreviewDeviceSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const previewAspectRatio =
+    previewDeviceSize &&
+    previewDeviceSize.width > 0 &&
+    previewDeviceSize.height > 0
+      ? previewDeviceSize.width / previewDeviceSize.height
+      : undefined;
   const [previewStatusText, setPreviewStatusText] = useState<string | null>(
     null,
   );
@@ -315,6 +329,7 @@ export default function MainContent({
     if (!isConnected) {
       setPreviewStatus(null);
       setPreviewStatusText(null);
+      setPreviewDeviceSize(null);
       setWebNavigationBusyAction(null);
       setWebIsLoading(false);
     }
@@ -634,7 +649,10 @@ export default function MainContent({
       </div>
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-surface">
-        <MobilePreviewFrame enabled={shouldFrameMobilePreview}>
+        <MobilePreviewFrame
+          aspectRatio={previewAspectRatio}
+          enabled={shouldFrameMobilePreview}
+        >
           {studioPlayground.phase === 'booting' ? (
             <div className="flex h-full items-center justify-center px-6 text-[14px] text-text-tertiary">
               Playground starting...
@@ -681,6 +699,7 @@ export default function MainContent({
                       statusLabel={previewStatusText || previewConnectingLabel}
                     />
                   }
+                  onDeviceSizeChange={setPreviewDeviceSize}
                   onScrcpyStatusChange={(status, statusText) => {
                     setPreviewStatus(status);
                     setPreviewStatusText(statusText);

--- a/apps/studio/src/renderer/components/MainContent/preview-layout.ts
+++ b/apps/studio/src/renderer/components/MainContent/preview-layout.ts
@@ -3,7 +3,7 @@ import type { StudioPlatformId } from '@shared/electron-contract';
 import type { StudioPreviewConnectionState } from '../../playground/preview-discovery';
 import { normalizeStudioPlatformId } from '../../playground/selectors';
 
-const MOBILE_PREVIEW_ASPECT_RATIO = 9 / 19.5;
+const MOBILE_PREVIEW_DEFAULT_ASPECT_RATIO = 9 / 19.5;
 const MOBILE_PREVIEW_HORIZONTAL_GUTTER_PX = 24;
 const MOBILE_PREVIEW_VERTICAL_GUTTER_PX = 56;
 
@@ -58,6 +58,7 @@ export function shouldEnableMobilePreviewFrame(
 export function fitMobilePreviewViewport(
   stageWidth: number,
   stageHeight: number,
+  aspectRatio: number = MOBILE_PREVIEW_DEFAULT_ASPECT_RATIO,
 ): {
   width: number;
   height: number;
@@ -78,11 +79,16 @@ export function fitMobilePreviewViewport(
     };
   }
 
-  const heightLimitedWidth = availableHeight * MOBILE_PREVIEW_ASPECT_RATIO;
+  const safeAspectRatio =
+    Number.isFinite(aspectRatio) && aspectRatio > 0
+      ? aspectRatio
+      : MOBILE_PREVIEW_DEFAULT_ASPECT_RATIO;
+
+  const heightLimitedWidth = availableHeight * safeAspectRatio;
   const width = Math.min(availableWidth, heightLimitedWidth);
 
   return {
     width,
-    height: width / MOBILE_PREVIEW_ASPECT_RATIO,
+    height: width / safeAspectRatio,
   };
 }

--- a/apps/studio/src/renderer/components/Playground/index.tsx
+++ b/apps/studio/src/renderer/components/Playground/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy, useMemo } from 'react';
 import { downloadStudioReport } from '../../playground/report-download';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
-import { type ConnectionStatus, PlaygroundShell } from '../PlaygroundShell';
+import { PlaygroundShell } from '../PlaygroundShell';
 import { StudioPlaygroundEmptyState } from './StudioPlaygroundEmptyState';
 
 declare const __APP_VERSION__: string;
@@ -20,19 +20,8 @@ export default function Playground() {
     [],
   );
 
-  const connectionStatus: ConnectionStatus =
-    studioPlayground.phase === 'error'
-      ? 'failed'
-      : studioPlayground.phase === 'ready'
-        ? studioPlayground.controller.state.sessionSetupError
-          ? 'failed'
-          : studioPlayground.controller.state.sessionViewState.connected
-            ? 'connected'
-            : 'disconnected'
-        : 'disconnected';
-
   return (
-    <PlaygroundShell connectionStatus={connectionStatus}>
+    <PlaygroundShell>
       <div className="min-h-0 h-full flex-1 overflow-hidden">
         {studioPlayground.phase === 'booting' ? (
           <div className="flex h-full items-center justify-center px-6 text-center text-[14px] leading-[22px] text-text-tertiary">

--- a/apps/studio/src/renderer/components/PlaygroundShell/ConnectionStatusDot.tsx
+++ b/apps/studio/src/renderer/components/PlaygroundShell/ConnectionStatusDot.tsx
@@ -1,7 +1,8 @@
 export type ConnectionStatus = 'connected' | 'disconnected' | 'failed';
 
-// Visible footprint = 8px solid disc + 2px translucent border on each side
-// of the same hue, so the SVG canvas is 12×12.
+// Outer translucent halo + solid inner disc of the same hue. Default
+// sizing is 12px outer / 8px inner; callers can pass a smaller `size`
+// (e.g. the 6px sidebar dot) and the inner scales proportionally.
 const PALETTE: Record<ConnectionStatus, { inner: string; border: string }> = {
   connected: {
     inner: 'rgba(18, 185, 129, 1)',
@@ -25,10 +26,16 @@ const LABEL: Record<ConnectionStatus, string> = {
 
 export interface ConnectionStatusDotProps {
   status: ConnectionStatus;
+  /** Outer halo diameter in px. Defaults to 12. */
+  size?: number;
 }
 
-export function ConnectionStatusDot({ status }: ConnectionStatusDotProps) {
+export function ConnectionStatusDot({
+  status,
+  size = 12,
+}: ConnectionStatusDotProps) {
   const { inner, border } = PALETTE[status];
+  const innerSize = Math.max(2, Math.round((size * 2) / 3));
   return (
     <span
       role="img"
@@ -36,8 +43,8 @@ export function ConnectionStatusDot({ status }: ConnectionStatusDotProps) {
       style={{
         display: 'inline-flex',
         flexShrink: 0,
-        width: 12,
-        height: 12,
+        width: size,
+        height: size,
         borderRadius: '50%',
         background: border,
         alignItems: 'center',
@@ -47,8 +54,8 @@ export function ConnectionStatusDot({ status }: ConnectionStatusDotProps) {
       <span
         style={{
           display: 'block',
-          width: 8,
-          height: 8,
+          width: innerSize,
+          height: innerSize,
           borderRadius: '50%',
           background: inner,
         }}

--- a/apps/studio/src/renderer/components/PlaygroundShell/PlaygroundShell.tsx
+++ b/apps/studio/src/renderer/components/PlaygroundShell/PlaygroundShell.tsx
@@ -1,33 +1,19 @@
 import type { ReactNode } from 'react';
-import {
-  type ConnectionStatus,
-  ConnectionStatusDot,
-} from './ConnectionStatusDot';
 import './playground-shell-skin.css';
 
 export interface PlaygroundShellProps {
   children: ReactNode;
   /** Label shown in the shell header. Defaults to `'Playground'`. */
   title?: string;
-  /**
-   * Device connection status indicator rendered next to the title.
-   * Omit to hide the dot entirely (e.g. on screens that don't represent
-   * a session).
-   */
-  connectionStatus?: ConnectionStatus;
 }
 
 export function PlaygroundShell({
   children,
   title = 'Playground',
-  connectionStatus,
 }: PlaygroundShellProps) {
   return (
     <div className="playground-shell">
       <div className="app-drag absolute left-0 top-0 z-10 flex h-[56px] w-full items-center gap-[6px] border-b border-border-subtle bg-surface px-[22px]">
-        {connectionStatus ? (
-          <ConnectionStatusDot status={connectionStatus} />
-        ) : null}
         <span className="text-[13px] leading-[22.1px] font-medium text-text-primary">
           {title}
         </span>

--- a/apps/studio/src/renderer/components/PlaygroundShell/index.ts
+++ b/apps/studio/src/renderer/components/PlaygroundShell/index.ts
@@ -1,2 +1,6 @@
 export { PlaygroundShell } from './PlaygroundShell';
-export type { ConnectionStatus } from './ConnectionStatusDot';
+export {
+  ConnectionStatusDot,
+  type ConnectionStatus,
+  type ConnectionStatusDotProps,
+} from './ConnectionStatusDot';

--- a/apps/studio/src/renderer/components/SettingsDock/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsDock/index.tsx
@@ -67,7 +67,7 @@ export default function SettingsDock({
 }: SettingsDockProps) {
   return (
     <div className="flex flex-col gap-[2px]">
-      <DockRow icon={<EnvIcon />} label="Env" onClick={onEnvClick} />
+      <DockRow icon={<EnvIcon />} label="Model Config" onClick={onEnvClick} />
       <DockRow
         active={settingsOpen}
         ariaExpanded={settingsOpen}

--- a/apps/studio/src/renderer/components/SettingsPanel/SettingItem.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/SettingItem.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 export interface SettingItemProps {
   label: string;
   onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   trailingIcon?: ReactNode;
   value?: string;
 }
@@ -10,6 +12,8 @@ export interface SettingItemProps {
 export default function SettingItem({
   label,
   onClick,
+  onMouseEnter,
+  onMouseLeave,
   trailingIcon,
   value,
 }: SettingItemProps) {
@@ -17,6 +21,8 @@ export default function SettingItem({
     <button
       className="flex h-[32px] w-full cursor-pointer items-center justify-between rounded-[10px] border-0 bg-transparent px-[8px] text-left hover:bg-surface-hover"
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       type="button"
     >
       <span className="overflow-hidden whitespace-nowrap font-sans text-[13px] leading-[22px] text-text-secondary">

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type StudioThemeMode,
   useStudioTheme,
@@ -158,6 +158,27 @@ export default function SettingsPanel({
   const [language] = useState<string>(() => readStoredLanguage());
   const [openPopover, setOpenPopover] = useState<'theme' | null>(null);
   const popoverWrapperRef = useRef<HTMLDivElement | null>(null);
+  // The Theme popover is hover-driven now. A 4px gap separates the trigger
+  // row from the floating option list, so we use a short grace period
+  // before closing — letting the cursor cross the gap without flicker.
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelScheduledClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    cancelScheduledClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      setOpenPopover(null);
+      closeTimerRef.current = null;
+    }, 120);
+  }, [cancelScheduledClose]);
+
+  useEffect(() => () => cancelScheduledClose(), [cancelScheduledClose]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -193,9 +214,11 @@ export default function SettingsPanel({
         <div className="flex flex-col">
           <SettingItem
             label="Theme"
-            onClick={() =>
-              setOpenPopover((prev) => (prev === 'theme' ? null : 'theme'))
-            }
+            onMouseEnter={() => {
+              cancelScheduledClose();
+              setOpenPopover('theme');
+            }}
+            onMouseLeave={scheduleClose}
             trailingIcon={<ChevronIcon />}
             value={THEME_LABELS[mode]}
           />
@@ -218,7 +241,11 @@ export default function SettingsPanel({
       </div>
 
       {openPopover === 'theme' ? (
-        <div className="absolute left-[calc(100%+4px)] top-[6px] z-50">
+        <div
+          className="absolute left-[calc(100%+4px)] top-[6px] z-50"
+          onMouseEnter={cancelScheduledClose}
+          onMouseLeave={scheduleClose}
+        >
           <OptionList
             onSelect={(value) => {
               setMode(value);

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -152,10 +152,11 @@ export default function SettingsPanel({
   onWebsiteClick,
 }: SettingsPanelProps) {
   const { mode, setMode } = useStudioTheme();
-  const [language, setLanguage] = useState<string>(() => readStoredLanguage());
-  const [openPopover, setOpenPopover] = useState<'language' | 'theme' | null>(
-    null,
-  );
+  // Language preference is persisted but not surfaced yet; the row is
+  // hidden until i18n actually ships. Keep the storage hook so a stored
+  // value survives the round-trip when the row returns.
+  const [language] = useState<string>(() => readStoredLanguage());
+  const [openPopover, setOpenPopover] = useState<'theme' | null>(null);
   const popoverWrapperRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -185,24 +186,11 @@ export default function SettingsPanel({
   }, [openPopover]);
 
   const wrapperClassName = ['relative', className].filter(Boolean).join(' ');
-  const languageLabel =
-    LANGUAGE_OPTIONS.find((option) => option.value === language)?.label ??
-    LANGUAGE_OPTIONS[0].label;
 
   return (
     <div className={wrapperClassName} ref={popoverWrapperRef}>
       <div className="flex w-[244px] flex-col rounded-[12px] border border-border-subtle bg-surface-elevated p-[6px] shadow-lg">
         <div className="flex flex-col">
-          <SettingItem
-            label="Language"
-            onClick={() =>
-              setOpenPopover((prev) =>
-                prev === 'language' ? null : 'language',
-              )
-            }
-            trailingIcon={<ChevronIcon />}
-            value={languageLabel}
-          />
           <SettingItem
             label="Theme"
             onClick={() =>
@@ -229,21 +217,8 @@ export default function SettingsPanel({
         </div>
       </div>
 
-      {openPopover === 'language' ? (
-        <div className="absolute left-[calc(100%+4px)] top-[6px] z-50">
-          <OptionList
-            onSelect={(value) => {
-              setLanguage(value);
-              setOpenPopover(null);
-            }}
-            options={LANGUAGE_OPTIONS}
-            selected={language}
-          />
-        </div>
-      ) : null}
-
       {openPopover === 'theme' ? (
-        <div className="absolute left-[calc(100%+4px)] top-[38px] z-50">
+        <div className="absolute left-[calc(100%+4px)] top-[6px] z-50">
           <OptionList
             onSelect={(value) => {
               setMode(value);

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -230,7 +230,7 @@ export default function SettingsPanel({
       </div>
 
       {openPopover === 'language' ? (
-        <div className="absolute bottom-0 left-[calc(100%+4px)] z-50">
+        <div className="absolute left-[calc(100%+4px)] top-[6px] z-50">
           <OptionList
             onSelect={(value) => {
               setLanguage(value);
@@ -243,7 +243,7 @@ export default function SettingsPanel({
       ) : null}
 
       {openPopover === 'theme' ? (
-        <div className="absolute bottom-0 left-[calc(100%+4px)] z-50">
+        <div className="absolute left-[calc(100%+4px)] top-[38px] z-50">
           <OptionList
             onSelect={(value) => {
               setMode(value);

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -265,6 +265,7 @@ export default function ShellLayout() {
           activeView={activeView}
           headerOffsetClass={collapsed ? collapsedHeaderOffsetClass : undefined}
           onSelectDeviceView={() => setActiveView('device')}
+          onSelectOverview={() => setActiveView('overview')}
         />
         {activeView !== 'overview' && (
           <>

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -1,14 +1,17 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { assetUrls } from '../../assets';
 import {
   buildDeviceSelectionFormValues,
   buildStudioSidebarDeviceBuckets,
   mergeSidebarDeviceBucketsWithDiscovery,
+  normalizeStudioPlatformId,
   resolveConnectedDeviceId,
+  resolveSelectedDeviceId,
 } from '../../playground/selectors';
 import type { StudioSidebarPlatformKey } from '../../playground/types';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
 import { MaskedIcon } from '../MaskedIcon';
+import { ConnectionStatusDot } from '../PlaygroundShell';
 import SettingsDock from '../SettingsDock';
 import type { ShellActiveView } from '../ShellLayout/types';
 
@@ -72,24 +75,22 @@ function SectionHeader({
 }) {
   return (
     <button
-      className="relative h-8 w-full appearance-none rounded-lg border-0 bg-transparent p-0 text-left hover:bg-surface-hover"
+      className="flex h-8 w-full appearance-none items-center gap-[6px] rounded-lg border-0 bg-transparent pl-[12px] pr-[16px] text-left hover:bg-surface-hover"
       onClick={onClick}
       type="button"
     >
       {iconSrc ? (
         <MaskedIcon
-          className="absolute left-[14px] top-[8px] h-4 w-4 text-text-secondary"
+          className="h-4 w-4 shrink-0 text-text-secondary"
           src={iconSrc}
         />
       ) : (
-        <div className="absolute left-[14px] top-[8px] h-4 w-4" />
+        <div className="h-4 w-4 shrink-0" />
       )}
-      <span className="absolute left-[44px] top-[5px] font-['Inter'] text-[13px] font-medium leading-[22px] text-text-secondary">
+      <span className="flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-secondary">
         {label}
       </span>
-      <div className="absolute left-[204px] top-0 flex h-full w-4 items-center justify-center">
-        <SectionChevron expanded={expanded} />
-      </div>
+      <SectionChevron expanded={expanded} />
     </button>
   );
 }
@@ -104,36 +105,37 @@ function DeviceRow({
 }) {
   return (
     <button
-      className={`relative h-8 w-full cursor-pointer appearance-none rounded-[10px] border-0 bg-transparent p-0 text-left transition-colors ${
+      className={`flex h-8 w-full cursor-pointer appearance-none items-center gap-[6px] rounded-[10px] border-0 pl-[12px] pr-[16px] text-left transition-colors ${
         selected
-          ? 'bg-surface-hover-strong hover:bg-surface-active'
-          : 'hover:bg-surface-hover active:bg-surface-active'
+          ? 'bg-surface-hover hover:bg-surface-hover'
+          : 'bg-transparent hover:bg-surface-hover active:bg-surface-active'
       }`}
       onClick={onClick}
       type="button"
     >
+      <div className="h-4 w-4 shrink-0" />
       <span
-        className={`absolute left-[44px] top-[9.5px] w-[154px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-normal leading-[13px] ${
-          selected ? 'text-text-primary' : 'text-text-secondary'
+        className={`flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] leading-[13px] ${
+          selected
+            ? 'font-medium text-text-primary'
+            : 'font-normal text-text-secondary'
         }`}
       >
         {label}
       </span>
-      <div className="absolute left-[204px] top-[8px] flex h-4 w-4 items-center justify-center">
-        <div
-          className={`h-[6px] w-[6px] rounded-full ${
-            status === 'active' ? 'bg-status-success' : 'bg-status-idle'
-          }`}
-        />
-      </div>
+      <ConnectionStatusDot
+        size={6}
+        status={status === 'active' ? 'connected' : 'disconnected'}
+      />
     </button>
   );
 }
 
 function EmptyDeviceRow() {
   return (
-    <div className="relative h-8 w-full rounded-lg">
-      <span className="absolute left-[44px] top-[9.5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-normal leading-[13px] text-text-tertiary">
+    <div className="flex h-8 w-full items-center gap-[6px] rounded-lg pl-[12px] pr-[16px]">
+      <div className="h-4 w-4 shrink-0" />
+      <span className="flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] font-normal leading-[13px] text-text-tertiary">
         No devices
       </span>
     </div>
@@ -161,6 +163,12 @@ export default function Sidebar({
     ios: true,
     web: true,
   });
+  // Sticky record of the user's most recent click. Kept locally so the
+  // highlight survives any transient form-state churn during the
+  // destroy → refreshSessionSetup → createSession round-trip.
+  const [stickySelection, setStickySelection] = useState<
+    { platformKey: StudioSidebarPlatformKey; deviceId: string } | undefined
+  >(undefined);
 
   const toggleSection = (sectionKey: StudioSidebarPlatformKey) => {
     setExpandedSections((current) => ({
@@ -194,10 +202,14 @@ export default function Sidebar({
     studioPlayground.discoveredDevices,
   );
 
-  const connectedDeviceId =
+  const runtimeInfo =
     studioPlayground.phase === 'ready'
-      ? resolveConnectedDeviceId(studioPlayground.controller.state.runtimeInfo)
-      : undefined;
+      ? studioPlayground.controller.state.runtimeInfo
+      : null;
+  const connectedDeviceId = resolveConnectedDeviceId(runtimeInfo);
+  const connectedPlatformKey = normalizeStudioPlatformId(
+    runtimeInfo?.platformId ?? runtimeInfo?.interface?.type,
+  );
 
   /**
    * Build a click-enabled device list for any platform section. The
@@ -236,6 +248,10 @@ export default function Sidebar({
         }
         const { actions, state } = studioPlayground.controller;
 
+        // Stamp the highlight synchronously so the row stays selected
+        // even before the form state propagates through useWatch.
+        setStickySelection({ platformKey, deviceId: item.id });
+
         if (item.selected && item.status === 'active') {
           onSelectDevice();
           return;
@@ -257,6 +273,10 @@ export default function Sidebar({
         }
         if (state.sessionViewState.connected) {
           await actions.destroySession();
+          // refreshSessionSetup inside destroySession may overwrite the
+          // selection we just stamped — re-apply it so the highlight
+          // and the next createSession agree.
+          state.form.setFieldsValue(selectionValues);
         }
         const sessionValues = {
           ...state.form.getFieldsValue(true),
@@ -267,15 +287,46 @@ export default function Sidebar({
     }));
   };
 
-  const selectedDeviceIds =
+  // Source-of-truth for the sidebar highlight is the form's selection
+  // (i.e. the row the user most recently clicked) — not the connected
+  // device, so the highlight stays put during the session swap from one
+  // device to another. The active-status dot still tracks the live
+  // connection separately.
+  const formValues =
     studioPlayground.phase === 'ready'
-      ? new Set(
-          Object.values(deviceBuckets)
-            .flat()
-            .filter((item) => item.selected)
-            .map((item) => item.id),
-        )
-      : new Set<string>();
+      ? studioPlayground.controller.state.formValues
+      : undefined;
+  const formSelectedPlatformKey = formValues
+    ? normalizeStudioPlatformId(formValues.platformId)
+    : undefined;
+  const formSelectedDeviceId = formValues
+    ? resolveSelectedDeviceId(formValues)
+    : undefined;
+
+  // Keep stickySelection in lockstep with the form whenever the form
+  // actually identifies a device. This way, if some downstream effect
+  // (e.g. refreshSessionSetup, discovery auto-select) updates the form,
+  // the sticky highlight follows instead of pointing at the previous
+  // click. We only clear sticky when the form has no selection AND no
+  // recent click — never let an empty form wipe a fresh click.
+  useEffect(() => {
+    if (!formSelectedPlatformKey || !formSelectedDeviceId) {
+      return;
+    }
+    setStickySelection((prev) => {
+      if (
+        prev &&
+        prev.platformKey === formSelectedPlatformKey &&
+        prev.deviceId === formSelectedDeviceId
+      ) {
+        return prev;
+      }
+      return {
+        platformKey: formSelectedPlatformKey,
+        deviceId: formSelectedDeviceId,
+      };
+    });
+  }, [formSelectedPlatformKey, formSelectedDeviceId]);
 
   const totalDeviceCount = sectionDefinitions.reduce(
     (sum, section) => sum + deviceBuckets[section.key].length,
@@ -295,7 +346,7 @@ export default function Sidebar({
   return (
     <div className="flex flex-col">
       <button
-        className={`relative h-8 w-full appearance-none border-0 p-0 text-left ${
+        className={`flex h-8 w-full appearance-none items-center gap-[6px] border-0 pl-[12px] pr-[16px] text-left ${
           overviewActive
             ? 'rounded-[10px] bg-black/5'
             : 'rounded-lg bg-transparent hover:bg-surface-hover'
@@ -304,20 +355,20 @@ export default function Sidebar({
         type="button"
       >
         <MaskedIcon
-          className="absolute left-[14px] top-[8px] h-4 w-4 text-text-secondary"
+          className="h-4 w-4 shrink-0 text-text-secondary"
           src={assetUrls.sidebar.overview}
         />
-        <span className="absolute left-[44px] top-[5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-medium leading-[22px] text-text-secondary">
+        <span className="flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-secondary">
           Overview
         </span>
-        <span className="absolute right-[12px] top-[6px] font-sans text-[11px] font-normal leading-[20px] text-text-tertiary">
+        <span className="shrink-0 font-sans text-[11px] font-normal leading-[20px] text-text-tertiary">
           {totalDeviceCount}
         </span>
       </button>
 
       <div className="mt-1 flex flex-col">
-        <div className="relative h-8 w-full">
-          <span className="absolute left-[14px] top-[5px] overflow-hidden whitespace-nowrap font-['Inter'] text-[13px] font-medium leading-[22px] text-text-tertiary">
+        <div className="flex h-8 w-full items-center pl-[12px]">
+          <span className="overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-tertiary">
             Platform
           </span>
         </div>
@@ -337,16 +388,43 @@ export default function Sidebar({
 
                 {isExpanded ? (
                   hasDevices ? (
-                    section.devices.map((device) => (
-                      <DeviceRow
-                        key={device.id}
-                        selected={
-                          !device.isPlaceholder &&
-                          selectedDeviceIds.has(device.id)
-                        }
-                        {...device}
-                      />
-                    ))
+                    section.devices.map((device) => {
+                      // Three independent signals can light up a row:
+                      //   - matchesConnected: this device is the one
+                      //     currently powering the middle preview area.
+                      //   - matchesForm: form's selectedDeviceId points
+                      //     here (the source of truth for "what the user
+                      //     picked" once it settles).
+                      //   - matchesSticky: synchronous record of the
+                      //     last click, kept locally so the highlight is
+                      //     instant.
+                      // OR-ing them avoids a single-frame gap during the
+                      // hand-off where `connectedDeviceId` has just
+                      // landed but the matching bucket entry hasn't
+                      // re-rendered with the same id yet.
+                      const matchesConnected =
+                        !!connectedDeviceId &&
+                        section.key === connectedPlatformKey &&
+                        device.id === connectedDeviceId;
+                      const matchesForm =
+                        !!formSelectedDeviceId &&
+                        section.key === formSelectedPlatformKey &&
+                        device.id === formSelectedDeviceId;
+                      const matchesSticky =
+                        !!stickySelection &&
+                        stickySelection.platformKey === section.key &&
+                        stickySelection.deviceId === device.id;
+                      return (
+                        <DeviceRow
+                          key={device.id}
+                          selected={
+                            !device.isPlaceholder &&
+                            (matchesConnected || matchesForm || matchesSticky)
+                          }
+                          {...device}
+                        />
+                      );
+                    })
                   ) : (
                     <EmptyDeviceRow
                       key={`${EMPTY_DEVICE_ID_PREFIX}${section.key}`}

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -75,7 +75,7 @@ function SectionHeader({
 }) {
   return (
     <button
-      className="flex h-8 w-full appearance-none items-center gap-[6px] rounded-lg border-0 bg-transparent pl-[12px] pr-[16px] text-left hover:bg-surface-hover"
+      className="flex h-8 w-full appearance-none items-center gap-[6px] rounded-lg border-0 bg-transparent pl-[12px] pr-[14px] text-left hover:bg-surface-hover"
       onClick={onClick}
       type="button"
     >
@@ -105,7 +105,7 @@ function DeviceRow({
 }) {
   return (
     <button
-      className={`flex h-8 w-full cursor-pointer appearance-none items-center gap-[6px] rounded-[10px] border-0 pl-[12px] pr-[16px] text-left transition-colors ${
+      className={`flex h-8 w-full cursor-pointer appearance-none items-center gap-[6px] rounded-[10px] border-0 pl-[12px] pr-[14px] text-left transition-colors ${
         selected
           ? 'bg-surface-hover hover:bg-surface-hover'
           : 'bg-transparent hover:bg-surface-hover active:bg-surface-active'
@@ -115,25 +115,27 @@ function DeviceRow({
     >
       <div className="h-4 w-4 shrink-0" />
       <span
-        className={`flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] leading-[13px] ${
+        className={`flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] ${
           selected
-            ? 'font-medium text-text-primary'
-            : 'font-normal text-text-secondary'
+            ? 'font-medium leading-[22.11px] text-text-primary'
+            : 'font-normal leading-[13px] text-text-secondary'
         }`}
       >
         {label}
       </span>
-      <ConnectionStatusDot
-        size={6}
-        status={status === 'active' ? 'connected' : 'disconnected'}
-      />
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+        <ConnectionStatusDot
+          size={6}
+          status={status === 'active' ? 'connected' : 'disconnected'}
+        />
+      </span>
     </button>
   );
 }
 
 function EmptyDeviceRow() {
   return (
-    <div className="flex h-8 w-full items-center gap-[6px] rounded-lg pl-[12px] pr-[16px]">
+    <div className="flex h-8 w-full items-center gap-[6px] rounded-lg pl-[12px] pr-[14px]">
       <div className="h-4 w-4 shrink-0" />
       <span className="flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] font-normal leading-[13px] text-text-tertiary">
         No devices
@@ -346,7 +348,7 @@ export default function Sidebar({
   return (
     <div className="flex flex-col">
       <button
-        className={`flex h-8 w-full appearance-none items-center gap-[6px] border-0 pl-[12px] pr-[16px] text-left ${
+        className={`flex h-8 w-full appearance-none items-center gap-[6px] border-0 pl-[12px] pr-[14px] text-left ${
           overviewActive
             ? 'rounded-[10px] bg-black/5'
             : 'rounded-lg bg-transparent hover:bg-surface-hover'
@@ -361,14 +363,14 @@ export default function Sidebar({
         <span className="flex-1 overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-secondary">
           Overview
         </span>
-        <span className="shrink-0 font-sans text-[11px] font-normal leading-[20px] text-text-tertiary">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center font-sans text-[11px] font-normal leading-none text-text-tertiary">
           {totalDeviceCount}
         </span>
       </button>
 
       <div className="mt-1 flex flex-col">
         <div className="flex h-8 w-full items-center pl-[12px]">
-          <span className="overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-tertiary">
+          <span className="overflow-hidden whitespace-nowrap font-sans text-[13px] font-medium leading-[22px] text-text-placeholder">
             Platform
           </span>
         </div>

--- a/apps/studio/src/renderer/playground/selectors.ts
+++ b/apps/studio/src/renderer/playground/selectors.ts
@@ -616,31 +616,28 @@ export function mergeSidebarDeviceBucketsWithDiscovery(
 
   for (const key of AUTHORITATIVE_DISCOVERY_PLATFORMS) {
     const discoveredBucket = discovered[key];
-    const discoveredIds = new Set(discoveredBucket.map((d) => d.id));
 
-    // Drop any session items whose id is not physically present anymore.
-    const survivingSessionItems = sessionBuckets[key].filter((item) =>
-      discoveredIds.has(item.id),
+    // Discovery is the source of truth for order — preserve it across
+    // selection changes so the sidebar doesn't reshuffle when the user
+    // clicks an item. For each discovered device, reuse the matching
+    // session entry (it already carries label/selected/active metadata),
+    // otherwise emit a fresh idle entry. Session items not present in
+    // discovery are dropped (catches unplug while connected).
+    const sessionItemsById = new Map(
+      sessionBuckets[key].map((item) => [item.id, item]),
     );
-    const survivingIds = new Set(survivingSessionItems.map((item) => item.id));
 
-    // Append discovered devices that aren't already covered by the
-    // session bucket (those already carry label/selected/active metadata).
-    const additions: StudioAndroidDeviceItem[] = [];
-    for (const dev of discoveredBucket) {
-      if (!survivingIds.has(dev.id)) {
-        additions.push({
+    merged[key] = discoveredBucket.map(
+      (dev) =>
+        sessionItemsById.get(dev.id) ?? {
           id: dev.id,
           label: dev.label,
           description: dev.description,
           selected: false,
           status: 'idle',
           sessionValues: dev.sessionValues,
-        });
-      }
-    }
-
-    merged[key] = [...survivingSessionItems, ...additions];
+        },
+    );
   }
 
   for (const key of ADDITIVE_DISCOVERY_PLATFORMS) {

--- a/apps/studio/tests/mobile-preview-frame.test.tsx
+++ b/apps/studio/tests/mobile-preview-frame.test.tsx
@@ -14,6 +14,8 @@ describe('MobilePreviewFrame', () => {
     );
 
     expect(html).toContain('translate-y-[-26px]');
+    expect(html).toContain('rounded-[8px]');
+    expect(html).toContain('border-border-subtle');
     expect(html).not.toContain('rounded-[34px]');
   });
 

--- a/apps/studio/tests/playground-selectors.test.ts
+++ b/apps/studio/tests/playground-selectors.test.ts
@@ -338,6 +338,47 @@ describe('mergeSidebarDeviceBucketsWithDiscovery', () => {
     ).toEqual([]);
   });
 
+  it('preserves discovery order across selection changes', () => {
+    // Regression: previously, the selected/active session item was prepended
+    // and other discovered devices appended, so clicking a later item moved
+    // it to the top and visually reshuffled the sidebar on every click.
+    const discovered = {
+      ...emptyBuckets,
+      computer: [
+        {
+          platformId: 'computer' as const,
+          id: 'studio-display',
+          label: 'StudioDisplay',
+          description: 'Primary display',
+        },
+        {
+          platformId: 'computer' as const,
+          id: 'color-lcd',
+          label: 'Color LCD',
+          description: '1',
+        },
+      ],
+    };
+    const sessionWithSecondSelected = {
+      ...emptyBuckets,
+      computer: [
+        {
+          id: 'color-lcd',
+          label: 'Color LCD',
+          selected: true,
+          status: 'idle' as const,
+        },
+      ],
+    };
+
+    expect(
+      mergeSidebarDeviceBucketsWithDiscovery(
+        sessionWithSecondSelected,
+        discovered,
+      ).computer.map((item) => item.id),
+    ).toEqual(['studio-display', 'color-lcd']);
+  });
+
   it('appends discovered devices that session setup has not surfaced', () => {
     const session = emptyBuckets;
     const discovered = {

--- a/apps/studio/tests/sidebar-settings.test.ts
+++ b/apps/studio/tests/sidebar-settings.test.ts
@@ -6,7 +6,7 @@ import SettingsPanel from '../src/renderer/components/SettingsPanel';
 import { ThemeProvider } from '../src/renderer/theme/ThemeProvider';
 
 describe('studio sidebar settings entrypoints', () => {
-  it('renders Settings and Env as stacked rows in the bottom dock', () => {
+  it('renders Settings and Model Config as stacked rows in the bottom dock', () => {
     const html = renderToStaticMarkup(
       createElement(SettingsDock, {
         onEnvClick: () => undefined,
@@ -16,20 +16,22 @@ describe('studio sidebar settings entrypoints', () => {
     );
 
     expect(html).toContain('Settings');
-    expect(html).toContain('Env');
-    expect(html).not.toContain('Model');
+    expect(html).toContain('Model Config');
+    expect(html).not.toContain('>Env<');
   });
 
-  it('keeps the settings panel focused on app preferences without an Environment row', () => {
+  it('keeps the settings panel focused on app preferences without a model config row', () => {
     const html = renderToStaticMarkup(
       createElement(ThemeProvider, null, createElement(SettingsPanel, {})),
     );
 
-    expect(html).toContain('Language');
+    // Language is intentionally hidden until i18n ships (storage hook
+    // still runs in the background).
+    expect(html).not.toContain('Language');
     expect(html).toContain('Theme');
     expect(html).toContain('GitHub');
     expect(html).toContain('Website');
     expect(html).not.toContain('Environment');
-    expect(html).not.toContain('Model');
+    expect(html).not.toContain('Model Config');
   });
 });

--- a/packages/playground-app/src/PlaygroundPreview.tsx
+++ b/packages/playground-app/src/PlaygroundPreview.tsx
@@ -10,6 +10,13 @@ import type { ScrcpyPreviewStatus } from './scrcpy-preview';
 
 export interface PlaygroundPreviewProps {
   connectingOverlay?: ReactNode;
+  /**
+   * Fires whenever the connected device's intrinsic screen size becomes
+   * available (initial mount) or changes (orientation flip / device
+   * swap). Consumers can use it to drive their own viewport sizing so
+   * the preview chrome tightly hugs the canvas without letterboxing.
+   */
+  onDeviceSizeChange?: (size: { width: number; height: number } | null) => void;
   onScrcpyStatusChange?: (
     status: ScrcpyPreviewStatus,
     statusText: string,

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -30,6 +30,7 @@ import type { ScrcpyPreviewStatus } from './scrcpy-preview';
 
 interface PreviewRendererProps {
   connectingOverlay?: ReactNode;
+  onDeviceSizeChange?: (size: { width: number; height: number } | null) => void;
   onScrcpyStatusChange?: (
     status: ScrcpyPreviewStatus,
     statusText: string,
@@ -58,6 +59,7 @@ function isNonLocalhostHttp(): boolean {
 
 export function PreviewRenderer({
   connectingOverlay,
+  onDeviceSizeChange,
   onScrcpyStatusChange,
   renderErrorOverlay,
   scrcpyViewportStyle,
@@ -74,6 +76,11 @@ export function PreviewRenderer({
   );
 
   const [deviceSize, setDeviceSize] = useState<DeviceSize | null>(null);
+  // Pixel dimensions reported by the scrcpy video-metadata event. This is
+  // the canvas's actual pixel buffer size — the authoritative source for
+  // any aspect-ratio calculation, since `/interface-info` can drift from
+  // the real stream resolution by a few pixels.
+  const [streamSize, setStreamSize] = useState<DeviceSize | null>(null);
   const [actionTypes, setActionTypes] = useState<string[] | null>(null);
   const manualControlQueueRef = useRef<Promise<unknown>>(Promise.resolve());
 
@@ -158,6 +165,20 @@ export function PreviewRenderer({
       clearInterval(timer);
     };
   }, [playgroundSDK, serverOnline]);
+
+  // Notify consumers when the connected device's intrinsic size changes —
+  // they can use it to size the surrounding chrome to the actual screen
+  // aspect (instead of a hardcoded 9:19.5 assumption that leaves
+  // letterboxing on most modern phones).
+  //
+  // Prefer the scrcpy stream's own pixel buffer dimensions over
+  // `/interface-info.size` when both are available. The canvas inside
+  // ScrcpyPanel sizes itself to the stream buffer, so any aspect-ratio
+  // derived from `/interface-info` can be off by a handful of pixels
+  // (the visible "white edge" inside the rounded device border).
+  useEffect(() => {
+    onDeviceSizeChange?.(streamSize ?? deviceSize);
+  }, [deviceSize, onDeviceSizeChange, streamSize]);
 
   const showManualControlError = useCallback(
     (fallback: string, error?: string) => {
@@ -341,6 +362,7 @@ export function PreviewRenderer({
         <ScrcpyPanel
           connectingOverlay={connectingOverlay}
           deviceId={previewConnection.deviceId}
+          onIntrinsicSize={setStreamSize}
           onStatusChange={onScrcpyStatusChange}
           renderErrorOverlay={renderErrorOverlay}
           serverUrl={previewConnection.scrcpyUrl}

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -43,6 +43,15 @@ export type ScrcpyErrorOverlayRenderer = (
 interface ScrcpyPanelProps {
   connectingOverlay?: ReactNode;
   deviceId?: string;
+  /**
+   * Fires when the underlying video stream's intrinsic resolution is
+   * known (scrcpy `video-metadata` event), and again with `null` when
+   * the stream tears down. Use this as the source of truth for any
+   * surrounding aspect-ratio calculations — it always matches the
+   * canvas's pixel buffer, unlike `/interface-info.size` which can
+   * drift from the actual stream dimensions by a few pixels.
+   */
+  onIntrinsicSize?: (size: { width: number; height: number } | null) => void;
   onStatusChange?: (status: ScrcpyPreviewStatus, statusText: string) => void;
   renderErrorOverlay?: ScrcpyErrorOverlayRenderer;
   serverUrl?: string;
@@ -60,6 +69,7 @@ interface VideoMetadata {
 export function ScrcpyPanel({
   connectingOverlay,
   deviceId,
+  onIntrinsicSize,
   onStatusChange,
   renderErrorOverlay,
   serverUrl,
@@ -163,6 +173,7 @@ export function ScrcpyPanel({
 
       disposeDecoder();
       clearCanvas();
+      onIntrinsicSize?.(null);
     };
 
     const scheduleReconnect = () => {
@@ -255,6 +266,17 @@ export function ScrcpyPanel({
           clearMetadataTimeout();
           disposeDecoder();
           setWaitingStatusMessage(getScrcpyDecoderStatusText());
+          if (
+            typeof metadata.width === 'number' &&
+            metadata.width > 0 &&
+            typeof metadata.height === 'number' &&
+            metadata.height > 0
+          ) {
+            onIntrinsicSize?.({
+              width: metadata.width,
+              height: metadata.height,
+            });
+          }
           const codecId = metadata.codec
             ? (metadata.codec as unknown as ScrcpyVideoCodecId)
             : ScrcpyVideoCodecId.H264;

--- a/packages/visualizer/src/component/universal-playground/index.less
+++ b/packages/visualizer/src/component/universal-playground/index.less
@@ -512,14 +512,21 @@
   // Vertical connector — drawn for every progress step so the line covers
   // the whole run, including the final step. Sits 4px to the right of the
   // "Execution Flow" header text (which starts at the toggle button's 4px
-  // left padding). Default span: top 0 to bottom -16px so adjacent segments
-  // bridge the list-item gap.
+  // left padding).
+  //
+  // Each segment extends `bottom: -8px` to bridge the visual gap between
+  // adjacent items. The gap is 8px because subsequent items carry a
+  // `margin-top: -8px` that collapses Ant List's natural 16px row gap
+  // down to 8px. Extending further (e.g. -16px) would overlap with the
+  // next item's segment and visibly thicken the line in the overlap zone
+  // — translucent rgba additions stack, which shows up as alternating
+  // bright bands in dark mode.
   .list-item:has(.progress-action-item)::after {
     content: '';
     position: absolute;
     left: 8px;
     top: 0;
-    bottom: -16px;
+    bottom: -8px;
     width: 1px;
     background: rgba(0, 0, 0, 0.08);
     pointer-events: none;


### PR DESCRIPTION
## Summary

The Language and Theme popovers in the bottom-left settings panel were positioned with `bottom-0`, which anchored them to the bottom of the panel and made them visually disconnected from the row that opened them.

Switch to `top-[6px]` (Language row) and `top-[38px]` (Theme row — 6px panel padding plus the 32px height of the first row) so each popover lines up with its trigger.

## Test plan

- [ ] Open Studio and click the **Settings** button in the bottom-left dock.
- [ ] Click **Language** — the popover should appear immediately to the right of the row, top-aligned with it.
- [ ] Click **Theme** — the popover should appear immediately to the right of the row, top-aligned with it.
- [ ] Both popovers should still close when clicking outside.