### PR TITLE
fix(shared): probe ports on 0.0.0.0 to match real listen host

### DIFF
--- a/packages/shared/src/node/port.ts
+++ b/packages/shared/src/node/port.ts
@@ -4,10 +4,15 @@ import { createServer } from 'node:net';
  * Check if a port is available
  */
 export async function isPortAvailable(port: number): Promise<boolean> {
+  // Probe with the same bind address the real playground/scrcpy servers use
+  // (`0.0.0.0`). Calling `listen(port)` without a host defaults to IPv6 `::`
+  // on most setups, which can succeed even when another process already
+  // holds the IPv4 wildcard for that port — leaving us to crash at real
+  // launch time after wrongly concluding the port was free.
   return new Promise((resolve) => {
     const server = createServer();
     server.on('error', () => resolve(false));
-    server.listen(port, () => {
+    server.listen(port, '0.0.0.0', () => {
       server.close(() => resolve(true));
     });
   });


### PR DESCRIPTION
## Summary
- `isPortAvailable` probed with `listen(port)` and no host, so Node bound the probe to IPv6 `::`. When a system service held the IPv4 wildcard for the same port (e.g. 5700 on macOS), the IPv6 probe could still succeed, `findAvailablePort` returned the busy port, and the real scrcpy/playground servers then crashed on `listen(port, '0.0.0.0', …)`.
- Probe on `0.0.0.0` to match the real listen host (see `packages/android-playground/src/scrcpy-server.ts:694` and `packages/playground/src/server.ts:1829`), so collisions surface up front and `findAvailablePort` actually advances to the next free port.

## Test plan
- [x] `pnpm run lint`
- [x] `npx nx test shared` (28 files / 324 tests pass)
- [ ] Manually reproduce: with another process bound to `0.0.0.0:5700`, launch the Android playground and confirm scrcpy auto-shifts to `5701`.