### PR TITLE
feat(android): add CLI flag to enable scrcpy

### DIFF
--- a/packages/android/src/mcp-tools.ts
+++ b/packages/android/src/mcp-tools.ts
@@ -16,24 +16,37 @@ const debug = getDebug('mcp:android-tools');
  */
 export class AndroidMidsceneTools extends BaseMidsceneTools<
   AndroidAgent,
-  string
+  {
+    deviceId?: string;
+    useScrcpy?: boolean;
+  }
 > {
   protected getCliReportSessionName() {
     return 'midscene-android';
   }
 
-  protected readonly initArgSpec: InitArgSpec<string> = {
+  protected readonly initArgSpec: InitArgSpec<{
+    deviceId?: string;
+    useScrcpy?: boolean;
+  }> = {
     namespace: 'android',
     shape: {
       deviceId: z
         .string()
         .optional()
         .describe('Android device ID (from adb devices)'),
+      useScrcpy: z
+        .boolean()
+        .optional()
+        .describe('Enable scrcpy accelerated screenshots'),
     },
     cli: {
       preferBareKeys: true,
     },
-    adapt: (extracted) => extracted?.deviceId as string | undefined,
+    adapt: (extracted) => ({
+      deviceId: extracted?.deviceId as string | undefined,
+      useScrcpy: extracted?.useScrcpy as boolean | undefined,
+    }),
   };
 
   protected createTemporaryDevice() {
@@ -42,7 +55,11 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
     return new AndroidDevice('temp-for-action-space', {});
   }
 
-  protected async ensureAgent(deviceId?: string): Promise<AndroidAgent> {
+  protected async ensureAgent(initArgs?: {
+    deviceId?: string;
+    useScrcpy?: boolean;
+  }): Promise<AndroidAgent> {
+    const deviceId = initArgs?.deviceId;
     if (this.agent && deviceId) {
       // If a specific deviceId is requested and we have an agent,
       // destroy it to create a new one with the new device
@@ -62,6 +79,7 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
     const reportOptions = this.readCliReportAgentOptions();
     const agent = await agentFromAdbDevice(deviceId, {
       autoDismissKeyboard: false,
+      ...(initArgs?.useScrcpy ? { scrcpyConfig: { enabled: true } } : {}),
       ...(reportOptions ?? {}),
     });
     this.agent = agent;
@@ -80,7 +98,8 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
         schema: this.getAgentInitArgSchema(),
         cli: this.getAgentInitArgCliMetadata(),
         handler: async (args: Record<string, unknown>) => {
-          const deviceId = this.extractAgentInitParam(args);
+          const initArgs = this.extractAgentInitParam(args);
+          const deviceId = initArgs?.deviceId;
           const reportSession = this.createNewCliReportSession(
             deviceId ?? 'auto',
           );
@@ -93,7 +112,7 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
             }
             this.agent = undefined;
           }
-          const agent = await this.ensureAgent(deviceId);
+          const agent = await this.ensureAgent(initArgs);
           const screenshot = await agent.page.screenshotBase64();
 
           return {

--- a/packages/android/tests/unit-test/cli.test.ts
+++ b/packages/android/tests/unit-test/cli.test.ts
@@ -128,6 +128,20 @@ describe('Android CLI integration', () => {
     });
   });
 
+  it('enables scrcpy when --use-scrcpy is provided', async () => {
+    const tools = new AndroidMidsceneTools();
+
+    await runToolsCLI(tools, 'midscene-android', {
+      stripPrefix: 'android_',
+      argv: ['take_screenshot', '--device-id', 'scrcpy-device', '--use-scrcpy'],
+    });
+
+    expect(agentFromAdbDevice).toHaveBeenCalledWith('scrcpy-device', {
+      autoDismissKeyboard: false,
+      scrcpyConfig: { enabled: true },
+    });
+  });
+
   it('strips init args from the payload passed to the action', async () => {
     const mockAgent = createMockAgent();
     vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);


### PR DESCRIPTION
### Motivation
- Add a CLI option to the Android tools so users can opt in to scrcpy-accelerated screenshots (`scrcpy`) to speed up device interactions and screenshot capture.

### Description
- Expand the Android CLI init args type from a plain `deviceId` to `{ deviceId?, useScrcpy? }` and add a `useScrcpy` boolean option to the init schema so the CLI accepts `--use-scrcpy`.
- Change the `adapt`/`initArgSpec` plumbing so parsed init args are returned as an object and thread the full init args through to `ensureAgent` instead of only `deviceId`.
- Update `ensureAgent` to accept the full init args and, when `useScrcpy` is true, pass `scrcpyConfig: { enabled: true }` into `agentFromAdbDevice` so the created agent enables scrcpy.
- Update the `android_connect` handler to extract the full init args and pass them to `ensureAgent`, and add a unit test that verifies `--use-scrcpy` results in `scrcpyConfig.enabled = true` being passed to `agentFromAdbDevice`.

### Testing
- Ran `pnpm run lint`; it failed in this environment due to Biome scanning large files under `./.pnpm-store` (file size limit), not due to code logic errors. 
- Ran `npx nx test @midscene/android` and focused test invocations; test runs failed in this environment because local workspace packages could not be resolved by the test runner (errors resolving `@midscene/shared/cli`, `@midscene/core`, etc.) and due to a misused vitest flag when attempting a single-file run. 
- The change was committed as `feat(android): add CLI flag to enable scrcpy` and includes modifications to `packages/android/src/mcp-tools.ts` and `packages/android/tests/unit-test/cli.test.ts` with the new test added and code adjusted accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1533082ab883249ec0cc555a5f3ca4)