### PR TITLE
feat(studio): brand Studio as Beta + expand v1.8 changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Build Studio and Nx dependencies
       run: npx nx build studio
 
-    - name: Package Midscene Studio
+    - name: Package Midscene Studio Beta
       run: pnpm --dir apps/studio run package:release -- --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --version=${{ needs.release.outputs.version }}
 
     - name: Upload packaged Studio artifact

--- a/apps/site/docs/en/changelog.mdx
+++ b/apps/site/docs/en/changelog.mdx
@@ -10,9 +10,6 @@ Midscene Studio is an Electron-based desktop app that brings every Midscene play
 
 - **Multi-platform playground**: Switch seamlessly between Web, Android, iOS, HarmonyOS, and Computer playgrounds inside the same Studio app
 - **Interactive device preview**: Manually drive Android / iOS / HarmonyOS device previews with mouse and touch input; Web preview supports live streaming
-- **Dark mode**: Built on semantic design tokens, with automatic system theme follow-up
-- **Auto updates**: Powered by electron-updater + GitHub Releases, so new versions are pushed automatically
-- **DMG installer**: macOS ships a drag-to-Applications DMG, with Developer ID signing and notarization configured in the build pipeline
 
 #### Coming next: record-to-replay Midscene scripts inside Studio
 

--- a/apps/site/docs/en/changelog.mdx
+++ b/apps/site/docs/en/changelog.mdx
@@ -1,23 +1,64 @@
 # Changelog
 
-## v1.8 - YAML Workflow, Device Integrations & Model Behavior Updates
+## v1.8 - Midscene Studio Desktop App, YAML Variables & Multi-Platform Enhancements
 
-v1.8 refines model reasoning defaults and brings new device/platform integration options.
+v1.8 introduces **Midscene Studio**, a brand-new desktop application, alongside YAML step result reuse, new interaction APIs (long press / clear input), refined model planning behavior, and broad upgrades across device integrations, the report system, and the MCP toolset.
+
+### Midscene Studio — A New Desktop Application (Beta)
+
+Midscene Studio is an Electron-based desktop app that brings every Midscene playground into a single native shell. It is currently in **Beta** — try it out and let us know what works (and what doesn't):
+
+- **Multi-platform playground**: Switch seamlessly between Web, Android, iOS, HarmonyOS, and Computer playgrounds inside the same Studio app
+- **Interactive device preview**: Manually drive Android / iOS / HarmonyOS device previews with mouse and touch input; Web preview supports live streaming
+- **Dark mode**: Built on semantic design tokens, with automatic system theme follow-up
+- **Auto updates**: Powered by electron-updater + GitHub Releases, so new versions are pushed automatically
+- **DMG installer**: macOS ships a drag-to-Applications DMG, with Developer ID signing and notarization configured in the build pipeline
+
+#### Coming next: record-to-replay Midscene scripts inside Studio
+
+We're building a full record → script → replay loop into Studio: drive a real device inside Studio, automatically capture the interaction as a structured Midscene script, then replay, debug, and export it without leaving the app. The capability will roll out across upcoming releases — stay tuned.
 
 ### YAML Workflow Enhancements
 
-- Android `runAdbShell` now accepts a `timeout` option in both the JavaScript API and YAML scripts. See: [Android API](./android-api-reference), [Automate with Scripts in YAML](./automate-with-scripts-in-yaml)
+- **Reuse step results**: YAML steps with `name` can be reused in later steps through `$name` and `${name}`. See: [Automate with Scripts in YAML](./automate-with-scripts-in-yaml#reuse-step-results)
+- **Android `runAdbShell` timeout**: A `timeout` option is now accepted in both the JavaScript API and YAML scripts. See: [Android API](./android-api-reference), [Automate with Scripts in YAML](./automate-with-scripts-in-yaml)
+
+### New Interaction APIs
+
+- **`agent.aiLongPress()`**: Long-press a target element to trigger long-press menus and similar gestures. See: [API Reference](./api.mdx#agentailongpress)
+- **`agent.aiClearInput()`**: Clear the contents of an input field, ideal when clearing needs to be its own step. See: [API Reference](./api.mdx#agentaiclearinput)
 
 ### Device and Platform Integrations
 
-- iOS now supports connecting to external WebDriverAgent sessions, making it easier to reuse an existing WDA setup
-- RDP connection options are now exposed through Computer MCP / CLI connection tools
+- **iOS external WDA sessions**: iOS now supports connecting to existing WebDriverAgent sessions, making it easier to reuse an external WDA setup
+- **Pluggable iOS device implementation**: The iOSDevice implementation can be overridden, enabling deeper extension or customization
+- **Computer remote desktop**: RDP connection options are now exposed through Computer MCP / CLI connection tools, letting you take over a remote Windows desktop directly
+- **`agentForComputer` rename**: `agentForComputer` is introduced as the primary API; the original `agentFromComputer` is kept as a deprecated alias
+- **Puppeteer CLI viewport options**: The Puppeteer CLI now accepts viewport configuration, so you can size the browser at launch from the command line
 
 ### Model and Planning Behavior
 
-- Model usage intent is now tracked separately from resolved config slots, making multi-model planning, locating, and report display clearer
-- For supported model families, Midscene now disables model-native thinking by default to improve execution speed and stability. See: [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode)
-- Doubao fast tier configuration is now supported through `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}`. See: [Common Model Configuration](./model-common-config)
+- **Usage intent decoupled from config slot**: Model usage intent is now tracked separately from resolved config slots, making multi-model planning, locating, and report display clearer
+- **Native thinking off by default**: For supported model families, Midscene now disables model-native thinking by default to improve execution speed and stability. See: [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode)
+- **Doubao fast tier**: Doubao fast tier configuration is now supported through `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}`. See: [Common Model Configuration](./model-common-config)
+- **GLM-5V-Turbo support**: Added support for Zhipu GLM-5V-Turbo. See: [Common Model Configuration](./model-common-config)
+- **Better scrollable select planning**: Planning for scrollable selects (dropdowns, scroll wheels) is more reliable in complex scenarios
+
+### MCP and Platform CLIs
+
+- **New `assert` MCP tool**: The MCP server now exposes an assertion tool backed by `aiAssert`, so AI assistants can run assertions directly. See: [MCP](./mcp)
+- **Image prompts in assert**: The assert CLI / MCP tool now accepts images as prompt input, so you can assert against a reference image
+- **Bare init args in platform CLIs**: Platform CLIs simplify argument passing and now accept platform Agent constructor options directly
+- **Playwright fixture passes Agent options through**: `PlaywrightAiFixture` now forwards `PlaywrightAgent` constructor options, so you can customize the Agent while keeping the fixture
+
+### Report System
+
+- **CLI report merging**: A new `report-tool merge` subcommand lets you combine multiple report files into one for centralized review
+- **Screenshot tool calls recorded in reports**: `take_screenshot` invocations now appear in reports, easing diagnosis of screenshot-related issues
+
+### Chrome Extension
+
+- **Automated Chrome Web Store publishing**: The Chrome Web Store extension release pipeline is now fully automated, shortening release cycles
 
 ### Bug Fixes
 
@@ -26,7 +67,16 @@ v1.8 refines model reasoning defaults and brings new device/platform integration
 - Fixed Bridge attachment after new-tab navigation
 - Fixed Playground tap projection on iOS / HarmonyOS / Computer
 - Fixed HarmonyOS per-call `autoDismissKeyboard`
-- Fixed Android Playground video streaming memory usage
+- Fixed excessive Android Playground video streaming memory usage
+- Fixed Computer scroll default distance not matching Web
+- Fixed out-of-range bbox handling for models that return normalized `[0,1000]` coordinates
+- Fixed `aiAct` options not being inherited in Bridge mode
+- Fixed Action API return values diverging from the documented shape
+- Fixed `maxTokens` not aligning with intent model config
+- Fixed server port probing on a non-`0.0.0.0` host that did not match the actual listen host
+- Fixed `deepThink` dump flag being lost in reports
+- Fixed sporadic dropped characters when typing on iOS
+- Fixed unwanted HarmonyOS system action delay overrides
 
 ## v1.7 - Flexible Report File Consumption, with Qwen 3.6 Support
 

--- a/apps/site/docs/zh/changelog.mdx
+++ b/apps/site/docs/zh/changelog.mdx
@@ -10,9 +10,6 @@ Midscene Studio 是一个基于 Electron 的桌面应用，把多平台 Playgrou
 
 - **多平台 Playground**：Web、Android、iOS、HarmonyOS、Computer 在同一个 Studio 应用中无缝切换
 - **设备交互预览**：Android / iOS / HarmonyOS 设备预览支持手动鼠标和触控控制；Web 预览支持实时画面流式渲染
-- **深色模式**：基于语义化设计 token 实现，自动跟随系统主题
-- **自动更新**：基于 electron-updater + GitHub Releases，新版本发布后自动推送
-- **DMG 安装包**：macOS 提供拖拽到 Applications 的标准 DMG 安装方式，构建已配置 Developer ID 签名与公证
 
 #### 下一步：在 Studio 中录制生成可回放的 Midscene 脚本
 

--- a/apps/site/docs/zh/changelog.mdx
+++ b/apps/site/docs/zh/changelog.mdx
@@ -1,23 +1,64 @@
 # 更新日志
 
-## v1.8 - YAML 工作流、设备集成与模型行为更新
+## v1.8 - Midscene Studio 桌面端、YAML 变量复用与多平台增强
 
-v1.8 版本调整模型思考模式默认行为，并补充了多项设备与平台集成能力。
+v1.8 版本带来全新的桌面端应用 **Midscene Studio**，新增 YAML 步骤结果复用、长按/清空输入等多项 API，并对模型规划行为、设备集成、报告系统和 MCP 工具集进行了全面升级。
+
+### 全新桌面端应用 Midscene Studio（Beta）
+
+Midscene Studio 是一个基于 Electron 的桌面应用，把多平台 Playground 整合进一个原生界面，开箱即用。当前处于 **Beta** 阶段，欢迎试用并反馈问题：
+
+- **多平台 Playground**：Web、Android、iOS、HarmonyOS、Computer 在同一个 Studio 应用中无缝切换
+- **设备交互预览**：Android / iOS / HarmonyOS 设备预览支持手动鼠标和触控控制；Web 预览支持实时画面流式渲染
+- **深色模式**：基于语义化设计 token 实现，自动跟随系统主题
+- **自动更新**：基于 electron-updater + GitHub Releases，新版本发布后自动推送
+- **DMG 安装包**：macOS 提供拖拽到 Applications 的标准 DMG 安装方式，构建已配置 Developer ID 签名与公证
+
+#### 下一步：在 Studio 中录制生成可回放的 Midscene 脚本
+
+我们正在 Studio 中打造一条「录制 → 脚本 → 回放」的闭环工作流：直接在 Studio 里对真实设备进行操作录制，自动生成结构化的 Midscene 脚本，并能即时在 Studio 内重新回放、调试、导出。该能力将在后续版本中陆续开放，敬请期待。
 
 ### YAML 工作流增强
 
-- Android `runAdbShell` 在 JavaScript API 和 YAML 脚本中都支持 `timeout` 选项。详见：[Android API](./android-api-reference)、[YAML 脚本自动化](./automate-with-scripts-in-yaml)
+- **步骤结果复用**：带有 `name` 的 YAML 步骤可以在后续步骤中通过 `$name` 和 `${name}` 复用结果。详见：[YAML 脚本自动化](./automate-with-scripts-in-yaml#复用步骤结果)
+- **Android runAdbShell timeout**：在 JavaScript API 和 YAML 脚本中都支持 `timeout` 选项。详见：[Android API](./android-api-reference)、[YAML 脚本自动化](./automate-with-scripts-in-yaml)
+
+### 新增交互 API
+
+- **`agent.aiLongPress()`**：对指定元素执行长按操作，适用于触发长按菜单等场景。详见 [API 文档](./api.mdx#agentailongpress)
+- **`agent.aiClearInput()`**：清空指定输入框的内容，适合把清空当作独立一步的场景。详见 [API 文档](./api.mdx#agentaiclearinput)
 
 ### 设备与平台集成
 
-- iOS 支持连接外部 WebDriverAgent 会话，方便复用已有 WDA 环境
-- Computer MCP / CLI 连接工具支持传入 RDP 连接选项
+- **iOS 连接外部 WDA 会话**：iOS 支持连接已有的 WebDriverAgent 会话，方便复用外部 WDA 环境
+- **iOS 设备实现可覆盖**：允许使用自定义 iOSDevice 实现，便于深度扩展或定制
+- **Computer 远程桌面**：Computer MCP / CLI 连接工具支持传入 RDP 连接选项，可直接接管远程 Windows 桌面
+- **`agentForComputer` 命名修正**：新增 `agentForComputer` 作为主推 API，原有 `agentFromComputer` 保留为向后兼容别名
+- **Puppeteer CLI viewport 选项**：Puppeteer CLI 新增窗口尺寸配置，方便在命令行中指定运行时的浏览器视口
 
 ### 模型与规划行为
 
-- 模型使用意图与实际解析到的配置槽位分离，多模型 Planning、定位和报告展示更清晰
-- 对于已支持的模型系列，Midscene 默认关闭模型原生思考，以提升执行速度和稳定性。详见：[模型原生的思考模式](./model-strategy#模型原生的思考模式)
-- 支持豆包低延迟模式配置方式，可通过 `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}` 开启。详见：[常用模型配置](./model-common-config)
+- **使用意图与配置槽位分离**：模型使用意图与实际解析到的配置槽位分离，多模型 Planning、定位和报告展示更清晰
+- **默认关闭原生思考**：对于已支持的模型系列，Midscene 默认关闭模型原生思考，以提升执行速度和稳定性。详见：[模型原生的思考模式](./model-strategy#模型原生的思考模式)
+- **豆包低延迟模式**：支持豆包低延迟模式配置方式，可通过 `MIDSCENE_MODEL_EXTRA_BODY_JSON={"service_tier":"fast"}` 开启。详见：[常用模型配置](./model-common-config)
+- **GLM-5V-Turbo 支持**：新增智谱 GLM-5V-Turbo 模型支持。详见：[常用模型配置](./model-common-config)
+- **滚动选择规划优化**：优化滚动选择（scrollable select）的规划流程，提升复杂下拉与滚轮选择场景的成功率
+
+### MCP 与平台 CLI
+
+- **新增 `assert` MCP 工具**：MCP 新增基于 `aiAssert` 的断言工具，AI 助手可以直接调用断言能力。详见：[MCP 服务](./mcp)
+- **Assert 支持图片提示**：Assert CLI / MCP 工具支持传入图片作为提示词，便于结合参考图进行断言
+- **平台 CLI 接受裸初始化参数**：各平台 CLI 简化参数传递方式，直接接受平台 Agent 构造参数
+- **Playwright fixture 透传 Agent 选项**：`PlaywrightAiFixture` 支持透传 `PlaywrightAgent` 构造参数，便于复用 fixture 时自定义 Agent 配置
+
+### 报告系统
+
+- **CLI 合并报告**：CLI 新增 `report-tool merge` 子命令，可将多份报告文件合并为一个，便于集中查看
+- **报告中记录截图工具调用**：截图工具（`take_screenshot`）的调用现在会在报告中显示，便于排查截图相关问题
+
+### Chrome 扩展
+
+- **Chrome Web Store 发布自动化**：扩展发布到 Chrome Web Store 的流程已自动化，缩短发布周期
 
 ### 问题修复
 
@@ -26,7 +67,16 @@ v1.8 版本调整模型思考模式默认行为，并补充了多项设备与平
 - 修复新标签页导航后的 Bridge 连接问题
 - 修复 iOS / HarmonyOS / Computer Playground 点击投影问题
 - 修复 HarmonyOS 单次调用 `autoDismissKeyboard` 的配置不生效问题
-- 修复 Android Playground 视频流内存占用问题
+- 修复 Android Playground 视频流内存占用过高的问题
+- 修复 Computer 滚动默认距离与 Web 不一致的问题
+- 修复部分模型返回归一化 [0,1000] 坐标超出范围的边界问题
+- 修复 Bridge 模式下 `aiAct` 选项未被继承的问题
+- 修复 Action API 返回值与文档不一致的问题
+- 修复 `maxTokens` 与意图模型配置不匹配的问题
+- 修复服务端端口探测时未使用 `0.0.0.0` 与实际监听 host 不一致的问题
+- 修复 `aiAct` 中 deepThink 标记在报告中丢失的问题
+- 修复 iOS 输入时偶发的字符丢失问题
+- 修复 HarmonyOS system action 延迟覆盖逻辑
 
 ## v1.7 - 灵活处理报告文件、支持 Qwen 3.6 模型
 

--- a/apps/studio/dev-app-update.yml
+++ b/apps/studio/dev-app-update.yml
@@ -1,4 +1,4 @@
 provider: github
 owner: web-infra-dev
 repo: midscene
-updaterCacheDirName: midscene-studio-updater
+updaterCacheDirName: midscene-studio-beta-updater

--- a/apps/studio/rsbuild.config.ts
+++ b/apps/studio/rsbuild.config.ts
@@ -105,7 +105,7 @@ export default defineConfig({
   environments: {
     renderer: {
       html: {
-        title: 'Midscene Studio',
+        title: 'Midscene Studio Beta',
       },
       source: {
         entry: {

--- a/apps/studio/scripts/build-update-metadata.mjs
+++ b/apps/studio/scripts/build-update-metadata.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 const GITHUB_OWNER = 'web-infra-dev';
 const GITHUB_REPO = 'midscene';
-const UPDATER_CACHE_DIR_NAME = 'midscene-studio-updater';
+const UPDATER_CACHE_DIR_NAME = 'midscene-studio-beta-updater';
 
 const PRERELEASE_TOKEN_RE = /[-.](alpha|beta|rc)([-.\d]|$)/i;
 

--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -35,8 +35,8 @@ export const releaseWorkspaceDir = path.join(
 export const artifactDir = path.join(releaseWorkspaceDir, 'artifacts');
 const packagingWorkspaceDir = path.join(releaseWorkspaceDir, 'workspace');
 const packagedDir = path.join(releaseWorkspaceDir, 'packaged');
-const packagedAppId = 'midscene-studio';
-const packagedProductName = 'Midscene Studio';
+const packagedAppId = 'midscene-studio-beta';
+const packagedProductName = 'Midscene Studio Beta';
 const packagedIgnorePatterns = [
   /^\/pnpm-lock\.yaml$/,
   /^\/vendor($|\/)/,

--- a/apps/studio/src/main/playground/multi-platform-runtime.ts
+++ b/apps/studio/src/main/playground/multi-platform-runtime.ts
@@ -701,7 +701,7 @@ export function createMultiPlatformRuntimeService({
           await playgroundCoreModules.prepareMultiPlatformPlayground(
             platforms,
             {
-              title: 'Midscene Studio',
+              title: 'Midscene Studio Beta',
               description: 'Multi-platform playground',
               selectorFieldKey: 'platformId',
               selectorVariant: 'cards',

--- a/apps/studio/src/main/updater-handlers.ts
+++ b/apps/studio/src/main/updater-handlers.ts
@@ -11,7 +11,7 @@ const debugUpdaterHandlers = getDebug('studio:updater-handlers', {
   console: true,
 });
 
-const UPDATER_CACHE_DIR_NAME = 'midscene-studio-updater';
+const UPDATER_CACHE_DIR_NAME = 'midscene-studio-beta-updater';
 
 interface MacUpdateScriptOptions {
   appPath: string;
@@ -179,17 +179,20 @@ async function installMacUpdate(updater: StudioUpdater): Promise<void> {
     return;
   }
 
-  // process.resourcesPath => .../Midscene Studio.app/Contents/Resources
+  // process.resourcesPath => .../Midscene Studio Beta.app/Contents/Resources
   // Step up two levels to reach the .app bundle root so the script can
   // replace it atomically.
   const appPath = path.resolve(process.resourcesPath, '..', '..');
   const execName = path.basename(process.execPath);
-  const tempDir = path.join(app.getPath('temp'), 'midscene-studio-update');
+  const tempDir = path.join(app.getPath('temp'), 'midscene-studio-beta-update');
   const scriptPath = path.join(
     app.getPath('temp'),
-    'midscene-studio-update.sh',
+    'midscene-studio-beta-update.sh',
   );
-  const logPath = path.join(app.getPath('temp'), 'midscene-studio-update.log');
+  const logPath = path.join(
+    app.getPath('temp'),
+    'midscene-studio-beta-update.log',
+  );
 
   const script = buildMacUpdateScript({
     appPath,

--- a/apps/studio/tests/android-runtime.test.ts
+++ b/apps/studio/tests/android-runtime.test.ts
@@ -106,7 +106,7 @@ describe('playground runtime bootstrap', () => {
             capturedPlatforms = platforms;
             return {
               platformId: 'multi-platform',
-              title: 'Midscene Studio',
+              title: 'Midscene Studio Beta',
               description: 'Multi-platform playground',
               metadata: {},
               sessionManager: {
@@ -215,7 +215,7 @@ describe('playground runtime bootstrap', () => {
             capturedPlatforms = platforms;
             return {
               platformId: 'multi-platform',
-              title: 'Midscene Studio',
+              title: 'Midscene Studio Beta',
               description: 'Multi-platform playground',
               metadata: {},
               sessionManager: {
@@ -335,7 +335,7 @@ describe('playground runtime bootstrap', () => {
             capturedPlatforms = platforms;
             return {
               platformId: 'multi-platform',
-              title: 'Midscene Studio',
+              title: 'Midscene Studio Beta',
               description: 'Multi-platform playground',
               metadata: {},
               sessionManager: {

--- a/apps/studio/tests/build-update-metadata.test.mjs
+++ b/apps/studio/tests/build-update-metadata.test.mjs
@@ -117,7 +117,7 @@ describe('buildAppUpdateYml', () => {
         'provider: github',
         'owner: web-infra-dev',
         'repo: midscene',
-        'updaterCacheDirName: midscene-studio-updater',
+        'updaterCacheDirName: midscene-studio-beta-updater',
         '',
       ].join('\n'),
     );

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -47,11 +47,11 @@ describe('package-electron helpers', () => {
 
   it('lays out the dmg with the .app on the left and /Applications on the right', () => {
     const spec = buildStudioDmgSpecification({
-      appBundlePath: '/tmp/Midscene Studio.app',
+      appBundlePath: '/tmp/Midscene Studio Beta.app',
       iconPath: '/tmp/midscene-icon.icns',
       backgroundPath: '/tmp/dmg-background.png',
     });
-    expect(spec.title).toBe('Midscene Studio');
+    expect(spec.title).toBe('Midscene Studio Beta');
     expect(spec.icon).toBe('/tmp/midscene-icon.icns');
     expect(spec.background).toBe('/tmp/dmg-background.png');
     expect(spec.window).toEqual({ size: { width: 540, height: 380 } });
@@ -65,8 +65,8 @@ describe('package-electron helpers', () => {
     // the background image lines up with them.
     expect(linkEntry?.y).toBe(fileEntry?.y);
     expect(linkEntry?.y).toBe(160);
-    expect(fileEntry?.path).toBe('/tmp/Midscene Studio.app');
-    expect(fileEntry?.name).toBe('Midscene Studio.app');
+    expect(fileEntry?.path).toBe('/tmp/Midscene Studio Beta.app');
+    expect(fileEntry?.name).toBe('Midscene Studio Beta.app');
   });
 
   it('builds a deterministic artifact basename', () => {
@@ -76,7 +76,7 @@ describe('package-electron helpers', () => {
         platform: 'darwin',
         arch: 'x64',
       }),
-    ).toBe('midscene-studio-v1.7.4-darwin-x64');
+    ).toBe('midscene-studio-beta-v1.7.4-darwin-x64');
   });
 
   it('defaults Windows packaging to x64 regardless of host arch', () => {
@@ -107,9 +107,9 @@ describe('package-electron helpers', () => {
       description: 'Studio shell',
       license: 'MIT',
       main: 'dist/main/main.cjs',
-      name: 'midscene-studio',
+      name: 'midscene-studio-beta',
       private: true,
-      productName: 'Midscene Studio',
+      productName: 'Midscene Studio Beta',
       type: 'module',
       version: '1.7.4',
     });
@@ -372,9 +372,12 @@ describe('package-electron helpers', () => {
     );
     const packagedOutputPath = path.join(
       tempRootDir,
-      'Midscene Studio-darwin-arm64',
+      'Midscene Studio Beta-darwin-arm64',
     );
-    const appBundlePath = path.join(packagedOutputPath, 'Midscene Studio.app');
+    const appBundlePath = path.join(
+      packagedOutputPath,
+      'Midscene Studio Beta.app',
+    );
 
     try {
       await fs.mkdir(appBundlePath, { recursive: true });
@@ -537,11 +540,11 @@ describe('package-electron helpers', () => {
     );
     const packagedOutputPath = path.join(
       tempRootDir,
-      'Midscene Studio-darwin-x64',
+      'Midscene Studio Beta-darwin-x64',
     );
     const packagedAppPath = path.join(
       packagedOutputPath,
-      'Midscene Studio.app',
+      'Midscene Studio Beta.app',
     );
     const packagedNodeModulesDir = path.join(
       packagedAppPath,
@@ -692,7 +695,7 @@ describe('package-electron helpers', () => {
           '@midscene/shared': 'file:vendor/midscene-shared',
         },
       },
-      productName: 'Midscene Studio',
+      productName: 'Midscene Studio Beta',
       version: '1.7.4',
     });
     expect(installManifest.pnpm).not.toHaveProperty('supportedArchitectures');
@@ -1182,7 +1185,7 @@ describe('package-electron helpers', () => {
     // `actions/upload-artifact` re-zip the raw `.app`, dropping xattrs and
     // breaking the notarization stapler ticket on macOS.
     expect(workflow).not.toMatch(/--skip-archive/);
-    expect(workflow).toMatch(/Package Midscene Studio/);
+    expect(workflow).toMatch(/Package Midscene Studio Beta/);
     expect(workflow).toMatch(/\.release\/studio\/artifacts\/\*\.zip/);
   });
 });

--- a/apps/studio/tests/updater-handlers.test.ts
+++ b/apps/studio/tests/updater-handlers.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({
   app: {
-    getName: () => 'Midscene Studio',
+    getName: () => 'Midscene Studio Beta',
     getPath: (name: string) =>
       name === 'home' ? mocks.homeDir : path.join(mocks.homeDir, name),
     isPackaged: true,
@@ -62,12 +62,12 @@ describe('shellQuote', () => {
 
 describe('buildMacUpdateScript', () => {
   const baseOptions = {
-    appPath: '/Applications/Midscene Studio.app',
-    execName: 'Midscene Studio',
-    zipPath: '/tmp/midscene/Midscene-Studio-darwin-arm64.zip',
-    tempDir: '/tmp/midscene-studio-update',
-    scriptPath: '/tmp/midscene-studio-update.sh',
-    logPath: '/tmp/midscene-studio-update.log',
+    appPath: '/Applications/Midscene Studio Beta.app',
+    execName: 'Midscene Studio Beta',
+    zipPath: '/tmp/midscene/Midscene-Studio-Beta-darwin-arm64.zip',
+    tempDir: '/tmp/midscene-studio-beta-update',
+    scriptPath: '/tmp/midscene-studio-beta-update.sh',
+    logPath: '/tmp/midscene-studio-beta-update.log',
   };
 
   it('produces a runnable bash script with all paths quoted', async () => {
@@ -76,8 +76,10 @@ describe('buildMacUpdateScript', () => {
     );
     const script = buildMacUpdateScript(baseOptions);
     expect(script.startsWith('#!/bin/bash\n')).toBe(true);
-    expect(script).toContain(`APP_PATH='/Applications/Midscene Studio.app'`);
-    expect(script).toContain(`EXEC_NAME='Midscene Studio'`);
+    expect(script).toContain(
+      `APP_PATH='/Applications/Midscene Studio Beta.app'`,
+    );
+    expect(script).toContain(`EXEC_NAME='Midscene Studio Beta'`);
     // Critical guard: refuse to mv into a path that still exists.
     expect(script).toContain('if [ -e "$APP_PATH" ]');
     expect(script).toContain('/bin/rm -rf "$APP_PATH"');
@@ -113,9 +115,9 @@ describe('updater handlers', () => {
         root,
         'Library',
         'Caches',
-        'midscene-studio-updater',
+        'midscene-studio-beta-updater',
         'pending',
-        'midscene-studio-v1.8.1-darwin-arm64.zip',
+        'midscene-studio-beta-v1.8.1-darwin-arm64.zip',
       );
       await fs.mkdir(path.dirname(zipPath), { recursive: true });
       await fs.writeFile(zipPath, 'zip');


### PR DESCRIPTION
## Summary

- Rewrite the v1.8 release announcement (zh + en) to surface features that landed in v1.7 but were missing from the published changelog: Midscene Studio shell, `agent.aiLongPress()` / `agent.aiClearInput()`, Puppeteer CLI viewport options, `assert` MCP tool, scrollable select planning, report-tool merge, Playwright fixture Agent options, GLM-5V-Turbo, etc.
- Position Midscene Studio as **Beta** in the changelog and tease the upcoming record-to-replay workflow.
- Rebrand Studio build artifacts and package name: packaged app id becomes `midscene-studio-beta`, product name becomes `Midscene Studio Beta`. This propagates to the release zip/dmg filenames, the macOS `.app` bundle, the HTML title, the multi-platform playground title, the electron-updater cache dir, the in-place mac update script paths, and the release workflow step name.
- Update the corresponding unit tests (`tests/package-electron.test.mjs`, `tests/build-update-metadata.test.mjs`, `tests/updater-handlers.test.ts`, `tests/android-runtime.test.ts`) to match the new naming.

## Test plan

- [x] `pnpm run lint`
- [x] `cd apps/studio && npx vitest run tests/package-electron.test.mjs tests/build-update-metadata.test.mjs tests/updater-handlers.test.ts tests/android-runtime.test.ts`
- [ ] Trigger a prepatch build from this branch and confirm the published Studio artifacts are named `midscene-studio-beta-v<version>-<platform>-<arch>.zip` / `.dmg` and the macOS bundle is `Midscene Studio Beta.app`