### PR TITLE
fix(core): break service import cycle breaking model verification

### DIFF
--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -1,12 +1,15 @@
 import { isAutoGLM, isUITars } from '@/ai-model/auto-glm/util';
 import {
-  AIResponseParseError,
   AiExtractElementInfo,
   AiLocateElement,
-  callAIWithObjectResponse,
-} from '@/ai-model/index';
-import { AiLocateSection, buildSearchAreaConfig } from '@/ai-model/inspect';
+  AiLocateSection,
+  buildSearchAreaConfig,
+} from '@/ai-model/inspect';
 import { elementDescriberInstruction } from '@/ai-model/prompt/describe';
+import {
+  AIResponseParseError,
+  callAIWithObjectResponse,
+} from '@/ai-model/service-caller';
 import { type AIArgs, expandSearchArea } from '@/common';
 import type {
   AIDescribeElementResponse,

--- a/packages/core/tests/unit-test/connectivity-service-cycle.test.ts
+++ b/packages/core/tests/unit-test/connectivity-service-cycle.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { IModelConfig } from '@midscene/shared/env';
+import ts from 'typescript';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callAI: vi.fn(),
+  callAIWithObjectResponse: vi.fn(),
+  AiExtractElementInfo: vi.fn(),
+  AiLocateElement: vi.fn(),
+  AiLocateSection: vi.fn(),
+  buildSearchAreaConfig: vi.fn(),
+}));
+
+vi.mock('@/ai-model/service-caller', () => ({
+  AIResponseParseError: class AIResponseParseError extends Error {},
+  callAI: mocks.callAI,
+  callAIWithObjectResponse: mocks.callAIWithObjectResponse,
+}));
+
+vi.mock('@/ai-model/service-caller/index', () => ({
+  AIResponseParseError: class AIResponseParseError extends Error {},
+  callAI: mocks.callAI,
+  callAIWithObjectResponse: mocks.callAIWithObjectResponse,
+}));
+
+vi.mock('@/ai-model/inspect', () => ({
+  AiExtractElementInfo: mocks.AiExtractElementInfo,
+  AiLocateElement: mocks.AiLocateElement,
+  AiLocateSection: mocks.AiLocateSection,
+  buildSearchAreaConfig: mocks.buildSearchAreaConfig,
+}));
+
+vi.mock('@midscene/shared/img', async () => {
+  const actual = await vi.importActual<typeof import('@midscene/shared/img')>(
+    '@midscene/shared/img',
+  );
+  return {
+    ...actual,
+    imageInfoOfBase64: vi.fn().mockResolvedValue({ width: 800, height: 450 }),
+  };
+});
+
+import { runConnectivityTest } from '@/ai-model/connectivity';
+
+function readImports(filePath: string): string[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const imports: string[] = [];
+
+  sourceFile.forEachChild((node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      imports.push(node.moduleSpecifier.text);
+    }
+  });
+
+  return imports;
+}
+
+describe('runConnectivityTest service load order', () => {
+  const defaultModelConfig: IModelConfig = {
+    modelName: 'test-model',
+    modelDescription: 'test-model-desc',
+    modelFamily: 'qwen2.5-vl',
+    intent: 'default',
+    slot: 'default',
+  };
+  const planningModelConfig: IModelConfig = {
+    modelName: 'test-planning-model',
+    modelDescription: 'test-planning-model-desc',
+    modelFamily: 'qwen2.5-vl',
+    intent: 'planning',
+    slot: 'planning',
+  };
+  const insightModelConfig: IModelConfig = {
+    modelName: 'test-insight-model',
+    modelDescription: 'test-insight-model-desc',
+    modelFamily: 'gpt-5',
+    intent: 'insight',
+    slot: 'insight',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs the default locate check through the real Service constructor', async () => {
+    mocks.callAI
+      .mockResolvedValueOnce({ content: 'CONNECTIVITY_OK' })
+      .mockResolvedValueOnce({ content: 'What needs to be done?' });
+    mocks.AiLocateElement.mockResolvedValue({
+      parseResult: {
+        elements: [
+          {
+            center: [300, 120],
+            rect: { left: 120, top: 90, width: 360, height: 60 },
+            description: 'main todo input box',
+            xpaths: [],
+            attributes: {},
+          },
+        ],
+        errors: [],
+      },
+      rect: { left: 120, top: 90, width: 360, height: 60 },
+      rawResponse: '{}',
+      usage: undefined,
+      reasoning_content: undefined,
+    });
+
+    const result = await runConnectivityTest({
+      defaultModelConfig,
+      planningModelConfig,
+      insightModelConfig,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.checks.map((item) => item.intent)).toEqual([
+      'planning',
+      'insight',
+      'default',
+    ]);
+    expect(mocks.AiLocateElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetElementDescription: 'the main todo input box',
+        modelConfig: defaultModelConfig,
+      }),
+    );
+  });
+
+  it('keeps service independent from the ai-model barrel', () => {
+    const serviceImports = readImports(
+      join(__dirname, '../../src/service/index.ts'),
+    );
+
+    expect(serviceImports).not.toEqual(
+      expect.arrayContaining(['@/ai-model', '@/ai-model/index']),
+    );
+  });
+});

--- a/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
+++ b/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
@@ -3,20 +3,23 @@ import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeContext } from '../utils';
 
-vi.mock('@/ai-model/index', () => ({
-  AIResponseParseError: class AIResponseParseError extends Error {},
+vi.mock('@/ai-model/inspect', () => ({
   AiExtractElementInfo: vi.fn(),
   AiLocateElement: vi.fn(),
-  callAIWithObjectResponse: vi.fn(),
-}));
-
-vi.mock('@/ai-model/inspect', () => ({
   AiLocateSection: vi.fn(),
   buildSearchAreaConfig: vi.fn(),
 }));
 
-import { AiLocateElement } from '@/ai-model/index';
-import { AiLocateSection, buildSearchAreaConfig } from '@/ai-model/inspect';
+vi.mock('@/ai-model/service-caller', () => ({
+  AIResponseParseError: class AIResponseParseError extends Error {},
+  callAIWithObjectResponse: vi.fn(),
+}));
+
+import {
+  AiLocateElement,
+  AiLocateSection,
+  buildSearchAreaConfig,
+} from '@/ai-model/inspect';
 
 describe('service.locate deepLocate routing', () => {
   const modelConfig: IModelConfig = {


### PR DESCRIPTION
## Summary

Fixes the Windows "Model verification failed" error where the `default`
intent check reports `index_js_default(...) is not a constructor` (while
`planning` and `insight` pass).

### Root cause

`runConnectivityTest` (packages/core/src/ai-model/connectivity.ts) constructs
`new Service(context)` for the `default`/locate check. `Service` is the default
export of `@/service`, which imported the `@/ai-model/index` barrel — and that
barrel re-exports `./connectivity`. This forms a cycle:

```
connectivity -> @/service -> @/ai-model/index (barrel) -> connectivity
```

In the compiled CJS output (`dist/lib`), `service/index.js` only assigns
`module.exports.default` and `__esModule` at the **end** of the module, after
its `require(... ai-model/index ...)` near the top. Depending on module load
order, `connectivity.js` ends up requiring `service` while it is still
mid-initialization, so it captures a namespace object without `__esModule`.
webpack's `__webpack_require__.n` then permanently returns the whole namespace
instead of `.default`, and `new (namespace)()` throws "is not a constructor".

Because it is load-order dependent, it reproduces on Windows packaged builds
(compiled CJS) but not in macOS source/ESM dev (live bindings tolerate the
cycle).

### Fix

Break the cycle by importing the specific submodules directly in
`packages/core/src/service/index.ts` instead of the `@/ai-model/index` barrel:

- `AiExtractElementInfo`, `AiLocateElement` -> `@/ai-model/inspect`
- `AIResponseParseError`, `callAIWithObjectResponse` -> `@/ai-model/service-caller`

`inspect` / `service-caller` do not import `service` or `connectivity`, so no
new cycle is introduced. No public API surface changes.

### Regression coverage

Adds `packages/core/tests/unit-test/connectivity-service-cycle.test.ts` to:

- run the connectivity `default` locate check through the real `Service`
  constructor instead of mocking `@/service` away;
- guard `packages/core/src/service/index.ts` against re-importing the
  `@/ai-model` barrel that recreates the connectivity/service cycle.

## Test plan

- [x] `pnpm --dir packages/core exec vitest run tests/unit-test/connectivity-service-cycle.test.ts tests/unit-test/connectivity.test.ts tests/unit-test/service-locate-deeplocate.test.ts`
- [x] `npx nx test @midscene/core`
- [x] `npx nx build @midscene/core`
- [x] `pnpm run lint`
- [x] Node check in previously-failing load order: `service.__esModule` is
  `true` and the default resolves to the `Service` constructor.
- [ ] Re-package the Windows app (Studio/extension) and confirm "Model
  verification" passes for the `default` intent.
