### PR TITLE
fix(shared): record screenshot tool in reports

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1397,11 +1397,13 @@ export class Agent<
   async recordToReport(
     title?: string,
     opt?: {
-      content: string;
+      content?: string;
+      screenshotBase64?: string;
     },
   ) {
     // 1. screenshot
-    const base64 = await this.interface.screenshotBase64();
+    const base64 =
+      opt?.screenshotBase64 ?? (await this.interface.screenshotBase64());
     const now = Date.now();
     const screenshot = ScreenshotItem.create(base64, now);
     // 2. build recorder

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -102,6 +102,42 @@ describe('Agent dump update screenshot serialization', () => {
     await agent.destroy();
   });
 
+  it('uses provided screenshot data when recording to report', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    const reportGeneratorStub = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {}),
+      finalize: vi.fn(async () => undefined),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    (agent as any).reportGenerator = reportGeneratorStub;
+
+    const providedScreenshot =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    await agent.recordToReport('snapshot', {
+      screenshotBase64: providedScreenshot,
+    });
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    expect(reportGeneratorStub.onExecutionUpdate).toHaveBeenCalled();
+
+    await agent.destroy();
+  });
+
   it('keeps dump callback payload bounded after many updates with large screenshots', async () => {
     const largeScreenshot = createLargeBase64DataUri(200_000);
     const agent = new Agent(

--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -571,6 +571,9 @@ export function generateCommonTools(
           if (!screenshot) {
             return createErrorResult('Screenshot not available');
           }
+          await agent.recordToReport?.('take_screenshot', {
+            screenshotBase64: screenshot,
+          });
           const { mimeType, body } = parseBase64(screenshot);
           return {
             content: [{ type: 'image', data: body, mimeType }],

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -110,6 +110,10 @@ export interface BaseAgent {
   page?: {
     screenshotBase64(): Promise<string>;
   };
+  recordToReport?: (
+    title?: string,
+    opt?: { content?: string; screenshotBase64?: string },
+  ) => Promise<void>;
   callActionInActionSpace?: (
     actionName: string,
     params?: unknown,

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -301,6 +301,31 @@ describe('generateToolsFromActionSpace', () => {
     });
   });
 
+  it('records take_screenshot in reports with the captured screenshot', async () => {
+    const screenshotBase64Fn = vi.fn().mockResolvedValue(screenshotBase64);
+    const recordToReport = vi.fn().mockResolvedValue(undefined);
+    const commonTools = generateCommonTools(async () => ({
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: {
+        screenshotBase64: screenshotBase64Fn,
+      },
+      recordToReport,
+    }));
+    const takeScreenshotTool = commonTools.find(
+      (tool) => tool.name === 'take_screenshot',
+    );
+
+    const result = await takeScreenshotTool?.handler({});
+
+    expect(screenshotBase64Fn).toHaveBeenCalledTimes(1);
+    expect(recordToReport).toHaveBeenCalledWith('take_screenshot', {
+      screenshotBase64,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'image', data: 'Zm9v', mimeType: 'image/png' }],
+    });
+  });
+
   // Guardrail for https://github.com/web-infra-dev/midscene/issues/2313:
   // A primitive Zod paramSchema (e.g. z.string()) used to silently fall
   // through extractActionSchema and leak the Zod instance's prototype


### PR DESCRIPTION
## Summary\n- record MCP take_screenshot calls in reports through recordToReport\n- reuse the captured screenshotBase64 so take_screenshot only captures once\n- add focused shared/core tests for the report recording path\n\n## Validation\n- pnpm --filter @midscene/shared exec vitest run tests/unit-test/tool-generator.test.ts\n- pnpm --filter @midscene/core exec vitest run tests/unit-test/agent-dump-update.test.ts\n- npx biome check packages/shared/src/mcp/types.ts packages/shared/src/mcp/tool-generator.ts packages/core/src/agent/agent.ts packages/shared/tests/unit-test/tool-generator.test.ts packages/core/tests/unit-test/agent-dump-update.test.ts --diagnostic-level=info --fix\n- git diff --check