### PR TITLE
fix(harmony): remove system action delay overrides

### DIFF
--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -802,8 +802,6 @@ const createPlatformActions = (
         'Terminate (force-stop) a HarmonyOS app by bundle name or mapped app name',
       interfaceAlias: 'terminate',
       paramSchema: terminateParamSchema,
-      delayBeforeRunner: 0,
-      delayAfterRunner: 0,
       call: async (param) => {
         if (!param.uri || param.uri.trim() === '') {
           throw new Error('Terminate requires a non-empty uri parameter');
@@ -814,8 +812,6 @@ const createPlatformActions = (
     HarmonyBackButton: defineAction({
       name: 'HarmonyBackButton',
       description: 'Trigger the system "back" operation on HarmonyOS devices',
-      delayBeforeRunner: 0,
-      delayAfterRunner: 0,
       call: async () => {
         await device.back();
       },
@@ -823,8 +819,6 @@ const createPlatformActions = (
     HarmonyHomeButton: defineAction({
       name: 'HarmonyHomeButton',
       description: 'Trigger the system "home" operation on HarmonyOS devices',
-      delayBeforeRunner: 0,
-      delayAfterRunner: 0,
       call: async () => {
         await device.home();
       },

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -1059,8 +1059,6 @@ const createPlatformActions = (device: IOSDevice) => {
       sample: {
         uri: 'com.apple.Preferences',
       },
-      delayBeforeRunner: 0,
-      delayAfterRunner: 0,
       call: async (param) => {
         if (!param.uri || param.uri.trim() === '') {
           throw new Error('Terminate requires a non-empty uri parameter');
@@ -1071,8 +1069,6 @@ const createPlatformActions = (device: IOSDevice) => {
     IOSHomeButton: defineAction({
       name: 'IOSHomeButton',
       description: 'Trigger the system "home" operation on iOS devices',
-      delayBeforeRunner: 0,
-      delayAfterRunner: 0,
       call: async () => {
         await device.home();
       },


### PR DESCRIPTION
## Summary
- remove hard-coded `delayBeforeRunner: 0` and `delayAfterRunner: 0` from Harmony system actions
- remove the same delay overrides from iOS terminate/home actions
- keep the shared core delay mechanism intact for callers that still configure it explicitly

## Validation
- `pnpm run lint`
- `pnpm --dir packages/ios exec vitest run tests/unit-test/device.test.ts tests/unit-test/agent.test.ts`
- `pnpm --dir packages/harmony exec vitest run tests/unit-test/device.test.ts -t "terminate|Launch/Terminate action schema contract|actionSpace"`
- `pnpm --dir packages/harmony run build`
- `pnpm --dir packages/ios run build`

## Notes
- Also attempted `pnpm --dir packages/harmony exec vitest run tests/unit-test/device.test.ts tests/unit-test/agent.test.ts`; the broad device suite still has existing failures around removed public helpers such as `device.tap`, `device.inputText`, and `device.keyboardPress`, while the terminate/action-space focused coverage passes.