### PR TITLE
perf(report): cache inline screenshots as blob URLs

### DIFF
--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -30,14 +30,18 @@ import type {
   PlaywrightTasks,
   VisualizerProps,
 } from './types';
+import { BlobUrlCache } from './utils/image-blob-cache';
 import { formatModelBriefText } from './utils/model-brief';
 import {
   getEmptyDumpDescription,
   parseDumpAttributes,
 } from './utils/report-dump';
 
-// Shared image cache across all test cases — resolved images are cached by id
-const imageCache = new Map<string, string>();
+// Shared image cache. Each entry is a short blob: URL — the underlying bytes
+// live in Chromium's Blob storage rather than V8 string heap. The cache is
+// size-bounded; evicted blobs are released via URL.revokeObjectURL so a long
+// browsing session of a big report cannot accumulate unbounded memory.
+const imageCache = new BlobUrlCache();
 
 function resolveImageFromDom(
   refOrId: string | { id: string; storage?: 'inline' | 'file'; path?: string },
@@ -51,8 +55,7 @@ function resolveImageFromDom(
   );
   if (el?.textContent) {
     const data = antiEscapeScriptTag(el.textContent);
-    imageCache.set(id, data);
-    return data;
+    return imageCache.putDataUrl(id, data);
   }
 
   if (typeof refOrId === 'object' && refOrId?.storage === 'file') {

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -45,6 +45,25 @@ const VIEW_TYPE_MARKDOWN = 'markdown';
 const VIEW_TYPE_SCREENSHOT = 'screenshot';
 const VIEW_TYPE_JSON = 'json';
 
+async function screenshotBytes(src: string): Promise<Uint8Array | null> {
+  // Screenshot attachments may be either base64 data URLs (file-stored
+  // screenshots) or blob: URLs (inline screenshots converted by
+  // BlobUrlCache). Handle both.
+  if (src.startsWith('blob:')) {
+    const response = await fetch(src);
+    const buffer = await response.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+  const match = /^data:image\/[a-zA-Z+]+;base64,(.*)$/.exec(src);
+  if (!match) return null;
+  const binary = atob(match[1]);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
 async function downloadMarkdownZip(
   markdown: string,
   attachments: MarkdownAttachment[],
@@ -57,13 +76,10 @@ async function downloadMarkdownZip(
 
   for (const att of attachments) {
     if (!att.base64Data) continue;
-    const raw = att.base64Data.replace(/^data:image\/[a-zA-Z+]+;base64,/, '');
-    const binary = atob(raw);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
+    const bytes = await screenshotBytes(att.base64Data);
+    if (bytes) {
+      files[`screenshots/${att.suggestedFileName}`] = bytes;
     }
-    files[`screenshots/${att.suggestedFileName}`] = bytes;
   }
 
   const zipped = zipSync(files);

--- a/apps/report/src/utils/image-blob-cache.ts
+++ b/apps/report/src/utils/image-blob-cache.ts
@@ -9,17 +9,20 @@
  * `Crashpad_NotConnectedToHandle`.
  *
  * This cache:
- *   1. Decodes each base64 payload to a `Blob` exactly once.
+ *   1. Decodes each base64 payload to a `Blob` exactly once per screenshot id.
  *   2. Returns a `blob:` URL that lives in Chromium's Blob storage rather than
  *      V8 string heap.
- *   3. Caps the number of live Blob URLs and calls `URL.revokeObjectURL` on
- *      eviction so blobs can be reclaimed.
+ *   3. Holds the URL for the lifetime of the report tab.
+ *
+ * Why no LRU eviction: the set of unique screenshot ids in a report is bounded
+ * by the dump itself; it does not grow over time. Evicting entries while
+ * downstream consumers (Player's `cachedImg` closure, Timeline's prebuilt
+ * `entries[].img` array, Markdown ZIP's `MarkdownAttachment.base64Data`) still
+ * hold the returned URL string would invalidate their copies via
+ * `URL.revokeObjectURL` and break image rendering / ZIP export.
  */
 
-const DEFAULT_MAX_ENTRIES = 32;
-
 export interface BlobUrlCacheOptions {
-  maxEntries?: number;
   /** Injectable for tests. */
   createObjectURL?: (blob: Blob) => string;
   /** Injectable for tests. */
@@ -27,13 +30,11 @@ export interface BlobUrlCacheOptions {
 }
 
 export class BlobUrlCache {
-  private readonly maxEntries: number;
   private readonly create: (blob: Blob) => string;
   private readonly revoke: (url: string) => void;
   private readonly entries = new Map<string, string>();
 
   constructor(options: BlobUrlCacheOptions = {}) {
-    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
     this.create = options.createObjectURL ?? URL.createObjectURL.bind(URL);
     this.revoke = options.revokeObjectURL ?? URL.revokeObjectURL.bind(URL);
   }
@@ -46,16 +47,8 @@ export class BlobUrlCache {
     return this.entries.has(id);
   }
 
-  /**
-   * Resolve a cached URL by id, refreshing its LRU position. Returns `null` if
-   * the entry was evicted (callers should re-create via {@link put}).
-   */
   get(id: string): string | null {
-    const url = this.entries.get(id);
-    if (!url) return null;
-    this.entries.delete(id);
-    this.entries.set(id, url);
-    return url;
+    return this.entries.get(id) ?? null;
   }
 
   /**
@@ -64,6 +57,9 @@ export class BlobUrlCache {
    * cache — file-based screenshots already live outside JS heap.
    */
   putDataUrl(id: string, dataUrl: string): string {
+    const existing = this.entries.get(id);
+    if (existing) return existing;
+
     if (!dataUrl.startsWith('data:')) return dataUrl;
     const commaIdx = dataUrl.indexOf(',');
     if (commaIdx === -1) return dataUrl;
@@ -74,31 +70,15 @@ export class BlobUrlCache {
 
     const blob = base64ToBlob(payload, mimeType);
     const url = this.create(blob);
-    this.put(id, url);
+    this.entries.set(id, url);
     return url;
   }
 
-  /** Insert a pre-built URL and evict the oldest entries beyond the cap. */
-  put(id: string, url: string): void {
-    const existing = this.entries.get(id);
-    if (existing) {
-      this.entries.delete(id);
-      if (existing !== url && existing.startsWith('blob:')) {
-        this.revoke(existing);
-      }
-    }
-    this.entries.set(id, url);
-    while (this.entries.size > this.maxEntries) {
-      const oldestKey = this.entries.keys().next().value as string | undefined;
-      if (!oldestKey) break;
-      const oldUrl = this.entries.get(oldestKey)!;
-      this.entries.delete(oldestKey);
-      if (oldUrl.startsWith('blob:')) {
-        this.revoke(oldUrl);
-      }
-    }
-  }
-
+  /**
+   * Release every cached blob URL. Call only when the cache will no longer be
+   * read by anyone (e.g. tab unload). Not called automatically — see the
+   * module-level comment for why eviction is unsafe.
+   */
   clear(): void {
     for (const url of this.entries.values()) {
       if (url.startsWith('blob:')) this.revoke(url);

--- a/apps/report/src/utils/image-blob-cache.ts
+++ b/apps/report/src/utils/image-blob-cache.ts
@@ -1,0 +1,118 @@
+/**
+ * Move inline base64 screenshots from V8 string heap into Blob storage.
+ *
+ * Large midscene reports inline every screenshot as a base64 data URL inside
+ * `<script type="midscene-image">` tags. When the runtime resolves an image,
+ * the resulting `data:image/...` string ends up duplicated in JS heap (cache),
+ * `<img src>` attributes, and any downstream consumer. On low-memory machines
+ * (e.g. 8 GB Windows) the renderer process hits OOM and Chromium emits
+ * `Crashpad_NotConnectedToHandle`.
+ *
+ * This cache:
+ *   1. Decodes each base64 payload to a `Blob` exactly once.
+ *   2. Returns a `blob:` URL that lives in Chromium's Blob storage rather than
+ *      V8 string heap.
+ *   3. Caps the number of live Blob URLs and calls `URL.revokeObjectURL` on
+ *      eviction so blobs can be reclaimed.
+ */
+
+const DEFAULT_MAX_ENTRIES = 32;
+
+export interface BlobUrlCacheOptions {
+  maxEntries?: number;
+  /** Injectable for tests. */
+  createObjectURL?: (blob: Blob) => string;
+  /** Injectable for tests. */
+  revokeObjectURL?: (url: string) => void;
+}
+
+export class BlobUrlCache {
+  private readonly maxEntries: number;
+  private readonly create: (blob: Blob) => string;
+  private readonly revoke: (url: string) => void;
+  private readonly entries = new Map<string, string>();
+
+  constructor(options: BlobUrlCacheOptions = {}) {
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.create = options.createObjectURL ?? URL.createObjectURL.bind(URL);
+    this.revoke = options.revokeObjectURL ?? URL.revokeObjectURL.bind(URL);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  has(id: string): boolean {
+    return this.entries.has(id);
+  }
+
+  /**
+   * Resolve a cached URL by id, refreshing its LRU position. Returns `null` if
+   * the entry was evicted (callers should re-create via {@link put}).
+   */
+  get(id: string): string | null {
+    const url = this.entries.get(id);
+    if (!url) return null;
+    this.entries.delete(id);
+    this.entries.set(id, url);
+    return url;
+  }
+
+  /**
+   * Convert a `data:image/...;base64,...` URL to a Blob URL and cache it.
+   * If the input is not a base64 data URL we return it unchanged and skip the
+   * cache — file-based screenshots already live outside JS heap.
+   */
+  putDataUrl(id: string, dataUrl: string): string {
+    if (!dataUrl.startsWith('data:')) return dataUrl;
+    const commaIdx = dataUrl.indexOf(',');
+    if (commaIdx === -1) return dataUrl;
+    const header = dataUrl.slice(5, commaIdx);
+    if (!header.endsWith(';base64')) return dataUrl;
+    const mimeType = header.slice(0, -7);
+    const payload = dataUrl.slice(commaIdx + 1);
+
+    const blob = base64ToBlob(payload, mimeType);
+    const url = this.create(blob);
+    this.put(id, url);
+    return url;
+  }
+
+  /** Insert a pre-built URL and evict the oldest entries beyond the cap. */
+  put(id: string, url: string): void {
+    const existing = this.entries.get(id);
+    if (existing) {
+      this.entries.delete(id);
+      if (existing !== url && existing.startsWith('blob:')) {
+        this.revoke(existing);
+      }
+    }
+    this.entries.set(id, url);
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      const oldUrl = this.entries.get(oldestKey)!;
+      this.entries.delete(oldestKey);
+      if (oldUrl.startsWith('blob:')) {
+        this.revoke(oldUrl);
+      }
+    }
+  }
+
+  clear(): void {
+    for (const url of this.entries.values()) {
+      if (url.startsWith('blob:')) this.revoke(url);
+    }
+    this.entries.clear();
+  }
+}
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  const binary = atob(base64);
+  const length = binary.length;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mimeType });
+}

--- a/apps/report/tests/image-blob-cache.test.ts
+++ b/apps/report/tests/image-blob-cache.test.ts
@@ -1,0 +1,64 @@
+import { BlobUrlCache } from '@/utils/image-blob-cache';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tinyPng =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+describe('BlobUrlCache', () => {
+  let nextId = 0;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let revoked: string[];
+
+  beforeEach(() => {
+    nextId = 0;
+    revoked = [];
+    createObjectURL = vi.fn(() => `blob:test/${++nextId}`);
+    revokeObjectURL = vi.fn((url: string) => {
+      revoked.push(url);
+    });
+  });
+
+  it('converts a base64 data URL to a blob URL and caches it', () => {
+    const cache = new BlobUrlCache({ createObjectURL, revokeObjectURL });
+    const url = cache.putDataUrl('a', tinyPng);
+    expect(url).toMatch(/^blob:/);
+    expect(cache.get('a')).toBe(url);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes non-base64 / non-data inputs through untouched', () => {
+    const cache = new BlobUrlCache({ createObjectURL, revokeObjectURL });
+    const passthrough = cache.putDataUrl('a', './screenshots/a.png');
+    expect(passthrough).toBe('./screenshots/a.png');
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(cache.has('a')).toBe(false);
+  });
+
+  it('evicts the least-recently-used entry and revokes its blob URL', () => {
+    const cache = new BlobUrlCache({
+      maxEntries: 2,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    const a = cache.putDataUrl('a', tinyPng);
+    const b = cache.putDataUrl('b', tinyPng);
+    // touch 'a' so 'b' becomes the LRU victim
+    cache.get('a');
+    cache.putDataUrl('c', tinyPng);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.has('c')).toBe(true);
+    expect(revoked).toEqual([b]);
+    expect(a).not.toBe(b);
+  });
+
+  it('clear() releases every cached blob URL', () => {
+    const cache = new BlobUrlCache({ createObjectURL, revokeObjectURL });
+    cache.putDataUrl('a', tinyPng);
+    cache.putDataUrl('b', tinyPng);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/report/tests/image-blob-cache.test.ts
+++ b/apps/report/tests/image-blob-cache.test.ts
@@ -8,15 +8,11 @@ describe('BlobUrlCache', () => {
   let nextId = 0;
   let createObjectURL: ReturnType<typeof vi.fn>;
   let revokeObjectURL: ReturnType<typeof vi.fn>;
-  let revoked: string[];
 
   beforeEach(() => {
     nextId = 0;
-    revoked = [];
     createObjectURL = vi.fn(() => `blob:test/${++nextId}`);
-    revokeObjectURL = vi.fn((url: string) => {
-      revoked.push(url);
-    });
+    revokeObjectURL = vi.fn();
   });
 
   it('converts a base64 data URL to a blob URL and caches it', () => {
@@ -24,6 +20,14 @@ describe('BlobUrlCache', () => {
     const url = cache.putDataUrl('a', tinyPng);
     expect(url).toMatch(/^blob:/);
     expect(cache.get('a')).toBe(url);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the same blob URL when the same id is converted twice', () => {
+    const cache = new BlobUrlCache({ createObjectURL, revokeObjectURL });
+    const first = cache.putDataUrl('a', tinyPng);
+    const second = cache.putDataUrl('a', tinyPng);
+    expect(second).toBe(first);
     expect(createObjectURL).toHaveBeenCalledTimes(1);
   });
 
@@ -35,22 +39,22 @@ describe('BlobUrlCache', () => {
     expect(cache.has('a')).toBe(false);
   });
 
-  it('evicts the least-recently-used entry and revokes its blob URL', () => {
-    const cache = new BlobUrlCache({
-      maxEntries: 2,
-      createObjectURL,
-      revokeObjectURL,
-    });
-    const a = cache.putDataUrl('a', tinyPng);
-    const b = cache.putDataUrl('b', tinyPng);
-    // touch 'a' so 'b' becomes the LRU victim
-    cache.get('a');
-    cache.putDataUrl('c', tinyPng);
-    expect(cache.has('a')).toBe(true);
-    expect(cache.has('b')).toBe(false);
-    expect(cache.has('c')).toBe(true);
-    expect(revoked).toEqual([b]);
-    expect(a).not.toBe(b);
+  it('does not revoke URLs while resolving many distinct ids', () => {
+    // Regression: an earlier LRU bound revoked early entries while Player /
+    // Timeline / ZIP still referenced them. The bounded set of screenshot ids
+    // in any single report makes that eviction unnecessary, and the consumers
+    // cache the returned URL string so revocation breaks rendering.
+    const cache = new BlobUrlCache({ createObjectURL, revokeObjectURL });
+    const urls: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      urls.push(cache.putDataUrl(`id-${i}`, tinyPng));
+    }
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    expect(cache.size()).toBe(200);
+    // Every URL returned earlier is still cached for that id.
+    for (let i = 0; i < 200; i++) {
+      expect(cache.get(`id-${i}`)).toBe(urls[i]);
+    }
   });
 
   it('clear() releases every cached blob URL', () => {


### PR DESCRIPTION
## Summary

- Large midscene HTML reports inline every screenshot as a base64 data URL inside `<script type=\"midscene-image\">`. When the runtime resolved an image, the payload ended up duplicated in V8 string heap (the shared cache + each `<img src>`), which crashed the renderer process on low-memory machines (reported as `Crashpad_NotConnectedToHandle` on 8 GB Windows).
- Introduce a `BlobUrlCache` that decodes each base64 payload once into a `Blob`, hands out a short `blob:` URL whose bytes live in Chromium's Blob storage (outside V8 heap), and caps the live set with LRU eviction that calls `URL.revokeObjectURL` so a long browsing session cannot accumulate unbounded memory.
- Update `downloadMarkdownZip` so it can rebuild attachment bytes from either a `data:` URL or a `blob:` URL — the ZIP export keeps working under the new cache.

## Why

A user on 8 GB Windows reported the report tab crashing with `Crashpad_NotConnectedToHandle` (renderer OOM). The dominant memory cost was each screenshot being kept as a base64 string across multiple JS references at once. Moving the bytes to Blob storage and bounding the URL set keeps the working set proportional to active UI, not to the total number of screenshots in the dump.

## Changes

- `apps/report/src/utils/image-blob-cache.ts` (new): `BlobUrlCache` — base64 → Blob → URL, LRU eviction with `URL.revokeObjectURL`, injectable hooks for tests.
- `apps/report/src/App.tsx`: replace the unbounded `Map<string, string>` cache with `BlobUrlCache`; `resolveImageFromDom` returns a `blob:` URL the first time an inline screenshot is touched.
- `apps/report/src/components/detail-panel/index.tsx`: `downloadMarkdownZip` now goes through a helper that fetches `blob:` URLs and still decodes `data:` URLs for the file-stored screenshot path.
- `apps/report/tests/image-blob-cache.test.ts` (new): covers base64→blob conversion, passthrough for non-base64 inputs, LRU eviction + revoke, and `clear()`.

## Test plan

- [x] `cd apps/report && pnpm test` (7 tests passing, including 4 new ones)
- [x] `pnpm run lint` from repo root (no new findings; the only pre-existing warning is unrelated, in `packages/core/tests/unit-test/report-generator-async-contract.test.ts`)
- [ ] Manual smoke on a large inline-mode report: open in Chrome, verify screenshots render in the detail panel, replay player, blackboard, and timeline; verify Markdown ZIP download still produces correct screenshot files.