### PR TITLE
refactor(playground-app): focus scrcpy video payload type

### DIFF
--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -1,6 +1,6 @@
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
 
-type RawScrcpyVideoData = ArrayBuffer | ArrayLike<number> | Uint8Array;
+type RawScrcpyVideoData = ArrayBuffer | ArrayBufferView;
 
 interface RawScrcpyVideoPacket {
   type?: string;
@@ -15,7 +15,7 @@ function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
   if (data instanceof ArrayBuffer) {
     return new Uint8Array(data);
   }
-  return new Uint8Array(data);
+  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
 interface ScrcpyVideoSocketLike {

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -4,7 +4,7 @@ import { createScrcpyVideoStream } from '../src/scrcpy-stream';
 
 interface RawVideoPayload {
   type?: string;
-  data: ArrayBuffer | ArrayLike<number> | Uint8Array;
+  data: ArrayBuffer | ArrayBufferView;
   keyFrame?: boolean;
 }
 
@@ -100,9 +100,12 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'data', data: [1, 2, 3] });
-    socket.dispatchVideoData({ type: 'configuration', data: [9] });
-    socket.dispatchVideoData({ type: 'data', data: [4, 5, 6] });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([1, 2, 3]) });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([9]),
+    });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([4, 5, 6]) });
     socket.dispatchDisconnect();
 
     const packets = await collected;
@@ -124,9 +127,20 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'configuration', data: [0] });
-    socket.dispatchVideoData({ type: 'data', data: [1], keyFrame: true });
-    socket.dispatchVideoData({ type: 'data', data: [2], keyFrame: false });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+      keyFrame: true,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([2]),
+      keyFrame: false,
+    });
     socket.dispatchDisconnect();
 
     const packets = await collected;
@@ -140,12 +154,13 @@ describe('createScrcpyVideoStream', () => {
     expect(dataPackets[1].keyframe).toBe(false);
   });
 
-  test('accepts Uint8Array and ArrayBuffer payloads from binary transport', async () => {
+  test('accepts ArrayBufferView and ArrayBuffer payloads from binary transport', async () => {
     const socket = new MockScrcpySocket();
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    const configBytes = new Uint8Array([10, 20, 30]);
+    const sourceBytes = new Uint8Array([99, 10, 20, 30, 88]);
+    const configBytes = new DataView(sourceBytes.buffer, 1, 3);
     const dataBuffer = new Uint8Array([40, 50, 60]).buffer;
 
     socket.dispatchVideoData({ type: 'configuration', data: configBytes });
@@ -170,8 +185,11 @@ describe('createScrcpyVideoStream', () => {
     const stream = createScrcpyVideoStream(socket);
     const collected = collectStream(stream);
 
-    socket.dispatchVideoData({ type: 'configuration', data: [0] });
-    socket.dispatchVideoData({ type: 'data', data: [1] });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([1]) });
     socket.dispatchDisconnect();
 
     const packets = await collected;


### PR DESCRIPTION
### Motivation
- The socket/video path was typed to accept `ArrayLike<number>` which encourages legacy or boxed-number payloads rather than real binary transport shapes; the intent is to make the type reflect what scrcpy/socket.io actually sends (binary buffers/views). 

### Description
- Narrow `RawScrcpyVideoData` from `ArrayBuffer | ArrayLike<number> | Uint8Array` to `ArrayBuffer | ArrayBufferView` so the API expresses binary-only payloads. 
- Update `toUint8Array` to preserve `ArrayBufferView` offsets and lengths by using `new Uint8Array(data.buffer, data.byteOffset, data.byteLength)` for non-`Uint8Array` views. 
- Adjust tests to feed binary payloads (use `Uint8Array` and a sliced `DataView`) instead of plain number arrays and rename one test to reflect `ArrayBufferView` acceptance. 

### Testing
- Ran linter and fixes for the modified files with: `pnpm exec biome check packages/playground-app/src/scrcpy-stream.ts packages/playground-app/tests/scrcpy-stream.test.ts --diagnostic-level=info --fix` and `pnpm exec biome check packages/playground-app/src/scrcpy-stream.ts packages/playground-app/tests/scrcpy-stream.test.ts --diagnostic-level=info --no-errors-on-unmatched`, which completed for the changed files. 
- Ran unit tests: `pnpm --filter @midscene/playground-app test -- scrcpy-stream.test.ts` and `npx nx test @midscene/playground-app -- scrcpy-stream.test.ts`, and all tests passed (`5 tests` in `scrcpy-stream.test.ts`). 
- Built the package: `npx nx build @midscene/playground-app`, which succeeded. 
- Ran workspace lint (`pnpm run lint`), which surfaced unrelated workspace-wide Biome issues (large files in `.pnpm-store` and one existing unused suppression); this failure is environmental and not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05372a61888324ad859e0762ea7886)