### PR TITLE
chore(security): replace issues helper action

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -4,13 +4,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  issues: write
-
 jobs:
   issue-close-require:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/midscene'
+    permissions:
+      issues: write
     steps:
       - name: Close inactive need reproduction issues
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -5,22 +5,21 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
-  # Permits `actions-cool/issues-helper` to close an issue
   issues: write
-  contents: read
 
 jobs:
   issue-close-require:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/midscene'
     steps:
-      - name: need reproduction
-        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
+      - name: Close inactive need reproduction issues
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          actions: 'close-issues'
-          labels: 'need reproduction'
-          inactive-day: 5
-          body: |
+          days-before-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-close: 5
+          stale-issue-label: 'need reproduction'
+          close-issue-message: |
             As the issue was labelled with `need reproduction`, but no response in 5 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions. For background, see [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required).
 
             由于该 issue 被标记为 "需要重现"，但在 5 天内没有回应，因此该 issue 将被关闭。如果你有任何进一步的问题，请随时发表评论并重新打开该 issue。背景请参考 [为什么需要最小重现](https://antfu.me/posts/why-reproductions-are-required-zh)。

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -4,14 +4,13 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
-
 jobs:
   reply-labeled:
     name: Reply need reproduction
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/midscene'
+    permissions:
+      issues: write
     steps:
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -5,8 +5,6 @@ on:
     types: [labeled]
 
 permissions:
-  contents: read
-  # Permits `actions-cool/issues-helper` to comment on an issue
   issues: write
 
 jobs:
@@ -17,9 +15,9 @@ jobs:
     steps:
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
-        with:
-          actions: 'create-comment'
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: |
             Hello @${{ github.event.issue.user.login }}. Please provide a reproduction repository or online demo. For background, see [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required). Thanks ❤️
+        run: gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"


### PR DESCRIPTION
## Summary

Replace the third-party `actions-cool/issues-helper` usage in issue-management workflows after the action was reported compromised.

The previous workflow referenced a pinned commit SHA, so this repository was not affected by the compromised tags.

The label reply workflow now uses GitHub CLI directly, and the inactive issue close workflow uses the official `actions/stale` action pinned to a commit SHA with minimal `issues: write` permissions.

## Validation

- `git diff --check`
- `pnpm run lint`

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7683
- https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
- https://docs.github.com/en/actions/tutorials/manage-your-work/add-comments-with-labels
- https://docs.github.com/en/actions/tutorials/manage-your-work/close-inactive-issues