### PR TITLE
fix(android-playground): stream scrcpy video as binary to avoid heap OOM

### DIFF
--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -573,9 +573,13 @@ export default class ScrcpyServer {
                       // ensure type field is correctly set to 'configuration' or 'data'
                       const frameType = value.type || 'data'; // default to 'data'
 
-                      // send video frame data to client
+                      // Forward the raw Uint8Array — socket.io transports it as
+                      // a binary frame. Converting via Array.from inflates each
+                      // byte to a boxed JS Number, blowing the V8 old space on
+                      // low-memory hosts (e.g. 8GB Windows) after a few seconds
+                      // of a 2 Mbps stream.
                       socket.emit('video-data', {
-                        data: Array.from(value.data),
+                        data: value.data,
                         type: frameType,
                         timestamp: Date.now(),
                         // fix keyframe access

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -1,6 +1,6 @@
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
 
-type RawScrcpyVideoData = ArrayBuffer | ArrayLike<number> | Uint8Array;
+type RawScrcpyVideoData = ArrayBuffer | ArrayBufferView;
 
 interface RawScrcpyVideoPacket {
   type?: string;
@@ -15,7 +15,7 @@ function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
   if (data instanceof ArrayBuffer) {
     return new Uint8Array(data);
   }
-  return new Uint8Array(data);
+  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
 interface ScrcpyVideoSocketLike {

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -1,9 +1,21 @@
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
 
+type RawScrcpyVideoData = ArrayBuffer | ArrayLike<number> | Uint8Array;
+
 interface RawScrcpyVideoPacket {
   type?: string;
-  data: ArrayLike<number>;
+  data: RawScrcpyVideoData;
   keyFrame?: boolean;
+}
+
+function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+  return new Uint8Array(data);
 }
 
 interface ScrcpyVideoSocketLike {
@@ -50,7 +62,7 @@ export function createScrcpyVideoStream(
     start(controller) {
       const handleVideoData = (data: RawScrcpyVideoPacket) => {
         try {
-          const payload = new Uint8Array(data.data);
+          const payload = toUint8Array(data.data);
           if (data.type === 'configuration') {
             controller.enqueue({
               type: 'configuration',

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -4,7 +4,7 @@ import { createScrcpyVideoStream } from '../src/scrcpy-stream';
 
 interface RawVideoPayload {
   type?: string;
-  data: ArrayLike<number>;
+  data: ArrayBuffer | ArrayLike<number> | Uint8Array;
   keyFrame?: boolean;
 }
 
@@ -138,6 +138,31 @@ describe('createScrcpyVideoStream', () => {
     expect(dataPackets).toHaveLength(2);
     expect(dataPackets[0].keyframe).toBe(true);
     expect(dataPackets[1].keyframe).toBe(false);
+  });
+
+  test('accepts Uint8Array and ArrayBuffer payloads from binary transport', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket);
+    const collected = collectStream(stream);
+
+    const configBytes = new Uint8Array([10, 20, 30]);
+    const dataBuffer = new Uint8Array([40, 50, 60]).buffer;
+
+    socket.dispatchVideoData({ type: 'configuration', data: configBytes });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: dataBuffer,
+      keyFrame: true,
+    });
+    socket.dispatchDisconnect();
+
+    const packets = await collected;
+
+    expect(packets).toHaveLength(2);
+    expect(packets[0].type).toBe('configuration');
+    expect(Array.from(packets[0].data)).toEqual([10, 20, 30]);
+    expect(packets[1].type).toBe('data');
+    expect(Array.from(packets[1].data)).toEqual([40, 50, 60]);
   });
 
   test('does not populate pts (no device timestamp available from socket)', async () => {

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -4,7 +4,7 @@ import { createScrcpyVideoStream } from '../src/scrcpy-stream';
 
 interface RawVideoPayload {
   type?: string;
-  data: ArrayBuffer | ArrayLike<number> | Uint8Array;
+  data: ArrayBuffer | ArrayBufferView;
   keyFrame?: boolean;
 }
 
@@ -100,9 +100,12 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'data', data: [1, 2, 3] });
-    socket.dispatchVideoData({ type: 'configuration', data: [9] });
-    socket.dispatchVideoData({ type: 'data', data: [4, 5, 6] });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([1, 2, 3]) });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([9]),
+    });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([4, 5, 6]) });
     socket.dispatchDisconnect();
 
     const packets = await collected;
@@ -124,9 +127,20 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'configuration', data: [0] });
-    socket.dispatchVideoData({ type: 'data', data: [1], keyFrame: true });
-    socket.dispatchVideoData({ type: 'data', data: [2], keyFrame: false });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+      keyFrame: true,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([2]),
+      keyFrame: false,
+    });
     socket.dispatchDisconnect();
 
     const packets = await collected;
@@ -140,12 +154,13 @@ describe('createScrcpyVideoStream', () => {
     expect(dataPackets[1].keyframe).toBe(false);
   });
 
-  test('accepts Uint8Array and ArrayBuffer payloads from binary transport', async () => {
+  test('accepts ArrayBufferView and ArrayBuffer payloads from binary transport', async () => {
     const socket = new MockScrcpySocket();
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    const configBytes = new Uint8Array([10, 20, 30]);
+    const sourceBytes = new Uint8Array([99, 10, 20, 30, 88]);
+    const configBytes = new DataView(sourceBytes.buffer, 1, 3);
     const dataBuffer = new Uint8Array([40, 50, 60]).buffer;
 
     socket.dispatchVideoData({ type: 'configuration', data: configBytes });
@@ -170,8 +185,11 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'configuration', data: [0] });
-    socket.dispatchVideoData({ type: 'data', data: [1] });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([1]) });
     socket.dispatchDisconnect();
 
     const packets = await collected;


### PR DESCRIPTION
## Summary

- Forward each scrcpy video frame as a `Uint8Array` so socket.io transports it
  as a binary message, instead of `Array.from(value.data)` which boxed every
  byte into a V8 `Number` (~8× heap inflation).
- The renderer in `@midscene/playground-app` now normalizes inbound
  `Uint8Array` / `ArrayBuffer` / `ArrayLike<number>` payloads through a small
  `toUint8Array` helper, with a unit test covering the new transport path.

## Why

On low-memory hosts (e.g. an 8 GB Windows machine) running
`npx --yes @midscene/android-playground`, the Node process crashed after a
few seconds of a 2 Mbps stream with:

```
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed -
JavaScript heap out of memory
```

The hot path was `packages/android-playground/src/scrcpy-server.ts`, which
called `Array.from(value.data)` on every frame before emitting it via
socket.io. Boxing each byte as a JS `Number` blew V8's old space and
caused repeated unsuccessful mark-sweeps. Sending the raw `Uint8Array`
keeps the bytes as a single binary blob and removes the inflation entirely.

## Test plan

- [x] `pnpm -w run lint`
- [x] `npx nx test playground-app` (49 tests passing, includes new
      `accepts Uint8Array and ArrayBuffer payloads from binary transport`)
- [x] `vitest --run` in `packages/android-playground` (11 tests passing)
- [x] `tsc --noEmit` in both `packages/android-playground` and
      `packages/playground-app`
- [ ] Manual smoke: launch `@midscene/android-playground` on Windows 8 GB
      and confirm the scrcpy preview no longer triggers heap OOM