### PR TITLE
fix(report): remove redundant before-calling screenshot

### DIFF
--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -244,17 +244,6 @@ const DetailPanel = (): JSX.Element => {
       </ScreenshotDisplay>
     ) : null;
 
-    // screenshot view
-    const screenshotFromContext = activeTask.uiContext?.screenshot;
-    if (screenshotFromContext?.base64) {
-      screenshotItems.push({
-        timestamp: activeTask.timing?.start ?? undefined,
-        screenshotTimestamp: screenshotFromContext.capturedAt,
-        screenshot: screenshotFromContext.base64,
-        timing: 'before-calling',
-      });
-    }
-
     if (activeTask.recorder?.length) {
       for (const item of activeTask.recorder) {
         if (item.screenshot?.base64) {


### PR DESCRIPTION
The before-calling screenshot in the report detail panel is derived from task.uiContext.screenshot.

It is the same image as UI Context, not a separately captured recorder snapshot.

The TaskRunner can also reuse UI Context within its 300ms cache window.

That makes the before-calling label ambiguous, so keep UI Context and remove the duplicate image.