### PR TITLE
chore(test): click player setting icon with deepLocate

### DIFF
--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -18,6 +18,7 @@ tasks:
   - name: settings popup opens and shows options
     flow:
       - ai: Hover over the video player area to reveal the playback controls, then click the settings icon at the bottom right of the player controls. The icon looks like a hexagon with a small circle in the center.
+        deepLocate: true
       - sleep: 1000
       - aiAssert: A settings popup is visible showing playback speed options or toggle switches
 


### PR DESCRIPTION
Avoid occasional click shifts that cause case failed