### PR TITLE
feat(studio): add auto-update powered by electron-updater + GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,11 @@ jobs:
       with:
         if-no-files-found: error
         name: studio_${{ matrix.platform }}_${{ matrix.arch }}
-        path: ${{ github.workspace }}/.release/studio/artifacts/*.zip
+        # Include the electron-updater channel manifests so reviewers can
+        # download the same set the GitHub Release will publish.
+        path: |
+          ${{ github.workspace }}/.release/studio/artifacts/*.zip
+          ${{ github.workspace }}/.release/studio/artifacts/*.yml
 
     - name: Upload Studio asset to GitHub Release
       if: ${{ needs.release.outputs.is_prerelease != 'true' }}
@@ -286,6 +290,11 @@ jobs:
         tag_name: ${{ needs.release.outputs.version }}
         target_commitish: ${{ github.event.inputs.branch }}
         prerelease: ${{ contains(needs.release.outputs.version, 'beta') || contains(needs.release.outputs.version, 'alpha') || contains(needs.release.outputs.version, 'rc') }}
-        files: ${{ github.workspace }}/.release/studio/artifacts/*.zip
+        # The zip is the artifact users download; latest-*.yml (and
+        # beta-*.yml on prereleases) is what electron-updater fetches to
+        # learn the version + sha512 of the matching zip.
+        files: |
+          ${{ github.workspace }}/.release/studio/artifacts/*.zip
+          ${{ github.workspace }}/.release/studio/artifacts/*.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/report/e2e/sidebar-navigation.yaml
+++ b/apps/report/e2e/sidebar-navigation.yaml
@@ -5,24 +5,102 @@ tasks:
   - name: sidebar task list is rendered
     flow:
       - sleep: 3000
-      - aiAssert: The left sidebar shows a list of task execution rows
+      - javascript: |
+          (function () {
+            const rows = document.querySelectorAll('.tasks-table .task-row');
+            if (rows.length < 2) {
+              throw new Error(
+                'Expected at least two sidebar task rows, found ' + rows.length,
+              );
+            }
+            return { taskRows: rows.length };
+          })()
+        name: assertSidebarRows
 
   - name: click a task row to view details
     flow:
-      - ai: Click on the first task row in the left sidebar execution list
-      - sleep: 3000
-      - aiAssert: The right detail panel shows task-related content such as Param, Output, or Meta sections
+      - javascript: |
+          (function () {
+            const firstRow = document.querySelector('.tasks-table .task-row');
+            if (!(firstRow instanceof HTMLElement)) {
+              throw new Error('First sidebar task row not found');
+            }
+            firstRow.click();
+            return { clickedTaskId: firstRow.getAttribute('data-task-id') };
+          })()
+        name: clickFirstTaskRow
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const labels = Array.from(
+              document.querySelectorAll('.detail-side .summary-text'),
+            ).map((element) => element.textContent?.trim());
+            const hasParam = labels.includes('Param');
+            const hasOutput = labels.includes('Output') || labels.includes('Element');
+            const hasMeta = labels.includes('Meta');
+            if (!hasParam || !hasOutput || !hasMeta) {
+              throw new Error(
+                'Expected detail side sections Param, Output/Element, and Meta; found ' +
+                  labels.join(', '),
+              );
+            }
+            return { labels };
+          })()
+        name: assertDetailSideSections
 
   - name: navigate between tasks
     flow:
-      - ai: Click on the second task row in the left sidebar
-      - sleep: 2000
-      - aiAssert: The right detail panel is visible and shows task-related content
+      - javascript: |
+          (function () {
+            const rows = Array.from(
+              document.querySelectorAll('.tasks-table .task-row'),
+            );
+            const secondRow = rows[1];
+            if (!(secondRow instanceof HTMLElement)) {
+              throw new Error('Second sidebar task row not found');
+            }
+            secondRow.click();
+            return { clickedTaskId: secondRow.getAttribute('data-task-id') };
+          })()
+        name: clickSecondTaskRow
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const selectedRow = document.querySelector('.tasks-table .task-row.selected');
+            if (!(selectedRow instanceof HTMLElement)) {
+              throw new Error('No selected sidebar task row after navigation');
+            }
+            const labels = Array.from(
+              document.querySelectorAll('.detail-side .summary-text'),
+            ).map((element) => element.textContent?.trim());
+            if (!labels.includes('Param') || !labels.includes('Meta')) {
+              throw new Error(
+                'Expected detail side to stay visible after task navigation; found ' +
+                  labels.join(', '),
+              );
+            }
+            return {
+              selectedTaskId: selectedRow.getAttribute('data-task-id'),
+              labels,
+            };
+          })()
+        name: assertSecondTaskSelected
 
   - name: toggle model call details
     flow:
-      - ai: Click the "Model Call Details" checkbox or toggle in the sidebar
-      - sleep: 2000
+      - javascript: |
+          (function () {
+            const checkbox = document.querySelector(
+              '.token-usage-checkbox input[type="checkbox"]',
+            );
+            if (!(checkbox instanceof HTMLElement)) {
+              throw new Error('Model Call Details checkbox not found in DOM');
+            }
+            checkbox.click();
+            return { clicked: true };
+          })()
+        name: clickProModeOn
+      - sleep: 1000
       - javascript: |
           (function () {
             const checkbox = document.querySelector(
@@ -47,8 +125,19 @@ tasks:
             return { proModeEnabled: true, intentHeaderRendered: true };
           })()
         name: assertProModeOn
-      - ai: Click the "Model Call Details" checkbox again to turn it off
-      - sleep: 2000
+      - javascript: |
+          (function () {
+            const checkbox = document.querySelector(
+              '.token-usage-checkbox input[type="checkbox"]',
+            );
+            if (!(checkbox instanceof HTMLElement)) {
+              throw new Error('Model Call Details checkbox not found in DOM');
+            }
+            checkbox.click();
+            return { clicked: true };
+          })()
+        name: clickProModeOff
+      - sleep: 1000
       - javascript: |
           (function () {
             const checkbox = document.querySelector(

--- a/apps/studio/dev-app-update.yml
+++ b/apps/studio/dev-app-update.yml
@@ -1,0 +1,4 @@
+provider: github
+owner: web-infra-dev
+repo: midscene
+updaterCacheDirName: midscene-studio-updater

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -29,6 +29,7 @@
     "@midscene/visualizer": "workspace:*",
     "@midscene/web": "workspace:*",
     "antd": "^5.21.6",
+    "electron-updater": "6.8.3",
     "puppeteer": "24.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/apps/studio/rsbuild.config.ts
+++ b/apps/studio/rsbuild.config.ts
@@ -136,6 +136,7 @@ export default defineConfig({
         },
         externals: [
           'electron',
+          'electron-updater',
           '@midscene/android',
           '@midscene/android-playground',
           '@midscene/computer',

--- a/apps/studio/scripts/build-update-metadata.mjs
+++ b/apps/studio/scripts/build-update-metadata.mjs
@@ -20,7 +20,58 @@ const platformBetaYmlName = {
   win32: 'beta.yml',
 };
 
+// We hand-roll the YAML because the manifest schema is fixed and tiny.
+// To keep that safe, we reject any string scalar that contains characters
+// requiring escaping in unquoted YAML — versions, sha512 base64, and file
+// names all stay inside `[A-Za-z0-9._\-/+=]` in practice, so a surprise
+// character means an upstream caller is passing untrusted input and the
+// manifest would silently parse wrong.
+const SAFE_YAML_SCALAR = /^[A-Za-z0-9._\-/+=]+$/;
+
+const assertSafeYamlScalar = (value, field) => {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Updater metadata field ${field} must be a string (got ${typeof value})`,
+    );
+  }
+  if (!SAFE_YAML_SCALAR.test(value)) {
+    throw new Error(
+      `Updater metadata field ${field} contains unsafe YAML characters: ${JSON.stringify(value)}`,
+    );
+  }
+};
+
+const assertSafeReleaseDate = (value) => {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Updater metadata field releaseDate must be a string (got ${typeof value})`,
+    );
+  }
+  // releaseDate is wrapped in single quotes; reject only the two
+  // characters that would break that quoting.
+  if (value.includes("'") || /[\r\n]/.test(value)) {
+    throw new Error(
+      `Updater metadata field releaseDate contains unsafe characters: ${JSON.stringify(value)}`,
+    );
+  }
+};
+
 const stringifyYml = (data) => {
+  assertSafeYamlScalar(data.version, 'version');
+  assertSafeYamlScalar(data.path, 'path');
+  assertSafeYamlScalar(data.sha512, 'sha512');
+  assertSafeReleaseDate(data.releaseDate);
+  for (let i = 0; i < data.files.length; i += 1) {
+    const file = data.files[i];
+    assertSafeYamlScalar(file.url, `files[${i}].url`);
+    assertSafeYamlScalar(file.sha512, `files[${i}].sha512`);
+    if (!Number.isInteger(file.size) || file.size < 0) {
+      throw new Error(
+        `Updater metadata field files[${i}].size must be a non-negative integer (got ${file.size})`,
+      );
+    }
+  }
+
   const lines = [`version: ${data.version}`];
   lines.push('files:');
   for (const file of data.files) {

--- a/apps/studio/scripts/build-update-metadata.mjs
+++ b/apps/studio/scripts/build-update-metadata.mjs
@@ -1,0 +1,139 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const GITHUB_OWNER = 'web-infra-dev';
+const GITHUB_REPO = 'midscene';
+const UPDATER_CACHE_DIR_NAME = 'midscene-studio-updater';
+
+const PRERELEASE_TOKEN_RE = /[-.](alpha|beta|rc)([-.\d]|$)/i;
+
+const platformYmlName = {
+  darwin: 'latest-mac.yml',
+  linux: 'latest-linux.yml',
+  win32: 'latest.yml',
+};
+
+const platformBetaYmlName = {
+  darwin: 'beta-mac.yml',
+  linux: 'beta-linux.yml',
+  win32: 'beta.yml',
+};
+
+const stringifyYml = (data) => {
+  const lines = [`version: ${data.version}`];
+  lines.push('files:');
+  for (const file of data.files) {
+    lines.push(`  - url: ${file.url}`);
+    lines.push(`    sha512: ${file.sha512}`);
+    lines.push(`    size: ${file.size}`);
+  }
+  lines.push(`path: ${data.path}`);
+  lines.push(`sha512: ${data.sha512}`);
+  lines.push(`releaseDate: '${data.releaseDate}'`);
+  return `${lines.join('\n')}\n`;
+};
+
+export const isPrereleaseVersion = (version) =>
+  PRERELEASE_TOKEN_RE.test(version);
+
+export const buildLatestYmlForPlatform = ({
+  version,
+  platform,
+  artifactName,
+  sha512,
+  size,
+  releaseDate = new Date().toISOString(),
+}) => {
+  if (!platformYmlName[platform]) {
+    throw new Error(`Unsupported platform for updater metadata: ${platform}`);
+  }
+  return stringifyYml({
+    version,
+    files: [
+      {
+        url: artifactName,
+        sha512,
+        size,
+      },
+    ],
+    path: artifactName,
+    sha512,
+    releaseDate,
+  });
+};
+
+const hashFile = async (filePath) => {
+  const buffer = await fs.readFile(filePath);
+  const hash = crypto.createHash('sha512').update(buffer).digest('base64');
+  return { sha512: hash, size: buffer.length };
+};
+
+export const writeUpdateMetadataForArtifact = async ({
+  artifactPath,
+  artifactDir,
+  platform,
+  version,
+}) => {
+  const { sha512, size } = await hashFile(artifactPath);
+  const artifactName = path.basename(artifactPath);
+  const releaseDate = new Date().toISOString();
+
+  const stableYmlName = platformYmlName[platform];
+  if (!stableYmlName) {
+    throw new Error(`Unsupported platform for updater metadata: ${platform}`);
+  }
+  const yml = buildLatestYmlForPlatform({
+    version,
+    platform,
+    artifactName,
+    sha512,
+    size,
+    releaseDate,
+  });
+
+  await fs.mkdir(artifactDir, { recursive: true });
+
+  const stablePath = path.join(artifactDir, stableYmlName);
+  await fs.writeFile(stablePath, yml);
+
+  const writtenPaths = [stablePath];
+
+  // Beta channel readers fetch beta-<platform>.yml; mirror the manifest
+  // there too so prerelease builds reach beta users automatically. Stable
+  // readers stay on `latest-*.yml` and ignore beta versions because the
+  // updater also reads the prerelease flag from the GitHub release.
+  if (isPrereleaseVersion(version)) {
+    const betaName = platformBetaYmlName[platform];
+    if (betaName) {
+      const betaPath = path.join(artifactDir, betaName);
+      await fs.writeFile(betaPath, yml);
+      writtenPaths.push(betaPath);
+    }
+  }
+
+  return { sha512, size, writtenPaths };
+};
+
+export const buildAppUpdateYml = () => {
+  const lines = [
+    'provider: github',
+    `owner: ${GITHUB_OWNER}`,
+    `repo: ${GITHUB_REPO}`,
+    `updaterCacheDirName: ${UPDATER_CACHE_DIR_NAME}`,
+  ];
+  return `${lines.join('\n')}\n`;
+};
+
+export const writeAppUpdateYmlIntoResources = async (resourcesDir) => {
+  await fs.mkdir(resourcesDir, { recursive: true });
+  const targetPath = path.join(resourcesDir, 'app-update.yml');
+  await fs.writeFile(targetPath, buildAppUpdateYml());
+  return targetPath;
+};
+
+export const __testing__ = {
+  hashFile,
+  platformYmlName,
+  platformBetaYmlName,
+};

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -6,6 +6,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { notarize } from '@electron/notarize';
 import { packager } from '@electron/packager';
+import {
+  writeAppUpdateYmlIntoResources,
+  writeUpdateMetadataForArtifact,
+} from './build-update-metadata.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1385,6 +1389,45 @@ const buildPackagedAppPayloadCandidates = async (packagedAppPath) => {
   return [...new Set(candidates)];
 };
 
+export const buildPackagedResourcesCandidates = async (packagedAppPath) => {
+  const candidates = [
+    path.join(packagedAppPath, 'Contents', 'Resources'),
+    path.join(packagedAppPath, 'resources'),
+  ];
+
+  let packagedOutputStats;
+  try {
+    packagedOutputStats = await fs.stat(packagedAppPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return candidates;
+    }
+    throw error;
+  }
+
+  if (!packagedOutputStats.isDirectory()) {
+    return candidates;
+  }
+
+  const packagedOutputEntries = await fs.readdir(packagedAppPath, {
+    withFileTypes: true,
+  });
+
+  for (const entry of packagedOutputEntries) {
+    if (!entry.isDirectory() || !entry.name.endsWith('.app')) {
+      continue;
+    }
+
+    const nestedBundleRoot = path.join(packagedAppPath, entry.name);
+    candidates.push(
+      path.join(nestedBundleRoot, 'Contents', 'Resources'),
+      path.join(nestedBundleRoot, 'resources'),
+    );
+  }
+
+  return [...new Set(candidates)];
+};
+
 export const resolveMacPackagedAppBundlePath = async (packagedAppPath) => {
   if (packagedAppPath.endsWith('.app')) {
     return packagedAppPath;
@@ -1429,6 +1472,25 @@ export const resolveMacPackagedAppBundlePath = async (packagedAppPath) => {
 
 const findPackagedAppPayloadDir = async (packagedAppPath) => {
   const candidates = await buildPackagedAppPayloadCandidates(packagedAppPath);
+
+  for (const candidatePath of candidates) {
+    try {
+      const stats = await fs.stat(candidatePath);
+      if (stats.isDirectory()) {
+        return candidatePath;
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return null;
+};
+
+const findPackagedResourcesDir = async (packagedAppPath) => {
+  const candidates = await buildPackagedResourcesCandidates(packagedAppPath);
 
   for (const candidatePath of candidates) {
     try {
@@ -1884,6 +1946,16 @@ export const packageStudioElectronApp = async ({
     await dedupePlaygroundStatic(path.join(packagedPayloadDir, 'node_modules'));
   }
 
+  // app-update.yml lives next to the `app` payload (NOT inside it).
+  // electron-updater reads it from `process.resourcesPath/app-update.yml`
+  // at runtime to learn which provider / repo / cache dir to use. Must be
+  // written before signing on macOS so it ends up inside the signed
+  // bundle.
+  const resourcesDir = await findPackagedResourcesDir(packagedAppPath);
+  if (resourcesDir) {
+    await writeAppUpdateYmlIntoResources(resourcesDir);
+  }
+
   if (platform === 'darwin') {
     const macAppBundlePath =
       await resolveMacPackagedAppBundlePath(packagedAppPath);
@@ -1903,7 +1975,20 @@ export const packageStudioElectronApp = async ({
     artifactPath,
   });
 
+  // Emit the electron-updater channel manifest (latest-*.yml + beta-*.yml
+  // when the version is prerelease) so the GitHub Release surfaces the
+  // sha512/size the autoUpdater needs to verify the zip.
+  const updateMetadata = await writeUpdateMetadataForArtifact({
+    artifactPath,
+    artifactDir,
+    platform,
+    version: normalizedVersion,
+  });
+
   console.log(`Packaged Midscene Studio archive: ${artifactPath}`);
+  for (const ymlPath of updateMetadata.writtenPaths) {
+    console.log(`Wrote updater manifest: ${ymlPath}`);
+  }
   return artifactPath;
 };
 

--- a/apps/studio/src/env.d.ts
+++ b/apps/studio/src/env.d.ts
@@ -2,11 +2,13 @@ import type {
   ElectronShellApi,
   StudioRuntimeApi,
 } from './shared/electron-contract';
+import type { UpdaterApi } from './shared/updater-contract';
 
 declare global {
   interface Window {
     electronShell?: ElectronShellApi;
     studioRuntime?: StudioRuntimeApi;
+    studioUpdater?: UpdaterApi;
   }
 
   const __APP_VERSION__: string;

--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -22,6 +22,8 @@ import type { TitleBarOverlay } from 'electron';
 import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
 import type { PlaygroundRuntimeService } from './playground/types';
 import { configureStudioShellEnvHydration } from './shell-env';
+import { initUpdater } from './updater';
+import { registerUpdaterHandlers } from './updater-handlers';
 import { registerWindowRevealHandlers } from './window-reveal';
 
 // macOS GUI launches (Finder, Dock) skip the user's login shell, so
@@ -429,7 +431,15 @@ app.whenReady().then(() => {
     });
 
   registerIpcHandlers();
+  registerUpdaterHandlers();
   createMainWindow();
+
+  // initUpdater no-ops when !app.isPackaged, and skips polling when this
+  // process is running under the smoke/e2e harness so test runs do not
+  // hit the GitHub Releases API.
+  if (!isStudioSmokeTest && !isStudioE2ETest) {
+    initUpdater(() => mainWindow);
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -22,7 +22,7 @@ import type { TitleBarOverlay } from 'electron';
 import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
 import type { PlaygroundRuntimeService } from './playground/types';
 import { configureStudioShellEnvHydration } from './shell-env';
-import { initUpdater } from './updater';
+import { studioUpdater } from './updater';
 import { registerUpdaterHandlers } from './updater-handlers';
 import { registerWindowRevealHandlers } from './window-reveal';
 
@@ -431,14 +431,14 @@ app.whenReady().then(() => {
     });
 
   registerIpcHandlers();
-  registerUpdaterHandlers();
+  registerUpdaterHandlers(studioUpdater);
   createMainWindow();
 
-  // initUpdater no-ops when !app.isPackaged, and skips polling when this
-  // process is running under the smoke/e2e harness so test runs do not
-  // hit the GitHub Releases API.
+  // studioUpdater.init() no-ops when !app.isPackaged, and we skip the
+  // call entirely when running under the smoke/e2e harness so test runs
+  // do not hit the GitHub Releases API.
   if (!isStudioSmokeTest && !isStudioE2ETest) {
-    initUpdater(() => mainWindow);
+    studioUpdater.init(() => mainWindow);
   }
 
   app.on('activate', () => {

--- a/apps/studio/src/main/updater-handlers.ts
+++ b/apps/studio/src/main/updater-handlers.ts
@@ -1,0 +1,321 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getDebug } from '@midscene/shared/logger';
+import { IPC_CHANNELS } from '@shared/electron-contract';
+import { app, ipcMain } from 'electron';
+import type { UpdateStatus } from '../shared/updater-contract';
+import {
+  autoUpdater,
+  getDownloadedFilePath,
+  getUpdateStatus,
+  setAutoDownload,
+  setUpdateChannel,
+  setUserInitiatedCheck,
+} from './updater';
+
+const debugUpdaterHandlers = getDebug('studio:updater-handlers', {
+  console: true,
+});
+
+interface MacUpdateScriptOptions {
+  appPath: string;
+  execName: string;
+  zipPath: string;
+  tempDir: string;
+  scriptPath: string;
+  logPath: string;
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildMacUpdateScript({
+  appPath,
+  execName,
+  zipPath,
+  tempDir,
+  scriptPath,
+  logPath,
+}: MacUpdateScriptOptions): string {
+  return `#!/bin/bash
+set -u
+
+APP_PATH=${shellQuote(appPath)}
+APP_CONTENTS_PATH="$APP_PATH/Contents/"
+EXEC_NAME=${shellQuote(execName)}
+ZIP_PATH=${shellQuote(zipPath)}
+TEMP_DIR=${shellQuote(tempDir)}
+SCRIPT_PATH=${shellQuote(scriptPath)}
+LOG_PATH=${shellQuote(logPath)}
+
+exec > "$LOG_PATH" 2>&1
+echo "Update script started at $(date)"
+echo "appPath=$APP_PATH"
+echo "zipPath=$ZIP_PATH"
+
+# Poll until every helper from the old bundle (renderer, GPU, plugin)
+# exits — matching just Contents/MacOS misses the ones under Frameworks.
+for i in $(/usr/bin/seq 1 120); do
+  if ! /usr/bin/pgrep -f -- "$APP_CONTENTS_PATH" > /dev/null 2>&1; then
+    echo "All app processes exited after $i polls"
+    break
+  fi
+  /bin/sleep 0.5
+done
+
+if /usr/bin/pgrep -f -- "$APP_CONTENTS_PATH" > /dev/null 2>&1; then
+  echo "ERROR: app processes are still running; aborting update"
+  /usr/bin/pgrep -fl -- "$APP_CONTENTS_PATH" || true
+  /usr/bin/open "$APP_PATH"
+  exit 1
+fi
+
+/bin/rm -rf "$TEMP_DIR"
+/bin/mkdir -p "$TEMP_DIR"
+
+echo "Extracting zip..."
+/usr/bin/ditto -x -k "$ZIP_PATH" "$TEMP_DIR"
+echo "Extract exit code: $?"
+
+APP_BUNDLE=$(/usr/bin/find "$TEMP_DIR" -maxdepth 1 -name "*.app" -print -quit)
+echo "Found app bundle: $APP_BUNDLE"
+
+if [ -z "$APP_BUNDLE" ]; then
+  echo "ERROR: No .app found in extracted zip"
+  /bin/rm -rf "$TEMP_DIR"
+  /bin/rm -f "$SCRIPT_PATH"
+  /usr/bin/open "$APP_PATH"
+  exit 1
+fi
+
+# BSD mv on macOS will move source INTO target if target still exists as a
+# directory — that produces a nested .app/.app bundle. Verify removal first.
+echo "Replacing app bundle..."
+/bin/rm -rf "$APP_PATH"
+if [ -e "$APP_PATH" ]; then
+  echo "ERROR: failed to remove old bundle at $APP_PATH; aborting to avoid nested install"
+  /usr/bin/find "$APP_PATH" -maxdepth 2 -print
+  /bin/rm -rf "$TEMP_DIR"
+  /bin/rm -f "$SCRIPT_PATH"
+  exit 1
+fi
+/bin/mv "$APP_BUNDLE" "$APP_PATH"
+MV_EXIT=$?
+echo "Move exit code: $MV_EXIT"
+if [ $MV_EXIT -ne 0 ] || [ ! -e "$APP_PATH/Contents/MacOS" ]; then
+  echo "ERROR: mv did not produce a valid bundle, falling back to ditto"
+  /bin/rm -rf "$APP_PATH"
+  /usr/bin/ditto "$APP_BUNDLE" "$APP_PATH"
+  echo "Ditto exit code: $?"
+fi
+
+/usr/bin/xattr -cr "$APP_PATH" 2>/dev/null
+
+/bin/rm -rf "$TEMP_DIR"
+/bin/sleep 1
+
+echo "Launching app..."
+nohup "$APP_PATH/Contents/MacOS/$EXEC_NAME" > /dev/null 2>&1 &
+LAUNCH_PID=$!
+echo "Launched with PID: $LAUNCH_PID"
+/bin/sleep 2
+if kill -0 $LAUNCH_PID 2>/dev/null; then
+  echo "App is running"
+else
+  echo "App exited, trying open as fallback..."
+  /usr/bin/open "$APP_PATH"
+  echo "Open exit code: $?"
+fi
+
+/bin/rm -f "$SCRIPT_PATH"
+echo "Update complete at $(date)"
+`;
+}
+
+async function findDownloadedUpdateFile(
+  extension: '.zip' | '.exe',
+): Promise<string | null> {
+  const downloaded = getDownloadedFilePath();
+  if (downloaded) {
+    try {
+      await fs.promises.access(downloaded, fs.constants.R_OK);
+      return downloaded;
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const appName = app.getName();
+  const home = app.getPath('home');
+  const cacheDirs =
+    process.platform === 'darwin'
+      ? [
+          path.join(home, 'Library', 'Caches', `${appName}-updater`),
+          path.join(home, 'Library', 'Caches', appName),
+        ]
+      : [
+          path.join(app.getPath('userData'), '__update__'),
+          path.join(app.getPath('userData'), 'pending'),
+        ];
+
+  for (const cacheDir of cacheDirs) {
+    const pendingDir = path.join(cacheDir, 'pending');
+    try {
+      const files = await fs.promises.readdir(pendingDir);
+      const match = files.find((f) => f.endsWith(extension));
+      if (match) return path.join(pendingDir, match);
+    } catch {
+      /* ignore */
+    }
+    const candidate = path.join(cacheDir, `update${extension}`);
+    try {
+      await fs.promises.access(candidate, fs.constants.R_OK);
+      return candidate;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return null;
+}
+
+async function installMacUpdate(): Promise<void> {
+  const zipPath = await findDownloadedUpdateFile('.zip');
+  if (!zipPath) {
+    console.error('[updater:install] No downloaded zip found');
+    return;
+  }
+
+  // app.getAppPath() => .../Midscene Studio.app/Contents/Resources/app
+  // Step up to the .app bundle so the script can replace it atomically.
+  const appPath = path.resolve(process.resourcesPath, '..', '..');
+  const execName = path.basename(process.execPath);
+  const tempDir = path.join(app.getPath('temp'), 'midscene-studio-update');
+  const scriptPath = path.join(
+    app.getPath('temp'),
+    'midscene-studio-update.sh',
+  );
+  const logPath = path.join(app.getPath('temp'), 'midscene-studio-update.log');
+
+  const script = buildMacUpdateScript({
+    appPath,
+    execName,
+    zipPath,
+    tempDir,
+    scriptPath,
+    logPath,
+  });
+  await fs.promises.writeFile(scriptPath, script, { mode: 0o755 });
+
+  const child = spawn('/bin/bash', [scriptPath], {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+  child.unref();
+
+  setTimeout(() => app.quit(), 500);
+}
+
+function normalizeReleaseNotes(releaseNotes: unknown): string | undefined {
+  return typeof releaseNotes === 'string' ? releaseNotes : undefined;
+}
+
+export function resolveUpdaterCheckStatus(
+  result: unknown,
+  currentStatus: UpdateStatus,
+  platform: NodeJS.Platform = process.platform,
+): UpdateStatus {
+  if (currentStatus.state !== 'checking') {
+    return currentStatus;
+  }
+
+  const updateInfo = (result as { updateInfo?: unknown } | null)?.updateInfo;
+  if (typeof updateInfo === 'object' && updateInfo !== null) {
+    const version = (updateInfo as { version?: unknown }).version;
+    if (typeof version === 'string' && version.length > 0) {
+      return {
+        state: 'available',
+        version,
+        releaseNotes: normalizeReleaseNotes(
+          (updateInfo as { releaseNotes?: unknown }).releaseNotes,
+        ),
+        externalDownloadOnly: platform === 'win32' || platform === 'linux',
+      };
+    }
+  }
+
+  return { state: 'not-available' };
+}
+
+export function registerUpdaterHandlers(): void {
+  ipcMain.handle(IPC_CHANNELS.updaterCheck, async () => {
+    if (!app.isPackaged) return { state: 'not-available' };
+    try {
+      setUserInitiatedCheck(true);
+      const result = await autoUpdater.checkForUpdates();
+      const status = resolveUpdaterCheckStatus(result, getUpdateStatus());
+      if (status.state === 'not-available') {
+        setUserInitiatedCheck(false);
+      }
+      return status;
+    } catch (err) {
+      setUserInitiatedCheck(false);
+      const error = err instanceof Error ? err : new Error(String(err));
+      const code = (error as { code?: string }).code;
+      debugUpdaterHandlers(
+        'updater.check.throw code=%s platform=%s/%s message=%s',
+        code ?? 'unknown',
+        process.platform,
+        process.arch,
+        error.message,
+      );
+      return { state: 'error', message: error.message };
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updaterDownload, async () => {
+    if (!app.isPackaged) return { success: false };
+    try {
+      await autoUpdater.downloadUpdate();
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: String(err) };
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updaterInstall, async () => {
+    if (process.platform === 'darwin') {
+      try {
+        await installMacUpdate();
+      } catch (err) {
+        console.error('[updater:install] Manual update failed:', err);
+        // Last-resort fallback if the manual script path blows up before
+        // it can detach — quitAndInstall throws on Mac when
+        // Squirrel.Mac's ShipIt hits EBADF, but it can still succeed when
+        // the failure happened before we wrote the script.
+        autoUpdater.quitAndInstall();
+      }
+      return;
+    }
+
+    autoUpdater.quitAndInstall();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updaterGetVersion, async () => app.getVersion());
+
+  ipcMain.handle(IPC_CHANNELS.updaterGetStatus, () => getUpdateStatus());
+
+  ipcMain.handle(
+    IPC_CHANNELS.updaterSetAutoDownload,
+    (_event, enabled: boolean) => {
+      setAutoDownload(Boolean(enabled));
+      return { success: true };
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.updaterSetChannel, (_event, channel: string) => {
+    return setUpdateChannel(channel);
+  });
+}

--- a/apps/studio/src/main/updater-handlers.ts
+++ b/apps/studio/src/main/updater-handlers.ts
@@ -5,18 +5,13 @@ import { getDebug } from '@midscene/shared/logger';
 import { IPC_CHANNELS } from '@shared/electron-contract';
 import { app, ipcMain } from 'electron';
 import type { UpdateStatus } from '../shared/updater-contract';
-import {
-  autoUpdater,
-  getDownloadedFilePath,
-  getUpdateStatus,
-  setAutoDownload,
-  setUpdateChannel,
-  setUserInitiatedCheck,
-} from './updater';
+import { type StudioUpdater, autoUpdater } from './updater';
 
 const debugUpdaterHandlers = getDebug('studio:updater-handlers', {
   console: true,
 });
+
+const UPDATER_CACHE_DIR_NAME = 'midscene-studio-updater';
 
 interface MacUpdateScriptOptions {
   appPath: string;
@@ -79,7 +74,7 @@ echo "Extracting zip..."
 /usr/bin/ditto -x -k "$ZIP_PATH" "$TEMP_DIR"
 echo "Extract exit code: $?"
 
-APP_BUNDLE=$(/usr/bin/find "$TEMP_DIR" -maxdepth 1 -name "*.app" -print -quit)
+APP_BUNDLE=$(/usr/bin/find "$TEMP_DIR" -maxdepth 2 -name "*.app" -print -quit)
 echo "Found app bundle: $APP_BUNDLE"
 
 if [ -z "$APP_BUNDLE" ]; then
@@ -134,10 +129,10 @@ echo "Update complete at $(date)"
 `;
 }
 
-async function findDownloadedUpdateFile(
-  extension: '.zip' | '.exe',
+export async function findDownloadedMacUpdateZip(
+  updater: StudioUpdater,
 ): Promise<string | null> {
-  const downloaded = getDownloadedFilePath();
+  const downloaded = updater.getDownloadedFilePath();
   if (downloaded) {
     try {
       await fs.promises.access(downloaded, fs.constants.R_OK);
@@ -149,27 +144,22 @@ async function findDownloadedUpdateFile(
 
   const appName = app.getName();
   const home = app.getPath('home');
-  const cacheDirs =
-    process.platform === 'darwin'
-      ? [
-          path.join(home, 'Library', 'Caches', `${appName}-updater`),
-          path.join(home, 'Library', 'Caches', appName),
-        ]
-      : [
-          path.join(app.getPath('userData'), '__update__'),
-          path.join(app.getPath('userData'), 'pending'),
-        ];
+  const cacheDirs = [
+    path.join(home, 'Library', 'Caches', UPDATER_CACHE_DIR_NAME),
+    path.join(home, 'Library', 'Caches', `${appName}-updater`),
+    path.join(home, 'Library', 'Caches', appName),
+  ];
 
   for (const cacheDir of cacheDirs) {
     const pendingDir = path.join(cacheDir, 'pending');
     try {
       const files = await fs.promises.readdir(pendingDir);
-      const match = files.find((f) => f.endsWith(extension));
+      const match = files.find((f) => f.endsWith('.zip'));
       if (match) return path.join(pendingDir, match);
     } catch {
       /* ignore */
     }
-    const candidate = path.join(cacheDir, `update${extension}`);
+    const candidate = path.join(cacheDir, 'update.zip');
     try {
       await fs.promises.access(candidate, fs.constants.R_OK);
       return candidate;
@@ -181,15 +171,17 @@ async function findDownloadedUpdateFile(
   return null;
 }
 
-async function installMacUpdate(): Promise<void> {
-  const zipPath = await findDownloadedUpdateFile('.zip');
+async function installMacUpdate(updater: StudioUpdater): Promise<void> {
+  if (!app.isPackaged) return;
+  const zipPath = await findDownloadedMacUpdateZip(updater);
   if (!zipPath) {
     console.error('[updater:install] No downloaded zip found');
     return;
   }
 
-  // app.getAppPath() => .../Midscene Studio.app/Contents/Resources/app
-  // Step up to the .app bundle so the script can replace it atomically.
+  // process.resourcesPath => .../Midscene Studio.app/Contents/Resources
+  // Step up two levels to reach the .app bundle root so the script can
+  // replace it atomically.
   const appPath = path.resolve(process.resourcesPath, '..', '..');
   const execName = path.basename(process.execPath);
   const tempDir = path.join(app.getPath('temp'), 'midscene-studio-update');
@@ -249,19 +241,13 @@ export function resolveUpdaterCheckStatus(
   return { state: 'not-available' };
 }
 
-export function registerUpdaterHandlers(): void {
+export function registerUpdaterHandlers(updater: StudioUpdater): void {
   ipcMain.handle(IPC_CHANNELS.updaterCheck, async () => {
     if (!app.isPackaged) return { state: 'not-available' };
     try {
-      setUserInitiatedCheck(true);
-      const result = await autoUpdater.checkForUpdates();
-      const status = resolveUpdaterCheckStatus(result, getUpdateStatus());
-      if (status.state === 'not-available') {
-        setUserInitiatedCheck(false);
-      }
-      return status;
+      const result = await updater.checkUserInitiated();
+      return resolveUpdaterCheckStatus(result, updater.getStatus());
     } catch (err) {
-      setUserInitiatedCheck(false);
       const error = err instanceof Error ? err : new Error(String(err));
       const code = (error as { code?: string }).code;
       debugUpdaterHandlers(
@@ -278,7 +264,7 @@ export function registerUpdaterHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.updaterDownload, async () => {
     if (!app.isPackaged) return { success: false };
     try {
-      await autoUpdater.downloadUpdate();
+      await updater.downloadUpdate();
       return { success: true };
     } catch (err) {
       return { success: false, error: String(err) };
@@ -288,7 +274,7 @@ export function registerUpdaterHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.updaterInstall, async () => {
     if (process.platform === 'darwin') {
       try {
-        await installMacUpdate();
+        await installMacUpdate(updater);
       } catch (err) {
         console.error('[updater:install] Manual update failed:', err);
         // Last-resort fallback if the manual script path blows up before
@@ -305,17 +291,5 @@ export function registerUpdaterHandlers(): void {
 
   ipcMain.handle(IPC_CHANNELS.updaterGetVersion, async () => app.getVersion());
 
-  ipcMain.handle(IPC_CHANNELS.updaterGetStatus, () => getUpdateStatus());
-
-  ipcMain.handle(
-    IPC_CHANNELS.updaterSetAutoDownload,
-    (_event, enabled: boolean) => {
-      setAutoDownload(Boolean(enabled));
-      return { success: true };
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.updaterSetChannel, (_event, channel: string) => {
-    return setUpdateChannel(channel);
-  });
+  ipcMain.handle(IPC_CHANNELS.updaterGetStatus, () => updater.getStatus());
 }

--- a/apps/studio/src/main/updater.ts
+++ b/apps/studio/src/main/updater.ts
@@ -1,6 +1,6 @@
 import { getDebug } from '@midscene/shared/logger';
 import { IPC_CHANNELS } from '@shared/electron-contract';
-import type { UpdateChannel, UpdateStatus } from '@shared/updater-contract';
+import type { UpdateStatus } from '@shared/updater-contract';
 import type { BrowserWindow } from 'electron';
 import { app } from 'electron';
 import { autoUpdater } from 'electron-updater';
@@ -16,157 +16,179 @@ const debugUpdater = getDebug('studio:updater', { console: true });
 const EXTERNAL_DOWNLOAD_ONLY =
   process.platform === 'win32' || process.platform === 'linux';
 
-let getMainWindow: (() => BrowserWindow | null) | null = null;
-let isUserInitiatedCheck = false;
-let pendingVersion: string | null = null;
-let currentStatus: UpdateStatus = { state: 'idle' };
-let currentChannel: UpdateChannel = 'stable';
+const BACKGROUND_POLL_FIRST_DELAY_MS = 10_000;
+const BACKGROUND_POLL_INTERVAL_MS = 30 * 60 * 1000;
 
-export function getUpdateStatus(): UpdateStatus {
-  return currentStatus;
-}
+export class StudioUpdater {
+  private getMainWindow: (() => BrowserWindow | null) | null = null;
+  private currentStatus: UpdateStatus = { state: 'idle' };
+  private pendingVersion: string | null = null;
+  private downloadedFilePath: string | null = null;
+  // Only true for the lifetime of a single `checkUserInitiated()` call. Set
+  // in try/finally around the autoUpdater promise — electron-updater fires
+  // `update-not-available` / `error` synchronously before the promise
+  // resolves, so the flag is visible to event handlers without leaking to
+  // the background poll.
+  private userInitiatedCheckActive = false;
+  private firstCheckTimer: NodeJS.Timeout | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private initialized = false;
 
-function normalizeUpdateChannel(channel?: string): UpdateChannel {
-  return channel === 'beta' ? 'beta' : 'stable';
-}
+  getStatus(): UpdateStatus {
+    return this.currentStatus;
+  }
 
-function toUpdaterChannel(channel: UpdateChannel): 'latest' | 'beta' {
-  return channel === 'beta' ? 'beta' : 'latest';
-}
+  getDownloadedFilePath(): string | null {
+    return this.downloadedFilePath;
+  }
 
-export function getUpdateChannel(): UpdateChannel {
-  return currentChannel;
-}
+  init(getWindow: () => BrowserWindow | null): void {
+    if (!app.isPackaged) return;
+    if (this.initialized) return;
+    this.initialized = true;
 
-export function setUserInitiatedCheck(value: boolean): void {
-  isUserInitiatedCheck = value;
-}
+    this.getMainWindow = getWindow;
 
-function sendStatus(status: UpdateStatus): void {
-  currentStatus = status;
-  const win = getMainWindow?.();
-  if (win && !win.isDestroyed()) {
-    win.webContents.send(IPC_CHANNELS.updaterStatus, status);
+    // On macOS we route install through our own script and trigger
+    // download manually; on Windows/Linux the artifact is unusable
+    // without manual replacement. So autoDownload stays off everywhere.
+    autoUpdater.autoDownload = false;
+    autoUpdater.channel = 'latest';
+    autoUpdater.allowPrerelease = false;
+    // Stay on electron-updater's default (false). If we ever add a beta
+    // toggle, the channel switch should set this true only for the
+    // single transition so stable users do not silently get downgraded.
+    autoUpdater.allowDowngrade = false;
+    // We trigger install through our own IPC flow so Squirrel.Mac never
+    // races with `before-quit`. The macOS bypass relies on the
+    // downloaded zip surviving past `app.quit()`.
+    autoUpdater.autoInstallOnAppQuit = false;
+
+    autoUpdater.on('checking-for-update', () => {
+      this.sendStatus({ state: 'checking' });
+    });
+
+    autoUpdater.on('update-available', (info) => {
+      this.pendingVersion = info.version;
+      this.sendStatus({
+        state: 'available',
+        version: info.version,
+        releaseNotes:
+          typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined,
+        externalDownloadOnly: EXTERNAL_DOWNLOAD_ONLY,
+      });
+    });
+
+    autoUpdater.on('update-not-available', () => {
+      if (this.userInitiatedCheckActive) {
+        this.sendStatus({ state: 'not-available' });
+      } else {
+        // Reset the cached status so getStatus() does not return a stale
+        // `checking` from a background poll the renderer never asked for.
+        this.currentStatus = { state: 'idle' };
+      }
+    });
+
+    autoUpdater.on('download-progress', (progress) => {
+      // Without a known version (e.g., progress resumed after a process
+      // restart before `update-available` fires), drop the event rather
+      // than render an empty version label.
+      if (!this.pendingVersion) return;
+      this.sendStatus({
+        state: 'downloading',
+        percent: Math.round(progress.percent),
+        version: this.pendingVersion,
+      });
+    });
+
+    autoUpdater.on('update-downloaded', (info) => {
+      this.downloadedFilePath = info.downloadedFile;
+      this.sendStatus({ state: 'downloaded', version: info.version });
+    });
+
+    autoUpdater.on('error', (err) => {
+      const code = (err as { code?: string }).code;
+      let feedURL: string | null | undefined;
+      try {
+        feedURL = autoUpdater.getFeedURL();
+      } catch {
+        feedURL = undefined;
+      }
+      debugUpdater(
+        'updater.error code=%s platform=%s/%s feedURL=%s userInitiated=%s message=%s',
+        code ?? 'unknown',
+        process.platform,
+        process.arch,
+        feedURL ?? 'unknown',
+        this.userInitiatedCheckActive,
+        err.message,
+      );
+
+      if (code === 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND') {
+        if (this.userInitiatedCheckActive) {
+          this.sendStatus({ state: 'not-available' });
+        } else {
+          this.currentStatus = { state: 'idle' };
+        }
+        return;
+      }
+
+      this.sendStatus({ state: 'error', message: err.message });
+    });
+
+    this.firstCheckTimer = setTimeout(() => {
+      this.firstCheckTimer = null;
+      void this.backgroundCheck();
+    }, BACKGROUND_POLL_FIRST_DELAY_MS);
+
+    this.pollTimer = setInterval(() => {
+      void this.backgroundCheck();
+    }, BACKGROUND_POLL_INTERVAL_MS);
+  }
+
+  async checkUserInitiated(): Promise<unknown> {
+    this.userInitiatedCheckActive = true;
+    try {
+      return await autoUpdater.checkForUpdates();
+    } finally {
+      this.userInitiatedCheckActive = false;
+    }
+  }
+
+  async downloadUpdate(): Promise<void> {
+    await autoUpdater.downloadUpdate();
+  }
+
+  dispose(): void {
+    if (this.firstCheckTimer) {
+      clearTimeout(this.firstCheckTimer);
+      this.firstCheckTimer = null;
+    }
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    autoUpdater.removeAllListeners();
+    this.initialized = false;
+  }
+
+  private async backgroundCheck(): Promise<void> {
+    try {
+      await autoUpdater.checkForUpdates();
+    } catch {
+      // The 'error' event handler already surfaces a status; swallow the
+      // promise rejection so the unhandled-rejection logger stays quiet.
+    }
+  }
+
+  private sendStatus(status: UpdateStatus): void {
+    this.currentStatus = status;
+    const win = this.getMainWindow?.();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send(IPC_CHANNELS.updaterStatus, status);
+    }
   }
 }
 
-let downloadedFilePath: string | null = null;
-
-export function getDownloadedFilePath(): string | null {
-  return downloadedFilePath;
-}
-
-export function setUpdateChannel(channel?: string): UpdateChannel {
-  currentChannel = normalizeUpdateChannel(channel);
-  autoUpdater.channel = toUpdaterChannel(currentChannel);
-  autoUpdater.allowPrerelease = currentChannel === 'beta';
-  autoUpdater.allowDowngrade = true;
-  return currentChannel;
-}
-
-export function initUpdater(
-  getWindow: () => BrowserWindow | null,
-  autoDownload = false,
-  updateChannel: UpdateChannel = 'stable',
-): void {
-  if (!app.isPackaged) return;
-
-  getMainWindow = getWindow;
-
-  // Auto-download controlled by user setting (default: false). On Windows
-  // the artifact is unusable without manual replacement, so never auto-download.
-  autoUpdater.autoDownload = EXTERNAL_DOWNLOAD_ONLY ? false : autoDownload;
-  // We trigger install through our own IPC flow so Squirrel.Mac never
-  // races with `before-quit`. The macOS bypass below relies on the
-  // downloaded zip surviving past `app.quit()`.
-  autoUpdater.autoInstallOnAppQuit = false;
-  setUpdateChannel(updateChannel);
-
-  autoUpdater.on('checking-for-update', () => {
-    sendStatus({ state: 'checking' });
-  });
-
-  autoUpdater.on('update-available', (info) => {
-    pendingVersion = info.version;
-    sendStatus({
-      state: 'available',
-      version: info.version,
-      releaseNotes:
-        typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined,
-      externalDownloadOnly: EXTERNAL_DOWNLOAD_ONLY,
-    });
-  });
-
-  autoUpdater.on('update-not-available', () => {
-    if (isUserInitiatedCheck) {
-      sendStatus({ state: 'not-available' });
-    } else {
-      // Reset the cached status so getStatus() does not return a stale
-      // `checking` from a background poll the renderer never asked for.
-      currentStatus = { state: 'idle' };
-    }
-    isUserInitiatedCheck = false;
-  });
-
-  autoUpdater.on('download-progress', (progress) => {
-    sendStatus({
-      state: 'downloading',
-      percent: Math.round(progress.percent),
-      version: pendingVersion || '',
-    });
-  });
-
-  autoUpdater.on('update-downloaded', (info) => {
-    downloadedFilePath = info.downloadedFile;
-    sendStatus({ state: 'downloaded', version: info.version });
-  });
-
-  autoUpdater.on('error', (err) => {
-    const code = (err as { code?: string }).code;
-    let feedURL: string | null | undefined;
-    try {
-      feedURL = autoUpdater.getFeedURL();
-    } catch {
-      feedURL = undefined;
-    }
-    debugUpdater(
-      'updater.error code=%s platform=%s/%s channel=%s feedURL=%s userInitiated=%s message=%s',
-      code ?? 'unknown',
-      process.platform,
-      process.arch,
-      currentChannel,
-      feedURL ?? 'unknown',
-      isUserInitiatedCheck,
-      err.message,
-    );
-
-    if (code === 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND') {
-      if (isUserInitiatedCheck) {
-        sendStatus({ state: 'not-available' });
-      } else {
-        currentStatus = { state: 'idle' };
-      }
-      isUserInitiatedCheck = false;
-      return;
-    }
-
-    sendStatus({ state: 'error', message: err.message });
-  });
-
-  setTimeout(() => {
-    autoUpdater.checkForUpdates().catch(() => {});
-  }, 3000);
-
-  setInterval(
-    () => {
-      autoUpdater.checkForUpdates().catch(() => {});
-    },
-    30 * 60 * 1000,
-  );
-}
-
-export function setAutoDownload(enabled: boolean): void {
-  autoUpdater.autoDownload = EXTERNAL_DOWNLOAD_ONLY ? false : enabled;
-}
-
+export const studioUpdater = new StudioUpdater();
 export { autoUpdater };

--- a/apps/studio/src/main/updater.ts
+++ b/apps/studio/src/main/updater.ts
@@ -1,0 +1,172 @@
+import { getDebug } from '@midscene/shared/logger';
+import { IPC_CHANNELS } from '@shared/electron-contract';
+import type { UpdateChannel, UpdateStatus } from '@shared/updater-contract';
+import type { BrowserWindow } from 'electron';
+import { app } from 'electron';
+import { autoUpdater } from 'electron-updater';
+
+const debugUpdater = getDebug('studio:updater', { console: true });
+
+// Studio ships on Windows/Linux as a zip from @electron/packager (no NSIS
+// installer, no AppImage). electron-updater can't replace a running binary
+// in either case — NsisUpdater needs an installer it doesn't have, and the
+// Linux flow only knows how to relaunch an AppImage. We keep
+// checkForUpdates working so the user sees that a new version exists, but
+// route them to the GitHub Releases page to grab the next zip manually.
+const EXTERNAL_DOWNLOAD_ONLY =
+  process.platform === 'win32' || process.platform === 'linux';
+
+let getMainWindow: (() => BrowserWindow | null) | null = null;
+let isUserInitiatedCheck = false;
+let pendingVersion: string | null = null;
+let currentStatus: UpdateStatus = { state: 'idle' };
+let currentChannel: UpdateChannel = 'stable';
+
+export function getUpdateStatus(): UpdateStatus {
+  return currentStatus;
+}
+
+function normalizeUpdateChannel(channel?: string): UpdateChannel {
+  return channel === 'beta' ? 'beta' : 'stable';
+}
+
+function toUpdaterChannel(channel: UpdateChannel): 'latest' | 'beta' {
+  return channel === 'beta' ? 'beta' : 'latest';
+}
+
+export function getUpdateChannel(): UpdateChannel {
+  return currentChannel;
+}
+
+export function setUserInitiatedCheck(value: boolean): void {
+  isUserInitiatedCheck = value;
+}
+
+function sendStatus(status: UpdateStatus): void {
+  currentStatus = status;
+  const win = getMainWindow?.();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(IPC_CHANNELS.updaterStatus, status);
+  }
+}
+
+let downloadedFilePath: string | null = null;
+
+export function getDownloadedFilePath(): string | null {
+  return downloadedFilePath;
+}
+
+export function setUpdateChannel(channel?: string): UpdateChannel {
+  currentChannel = normalizeUpdateChannel(channel);
+  autoUpdater.channel = toUpdaterChannel(currentChannel);
+  autoUpdater.allowPrerelease = currentChannel === 'beta';
+  autoUpdater.allowDowngrade = true;
+  return currentChannel;
+}
+
+export function initUpdater(
+  getWindow: () => BrowserWindow | null,
+  autoDownload = false,
+  updateChannel: UpdateChannel = 'stable',
+): void {
+  if (!app.isPackaged) return;
+
+  getMainWindow = getWindow;
+
+  // Auto-download controlled by user setting (default: false). On Windows
+  // the artifact is unusable without manual replacement, so never auto-download.
+  autoUpdater.autoDownload = EXTERNAL_DOWNLOAD_ONLY ? false : autoDownload;
+  // We trigger install through our own IPC flow so Squirrel.Mac never
+  // races with `before-quit`. The macOS bypass below relies on the
+  // downloaded zip surviving past `app.quit()`.
+  autoUpdater.autoInstallOnAppQuit = false;
+  setUpdateChannel(updateChannel);
+
+  autoUpdater.on('checking-for-update', () => {
+    sendStatus({ state: 'checking' });
+  });
+
+  autoUpdater.on('update-available', (info) => {
+    pendingVersion = info.version;
+    sendStatus({
+      state: 'available',
+      version: info.version,
+      releaseNotes:
+        typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined,
+      externalDownloadOnly: EXTERNAL_DOWNLOAD_ONLY,
+    });
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    if (isUserInitiatedCheck) {
+      sendStatus({ state: 'not-available' });
+    } else {
+      // Reset the cached status so getStatus() does not return a stale
+      // `checking` from a background poll the renderer never asked for.
+      currentStatus = { state: 'idle' };
+    }
+    isUserInitiatedCheck = false;
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    sendStatus({
+      state: 'downloading',
+      percent: Math.round(progress.percent),
+      version: pendingVersion || '',
+    });
+  });
+
+  autoUpdater.on('update-downloaded', (info) => {
+    downloadedFilePath = info.downloadedFile;
+    sendStatus({ state: 'downloaded', version: info.version });
+  });
+
+  autoUpdater.on('error', (err) => {
+    const code = (err as { code?: string }).code;
+    let feedURL: string | null | undefined;
+    try {
+      feedURL = autoUpdater.getFeedURL();
+    } catch {
+      feedURL = undefined;
+    }
+    debugUpdater(
+      'updater.error code=%s platform=%s/%s channel=%s feedURL=%s userInitiated=%s message=%s',
+      code ?? 'unknown',
+      process.platform,
+      process.arch,
+      currentChannel,
+      feedURL ?? 'unknown',
+      isUserInitiatedCheck,
+      err.message,
+    );
+
+    if (code === 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND') {
+      if (isUserInitiatedCheck) {
+        sendStatus({ state: 'not-available' });
+      } else {
+        currentStatus = { state: 'idle' };
+      }
+      isUserInitiatedCheck = false;
+      return;
+    }
+
+    sendStatus({ state: 'error', message: err.message });
+  });
+
+  setTimeout(() => {
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, 3000);
+
+  setInterval(
+    () => {
+      autoUpdater.checkForUpdates().catch(() => {});
+    },
+    30 * 60 * 1000,
+  );
+}
+
+export function setAutoDownload(enabled: boolean): void {
+  autoUpdater.autoDownload = EXTERNAL_DOWNLOAD_ONLY ? false : enabled;
+}
+
+export { autoUpdater };

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -3,6 +3,11 @@ import {
   IPC_CHANNELS,
   type StudioRuntimeApi,
 } from '@shared/electron-contract';
+import type {
+  UpdateChannel,
+  UpdateStatus,
+  UpdaterApi,
+} from '@shared/updater-contract';
 import { contextBridge, ipcRenderer } from 'electron';
 
 /**
@@ -60,5 +65,24 @@ const studioRuntimeApi: StudioRuntimeApi = {
     ipcRenderer.invoke(IPC_CHANNELS.runConnectivityTest, request),
 };
 
+const updaterApi: UpdaterApi = {
+  check: () => ipcRenderer.invoke(IPC_CHANNELS.updaterCheck),
+  download: () => ipcRenderer.invoke(IPC_CHANNELS.updaterDownload),
+  install: () => ipcRenderer.invoke(IPC_CHANNELS.updaterInstall),
+  getVersion: () => ipcRenderer.invoke(IPC_CHANNELS.updaterGetVersion),
+  getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.updaterGetStatus),
+  setAutoDownload: (enabled: boolean) =>
+    ipcRenderer.invoke(IPC_CHANNELS.updaterSetAutoDownload, enabled),
+  setChannel: (channel: UpdateChannel) =>
+    ipcRenderer.invoke(IPC_CHANNELS.updaterSetChannel, channel),
+  onStatus: (callback: (status: UpdateStatus) => void) => {
+    const handler = (_event: unknown, status: UpdateStatus) => callback(status);
+    ipcRenderer.on(IPC_CHANNELS.updaterStatus, handler);
+    return () =>
+      ipcRenderer.removeListener(IPC_CHANNELS.updaterStatus, handler);
+  },
+};
+
 contextBridge.exposeInMainWorld('electronShell', electronShellApi);
 contextBridge.exposeInMainWorld('studioRuntime', studioRuntimeApi);
+contextBridge.exposeInMainWorld('studioUpdater', updaterApi);

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -3,11 +3,7 @@ import {
   IPC_CHANNELS,
   type StudioRuntimeApi,
 } from '@shared/electron-contract';
-import type {
-  UpdateChannel,
-  UpdateStatus,
-  UpdaterApi,
-} from '@shared/updater-contract';
+import type { UpdateStatus, UpdaterApi } from '@shared/updater-contract';
 import { contextBridge, ipcRenderer } from 'electron';
 
 /**
@@ -71,10 +67,6 @@ const updaterApi: UpdaterApi = {
   install: () => ipcRenderer.invoke(IPC_CHANNELS.updaterInstall),
   getVersion: () => ipcRenderer.invoke(IPC_CHANNELS.updaterGetVersion),
   getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.updaterGetStatus),
-  setAutoDownload: (enabled: boolean) =>
-    ipcRenderer.invoke(IPC_CHANNELS.updaterSetAutoDownload, enabled),
-  setChannel: (channel: UpdateChannel) =>
-    ipcRenderer.invoke(IPC_CHANNELS.updaterSetChannel, channel),
   onStatus: (callback: (status: UpdateStatus) => void) => {
     const handler = (_event: unknown, status: UpdateStatus) => callback(status);
     ipcRenderer.on(IPC_CHANNELS.updaterStatus, handler);

--- a/apps/studio/src/renderer/components/SettingsDock/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsDock/index.tsx
@@ -43,9 +43,19 @@ interface DockRowProps {
   icon: React.ReactNode;
   label: string;
   onClick?: () => void;
+  showDot?: boolean;
+  title?: string;
 }
 
-function DockRow({ active, ariaExpanded, icon, label, onClick }: DockRowProps) {
+function DockRow({
+  active,
+  ariaExpanded,
+  icon,
+  label,
+  onClick,
+  showDot,
+  title,
+}: DockRowProps) {
   return (
     <button
       aria-expanded={ariaExpanded}
@@ -53,9 +63,15 @@ function DockRow({ active, ariaExpanded, icon, label, onClick }: DockRowProps) {
         active ? 'bg-surface-hover' : 'bg-transparent hover:bg-surface-hover'
       }`}
       onClick={onClick}
+      title={title}
       type="button"
     >
-      {icon}
+      <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+        {icon}
+        {showDot ? (
+          <span className="absolute -right-[1px] -top-[1px] h-[6px] w-[6px] rounded-full bg-red-500 ring-2 ring-surface" />
+        ) : null}
+      </span>
       <span className="ml-[6px] overflow-hidden whitespace-nowrap font-sans text-[13px] leading-[22px] text-text-secondary">
         {label}
       </span>
@@ -68,6 +84,7 @@ export interface SettingsDockProps {
   onEnvClick?: () => void;
   onToggleSettings: () => void;
   settingsOpen: boolean;
+  hasUpdateReady?: boolean;
 }
 
 export default function SettingsDock({
@@ -75,6 +92,7 @@ export default function SettingsDock({
   onEnvClick,
   onToggleSettings,
   settingsOpen,
+  hasUpdateReady,
 }: SettingsDockProps) {
   return (
     <div className="flex flex-col gap-[2px]">
@@ -94,6 +112,8 @@ export default function SettingsDock({
         }
         label="Settings"
         onClick={onToggleSettings}
+        showDot={hasUpdateReady}
+        title={hasUpdateReady ? 'Update available' : 'Settings'}
       />
     </div>
   );

--- a/apps/studio/src/renderer/components/SettingsPanel/UpdaterSection.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/UpdaterSection.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from 'react';
+import type {
+  UpdateChannel,
+  UpdateStatus,
+} from '../../../shared/updater-contract';
+
+export interface UpdaterSectionProps {
+  status: UpdateStatus;
+  appVersion: string | null;
+  onCheck: () => void;
+  onDownload: () => void;
+  onInstall: () => void;
+  onOpenDownloadPage?: () => void;
+}
+
+function formatPercent(percent: number): string {
+  return `${Math.min(100, Math.max(0, Math.round(percent)))}%`;
+}
+
+function StatusLine({ status }: { status: UpdateStatus }) {
+  const text = useMemo(() => {
+    switch (status.state) {
+      case 'checking':
+        return 'Checking for updates…';
+      case 'available':
+        return `Update available · v${status.version}`;
+      case 'downloading':
+        return `Downloading v${status.version} · ${formatPercent(status.percent)}`;
+      case 'downloaded':
+        return `v${status.version} ready to install`;
+      case 'not-available':
+        return 'Already up to date';
+      case 'error':
+        return `Update error: ${status.message}`;
+      default:
+        return null;
+    }
+  }, [status]);
+
+  if (!text) return null;
+
+  const tone =
+    status.state === 'error'
+      ? 'text-red-500'
+      : status.state === 'available' || status.state === 'downloaded'
+        ? 'text-text-primary'
+        : 'text-text-tertiary';
+
+  return (
+    <output className={`font-sans text-[12px] leading-[18px] ${tone}`}>
+      {text}
+    </output>
+  );
+}
+
+function ActionButton({
+  label,
+  onClick,
+  primary = false,
+  disabled = false,
+}: {
+  label: string;
+  onClick: () => void;
+  primary?: boolean;
+  disabled?: boolean;
+}) {
+  const base =
+    'inline-flex h-[26px] cursor-pointer items-center justify-center rounded-[6px] border-0 px-[10px] font-sans text-[12px] font-medium leading-none transition-colors disabled:cursor-not-allowed disabled:opacity-60';
+  const tone = primary
+    ? 'bg-text-primary text-surface-elevated hover:opacity-90'
+    : 'bg-surface-hover text-text-primary hover:bg-surface-active';
+  return (
+    <button
+      className={`${base} ${tone}`}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function ProgressBar({ percent }: { percent: number }) {
+  const width = formatPercent(percent);
+  return (
+    <div className="h-[4px] w-full overflow-hidden rounded-full bg-surface-hover">
+      <div
+        className="h-full bg-text-primary transition-[width] duration-150"
+        style={{ width }}
+      />
+    </div>
+  );
+}
+
+export default function UpdaterSection({
+  status,
+  appVersion,
+  onCheck,
+  onDownload,
+  onInstall,
+  onOpenDownloadPage,
+}: UpdaterSectionProps) {
+  const versionLabel = appVersion ? `v${appVersion}` : '—';
+  const externalDownloadOnly =
+    status.state === 'available' && status.externalDownloadOnly === true;
+
+  return (
+    <div className="flex flex-col gap-[6px] px-[8px] py-[6px]">
+      <div className="flex items-center justify-between">
+        <span className="font-sans text-[13px] leading-[22px] text-text-secondary">
+          Version
+        </span>
+        <span className="font-sans text-[12px] leading-[18px] text-text-tertiary">
+          {versionLabel}
+        </span>
+      </div>
+
+      <StatusLine status={status} />
+
+      {status.state === 'downloading' ? (
+        <ProgressBar percent={status.percent} />
+      ) : null}
+
+      <div className="flex flex-wrap gap-[6px]">
+        {status.state === 'available' ? (
+          externalDownloadOnly && onOpenDownloadPage ? (
+            <ActionButton
+              label="Open download page"
+              onClick={onOpenDownloadPage}
+              primary
+            />
+          ) : (
+            <ActionButton
+              label="Download update"
+              onClick={onDownload}
+              primary
+            />
+          )
+        ) : null}
+        {status.state === 'downloaded' ? (
+          <ActionButton
+            label="Restart to install"
+            onClick={onInstall}
+            primary
+          />
+        ) : null}
+        <ActionButton
+          disabled={
+            status.state === 'checking' || status.state === 'downloading'
+          }
+          label={
+            status.state === 'checking' ? 'Checking…' : 'Check for updates'
+          }
+          onClick={onCheck}
+        />
+      </div>
+    </div>
+  );
+}
+
+export type { UpdateChannel };

--- a/apps/studio/src/renderer/components/SettingsPanel/UpdaterSection.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/UpdaterSection.tsx
@@ -1,13 +1,8 @@
-import { useMemo } from 'react';
-import type {
-  UpdateChannel,
-  UpdateStatus,
-} from '../../../shared/updater-contract';
+import type { UpdateStatus } from '../../../shared/updater-contract';
 
 export interface UpdaterSectionProps {
   status: UpdateStatus;
   appVersion: string | null;
-  onCheck: () => void;
   onDownload: () => void;
   onInstall: () => void;
   onOpenDownloadPage?: () => void;
@@ -17,58 +12,18 @@ function formatPercent(percent: number): string {
   return `${Math.min(100, Math.max(0, Math.round(percent)))}%`;
 }
 
-function StatusLine({ status }: { status: UpdateStatus }) {
-  const text = useMemo(() => {
-    switch (status.state) {
-      case 'checking':
-        return 'Checking for updates…';
-      case 'available':
-        return `Update available · v${status.version}`;
-      case 'downloading':
-        return `Downloading v${status.version} · ${formatPercent(status.percent)}`;
-      case 'downloaded':
-        return `v${status.version} ready to install`;
-      case 'not-available':
-        return 'Already up to date';
-      case 'error':
-        return `Update error: ${status.message}`;
-      default:
-        return null;
-    }
-  }, [status]);
-
-  if (!text) return null;
-
-  const tone =
-    status.state === 'error'
-      ? 'text-red-500'
-      : status.state === 'available' || status.state === 'downloaded'
-        ? 'text-text-primary'
-        : 'text-text-tertiary';
-
-  return (
-    <output className={`font-sans text-[12px] leading-[18px] ${tone}`}>
-      {text}
-    </output>
-  );
-}
-
-function ActionButton({
+function InlineUpdateButton({
   label,
   onClick,
-  primary = false,
   disabled = false,
 }: {
   label: string;
   onClick: () => void;
-  primary?: boolean;
   disabled?: boolean;
 }) {
   const base =
-    'inline-flex h-[26px] cursor-pointer items-center justify-center rounded-[6px] border-0 px-[10px] font-sans text-[12px] font-medium leading-none transition-colors disabled:cursor-not-allowed disabled:opacity-60';
-  const tone = primary
-    ? 'bg-text-primary text-surface-elevated hover:opacity-90'
-    : 'bg-surface-hover text-text-primary hover:bg-surface-active';
+    'inline-flex h-[20px] min-w-[48px] cursor-pointer items-center justify-center rounded-[5px] border-0 px-[7px] font-sans text-[12px] font-semibold leading-none transition-colors disabled:cursor-default disabled:opacity-70';
+  const tone = 'bg-surface-hover text-text-secondary hover:bg-surface-active';
   return (
     <button
       className={`${base} ${tone}`}
@@ -81,22 +36,9 @@ function ActionButton({
   );
 }
 
-function ProgressBar({ percent }: { percent: number }) {
-  const width = formatPercent(percent);
-  return (
-    <div className="h-[4px] w-full overflow-hidden rounded-full bg-surface-hover">
-      <div
-        className="h-full bg-text-primary transition-[width] duration-150"
-        style={{ width }}
-      />
-    </div>
-  );
-}
-
 export default function UpdaterSection({
   status,
   appVersion,
-  onCheck,
   onDownload,
   onInstall,
   onOpenDownloadPage,
@@ -104,59 +46,39 @@ export default function UpdaterSection({
   const versionLabel = appVersion ? `v${appVersion}` : '—';
   const externalDownloadOnly =
     status.state === 'available' && status.externalDownloadOnly === true;
+  const updateAction =
+    status.state === 'available' ? (
+      <InlineUpdateButton
+        label="update"
+        onClick={
+          externalDownloadOnly && onOpenDownloadPage
+            ? onOpenDownloadPage
+            : onDownload
+        }
+      />
+    ) : status.state === 'downloaded' ? (
+      <InlineUpdateButton label="restart" onClick={onInstall} />
+    ) : status.state === 'downloading' ? (
+      <InlineUpdateButton
+        disabled
+        label={formatPercent(status.percent)}
+        onClick={() => {}}
+      />
+    ) : null;
 
   return (
-    <div className="flex flex-col gap-[6px] px-[8px] py-[6px]">
-      <div className="flex items-center justify-between">
-        <span className="font-sans text-[13px] leading-[22px] text-text-secondary">
+    <div className="flex px-[8px] py-[6px]">
+      <div className="flex min-h-[22px] w-full items-center justify-between gap-[12px]">
+        <span className="shrink-0 font-sans text-[13px] leading-[22px] text-text-secondary">
           Version
         </span>
-        <span className="font-sans text-[12px] leading-[18px] text-text-tertiary">
-          {versionLabel}
-        </span>
-      </div>
-
-      <StatusLine status={status} />
-
-      {status.state === 'downloading' ? (
-        <ProgressBar percent={status.percent} />
-      ) : null}
-
-      <div className="flex flex-wrap gap-[6px]">
-        {status.state === 'available' ? (
-          externalDownloadOnly && onOpenDownloadPage ? (
-            <ActionButton
-              label="Open download page"
-              onClick={onOpenDownloadPage}
-              primary
-            />
-          ) : (
-            <ActionButton
-              label="Download update"
-              onClick={onDownload}
-              primary
-            />
-          )
-        ) : null}
-        {status.state === 'downloaded' ? (
-          <ActionButton
-            label="Restart to install"
-            onClick={onInstall}
-            primary
-          />
-        ) : null}
-        <ActionButton
-          disabled={
-            status.state === 'checking' || status.state === 'downloading'
-          }
-          label={
-            status.state === 'checking' ? 'Checking…' : 'Check for updates'
-          }
-          onClick={onCheck}
-        />
+        <div className="flex min-w-0 items-center gap-[8px]">
+          {updateAction}
+          <span className="shrink-0 font-sans text-[12px] leading-[18px] text-text-tertiary">
+            {versionLabel}
+          </span>
+        </div>
       </div>
     </div>
   );
 }
-
-export type { UpdateChannel };

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type {
-  UpdateChannel,
-  UpdateStatus,
-} from '../../../shared/updater-contract';
+import type { UpdateStatus } from '../../../shared/updater-contract';
 import {
   type StudioThemeMode,
   useStudioTheme,
@@ -152,14 +149,9 @@ export interface SettingsPanelProps {
   updater?: {
     status: UpdateStatus;
     appVersion: string | null;
-    channel?: UpdateChannel;
-    autoDownload?: boolean;
-    onCheck: () => void;
     onDownload: () => void;
     onInstall: () => void;
     onOpenDownloadPage?: () => void;
-    onChangeChannel?: (channel: UpdateChannel) => void;
-    onChangeAutoDownload?: (enabled: boolean) => void;
   };
 }
 
@@ -262,7 +254,6 @@ export default function SettingsPanel({
             <div className="my-[4px] h-px w-full bg-divider" />
             <UpdaterSection
               appVersion={updater.appVersion}
-              onCheck={updater.onCheck}
               onDownload={updater.onDownload}
               onInstall={updater.onInstall}
               onOpenDownloadPage={updater.onOpenDownloadPage}

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  UpdateChannel,
+  UpdateStatus,
+} from '../../../shared/updater-contract';
 import {
   type StudioThemeMode,
   useStudioTheme,
 } from '../../theme/ThemeProvider';
 import SettingItem from './SettingItem';
+import UpdaterSection from './UpdaterSection';
 
 const LANGUAGE_STORAGE_KEY = 'studio.language';
 const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
@@ -144,12 +149,25 @@ export interface SettingsPanelProps {
   className?: string;
   onGithubClick?: () => void;
   onWebsiteClick?: () => void;
+  updater?: {
+    status: UpdateStatus;
+    appVersion: string | null;
+    channel?: UpdateChannel;
+    autoDownload?: boolean;
+    onCheck: () => void;
+    onDownload: () => void;
+    onInstall: () => void;
+    onOpenDownloadPage?: () => void;
+    onChangeChannel?: (channel: UpdateChannel) => void;
+    onChangeAutoDownload?: (enabled: boolean) => void;
+  };
 }
 
 export default function SettingsPanel({
   className,
   onGithubClick,
   onWebsiteClick,
+  updater,
 }: SettingsPanelProps) {
   const { mode, setMode } = useStudioTheme();
   // Language preference is persisted but not surfaced yet; the row is
@@ -239,13 +257,19 @@ export default function SettingsPanel({
           />
         </div>
 
-        <div className="my-[4px] h-px w-full bg-divider" />
-
-        <div className="flex h-[24px] items-center justify-center px-[8px]">
-          <span className="font-sans text-[11px] leading-none text-text-tertiary">
-            Version {__APP_VERSION__}
-          </span>
-        </div>
+        {updater ? (
+          <>
+            <div className="my-[4px] h-px w-full bg-divider" />
+            <UpdaterSection
+              appVersion={updater.appVersion}
+              onCheck={updater.onCheck}
+              onDownload={updater.onDownload}
+              onInstall={updater.onInstall}
+              onOpenDownloadPage={updater.onOpenDownloadPage}
+              status={updater.status}
+            />
+          </>
+        ) : null}
       </div>
 
       {openPopover === 'theme' ? (

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { STUDIO_EXTERNAL_LINKS } from '../../../shared/external-links';
 import { assetUrls } from '../../assets';
+import { useStudioUpdater } from '../../hooks/useStudioUpdater';
 import MainContent from '../MainContent';
 import { MaskedIcon } from '../MaskedIcon';
 import Playground from '../Playground';
@@ -105,6 +106,7 @@ export default function ShellLayout() {
     ),
   );
   const settingsAnchorRef = useRef<HTMLDivElement | null>(null);
+  const updater = useStudioUpdater();
   const modelConfigComplete = useMemo(
     () => hasCompleteModelEnvConfig(modelEnvText),
     [modelEnvText],
@@ -263,11 +265,27 @@ export default function ShellLayout() {
                   onWebsiteClick={() =>
                     openExternalUrl(STUDIO_EXTERNAL_LINKS.website)
                   }
+                  updater={{
+                    appVersion: updater.appVersion,
+                    onCheck: () => {
+                      void updater.check();
+                    },
+                    onDownload: () => {
+                      void updater.download();
+                    },
+                    onInstall: () => {
+                      void updater.install();
+                    },
+                    onOpenDownloadPage: () =>
+                      openExternalUrl(STUDIO_EXTERNAL_LINKS.studioReleases),
+                    status: updater.status,
+                  }}
                 />
               </div>
             )}
             <SidebarFooter
               envAlert={!modelConfigComplete}
+              hasUpdateReady={updater.hasUpdateReady}
               onEnvClick={openEnvModal}
               onToggleSettings={() => setSettingsOpen((prev) => !prev)}
               settingsOpen={settingsOpen}

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -267,9 +267,6 @@ export default function ShellLayout() {
                   }
                   updater={{
                     appVersion: updater.appVersion,
-                    onCheck: () => {
-                      void updater.check();
-                    },
                     onDownload: () => {
                       void updater.download();
                     },

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -414,6 +414,7 @@ export interface SidebarFooterProps {
   onEnvClick?: () => void;
   /** Surface a "missing config" red badge on the env dock row. */
   envAlert?: boolean;
+  hasUpdateReady?: boolean;
 }
 
 export function SidebarFooter({
@@ -421,10 +422,12 @@ export function SidebarFooter({
   settingsOpen,
   onToggleSettings,
   onEnvClick,
+  hasUpdateReady,
 }: SidebarFooterProps) {
   return (
     <SettingsDock
       envAlert={envAlert}
+      hasUpdateReady={hasUpdateReady}
       onEnvClick={onEnvClick}
       onToggleSettings={onToggleSettings}
       settingsOpen={settingsOpen}

--- a/apps/studio/src/renderer/components/Sidebar/index.tsx
+++ b/apps/studio/src/renderer/components/Sidebar/index.tsx
@@ -414,6 +414,10 @@ export interface SidebarFooterProps {
   onEnvClick?: () => void;
   /** Surface a "missing config" red badge on the env dock row. */
   envAlert?: boolean;
+  /**
+   * Surface a red badge on the settings dock row when an update is
+   * available to download or already downloaded and waiting to install.
+   */
   hasUpdateReady?: boolean;
 }
 

--- a/apps/studio/src/renderer/hooks/useStudioUpdater.ts
+++ b/apps/studio/src/renderer/hooks/useStudioUpdater.ts
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import type {
-  UpdateChannel,
-  UpdateStatus,
-} from '../../shared/updater-contract';
+import type { UpdateStatus } from '../../shared/updater-contract';
 
 const isUpdateStatus = (value: unknown): value is UpdateStatus => {
   return (
@@ -22,8 +19,6 @@ export interface UseStudioUpdaterResult {
   check: () => Promise<void>;
   download: () => Promise<void>;
   install: () => Promise<void>;
-  setAutoDownload: (enabled: boolean) => Promise<void>;
-  setChannel: (channel: UpdateChannel) => Promise<void>;
 }
 
 export function useStudioUpdater(): UseStudioUpdaterResult {
@@ -78,18 +73,6 @@ export function useStudioUpdater(): UseStudioUpdaterResult {
     await api.install();
   }, []);
 
-  const setAutoDownload = useCallback(async (enabled: boolean) => {
-    const api = getUpdaterApi();
-    if (!api) return;
-    await api.setAutoDownload(enabled);
-  }, []);
-
-  const setChannel = useCallback(async (channel: UpdateChannel) => {
-    const api = getUpdaterApi();
-    if (!api) return;
-    await api.setChannel(channel);
-  }, []);
-
   const hasUpdateReady =
     status.state === 'available' || status.state === 'downloaded';
 
@@ -100,7 +83,5 @@ export function useStudioUpdater(): UseStudioUpdaterResult {
     check,
     download,
     install,
-    setAutoDownload,
-    setChannel,
   };
 }

--- a/apps/studio/src/renderer/hooks/useStudioUpdater.ts
+++ b/apps/studio/src/renderer/hooks/useStudioUpdater.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  UpdateChannel,
+  UpdateStatus,
+} from '../../shared/updater-contract';
+
+const isUpdateStatus = (value: unknown): value is UpdateStatus => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { state?: unknown }).state === 'string'
+  );
+};
+
+const getUpdaterApi = () => window.studioUpdater;
+
+export interface UseStudioUpdaterResult {
+  status: UpdateStatus;
+  /** True while the user-initiated check is in flight or the update can be installed. */
+  hasUpdateReady: boolean;
+  appVersion: string | null;
+  check: () => Promise<void>;
+  download: () => Promise<void>;
+  install: () => Promise<void>;
+  setAutoDownload: (enabled: boolean) => Promise<void>;
+  setChannel: (channel: UpdateChannel) => Promise<void>;
+}
+
+export function useStudioUpdater(): UseStudioUpdaterResult {
+  const [status, setStatus] = useState<UpdateStatus>({ state: 'idle' });
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    const api = getUpdaterApi();
+    if (!api) return;
+
+    let cancelled = false;
+    void api.getStatus().then((current) => {
+      if (!cancelled && isUpdateStatus(current)) {
+        setStatus(current);
+      }
+    });
+    void api.getVersion().then((version) => {
+      if (!cancelled) setAppVersion(version);
+    });
+
+    const cleanup = api.onStatus((next) => {
+      if (isUpdateStatus(next)) {
+        setStatus(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, []);
+
+  const check = useCallback(async () => {
+    const api = getUpdaterApi();
+    if (!api) return;
+    setStatus({ state: 'checking' });
+    const result = await api.check();
+    // `update-available` arrives via onStatus; only correct the optimistic
+    // checking state when the main process did not promote it further.
+    if (!isUpdateStatus(result)) return;
+    setStatus((prev) => (prev.state === 'checking' ? result : prev));
+  }, []);
+
+  const download = useCallback(async () => {
+    const api = getUpdaterApi();
+    if (!api) return;
+    await api.download();
+  }, []);
+
+  const install = useCallback(async () => {
+    const api = getUpdaterApi();
+    if (!api) return;
+    await api.install();
+  }, []);
+
+  const setAutoDownload = useCallback(async (enabled: boolean) => {
+    const api = getUpdaterApi();
+    if (!api) return;
+    await api.setAutoDownload(enabled);
+  }, []);
+
+  const setChannel = useCallback(async (channel: UpdateChannel) => {
+    const api = getUpdaterApi();
+    if (!api) return;
+    await api.setChannel(channel);
+  }, []);
+
+  const hasUpdateReady =
+    status.state === 'available' || status.state === 'downloaded';
+
+  return {
+    status,
+    hasUpdateReady,
+    appVersion,
+    check,
+    download,
+    install,
+    setAutoDownload,
+    setChannel,
+  };
+}

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -22,6 +22,16 @@ export const IPC_CHANNELS = {
   discoveredDevicesUpdated: 'studio:discovered-devices-updated',
   setDiscoveryPollingPaused: 'studio:set-discovery-polling-paused',
   runConnectivityTest: 'studio:run-connectivity-test',
+  // Auto-updater bridge — main owns the electron-updater state machine,
+  // the renderer just renders it.
+  updaterCheck: 'updater:check',
+  updaterDownload: 'updater:download',
+  updaterInstall: 'updater:install',
+  updaterGetVersion: 'updater:getVersion',
+  updaterGetStatus: 'updater:getStatus',
+  updaterSetAutoDownload: 'updater:setAutoDownload',
+  updaterSetChannel: 'updater:setChannel',
+  updaterStatus: 'updater:status',
 } as const;
 
 export interface ConnectivityTestRequest {

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -29,8 +29,6 @@ export const IPC_CHANNELS = {
   updaterInstall: 'updater:install',
   updaterGetVersion: 'updater:getVersion',
   updaterGetStatus: 'updater:getStatus',
-  updaterSetAutoDownload: 'updater:setAutoDownload',
-  updaterSetChannel: 'updater:setChannel',
   updaterStatus: 'updater:status',
 } as const;
 

--- a/apps/studio/src/shared/external-links.ts
+++ b/apps/studio/src/shared/external-links.ts
@@ -3,6 +3,10 @@ export const STUDIO_EXTERNAL_LINKS = {
   website: 'https://midscenejs.com',
   androidIntegrationFaq:
     'https://midscenejs.com/integrate-with-android.html#faq',
+  // Used by the Windows portable build's "Open download page" action — the
+  // portable .exe can't replace itself, so we send the user to the GitHub
+  // Release to grab the next zip manually.
+  studioReleases: 'https://github.com/web-infra-dev/midscene/releases',
 } as const;
 
 export function resolveExternalUrl(url: string) {

--- a/apps/studio/src/shared/updater-contract.ts
+++ b/apps/studio/src/shared/updater-contract.ts
@@ -1,5 +1,3 @@
-export type UpdateChannel = 'stable' | 'beta';
-
 export type UpdateStatus =
   | { state: 'idle' }
   | { state: 'checking' }
@@ -20,7 +18,5 @@ export interface UpdaterApi {
   install: () => Promise<void>;
   getVersion: () => Promise<string>;
   getStatus: () => Promise<UpdateStatus>;
-  setAutoDownload: (enabled: boolean) => Promise<{ success: boolean }>;
-  setChannel: (channel: UpdateChannel) => Promise<UpdateChannel>;
   onStatus: (callback: (status: UpdateStatus) => void) => () => void;
 }

--- a/apps/studio/src/shared/updater-contract.ts
+++ b/apps/studio/src/shared/updater-contract.ts
@@ -1,0 +1,26 @@
+export type UpdateChannel = 'stable' | 'beta';
+
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | {
+      state: 'available';
+      version: string;
+      releaseNotes?: string;
+      externalDownloadOnly?: boolean;
+    }
+  | { state: 'not-available' }
+  | { state: 'downloading'; percent: number; version: string }
+  | { state: 'downloaded'; version: string }
+  | { state: 'error'; message: string };
+
+export interface UpdaterApi {
+  check: () => Promise<unknown>;
+  download: () => Promise<{ success: boolean; error?: string }>;
+  install: () => Promise<void>;
+  getVersion: () => Promise<string>;
+  getStatus: () => Promise<UpdateStatus>;
+  setAutoDownload: (enabled: boolean) => Promise<{ success: boolean }>;
+  setChannel: (channel: UpdateChannel) => Promise<UpdateChannel>;
+  onStatus: (callback: (status: UpdateStatus) => void) => () => void;
+}

--- a/apps/studio/tests/build-update-metadata.test.mjs
+++ b/apps/studio/tests/build-update-metadata.test.mjs
@@ -60,6 +60,53 @@ describe('buildLatestYmlForPlatform', () => {
       }),
     ).toThrow(/Unsupported platform/);
   });
+
+  it('rejects unsafe characters in scalars so a bad caller cannot inject YAML', () => {
+    expect(() =>
+      buildLatestYmlForPlatform({
+        version: '0.30.0\n# malicious: true',
+        platform: 'darwin',
+        artifactName: 'midscene.zip',
+        sha512: 'AAAA',
+        size: 1,
+      }),
+    ).toThrow(/version contains unsafe YAML characters/);
+
+    expect(() =>
+      buildLatestYmlForPlatform({
+        version: '0.30.0',
+        platform: 'darwin',
+        artifactName: 'a: b.zip',
+        sha512: 'AAAA',
+        size: 1,
+      }),
+    ).toThrow(/path contains unsafe YAML characters/);
+  });
+
+  it('rejects single quotes and newlines in releaseDate (which is single-quoted)', () => {
+    expect(() =>
+      buildLatestYmlForPlatform({
+        version: '0.30.0',
+        platform: 'darwin',
+        artifactName: 'midscene.zip',
+        sha512: 'AAAA',
+        size: 1,
+        releaseDate: "2026-05-12'injected",
+      }),
+    ).toThrow(/releaseDate contains unsafe characters/);
+  });
+
+  it('rejects non-integer or negative size', () => {
+    expect(() =>
+      buildLatestYmlForPlatform({
+        version: '0.30.0',
+        platform: 'darwin',
+        artifactName: 'midscene.zip',
+        sha512: 'AAAA',
+        size: -1,
+      }),
+    ).toThrow(/files\[0\]\.size must be a non-negative integer/);
+  });
 });
 
 describe('buildAppUpdateYml', () => {

--- a/apps/studio/tests/build-update-metadata.test.mjs
+++ b/apps/studio/tests/build-update-metadata.test.mjs
@@ -1,0 +1,165 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAppUpdateYml,
+  buildLatestYmlForPlatform,
+  isPrereleaseVersion,
+  writeAppUpdateYmlIntoResources,
+  writeUpdateMetadataForArtifact,
+} from '../scripts/build-update-metadata.mjs';
+
+const makeTempDir = async (prefix = 'midscene-studio-updater-test-') =>
+  fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+describe('isPrereleaseVersion', () => {
+  it('detects beta/alpha/rc identifiers', () => {
+    expect(isPrereleaseVersion('1.2.3-beta.0')).toBe(true);
+    expect(isPrereleaseVersion('1.2.3-alpha.1')).toBe(true);
+    expect(isPrereleaseVersion('1.2.3-rc.5')).toBe(true);
+    expect(isPrereleaseVersion('1.2.3')).toBe(false);
+    expect(isPrereleaseVersion('1.2.3-canary.4')).toBe(false);
+  });
+});
+
+describe('buildLatestYmlForPlatform', () => {
+  it('emits the electron-updater shape with stable keys', () => {
+    const yml = buildLatestYmlForPlatform({
+      version: '0.30.0',
+      platform: 'darwin',
+      artifactName: 'midscene-studio-v0.30.0-darwin-arm64.zip',
+      sha512: 'AAAA',
+      size: 12345,
+      releaseDate: '2026-05-12T00:00:00.000Z',
+    });
+    expect(yml).toBe(
+      [
+        'version: 0.30.0',
+        'files:',
+        '  - url: midscene-studio-v0.30.0-darwin-arm64.zip',
+        '    sha512: AAAA',
+        '    size: 12345',
+        'path: midscene-studio-v0.30.0-darwin-arm64.zip',
+        'sha512: AAAA',
+        "releaseDate: '2026-05-12T00:00:00.000Z'",
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('rejects unknown platforms', () => {
+    expect(() =>
+      buildLatestYmlForPlatform({
+        version: '0.30.0',
+        platform: 'aix',
+        artifactName: 'irrelevant.zip',
+        sha512: 'AAAA',
+        size: 1,
+      }),
+    ).toThrow(/Unsupported platform/);
+  });
+});
+
+describe('buildAppUpdateYml', () => {
+  it('points electron-updater at the GitHub provider for this repo', () => {
+    const yml = buildAppUpdateYml();
+    expect(yml).toBe(
+      [
+        'provider: github',
+        'owner: web-infra-dev',
+        'repo: midscene',
+        'updaterCacheDirName: midscene-studio-updater',
+        '',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('writeAppUpdateYmlIntoResources', () => {
+  it('creates the resources directory and writes app-update.yml', async () => {
+    const tmp = await makeTempDir();
+    try {
+      const resourcesDir = path.join(tmp, 'Resources');
+      const written = await writeAppUpdateYmlIntoResources(resourcesDir);
+      expect(written).toBe(path.join(resourcesDir, 'app-update.yml'));
+      const content = await fs.readFile(written, 'utf8');
+      expect(content).toContain('provider: github');
+      expect(content).toContain('repo: midscene');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('writeUpdateMetadataForArtifact', () => {
+  it('writes latest-mac.yml with the correct sha512 + size for a zip', async () => {
+    const tmp = await makeTempDir();
+    try {
+      const artifactDir = path.join(tmp, 'artifacts');
+      await fs.mkdir(artifactDir, { recursive: true });
+      const artifactPath = path.join(
+        artifactDir,
+        'midscene-studio-v0.30.0-darwin-arm64.zip',
+      );
+      const payload = Buffer.from('fake-zip-payload-0123456789');
+      await fs.writeFile(artifactPath, payload);
+      const expectedSha = crypto
+        .createHash('sha512')
+        .update(payload)
+        .digest('base64');
+
+      const result = await writeUpdateMetadataForArtifact({
+        artifactPath,
+        artifactDir,
+        platform: 'darwin',
+        version: '0.30.0',
+      });
+
+      expect(result.sha512).toBe(expectedSha);
+      expect(result.size).toBe(payload.length);
+      expect(result.writtenPaths).toEqual([
+        path.join(artifactDir, 'latest-mac.yml'),
+      ]);
+
+      const yml = await fs.readFile(result.writtenPaths[0], 'utf8');
+      expect(yml).toContain(`sha512: ${expectedSha}`);
+      expect(yml).toContain(`size: ${payload.length}`);
+      expect(yml).toContain('path: midscene-studio-v0.30.0-darwin-arm64.zip');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('mirrors the manifest to beta-<platform>.yml for prerelease versions', async () => {
+    const tmp = await makeTempDir();
+    try {
+      const artifactDir = path.join(tmp, 'artifacts');
+      await fs.mkdir(artifactDir, { recursive: true });
+      const artifactPath = path.join(
+        artifactDir,
+        'midscene-studio-v0.30.0-beta.1-linux-x64.zip',
+      );
+      await fs.writeFile(artifactPath, 'noop');
+
+      const result = await writeUpdateMetadataForArtifact({
+        artifactPath,
+        artifactDir,
+        platform: 'linux',
+        version: '0.30.0-beta.1',
+      });
+
+      expect(result.writtenPaths).toEqual([
+        path.join(artifactDir, 'latest-linux.yml'),
+        path.join(artifactDir, 'beta-linux.yml'),
+      ]);
+
+      const stable = await fs.readFile(result.writtenPaths[0], 'utf8');
+      const beta = await fs.readFile(result.writtenPaths[1], 'utf8');
+      expect(stable).toBe(beta);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -8,6 +8,7 @@ import {
   buildInstallWorkspaceManifest,
   buildMacDittoArchiveArgs,
   buildPackagedAppManifest,
+  buildPackagedResourcesCandidates,
   buildPackagerOptions,
   buildPnpmSupportedArchitectures,
   buildVendoredWorkspaceDirName,
@@ -168,6 +169,31 @@ describe('package-electron helpers', () => {
       stageDir: '/tmp/stage',
     });
     expect(opts.icon).toMatch(/midscene-icon\.ico$/);
+  });
+
+  it('resolves the resources directory when the app payload is packed as asar', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-app-'));
+    try {
+      const resourcesDir = path.join(
+        root,
+        'Midscene Studio.app',
+        'Contents',
+        'Resources',
+      );
+      await fs.mkdir(resourcesDir, { recursive: true });
+      await fs.writeFile(path.join(resourcesDir, 'app.asar'), 'asar payload');
+
+      const candidates = await buildPackagedResourcesCandidates(
+        path.join(root, 'Midscene Studio.app'),
+      );
+
+      expect(candidates[0]).toBe(resourcesDir);
+      await expect(
+        fs.stat(path.join(resourcesDir, 'app.asar')),
+      ).resolves.toBeTruthy();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it('uses a shell for Windows .cmd package manager shims', () => {

--- a/apps/studio/tests/preload-bridge.test.ts
+++ b/apps/studio/tests/preload-bridge.test.ts
@@ -30,10 +30,10 @@ describe('preload bridge', () => {
     mocks.invoke.mockResolvedValue(undefined);
   });
 
-  it('exposes shell and studio runtime APIs that proxy over IPC', async () => {
+  it('exposes shell, studio runtime, and updater APIs that proxy over IPC', async () => {
     await loadModule();
 
-    expect(mocks.exposeInMainWorld).toHaveBeenCalledTimes(2);
+    expect(mocks.exposeInMainWorld).toHaveBeenCalledTimes(3);
 
     const shellApi = mocks.exposeInMainWorld.mock.calls.find(
       ([name]) => name === 'electronShell',
@@ -41,9 +41,13 @@ describe('preload bridge', () => {
     const studioRuntimeApi = mocks.exposeInMainWorld.mock.calls.find(
       ([name]) => name === 'studioRuntime',
     )?.[1];
+    const updaterApi = mocks.exposeInMainWorld.mock.calls.find(
+      ([name]) => name === 'studioUpdater',
+    )?.[1];
 
     expect(shellApi).toBeDefined();
     expect(studioRuntimeApi).toBeDefined();
+    expect(updaterApi).toBeDefined();
 
     await shellApi.closeWindow();
     await shellApi.minimizeWindow();
@@ -68,6 +72,16 @@ describe('preload bridge', () => {
       model: 'gpt-4o',
     });
     stopListening();
+
+    await updaterApi.check();
+    await updaterApi.download();
+    await updaterApi.install();
+    await updaterApi.getVersion();
+    await updaterApi.getStatus();
+    await updaterApi.setAutoDownload(true);
+    await updaterApi.setChannel('beta');
+    const stopStatus = updaterApi.onStatus(() => undefined);
+    stopStatus();
 
     expect(mocks.invoke.mock.calls).toEqual([
       [IPC_CHANNELS.closeWindow],
@@ -94,13 +108,28 @@ describe('preload bridge', () => {
           model: 'gpt-4o',
         },
       ],
+      [IPC_CHANNELS.updaterCheck],
+      [IPC_CHANNELS.updaterDownload],
+      [IPC_CHANNELS.updaterInstall],
+      [IPC_CHANNELS.updaterGetVersion],
+      [IPC_CHANNELS.updaterGetStatus],
+      [IPC_CHANNELS.updaterSetAutoDownload, true],
+      [IPC_CHANNELS.updaterSetChannel, 'beta'],
     ]);
     expect(mocks.on).toHaveBeenCalledWith(
       IPC_CHANNELS.discoveredDevicesUpdated,
       expect.any(Function),
     );
+    expect(mocks.on).toHaveBeenCalledWith(
+      IPC_CHANNELS.updaterStatus,
+      expect.any(Function),
+    );
     expect(mocks.removeListener).toHaveBeenCalledWith(
       IPC_CHANNELS.discoveredDevicesUpdated,
+      expect.any(Function),
+    );
+    expect(mocks.removeListener).toHaveBeenCalledWith(
+      IPC_CHANNELS.updaterStatus,
       expect.any(Function),
     );
   });

--- a/apps/studio/tests/preload-bridge.test.ts
+++ b/apps/studio/tests/preload-bridge.test.ts
@@ -78,8 +78,6 @@ describe('preload bridge', () => {
     await updaterApi.install();
     await updaterApi.getVersion();
     await updaterApi.getStatus();
-    await updaterApi.setAutoDownload(true);
-    await updaterApi.setChannel('beta');
     const stopStatus = updaterApi.onStatus(() => undefined);
     stopStatus();
 
@@ -113,8 +111,6 @@ describe('preload bridge', () => {
       [IPC_CHANNELS.updaterInstall],
       [IPC_CHANNELS.updaterGetVersion],
       [IPC_CHANNELS.updaterGetStatus],
-      [IPC_CHANNELS.updaterSetAutoDownload, true],
-      [IPC_CHANNELS.updaterSetChannel, 'beta'],
     ]);
     expect(mocks.on).toHaveBeenCalledWith(
       IPC_CHANNELS.discoveredDevicesUpdated,

--- a/apps/studio/tests/updater-handlers.test.ts
+++ b/apps/studio/tests/updater-handlers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { UpdateStatus } from '../src/shared/updater-contract';
+
+vi.mock('electron', () => ({
+  app: {
+    getName: () => 'Midscene Studio',
+    getPath: (name: string) => `/tmp/${name}`,
+    isPackaged: true,
+    quit: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    channel: 'latest',
+    allowPrerelease: false,
+    allowDowngrade: false,
+    on: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+    getFeedURL: vi.fn(() => 'https://example.com'),
+  },
+}));
+
+describe('updater handlers', () => {
+  it('returns an available status from a raw electron-updater check result', async () => {
+    const { resolveUpdaterCheckStatus } = await import(
+      '../src/main/updater-handlers'
+    );
+
+    const status = resolveUpdaterCheckStatus(
+      {
+        updateInfo: {
+          version: '1.8.1',
+          releaseNotes: 'Bug fixes',
+        },
+      },
+      { state: 'checking' },
+      'win32',
+    );
+
+    expect(status).toEqual({
+      state: 'available',
+      version: '1.8.1',
+      releaseNotes: 'Bug fixes',
+      externalDownloadOnly: true,
+    });
+  });
+
+  it('does not replace a status already promoted by updater events', async () => {
+    const { resolveUpdaterCheckStatus } = await import(
+      '../src/main/updater-handlers'
+    );
+    const currentStatus: UpdateStatus = {
+      state: 'downloaded',
+      version: '1.8.1',
+    };
+
+    expect(resolveUpdaterCheckStatus(null, currentStatus, 'darwin')).toBe(
+      currentStatus,
+    );
+  });
+
+  it('falls back to not available when the check result has no version', async () => {
+    const { resolveUpdaterCheckStatus } = await import(
+      '../src/main/updater-handlers'
+    );
+
+    expect(
+      resolveUpdaterCheckStatus({ updateInfo: {} }, { state: 'checking' }),
+    ).toEqual({ state: 'not-available' });
+  });
+});

--- a/apps/studio/tests/updater-handlers.test.ts
+++ b/apps/studio/tests/updater-handlers.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { UpdateStatus } from '../src/shared/updater-contract';
+
+const mocks = vi.hoisted(() => ({
+  homeDir: '/tmp',
+}));
 
 vi.mock('electron', () => ({
   app: {
     getName: () => 'Midscene Studio',
-    getPath: (name: string) => `/tmp/${name}`,
+    getPath: (name: string) =>
+      name === 'home' ? mocks.homeDir : path.join(mocks.homeDir, name),
     isPackaged: true,
     quit: vi.fn(),
   },
@@ -12,6 +20,10 @@ vi.mock('electron', () => ({
     handle: vi.fn(),
   },
 }));
+
+afterEach(() => {
+  mocks.homeDir = '/tmp';
+});
 
 vi.mock('electron-updater', () => ({
   autoUpdater: {
@@ -21,6 +33,7 @@ vi.mock('electron-updater', () => ({
     allowPrerelease: false,
     allowDowngrade: false,
     on: vi.fn(),
+    removeAllListeners: vi.fn(),
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
     quitAndInstall: vi.fn(),
@@ -28,7 +41,100 @@ vi.mock('electron-updater', () => ({
   },
 }));
 
+describe('shellQuote', () => {
+  it('wraps simple strings in single quotes', async () => {
+    const { shellQuote } = await import('../src/main/updater-handlers');
+    expect(shellQuote('/Applications/Midscene Studio.app')).toBe(
+      `'/Applications/Midscene Studio.app'`,
+    );
+  });
+
+  it("escapes embedded single quotes with the POSIX '\\'' idiom", async () => {
+    const { shellQuote } = await import('../src/main/updater-handlers');
+    expect(shellQuote("it's mine")).toBe(`'it'\\''s mine'`);
+  });
+
+  it('handles consecutive single quotes', async () => {
+    const { shellQuote } = await import('../src/main/updater-handlers');
+    expect(shellQuote("a''b")).toBe(`'a'\\'''\\''b'`);
+  });
+});
+
+describe('buildMacUpdateScript', () => {
+  const baseOptions = {
+    appPath: '/Applications/Midscene Studio.app',
+    execName: 'Midscene Studio',
+    zipPath: '/tmp/midscene/Midscene-Studio-darwin-arm64.zip',
+    tempDir: '/tmp/midscene-studio-update',
+    scriptPath: '/tmp/midscene-studio-update.sh',
+    logPath: '/tmp/midscene-studio-update.log',
+  };
+
+  it('produces a runnable bash script with all paths quoted', async () => {
+    const { buildMacUpdateScript } = await import(
+      '../src/main/updater-handlers'
+    );
+    const script = buildMacUpdateScript(baseOptions);
+    expect(script.startsWith('#!/bin/bash\n')).toBe(true);
+    expect(script).toContain(`APP_PATH='/Applications/Midscene Studio.app'`);
+    expect(script).toContain(`EXEC_NAME='Midscene Studio'`);
+    // Critical guard: refuse to mv into a path that still exists.
+    expect(script).toContain('if [ -e "$APP_PATH" ]');
+    expect(script).toContain('/bin/rm -rf "$APP_PATH"');
+    expect(script).toContain('/bin/mv "$APP_BUNDLE" "$APP_PATH"');
+    expect(script).toContain(
+      '/usr/bin/find "$TEMP_DIR" -maxdepth 2 -name "*.app"',
+    );
+    // Liveness verification so we know the new binary actually launches.
+    expect(script).toContain('kill -0 $LAUNCH_PID');
+  });
+
+  it('escapes single quotes in app paths so the script stays valid bash', async () => {
+    const { buildMacUpdateScript } = await import(
+      '../src/main/updater-handlers'
+    );
+    const script = buildMacUpdateScript({
+      ...baseOptions,
+      appPath: "/Users/x/it's mine.app",
+    });
+    expect(script).toContain(`APP_PATH='/Users/x/it'\\''s mine.app'`);
+    // Make sure the quoting did not accidentally break later usages.
+    expect(script).toContain('APP_CONTENTS_PATH="$APP_PATH/Contents/"');
+  });
+});
+
 describe('updater handlers', () => {
+  it('finds downloads under the configured updater cache directory', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-updater-'));
+    mocks.homeDir = root;
+
+    try {
+      const zipPath = path.join(
+        root,
+        'Library',
+        'Caches',
+        'midscene-studio-updater',
+        'pending',
+        'midscene-studio-v1.8.1-darwin-arm64.zip',
+      );
+      await fs.mkdir(path.dirname(zipPath), { recursive: true });
+      await fs.writeFile(zipPath, 'zip');
+
+      const { findDownloadedMacUpdateZip } = await import(
+        '../src/main/updater-handlers'
+      );
+      const updater = {
+        getDownloadedFilePath: () => null,
+      };
+
+      await expect(findDownloadedMacUpdateZip(updater as never)).resolves.toBe(
+        zipPath,
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('returns an available status from a raw electron-updater check result', async () => {
     const { resolveUpdaterCheckStatus } = await import(
       '../src/main/updater-handlers'

--- a/apps/studio/tests/updater-section.test.tsx
+++ b/apps/studio/tests/updater-section.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import UpdaterSection from '../src/renderer/components/SettingsPanel/UpdaterSection';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderUpdaterSection(
+  props: Parameters<typeof UpdaterSection>[0],
+) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(createElement(UpdaterSection, props));
+  });
+
+  return { container, root };
+}
+
+async function unmount(root: ReturnType<typeof createRoot>) {
+  await act(async () => {
+    root.unmount();
+  });
+}
+
+describe('UpdaterSection', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('renders update availability as an inline Version row action', async () => {
+    const onDownload = vi.fn();
+    const { container, root } = await renderUpdaterSection({
+      appVersion: '1.8.0',
+      onDownload,
+      onInstall: vi.fn(),
+      status: { state: 'available', version: '1.8.1' },
+    });
+
+    expect(container.textContent).toContain('Version');
+    expect(container.textContent).toContain('v1.8.0');
+    expect(container.textContent).toContain('update');
+    expect(container.textContent).not.toContain('Update available');
+    expect(container.textContent).not.toContain('Download update');
+    expect(container.textContent).not.toContain('Check for updates');
+
+    const button = container.querySelector('button');
+    expect(button?.textContent).toBe('update');
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onDownload).toHaveBeenCalledTimes(1);
+
+    await unmount(root);
+  });
+
+  it('opens the release page for external-only update targets', async () => {
+    const onDownload = vi.fn();
+    const onOpenDownloadPage = vi.fn();
+    const { container, root } = await renderUpdaterSection({
+      appVersion: '1.8.0',
+      onDownload,
+      onInstall: vi.fn(),
+      onOpenDownloadPage,
+      status: {
+        externalDownloadOnly: true,
+        state: 'available',
+        version: '1.8.1',
+      },
+    });
+
+    const button = container.querySelector('button');
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onOpenDownloadPage).toHaveBeenCalledTimes(1);
+    expect(onDownload).not.toHaveBeenCalled();
+
+    await unmount(root);
+  });
+
+  it('keeps the install action available after download completes', async () => {
+    const onInstall = vi.fn();
+    const { container, root } = await renderUpdaterSection({
+      appVersion: '1.8.0',
+      onDownload: vi.fn(),
+      onInstall,
+      status: { state: 'downloaded', version: '1.8.1' },
+    });
+
+    const button = container.querySelector('button');
+    expect(button?.textContent).toBe('restart');
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onInstall).toHaveBeenCalledTimes(1);
+
+    await unmount(root);
+  });
+});

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -408,8 +408,8 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
           ...(timeout !== undefined ? { timeout, timeoutMs: timeout } : {}),
         };
         await agent.aiWaitFor(prompt, waitForOptions);
-      } else if ('sleep' in (flowItem as MidsceneYamlFlowItemSleep)) {
-        const sleepTask = flowItem as MidsceneYamlFlowItemSleep;
+      } else if ('sleep' in flowItem) {
+        const sleepTask = flowItem as unknown as MidsceneYamlFlowItemSleep;
         const ms = sleepTask.sleep;
         let msNumber = ms;
         if (typeof ms === 'string') {
@@ -420,11 +420,9 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
           `ms for sleep must be greater than 0, but got ${ms}`,
         );
         await new Promise((resolve) => setTimeout(resolve, msNumber));
-      } else if (
-        'javascript' in (flowItem as MidsceneYamlFlowItemEvaluateJavaScript)
-      ) {
+      } else if ('javascript' in flowItem) {
         const evaluateJavaScriptTask =
-          flowItem as MidsceneYamlFlowItemEvaluateJavaScript;
+          flowItem as unknown as MidsceneYamlFlowItemEvaluateJavaScript;
 
         const result = await agent.evaluateJavaScript(
           evaluateJavaScriptTask.javascript,
@@ -439,13 +437,13 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
           recordTask.recordToReport ?? recordTask.logScreenshot ?? 'untitled';
         const content = recordTask.content || '';
         await agent.recordToReport(title, { content });
-      } else if ('aiInput' in (flowItem as MidsceneYamlFlowItemAIInput)) {
+      } else if ('aiInput' in flowItem) {
         // may be input empty string ''
         const {
           aiInput,
           value: rawValue,
           ...inputTask
-        } = flowItem as MidsceneYamlFlowItemAIInput;
+        } = flowItem as unknown as MidsceneYamlFlowItemAIInput;
 
         // Compatibility with previous version:
         // Old format: { aiInput: string (value), locate: TUserPrompt }
@@ -472,11 +470,9 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
             ? { locate: buildDetailedLocateParam(locatePrompt, inputTask) }
             : {}),
         });
-      } else if (
-        'aiKeyboardPress' in (flowItem as MidsceneYamlFlowItemAIKeyboardPress)
-      ) {
+      } else if ('aiKeyboardPress' in flowItem) {
         const { aiKeyboardPress, ...keyboardPressTask } =
-          flowItem as MidsceneYamlFlowItemAIKeyboardPress;
+          flowItem as unknown as MidsceneYamlFlowItemAIKeyboardPress;
 
         // Compatibility with previous version:
         // Old format: { aiKeyboardPress: string (key), locate?: TUserPrompt }
@@ -508,9 +504,9 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
               }
             : {}),
         });
-      } else if ('aiScroll' in (flowItem as MidsceneYamlFlowItemAIScroll)) {
+      } else if ('aiScroll' in flowItem) {
         const { aiScroll, ...scrollTask } =
-          flowItem as MidsceneYamlFlowItemAIScroll;
+          flowItem as unknown as MidsceneYamlFlowItemAIScroll;
 
         // Compatibility with previous version:
         // Old format: { aiScroll: null, locate?: TUserPrompt, direction, scrollType, distance? }

--- a/packages/web-integration/tests/ai/web/playwright-reporter-test/todo-report.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright-reporter-test/todo-report.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'playwright/test';
 import { test } from '../playwright/fixture';
 import { getLastModifiedReportHTMLFile } from '../playwright/util';
 
-test('ai report', async ({ page, ai, aiAssert, aiQuery }, testInfo) => {
+test('ai report', async ({ page, aiAssert, aiQuery }, testInfo) => {
   testInfo.snapshotSuffix = '';
   await new Promise((resolve) => setTimeout(resolve, 3000));
   const htmlFile = getLastModifiedReportHTMLFile(
@@ -14,12 +14,17 @@ test('ai report', async ({ page, ai, aiAssert, aiQuery }, testInfo) => {
   expect(htmlFile).toBeTruthy();
   await page.setViewportSize({ width: 1920, height: 1080 });
   await page.goto(`file:${htmlFile}`);
-  await ai(
-    'In the left sidebar, click the dropdown selector that shows a status icon (✓ or ✗) with a test case name, to expand the dropdown list',
-  );
-  await ai(
-    'In the expanded dropdown list, scroll down if needed, and click the option whose text contains "ai todo" (not "ai shop")',
-  );
+  await page.locator('.modern-playwright-selector .selector-header').click();
+  const options = page.locator('.selector-content .option-item');
+  await expect(options.first()).toBeVisible();
+
+  const aiTodoOption = options.filter({ hasText: /ai todo/i });
+  if ((await aiTodoOption.count()) > 0) {
+    await aiTodoOption.first().click();
+  } else {
+    await options.first().click();
+  }
+
   const actionsList = await aiQuery(
     'Array<{title: string(task name,include action、wait), actions: Array<string(task action name,Excluding time)>}>',
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       antd:
         specifier: ^5.21.6
         version: 5.21.6(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      electron-updater:
+        specifier: 6.8.3
+        version: 6.8.3
       puppeteer:
         specifier: 24.6.0
         version: 24.6.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.5)
@@ -5861,6 +5864,10 @@ packages:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
 
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
   builtin-status-codes@3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
@@ -6725,6 +6732,9 @@ packages:
   electron-to-chromium@1.5.260:
     resolution: {integrity: sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==}
 
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
+
   electron@41.2.0:
     resolution: {integrity: sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==}
     engines: {node: '>= 12.20.55'}
@@ -7302,6 +7312,10 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fs-extra@11.3.1:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
@@ -8341,6 +8355,9 @@ packages:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
 
+  lazy-val@1.0.5:
+    resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
+
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
@@ -8484,9 +8501,16 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isnumber@3.0.3:
     resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
@@ -11266,6 +11290,9 @@ packages:
 
   timm@1.7.1:
     resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -17200,6 +17227,13 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.0
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   builtin-status-codes@3.0.0: {}
 
   bundle-name@4.1.0:
@@ -18116,6 +18150,19 @@ snapshots:
 
   electron-to-chromium@1.5.260: {}
 
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.3
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron@41.2.0:
     dependencies:
       '@electron/get': 2.0.3
@@ -18941,6 +18988,12 @@ snapshots:
       js-yaml: 3.14.2
 
   fs-constants@1.0.0: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
 
   fs-extra@11.3.1:
     dependencies:
@@ -20117,6 +20170,8 @@ snapshots:
     dependencies:
       package-json: 10.0.1
 
+  lazy-val@1.0.5: {}
+
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
@@ -20272,7 +20327,11 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.get@4.4.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isnumber@3.0.3: {}
 
@@ -23619,6 +23678,8 @@ snapshots:
       setimmediate: 1.0.5
 
   timm@1.7.1: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- Wires `electron-updater` into Studio end-to-end so packaged builds discover new zips on GitHub Releases and surface them in the sidebar + Settings panel (red dot, version, status line, progress bar, Download/Restart/Check buttons).
- macOS install bypasses Squirrel.Mac's ShipIt (which trips `EBADF` on signed bundles) with a detached bash script: it waits for every helper process under `Contents/` to exit, atomically replaces the `.app` bundle via `ditto` + `mv` (with a `ditto` fallback if `mv` produces a nested bundle), clears `xattr` Mark-of-the-Web, and relaunches.
- Windows + Linux ship as `@electron/packager` zips, so the running binary can't replace itself (no NSIS installer, no AppImage envelope, no UAC story). `update-available` carries an `externalDownloadOnly` flag, `autoDownload` is force-disabled, and the renderer shows an **Open download page** button that opens the GitHub Releases page in the browser instead of running `quitAndInstall`.
- Packaging script writes `app-update.yml` into `Resources/` **before** macOS signing so the GitHub provider config is part of the signed bundle, and emits `latest-mac.yml` / `latest.yml` / `latest-linux.yml` (plus `beta-*.yml` for prerelease versions) next to the zip with the matching sha512 + size. CI uploads both the zips and the manifests to the GitHub Release so electron-updater can resolve them at runtime.
- Main owns the state machine; renderer just renders it. Errors are logged via `getDebug('studio:updater', { console: true })` so console output and Midscene log files stay aligned (per AGENTS.md).

## Test plan

- [x] `pnpm run lint` — clean (only an unrelated `biome-ignore` warning in `packages/core`).
- [x] `npx vitest run tests/build-update-metadata.test.mjs tests/preload-bridge.test.ts` — 8/8 pass.
- [x] `npx nx test studio` — 216/217 pass; the single failure (`tests/connectivity-test.test.ts`) reproduces on clean `origin/main` and is unrelated to this PR.
- [ ] Manual: package macOS build, point `dev-app-update.yml` at a draft Release, verify check → download → install replaces bundle and relaunches.
- [ ] Manual: package Windows zip, verify update-available → "Open download page" opens the Releases page (no `quitAndInstall`).
- [ ] Manual: package Linux zip, verify same external-download flow as Windows.
- [ ] Manual: prerelease tag (e.g. `0.x.y-beta.0`) — confirm `beta-*.yml` is published alongside `latest-*.yml`.