### PR TITLE
fix(shared): record take_screenshot in reports

### DIFF
--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -370,6 +370,25 @@ async function executeAction(
   throw new Error(`Action "${actionName}" is not supported by this agent`);
 }
 
+type ScreenshotReportAgent = BaseAgent & {
+  recordToReport?: (title?: string, opt?: { content: string }) => Promise<void>;
+  logScreenshot?: (title?: string, opt?: { content: string }) => Promise<void>;
+};
+
+async function recordScreenshotToReport(
+  agent: BaseAgent,
+  title: string,
+): Promise<void> {
+  const reportAgent = agent as ScreenshotReportAgent;
+  if (typeof reportAgent.recordToReport === 'function') {
+    await reportAgent.recordToReport(title);
+    return;
+  }
+  if (typeof reportAgent.logScreenshot === 'function') {
+    await reportAgent.logScreenshot(title);
+  }
+}
+
 /**
  * Capture screenshot and return as tool result
  */
@@ -568,6 +587,7 @@ export function generateCommonTools(
           if (!screenshot) {
             return createErrorResult('Screenshot not available');
           }
+          await recordScreenshotToReport(agent, 'take_screenshot');
           const { mimeType, body } = parseBase64(screenshot);
           return {
             content: [{ type: 'image', data: body, mimeType }],

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -270,6 +270,27 @@ describe('generateToolsFromActionSpace', () => {
     );
   });
 
+  it('records take_screenshot in report-capable agents', async () => {
+    const recordToReport = vi.fn().mockResolvedValue(undefined);
+    const commonTools = generateCommonTools(async () => ({
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: {
+        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+      },
+      recordToReport,
+    }));
+    const takeScreenshotTool = commonTools.find(
+      (tool) => tool.name === 'take_screenshot',
+    );
+
+    const result = await takeScreenshotTool?.handler({});
+
+    expect(recordToReport).toHaveBeenCalledWith('take_screenshot');
+    expect(result).toEqual({
+      content: [{ type: 'image', data: 'Zm9v', mimeType: 'image/png' }],
+    });
+  });
+
   // Guardrail for https://github.com/web-infra-dev/midscene/issues/2313:
   // A primitive Zod paramSchema (e.g. z.string()) used to silently fall
   // through extractActionSchema and leak the Zod instance's prototype


### PR DESCRIPTION
## Summary

Fixes #2395.

`take_screenshot` returned the captured image directly, so CLI sessions could announce an HTML report path without writing any report execution. This updates the common screenshot tool to record the screenshot command through the existing report API when the active agent supports it, while keeping the image response unchanged.

## Changes

- Record `take_screenshot` via `recordToReport`/`logScreenshot` for report-capable agents.
- Add a regression test that verifies the screenshot tool still returns image content and records the command for report generation.

## Testing

- `pnpm --filter @midscene/shared test -- tests/unit-test/tool-generator.test.ts -t "records take_screenshot"` (failed before the fix, passed after)
- `pnpm --filter @midscene/shared test -- tests/unit-test/tool-generator.test.ts`
- `npx nx test @midscene/shared -- tests/unit-test/tool-generator.test.ts`
- `npx nx test @midscene/shared`
- `npx nx build @midscene/shared`
- `pnpm run lint`
- `pnpm --filter @midscene/android test -- tests/unit-test/mcp-tools.test.ts`
- `npx nx test @midscene/android`
- `npx nx build @midscene/android`
- `git diff --check`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.