### PR TITLE
feat(ios): support external WDA sessions

### DIFF
--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -131,6 +131,12 @@ export type IOSDeviceOpt = {
   wdaPort?: number;
   /** WebDriverAgent host (default: 'localhost') */
   wdaHost?: string;
+  /**
+   * Existing WebDriverAgent session ID to reuse.
+   * When provided, Midscene skips creating a new WDA session and does not delete
+   * the external session during cleanup.
+   */
+  sessionId?: string;
   /** Whether to use WebDriverAgent */
   useWDA?: boolean;
   /** WDA MJPEG server port for real-time screen streaming (default: 9100) */

--- a/packages/core/tests/unit-test/device-options.test.ts
+++ b/packages/core/tests/unit-test/device-options.test.ts
@@ -57,6 +57,7 @@ describe('Device Options Type Definitions', () => {
         iOSDeviceClassOverride: '@private-package/ios',
         wdaPort: 8100,
         wdaHost: 'localhost',
+        sessionId: 'external-session-id',
         useWDA: true,
         autoDismissKeyboard: true,
       };
@@ -132,6 +133,7 @@ describe('Device Options Type Definitions', () => {
         iOSDeviceClassOverride: '@private-package/ios',
         wdaPort: 8100,
         wdaHost: 'localhost',
+        sessionId: 'external-session-id',
         useWDA: true,
         autoDismissKeyboard: true,
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -42,7 +42,6 @@ export class IOSDevice implements AbstractInterface {
   private deviceId: string;
   private devicePixelRatio = 1;
   private devicePixelRatioInitialized = false;
-  private cachedScreenSize: Size | null = null;
   private destroyed = false;
   private description: string | undefined;
   private customActions?: DeviceAction<any>[];
@@ -395,19 +394,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     // Ensure device pixel ratio is initialized
     await this.initializeDevicePixelRatio();
 
-    let windowSize: Size;
-    try {
-      windowSize = await this.wdaBackend.getWindowSize();
-      this.cachedScreenSize = windowSize;
-    } catch (error) {
-      if (!this.cachedScreenSize) {
-        throw error;
-      }
-      debugDevice(
-        `Failed to get iOS window size from WDA, using cached size: ${error}`,
-      );
-      windowSize = this.cachedScreenSize;
-    }
+    const windowSize = await this.wdaBackend.getWindowSize();
 
     return {
       width: windowSize.width,

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -42,6 +42,7 @@ export class IOSDevice implements AbstractInterface {
   private deviceId: string;
   private devicePixelRatio = 1;
   private devicePixelRatioInitialized = false;
+  private cachedScreenSize: Size | null = null;
   private destroyed = false;
   private description: string | undefined;
   private customActions?: DeviceAction<any>[];
@@ -394,7 +395,19 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     // Ensure device pixel ratio is initialized
     await this.initializeDevicePixelRatio();
 
-    const windowSize = await this.wdaBackend.getWindowSize();
+    let windowSize: Size;
+    try {
+      windowSize = await this.wdaBackend.getWindowSize();
+      this.cachedScreenSize = windowSize;
+    } catch (error) {
+      if (!this.cachedScreenSize) {
+        throw error;
+      }
+      debugDevice(
+        `Failed to get iOS window size from WDA, using cached size: ${error}`,
+      );
+      windowSize = this.cachedScreenSize;
+    }
 
     return {
       width: windowSize.width,

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -228,6 +228,7 @@ export class IOSDevice implements AbstractInterface {
     this.wdaBackend = new WebDriverAgentBackend({
       port: wdaPort,
       host: wdaHost,
+      ...(options?.sessionId ? { sessionId: options.sessionId } : {}),
     });
     this.wdaManager = WDAManager.getInstance(wdaPort, wdaHost);
     this.mjpegStreamUrl = `http://${wdaHost}:${mjpegPort}`;
@@ -257,8 +258,13 @@ export class IOSDevice implements AbstractInterface {
       // Start WebDriverAgent
       await this.wdaManager.start();
 
-      // Create WDA session
-      await this.wdaBackend.createSession();
+      if (this.options?.sessionId) {
+        debugDevice(`Using existing WDA session: ${this.options.sessionId}`);
+        await this.wdaBackend.setupExistingSession();
+      } else {
+        // Create WDA session
+        await this.wdaBackend.createSession();
+      }
 
       // Try to get real device info from WebDriverAgent
       const deviceInfo = await this.wdaBackend.getDeviceInfo();

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -593,6 +593,11 @@ export class IOSWebDriverClient extends WebDriverClient {
     }
   }
 
+  async setupExistingSession(): Promise<void> {
+    this.ensureSession();
+    await this.setupIOSSession();
+  }
+
   /**
    * Execute a WebDriverAgent API request directly
    * This is the iOS equivalent of Android's runAdbShell

--- a/packages/ios/src/mcp-tools.ts
+++ b/packages/ios/src/mcp-tools.ts
@@ -20,6 +20,10 @@ const iosInitArgShape = {
     .optional()
     .describe('WebDriverAgent host, defaults to localhost'),
   wdaPort: z.number().optional().describe('WebDriverAgent port'),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Existing WebDriverAgent session ID to reuse'),
   useWDA: z
     .boolean()
     .optional()
@@ -32,7 +36,7 @@ const iosInitArgShape = {
 
 type IOSInitArgs = Pick<
   IOSDeviceOpt,
-  'deviceId' | 'wdaHost' | 'wdaPort' | 'useWDA' | 'wdaMjpegPort'
+  'deviceId' | 'wdaHost' | 'wdaPort' | 'sessionId' | 'useWDA' | 'wdaMjpegPort'
 >;
 
 /**

--- a/packages/ios/src/mcp-tools.ts
+++ b/packages/ios/src/mcp-tools.ts
@@ -39,6 +39,25 @@ type IOSInitArgs = Pick<
   'deviceId' | 'wdaHost' | 'wdaPort' | 'sessionId' | 'useWDA' | 'wdaMjpegPort'
 >;
 
+function getTargetIdentity(initArgs?: IOSInitArgs): string {
+  if (initArgs?.deviceId) {
+    return initArgs.sessionId
+      ? `${initArgs.deviceId}-session-${initArgs.sessionId}`
+      : initArgs.deviceId;
+  }
+
+  if (initArgs?.wdaHost || initArgs?.wdaPort || initArgs?.sessionId) {
+    const wdaHost = initArgs.wdaHost ?? 'localhost';
+    const wdaPort = initArgs.wdaPort ?? 'default';
+    const sessionSegment = initArgs.sessionId
+      ? `-session-${initArgs.sessionId}`
+      : '';
+    return `wda-${wdaHost}-${wdaPort}${sessionSegment}`;
+  }
+
+  return 'auto';
+}
+
 /**
  * iOS-specific tools manager
  * Extends BaseMidsceneTools to provide iOS WebDriverAgent connection tools
@@ -105,11 +124,7 @@ export class IOSMidsceneTools extends BaseMidsceneTools<IOSAgent, IOSInitArgs> {
         cli: this.getAgentInitArgCliMetadata(),
         handler: async (args: Record<string, unknown>) => {
           const initArgs = this.extractAgentInitParam(args);
-          const identity =
-            initArgs?.deviceId ??
-            (initArgs?.wdaHost || initArgs?.wdaPort
-              ? `wda-${initArgs.wdaHost ?? 'localhost'}-${initArgs.wdaPort ?? 'default'}`
-              : 'auto');
+          const identity = getTargetIdentity(initArgs);
           const reportSession = this.createNewCliReportSession(identity);
           this.commitCliReportSession(reportSession);
           if (this.agent) {

--- a/packages/ios/src/platform.ts
+++ b/packages/ios/src/platform.ts
@@ -58,6 +58,13 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
               defaultValue: DEFAULT_WDA_PORT,
               placeholder: DEFAULT_WDA_PORT.toString(),
             },
+            {
+              key: 'sessionId',
+              label: 'WebDriverAgent session ID',
+              type: 'text',
+              required: false,
+              placeholder: 'Existing session ID',
+            },
           ],
         };
       },
@@ -76,11 +83,16 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
             `Invalid WebDriverAgent port: ${String(input?.port)}`,
           );
         }
+        const sessionId =
+          typeof input?.sessionId === 'string' && input.sessionId.trim()
+            ? input.sessionId.trim()
+            : undefined;
 
         const connectAgent = async (): Promise<IOSAgent> => {
           return agentFromWebDriverAgent({
             wdaHost: host,
             wdaPort: port,
+            ...(sessionId ? { sessionId } : {}),
           });
         };
 
@@ -100,6 +112,7 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
           metadata: {
             wdaHost: host,
             wdaPort: port,
+            ...(sessionId ? { sessionId } : {}),
             ...(deviceInfo ? { deviceInfo } : {}),
           },
         };

--- a/packages/ios/tests/unit-test/cli-launch.test.ts
+++ b/packages/ios/tests/unit-test/cli-launch.test.ts
@@ -67,6 +67,35 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
     );
   });
 
+  it('passes external WDA session args through `connect`', async () => {
+    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+      createMockAgent() as any,
+    );
+
+    await runToolsCLI(new IOSMidsceneTools(), 'midscene-ios', {
+      stripPrefix: 'ios_',
+      version: '0.0.0-test',
+      argv: [
+        'connect',
+        '--wda-host',
+        '127.0.0.1',
+        '--wda-port',
+        '8100',
+        '--session-id',
+        'external-session-id',
+      ],
+    });
+
+    expect(agentFromWebDriverAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoDismissKeyboard: false,
+        wdaHost: '127.0.0.1',
+        wdaPort: 8100,
+        sessionId: 'external-session-id',
+      }),
+    );
+  });
+
   it('routes `terminate --uri <bundle>` through to callActionInActionSpace with { uri }', async () => {
     const mockAgent = createMockAgent();
     vi.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -22,6 +22,7 @@ describe('IOSDevice', () => {
       createSession: vi
         .fn()
         .mockResolvedValue({ sessionId: 'test-session-id' }),
+      setupExistingSession: vi.fn().mockResolvedValue(undefined),
       deleteSession: vi.fn().mockResolvedValue(undefined),
       getWindowSize: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
       takeScreenshot: vi.fn().mockResolvedValue('base64-screenshot'),
@@ -120,6 +121,20 @@ describe('IOSDevice', () => {
       expect(MockedWdaClient).toHaveBeenCalledWith({
         port: 9100,
         host: 'custom-host',
+      });
+    });
+
+    it('should pass existing WDA session ID when specified', () => {
+      const device = new IOSDevice({
+        wdaPort: 9100,
+        wdaHost: 'custom-host',
+        sessionId: 'external-session-id',
+      });
+      expect(device).toBeDefined();
+      expect(MockedWdaClient).toHaveBeenCalledWith({
+        port: 9100,
+        host: 'custom-host',
+        sessionId: 'external-session-id',
       });
     });
   });
@@ -230,6 +245,21 @@ describe('IOSDevice', () => {
     it('should connect to device successfully', async () => {
       await expect(device.connect()).resolves.not.toThrow();
       expect(mockWdaClient.createSession).toHaveBeenCalled();
+    });
+
+    it('should reuse an existing WDA session without creating a new one', async () => {
+      const externalSessionDevice = new IOSDevice({
+        wdaPort: DEFAULT_WDA_PORT,
+        wdaHost: 'localhost',
+        sessionId: 'external-session-id',
+      });
+
+      await expect(externalSessionDevice.connect()).resolves.not.toThrow();
+
+      expect(mockWdaClient.createSession).not.toHaveBeenCalled();
+      expect(mockWdaClient.setupExistingSession).toHaveBeenCalled();
+
+      await externalSessionDevice.destroy();
     });
 
     it('should handle connection failure', async () => {

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -281,21 +281,6 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.getWindowSize).toHaveBeenCalled();
     });
 
-    it('should reuse cached screen size when WDA size request times out after connection', async () => {
-      await device.connect();
-
-      mockWdaClient.getWindowSize.mockRejectedValue(
-        new Error('Request timeout after 30000ms'),
-      );
-
-      const size = await device.size();
-
-      expect(size).toEqual({
-        width: 375,
-        height: 812,
-      });
-    });
-
     it('should take screenshot after connection', async () => {
       await device.connect();
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -281,6 +281,21 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.getWindowSize).toHaveBeenCalled();
     });
 
+    it('should reuse cached screen size when WDA size request times out after connection', async () => {
+      await device.connect();
+
+      mockWdaClient.getWindowSize.mockRejectedValue(
+        new Error('Request timeout after 30000ms'),
+      );
+
+      const size = await device.size();
+
+      expect(size).toEqual({
+        width: 375,
+        height: 812,
+      });
+    });
+
     it('should take screenshot after connection', async () => {
       await device.connect();
 

--- a/packages/ios/tests/unit-test/mcp-tools.test.ts
+++ b/packages/ios/tests/unit-test/mcp-tools.test.ts
@@ -48,13 +48,18 @@ describe('IOSMidsceneTools', () => {
     expect(takeScreenshotTool).toBeDefined();
 
     await takeScreenshotTool?.handler({
-      ios: { deviceId: 'ios-target', 'wda-port': 8100 },
+      ios: {
+        deviceId: 'ios-target',
+        'wda-port': 8100,
+        sessionId: 'external-session-id',
+      },
     });
 
     expect(agentFromWebDriverAgent).toHaveBeenCalledWith({
       autoDismissKeyboard: false,
       deviceId: 'ios-target',
       wdaPort: 8100,
+      sessionId: 'external-session-id',
     });
   });
 
@@ -102,12 +107,14 @@ describe('IOSMidsceneTools', () => {
       expect.objectContaining({
         'ios.deviceId': expect.anything(),
         'ios.wdaPort': expect.anything(),
+        'ios.sessionId': expect.anything(),
       }),
     );
     expect(actTool?.schema).toEqual(
       expect.objectContaining({
         'ios.deviceId': expect.anything(),
         'ios.wdaPort': expect.anything(),
+        'ios.sessionId': expect.anything(),
       }),
     );
   });

--- a/packages/ios/tests/unit-test/mcp-tools.test.ts
+++ b/packages/ios/tests/unit-test/mcp-tools.test.ts
@@ -55,12 +55,14 @@ describe('IOSMidsceneTools', () => {
       },
     });
 
-    expect(agentFromWebDriverAgent).toHaveBeenCalledWith({
-      autoDismissKeyboard: false,
-      deviceId: 'ios-target',
-      wdaPort: 8100,
-      sessionId: 'external-session-id',
-    });
+    expect(agentFromWebDriverAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoDismissKeyboard: false,
+        deviceId: 'ios-target',
+        wdaPort: 8100,
+        sessionId: 'external-session-id',
+      }),
+    );
   });
 
   it('passes top-level ios aliases to act', async () => {
@@ -82,11 +84,13 @@ describe('IOSMidsceneTools', () => {
       'wda-port': 8101,
     });
 
-    expect(agentFromWebDriverAgent).toHaveBeenCalledWith({
-      autoDismissKeyboard: false,
-      wdaHost: '127.0.0.1',
-      wdaPort: 8101,
-    });
+    expect(agentFromWebDriverAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoDismissKeyboard: false,
+        wdaHost: '127.0.0.1',
+        wdaPort: 8101,
+      }),
+    );
     expect(mockAgent.aiAction).toHaveBeenCalledWith('open settings', {
       deepThink: false,
     });
@@ -156,5 +160,46 @@ describe('IOSMidsceneTools', () => {
 
     expect(agentFromWebDriverAgent).toHaveBeenCalledTimes(2);
     expect(firstAgent.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the iOS agent when only the external WDA session changes', async () => {
+    const firstAgent = createMockAgent();
+    const secondAgent = createMockAgent();
+    vi.mocked(agentFromWebDriverAgent)
+      .mockResolvedValueOnce(firstAgent as any)
+      .mockResolvedValueOnce(secondAgent as any);
+
+    const tools = new IOSMidsceneTools();
+    await tools.initTools();
+
+    const takeScreenshotTool = tools
+      .getToolDefinitions()
+      .find((tool) => tool.name === 'take_screenshot');
+
+    await takeScreenshotTool?.handler({
+      ios: {
+        wdaHost: '127.0.0.1',
+        wdaPort: 8100,
+        sessionId: 'session-A',
+      },
+    });
+    await takeScreenshotTool?.handler({
+      ios: {
+        wdaHost: '127.0.0.1',
+        wdaPort: 8100,
+        sessionId: 'session-B',
+      },
+    });
+
+    expect(agentFromWebDriverAgent).toHaveBeenCalledTimes(2);
+    expect(firstAgent.destroy).toHaveBeenCalledTimes(1);
+    expect(agentFromWebDriverAgent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        autoDismissKeyboard: false,
+        wdaHost: '127.0.0.1',
+        wdaPort: 8100,
+        sessionId: 'session-B',
+      }),
+    );
   });
 });

--- a/packages/ios/tests/unit-test/platform-session-manager.test.ts
+++ b/packages/ios/tests/unit-test/platform-session-manager.test.ts
@@ -43,21 +43,25 @@ describe('iosPlaygroundPlatform session manager', () => {
     expect(setup?.fields).toMatchObject([
       { key: 'host', defaultValue: 'localhost' },
       { key: 'port', defaultValue: 8100 },
+      { key: 'sessionId', required: false },
     ]);
 
     const created = await prepared.sessionManager?.createSession({
       host: 'localhost',
       port: 8100,
+      sessionId: 'external-session-id',
     });
 
     expect(created?.displayName).toBe('iPhone 16 (Simulator)');
     expect(created?.metadata).toMatchObject({
       wdaHost: 'localhost',
       wdaPort: 8100,
+      sessionId: 'external-session-id',
     });
     expect(agentFromWebDriverAgentMock).toHaveBeenCalledWith({
       wdaHost: 'localhost',
       wdaPort: 8100,
+      sessionId: 'external-session-id',
     });
   });
 

--- a/packages/shared/src/img/info.ts
+++ b/packages/shared/src/img/info.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { Buffer } from 'node:buffer';
 import type { Size } from '../types';
 import getPhoton from './get-photon';
 
@@ -15,9 +16,26 @@ export async function imageInfoOfBase64(
   imageBase64: string,
 ): Promise<ImageInfo> {
   const { PhotonImage } = await getPhoton();
-  const base64Data = imageBase64.replace(/^data:image\/\w+;base64,/, '');
+  const base64Data = imageBase64
+    .replace(/^data:image\/\w+;base64,/, '')
+    .replace(/\s/g, '');
+  assert(base64Data, 'Invalid image: empty base64 data');
+  assert(
+    /^[A-Za-z0-9+/]+={0,2}$/.test(base64Data) && base64Data.length % 4 !== 1,
+    'Invalid image: malformed base64 data',
+  );
+  const imageBuffer = Buffer.from(base64Data, 'base64');
+  assert(isValidImageBuffer(imageBuffer), 'Invalid image: unsupported format');
   // Support both sync (Photon) and async (Canvas fallback) versions
-  const result = PhotonImage.new_from_base64(base64Data);
+  let result: ReturnType<typeof PhotonImage.new_from_base64>;
+  try {
+    result = PhotonImage.new_from_base64(base64Data);
+  } catch (error) {
+    throw new Error(
+      `Invalid image: failed to decode base64 data (${error instanceof Error ? error.message : String(error)})`,
+      { cause: error },
+    );
+  }
   const image = result instanceof Promise ? await result : result;
   const width = image.get_width();
   const height = image.get_height();

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -154,8 +154,10 @@ export async function resizeAndConvertImgBuffer(
   };
 }
 
+export const normalizeBase64Body = (body: string) => body.replace(/\s/g, '');
+
 export const createImgBase64ByFormat = (format: string, body: string) => {
-  return `data:image/${format};base64,${body}`;
+  return `data:image/${format};base64,${normalizeBase64Body(body)}`;
 };
 
 export async function resizeImgBase64(
@@ -397,7 +399,8 @@ export const preProcessImageUrl = async (
     );
   }
   if (url.startsWith('data:')) {
-    return url;
+    const { mimeType, body } = parseBase64(url);
+    return `data:${mimeType};base64,${body}`;
   } else if (url.startsWith('http://') || url.startsWith('https://')) {
     if (!convertHttpImage2Base64) {
       return url;
@@ -426,7 +429,9 @@ export const parseBase64 = (
     return {
       // 5 means 'data:'
       mimeType: fullBase64String.slice(5, index),
-      body: fullBase64String.slice(index + separator.length),
+      body: normalizeBase64Body(
+        fullBase64String.slice(index + separator.length),
+      ),
     };
   } catch (e) {
     throw new Error(

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -53,11 +53,23 @@ describe('imageInfoOfBase64', () => {
   it('throws error for invalid base64 data', async () => {
     const invalidBase64 = 'data:image/png;base64,notvalidbase64data';
 
-    await expect(imageInfoOfBase64(invalidBase64)).rejects.toThrow();
+    await expect(imageInfoOfBase64(invalidBase64)).rejects.toThrow(
+      'Invalid image',
+    );
+  });
+
+  it('throws clear error for valid base64 that is not an image', async () => {
+    const nonImageBase64 = 'data:image/png;base64,Zm9v';
+
+    await expect(imageInfoOfBase64(nonImageBase64)).rejects.toThrow(
+      'Invalid image: unsupported format',
+    );
   });
 
   it('throws error for empty string', async () => {
-    await expect(imageInfoOfBase64('')).rejects.toThrow();
+    await expect(imageInfoOfBase64('')).rejects.toThrow(
+      'Invalid image: empty base64 data',
+    );
   });
 });
 

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -279,6 +279,14 @@ describe('image utils', () => {
     );
   });
 
+  it('parseBase64 normalizes wrapped base64 bodies', () => {
+    const base64 =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA\r\nAu4AAAU2CAYAAADK1zMG';
+    const { mimeType, body } = parseBase64(base64);
+    expect(mimeType).toBe('image/png');
+    expect(body).toBe('iVBORw0KGgoAAAANSUhEUgAAAu4AAAU2CAYAAADK1zMG');
+  });
+
   it('parseBase64, invalid', () => {
     const base64 = 'IamNotBase64';
     expect(() => parseBase64(base64)).toThrowError(
@@ -289,6 +297,11 @@ describe('image utils', () => {
   it('createImgBase64ByFormat', () => {
     const base64 = createImgBase64ByFormat('png', 'foo');
     expect(base64).toBe('data:image/png;base64,foo');
+  });
+
+  it('createImgBase64ByFormat strips WDA-style line wrapping', () => {
+    const base64 = createImgBase64ByFormat('png', 'abc\r\ndef ghi');
+    expect(base64).toBe('data:image/png;base64,abcdefghi');
   });
 
   // it(

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -24,6 +24,12 @@ describe('preapareImageUrl', () => {
     );
   });
 
+  it('base64 string will be normalized for url-safe model payloads', async () => {
+    expect(
+      await preProcessImageUrl('data:image/png;base64,aaa\r\nbbb ccc', false),
+    ).toBe('data:image/png;base64,aaabbbccc');
+  });
+
   it('local file path will be converted to base64', async () => {
     expect(
       await preProcessImageUrl(

--- a/packages/webdriver/src/clients/WebDriverClient.ts
+++ b/packages/webdriver/src/clients/WebDriverClient.ts
@@ -8,6 +8,7 @@ const debugClient = getDebug('webdriver:client');
 export class WebDriverClient {
   protected baseUrl: string;
   protected sessionId: string | null = null;
+  protected ownsSession = false;
   protected port: number;
   protected host: string;
   protected timeout: number;
@@ -17,6 +18,8 @@ export class WebDriverClient {
     this.host = options.host || 'localhost';
     this.timeout = options.timeout || 30000;
     this.baseUrl = `http://${this.host}:${this.port}`;
+    this.sessionId = options.sessionId || null;
+    this.ownsSession = !options.sessionId;
 
     debugClient(`Initialized WebDriver client on ${this.host}:${this.port}`);
   }
@@ -44,6 +47,7 @@ export class WebDriverClient {
       });
 
       this.sessionId = response.sessionId || response.value?.sessionId;
+      this.ownsSession = true;
 
       if (!this.sessionId) {
         throw new Error('Failed to get session ID from response');
@@ -65,6 +69,12 @@ export class WebDriverClient {
   async deleteSession(): Promise<void> {
     if (!this.sessionId) {
       debugClient('No active session to delete');
+      return;
+    }
+
+    if (!this.ownsSession) {
+      debugClient(`Detached external session: ${this.sessionId}`);
+      this.sessionId = null;
       return;
     }
 

--- a/packages/webdriver/src/clients/types.ts
+++ b/packages/webdriver/src/clients/types.ts
@@ -29,6 +29,12 @@ export interface WebDriverOptions {
   port?: number;
   host?: string;
   timeout?: number;
+  /**
+   * Existing WebDriver session ID to attach to instead of creating a new one.
+   * Sessions provided by the caller are detached locally on cleanup and are not
+   * deleted from the remote WebDriver server.
+   */
+  sessionId?: string;
 }
 
 export interface Point {

--- a/packages/webdriver/tests/unit-test/buildSessionEndpoint.test.ts
+++ b/packages/webdriver/tests/unit-test/buildSessionEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { WebDriverClient } from '../../src/clients/WebDriverClient';
 
 // Expose protected method for testing
@@ -44,5 +44,23 @@ describe('WebDriverClient.buildSessionEndpoint', () => {
     expect(() =>
       noSessionClient.testBuildSessionEndpoint('/wda/screen'),
     ).toThrow('No active WebDriver session');
+  });
+});
+
+describe('WebDriverClient external session cleanup', () => {
+  it('should detach external sessions without deleting them from the server', async () => {
+    const client = new WebDriverClient({
+      port: 8100,
+      host: 'localhost',
+      sessionId: 'external-session',
+    });
+    const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+
+    expect(client.sessionInfo?.sessionId).toBe('external-session');
+
+    await client.deleteSession();
+
+    expect(makeRequestSpy).not.toHaveBeenCalled();
+    expect(client.sessionInfo).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `sessionId` support to iOS WebDriverAgent options so callers can reuse an existing WDA session.
- Keep the existing default behavior unchanged: when `sessionId` is omitted, Midscene still creates and owns the WDA session.
- Detach external sessions locally during cleanup instead of sending DELETE to the remote WDA session.
- Expose the optional session ID through iOS MCP init args and the iOS playground setup form.

## Validation
- `pnpm --dir packages/webdriver test -- --run tests/unit-test/buildSessionEndpoint.test.ts`
- `pnpm --dir packages/ios test -- tests/unit-test/device.test.ts tests/unit-test/mcp-tools.test.ts tests/unit-test/platform-session-manager.test.ts tests/unit-test/executeRequest-session-prefix.test.ts`
- `pnpm --dir packages/core test -- tests/unit-test/device-options.test.ts`
- `npx nx test @midscene/webdriver -- --run`
- `npx nx test @midscene/core -- tests/unit-test/device-options.test.ts`
- `npx nx test @midscene/ios -- tests/unit-test/device.test.ts tests/unit-test/mcp-tools.test.ts tests/unit-test/platform-session-manager.test.ts tests/unit-test/executeRequest-session-prefix.test.ts`
- `npx nx build @midscene/webdriver`
- `npx nx build @midscene/core`
- `npx nx build @midscene/ios`
- `pnpm run lint`