### PR TITLE
fix(computer): self-heal phased-scroll +x bit lost in npm tarball

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1,5 +1,5 @@
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { chmodSync, existsSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -251,6 +251,18 @@ export function getPhasedScrollBinary(): string | null {
     phasedScrollBinaryPath = null;
     return null;
   }
+  // npm tarball extraction drops the executable bit on packed files (mode
+  // becomes 0644). Self-heal once at resolution time so spawnSync doesn't
+  // come back with status:null/EACCES on every scroll.
+  try {
+    const st = statSync(binPath);
+    if ((st.mode & 0o111) === 0) {
+      chmodSync(binPath, 0o755);
+      debugDevice('phased-scroll: restored executable bit on', binPath);
+    }
+  } catch (err) {
+    debugDevice('phased-scroll: chmod self-heal failed', err);
+  }
   phasedScrollBinaryPath = binPath;
   return binPath;
 }
@@ -275,11 +287,24 @@ export function runPhasedScroll(
     if (res.status === 0) return true;
     if (!phasedScrollExecWarned) {
       phasedScrollExecWarned = true;
+      // status === null means the child was killed by a signal before it
+      // could exit normally — usually EACCES (binary not executable) or a
+      // codesign/quarantine rejection. status !== 0 means the helper exited
+      // on its own; on macOS that's almost always Accessibility denial.
+      const hint =
+        res.status === null
+          ? `signal ${res.signal ?? 'unknown'}; the binary may not be executable (npm tarball extraction can drop the +x bit) or may be blocked by quarantine. Try: chmod +x "${bin}"`
+          : 'this usually means Accessibility permission has not been granted to the host process (System Settings → Privacy & Security → Accessibility)';
       console.warn(
-        `[@midscene/computer] phased-scroll helper exited with status ${res.status}; falling back to keyboard/libnut. This usually means Accessibility permission has not been granted to the host process.`,
+        `[@midscene/computer] phased-scroll helper failed (exit=${res.status}, signal=${res.signal ?? 'none'}); falling back to keyboard/libnut. ${hint}`,
       );
     }
-    debugDevice('phased-scroll exited non-zero', res.status, res.error);
+    debugDevice(
+      'phased-scroll exited non-zero',
+      res.status,
+      res.signal,
+      res.error,
+    );
     return false;
   } catch (err) {
     if (!phasedScrollExecWarned) {

--- a/packages/computer/tests/ai/chrome-extension-helpers.ts
+++ b/packages/computer/tests/ai/chrome-extension-helpers.ts
@@ -8,8 +8,11 @@ import { isHeadlessLinux } from './test-utils';
 
 export const CDP_PORT = 9222;
 const USER_DATA_DIR = '/tmp/midscene-chrome-ext-test';
-const BROWSER_STARTUP_DELAY = 10_000;
 const EXTENSION_POLL_INTERVAL = 2_000;
+// On slow CI runners Chrome can take 30s+ from spawn to a listening CDP
+// endpoint, so poll for readiness instead of sleeping a fixed amount.
+const CDP_READY_MAX_ATTEMPTS = 30; // 30 × 2s = 60s
+const CDP_READY_INTERVAL = 2_000;
 const CDP_INJECTION_TIMEOUT = 10_000;
 const NAVIGATE_INJECT_TIMEOUT = 15_000;
 const RELOAD_TIMEOUT = 5_000;
@@ -118,12 +121,37 @@ export async function launchChromeWithExtension(
   });
 
   child.unref();
-  await sleep(BROWSER_STARTUP_DELAY);
+  await waitForCdpReady();
+}
+
+// Wait until Chrome's CDP endpoint answers, i.e. the browser is actually up.
+// A fixed sleep either wastes time on fast runners or races browser startup on
+// slow ones (the latter showed up as "extension not found": the poll window was
+// spent waiting for Chrome itself, leaving no time for the extension to register).
+async function waitForCdpReady(
+  maxAttempts = CDP_READY_MAX_ATTEMPTS,
+): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`);
+      if (res.ok) {
+        console.log(`CDP endpoint ready after ${i + 1} attempt(s)`);
+        return;
+      }
+    } catch {
+      // browser not listening yet, retry
+    }
+    console.log(`Waiting for CDP endpoint (${i + 1}/${maxAttempts})...`);
+    await sleep(CDP_READY_INTERVAL);
+  }
+  console.warn(
+    `CDP endpoint not ready after ${maxAttempts} attempts; continuing anyway`,
+  );
 }
 
 // ─── Extension ID Reader ────────────────────────────────────────────────────
 
-export async function readExtensionId(maxAttempts = 15): Promise<string> {
+export async function readExtensionId(maxAttempts = 30): Promise<string> {
   const prefsPath = path.join(USER_DATA_DIR, 'Default', 'Preferences');
 
   for (let i = 0; i < maxAttempts; i++) {

--- a/packages/computer/tests/unit-test/phased-scroll.test.ts
+++ b/packages/computer/tests/unit-test/phased-scroll.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getPhasedScrollBinary } from '../../src/device';
@@ -25,5 +25,14 @@ describe('phased-scroll binary resolution', () => {
     const pkgRoot = resolve(__dirname, '../..');
     expect(binPath.startsWith(pkgRoot)).toBe(true);
     expect(binPath.endsWith('bin/darwin/phased-scroll')).toBe(true);
+  });
+
+  it('resolved binary is executable (self-heals stripped exec bit)', () => {
+    if (process.platform !== 'darwin') return;
+    const binPath = getPhasedScrollBinary() as string;
+    // npm tarball extraction can land the file as 0644. The resolver should
+    // have already restored the executable bit before returning the path.
+    const mode = statSync(binPath).mode & 0o111;
+    expect(mode).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- npm tarball extraction strips the executable bit on packed files (mode lands as `0644` instead of `0755`). On macOS the bundled `bin/darwin/phased-scroll` helper is then unrunnable, so `spawnSync` returns `status: null` and every scroll silently falls back to the slower libnut path with a misleading "Accessibility permission" warning.
- Self-heal once at lazy resolution time inside `getPhasedScrollBinary` — `chmod 0755` if the +x bits are missing — so npm/npx-installed users get the phased-scroll path on the very first scroll.
- Tighten the failure warning in `runPhasedScroll` so the next time it does fire it tells the user whether to fix Accessibility permission (`status !== 0`) or the executable bit / quarantine (`status === null`).

## Repro before this fix

```
npx -y @midscene/computer-playground@beta
# trigger any scroll action
# → "[@midscene/computer] phased-scroll helper exited with status null;
#    falling back to keyboard/libnut. This usually means Accessibility
#    permission has not been granted to the host process."
```

The warning is wrong: Accessibility was granted; the helper itself was non-executable.

```
$ ls -la ~/.npm/_npx/<hash>/node_modules/@midscene/computer/bin/darwin/phased-scroll
-rw-r--r--  ...  phased-scroll      # mode 0644, no +x
```

After `chmod +x` on the cached binary, the same `spawnSync` call returns `exit: 0` and scrolling works. This is the same set of bytes — only the chmod differs (codesign hashes match).

## Why self-heal at runtime instead of postinstall

A `postinstall` hook would only run on direct installs and is skipped under common flags (`--ignore-scripts`, `pnpm install --frozen-lockfile --ignore-scripts` in CI, plenty of hardened workspace setups). Self-heal in `getPhasedScrollBinary` is one stat + one chmod on the lazy resolution path, runs everywhere, and stays correct after re-installs without coordinating with the install lifecycle.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx test computer` (45/45 passing, includes a new test that asserts the resolved binary always has the executable bit set)
- [x] Live repro: chmod the bundled binary back to `0644`, call `device.performScroll(...)` via the built `dist/`, observe mode flips back to `0755` and the scroll lands.