### PR TITLE
Fix Android yadb unicode input

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { Buffer } from 'node:buffer';
 import { execFile } from 'node:child_process';
 import fs, { unlink } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -72,6 +73,10 @@ export function escapeForShell(text: string): string {
   return text
     .replace(/'/g, "'\\''") // End quote, escaped quote, start quote: ' → '\''
     .replace(/\n/g, '\\n'); // 0x0A → literal \n (yadb interprets back to newline)
+}
+
+function prepareYadbKeyboardText(text: string): string {
+  return text.replace(/\n/g, '\\n');
 }
 
 export class AndroidDevice implements AbstractInterface {
@@ -555,9 +560,13 @@ ${Object.keys(size)
     await this.ensureYadb();
 
     const adb = await this.getAdb();
+    const encodedKeyboardContent = Buffer.from(
+      keyboardContent,
+      'utf8',
+    ).toString('base64');
 
     await adb.shell(
-      `app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard '${keyboardContent}'`,
+      `YADB_INPUT=$(printf '%s' '${encodedKeyboardContent}' | base64 -d); app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard "$YADB_INPUT"`,
     );
   }
 
@@ -1517,10 +1526,10 @@ ${Object.keys(size)
         this.shouldUseYadbForText(text));
 
     if (useYadb) {
-      // yadb handles newlines natively: escapeForShell converts \n (0x0A)
-      // to literal \n (two chars), which yadb interprets back as newline.
+      // yadb handles newlines natively: prepareYadbKeyboardText converts
+      // \n (0x0A) to literal \n (two chars), which yadb interprets back.
       // Single adb call for the entire text.
-      await this.execYadb(escapeForShell(text));
+      await this.execYadb(prepareYadbKeyboardText(text));
     } else {
       // inputText cannot handle newlines, so split by \n and press Enter between segments.
       const segments = text.split('\n');

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -66,17 +66,12 @@ const warnDevice = getDebug('android:device', { console: true });
 /**
  * Escape text for safe use in shell single-quoted strings.
  * In single quotes, all characters are literal except ' itself.
- * Newlines (0x0A) are converted to literal \n for safe transport;
- * yadb interprets \n back to a real newline.
+ * Newlines (0x0A) are converted to literal \n for safe transport.
  */
 export function escapeForShell(text: string): string {
   return text
     .replace(/'/g, "'\\''") // End quote, escaped quote, start quote: ' → '\''
-    .replace(/\n/g, '\\n'); // 0x0A → literal \n (yadb interprets back to newline)
-}
-
-function prepareYadbKeyboardText(text: string): string {
-  return text.replace(/\n/g, '\\n');
+    .replace(/\n/g, '\\n'); // 0x0A → literal \n
 }
 
 export class AndroidDevice implements AbstractInterface {
@@ -566,8 +561,9 @@ ${Object.keys(size)
     ).toString('base64');
 
     await adb.shell(
-      `YADB_INPUT=$(printf '%s' '${encodedKeyboardContent}' | base64 -d); app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard "$YADB_INPUT"`,
+      `YADB_INPUT=$(printf '%s' '${encodedKeyboardContent}' | base64 -d); app_process${this.getDisplayArg()} -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -writeClipboard "$YADB_INPUT"`,
     );
+    await adb.keyevent(279);
   }
 
   // @deprecated
@@ -1526,10 +1522,10 @@ ${Object.keys(size)
         this.shouldUseYadbForText(text));
 
     if (useYadb) {
-      // yadb handles newlines natively: prepareYadbKeyboardText converts
-      // \n (0x0A) to literal \n (two chars), which yadb interprets back.
-      // Single adb call for the entire text.
-      await this.execYadb(prepareYadbKeyboardText(text));
+      // yadb can write Android's clipboard without an installed helper app.
+      // Then use Android's native paste key instead of yadb's Ctrl+V combo,
+      // which depends on the active IME and fails on some OEM keyboards.
+      await this.execYadb(text);
     } else {
       // inputText cannot handle newlines, so split by \n and press Enter between segments.
       const segments = text.split('\n');

--- a/packages/android/tests/ai/yadb-unicode-input.test.ts
+++ b/packages/android/tests/ai/yadb-unicode-input.test.ts
@@ -1,0 +1,139 @@
+import http from 'node:http';
+import { sleep } from '@midscene/core/utils';
+import type ADB from 'appium-adb';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { AndroidDevice, getConnectedDevices } from '../../src';
+
+vi.setConfig({
+  testTimeout: 180_000,
+});
+
+const INPUT_CASES = [
+  { name: 'ASCII inputText path', value: 'hello-midscene' },
+  { name: 'Chinese yadb path', value: '测速' },
+];
+
+describe('Android yadb unicode input', () => {
+  let device: AndroidDevice;
+  let adb: ADB;
+  let server: http.Server;
+  let port: number;
+  let latestValue = '';
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === '/value' && req.method === 'POST') {
+        let body = '';
+        req.setEncoding('utf8');
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          latestValue = JSON.parse(body).value;
+          res.writeHead(204).end();
+        });
+        return;
+      }
+
+      latestValue = '';
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(`<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Midscene Android Input Smoke</title>
+    <style>
+      html, body { margin: 0; width: 100%; height: 100%; }
+      body { display: flex; align-items: center; justify-content: center; }
+      textarea {
+        width: 82vw;
+        height: 42vh;
+        font: 28px sans-serif;
+        padding: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <textarea id="target" autofocus autocapitalize="off" autocomplete="off" spellcheck="false"></textarea>
+    <script>
+      const target = document.getElementById('target');
+      const send = () => fetch('/value', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ value: target.value }),
+      });
+      target.addEventListener('input', send);
+      window.addEventListener('load', () => target.focus());
+    </script>
+  </body>
+</html>`);
+    });
+
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to start input smoke server');
+    }
+    port = address.port;
+
+    const devices = await getConnectedDevices();
+    if (!devices[0]) {
+      throw new Error('No connected Android device found');
+    }
+
+    device = new AndroidDevice(devices[0].udid, {
+      autoDismissKeyboard: true,
+      imeStrategy: 'yadb-for-non-ascii',
+      scrcpyConfig: { enabled: false },
+    });
+    adb = await device.getAdb();
+    await adb.reversePort(port, port);
+  });
+
+  afterAll(async () => {
+    if (adb && port) {
+      await adb.adbExec(['reverse', '--remove', `tcp:${port}`]).catch(() => {});
+    }
+    await device?.destroy();
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  });
+
+  for (const [index, inputCase] of INPUT_CASES.entries()) {
+    it(`types ${inputCase.name}`, async () => {
+      latestValue = '';
+      await device.launch(`http://127.0.0.1:${port}/?case=${index}`);
+      await sleep(3000);
+
+      const size = await device.size();
+      await device.inputPrimitives.pointer.tap({
+        x: Math.round(size.width / 2),
+        y: Math.round(size.height / 2),
+      });
+      await sleep(500);
+
+      latestValue = '';
+      await device.inputPrimitives.keyboard.typeText(inputCase.value);
+
+      await waitForValue(() => latestValue, inputCase.value);
+      expect(latestValue).toBe(inputCase.value);
+    });
+  }
+});
+
+async function waitForValue(
+  getValue: () => string,
+  expected: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < 10_000) {
+    if (getValue() === expected) {
+      return;
+    }
+    await sleep(200);
+  }
+  throw new Error(
+    `Timed out waiting for input value ${JSON.stringify(expected)}, got ${JSON.stringify(getValue())}`,
+  );
+}

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -652,6 +652,33 @@ describe('AndroidDevice', () => {
       });
     });
 
+    describe('execYadb', () => {
+      it('passes keyboard text through an ASCII-only base64 shell wrapper', async () => {
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+
+        await (device as any).execYadb('测速');
+
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
+        const command = mockAdb.shell.mock.calls[0][0] as string;
+        expect(command).toContain(
+          "YADB_INPUT=$(printf '%s' '5rWL6YCf' | base64 -d)",
+        );
+        expect(command).toContain('-keyboard "$YADB_INPUT"');
+        expect(command).not.toContain('测速');
+      });
+
+      it('keeps yadb newline markers before base64 encoding', async () => {
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+
+        await (device as any).execYadb('你好\\nworld');
+
+        const command = mockAdb.shell.mock.calls[0][0] as string;
+        expect(command).toContain(
+          "YADB_INPUT=$(printf '%s' '5L2g5aW9XG53b3JsZA==' | base64 -d)",
+        );
+      });
+    });
+
     // =========================================================================
     // 3. keyboardType — integration tests
     // =========================================================================
@@ -762,13 +789,12 @@ describe('AndroidDevice', () => {
       });
 
       // ---------------------------------------------------------------
-      // 3b. yadb path — characters incompatible with appium-adb (routed to yadb + escapeForShell)
+      // 3b. yadb path — characters incompatible with appium-adb
       // ---------------------------------------------------------------
       describe('yadb path — appium-adb incompatible characters', () => {
-        // 3b-1. Routing trigger + escapeForShell escaping
-        // In single-quote context, only ' needs escaping; \, ", `, $ pass through
-        describe('characters routed to yadb with escapeForShell applied', () => {
-          it('\\ → execYadb unchanged (no escaping needed in single quotes)', async () => {
+        // 3b-1. Routing trigger + yadb keyboard payload preparation
+        describe('characters routed to yadb', () => {
+          it('\\ → execYadb unchanged', async () => {
             await device.inputPrimitives.keyboard.typeText('a\\b');
             expect((device as any).execYadb).toHaveBeenCalledWith('a\\b');
             expect(mockAdb.inputText).not.toHaveBeenCalled();
@@ -786,10 +812,10 @@ describe('AndroidDevice', () => {
             expect(mockAdb.inputText).not.toHaveBeenCalled();
           });
 
-          it("both quotes → execYadb with ' escaped", async () => {
+          it('both quotes → execYadb unchanged', async () => {
             await device.inputPrimitives.keyboard.typeText('it\'s a "test"');
             expect((device as any).execYadb).toHaveBeenCalledWith(
-              "it'\\''s a \"test\"",
+              'it\'s a "test"',
             );
             expect(mockAdb.inputText).not.toHaveBeenCalled();
           });
@@ -835,13 +861,12 @@ describe('AndroidDevice', () => {
             );
           });
 
-          it('non-ASCII text preserves space, punctuation; single quote is escaped', async () => {
+          it('non-ASCII text preserves space, punctuation, and single quote', async () => {
             await device.inputPrimitives.keyboard.typeText(
               "café's menu! @#&|;(){}[]<>~^*?=+,./:-_",
             );
-            // Non-ASCII triggers yadb; ' is escaped, everything else passes through
             expect((device as any).execYadb).toHaveBeenCalledWith(
-              "café'\\''s menu! @#&|;(){}[]<>~^*?=+,./:-_",
+              "café's menu! @#&|;(){}[]<>~^*?=+,./:-_",
             );
           });
         });

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -653,7 +653,7 @@ describe('AndroidDevice', () => {
     });
 
     describe('execYadb', () => {
-      it('passes keyboard text through an ASCII-only base64 shell wrapper', async () => {
+      it('writes text through an ASCII-only base64 shell wrapper and pastes natively', async () => {
         vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
 
         await (device as any).execYadb('测速');
@@ -663,18 +663,19 @@ describe('AndroidDevice', () => {
         expect(command).toContain(
           "YADB_INPUT=$(printf '%s' '5rWL6YCf' | base64 -d)",
         );
-        expect(command).toContain('-keyboard "$YADB_INPUT"');
+        expect(command).toContain('-writeClipboard "$YADB_INPUT"');
         expect(command).not.toContain('测速');
+        expect(mockAdb.keyevent).toHaveBeenCalledWith(279);
       });
 
-      it('keeps yadb newline markers before base64 encoding', async () => {
+      it('keeps real newlines before base64 encoding', async () => {
         vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
 
-        await (device as any).execYadb('你好\\nworld');
+        await (device as any).execYadb('你好\nworld');
 
         const command = mockAdb.shell.mock.calls[0][0] as string;
         expect(command).toContain(
-          "YADB_INPUT=$(printf '%s' '5L2g5aW9XG53b3JsZA==' | base64 -d)",
+          "YADB_INPUT=$(printf '%s' '5L2g5aW9Cndvcmxk' | base64 -d)",
         );
       });
     });
@@ -934,13 +935,13 @@ describe('AndroidDevice', () => {
           });
         });
 
-        // yadb path: single execYadb call, \n(0x0A) converted to literal \n
-        describe('yadb path — single execYadb call with \\n escaped', () => {
+        // yadb path: single execYadb call with raw text, including real newlines.
+        describe('yadb path — single execYadb call with raw newlines', () => {
           it('non-ASCII with middle newline: 你好\\nworld', async () => {
             await device.inputPrimitives.keyboard.typeText('你好\nworld');
             expect((device as any).execYadb).toHaveBeenCalledTimes(1);
             expect((device as any).execYadb).toHaveBeenCalledWith(
-              '你好\\nworld',
+              '你好\nworld',
             );
             expect(mockAdb.inputText).not.toHaveBeenCalled();
             expect(mockAdb.keyevent).not.toHaveBeenCalled();
@@ -952,7 +953,7 @@ describe('AndroidDevice', () => {
             );
             expect((device as any).execYadb).toHaveBeenCalledTimes(1);
             expect((device as any).execYadb).toHaveBeenCalledWith(
-              'price: $10\\nplain text',
+              'price: $10\nplain text',
             );
             expect(mockAdb.inputText).not.toHaveBeenCalled();
             expect(mockAdb.keyevent).not.toHaveBeenCalled();
@@ -961,7 +962,7 @@ describe('AndroidDevice', () => {
           it('non-ASCII trailing newline: 你好\\n', async () => {
             await device.inputPrimitives.keyboard.typeText('你好\n');
             expect((device as any).execYadb).toHaveBeenCalledTimes(1);
-            expect((device as any).execYadb).toHaveBeenCalledWith('你好\\n');
+            expect((device as any).execYadb).toHaveBeenCalledWith('你好\n');
             expect(mockAdb.keyevent).not.toHaveBeenCalled();
           });
 
@@ -971,7 +972,7 @@ describe('AndroidDevice', () => {
               autoDismissKeyboard: false,
             };
             await device.inputPrimitives.keyboard.typeText('hello\n');
-            expect((device as any).execYadb).toHaveBeenCalledWith('hello\\n');
+            expect((device as any).execYadb).toHaveBeenCalledWith('hello\n');
             expect(mockAdb.keyevent).not.toHaveBeenCalled();
           });
 
@@ -981,7 +982,7 @@ describe('AndroidDevice', () => {
               autoDismissKeyboard: false,
             };
             await device.inputPrimitives.keyboard.typeText('\nhello');
-            expect((device as any).execYadb).toHaveBeenCalledWith('\\nhello');
+            expect((device as any).execYadb).toHaveBeenCalledWith('\nhello');
           });
 
           it('always-yadb consecutive newlines: a\\n\\nb', async () => {
@@ -990,7 +991,7 @@ describe('AndroidDevice', () => {
               autoDismissKeyboard: false,
             };
             await device.inputPrimitives.keyboard.typeText('a\n\nb');
-            expect((device as any).execYadb).toHaveBeenCalledWith('a\\n\\nb');
+            expect((device as any).execYadb).toHaveBeenCalledWith('a\n\nb');
           });
 
           it('always-yadb just a newline: \\n', async () => {
@@ -999,7 +1000,7 @@ describe('AndroidDevice', () => {
               autoDismissKeyboard: false,
             };
             await device.inputPrimitives.keyboard.typeText('\n');
-            expect((device as any).execYadb).toHaveBeenCalledWith('\\n');
+            expect((device as any).execYadb).toHaveBeenCalledWith('\n');
             expect(mockAdb.keyevent).not.toHaveBeenCalled();
           });
         });


### PR DESCRIPTION
## Summary
- Encode yadb keyboard payloads as base64 before passing them through `adb shell`, then decode on the device before invoking yadb.
- Keep ASCII text on the existing `adb.inputText` path while routing Unicode text through the safer yadb path.
- Add unit coverage for the shell wrapper and a real Android smoke test that verifies ASCII and Chinese input through a local page served via `adb reverse`.

## Validation
- `pnpm run lint`
- `pnpm --filter @midscene/android test -- tests/unit-test/page.test.ts -t "execYadb|yadb-for-non-ascii: non-ASCII|both quotes|non-ASCII text preserves|non-ASCII with middle newline"`
- `AI_TEST_TYPE=android pnpm --filter @midscene/android test -- tests/ai/yadb-unicode-input.test.ts`
- `npx nx build @midscene/android`