### PR TITLE
Append UTC offset to getReadableTimeString and update tests to match

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -805,5 +805,16 @@ export const getReadableTimeString = (
     .replace('mm', minutes)
     .replace('ss', seconds);
 
-  return `${timeString} (${format})`;
+  const timezoneOffsetMinutes = -now.getTimezoneOffset();
+  const timezoneSign = timezoneOffsetMinutes >= 0 ? '+' : '-';
+  const timezoneHours = String(
+    Math.floor(Math.abs(timezoneOffsetMinutes) / 60),
+  ).padStart(2, '0');
+  const timezoneMinutes = String(Math.abs(timezoneOffsetMinutes) % 60).padStart(
+    2,
+    '0',
+  );
+  const timezone = `UTC${timezoneSign}${timezoneHours}:${timezoneMinutes}`;
+
+  return `${timeString} (${format}, ${timezone})`;
 };

--- a/packages/core/tests/unit-test/task-executor-concurrency.test.ts
+++ b/packages/core/tests/unit-test/task-executor-concurrency.test.ts
@@ -167,7 +167,9 @@ describe('TaskExecutor concurrency isolation', () => {
     );
     expect(seenPendingFeedback).toEqual([
       '',
-      'Current time: 2023-10-15 15:37:00 (YYYY-MM-DD HH:mm:ss)',
+      expect.stringMatching(
+        /^Current time: 2023-10-15 15:37:00 \(YYYY-MM-DD HH:mm:ss, UTC[+-]\d{2}:\d{2}\)$/,
+      ),
     ]);
   });
 
@@ -225,7 +227,9 @@ describe('TaskExecutor concurrency isolation', () => {
 
     expect(seenPendingFeedback).toEqual([
       '',
-      'Current time: 2023-10-15 08:30:00 (YYYY-MM-DD HH:mm:ss)',
+      expect.stringMatching(
+        /^Current time: 2023-10-15 08:30:00 \(YYYY-MM-DD HH:mm:ss, UTC[+-]\d{2}:\d{2}\)$/,
+      ),
     ]);
   });
 });


### PR DESCRIPTION
### Motivation

- Improve readability and context of timestamps by including the local timezone offset in the human-readable time string returned by `getReadableTimeString`.
- Adjust tests that asserted exact time strings to accept the appended timezone portion which can vary by environment.

### Description

- Update `getReadableTimeString` to compute the system timezone offset and append a `UTC±HH:MM` suffix to the returned string, changing the return to ``${timeString} (${format}, ${timezone})``.
- Construct the timezone as `UTC` followed by a signed hour and minute offset derived from `Date.prototype.getTimezoneOffset`.
- Relax two expectations in `packages/core/tests/unit-test/task-executor-concurrency.test.ts` to use `expect.stringMatching` with a regex that matches the new `(..., UTC±HH:MM)` format instead of a fixed literal string.

### Testing

- Ran the updated unit tests in `packages/core/tests/unit-test/task-executor-concurrency.test.ts` which exercise `TaskExecutor` pending feedback handling, and the updated assertions passed.
- All modified expectations in the test file succeeded with the new regex-based checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ecfed3a348324b87f08e5d3572681)