### PR TITLE
feat(core): add merge action to report-tool CLI

### DIFF
--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -65,11 +65,12 @@ Merge multiple report files into a single combined report:
 
 ```shell
 npx @midscene/web report-tool --action merge \
-  --htmlPaths '["./midscene_run/report/case-a/index.html","./midscene_run/report/case-b.html"]' \
+  --htmlReport ./midscene_run/report/case-a/index.html \
+  --htmlReport ./midscene_run/report/case-b.html \
   --outputDir ./merged --outputName all-cases
 ```
 
-`--htmlPaths` accepts a JSON array or a comma-separated list. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
+Repeat `--htmlReport` once per source report. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
 
 ## Parse With The JavaScript SDK
 

--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -64,7 +64,7 @@ npx @midscene/web report-tool --action to-markdown --htmlPath ./midscene_run/rep
 Merge multiple report files into a single combined report:
 
 ```shell
-npx @midscene/web report-tool --action merge \
+npx @midscene/web report-tool --action merge-html \
   --htmlReport ./midscene_run/report/case-a/index.html \
   --htmlReport ./midscene_run/report/case-b.html \
   --outputDir ./merged --outputName all-cases
@@ -112,7 +112,6 @@ console.log(mergedResult.mergedReportPath);
 - `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
 - `mergeReportFiles` combines several report files into one merged HTML report. It is a thin wrapper over [`ReportMergingTool`](./api#new-reportmergingtool) that derives `testTitle`/`testDescription` from each source report's `groupName` automatically. Use it when you run multiple CLI actions or tests and want to consolidate their reports.
 
-Use `splitReportFile` when you want the most complete, programmatic raw data. Use `reportFileToMarkdown` when you want readable content for summarization or downstream content generation. Use `mergeReportFiles` (or `--action merge` on the CLI) when you have several report HTML files to combine.
 
 ## About Fields In JSON And Markdown
 

--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -61,12 +61,26 @@ Convert the report file into Markdown and write the result into the `output-mark
 npx @midscene/web report-tool --action to-markdown --htmlPath ./midscene_run/report/puppeteer-2026/index.html --outputDir ./output-markdown
 ```
 
+Merge multiple report files into a single combined report:
+
+```shell
+npx @midscene/web report-tool --action merge \
+  --htmlPaths '["./midscene_run/report/case-a/index.html","./midscene_run/report/case-b.html"]' \
+  --outputDir ./merged --outputName all-cases
+```
+
+`--htmlPaths` accepts a JSON array or a comma-separated list. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
+
 ## Parse With The JavaScript SDK
 
-If you prefer to control report parsing in code, use `splitReportFile` and `reportFileToMarkdown` from `@midscene/core`.
+If you prefer to control report parsing in code, use `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` from `@midscene/core`.
 
 ```ts
-import { reportFileToMarkdown, splitReportFile } from '@midscene/core';
+import {
+  mergeReportFiles,
+  reportFileToMarkdown,
+  splitReportFile,
+} from '@midscene/core';
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -79,14 +93,25 @@ const markdownResult = await reportFileToMarkdown({
   outputDir: './output-markdown',
 });
 console.log(markdownResult.markdownFiles);
+
+const mergedResult = mergeReportFiles({
+  htmlPaths: [
+    './midscene_run/report/case-a/index.html',
+    './midscene_run/report/case-b.html',
+  ],
+  outputDir: './merged',
+  outputName: 'all-cases',
+});
+console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile` and `reportFileToMarkdown` serve different outputs:
+`splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
 
 - `splitReportFile` generates JSON files for the original structured objects (one `*.execution.json` per execution). The JSON keeps the raw `ReportActionDump`-style data and exports screenshots alongside it. The returned `executionJsonFiles` and `screenshotFiles` are lists of generated file paths.
 - `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
+- `mergeReportFiles` combines several report files into one merged HTML report. It is a thin wrapper over [`ReportMergingTool`](./api#new-reportmergingtool) that derives `testTitle`/`testDescription` from each source report's `groupName` automatically. Use it when you run multiple CLI actions or tests and want to consolidate their reports.
 
-Use `splitReportFile` when you want the most complete, programmatic raw data. Use `reportFileToMarkdown` when you want readable content for summarization or downstream content generation.
+Use `splitReportFile` when you want the most complete, programmatic raw data. Use `reportFileToMarkdown` when you want readable content for summarization or downstream content generation. Use `mergeReportFiles` (or `--action merge` on the CLI) when you have several report HTML files to combine.
 
 ## About Fields In JSON And Markdown
 

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -65,11 +65,12 @@ npx @midscene/web report-tool --action to-markdown --htmlPath ./midscene_run/rep
 
 ```shell
 npx @midscene/web report-tool --action merge \
-  --htmlPaths '["./midscene_run/report/case-a/index.html","./midscene_run/report/case-b.html"]' \
+  --htmlReport ./midscene_run/report/case-a/index.html \
+  --htmlReport ./midscene_run/report/case-b.html \
   --outputDir ./merged --outputName all-cases
 ```
 
-`--htmlPaths` 同时接受 JSON 数组和英文逗号分隔的列表；`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
+每多合并一份报告就重复一次 `--htmlReport`。`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
 
 ## 使用 JavaScript SDK 解析
 

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -64,7 +64,7 @@ npx @midscene/web report-tool --action to-markdown --htmlPath ./midscene_run/rep
 将多个报告文件合并为一份汇总报告：
 
 ```shell
-npx @midscene/web report-tool --action merge \
+npx @midscene/web report-tool --action merge-html \
   --htmlReport ./midscene_run/report/case-a/index.html \
   --htmlReport ./midscene_run/report/case-b.html \
   --outputDir ./merged --outputName all-cases
@@ -112,7 +112,6 @@ console.log(mergedResult.mergedReportPath);
 - `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
 - `mergeReportFiles` 会把多份报告合并成一份汇总 HTML 报告，是 [`ReportMergingTool`](./api#new-reportmergingtool) 的轻量封装：会自动从每份源报告里读取 `groupName` 作为 `testTitle`/`testDescription`，省去了手工准备 `reportAttributes` 的步骤。命令行多次调用或多个测试用例产生多份报告后，使用它进行汇总最为合适。
 
-如果你想保留最完整、可编程处理的数据，优先使用 `splitReportFile`；如果你想直接阅读、总结，或用于二次生成（例如生成视频脚本），优先使用 `reportFileToMarkdown`；如果你想把多份报告聚合为一份，优先使用 `mergeReportFiles`（或命令行的 `--action merge`）。
 
 ## 关于 JSON 和 Markdown 的内容字段
 

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -61,12 +61,26 @@ npx @midscene/web report-tool --action split --htmlPath ./midscene_run/report/pu
 npx @midscene/web report-tool --action to-markdown --htmlPath ./midscene_run/report/puppeteer-2026/index.html --outputDir ./output-markdown
 ```
 
+将多个报告文件合并为一份汇总报告：
+
+```shell
+npx @midscene/web report-tool --action merge \
+  --htmlPaths '["./midscene_run/report/case-a/index.html","./midscene_run/report/case-b.html"]' \
+  --outputDir ./merged --outputName all-cases
+```
+
+`--htmlPaths` 同时接受 JSON 数组和英文逗号分隔的列表；`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
+
 ## 使用 JavaScript SDK 解析
 
-如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile` 和 `reportFileToMarkdown`。
+如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles`。
 
 ```ts
-import { reportFileToMarkdown, splitReportFile } from '@midscene/core';
+import {
+  mergeReportFiles,
+  reportFileToMarkdown,
+  splitReportFile,
+} from '@midscene/core';
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -79,14 +93,25 @@ const markdownResult = await reportFileToMarkdown({
   outputDir: './output-markdown',
 });
 console.log(markdownResult.markdownFiles);
+
+const mergedResult = mergeReportFiles({
+  htmlPaths: [
+    './midscene_run/report/case-a/index.html',
+    './midscene_run/report/case-b.html',
+  ],
+  outputDir: './merged',
+  outputName: 'all-cases',
+});
+console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile` 和 `reportFileToMarkdown` 的用途不同：
+`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
 
 - `splitReportFile` 会产出“原始对象”对应的 JSON 文件（每个 execution 一个 `*.execution.json`），内容是 `ReportActionDump` 的原始结构化数据，同时会导出截图文件。返回值中的 `executionJsonFiles` 和 `screenshotFiles` 都是生成后的文件路径列表。
 - `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
+- `mergeReportFiles` 会把多份报告合并成一份汇总 HTML 报告，是 [`ReportMergingTool`](./api#new-reportmergingtool) 的轻量封装：会自动从每份源报告里读取 `groupName` 作为 `testTitle`/`testDescription`，省去了手工准备 `reportAttributes` 的步骤。命令行多次调用或多个测试用例产生多份报告后，使用它进行汇总最为合适。
 
-如果你想保留最完整、可编程处理的数据，优先使用 `splitReportFile`；如果你想直接阅读、总结，或用于二次生成（例如生成视频脚本），优先使用 `reportFileToMarkdown`。
+如果你想保留最完整、可编程处理的数据，优先使用 `splitReportFile`；如果你想直接阅读、总结，或用于二次生成（例如生成视频脚本），优先使用 `reportFileToMarkdown`；如果你想把多份报告聚合为一份，优先使用 `mergeReportFiles`（或命令行的 `--action merge`）。
 
 ## 关于 JSON 和 Markdown 的内容字段
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,11 +84,14 @@ export {
   createReportCliCommands,
   reportFileToMarkdown,
   splitReportFile,
+  mergeReportFiles,
   type ConsumeReportFileAction,
   type ReportFileToMarkdownOptions,
   type ReportCliCommandDefinition,
   type ReportCliCommandEntry,
   type SplitReportFileOptions,
+  type MergeReportFilesOptions,
+  type MergeReportFilesResult,
 } from './report-cli';
 
 // ScreenshotItem

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -8,9 +8,14 @@ import {
 import * as path from 'node:path';
 import { z } from 'zod';
 import { resolveScreenshotSource } from './dump/screenshot-store';
-import { collectDedupedExecutions, splitReportHtmlByExecution } from './report';
+import {
+  ReportMergingTool,
+  collectDedupedExecutions,
+  splitReportHtmlByExecution,
+} from './report';
 import { reportToMarkdown } from './report-markdown';
 import type { MarkdownAttachment } from './report-markdown';
+import type { ReportFileAttributes, TestStatus } from './types';
 import { ReportActionDump } from './types';
 
 type ReportCliToolResult = {
@@ -35,7 +40,7 @@ export interface ReportCliCommandEntry {
   def: ReportCliCommandDefinition;
 }
 
-export type ConsumeReportFileAction = 'split' | 'to-markdown';
+export type ConsumeReportFileAction = 'split' | 'to-markdown' | 'merge';
 
 export interface ConsumeReportFileOptions {
   htmlPath: string;
@@ -44,6 +49,17 @@ export interface ConsumeReportFileOptions {
 
 export type SplitReportFileOptions = ConsumeReportFileOptions;
 export type ReportFileToMarkdownOptions = ConsumeReportFileOptions;
+
+export interface MergeReportFilesOptions {
+  htmlPaths: string[];
+  outputDir?: string;
+  outputName?: string;
+  overwrite?: boolean;
+}
+
+export interface MergeReportFilesResult {
+  mergedReportPath: string;
+}
 
 function writeAttachmentFromReport(
   attachment: MarkdownAttachment,
@@ -200,40 +216,182 @@ export async function reportFileToMarkdown(
   return markdownFromReport(resolvedHtmlPath, outputDir);
 }
 
+function deriveReportAttributesFromHtml(
+  htmlPath: string,
+  index: number,
+): ReportFileAttributes {
+  const fallbackId = `${path.basename(path.dirname(htmlPath)) || path.basename(htmlPath, path.extname(htmlPath))}-${index + 1}`;
+  try {
+    const { baseDump } = collectDedupedExecutions(htmlPath);
+    return {
+      testId: fallbackId,
+      testTitle: baseDump.groupName || fallbackId,
+      testDescription: baseDump.groupDescription ?? '',
+      testDuration: 0,
+      testStatus: 'passed' as TestStatus,
+    };
+  } catch {
+    return {
+      testId: fallbackId,
+      testTitle: fallbackId,
+      testDescription: '',
+      testDuration: 0,
+      testStatus: 'passed' as TestStatus,
+    };
+  }
+}
+
+export function mergeReportFiles(
+  options: MergeReportFilesOptions,
+): MergeReportFilesResult {
+  const { htmlPaths, outputDir, outputName, overwrite = false } = options;
+  if (!htmlPaths || htmlPaths.length === 0) {
+    throw new Error('mergeReportFiles: htmlPaths is required');
+  }
+
+  const resolvedPaths = htmlPaths.map((p) => resolveReportHtmlPath(p));
+
+  const tool = new ReportMergingTool();
+  resolvedPaths.forEach((htmlPath, index) => {
+    tool.append({
+      reportFilePath: htmlPath,
+      reportAttributes: deriveReportAttributesFromHtml(htmlPath, index),
+    });
+  });
+
+  const mergedReportPath = tool.mergeReports(outputName ?? 'AUTO', {
+    overwrite,
+    outputDir,
+  });
+
+  if (!mergedReportPath) {
+    throw new Error('mergeReportFiles: failed to produce a merged report');
+  }
+
+  return { mergedReportPath };
+}
+
+function normalizeHtmlPathsArg(raw: unknown): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (p): p is string => typeof p === 'string' && p.length > 0,
+    );
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return parsed.filter(
+            (p): p is string => typeof p === 'string' && p.length > 0,
+          );
+        }
+      } catch {
+        // fall through to comma-split
+      }
+    }
+    return trimmed
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+  }
+  return undefined;
+}
+
 const reportCommandDefinition: ReportCliCommandDefinition = {
   name: 'report-tool',
   description:
-    'Transform Midscene report artifacts, including splitting executions and converting to markdown.',
+    'Transform Midscene report artifacts, including splitting executions, converting to markdown, and merging multiple reports.',
   schema: {
     action: z
-      .enum(['split', 'to-markdown'])
+      .enum(['split', 'to-markdown', 'merge'])
       .optional()
       .describe(
-        'Report action to run. Supports: split, to-markdown. Defaults to split.',
+        'Report action to run. Supports: split, to-markdown, merge. Defaults to split.',
       ),
     htmlPath: z
       .string()
       .optional()
-      .describe('Input report HTML path (e.g. ./report/index.html)'),
+      .describe(
+        'Input report HTML path (e.g. ./report/index.html). Used by split and to-markdown.',
+      ),
+    htmlPaths: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe(
+        'Input report HTML paths for the merge action. Accepts a JSON array (e.g. \'["a/index.html","b.html"]\') or a comma-separated list.',
+      ),
     outputDir: z
       .string()
       .optional()
-      .describe('Output directory for generated report artifacts'),
+      .describe(
+        'Output directory for generated report artifacts. For merge, defaults to the Midscene report directory.',
+      ),
+    outputName: z
+      .string()
+      .optional()
+      .describe(
+        'Output report file/directory name (without .html) for the merge action. Defaults to an auto-generated name.',
+      ),
+    overwrite: z
+      .union([z.boolean(), z.string()])
+      .optional()
+      .describe(
+        'Overwrite the existing merged report file if present (merge action only).',
+      ),
   },
   handler: async (args) => {
     const {
       action = 'split',
       htmlPath,
+      htmlPaths,
       outputDir,
+      outputName,
+      overwrite,
     } = args as {
       action?: string;
       htmlPath?: string;
+      htmlPaths?: unknown;
       outputDir?: string;
+      outputName?: string;
+      overwrite?: unknown;
     };
-    if (action !== 'split' && action !== 'to-markdown') {
+    if (action !== 'split' && action !== 'to-markdown' && action !== 'merge') {
       throw new Error(
-        `report-tool: unsupported --action value "${action}". Currently supported: split, to-markdown`,
+        `report-tool: unsupported --action value "${action}". Currently supported: split, to-markdown, merge`,
       );
+    }
+
+    if (action === 'merge') {
+      const paths = normalizeHtmlPathsArg(htmlPaths);
+      if (!paths || paths.length === 0) {
+        throw new Error(
+          'report-tool: --htmlPaths is required for action "merge". Provide a JSON array or comma-separated list of report paths.',
+        );
+      }
+
+      const overwriteFlag =
+        overwrite === true || overwrite === 'true' || overwrite === '1';
+
+      const result = mergeReportFiles({
+        htmlPaths: paths,
+        outputDir,
+        outputName,
+        overwrite: overwriteFlag,
+      });
+
+      return {
+        isError: false,
+        content: [
+          {
+            type: 'text',
+            text: `Merged ${paths.length} report(s) into ${result.mergedReportPath}`,
+          },
+        ],
+      };
     }
 
     if (!htmlPath) {

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -271,7 +271,7 @@ export function mergeReportFiles(
   return { mergedReportPath };
 }
 
-function normalizeHtmlPathsArg(raw: unknown): string[] | undefined {
+function normalizeHtmlReportArg(raw: unknown): string[] | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (Array.isArray(raw)) {
     return raw.filter(
@@ -280,23 +280,7 @@ function normalizeHtmlPathsArg(raw: unknown): string[] | undefined {
   }
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
-    if (!trimmed) return [];
-    if (trimmed.startsWith('[')) {
-      try {
-        const parsed = JSON.parse(trimmed);
-        if (Array.isArray(parsed)) {
-          return parsed.filter(
-            (p): p is string => typeof p === 'string' && p.length > 0,
-          );
-        }
-      } catch {
-        // fall through to comma-split
-      }
-    }
-    return trimmed
-      .split(',')
-      .map((p) => p.trim())
-      .filter((p) => p.length > 0);
+    return trimmed ? [trimmed] : [];
   }
   return undefined;
 }
@@ -318,11 +302,11 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
       .describe(
         'Input report HTML path (e.g. ./report/index.html). Used by split and to-markdown.',
       ),
-    htmlPaths: z
+    htmlReport: z
       .union([z.string(), z.array(z.string())])
       .optional()
       .describe(
-        'Input report HTML paths for the merge action. Accepts a JSON array (e.g. \'["a/index.html","b.html"]\') or a comma-separated list.',
+        'Input report HTML path for the merge action. Repeat the flag to merge multiple reports (e.g. --htmlReport ./a/index.html --htmlReport ./b.html).',
       ),
     outputDir: z
       .string()
@@ -347,14 +331,14 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
     const {
       action = 'split',
       htmlPath,
-      htmlPaths,
+      htmlReport,
       outputDir,
       outputName,
       overwrite,
     } = args as {
       action?: string;
       htmlPath?: string;
-      htmlPaths?: unknown;
+      htmlReport?: unknown;
       outputDir?: string;
       outputName?: string;
       overwrite?: unknown;
@@ -366,10 +350,10 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
     }
 
     if (action === 'merge') {
-      const paths = normalizeHtmlPathsArg(htmlPaths);
+      const paths = normalizeHtmlReportArg(htmlReport);
       if (!paths || paths.length === 0) {
         throw new Error(
-          'report-tool: --htmlPaths is required for action "merge". Provide a JSON array or comma-separated list of report paths.',
+          'report-tool: --htmlReport is required for action "merge". Repeat --htmlReport for each report (e.g. --htmlReport ./a/index.html --htmlReport ./b.html).',
         );
       }
 

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -40,7 +40,7 @@ export interface ReportCliCommandEntry {
   def: ReportCliCommandDefinition;
 }
 
-export type ConsumeReportFileAction = 'split' | 'to-markdown' | 'merge';
+export type ConsumeReportFileAction = 'split' | 'to-markdown' | 'merge-html';
 
 export interface ConsumeReportFileOptions {
   htmlPath: string;
@@ -291,10 +291,10 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
     'Transform Midscene report artifacts, including splitting executions, converting to markdown, and merging multiple reports.',
   schema: {
     action: z
-      .enum(['split', 'to-markdown', 'merge'])
+      .enum(['split', 'to-markdown', 'merge-html'])
       .optional()
       .describe(
-        'Report action to run. Supports: split, to-markdown, merge. Defaults to split.',
+        'Report action to run. Supports: split, to-markdown, merge-html. Defaults to split.',
       ),
     htmlPath: z
       .string()
@@ -343,17 +343,21 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
       outputName?: string;
       overwrite?: unknown;
     };
-    if (action !== 'split' && action !== 'to-markdown' && action !== 'merge') {
+    if (
+      action !== 'split' &&
+      action !== 'to-markdown' &&
+      action !== 'merge-html'
+    ) {
       throw new Error(
-        `report-tool: unsupported --action value "${action}". Currently supported: split, to-markdown, merge`,
+        `report-tool: unsupported --action value "${action}". Currently supported: split, to-markdown, merge-html`,
       );
     }
 
-    if (action === 'merge') {
+    if (action === 'merge-html') {
       const paths = normalizeHtmlReportArg(htmlReport);
       if (!paths || paths.length === 0) {
         throw new Error(
-          'report-tool: --htmlReport is required for action "merge". Repeat --htmlReport for each report (e.g. --htmlReport ./a/index.html --htmlReport ./b.html).',
+          'report-tool: --htmlReport is required for action "merge-html". Repeat --htmlReport for each report (e.g. --htmlReport ./a/index.html --htmlReport ./b.html).',
         );
       }
 

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -142,16 +142,26 @@ export class ReportMergingTool {
     opts?: {
       rmOriginalReports?: boolean;
       overwrite?: boolean;
+      outputDir?: string;
     },
   ): string | null {
-    const { rmOriginalReports = false, overwrite = false } = opts ?? {};
+    const {
+      rmOriginalReports = false,
+      overwrite = false,
+      outputDir,
+    } = opts ?? {};
 
     if (this.reportInfos.length === 0) {
       logMsg('No reports to merge');
       return null;
     }
 
-    const targetDir = getMidsceneRunSubDir('report');
+    const targetDir = outputDir
+      ? path.resolve(outputDir)
+      : getMidsceneRunSubDir('report');
+    if (outputDir) {
+      mkdirSync(targetDir, { recursive: true });
+    }
 
     // Check if any source report is directory mode
     const hasDirectoryModeReport = this.reportInfos.some((info) => {

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -12,6 +12,7 @@ import { generateDumpScriptTag, generateImageScriptTag } from '../../src/dump';
 import type { ScreenshotRef } from '../../src/dump/screenshot-store';
 import {
   createReportCliCommands,
+  mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '../../src/report-cli';
@@ -462,5 +463,129 @@ describe('createReportCliCommands', () => {
     expect(readFileSync(exportedScreenshot)).toEqual(
       readFileSync(sourceScreenshotPath),
     );
+  });
+
+  function writeFakeReport(
+    dirName: string,
+    groupName: string,
+    executionId: string,
+  ): string {
+    const reportPath = join(tmpDir, dirName, 'index.html');
+    mkdirSync(join(tmpDir, dirName), { recursive: true });
+
+    const screenshot = ScreenshotItem.create(fakeBase64(100), Date.now());
+    const dump = new ReportActionDump({
+      groupName,
+      groupDescription: `${groupName}-desc`,
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createExecution(executionId, screenshot)],
+    });
+
+    const html = [
+      generateImageScriptTag(screenshot.id, screenshot.base64),
+      generateDumpScriptTag(dump.serialize(), {
+        'data-group-id': `group-${executionId}`,
+      }),
+    ].join('\n');
+    writeFileSync(reportPath, html, 'utf-8');
+    return reportPath;
+  }
+
+  it('merges multiple reports via the JS SDK API', () => {
+    const reportA = writeFakeReport('merge-input-a', 'group-A', 'exec-A');
+    const reportB = writeFakeReport('merge-input-b', 'group-B', 'exec-B');
+
+    const outputDir = join(tmpDir, 'merge-output-sdk');
+    const result = mergeReportFiles({
+      htmlPaths: [reportA, reportB],
+      outputDir,
+      outputName: 'merged-sdk',
+    });
+
+    expect(result.mergedReportPath.startsWith(outputDir)).toBe(true);
+    expect(existsSync(result.mergedReportPath)).toBe(true);
+
+    const merged = readFileSync(result.mergedReportPath, 'utf-8');
+    const idMatches = merged.match(/playwright_test_id="[^"]+"/g) ?? [];
+    expect(idMatches.length).toBe(2);
+    expect(merged).toContain('group-A');
+    expect(merged).toContain('group-B');
+  });
+
+  it('runs the merge action through the generic report command', async () => {
+    const reportA = writeFakeReport('merge-cli-a', 'cli-group-A', 'exec-cli-A');
+    const reportB = writeFakeReport('merge-cli-b', 'cli-group-B', 'exec-cli-B');
+
+    const outputDir = join(tmpDir, 'merge-output-cli');
+    const [command] = createReportCliCommands();
+    const result = await command.def.handler({
+      action: 'merge',
+      htmlPaths: JSON.stringify([reportA, reportB]),
+      outputDir,
+      outputName: 'merged-cli',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Merged 2 report(s) into');
+
+    const mergedPath = join(outputDir, 'merged-cli.html');
+    expect(existsSync(mergedPath)).toBe(true);
+  });
+
+  it('accepts comma-separated htmlPaths for the merge action', async () => {
+    const reportA = writeFakeReport('merge-csv-a', 'csv-group-A', 'exec-csv-A');
+    const reportB = writeFakeReport('merge-csv-b', 'csv-group-B', 'exec-csv-B');
+
+    const outputDir = join(tmpDir, 'merge-output-csv');
+    const [command] = createReportCliCommands();
+    const result = await command.def.handler({
+      action: 'merge',
+      htmlPaths: `${reportA},${reportB}`,
+      outputDir,
+      outputName: 'merged-csv',
+    });
+
+    expect(result.isError).toBe(false);
+    const mergedPath = join(outputDir, 'merged-csv.html');
+    expect(existsSync(mergedPath)).toBe(true);
+  });
+
+  it('throws when --htmlPaths is missing for the merge action', async () => {
+    const [command] = createReportCliCommands();
+
+    await expect(
+      command.def.handler({
+        action: 'merge',
+        outputDir: join(tmpDir, 'merge-missing'),
+      }),
+    ).rejects.toThrow('report-tool: --htmlPaths is required');
+  });
+
+  it('throws when merge target already exists without --overwrite', async () => {
+    const reportA = writeFakeReport('merge-ow-a', 'ow-A', 'exec-ow-A');
+    const outputDir = join(tmpDir, 'merge-output-overwrite');
+
+    mergeReportFiles({
+      htmlPaths: [reportA],
+      outputDir,
+      outputName: 'merged-ow',
+    });
+
+    expect(() =>
+      mergeReportFiles({
+        htmlPaths: [reportA],
+        outputDir,
+        outputName: 'merged-ow',
+      }),
+    ).toThrow('Report file already exists');
+
+    const second = mergeReportFiles({
+      htmlPaths: [reportA],
+      outputDir,
+      outputName: 'merged-ow',
+      overwrite: true,
+    });
+    expect(existsSync(second.mergedReportPath)).toBe(true);
   });
 });

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -7,7 +7,8 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseCliArgs, runToolsCLI } from '@midscene/shared/cli';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateDumpScriptTag, generateImageScriptTag } from '../../src/dump';
 import type { ScreenshotRef } from '../../src/dump/screenshot-store';
 import {
@@ -521,7 +522,7 @@ describe('createReportCliCommands', () => {
     const [command] = createReportCliCommands();
     const result = await command.def.handler({
       action: 'merge',
-      htmlPaths: JSON.stringify([reportA, reportB]),
+      htmlReport: [reportA, reportB],
       outputDir,
       outputName: 'merged-cli',
     });
@@ -533,25 +534,28 @@ describe('createReportCliCommands', () => {
     expect(existsSync(mergedPath)).toBe(true);
   });
 
-  it('accepts comma-separated htmlPaths for the merge action', async () => {
-    const reportA = writeFakeReport('merge-csv-a', 'csv-group-A', 'exec-csv-A');
-    const reportB = writeFakeReport('merge-csv-b', 'csv-group-B', 'exec-csv-B');
+  it('accepts a single --htmlReport for the merge action', async () => {
+    const reportA = writeFakeReport(
+      'merge-single-a',
+      'single-group-A',
+      'exec-single-A',
+    );
 
-    const outputDir = join(tmpDir, 'merge-output-csv');
+    const outputDir = join(tmpDir, 'merge-output-single');
     const [command] = createReportCliCommands();
     const result = await command.def.handler({
       action: 'merge',
-      htmlPaths: `${reportA},${reportB}`,
+      htmlReport: reportA,
       outputDir,
-      outputName: 'merged-csv',
+      outputName: 'merged-single',
     });
 
     expect(result.isError).toBe(false);
-    const mergedPath = join(outputDir, 'merged-csv.html');
+    const mergedPath = join(outputDir, 'merged-single.html');
     expect(existsSync(mergedPath)).toBe(true);
   });
 
-  it('throws when --htmlPaths is missing for the merge action', async () => {
+  it('throws when --htmlReport is missing for the merge action', async () => {
     const [command] = createReportCliCommands();
 
     await expect(
@@ -559,7 +563,58 @@ describe('createReportCliCommands', () => {
         action: 'merge',
         outputDir: join(tmpDir, 'merge-missing'),
       }),
-    ).rejects.toThrow('report-tool: --htmlPaths is required');
+    ).rejects.toThrow('report-tool: --htmlReport is required');
+  });
+
+  it('drives the merge action end-to-end through runToolsCLI argv', async () => {
+    const reportA = writeFakeReport('merge-e2e-a', 'e2e-group-A', 'exec-e2e-A');
+    const reportB = writeFakeReport('merge-e2e-b', 'e2e-group-B', 'exec-e2e-B');
+
+    const outputDir = join(tmpDir, 'merge-output-e2e');
+    const [command] = createReportCliCommands();
+
+    const restArgs = [
+      '--action',
+      'merge',
+      '--htmlReport',
+      reportA,
+      '--htmlReport',
+      reportB,
+      '--outputDir',
+      outputDir,
+      '--outputName',
+      'merged-e2e',
+    ];
+    expect(parseCliArgs(restArgs)).toEqual({
+      action: 'merge',
+      htmlReport: [reportA, reportB],
+      outputDir,
+      outputName: 'merged-e2e',
+    });
+
+    const logs: string[] = [];
+    const consoleSpy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((...args: unknown[]) => {
+        logs.push(args.map((a) => String(a)).join(' '));
+      });
+
+    const tools = {
+      initTools: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      getToolDefinitions: vi.fn().mockReturnValue([]),
+    } as any;
+
+    await runToolsCLI(tools, 'midscene-test', {
+      argv: ['report-tool', ...restArgs],
+      extraCommands: [command],
+    });
+
+    consoleSpy.mockRestore();
+
+    const mergedPath = join(outputDir, 'merged-e2e.html');
+    expect(existsSync(mergedPath)).toBe(true);
+    expect(logs.join('\n')).toContain('Merged 2 report(s) into');
   });
 
   it('throws when merge target already exists without --overwrite', async () => {

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -316,7 +316,7 @@ describe('createReportCliCommands', () => {
         outputDir: join(tmpDir, 'unused-output'),
       }),
     ).rejects.toThrow(
-      'report-tool: unsupported --action value "invalid-action". Currently supported: split, to-markdown',
+      'report-tool: unsupported --action value "invalid-action". Currently supported: split, to-markdown, merge-html',
     );
   });
 
@@ -521,7 +521,7 @@ describe('createReportCliCommands', () => {
     const outputDir = join(tmpDir, 'merge-output-cli');
     const [command] = createReportCliCommands();
     const result = await command.def.handler({
-      action: 'merge',
+      action: 'merge-html',
       htmlReport: [reportA, reportB],
       outputDir,
       outputName: 'merged-cli',
@@ -544,7 +544,7 @@ describe('createReportCliCommands', () => {
     const outputDir = join(tmpDir, 'merge-output-single');
     const [command] = createReportCliCommands();
     const result = await command.def.handler({
-      action: 'merge',
+      action: 'merge-html',
       htmlReport: reportA,
       outputDir,
       outputName: 'merged-single',
@@ -560,7 +560,7 @@ describe('createReportCliCommands', () => {
 
     await expect(
       command.def.handler({
-        action: 'merge',
+        action: 'merge-html',
         outputDir: join(tmpDir, 'merge-missing'),
       }),
     ).rejects.toThrow('report-tool: --htmlReport is required');
@@ -575,7 +575,7 @@ describe('createReportCliCommands', () => {
 
     const restArgs = [
       '--action',
-      'merge',
+      'merge-html',
       '--htmlReport',
       reportA,
       '--htmlReport',
@@ -586,7 +586,7 @@ describe('createReportCliCommands', () => {
       'merged-e2e',
     ];
     expect(parseCliArgs(restArgs)).toEqual({
-      action: 'merge',
+      action: 'merge-html',
       htmlReport: [reportA, reportB],
       outputDir,
       outputName: 'merged-e2e',

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -209,6 +209,25 @@ describe('parseCliArgs', () => {
       'android.device-id': '127.0.0.1:7555',
     });
   });
+
+  it('accumulates repeated flags into an array', () => {
+    expect(
+      parseCliArgs([
+        '--htmlReport',
+        'a.html',
+        '--htmlReport',
+        'b.html',
+        '--htmlReport',
+        'c.html',
+      ]),
+    ).toEqual({ htmlReport: ['a.html', 'b.html', 'c.html'] });
+  });
+
+  it('accumulates repeated --key=value into an array', () => {
+    expect(parseCliArgs(['--report=a.html', '--report=b.html'])).toEqual({
+      report: ['a.html', 'b.html'],
+    });
+  });
 });
 
 describe('removePrefix', () => {


### PR DESCRIPTION
## Summary

- Add a `merge` action to the generic `report-tool` command so multiple HTML reports produced by separate CLI invocations can be combined into a single report without writing custom scripts.
- Expose `mergeReportFiles` from `@midscene/core` as the matching JS SDK so the same workflow is reachable in code.
- Extend `ReportMergingTool.mergeReports` with an optional `outputDir` override; default behavior is unchanged, so existing callers (Playwright reporter, etc.) are unaffected.
- The CLI auto-derives `testTitle` / `testDescription` from each source report's `groupName` / `groupDescription`, so users do not need to supply per-report metadata.
- Update EN/ZH `consume-report-file` docs with CLI and SDK examples.

## Motivation

CLI-based testing flows (e.g. `npx @midscene/android <action> ...`) generate one HTML report per invocation. There was no way to merge them other than manually editing HTML, even though the JS `new ReportMergingTool()` API has existed. This PR closes that gap so the CLI matches the JS SDK.

## CLI usage

```bash
npx @midscene/android report-tool --action merge \
  --htmlPaths '["./midscene_run/report/case-a/index.html","./midscene_run/report/case-b.html"]' \
  --outputDir ./merged \
  --outputName all-cases
```

`--htmlPaths` accepts a JSON array or a comma-separated list. Each path can be an HTML file or a directory containing `index.html`. `--outputDir`, `--outputName`, and `--overwrite` are optional; defaults match the existing `ReportMergingTool` behavior.

## JS SDK usage

```ts
import { mergeReportFiles } from '@midscene/core';

const result = mergeReportFiles({
  htmlPaths: [
    './midscene_run/report/case-a/index.html',
    './midscene_run/report/case-b.html',
  ],
  outputDir: './merged',
  outputName: 'all-cases',
});
console.log(result.mergedReportPath);
```

## Test plan

- [x] `pnpm --filter @midscene/core test -- tests/unit-test/report-cli.test.ts` (19 tests, 5 new: SDK merge, CLI merge, comma-separated paths, missing-arg error, overwrite semantics)
- [x] `pnpm --filter @midscene/core test -- tests/unit-test/report.test.ts` (existing `ReportMergingTool` suite still passes; 31 tests total across both files)
- [x] `npx nx build core` and `npx nx build android`
- [x] `node packages/android/dist/lib/cli.js report-tool --help` shows the new `merge` action and options
- [x] `pnpm run lint`