### PR TITLE
fix(playground): keep connected=true during recreateAgent window

### DIFF
--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -593,19 +593,32 @@ class PlaygroundServer {
     });
   }
 
-  getSessionInfo(): PlaygroundSessionState & {
-    setupState: 'required' | 'ready' | 'blocked';
-    setupBlockingReason?: string;
-  } {
-    const connected = this.sessionManager
+  /**
+   * Treat a session as connected when either:
+   * - we have a live agent, OR
+   * - we are mid-recreate (`_agentReady === false`).
+   *
+   * `recreateAgent` (e.g. via /cancel) nulls `_activeConnection.agent`
+   * before the factory swaps in a fresh one. Without this guard the UI
+   * sees a brief `connected: false` window and flashes the
+   * SessionSetupPanel ("create agent" form) for ~1–2 seconds.
+   */
+  private isEffectivelyConnected(): boolean {
+    const rawConnected = this.sessionManager
       ? Boolean(
           this._activeConnection.session?.connected &&
             this._activeConnection.agent,
         )
       : Boolean(this._activeConnection.agent);
+    return rawConnected || !this._agentReady;
+  }
 
+  getSessionInfo(): PlaygroundSessionState & {
+    setupState: 'required' | 'ready' | 'blocked';
+    setupBlockingReason?: string;
+  } {
     return {
-      connected,
+      connected: this.isEffectivelyConnected(),
       displayName: this._activeConnection.session?.displayName,
       metadata: {
         ...(this._activeConnection.session?.metadata || {}),
@@ -616,17 +629,10 @@ class PlaygroundServer {
   }
 
   private buildSessionMetadata(): Record<string, unknown> {
-    const sessionConnected = this.sessionManager
-      ? Boolean(
-          this._activeConnection.session?.connected &&
-            this._activeConnection.agent,
-        )
-      : Boolean(this._activeConnection.agent);
-
     return {
       ...(this._basePreparedMetadata || {}),
       ...(this._activeConnection.session?.metadata || {}),
-      sessionConnected,
+      sessionConnected: this.isEffectivelyConnected(),
       sessionDisplayName: this._activeConnection.session?.displayName,
       setupState: this.sessionSetupState,
       ...(this.sessionSetupBlockingReason


### PR DESCRIPTION
## Problem

Builds on #2548. After clicking **Stop** in the computer playground, the UI briefly flashes the **"create agent" SessionSetupPanel** for ~1–2 seconds before reverting to the playground view. From the user's perspective this looks like a transient disconnect / reconnect.

## Root cause

The frontend at [`PlaygroundConversationPanel.tsx:132`](https://github.com/web-infra-dev/midscene/blob/main/packages/playground-app/src/panels/PlaygroundConversationPanel.tsx#L132) renders the playground or the setup form based purely on `sessionViewState.connected`:

```tsx
state.sessionViewState.connected
  ? <UniversalPlayground />
  : <SessionSetupPanel />   // ← falls back to "create agent" form
```

On the server side, `getSessionInfo().connected` is computed as:

```ts
connected = Boolean(this._activeConnection.agent)
```

But `recreateAgent` (triggered by `/cancel`) destroys the old agent **before** the factory swaps in a fresh one:

```ts
private async recreateAgent({ preserveActiveStream }) {
  this._agentReady = false;
  await this.destroyCurrentAgent({ preserveActiveStream });   // ← agent = null
  // ⇣ window of ~1–2s where connected reports false
  this.setActiveAgent(await this._activeConnection.agentFactory(), ...);
  this._agentReady = true;
}
```

So during the recreate window the UI sees `connected: false` and renders the setup form.

The server already tracks the transient state via `_agentReady`, but it wasn't being surfaced to clients.

## Fix

One change: extract `isEffectivelyConnected()` and use it in both `getSessionInfo()` and `buildSessionMetadata()`. It returns `true` when either:
- we have a live agent, OR
- `_agentReady === false` (we're mid-recreate)

```ts
private isEffectivelyConnected(): boolean {
  const rawConnected = this.sessionManager
    ? Boolean(this._activeConnection.session?.connected && this._activeConnection.agent)
    : Boolean(this._activeConnection.agent);
  return rawConnected || !this._agentReady;
}
```

## Why this is enough on its own

We considered three other angles during investigation; all turned out to be either symptoms of the same root cause or out of scope for this PR:

| Considered fix | Verdict |
|----------------|---------|
| Server returns empty schema instead of 404 from `/session/setup` during recreate window | Symptom — only matters if the UI was already polling setup, which only happens because `connected` flipped false. Solved upstream by this PR. |
| Frontend setup-poll guard (`setupState === 'ready'`) | Same — covers the symptom, not the cause. |
| LLM-side abort gate (mirror of `ComputerInputDriver`) | Real issue but **independent of the UI flash**. Different timescale (10–30s LLM stream hang) and would deserve a separate PR if pursued. |

Verified by toggling each combination locally: only the `connected` patch eliminates the flash; the other patches are unnecessary once `connected` is fixed.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `npx nx build @midscene/computer-playground` — clean
- [x] Manual: ran computer-playground locally, hit Stop at various task stages, no SessionSetupPanel flash
- [x] Manual: confirmed playground still correctly shows SessionSetupPanel when there genuinely is no agent (cold start)
