### PR TITLE
fix(core): throw on out-of-range bbox from normalized-[0,1000] models

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -237,10 +237,7 @@ export function adaptBbox(
     // Default: normalized 0-1000 coordinate system
     // Includes: qwen3-vl, qwen3.5, qwen3.6, glm-v, auto-glm, auto-glm-multilingual,
     // and future models.
-    if (modelFamily !== undefined) {
-      assertNormalized01000Bbox(normalizedBbox, modelFamily, width, height);
-    }
-    result = normalized01000(normalizedBbox as number[], width, height);
+    result = normalized01000(normalizedBbox, width, height, modelFamily);
   }
 
   return result;
@@ -282,15 +279,22 @@ function assertNormalized01000Bbox(
 
 // x1, y1, x2, y2 -> 0-1000
 export function normalized01000(
-  bbox: number[],
+  bbox: number[] | string[] | string,
   width: number,
   height: number,
+  modelFamily?: TModelFamily | undefined,
 ): [number, number, number, number] {
+  if (modelFamily !== undefined) {
+    assertNormalized01000Bbox(bbox, modelFamily, width, height);
+  }
+
+  const normalizedBbox = bbox as number[];
+
   return [
-    Math.round((bbox[0] * width) / 1000),
-    Math.round((bbox[1] * height) / 1000),
-    Math.round((bbox[2] * width) / 1000),
-    Math.round((bbox[3] * height) / 1000),
+    Math.round((normalizedBbox[0] * width) / 1000),
+    Math.round((normalizedBbox[1] * height) / 1000),
+    Math.round((normalizedBbox[2] * width) / 1000),
+    Math.round((normalizedBbox[3] * height) / 1000),
   ];
 }
 

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -243,40 +243,6 @@ export function adaptBbox(
   return result;
 }
 
-// Validate a bbox that is expected to be in the normalized [0, 1000] coordinate
-// system. Some grounding models (notably qwen3.5 / qwen3.6) occasionally emit
-// raw pixel coordinates such as [0, 500, 1080, 1920] instead of normalized
-// values, which silently expands the resulting rect well beyond the screenshot
-// and produces off-screen ADB swipes. Surface that mismatch to the caller
-// instead of letting the bad coordinates propagate.
-function assertNormalized01000Bbox(
-  bbox: number[] | string[] | string,
-  modelFamily: TModelFamily | undefined,
-  width: number,
-  height: number,
-): asserts bbox is number[] {
-  const familyLabel = modelFamily ?? 'unknown';
-
-  if (!Array.isArray(bbox)) {
-    throw new Error(
-      `Model family "${familyLabel}" returned a non-array bbox for the normalized [0, 1000] format: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). Expected an array of 4 numbers.`,
-    );
-  }
-
-  for (const value of bbox) {
-    if (
-      typeof value !== 'number' ||
-      !Number.isFinite(value) ||
-      value < 0 ||
-      value > 1000
-    ) {
-      throw new Error(
-        `Model family "${familyLabel}" returned a bbox outside the expected [0, 1000] normalized range: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). This usually means the model emitted pixel-style coordinates instead of normalized values. Consider switching MIDSCENE_MODEL_FAMILY to a more reliable visual grounding family (e.g. "qwen3-vl"), or revisit the bbox prompt for this model.`,
-      );
-    }
-  }
-}
-
 // x1, y1, x2, y2 -> 0-1000
 export function normalized01000(
   bbox: number[] | string[] | string,
@@ -285,7 +251,24 @@ export function normalized01000(
   modelFamily?: TModelFamily | undefined,
 ): [number, number, number, number] {
   if (modelFamily !== undefined) {
-    assertNormalized01000Bbox(bbox, modelFamily, width, height);
+    if (!Array.isArray(bbox)) {
+      throw new Error(
+        `Model family "${modelFamily}" returned a non-array bbox for the normalized [0, 1000] format: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). Expected an array of 4 numbers.`,
+      );
+    }
+
+    for (const value of bbox) {
+      if (
+        typeof value !== 'number' ||
+        !Number.isFinite(value) ||
+        value < 0 ||
+        value > 1000
+      ) {
+        throw new Error(
+          `Model family "${modelFamily}" returned a bbox outside the expected [0, 1000] normalized range: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). This usually means the model emitted pixel-style coordinates instead of normalized values. Consider switching MIDSCENE_MODEL_FAMILY to a more reliable visual grounding family (e.g. "qwen3-vl"), or revisit the bbox prompt for this model.`,
+        );
+      }
+    }
   }
 
   const normalizedBbox = bbox as number[];

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -235,11 +235,49 @@ export function adaptBbox(
     result = adaptGpt5Bbox(normalizedBbox);
   } else {
     // Default: normalized 0-1000 coordinate system
-    // Includes: qwen3-vl, qwen3.5, glm-v, auto-glm, auto-glm-multilingual, and future models
+    // Includes: qwen3-vl, qwen3.5, qwen3.6, glm-v, auto-glm, auto-glm-multilingual,
+    // and future models.
+    if (modelFamily !== undefined) {
+      assertNormalized01000Bbox(normalizedBbox, modelFamily, width, height);
+    }
     result = normalized01000(normalizedBbox as number[], width, height);
   }
 
   return result;
+}
+
+// Validate a bbox that is expected to be in the normalized [0, 1000] coordinate
+// system. Some grounding models (notably qwen3.5 / qwen3.6) occasionally emit
+// raw pixel coordinates such as [0, 500, 1080, 1920] instead of normalized
+// values, which silently expands the resulting rect well beyond the screenshot
+// and produces off-screen ADB swipes. Surface that mismatch to the caller
+// instead of letting the bad coordinates propagate.
+function assertNormalized01000Bbox(
+  bbox: number[] | string[] | string,
+  modelFamily: TModelFamily | undefined,
+  width: number,
+  height: number,
+): asserts bbox is number[] {
+  const familyLabel = modelFamily ?? 'unknown';
+
+  if (!Array.isArray(bbox)) {
+    throw new Error(
+      `Model family "${familyLabel}" returned a non-array bbox for the normalized [0, 1000] format: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). Expected an array of 4 numbers.`,
+    );
+  }
+
+  for (const value of bbox) {
+    if (
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      value < 0 ||
+      value > 1000
+    ) {
+      throw new Error(
+        `Model family "${familyLabel}" returned a bbox outside the expected [0, 1000] normalized range: ${JSON.stringify(bbox)} (shotSize=${width}x${height}). This usually means the model emitted pixel-style coordinates instead of normalized values. Consider switching MIDSCENE_MODEL_FAMILY to a more reliable visual grounding family (e.g. "qwen3-vl"), or revisit the bbox prompt for this model.`,
+      );
+    }
+  }
 }
 
 // x1, y1, x2, y2 -> 0-1000

--- a/packages/core/tests/unit-test/adapt_bbox.test.ts
+++ b/packages/core/tests/unit-test/adapt_bbox.test.ts
@@ -317,6 +317,65 @@ describe('normalized-0-1000 and gemini', () => {
   });
 });
 
+describe('adaptBbox - normalized [0, 1000] range guard', () => {
+  it('accepts an in-range bbox for qwen3.6', () => {
+    const result = adaptBbox([100, 200, 300, 400], 720, 1600, 'qwen3.6');
+    expect(result).toEqual([72, 320, 216, 640]);
+  });
+
+  it('accepts boundary values 0 and 1000', () => {
+    const result = adaptBbox([0, 0, 1000, 1000], 720, 1600, 'qwen3-vl');
+    expect(result).toEqual([0, 0, 720, 1600]);
+  });
+
+  it('throws when a coordinate exceeds 1000 (real qwen3.6 failure case)', () => {
+    // Observed in the wild: tongyi/qwen3.6-plus emitted pixel-style coords
+    // [0, 500, 1080, 1920] against a 720x1600 shot, which propagated to an
+    // off-screen ADB swipe.
+    expect(() =>
+      adaptBbox([0, 500, 1080, 1920], 720, 1600, 'qwen3.6'),
+    ).toThrowError(/outside the expected \[0, 1000\] normalized range/);
+  });
+
+  it('error message includes the model family, the raw bbox, and shotSize', () => {
+    try {
+      adaptBbox([0, 500, 1080, 1920], 720, 1600, 'qwen3.6');
+      throw new Error('expected adaptBbox to throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('qwen3.6');
+      expect(msg).toContain('[0,500,1080,1920]');
+      expect(msg).toContain('shotSize=720x1600');
+      expect(msg).toContain('MIDSCENE_MODEL_FAMILY');
+    }
+  });
+
+  it('throws on negative coordinates', () => {
+    expect(() =>
+      adaptBbox([-1, 200, 300, 400], 720, 1600, 'qwen3.5'),
+    ).toThrowError(/outside the expected \[0, 1000\] normalized range/);
+  });
+
+  it('throws on non-finite coordinates (NaN)', () => {
+    expect(() =>
+      adaptBbox([Number.NaN, 200, 300, 400], 720, 1600, 'glm-v'),
+    ).toThrowError(/outside the expected \[0, 1000\] normalized range/);
+  });
+
+  it('throws on a non-array bbox payload', () => {
+    expect(() =>
+      adaptBbox('not-a-bbox' as any, 720, 1600, 'auto-glm'),
+    ).toThrowError(/non-array bbox for the normalized \[0, 1000\] format/);
+  });
+
+  it('does not validate range for families that own their own coordinate format', () => {
+    // qwen2.5-vl uses raw pixel coords and must keep working with values > 1000.
+    expect(() =>
+      adaptBbox([0, 500, 1080, 1920], 720, 1600, 'qwen2.5-vl'),
+    ).not.toThrow();
+  });
+});
+
 describe('adaptBboxToRect - boundary overflow cases', () => {
   it('should handle x1 overflow (negative left)', () => {
     const result = adaptBboxToRect([-100, 200, 300, 400], 2000, 3000);

--- a/packages/core/tests/unit-test/adapt_bbox.test.ts
+++ b/packages/core/tests/unit-test/adapt_bbox.test.ts
@@ -304,6 +304,12 @@ describe('normalized-0-1000 and gemini', () => {
     `);
   });
 
+  it('normalized-0-1000 throws with model family context', () => {
+    expect(() =>
+      normalized01000([0, 500, 1080, 1920], 720, 1600, 'qwen3.6'),
+    ).toThrowError(/outside the expected \[0, 1000\] normalized range/);
+  });
+
   it('gemini', () => {
     const result = adaptGeminiBbox([100, 150, 200, 250], 2000, 2000);
     expect(result).toMatchInlineSnapshot(`


### PR DESCRIPTION
> Reopened from upstream branch (previously #2513 from a fork, where secrets-gated AI / e2e CI jobs cannot run).

## Summary

- When `MIDSCENE_MODEL_FAMILY` routes through `normalized01000` in `adaptBbox` (qwen3-vl / qwen3.5 / qwen3.6 / glm-v / auto-glm{,-multilingual}), enforce that each bbox component sits in `[0, 1000]` and throw with `(modelFamily, raw bbox, shotSize)` otherwise.
- The guard only fires when `modelFamily` is explicitly provided. Existing `adaptBboxToRect` boundary-clamp behaviour (used in unit tests, called without a family) is preserved.
- Added 8 new tests in `packages/core/tests/unit-test/adapt_bbox.test.ts` covering in-range, boundary, out-of-range, negative, NaN, non-array, and the qwen2.5-vl negative case.

## Why

Observed in a Mi Car app yaml run (Midscene CLI 1.8.3, `tongyi/qwen3.6-plus`): the model occasionally emitted pixel-style coords like `[0, 500, 1080, 1920]` for the \"scrollable list region\". `adaptBbox` happily fed those into `normalized01000` against a 720×1600 shot, producing `center = [389, 1936]` (well outside the screenshot). The resulting ADB `input swipe 778 4268 778 2167` landed off-screen, the page never scrolled, the agent kept replanning, and the run ended with a generic \"Replanned 20 times, exceeding the limit\" error — the real signal (\"model returned out-of-range bbox\") was lost.

The change matches the project design principle in `AGENTS.md`: *Throw errors instead of returning blank values when something goes wrong.*

## Test plan

- [x] `cd packages/core && pnpm exec vitest run tests/unit-test/adapt_bbox.test.ts` — 37 tests pass (8 new).
- [x] `pnpm run lint` (root) — clean.
- [ ] Optional: an integration test against a live qwen3.6 endpoint to confirm the new error surfaces in `aiAct` task output.

## Notes for reviewers

- Error message includes a remedy hint (\"switch MIDSCENE_MODEL_FAMILY to qwen3-vl, or revisit the bbox prompt\") so users can self-triage.
- We intentionally do NOT auto-detect / rescale pixel coords. Self-healing here would hide model regressions; the explicit failure is the desired UX.
- Same pattern can be extended later to other families' bbox validators if similar regressions appear.