### PR TITLE
fix(web-integration): wait for new tab navigation before bridge attach

### DIFF
--- a/packages/web-integration/src/bridge-mode/page-browser-side.ts
+++ b/packages/web-integration/src/bridge-mode/page-browser-side.ts
@@ -16,6 +16,66 @@ import { BridgeClient } from './io-client';
 
 declare const __VERSION__: string;
 
+const NEW_TAB_LOAD_TIMEOUT_MS = 30_000;
+
+function isBlankUrl(url: string | undefined): boolean {
+  if (!url) return true;
+  return url === 'about:blank' || url.startsWith('chrome://newtab');
+}
+
+// Wait until the freshly created tab has navigated away from about:blank
+// and reached `status === 'complete'`. Resolves on timeout instead of
+// throwing so callers degrade to the existing lazy-attach behavior.
+function waitForTabNavigationComplete(
+  tabId: number,
+  targetUrl: string,
+  timeoutMs = NEW_TAB_LOAD_TIMEOUT_MS,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+      } catch {}
+      clearTimeout(timer);
+      resolve();
+    };
+
+    const isReady = (tab: chrome.tabs.Tab | undefined): boolean => {
+      if (!tab) return false;
+      if (tab.status !== 'complete') return false;
+      const currentUrl = tab.url || tab.pendingUrl || '';
+      // Skip the initial about:blank "complete" that fires before
+      // the target URL navigation kicks in.
+      if (isBlankUrl(currentUrl) && !isBlankUrl(targetUrl)) return false;
+      return true;
+    };
+
+    const onUpdated = (
+      id: number,
+      _info: chrome.tabs.TabChangeInfo,
+      tab: chrome.tabs.Tab,
+    ) => {
+      if (id !== tabId) return;
+      if (isReady(tab)) finish();
+    };
+
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    const timer = setTimeout(finish, timeoutMs);
+
+    // Handle the race where the tab already finished loading before
+    // we registered the listener.
+    chrome.tabs
+      .get(tabId)
+      .then((tab) => {
+        if (isReady(tab)) finish();
+      })
+      .catch(() => {});
+  });
+}
+
 export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
   public bridgeClient: BridgeClient | null = null;
 
@@ -181,6 +241,14 @@ export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
     if (options?.forceSameTabNavigation) {
       this.forceSameTabNavigation = true;
     }
+
+    // chrome.tabs.create returns immediately with an about:blank target,
+    // then navigates to `url`. If we attach the debugger during that
+    // cross-origin transition Site Isolation will detach it again, leaving
+    // the first CDP command to fail with "Debugger is not attached to the
+    // tab". Wait for navigation to settle so the lazy attach lands on a
+    // stable target.
+    await waitForTabNavigationComplete(tabId, url);
 
     await this.setActiveTabId(tabId);
   }


### PR DESCRIPTION
## Summary

`chrome.tabs.create({ url })` returns immediately with an `about:blank` target and then navigates to the requested URL. With Chrome Site Isolation, that cross-origin transition tears down any debugger attached too early — which is exactly what happens to the lazy attach triggered by the first CDP command in bridge `newTabWithUrl` mode.

The attach lands mid-transition, gets detached, and `ensureDebuggerAttached` fails inside the `await this.enableWaterFlowAnimation()` call with `Debugger is not attached to the tab`. That error is thrown from inside the `catch` block of `sendCommandToDebugger`, so the retry loop never runs again and the failure surfaces to the YAML user.

## Reproduction

```yaml
web:
  url: "https://magic-cn.bytedance.net/editor/..."
  bridgeMode: newTabWithUrl
tasks:
  - name: minimal repro
    flow:
      - aiAssert: page is loaded
```

Run via `npx @midscene/cli` with the Midscene Chrome extension connected. The first CDP command fails with `Debugger is not attached to the tab`.

The existing bridge integration tests work around this by inserting `await sleep(3000)` after `connectNewTabWithUrl` (see `packages/web-integration/tests/ai/bridge/agent.test.ts:42`), but YAML users have no way to insert that wait.

## Fix

`packages/web-integration/src/bridge-mode/page-browser-side.ts`

- Add a `waitForTabNavigationComplete(tabId, url)` helper that resolves once the new tab reaches `status === 'complete'` and is no longer pointing at `about:blank` / `chrome://newtab`, with a 30s timeout that falls back to the previous behavior.
- Call it inside `connectNewTabWithUrl` before `setActiveTabId`, so by the time the first CDP command triggers the lazy attach, the tab is on a stable origin and Site Isolation will not detach the debugger again.

`connectCurrentTab` is unchanged — there is no cross-origin transition for an already-loaded tab.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx build web` (TypeScript declaration generation included)
- [x] `npx vitest --run tests/unit-test/bridge` — 19/19 passed
- [ ] Manual: run the YAML repro above against the Chrome extension and confirm the assertion passes without any manual `sleep`.