### PR TITLE
docs(site): update changelog for v1.8

### DIFF
--- a/apps/site/docs/en/changelog.mdx
+++ b/apps/site/docs/en/changelog.mdx
@@ -1,5 +1,34 @@
 # Changelog
 
+## v1.8 - YAML Variables, Device Integrations & Model Behavior Updates
+
+v1.8 adds YAML result reuse, refines model reasoning defaults, and brings new device/platform integration options.
+
+### YAML Workflow Enhancements
+
+- YAML steps with `name` can be reused in later steps through `$name` and `${name}`. See: [Automate with Scripts in YAML](./automate-with-scripts-in-yaml#reuse-step-results)
+- Android `runAdbShell` now accepts a `timeout` option in both the JavaScript API and YAML scripts. See: [Android API](./android-api-reference), [Automate with Scripts in YAML](./automate-with-scripts-in-yaml)
+
+### Device and Platform Integrations
+
+- iOS now supports connecting to external WebDriverAgent sessions, making it easier to reuse an existing WDA setup
+- RDP connection options are now exposed through Computer MCP / CLI connection tools
+
+### Model and Planning Behavior
+
+- Model usage intent is now tracked separately from resolved config slots, making multi-model planning, locating, and report display clearer
+- For supported model families, Midscene now disables model-native thinking by default to improve execution speed and stability. See: [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode)
+- Doubao fast tier configuration is now supported through `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}`. See: [Common Model Configuration](./model-common-config)
+
+### Bug Fixes
+
+- Fixed `aiAct` completion being emitted before actions actually run
+- Fixed insight prompts prioritizing reference images over the current screenshot in some cases
+- Fixed Bridge attachment after new-tab navigation
+- Fixed Playground tap projection on iOS / HarmonyOS / Computer
+- Fixed HarmonyOS per-call `autoDismissKeyboard`
+- Fixed Android Playground video streaming memory usage
+
 ## v1.7 - Flexible Report File Consumption, with Qwen 3.6 Support
 
 ### Flexible Report File Consumption

--- a/apps/site/docs/zh/changelog.mdx
+++ b/apps/site/docs/zh/changelog.mdx
@@ -1,5 +1,34 @@
 # 更新日志
 
+## v1.8 - YAML 变量复用、设备集成与模型行为更新
+
+v1.8 版本新增 YAML 步骤结果复用能力，调整模型思考模式默认行为，并补充了多项设备与平台集成能力。
+
+### YAML 工作流增强
+
+- 带有 `name` 的 YAML 步骤可以在后续步骤中通过 `$name` 和 `${name}` 复用结果。详见：[YAML 脚本自动化](./automate-with-scripts-in-yaml#复用步骤结果)
+- Android `runAdbShell` 在 JavaScript API 和 YAML 脚本中都支持 `timeout` 选项。详见：[Android API](./android-api-reference)、[YAML 脚本自动化](./automate-with-scripts-in-yaml)
+
+### 设备与平台集成
+
+- iOS 支持连接外部 WebDriverAgent 会话，方便复用已有 WDA 环境
+- Computer MCP / CLI 连接工具支持传入 RDP 连接选项
+
+### 模型与规划行为
+
+- 模型使用意图与实际解析到的配置槽位分离，多模型 Planning、定位和报告展示更清晰
+- 对于已支持的模型系列，Midscene 默认关闭模型原生思考，以提升执行速度和稳定性。详见：[模型原生的思考模式](./model-strategy#模型原生的思考模式)
+- 支持豆包低延迟模式配置方式，可通过 `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}` 开启。详见：[常用模型配置](./model-common-config)
+
+### 问题修复
+
+- 修复 `aiAct` 在动作真正执行前就触发完成状态的问题
+- 修复 Insight prompt 在部分场景下优先使用参考图而不是当前截图的问题
+- 修复新标签页导航后的 Bridge 连接问题
+- 修复 iOS / HarmonyOS / Computer Playground 点击投影问题
+- 修复 HarmonyOS 单次调用 `autoDismissKeyboard` 的配置不生效问题
+- 修复 Android Playground 视频流内存占用问题
+
 ## v1.7 - 灵活处理报告文件、支持 Qwen 3.6 模型
 
 ### 灵活处理报告文件


### PR DESCRIPTION
## Summary

- Add the v1.8 changelog section to the English and Chinese docs.
- Cover YAML result reuse, device integration updates, model behavior changes, Doubao fast tier support, and bug fixes.

## Validation

- `pnpm run lint`
- `git diff --check -- apps/site/docs/en/changelog.mdx apps/site/docs/zh/changelog.mdx`