### PR TITLE
Accumulate repeated CLI flags and switch assert images to `--image`/`--image-name` pairs

### DIFF
--- a/packages/shared/src/cli/cli-args.ts
+++ b/packages/shared/src/cli/cli-args.ts
@@ -44,7 +44,19 @@ export function parseCliArgs(args: string[]): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   walkCliArgs(args, (key, value) => {
-    result[key] = value;
+    const existing = result[key];
+    if (existing === undefined) {
+      result[key] = value;
+      return;
+    }
+
+    if (Array.isArray(existing)) {
+      existing.push(value);
+      result[key] = existing;
+      return;
+    }
+
+    result[key] = [existing, value];
   });
 
   return result;

--- a/packages/shared/src/cli/cli-args.ts
+++ b/packages/shared/src/cli/cli-args.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { getKeyAliases } from '../key-alias-utils';
 import type { ToolCliOption, ToolDefinition } from '../mcp/types';
+import { CLIError } from './cli-error';
 
 export function parseValue(raw: string): unknown {
   if (raw.startsWith('{') || raw.startsWith('[')) {
@@ -182,4 +183,55 @@ export function formatCliValidationError(
   const optionName =
     typeof issue?.path[0] === 'string' ? `--${issue.path[0]}` : 'CLI arguments';
   return `Invalid value for "${optionName}" in ${scriptName} ${commandName}: ${issue?.message ?? parsed.error.message}`;
+}
+
+/**
+ * Move CLI args parsed under accepted alias spellings (kebab-case, alternate
+ * casings, `cli.options.aliases` entries) onto the schema's canonical key so
+ * tool handlers can read them with a single field name regardless of which
+ * spelling the user typed. Throws `CLIError` on conflicting double-spellings
+ * (e.g. both `--imageName` and `--image-name`).
+ */
+export function canonicalizeCliArgKeys(
+  scriptName: string,
+  commandName: string,
+  def: ToolDefinition,
+  rawArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (Object.keys(def.schema).length === 0) return rawArgs;
+
+  const result: Record<string, unknown> = { ...rawArgs };
+
+  for (const schemaKey of Object.keys(def.schema)) {
+    const cliOption = def.cli?.options?.[schemaKey];
+    const acceptedSpellings = getAcceptedCliOptionNames(schemaKey, cliOption);
+
+    let chosenSpelling: string | undefined;
+    let chosenValue: unknown;
+
+    for (const spelling of acceptedSpellings) {
+      if (spelling === schemaKey) continue;
+      if (!(spelling in result)) continue;
+      if (chosenSpelling !== undefined) {
+        throw new CLIError(
+          `Conflicting CLI options "--${chosenSpelling}" and "--${spelling}" for ${scriptName} ${commandName}: both target "${schemaKey}". Use one spelling.`,
+        );
+      }
+      chosenSpelling = spelling;
+      chosenValue = result[spelling];
+    }
+
+    if (chosenSpelling === undefined) continue;
+
+    if (schemaKey in result && result[schemaKey] !== chosenValue) {
+      throw new CLIError(
+        `Conflicting CLI options "--${schemaKey}" and "--${chosenSpelling}" for ${scriptName} ${commandName}: both target "${schemaKey}". Use one spelling.`,
+      );
+    }
+
+    result[schemaKey] = chosenValue;
+    delete result[chosenSpelling];
+  }
+
+  return result;
 }

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -10,6 +10,7 @@ import type {
   ToolResultContent,
 } from '../mcp/types';
 import {
+  canonicalizeCliArgKeys,
   formatCliValidationError,
   getCliOptionDisplay,
   parseCliArgs,
@@ -214,9 +215,16 @@ export async function runToolsCLI(
     throw new CLIError(cliValidationError);
   }
 
-  debug('command: %s, args: %s', match.name, JSON.stringify(parsedArgs));
+  const handlerArgs = canonicalizeCliArgKeys(
+    scriptName,
+    match.name,
+    match.def,
+    parsedArgs,
+  );
 
-  const result = await match.def.handler(parsedArgs);
+  debug('command: %s, args: %s', match.name, JSON.stringify(handlerArgs));
+
+  const result = await match.def.handler(handlerArgs);
   debug(
     'command %s completed, isError: %s',
     match.name,

--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -649,7 +649,8 @@ export function generateCommonTools(
           }
           const userPrompt = composeUserPrompt({
             prompt,
-            images: args.images,
+            image: args.image,
+            imageName: args.imageName,
             convertHttpImage2Base64: args.convertHttpImage2Base64,
           });
           await agent.aiAssert(userPrompt);

--- a/packages/shared/src/mcp/user-prompt.ts
+++ b/packages/shared/src/mcp/user-prompt.ts
@@ -3,59 +3,39 @@ import type { UserPromptLike } from './types';
 
 type PromptReferenceImage = { name: string; url: string };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isReferenceImage(value: unknown): value is PromptReferenceImage {
-  return (
-    isRecord(value) &&
-    typeof value.name === 'string' &&
-    typeof value.url === 'string'
-  );
-}
-
-function validateImagesArray(raw: unknown[]): PromptReferenceImage[] {
-  return raw.map((item, index) => {
-    if (!isReferenceImage(item)) {
-      throw new Error(
-        `images[${index}]: expected an object with string fields "name" and "url".`,
-      );
-    }
-    // White-list known fields so unrelated keys do not propagate to aiAssert.
-    return { name: item.name, url: item.url };
-  });
-}
-
-function parseImagesValue(raw: unknown): PromptReferenceImage[] {
+function normalizeStringList(raw: unknown, fieldName: string): string[] {
   if (raw === undefined || raw === null) return [];
-
-  if (Array.isArray(raw)) {
-    return validateImagesArray(raw);
-  }
-
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
-    if (!trimmed) return [];
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      throw new Error(
-        'images: expected a JSON array of { name, url } objects (got a non-JSON string).',
-      );
-    }
-    if (!Array.isArray(parsed)) {
-      throw new Error(
-        'images: expected a JSON array of { name, url } objects (got a non-array JSON value).',
-      );
-    }
-    return validateImagesArray(parsed);
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((item, index) => {
+      if (typeof item !== 'string') {
+        throw new Error(`${fieldName}[${index}]: expected a string.`);
+      }
+      return item.trim();
+    });
+  }
+  throw new Error(
+    `${fieldName}: expected a string or string array, got ${typeof raw}.`,
+  );
+}
+
+function composeImages(input: {
+  image?: unknown;
+  imageName?: unknown;
+}): PromptReferenceImage[] {
+  const urls = normalizeStringList(input.image, 'image');
+  const names = normalizeStringList(input.imageName, 'imageName');
+
+  if (urls.length !== names.length) {
+    throw new Error(
+      `image/imageName: expected the same number of --image and --image-name values, got ${urls.length} image(s) and ${names.length} image name(s).`,
+    );
   }
 
-  throw new Error(
-    `images: expected an array or JSON string, got ${typeof raw}.`,
-  );
+  return urls.map((url, index) => ({ name: names[index], url }));
 }
 
 function coerceBoolean(value: unknown): boolean | undefined {
@@ -76,24 +56,16 @@ function coerceBoolean(value: unknown): boolean | undefined {
   );
 }
 
-/**
- * Build a TUserPrompt-compatible value from the CLI/MCP `assert` input.
- *
- * Field names mirror the JS SDK (`prompt`, `images`, `convertHttpImage2Base64`)
- * so calls stay one-to-one with `agent.aiAssert({ prompt, images, ... })`. Each
- * image's `url` may be an http(s) URL, a `data:` URI, or a local file path —
- * `@midscene/shared/img/preProcessImageUrl` resolves all three forms at
- * model-call time, so the CLI does not need a separate local-file flag.
- *
- * Returns the bare prompt string when no images are supplied, preserving
- * existing behavior for plain text assertions.
- */
 export function composeUserPrompt(input: {
   prompt: string;
-  images?: unknown;
+  image?: unknown;
+  imageName?: unknown;
   convertHttpImage2Base64?: unknown;
 }): UserPromptLike {
-  const images = parseImagesValue(input.images);
+  const images = composeImages({
+    image: input.image,
+    imageName: input.imageName,
+  });
   const convertFlag = coerceBoolean(input.convertHttpImage2Base64);
 
   if (images.length === 0 && convertFlag === undefined) {
@@ -110,19 +82,16 @@ export function composeUserPrompt(input: {
   return payload;
 }
 
-/**
- * Zod schema fragment for the multimodal extras accepted by the `assert`
- * tool. Mixed into the tool's schema via `...promptInputExtraSchema`.
- */
 export const promptInputExtraSchema = {
-  images: z
-    .union([
-      z.string(),
-      z.array(z.object({ name: z.string(), url: z.string() })),
-    ])
+  image: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .describe('Reference image URL/path. Repeat --image for multiple images.'),
+  imageName: z
+    .union([z.string(), z.array(z.string())])
     .optional()
     .describe(
-      'Reference images. JSON array of { "name", "url" }. Each url may be an http(s) URL, a data: URI, or a local file path (resolved by @midscene/core).',
+      'Reference image name. Repeat --image-name; must align with --image order.',
     ),
   convertHttpImage2Base64: z
     .union([z.boolean(), z.string()])

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -7,6 +7,7 @@ import {
   runToolsCLI,
 } from '@/cli';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 describe('parseValue', () => {
   it('parses JSON objects', () => {
@@ -678,5 +679,120 @@ describe('runToolsCLI', () => {
     });
     expect(consoleSpy).toHaveBeenCalledWith('split done');
     consoleSpy.mockRestore();
+  });
+
+  it('canonicalizes kebab-case spellings to schema keys before dispatch', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    });
+    const tools = {
+      initTools: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      getToolDefinitions: vi.fn().mockReturnValue([
+        {
+          name: 'assert',
+          description: 'assert',
+          schema: {
+            prompt: z.string(),
+            imageName: z.union([z.string(), z.array(z.string())]).optional(),
+          },
+          handler,
+        },
+      ]),
+    } as any;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: [
+        'assert',
+        '--prompt',
+        'p',
+        '--image-name',
+        'a',
+        '--image-name',
+        'b',
+      ],
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      prompt: 'p',
+      imageName: ['a', 'b'],
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('canonicalizes preferredName/aliases for namespaced fields', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    });
+    const tools = {
+      initTools: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      getToolDefinitions: vi.fn().mockReturnValue([
+        {
+          name: 'android_connect',
+          description: 'connect',
+          schema: { 'android.deviceId': z.string().optional() },
+          cli: {
+            options: {
+              'android.deviceId': {
+                preferredName: 'device-id',
+                aliases: ['deviceId'],
+              },
+            },
+          },
+          handler,
+        },
+      ]),
+    } as any;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'midscene-android', {
+      stripPrefix: 'android_',
+      argv: ['connect', '--device-id', 'emulator-5554'],
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      'android.deviceId': 'emulator-5554',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('throws CLIError when the same field is set under conflicting spellings', async () => {
+    const handler = vi.fn();
+    const tools = {
+      initTools: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      getToolDefinitions: vi.fn().mockReturnValue([
+        {
+          name: 'assert',
+          description: 'assert',
+          schema: {
+            prompt: z.string(),
+            imageName: z.string().optional(),
+          },
+          handler,
+        },
+      ]),
+    } as any;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      runToolsCLI(tools, 'test-cli', {
+        argv: [
+          'assert',
+          '--prompt',
+          'p',
+          '--imageName',
+          'camel',
+          '--image-name',
+          'kebab',
+        ],
+      }),
+    ).rejects.toThrow(/Conflicting CLI options.*image-name/);
+    expect(handler).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 });

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -185,6 +185,24 @@ describe('parseCliArgs', () => {
     });
   });
 
+  it('accumulates repeated flags into arrays', () => {
+    expect(
+      parseCliArgs([
+        '--image',
+        './a.png',
+        '--image',
+        './b.png',
+        '--image-name',
+        'a',
+        '--image-name',
+        'b',
+      ]),
+    ).toEqual({
+      image: ['./a.png', './b.png'],
+      'image-name': ['a', 'b'],
+    });
+  });
+
   it('preserves dotted kebab-case keys as flat args', () => {
     expect(parseCliArgs(['--android.device-id', '127.0.0.1:7555'])).toEqual({
       'android.device-id': '127.0.0.1:7555',

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -322,10 +322,11 @@ describe('composeUserPrompt', () => {
     expect(composeUserPrompt({ prompt: 'just text' })).toBe('just text');
   });
 
-  it('accepts an images JSON array string', () => {
+  it('accepts paired image and imageName values', () => {
     const result = composeUserPrompt({
       prompt: 'compare to the logo',
-      images: '[{"name":"logo","url":"https://x/y.png"}]',
+      image: 'https://x/y.png',
+      imageName: 'logo',
     });
     expect(result).toEqual({
       prompt: 'compare to the logo',
@@ -333,10 +334,11 @@ describe('composeUserPrompt', () => {
     });
   });
 
-  it('accepts a native images array with convertHttpImage2Base64', () => {
+  it('accepts paired image arguments with convertHttpImage2Base64', () => {
     const result = composeUserPrompt({
       prompt: 'p',
-      images: [{ name: 'a', url: 'https://x/a.png' }],
+      image: 'https://x/a.png',
+      imageName: 'a',
       convertHttpImage2Base64: true,
     });
     expect(result).toEqual({
@@ -352,7 +354,8 @@ describe('composeUserPrompt', () => {
     // preProcessImageUrl during the actual model call.
     const result = composeUserPrompt({
       prompt: 'find the red marker',
-      images: '[{"name":"marker","url":"./fixtures/red.png"}]',
+      image: './fixtures/red.png',
+      imageName: 'marker',
     });
 
     expect(result).toEqual({
@@ -364,7 +367,8 @@ describe('composeUserPrompt', () => {
   it('coerces stringified booleans for convertHttpImage2Base64', () => {
     const result = composeUserPrompt({
       prompt: 'p',
-      images: [{ name: 'a', url: 'https://x/a.png' }],
+      image: 'https://x/a.png',
+      imageName: 'a',
       convertHttpImage2Base64: 'true',
     });
     expect(result).toMatchObject({ convertHttpImage2Base64: true });
@@ -374,46 +378,43 @@ describe('composeUserPrompt', () => {
     expect(() =>
       composeUserPrompt({
         prompt: 'p',
-        images: [{ name: 'a', url: 'https://x/a.png' }],
+        image: 'https://x/a.png',
+        imageName: 'a',
         convertHttpImage2Base64: 'maybe',
       }),
     ).toThrow(/convertHttpImage2Base64/);
   });
 
-  it('throws when images is a non-JSON string', () => {
+  it('throws when image is not a string or string array', () => {
     expect(() =>
-      composeUserPrompt({ prompt: 'p', images: 'not-json' }),
-    ).toThrow(/images:/);
+      composeUserPrompt({ prompt: 'p', image: 42 as unknown as string }),
+    ).toThrow(/image:/);
   });
 
-  it('throws when an images array entry is missing name or url', () => {
-    expect(() =>
-      composeUserPrompt({
-        prompt: 'p',
-        images: '[{"name":"x"}]',
-      }),
-    ).toThrow(/images\[0\]/);
-  });
-
-  it('throws when an images array entry contains a non-reference item', () => {
+  it('throws when image/imageName counts do not match', () => {
     expect(() =>
       composeUserPrompt({
         prompt: 'p',
-        images: [{ name: 'a', url: 'https://x/a.png' }, 'junk'],
+        image: 'https://x/a.png',
       }),
-    ).toThrow(/images\[1\]/);
+    ).toThrow(/same number/);
   });
 
-  it('strips unknown fields from image entries before forwarding', () => {
+  it('throws when imageName array contains non-string items', () => {
+    expect(() =>
+      composeUserPrompt({
+        prompt: 'p',
+        image: ['https://x/a.png'],
+        imageName: [123 as unknown as string],
+      }),
+    ).toThrow(/imageName\[0\]/);
+  });
+
+  it('builds images array from image/imageName pairs', () => {
     const result = composeUserPrompt({
       prompt: 'p',
-      images: [
-        {
-          name: 'a',
-          url: 'https://x/a.png',
-          secret: 'should-not-propagate',
-        } as unknown as { name: string; url: string },
-      ],
+      image: 'https://x/a.png',
+      imageName: 'a',
     });
     expect(result).toEqual({
       prompt: 'p',
@@ -421,15 +422,19 @@ describe('composeUserPrompt', () => {
     });
   });
 
-  it('throws when images JSON is not an array', () => {
+  it('throws when repeated image/imageName values are unbalanced', () => {
     expect(() =>
-      composeUserPrompt({ prompt: 'p', images: '{"name":"x","url":"y"}' }),
-    ).toThrow(/non-array JSON/);
+      composeUserPrompt({
+        prompt: 'p',
+        image: ['https://x/a.png'],
+        imageName: [],
+      }),
+    ).toThrow(/same number/);
   });
 
-  it('throws when images is neither a string nor an array', () => {
+  it('throws when imageName is neither a string nor a string array', () => {
     expect(() =>
-      composeUserPrompt({ prompt: 'p', images: 42 as unknown as string }),
+      composeUserPrompt({ prompt: 'p', imageName: 42 as unknown as string }),
     ).toThrow(/got number/);
   });
 });
@@ -462,7 +467,8 @@ describe('generateCommonTools — assert image prompts', () => {
     const assert = tools.find((t) => t.name === 'assert')!;
     await assert.handler({
       prompt: 'the visible badge matches the reference image',
-      images: '[{"name":"target","url":"https://example.com/btn.png"}]',
+      image: 'https://example.com/btn.png',
+      imageName: 'target',
     });
 
     expect(aiAssert).toHaveBeenCalledWith({
@@ -482,7 +488,8 @@ describe('generateCommonTools — assert image prompts', () => {
     const assert = tools.find((t) => t.name === 'assert')!;
     await assert.handler({
       prompt: 'the visible badge matches the supplied image',
-      images: '[{"name":"badge","url":"./fixtures/badge.png"}]',
+      image: './fixtures/badge.png',
+      imageName: 'badge',
     });
 
     expect(aiAssert).toHaveBeenCalledWith({
@@ -499,8 +506,10 @@ describe('generateCommonTools — assert image prompts', () => {
 
     const assertSchema = tools.find((t) => t.name === 'assert')!.schema;
     expect(assertSchema).toHaveProperty('prompt');
-    expect(assertSchema).toHaveProperty('images');
+    expect(assertSchema).toHaveProperty('image');
+    expect(assertSchema).toHaveProperty('imageName');
     expect(assertSchema).toHaveProperty('convertHttpImage2Base64');
+    expect(assertSchema).not.toHaveProperty('images');
     expect(assertSchema).not.toHaveProperty('imageFiles');
 
     // act schema stays string-only because the underlying core aiAct

--- a/packages/web-integration/tests/ai/web/puppeteer/cli-assert-image-prompt.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/cli-assert-image-prompt.test.ts
@@ -13,8 +13,8 @@ const GITHUB_LOGO_FIXTURE = path.resolve(
 
 /**
  * Exercise the CLI / MCP `assert` tool exposed by `generateCommonTools`
- * with the multimodal `images` payload. This proves the CLI handler path
- * (`npx @midscene/* assert --prompt … --images …`) forwards the image
+ * with multimodal image params. This proves the CLI handler path
+ * (`npx @midscene/* assert --prompt … --image … --image-name …`) forwards the image
  * reference all the way to `agent.aiAssert` and the real model call
  * succeeds, mirroring the SDK-level test in `playwright/image-prompt.spec.ts`.
  */
@@ -44,12 +44,8 @@ describe(
       // NO logo should pass even though we attach a reference image.
       const result = await assertTool.handler({
         prompt: 'There is no github logo on the current screen.',
-        images: [
-          {
-            name: 'github-logo',
-            url: GITHUB_LOGO_FIXTURE,
-          },
-        ],
+        image: GITHUB_LOGO_FIXTURE,
+        imageName: 'github-logo',
       });
 
       expect(result.isError).toBeFalsy();
@@ -59,21 +55,19 @@ describe(
       });
     });
 
-    it('accepts a JSON-string images payload (matches CLI argv parsing)', async () => {
+    it('accepts repeated image/image-name args (matches CLI argv parsing)', async () => {
       const { originPage, reset } = await launchPage('about:blank');
       ctx.resetFn = reset;
       ctx.agent = new PuppeteerAgent(originPage);
 
       const assertTool = buildAssertTool(ctx.agent);
 
-      // `cli-args.parseValue` JSON.parses argv beginning with `[`, so the
-      // handler receives an already-parsed array. Simulating the pre-parsed
-      // string form here guards both code paths.
+      // Repeated CLI flags are accumulated as arrays by parseCliArgs. Simulate
+      // that parsed argv shape here to match the actual command path.
       const result = await assertTool.handler({
         prompt: 'There is no github logo on the current screen.',
-        images: JSON.stringify([
-          { name: 'github-logo', url: GITHUB_LOGO_FIXTURE },
-        ]),
+        image: [GITHUB_LOGO_FIXTURE],
+        imageName: ['github-logo'],
       });
 
       expect(result.isError).toBeFalsy();
@@ -95,12 +89,8 @@ describe(
       // `isError: true` rather than throwing, matching the CLI contract.
       const result = await assertTool.handler({
         prompt: 'There is a github logo on the current screen.',
-        images: [
-          {
-            name: 'github-logo',
-            url: GITHUB_LOGO_FIXTURE,
-          },
-        ],
+        image: GITHUB_LOGO_FIXTURE,
+        imageName: 'github-logo',
       });
 
       expect(result.isError).toBe(true);


### PR DESCRIPTION
### Motivation

- Simplify and harden CLI handling for multimodal assertions by supporting repeated flags instead of requiring JSON blobs for images. 
- Make the assert tool accept explicit `--image` and `--image-name` values so CLI parsing and validation are clearer and less error-prone.

### Description

- Update `parseCliArgs` to accumulate repeated flags into arrays so multiple occurrences of the same `--flag` produce `['a','b']` rather than overwriting previous values. 
- Replace the previous `images` JSON-array handling with separate `image` and `imageName` inputs by adding `normalizeStringList` and `composeImages` helpers and changing `composeUserPrompt` to build a sanitized `images` array from paired `image` / `imageName` values. 
- Change the `assert` tool handler in `generateCommonTools` to use `args.image` and `args.imageName` and to forward composed images to `agent.aiAssert`. 
- Update the Zod schema `promptInputExtraSchema` to expose `image` and `imageName` (string or string-array) and updated descriptions, and adjust comments and tests to reflect the new CLI shape.

### Testing

- Ran the `@midscene/shared` unit tests (Vitest) including `cli-runner.test.ts` and `tool-generator.test.ts`, and they passed. 
- Ran the web-integration Puppeteer test for CLI assert image prompts (`cli-assert-image-prompt.test.ts`), and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffe1b66e08324b86a16a09d60ea54)