### PR TITLE
fix(computer): align default scroll distance with web (~70% of screen)

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -70,9 +70,11 @@ const EDGE_SCROLL_STEPS = 400;
 // minimum of 10 steps so small distances still feel momentum-like.
 const PHASED_PIXELS_PER_STEP = 30;
 const PHASED_MIN_STEPS = 10;
-// Approximate viewport height for mapping "distance in px" to PageUp/PageDown
-// count when falling back to keyboard navigation.
-const APPROX_VIEWPORT_HEIGHT_PX = 600;
+// Default scroll distance is 70% of the screen size on the relevant axis,
+// matching the web puppeteer/chrome-extension behavior so a model that simply
+// says "scroll down" without a distance gets a roughly one-screen scroll on
+// every platform.
+const DEFAULT_SCROLL_VIEWPORT_RATIO = 0.7;
 
 type EdgeScrollType =
   | 'scrollToTop'
@@ -942,13 +944,24 @@ Original error: ${lastRawMessage}`,
     }
 
     if (scrollType === 'singleAction' || !scrollType) {
-      const distance = param?.distance || 500;
       const direction = (param?.direction || 'down') as ScrollDirection;
       const isKnownDirection =
         direction === 'up' ||
         direction === 'down' ||
         direction === 'left' ||
         direction === 'right';
+      const isHorizontal = direction === 'left' || direction === 'right';
+
+      let distance: number | undefined = param?.distance ?? undefined;
+      let screenSize: Size | undefined;
+      if (!distance) {
+        screenSize = await this.size();
+        const base = isHorizontal ? screenSize.width : screenSize.height;
+        distance = Math.max(
+          1,
+          Math.round(base * DEFAULT_SCROLL_VIEWPORT_RATIO),
+        );
+      }
 
       if (isKnownDirection) {
         const steps = Math.max(
@@ -962,10 +975,8 @@ Original error: ${lastRawMessage}`,
       }
 
       if (this.useAppleScript && (direction === 'up' || direction === 'down')) {
-        const pages = Math.max(
-          1,
-          Math.round(distance / APPROX_VIEWPORT_HEIGHT_PX),
-        );
+        if (!screenSize) screenSize = await this.size();
+        const pages = Math.max(1, Math.round(distance / screenSize.height));
         const key = direction === 'up' ? 'pageup' : 'pagedown';
         for (let i = 0; i < pages; i++) {
           sendKeyViaAppleScript(key);

--- a/packages/computer/src/rdp/device.ts
+++ b/packages/computer/src/rdp/device.ts
@@ -38,6 +38,7 @@ const INPUT_CLEAR_DELAY = 150;
 const SCROLL_STEP_DELAY = 100;
 const SCROLL_COMPLETE_DELAY = 500;
 const DEFAULT_SCROLL_DISTANCE = 480;
+const DEFAULT_SCROLL_VIEWPORT_RATIO = 0.7;
 const EDGE_SCROLL_STEPS = 10;
 const DEFAULT_SCROLL_STEP_AMOUNT = 120;
 
@@ -173,7 +174,8 @@ export class RDPDevice implements AbstractInterface {
         }
         await this.performWheel(
           param.direction || 'down',
-          param.distance || DEFAULT_SCROLL_DISTANCE,
+          param.distance ||
+            this.defaultScrollDistance(param.direction || 'down'),
           target?.center[0],
           target?.center[1],
         );
@@ -313,6 +315,16 @@ export class RDPDevice implements AbstractInterface {
       default:
         throw new Error(`Unsupported scroll type: ${scrollType}`);
     }
+  }
+
+  private defaultScrollDistance(direction: RDPScrollDirection): number {
+    const size = this.connectionInfo?.size;
+    if (!size) {
+      return DEFAULT_SCROLL_DISTANCE;
+    }
+    const isHorizontal = direction === 'left' || direction === 'right';
+    const base = isHorizontal ? size.width : size.height;
+    return Math.max(1, Math.round(base * DEFAULT_SCROLL_VIEWPORT_RATIO));
   }
 
   private async movePointer(


### PR DESCRIPTION
## Summary

- The desktop computer device previously used a hardcoded **500 px** (libnut / AppleScript path) and **480 px** (RDP path) as the default scroll distance when the model did not provide an explicit `distance`.
- On 1080p / 1440p displays this only nudges the viewport by a small fraction, so prompts like "scroll down" appear to do nothing and the model has to retry many times to make progress through long lists.
- Web puppeteer / chrome-extension have long defaulted to `innerHeight * 0.7` (and `innerWidth * 0.7` for horizontal). This PR brings the desktop backends into the same convention so the default behavior is consistent across web, mobile, and desktop.

## Changes

- **libnut / AppleScript (Windows / Linux / macOS)** — `packages/computer/src/device.ts`
  - Default distance is now `screen.height * 0.7` for vertical scrolls and `screen.width * 0.7` for horizontal scrolls.
  - The macOS AppleScript `PageUp` / `PageDown` fallback now uses the real screen height instead of the hardcoded `APPROX_VIEWPORT_HEIGHT_PX = 600` approximation when computing how many page-key presses are needed.
  - Removed the unused `APPROX_VIEWPORT_HEIGHT_PX` constant; introduced `DEFAULT_SCROLL_VIEWPORT_RATIO = 0.7`.

- **RDP** — `packages/computer/src/rdp/device.ts`
  - Single-action scroll default is now computed from `connectionInfo.size` using the same `0.7` ratio (per axis).
  - Falls back to the previous hardcoded `480` if `connectionInfo` is not available yet.
  - Edge-scroll step amount (`scrollToTop` / `scrollToBottom` / etc.) is intentionally left at `480` because it is the per-tick wheel amount, not a "one screen" semantic.

The shared `actionScrollParamSchema` (in `@midscene/core`) is **not** changed — this PR only affects what happens when the model does not pass a `distance`. Callers can still override with an explicit value.

## User-visible effect

Before, on Windows / Linux:

> "scroll down" → 500 px → barely moves on 1080p, looks broken on 1440p.

After:

> "scroll down" → ~70% of screen → roughly one screen worth of content, matching the web experience.

The Kylin Linux target that's coming next inherits the same behavior automatically (single shared core).

## Test plan

- [x] `npx nx test computer` — 9 test files / 44 tests pass
- [x] `pnpm run lint` — clean
- [ ] Manual smoke on Windows desktop with a long list page, with and without explicit `distance`
- [ ] Manual smoke on macOS (phased-scroll path) and AppleScript fallback path
- [ ] Manual smoke on an RDP session