### PR TITLE
fix(site): tune Bilibili and iQIYI logo widths

### DIFF
--- a/apps/site/theme/components/WhoIsUsing.tsx
+++ b/apps/site/theme/components/WhoIsUsing.tsx
@@ -110,7 +110,7 @@ export function WhoIsUsing() {
       name: t('userIqiyi'),
       url: 'https://www.iqiyi.com',
       logo: '/images/users/iqiyi-color.svg',
-      logoWidth: 140,
+      logoWidth: 200,
     },
     {
       kind: 'logo',

--- a/apps/site/theme/components/WhoIsUsing.tsx
+++ b/apps/site/theme/components/WhoIsUsing.tsx
@@ -117,7 +117,7 @@ export function WhoIsUsing() {
       name: t('userBilibili'),
       url: 'https://www.bilibili.com',
       logo: t('userBilibiliLogo'),
-      logoWidth: 140,
+      logoWidth: Number(t('userBilibiliLogoWidth')),
     },
   ];
 

--- a/apps/site/theme/i18n/enUS.ts
+++ b/apps/site/theme/i18n/enUS.ts
@@ -103,6 +103,7 @@ and more`,
   userSodaMusic: 'Soda Music',
   userBilibili: 'Bilibili',
   userBilibiliLogo: '/images/users/bilibili-color.svg',
+  userBilibiliLogoWidth: '90',
   userDoubao: 'Doubao',
 
   // Links

--- a/apps/site/theme/i18n/zhCN.ts
+++ b/apps/site/theme/i18n/zhCN.ts
@@ -98,6 +98,7 @@ export const ZH_CN: Record<keyof typeof EN_US, string> = {
   userSodaMusic: '汽水音乐',
   userBilibili: '哔哩哔哩',
   userBilibiliLogo: '/images/users/bilibili-zh-color.svg',
+  userBilibiliLogoWidth: '120',
   userDoubao: '豆包',
 
   // Links


### PR DESCRIPTION
## Summary
- The Latin and Chinese Bilibili wordmarks have very different aspect ratios (about 2.24:1 vs 3.53:1), so a single 140px width made the Chinese logo render visually heavier than the surrounding icon/text entries. Drive `logoWidth` through the existing i18n map (`userBilibiliLogoWidth`): 90px for the Latin wordmark and 120px for the Chinese wordmark, which lines each version up with the rest of the row.
- The iQIYI wordmark has an unusually wide aspect ratio (about 6.47:1), so the previous 140px width rendered it at only ~22px tall — visibly smaller than the surrounding icons and text. Bump the width to 200px so it sits closer to ~31px tall, in line with other entries.

## Test plan
- [x] `pnpm run lint`
- [ ] Visual check of the homepage in both `en` and `zh` locales (please verify in preview)