### PR TITLE
fix(core): interpolate bare $var inside longer yaml strings

### DIFF
--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -62,7 +62,10 @@ import {
 const debug = getDebug('yaml-player');
 
 const VARIABLE_FULL_MATCH_RE = /^\$([a-zA-Z_][a-zA-Z0-9_]*)$/;
-const VARIABLE_EMBEDDED_RE = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+// Embedded references inside a longer string support both `${name}` and bare
+// `$name`. The braced form is tried first so `${name}` is not split.
+const VARIABLE_EMBEDDED_RE =
+  /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
 function deepTransform(
   value: unknown,
@@ -322,7 +325,8 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         return this.result[varName];
       }
 
-      return val.replace(VARIABLE_EMBEDDED_RE, (_, varName) => {
+      return val.replace(VARIABLE_EMBEDDED_RE, (_, bracedName, bareName) => {
+        const varName = bracedName ?? bareName;
         if (!(varName in this.result)) {
           throw new Error(`Variable "${varName}" is not defined`);
         }

--- a/packages/core/tests/unit-test/player-action-dispatch.test.ts
+++ b/packages/core/tests/unit-test/player-action-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { buildYamlFlowFromPlans } from '@/common';
 import { ScriptPlayer } from '@/yaml/player';
+import { parseYamlScript } from '@/yaml/utils';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -417,6 +418,54 @@ describe('player action dispatch ordering', () => {
       );
     });
 
+    it('should interpolate bare $var inside longer strings', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent({
+        aiAssert: vi.fn().mockResolvedValue({ pass: true }),
+      });
+      player.result.currentShowName = 'Stranger Things';
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiAssert: 'assert the page shows [$currentShowName] now' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.aiAssert).toHaveBeenCalledWith(
+        'assert the page shows [Stranger Things] now',
+        undefined,
+        expect.anything(),
+      );
+    });
+
+    it('should JSON-serialize non-string values for embedded $var', async () => {
+      const player = createPlayerWithActionSpace([]);
+      const agent = createMockAgent({
+        aiAssert: vi.fn().mockResolvedValue({ pass: true }),
+      });
+      player.result.show = { name: 'Show', season: 2 };
+
+      const taskStatus = {
+        name: 'test',
+        flow: [{ aiAssert: 'the page shows $show details' }],
+        index: 0,
+        status: 'running' as const,
+        totalSteps: 1,
+      };
+
+      await player.playTask(taskStatus, agent);
+
+      expect(agent.aiAssert).toHaveBeenCalledWith(
+        'the page shows {"name":"Show","season":2} details',
+        undefined,
+        expect.anything(),
+      );
+    });
+
     it('should throw when referencing undefined variable', async () => {
       const player = createPlayerWithActionSpace([]);
       const agent = createMockAgent();
@@ -514,6 +563,45 @@ describe('player action dispatch ordering', () => {
       3,
       'RunAdbShell',
       { command: 'input keyevent 3' },
+    );
+  });
+});
+
+// Regression for #2509 follow-up: a value captured by `aiQuery ... name: x` in
+// one step must interpolate into a later step's prompt even when referenced as
+// a bare `$x` embedded inside a longer string (not only `${x}`).
+describe('yaml cross-step variable interpolation (end-to-end)', () => {
+  it('interpolates a bare $var captured by aiQuery into a later aiAssert prompt', async () => {
+    const yaml = `
+tasks:
+  - name: binge watching test
+    flow:
+      - aiQuery: remember the name of the current show
+        name: currentShowName
+      - aiAssert: assert the page shows [$currentShowName] now
+`;
+    const seenAssertPrompt: { value?: string } = {};
+    const agent = {
+      getActionSpace: async () => [],
+      aiQuery: vi.fn().mockResolvedValue('Stranger Things'),
+      aiAssert: vi.fn(async (prompt: string) => {
+        seenAssertPrompt.value = prompt;
+        return { pass: true, thought: 'ok', message: '' };
+      }),
+    };
+
+    const script = parseYamlScript(yaml, 'demo.yaml');
+    const player = new ScriptPlayer(script as any, async () => ({
+      agent: agent as any,
+      freeFn: [],
+    }));
+
+    await player.run();
+
+    expect(player.status).toBe('done');
+    expect(player.result.currentShowName).toBe('Stranger Things');
+    expect(seenAssertPrompt.value).toBe(
+      'assert the page shows [Stranger Things] now',
     );
   });
 });


### PR DESCRIPTION
## Problem

Runtime YAML variable interpolation in `ScriptPlayer` supported two forms:

- whole-field `$name` — replaced with the stored result, preserving the original type;
- embedded `${name}` — replaced inside a longer string.

A **bare `$name` embedded inside a longer string** matched neither pattern, so it was left literal. Reproduction (the user's case):

```yaml
tasks:
  - name: 追剧测试
    flow:
      - aiQuery: 记住当前剧的剧名
        name: currentShowName
      - aiAssert: 判断当前页面存在【$currentShowName】这部剧
```

`$currentShowName` was passed through unchanged, so the assertion never saw the captured value.

## Fix

Extend the embedded interpolation pattern to accept both `${name}` and bare `$name` (the braced form is matched first so `${name}` is never split):

```ts
const VARIABLE_EMBEDDED_RE =
  /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
```

Behavior is otherwise unchanged and matches the documented contract:

- whole-field `$name` still preserves the original result type;
- embedded references are stringified (`JSON.stringify` for non-strings);
- referencing an undefined variable still throws `Variable "x" is not defined`.

## Behavior change to note

A literal `$word` embedded in a prompt where `word` is not a defined variable now throws (previously it was kept as-is). This is consistent with the existing "undefined variable throws" rule already applied to `${name}` and whole-field `$name`. There is no escaping mechanism yet; if a literal `$` is needed in the future it can be added separately.

## Validation

- **Real run** through the built `@midscene/core` `ScriptPlayer` with a mock agent (aiQuery returns `繁花`, aiAssert records its prompt): the assertion received `判断当前页面存在【繁花】这部剧` and the suite finished `done`.
- New unit tests: bare `$var` embedded in a longer string; non-string `$var` JSON-serialized; plus an **end-to-end regression test** that parses the exact YAML above and runs the full flow.
- `player-action-dispatch.test.ts` — 20/20 ✓
- `nx test core` — only pre-existing, unrelated failure (`merge-browser-parse.test.ts`, fails on the clean branch too); all interpolation tests pass.
- `pnpm run lint` ✓; `nx build core` ✓.