### PR TITLE
docs(site): clarify yaml glob ordering

### DIFF
--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -212,7 +212,7 @@ Call the Agent's [`runYaml`](./api#runyaml) method to execute YAML from JavaScri
 
 The CLI provides parameters to control how scripts run:
 
-- `--files <file1> <file2> ...`: List of script files. Executes in order, sequentially by default (`--concurrent` is `1`), or concurrently when `--concurrent` is set. Supports [glob](https://www.npmjs.com/package/glob) patterns.
+- `--files <file1> <file2> ...`: List of script files. Executes in order, sequentially by default (`--concurrent` is `1`), or concurrently when `--concurrent` is set. Supports [glob](https://www.npmjs.com/package/glob) patterns; when a glob pattern or directory matches multiple files, matched files are added to the execution list in lexicographic path order.
 - `--concurrent <number>`: Number of concurrent executions. Default `1`.
 - `--continue-on-error`: Continue running remaining scripts even if one fails. Default off.
 - `--share-browser-context`: Share browser context (cookies, `localStorage`, etc.) across scripts. Default off.

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -216,7 +216,7 @@ web:
 
 命令行工具提供了多项参数，用于控制脚本的执行行为：
 
-- `--files <file1> <file2> ...`：指定脚本文件列表。默认按顺序执行（`--concurrent` 为 `1`），可通过 `--concurrent` 设置并发数量。支持 [glob](https://www.npmjs.com/package/glob) 通配符语法。
+- `--files <file1> <file2> ...`：指定脚本文件列表。默认按顺序执行（`--concurrent` 为 `1`），可通过 `--concurrent` 设置并发数量。支持 [glob](https://www.npmjs.com/package/glob) 通配符语法；当 glob 或目录匹配到多个文件时，匹配结果会按文件路径的字典序排序后加入执行列表。
 - `--concurrent <number>`：设置并发执行的数量，默认 `1`。
 - `--continue-on-error`：启用后，即使某个脚本失败也会继续执行后续脚本。默认关闭。
 - `--share-browser-context`：在多个脚本之间共享浏览器上下文（Cookies、`localStorage` 等），适合需要连续登录态的场景。默认关闭。


### PR DESCRIPTION
## Summary

- Clarify that YAML runner glob and directory matches are added in lexicographic path order.
- Keep the English and Chinese YAML runner docs synchronized.

## Validation

- Not run, docs-only change. Per request, lint was not run.