### PR TITLE
docs(site): clarify concurrent YAML examples

### DIFF
--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -237,10 +237,10 @@ Use `--files` to specify execution order:
 midscene --files ./login.yaml ./buy/*.yaml ./checkout.yaml
 ```
 
-Run all scripts with a concurrency of 4 and continue when errors occur:
+Run multiple independent search scripts with a concurrency of 4 and continue when errors occur:
 
 ```bash
-midscene --files './scripts/**/*.yaml' --concurrent 4 --continue-on-error
+midscene --files './scripts/search-*.yaml' --concurrent 4 --continue-on-error
 ```
 
 ### Write command-line arguments in a file
@@ -249,13 +249,13 @@ You can place arguments in a YAML config file and reference it with `--config`. 
 
 ```yaml
 files:
-  - './scripts/login.yaml'
-  - './scripts/search.yaml'
-  - './scripts/**/*.yaml'
+  - './scripts/search-iphone.yaml'
+  - './scripts/search-laptop.yaml'
+  - './scripts/search-headphones.yaml'
+  - './scripts/search-camera.yaml'
 
 concurrent: 4
 continueOnError: true
-shareBrowserContext: true
 ```
 
 Run with:

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -241,10 +241,10 @@ web:
 midscene --files ./login.yaml ./buy/*.yaml ./checkout.yaml
 ```
 
-以 4 个并发执行所有脚本，并在出错时继续运行：
+以 4 个并发执行多个互不依赖的搜索脚本，并在出错时继续运行：
 
 ```bash
-midscene --files './scripts/**/*.yaml' --concurrent 4 --continue-on-error
+midscene --files './scripts/search-*.yaml' --concurrent 4 --continue-on-error
 ```
 
 ### 通过文件编写命令行参数
@@ -253,13 +253,13 @@ midscene --files './scripts/**/*.yaml' --concurrent 4 --continue-on-error
 
 ```yaml
 files:
-  - './scripts/login.yaml'
-  - './scripts/search.yaml'
-  - './scripts/**/*.yaml'
+  - './scripts/search-iphone.yaml'
+  - './scripts/search-laptop.yaml'
+  - './scripts/search-headphones.yaml'
+  - './scripts/search-camera.yaml'
 
 concurrent: 4
 continueOnError: true
-shareBrowserContext: true
 ```
 
 运行方式：


### PR DESCRIPTION
### Motivation
- The concurrent example implied running a `login` script in parallel which is misleading because login is typically serial and may require shared browser context.
- Clarify the docs so the `--concurrent` example shows independent, parallelizable tasks instead of a login flow.

### Description
- Updated the English doc `apps/site/docs/en/yaml-script-runner.mdx` to reword the concurrent example to describe "multiple independent search scripts" and changed the example glob to `./scripts/search-*.yaml`.
- Updated the Chinese doc `apps/site/docs/zh/yaml-script-runner.mdx` with the same rewording and example glob for parity.
- Replaced the YAML config example in both files to list independent search scripts (`search-iphone.yaml`, `search-laptop.yaml`, `search-headphones.yaml`, `search-camera.yaml`) and removed the `login.yaml` and `shareBrowserContext` usage from the concurrent example.

### Testing
- Ran `pnpm run lint`, which failed due to Biome processing large files in the local `.pnpm-store` (environmental cache size limit) and is unrelated to the doc changes.
- Ran `pnpm exec biome check apps/site/docs/en/yaml-script-runner.mdx apps/site/docs/zh/yaml-script-runner.mdx --diagnostic-level=info --no-errors-on-unmatched`, which completed successfully.
- Ran `git diff --check` to ensure no diff issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017b16c71883248d1408095f75d202)