### PR TITLE
fix(studio): always archive packaged Studio app to preserve macOS signature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,24 +269,10 @@ jobs:
     - name: Build Studio and Nx dependencies
       run: npx nx build studio
 
-    - name: Package prerelease Midscene Studio
-      if: ${{ needs.release.outputs.is_prerelease == 'true' }}
-      run: pnpm --dir apps/studio run package:release -- --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --version=${{ needs.release.outputs.version }} --skip-archive
-
-    - name: Package release Midscene Studio
-      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
+    - name: Package Midscene Studio
       run: pnpm --dir apps/studio run package:release -- --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --version=${{ needs.release.outputs.version }}
 
-    - name: Upload prerelease packaged Studio artifact
-      if: ${{ needs.release.outputs.is_prerelease == 'true' }}
-      uses: actions/upload-artifact@v4
-      with:
-        if-no-files-found: error
-        name: studio_${{ matrix.platform }}_${{ matrix.arch }}
-        path: ${{ github.workspace }}/.release/studio/packaged/*
-
-    - name: Upload release packaged Studio archive
-      if: ${{ needs.release.outputs.is_prerelease != 'true' }}
+    - name: Upload packaged Studio artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -1582,15 +1582,22 @@ const createPackagingWorkspace = async ({
   );
 };
 
+// `--sequesterRsrc` and `--keepParent` are load-bearing for macOS: they keep
+// extended attributes (where the notarization stapler ticket lives) and the
+// Electron `.app` framework symlinks intact through the zip round-trip.
+// Without them, Gatekeeper rejects the unzipped bundle with
+// "Apple cannot verify Midscene Studio.app".
+export const buildMacDittoArchiveArgs = ({ sourcePath, artifactPath }) => [
+  '-c',
+  '-k',
+  '--sequesterRsrc',
+  '--keepParent',
+  sourcePath,
+  artifactPath,
+];
+
 const archiveWithDitto = async ({ sourcePath, artifactPath }) => {
-  await run('ditto', [
-    '-c',
-    '-k',
-    '--sequesterRsrc',
-    '--keepParent',
-    sourcePath,
-    artifactPath,
-  ]);
+  await run('ditto', buildMacDittoArchiveArgs({ sourcePath, artifactPath }));
 };
 
 const archiveWithZip = async ({ sourcePath, artifactPath }) => {
@@ -1607,6 +1614,20 @@ const archiveWithPowerShell = async ({ sourcePath, artifactPath }) => {
   ]);
 };
 
+// Returns the archiver name selected for a given host platform. Exported so
+// regression tests can assert macOS always routes through `ditto` — anything
+// else (the generic zip used by `actions/upload-artifact`, `zip`, etc.) drops
+// xattrs and breaks the signed/notarized bundle.
+export const resolvePackagedAppArchiver = (hostPlatform) => {
+  if (hostPlatform === 'darwin') {
+    return 'ditto';
+  }
+  if (hostPlatform === 'win32') {
+    return 'powershell';
+  }
+  return 'zip';
+};
+
 const archivePackagedApp = async ({
   hostPlatform,
   sourcePath,
@@ -1615,6 +1636,10 @@ const archivePackagedApp = async ({
   await removeIfExists(artifactPath);
   await fs.mkdir(path.dirname(artifactPath), { recursive: true });
 
+  // macOS MUST go through ditto. Skipping archive (or substituting a generic
+  // zip step like `actions/upload-artifact`'s internal compressor) strips the
+  // stapled notarization ticket and breaks `_CodeSignature/CodeResources`,
+  // causing Gatekeeper to refuse to launch the bundle after download.
   if (hostPlatform === 'darwin') {
     await archiveWithDitto({ sourcePath, artifactPath });
     return artifactPath;
@@ -1815,7 +1840,6 @@ export const packageStudioElectronApp = async ({
   version,
   platform = process.platform,
   arch = resolveDefaultPackageArch(platform, process.arch),
-  skipArchive = false,
 } = {}) => {
   const normalizedVersion = normalizeReleaseVersion(version);
   const baseName = buildArtifactBaseName({
@@ -1873,13 +1897,6 @@ export const packageStudioElectronApp = async ({
     });
   }
 
-  if (skipArchive) {
-    console.log(
-      `Skipping Midscene Studio archive creation. Packaged app: ${packagedAppPath}`,
-    );
-    return packagedAppPath;
-  }
-
   await archivePackagedApp({
     hostPlatform: process.platform,
     sourcePath: packagedAppPath,
@@ -1901,7 +1918,6 @@ if (isDirectInvocation) {
     options: {
       arch: { type: 'string' },
       platform: { type: 'string' },
-      'skip-archive': { type: 'boolean' },
       version: { type: 'string' },
     },
   });
@@ -1915,7 +1931,6 @@ if (isDirectInvocation) {
   await packageStudioElectronApp({
     arch: values.arch,
     platform: values.platform,
-    skipArchive: values['skip-archive'],
     version,
   });
 }

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -6,6 +6,7 @@ import {
   assertPortablePackagedNodeModules,
   buildArtifactBaseName,
   buildInstallWorkspaceManifest,
+  buildMacDittoArchiveArgs,
   buildPackagedAppManifest,
   buildPackagerOptions,
   buildPnpmSupportedArchitectures,
@@ -30,6 +31,7 @@ import {
   resolveMacCodeSignEntitlementsPath,
   resolveMacPackagedAppBundlePath,
   resolveMacPackagedAppSecurity,
+  resolvePackagedAppArchiver,
   resolvePackagerIconPath,
   shouldUseShellForCommand,
   slimStageNodeModules,
@@ -1090,5 +1092,46 @@ describe('package-electron helpers', () => {
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+
+  // Regression guards for macOS signing/notarization survival. Skipping any of
+  // these allows the packaged `.app` to lose its stapler ticket through the
+  // GitHub artifact zip round-trip, producing the
+  // "Apple cannot verify Midscene Studio.app" Gatekeeper rejection.
+  it('keeps `--sequesterRsrc` and `--keepParent` in the macOS ditto archive args', () => {
+    const args = buildMacDittoArchiveArgs({
+      sourcePath: '/tmp/Midscene Studio.app',
+      artifactPath: '/tmp/Midscene Studio.zip',
+    });
+    expect(args).toContain('--sequesterRsrc');
+    expect(args).toContain('--keepParent');
+    expect(args).toContain('-c');
+    expect(args).toContain('-k');
+    expect(args[args.length - 2]).toBe('/tmp/Midscene Studio.app');
+    expect(args[args.length - 1]).toBe('/tmp/Midscene Studio.zip');
+  });
+
+  it('always routes macOS archiving through ditto', () => {
+    expect(resolvePackagedAppArchiver('darwin')).toBe('ditto');
+    expect(resolvePackagedAppArchiver('win32')).toBe('powershell');
+    expect(resolvePackagedAppArchiver('linux')).toBe('zip');
+  });
+
+  it('release workflow always archives the Studio app and never skips it', async () => {
+    const workflowPath = path.join(
+      releaseWorkspaceDir,
+      '..',
+      '..',
+      '.github',
+      'workflows',
+      'release.yml',
+    );
+    const workflow = await fs.readFile(workflowPath, 'utf8');
+    // `--skip-archive` would bypass `archivePackagedApp` and let
+    // `actions/upload-artifact` re-zip the raw `.app`, dropping xattrs and
+    // breaking the notarization stapler ticket on macOS.
+    expect(workflow).not.toMatch(/--skip-archive/);
+    expect(workflow).toMatch(/Package Midscene Studio/);
+    expect(workflow).toMatch(/\.release\/studio\/artifacts\/\*\.zip/);
   });
 });


### PR DESCRIPTION
## Summary

- Revert `--skip-archive` introduced in #2462 so every Studio build (prerelease + release) flows through `archivePackagedApp`. On macOS that is `ditto -c -k --sequesterRsrc --keepParent`, the only container that survives the GitHub-artifact zip round-trip with extended attributes (stapled notarization ticket) and framework symlinks intact.
- Add regression guards so a future CI tweak cannot silently bypass `ditto` again:
  - export `buildMacDittoArchiveArgs` and assert `--sequesterRsrc` + `--keepParent`
  - export `resolvePackagedAppArchiver` and assert `darwin -> ditto`
  - read `release.yml` from disk in the unit test and assert it never contains `--skip-archive` and still uploads from `.release/studio/artifacts/*.zip`

## Why

After #2462 the prerelease path uploaded the raw `Midscene Studio.app` directory through `actions/upload-artifact@v4`. The artifact's generic zip drops xattrs and breaks `_CodeSignature/CodeResources`, so downloading and unzipping on macOS triggered:

> 未打开"Midscene Studio.app"
> Apple无法验证"Midscene Studio.app"是否包含可能危害Mac安全或泄漏隐私的恶意软件。

CI logs confirm signing + notarization run cleanly on the macOS job — the corruption was strictly in the upload-side zip.

## Test plan

- [x] `pnpm --dir apps/studio exec vitest run tests/package-electron.test.mjs` — 48/48 pass (3 new regression cases)
- [x] `pnpm run lint`
- [ ] Trigger `release.yml` prepatch on this branch, download the `studio_darwin_arm64` artifact, double-click on macOS, confirm Gatekeeper accepts the bundle.