### PR TITLE
fix(computer): disarm input on agent destroy

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -302,31 +302,164 @@ export function runPhasedScroll(
   }
 }
 
-/**
- * Smooth mouse movement to trigger mousemove events
- */
-async function smoothMoveMouse(
-  targetX: number,
-  targetY: number,
-  steps: number,
-  stepDelay: number,
-  assertInputActive: () => void = () => {},
-  wait: (ms: number) => Promise<void> = async (ms) => {
-    await sleep(ms);
-  },
-): Promise<void> {
-  assert(libnut, 'libnut not initialized');
-  const currentPos = libnut.getMousePos();
-  for (let i = 1; i <= steps; i++) {
-    assertInputActive();
-    const stepX = Math.round(
-      currentPos.x + ((targetX - currentPos.x) * i) / steps,
+type MouseButton = 'left' | 'right' | 'middle';
+
+class ComputerInputDriver {
+  private destroyed = false;
+  private pendingInputDelayWaits = new Set<{
+    timeoutId: ReturnType<typeof setTimeout>;
+    reject: (error: Error) => void;
+  }>();
+
+  constructor(private readonly useAppleScript: () => boolean) {}
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.rejectPendingInputDelays();
+  }
+
+  getScreenSize(): Size {
+    return this.getLibnutOrThrow('getScreenSize').getScreenSize();
+  }
+
+  getMousePos(): { x: number; y: number } {
+    return this.getLibnutOrThrow('getMousePos').getMousePos();
+  }
+
+  moveMouse(x: number, y: number): void {
+    this.getLibnutOrThrow('moveMouse').moveMouse(x, y);
+  }
+
+  mouseClick(button?: MouseButton, double?: boolean): void {
+    this.getLibnutOrThrow('mouseClick').mouseClick(button, double);
+  }
+
+  mouseToggle(state: 'up' | 'down', button: MouseButton = 'left'): void {
+    this.getLibnutOrThrow('mouseToggle').mouseToggle(state, button);
+  }
+
+  scrollMouse(x: number, y: number): void {
+    this.getLibnutOrThrow('scrollMouse').scrollMouse(x, y);
+  }
+
+  keyTap(key: string, modifiers?: string[]): void {
+    this.getLibnutOrThrow('keyTap').keyTap(key, modifiers);
+  }
+
+  sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
+    this.assertActive('sendKeyViaAppleScript');
+    sendKeyViaAppleScript(key, modifiers);
+  }
+
+  sendKey(key: string, modifiers: string[] = []): void {
+    if (this.useAppleScript()) {
+      this.sendKeyViaAppleScript(key, modifiers);
+      return;
+    }
+
+    if (modifiers.length > 0) {
+      this.keyTap(key, modifiers);
+    } else {
+      this.keyTap(key);
+    }
+  }
+
+  runPhasedScroll(
+    direction: ScrollDirection,
+    pixels: number,
+    steps: number,
+  ): boolean {
+    this.assertActive('runPhasedScroll');
+    return runPhasedScroll(direction, pixels, steps);
+  }
+
+  async delay(ms: number): Promise<void> {
+    this.assertActive('delay');
+    return new Promise((resolve, reject) => {
+      const waitRef = {
+        timeoutId: setTimeout(() => {
+          this.pendingInputDelayWaits.delete(waitRef);
+          try {
+            this.assertActive('delay');
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        }, ms),
+        reject,
+      };
+      this.pendingInputDelayWaits.add(waitRef);
+    });
+  }
+
+  async smoothMoveMouse(
+    targetX: number,
+    targetY: number,
+    steps: number,
+    stepDelay: number,
+  ): Promise<void> {
+    const currentPos = this.getMousePos();
+    for (let i = 1; i <= steps; i++) {
+      const stepX = Math.round(
+        currentPos.x + ((targetX - currentPos.x) * i) / steps,
+      );
+      const stepY = Math.round(
+        currentPos.y + ((targetY - currentPos.y) * i) / steps,
+      );
+      this.moveMouse(stepX, stepY);
+      await this.delay(stepDelay);
+    }
+  }
+
+  async withMouseButton<T>(
+    button: MouseButton,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    this.mouseToggle('down', button);
+    try {
+      return await run();
+    } finally {
+      this.releaseMouseButton(button);
+    }
+  }
+
+  private getLibnutOrThrow(methodName: string): LibNut {
+    this.assertActive(methodName);
+    assert(libnut, 'libnut not initialized');
+    return libnut;
+  }
+
+  private assertActive(methodName: string): void {
+    if (this.destroyed) {
+      throw this.createDestroyedError(methodName);
+    }
+  }
+
+  private createDestroyedError(methodName: string): Error {
+    return new Error(
+      `ComputerDevice has been destroyed (cannot run ${methodName})`,
     );
-    const stepY = Math.round(
-      currentPos.y + ((targetY - currentPos.y) * i) / steps,
-    );
-    libnut.moveMouse(stepX, stepY);
-    await wait(stepDelay);
+  }
+
+  private releaseMouseButton(button: MouseButton): void {
+    try {
+      assert(libnut, 'libnut not initialized');
+      libnut.mouseToggle('up', button);
+    } catch (error) {
+      debugDevice(`Failed to release mouse button ${button}: ${error}`);
+    }
+  }
+
+  private rejectPendingInputDelays(): void {
+    const error = this.createDestroyedError('in-flight input');
+    for (const waitRef of this.pendingInputDelayWaits) {
+      clearTimeout(waitRef.timeoutId);
+      waitRef.reject(error);
+    }
+    this.pendingInputDelayWaits.clear();
   }
 }
 
@@ -430,10 +563,9 @@ export class ComputerDevice implements AbstractInterface {
   private destroyed = false;
   private xvfbInstance?: XvfbInstance;
   private xvfbCleanup?: () => void;
-  private pendingInputDelayWaits = new Set<{
-    timeoutId: ReturnType<typeof setTimeout>;
-    reject: (error: Error) => void;
-  }>();
+  private readonly inputDriver = new ComputerInputDriver(
+    () => this.useAppleScript,
+  );
   /**
    * On macOS, use AppleScript for keyboard operations by default
    * to avoid focus issues with system overlays (e.g. Spotlight).
@@ -441,109 +573,88 @@ export class ComputerDevice implements AbstractInterface {
   private useAppleScript: boolean;
   uri?: string;
 
-  readonly inputPrimitives: ComputerInputPrimitives = this.gateInputPrimitives({
+  readonly inputPrimitives: ComputerInputPrimitives = {
     pointer: {
       tap: async ({ x, y }) => {
-        assert(libnut, 'libnut not initialized');
         const targetX = Math.round(x);
         const targetY = Math.round(y);
 
-        await smoothMoveMouse(
+        await this.inputDriver.smoothMoveMouse(
           targetX,
           targetY,
           SMOOTH_MOVE_STEPS_TAP,
           SMOOTH_MOVE_DELAY_TAP,
-          () => this.assertInputActive('tap'),
-          (ms) => this.waitForInputDelayOrThrow(ms),
         );
-        this.assertInputActive('tap');
-        libnut.mouseToggle('down', 'left');
-        try {
-          await this.waitForInputDelayOrThrow(CLICK_HOLD_DURATION);
-        } finally {
-          libnut.mouseToggle('up', 'left');
-        }
+        await this.inputDriver.withMouseButton('left', async () => {
+          await this.inputDriver.delay(CLICK_HOLD_DURATION);
+        });
       },
       doubleClick: async ({ x, y }) => {
-        assert(libnut, 'libnut not initialized');
-        libnut.moveMouse(Math.round(x), Math.round(y));
-        libnut.mouseClick('left', true);
+        this.inputDriver.moveMouse(Math.round(x), Math.round(y));
+        this.inputDriver.mouseClick('left', true);
       },
       rightClick: async ({ x, y }) => {
-        assert(libnut, 'libnut not initialized');
-        libnut.moveMouse(Math.round(x), Math.round(y));
-        libnut.mouseClick('right');
+        this.inputDriver.moveMouse(Math.round(x), Math.round(y));
+        this.inputDriver.mouseClick('right');
       },
       hover: async ({ x, y }) => {
-        assert(libnut, 'libnut not initialized');
-        await smoothMoveMouse(
+        await this.inputDriver.smoothMoveMouse(
           Math.round(x),
           Math.round(y),
           SMOOTH_MOVE_STEPS_MOUSE_MOVE,
           SMOOTH_MOVE_DELAY_MOUSE_MOVE,
-          () => this.assertInputActive('hover'),
-          (ms) => this.waitForInputDelayOrThrow(ms),
         );
-        await this.waitForInputDelayOrThrow(MOUSE_MOVE_EFFECT_WAIT);
+        await this.inputDriver.delay(MOUSE_MOVE_EFFECT_WAIT);
       },
       dragAndDrop: async (from, to) => {
-        assert(libnut, 'libnut not initialized');
-        libnut.moveMouse(Math.round(from.x), Math.round(from.y));
-        libnut.mouseToggle('down', 'left');
-        try {
-          await this.waitForInputDelayOrThrow(100);
-          libnut.moveMouse(Math.round(to.x), Math.round(to.y));
-          await this.waitForInputDelayOrThrow(100);
-        } finally {
-          libnut.mouseToggle('up', 'left');
-        }
+        this.inputDriver.moveMouse(Math.round(from.x), Math.round(from.y));
+        await this.inputDriver.withMouseButton('left', async () => {
+          await this.inputDriver.delay(100);
+          this.inputDriver.moveMouse(Math.round(to.x), Math.round(to.y));
+          await this.inputDriver.delay(100);
+        });
       },
     },
     keyboard: {
       typeText: async (value, opts) => {
-        assert(libnut, 'libnut not initialized');
         const element = opts?.target as LocateResultElement | undefined;
 
         if (element) {
           const [x, y] = element.center;
-          libnut.moveMouse(Math.round(x), Math.round(y));
-          libnut.mouseClick('left');
-          await this.waitForInputDelayOrThrow(INPUT_FOCUS_DELAY);
+          this.inputDriver.moveMouse(Math.round(x), Math.round(y));
+          this.inputDriver.mouseClick('left');
+          await this.inputDriver.delay(INPUT_FOCUS_DELAY);
 
           if (opts?.replace !== false) {
             await this.selectAllAndDelete();
-            await this.waitForInputDelayOrThrow(INPUT_CLEAR_DELAY);
+            await this.inputDriver.delay(INPUT_CLEAR_DELAY);
           }
         }
 
         await this.smartTypeString(value);
       },
       keyboardPress: async (keyName, opts) => {
-        assert(libnut, 'libnut not initialized');
-
         const target = opts?.target as LocateResultElement | undefined;
         if (target) {
           const [x, y] = target.center;
-          libnut.moveMouse(Math.round(x), Math.round(y));
-          libnut.mouseClick('left');
-          await this.waitForInputDelayOrThrow(50);
+          this.inputDriver.moveMouse(Math.round(x), Math.round(y));
+          this.inputDriver.mouseClick('left');
+          await this.inputDriver.delay(50);
         }
 
         await this.pressKeyboardShortcut(keyName);
       },
       clearInput: async (target) => {
-        assert(libnut, 'libnut not initialized');
-
         if (target) {
           const element = target as LocateResultElement;
           const [x, y] = element.center;
-          libnut.moveMouse(Math.round(x), Math.round(y));
-          libnut.mouseClick('left');
-          await this.waitForInputDelayOrThrow(100);
+          this.inputDriver.moveMouse(Math.round(x), Math.round(y));
+          this.inputDriver.mouseClick('left');
+          await this.inputDriver.delay(100);
         }
 
         await this.selectAllAndDelete();
-        await this.waitForInputDelayOrThrow(50);
+        await this.inputDriver.delay(50);
       },
     },
     scroll: {
@@ -551,7 +662,7 @@ export class ComputerDevice implements AbstractInterface {
         await this.performScroll(param);
       },
     },
-  });
+  };
 
   constructor(options?: ComputerDeviceOpt) {
     this.options = options;
@@ -667,8 +778,7 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
 
     // Step 2: Move the mouse
     console.log('[HealthCheck] Moving mouse...');
-    assert(libnut, 'libnut not initialized');
-    const startPos = libnut.getMousePos();
+    const startPos = this.inputDriver.getMousePos();
     console.log(
       `[HealthCheck] Current mouse position: (${startPos.x}, ${startPos.y})`,
     );
@@ -680,10 +790,10 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     const targetY = startPos.y + offsetY;
 
     console.log(`[HealthCheck] Moving mouse to (${targetX}, ${targetY})...`);
-    libnut.moveMouse(targetX, targetY);
+    this.inputDriver.moveMouse(targetX, targetY);
     await sleep(50);
 
-    const movedPos = libnut.getMousePos();
+    const movedPos = this.inputDriver.getMousePos();
     console.log(
       `[HealthCheck] Mouse position after move: (${movedPos.x}, ${movedPos.y})`,
     );
@@ -707,7 +817,7 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     }
 
     // Restore original position
-    libnut.moveMouse(startPos.x, startPos.y);
+    this.inputDriver.moveMouse(startPos.x, startPos.y);
     console.log(
       `[HealthCheck] Mouse restored to (${startPos.x}, ${startPos.y})`,
     );
@@ -819,9 +929,8 @@ Original error: ${lastRawMessage}`,
   }
 
   async size(): Promise<Size> {
-    assert(libnut, 'libnut not initialized');
     try {
-      const screenSize = libnut.getScreenSize();
+      const screenSize = this.inputDriver.getScreenSize();
       return {
         width: screenSize.width,
         height: screenSize.height,
@@ -841,7 +950,6 @@ Original error: ${lastRawMessage}`,
    * 4. Restores old clipboard content
    */
   private async typeViaClipboard(text: string): Promise<void> {
-    assert(libnut, 'libnut not initialized');
     debugDevice('Using clipboard to input text', {
       textLength: text.length,
       preview: text.substring(0, 20),
@@ -854,16 +962,16 @@ Original error: ${lastRawMessage}`,
     try {
       // 2. Write new content to clipboard
       await clipboardy.default.write(text);
-      await this.waitForInputDelayOrThrow(50);
+      await this.inputDriver.delay(50);
 
       // 3. Simulate paste shortcut
       if (this.useAppleScript) {
-        sendKeyViaAppleScript('v', ['command']);
+        this.inputDriver.sendKeyViaAppleScript('v', ['command']);
       } else {
         const modifier = process.platform === 'darwin' ? 'command' : 'control';
-        libnut.keyTap('v', [modifier]);
+        this.inputDriver.keyTap('v', [modifier]);
       }
-      await this.waitForInputDelayOrThrow(100);
+      await this.inputDriver.delay(100);
     } finally {
       // 4. Restore old clipboard content
       if (oldClipboard) {
@@ -881,27 +989,24 @@ Original error: ${lastRawMessage}`,
    * which can swallow characters or convert them when a non-English IME is active.
    */
   private async smartTypeString(text: string): Promise<void> {
-    assert(libnut, 'libnut not initialized');
     await this.typeViaClipboard(text);
   }
 
   private async selectAllAndDelete(): Promise<void> {
-    assert(libnut, 'libnut not initialized');
     if (this.useAppleScript) {
-      sendKeyViaAppleScript('a', ['command']);
-      await this.waitForInputDelayOrThrow(50);
-      sendKeyViaAppleScript('backspace', []);
+      this.inputDriver.sendKeyViaAppleScript('a', ['command']);
+      await this.inputDriver.delay(50);
+      this.inputDriver.sendKeyViaAppleScript('backspace', []);
       return;
     }
 
     const modifier = process.platform === 'darwin' ? 'command' : 'control';
-    libnut.keyTap('a', [modifier]);
-    await this.waitForInputDelayOrThrow(50);
-    libnut.keyTap('backspace');
+    this.inputDriver.keyTap('a', [modifier]);
+    await this.inputDriver.delay(50);
+    this.inputDriver.keyTap('backspace');
   }
 
   private async pressKeyboardShortcut(keyName: string): Promise<void> {
-    assert(libnut, 'libnut not initialized');
     const keys = keyName.split('+');
     const modifiers = keys.slice(0, -1).map(normalizeKeyName);
     const key = normalizePrimaryKey(keys[keys.length - 1]);
@@ -913,22 +1018,14 @@ Original error: ${lastRawMessage}`,
       driver: this.useAppleScript ? 'applescript' : 'libnut',
     });
 
-    if (this.useAppleScript) {
-      sendKeyViaAppleScript(key, modifiers);
-    } else if (modifiers.length > 0) {
-      libnut.keyTap(key, modifiers);
-    } else {
-      libnut.keyTap(key);
-    }
+    this.inputDriver.sendKey(key, modifiers);
   }
 
   private async performScroll(param: any): Promise<void> {
-    assert(libnut, 'libnut not initialized');
-
     if (param.locate) {
       const element = param.locate as LocateResultElement;
       const [x, y] = element.center;
-      libnut.moveMouse(Math.round(x), Math.round(y));
+      this.inputDriver.moveMouse(Math.round(x), Math.round(y));
     }
 
     const scrollType = param?.scrollType;
@@ -939,27 +1036,26 @@ Original error: ${lastRawMessage}`,
         : null;
     if (edgeSpec) {
       if (
-        runPhasedScroll(
+        this.inputDriver.runPhasedScroll(
           edgeSpec.direction,
           EDGE_SCROLL_TOTAL_PX,
           EDGE_SCROLL_STEPS,
         )
       ) {
-        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
+        await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
         return;
       }
 
       if (this.useAppleScript) {
-        sendKeyViaAppleScript(edgeSpec.key);
-        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
+        this.inputDriver.sendKeyViaAppleScript(edgeSpec.key);
+        await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
         return;
       }
 
       const [dx, dy] = edgeSpec.libnut;
       for (let i = 0; i < SCROLL_REPEAT_COUNT; i++) {
-        this.assertInputActive('scroll');
-        libnut.scrollMouse(dx, dy);
-        await this.waitForInputDelayOrThrow(SCROLL_STEP_DELAY);
+        this.inputDriver.scrollMouse(dx, dy);
+        await this.inputDriver.delay(SCROLL_STEP_DELAY);
       }
       return;
     }
@@ -989,8 +1085,8 @@ Original error: ${lastRawMessage}`,
           PHASED_MIN_STEPS,
           Math.round(distance / PHASED_PIXELS_PER_STEP),
         );
-        if (runPhasedScroll(direction, distance, steps)) {
-          await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
+        if (this.inputDriver.runPhasedScroll(direction, distance, steps)) {
+          await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
           return;
         }
       }
@@ -1000,11 +1096,10 @@ Original error: ${lastRawMessage}`,
         const pages = Math.max(1, Math.round(distance / screenSize.height));
         const key = direction === 'up' ? 'pageup' : 'pagedown';
         for (let i = 0; i < pages; i++) {
-          this.assertInputActive('scroll');
-          sendKeyViaAppleScript(key);
-          await this.waitForInputDelayOrThrow(SCROLL_STEP_DELAY);
+          this.inputDriver.sendKeyViaAppleScript(key);
+          await this.inputDriver.delay(SCROLL_STEP_DELAY);
         }
-        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
+        await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
         return;
       }
 
@@ -1017,9 +1112,8 @@ Original error: ${lastRawMessage}`,
       };
 
       const [dx, dy] = directionMap[direction] || [0, -ticks];
-      this.assertInputActive('scroll');
-      libnut.scrollMouse(dx, dy);
-      await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
+      this.inputDriver.scrollMouse(dx, dy);
+      await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
       return;
     }
 
@@ -1046,7 +1140,7 @@ Original error: ${lastRawMessage}`,
     }
 
     this.destroyed = true;
-    this.rejectPendingInputDelays();
+    this.inputDriver.destroy();
 
     if (this.xvfbInstance) {
       this.xvfbInstance.stop();
@@ -1060,68 +1154,6 @@ Original error: ${lastRawMessage}`,
     }
 
     debugDevice('Computer device destroyed');
-  }
-
-  private createDestroyedError(methodName: string): Error {
-    return new Error(
-      `ComputerDevice has been destroyed (cannot run ${methodName})`,
-    );
-  }
-
-  private assertInputActive(methodName: string): void {
-    if (this.destroyed) {
-      throw this.createDestroyedError(methodName);
-    }
-  }
-
-  private waitForInputDelayOrThrow(ms: number): Promise<void> {
-    this.assertInputActive('input wait');
-    return new Promise((resolve, reject) => {
-      const waitRef = {
-        timeoutId: setTimeout(() => {
-          this.pendingInputDelayWaits.delete(waitRef);
-          try {
-            this.assertInputActive('input wait');
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        }, ms),
-        reject,
-      };
-      this.pendingInputDelayWaits.add(waitRef);
-    });
-  }
-
-  private rejectPendingInputDelays(): void {
-    const error = this.createDestroyedError('in-flight input');
-    for (const waitRef of this.pendingInputDelayWaits) {
-      clearTimeout(waitRef.timeoutId);
-      waitRef.reject(error);
-    }
-    this.pendingInputDelayWaits.clear();
-  }
-
-  private gateInputPrimitives<T extends Record<string, any>>(primitives: T): T {
-    const wrap = (path: string, value: unknown): unknown => {
-      if (typeof value === 'function') {
-        return async (...args: unknown[]) => {
-          this.assertInputActive(path);
-          return (value as (...args: unknown[]) => unknown)(...args);
-        };
-      }
-      if (value && typeof value === 'object') {
-        return Object.fromEntries(
-          Object.entries(value).map(([name, child]) => [
-            name,
-            wrap(`${path}.${name}`, child),
-          ]),
-        );
-      }
-      return value;
-    };
-
-    return wrap('inputPrimitives', primitives) as T;
   }
 
   async url(): Promise<string> {

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -310,10 +310,15 @@ async function smoothMoveMouse(
   targetY: number,
   steps: number,
   stepDelay: number,
+  assertInputActive: () => void = () => {},
+  wait: (ms: number) => Promise<void> = async (ms) => {
+    await sleep(ms);
+  },
 ): Promise<void> {
   assert(libnut, 'libnut not initialized');
   const currentPos = libnut.getMousePos();
   for (let i = 1; i <= steps; i++) {
+    assertInputActive();
     const stepX = Math.round(
       currentPos.x + ((targetX - currentPos.x) * i) / steps,
     );
@@ -321,7 +326,7 @@ async function smoothMoveMouse(
       currentPos.y + ((targetY - currentPos.y) * i) / steps,
     );
     libnut.moveMouse(stepX, stepY);
-    await sleep(stepDelay);
+    await wait(stepDelay);
   }
 }
 
@@ -425,6 +430,10 @@ export class ComputerDevice implements AbstractInterface {
   private destroyed = false;
   private xvfbInstance?: XvfbInstance;
   private xvfbCleanup?: () => void;
+  private activeInputWaits = new Set<{
+    timeoutId: ReturnType<typeof setTimeout>;
+    reject: (error: Error) => void;
+  }>();
   /**
    * On macOS, use AppleScript for keyboard operations by default
    * to avoid focus issues with system overlays (e.g. Spotlight).
@@ -432,7 +441,7 @@ export class ComputerDevice implements AbstractInterface {
   private useAppleScript: boolean;
   uri?: string;
 
-  readonly inputPrimitives: ComputerInputPrimitives = {
+  readonly inputPrimitives: ComputerInputPrimitives = this.gateInputPrimitives({
     pointer: {
       tap: async ({ x, y }) => {
         assert(libnut, 'libnut not initialized');
@@ -444,10 +453,16 @@ export class ComputerDevice implements AbstractInterface {
           targetY,
           SMOOTH_MOVE_STEPS_TAP,
           SMOOTH_MOVE_DELAY_TAP,
+          () => this.assertInputActive('tap'),
+          (ms) => this.inputWait(ms),
         );
+        this.assertInputActive('tap');
         libnut.mouseToggle('down', 'left');
-        await sleep(CLICK_HOLD_DURATION);
-        libnut.mouseToggle('up', 'left');
+        try {
+          await this.inputWait(CLICK_HOLD_DURATION);
+        } finally {
+          libnut.mouseToggle('up', 'left');
+        }
       },
       doubleClick: async ({ x, y }) => {
         assert(libnut, 'libnut not initialized');
@@ -466,17 +481,22 @@ export class ComputerDevice implements AbstractInterface {
           Math.round(y),
           SMOOTH_MOVE_STEPS_MOUSE_MOVE,
           SMOOTH_MOVE_DELAY_MOUSE_MOVE,
+          () => this.assertInputActive('hover'),
+          (ms) => this.inputWait(ms),
         );
-        await sleep(MOUSE_MOVE_EFFECT_WAIT);
+        await this.inputWait(MOUSE_MOVE_EFFECT_WAIT);
       },
       dragAndDrop: async (from, to) => {
         assert(libnut, 'libnut not initialized');
         libnut.moveMouse(Math.round(from.x), Math.round(from.y));
         libnut.mouseToggle('down', 'left');
-        await sleep(100);
-        libnut.moveMouse(Math.round(to.x), Math.round(to.y));
-        await sleep(100);
-        libnut.mouseToggle('up', 'left');
+        try {
+          await this.inputWait(100);
+          libnut.moveMouse(Math.round(to.x), Math.round(to.y));
+          await this.inputWait(100);
+        } finally {
+          libnut.mouseToggle('up', 'left');
+        }
       },
     },
     keyboard: {
@@ -488,11 +508,11 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = element.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await sleep(INPUT_FOCUS_DELAY);
+          await this.inputWait(INPUT_FOCUS_DELAY);
 
           if (opts?.replace !== false) {
             await this.selectAllAndDelete();
-            await sleep(INPUT_CLEAR_DELAY);
+            await this.inputWait(INPUT_CLEAR_DELAY);
           }
         }
 
@@ -506,7 +526,7 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = target.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await sleep(50);
+          await this.inputWait(50);
         }
 
         await this.pressKeyboardShortcut(keyName);
@@ -519,11 +539,11 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = element.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await sleep(100);
+          await this.inputWait(100);
         }
 
         await this.selectAllAndDelete();
-        await sleep(50);
+        await this.inputWait(50);
       },
     },
     scroll: {
@@ -531,7 +551,7 @@ export class ComputerDevice implements AbstractInterface {
         await this.performScroll(param);
       },
     },
-  };
+  });
 
   constructor(options?: ComputerDeviceOpt) {
     this.options = options;
@@ -834,7 +854,7 @@ Original error: ${lastRawMessage}`,
     try {
       // 2. Write new content to clipboard
       await clipboardy.default.write(text);
-      await sleep(50);
+      await this.inputWait(50);
 
       // 3. Simulate paste shortcut
       if (this.useAppleScript) {
@@ -843,7 +863,7 @@ Original error: ${lastRawMessage}`,
         const modifier = process.platform === 'darwin' ? 'command' : 'control';
         libnut.keyTap('v', [modifier]);
       }
-      await sleep(100);
+      await this.inputWait(100);
     } finally {
       // 4. Restore old clipboard content
       if (oldClipboard) {
@@ -869,14 +889,14 @@ Original error: ${lastRawMessage}`,
     assert(libnut, 'libnut not initialized');
     if (this.useAppleScript) {
       sendKeyViaAppleScript('a', ['command']);
-      await sleep(50);
+      await this.inputWait(50);
       sendKeyViaAppleScript('backspace', []);
       return;
     }
 
     const modifier = process.platform === 'darwin' ? 'command' : 'control';
     libnut.keyTap('a', [modifier]);
-    await sleep(50);
+    await this.inputWait(50);
     libnut.keyTap('backspace');
   }
 
@@ -925,20 +945,21 @@ Original error: ${lastRawMessage}`,
           EDGE_SCROLL_STEPS,
         )
       ) {
-        await sleep(SCROLL_COMPLETE_DELAY);
+        await this.inputWait(SCROLL_COMPLETE_DELAY);
         return;
       }
 
       if (this.useAppleScript) {
         sendKeyViaAppleScript(edgeSpec.key);
-        await sleep(SCROLL_COMPLETE_DELAY);
+        await this.inputWait(SCROLL_COMPLETE_DELAY);
         return;
       }
 
       const [dx, dy] = edgeSpec.libnut;
       for (let i = 0; i < SCROLL_REPEAT_COUNT; i++) {
+        this.assertInputActive('scroll');
         libnut.scrollMouse(dx, dy);
-        await sleep(SCROLL_STEP_DELAY);
+        await this.inputWait(SCROLL_STEP_DELAY);
       }
       return;
     }
@@ -969,7 +990,7 @@ Original error: ${lastRawMessage}`,
           Math.round(distance / PHASED_PIXELS_PER_STEP),
         );
         if (runPhasedScroll(direction, distance, steps)) {
-          await sleep(SCROLL_COMPLETE_DELAY);
+          await this.inputWait(SCROLL_COMPLETE_DELAY);
           return;
         }
       }
@@ -979,10 +1000,11 @@ Original error: ${lastRawMessage}`,
         const pages = Math.max(1, Math.round(distance / screenSize.height));
         const key = direction === 'up' ? 'pageup' : 'pagedown';
         for (let i = 0; i < pages; i++) {
+          this.assertInputActive('scroll');
           sendKeyViaAppleScript(key);
-          await sleep(SCROLL_STEP_DELAY);
+          await this.inputWait(SCROLL_STEP_DELAY);
         }
-        await sleep(SCROLL_COMPLETE_DELAY);
+        await this.inputWait(SCROLL_COMPLETE_DELAY);
         return;
       }
 
@@ -995,8 +1017,9 @@ Original error: ${lastRawMessage}`,
       };
 
       const [dx, dy] = directionMap[direction] || [0, -ticks];
+      this.assertInputActive('scroll');
       libnut.scrollMouse(dx, dy);
-      await sleep(SCROLL_COMPLETE_DELAY);
+      await this.inputWait(SCROLL_COMPLETE_DELAY);
       return;
     }
 
@@ -1022,6 +1045,9 @@ Original error: ${lastRawMessage}`,
       return;
     }
 
+    this.destroyed = true;
+    this.cancelActiveInputWaits();
+
     if (this.xvfbInstance) {
       this.xvfbInstance.stop();
       this.xvfbInstance = undefined;
@@ -1033,8 +1059,69 @@ Original error: ${lastRawMessage}`,
       this.xvfbCleanup = undefined;
     }
 
-    this.destroyed = true;
     debugDevice('Computer device destroyed');
+  }
+
+  private createDestroyedError(methodName: string): Error {
+    return new Error(
+      `ComputerDevice has been destroyed (cannot run ${methodName})`,
+    );
+  }
+
+  private assertInputActive(methodName: string): void {
+    if (this.destroyed) {
+      throw this.createDestroyedError(methodName);
+    }
+  }
+
+  private inputWait(ms: number): Promise<void> {
+    this.assertInputActive('input wait');
+    return new Promise((resolve, reject) => {
+      const waitRef = {
+        timeoutId: setTimeout(() => {
+          this.activeInputWaits.delete(waitRef);
+          try {
+            this.assertInputActive('input wait');
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        }, ms),
+        reject,
+      };
+      this.activeInputWaits.add(waitRef);
+    });
+  }
+
+  private cancelActiveInputWaits(): void {
+    const error = this.createDestroyedError('in-flight input');
+    for (const waitRef of this.activeInputWaits) {
+      clearTimeout(waitRef.timeoutId);
+      waitRef.reject(error);
+    }
+    this.activeInputWaits.clear();
+  }
+
+  private gateInputPrimitives<T extends Record<string, any>>(primitives: T): T {
+    const wrap = (path: string, value: unknown): unknown => {
+      if (typeof value === 'function') {
+        return async (...args: unknown[]) => {
+          this.assertInputActive(path);
+          return (value as (...args: unknown[]) => unknown)(...args);
+        };
+      }
+      if (value && typeof value === 'object') {
+        return Object.fromEntries(
+          Object.entries(value).map(([name, child]) => [
+            name,
+            wrap(`${path}.${name}`, child),
+          ]),
+        );
+      }
+      return value;
+    };
+
+    return wrap('inputPrimitives', primitives) as T;
   }
 
   async url(): Promise<string> {

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -430,7 +430,7 @@ export class ComputerDevice implements AbstractInterface {
   private destroyed = false;
   private xvfbInstance?: XvfbInstance;
   private xvfbCleanup?: () => void;
-  private activeInputWaits = new Set<{
+  private pendingInputDelayWaits = new Set<{
     timeoutId: ReturnType<typeof setTimeout>;
     reject: (error: Error) => void;
   }>();
@@ -454,12 +454,12 @@ export class ComputerDevice implements AbstractInterface {
           SMOOTH_MOVE_STEPS_TAP,
           SMOOTH_MOVE_DELAY_TAP,
           () => this.assertInputActive('tap'),
-          (ms) => this.inputWait(ms),
+          (ms) => this.waitForInputDelayOrThrow(ms),
         );
         this.assertInputActive('tap');
         libnut.mouseToggle('down', 'left');
         try {
-          await this.inputWait(CLICK_HOLD_DURATION);
+          await this.waitForInputDelayOrThrow(CLICK_HOLD_DURATION);
         } finally {
           libnut.mouseToggle('up', 'left');
         }
@@ -482,18 +482,18 @@ export class ComputerDevice implements AbstractInterface {
           SMOOTH_MOVE_STEPS_MOUSE_MOVE,
           SMOOTH_MOVE_DELAY_MOUSE_MOVE,
           () => this.assertInputActive('hover'),
-          (ms) => this.inputWait(ms),
+          (ms) => this.waitForInputDelayOrThrow(ms),
         );
-        await this.inputWait(MOUSE_MOVE_EFFECT_WAIT);
+        await this.waitForInputDelayOrThrow(MOUSE_MOVE_EFFECT_WAIT);
       },
       dragAndDrop: async (from, to) => {
         assert(libnut, 'libnut not initialized');
         libnut.moveMouse(Math.round(from.x), Math.round(from.y));
         libnut.mouseToggle('down', 'left');
         try {
-          await this.inputWait(100);
+          await this.waitForInputDelayOrThrow(100);
           libnut.moveMouse(Math.round(to.x), Math.round(to.y));
-          await this.inputWait(100);
+          await this.waitForInputDelayOrThrow(100);
         } finally {
           libnut.mouseToggle('up', 'left');
         }
@@ -508,11 +508,11 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = element.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await this.inputWait(INPUT_FOCUS_DELAY);
+          await this.waitForInputDelayOrThrow(INPUT_FOCUS_DELAY);
 
           if (opts?.replace !== false) {
             await this.selectAllAndDelete();
-            await this.inputWait(INPUT_CLEAR_DELAY);
+            await this.waitForInputDelayOrThrow(INPUT_CLEAR_DELAY);
           }
         }
 
@@ -526,7 +526,7 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = target.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await this.inputWait(50);
+          await this.waitForInputDelayOrThrow(50);
         }
 
         await this.pressKeyboardShortcut(keyName);
@@ -539,11 +539,11 @@ export class ComputerDevice implements AbstractInterface {
           const [x, y] = element.center;
           libnut.moveMouse(Math.round(x), Math.round(y));
           libnut.mouseClick('left');
-          await this.inputWait(100);
+          await this.waitForInputDelayOrThrow(100);
         }
 
         await this.selectAllAndDelete();
-        await this.inputWait(50);
+        await this.waitForInputDelayOrThrow(50);
       },
     },
     scroll: {
@@ -854,7 +854,7 @@ Original error: ${lastRawMessage}`,
     try {
       // 2. Write new content to clipboard
       await clipboardy.default.write(text);
-      await this.inputWait(50);
+      await this.waitForInputDelayOrThrow(50);
 
       // 3. Simulate paste shortcut
       if (this.useAppleScript) {
@@ -863,7 +863,7 @@ Original error: ${lastRawMessage}`,
         const modifier = process.platform === 'darwin' ? 'command' : 'control';
         libnut.keyTap('v', [modifier]);
       }
-      await this.inputWait(100);
+      await this.waitForInputDelayOrThrow(100);
     } finally {
       // 4. Restore old clipboard content
       if (oldClipboard) {
@@ -889,14 +889,14 @@ Original error: ${lastRawMessage}`,
     assert(libnut, 'libnut not initialized');
     if (this.useAppleScript) {
       sendKeyViaAppleScript('a', ['command']);
-      await this.inputWait(50);
+      await this.waitForInputDelayOrThrow(50);
       sendKeyViaAppleScript('backspace', []);
       return;
     }
 
     const modifier = process.platform === 'darwin' ? 'command' : 'control';
     libnut.keyTap('a', [modifier]);
-    await this.inputWait(50);
+    await this.waitForInputDelayOrThrow(50);
     libnut.keyTap('backspace');
   }
 
@@ -945,13 +945,13 @@ Original error: ${lastRawMessage}`,
           EDGE_SCROLL_STEPS,
         )
       ) {
-        await this.inputWait(SCROLL_COMPLETE_DELAY);
+        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
         return;
       }
 
       if (this.useAppleScript) {
         sendKeyViaAppleScript(edgeSpec.key);
-        await this.inputWait(SCROLL_COMPLETE_DELAY);
+        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
         return;
       }
 
@@ -959,7 +959,7 @@ Original error: ${lastRawMessage}`,
       for (let i = 0; i < SCROLL_REPEAT_COUNT; i++) {
         this.assertInputActive('scroll');
         libnut.scrollMouse(dx, dy);
-        await this.inputWait(SCROLL_STEP_DELAY);
+        await this.waitForInputDelayOrThrow(SCROLL_STEP_DELAY);
       }
       return;
     }
@@ -990,7 +990,7 @@ Original error: ${lastRawMessage}`,
           Math.round(distance / PHASED_PIXELS_PER_STEP),
         );
         if (runPhasedScroll(direction, distance, steps)) {
-          await this.inputWait(SCROLL_COMPLETE_DELAY);
+          await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
           return;
         }
       }
@@ -1002,9 +1002,9 @@ Original error: ${lastRawMessage}`,
         for (let i = 0; i < pages; i++) {
           this.assertInputActive('scroll');
           sendKeyViaAppleScript(key);
-          await this.inputWait(SCROLL_STEP_DELAY);
+          await this.waitForInputDelayOrThrow(SCROLL_STEP_DELAY);
         }
-        await this.inputWait(SCROLL_COMPLETE_DELAY);
+        await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
         return;
       }
 
@@ -1019,7 +1019,7 @@ Original error: ${lastRawMessage}`,
       const [dx, dy] = directionMap[direction] || [0, -ticks];
       this.assertInputActive('scroll');
       libnut.scrollMouse(dx, dy);
-      await this.inputWait(SCROLL_COMPLETE_DELAY);
+      await this.waitForInputDelayOrThrow(SCROLL_COMPLETE_DELAY);
       return;
     }
 
@@ -1046,7 +1046,7 @@ Original error: ${lastRawMessage}`,
     }
 
     this.destroyed = true;
-    this.cancelActiveInputWaits();
+    this.rejectPendingInputDelays();
 
     if (this.xvfbInstance) {
       this.xvfbInstance.stop();
@@ -1074,12 +1074,12 @@ Original error: ${lastRawMessage}`,
     }
   }
 
-  private inputWait(ms: number): Promise<void> {
+  private waitForInputDelayOrThrow(ms: number): Promise<void> {
     this.assertInputActive('input wait');
     return new Promise((resolve, reject) => {
       const waitRef = {
         timeoutId: setTimeout(() => {
-          this.activeInputWaits.delete(waitRef);
+          this.pendingInputDelayWaits.delete(waitRef);
           try {
             this.assertInputActive('input wait');
             resolve();
@@ -1089,17 +1089,17 @@ Original error: ${lastRawMessage}`,
         }, ms),
         reject,
       };
-      this.activeInputWaits.add(waitRef);
+      this.pendingInputDelayWaits.add(waitRef);
     });
   }
 
-  private cancelActiveInputWaits(): void {
+  private rejectPendingInputDelays(): void {
     const error = this.createDestroyedError('in-flight input');
-    for (const waitRef of this.activeInputWaits) {
+    for (const waitRef of this.pendingInputDelayWaits) {
       clearTimeout(waitRef.timeoutId);
       waitRef.reject(error);
     }
-    this.activeInputWaits.clear();
+    this.pendingInputDelayWaits.clear();
   }
 
   private gateInputPrimitives<T extends Record<string, any>>(primitives: T): T {

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -20,22 +19,15 @@ import { sleep } from '@midscene/core/utils';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import screenshot from 'screenshot-desktop';
+import {
+  ComputerInputDriver,
+  type LibNut,
+  type ScrollDirection,
+} from './input-driver';
 import type { XvfbInstance } from './xvfb';
 import { checkXvfbInstalled, needsXvfb, startXvfb } from './xvfb';
 
 declare const __VERSION__: string;
-
-// Type definitions
-interface LibNut {
-  getScreenSize(): { width: number; height: number };
-  getMousePos(): { x: number; y: number };
-  moveMouse(x: number, y: number): void;
-  mouseClick(button?: 'left' | 'right' | 'middle', double?: boolean): void;
-  mouseToggle(state: 'up' | 'down', button?: 'left' | 'right' | 'middle'): void;
-  scrollMouse(x: number, y: number): void;
-  keyTap(key: string, modifiers?: string[]): void;
-  typeString(text: string): void;
-}
 
 interface ScreenshotOptions {
   format: 'png' | 'jpg';
@@ -81,7 +73,6 @@ type EdgeScrollType =
   | 'scrollToBottom'
   | 'scrollToLeft'
   | 'scrollToRight';
-type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 
 interface EdgeScrollStrategy {
   direction: ScrollDirection;
@@ -302,167 +293,6 @@ export function runPhasedScroll(
   }
 }
 
-type MouseButton = 'left' | 'right' | 'middle';
-
-class ComputerInputDriver {
-  private destroyed = false;
-  private pendingInputDelayWaits = new Set<{
-    timeoutId: ReturnType<typeof setTimeout>;
-    reject: (error: Error) => void;
-  }>();
-
-  constructor(private readonly useAppleScript: () => boolean) {}
-
-  destroy(): void {
-    if (this.destroyed) {
-      return;
-    }
-    this.destroyed = true;
-    this.rejectPendingInputDelays();
-  }
-
-  getScreenSize(): Size {
-    return this.getLibnutOrThrow('getScreenSize').getScreenSize();
-  }
-
-  getMousePos(): { x: number; y: number } {
-    return this.getLibnutOrThrow('getMousePos').getMousePos();
-  }
-
-  moveMouse(x: number, y: number): void {
-    this.getLibnutOrThrow('moveMouse').moveMouse(x, y);
-  }
-
-  mouseClick(button?: MouseButton, double?: boolean): void {
-    this.getLibnutOrThrow('mouseClick').mouseClick(button, double);
-  }
-
-  mouseToggle(state: 'up' | 'down', button: MouseButton = 'left'): void {
-    this.getLibnutOrThrow('mouseToggle').mouseToggle(state, button);
-  }
-
-  scrollMouse(x: number, y: number): void {
-    this.getLibnutOrThrow('scrollMouse').scrollMouse(x, y);
-  }
-
-  keyTap(key: string, modifiers?: string[]): void {
-    this.getLibnutOrThrow('keyTap').keyTap(key, modifiers);
-  }
-
-  sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
-    this.assertActive('sendKeyViaAppleScript');
-    sendKeyViaAppleScript(key, modifiers);
-  }
-
-  sendKey(key: string, modifiers: string[] = []): void {
-    if (this.useAppleScript()) {
-      this.sendKeyViaAppleScript(key, modifiers);
-      return;
-    }
-
-    if (modifiers.length > 0) {
-      this.keyTap(key, modifiers);
-    } else {
-      this.keyTap(key);
-    }
-  }
-
-  runPhasedScroll(
-    direction: ScrollDirection,
-    pixels: number,
-    steps: number,
-  ): boolean {
-    this.assertActive('runPhasedScroll');
-    return runPhasedScroll(direction, pixels, steps);
-  }
-
-  async delay(ms: number): Promise<void> {
-    this.assertActive('delay');
-    return new Promise((resolve, reject) => {
-      const waitRef = {
-        timeoutId: setTimeout(() => {
-          this.pendingInputDelayWaits.delete(waitRef);
-          try {
-            this.assertActive('delay');
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        }, ms),
-        reject,
-      };
-      this.pendingInputDelayWaits.add(waitRef);
-    });
-  }
-
-  async smoothMoveMouse(
-    targetX: number,
-    targetY: number,
-    steps: number,
-    stepDelay: number,
-  ): Promise<void> {
-    const currentPos = this.getMousePos();
-    for (let i = 1; i <= steps; i++) {
-      const stepX = Math.round(
-        currentPos.x + ((targetX - currentPos.x) * i) / steps,
-      );
-      const stepY = Math.round(
-        currentPos.y + ((targetY - currentPos.y) * i) / steps,
-      );
-      this.moveMouse(stepX, stepY);
-      await this.delay(stepDelay);
-    }
-  }
-
-  async withMouseButton<T>(
-    button: MouseButton,
-    run: () => Promise<T>,
-  ): Promise<T> {
-    this.mouseToggle('down', button);
-    try {
-      return await run();
-    } finally {
-      this.releaseMouseButton(button);
-    }
-  }
-
-  private getLibnutOrThrow(methodName: string): LibNut {
-    this.assertActive(methodName);
-    assert(libnut, 'libnut not initialized');
-    return libnut;
-  }
-
-  private assertActive(methodName: string): void {
-    if (this.destroyed) {
-      throw this.createDestroyedError(methodName);
-    }
-  }
-
-  private createDestroyedError(methodName: string): Error {
-    return new Error(
-      `ComputerDevice has been destroyed (cannot run ${methodName})`,
-    );
-  }
-
-  private releaseMouseButton(button: MouseButton): void {
-    try {
-      assert(libnut, 'libnut not initialized');
-      libnut.mouseToggle('up', button);
-    } catch (error) {
-      debugDevice(`Failed to release mouse button ${button}: ${error}`);
-    }
-  }
-
-  private rejectPendingInputDelays(): void {
-    const error = this.createDestroyedError('in-flight input');
-    for (const waitRef of this.pendingInputDelayWaits) {
-      clearTimeout(waitRef.timeoutId);
-      waitRef.reject(error);
-    }
-    this.pendingInputDelayWaits.clear();
-  }
-}
-
 // Key name mapping for cross-platform compatibility
 // Note: Modifier keys have different names when used as primary key vs modifier
 const KEY_NAME_MAP: Record<string, string> = {
@@ -563,9 +393,13 @@ export class ComputerDevice implements AbstractInterface {
   private destroyed = false;
   private xvfbInstance?: XvfbInstance;
   private xvfbCleanup?: () => void;
-  private readonly inputDriver = new ComputerInputDriver(
-    () => this.useAppleScript,
-  );
+  private readonly inputDriver = new ComputerInputDriver({
+    getLibnut: () => libnut,
+    useAppleScript: () => this.useAppleScript,
+    sendKeyViaAppleScript,
+    runPhasedScroll,
+    debug: (message) => debugDevice(message),
+  });
   /**
    * On macOS, use AppleScript for keyboard operations by default
    * to avoid focus issues with system overlays (e.g. Spotlight).

--- a/packages/computer/src/input-driver.ts
+++ b/packages/computer/src/input-driver.ts
@@ -57,7 +57,17 @@ export class ComputerInputDriver {
   }
 
   mouseClick(button?: MouseButton, double?: boolean): void {
-    this.getLibnutOrThrow('mouseClick').mouseClick(button, double);
+    const lib = this.getLibnutOrThrow('mouseClick');
+    // libnut is a native binding that distinguishes "no argument" from
+    // "explicit undefined" — passing undefined for optional args trips
+    // "A boolean was expected" / "A string was expected" type checks.
+    if (double !== undefined) {
+      lib.mouseClick(button, double);
+    } else if (button !== undefined) {
+      lib.mouseClick(button);
+    } else {
+      lib.mouseClick();
+    }
   }
 
   mouseToggle(state: 'up' | 'down', button: MouseButton = 'left'): void {
@@ -69,7 +79,13 @@ export class ComputerInputDriver {
   }
 
   keyTap(key: string, modifiers?: string[]): void {
-    this.getLibnutOrThrow('keyTap').keyTap(key, modifiers);
+    const lib = this.getLibnutOrThrow('keyTap');
+    // See note on mouseClick — avoid passing explicit undefined to libnut.
+    if (modifiers !== undefined) {
+      lib.keyTap(key, modifiers);
+    } else {
+      lib.keyTap(key);
+    }
   }
 
   sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {

--- a/packages/computer/src/input-driver.ts
+++ b/packages/computer/src/input-driver.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert';
+import type { Size } from '@midscene/core';
+
+export interface LibNut {
+  getScreenSize(): { width: number; height: number };
+  getMousePos(): { x: number; y: number };
+  moveMouse(x: number, y: number): void;
+  mouseClick(button?: MouseButton, double?: boolean): void;
+  mouseToggle(state: 'up' | 'down', button?: MouseButton): void;
+  scrollMouse(x: number, y: number): void;
+  keyTap(key: string, modifiers?: string[]): void;
+  typeString(text: string): void;
+}
+
+export type MouseButton = 'left' | 'right' | 'middle';
+export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+
+interface ComputerInputDriverOptions {
+  getLibnut(): LibNut | null;
+  useAppleScript(): boolean;
+  sendKeyViaAppleScript(key: string, modifiers?: string[]): void;
+  runPhasedScroll(
+    direction: ScrollDirection,
+    pixels: number,
+    steps: number,
+  ): boolean;
+  debug(message: string): void;
+}
+
+export class ComputerInputDriver {
+  private destroyed = false;
+  private pendingInputDelayWaits = new Set<{
+    timeoutId: ReturnType<typeof setTimeout>;
+    reject: (error: Error) => void;
+  }>();
+
+  constructor(private readonly options: ComputerInputDriverOptions) {}
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.rejectPendingInputDelays();
+  }
+
+  getScreenSize(): Size {
+    return this.getLibnutOrThrow('getScreenSize').getScreenSize();
+  }
+
+  getMousePos(): { x: number; y: number } {
+    return this.getLibnutOrThrow('getMousePos').getMousePos();
+  }
+
+  moveMouse(x: number, y: number): void {
+    this.getLibnutOrThrow('moveMouse').moveMouse(x, y);
+  }
+
+  mouseClick(button?: MouseButton, double?: boolean): void {
+    this.getLibnutOrThrow('mouseClick').mouseClick(button, double);
+  }
+
+  mouseToggle(state: 'up' | 'down', button: MouseButton = 'left'): void {
+    this.getLibnutOrThrow('mouseToggle').mouseToggle(state, button);
+  }
+
+  scrollMouse(x: number, y: number): void {
+    this.getLibnutOrThrow('scrollMouse').scrollMouse(x, y);
+  }
+
+  keyTap(key: string, modifiers?: string[]): void {
+    this.getLibnutOrThrow('keyTap').keyTap(key, modifiers);
+  }
+
+  sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
+    this.assertActive('sendKeyViaAppleScript');
+    this.options.sendKeyViaAppleScript(key, modifiers);
+  }
+
+  sendKey(key: string, modifiers: string[] = []): void {
+    if (this.options.useAppleScript()) {
+      this.sendKeyViaAppleScript(key, modifiers);
+      return;
+    }
+
+    if (modifiers.length > 0) {
+      this.keyTap(key, modifiers);
+    } else {
+      this.keyTap(key);
+    }
+  }
+
+  runPhasedScroll(
+    direction: ScrollDirection,
+    pixels: number,
+    steps: number,
+  ): boolean {
+    this.assertActive('runPhasedScroll');
+    return this.options.runPhasedScroll(direction, pixels, steps);
+  }
+
+  async delay(ms: number): Promise<void> {
+    this.assertActive('delay');
+    return new Promise((resolve, reject) => {
+      const waitRef = {
+        timeoutId: setTimeout(() => {
+          this.pendingInputDelayWaits.delete(waitRef);
+          try {
+            this.assertActive('delay');
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        }, ms),
+        reject,
+      };
+      this.pendingInputDelayWaits.add(waitRef);
+    });
+  }
+
+  async smoothMoveMouse(
+    targetX: number,
+    targetY: number,
+    steps: number,
+    stepDelay: number,
+  ): Promise<void> {
+    const currentPos = this.getMousePos();
+    for (let i = 1; i <= steps; i++) {
+      const stepX = Math.round(
+        currentPos.x + ((targetX - currentPos.x) * i) / steps,
+      );
+      const stepY = Math.round(
+        currentPos.y + ((targetY - currentPos.y) * i) / steps,
+      );
+      this.moveMouse(stepX, stepY);
+      await this.delay(stepDelay);
+    }
+  }
+
+  async withMouseButton<T>(
+    button: MouseButton,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    this.mouseToggle('down', button);
+    try {
+      return await run();
+    } finally {
+      this.releaseMouseButton(button);
+    }
+  }
+
+  private getLibnutOrThrow(methodName: string): LibNut {
+    this.assertActive(methodName);
+    const libnut = this.options.getLibnut();
+    assert(libnut, 'libnut not initialized');
+    return libnut;
+  }
+
+  private assertActive(methodName: string): void {
+    if (this.destroyed) {
+      throw this.createDestroyedError(methodName);
+    }
+  }
+
+  private createDestroyedError(methodName: string): Error {
+    return new Error(
+      `ComputerDevice has been destroyed (cannot run ${methodName})`,
+    );
+  }
+
+  private releaseMouseButton(button: MouseButton): void {
+    try {
+      const libnut = this.options.getLibnut();
+      assert(libnut, 'libnut not initialized');
+      libnut.mouseToggle('up', button);
+    } catch (error) {
+      this.options.debug(`Failed to release mouse button ${button}: ${error}`);
+    }
+  }
+
+  private rejectPendingInputDelays(): void {
+    const error = this.createDestroyedError('in-flight input');
+    for (const waitRef of this.pendingInputDelayWaits) {
+      clearTimeout(waitRef.timeoutId);
+      waitRef.reject(error);
+    }
+    this.pendingInputDelayWaits.clear();
+  }
+}

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -147,4 +147,21 @@ describe('ComputerDevice destroy input gate', () => {
       moveCountAfterDestroy,
     );
   });
+
+  it('releases the mouse button when destroy interrupts a tap hold', async () => {
+    const { ComputerDevice } = await import('../../src/device');
+    const device = new ComputerDevice({});
+    await device.connect();
+
+    const tapPromise = device.inputPrimitives.pointer.tap({ x: 200, y: 120 });
+
+    await vi.waitFor(() => {
+      expect(mockState.libnut.mouseToggle).toHaveBeenCalledWith('down', 'left');
+    });
+
+    await device.destroy();
+
+    await expect(tapPromise).rejects.toThrow(/destroyed/);
+    expect(mockState.libnut.mouseToggle).toHaveBeenCalledWith('up', 'left');
+  });
 });

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -121,3 +121,30 @@ describe('ComputerDevice AppleScript security', () => {
     ]);
   });
 });
+
+describe('ComputerDevice destroy input gate', () => {
+  it('interrupts an in-flight pointer action and blocks later input', async () => {
+    const { ComputerDevice } = await import('../../src/device');
+    const device = new ComputerDevice({});
+    await device.connect();
+
+    const hoverPromise = device.inputPrimitives.pointer.hover({
+      x: 200,
+      y: 120,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await device.destroy();
+
+    await expect(hoverPromise).rejects.toThrow(/destroyed/);
+    const moveCountAfterDestroy = mockState.libnut.moveMouse.mock.calls.length;
+
+    await expect(
+      device.inputPrimitives.pointer.hover({ x: 210, y: 130 }),
+    ).rejects.toThrow(/destroyed/);
+
+    expect(mockState.libnut.moveMouse).toHaveBeenCalledTimes(
+      moveCountAfterDestroy,
+    );
+  });
+});

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -165,3 +165,50 @@ describe('ComputerDevice destroy input gate', () => {
     expect(mockState.libnut.mouseToggle).toHaveBeenCalledWith('up', 'left');
   });
 });
+
+describe('ComputerInputDriver native arg handling', () => {
+  // libnut is a native binding that distinguishes "no argument" from
+  // "explicit undefined" — passing `(button, undefined)` trips its
+  // "A boolean was expected" type check, and `(key, undefined)` trips
+  // "A string was expected". The driver wrapper must not forward
+  // undefined for optional trailing args.
+  it('omits trailing undefined args when calling libnut.mouseClick', async () => {
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: vi.fn(),
+      runPhasedScroll: vi.fn(() => true),
+      debug: vi.fn(),
+    });
+
+    driver.mouseClick('right');
+    expect(mockState.libnut.mouseClick).toHaveBeenLastCalledWith('right');
+    // Confirm exactly one positional arg — no trailing undefined leaked.
+    expect(mockState.libnut.mouseClick.mock.lastCall).toHaveLength(1);
+
+    driver.mouseClick('left', true);
+    expect(mockState.libnut.mouseClick).toHaveBeenLastCalledWith('left', true);
+
+    driver.mouseClick();
+    expect(mockState.libnut.mouseClick.mock.lastCall).toHaveLength(0);
+  });
+
+  it('omits trailing undefined modifiers when calling libnut.keyTap', async () => {
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: vi.fn(),
+      runPhasedScroll: vi.fn(() => true),
+      debug: vi.fn(),
+    });
+
+    driver.keyTap('backspace');
+    expect(mockState.libnut.keyTap).toHaveBeenLastCalledWith('backspace');
+    expect(mockState.libnut.keyTap.mock.lastCall).toHaveLength(1);
+
+    driver.keyTap('a', ['command']);
+    expect(mockState.libnut.keyTap).toHaveBeenLastCalledWith('a', ['command']);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1383,15 +1383,25 @@ export class Agent<
       return;
     }
 
+    this.destroyed = true;
+    let interfaceDestroyError: unknown;
+    try {
+      await this.interface.destroy?.();
+    } catch (error) {
+      interfaceDestroyError = error;
+    }
+
     // Wait for all queued write operations to complete
     await this.reportGenerator.flush();
 
     const finalPath = await this.reportGenerator.finalize();
     this.reportFile = finalPath;
 
-    await this.interface.destroy?.();
     this.resetDump(); // reset dump to release memory
-    this.destroyed = true;
+
+    if (interfaceDestroyError) {
+      throw interfaceDestroyError;
+    }
   }
 
   async recordToReport(

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -200,4 +200,40 @@ describe('Agent dump update screenshot serialization', () => {
 
     await agent.destroy();
   });
+
+  it('destroys the interface before flushing the final report', async () => {
+    const order: string[] = [];
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        destroy: vi.fn(async () => {
+          order.push('interface.destroy');
+        }),
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    (agent as any).reportGenerator = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {
+        order.push('report.flush');
+      }),
+      finalize: vi.fn(async () => {
+        order.push('report.finalize');
+        return undefined;
+      }),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    await agent.destroy();
+
+    expect(order).toEqual([
+      'interface.destroy',
+      'report.flush',
+      'report.finalize',
+    ]);
+  });
 });

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -593,19 +593,32 @@ class PlaygroundServer {
     });
   }
 
-  getSessionInfo(): PlaygroundSessionState & {
-    setupState: 'required' | 'ready' | 'blocked';
-    setupBlockingReason?: string;
-  } {
-    const connected = this.sessionManager
+  /**
+   * Treat a session as connected when either:
+   * - we have a live agent, OR
+   * - we are mid-recreate (`_agentReady === false`).
+   *
+   * `recreateAgent` (e.g. via /cancel) nulls `_activeConnection.agent`
+   * before the factory swaps in a fresh one. Without this guard the UI
+   * sees a brief `connected: false` window and flashes the
+   * SessionSetupPanel ("create agent" form) for ~1–2 seconds.
+   */
+  private isEffectivelyConnected(): boolean {
+    const rawConnected = this.sessionManager
       ? Boolean(
           this._activeConnection.session?.connected &&
             this._activeConnection.agent,
         )
       : Boolean(this._activeConnection.agent);
+    return rawConnected || !this._agentReady;
+  }
 
+  getSessionInfo(): PlaygroundSessionState & {
+    setupState: 'required' | 'ready' | 'blocked';
+    setupBlockingReason?: string;
+  } {
     return {
-      connected,
+      connected: this.isEffectivelyConnected(),
       displayName: this._activeConnection.session?.displayName,
       metadata: {
         ...(this._activeConnection.session?.metadata || {}),
@@ -616,17 +629,10 @@ class PlaygroundServer {
   }
 
   private buildSessionMetadata(): Record<string, unknown> {
-    const sessionConnected = this.sessionManager
-      ? Boolean(
-          this._activeConnection.session?.connected &&
-            this._activeConnection.agent,
-        )
-      : Boolean(this._activeConnection.agent);
-
     return {
       ...(this._basePreparedMetadata || {}),
       ...(this._activeConnection.session?.metadata || {}),
-      sessionConnected,
+      sessionConnected: this.isEffectivelyConnected(),
       sessionDisplayName: this._activeConnection.session?.displayName,
       setupState: this.sessionSetupState,
       ...(this.sessionSetupBlockingReason

--- a/packages/playground/tests/unit/server-connected-during-recreate.test.ts
+++ b/packages/playground/tests/unit/server-connected-during-recreate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { PlaygroundServer } from '../../src/server';
+
+/**
+ * Regression test for the "create agent" form flashing after /cancel.
+ *
+ * recreateAgent() nulls _activeConnection.agent between destroying the
+ * old agent and the factory swapping in a new one. The frontend at
+ * PlaygroundConversationPanel.tsx:132 renders SessionSetupPanel whenever
+ * sessionViewState.connected is false, so without this guard the UI
+ * flashes the "create agent" form for ~1–2 seconds whenever a user
+ * hits Stop.
+ *
+ * isEffectivelyConnected() must return true while _agentReady === false
+ * even if agent is null, so the UI stays calm during the recreate window.
+ */
+describe('PlaygroundServer connected state during recreateAgent', () => {
+  function makeFakeAgent() {
+    // Minimal stub — the connected check only inspects identity, not methods.
+    return {} as any;
+  }
+
+  function makeServer() {
+    // Pass a factory so recreateAgent has something to swap in.
+    return new PlaygroundServer(() => makeFakeAgent());
+  }
+
+  it('reports connected=true when an agent is live and not recreating', () => {
+    const server = makeServer();
+    (server as any)._activeConnection.agent = makeFakeAgent();
+    (server as any)._agentReady = true;
+
+    expect(server.getSessionInfo().connected).toBe(true);
+  });
+
+  it('reports connected=false at cold start (no agent, not recreating)', () => {
+    const server = makeServer();
+    (server as any)._activeConnection.agent = null;
+    (server as any)._agentReady = true;
+
+    expect(server.getSessionInfo().connected).toBe(false);
+  });
+
+  it('reports connected=true during the recreate window (agent=null, _agentReady=false)', () => {
+    const server = makeServer();
+    // Simulate the exact mid-recreate state: agent has been destroyed
+    // but the factory hasn't swapped in the replacement yet.
+    (server as any)._activeConnection.agent = null;
+    (server as any)._agentReady = false;
+
+    expect(server.getSessionInfo().connected).toBe(true);
+  });
+
+  it('flips connected back to false once recreate finishes without a fresh agent', () => {
+    const server = makeServer();
+    // Recreate window closed (e.g. factory threw), no agent installed.
+    (server as any)._activeConnection.agent = null;
+    (server as any)._agentReady = true;
+
+    expect(server.getSessionInfo().connected).toBe(false);
+  });
+
+  it('surfaces the same guard through buildSessionMetadata().sessionConnected', () => {
+    const server = makeServer();
+    (server as any)._activeConnection.agent = null;
+    (server as any)._agentReady = false;
+
+    const metadata = (server as any).buildSessionMetadata() as {
+      sessionConnected: boolean;
+    };
+    expect(metadata.sessionConnected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- make `Agent.destroy()` destroy the active interface before report flush/finalize so cancel/recreate disarms the underlying runtime immediately
- add a ComputerDevice input gate that marks the device destroyed first, rejects in-flight input waits, and blocks stale input primitives from reaching libnut/AppleScript after destroy
- keep mouse button release in `finally` for tap/drag paths so cancellation does not leave a button held down

This is the narrower alternative to #2535: instead of plumbing AbortSignal through every action/task method, the cancel path keeps using destroy+recreate, and destroy now cuts off the bottom input surface first.

## Validation

- `pnpm run lint`
- `npx nx test @midscene/computer -- tests/unit-test/device-security.test.ts`
- `npx nx test @midscene/core -- tests/unit-test/agent-dump-update.test.ts`
- `npx nx build @midscene/core`
- `npx nx build @midscene/computer`