### PR TITLE
fix(web-integration): inherit bridge aiAct options

### DIFF
--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -209,15 +209,6 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
     await this.setDestroyOptionsAfterConnect();
   }
 
-  async aiAct(prompt: string, options?: any) {
-    if (options) {
-      console.warn(
-        'the `options` parameter of aiAct is not supported in cli side',
-      );
-    }
-    return await super.aiAct(prompt);
-  }
-
   async destroy(closeNewTabsAfterDisconnect?: boolean) {
     if (typeof closeNewTabsAfterDisconnect === 'boolean') {
       await this.page.setDestroyOptions({


### PR DESCRIPTION
Remove the AgentOverChromeBridge aiAct override.

Bridge mode now uses the core Agent implementation, like aiTap and other AI APIs.

Status updates are already wired through onTaskStartTip in the constructor.

The override silently dropped AiActOptions.

That included deepThink, cacheable, deepLocate, fileChooserAccept, and abortSignal.