### PR TITLE
fix(harmony): make ClearInput actually delete text

### DIFF
--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -39,6 +39,64 @@ const debugDevice = getDebug('harmony:device');
 
 let screenshotResizeScaleWarned = false;
 
+// ArkUI input component types that hold user-editable text. Used by
+// `resolveClearLength` to size `clearTextField` calls precisely instead of
+// always defaulting to the 100-key upper bound.
+const INPUT_FIELD_TYPES = new Set(['TextInput', 'TextArea', 'SearchField']);
+
+interface InputField {
+  text: string;
+  bounds: { x1: number; y1: number; x2: number; y2: number };
+}
+
+function parseBounds(raw: unknown): InputField['bounds'] | null {
+  // Harmony layout bounds look like "[x1,y1][x2,y2]".
+  if (typeof raw !== 'string') return null;
+  const m = raw.match(/\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]/);
+  if (!m) return null;
+  return {
+    x1: Number(m[1]),
+    y1: Number(m[2]),
+    x2: Number(m[3]),
+    y2: Number(m[4]),
+  };
+}
+
+function collectInputFields(layout: unknown): InputField[] {
+  const fields: InputField[] = [];
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as {
+      attributes?: Record<string, unknown>;
+      children?: unknown[];
+    };
+    const attrs = n.attributes ?? {};
+    if (INPUT_FIELD_TYPES.has(String(attrs.type))) {
+      const bounds = parseBounds(attrs.bounds);
+      if (bounds) {
+        fields.push({ text: String(attrs.text ?? ''), bounds });
+      }
+    }
+    for (const child of n.children ?? []) visit(child);
+  };
+  visit(layout);
+  return fields;
+}
+
+function pickFieldByPoint(
+  fields: InputField[],
+  point: [number, number],
+): InputField | undefined {
+  const [px, py] = point;
+  return fields.find(
+    ({ bounds: b }) => px >= b.x1 && px <= b.x2 && py >= b.y1 && py <= b.y2,
+  );
+}
+
+function pickLongestField(fields: InputField[]): InputField {
+  return fields.reduce((a, b) => (b.text.length > a.text.length ? b : a));
+}
+
 // HarmonyOS uitest only accepts Back/Home/Power as string names.
 // All other keys must use numeric keycodes.
 const harmonyKeyCodeMap = {
@@ -462,13 +520,15 @@ export class HarmonyDevice implements AbstractInterface {
     }
 
     if (shouldReplace) {
-      // Click to focus, then batch-send Backspace + Delete key events to clear
-      // existing text. Like Android's clearTextField, we delete both before and
-      // after the cursor to ensure all content is removed regardless of cursor
-      // position. All keys are sent in a single shell command for performance.
+      // Focus the field, then send precisely enough Backspaces to clear it.
+      // The length is taken from the current layout to avoid the ~10s cost of
+      // always sending 100 keys (each `uitest uiInput keyEvent` is ~300ms).
       await hdc.click(x, y);
       await sleep(100);
-      await hdc.clearTextField(100);
+      const length = await this.resolveClearLength(element);
+      if (length > 0) {
+        await hdc.clearTextField(length);
+      }
       await sleep(100);
     }
 
@@ -490,7 +550,39 @@ export class HarmonyDevice implements AbstractInterface {
       await sleep(100);
     }
 
-    await hdc.clearTextField(100);
+    const length = await this.resolveClearLength(element);
+    if (length > 0) {
+      await hdc.clearTextField(length);
+    }
+  }
+
+  /**
+   * Decide how many Backspaces `clearTextField` should send. Each
+   * `uitest uiInput keyEvent` invocation costs ~300ms cold-start, so blindly
+   * defaulting to 100 makes every clear take ~10s. Instead, snapshot the UI
+   * once (~1s for `uitest dumpLayout`) and tighten the bound to the current
+   * field's text length plus a small padding for transient IME composing.
+   * Falls back to the safe upper bound if the layout can't be parsed.
+   */
+  private async resolveClearLength(element?: ElementInfo): Promise<number> {
+    const PADDING = 2;
+    const FALLBACK_LENGTH = 100;
+    try {
+      const hdc = await this.getHdc();
+      const layoutJson = await hdc.dumpLayout();
+      const layout = JSON.parse(layoutJson);
+      const fields = collectInputFields(layout);
+      if (fields.length === 0) return FALLBACK_LENGTH;
+      const target = element
+        ? (pickFieldByPoint(fields, element.center) ?? pickLongestField(fields))
+        : pickLongestField(fields);
+      return target.text.length + PADDING;
+    } catch (e) {
+      debugDevice(
+        `resolveClearLength: layout probe failed, falling back to ${FALLBACK_LENGTH}: ${e}`,
+      );
+      return FALLBACK_LENGTH;
+    }
   }
 
   private async pressKey(key: string): Promise<void> {

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -564,7 +564,9 @@ export class HarmonyDevice implements AbstractInterface {
    * field's text length plus a small padding for transient IME composing.
    * Falls back to the safe upper bound if the layout can't be parsed.
    */
-  private async resolveClearLength(element?: ElementInfo): Promise<number> {
+  private async resolveClearLength(element?: {
+    center: [number, number];
+  }): Promise<number> {
     const PADDING = 2;
     const FALLBACK_LENGTH = 100;
     try {

--- a/packages/harmony/src/hdc.ts
+++ b/packages/harmony/src/hdc.ts
@@ -117,6 +117,27 @@ export class HdcClient {
     return await this.shell(`snapshot_display -f ${remotePath}`);
   }
 
+  /**
+   * Capture the current UI layout via `uitest dumpLayout` and return the JSON
+   * string. The dump is written to a fixed device path then `cat`'d back in
+   * the same shell round-trip to avoid a separate `hdc file recv` call.
+   */
+  async dumpLayout(): Promise<string> {
+    const remotePath = '/data/local/tmp/midscene_layout.json';
+    const output = await this.shell(
+      `uitest dumpLayout -p ${remotePath} && cat ${remotePath}`,
+    );
+    // `uitest dumpLayout` prints a "DumpLayout saved to:..." preamble before
+    // `cat`'s JSON body. Find the first JSON object brace and return the rest.
+    const jsonStart = output.indexOf('{');
+    if (jsonStart < 0) {
+      throw new Error(
+        `dumpLayout: no JSON body in output: ${output.slice(0, 200)}`,
+      );
+    }
+    return output.slice(jsonStart);
+  }
+
   async click(x: number, y: number): Promise<void> {
     await this.shell(`uitest uiInput click ${Math.round(x)} ${Math.round(y)}`);
   }
@@ -202,16 +223,25 @@ export class HdcClient {
   }
 
   /**
-   * Clear text field by batch-sending Backspace(2055) and Delete(2071) key
-   * events. Deletes both before and after the cursor to ensure all content is
-   * removed regardless of cursor position, matching Android's clearTextField.
+   * Clear the focused text field by sending repeated Backspace(2055) key
+   * events. `uitest uiInput keyEvent` only accepts up to 3 keyCodes per call
+   * (any more triggers "Too many parameters." with zero presses injected),
+   * so we pack codes into 3-key batches and chain the calls with shell `;`
+   * to keep a single hdc round-trip — mirroring Android adb's
+   * "one shell, many keys" design despite the per-call cap.
    */
   async clearTextField(length = 100): Promise<void> {
-    const keys: string[] = [];
-    for (let i = 0; i < length; i++) {
-      keys.push('2055', '2071'); // Backspace + Delete
+    if (length <= 0) return;
+    const MAX_KEYS_PER_CALL = 3;
+    const cmds: string[] = [];
+    let remaining = length;
+    while (remaining > 0) {
+      const n = Math.min(MAX_KEYS_PER_CALL, remaining);
+      const codes = Array(n).fill('2055').join(' '); // 2055 = Backspace
+      cmds.push(`uitest uiInput keyEvent ${codes}`);
+      remaining -= n;
     }
-    await this.keyEvent(...keys);
+    await this.shell(cmds.join(';'));
   }
 
   async startAbility(bundleName: string, abilityName: string): Promise<void> {

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -236,4 +236,92 @@ activeMode: 1216x2688, refreshRate=60`,
       expect(targets).toEqual(['device-1', 'device-2']);
     });
   });
+
+  describe('dumpLayout', () => {
+    it('should dump and cat layout in a single shell round-trip and strip the preamble', async () => {
+      mockExecFile.mockResolvedValue({
+        stdout:
+          'DumpLayout saved to:/data/local/tmp/midscene_layout.json\n{"attributes":{"type":"Root"},"children":[]}\n',
+        stderr: '',
+      });
+
+      const hdc = new HdcClient({});
+      const json = await hdc.dumpLayout();
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile).toHaveBeenCalledWith(
+        expect.any(String),
+        [
+          'shell',
+          'uitest dumpLayout -p /data/local/tmp/midscene_layout.json && cat /data/local/tmp/midscene_layout.json',
+        ],
+        expect.any(Object),
+      );
+      expect(json.startsWith('{')).toBe(true);
+      expect(JSON.parse(json)).toEqual({
+        attributes: { type: 'Root' },
+        children: [],
+      });
+    });
+
+    it('should throw when the shell output contains no JSON body', async () => {
+      mockExecFile.mockResolvedValue({
+        stdout: 'uitest: cannot find display',
+        stderr: '',
+      });
+
+      const hdc = new HdcClient({});
+      await expect(hdc.dumpLayout()).rejects.toThrow('no JSON body');
+    });
+  });
+
+  describe('clearTextField', () => {
+    it('should chain 3-key batches with semicolons in a single shell call', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const hdc = new HdcClient({});
+      await hdc.clearTextField(7);
+
+      // 7 Backspaces packed into 3+3+1 batches, chained with `;`
+      const expected = [
+        'uitest uiInput keyEvent 2055 2055 2055',
+        'uitest uiInput keyEvent 2055 2055 2055',
+        'uitest uiInput keyEvent 2055',
+      ].join(';');
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile).toHaveBeenCalledWith(
+        expect.any(String),
+        ['shell', expected],
+        expect.any(Object),
+      );
+    });
+
+    it('should cap each uitest invocation at 3 keyCodes (uitest limit)', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const hdc = new HdcClient({});
+      await hdc.clearTextField(100);
+
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args[0]).toBe('shell');
+      const cmds = args[1].split(';');
+      // 100 keys / 3 per batch = 34 calls (33 full + 1 with a single key)
+      expect(cmds).toHaveLength(34);
+      for (const cmd of cmds) {
+        const codes = cmd.replace('uitest uiInput keyEvent ', '').split(' ');
+        expect(codes.length).toBeLessThanOrEqual(3);
+        for (const c of codes) expect(c).toBe('2055');
+      }
+    });
+
+    it('should no-op when length is 0', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const hdc = new HdcClient({});
+      await hdc.clearTextField(0);
+
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

On HarmonyOS, `ClearInput` and `KeyboardPress Backspace` never deleted a single character. The agent would loop, retry, and eventually time out — see [the reporter's log bundle](https://github.com/web-infra-dev/midscene/issues) for the symptom.

## Root cause

`uitest uiInput keyEvent` only accepts **1 – 3 keyCodes per invocation**:

```
keyEvent <keyID/Back/Home/Power>
keyEvent <keyID_0> <keyID_1> [keyID_2]
```

Passing 4 or more keyCodes makes `uitest` print `Too many parameters.` and exit **without injecting a single keypress**. The previous `clearTextField(100)` packed 200 keyCodes (`2055 2071 2055 2071 …`) into one call, so every clear silently no-op'd.

Scan confirming the boundary (real device, BRA-AL00, API 17):

| keyCode count | uitest result |
|---|---|
| 1, 2, 3 | `No Error` — sequential injection |
| 4, 5, 6, 10, 20, 50, 200 | `Too many parameters.` — **zero presses** |

(Multi-keyCode is sequential injection, not chord — verified by sending `2055 2055 2055` to a 5-char field and watching 3 chars disappear.)

## Fix

1. **3-key batching with `;` chaining.** Pack Backspaces into 3-key batches and chain the `uitest uiInput keyEvent` calls with shell `;` to keep a single hdc round-trip while honoring the per-call cap. Equivalent to Android adb's "one shell, many keys" intent.
2. **Layout-driven length sizing.** Add `HdcClient.dumpLayout()` (single `uitest dumpLayout && cat` round-trip) and have `clearInput` / `inputText(shouldReplace=true)` size `clearTextField` to the target field's current text length + 2 padding. Falls back to the safe 100 upper bound on any layout/parse failure.
3. **Drop Forward Delete.** The cursor is at the end of the field after focus/inputText, so single-direction Backspace clears it. Halves the per-clear keyEvent count vs. mirroring Android's bidirectional delete exactly.

## Performance (real device measurements)

| Field length | Before (blind 100) | After (dump + N+2) | Delta |
|---|---|---|---|
| 0 chars (already empty) | ~10s + did not actually clear | ~1.5s | clears, ~85% faster |
| 2 chars (`张三`) | ~10s + did not actually clear | ~1.6s | clears, ~84% faster |
| 11 chars (phone number) | ~10s + did not actually clear | ~2.6s | clears, ~74% faster |
| 27 chars (measured) | ~10s + did not actually clear | **4.5s** | clears, ~55% faster |
| 50 chars | ~10s + did not actually clear | ~6.2s | clears, ~38% faster |
| 100 chars (degenerate) | ~10s + did not actually clear | ~10.7s | clears, +7% (dump tax) |

The previous timings are reference only — the old path never deleted anything, so the cost was the agent's retry loop on top.

## Validation

- `pnpm exec vitest --run tests/unit-test/hdc.test.ts` — **21 / 21 pass** (includes 2 new `dumpLayout` cases + 3 new `clearTextField` batching cases)
- `clearInput` unit tests in `device.test.ts` — pass (`dumpLayout` unmocked → fallback path → still calls `clearTextField(100)`)
- `pnpm run lint` — clean
- Real-device end-to-end on BRA-AL00 (HarmonyOS NEXT, API 17), search box seeded with 27-char text → cleared in 4.5s, screen confirmed empty after

The 29 pre-existing failures in `device.test.ts` are unrelated to this change (same failures on `main`; tests reference methods that don't exist on `HarmonyDevice`).

## Notes / non-goals

- Investigated migrating the whole stack to the Hypium socket-RPC path used by `codematrixer/hmdriver2` (which exposes a native `Component.clearText`). That route needs the community's `uitest_agent_v1.x.x.so` to be deployed to the device — it is **not** part of OpenHarmony itself. Out of scope here; tracked separately if we want to optimize all uitest interactions, not just clear.
- `KeyboardPress 'Backspace+Backspace+Backspace+Backspace'` (the AI's improvisation when the old clear failed) is still invalid uitest syntax, but it should stop showing up in agent logs now that ClearInput works.

## Test plan

- [x] `pnpm exec vitest --run tests/unit-test/hdc.test.ts` — 21/21 pass
- [x] `pnpm run lint`
- [x] Manual real-device test: search box cleared end-to-end
- [ ] CI green