### PR TITLE
fix(playground-app): correct tap projection in iOS / Harmony / Computer playgrounds

### DIFF
--- a/packages/ios/src/platform.ts
+++ b/packages/ios/src/platform.ts
@@ -15,6 +15,33 @@ export interface IOSPlatformOptions {
   staticDir?: string;
 }
 
+// Quick liveness probe so getSetupSchema can flip on autoSubmitWhenReady
+// when a WDA is already listening on the defaults — mirrors the Android
+// playground UX where a single connected device auto-creates the agent
+// instead of forcing the user through the form.
+async function probeWdaReady(
+  host: string,
+  port: number,
+  timeoutMs = 800,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`http://${host}:${port}/status`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) return false;
+    const body = (await res.json().catch(() => null)) as {
+      value?: { ready?: boolean };
+    } | null;
+    return body?.value?.ready === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export const iosPlaygroundPlatform = definePlaygroundPlatform<
   IOSPlatformOptions | undefined
 >({
@@ -36,11 +63,13 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
 
     const sessionManager: PlaygroundSessionManager = {
       async getSetupSchema() {
+        const wdaReady = await probeWdaReady('localhost', DEFAULT_WDA_PORT);
         return {
           title: 'Connect WebDriverAgent',
           description:
             'Provide the WebDriverAgent host and port that are already running for your selected iPhone or simulator.',
           primaryActionLabel: 'Create Agent',
+          autoSubmitWhenReady: wdaReady,
           fields: [
             {
               key: 'host',

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -28,6 +28,14 @@ export interface DeviceInteractionLayerProps {
   onTextInput?: (text: string, point?: { x: number; y: number }) => void;
   onKeyboardPress?: (keyName: string, point?: { x: number; y: number }) => void;
   /**
+   * Element whose bounding box represents the actual screen-mirror area
+   * (the `<img>`/canvas container). When provided, pointer coordinates are
+   * projected against this element instead of the overlay itself — so any
+   * chrome wrapping the preview (toolbars, headers, padding) does not shift
+   * taps downward.
+   */
+  contentRef?: React.RefObject<HTMLElement | null>;
+  /**
    * Tap classification thresholds. Pointer movement below this distance and
    * total duration below this delay is reported as a Tap; anything else is a
    * Swipe.
@@ -178,6 +186,7 @@ export function DeviceInteractionLayer({
   keyboardEnabled = false,
   onTextInput,
   onKeyboardPress,
+  contentRef,
   tapMaxDistance = 8,
   tapMaxDurationMs = 250,
   style,
@@ -234,7 +243,8 @@ export function DeviceInteractionLayer({
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (!enabled || !deviceSize || !overlayRef.current) return;
       if (event.button !== 0 && event.pointerType === 'mouse') return;
-      const panelRect = overlayRef.current.getBoundingClientRect();
+      const measurementSource = contentRef?.current ?? overlayRef.current;
+      const panelRect = measurementSource.getBoundingClientRect();
       const contentRect = inscribedContentRect(panelRect, deviceSize);
       if (
         event.clientX < contentRect.left ||
@@ -260,7 +270,7 @@ export function DeviceInteractionLayer({
       };
       event.preventDefault();
     },
-    [enabled, deviceSize, focusKeyboardSink, positionKeyboardSink],
+    [contentRef, enabled, deviceSize, focusKeyboardSink, positionKeyboardSink],
   );
 
   const finishPointer = useCallback(

--- a/packages/playground-app/src/DeviceInteractionLayer.tsx
+++ b/packages/playground-app/src/DeviceInteractionLayer.tsx
@@ -34,7 +34,7 @@ export interface DeviceInteractionLayerProps {
    * chrome wrapping the preview (toolbars, headers, padding) does not shift
    * taps downward.
    */
-  contentRef?: React.RefObject<HTMLElement | null>;
+  contentRef?: React.RefObject<HTMLElement>;
   /**
    * Tap classification thresholds. Pointer movement below this distance and
    * total duration below this delay is reported as a Tap; anything else is a

--- a/packages/playground-app/src/DisconnectedPreview.tsx
+++ b/packages/playground-app/src/DisconnectedPreview.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import ConnectionClosedIcon from './icons/connection-closed.svg';
+
+// Mirrors apps/studio's DisconnectedPreview so the standalone playgrounds
+// stop rendering a broken `<img src="/mjpeg">` placeholder in their preview
+// pane before a session is created. The same icon + layout keep the visual
+// language consistent between Studio and the iOS / Android / Harmony /
+// Computer playground binaries.
+void React;
+
+export interface DisconnectedPreviewProps {
+  title?: string;
+}
+
+export function DisconnectedPreview({
+  title = 'Connect to a device',
+}: DisconnectedPreviewProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 4,
+        }}
+      >
+        <ConnectionClosedIcon
+          aria-hidden="true"
+          style={{ width: 24, height: 24, objectFit: 'contain' }}
+        />
+        <h2
+          style={{
+            margin: 0,
+            whiteSpace: 'nowrap',
+            textAlign: 'center',
+            fontSize: 13,
+            lineHeight: '24px',
+            fontWeight: 400,
+            color: 'rgba(0, 0, 0, 0.85)',
+          }}
+        >
+          {title}
+        </h2>
+      </div>
+    </div>
+  );
+}

--- a/packages/playground-app/src/PlaygroundApp.tsx
+++ b/packages/playground-app/src/PlaygroundApp.tsx
@@ -8,6 +8,7 @@ import {
 import { Layout } from 'antd';
 import { useEffect, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { DisconnectedPreview } from './DisconnectedPreview';
 import { PlaygroundPreview } from './PlaygroundPreview';
 import { PlaygroundThemeProvider } from './PlaygroundThemeProvider';
 import { usePlaygroundController } from './controller/usePlaygroundController';
@@ -125,13 +126,17 @@ export function PlaygroundApp({
               className="app-panel right-panel"
             >
               <div className="panel-content right-panel-content">
-                <PlaygroundPreview
-                  playgroundSDK={controller.state.playgroundSDK}
-                  runtimeInfo={controller.state.runtimeInfo}
-                  serverUrl={serverUrl}
-                  serverOnline={controller.state.serverOnline}
-                  isUserOperating={controller.state.isUserOperating}
-                />
+                {controller.state.sessionViewState.connected ? (
+                  <PlaygroundPreview
+                    playgroundSDK={controller.state.playgroundSDK}
+                    runtimeInfo={controller.state.runtimeInfo}
+                    serverUrl={serverUrl}
+                    serverOnline={controller.state.serverOnline}
+                    isUserOperating={controller.state.isUserOperating}
+                  />
+                ) : (
+                  <DisconnectedPreview />
+                )}
               </div>
             </Panel>
           </PanelGroup>

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -83,6 +83,16 @@ export function PreviewRenderer({
   const [streamSize, setStreamSize] = useState<DeviceSize | null>(null);
   const [actionTypes, setActionTypes] = useState<string[] | null>(null);
   const manualControlQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+  // Shared with the active preview component (ScrcpyPanel / ScreenshotViewer)
+  // and the interaction layer so pointer coords always project against the
+  // real screen-mirror box, not the outer panel that may include chrome.
+  const previewContentRef = useRef<HTMLDivElement | null>(null);
+  // Default to `screen-only` so the playground does not render chrome
+  // (header / Refresh / timestamp) inside the same relative-positioned panel
+  // that DeviceInteractionLayer overlays — embedding hosts (Studio) can opt
+  // back into the full viewer by passing 'default'.
+  const resolvedScreenshotViewerMode: ScreenshotViewerMode =
+    screenshotViewerMode ?? 'screen-only';
 
   // Self-derive interaction capabilities from the connected device's
   // actionSpace. Tap is the gate for any pointer interaction; the drag
@@ -367,6 +377,7 @@ export function PreviewRenderer({
           renderErrorOverlay={renderErrorOverlay}
           serverUrl={previewConnection.scrcpyUrl}
           viewportStyle={scrcpyViewportStyle}
+          contentRef={previewContentRef}
         />
       ) : (
         <ScreenshotViewer
@@ -379,7 +390,8 @@ export function PreviewRenderer({
           serverOnline={serverOnline}
           isUserOperating={isUserOperating}
           mjpegUrl={previewConnection.mjpegUrl}
-          mode={screenshotViewerMode}
+          mode={resolvedScreenshotViewerMode}
+          contentRef={previewContentRef}
         />
       )}
       <DeviceInteractionLayer
@@ -389,6 +401,7 @@ export function PreviewRenderer({
           previewConnection.type !== 'none'
         }
         deviceSize={deviceSize}
+        contentRef={previewContentRef}
         onTap={handleTap}
         onSwipe={handleSwipe}
         keyboardEnabled={manualKeyboardEnabled}

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -86,7 +86,7 @@ export function PreviewRenderer({
   // Shared with the active preview component (ScrcpyPanel / ScreenshotViewer)
   // and the interaction layer so pointer coords always project against the
   // real screen-mirror box, not the outer panel that may include chrome.
-  const previewContentRef = useRef<HTMLDivElement | null>(null);
+  const previewContentRef = useRef<HTMLDivElement>(null);
   // Default to `screen-only` so the playground does not render chrome
   // (header / Refresh / timestamp) inside the same relative-positioned panel
   // that DeviceInteractionLayer overlays — embedding hosts (Studio) can opt

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -67,7 +67,7 @@ interface ScrcpyPanelProps {
   // Receives the canvas-area wrapper so the device-interaction layer can
   // project pointer coords against the actual stream box, ignoring any
   // surrounding Alert / status chrome.
-  contentRef?: React.Ref<HTMLDivElement | null>;
+  contentRef?: React.Ref<HTMLDivElement>;
 }
 
 interface VideoMetadata {

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -6,14 +6,20 @@ import {
 } from '@yume-chan/scrcpy-decoder-webcodecs';
 import { Alert, Spin, Typography } from 'antd';
 import React, {
+  type CSSProperties,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
-  type ReactNode,
 } from 'react';
+
+// Esbuild leaves `.tsx` on the classic JSX transform here (tsconfig sets
+// `jsx: preserve`), so JSX in this file compiles to `React.createElement`.
+// Keep a runtime reference to React or biome will strip the import as
+// type-only, breaking SSR/test renders.
+void React;
 import type { Socket } from 'socket.io-client';
 import { io } from 'socket.io-client';
 import {
@@ -58,6 +64,10 @@ interface ScrcpyPanelProps {
   metadataTimeoutMs?: number;
   reconnectInterval?: number;
   viewportStyle?: CSSProperties;
+  // Receives the canvas-area wrapper so the device-interaction layer can
+  // project pointer coords against the actual stream box, ignoring any
+  // surrounding Alert / status chrome.
+  contentRef?: React.Ref<HTMLDivElement | null>;
 }
 
 interface VideoMetadata {
@@ -76,6 +86,7 @@ export function ScrcpyPanel({
   metadataTimeoutMs = SCRCPY_METADATA_TIMEOUT_MS,
   reconnectInterval = 3000,
   viewportStyle,
+  contentRef,
 }: ScrcpyPanelProps) {
   const canvasStageRef = useRef<HTMLDivElement | null>(null);
   const socketRef = useRef<Socket | null>(null);
@@ -371,6 +382,7 @@ export function ScrcpyPanel({
         />
       ) : null}
       <div
+        ref={contentRef}
         style={{
           position: 'relative',
           flex: 1,

--- a/packages/playground-app/src/icons/connection-closed.svg
+++ b/packages/playground-app/src/icons/connection-closed.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 9.48259C18.6126 6.27244 14.0595 5.0029 9.75 5.674" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 12.8994C17.6433 11.5427 15.9908 10.6621 14.25 10.2576" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12.8995C5.6638 12.2357 6.39845 11.6858 7.17955 11.25" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 16.1569C8.7194 15.4376 9.5843 14.9524 10.5 14.7016" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 19.9999C12.6904 19.9999 13.25 19.4403 13.25 18.7499C13.25 18.0596 12.6904 17.4999 12 17.4999C11.3097 17.4999 10.75 18.0596 10.75 18.7499C10.75 19.4403 11.3097 19.9999 12 19.9999Z" fill="#6D6D6D"/>
+<path d="M20 19.9999L4 3.99994" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 9.48268C2.2944 9.20368 2.59761 8.93933 2.9087 8.68968C3.18321 8.46933 3.46385 8.26043 3.74999 8.06293" stroke="#6D6D6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/playground-app/tests/device-interaction-layer.test.ts
+++ b/packages/playground-app/tests/device-interaction-layer.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, createElement } from 'react';
+import { act, createElement, createRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
@@ -375,6 +375,161 @@ describe('DeviceInteractionLayer keyboard capture', () => {
 
     expect(event.defaultPrevented).toBe(false);
     expect(onKeyboardPress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+describe('DeviceInteractionLayer contentRef projection', () => {
+  // Regression for the iOS Playground tap-offset bug: the overlay covers the
+  // whole preview panel (header + image), but coordinates must be projected
+  // against the actual screen-mirror box so chrome above the image does not
+  // shift taps downward.
+  const overlayRect = {
+    bottom: 800,
+    height: 800,
+    left: 0,
+    right: 400,
+    top: 0,
+    width: 400,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as const;
+  // 80px of chrome at the top, then a 400x720 screen-mirror box that exactly
+  // matches the device aspect (so there is no internal letterboxing).
+  const contentRect = {
+    bottom: 800,
+    height: 720,
+    left: 0,
+    right: 400,
+    top: 80,
+    width: 400,
+    x: 0,
+    y: 80,
+    toJSON: () => ({}),
+  } as const;
+
+  async function renderWithContentRef(options: {
+    onTap: ReturnType<typeof vi.fn>;
+    withContentRef: boolean;
+  }) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const contentElement = document.createElement('div');
+    document.body.appendChild(contentElement);
+    Object.defineProperty(contentElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => contentRect,
+    });
+    const ref = createRef<HTMLDivElement | null>();
+    (ref as { current: HTMLDivElement | null }).current = contentElement;
+
+    await act(async () => {
+      root.render(
+        createElement(DeviceInteractionLayer, {
+          enabled: true,
+          deviceSize: { width: 1000, height: 1800 },
+          onTap: options.onTap,
+          contentRef: options.withContentRef ? ref : undefined,
+        }),
+      );
+    });
+
+    const overlay = container.querySelector(
+      '[data-midscene-device-interaction-layer="true"]',
+    ) as HTMLDivElement;
+    Object.defineProperty(overlay, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'releasePointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => overlayRect,
+    });
+
+    return { container, contentElement, overlay, root };
+  }
+
+  it('projects taps against the screen-mirror box, not the surrounding overlay', async () => {
+    const onTap = vi.fn();
+    const { overlay, root } = await renderWithContentRef({
+      onTap,
+      withContentRef: true,
+    });
+
+    // Click 10% from the top of the actual screen-mirror box (which starts
+    // 80px below the overlay top). clientY = 80 + 0.1*720 = 152.
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 200,
+          clientY: 152,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 200,
+          clientY: 152,
+        }),
+      );
+    });
+
+    // ratioX = 200/400 = 0.5  → x = 500
+    // ratioY = (152-80)/720 = 0.1 → y = 180
+    expect(onTap).toHaveBeenCalledWith({ x: 500, y: 180 });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('falls back to the overlay rect when no contentRef is passed', async () => {
+    const onTap = vi.fn();
+    const { overlay, root } = await renderWithContentRef({
+      onTap,
+      withContentRef: false,
+    });
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 200,
+          clientY: 152,
+        }),
+      );
+      overlay.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          clientX: 200,
+          clientY: 152,
+        }),
+      );
+    });
+
+    // Without contentRef the projection uses the 400x800 overlay rect; the
+    // 1000x1800 device aspect is taller than the panel, so the inscribed
+    // image is 400x720 letterboxed with top = (800-720)/2 = 40.
+    // ratioY = (152-40)/720 ≈ 0.1556 → y ≈ 280.
+    expect(onTap).toHaveBeenCalledTimes(1);
+    const projected = onTap.mock.calls[0][0];
+    expect(projected.x).toBe(500);
+    expect(projected.y).toBeGreaterThan(270);
+    expect(projected.y).toBeLessThan(285);
 
     await act(async () => {
       root.unmount();

--- a/packages/playground-app/tests/device-interaction-layer.test.ts
+++ b/packages/playground-app/tests/device-interaction-layer.test.ts
@@ -425,7 +425,7 @@ describe('DeviceInteractionLayer contentRef projection', () => {
       configurable: true,
       value: () => contentRect,
     });
-    const ref = createRef<HTMLDivElement | null>();
+    const ref = createRef<HTMLDivElement>();
     (ref as { current: HTMLDivElement | null }).current = contentElement;
 
     await act(async () => {

--- a/packages/playground-app/tests/preview-renderer-default-mode.test.ts
+++ b/packages/playground-app/tests/preview-renderer-default-mode.test.ts
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const screenshotViewerMock = vi.fn(() => null);
+
+vi.mock('@midscene/visualizer', () => ({
+  ScreenshotViewer: (props: unknown) => screenshotViewerMock(props),
+}));
+
+import { PreviewRenderer } from '../src/PreviewRenderer';
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('PreviewRenderer screenshot viewer defaults', () => {
+  // Studio used to be the only embed that asked for screen-only mode; in the
+  // standalone playgrounds we fell back to the chrome-wrapped default viewer,
+  // which silently pushed pointer taps downward because the interaction layer
+  // measured the full panel instead of the actual screen-mirror box. Default
+  // to screen-only so every playground app picks up the fix automatically.
+  it('defaults the ScreenshotViewer to screen-only when no mode is provided', async () => {
+    screenshotViewerMock.mockClear();
+    const playgroundSDK = {
+      getInterfaceInfo: vi.fn(async () => null),
+      getScreenshot: vi.fn(async () => null),
+      interact: vi.fn(async () => ({ ok: true })),
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(PreviewRenderer, {
+          playgroundSDK,
+          runtimeInfo: {
+            interface: { type: 'puppeteer' },
+            metadata: {},
+            preview: {
+              kind: 'mjpeg',
+              mjpegPath: '/mjpeg',
+            },
+          },
+          serverOnline: true,
+          serverUrl: 'http://127.0.0.1:5800',
+          isUserOperating: false,
+        } as any),
+      );
+    });
+    await flushPromises();
+
+    expect(screenshotViewerMock).toHaveBeenCalled();
+    const lastCall = screenshotViewerMock.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const props = lastCall![0] as { mode?: string; contentRef?: unknown };
+    expect(props.mode).toBe('screen-only');
+    expect(props.contentRef).toBeDefined();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('honors an explicit mode override (Studio passes "default")', async () => {
+    screenshotViewerMock.mockClear();
+    const playgroundSDK = {
+      getInterfaceInfo: vi.fn(async () => null),
+      getScreenshot: vi.fn(async () => null),
+      interact: vi.fn(async () => ({ ok: true })),
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(PreviewRenderer, {
+          playgroundSDK,
+          runtimeInfo: {
+            interface: { type: 'puppeteer' },
+            metadata: {},
+            preview: {
+              kind: 'mjpeg',
+              mjpegPath: '/mjpeg',
+            },
+          },
+          serverOnline: true,
+          serverUrl: 'http://127.0.0.1:5800',
+          isUserOperating: false,
+          screenshotViewerMode: 'default',
+        } as any),
+      );
+    });
+    await flushPromises();
+
+    const props = screenshotViewerMock.mock.calls.at(-1)![0] as {
+      mode?: string;
+    };
+    expect(props.mode).toBe('default');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -27,7 +27,7 @@ interface ScreenshotViewerProps {
   // Receives the wrapper that holds the image. Consumers (e.g. the playground
   // device-interaction layer) project pointer coords against this rect so any
   // surrounding chrome — header, padding, toolbar — never shifts the mapping.
-  contentRef?: React.Ref<HTMLDivElement | null>;
+  contentRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function ScreenshotViewer({

--- a/packages/visualizer/src/component/screenshot-viewer/index.tsx
+++ b/packages/visualizer/src/component/screenshot-viewer/index.tsx
@@ -3,6 +3,11 @@ import { Button, Spin, Tooltip } from 'antd';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './index.less';
 
+// Esbuild leaves `.tsx` on the classic JSX transform here, so JSX in this file
+// compiles to `React.createElement`. Keep a runtime reference to React or
+// biome will strip the import as type-only, breaking SSR/test renders.
+void React;
+
 export type ScreenshotViewerMode = 'default' | 'screen-only';
 
 interface ScreenshotViewerProps {
@@ -19,6 +24,10 @@ interface ScreenshotViewerProps {
   isUserOperating?: boolean; // Whether user is currently operating
   mjpegUrl?: string; // When provided, use MJPEG live stream instead of polling
   mode?: ScreenshotViewerMode;
+  // Receives the wrapper that holds the image. Consumers (e.g. the playground
+  // device-interaction layer) project pointer coords against this rect so any
+  // surrounding chrome — header, padding, toolbar — never shifts the mapping.
+  contentRef?: React.Ref<HTMLDivElement | null>;
 }
 
 export default function ScreenshotViewer({
@@ -28,6 +37,7 @@ export default function ScreenshotViewer({
   isUserOperating = false,
   mjpegUrl,
   mode = 'default',
+  contentRef,
 }: ScreenshotViewerProps) {
   const [screenshot, setScreenshot] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -272,7 +282,7 @@ export default function ScreenshotViewer({
   };
 
   const screenshotContent = (
-    <div className="screenshot-content">
+    <div className="screenshot-content" ref={contentRef}>
       {isMjpeg ? (
         <img
           key={mjpegRetryToken || 'initial'}


### PR DESCRIPTION
## Summary

Mouse taps in the iOS, Harmony, and Computer playgrounds (and in the Android playground when scrcpy falls back to the screenshot stream) landed visibly lower than where the user clicked. The standalone playgrounds rendered `ScreenshotViewer` in its default mode, which keeps a header + status row inside the same relative-positioned panel that `DeviceInteractionLayer` overlays. The interaction layer measured the full panel via `getBoundingClientRect`, so the inscribed device rect was shifted up by the chrome height and every tap projected roughly half-a-chrome lower than the cursor position.

Studio was unaffected because it already passes `screenshotViewerMode="screen-only"` and bypasses the chrome.

### Fix 1 — default `screenshotViewerMode` to `screen-only`
- `PreviewRenderer` now resolves the prop with `screenshotViewerMode ?? 'screen-only'`. Every playground app picks up the fix without changes; Studio still opts into chrome by passing `'default'` explicitly.

### Fix 2 — project taps against the actual screen-mirror box
- `DeviceInteractionLayer` accepts a `contentRef` and prefers it over its own overlay rect when measuring. The fallback to overlay rect preserves the old behavior for any caller that does not pass the ref.
- `ScreenshotViewer` (visualizer) and `ScrcpyPanel` forward an external `contentRef` onto the wrapper that holds the image / canvas — the wrapper whose bounds match where the device pixels are actually drawn.
- `PreviewRenderer` threads a shared `previewContentRef` to whichever preview component is active and to `DeviceInteractionLayer`, so the projection stays correct even if chrome is reintroduced later.

### Tests
- `packages/playground-app/tests/device-interaction-layer.test.ts`: new `DeviceInteractionLayer contentRef projection` suite that simulates the iOS playground (overlay 400×800, chrome 80px, image 400×720, device 1000×1800) and verifies a click at `(200, 152)` projects to `(500, 180)` with `contentRef`, and falls back to the overlay-based (off-by-chrome) projection without it.
- `packages/playground-app/tests/preview-renderer-default-mode.test.ts` (new): asserts `PreviewRenderer` defaults `ScreenshotViewer.mode` to `'screen-only'` and forwards `contentRef`, and that an explicit `'default'` from Studio is honored.

### Notes
- `ScrcpyPanel.tsx` and `screenshot-viewer/index.tsx` needed the same `void React;` runtime-binding shim already present in `DeviceInteractionLayer.tsx`. Biome strips type-only React imports, but both files compile JSX to `React.createElement` because `tsconfig` sets `jsx: preserve`.

## Test plan
- [x] `npx nx test playground-app` (53 passed across 14 files)
- [x] `npx nx test visualizer` (77 passed across 16 files)
- [x] `pnpm run lint` (clean; the one remaining warning is a pre-existing biome-ignore in `core/tests/unit-test/report-generator-async-contract.test.ts` and is unrelated to this change)
- [ ] Manual: open the iOS playground, MJPEG stream connected, click an icon near the top of the device image and confirm the tap is forwarded at the same vertical position rather than ~half-a-header lower.
- [ ] Manual: open Studio (which keeps the screenshot chrome via `MobilePreviewFrame`) and confirm click-to-control still works unchanged.