### PR TITLE
fix(studio): move runtime logs to temp run dir

### DIFF
--- a/apps/studio/scripts/runtime-env.mjs
+++ b/apps/studio/scripts/runtime-env.mjs
@@ -1,8 +1,12 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 export const resolveRepoEnvPath = (studioRootDir) =>
   path.resolve(studioRootDir, '..', '..', '.env');
+
+export const resolveDefaultStudioRunDir = () =>
+  path.join(os.tmpdir(), 'midscene-studio');
 
 export const buildStudioRuntimeEnv = ({
   baseEnv = process.env,
@@ -36,6 +40,10 @@ function finalizeStudioRuntimeEnv(env, envPathExists, studioRootDir) {
     if (envPathExists(repoEnvPath)) {
       env.DOTENV_CONFIG_PATH = repoEnvPath;
     }
+  }
+
+  if (!env.MIDSCENE_RUN_DIR) {
+    env.MIDSCENE_RUN_DIR = resolveDefaultStudioRunDir();
   }
 
   return env;

--- a/apps/studio/tests/runtime-env.test.mjs
+++ b/apps/studio/tests/runtime-env.test.mjs
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildStudioRuntimeEnv,
+  resolveDefaultStudioRunDir,
   resolveRepoEnvPath,
 } from '../scripts/runtime-env.mjs';
 
@@ -34,6 +35,24 @@ describe('runtime-env', () => {
     });
 
     expect(env.DOTENV_CONFIG_PATH).toBe('/custom/.env');
+  });
+
+  it('defaults the Studio run directory to a system temp directory', () => {
+    const env = buildStudioRuntimeEnv({
+      baseEnv: {},
+      studioRootDir,
+    });
+
+    expect(env.MIDSCENE_RUN_DIR).toBe(resolveDefaultStudioRunDir());
+  });
+
+  it('preserves an existing MIDSCENE_RUN_DIR override', () => {
+    const env = buildStudioRuntimeEnv({
+      baseEnv: { MIDSCENE_RUN_DIR: '/custom/studio-run' },
+      studioRootDir,
+    });
+
+    expect(env.MIDSCENE_RUN_DIR).toBe('/custom/studio-run');
   });
 
   it('strips NODE_PATH so Electron resolves workspace packages deterministically', () => {


### PR DESCRIPTION
## Summary
- Default Studio runtime output to the existing `MIDSCENE_RUN_DIR` mechanism under the system temp directory.
- Keep explicit `MIDSCENE_RUN_DIR` overrides intact.
- Add runtime-env coverage for the default temp run directory and override behavior.

## Validation
- `pnpm --filter studio test -- tests/runtime-env.test.mjs`
- `pnpm --filter @midscene/shared test -- tests/unit-test/env/utils.test.ts`
- `pnpm run lint`
