### PR TITLE
fix(core): disable reasoning for locate requests

### DIFF
--- a/apps/chrome-extension/src/extension/recorder/utils.ts
+++ b/apps/chrome-extension/src/extension/recorder/utils.ts
@@ -320,7 +320,10 @@ export const generateRecordTitle = async (
       const response = await callAIWithObjectResponse<{
         title: string;
         description: string;
-      }>([prompt[0], prompt[1]], modelConfig);
+      }>([prompt[0], prompt[1]], modelConfig, {
+        // Model reasoning is unnecessary here.
+        reasoningEnabled: false,
+      });
       if (response?.content) {
         return {
           title: response.content.title as string,
@@ -623,7 +626,10 @@ const generateAIMindmap = async (
       },
     ];
 
-    const response = await callAIWithStringResponse(prompt, modelConfig);
+    const response = await callAIWithStringResponse(prompt, modelConfig, {
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
+    });
 
     if (response?.content && typeof response.content === 'string') {
       return response.content as string;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -927,7 +927,7 @@ export class Agent<
           defaultIntentModelConfig.openaiBaseURL;
 
       const includeBboxInPlanning =
-        !planningModeDeepThink && noIndividualLocateModel;
+        !modelReasoningEnabled && noIndividualLocateModel;
 
       debug('setting includeBboxInPlanning to', includeBboxInPlanning, {
         planningModeDeepThink,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,6 +1,6 @@
 import { isAutoGLM, isUITars } from '@/ai-model/auto-glm/util';
 import yaml from 'js-yaml';
-import type { TUserPrompt } from '../ai-model/index';
+import { type TUserPrompt, resolveReasoningEnabled } from '../ai-model/index';
 import { ScreenshotItem } from '../screenshot-item';
 import Service from '../service/index';
 // Import types and values directly from their source files to avoid circular dependency
@@ -910,7 +910,13 @@ export class Agent<
         this.modelConfigManager.getModelConfig('planning');
       const defaultIntentModelConfig =
         this.modelConfigManager.getModelConfig('default');
-      const deepThink = opt?.deepThink === 'unset' ? undefined : opt?.deepThink;
+      // Controls whether the model request should enable provider-specific reasoning.
+      const modelReasoningEnabled = resolveReasoningEnabled({
+        deepThink: opt?.deepThink,
+        modelConfig: modelConfigForPlanning,
+      });
+      // Controls the aiAct planning mode, such as sub-goal prompts and bbox strategy.
+      const planningModeDeepThink = opt?.deepThink === true;
 
       const deepLocate = opt?.deepLocate;
 
@@ -920,10 +926,12 @@ export class Agent<
         modelConfigForPlanning.openaiBaseURL ===
           defaultIntentModelConfig.openaiBaseURL;
 
-      const includeBboxInPlanning = !deepThink && noIndividualLocateModel;
+      const includeBboxInPlanning =
+        !planningModeDeepThink && noIndividualLocateModel;
 
       debug('setting includeBboxInPlanning to', includeBboxInPlanning, {
-        deepThink,
+        planningModeDeepThink,
+        modelReasoningEnabled,
         noIndividualLocateModel,
       });
 
@@ -956,7 +964,7 @@ export class Agent<
       }
 
       // If cache matched but is not executable, fall through to normal execution
-      const imagesIncludeCount: number = deepThink ? 2 : 1;
+      const imagesIncludeCount: number = opt?.deepThink ? 2 : 1;
       const { output: actionOutput } = await this.taskExecutor.action(
         taskPrompt,
         modelConfigForPlanning,
@@ -966,7 +974,8 @@ export class Agent<
         cacheable,
         replanningCycleLimit,
         imagesIncludeCount,
-        deepThink,
+        planningModeDeepThink,
+        modelReasoningEnabled,
         fileChooserAccept,
         deepLocate,
         abortSignal,

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -16,7 +16,6 @@ import type Service from '@/service';
 import type { TaskRunner } from '@/task-runner';
 import { TaskExecutionError } from '@/task-runner';
 import type {
-  DeepThinkOption,
   DeviceAction,
   ExecutionTaskApply,
   ExecutionTaskInsightQueryApply,
@@ -255,7 +254,8 @@ export class TaskExecutor {
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
     imagesIncludeCount?: number,
-    deepThink?: DeepThinkOption,
+    planningModeDeepThink?: boolean,
+    modelReasoningEnabled?: boolean,
     fileChooserAccept?: string[],
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
@@ -278,7 +278,8 @@ export class TaskExecutor {
         cacheable,
         replanningCycleLimitOverride,
         imagesIncludeCount,
-        deepThink,
+        planningModeDeepThink,
+        modelReasoningEnabled,
         deepLocate,
         abortSignal,
       );
@@ -294,7 +295,8 @@ export class TaskExecutor {
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
     imagesIncludeCount?: number,
-    deepThink?: DeepThinkOption,
+    planningModeDeepThink?: boolean,
+    modelReasoningEnabled?: boolean,
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
   ): Promise<
@@ -348,7 +350,8 @@ export class TaskExecutor {
             userInstruction: userPrompt,
             aiActContext,
             imagesIncludeCount,
-            deepThink,
+            planningModeDeepThink,
+            modelReasoningEnabled,
             ...(subGoalStatus ? { subGoalStatus } : {}),
             ...(memoriesStatus ? { memoriesStatus } : {}),
           },
@@ -388,7 +391,8 @@ export class TaskExecutor {
                 conversationHistory,
                 includeBbox: includeBboxInPlanning,
                 imagesIncludeCount,
-                deepThink,
+                planningModeDeepThink,
+                modelReasoningEnabled,
                 abortSignal,
               });
             } catch (planError) {

--- a/packages/core/src/ai-model/auto-glm/planning.ts
+++ b/packages/core/src/ai-model/auto-glm/planning.ts
@@ -52,7 +52,11 @@ export async function autoGLMPlanning(
   const { content: rawResponse, usage } = await callAIWithStringResponse(
     msgs,
     modelConfig,
-    { abortSignal: options.abortSignal },
+    {
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
+      abortSignal: options.abortSignal,
+    },
   );
 
   debug('autoGLMPlanning rawResponse:', rawResponse);

--- a/packages/core/src/ai-model/connectivity.ts
+++ b/packages/core/src/ai-model/connectivity.ts
@@ -119,6 +119,10 @@ export async function runConnectivityTest(
           },
         ],
         config.planningModelConfig,
+        {
+          // Model reasoning is unnecessary here.
+          reasoningEnabled: false,
+        },
       );
       const content = result.content.trim();
       const passed = content.includes(TEXT_EXPECTED_TOKEN);
@@ -163,6 +167,10 @@ export async function runConnectivityTest(
           },
         ],
         config.insightModelConfig,
+        {
+          // Model reasoning is unnecessary here.
+          reasoningEnabled: false,
+        },
       );
       const normalized = normalizeText(result.content);
       checks.push(

--- a/packages/core/src/ai-model/index.ts
+++ b/packages/core/src/ai-model/index.ts
@@ -3,6 +3,7 @@ export {
   callAIWithStringResponse,
   callAIWithObjectResponse,
   callAI,
+  resolveReasoningEnabled,
 } from './service-caller/index';
 export {
   runConnectivityTest,

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -52,6 +52,7 @@ import {
   callAI,
   callAIWithObjectResponse,
   callAIWithStringResponse,
+  resolveReasoningEnabled,
 } from './service-caller/index';
 
 export type AIArgs = [
@@ -236,6 +237,8 @@ export async function AiLocateElement(options: {
   if (isAutoGLM(modelFamily)) {
     const { content: rawResponseContent, usage } =
       await callAIWithStringResponse(msgs, modelConfig, {
+        // Model reasoning is unnecessary here.
+        reasoningEnabled: false,
         abortSignal: options.abortSignal,
       });
 
@@ -307,7 +310,10 @@ export async function AiLocateElement(options: {
     res = await callAIWithObjectResponse<AIElementResponse | [number, number]>(
       msgs,
       modelConfig,
-      { abortSignal: options.abortSignal },
+      {
+        reasoningEnabled: resolveReasoningEnabled({ modelConfig }),
+        abortSignal: options.abortSignal,
+      },
     );
   } catch (callError) {
     // Return error with usage and rawResponse if available
@@ -447,7 +453,10 @@ export async function AiLocateSection(options: {
     result = await callAIWithObjectResponse<AISectionLocatorResponse>(
       msgs,
       modelConfig,
-      { abortSignal: options.abortSignal },
+      {
+        reasoningEnabled: resolveReasoningEnabled({ modelConfig }),
+        abortSignal: options.abortSignal,
+      },
     );
   } catch (callError) {
     // Return error with usage and rawResponse if available
@@ -594,7 +603,9 @@ export async function AiExtractElementInfo<T>(options: {
     content: rawResponse,
     usage,
     reasoning_content,
-  } = await callAI(msgs, modelConfig);
+  } = await callAI(msgs, modelConfig, {
+    reasoningEnabled: resolveReasoningEnabled({ modelConfig }),
+  });
 
   // Parse XML response to JSON object
   let parseResult: AIDataExtractionResponse<T>;
@@ -639,12 +650,13 @@ export async function AiJudgeOrderSensitive(
   ];
 
   debugInspect(
-    'AiJudgeOrderSensitive: deepThink=false, description=%s',
+    'AiJudgeOrderSensitive: reasoningEnabled=false, description=%s',
     description,
   );
 
   const result = await callAIFn(msgs, modelConfig, {
-    deepThink: false,
+    // Model reasoning is unnecessary here.
+    reasoningEnabled: false,
   });
 
   return {

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -307,11 +307,13 @@ export async function AiLocateElement(options: {
     >
   >;
   try {
+    debugInspect('AiLocateElement: reasoningEnabled forced false');
     res = await callAIWithObjectResponse<AIElementResponse | [number, number]>(
       msgs,
       modelConfig,
       {
-        reasoningEnabled: resolveReasoningEnabled({ modelConfig }),
+        // Model reasoning is unnecessary for locate requests.
+        reasoningEnabled: false,
         abortSignal: options.abortSignal,
       },
     );
@@ -450,11 +452,13 @@ export async function AiLocateSection(options: {
     ReturnType<typeof callAIWithObjectResponse<AISectionLocatorResponse>>
   >;
   try {
+    debugSection('AiLocateSection: reasoningEnabled forced false');
     result = await callAIWithObjectResponse<AISectionLocatorResponse>(
       msgs,
       modelConfig,
       {
-        reasoningEnabled: resolveReasoningEnabled({ modelConfig }),
+        // Model reasoning is unnecessary for locate requests.
+        reasoningEnabled: false,
         abortSignal: options.abortSignal,
       },
     );

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -1,5 +1,4 @@
 import type {
-  DeepThinkOption,
   DeviceAction,
   InterfaceType,
   PlanningAIResponse,
@@ -116,7 +115,10 @@ export async function plan(
     conversationHistory: ConversationHistory;
     includeBbox: boolean;
     imagesIncludeCount?: number;
-    deepThink?: DeepThinkOption;
+    // Controls aiAct planning prompt shape and state updates, such as sub-goals.
+    planningModeDeepThink?: boolean;
+    // Controls provider-specific model reasoning parameters for the LLM request.
+    modelReasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   },
 ): Promise<PlanningAIResponse> {
@@ -126,8 +128,8 @@ export async function plan(
 
   const { modelFamily } = modelConfig;
 
-  // Only enable sub-goals when deepThink is true
-  const includeSubGoals = opts.deepThink === true;
+  // Only enable sub-goals when aiAct is in deep-thinking planning mode.
+  const includeSubGoals = opts.planningModeDeepThink === true;
 
   const systemPrompt = await systemPromptToTaskPlanning({
     actionSpace: opts.actionSpace,
@@ -170,8 +172,8 @@ export async function plan(
   let latestFeedbackMessage: ChatCompletionMessageParam;
 
   // Build sub-goal status text to include in the message
-  // In deepThink mode: show full sub-goals with logs
-  // In non-deepThink mode: show historical execution logs
+  // In planning deep-think mode: show full sub-goals with logs
+  // Otherwise: show historical execution logs
   const subGoalsText = includeSubGoals
     ? conversationHistory.subGoalsToText()
     : conversationHistory.historicalLogsToText();
@@ -236,7 +238,7 @@ export async function plan(
     usage,
     reasoning_content,
   } = await callAI(msgs, modelConfig, {
-    deepThink: opts.deepThink === 'unset' ? undefined : opts.deepThink,
+    reasoningEnabled: opts.modelReasoningEnabled,
     abortSignal: opts.abortSignal,
   });
 
@@ -247,7 +249,7 @@ export async function plan(
       planFromAI = parseXMLPlanningResponse(rawResponse, modelFamily);
     } catch {
       const retry = await callAI(msgs, modelConfig, {
-        deepThink: opts.deepThink === 'unset' ? undefined : opts.deepThink,
+        reasoningEnabled: opts.modelReasoningEnabled,
         abortSignal: opts.abortSignal,
       });
       rawResponse = retry.content;
@@ -271,7 +273,7 @@ export async function plan(
     if (planFromAI.finalizeSuccess !== undefined) {
       debug('task completed via <complete> tag, stop planning');
       shouldContinuePlanning = false;
-      // Mark all sub-goals as finished when goal is completed (only when deepThink is enabled)
+      // Mark all sub-goals as finished when goal is completed in planning deep-think mode.
       if (includeSubGoals) {
         conversationHistory.markAllSubGoalsFinished();
       }
@@ -316,7 +318,7 @@ export async function plan(
       });
     });
 
-    // Update sub-goals in conversation history based on response (only when deepThink is enabled)
+    // Update sub-goals in conversation history only in planning deep-think mode.
     if (includeSubGoals) {
       if (planFromAI.updateSubGoals?.length) {
         conversationHistory.mergeSubGoals(planFromAI.updateSubGoals);
@@ -331,7 +333,7 @@ export async function plan(
         conversationHistory.appendSubGoalLog(planFromAI.log);
       }
     } else {
-      // In non-deepThink mode, accumulate logs as historical execution steps
+      // Without planning deep-think mode, accumulate logs as historical execution steps.
       if (planFromAI.log) {
         conversationHistory.appendHistoricalLog(planFromAI.log);
       }

--- a/packages/core/src/ai-model/prompt/playwright-generator.ts
+++ b/packages/core/src/ai-model/prompt/playwright-generator.ts
@@ -126,7 +126,10 @@ ${PLAYWRIGHT_EXAMPLE_CODE}`;
     },
   ];
 
-  const response = await callAIWithStringResponse(prompt, modelConfig);
+  const response = await callAIWithStringResponse(prompt, modelConfig, {
+    // Model reasoning is unnecessary here.
+    reasoningEnabled: false,
+  });
 
   if (response?.content && typeof response.content === 'string') {
     return response.content;
@@ -211,10 +214,15 @@ ${PLAYWRIGHT_EXAMPLE_CODE}`;
     return await callAI(prompt, modelConfig, {
       stream: true,
       onChunk: options.onChunk,
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
     });
   } else {
     // Fallback to non-streaming
-    const response = await callAIWithStringResponse(prompt, modelConfig);
+    const response = await callAIWithStringResponse(prompt, modelConfig, {
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
+    });
 
     if (response?.content && typeof response.content === 'string') {
       return {

--- a/packages/core/src/ai-model/prompt/yaml-generator.ts
+++ b/packages/core/src/ai-model/prompt/yaml-generator.ts
@@ -371,7 +371,10 @@ export const generateYamlTest = async (
       language: options.language,
     });
 
-    const response = await callAIWithStringResponse(prompt, modelConfig);
+    const response = await callAIWithStringResponse(prompt, modelConfig, {
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
+    });
 
     if (response?.content && typeof response.content === 'string') {
       return response.content;
@@ -424,10 +427,15 @@ export const generateYamlTestStream = async (
       return await callAI(prompt, modelConfig, {
         stream: true,
         onChunk: options.onChunk,
+        // Model reasoning is unnecessary here.
+        reasoningEnabled: false,
       });
     } else {
       // Fallback to non-streaming
-      const response = await callAIWithStringResponse(prompt, modelConfig);
+      const response = await callAIWithStringResponse(prompt, modelConfig, {
+        // Model reasoning is unnecessary here.
+        reasoningEnabled: false,
+      });
 
       if (response?.content && typeof response.content === 'string') {
         return {

--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -1,7 +1,6 @@
 import type {
   AIUsageInfo,
   CodeGenerationChunk,
-  DeepThinkOption,
   StreamingCallback,
 } from '@/types';
 import type { IModelConfig } from '@midscene/shared/env';
@@ -18,7 +17,13 @@ const CODEX_TEXT_INPUT_MAX_LENGTH = 256 * 1024;
 const debugCodex = getDebug('ai:call:codex');
 const warnCodex = getDebug('ai:call:codex', { console: true });
 
-type CodexReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+type CodexReasoningEffort =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh';
 
 type JsonRpcRequest = {
   id: string | number;
@@ -251,17 +256,19 @@ const extractImageInputs = (
 };
 
 export const resolveCodexReasoningEffort = ({
-  deepThink,
+  reasoningEnabled,
   modelConfig,
 }: {
-  deepThink?: DeepThinkOption;
+  reasoningEnabled?: boolean;
   modelConfig: IModelConfig;
 }): CodexReasoningEffort | undefined => {
-  if (deepThink === true) return 'high';
-  if (deepThink === false) return 'low';
+  if (reasoningEnabled === true) return 'high';
+  if (reasoningEnabled === false) return 'none';
 
   const normalized = modelConfig.reasoningEffort?.trim().toLowerCase();
   if (
+    normalized === 'none' ||
+    normalized === 'minimal' ||
     normalized === 'low' ||
     normalized === 'medium' ||
     normalized === 'high' ||
@@ -269,9 +276,6 @@ export const resolveCodexReasoningEffort = ({
   ) {
     return normalized;
   }
-
-  if (modelConfig.reasoningEnabled === true) return 'high';
-  if (modelConfig.reasoningEnabled === false) return 'low';
 
   return undefined;
 };
@@ -389,14 +393,14 @@ class CodexAppServerConnection {
     modelConfig,
     stream,
     onChunk,
-    deepThink,
+    reasoningEnabled,
     abortSignal,
   }: {
     messages: ChatCompletionMessageParam[];
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    deepThink?: DeepThinkOption;
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   }): Promise<CodexTurnResult> {
     const startTime = Date.now();
@@ -406,7 +410,10 @@ class CodexAppServerConnection {
 
     const { developerInstructions, input } =
       buildCodexTurnPayloadFromMessages(messages);
-    const effort = resolveCodexReasoningEffort({ deepThink, modelConfig });
+    const effort = resolveCodexReasoningEffort({
+      reasoningEnabled,
+      modelConfig,
+    });
 
     let threadId: string | undefined;
     let turnId: string | undefined;
@@ -918,14 +925,14 @@ class CodexAppServerConnectionManager {
     modelConfig,
     stream,
     onChunk,
-    deepThink,
+    reasoningEnabled,
     abortSignal,
   }: {
     messages: ChatCompletionMessageParam[];
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    deepThink?: DeepThinkOption;
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   }): Promise<CodexTurnResult> {
     return this.runner.run(async () => {
@@ -936,7 +943,7 @@ class CodexAppServerConnectionManager {
           modelConfig,
           stream,
           onChunk,
-          deepThink,
+          reasoningEnabled,
           abortSignal,
         });
       } catch (error) {
@@ -977,7 +984,7 @@ export async function callAIWithCodexAppServer(
   options?: {
     stream?: boolean;
     onChunk?: StreamingCallback;
-    deepThink?: DeepThinkOption;
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   },
 ): Promise<CodexTurnResult> {
@@ -992,7 +999,7 @@ export async function callAIWithCodexAppServer(
     modelConfig,
     stream: options?.stream,
     onChunk: options?.onChunk,
-    deepThink: options?.deepThink,
+    reasoningEnabled: options?.reasoningEnabled,
     abortSignal: options?.abortSignal,
   });
 }

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -234,7 +234,7 @@ export async function callAI(
   options?: {
     stream?: boolean;
     onChunk?: StreamingCallback;
-    deepThink?: DeepThinkOption;
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   },
 ): Promise<{
@@ -328,22 +328,12 @@ export async function callAI(
     (commonConfig as unknown as Record<string, number>).frequency_penalty = 0.2;
   }
 
-  // Merge deepThink (per-request boolean) with reasoning config (model-level)
-  // deepThink takes priority as a per-request override for reasoningEnabled
-  const mergedEnableReasoning = (() => {
-    const normalizedDeepThink =
-      options?.deepThink === 'unset' ? undefined : options?.deepThink;
-    if (normalizedDeepThink === true) return true;
-    if (normalizedDeepThink === false) return false;
-    return modelConfig.reasoningEnabled;
-  })();
-
   const {
     config: reasoningEffortConfig,
     debugMessage: reasoningEffortDebugMessage,
     warningMessage,
   } = resolveReasoningConfig({
-    reasoningEnabled: mergedEnableReasoning,
+    reasoningEnabled: options?.reasoningEnabled,
     reasoningEffort: modelConfig.reasoningEffort,
     reasoningBudget: modelConfig.reasoningBudget,
     modelFamily,
@@ -608,7 +598,7 @@ export async function callAIWithObjectResponse<T>(
   messages: ChatCompletionMessageParam[],
   modelConfig: IModelConfig,
   options?: {
-    deepThink?: DeepThinkOption;
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   },
 ): Promise<{
@@ -618,7 +608,7 @@ export async function callAIWithObjectResponse<T>(
   reasoning_content?: string;
 }> {
   const response = await callAI(messages, modelConfig, {
-    deepThink: options?.deepThink,
+    reasoningEnabled: options?.reasoningEnabled,
     abortSignal: options?.abortSignal,
   });
   assert(response, 'empty response');
@@ -643,13 +633,26 @@ export async function callAIWithStringResponse(
   msgs: AIArgs,
   modelConfig: IModelConfig,
   options?: {
+    reasoningEnabled?: boolean;
     abortSignal?: AbortSignal;
   },
 ): Promise<{ content: string; usage?: AIUsageInfo }> {
   const { content, usage } = await callAI(msgs, modelConfig, {
+    reasoningEnabled: options?.reasoningEnabled,
     abortSignal: options?.abortSignal,
   });
   return { content, usage };
+}
+
+export function resolveReasoningEnabled({
+  deepThink,
+  modelConfig,
+}: {
+  deepThink?: DeepThinkOption;
+  modelConfig: IModelConfig;
+}): boolean | undefined {
+  const explicitDeepThink = deepThink === 'unset' ? undefined : deepThink;
+  return explicitDeepThink ?? modelConfig.reasoningEnabled;
 }
 
 export function extractJSONFromCodeBlock(response: string) {

--- a/packages/core/src/ai-model/ui-tars-planning.ts
+++ b/packages/core/src/ai-model/ui-tars-planning.ts
@@ -86,7 +86,11 @@ export async function uiTarsPlanning(
       ...conversationHistory.snapshot(),
     ],
     modelConfig,
-    { abortSignal: options.abortSignal },
+    {
+      // Model reasoning is unnecessary here.
+      reasoningEnabled: false,
+      abortSignal: options.abortSignal,
+    },
   );
 
   let convertedText: string;

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -398,6 +398,10 @@ export default class Service {
     const res = await callAIWithObjectResponse<AIDescribeElementResponse>(
       msgs,
       modelConfig,
+      {
+        // Model reasoning is unnecessary here.
+        reasoningEnabled: false,
+      },
     );
 
     const { content } = res;

--- a/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
+++ b/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
@@ -3,7 +3,7 @@ import type { IModelConfig } from '@midscene/shared/env';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('AiJudgeOrderSensitive', () => {
-  it('forces deepThink to false when judging order sensitivity', async () => {
+  it('forces reasoning to false when judging order sensitivity', async () => {
     const callAIFn = vi.fn().mockResolvedValue({
       content: { isOrderSensitive: true },
       usage: { total_tokens: 12 },
@@ -31,7 +31,7 @@ describe('AiJudgeOrderSensitive', () => {
         }),
       ],
       modelConfig,
-      { deepThink: false },
+      { reasoningEnabled: false },
     );
 
     expect(result).toEqual({

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -32,27 +32,26 @@ describe('codex app-server provider helper', () => {
     expect(isCodexAppServerProvider(undefined)).toBe(false);
   });
 
-  it('maps deepThink and reasoning effort to codex effort', () => {
+  it('maps reasoningEnabled and reasoning effort to codex effort', () => {
     expect(
       resolveCodexReasoningEffort({
-        deepThink: true,
+        reasoningEnabled: true,
         modelConfig: baseModelConfig,
       }),
     ).toBe('high');
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: false,
+        reasoningEnabled: false,
         modelConfig: {
           ...baseModelConfig,
           reasoningEffort: 'xhigh',
         },
       }),
-    ).toBe('low');
+    ).toBe('none');
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: 'unset',
         modelConfig: {
           ...baseModelConfig,
           reasoningEffort: 'medium',
@@ -62,7 +61,24 @@ describe('codex app-server provider helper', () => {
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: 'unset',
+        modelConfig: {
+          ...baseModelConfig,
+          reasoningEffort: 'minimal',
+        },
+      }),
+    ).toBe('minimal');
+
+    expect(
+      resolveCodexReasoningEffort({
+        modelConfig: {
+          ...baseModelConfig,
+          reasoningEffort: 'none',
+        },
+      }),
+    ).toBe('none');
+
+    expect(
+      resolveCodexReasoningEffort({
         modelConfig: {
           ...baseModelConfig,
           reasoningEffort: 'invalid-effort',
@@ -72,34 +88,27 @@ describe('codex app-server provider helper', () => {
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: 'unset',
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEnabled: true,
-        },
+        reasoningEnabled: true,
+        modelConfig: baseModelConfig,
       }),
     ).toBe('high');
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: 'unset',
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEnabled: false,
-        },
+        reasoningEnabled: false,
+        modelConfig: baseModelConfig,
       }),
-    ).toBe('low');
+    ).toBe('none');
 
     expect(
       resolveCodexReasoningEffort({
-        deepThink: 'unset',
+        reasoningEnabled: false,
         modelConfig: {
           ...baseModelConfig,
-          reasoningEnabled: false,
           reasoningEffort: 'medium',
         },
       }),
-    ).toBe('medium');
+    ).toBe('none');
   });
 
   it('converts chat messages into codex turn payload', () => {

--- a/packages/core/tests/unit-test/inspect-locate-reasoning.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-reasoning.test.ts
@@ -1,0 +1,131 @@
+import { Agent } from '@/agent';
+import { AiLocateElement, AiLocateSection } from '@/ai-model/inspect';
+import { callAIWithObjectResponse } from '@/ai-model/service-caller/index';
+import type { AbstractInterface } from '@/device';
+import type { UIContext } from '@/types';
+import {
+  type IModelConfig,
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_FAMILY,
+  MIDSCENE_MODEL_NAME,
+  MIDSCENE_MODEL_REASONING_ENABLED,
+} from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ai-model/service-caller/index', () => ({
+  callAIWithObjectResponse: vi.fn(),
+  callAIWithStringResponse: vi.fn(),
+  callAI: vi.fn(),
+  resolveReasoningEnabled: vi.fn(
+    ({ deepThink, modelConfig }) =>
+      (deepThink === 'unset' ? undefined : deepThink) ??
+      modelConfig.reasoningEnabled,
+  ),
+  AIResponseParseError: class AIResponseParseError extends Error {},
+}));
+
+const context: UIContext = {
+  screenshot: {
+    base64: 'data:image/png;base64,test',
+  },
+  shotSize: {
+    width: 100,
+    height: 100,
+  },
+} as UIContext;
+
+const modelConfig: IModelConfig = {
+  modelName: 'test-model',
+  reasoningEnabled: true,
+};
+
+describe('inspect locate reasoning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables model reasoning for element locate requests', async () => {
+    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+      content: {
+        bbox: [0, 0, 50, 50],
+      },
+      contentString: '{"bbox":[0,0,50,50]}',
+    });
+
+    await AiLocateElement({
+      context,
+      targetElementDescription: 'submit button',
+      modelConfig,
+    });
+
+    expect(callAIWithObjectResponse).toHaveBeenCalledWith(
+      expect.any(Array),
+      modelConfig,
+      expect.objectContaining({
+        reasoningEnabled: false,
+      }),
+    );
+  });
+
+  it('disables model reasoning for section locate requests', async () => {
+    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+      content: {},
+      contentString: '{}',
+    });
+
+    await AiLocateSection({
+      context,
+      sectionDescription: 'login form',
+      modelConfig,
+    });
+
+    expect(callAIWithObjectResponse).toHaveBeenCalledWith(
+      expect.any(Array),
+      modelConfig,
+      expect.objectContaining({
+        reasoningEnabled: false,
+      }),
+    );
+  });
+});
+
+describe('aiAct planning locate reasoning', () => {
+  it('excludes bbox from planning when model reasoning is enabled by config', async () => {
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: vi.fn().mockReturnValue([]),
+    } as unknown as AbstractInterface;
+    const agent = new Agent(mockInterface, {
+      generateReport: false,
+      modelConfig: {
+        [MIDSCENE_MODEL_NAME]: 'test-model',
+        [MIDSCENE_MODEL_API_KEY]: 'test-key',
+        [MIDSCENE_MODEL_BASE_URL]: 'https://example.com/v1',
+        [MIDSCENE_MODEL_FAMILY]: 'qwen2.5-vl',
+        [MIDSCENE_MODEL_REASONING_ENABLED]: 'true',
+      },
+    });
+    const actionSpy = vi
+      .spyOn(agent.taskExecutor, 'action')
+      .mockResolvedValue({} as any);
+
+    await agent.aiAct('click the submit button');
+
+    expect(actionSpy).toHaveBeenCalledWith(
+      'click the submit button',
+      expect.any(Object),
+      expect.any(Object),
+      false,
+      undefined,
+      undefined,
+      expect.any(Number),
+      1,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -60,7 +60,8 @@ describe('plan XML parse retry', () => {
       modelConfig,
       conversationHistory: new ConversationHistory(),
       includeBbox: false,
-      deepThink: false,
+      planningModeDeepThink: false,
+      modelReasoningEnabled: false,
     });
 
     expect(callAI).toHaveBeenCalledTimes(2);

--- a/packages/core/tests/unit-test/prompt/playwright-generator.test.ts
+++ b/packages/core/tests/unit-test/prompt/playwright-generator.test.ts
@@ -298,6 +298,9 @@ test('Generated test', async ({ aiInput, aiAssert, aiTap, page }) => {
           }),
         ]),
         mockedModelConfig,
+        {
+          reasoningEnabled: false,
+        },
       );
     });
 

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -1,5 +1,6 @@
 import {
   resolveReasoningConfig,
+  resolveReasoningEnabled,
   safeParseJson,
 } from '@/ai-model/service-caller';
 import type { IModelConfig } from '@midscene/shared/env';
@@ -493,6 +494,52 @@ describe('service-caller', () => {
         modelFamily: 'gemini' as any,
       });
       expect(result.config).toEqual({ reasoning_effort: 'high' });
+    });
+  });
+
+  describe('resolveReasoningEnabled', () => {
+    const modelConfig: IModelConfig = {
+      modelName: 'test-model',
+      modelDescription: 'test',
+      intent: 'planning',
+      reasoningEnabled: true,
+    };
+
+    it('lets explicit deepThink override model reasoning config', () => {
+      expect(
+        resolveReasoningEnabled({
+          deepThink: false,
+          modelConfig,
+        }),
+      ).toBe(false);
+
+      expect(
+        resolveReasoningEnabled({
+          deepThink: true,
+          modelConfig: {
+            ...modelConfig,
+            reasoningEnabled: false,
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('falls back to model reasoning config when deepThink is unset', () => {
+      expect(
+        resolveReasoningEnabled({
+          deepThink: 'unset',
+          modelConfig,
+        }),
+      ).toBe(true);
+
+      expect(
+        resolveReasoningEnabled({
+          modelConfig: {
+            ...modelConfig,
+            reasoningEnabled: undefined,
+          },
+        }),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -14,6 +14,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Mock AI service caller
 vi.mock('@/ai-model/service-caller/index', () => ({
   callAIWithObjectResponse: vi.fn(),
+  resolveReasoningEnabled: vi.fn(
+    ({ deepThink, modelConfig }) =>
+      (deepThink === 'unset' ? undefined : deepThink) ??
+      modelConfig.reasoningEnabled,
+  ),
   AIResponseParseError: class AIResponseParseError extends Error {},
 }));
 


### PR DESCRIPTION
- Force element and section locate calls to send reasoningEnabled=false.

- Keep bbox out of planning when the planning request enables reasoning.

- Add coverage for locate reasoning behavior and aiAct bbox planning.

rely on #2456 