### PR TITLE
feat(testing-framework): add config-driven Rstest runner

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "@midscene/ios": "workspace:*",
     "@midscene/shared": "workspace:*",
     "@midscene/web": "workspace:*",
+    "@rstest/core": "0.8.0",
     "http-server": "14.1.1",
     "lodash.merge": "4.6.2",
     "puppeteer": "24.6.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "@midscene/core": "workspace:*",
     "@midscene/ios": "workspace:*",
     "@midscene/shared": "workspace:*",
+    "@midscene/testing-framework": "workspace:*",
     "@midscene/web": "workspace:*",
     "@rstest/core": "0.8.0",
     "http-server": "14.1.1",

--- a/packages/cli/rslib.config.ts
+++ b/packages/cli/rslib.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
   source: {
     entry: {
       index: 'src/index.ts',
+      'framework/index': 'src/framework/index.ts',
     },
     define: {
       __VERSION__: JSON.stringify(version),

--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -1,9 +1,20 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
+import {
+  collectFrameworkTestFiles,
+  loadMidsceneConfig,
+} from '@midscene/testing-framework';
 import type { BatchRunnerConfig } from '../batch-runner';
 import { matchYamlFiles } from '../cli-utils';
+import { createRstestFrameworkProject } from './config-project';
 import {
   type CreateRstestYamlProjectOptions,
   type GeneratedRstestYamlProject,
@@ -70,6 +81,36 @@ const parseFrameworkTestArgs = (args: string[]): ParsedFrameworkArgs => {
     throw new Error(`Unexpected argument: ${arg}`);
   }
   return parsed;
+};
+
+const MIDSCENE_CONFIG_FILES = [
+  'midscene.config.ts',
+  'midscene.config.mts',
+  'midscene.config.cts',
+  'midscene.config.js',
+  'midscene.config.mjs',
+  'midscene.config.cjs',
+];
+
+const findMidsceneConfigPath = (targetPath: string): string | undefined => {
+  const resolvedPath = resolve(targetPath);
+  if (!existsSync(resolvedPath)) {
+    return undefined;
+  }
+
+  const stats = statSync(resolvedPath);
+  if (stats.isFile()) {
+    const fileName = resolvedPath.split(/[\\/]/).pop();
+    return fileName?.startsWith('midscene.config.') ? resolvedPath : undefined;
+  }
+
+  if (!stats.isDirectory()) {
+    return undefined;
+  }
+
+  return MIDSCENE_CONFIG_FILES.map((fileName) =>
+    resolve(resolvedPath, fileName),
+  ).find((configPath) => existsSync(configPath));
 };
 
 const resolveYamlFiles = async (
@@ -288,26 +329,65 @@ export async function runFrameworkTestCommand(
   commandOptions: FrameworkTestCommandOptions = {},
 ): Promise<number> {
   const parsed = parseFrameworkTestArgs(rawArgs);
-  const projectDir = resolve(
+  const requestedPath = resolve(
     commandOptions.projectDir || parsed.path || process.cwd(),
   );
 
-  if (!existsSync(projectDir)) {
-    throw new Error(`Project path does not exist: ${projectDir}`);
+  if (!existsSync(requestedPath)) {
+    throw new Error(`Project path does not exist: ${requestedPath}`);
+  }
+
+  const configPath = findMidsceneConfigPath(requestedPath);
+  if (configPath) {
+    const loadedConfig = await loadMidsceneConfig(configPath);
+    const files = await collectFrameworkTestFiles({
+      root: loadedConfig.root,
+      config: (commandOptions.files || parsed.files)?.length
+        ? {
+            ...loadedConfig.config,
+            testDir: '.',
+            include: commandOptions.files || parsed.files,
+            exclude: [],
+          }
+        : loadedConfig.config,
+    });
+
+    if (files.length === 0) {
+      throw new Error(`No test files found in ${loadedConfig.root}`);
+    }
+
+    const project = createRstestFrameworkProject({
+      loadedConfig,
+      files,
+      outputDir: commandOptions.outputDir,
+      maxConcurrency:
+        commandOptions.concurrent ??
+        parsed.concurrent ??
+        loadedConfig.config.testRunner?.maxConcurrency,
+      testTimeout: loadedConfig.config.testRunner?.testTimeout,
+      bail: loadedConfig.config.testRunner?.bail,
+    });
+
+    const runner = commandOptions.rstestRunner || runRstestCli;
+    return runner({
+      configFile: project.configFile,
+      cwd: loadedConfig.root,
+      stdio: commandOptions.stdio,
+    });
   }
 
   const files = await resolveYamlFiles({
-    projectDir,
+    projectDir: requestedPath,
     files: commandOptions.files || parsed.files,
   });
 
   if (files.length === 0) {
-    throw new Error(`No yaml files found in ${projectDir}`);
+    throw new Error(`No yaml files found in ${requestedPath}`);
   }
 
   const projectOptions: CreateRstestYamlProjectOptions = {
     files,
-    projectDir,
+    projectDir: requestedPath,
     outputDir: commandOptions.outputDir,
     frameworkImport: commandOptions.frameworkImport,
     headed: commandOptions.headed ?? parsed.headed,
@@ -319,7 +399,7 @@ export async function runFrameworkTestCommand(
   const runner = commandOptions.rstestRunner || runRstestCli;
   return runner({
     configFile: project.configFile,
-    cwd: projectDir,
+    cwd: requestedPath,
     stdio: commandOptions.stdio,
   });
 }

--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -1,0 +1,325 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import type { MidsceneYamlConfigResult } from '@midscene/core';
+import { getMidsceneRunSubDir } from '@midscene/shared/common';
+import type { BatchRunnerConfig } from '../batch-runner';
+import { matchYamlFiles } from '../cli-utils';
+import {
+  type CreateRstestYamlProjectOptions,
+  type GeneratedRstestYamlProject,
+  createRstestYamlProject,
+} from './rstest-project';
+import { runRstestCli } from './rstest-runner';
+
+export interface FrameworkTestCommandOptions {
+  projectDir?: string;
+  files?: string[];
+  concurrent?: number;
+  headed?: boolean;
+  keepWindow?: boolean;
+  outputDir?: string;
+  frameworkImport?: string;
+  stdio?: 'inherit' | 'pipe';
+  rstestRunner?: typeof runRstestCli;
+}
+
+interface ParsedFrameworkArgs {
+  path?: string;
+  files?: string[];
+  concurrent?: number;
+  headed?: boolean;
+  keepWindow?: boolean;
+}
+
+const parseFrameworkTestArgs = (args: string[]): ParsedFrameworkArgs => {
+  const parsed: ParsedFrameworkArgs = {};
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--files') {
+      parsed.files = [];
+      while (args[index + 1] && !args[index + 1].startsWith('--')) {
+        parsed.files.push(args[++index]);
+      }
+      continue;
+    }
+    if (arg === '--concurrent') {
+      const value = args[++index];
+      const concurrent = Number.parseInt(value, 10);
+      if (!Number.isFinite(concurrent) || concurrent <= 0) {
+        throw new Error(`--concurrent must be a positive number, got ${value}`);
+      }
+      parsed.concurrent = concurrent;
+      continue;
+    }
+    if (arg === '--headed') {
+      parsed.headed = true;
+      continue;
+    }
+    if (arg === '--keep-window') {
+      parsed.keepWindow = true;
+      parsed.headed = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      throw new Error(`Unknown midscene test option: ${arg}`);
+    }
+    if (!parsed.path) {
+      parsed.path = arg;
+      continue;
+    }
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+  return parsed;
+};
+
+const resolveYamlFiles = async (
+  options: FrameworkTestCommandOptions,
+): Promise<string[]> => {
+  const patterns =
+    options.files && options.files.length > 0
+      ? options.files
+      : [options.projectDir || '.'];
+
+  const files: string[] = [];
+  for (const pattern of patterns) {
+    const matched = await matchYamlFiles(pattern, {
+      cwd: options.projectDir ? resolve(options.projectDir) : undefined,
+    });
+    files.push(...matched);
+  }
+
+  return files;
+};
+
+const createCaseOptions = (
+  config: BatchRunnerConfig,
+): CreateRstestYamlProjectOptions['caseOptions'] => {
+  const caseOptions: CreateRstestYamlProjectOptions['caseOptions'] = {};
+  for (const file of config.files) {
+    caseOptions[resolve(file)] = {
+      globalConfig: config.globalConfig,
+    };
+  }
+  return caseOptions;
+};
+
+const getSummaryAbsolutePath = (summary: string): string =>
+  resolve(getMidsceneRunSubDir('output'), summary);
+
+const readProjectResults = (
+  project: GeneratedRstestYamlProject,
+): MidsceneYamlConfigResult[] =>
+  project.cases.map((item) => {
+    if (existsSync(item.resultFile)) {
+      return JSON.parse(
+        readFileSync(item.resultFile, 'utf8'),
+      ) as MidsceneYamlConfigResult;
+    }
+
+    return {
+      file: item.yamlFile,
+      success: false,
+      executed: false,
+      output: undefined,
+      report: undefined,
+      duration: 0,
+      resultType: 'notExecuted',
+      error: 'Not executed',
+    };
+  });
+
+const writeSummaryFile = (
+  summary: string,
+  results: MidsceneYamlConfigResult[],
+): string => {
+  const indexPath = getSummaryAbsolutePath(summary);
+  const outputDir = dirname(indexPath);
+  mkdirSync(outputDir, { recursive: true });
+
+  const indexData = {
+    summary: {
+      total: results.length,
+      successful: results.filter((r) => r.resultType === 'success').length,
+      failed: results.filter((r) => r.resultType === 'failed').length,
+      partialFailed: results.filter((r) => r.resultType === 'partialFailed')
+        .length,
+      notExecuted: results.filter((r) => r.resultType === 'notExecuted').length,
+      totalDuration: results.reduce((sum, r) => sum + (r.duration || 0), 0),
+      generatedAt: new Date().toLocaleString(),
+    },
+    results: results.map((result) => ({
+      script: relative(outputDir, result.file),
+      success: result.success,
+      resultType: result.resultType,
+      output: result.output
+        ? (() => {
+            const relativePath = relative(outputDir, result.output);
+            return relativePath.startsWith('.')
+              ? relativePath
+              : `./${relativePath}`;
+          })()
+        : undefined,
+      report: result.report ? relative(outputDir, result.report) : undefined,
+      error: result.error,
+      duration: result.duration,
+    })),
+  };
+
+  writeFileSync(indexPath, JSON.stringify(indexData, null, 2));
+  return indexPath;
+};
+
+const printExecutionPlan = (config: BatchRunnerConfig): void => {
+  console.log('   Scripts:');
+  for (const file of config.files) {
+    console.log(`     - ${file}`);
+  }
+  console.log('📋 Execution plan');
+  console.log(`   Concurrency: ${config.concurrent}`);
+  console.log(`   Keep window: ${config.keepWindow}`);
+  console.log(`   Headed: ${config.headed}`);
+  console.log(`   Continue on error: ${config.continueOnError}`);
+  console.log(
+    `   Share browser context: ${config.shareBrowserContext ?? false}`,
+  );
+  console.log(`   Summary output: ${config.summary}`);
+};
+
+const printExecutionSummary = (
+  results: MidsceneYamlConfigResult[],
+  summaryPath: string,
+): boolean => {
+  const totalDuration = results.reduce((sum, r) => sum + (r.duration || 0), 0);
+  const successfulFiles = results.filter((r) => r.resultType === 'success');
+  const failedFiles = results.filter((r) => r.resultType === 'failed');
+  const partialFailedFiles = results.filter(
+    (r) => r.resultType === 'partialFailed',
+  );
+  const notExecutedFiles = results.filter(
+    (r) => r.resultType === 'notExecuted',
+  );
+  const success =
+    failedFiles.length === 0 &&
+    partialFailedFiles.length === 0 &&
+    notExecutedFiles.length === 0;
+
+  console.log('\n📊 Execution Summary:');
+  console.log(`   Total files: ${results.length}`);
+  console.log(`   Successful: ${successfulFiles.length}`);
+  console.log(`   Failed: ${failedFiles.length}`);
+  console.log(`   Partial failed: ${partialFailedFiles.length}`);
+  console.log(`   Not executed: ${notExecutedFiles.length}`);
+  console.log(`   Duration: ${(totalDuration / 1000).toFixed(2)}s`);
+  console.log(`   Summary: ${summaryPath}`);
+
+  if (successfulFiles.length > 0) {
+    console.log('\n✅ Successful files:');
+    successfulFiles.forEach((result) => {
+      console.log(`   ${result.file}`);
+    });
+  }
+
+  if (failedFiles.length > 0) {
+    console.log('\n❌ Failed files');
+    failedFiles.forEach((result) => {
+      console.log(`   ${result.file}`);
+    });
+  }
+
+  if (partialFailedFiles.length > 0) {
+    console.log('\n⚠️  Partial failed files (some tasks failed)');
+    partialFailedFiles.forEach((result) => {
+      console.log(`   ${result.file}`);
+    });
+  }
+
+  if (notExecutedFiles.length > 0) {
+    console.log('\n⏸️ Not executed files');
+    notExecutedFiles.forEach((result) => {
+      console.log(`   ${result.file}`);
+    });
+  }
+
+  if (success) {
+    console.log('\n🎉 All files executed successfully!');
+  } else {
+    console.log('\n⚠️ Some files failed or were not executed.');
+  }
+
+  return success;
+};
+
+export async function runFrameworkTestConfig(
+  config: BatchRunnerConfig,
+  commandOptions: FrameworkTestCommandOptions = {},
+): Promise<number> {
+  printExecutionPlan(config);
+
+  const projectDir = resolve(commandOptions.projectDir || process.cwd());
+  const project = createRstestYamlProject({
+    files: config.files,
+    projectDir,
+    outputDir: commandOptions.outputDir,
+    frameworkImport: commandOptions.frameworkImport,
+    caseOptions: createCaseOptions(config),
+    headed: commandOptions.headed ?? config.headed,
+    keepWindow: commandOptions.keepWindow ?? config.keepWindow,
+    maxConcurrency: commandOptions.concurrent ?? config.concurrent,
+    bail: config.continueOnError ? 0 : 1,
+  });
+
+  const runner = commandOptions.rstestRunner || runRstestCli;
+  const exitCode = await runner({
+    configFile: project.configFile,
+    cwd: projectDir,
+    stdio: commandOptions.stdio,
+  });
+
+  const results = readProjectResults(project);
+  const summaryPath = writeSummaryFile(config.summary, results);
+  console.log('Execution finished:');
+  const success = printExecutionSummary(results, summaryPath);
+
+  return success ? exitCode : 1;
+}
+
+export async function runFrameworkTestCommand(
+  rawArgs: string[],
+  commandOptions: FrameworkTestCommandOptions = {},
+): Promise<number> {
+  const parsed = parseFrameworkTestArgs(rawArgs);
+  const projectDir = resolve(
+    commandOptions.projectDir || parsed.path || process.cwd(),
+  );
+
+  if (!existsSync(projectDir)) {
+    throw new Error(`Project path does not exist: ${projectDir}`);
+  }
+
+  const files = await resolveYamlFiles({
+    projectDir,
+    files: commandOptions.files || parsed.files,
+  });
+
+  if (files.length === 0) {
+    throw new Error(`No yaml files found in ${projectDir}`);
+  }
+
+  const projectOptions: CreateRstestYamlProjectOptions = {
+    files,
+    projectDir,
+    outputDir: commandOptions.outputDir,
+    frameworkImport: commandOptions.frameworkImport,
+    headed: commandOptions.headed ?? parsed.headed,
+    keepWindow: commandOptions.keepWindow ?? parsed.keepWindow,
+    maxConcurrency: commandOptions.concurrent ?? parsed.concurrent ?? 1,
+  };
+  const project = createRstestYamlProject(projectOptions);
+
+  const runner = commandOptions.rstestRunner || runRstestCli;
+  return runner({
+    configFile: project.configFile,
+    cwd: projectDir,
+    stdio: commandOptions.stdio,
+  });
+}

--- a/packages/cli/src/framework/config-project.ts
+++ b/packages/cli/src/framework/config-project.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { getMidsceneRunDir } from '@midscene/shared/common';
+import type {
+  FrameworkTestFile,
+  LoadedMidsceneConfig,
+} from '@midscene/testing-framework';
+import { createYamlFrameworkTestSource } from '@midscene/testing-framework/runtime';
+import {
+  createConfigContent,
+  resolveTestName,
+  safeFileStem,
+  toPosixPath,
+} from './rstest-project';
+import { resolveRstestCoreImportPath } from './rstest-runner';
+
+export interface CreateRstestFrameworkProjectOptions {
+  loadedConfig: LoadedMidsceneConfig;
+  files: FrameworkTestFile[];
+  outputDir?: string;
+  runtimeImport?: string;
+  rstestImport?: string;
+  maxConcurrency?: number;
+  testTimeout?: number;
+  bail?: number;
+}
+
+export interface GeneratedFrameworkYamlTestCase {
+  yamlFile: string;
+  testFile: string;
+  testName: string;
+}
+
+export interface GeneratedRstestFrameworkProject {
+  projectDir: string;
+  configFile: string;
+  generatedDir: string;
+  yamlCases: GeneratedFrameworkYamlTestCase[];
+  testFiles: string[];
+}
+
+const DEFAULT_TEST_TIMEOUT = 3 * 60 * 1000;
+
+const createDefaultOutputDir = (projectRoot: string): string =>
+  join(
+    resolve(projectRoot, getMidsceneRunDir()),
+    'tmp',
+    `rstest-framework-${Date.now()}`,
+  );
+
+export function createRstestFrameworkProject(
+  options: CreateRstestFrameworkProjectOptions,
+): GeneratedRstestFrameworkProject {
+  const projectRoot = options.loadedConfig.root;
+  const outputDir = options.outputDir || createDefaultOutputDir(projectRoot);
+  const generatedDir = join(outputDir, 'generated');
+  const runtimeImport =
+    options.runtimeImport || '@midscene/testing-framework/runtime';
+  const rstestImport = options.rstestImport || resolveRstestCoreImportPath();
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(generatedDir, { recursive: true });
+
+  const yamlFiles = options.files.filter((file) => file.type === 'yaml');
+  const yamlCases = yamlFiles.map((file, index) => {
+    const yamlFile = resolve(file.filePath);
+    const testName = resolveTestName(projectRoot, yamlFile);
+    const fileStem = safeFileStem(yamlFile, index);
+    const testFile = join(generatedDir, `${fileStem}.test.ts`);
+    writeFileSync(
+      testFile,
+      createYamlFrameworkTestSource({
+        configPath: options.loadedConfig.path,
+        filePath: yamlFile,
+        testName,
+        runtimeImport,
+        rstestImport,
+      }),
+    );
+    return { yamlFile, testFile, testName };
+  });
+
+  const testFiles = [
+    ...yamlCases.map((item) => item.testFile),
+    ...options.files
+      .filter((file) => file.type === 'test')
+      .map((file) => resolve(file.filePath)),
+  ];
+
+  const configFile = join(outputDir, 'rstest.config.ts');
+  writeFileSync(
+    configFile,
+    createConfigContent({
+      root: projectRoot,
+      include: testFiles.map((file) => toPosixPath(file)),
+      maxConcurrency: options.maxConcurrency,
+      testTimeout: options.testTimeout ?? DEFAULT_TEST_TIMEOUT,
+      bail: options.bail,
+    }),
+  );
+
+  return {
+    projectDir: outputDir,
+    configFile,
+    generatedDir,
+    yamlCases,
+    testFiles,
+  };
+}

--- a/packages/cli/src/framework/index.ts
+++ b/packages/cli/src/framework/index.ts
@@ -1,0 +1,18 @@
+export { runFrameworkTestCommand, runFrameworkTestConfig } from './command';
+export { createRstestYamlProject, resolveTestName } from './rstest-project';
+export {
+  resolveRstestBinPath,
+  resolveRstestCoreImportPath,
+  runRstestCli,
+} from './rstest-runner';
+export { runYamlCaseInChildProcess } from './yaml-child-process';
+export { getYamlPlayerFailure, runYamlCase } from './yaml-case';
+export type { FrameworkTestCommandOptions } from './command';
+export type {
+  CreateRstestYamlProjectOptions,
+  GeneratedRstestYamlProject,
+  GeneratedYamlTestCase,
+} from './rstest-project';
+export type { RunRstestCliOptions } from './rstest-runner';
+export type { RunYamlCaseInChildProcessOptions } from './yaml-child-process';
+export type { RunYamlCaseOptions, RunYamlCaseResult } from './yaml-case';

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -1,0 +1,207 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  basename,
+  dirname,
+  extname,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
+import { getMidsceneRunSubDir } from '@midscene/shared/common';
+import { resolveRstestCoreImportPath } from './rstest-runner';
+import type { RunYamlCaseInChildProcessOptions } from './yaml-child-process';
+
+type GeneratedCaseOptions = Omit<
+  RunYamlCaseInChildProcessOptions,
+  'file' | 'frameworkImport'
+>;
+
+export interface CreateRstestYamlProjectOptions {
+  files: string[];
+  projectDir?: string;
+  outputDir?: string;
+  resultDir?: string;
+  frameworkImport?: string;
+  rstestImport?: string;
+  caseOptions?: Record<string, GeneratedCaseOptions>;
+  headed?: boolean;
+  keepWindow?: boolean;
+  maxConcurrency?: number;
+  testTimeout?: number;
+  bail?: number;
+}
+
+export interface GeneratedYamlTestCase {
+  yamlFile: string;
+  testFile: string;
+  resultFile: string;
+  testName: string;
+}
+
+export interface GeneratedRstestYamlProject {
+  projectDir: string;
+  configFile: string;
+  generatedDir: string;
+  cases: GeneratedYamlTestCase[];
+}
+
+const toPosixPath = (value: string): string => value.split(sep).join('/');
+
+const toImportLiteral = (value: string): string =>
+  JSON.stringify(toPosixPath(value));
+
+const safeFileStem = (file: string, index: number): string => {
+  const base = basename(file, extname(file))
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${String(index + 1).padStart(3, '0')}-${base || 'case'}`;
+};
+
+export const resolveTestName = (
+  projectDir: string,
+  yamlFile: string,
+): string => {
+  const relativePath = relative(projectDir, yamlFile);
+  return toPosixPath(relativePath.startsWith('..') ? yamlFile : relativePath);
+};
+
+const createGeneratedTestContent = (options: {
+  rstestImport: string;
+  frameworkImport: string;
+  yamlFile: string;
+  resultFile?: string;
+  testName: string;
+  headed?: boolean;
+  keepWindow?: boolean;
+  caseOptions?: GeneratedCaseOptions;
+}): string => {
+  const runOptions = {
+    file: options.yamlFile,
+    ...options.caseOptions,
+    ...(options.headed !== undefined ? { headed: options.headed } : {}),
+    ...(options.keepWindow !== undefined
+      ? { keepWindow: options.keepWindow }
+      : {}),
+  };
+
+  return `import { test } from ${toImportLiteral(options.rstestImport)};
+
+test(${JSON.stringify(options.testName)}, async () => {
+  const framework = await import(${toImportLiteral(options.frameworkImport)});
+  const runYamlCaseInChildProcess =
+    framework.runYamlCaseInChildProcess ||
+    framework.default?.runYamlCaseInChildProcess;
+  const runYamlCase = framework.runYamlCase || framework.default?.runYamlCase;
+  if (typeof runYamlCaseInChildProcess === 'function') {
+    await runYamlCaseInChildProcess({
+      ...${JSON.stringify(runOptions, null, 2)},
+      frameworkImport: ${toImportLiteral(options.frameworkImport)}${
+        options.resultFile
+          ? `,
+      resultFile: ${toImportLiteral(options.resultFile)}`
+          : ''
+      }
+    });
+    return;
+  }
+  if (typeof runYamlCase !== 'function') {
+    throw new Error('Cannot find runYamlCase from Midscene framework entry');
+  }
+  await runYamlCase(${JSON.stringify(runOptions, null, 2)});
+});
+`;
+};
+
+const createConfigContent = (options: {
+  root: string;
+  include: string[];
+  maxConcurrency?: number;
+  testTimeout: number;
+  bail?: number;
+}): string => {
+  const config = {
+    root: options.root,
+    include: options.include,
+    testEnvironment: 'node',
+    testTimeout: options.testTimeout,
+    ...(options.maxConcurrency !== undefined
+      ? { maxConcurrency: options.maxConcurrency }
+      : {}),
+    ...(options.bail !== undefined ? { bail: options.bail } : {}),
+  };
+
+  return `export default ${JSON.stringify(config, null, 2)};
+`;
+};
+
+const resolveDefaultFrameworkImport = (): string => {
+  const entry = process.argv[1] ? resolve(process.argv[1]) : '';
+  const candidates = [
+    entry ? join(dirname(entry), 'framework', 'index.js') : '',
+    entry
+      ? join(dirname(entry), '..', 'dist', 'lib', 'framework', 'index.js')
+      : '',
+  ].filter(Boolean);
+
+  const matched = candidates.find((candidate) => existsSync(candidate));
+  return matched || '@midscene/cli/dist/lib/framework/index.js';
+};
+
+export function createRstestYamlProject(
+  options: CreateRstestYamlProjectOptions,
+): GeneratedRstestYamlProject {
+  const projectDir = resolve(options.projectDir || process.cwd());
+  const outputDir =
+    options.outputDir ||
+    join(getMidsceneRunSubDir('tmp'), `rstest-yaml-${Date.now()}`);
+  const generatedDir = join(outputDir, 'generated');
+  const resultDir = options.resultDir || join(outputDir, 'results');
+  const frameworkImport =
+    options.frameworkImport || resolveDefaultFrameworkImport();
+  const rstestImport = options.rstestImport || resolveRstestCoreImportPath();
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(generatedDir, { recursive: true });
+
+  const cases = options.files.map((file, index) => {
+    const yamlFile = resolve(file);
+    const testName = resolveTestName(projectDir, yamlFile);
+    const fileStem = safeFileStem(yamlFile, index);
+    const resultFile = join(resultDir, `${fileStem}.json`);
+    const testFile = join(generatedDir, `${fileStem}.test.ts`);
+    writeFileSync(
+      testFile,
+      createGeneratedTestContent({
+        rstestImport,
+        frameworkImport,
+        yamlFile,
+        resultFile,
+        testName,
+        caseOptions: options.caseOptions?.[yamlFile],
+        headed: options.headed,
+        keepWindow: options.keepWindow,
+      }),
+    );
+    return { yamlFile, testFile, resultFile, testName };
+  });
+
+  const configFile = join(outputDir, 'rstest.config.ts');
+  writeFileSync(
+    configFile,
+    createConfigContent({
+      root: projectDir,
+      include: cases.map((item) => toPosixPath(item.testFile)),
+      maxConcurrency: options.maxConcurrency,
+      testTimeout: options.testTimeout ?? 3 * 60 * 1000,
+      bail: options.bail,
+    }),
+  );
+
+  return {
+    projectDir: outputDir,
+    configFile,
+    generatedDir,
+    cases,
+  };
+}

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -46,12 +46,13 @@ export interface GeneratedRstestYamlProject {
   cases: GeneratedYamlTestCase[];
 }
 
-const toPosixPath = (value: string): string => value.split(sep).join('/');
+export const toPosixPath = (value: string): string =>
+  value.split(sep).join('/');
 
 const toImportLiteral = (value: string): string =>
   JSON.stringify(toPosixPath(value));
 
-const safeFileStem = (file: string, index: number): string => {
+export const safeFileStem = (file: string, index: number): string => {
   const base = basename(file, extname(file))
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '');
@@ -113,7 +114,7 @@ test(${JSON.stringify(options.testName)}, async () => {
 `;
 };
 
-const createConfigContent = (options: {
+export const createConfigContent = (options: {
   root: string;
   include: string[];
   maxConcurrency?: number;

--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -1,0 +1,69 @@
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+
+export interface RunRstestCliOptions {
+  configFile: string;
+  cwd?: string;
+  stdio?: 'inherit' | 'pipe';
+  extraArgs?: string[];
+}
+
+const requireFromCliEntry = () => {
+  const entry = process.argv[1]
+    ? resolve(process.argv[1])
+    : join(process.cwd(), 'midscene-cli.js');
+  return createRequire(entry);
+};
+
+export function resolveRstestBinPath(): string {
+  const require = requireFromCliEntry();
+  const packageJsonPath = require.resolve('@rstest/core/package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    bin?: { rstest?: string };
+  };
+  const binPath = packageJson.bin?.rstest;
+  if (!binPath) {
+    throw new Error('@rstest/core does not expose a rstest binary');
+  }
+  return join(dirname(packageJsonPath), binPath);
+}
+
+export function resolveRstestCoreImportPath(): string {
+  const require = requireFromCliEntry();
+  const packageJsonPath = require.resolve('@rstest/core/package.json');
+  return join(dirname(packageJsonPath), 'dist', 'index.js');
+}
+
+export async function runRstestCli(
+  options: RunRstestCliOptions,
+): Promise<number> {
+  const args = [
+    resolveRstestBinPath(),
+    '--config',
+    resolve(options.configFile),
+    ...(options.extraArgs || []),
+  ];
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd || process.cwd(),
+      stdio: options.stdio || 'inherit',
+      env: process.env,
+    });
+    if (options.stdio === 'pipe') {
+      child.stdout?.resume();
+      child.stderr?.resume();
+    }
+
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Rstest was terminated by signal ${signal}`));
+        return;
+      }
+      resolvePromise(code ?? 1);
+    });
+  });
+}

--- a/packages/cli/src/framework/yaml-case.ts
+++ b/packages/cli/src/framework/yaml-case.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type {
+  MidsceneYamlScript,
+  MidsceneYamlScriptAndroidEnv,
+  MidsceneYamlScriptEnv,
+  MidsceneYamlScriptIOSEnv,
+  MidsceneYamlScriptWebEnv,
+  ScriptPlayerTaskStatus,
+} from '@midscene/core';
+import { type ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
+import merge from 'lodash.merge';
+import { createYamlPlayer } from '../create-yaml-player';
+
+export interface RunYamlCaseGlobalConfig {
+  web?: MidsceneYamlScriptWebEnv;
+  android?: MidsceneYamlScriptAndroidEnv;
+  ios?: MidsceneYamlScriptIOSEnv;
+  target?: MidsceneYamlScriptWebEnv;
+}
+
+export interface RunYamlCaseOptions {
+  file: string;
+  executionConfig?: MidsceneYamlScript;
+  globalConfig?: RunYamlCaseGlobalConfig;
+  headed?: boolean;
+  keepWindow?: boolean;
+}
+
+export interface RunYamlCaseResult {
+  file: string;
+  output?: string;
+  report?: string | null;
+  duration: number;
+}
+
+const taskErrorMessage = (task: ScriptPlayerTaskStatus): string | undefined => {
+  if (task.error?.message) {
+    return task.error.message;
+  }
+
+  if (task.status === 'error') {
+    return `Task "${task.name}" failed`;
+  }
+
+  return undefined;
+};
+
+const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const normalizeTargetConfig = (
+  config: MidsceneYamlScript | RunYamlCaseGlobalConfig,
+) => {
+  if (config.target) {
+    config.web = {
+      ...config.target,
+      ...config.web,
+    };
+    config.target = undefined;
+  }
+};
+
+const createExecutionConfig = (
+  file: string,
+  globalConfig: RunYamlCaseGlobalConfig,
+): MidsceneYamlScript => {
+  const content = readFileSync(file, 'utf8');
+  const fileConfig = cloneJson(parseYamlScript(content, file));
+  normalizeTargetConfig(fileConfig);
+
+  const clonedGlobalConfig = cloneJson(globalConfig);
+  normalizeTargetConfig(clonedGlobalConfig);
+
+  return merge(fileConfig, clonedGlobalConfig);
+};
+
+export const getYamlPlayerFailure = (
+  player: ScriptPlayer<MidsceneYamlScriptEnv>,
+): Error | undefined => {
+  if (player.errorInSetup) {
+    return player.errorInSetup;
+  }
+
+  const failedMessages =
+    player.taskStatusList?.map(taskErrorMessage).filter(Boolean) || [];
+
+  if (player.status === 'error' || failedMessages.length > 0) {
+    const details = failedMessages.length
+      ? failedMessages.join('; ')
+      : 'YAML case failed';
+    const reportLine = player.reportFile
+      ? `\nReport: ${player.reportFile}`
+      : '';
+    const outputLine = player.output ? `\nOutput: ${player.output}` : '';
+    return new Error(`${details}${reportLine}${outputLine}`);
+  }
+
+  return undefined;
+};
+
+export async function runYamlCase(
+  options: RunYamlCaseOptions,
+): Promise<RunYamlCaseResult> {
+  const file = resolve(options.file);
+  const startTime = Date.now();
+  const executionConfig =
+    options.executionConfig ||
+    (options.globalConfig
+      ? createExecutionConfig(file, options.globalConfig)
+      : undefined);
+  const player = await createYamlPlayer(file, executionConfig, {
+    headed: options.headed,
+    keepWindow: options.keepWindow,
+  });
+
+  await player.run();
+
+  const failure = getYamlPlayerFailure(player);
+  if (failure) {
+    throw failure;
+  }
+
+  return {
+    file,
+    output: player.output || undefined,
+    report: player.reportFile,
+    duration: Date.now() - startTime,
+  };
+}

--- a/packages/cli/src/framework/yaml-child-process.ts
+++ b/packages/cli/src/framework/yaml-child-process.ts
@@ -1,0 +1,208 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { RunYamlCaseOptions, RunYamlCaseResult } from './yaml-case';
+
+export interface RunYamlCaseInChildProcessOptions extends RunYamlCaseOptions {
+  frameworkImport?: string;
+  cwd?: string;
+  resultFile?: string;
+  timeout?: number;
+  stdio?: 'inherit' | 'pipe';
+}
+
+interface ChildMessage {
+  type?: 'result' | 'error';
+  result?: RunYamlCaseResult;
+  error?: {
+    message?: string;
+    stack?: string;
+  };
+}
+
+const childRunnerScript = `
+const options = JSON.parse(process.env.MIDSCENE_YAML_CASE_OPTIONS || '{}');
+const frameworkImport = process.env.MIDSCENE_FRAMEWORK_IMPORT;
+
+(async () => {
+  if (!frameworkImport) {
+    throw new Error('MIDSCENE_FRAMEWORK_IMPORT is required');
+  }
+  const framework = await import(frameworkImport);
+  const runYamlCase = framework.runYamlCase || framework.default?.runYamlCase;
+  if (typeof runYamlCase !== 'function') {
+    throw new Error('Cannot find runYamlCase from Midscene framework entry');
+  }
+  const result = await runYamlCase(options);
+  process.send?.({ type: 'result', result });
+})().catch((error) => {
+  const message = error?.message || String(error);
+  const stack = error?.stack || message;
+  process.send?.({ type: 'error', error: { message, stack } });
+  console.error(stack);
+  process.exit(1);
+});
+`;
+
+const formatChildFailure = (details: {
+  file: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  error?: ChildMessage['error'];
+  stderr: string;
+}): Error => {
+  const status = details.signal
+    ? `signal ${details.signal}`
+    : `exit code ${details.code ?? 1}`;
+  const message =
+    details.error?.message ||
+    details.stderr.trim() ||
+    `YAML case failed with ${status}`;
+  const suffix = details.error?.stack || details.stderr.trim();
+  return new Error(
+    `YAML case failed: ${details.file}\n${message}${
+      suffix && suffix !== message ? `\n${suffix}` : ''
+    }`,
+  );
+};
+
+const writeResultFile = (resultFile: string | undefined, data: unknown) => {
+  if (!resultFile) {
+    return;
+  }
+  mkdirSync(dirname(resultFile), { recursive: true });
+  writeFileSync(resultFile, JSON.stringify(data, null, 2));
+};
+
+export async function runYamlCaseInChildProcess(
+  options: RunYamlCaseInChildProcessOptions,
+): Promise<RunYamlCaseResult> {
+  const {
+    cwd,
+    frameworkImport = '@midscene/cli/dist/lib/framework/index.js',
+    resultFile,
+    stdio = 'inherit',
+    timeout,
+    ...runOptions
+  } = options;
+  const file = resolve(runOptions.file);
+  const childOptions: RunYamlCaseOptions = {
+    ...runOptions,
+    file,
+  };
+  const startTime = Date.now();
+
+  return new Promise((resolvePromise, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let result: RunYamlCaseResult | undefined;
+    let childError: ChildMessage['error'];
+    let settled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const child = spawn(process.execPath, ['-e', childRunnerScript], {
+      cwd: cwd || process.cwd(),
+      env: {
+        ...process.env,
+        MIDSCENE_FRAMEWORK_IMPORT: frameworkImport,
+        MIDSCENE_YAML_CASE_OPTIONS: JSON.stringify(childOptions),
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    if (timeout) {
+      timeoutId = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        child.kill('SIGTERM');
+        cleanup();
+        reject(new Error(`YAML case timed out after ${timeout}ms: ${file}`));
+      }, timeout);
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdio === 'inherit') {
+        process.stdout.write(chunk);
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stdio === 'inherit') {
+        process.stderr.write(chunk);
+      }
+    });
+
+    child.on('message', (message: ChildMessage) => {
+      if (message?.type === 'result') {
+        result = message.result;
+      }
+      if (message?.type === 'error') {
+        childError = message.error;
+      }
+    });
+
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    });
+
+    child.on('close', (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+
+      if (code === 0 && !signal) {
+        const successResult = result || {
+          file,
+          duration: Date.now() - startTime,
+        };
+        writeResultFile(resultFile, {
+          file: successResult.file,
+          success: true,
+          executed: true,
+          output: successResult.output,
+          report: successResult.report,
+          duration: successResult.duration,
+          resultType: 'success',
+        });
+        resolvePromise(successResult);
+        return;
+      }
+
+      const failure = formatChildFailure({
+        file,
+        code,
+        signal,
+        error: childError,
+        stderr: stderr || stdout,
+      });
+      writeResultFile(resultFile, {
+        file,
+        success: false,
+        executed: true,
+        output: undefined,
+        report: undefined,
+        duration: Date.now() - startTime,
+        resultType: 'failed',
+        error: childError?.message || failure.message,
+      });
+      reject(failure);
+    });
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,14 +5,26 @@ import { runToolsCLI } from '@midscene/shared/cli';
 import type { BaseMidsceneTools } from '@midscene/shared/mcp/base-tools';
 import dotenv from 'dotenv';
 import { version } from '../package.json';
-import { BatchRunner } from './batch-runner';
 import { matchYamlFiles, parseProcessArgs } from './cli-utils';
 import { createConfig, createFilesConfig } from './config-factory';
+import { runFrameworkTestCommand, runFrameworkTestConfig } from './framework';
 
 Promise.resolve(
   (async () => {
     const rawArgs = process.argv.slice(2);
     const [firstArg] = rawArgs;
+    if (firstArg === 'test') {
+      const dotEnvConfigFile = join(process.cwd(), '.env');
+      if (existsSync(dotEnvConfigFile)) {
+        console.log(`   Env file: ${dotEnvConfigFile}`);
+        dotenv.config({
+          path: dotEnvConfigFile,
+        });
+      }
+      const exitCode = await runFrameworkTestCommand(rawArgs.slice(1));
+      process.exit(exitCode);
+    }
+
     if (firstArg === 'report-tool') {
       await runToolsCLI(
         {
@@ -98,11 +110,7 @@ Promise.resolve(
       });
     }
 
-    const executor = new BatchRunner(config);
-
-    await executor.run();
-
-    const success = executor.printExecutionSummary();
+    const exitCode = await runFrameworkTestConfig(config);
 
     if (config.keepWindow) {
       // hang the process to keep the browser window open
@@ -110,10 +118,7 @@ Promise.resolve(
         console.log('browser is still running, use ctrl+c to stop it');
       }, 5000);
     } else {
-      if (!success) {
-        process.exit(1);
-      }
-      process.exit(0);
+      process.exit(exitCode);
     }
   })().catch((e) => {
     console.error(e);

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -1,0 +1,199 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  runFrameworkTestCommand,
+  runFrameworkTestConfig,
+} from '@/framework/command';
+import { describe, expect, test } from 'vitest';
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-command-'));
+
+describe('framework test command', () => {
+  test('discovers YAML files, generates a Rstest project, and passes the config to the runner', async () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'cases', 'checkout.yaml');
+    mkdirSync(join(root, 'cases'), { recursive: true });
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    const calls: Array<{ configFile: string; cwd?: string }> = [];
+
+    try {
+      const exitCode = await runFrameworkTestCommand(
+        [root, '--concurrent', '3'],
+        {
+          outputDir,
+          frameworkImport: '@test/framework',
+          rstestRunner: async (options) => {
+            calls.push(options);
+            return 7;
+          },
+        },
+      );
+
+      expect(exitCode).toBe(7);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].cwd).toBe(root);
+      expect(calls[0].configFile).toBe(join(outputDir, 'rstest.config.ts'));
+      expect(readFileSync(calls[0].configFile, 'utf8')).toContain(
+        '"maxConcurrency": 3',
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('supports --files filtering without changing the project root', async () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'generated-runner');
+    const included = join(root, 'cases', 'included.yaml');
+    const skipped = join(root, 'cases', 'skipped.yaml');
+    mkdirSync(join(root, 'cases'), { recursive: true });
+    writeFileSync(included, 'web:\n  url: about:blank\ntasks: []\n');
+    writeFileSync(skipped, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      await runFrameworkTestCommand([root, '--files', 'cases/included.yaml'], {
+        outputDir,
+        rstestRunner: async () => 0,
+      });
+
+      const config = readFileSync(join(outputDir, 'rstest.config.ts'), 'utf8');
+      expect(config).toContain('included');
+      expect(config).not.toContain('skipped');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when no YAML files are found', async () => {
+    const root = createTempDir();
+
+    try {
+      await expect(
+        runFrameworkTestCommand([root], {
+          rstestRunner: async () => 0,
+        }),
+      ).rejects.toThrow(/No yaml files found/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('can run a generated Rstest project end to end with a test framework import override', async () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const framework = join(root, 'framework.ts');
+    const marker = join(root, 'marker.txt');
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+    writeFileSync(
+      framework,
+      `import { writeFileSync } from 'node:fs';
+export async function runYamlCaseInChildProcess(options: { file: string }) {
+  writeFileSync(${JSON.stringify(marker)}, options.file);
+}
+`,
+    );
+
+    try {
+      const exitCode = await runFrameworkTestCommand([root], {
+        outputDir,
+        frameworkImport: framework,
+        stdio: 'pipe',
+      });
+
+      expect(exitCode).toBe(0);
+      expect(readFileSync(marker, 'utf8')).toBe(yaml);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('runs an existing CLI config through Rstest and writes the summary file', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const framework = join(root, 'framework.ts');
+    const marker = join(root, 'execution-config.json');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: https://file.example\ntasks: []\n');
+    writeFileSync(
+      framework,
+      `import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+export async function runYamlCaseInChildProcess(options: any) {
+  mkdirSync(dirname(options.resultFile), { recursive: true });
+  writeFileSync(${JSON.stringify(marker)}, JSON.stringify(options.globalConfig));
+  writeFileSync(options.resultFile, JSON.stringify({
+    file: options.file,
+    success: true,
+    executed: true,
+    output: null,
+    report: null,
+    duration: 12,
+    resultType: 'success'
+  }));
+}
+`,
+    );
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yaml],
+          concurrent: 2,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {
+            web: {
+              viewportWidth: 1280,
+            },
+          },
+          headed: true,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: framework,
+          stdio: 'pipe',
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(
+        readFileSync(join(outputDir, 'rstest.config.ts'), 'utf8'),
+      ).toContain('"bail": 1');
+      expect(JSON.parse(readFileSync(marker, 'utf8'))).toMatchObject({
+        web: {
+          viewportWidth: 1280,
+        },
+      });
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary.successful).toBe(1);
+      expect(summary.results[0].success).toBe(true);
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -6,7 +6,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   runFrameworkTestCommand,
   runFrameworkTestConfig,
@@ -16,6 +16,113 @@ import { describe, expect, test } from 'vitest';
 const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-command-'));
 
 describe('framework test command', () => {
+  test('uses midscene.config.ts to collect yaml and TypeScript tests for Rstest', async () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'generated-runner');
+    const e2e = join(root, 'e2e');
+    const yaml = join(e2e, 'checkout.yaml');
+    const directTest = join(e2e, 'checkout-risk.test.ts');
+    const skipped = join(e2e, 'skip.yaml');
+    const frameworkSource = resolve(
+      __dirname,
+      '../../../../testing-framework/src',
+    );
+    mkdirSync(e2e, { recursive: true });
+    writeFileSync(yaml, 'flow:\n  - aiAssert: Checkout page is visible\n');
+    writeFileSync(directTest, 'test("risk", () => {})\n');
+    writeFileSync(skipped, 'flow: []\n');
+    writeFileSync(
+      join(root, 'midscene.config.ts'),
+      `import { defineMidsceneConfig } from ${JSON.stringify(frameworkSource)};
+
+export default defineMidsceneConfig({
+  testDir: './e2e',
+  include: ['**/*.yaml', '**/*.test.ts'],
+  exclude: ['**/skip.yaml'],
+  testRunner: {
+    maxConcurrency: 2,
+    bail: 1,
+    testTimeout: 90_000,
+  },
+});
+`,
+    );
+
+    const calls: Array<{ configFile: string; cwd?: string }> = [];
+
+    try {
+      const exitCode = await runFrameworkTestCommand([root], {
+        outputDir,
+        rstestRunner: async (options) => {
+          calls.push(options);
+          return 0;
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].cwd).toBe(root);
+      expect(calls[0].configFile).toBe(join(outputDir, 'rstest.config.ts'));
+
+      const rstestConfig = readFileSync(calls[0].configFile, 'utf8');
+      expect(rstestConfig).toContain('"maxConcurrency": 2');
+      expect(rstestConfig).toContain('"bail": 1');
+      expect(rstestConfig).toContain('"testTimeout": 90000');
+      expect(rstestConfig).toContain(directTest);
+      expect(rstestConfig).not.toContain(skipped);
+
+      const generatedSource = readFileSync(
+        join(outputDir, 'generated', '001-checkout.test.ts'),
+        'utf8',
+      );
+      expect(generatedSource).toContain(
+        `import config from ${JSON.stringify(join(root, 'midscene.config.ts'))}`,
+      );
+      expect(generatedSource).toContain('runYamlFrameworkCase');
+      expect(generatedSource).toContain(yaml);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('creates the default generated Rstest project under the configured project root', async () => {
+    const root = createTempDir();
+    const e2e = join(root, 'e2e');
+    const frameworkSource = resolve(
+      __dirname,
+      '../../../../testing-framework/src',
+    );
+    mkdirSync(e2e, { recursive: true });
+    writeFileSync(join(e2e, 'checkout.yaml'), 'flow: []\n');
+    writeFileSync(
+      join(root, 'midscene.config.ts'),
+      `import { defineMidsceneConfig } from ${JSON.stringify(frameworkSource)};
+export default defineMidsceneConfig({
+  testDir: './e2e',
+});
+`,
+    );
+
+    const calls: Array<{ configFile: string; cwd?: string }> = [];
+
+    try {
+      await runFrameworkTestCommand([root], {
+        rstestRunner: async (options) => {
+          calls.push(options);
+          return 0;
+        },
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].cwd).toBe(root);
+      expect(calls[0].configFile).toContain(
+        join(root, 'midscene_run', 'tmp', 'rstest-framework-'),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('discovers YAML files, generates a Rstest project, and passes the config to the runner', async () => {
     const root = createTempDir();
     const outputDir = join(root, 'generated-runner');

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -1,0 +1,90 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createRstestYamlProject,
+  resolveTestName,
+} from '@/framework/rstest-project';
+import { describe, expect, test } from 'vitest';
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-rstest-'));
+
+describe('rstest yaml project generation', () => {
+  test('generates a Rstest config and one test file for each YAML file', () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'runner');
+    const yamlA = join(root, 'cases', 'checkout.yaml');
+    const yamlB = join(root, 'cases', '中文 case.yaml');
+    mkdirSync(join(root, 'cases'), { recursive: true });
+    writeFileSync(yamlA, 'web:\n  url: about:blank\ntasks: []\n');
+    writeFileSync(yamlB, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      const project = createRstestYamlProject({
+        files: [yamlA, yamlB],
+        projectDir: root,
+        outputDir,
+        frameworkImport: '@test/framework',
+        rstestImport: '@test/rstest-core',
+        maxConcurrency: 2,
+      });
+
+      expect(project.configFile).toBe(join(outputDir, 'rstest.config.ts'));
+      expect(project.cases).toHaveLength(2);
+      expect(project.cases[0].testName).toBe('cases/checkout.yaml');
+      expect(project.cases[0].resultFile).toBe(
+        join(outputDir, 'results', '001-checkout.json'),
+      );
+      expect(project.cases[1].testName).toBe('cases/中文 case.yaml');
+
+      const config = readFileSync(project.configFile, 'utf8');
+      expect(config).toContain('"maxConcurrency": 2');
+      expect(config).toContain(project.cases[0].testFile);
+
+      const generated = readFileSync(project.cases[1].testFile, 'utf8');
+      expect(generated).toContain('import { test } from "@test/rstest-core"');
+      expect(generated).toContain('await import("@test/framework")');
+      expect(generated).toContain('runYamlCaseInChildProcess');
+      expect(generated).toContain('frameworkImport: "@test/framework"');
+      expect(generated).toContain(JSON.stringify(yamlB));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('replaces stale generated files when output directory already exists', () => {
+    const root = createTempDir();
+    const outputDir = join(root, 'runner');
+    const staleFile = join(outputDir, 'generated', 'stale.test.ts');
+    const yaml = join(root, 'case.yaml');
+    mkdirSync(join(outputDir, 'generated'), { recursive: true });
+    writeFileSync(staleFile, 'stale', { flag: 'w' });
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      const project = createRstestYamlProject({
+        files: [yaml],
+        projectDir: root,
+        outputDir,
+      });
+
+      expect(project.cases).toHaveLength(1);
+      expect(() => readFileSync(staleFile, 'utf8')).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('uses absolute path as test name when YAML is outside the project root', () => {
+    const projectDir = '/tmp/project';
+    const yamlFile = '/tmp/other/script.yaml';
+
+    expect(resolveTestName(projectDir, yamlFile)).toBe(yamlFile);
+  });
+});

--- a/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveRstestBinPath, runRstestCli } from '@/framework/rstest-runner';
+import { describe, expect, test } from 'vitest';
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-rstest-cli-'));
+
+describe('rstest runner', () => {
+  test('resolves the bundled Rstest binary', () => {
+    expect(resolveRstestBinPath()).toMatch(/@rstest[/\\]core/);
+  });
+
+  test('returns zero for a passing Rstest project and non-zero for a failing one', async () => {
+    const root = createTempDir();
+    const passing = join(root, 'passing.test.ts');
+    const failing = join(root, 'failing.test.ts');
+    const config = join(root, 'rstest.config.ts');
+
+    try {
+      writeFileSync(
+        passing,
+        "import { test, expect } from '@rstest/core';\ntest('pass', () => expect(1).toBe(1));\n",
+      );
+      writeFileSync(
+        failing,
+        "import { test, expect } from '@rstest/core';\ntest('fail', () => expect(1).toBe(2));\n",
+      );
+      writeFileSync(
+        config,
+        `import { defineConfig } from '@rstest/core';
+export default defineConfig({
+  root: ${JSON.stringify(root)},
+  include: [${JSON.stringify(passing)}],
+});
+`,
+      );
+
+      await expect(
+        runRstestCli({ configFile: config, cwd: root, stdio: 'pipe' }),
+      ).resolves.toBe(0);
+
+      writeFileSync(
+        config,
+        `import { defineConfig } from '@rstest/core';
+export default defineConfig({
+  root: ${JSON.stringify(root)},
+  include: [${JSON.stringify(failing)}],
+});
+`,
+      );
+
+      await expect(
+        runRstestCli({ configFile: config, cwd: root, stdio: 'pipe' }),
+      ).resolves.not.toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/unit-test/framework/yaml-case.test.ts
+++ b/packages/cli/tests/unit-test/framework/yaml-case.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createYamlPlayer } from '@/create-yaml-player';
+import { runYamlCase } from '@/framework/yaml-case';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@/create-yaml-player', () => ({
+  createYamlPlayer: vi.fn(),
+}));
+
+const createPlayer = (overrides: Record<string, any> = {}) => ({
+  status: 'done',
+  output: '/tmp/output.json',
+  reportFile: '/tmp/report.html',
+  errorInSetup: undefined,
+  taskStatusList: [],
+  run: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-yaml-case-'));
+
+describe('runYamlCase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('runs a YAML player and returns output metadata', async () => {
+    const player = createPlayer();
+    vi.mocked(createYamlPlayer).mockResolvedValue(player as any);
+
+    const result = await runYamlCase({ file: 'relative.yaml', headed: true });
+
+    expect(createYamlPlayer).toHaveBeenCalledWith(
+      expect.stringMatching(/relative\.yaml$/),
+      undefined,
+      { headed: true, keepWindow: undefined },
+    );
+    expect(player.run).toHaveBeenCalledTimes(1);
+    expect(result.output).toBe('/tmp/output.json');
+    expect(result.report).toBe('/tmp/report.html');
+  });
+
+  test('passes merged execution config to the YAML player', async () => {
+    const player = createPlayer();
+    const executionConfig = {
+      web: {
+        url: 'https://example.com',
+        viewportWidth: 1280,
+      },
+      tasks: [],
+    };
+    vi.mocked(createYamlPlayer).mockResolvedValue(player as any);
+
+    await runYamlCase({ file: 'relative.yaml', executionConfig });
+
+    expect(createYamlPlayer).toHaveBeenCalledWith(
+      expect.stringMatching(/relative\.yaml$/),
+      executionConfig,
+      { headed: undefined, keepWindow: undefined },
+    );
+  });
+
+  test('merges global config inside the YAML case process', async () => {
+    const root = createTempDir();
+    const yaml = join(root, 'case.yaml');
+    const player = createPlayer();
+    vi.mocked(createYamlPlayer).mockResolvedValue(player as any);
+    writeFileSync(yaml, 'web:\n  url: https://file.example\ntasks: []\n');
+
+    try {
+      await runYamlCase({
+        file: yaml,
+        globalConfig: {
+          web: {
+            viewportWidth: 1280,
+          },
+        },
+      });
+
+      expect(createYamlPlayer).toHaveBeenCalledWith(
+        yaml,
+        expect.objectContaining({
+          web: {
+            url: 'https://file.example',
+            viewportWidth: 1280,
+          },
+          tasks: [],
+        }),
+        { headed: undefined, keepWindow: undefined },
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('throws setup errors from the YAML player', async () => {
+    const error = new Error('setup failed');
+    const player = createPlayer({
+      status: 'error',
+      errorInSetup: error,
+    });
+    vi.mocked(createYamlPlayer).mockResolvedValue(player as any);
+
+    await expect(runYamlCase({ file: 'broken.yaml' })).rejects.toThrow(
+      'setup failed',
+    );
+  });
+
+  test('throws task failures with report and output paths', async () => {
+    const player = createPlayer({
+      status: 'error',
+      taskStatusList: [
+        {
+          name: 'check result',
+          status: 'error',
+          error: new Error('assertion failed'),
+        },
+      ],
+    });
+    vi.mocked(createYamlPlayer).mockResolvedValue(player as any);
+
+    await expect(runYamlCase({ file: 'failed.yaml' })).rejects.toThrow(
+      /assertion failed[\s\S]*Report: \/tmp\/report\.html[\s\S]*Output: \/tmp\/output\.json/,
+    );
+  });
+});

--- a/packages/cli/tests/unit-test/framework/yaml-child-process.test.ts
+++ b/packages/cli/tests/unit-test/framework/yaml-child-process.test.ts
@@ -1,0 +1,92 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runYamlCaseInChildProcess } from '@/framework/yaml-child-process';
+import { describe, expect, test } from 'vitest';
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-child-'));
+
+describe('runYamlCaseInChildProcess', () => {
+  test('runs the YAML case through an isolated child process', async () => {
+    const root = createTempDir();
+    const framework = join(root, 'framework.mjs');
+    const marker = join(root, 'marker.json');
+    const resultFile = join(root, 'result.json');
+
+    writeFileSync(
+      framework,
+      `import { writeFileSync } from 'node:fs';
+export async function runYamlCase(options) {
+  writeFileSync(${JSON.stringify(marker)}, JSON.stringify(options));
+  return { file: options.file, output: 'output.json', report: 'report.html', duration: 9 };
+}
+`,
+    );
+
+    try {
+      const result = await runYamlCaseInChildProcess({
+        file: join(root, 'case.yaml'),
+        headed: true,
+        keepWindow: false,
+        frameworkImport: framework,
+        resultFile,
+        stdio: 'pipe',
+      });
+
+      expect(result.output).toBe('output.json');
+      expect(result.report).toBe('report.html');
+      expect(JSON.parse(readFileSync(marker, 'utf8'))).toEqual({
+        file: join(root, 'case.yaml'),
+        headed: true,
+        keepWindow: false,
+      });
+      expect(JSON.parse(readFileSync(resultFile, 'utf8'))).toMatchObject({
+        file: join(root, 'case.yaml'),
+        success: true,
+        executed: true,
+        resultType: 'success',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('surfaces child process failures to the Rstest case', async () => {
+    const root = createTempDir();
+    const framework = join(root, 'framework.mjs');
+    const resultFile = join(root, 'result.json');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      framework,
+      `export async function runYamlCase(options) {
+  throw new Error('child failed: ' + options.file);
+}
+`,
+    );
+
+    try {
+      await expect(
+        runYamlCaseInChildProcess({
+          file: join(root, 'failed.yaml'),
+          frameworkImport: framework,
+          resultFile,
+          stdio: 'pipe',
+        }),
+      ).rejects.toThrow(/child failed: .*failed\.yaml/);
+      expect(JSON.parse(readFileSync(resultFile, 'utf8'))).toMatchObject({
+        file: join(root, 'failed.yaml'),
+        success: false,
+        executed: true,
+        resultType: 'failed',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/testing-framework/package.json
+++ b/packages/testing-framework/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@midscene/testing-framework",
+  "description": "Midscene UI testing framework runtime built on Rstest.",
+  "version": "1.8.4",
+  "repository": "https://github.com/web-infra-dev/midscene",
+  "homepage": "https://midscenejs.com/",
+  "main": "./dist/lib/index.js",
+  "types": "./dist/types/index.d.ts",
+  "module": "./dist/es/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/es/index.mjs",
+      "require": "./dist/lib/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/types/runtime/index.d.ts",
+      "import": "./dist/es/runtime/index.mjs",
+      "require": "./dist/lib/runtime/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "dev": "npm run build:watch",
+    "build": "rslib build",
+    "build:watch": "rslib build --watch --no-clean",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "@midscene/android": "workspace:*",
+    "@midscene/core": "workspace:*",
+    "@midscene/shared": "workspace:*",
+    "@midscene/web": "workspace:*",
+    "glob": "11.0.0",
+    "jiti": "2.6.1",
+    "js-yaml": "4.1.0"
+  },
+  "devDependencies": {
+    "@rslib/core": "^0.18.3",
+    "@types/js-yaml": "4.0.9",
+    "@types/node": "^18.0.0",
+    "playwright": "^1.45.0",
+    "typescript": "^5.8.3",
+    "vitest": "3.0.5"
+  },
+  "peerDependencies": {
+    "playwright": "^1.45.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=18.19.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "license": "MIT"
+}

--- a/packages/testing-framework/rslib.config.ts
+++ b/packages/testing-framework/rslib.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from '@rslib/core';
+import { version } from './package.json';
+
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      output: {
+        distPath: {
+          root: 'dist/lib',
+        },
+      },
+      format: 'cjs',
+      syntax: 'es2020',
+    },
+    {
+      bundle: false,
+      output: {
+        distPath: {
+          root: 'dist/es',
+        },
+      },
+      format: 'esm',
+      syntax: 'es2020',
+      dts: {
+        distPath: 'dist/types',
+      },
+    },
+  ],
+  source: {
+    define: {
+      __VERSION__: JSON.stringify(version),
+    },
+    tsconfigPath: 'tsconfig.build.json',
+  },
+  output: {
+    sourceMap: true,
+  },
+});

--- a/packages/testing-framework/src/config.ts
+++ b/packages/testing-framework/src/config.ts
@@ -1,0 +1,95 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { glob } from 'glob';
+import { createJiti } from 'jiti';
+import type {
+  FrameworkTestFile,
+  LoadedMidsceneConfig,
+  MidsceneFrameworkConfig,
+} from './types';
+
+export function defineMidsceneConfig<T extends MidsceneFrameworkConfig>(
+  config: T,
+): T {
+  return config;
+}
+
+export async function loadMidsceneConfig(
+  configPath = resolve(process.cwd(), 'midscene.config.ts'),
+): Promise<LoadedMidsceneConfig> {
+  const resolvedPath = resolve(configPath);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`midscene.config.ts not found: ${resolvedPath}`);
+  }
+
+  const jiti = createJiti(resolvedPath, {
+    moduleCache: false,
+  });
+  const config = await jiti.import<MidsceneFrameworkConfig | undefined>(
+    resolvedPath,
+    {
+      default: true,
+    },
+  );
+  if (!config || typeof config !== 'object') {
+    throw new Error(
+      `midscene config must export a default object: ${resolvedPath}`,
+    );
+  }
+
+  return {
+    path: resolvedPath,
+    root: dirname(resolvedPath),
+    config,
+  };
+}
+
+const toPosixPath = (value: string): string => value.split('\\').join('/');
+
+const uniqueSorted = (files: string[]): string[] =>
+  Array.from(new Set(files)).sort((a, b) => a.localeCompare(b));
+
+const inferFileType = (filePath: string): FrameworkTestFile['type'] => {
+  if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+    return 'yaml';
+  }
+  return 'test';
+};
+
+export async function collectFrameworkTestFiles(input: {
+  root: string;
+  config: MidsceneFrameworkConfig;
+}): Promise<FrameworkTestFile[]> {
+  const testDir = input.config.testDir || './e2e';
+  const include =
+    input.config.include && input.config.include.length > 0
+      ? input.config.include
+      : ['**/*.yaml', '**/*.yml', '**/*.test.ts'];
+  const exclude = input.config.exclude || [];
+  const cwd = resolve(input.root, testDir);
+
+  const files: string[] = [];
+  for (const pattern of include) {
+    const matched = await glob(pattern, {
+      cwd,
+      absolute: true,
+      ignore: exclude,
+      nodir: true,
+      dot: true,
+    });
+    files.push(...matched);
+  }
+
+  return uniqueSorted(files).map((filePath) => {
+    const relativeToRoot = toPosixPath(
+      filePath.startsWith(input.root)
+        ? filePath.slice(input.root.length + 1)
+        : filePath,
+    );
+    return {
+      filePath,
+      relativePath: relativeToRoot,
+      type: inferFileType(filePath),
+    };
+  });
+}

--- a/packages/testing-framework/src/index.ts
+++ b/packages/testing-framework/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  collectFrameworkTestFiles,
+  defineMidsceneConfig,
+  loadMidsceneConfig,
+} from './config';
+export type {
+  CustomYamlStepContext,
+  CustomYamlStepHandler,
+  FrameworkAgent,
+  FrameworkSetupResult,
+  FrameworkTargetConfig,
+  FrameworkTargetType,
+  FrameworkTestFile,
+  LoadedMidsceneConfig,
+  MidsceneFrameworkConfig,
+  NormalizedYamlCase,
+} from './types';

--- a/packages/testing-framework/src/runtime/index.ts
+++ b/packages/testing-framework/src/runtime/index.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import type { MidsceneFrameworkConfig } from '../types';
+import { setupFrameworkAgent } from './setup';
+import { createYamlFrameworkTestSource } from './source';
+import {
+  normalizeYamlCase,
+  runBuiltinYamlCase,
+  runYamlFlowWithCustomSteps,
+} from './yaml';
+
+export { createYamlFrameworkTestSource } from './source';
+export {
+  normalizeYamlCase,
+  runBuiltinYamlCase,
+  runYamlFlowWithCustomSteps,
+} from './yaml';
+export { createDefaultSetup, setupFrameworkAgent } from './setup';
+
+const caseNameFromPath = (filePath: string): string =>
+  basename(filePath, extname(filePath)) || 'case';
+
+export async function runYamlFrameworkCase(options: {
+  config: MidsceneFrameworkConfig;
+  configPath?: string;
+  filePath: string;
+}): Promise<void> {
+  const content = await readFile(options.filePath, 'utf8');
+  const normalizedCase = normalizeYamlCase(content, options.filePath);
+  const setupResult = await setupFrameworkAgent(options.config);
+
+  try {
+    if (options.config.yamlSteps) {
+      const state: Record<string, unknown> = {};
+      for (const task of normalizedCase.tasks) {
+        await runYamlFlowWithCustomSteps({
+          agent: setupResult.agent,
+          filePath: options.filePath,
+          caseName: task.name || caseNameFromPath(options.filePath),
+          flow: task.flow,
+          yamlSteps: options.config.yamlSteps,
+          state,
+        });
+      }
+      return;
+    }
+
+    await runBuiltinYamlCase({
+      agent: setupResult.agent,
+      normalizedCase,
+      config: options.config,
+    });
+  } finally {
+    await setupResult.teardown?.();
+  }
+}

--- a/packages/testing-framework/src/runtime/setup.ts
+++ b/packages/testing-framework/src/runtime/setup.ts
@@ -1,0 +1,92 @@
+import type { FrameworkSetupResult, MidsceneFrameworkConfig } from '../types';
+
+export async function createDefaultSetup(
+  config: MidsceneFrameworkConfig,
+): Promise<FrameworkSetupResult> {
+  if (!config.target) {
+    throw new Error('midscene.config.ts must provide target or setup');
+  }
+
+  const options = config.target.options || {};
+  if (config.target.type === 'android') {
+    const { agentFromAdbDevice } = await import('@midscene/android');
+    const { deviceId, launch, ...deviceOptions } = options as Record<
+      string,
+      unknown
+    >;
+    const agent = await agentFromAdbDevice(
+      typeof deviceId === 'string' ? deviceId : undefined,
+      {
+        ...config.agentOptions,
+        ...deviceOptions,
+      },
+    );
+
+    if (typeof launch === 'string' && launch) {
+      await agent.launch(launch);
+    }
+
+    return {
+      agent,
+      async teardown() {
+        if (
+          typeof launch === 'string' &&
+          launch &&
+          !launch.startsWith('http')
+        ) {
+          await agent.terminate(launch);
+        }
+      },
+    };
+  }
+
+  if (config.target.type === 'web') {
+    const [{ PlaywrightAgent }, { chromium }] = await Promise.all([
+      import('@midscene/web/playwright'),
+      import('playwright'),
+    ]);
+    const targetOptions = options as {
+      url?: string;
+      viewport?: { width: number; height: number };
+      headless?: boolean;
+    };
+    if (!targetOptions.url) {
+      throw new Error('target.options.url is required for web target');
+    }
+
+    const browser = await chromium.launch({
+      headless: targetOptions.headless ?? true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    const context = await browser.newContext({
+      viewport: targetOptions.viewport,
+    });
+    const page = await context.newPage();
+    await page.goto(targetOptions.url);
+
+    return {
+      agent: new PlaywrightAgent(page, config.agentOptions),
+      browser,
+      context,
+      page,
+      async teardown() {
+        await context.close();
+        await browser.close();
+      },
+    };
+  }
+
+  throw new Error(`Unsupported target.type: ${config.target.type}`);
+}
+
+export async function setupFrameworkAgent(
+  config: MidsceneFrameworkConfig,
+): Promise<FrameworkSetupResult> {
+  if (config.setup) {
+    return config.setup({
+      agentOptions: config.agentOptions || {},
+    });
+  }
+
+  return createDefaultSetup(config);
+}

--- a/packages/testing-framework/src/runtime/source.ts
+++ b/packages/testing-framework/src/runtime/source.ts
@@ -1,0 +1,20 @@
+export function createYamlFrameworkTestSource(options: {
+  configPath: string;
+  filePath: string;
+  testName: string;
+  runtimeImport: string;
+  rstestImport: string;
+}): string {
+  return `import { test } from ${JSON.stringify(options.rstestImport)};
+import config from ${JSON.stringify(options.configPath)};
+import { runYamlFrameworkCase } from ${JSON.stringify(options.runtimeImport)};
+
+test(${JSON.stringify(options.testName)}, async () => {
+  await runYamlFrameworkCase({
+    config,
+    configPath: ${JSON.stringify(options.configPath)},
+    filePath: ${JSON.stringify(options.filePath)}
+  });
+});
+`;
+}

--- a/packages/testing-framework/src/runtime/yaml.ts
+++ b/packages/testing-framework/src/runtime/yaml.ts
@@ -1,0 +1,166 @@
+import { basename, extname } from 'node:path';
+import type { MidsceneYamlFlowItem } from '@midscene/core';
+import yaml from 'js-yaml';
+import type {
+  CustomYamlStepHandler,
+  FrameworkAgent,
+  MidsceneFrameworkConfig,
+  NormalizedYamlCase,
+} from '../types';
+
+const builtinStepNames = new Set([
+  'ai',
+  'aiAct',
+  'aiAction',
+  'aiAssert',
+  'aiQuery',
+  'aiInput',
+  'aiTap',
+  'aiHover',
+  'aiScroll',
+  'aiKeyboardPress',
+  'aiWaitFor',
+  'sleep',
+  'javascript',
+  'recordToReport',
+  'logScreenshot',
+  'launch',
+  'terminate',
+  'runAdbShell',
+  'RunAdbShell',
+  'runWdaRequest',
+  'RunWdaRequest',
+]);
+
+const readSingleStep = (
+  step: unknown,
+  filePath: string,
+  stepIndex: number,
+): { stepName: string; value: unknown } => {
+  if (!step || typeof step !== 'object' || Array.isArray(step)) {
+    throw new Error(`${filePath} step ${stepIndex + 1} must be an object`);
+  }
+
+  const entries = Object.entries(step as Record<string, unknown>);
+  if (entries.length !== 1) {
+    throw new Error(
+      `${filePath} step ${stepIndex + 1} must contain exactly one key`,
+    );
+  }
+
+  const [stepName, value] = entries[0];
+  return { stepName, value };
+};
+
+const caseNameFromPath = (filePath: string): string =>
+  basename(filePath, extname(filePath)) || 'case';
+
+export function normalizeYamlCase(
+  content: string,
+  filePath: string,
+): NormalizedYamlCase {
+  const parsed = yaml.load(content) as Record<string, unknown> | undefined;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${filePath} must be a YAML object`);
+  }
+
+  if (Array.isArray(parsed.tasks)) {
+    return {
+      tasks: parsed.tasks as NormalizedYamlCase['tasks'],
+      raw: parsed,
+    };
+  }
+
+  if (Array.isArray(parsed.flow)) {
+    const { flow, ...rest } = parsed;
+    return {
+      tasks: [
+        {
+          name: caseNameFromPath(filePath),
+          flow: flow as MidsceneYamlFlowItem[],
+        },
+      ],
+      raw: rest,
+    };
+  }
+
+  throw new Error(`${filePath} must include either tasks or flow`);
+}
+
+const dumpSingleBuiltinStep = (caseName: string, step: unknown): string =>
+  yaml.dump(
+    {
+      tasks: [
+        {
+          name: caseName,
+          flow: [step],
+        },
+      ],
+    },
+    {
+      lineWidth: -1,
+      noRefs: true,
+    },
+  );
+
+export async function runYamlFlowWithCustomSteps(options: {
+  agent: FrameworkAgent;
+  filePath: string;
+  caseName: string;
+  flow: MidsceneYamlFlowItem[];
+  yamlSteps?: Record<string, CustomYamlStepHandler>;
+  state: Record<string, unknown>;
+}): Promise<void> {
+  for (const [stepIndex, step] of options.flow.entries()) {
+    const { stepName, value } = readSingleStep(
+      step,
+      options.filePath,
+      stepIndex,
+    );
+
+    if (builtinStepNames.has(stepName)) {
+      await options.agent.runYaml(
+        dumpSingleBuiltinStep(`${options.caseName}:${stepName}`, step),
+      );
+      continue;
+    }
+
+    const customStep = options.yamlSteps?.[stepName];
+    if (!customStep) {
+      throw new Error(
+        `${options.filePath} step ${stepIndex + 1} uses unknown step "${stepName}"`,
+      );
+    }
+
+    await customStep(value, {
+      agent: options.agent,
+      state: options.state,
+      filePath: options.filePath,
+      stepIndex,
+      stepName,
+    });
+  }
+}
+
+const mergeYamlCaseWithConfig = (
+  normalizedCase: NormalizedYamlCase,
+  config: MidsceneFrameworkConfig,
+): Record<string, unknown> => ({
+  ...normalizedCase.raw,
+  ...(config.target ? { target: config.target } : {}),
+  ...(config.agentOptions ? { agent: config.agentOptions } : {}),
+  tasks: normalizedCase.tasks,
+});
+
+export async function runBuiltinYamlCase(options: {
+  agent: FrameworkAgent;
+  normalizedCase: NormalizedYamlCase;
+  config: MidsceneFrameworkConfig;
+}): Promise<void> {
+  await options.agent.runYaml(
+    yaml.dump(mergeYamlCaseWithConfig(options.normalizedCase, options.config), {
+      lineWidth: -1,
+      noRefs: true,
+    }),
+  );
+}

--- a/packages/testing-framework/src/types.ts
+++ b/packages/testing-framework/src/types.ts
@@ -1,0 +1,74 @@
+import type { MidsceneYamlFlowItem } from '@midscene/core';
+
+export type FrameworkTargetType = 'web' | 'android' | 'ios' | 'computer';
+
+export interface FrameworkTargetConfig {
+  type: FrameworkTargetType;
+  options?: Record<string, unknown>;
+}
+
+export interface FrameworkAgent {
+  runYaml: (yamlScriptContent: string) => Promise<unknown>;
+}
+
+export interface FrameworkSetupResult {
+  agent: FrameworkAgent;
+  teardown?: () => Promise<void>;
+  [key: string]: unknown;
+}
+
+export interface CustomYamlStepContext {
+  agent: FrameworkAgent;
+  state: Record<string, unknown>;
+  filePath: string;
+  stepIndex: number;
+  stepName: string;
+}
+
+export type CustomYamlStepHandler = (
+  value: unknown,
+  context: CustomYamlStepContext,
+) => Promise<void> | void;
+
+export interface MidsceneFrameworkConfig {
+  target?: FrameworkTargetConfig;
+  testDir?: string;
+  include?: string[];
+  exclude?: string[];
+  testRunner?: {
+    maxConcurrency?: number;
+    bail?: number;
+    testTimeout?: number;
+    retry?: number;
+  };
+  output?: {
+    summary?: string;
+    reportDir?: string;
+  };
+  agentOptions?: Record<string, unknown>;
+  setup?: (context: {
+    agentOptions: Record<string, unknown>;
+  }) => Promise<FrameworkSetupResult>;
+  yamlSteps?: Record<string, CustomYamlStepHandler>;
+}
+
+export interface LoadedMidsceneConfig {
+  path: string;
+  root: string;
+  config: MidsceneFrameworkConfig;
+}
+
+export interface FrameworkTestFile {
+  filePath: string;
+  relativePath: string;
+  type: 'yaml' | 'test';
+}
+
+export interface NormalizedYamlCase {
+  tasks: Array<{
+    name: string;
+    flow: MidsceneYamlFlowItem[];
+    continueOnError?: boolean;
+  }>;
+  raw: Record<string, unknown>;
+}

--- a/packages/testing-framework/tests/framework-contract.test.ts
+++ b/packages/testing-framework/tests/framework-contract.test.ts
@@ -1,0 +1,221 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  collectFrameworkTestFiles,
+  defineMidsceneConfig,
+  loadMidsceneConfig,
+} from '../src';
+import {
+  createYamlFrameworkTestSource,
+  normalizeYamlCase,
+  runYamlFlowWithCustomSteps,
+} from '../src/runtime';
+
+const createTempDir = () => mkdtempSync(join(tmpdir(), 'midscene-framework-'));
+
+describe('testing framework contract', () => {
+  it('loads midscene.config.ts as the typed source of truth', async () => {
+    const root = createTempDir();
+    const configFile = join(root, 'midscene.config.ts');
+    writeFileSync(
+      configFile,
+      `
+        import { defineMidsceneConfig } from ${JSON.stringify(resolve(__dirname, '../src'))};
+
+        export default defineMidsceneConfig({
+          target: {
+            type: 'android',
+            options: {
+              deviceId: 'emulator-5554',
+              launch: 'https://www.ebay.com',
+              autoDismissKeyboard: false,
+            },
+          },
+          testDir: './e2e',
+          include: ['**/*.yaml'],
+          testRunner: {
+            maxConcurrency: 1,
+            bail: 0,
+            testTimeout: 120_000,
+          },
+          output: {
+            summary: './midscene_run/output/summary.json',
+          },
+          agentOptions: {
+            reportFileName: 'android-config-demo',
+            cache: true,
+          },
+        });
+      `,
+    );
+
+    const loaded = await loadMidsceneConfig(configFile);
+
+    expect(loaded.path).toBe(configFile);
+    expect(loaded.root).toBe(root);
+    expect(loaded.config.target?.type).toBe('android');
+    expect(loaded.config.testRunner?.testTimeout).toBe(120_000);
+    expect(loaded.config.output?.summary).toBe(
+      './midscene_run/output/summary.json',
+    );
+  });
+
+  it('loads TypeScript config files in a plain Node process', () => {
+    const root = createTempDir();
+    const configFile = join(root, 'midscene.config.ts');
+    writeFileSync(
+      configFile,
+      `
+        type LocalConfig = { testDir: string };
+        const config: LocalConfig = {
+          testDir: './e2e',
+        };
+        export default config;
+      `,
+    );
+
+    const packageRoot = resolve(__dirname, '..');
+    const sourceEntry = resolve(packageRoot, 'src/index.ts');
+    const script = `
+      const { createJiti } = require('jiti');
+      const jiti = createJiti(${JSON.stringify(sourceEntry)}, { moduleCache: false });
+      const { loadMidsceneConfig } = jiti(${JSON.stringify(sourceEntry)});
+      loadMidsceneConfig(${JSON.stringify(configFile)})
+        .then((loaded) => {
+          if (loaded.config.testDir !== './e2e') {
+            throw new Error('Unexpected testDir: ' + loaded.config.testDir);
+          }
+        })
+        .catch((error) => {
+          console.error(error);
+          process.exit(1);
+        });
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it('collects yaml and TypeScript cases from testDir/include/exclude', async () => {
+    const root = createTempDir();
+    writeFileSync(join(root, 'midscene.config.ts'), 'export default {};');
+    const e2e = join(root, 'e2e');
+    const nested = join(e2e, 'nested');
+    await import('node:fs/promises').then(async ({ mkdir }) => {
+      await mkdir(nested, { recursive: true });
+    });
+    writeFileSync(join(e2e, 'checkout.yaml'), 'flow: []');
+    writeFileSync(join(e2e, 'checkout-risk.test.ts'), 'test("risk", () => {})');
+    writeFileSync(join(e2e, 'draft.yaml'), 'flow: []');
+    writeFileSync(join(nested, 'support.yml'), 'flow: []');
+
+    const files = await collectFrameworkTestFiles({
+      root,
+      config: defineMidsceneConfig({
+        testDir: './e2e',
+        include: ['**/*.yaml', '**/*.yml', '**/*.test.ts'],
+        exclude: ['**/*.draft.yaml', '**/draft.yaml'],
+      }),
+    });
+
+    expect(files.map((file) => file.relativePath)).toEqual([
+      'e2e/checkout-risk.test.ts',
+      'e2e/checkout.yaml',
+      'e2e/nested/support.yml',
+    ]);
+  });
+
+  it('normalizes flow-only YAML into a single runnable task', () => {
+    const result = normalizeYamlCase(
+      `
+        flow:
+          - aiAct: Search for "hoodie"
+          - aiAssert: The page shows search results.
+      `,
+      'e2e/search.yaml',
+    );
+
+    expect(result.tasks).toEqual([
+      {
+        name: 'search',
+        flow: [
+          { aiAct: 'Search for "hoodie"' },
+          { aiAssert: 'The page shows search results.' },
+        ],
+      },
+    ]);
+  });
+
+  it('dispatches custom YAML steps with agent, state and step metadata', async () => {
+    const agent = {
+      runYaml: vi.fn(async () => undefined),
+    };
+    const seedOrder = vi.fn(async (value, ctx) => {
+      ctx.state.lastOrderId = value.orderId;
+    });
+    const assertOrderStatus = vi.fn();
+
+    await runYamlFlowWithCustomSteps({
+      agent,
+      filePath: '/project/e2e/order-details.yaml',
+      caseName: 'order-details',
+      flow: [
+        { seedOrder: { orderId: 'E2E-10001', status: 'paid' } },
+        { aiAct: 'Open my orders' },
+        { assertOrderStatus: { status: 'paid' } },
+      ],
+      yamlSteps: {
+        seedOrder,
+        assertOrderStatus,
+      },
+      state: {},
+    });
+
+    expect(seedOrder).toHaveBeenCalledWith(
+      { orderId: 'E2E-10001', status: 'paid' },
+      expect.objectContaining({
+        agent,
+        filePath: '/project/e2e/order-details.yaml',
+        stepIndex: 0,
+        stepName: 'seedOrder',
+      }),
+    );
+    expect(agent.runYaml).toHaveBeenCalledWith(
+      expect.stringContaining('aiAct: Open my orders'),
+    );
+    expect(assertOrderStatus).toHaveBeenCalledWith(
+      { status: 'paid' },
+      expect.objectContaining({
+        state: { lastOrderId: 'E2E-10001' },
+        stepIndex: 2,
+        stepName: 'assertOrderStatus',
+      }),
+    );
+  });
+
+  it('generates yaml virtual test sources that import midscene.config.ts', () => {
+    const source = createYamlFrameworkTestSource({
+      configPath: '/project/midscene.config.ts',
+      filePath: '/project/e2e/order-details.yaml',
+      testName: 'e2e/order-details.yaml',
+      runtimeImport: '@midscene/testing-framework/runtime',
+      rstestImport: '@rstest/core',
+    });
+
+    expect(source).toContain('import { test } from "@rstest/core"');
+    expect(source).toContain(
+      'import config from "/project/midscene.config.ts"',
+    );
+    expect(source).toContain(
+      'import { runYamlFrameworkCase } from "@midscene/testing-framework/runtime"',
+    );
+    expect(source).toContain('test("e2e/order-details.yaml"');
+  });
+});

--- a/packages/testing-framework/tsconfig.build.json
+++ b/packages/testing-framework/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/testing-framework/tsconfig.json
+++ b/packages/testing-framework/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "module": "esnext",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "rootDir": ".",
+    "rootDir": "./src",
     "declarationDir": "dist/types",
     "types": ["node"]
   },
@@ -20,9 +17,6 @@
     },
     {
       "path": "../shared"
-    },
-    {
-      "path": "../testing-framework"
     },
     {
       "path": "../web-integration"

--- a/packages/testing-framework/vitest.config.ts
+++ b/packages/testing-framework/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 3 * 60 * 1000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.23
@@ -183,7 +183,7 @@ importers:
         version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@tailwindcss/postcss':
         specifier: 4.1.11
         version: 4.1.11
@@ -259,7 +259,7 @@ importers:
         version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.23
@@ -311,7 +311,7 @@ importers:
         version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.23
@@ -372,7 +372,7 @@ importers:
         version: 1.4.1(@rsbuild/core@1.6.15)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.23
@@ -592,7 +592,7 @@ importers:
         version: 1.2.2(@rsbuild/core@1.6.15)(typescript@5.8.3)
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+        version: 1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
       '@tailwindcss/postcss':
         specifier: 4.1.11
         version: 4.1.11
@@ -825,6 +825,9 @@ importers:
       '@midscene/web':
         specifier: workspace:*
         version: link:../web-integration
+      '@rstest/core':
+        specifier: 0.8.0
+        version: 0.8.0(jsdom@29.0.2)
       http-server:
         specifier: 14.1.1
         version: 14.1.1
@@ -2300,19 +2303,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':
@@ -3569,20 +3569,38 @@ packages:
   '@module-federation/error-codes@0.21.6':
     resolution: {integrity: sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==}
 
+  '@module-federation/error-codes@0.22.0':
+    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
+
   '@module-federation/runtime-core@0.21.6':
     resolution: {integrity: sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==}
+
+  '@module-federation/runtime-core@0.22.0':
+    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
 
   '@module-federation/runtime-tools@0.21.6':
     resolution: {integrity: sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==}
 
+  '@module-federation/runtime-tools@0.22.0':
+    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
+
   '@module-federation/runtime@0.21.6':
     resolution: {integrity: sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==}
+
+  '@module-federation/runtime@0.22.0':
+    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
 
   '@module-federation/sdk@0.21.6':
     resolution: {integrity: sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==}
 
+  '@module-federation/sdk@0.22.0':
+    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
+
   '@module-federation/webpack-bundler-runtime@0.21.6':
     resolution: {integrity: sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -4298,6 +4316,11 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@rsbuild/core@1.7.2':
+    resolution: {integrity: sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   '@rsbuild/core@2.0.0-beta.11':
     resolution: {integrity: sha512-IBbQx7SrnSpD7j2p2qyq3qDxoqmG4E6lcflTpbBitX6iUrzpVRQbP4rktXZ2iuY7ph9+FtUK/SVAVA+Ocm3Nig==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4417,6 +4440,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.7.11':
+    resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-arm64@2.0.0-beta.9':
     resolution: {integrity: sha512-9Aao24b+lrVGG25itl2c7e6HK6eNH5J5ao1Uq5UoSwSJZOxRPuY+QlHIvE2tyt833Ly9qcT1J7os2AIUNlF6Vw==}
     cpu: [arm64]
@@ -4429,6 +4457,11 @@ packages:
 
   '@rspack/binding-darwin-x64@1.6.8':
     resolution: {integrity: sha512-ku1XpTEPt6Za11zhpFWhfwrTQogcgi9RJrOUVC4FESiPO9aKyd4hJ+JiPgLY0MZOqsptK6vEAgOip+uDVXrCpg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.7.11':
+    resolution: {integrity: sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==}
     cpu: [x64]
     os: [darwin]
 
@@ -4447,6 +4480,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.7.11':
+    resolution: {integrity: sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.9':
     resolution: {integrity: sha512-k2DPN3B2qaz4L/h/R+l7rbDk/lLwbR/sayfsHZ8sLdZ3f6pvaSI9ejrsFv0nU4OmKCQsz4zYuoKTVFPtDfbGjA==}
     cpu: [arm64]
@@ -4459,6 +4497,11 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
     resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.7.11':
+    resolution: {integrity: sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==}
     cpu: [arm64]
     os: [linux]
 
@@ -4477,6 +4520,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.7.11':
+    resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.9':
     resolution: {integrity: sha512-z/EOUKEq5rq4sYsVSFL9uzdPtTPVA82x3gsRJlDTfEcruZZI7Y6JKUkpDYkC0LivXqyOnoOz8slAFd2/dByRtA==}
     cpu: [x64]
@@ -4489,6 +4537,11 @@ packages:
 
   '@rspack/binding-linux-x64-musl@1.6.8':
     resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.7.11':
+    resolution: {integrity: sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==}
     cpu: [x64]
     os: [linux]
 
@@ -4505,6 +4558,10 @@ packages:
     resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@1.7.11':
+    resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-wasm32-wasi@2.0.0-beta.9':
     resolution: {integrity: sha512-Vl7aDAt7DCqtZ/RJd8hLFjQqufX+efL/XZG3qADsagl/SspH1ItJ7N6X1S8o50eKoshy27Jr7mQYZEdufX9qhQ==}
     cpu: [wasm32]
@@ -4516,6 +4573,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@1.6.8':
     resolution: {integrity: sha512-23YX7zlOZlub+nPGDBUzktb4D5D6ETUAluKjXEeHIZ9m7fSlEYBnGL66YE+3t1DHXGd0OqsdwlvrNGcyo6EXDQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.7.11':
+    resolution: {integrity: sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==}
     cpu: [arm64]
     os: [win32]
 
@@ -4534,6 +4596,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.7.11':
+    resolution: {integrity: sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.9':
     resolution: {integrity: sha512-Oii4HpCEH3CBDKSXcS6EVlV9nGYVKAV/uBLSsuZ0RNdEG0i+OHvEiicqHAwuIYZNlH4Ea/Vwc+Dl5PM2twCZ4Q==}
     cpu: [ia32]
@@ -4549,6 +4616,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.7.11':
+    resolution: {integrity: sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.9':
     resolution: {integrity: sha512-7UFjyy7QMtWvf1CBEVQkHL6bJBKaVY9yq9+Qxb7ggtxvpBbkoYykdsrhMTvr/f5TBjBqHmyeb0/oYXqo5pWFBQ==}
     cpu: [x64]
@@ -4559,6 +4631,9 @@ packages:
 
   '@rspack/binding@1.6.8':
     resolution: {integrity: sha512-lUeL4mbwGo+nqRKqFDCm9vH2jv9FNMVt1X8jqayWRcOCPlj/2UVMEFgqjR7Pp2vlvnTKq//31KbDBJmDZq31RQ==}
+
+  '@rspack/binding@1.7.11':
+    resolution: {integrity: sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==}
 
   '@rspack/binding@2.0.0-beta.9':
     resolution: {integrity: sha512-QgkOvzl6BJc4Vg5eaY9r7MkHNfXvVZPgTIeYkdBEOYPowdyCLhlG9vH7QltqLKP9KDNel70YIeMyUrpTqez01w==}
@@ -4574,6 +4649,15 @@ packages:
 
   '@rspack/core@1.6.8':
     resolution: {integrity: sha512-FolcIAH5FW4J2FET+qwjd1kNeFbCkd0VLuIHO0thyolEjaPSxw5qxG67DA7BZGm6PVcoiSgPLks1DL6eZ8c+fA==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.7.11':
+    resolution: {integrity: sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -4657,6 +4741,19 @@ packages:
 
   '@rspress/shared@2.0.8':
     resolution: {integrity: sha512-kvfBUvMvWcn/7PJHqZxPeu1yblzvAuB1/gk/1orp5KsYu3wbZ7X3Hsm9smDJVs5Plw1iPt67t9fOYNSM0+VjUA==}
+
+  '@rstest/core@0.8.0':
+    resolution: {integrity: sha512-zHpWPYN7T27YrtRwMM4dVm5PU1qQzAhX2ALspll1QT49BzuRHmJc2h3MaXTQ8F9k7sPMbhE+pGx9JQ7Vn7r+rQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    peerDependencies:
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   '@rushstack/node-core-library@5.14.0':
     resolution: {integrity: sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==}
@@ -4951,6 +5048,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.0.279':
     resolution: {integrity: sha512-wl0IxQ2OQiMazPZM5LimHQ7Jwd72/O8UvvzyptplXT2S4eUqXH5C0n8S+v8PtKhyX89p0igCPpNy3Bwksyk57g==}
 
@@ -4968,6 +5068,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -14428,15 +14531,27 @@ snapshots:
 
   '@module-federation/error-codes@0.21.6': {}
 
+  '@module-federation/error-codes@0.22.0': {}
+
   '@module-federation/runtime-core@0.21.6':
     dependencies:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/sdk': 0.21.6
 
+  '@module-federation/runtime-core@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
   '@module-federation/runtime-tools@0.21.6':
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/webpack-bundler-runtime': 0.21.6
+
+  '@module-federation/runtime-tools@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/webpack-bundler-runtime': 0.22.0
 
   '@module-federation/runtime@0.21.6':
     dependencies:
@@ -14444,12 +14559,25 @@ snapshots:
       '@module-federation/runtime-core': 0.21.6
       '@module-federation/sdk': 0.21.6
 
+  '@module-federation/runtime@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/runtime-core': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
   '@module-federation/sdk@0.21.6': {}
+
+  '@module-federation/sdk@0.22.0': {}
 
   '@module-federation/webpack-bundler-runtime@0.21.6':
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/sdk': 0.21.6
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/sdk': 0.22.0
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -15164,6 +15292,14 @@ snapshots:
       core-js: 3.47.0
       jiti: 2.6.1
 
+  '@rsbuild/core@1.7.2':
+    dependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.21
+      core-js: 3.47.0
+      jiti: 2.6.1
+
   '@rsbuild/core@2.0.0-beta.11(core-js@3.47.0)':
     dependencies:
       '@rspack/core': 2.0.0-beta.9(@swc/helpers@0.5.21)
@@ -15329,12 +15465,12 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-type-check@1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.3.2(@rsbuild/core@1.6.15)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3)
+      ts-checker-rspack-plugin: 1.2.2(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3)
     optionalDependencies:
       '@rsbuild/core': 1.6.15
     transitivePeerDependencies:
@@ -15506,6 +15642,9 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.6.8':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.7.11':
+    optional: true
+
   '@rspack/binding-darwin-arm64@2.0.0-beta.9':
     optional: true
 
@@ -15513,6 +15652,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-darwin-x64@1.6.8':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.7.11':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0-beta.9':
@@ -15524,6 +15666,9 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.6.8':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.7.11':
+    optional: true
+
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.9':
     optional: true
 
@@ -15531,6 +15676,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.7.11':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.9':
@@ -15542,6 +15690,9 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.6.8':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.7.11':
+    optional: true
+
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.9':
     optional: true
 
@@ -15549,6 +15700,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.6.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.7.11':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.0-beta.9':
@@ -15564,6 +15718,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rspack/binding-wasm32-wasi@1.7.11':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rspack/binding-wasm32-wasi@2.0.0-beta.9':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
@@ -15575,6 +15734,9 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.6.8':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.7.11':
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.9':
     optional: true
 
@@ -15584,6 +15746,9 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.6.8':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.7.11':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.9':
     optional: true
 
@@ -15591,6 +15756,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.6.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.7.11':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.9':
@@ -15622,6 +15790,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.6.8
       '@rspack/binding-win32-x64-msvc': 1.6.8
 
+  '@rspack/binding@1.7.11':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.7.11
+      '@rspack/binding-darwin-x64': 1.7.11
+      '@rspack/binding-linux-arm64-gnu': 1.7.11
+      '@rspack/binding-linux-arm64-musl': 1.7.11
+      '@rspack/binding-linux-x64-gnu': 1.7.11
+      '@rspack/binding-linux-x64-musl': 1.7.11
+      '@rspack/binding-wasm32-wasi': 1.7.11
+      '@rspack/binding-win32-arm64-msvc': 1.7.11
+      '@rspack/binding-win32-ia32-msvc': 1.7.11
+      '@rspack/binding-win32-x64-msvc': 1.7.11
+
   '@rspack/binding@2.0.0-beta.9':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 2.0.0-beta.9
@@ -15647,6 +15828,14 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.21.6
       '@rspack/binding': 1.6.8
+      '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.21
+
+  '@rspack/core@1.7.11(@swc/helpers@0.5.21)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.22.0
+      '@rspack/binding': 1.7.11
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.21
@@ -15768,6 +15957,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
+
+  '@rstest/core@0.8.0(jsdom@29.0.2)':
+    dependencies:
+      '@rsbuild/core': 1.7.2
+      '@types/chai': 5.2.3
+      tinypool: 1.1.1
+    optionalDependencies:
+      jsdom: 29.0.2
 
   '@rushstack/node-core-library@5.14.0(@types/node@18.19.118)':
     dependencies:
@@ -16135,6 +16332,11 @@ snapshots:
       '@types/node': 18.19.130
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chrome@0.0.279':
     dependencies:
       '@types/filesystem': 0.0.36
@@ -16157,6 +16359,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -23977,7 +24181,7 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-checker-rspack-plugin@1.2.2(@rspack/core@1.6.8(@swc/helpers@0.5.21))(typescript@5.8.3):
+  ts-checker-rspack-plugin@1.2.2(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.8.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.1.0
@@ -23988,7 +24192,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.3
     optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.21)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
 
   ts-checker-rspack-plugin@1.2.2(@rspack/core@2.0.0-beta.9(@swc/helpers@0.5.21))(typescript@5.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ importers:
       '@midscene/shared':
         specifier: workspace:*
         version: link:../shared
+      '@midscene/testing-framework':
+        specifier: workspace:*
+        version: link:../testing-framework
       '@midscene/web':
         specifier: workspace:*
         version: link:../web-integration
@@ -1618,6 +1621,49 @@ importers:
       vitest:
         specifier: 3.0.5
         version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
+
+  packages/testing-framework:
+    dependencies:
+      '@midscene/android':
+        specifier: workspace:*
+        version: link:../android
+      '@midscene/core':
+        specifier: workspace:*
+        version: link:../core
+      '@midscene/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@midscene/web':
+        specifier: workspace:*
+        version: link:../web-integration
+      glob:
+        specifier: 11.0.0
+        version: 11.0.0
+      jiti:
+        specifier: 2.6.1
+        version: 2.6.1
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
+    devDependencies:
+      '@rslib/core':
+        specifier: ^0.18.3
+        version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.130))(typescript@5.8.3)
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.130
+      playwright:
+        specifier: ^1.45.0
+        version: 1.58.1
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.130)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
 
   packages/visualizer:
     dependencies:
@@ -5903,9 +5949,6 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -8393,10 +8436,6 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
@@ -8761,10 +8800,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.0.2:
-    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -9144,10 +9179,6 @@ packages:
 
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
@@ -9715,10 +9746,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -14310,6 +14337,15 @@ snapshots:
       - '@types/node'
     optional: true
 
+  '@microsoft/api-extractor-model@7.30.7(@types/node@18.19.130)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.130)
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   '@microsoft/api-extractor-model@7.30.7(@types/node@18.19.62)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -14337,6 +14373,25 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.15.4(@types/node@18.19.118)
       '@rushstack/ts-command-line': 5.0.2(@types/node@18.19.118)
+      lodash: 4.17.23
+      minimatch: 10.0.3
+      resolve: 1.22.11
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@microsoft/api-extractor@7.52.10(@types/node@18.19.130)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.7(@types/node@18.19.130)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.130)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.15.4(@types/node@18.19.130)
+      '@rushstack/ts-command-line': 5.0.2(@types/node@18.19.130)
       lodash: 4.17.23
       minimatch: 10.0.3
       resolve: 1.22.11
@@ -15616,6 +15671,16 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
+  '@rslib/core@0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.130))(typescript@5.8.3)':
+    dependencies:
+      '@rsbuild/core': 1.6.15
+      rsbuild-plugin-dts: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.130))(@rsbuild/core@1.6.15)(typescript@5.8.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.52.10(@types/node@18.19.130)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+
   '@rslib/core@0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.62))(typescript@5.8.3)':
     dependencies:
       '@rsbuild/core': 1.6.15
@@ -15980,6 +16045,20 @@ snapshots:
       '@types/node': 18.19.118
     optional: true
 
+  '@rushstack/node-core-library@5.14.0(@types/node@18.19.130)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.4
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.19.130
+    optional: true
+
   '@rushstack/node-core-library@5.14.0(@types/node@18.19.62)':
     dependencies:
       ajv: 8.13.0
@@ -16022,6 +16101,14 @@ snapshots:
       '@types/node': 18.19.118
     optional: true
 
+  '@rushstack/terminal@0.15.4(@types/node@18.19.130)':
+    dependencies:
+      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.130)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 18.19.130
+    optional: true
+
   '@rushstack/terminal@0.15.4(@types/node@18.19.62)':
     dependencies:
       '@rushstack/node-core-library': 5.14.0(@types/node@18.19.62)
@@ -16041,6 +16128,16 @@ snapshots:
   '@rushstack/ts-command-line@5.0.2(@types/node@18.19.118)':
     dependencies:
       '@rushstack/terminal': 0.15.4(@types/node@18.19.118)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@rushstack/ts-command-line@5.0.2(@types/node@18.19.130)':
+    dependencies:
+      '@rushstack/terminal': 0.15.4(@types/node@18.19.130)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -17441,10 +17538,6 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -17697,7 +17790,7 @@ snapshots:
       commander: 11.1.0
       edit-json-file: 1.8.1
       globby: 13.2.2
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       semver: 7.5.2
       table: 6.9.0
       type-fest: 4.41.0
@@ -18081,7 +18174,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -19544,10 +19637,10 @@ snapshots:
     dependencies:
       foreground-child: 3.3.0
       jackspeak: 4.0.2
-      minimatch: 10.0.1
-      minipass: 7.1.2
+      minimatch: 10.2.5
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
@@ -20424,10 +20517,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   jsbn@1.1.0: {}
 
   jsdom@29.0.2:
@@ -20777,8 +20866,6 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.0.2: {}
 
   lru-cache@11.3.5: {}
 
@@ -21405,10 +21492,6 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
@@ -21999,11 +22082,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.0.2
       minipass: 7.1.2
 
   path-scurry@2.0.2:
@@ -23146,6 +23224,14 @@ snapshots:
       '@rsbuild/core': 1.6.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.10(@types/node@18.19.118)
+      typescript: 5.8.3
+
+  rsbuild-plugin-dts@0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.130))(@rsbuild/core@1.6.15)(typescript@5.8.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 1.6.15
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.52.10(@types/node@18.19.130)
       typescript: 5.8.3
 
   rsbuild-plugin-dts@0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.62))(@rsbuild/core@1.6.15)(typescript@5.8.3):


### PR DESCRIPTION
## Summary

This is a follow-up PR stacked on top of `codex/rstest-yaml-runner`.

It intentionally keeps the new UI Testing Framework project model separate from the phase-one Rstest migration. Phase one should only switch the existing YAML/config.yml execution path to Rstest without changing user-facing usage.

This PR contains the later-stage exploration for:

- adding a new `@midscene/testing-framework` package
- loading `midscene.config.*` as the framework source of truth
- collecting YAML and TypeScript test files from `testDir/include/exclude`
- normalizing top-level YAML `flow` into runnable tasks
- dispatching custom `yamlSteps`
- generating Rstest test sources for framework YAML cases
- routing `midscene test` through the config-driven framework path when a `midscene.config.*` file exists

## Validation

- `npx nx test @midscene/testing-framework`
- `npx nx test @midscene/cli -- tests/unit-test/framework/command.test.ts`
- `npx nx build @midscene/cli`
- `pnpm run lint`
- Manual smoke: built `packages/cli/bin/midscene test <temp project>` with `midscene.config.ts`, flow-only YAML, and a fake setup agent.

## Notes

This PR should not be merged as part of the first phase. It is separated so phase one can stay focused on the existing usage contract and the internal Rstest runner switch.