### PR TITLE
feat(computer): expose RDP options in connect CLI

### DIFF
--- a/packages/computer/src/mcp-tools.ts
+++ b/packages/computer/src/mcp-tools.ts
@@ -5,8 +5,13 @@ import {
   type InitArgSpec,
 } from '@midscene/shared/mcp/base-tools';
 import type { ToolDefinition } from '@midscene/shared/mcp/types';
-import { type ComputerAgent, agentFromComputer } from './agent';
+import {
+  type ComputerAgent,
+  agentForRDPComputer,
+  agentFromComputer,
+} from './agent';
 import { ComputerDevice, type ComputerDeviceOpt } from './device';
+import type { RDPConnectionConfig } from './rdp/protocol';
 
 const debug = getDebug('mcp:computer-tools');
 
@@ -14,14 +19,72 @@ const computerInitArgShape = {
   displayId: z
     .string()
     .optional()
-    .describe('Display ID (from computer_list_displays)'),
+    .describe(
+      'Display ID for local mode (from computer_list_displays). Ignored when host is set.',
+    ),
   headless: z
     .boolean()
     .optional()
-    .describe('Start virtual display via Xvfb (Linux only)'),
+    .describe(
+      'Start virtual display via Xvfb (Linux local mode only). Ignored when host is set.',
+    ),
+  // RDP options. Providing `host` switches connect into RDP mode and routes
+  // the session through the RDP helper binary instead of the local desktop.
+  host: z
+    .string()
+    .optional()
+    .describe('RDP host (FQDN or IP). Set this to connect via RDP.'),
+  port: z
+    .number()
+    .optional()
+    .describe('RDP port (default 3389). RDP mode only.'),
+  username: z.string().optional().describe('RDP username. RDP mode only.'),
+  password: z
+    .string()
+    .optional()
+    .describe(
+      'RDP password. RDP mode only. Prefer setting via environment or a secrets manager.',
+    ),
+  domain: z.string().optional().describe('RDP domain. RDP mode only.'),
+  adminSession: z
+    .boolean()
+    .optional()
+    .describe('Attach to the RDP admin/console session. RDP mode only.'),
+  ignoreCertificate: z
+    .boolean()
+    .optional()
+    .describe('Skip TLS certificate validation. RDP mode only.'),
+  securityProtocol: z
+    .enum(['auto', 'tls', 'nla', 'rdp'])
+    .optional()
+    .describe(
+      'RDP security protocol negotiation (default auto). RDP mode only.',
+    ),
+  desktopWidth: z
+    .number()
+    .optional()
+    .describe('Remote desktop width in pixels. RDP mode only.'),
+  desktopHeight: z
+    .number()
+    .optional()
+    .describe('Remote desktop height in pixels. RDP mode only.'),
 };
 
-type ComputerInitArgs = Pick<ComputerDeviceOpt, 'displayId' | 'headless'>;
+type ComputerLocalInitArgs = Pick<ComputerDeviceOpt, 'displayId' | 'headless'>;
+type ComputerRDPInitArgs = Pick<
+  RDPConnectionConfig,
+  | 'host'
+  | 'port'
+  | 'username'
+  | 'password'
+  | 'domain'
+  | 'adminSession'
+  | 'ignoreCertificate'
+  | 'securityProtocol'
+  | 'desktopWidth'
+  | 'desktopHeight'
+>;
+type ComputerInitArgs = ComputerLocalInitArgs & ComputerRDPInitArgs;
 
 /**
  * Computer-specific tools manager
@@ -50,12 +113,11 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
   }
 
   protected async ensureAgent(opts?: ComputerInitArgs): Promise<ComputerAgent> {
-    const displayId = opts?.displayId;
-    const headless = opts?.headless;
+    const hasAnyOpt = !!opts && Object.keys(opts).length > 0;
 
-    if (this.agent && (displayId !== undefined || headless !== undefined)) {
-      // If a specific displayId is requested and we have an agent,
-      // destroy it to create a new one with the new display
+    if (this.agent && hasAnyOpt) {
+      // Any new init args force a fresh agent so subsequent calls cannot
+      // silently reuse a session bound to a different display or RDP host.
       try {
         await this.agent.destroy?.();
       } catch (error) {
@@ -68,8 +130,41 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
       return this.agent;
     }
 
-    debug('Creating Computer agent with displayId:', displayId || 'primary');
     const reportOptions = this.readCliReportAgentOptions();
+
+    if (opts?.host) {
+      debug('Creating RDP Computer agent for host:', opts.host);
+      const rdpOpts = {
+        host: opts.host,
+        ...(opts.port !== undefined ? { port: opts.port } : {}),
+        ...(opts.username !== undefined ? { username: opts.username } : {}),
+        ...(opts.password !== undefined ? { password: opts.password } : {}),
+        ...(opts.domain !== undefined ? { domain: opts.domain } : {}),
+        ...(opts.adminSession !== undefined
+          ? { adminSession: opts.adminSession }
+          : {}),
+        ...(opts.ignoreCertificate !== undefined
+          ? { ignoreCertificate: opts.ignoreCertificate }
+          : {}),
+        ...(opts.securityProtocol !== undefined
+          ? { securityProtocol: opts.securityProtocol }
+          : {}),
+        ...(opts.desktopWidth !== undefined
+          ? { desktopWidth: opts.desktopWidth }
+          : {}),
+        ...(opts.desktopHeight !== undefined
+          ? { desktopHeight: opts.desktopHeight }
+          : {}),
+        ...(reportOptions ?? {}),
+      };
+      const agent = await agentForRDPComputer(rdpOpts);
+      this.agent = agent;
+      return agent;
+    }
+
+    const displayId = opts?.displayId;
+    const headless = opts?.headless;
+    debug('Creating Computer agent with displayId:', displayId || 'primary');
     const agentOpts = {
       ...(displayId ? { displayId } : {}),
       ...(headless !== undefined ? { headless } : {}),
@@ -90,14 +185,15 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
       {
         name: 'computer_connect',
         description:
-          'Connect to computer desktop. Provide displayId to connect to a specific display (use computer_list_displays to get available IDs). If not provided, uses the primary display.',
+          'Connect to a computer desktop. Default (local) mode controls the local machine; pass displayId to target a specific local display (see computer_list_displays). Pass host (with optional port/username/password/domain/securityProtocol/ignoreCertificate/adminSession/desktopWidth/desktopHeight) to connect to a remote Windows desktop via RDP instead.',
         schema: this.getAgentInitArgSchema(),
         cli: this.getAgentInitArgCliMetadata(),
         handler: async (args: Record<string, unknown>) => {
           const initArgs = this.extractAgentInitParam(args);
-          const reportSession = this.createNewCliReportSession(
-            initArgs?.displayId ?? 'primary',
-          );
+          const targetIdentity = initArgs?.host
+            ? `rdp:${initArgs.host}`
+            : (initArgs?.displayId ?? 'primary');
+          const reportSession = this.createNewCliReportSession(targetIdentity);
           this.commitCliReportSession(reportSession);
           if (this.agent) {
             try {
@@ -110,11 +206,19 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
           const agent = await this.ensureAgent(initArgs);
           const screenshot = await agent.interface.screenshotBase64();
 
+          const connectedDescription = initArgs?.host
+            ? ` via RDP (${initArgs.host}${initArgs.port ? `:${initArgs.port}` : ''}${
+                initArgs.username ? ` as ${initArgs.username}` : ''
+              })`
+            : initArgs?.displayId
+              ? ` (Display: ${initArgs.displayId})`
+              : ' (Primary display)';
+
           return {
             content: [
               {
                 type: 'text',
-                text: `Connected to computer${initArgs?.displayId ? ` (Display: ${initArgs.displayId})` : ' (Primary display)'}`,
+                text: `Connected to computer${connectedDescription}`,
               },
               ...this.buildScreenshotContent(screenshot),
             ],

--- a/packages/computer/src/mcp-tools.ts
+++ b/packages/computer/src/mcp-tools.ts
@@ -11,9 +11,16 @@ import {
   agentFromComputer,
 } from './agent';
 import { ComputerDevice, type ComputerDeviceOpt } from './device';
-import type { RDPConnectionConfig } from './rdp/protocol';
+import type { RDPConnectionConfig, RDPSecurityProtocol } from './rdp/protocol';
 
 const debug = getDebug('mcp:computer-tools');
+
+const RDP_SECURITY_PROTOCOLS = [
+  'auto',
+  'tls',
+  'nla',
+  'rdp',
+] as const satisfies readonly RDPSecurityProtocol[];
 
 const computerInitArgShape = {
   displayId: z
@@ -30,61 +37,113 @@ const computerInitArgShape = {
     ),
   // RDP options. Providing `host` switches connect into RDP mode and routes
   // the session through the RDP helper binary instead of the local desktop.
+  // All other RDP options below are silently ignored unless `host` is set.
   host: z
     .string()
     .optional()
-    .describe('RDP host (FQDN or IP). Set this to connect via RDP.'),
+    .describe('RDP host (FQDN or IP). Set this to switch into RDP mode.'),
   port: z
     .number()
     .optional()
-    .describe('RDP port (default 3389). RDP mode only.'),
-  username: z.string().optional().describe('RDP username. RDP mode only.'),
+    .describe('RDP port (default 3389). Requires host.'),
+  username: z.string().optional().describe('RDP username. Requires host.'),
   password: z
     .string()
     .optional()
     .describe(
-      'RDP password. RDP mode only. Prefer setting via environment or a secrets manager.',
+      'RDP password. Requires host. Prefer setting via environment or a secrets manager.',
     ),
-  domain: z.string().optional().describe('RDP domain. RDP mode only.'),
+  domain: z.string().optional().describe('RDP domain. Requires host.'),
   adminSession: z
     .boolean()
     .optional()
-    .describe('Attach to the RDP admin/console session. RDP mode only.'),
+    .describe('Attach to the RDP admin/console session. Requires host.'),
   ignoreCertificate: z
     .boolean()
     .optional()
-    .describe('Skip TLS certificate validation. RDP mode only.'),
+    .describe('Skip TLS certificate validation. Requires host.'),
   securityProtocol: z
-    .enum(['auto', 'tls', 'nla', 'rdp'])
+    .enum(RDP_SECURITY_PROTOCOLS)
     .optional()
     .describe(
-      'RDP security protocol negotiation (default auto). RDP mode only.',
+      'RDP security protocol negotiation (default auto). Requires host.',
     ),
   desktopWidth: z
     .number()
     .optional()
-    .describe('Remote desktop width in pixels. RDP mode only.'),
+    .describe('Remote desktop width in pixels. Requires host.'),
   desktopHeight: z
     .number()
     .optional()
-    .describe('Remote desktop height in pixels. RDP mode only.'),
+    .describe('Remote desktop height in pixels. Requires host.'),
 };
 
-type ComputerLocalInitArgs = Pick<ComputerDeviceOpt, 'displayId' | 'headless'>;
-type ComputerRDPInitArgs = Pick<
-  RDPConnectionConfig,
-  | 'host'
-  | 'port'
-  | 'username'
-  | 'password'
-  | 'domain'
-  | 'adminSession'
-  | 'ignoreCertificate'
-  | 'securityProtocol'
-  | 'desktopWidth'
-  | 'desktopHeight'
+/** Init args for the local desktop agent (macOS/Windows/Linux). */
+export type ComputerLocalInitArgs = {
+  mode: 'local';
+} & Pick<ComputerDeviceOpt, 'displayId' | 'headless'>;
+
+/** Init args for the RDP remote-desktop agent. */
+export type ComputerRDPInitArgs = {
+  mode: 'rdp';
+} & RDPConnectionConfig;
+
+/**
+ * Discriminated union describing the two ways `computer_*` tools can spawn an
+ * agent. `mode` is filled in by `initArgSpec.adapt` based on whether `host` is
+ * set, so callers (CLI/MCP/YAML) never have to provide it explicitly.
+ */
+export type ComputerInitArgs = ComputerLocalInitArgs | ComputerRDPInitArgs;
+
+type ExtractedComputerInitArgs = Partial<
+  Pick<ComputerDeviceOpt, 'displayId' | 'headless'> & RDPConnectionConfig
 >;
-type ComputerInitArgs = ComputerLocalInitArgs & ComputerRDPInitArgs;
+
+function adaptComputerInitArgs(
+  extracted: ExtractedComputerInitArgs | undefined,
+): ComputerInitArgs | undefined {
+  if (!extracted || Object.keys(extracted).length === 0) {
+    return undefined;
+  }
+  if (extracted.host) {
+    // Drop local-only fields; they're meaningless in RDP mode.
+    const { displayId: _d, headless: _h, ...rdpFields } = extracted;
+    return {
+      mode: 'rdp',
+      ...rdpFields,
+      host: extracted.host,
+    };
+  }
+  return {
+    mode: 'local',
+    displayId: extracted.displayId,
+    headless: extracted.headless,
+  };
+}
+
+function shouldRetargetAgent(opts: ComputerInitArgs | undefined): boolean {
+  if (!opts) return false;
+  if (opts.mode === 'rdp') return true;
+  return opts.displayId !== undefined || opts.headless !== undefined;
+}
+
+function describeConnectTarget(opts: ComputerInitArgs | undefined): string {
+  if (opts?.mode === 'rdp') {
+    const portSuffix = opts.port ? `:${opts.port}` : '';
+    const userSuffix = opts.username ? ` as ${opts.username}` : '';
+    return ` via RDP (${opts.host}${portSuffix}${userSuffix})`;
+  }
+  if (opts?.mode === 'local' && opts.displayId) {
+    return ` (Display: ${opts.displayId})`;
+  }
+  return ' (Primary display)';
+}
+
+function getCliReportSessionTarget(opts: ComputerInitArgs | undefined): string {
+  if (opts?.mode === 'rdp') return `rdp:${opts.host}`;
+  if (opts?.mode === 'local' && opts.displayId) return opts.displayId;
+  return 'primary';
+}
 
 /**
  * Computer-specific tools manager
@@ -104,7 +163,8 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
     cli: {
       preferBareKeys: true,
     },
-    adapt: (extracted) => extracted as ComputerInitArgs | undefined,
+    adapt: (extracted) =>
+      adaptComputerInitArgs(extracted as ExtractedComputerInitArgs | undefined),
   };
 
   protected createTemporaryDevice() {
@@ -113,11 +173,10 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
   }
 
   protected async ensureAgent(opts?: ComputerInitArgs): Promise<ComputerAgent> {
-    const hasAnyOpt = !!opts && Object.keys(opts).length > 0;
-
-    if (this.agent && hasAnyOpt) {
-      // Any new init args force a fresh agent so subsequent calls cannot
-      // silently reuse a session bound to a different display or RDP host.
+    if (this.agent && shouldRetargetAgent(opts)) {
+      // Only displayId/headless/host actually change the underlying device
+      // target; for any of those we tear down the current agent so the next
+      // call rebuilds against the new target.
       try {
         await this.agent.destroy?.();
       } catch (error) {
@@ -132,38 +191,19 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
 
     const reportOptions = this.readCliReportAgentOptions();
 
-    if (opts?.host) {
+    if (opts?.mode === 'rdp') {
       debug('Creating RDP Computer agent for host:', opts.host);
-      const rdpOpts = {
-        host: opts.host,
-        ...(opts.port !== undefined ? { port: opts.port } : {}),
-        ...(opts.username !== undefined ? { username: opts.username } : {}),
-        ...(opts.password !== undefined ? { password: opts.password } : {}),
-        ...(opts.domain !== undefined ? { domain: opts.domain } : {}),
-        ...(opts.adminSession !== undefined
-          ? { adminSession: opts.adminSession }
-          : {}),
-        ...(opts.ignoreCertificate !== undefined
-          ? { ignoreCertificate: opts.ignoreCertificate }
-          : {}),
-        ...(opts.securityProtocol !== undefined
-          ? { securityProtocol: opts.securityProtocol }
-          : {}),
-        ...(opts.desktopWidth !== undefined
-          ? { desktopWidth: opts.desktopWidth }
-          : {}),
-        ...(opts.desktopHeight !== undefined
-          ? { desktopHeight: opts.desktopHeight }
-          : {}),
+      const { mode: _mode, ...rdpFields } = opts;
+      const agent = await agentForRDPComputer({
+        ...rdpFields,
         ...(reportOptions ?? {}),
-      };
-      const agent = await agentForRDPComputer(rdpOpts);
+      });
       this.agent = agent;
       return agent;
     }
 
-    const displayId = opts?.displayId;
-    const headless = opts?.headless;
+    const displayId = opts?.mode === 'local' ? opts.displayId : undefined;
+    const headless = opts?.mode === 'local' ? opts.headless : undefined;
     debug('Creating Computer agent with displayId:', displayId || 'primary');
     const agentOpts = {
       ...(displayId ? { displayId } : {}),
@@ -184,16 +224,19 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
     return [
       {
         name: 'computer_connect',
-        description:
-          'Connect to a computer desktop. Default (local) mode controls the local machine; pass displayId to target a specific local display (see computer_list_displays). Pass host (with optional port/username/password/domain/securityProtocol/ignoreCertificate/adminSession/desktopWidth/desktopHeight) to connect to a remote Windows desktop via RDP instead.',
+        description: [
+          'Connect to a computer desktop.',
+          'Default (local) mode controls the local machine; pass displayId to target a specific local display (see computer_list_displays).',
+          'Pass host to switch to RDP mode and connect to a remote Windows desktop via the RDP helper binary.',
+          'RDP-related options (port/username/password/domain/securityProtocol/ignoreCertificate/adminSession/desktopWidth/desktopHeight) only take effect when host is set.',
+        ].join(' '),
         schema: this.getAgentInitArgSchema(),
         cli: this.getAgentInitArgCliMetadata(),
         handler: async (args: Record<string, unknown>) => {
           const initArgs = this.extractAgentInitParam(args);
-          const targetIdentity = initArgs?.host
-            ? `rdp:${initArgs.host}`
-            : (initArgs?.displayId ?? 'primary');
-          const reportSession = this.createNewCliReportSession(targetIdentity);
+          const reportSession = this.createNewCliReportSession(
+            getCliReportSessionTarget(initArgs),
+          );
           this.commitCliReportSession(reportSession);
           if (this.agent) {
             try {
@@ -206,19 +249,11 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
           const agent = await this.ensureAgent(initArgs);
           const screenshot = await agent.interface.screenshotBase64();
 
-          const connectedDescription = initArgs?.host
-            ? ` via RDP (${initArgs.host}${initArgs.port ? `:${initArgs.port}` : ''}${
-                initArgs.username ? ` as ${initArgs.username}` : ''
-              })`
-            : initArgs?.displayId
-              ? ` (Display: ${initArgs.displayId})`
-              : ' (Primary display)';
-
           return {
             content: [
               {
                 type: 'text',
-                text: `Connected to computer${connectedDescription}`,
+                text: `Connected to computer${describeConnectTarget(initArgs)}`,
               },
               ...this.buildScreenshotContent(screenshot),
             ],

--- a/packages/computer/tests/unit-test/mcp-tools.test.ts
+++ b/packages/computer/tests/unit-test/mcp-tools.test.ts
@@ -1,9 +1,13 @@
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { getMidsceneRunBaseDir } from '@midscene/shared/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { agentFromComputer } from '../../src/agent';
+import { agentForRDPComputer, agentFromComputer } from '../../src/agent';
 import { ComputerMidsceneTools } from '../../src/mcp-tools';
 
 vi.mock('../../src/agent', () => ({
   agentFromComputer: vi.fn(),
+  agentForRDPComputer: vi.fn(),
 }));
 
 vi.mock('../../src/device', () => ({
@@ -29,13 +33,23 @@ function createMockAgent() {
   };
 }
 
+function clearCliReportSession(): void {
+  const sessionDir = join(getMidsceneRunBaseDir(), 'cli-report-session');
+  if (existsSync(sessionDir)) {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+}
+
 describe('ComputerMidsceneTools', () => {
   beforeEach(() => {
+    clearCliReportSession();
     vi.mocked(agentFromComputer).mockResolvedValue(createMockAgent() as any);
+    vi.mocked(agentForRDPComputer).mockResolvedValue(createMockAgent() as any);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    clearCliReportSession();
   });
 
   it('passes namespaced computer init args to take_screenshot', async () => {
@@ -105,7 +119,66 @@ describe('ComputerMidsceneTools', () => {
       expect.objectContaining({
         'computer.displayId': expect.anything(),
         'computer.headless': expect.anything(),
+        'computer.host': expect.anything(),
+        'computer.port': expect.anything(),
+        'computer.username': expect.anything(),
+        'computer.password': expect.anything(),
+        'computer.securityProtocol': expect.anything(),
       }),
     );
+  });
+
+  it('routes connect with host to agentForRDPComputer', async () => {
+    const tools = new ComputerMidsceneTools();
+    await tools.initTools();
+
+    const connectTool = tools
+      .getToolDefinitions()
+      .find((tool) => tool.name === 'computer_connect');
+
+    expect(connectTool).toBeDefined();
+
+    await connectTool?.handler({
+      host: 'remote.example.com',
+      port: 3390,
+      username: 'admin',
+      password: 'secret',
+      'security-protocol': 'nla',
+      'ignore-certificate': true,
+    });
+
+    expect(agentForRDPComputer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'remote.example.com',
+        port: 3390,
+        username: 'admin',
+        password: 'secret',
+        securityProtocol: 'nla',
+        ignoreCertificate: true,
+      }),
+    );
+    expect(agentFromComputer).not.toHaveBeenCalled();
+  });
+
+  it('keeps local connect path when host is omitted', async () => {
+    const tools = new ComputerMidsceneTools();
+    await tools.initTools();
+
+    const connectTool = tools
+      .getToolDefinitions()
+      .find((tool) => tool.name === 'computer_connect');
+
+    expect(connectTool).toBeDefined();
+
+    await connectTool?.handler({
+      'display-id': 'display-2',
+    });
+
+    expect(agentFromComputer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayId: 'display-2',
+      }),
+    );
+    expect(agentForRDPComputer).not.toHaveBeenCalled();
   });
 });

--- a/packages/computer/tests/unit-test/mcp-tools.test.ts
+++ b/packages/computer/tests/unit-test/mcp-tools.test.ts
@@ -160,6 +160,34 @@ describe('ComputerMidsceneTools', () => {
     expect(agentFromComputer).not.toHaveBeenCalled();
   });
 
+  it('routes action tools with namespaced host to agentForRDPComputer', async () => {
+    const tools = new ComputerMidsceneTools();
+    await tools.initTools();
+
+    const takeScreenshotTool = tools
+      .getToolDefinitions()
+      .find((tool) => tool.name === 'take_screenshot');
+
+    expect(takeScreenshotTool).toBeDefined();
+
+    await takeScreenshotTool?.handler({
+      computer: {
+        host: 'remote.example.com',
+        port: 3389,
+        username: 'admin',
+      },
+    });
+
+    expect(agentForRDPComputer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'remote.example.com',
+        port: 3389,
+        username: 'admin',
+      }),
+    );
+    expect(agentFromComputer).not.toHaveBeenCalled();
+  });
+
   it('keeps local connect path when host is omitted', async () => {
     const tools = new ComputerMidsceneTools();
     await tools.initTools();


### PR DESCRIPTION
## Summary

- Add `host`, `port`, `username`, `password`, `domain`, `adminSession`, `ignoreCertificate`, `securityProtocol`, `desktopWidth`, and `desktopHeight` options to the `computer_connect` MCP tool / `midscene-computer connect` CLI.
- When `host` is provided, `ensureAgent` builds the session via `agentForRDPComputer` and routes every subsequent action through the RDP helper binary. The existing local desktop path is unchanged when no host is supplied.
- Refresh the `connect` tool description and success message so RDP targets surface as `Connected to computer via RDP (host[:port] as user)` rather than the local-display string.
- Cover the new branch with two unit tests (RDP route, local route) and reset the on-disk CLI report session between tests so existing assertions remain stable.

## Why

`@midscene/computer` already ships an RDP runtime (`RDPDevice`, `agentForRDPComputer`, helper binary), but the CLI / MCP layer only accepted `displayId` and `headless`, so consumers — including the `computer-automation` skill that calls `npx -y @midscene/computer@1 connect ...` — had no way to target a remote Windows host. This change finishes the wiring so RDP is reachable from the same `connect` entry point that local mode uses.

## Test plan

- [x] `npx vitest run tests/unit-test` (44/44 passing in `@midscene/computer`)
- [x] `npx nx build computer`
- [x] `pnpm run lint`
- [x] Manual: `node dist/lib/cli.js connect --help` shows all RDP flags with the expected kebab-case spellings and aliases.