### PR TITLE
feat(core): distinguish model usage intent from config slot

### DIFF
--- a/apps/report/package.json
+++ b/apps/report/package.json
@@ -8,6 +8,8 @@
     "dev:rsdoctor": "RSDOCTOR=true rsbuild dev",
     "build:rsdoctor": "RSDOCTOR=true rsbuild build",
     "preview": "rsbuild preview",
+    "test": "vitest --run",
+    "test:watch": "vitest",
     "generate-demo": "node scripts/generate-demo-report.mjs",
     "e2e": "node scripts/generate-demo-report.mjs && node ../../packages/cli/bin/midscene ./e2e/"
   },
@@ -38,6 +40,7 @@
     "@types/react-dom": "^18.3.1",
     "less": "^4.2.0",
     "rsbuild-plugin-workspace-dev": "0.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "3.0.5"
   }
 }

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -30,6 +30,7 @@ import type {
   PlaywrightTasks,
   VisualizerProps,
 } from './types';
+import { formatModelBriefText } from './utils/model-brief';
 import {
   getEmptyDumpDescription,
   parseDumpAttributes,
@@ -66,15 +67,6 @@ let globalRenderCount = 1;
 const SIDEBAR_WIDTH_KEY = 'midscene-sidebar-width';
 const DEFAULT_SIDEBAR_WIDTH = 280;
 
-const formatModelBrief = (
-  modelBrief: ModelBrief,
-  includeIntent: boolean,
-): string => {
-  const { name, modelDescription, intent } = modelBrief;
-  const base = modelDescription ? `${name}(${modelDescription})` : name;
-  return includeIntent ? `${intent}/${base}` : `${base}`;
-};
-
 function Visualizer(props: VisualizerProps): JSX.Element {
   const { dumps } = props;
 
@@ -97,9 +89,7 @@ function Visualizer(props: VisualizerProps): JSX.Element {
   const playwrightAttributes = useExecutionDump(
     (store) => store.playwrightAttributes,
   );
-  const modelBriefText = modelBriefs
-    .map((brief) => formatModelBrief(brief, modelBriefs.length > 1))
-    .join(', ');
+  const modelBriefText = formatModelBriefText(modelBriefs);
   const reset = useExecutionDump((store) => store.reset);
   const [mainLayoutChangeFlag, setMainLayoutChangeFlag] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(() => {

--- a/apps/report/src/utils/model-brief.ts
+++ b/apps/report/src/utils/model-brief.ts
@@ -1,0 +1,19 @@
+import type { ModelBrief } from '@midscene/core';
+
+const formatModelBrief = (
+  modelBrief: ModelBrief,
+  includeIntent: boolean,
+): string => {
+  const { name, modelDescription, intent } = modelBrief;
+  const base = modelDescription ? `${name}(${modelDescription})` : name;
+  return includeIntent ? `${intent}/${base}` : `${base}`;
+};
+
+export const formatModelBriefText = (modelBriefs: ModelBrief[]): string => {
+  const includeIntent =
+    new Set(modelBriefs.map((brief) => brief.name)).size > 1;
+  const briefsToDisplay = includeIntent ? modelBriefs : modelBriefs.slice(0, 1);
+  return briefsToDisplay
+    .map((brief) => formatModelBrief(brief, includeIntent))
+    .join(', ');
+};

--- a/apps/report/tests/model-brief.test.ts
+++ b/apps/report/tests/model-brief.test.ts
@@ -1,0 +1,68 @@
+import { formatModelBriefText } from '@/utils/model-brief';
+import type { ModelBrief } from '@midscene/core';
+import { describe, expect, it } from 'vitest';
+
+describe('formatModelBriefText', () => {
+  it('hides intent when all intents use the same model', () => {
+    const modelBriefs: ModelBrief[] = [
+      {
+        intent: 'default',
+        name: 'gpt-4o',
+        modelDescription: 'shared model',
+      },
+      {
+        intent: 'planning',
+        name: 'gpt-4o',
+        modelDescription: 'shared model',
+      },
+      {
+        intent: 'insight',
+        name: 'gpt-4o',
+        modelDescription: 'shared model',
+      },
+    ];
+
+    expect(formatModelBriefText(modelBriefs)).toBe('gpt-4o(shared model)');
+  });
+
+  it('still hides intent when descriptions differ but model names are the same', () => {
+    const modelBriefs: ModelBrief[] = [
+      {
+        intent: 'default',
+        name: 'gpt-4o',
+        modelDescription: 'default lane',
+      },
+      {
+        intent: 'planning',
+        name: 'gpt-4o',
+        modelDescription: 'planner lane',
+      },
+    ];
+
+    expect(formatModelBriefText(modelBriefs)).toBe('gpt-4o(default lane)');
+  });
+
+  it('shows intent when multiple different models are used together', () => {
+    const modelBriefs: ModelBrief[] = [
+      {
+        intent: 'default',
+        name: 'gpt-4o',
+        modelDescription: 'shared model',
+      },
+      {
+        intent: 'planning',
+        name: 'o3',
+        modelDescription: 'planner',
+      },
+      {
+        intent: 'insight',
+        name: 'gpt-4o',
+        modelDescription: 'shared model',
+      },
+    ];
+
+    expect(formatModelBriefText(modelBriefs)).toBe(
+      'default/gpt-4o(shared model), planning/o3(planner), insight/gpt-4o(shared model)',
+    );
+  });
+});

--- a/apps/report/vitest.config.ts
+++ b/apps/report/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['tests/**/*.test.ts'],
   },
 });

--- a/apps/studio/src/shared/model-connection.ts
+++ b/apps/studio/src/shared/model-connection.ts
@@ -67,10 +67,8 @@ export function resolveModelConnectionWithConfig(
   const modelConfigManager = new ModelConfigManager(
     normalizedProvider as TModelConfig,
   );
-  const modelConfig: IModelConfig = {
-    ...modelConfigManager.getModelConfig('default'),
-    intent: 'default',
-  };
+  const modelConfig: IModelConfig =
+    modelConfigManager.getModelConfig('default');
 
   return {
     apiKey,

--- a/apps/studio/tests/connectivity-test.test.ts
+++ b/apps/studio/tests/connectivity-test.test.ts
@@ -43,6 +43,7 @@ describe('runConnectivityTest', () => {
         openaiBaseURL: 'https://api.example.com/v1',
         modelName: 'gpt-4o',
         intent: 'default',
+        slot: 'default',
         timeout: 30_000,
       }),
       expect.objectContaining({

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -3,6 +3,7 @@ import type { AbstractInterface } from '@/device';
 import type Service from '@/service';
 import { setTimingFieldOnce } from '@/task-timing';
 import type {
+  AIUsageInfo,
   DetailedLocateParam,
   DeviceAction,
   ElementCacheFeature,
@@ -24,6 +25,7 @@ import { generateElementByRect } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import type { TaskCache } from './task-cache';
+import { withUsageIntent } from './usage-intent';
 import {
   ifPlanLocateParamIsBbox,
   matchElementFromCache,
@@ -420,7 +422,7 @@ export class TaskBuilder {
             dump,
             rawResponse: dump.taskInfo?.rawResponse,
           };
-          task.usage = dump.taskInfo?.usage;
+          task.usage = withUsageIntent(dump.taskInfo?.usage, 'default');
           if (dump.taskInfo?.searchAreaUsage) {
             task.searchAreaUsage = dump.taskInfo.searchAreaUsage;
           }

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -41,6 +41,7 @@ export { locatePlanForLocate } from './task-builder';
 import { setTimingFieldOnce } from '@/task-timing';
 import { descriptionOfTree } from '@midscene/shared/extractor';
 import { taskTitleStr } from './ui-utils';
+import { withUsageIntent } from './usage-intent';
 import { parsePrompt } from './utils';
 
 interface ExecutionResult<OutputType = any> {
@@ -393,7 +394,10 @@ export class TaskExecutor {
             } catch (planError) {
               if (planError instanceof AIResponseParseError) {
                 // Record usage and rawResponse even when parsing fails
-                executorContext.task.usage = planError.usage;
+                executorContext.task.usage = withUsageIntent(
+                  planError.usage,
+                  'planning',
+                );
                 executorContext.task.log = {
                   ...(executorContext.task.log || {}),
                   rawResponse: planError.rawResponse,
@@ -425,7 +429,7 @@ export class TaskExecutor {
               ...(executorContext.task.log || {}),
               rawResponse,
             };
-            executorContext.task.usage = usage;
+            executorContext.task.usage = withUsageIntent(usage, 'planning');
             executorContext.task.reasoning_content = reasoning_content;
             executorContext.task.output = {
               actions: actions || [],
@@ -580,7 +584,7 @@ export class TaskExecutor {
             dump,
             rawResponse: dump.taskInfo?.rawResponse,
           };
-          task.usage = dump.taskInfo?.usage;
+          task.usage = withUsageIntent(dump.taskInfo?.usage, 'insight');
           if (dump.taskInfo?.reasoning_content) {
             task.reasoning_content = dump.taskInfo.reasoning_content;
           }

--- a/packages/core/src/agent/usage-intent.ts
+++ b/packages/core/src/agent/usage-intent.ts
@@ -1,0 +1,26 @@
+import type { AIUsageInfo } from '@/types';
+import type { TIntent } from '@midscene/shared/env';
+import { getDebug } from '@midscene/shared/logger';
+
+const warnUsageIntent = getDebug('agent:usage-intent', { console: true });
+
+export function withUsageIntent(
+  usage: AIUsageInfo | undefined,
+  intent: TIntent,
+): AIUsageInfo | undefined {
+  if (!usage) {
+    return undefined;
+  }
+
+  if (usage.intent) {
+    warnUsageIntent(
+      `intent is already set to "${usage.intent}", skipping overwrite to "${intent}"`,
+    );
+    return usage;
+  }
+
+  return {
+    ...usage,
+    intent,
+  };
+}

--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -729,7 +729,8 @@ class CodexAppServerConnection {
       time_cost: Date.now() - startTime,
       model_name: modelConfig.modelName,
       model_description: modelConfig.modelDescription,
-      intent: modelConfig.intent,
+      slot: modelConfig.slot,
+      intent: undefined,
       request_id: turnId,
     } satisfies AIUsageInfo;
   }

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -324,7 +324,8 @@ export async function callAI(
       time_cost: timeCost ?? 0,
       model_name: modelName,
       model_description: modelDescription,
-      intent: modelConfig.intent,
+      slot: modelConfig.slot,
+      intent: undefined,
       request_id: requestId ?? undefined,
     } satisfies AIUsageInfo;
   };
@@ -544,7 +545,7 @@ export async function callAI(
           const wasHardTimeout = isHardTimeoutError(lastError);
           if (wasHardTimeout) {
             warnCall(
-              `AI call hit hard timeout (${effectiveTimeoutMs}ms, attempt ${attempt}/${maxAttempts}, model ${modelName}, intent ${modelConfig.intent})`,
+              `AI call hit hard timeout (${effectiveTimeoutMs}ms, attempt ${attempt}/${maxAttempts}, model ${modelName}, slot ${modelConfig.slot})`,
             );
           }
           // Do not retry if the request was aborted by the caller

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,7 +44,15 @@ export type AIUsageInfo = Record<string, any> & {
   time_cost: number | undefined;
   model_name: string | undefined;
   model_description: string | undefined;
+  /**
+   * Semantic intent of the model call, such as default, planning, or insight.
+   */
   intent: string | undefined;
+  /**
+   * Config slot where the model config was resolved from. For example, a
+   * planning call may use the default slot when no planning model is configured.
+   */
+  slot: string | undefined;
   request_id: string | undefined;
 };
 

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -76,6 +76,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "default",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -91,7 +92,7 @@ describe('Agent with custom OpenAI client', () => {
           "createOpenAIClient": undefined,
           "extraBody": undefined,
           "httpProxy": undefined,
-          "intent": "default",
+          "intent": "planning",
           "modelDescription": "qwen2.5-vl mode",
           "modelFamily": "qwen2.5-vl",
           "modelName": "qwen2.5-vl-max",
@@ -103,6 +104,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "default",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -118,7 +120,7 @@ describe('Agent with custom OpenAI client', () => {
           "createOpenAIClient": undefined,
           "extraBody": undefined,
           "httpProxy": undefined,
-          "intent": "default",
+          "intent": "insight",
           "modelDescription": "qwen2.5-vl mode",
           "modelFamily": "qwen2.5-vl",
           "modelName": "qwen2.5-vl-max",
@@ -130,6 +132,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "default",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -169,6 +172,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "default",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -196,6 +200,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "planning",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -223,6 +228,7 @@ describe('Agent with custom OpenAI client', () => {
           "reasoningEnabled": undefined,
           "retryCount": 1,
           "retryInterval": 2000,
+          "slot": "insight",
           "socksProxy": undefined,
           "temperature": 0,
           "timeout": undefined,
@@ -313,12 +319,14 @@ describe('Agent with custom OpenAI client', () => {
       );
       expect(planningConfig.createOpenAIClient).toBe(mockCreateClient);
       expect(planningConfig.intent).toBe('planning');
+      expect(planningConfig.slot).toBe('planning');
 
       const defaultConfig = (agent as any).modelConfigManager.getModelConfig(
         'default',
       );
       expect(defaultConfig.createOpenAIClient).toBe(mockCreateClient);
       expect(defaultConfig.intent).toBe('default');
+      expect(defaultConfig.slot).toBe('default');
     });
   });
 

--- a/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
+++ b/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
@@ -13,6 +13,7 @@ describe('AiJudgeOrderSensitive', () => {
       modelName: 'test-model',
       modelDescription: 'test model',
       intent: 'default',
+      slot: 'default',
     };
 
     const result = await AiJudgeOrderSensitive(

--- a/packages/core/tests/unit-test/bbox-locate-cache.test.ts
+++ b/packages/core/tests/unit-test/bbox-locate-cache.test.ts
@@ -66,6 +66,7 @@ describe('bbox locate cache fix', () => {
     modelName: 'test-model',
     modelDescription: 'test model for unit tests',
     intent: 'default',
+    slot: 'default',
   };
 
   beforeEach(() => {
@@ -373,6 +374,76 @@ describe('bbox locate cache fix', () => {
       // Verify cacheFeatureForPoint was NOT called (cache already exists)
       expect(mockInterface.cacheFeatureForPoint).not.toHaveBeenCalled();
     });
+  });
+
+  it('should annotate AI locate usage with default intent while preserving raw slot', async () => {
+    vi.mocked(mockInterface.rectMatchesCacheFeature).mockResolvedValue(
+      undefined,
+    );
+    vi.mocked(mockService.locate).mockResolvedValueOnce({
+      element: {
+        id: 'element-id',
+        center: [500, 300],
+        rect: { left: 450, top: 280, width: 100, height: 40 },
+        xpaths: ['/html/body/input[1]'],
+        attributes: {},
+      },
+      dump: {
+        taskInfo: {
+          rawResponse: '{"bbox":[450,280,550,320]}',
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 2,
+            total_tokens: 12,
+            model_name: 'test-model',
+            slot: 'default',
+          },
+        },
+      },
+    } as any);
+
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'search input box',
+            },
+          },
+          thought: 'tap the search box',
+        },
+      ],
+      mockModelConfig,
+      mockModelConfig,
+      { cacheable: false },
+    );
+
+    const locateTask = tasks.find((task) => task.subType === 'Locate');
+    expect(locateTask).toBeDefined();
+
+    const runtimeTask = {
+      type: 'Planning',
+      subType: 'Locate',
+      param: locateTask!.param,
+      status: 'running',
+      timing: { start: Date.now(), end: 0, cost: 0 },
+      executor: locateTask!.executor,
+    } as any;
+
+    await locateTask!.executor(locateTask!.param, {
+      task: runtimeTask,
+      uiContext: await createMockUIContext(validBase64Image),
+    });
+
+    expect(runtimeTask.usage).toMatchObject({
+      intent: 'default',
+      slot: 'default',
+    });
+    expect(runtimeTask.log?.dump?.taskInfo?.usage).toMatchObject({
+      slot: 'default',
+    });
+    expect(runtimeTask.log?.dump?.taskInfo?.usage?.intent).toBeUndefined();
   });
 
   describe('cache hit on second execution', () => {

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -14,6 +14,7 @@ const baseModelConfig: IModelConfig = {
   modelName: 'gpt-5.4',
   modelDescription: 'codex',
   intent: 'default',
+  slot: 'default',
 };
 
 describe('codex app-server provider helper', () => {

--- a/packages/core/tests/unit-test/connectivity.test.ts
+++ b/packages/core/tests/unit-test/connectivity.test.ts
@@ -32,18 +32,21 @@ describe('runConnectivityTest', () => {
     modelDescription: 'test-model-desc',
     modelFamily: 'qwen2.5-vl',
     intent: 'default',
+    slot: 'default',
   };
   const planningModelConfig: IModelConfig = {
     modelName: 'test-planning-model',
     modelDescription: 'test-planning-model-desc',
     modelFamily: 'qwen2.5-vl',
     intent: 'planning',
+    slot: 'planning',
   };
   const insightModelConfig: IModelConfig = {
     modelName: 'test-insight-model',
     modelDescription: 'test-insight-model-desc',
     modelFamily: 'gpt-5',
     intent: 'insight',
+    slot: 'insight',
   };
 
   beforeEach(() => {

--- a/packages/core/tests/unit-test/gpt-image-detail.test.ts
+++ b/packages/core/tests/unit-test/gpt-image-detail.test.ts
@@ -22,6 +22,7 @@ const baseModelConfig: IModelConfig = {
   openaiBaseURL: 'https://api.openai.com/v1',
   modelFamily: 'gpt-5',
   intent: 'default',
+  slot: 'default',
 };
 
 const imageMessage = [
@@ -109,6 +110,7 @@ describe('GPT image detail handling', () => {
     await callAI(imageMessage, {
       ...baseModelConfig,
       intent: 'planning',
+      slot: 'planning',
     });
 
     expect(mockCreate).toHaveBeenCalledWith(

--- a/packages/core/tests/unit-test/prompt/playwright-generator.test.ts
+++ b/packages/core/tests/unit-test/prompt/playwright-generator.test.ts
@@ -272,7 +272,7 @@ test('Generated test', async ({ aiInput, aiAssert, aiTap, page }) => {
       modelName: 'mock',
       modelDescription: 'mock',
       intent: 'default',
-      from: 'modelConfig',
+      slot: 'default',
     } as const satisfies IModelConfig;
 
     test('should generate Playwright test successfully', async () => {

--- a/packages/core/tests/unit-test/prompt/yaml-generator.test.ts
+++ b/packages/core/tests/unit-test/prompt/yaml-generator.test.ts
@@ -33,7 +33,7 @@ const mockedModelConfig = {
   modelName: 'mock',
   modelDescription: 'mock',
   intent: 'default',
-  from: 'modelConfig',
+  slot: 'default',
 } as const satisfies IModelConfig;
 
 describe('yaml-generator', () => {

--- a/packages/core/tests/unit-test/proxy-configuration.test.ts
+++ b/packages/core/tests/unit-test/proxy-configuration.test.ts
@@ -61,6 +61,7 @@ describe('Proxy Configuration', () => {
         httpProxy: httpProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 1000,
       };
 
@@ -84,6 +85,7 @@ describe('Proxy Configuration', () => {
         httpProxy: httpProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -107,6 +109,7 @@ describe('Proxy Configuration', () => {
         httpProxy: httpProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -132,6 +135,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 1000,
       };
 
@@ -157,6 +161,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -182,6 +187,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -209,6 +215,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -229,6 +236,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -250,6 +258,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -271,6 +280,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 500,
       };
 
@@ -296,6 +306,7 @@ describe('Proxy Configuration', () => {
         socksProxy: socksProxy,
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 1000,
       };
 
@@ -321,6 +332,7 @@ describe('Proxy Configuration', () => {
         openaiApiKey: 'test-key',
         modelDescription: 'test',
         intent: 'default',
+        slot: 'default',
         timeout: 5000,
       };
 

--- a/packages/core/tests/unit-test/service-caller-empty-content.test.ts
+++ b/packages/core/tests/unit-test/service-caller-empty-content.test.ts
@@ -39,7 +39,7 @@ describe('service-caller empty content handling', () => {
       openaiBaseURL: 'https://api.openai.com/v1',
       modelDescription: 'test model',
       intent: 'default',
-      from: 'modelConfig',
+      slot: 'default',
     };
 
     const promise = callAI([{ role: 'user', content: 'hello' }], modelConfig);
@@ -56,8 +56,10 @@ describe('service-caller empty content handling', () => {
         total_tokens: 12,
         model_name: 'gpt-4o',
         model_description: 'test model',
+        slot: 'default',
         request_id: 'req_test_123',
       });
+      expect(typedError.usage?.intent).toBeUndefined();
       expect(typedError.rawResponse).toContain('"choices"');
     }
   });

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -20,6 +20,7 @@ const baseModelConfig: IModelConfig = {
   openaiApiKey: 'test-key',
   openaiBaseURL: 'https://example.com/v1',
   intent: 'planning',
+  slot: 'planning',
 };
 
 describe('service-caller reasoning fallback', () => {

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -20,7 +20,7 @@ const baseConfig = (overrides: Partial<IModelConfig> = {}): IModelConfig =>
     openaiBaseURL: 'https://api.openai.com/v1',
     modelDescription: 'test model',
     intent: 'default',
-    from: 'modelConfig',
+    slot: 'default',
     retryCount: 0,
     ...overrides,
   }) as IModelConfig;

--- a/packages/core/tests/unit-test/service-caller.test.ts
+++ b/packages/core/tests/unit-test/service-caller.test.ts
@@ -147,7 +147,7 @@ describe('service-caller', () => {
         openaiBaseURL: 'https://api.openai.com/v1',
         modelDescription: 'test',
         intent: 'default',
-        from: 'modelConfig',
+        slot: 'default',
         createOpenAIClient: mockCreateClient,
       };
 
@@ -163,7 +163,7 @@ describe('service-caller', () => {
         openaiBaseURL: 'https://api.openai.com/v1',
         modelDescription: 'test',
         intent: 'default',
-        from: 'env',
+        slot: 'default',
       };
 
       // Should not have createOpenAIClient

--- a/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
+++ b/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
@@ -24,6 +24,7 @@ describe('service.locate deepLocate routing', () => {
     modelName: 'test-model',
     modelDescription: 'test-model-desc',
     intent: 'default',
+    slot: 'default',
   };
 
   beforeEach(() => {

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -44,6 +44,7 @@ const insightFindTask = (shouldThrow?: boolean) => {
           modelName: 'mock-model',
           modelDescription: 'mock-model-description',
           intent: 'default',
+          slot: 'default',
         },
       );
       return {

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -1,4 +1,5 @@
 import { TaskExecutor } from '@/agent/tasks';
+import * as aiModel from '@/ai-model';
 import { ScreenshotItem } from '@/screenshot-item';
 import type { ServiceDump } from '@/types';
 import type { IModelConfig } from '@midscene/shared/env';
@@ -69,6 +70,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -113,6 +115,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -153,6 +156,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -197,6 +201,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -219,6 +224,196 @@ describe('TaskExecutor - Null Data Handling', () => {
       expect(result.thought).toBe('Condition is met');
     });
 
+    it('should preserve insight intent while recording resolved config slot', async () => {
+      const dump = {
+        ...createMockDump({ Boolean: true }, 'Condition is met'),
+        taskInfo: {
+          durationMs: 100,
+          rawResponse: '{"Boolean":true}',
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 3,
+            total_tokens: 15,
+            model_name: 'mock-model',
+            slot: 'default',
+          },
+        },
+      } as ServiceDump;
+
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: {
+            Boolean: true,
+          },
+          usage: dump.taskInfo?.usage,
+          thought: 'Condition is met',
+          dump,
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+        slot: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'Boolean',
+        'Element is visible',
+        mockModelConfig,
+        {},
+      );
+
+      const result = await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      expect(result.output).toBe(true);
+      expect(queryTask.usage).toMatchObject({
+        intent: 'insight',
+        slot: 'default',
+      });
+      expect(queryTask.log?.dump?.taskInfo?.usage).toMatchObject({
+        slot: 'default',
+      });
+      expect(queryTask.log?.dump?.taskInfo?.usage?.intent).toBeUndefined();
+    });
+
+    it('should preserve planning intent while recording resolved config slot', async () => {
+      const planSpy = vi.spyOn(aiModel, 'plan').mockResolvedValue({
+        actions: [],
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 5,
+          total_tokens: 25,
+          model_name: 'mock-plan-model',
+          slot: 'default',
+        },
+        rawResponse: '{"actions":[]}',
+        shouldContinuePlanning: false,
+        output: 'done',
+      } as any);
+
+      const mockService = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const planningModelConfig: IModelConfig = {
+        modelName: 'mock-plan-model',
+        modelDescription: 'mock-plan-model-description',
+        intent: 'default',
+        slot: 'default',
+      };
+
+      const defaultModelConfig: IModelConfig = {
+        modelName: 'mock-default-model',
+        modelDescription: 'mock-default-model-description',
+        intent: 'default',
+        slot: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor(
+        { interfaceType: 'web' } as any,
+        mockService,
+        {
+          actionSpace: [],
+          replanningCycleLimit: 1,
+        },
+      );
+
+      const result = await taskExecutor.action(
+        'complete the task',
+        planningModelConfig,
+        defaultModelConfig,
+        false,
+      );
+
+      const planningTask = result.runner.tasks[0];
+      expect(planningTask.type).toBe('Planning');
+      expect(planningTask.usage).toMatchObject({
+        intent: 'planning',
+        slot: 'default',
+      });
+
+      planSpy.mockRestore();
+    });
+
+    it('should preserve existing intent and warn instead of overwriting it', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const dump = {
+        ...createMockDump({ Boolean: true }, 'Condition is met'),
+        taskInfo: {
+          durationMs: 100,
+          rawResponse: '{"Boolean":true}',
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 3,
+            total_tokens: 15,
+            model_name: 'mock-model',
+            intent: 'preexisting',
+            slot: 'default',
+          },
+        },
+      } as ServiceDump;
+
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: {
+            Boolean: true,
+          },
+          usage: dump.taskInfo?.usage,
+          thought: 'Condition is met',
+          dump,
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+        slot: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'Boolean',
+        'Element is visible',
+        mockModelConfig,
+        {},
+      );
+
+      await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      expect(queryTask.usage).toMatchObject({
+        intent: 'preexisting',
+        slot: 'default',
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Midscene]',
+        'intent is already set to "preexisting", skipping overwrite to "insight"',
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it('should handle string data for WaitFor operation', async () => {
       const mockInsight = {
         contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
@@ -237,6 +432,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -275,6 +471,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -315,6 +512,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -358,6 +556,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -412,6 +611,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {
@@ -449,6 +649,7 @@ describe('TaskExecutor - Null Data Handling', () => {
         modelName: 'mock-model',
         modelDescription: 'mock-model-description',
         intent: 'default',
+        slot: 'default',
       };
 
       const taskExecutor = new TaskExecutor({} as any, mockInsight, {

--- a/packages/shared/src/env/model-config-manager.ts
+++ b/packages/shared/src/env/model-config-manager.ts
@@ -68,14 +68,17 @@ export class ModelConfigManager {
     this.modelConfigMap = {
       default: {
         ...defaultConfig,
+        intent: 'default',
         createOpenAIClient: this.createOpenAIClientFn,
       },
       insight: {
         ...(insightConfig || defaultConfig),
+        intent: 'insight',
         createOpenAIClient: this.createOpenAIClientFn,
       },
       planning: {
         ...(planningConfig || defaultConfig),
+        intent: 'planning',
         createOpenAIClient: this.createOpenAIClientFn,
       },
     };

--- a/packages/shared/src/env/parse-model-config.ts
+++ b/packages/shared/src/env/parse-model-config.ts
@@ -244,6 +244,7 @@ export const parseOpenaiSdkConfig = ({
     modelName: modelName!,
     modelDescription,
     intent: '-' as any,
+    slot: '-' as any,
     timeout: provider[keys.timeout]
       ? Number(provider[keys.timeout])
       : undefined,
@@ -308,6 +309,7 @@ export const decideModelConfigFromIntentConfig = (
     useLegacyLogic: intent === 'default',
   });
   finalResult.intent = intent;
+  finalResult.slot = intent;
 
   debugLog(
     'decideModelConfig result by agent.modelConfig() with intent',

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -427,7 +427,7 @@ export enum UITarsModelVersion {
 
 /**
  * Callback to create custom OpenAI client instance
- * @param config - Resolved model configuration including apiKey, baseURL, modelName, intent, etc.
+ * @param config - Resolved model configuration including apiKey, baseURL, modelName, intent, slot, etc.
  * @returns OpenAI client instance (can be wrapped with langsmith, langfuse, etc.)
  *
  * Note: Wrapper functions like langsmith's wrapOpenAI() return the same OpenAI instance
@@ -521,9 +521,16 @@ export interface IModelConfig {
   uiTarsModelVersion?: UITarsModelVersion;
   modelDescription: string;
   /**
-   * original intent from the config
+   * The semantic intent this config is requested for.
+   * For example, getModelConfig('planning') always returns intent === 'planning'.
    */
   intent: TIntent;
+  /**
+   * The model-config slot this config was resolved from.
+   * For example, getModelConfig('planning') may resolve from slot === 'default'
+   * when MIDSCENE_PLANNING_MODEL_NAME is not configured.
+   */
+  slot: TIntent;
   /**
    * Custom OpenAI client factory function
    *

--- a/packages/shared/tests/unit-test/env/decide-model.test.ts
+++ b/packages/shared/tests/unit-test/env/decide-model.test.ts
@@ -18,6 +18,7 @@ describe('decideModelConfigFromIntentConfig', () => {
   it('parses intent specific config', () => {
     const result = decideModelConfigFromIntentConfig('insight', baseConfig)!;
     expect(result.intent).toBe('insight');
+    expect(result.slot).toBe('insight');
     expect(result.modelName).toBe('insight-model');
     expect(result.openaiApiKey).toBe('insight-key');
     expect(result.openaiBaseURL).toBe('https://insight.example.com');

--- a/packages/shared/tests/unit-test/env/helper.test.ts
+++ b/packages/shared/tests/unit-test/env/helper.test.ts
@@ -6,7 +6,6 @@ describe('maskConfig', () => {
   it('key will be masked', () => {
     const config: IModelConfig = {
       modelName: 'test-model',
-      from: 'env',
       openaiApiKey: 'sk-thisisafakekeythatislongenough',
       socksProxy: 'socks://proxy.example.com:1080',
       httpProxy: 'http://proxy.example.com:8080',
@@ -15,11 +14,12 @@ describe('maskConfig', () => {
       modelFamily: 'doubao-vision',
       modelDescription: '',
       intent: 'default',
+      slot: 'default',
     };
     expect(maskConfig(config)).toEqual({
-      from: 'env',
       httpProxy: 'http://proxy.example.com:8080',
       intent: 'default',
+      slot: 'default',
       modelDescription: '',
       modelName: 'test-model',
       openaiApiKey: 'sk-***************************ugh',

--- a/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
@@ -60,6 +60,34 @@ describe('ModelConfigManager', () => {
     expect(defaultConfig.modelName).toBe('gpt-4');
     expect(insightConfig.modelName).toBe('gpt-4-vision');
     expect(planningConfig.modelName).toBe('qwen-vl-plus');
+    expect(defaultConfig.intent).toBe('default');
+    expect(defaultConfig.slot).toBe('default');
+    expect(insightConfig.intent).toBe('insight');
+    expect(insightConfig.slot).toBe('insight');
+    expect(planningConfig.intent).toBe('planning');
+    expect(planningConfig.slot).toBe('planning');
+  });
+
+  it('records intent and slot when intent config falls back to default', () => {
+    const {
+      [MIDSCENE_INSIGHT_MODEL_NAME]: _insightName,
+      [MIDSCENE_INSIGHT_MODEL_API_KEY]: _insightApiKey,
+      [MIDSCENE_INSIGHT_MODEL_BASE_URL]: _insightBaseUrl,
+      [MIDSCENE_PLANNING_MODEL_NAME]: _planningName,
+      [MIDSCENE_PLANNING_MODEL_API_KEY]: _planningApiKey,
+      [MIDSCENE_PLANNING_MODEL_BASE_URL]: _planningBaseUrl,
+      ...configWithoutIntentModels
+    } = baseMap;
+    const manager = new ModelConfigManager(configWithoutIntentModels);
+
+    const insightConfig = manager.getModelConfig('insight');
+    const planningConfig = manager.getModelConfig('planning');
+    expect(insightConfig.intent).toBe('insight');
+    expect(insightConfig.slot).toBe('default');
+    expect(insightConfig.modelName).toBe('gpt-4');
+    expect(planningConfig.intent).toBe('planning');
+    expect(planningConfig.slot).toBe('default');
+    expect(planningConfig.modelName).toBe('gpt-4');
   });
 
   it('prefer MIDSCENE_MODEL', () => {
@@ -78,6 +106,7 @@ describe('ModelConfigManager', () => {
     expect(config.openaiApiKey).toBe('env-key');
     expect(config.openaiBaseURL).toBe('https://env.example.com');
     expect(config.intent).toBe('default');
+    expect(config.slot).toBe('default');
   });
 
   it('reads from environment when no config function provided', () => {
@@ -94,6 +123,7 @@ describe('ModelConfigManager', () => {
     expect(config.openaiApiKey).toBe('env-key');
     expect(config.openaiBaseURL).toBe('https://env.example.com');
     expect(config.intent).toBe('default');
+    expect(config.slot).toBe('default');
   });
 
   it('provides upload server URL from openaiExtraConfig', () => {

--- a/packages/web-integration/tests/unit-test/agent.test.ts
+++ b/packages/web-integration/tests/unit-test/agent.test.ts
@@ -66,7 +66,7 @@ const mockedModelConfig = {
 
 const modelConfigCalcByMockedModelConfig = {
   httpProxy: undefined,
-  intent: 'default',
+  intent: 'insight',
   modelDescription: 'qwen3-vl mode',
   modelName: 'mock-model',
   openaiApiKey: 'mock-api-key',
@@ -77,8 +77,13 @@ const modelConfigCalcByMockedModelConfig = {
   uiTarsModelVersion: undefined,
   modelFamily: 'qwen3-vl',
   createOpenAIClient: undefined,
+  extraBody: undefined,
+  reasoningBudget: undefined,
+  reasoningEffort: undefined,
+  reasoningEnabled: undefined,
   retryCount: 1,
   retryInterval: 2000,
+  slot: 'default',
   timeout: undefined,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jsdom@29.0.2)(less@4.2.2)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
 
   apps/site:
     dependencies:
@@ -2290,19 +2293,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':


### PR DESCRIPTION
This change separates two model usage concepts:

- `intent`: the semantic purpose of the model call, such as `default`, `planning`, or `insight`.
- `slot`: the resolved model config slot actually used, such as `default` when a `planning` call falls back to the default model config.

This makes report usage clearer: the UI shows what the call was for, while the raw usage still records where the model config came from.

It also updates the related types, report/visualizer reads, and unit tests for fallback and usage annotation cases.