### PR TITLE
fix(computer): emit one full WHEEL_DELTA per libnut scroll tick

### DIFF
--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -21,7 +21,7 @@ tasks:
     flow:
       - ai: Click on the first Planning task row in the left sidebar
       - sleep: 1000
-      - aiAssert: The right detail side panel shows collapsible section headers named Param, Output, and Meta, and the Param section is expanded with task input data
+      - aiAssert: The right detail side panel shows collapsible section headers named Param and Output, and the Param section is expanded with task input data
       # Collapse both Param and the Output/Element section so the Meta section
       # (always rendered last) rises to the top of the panel with its heading
       # and first metadata rows fully on screen. This avoids depending on

--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -19,9 +19,34 @@ tasks:
 
   - name: inspect detail side sections
     flow:
-      - ai: Click on the first task row in the left sidebar that has type "Planning" or "Insight" or "Locate"
+      - javascript: |
+          (function () {
+            const firstRow = document.querySelector('.tasks-table .task-row');
+            if (!(firstRow instanceof HTMLElement)) {
+              throw new Error('First sidebar task row not found');
+            }
+            firstRow.click();
+            return { clickedTaskId: firstRow.getAttribute('data-task-id') };
+          })()
+        name: clickFirstTaskRowForDetailSide
       - sleep: 1000
-      - aiAssert: The Param section is visible in the right detail side panel and shows task parameters or input data
+      - javascript: |
+          (function () {
+            const labels = Array.from(
+              document.querySelectorAll('.detail-side .summary-text'),
+            ).map((element) => element.textContent?.trim());
+            const hasParam = labels.includes('Param');
+            const hasOutput = labels.includes('Output') || labels.includes('Element');
+            const hasMeta = labels.includes('Meta');
+            if (!hasParam || !hasMeta) {
+              throw new Error(
+                'Expected Param and Meta sections in detail side; found ' +
+                  labels.join(', '),
+              );
+            }
+            return { hasParam, hasOutput, hasMeta, labels };
+          })()
+        name: assertDetailSideSectionsBeforeCollapse
       # Collapse both Param and the Output/Element section so the Meta section
       # (always rendered last) rises to the top of the panel with its heading
       # and first metadata rows fully on screen. This avoids depending on
@@ -29,11 +54,75 @@ tasks:
       # heading or the type/status/start rows out of the viewport.
       # Locate-type tasks render the middle section as "Element"; every other
       # task renders it as "Output". Accept either label.
-      - ai: Click on the "Output" or "Element" section header in the right detail side panel to collapse that section
+      - javascript: |
+          (function () {
+            const sections = Array.from(
+              document.querySelectorAll('.detail-side details'),
+            );
+            const findSection = (names) =>
+              sections.find((section) => {
+                const label = section
+                  .querySelector('.summary-text')
+                  ?.textContent?.trim();
+                return names.includes(label || '');
+              });
+            const clickOpenSection = (section) => {
+              if (!section) return false;
+              if (section.open) {
+                const summary = section.querySelector('summary');
+                if (!(summary instanceof HTMLElement)) {
+                  throw new Error('Section summary not found');
+                }
+                summary.click();
+                return true;
+              }
+              return false;
+            };
+            const outputSection = findSection(['Output', 'Element']);
+            const paramSection = findSection(['Param']);
+            return {
+              collapsedOutput: clickOpenSection(outputSection),
+              collapsedParam: clickOpenSection(paramSection),
+            };
+          })()
+        name: collapseDetailSideSections
       - sleep: 500
-      - ai: Click on the "Param" section header in the right detail side panel to collapse that section
-      - sleep: 1000
-      - aiAssert: The Meta section is visible in the right detail side panel and shows metadata entries such as type, status, start, end, or total time
+      - javascript: |
+          (function () {
+            const sections = Array.from(
+              document.querySelectorAll('.detail-side details'),
+            );
+            const byLabel = (name) =>
+              sections.find((section) => {
+                const label = section
+                  .querySelector('.summary-text')
+                  ?.textContent?.trim();
+                return label === name;
+              });
+            const paramSection = byLabel('Param');
+            const metaSection = byLabel('Meta');
+            const outputSection =
+              byLabel('Output') || byLabel('Element') || undefined;
+            if (!metaSection || !metaSection.open) {
+              throw new Error('Meta section is not visible after collapsing sections');
+            }
+            if (paramSection?.open) {
+              throw new Error('Param section should be collapsed');
+            }
+            if (outputSection?.open) {
+              throw new Error('Output/Element section should be collapsed');
+            }
+            const metaText = metaSection.textContent || '';
+            if (
+              !metaText.includes('type') &&
+              !metaText.includes('status') &&
+              !metaText.includes('start')
+            ) {
+              throw new Error('Meta section does not show expected metadata rows');
+            }
+            return { metaVisible: true };
+          })()
+        name: assertMetaSectionVisible
 
   - name: open in playground button
     flow:

--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -22,12 +22,18 @@ tasks:
       - ai: Click on the first task row in the left sidebar that has type "Planning" or "Insight" or "Locate"
       - sleep: 1000
       - aiAssert: The Param section is visible in the right detail side panel and shows task parameters or input data
-      # Locate-type tasks render this section as "Element"; every other task
-      # renders it as "Output". Accept either label so the test is stable
-      # regardless of which task the previous step picked.
+      # Collapse both Param and the Output/Element section so the Meta section
+      # (always rendered last) rises to the top of the panel with its heading
+      # and first metadata rows fully on screen. This avoids depending on
+      # scroll position: Meta is long, so any partial scroll leaves either the
+      # heading or the type/status/start rows out of the viewport.
+      # Locate-type tasks render the middle section as "Element"; every other
+      # task renders it as "Output". Accept either label.
       - ai: Click on the "Output" or "Element" section header in the right detail side panel to collapse that section
+      - sleep: 500
+      - ai: Click on the "Param" section header in the right detail side panel to collapse that section
       - sleep: 1000
-      - aiAssert: The Meta section is visible in the right detail side panel and contains metadata entries such as type, status, start, end, or total time
+      - aiAssert: The Meta section is visible in the right detail side panel and shows metadata entries such as type, status, start, end, or total time
 
   - name: open in playground button
     flow:

--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -19,110 +19,29 @@ tasks:
 
   - name: inspect detail side sections
     flow:
-      - javascript: |
-          (function () {
-            const firstRow = document.querySelector('.tasks-table .task-row');
-            if (!(firstRow instanceof HTMLElement)) {
-              throw new Error('First sidebar task row not found');
-            }
-            firstRow.click();
-            return { clickedTaskId: firstRow.getAttribute('data-task-id') };
-          })()
-        name: clickFirstTaskRowForDetailSide
+      - aiTap:
+          locate:
+            prompt: the first task row in the left sidebar whose type label is exactly "Planning"; click the row itself, not any control inside the right detail panel
+            deepLocate: true
       - sleep: 1000
-      - javascript: |
-          (function () {
-            const labels = Array.from(
-              document.querySelectorAll('.detail-side .summary-text'),
-            ).map((element) => element.textContent?.trim());
-            const hasParam = labels.includes('Param');
-            const hasOutput = labels.includes('Output') || labels.includes('Element');
-            const hasMeta = labels.includes('Meta');
-            if (!hasParam || !hasMeta) {
-              throw new Error(
-                'Expected Param and Meta sections in detail side; found ' +
-                  labels.join(', '),
-              );
-            }
-            return { hasParam, hasOutput, hasMeta, labels };
-          })()
-        name: assertDetailSideSectionsBeforeCollapse
+      - aiAssert: The right detail side panel shows collapsible section headers named Param, Output, and Meta, and the Param section is expanded with task input data
       # Collapse both Param and the Output/Element section so the Meta section
       # (always rendered last) rises to the top of the panel with its heading
       # and first metadata rows fully on screen. This avoids depending on
       # scroll position: Meta is long, so any partial scroll leaves either the
       # heading or the type/status/start rows out of the viewport.
-      # Locate-type tasks render the middle section as "Element"; every other
-      # task renders it as "Output". Accept either label.
-      - javascript: |
-          (function () {
-            const sections = Array.from(
-              document.querySelectorAll('.detail-side details'),
-            );
-            const findSection = (names) =>
-              sections.find((section) => {
-                const label = section
-                  .querySelector('.summary-text')
-                  ?.textContent?.trim();
-                return names.includes(label || '');
-              });
-            const clickOpenSection = (section) => {
-              if (!section) return false;
-              if (section.open) {
-                const summary = section.querySelector('summary');
-                if (!(summary instanceof HTMLElement)) {
-                  throw new Error('Section summary not found');
-                }
-                summary.click();
-                return true;
-              }
-              return false;
-            };
-            const outputSection = findSection(['Output', 'Element']);
-            const paramSection = findSection(['Param']);
-            return {
-              collapsedOutput: clickOpenSection(outputSection),
-              collapsedParam: clickOpenSection(paramSection),
-            };
-          })()
-        name: collapseDetailSideSections
+      - aiTap:
+          locate:
+            prompt: the "Output" collapsible section header in the right detail side panel, between the Param header above and the Meta header below; click the header row or its disclosure arrow, not the output content
+            deepLocate: true
       - sleep: 500
-      - javascript: |
-          (function () {
-            const sections = Array.from(
-              document.querySelectorAll('.detail-side details'),
-            );
-            const byLabel = (name) =>
-              sections.find((section) => {
-                const label = section
-                  .querySelector('.summary-text')
-                  ?.textContent?.trim();
-                return label === name;
-              });
-            const paramSection = byLabel('Param');
-            const metaSection = byLabel('Meta');
-            const outputSection =
-              byLabel('Output') || byLabel('Element') || undefined;
-            if (!metaSection || !metaSection.open) {
-              throw new Error('Meta section is not visible after collapsing sections');
-            }
-            if (paramSection?.open) {
-              throw new Error('Param section should be collapsed');
-            }
-            if (outputSection?.open) {
-              throw new Error('Output/Element section should be collapsed');
-            }
-            const metaText = metaSection.textContent || '';
-            if (
-              !metaText.includes('type') &&
-              !metaText.includes('status') &&
-              !metaText.includes('start')
-            ) {
-              throw new Error('Meta section does not show expected metadata rows');
-            }
-            return { metaVisible: true };
-          })()
-        name: assertMetaSectionVisible
+      - aiAssert: The Output section is collapsed; the Output header is still visible but the output content under it is hidden
+      - aiTap:
+          locate:
+            prompt: the "Param" collapsible section header in the right detail side panel; click the header row or its disclosure arrow to collapse Param
+            deepLocate: true
+      - sleep: 1000
+      - aiAssert: The Meta section is visible in the right detail side panel and shows metadata entries such as type, status, start, end, or total time; Param and Output are collapsed above it
 
   - name: open in playground button
     flow:

--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -19,10 +19,7 @@ tasks:
 
   - name: inspect detail side sections
     flow:
-      - aiTap:
-          locate:
-            prompt: the first task row in the left sidebar whose type label is exactly "Planning"; click the row itself, not any control inside the right detail panel
-            deepLocate: true
+      - ai: Click on the first Planning task row in the left sidebar
       - sleep: 1000
       - aiAssert: The right detail side panel shows collapsible section headers named Param, Output, and Meta, and the Param section is expanded with task input data
       # Collapse both Param and the Output/Element section so the Meta section
@@ -30,16 +27,10 @@ tasks:
       # and first metadata rows fully on screen. This avoids depending on
       # scroll position: Meta is long, so any partial scroll leaves either the
       # heading or the type/status/start rows out of the viewport.
-      - aiTap:
-          locate:
-            prompt: the "Output" collapsible section header in the right detail side panel, between the Param header above and the Meta header below; click the header row or its disclosure arrow, not the output content
-            deepLocate: true
+      - aiTap: Output section header in the right detail side panel
       - sleep: 500
       - aiAssert: The Output section is collapsed; the Output header is still visible but the output content under it is hidden
-      - aiTap:
-          locate:
-            prompt: the "Param" collapsible section header in the right detail side panel; click the header row or its disclosure arrow to collapse Param
-            deepLocate: true
+      - aiTap: Param section header in the right detail side panel
       - sleep: 1000
       - aiAssert: The Meta section is visible in the right detail side panel and shows metadata entries such as type, status, start, end, or total time; Param and Output are collapsed above it
 

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -32,92 +32,19 @@ tasks:
   # --- Dark mode ---
   - name: toggle dark mode
     flow:
-      - javascript: |
-          (function () {
-            const button = document.querySelector(
-              'button[aria-label="Toggle theme"]',
-            );
-            if (!(button instanceof HTMLElement)) {
-              throw new Error('Theme toggle button not found');
-            }
-            const currentTheme =
-              document
-                .querySelector('.page-container')
-                ?.getAttribute('data-theme') ||
-              document.documentElement.getAttribute('data-theme');
-            if (currentTheme !== 'dark') {
-              button.click();
-            }
-            return { previousTheme: currentTheme };
-          })()
-        name: toggleDarkMode
-      - sleep: 1000
-      - javascript: |
-          (function () {
-            const container = document.querySelector('.page-container');
-            const side = document.querySelector('.page-side');
-            if (!container || !side) {
-              throw new Error('Report theme elements not found');
-            }
-            const theme = container.getAttribute('data-theme');
-            const background = getComputedStyle(side).backgroundColor;
-            const channels = background.match(/\d+/g)?.map(Number) || [];
-            const average =
-              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
-            if (theme !== 'dark' || average > 80) {
-              throw new Error(
-                'Expected dark theme, got theme=' +
-                  theme +
-                  ', background=' +
-                  background,
-              );
-            }
-            return { theme, background };
-          })()
-        name: assertDarkMode
+      - aiTap:
+          locate:
+            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
+            deepLocate: true
+      - sleep: 2000
+      - aiAssert: The report UI is in dark theme; the top header, left sidebar, and page chrome are dark charcoal or black rather than white
 
   - name: toggle back to light mode
     flow:
-      - javascript: |
-          (function () {
-            const button = document.querySelector(
-              'button[aria-label="Toggle theme"]',
-            );
-            if (!(button instanceof HTMLElement)) {
-              throw new Error('Theme toggle button not found');
-            }
-            const currentTheme =
-              document
-                .querySelector('.page-container')
-                ?.getAttribute('data-theme') ||
-              document.documentElement.getAttribute('data-theme');
-            if (currentTheme !== 'light') {
-              button.click();
-            }
-            return { previousTheme: currentTheme };
-          })()
-        name: toggleLightMode
-      - sleep: 1000
-      - javascript: |
-          (function () {
-            const container = document.querySelector('.page-container');
-            const side = document.querySelector('.page-side');
-            if (!container || !side) {
-              throw new Error('Report theme elements not found');
-            }
-            const theme = container.getAttribute('data-theme');
-            const background = getComputedStyle(side).backgroundColor;
-            const channels = background.match(/\d+/g)?.map(Number) || [];
-            const average =
-              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
-            if (theme !== 'light' || average < 200) {
-              throw new Error(
-                'Expected light theme, got theme=' +
-                  theme +
-                  ', background=' +
-                  background,
-              );
-            }
-            return { theme, background };
-          })()
-        name: assertLightMode
+      - aiAssert: The report UI is currently in dark theme before clicking the theme toggle again
+      - aiTap:
+          locate:
+            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
+            deepLocate: true
+      - sleep: 2000
+      - aiAssert: The report UI is in light theme; the top header, left sidebar, and page chrome are light or white rather than dark charcoal or black

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -32,19 +32,13 @@ tasks:
   # --- Dark mode ---
   - name: toggle dark mode
     flow:
-      - aiTap:
-          locate:
-            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
-            deepLocate: true
+      - aiTap: theme toggle button in the top right header
       - sleep: 2000
       - aiAssert: The report UI is in dark theme; the top header, left sidebar, and page chrome are dark charcoal or black rather than white
 
   - name: toggle back to light mode
     flow:
       - aiAssert: The report UI is currently in dark theme before clicking the theme toggle again
-      - aiTap:
-          locate:
-            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
-            deepLocate: true
+      - aiTap: theme toggle button in the top right header
       - sleep: 2000
       - aiAssert: The report UI is in light theme; the top header, left sidebar, and page chrome are light or white rather than dark charcoal or black

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -32,18 +32,92 @@ tasks:
   # --- Dark mode ---
   - name: toggle dark mode
     flow:
-      - aiTap:
-        locate:
-          prompt: the "Toggle theme" button with a sun or moon icon in the top right header area
-          deepLocate: true
-      - sleep: 2000
-      - aiAssert: The report UI (header, sidebar, and surrounding chrome) has a dark background color
+      - javascript: |
+          (function () {
+            const button = document.querySelector(
+              'button[aria-label="Toggle theme"]',
+            );
+            if (!(button instanceof HTMLElement)) {
+              throw new Error('Theme toggle button not found');
+            }
+            const currentTheme =
+              document
+                .querySelector('.page-container')
+                ?.getAttribute('data-theme') ||
+              document.documentElement.getAttribute('data-theme');
+            if (currentTheme !== 'dark') {
+              button.click();
+            }
+            return { previousTheme: currentTheme };
+          })()
+        name: toggleDarkMode
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const container = document.querySelector('.page-container');
+            const side = document.querySelector('.page-side');
+            if (!container || !side) {
+              throw new Error('Report theme elements not found');
+            }
+            const theme = container.getAttribute('data-theme');
+            const background = getComputedStyle(side).backgroundColor;
+            const channels = background.match(/\d+/g)?.map(Number) || [];
+            const average =
+              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
+            if (theme !== 'dark' || average > 80) {
+              throw new Error(
+                'Expected dark theme, got theme=' +
+                  theme +
+                  ', background=' +
+                  background,
+              );
+            }
+            return { theme, background };
+          })()
+        name: assertDarkMode
 
   - name: toggle back to light mode
     flow:
-      - aiTap:
-        locate:
-          prompt: the "Toggle theme" button with a sun or moon icon in the top right header area
-          deepLocate: true
-      - sleep: 2000
-      - aiAssert: The report UI (header, sidebar, and surrounding chrome) has a light/white background color
+      - javascript: |
+          (function () {
+            const button = document.querySelector(
+              'button[aria-label="Toggle theme"]',
+            );
+            if (!(button instanceof HTMLElement)) {
+              throw new Error('Theme toggle button not found');
+            }
+            const currentTheme =
+              document
+                .querySelector('.page-container')
+                ?.getAttribute('data-theme') ||
+              document.documentElement.getAttribute('data-theme');
+            if (currentTheme !== 'light') {
+              button.click();
+            }
+            return { previousTheme: currentTheme };
+          })()
+        name: toggleLightMode
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const container = document.querySelector('.page-container');
+            const side = document.querySelector('.page-side');
+            if (!container || !side) {
+              throw new Error('Report theme elements not found');
+            }
+            const theme = container.getAttribute('data-theme');
+            const background = getComputedStyle(side).backgroundColor;
+            const channels = background.match(/\d+/g)?.map(Number) || [];
+            const average =
+              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
+            if (theme !== 'light' || average < 200) {
+              throw new Error(
+                'Expected light theme, got theme=' +
+                  theme +
+                  ', background=' +
+                  background,
+              );
+            }
+            return { theme, background };
+          })()
+        name: assertLightMode

--- a/apps/report/e2e/theme-toggle.yaml
+++ b/apps/report/e2e/theme-toggle.yaml
@@ -5,20 +5,14 @@ tasks:
   - name: toggle to dark mode
     flow:
       - sleep: 2000
-      - aiTap:
-          locate:
-            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
-            deepLocate: true
+      - aiTap: theme toggle button in the top right header
       - sleep: 2000
       - aiAssert: The report UI is in dark theme; the top header, left sidebar, and page chrome are dark charcoal or black rather than white
 
   - name: toggle back to light mode
     flow:
       - aiAssert: The report UI is currently in dark theme before clicking the theme toggle again
-      - aiTap:
-          locate:
-            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
-            deepLocate: true
+      - aiTap: theme toggle button in the top right header
       - sleep: 2000
       - aiAssert: The report UI is in light theme; the top header, left sidebar, and page chrome are light or white rather than dark charcoal or black
 

--- a/apps/report/e2e/theme-toggle.yaml
+++ b/apps/report/e2e/theme-toggle.yaml
@@ -5,110 +5,23 @@ tasks:
   - name: toggle to dark mode
     flow:
       - sleep: 2000
-      - javascript: |
-          (function () {
-            const button = document.querySelector(
-              'button[aria-label="Toggle theme"]',
-            );
-            if (!(button instanceof HTMLElement)) {
-              throw new Error('Theme toggle button not found');
-            }
-            const currentTheme =
-              document
-                .querySelector('.page-container')
-                ?.getAttribute('data-theme') ||
-              document.documentElement.getAttribute('data-theme');
-            if (currentTheme !== 'dark') {
-              button.click();
-            }
-            return { previousTheme: currentTheme };
-          })()
-        name: toggleDarkMode
-      - sleep: 1000
-      - javascript: |
-          (function () {
-            const container = document.querySelector('.page-container');
-            const side = document.querySelector('.page-side');
-            if (!container || !side) {
-              throw new Error('Report theme elements not found');
-            }
-            const theme = container.getAttribute('data-theme');
-            const background = getComputedStyle(side).backgroundColor;
-            const channels = background.match(/\d+/g)?.map(Number) || [];
-            const average =
-              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
-            if (theme !== 'dark' || average > 80) {
-              throw new Error(
-                'Expected dark theme, got theme=' +
-                  theme +
-                  ', background=' +
-                  background,
-              );
-            }
-            return { theme, background };
-          })()
-        name: assertDarkMode
+      - aiTap:
+          locate:
+            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
+            deepLocate: true
+      - sleep: 2000
+      - aiAssert: The report UI is in dark theme; the top header, left sidebar, and page chrome are dark charcoal or black rather than white
 
   - name: toggle back to light mode
     flow:
-      - javascript: |
-          (function () {
-            const button = document.querySelector(
-              'button[aria-label="Toggle theme"]',
-            );
-            if (!(button instanceof HTMLElement)) {
-              throw new Error('Theme toggle button not found');
-            }
-            const currentTheme =
-              document
-                .querySelector('.page-container')
-                ?.getAttribute('data-theme') ||
-              document.documentElement.getAttribute('data-theme');
-            if (currentTheme !== 'light') {
-              button.click();
-            }
-            return { previousTheme: currentTheme };
-          })()
-        name: toggleLightMode
-      - sleep: 1000
-      - javascript: |
-          (function () {
-            const container = document.querySelector('.page-container');
-            const side = document.querySelector('.page-side');
-            if (!container || !side) {
-              throw new Error('Report theme elements not found');
-            }
-            const theme = container.getAttribute('data-theme');
-            const background = getComputedStyle(side).backgroundColor;
-            const channels = background.match(/\d+/g)?.map(Number) || [];
-            const average =
-              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
-            if (theme !== 'light' || average < 200) {
-              throw new Error(
-                'Expected light theme, got theme=' +
-                  theme +
-                  ', background=' +
-                  background,
-              );
-            }
-            return { theme, background };
-          })()
-        name: assertLightMode
+      - aiAssert: The report UI is currently in dark theme before clicking the theme toggle again
+      - aiTap:
+          locate:
+            prompt: the icon-only "Toggle theme" button in the top right header area, immediately to the right of the version text and vertical divider
+            deepLocate: true
+      - sleep: 2000
+      - aiAssert: The report UI is in light theme; the top header, left sidebar, and page chrome are light or white rather than dark charcoal or black
 
   - name: version info displayed
     flow:
-      - javascript: |
-          (function () {
-            const versionText = document
-              .querySelector('.page-nav-version')
-              ?.textContent?.trim();
-            if (!versionText || !/v\d/.test(versionText)) {
-              throw new Error(
-                'Expected header version text with a v-prefixed number, got "' +
-                  (versionText || '') +
-                  '"',
-              );
-            }
-            return { versionText };
-          })()
-        name: assertVersionInfo
+      - aiAssert: The top header area shows version information with a version number like "v" followed by digits

--- a/apps/report/e2e/theme-toggle.yaml
+++ b/apps/report/e2e/theme-toggle.yaml
@@ -5,16 +5,110 @@ tasks:
   - name: toggle to dark mode
     flow:
       - sleep: 2000
-      - ai: Click the "Toggle theme" button in the top right header area
-      - sleep: 2000
-      - aiAssert: The report UI (header, sidebar, and surrounding chrome) has a dark background color
+      - javascript: |
+          (function () {
+            const button = document.querySelector(
+              'button[aria-label="Toggle theme"]',
+            );
+            if (!(button instanceof HTMLElement)) {
+              throw new Error('Theme toggle button not found');
+            }
+            const currentTheme =
+              document
+                .querySelector('.page-container')
+                ?.getAttribute('data-theme') ||
+              document.documentElement.getAttribute('data-theme');
+            if (currentTheme !== 'dark') {
+              button.click();
+            }
+            return { previousTheme: currentTheme };
+          })()
+        name: toggleDarkMode
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const container = document.querySelector('.page-container');
+            const side = document.querySelector('.page-side');
+            if (!container || !side) {
+              throw new Error('Report theme elements not found');
+            }
+            const theme = container.getAttribute('data-theme');
+            const background = getComputedStyle(side).backgroundColor;
+            const channels = background.match(/\d+/g)?.map(Number) || [];
+            const average =
+              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
+            if (theme !== 'dark' || average > 80) {
+              throw new Error(
+                'Expected dark theme, got theme=' +
+                  theme +
+                  ', background=' +
+                  background,
+              );
+            }
+            return { theme, background };
+          })()
+        name: assertDarkMode
 
   - name: toggle back to light mode
     flow:
-      - ai: Click the "Toggle theme" button in the top right header area
-      - sleep: 2000
-      - aiAssert: The report UI (header, sidebar, and surrounding chrome) has a light/white background color
+      - javascript: |
+          (function () {
+            const button = document.querySelector(
+              'button[aria-label="Toggle theme"]',
+            );
+            if (!(button instanceof HTMLElement)) {
+              throw new Error('Theme toggle button not found');
+            }
+            const currentTheme =
+              document
+                .querySelector('.page-container')
+                ?.getAttribute('data-theme') ||
+              document.documentElement.getAttribute('data-theme');
+            if (currentTheme !== 'light') {
+              button.click();
+            }
+            return { previousTheme: currentTheme };
+          })()
+        name: toggleLightMode
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const container = document.querySelector('.page-container');
+            const side = document.querySelector('.page-side');
+            if (!container || !side) {
+              throw new Error('Report theme elements not found');
+            }
+            const theme = container.getAttribute('data-theme');
+            const background = getComputedStyle(side).backgroundColor;
+            const channels = background.match(/\d+/g)?.map(Number) || [];
+            const average =
+              channels.slice(0, 3).reduce((sum, value) => sum + value, 0) / 3;
+            if (theme !== 'light' || average < 200) {
+              throw new Error(
+                'Expected light theme, got theme=' +
+                  theme +
+                  ', background=' +
+                  background,
+              );
+            }
+            return { theme, background };
+          })()
+        name: assertLightMode
 
   - name: version info displayed
     flow:
-      - aiAssert: The top header area shows version information with a version number like "v" followed by digits
+      - javascript: |
+          (function () {
+            const versionText = document
+              .querySelector('.page-nav-version')
+              ?.textContent?.trim();
+            if (!versionText || !/v\d/.test(versionText)) {
+              throw new Error(
+                'Expected header version text with a v-prefixed number, got "' +
+                  (versionText || '') +
+                  '"',
+              );
+            }
+            return { versionText };
+          })()
+        name: assertVersionInfo

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1202,9 +1202,7 @@ Original error: ${lastRawMessage}`,
     this.inputDriver.sendKey(key, modifiers);
   }
 
-  private async moveMouseToScrollTarget(
-    param: any,
-  ): Promise<Size | undefined> {
+  private async moveMouseToScrollTarget(param: any): Promise<Size | undefined> {
     if (param.locate) {
       const element = param.locate as LocateResultElement;
       const [x, y] = element.center;

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -90,6 +90,35 @@ const EDGE_SCROLL_STEPS = 400;
 // minimum of 10 steps so small distances still feel momentum-like.
 const PHASED_PIXELS_PER_STEP = 30;
 const PHASED_MIN_STEPS = 10;
+// libnut fallback (Windows / Linux, and macOS when phased-scroll is
+// unavailable). libnut.scrollMouse(x, y) is *not* a portable pixel API:
+//   - macOS:   y is a CG pixel scroll delta
+//   - Linux:   y is the number of XButton4/5 press-release pairs (1 = one
+//              wheel notch)
+//   - Windows: y is forwarded directly to MOUSEEVENTF_WHEEL's `mouseData`,
+//              where the unit is WHEEL_DELTA (= 120) per detent
+// Calling scrollMouse(0, 6) on Windows therefore sends `mouseData = 6` —
+// far below one detent — which gets silently accumulated and is frequently
+// discarded by Chromium's WheelEventQueue (Electron apps like Lark/Feishu
+// see this as "scroll did nothing"). Always emit one detent per call, and
+// pace the calls so blink doesn't coalesce them into a single tick.
+const LIBNUT_FALLBACK_PIXELS_PER_DETENT = 100;
+const LIBNUT_FALLBACK_TICK_DELAY_MS = 30;
+const LIBNUT_FALLBACK_MAX_DETENTS = 200;
+const LIBNUT_FALLBACK_DETENT_AMOUNT = process.platform === 'win32' ? 120 : 1;
+// Edge scrolls (scrollToTop / scrollToBottom / ...) must drive all the way to
+// the boundary on every backend. The phased path requests EDGE_SCROLL_TOTAL_PX
+// (50_000 px); the libnut fallback aims for the same distance, capped at
+// LIBNUT_FALLBACK_MAX_DETENTS so a misconfigured screen size can't wedge the
+// process. Chromium clamps wheel events at the boundary, so overshooting is
+// free. Exported for regression coverage.
+export const LIBNUT_FALLBACK_EDGE_DETENTS = Math.min(
+  LIBNUT_FALLBACK_MAX_DETENTS,
+  Math.max(
+    1,
+    Math.ceil(EDGE_SCROLL_TOTAL_PX / LIBNUT_FALLBACK_PIXELS_PER_DETENT),
+  ),
+);
 // Default scroll distance is 70% of the screen size on the relevant axis,
 // matching the web puppeteer/chrome-extension behavior so a model that simply
 // says "scroll down" without a distance gets a roughly one-screen scroll on
@@ -105,6 +134,9 @@ type EdgeScrollType =
 interface EdgeScrollStrategy {
   direction: ScrollDirection;
   key: 'home' | 'end';
+  // Unit vector for libnut.scrollMouse direction. Magnitude is applied
+  // separately by emitDetents() so each call is one full detent on every
+  // platform (see LIBNUT_FALLBACK_DETENT_AMOUNT).
   libnut: readonly [number, number];
 }
 
@@ -112,10 +144,10 @@ interface EdgeScrollStrategy {
 // only requires one entry here; the three backends (phased binary /
 // AppleScript / libnut) all read from the same spec.
 const EDGE_SCROLL_SPEC: Record<EdgeScrollType, EdgeScrollStrategy> = {
-  scrollToTop: { direction: 'up', key: 'home', libnut: [0, 10] },
-  scrollToBottom: { direction: 'down', key: 'end', libnut: [0, -10] },
-  scrollToLeft: { direction: 'left', key: 'home', libnut: [-10, 0] },
-  scrollToRight: { direction: 'right', key: 'end', libnut: [10, 0] },
+  scrollToTop: { direction: 'up', key: 'home', libnut: [0, 1] },
+  scrollToBottom: { direction: 'down', key: 'end', libnut: [0, -1] },
+  scrollToLeft: { direction: 'left', key: 'home', libnut: [-1, 0] },
+  scrollToRight: { direction: 'right', key: 'end', libnut: [1, 0] },
 };
 
 // macOS AppleScript key code mapping
@@ -1170,13 +1202,32 @@ Original error: ${lastRawMessage}`,
     this.inputDriver.sendKey(key, modifiers);
   }
 
-  private async performScroll(param: any): Promise<void> {
+  private async moveMouseToScrollTarget(
+    param: any,
+  ): Promise<Size | undefined> {
     if (param.locate) {
       const element = param.locate as LocateResultElement;
       const [x, y] = element.center;
       const point = this.toGlobalPoint({ x, y });
       this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
+      return undefined;
     }
+
+    // Wheel events are delivered to the window under the cursor. For an
+    // untargeted "scroll down", anchor the cursor in the viewport instead of
+    // relying on wherever the previous action left it.
+    const screenSize = await this.size();
+    const point = this.toGlobalPoint({
+      x: screenSize.width / 2,
+      y: screenSize.height / 2,
+    });
+    this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
+    await this.inputDriver.delay(MOUSE_MOVE_EFFECT_WAIT);
+    return screenSize;
+  }
+
+  private async performScroll(param: any): Promise<void> {
+    let screenSize = await this.moveMouseToScrollTarget(param);
 
     const scrollType = param?.scrollType;
 
@@ -1202,11 +1253,13 @@ Original error: ${lastRawMessage}`,
         return;
       }
 
-      const [dx, dy] = edgeSpec.libnut;
-      for (let i = 0; i < SCROLL_REPEAT_COUNT; i++) {
-        this.inputDriver.scrollMouse(dx, dy);
-        await this.inputDriver.delay(SCROLL_STEP_DELAY);
-      }
+      const [ux, uy] = edgeSpec.libnut;
+      await this.inputDriver.emitScrollDetents(
+        ux * LIBNUT_FALLBACK_DETENT_AMOUNT,
+        uy * LIBNUT_FALLBACK_DETENT_AMOUNT,
+        LIBNUT_FALLBACK_EDGE_DETENTS,
+        LIBNUT_FALLBACK_TICK_DELAY_MS,
+      );
       return;
     }
 
@@ -1220,9 +1273,8 @@ Original error: ${lastRawMessage}`,
       const isHorizontal = direction === 'left' || direction === 'right';
 
       let distance: number | undefined = param?.distance ?? undefined;
-      let screenSize: Size | undefined;
       if (!distance) {
-        screenSize = await this.size();
+        screenSize ??= await this.size();
         const base = isHorizontal ? screenSize.width : screenSize.height;
         distance = Math.max(
           1,
@@ -1253,16 +1305,23 @@ Original error: ${lastRawMessage}`,
         return;
       }
 
-      const ticks = Math.ceil(distance / 100);
-      const directionMap: Record<string, [number, number]> = {
-        up: [0, ticks],
-        down: [0, -ticks],
-        left: [-ticks, 0],
-        right: [ticks, 0],
+      const detents = Math.min(
+        LIBNUT_FALLBACK_MAX_DETENTS,
+        Math.max(1, Math.ceil(distance / LIBNUT_FALLBACK_PIXELS_PER_DETENT)),
+      );
+      const directionUnit: Record<string, [number, number]> = {
+        up: [0, 1],
+        down: [0, -1],
+        left: [-1, 0],
+        right: [1, 0],
       };
-
-      const [dx, dy] = directionMap[direction] || [0, -ticks];
-      this.inputDriver.scrollMouse(dx, dy);
+      const [ux, uy] = directionUnit[direction] || [0, -1];
+      await this.inputDriver.emitScrollDetents(
+        ux * LIBNUT_FALLBACK_DETENT_AMOUNT,
+        uy * LIBNUT_FALLBACK_DETENT_AMOUNT,
+        detents,
+        LIBNUT_FALLBACK_TICK_DELAY_MS,
+      );
       await this.inputDriver.delay(SCROLL_COMPLETE_DELAY);
       return;
     }

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1202,6 +1202,23 @@ Original error: ${lastRawMessage}`,
     this.inputDriver.sendKey(key, modifiers);
   }
 
+  private resolveUntargetedScrollPoint(screenSize: Size): Point {
+    if (process.platform === 'win32') {
+      const activeWindowRect = this.inputDriver.getActiveWindowRect();
+      if (activeWindowRect) {
+        return {
+          x: activeWindowRect.x + activeWindowRect.width / 2,
+          y: activeWindowRect.y + activeWindowRect.height / 2,
+        };
+      }
+    }
+
+    return this.toGlobalPoint({
+      x: screenSize.width / 2,
+      y: screenSize.height / 2,
+    });
+  }
+
   private async moveMouseToScrollTarget(param: any): Promise<Size | undefined> {
     if (param.locate) {
       const element = param.locate as LocateResultElement;
@@ -1212,13 +1229,13 @@ Original error: ${lastRawMessage}`,
     }
 
     // Wheel events are delivered to the window under the cursor. For an
-    // untargeted "scroll down", anchor the cursor in the viewport instead of
-    // relying on wherever the previous action left it.
+    // untargeted "scroll down", anchor the cursor in the active viewport
+    // instead of relying on wherever the previous action left it.
     const screenSize = await this.size();
-    const point = this.toGlobalPoint({
-      x: screenSize.width / 2,
-      y: screenSize.height / 2,
-    });
+    if (process.platform === 'win32' && this.inputDriver.focusActiveWindow()) {
+      await this.inputDriver.delay(CLICK_FOCUS_SETTLE_DELAY);
+    }
+    const point = this.resolveUntargetedScrollPoint(screenSize);
     this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
     await this.inputDriver.delay(MOUSE_MOVE_EFFECT_WAIT);
     return screenSize;

--- a/packages/computer/src/input-driver.ts
+++ b/packages/computer/src/input-driver.ts
@@ -78,6 +78,29 @@ export class ComputerInputDriver {
     this.getLibnutOrThrow('scrollMouse').scrollMouse(x, y);
   }
 
+  /**
+   * Emit one `libnut.scrollMouse` call per detent and pace them with
+   * `delayMs`. Per-call magnitude is fixed by the caller so each call is
+   * exactly one detent on the target platform — on Windows the libnut
+   * binding forwards `mouseData` straight to `MOUSEEVENTF_WHEEL`, where
+   * sub-WHEEL_DELTA values (< 120) get accumulated and frequently dropped
+   * by Chromium's WheelEventQueue.
+   */
+  async emitScrollDetents(
+    dx: number,
+    dy: number,
+    detents: number,
+    delayMs: number,
+  ): Promise<void> {
+    this.assertActive('emitScrollDetents');
+    for (let i = 0; i < detents; i++) {
+      this.scrollMouse(dx, dy);
+      if (i < detents - 1) {
+        await this.delay(delayMs);
+      }
+    }
+  }
+
   keyTap(key: string, modifiers?: string[]): void {
     const lib = this.getLibnutOrThrow('keyTap');
     // See note on mouseClick — avoid passing explicit undefined to libnut.

--- a/packages/computer/src/input-driver.ts
+++ b/packages/computer/src/input-driver.ts
@@ -10,10 +10,20 @@ export interface LibNut {
   scrollMouse(x: number, y: number): void;
   keyTap(key: string, modifiers?: string[]): void;
   typeString(text: string): void;
+  getActiveWindow?(): number;
+  getWindowRect?(handle: number): WindowRect;
+  focusWindow?(handle: number): void;
 }
 
 export type MouseButton = 'left' | 'right' | 'middle';
 export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+
+export interface WindowRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 interface ComputerInputDriverOptions {
   getLibnut(): LibNut | null;
@@ -54,6 +64,58 @@ export class ComputerInputDriver {
 
   moveMouse(x: number, y: number): void {
     this.getLibnutOrThrow('moveMouse').moveMouse(x, y);
+  }
+
+  focusActiveWindow(): boolean {
+    const lib = this.getLibnutOrThrow('focusActiveWindow');
+    if (
+      typeof lib.getActiveWindow !== 'function' ||
+      typeof lib.focusWindow !== 'function'
+    ) {
+      return false;
+    }
+
+    try {
+      const handle = lib.getActiveWindow();
+      if (!handle) return false;
+      lib.focusWindow(handle);
+      return true;
+    } catch (error) {
+      this.options.debug(`focusActiveWindow failed: ${error}`);
+      return false;
+    }
+  }
+
+  getActiveWindowRect(): WindowRect | null {
+    const lib = this.getLibnutOrThrow('getActiveWindowRect');
+    if (
+      typeof lib.getActiveWindow !== 'function' ||
+      typeof lib.getWindowRect !== 'function'
+    ) {
+      return null;
+    }
+
+    try {
+      const handle = lib.getActiveWindow();
+      if (!handle) return null;
+
+      const rect = lib.getWindowRect(handle);
+      if (
+        !Number.isFinite(rect.x) ||
+        !Number.isFinite(rect.y) ||
+        !Number.isFinite(rect.width) ||
+        !Number.isFinite(rect.height) ||
+        rect.width <= 0 ||
+        rect.height <= 0
+      ) {
+        return null;
+      }
+
+      return rect;
+    } catch (error) {
+      this.options.debug(`getActiveWindowRect failed: ${error}`);
+      return null;
+    }
   }
 
   mouseClick(button?: MouseButton, double?: boolean): void {

--- a/packages/computer/src/types/libnut.d.ts
+++ b/packages/computer/src/types/libnut.d.ts
@@ -9,6 +9,13 @@ declare module '@computer-use/libnut/dist/import_libnut.js' {
     y: number;
   }
 
+  interface Rect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
   type MouseButton = 'left' | 'right' | 'middle';
   type ToggleState = 'up' | 'down';
 
@@ -21,6 +28,9 @@ declare module '@computer-use/libnut/dist/import_libnut.js' {
     scrollMouse(x: number, y: number): void;
     keyTap(key: string, modifiers?: string[]): void;
     typeString(text: string): void;
+    getActiveWindow?(): number;
+    getWindowRect?(handle: number): Rect;
+    focusWindow?(handle: number): void;
   }
 
   export const libnut: LibNut;
@@ -37,6 +47,13 @@ declare module '@computer-use/libnut/dist/import_libnut' {
     y: number;
   }
 
+  interface Rect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
   type MouseButton = 'left' | 'right' | 'middle';
   type ToggleState = 'up' | 'down';
 
@@ -49,6 +66,9 @@ declare module '@computer-use/libnut/dist/import_libnut' {
     scrollMouse(x: number, y: number): void;
     keyTap(key: string, modifiers?: string[]): void;
     typeString(text: string): void;
+    getActiveWindow?(): number;
+    getWindowRect?(handle: number): Rect;
+    focusWindow?(handle: number): void;
   }
 
   export const libnut: LibNut;

--- a/packages/computer/tests/ai/chrome-extension-helpers.ts
+++ b/packages/computer/tests/ai/chrome-extension-helpers.ts
@@ -151,10 +151,40 @@ async function waitForCdpReady(
 
 // ─── Extension ID Reader ────────────────────────────────────────────────────
 
+// Read the extension id from the live CDP target list. The extension's
+// service worker registers as a `chrome-extension://<id>/...` target as soon
+// as it boots — typically well before Chrome flushes the id into the on-disk
+// Preferences file. Only one extension is loaded
+// (`--disable-extensions-except`), so any chrome-extension target is ours.
+async function readExtensionIdFromCdp(): Promise<string | null> {
+  try {
+    const targets = await listCdpTargets();
+    for (const t of targets) {
+      const match = t.url?.match(/^chrome-extension:\/\/([a-p]{32})\//);
+      if (
+        match &&
+        (t.type === 'service_worker' ||
+          t.type === 'background_page' ||
+          t.type === 'page')
+      ) {
+        return match[1];
+      }
+    }
+  } catch {
+    // CDP endpoint not up yet — caller will retry.
+  }
+  return null;
+}
+
 export async function readExtensionId(maxAttempts = 30): Promise<string> {
   const prefsPath = path.join(USER_DATA_DIR, 'Default', 'Preferences');
 
   for (let i = 0; i < maxAttempts; i++) {
+    // Preferences is the source of truth (lets us match by manifest name),
+    // but it is only flushed to disk periodically, so on a slow CI runner it
+    // can lag tens of seconds behind the extension actually loading. Try it
+    // first, then fall back to the CDP target list which reflects the live
+    // state immediately.
     if (fs.existsSync(prefsPath)) {
       try {
         const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
@@ -174,9 +204,13 @@ export async function readExtensionId(maxAttempts = 30): Promise<string> {
         // retry
       }
     }
-    console.log(
-      `Waiting for extension in Preferences (${i + 1}/${maxAttempts})...`,
-    );
+
+    const cdpId = await readExtensionIdFromCdp();
+    if (cdpId) {
+      return cdpId;
+    }
+
+    console.log(`Waiting for extension (${i + 1}/${maxAttempts})...`);
     await sleep(EXTENSION_POLL_INTERVAL);
   }
   throw new Error(

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -114,6 +114,15 @@ async function runPointerTap(
   await device.inputPrimitives.pointer!.tap(point, opts);
 }
 
+async function createConnectedDeviceForPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform });
+  const device = await createConnectedDevice();
+  mockState.libnut.moveMouse.mockClear();
+  mockState.libnut.mouseClick.mockClear();
+  mockState.libnut.scrollMouse.mockClear();
+  return device;
+}
+
 describe('ComputerDevice AppleScript security', () => {
   it('uses execFileSync to avoid shell interpolation when sending keys', async () => {
     const payload = `'; touch /tmp/midscene-shell-injection-proof; echo '`;
@@ -226,6 +235,21 @@ describe('ComputerInputDriver native arg handling', () => {
 
     driver.keyTap('a', ['command']);
     expect(mockState.libnut.keyTap).toHaveBeenLastCalledWith('a', ['command']);
+  });
+});
+
+describe('ComputerDevice scroll targeting', () => {
+  it('anchors untargeted libnut scrolls at screen center without clicking', async () => {
+    const device = await createConnectedDeviceForPlatform('win32');
+
+    await device.inputPrimitives.scroll!.scroll({
+      scrollType: 'singleAction',
+      direction: 'down',
+    });
+
+    expect(mockState.libnut.moveMouse).toHaveBeenCalledWith(400, 300);
+    expect(mockState.libnut.mouseClick).not.toHaveBeenCalled();
+    expect(mockState.libnut.scrollMouse).toHaveBeenCalled();
   });
 });
 

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -26,6 +26,9 @@ const mockState = vi.hoisted(() => {
     scrollMouse: vi.fn(),
     keyTap: vi.fn(),
     typeString: vi.fn(),
+    getActiveWindow: vi.fn(() => 0),
+    getWindowRect: vi.fn(),
+    focusWindow: vi.fn(),
   };
 
   const createRequire = vi.fn(() =>
@@ -48,6 +51,10 @@ const mockState = vi.hoisted(() => {
     libnut.scrollMouse.mockClear();
     libnut.keyTap.mockClear();
     libnut.typeString.mockClear();
+    libnut.getActiveWindow.mockClear();
+    libnut.getActiveWindow.mockReturnValue(0);
+    libnut.getWindowRect.mockClear();
+    libnut.focusWindow.mockClear();
     createRequire.mockClear();
   };
 
@@ -248,6 +255,29 @@ describe('ComputerDevice scroll targeting', () => {
     });
 
     expect(mockState.libnut.moveMouse).toHaveBeenCalledWith(400, 300);
+    expect(mockState.libnut.focusWindow).not.toHaveBeenCalled();
+    expect(mockState.libnut.mouseClick).not.toHaveBeenCalled();
+    expect(mockState.libnut.scrollMouse).toHaveBeenCalled();
+  });
+
+  it('focuses and anchors untargeted Windows scrolls at the active window center', async () => {
+    const device = await createConnectedDeviceForPlatform('win32');
+    mockState.libnut.getActiveWindow.mockReturnValue(123);
+    mockState.libnut.getWindowRect.mockReturnValue({
+      x: 40,
+      y: 80,
+      width: 360,
+      height: 500,
+    });
+
+    await device.inputPrimitives.scroll!.scroll({
+      scrollType: 'singleAction',
+      direction: 'down',
+    });
+
+    expect(mockState.libnut.getWindowRect).toHaveBeenCalledWith(123);
+    expect(mockState.libnut.focusWindow).toHaveBeenCalledWith(123);
+    expect(mockState.libnut.moveMouse).toHaveBeenCalledWith(220, 330);
     expect(mockState.libnut.mouseClick).not.toHaveBeenCalled();
     expect(mockState.libnut.scrollMouse).toHaveBeenCalled();
   });

--- a/packages/computer/tests/unit-test/input-driver-scroll.test.ts
+++ b/packages/computer/tests/unit-test/input-driver-scroll.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LIBNUT_FALLBACK_EDGE_DETENTS } from '../../src/device';
+import { ComputerInputDriver, type LibNut } from '../../src/input-driver';
+
+function makeDriver(scrollMouse = vi.fn()) {
+  const lib: LibNut = {
+    getScreenSize: () => ({ width: 1, height: 1 }),
+    getMousePos: () => ({ x: 0, y: 0 }),
+    moveMouse: vi.fn(),
+    mouseClick: vi.fn(),
+    mouseToggle: vi.fn(),
+    scrollMouse,
+    keyTap: vi.fn(),
+    typeString: vi.fn(),
+  };
+  const driver = new ComputerInputDriver({
+    getLibnut: () => lib,
+    useAppleScript: () => false,
+    sendKeyViaAppleScript: vi.fn(),
+    runPhasedScroll: vi.fn().mockReturnValue(false),
+    debug: vi.fn(),
+  });
+  return { driver, scrollMouse };
+}
+
+describe('ComputerInputDriver.emitScrollDetents', () => {
+  it('emits one libnut.scrollMouse call per detent', async () => {
+    const { driver, scrollMouse } = makeDriver();
+    await driver.emitScrollDetents(0, -120, 6, 0);
+    expect(scrollMouse).toHaveBeenCalledTimes(6);
+    for (const call of scrollMouse.mock.calls) {
+      expect(call).toEqual([0, -120]);
+    }
+  });
+
+  it('paces calls with the requested delay between them', async () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, scrollMouse } = makeDriver();
+      const promise = driver.emitScrollDetents(0, -120, 3, 50);
+
+      // First call fires synchronously before any delay.
+      expect(scrollMouse).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(scrollMouse).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(scrollMouse).toHaveBeenCalledTimes(3);
+
+      // No trailing delay after the last detent — the resolution scheduler
+      // still needs a microtask flush, but no further timer advance.
+      await promise;
+      expect(scrollMouse).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('passes through dx for horizontal scroll', async () => {
+    const { driver, scrollMouse } = makeDriver();
+    await driver.emitScrollDetents(120, 0, 2, 0);
+    expect(scrollMouse.mock.calls).toEqual([
+      [120, 0],
+      [120, 0],
+    ]);
+  });
+
+  it('edge-scroll fallback aims for the full boundary distance', () => {
+    // Regression: the first cut of this refactor wired edge scrolls to
+    // SCROLL_REPEAT_COUNT (10) detents, which at 100 px/detent is only
+    // ~1000 px — long pages stopped far short of the top/bottom. The
+    // libnut fallback has to target the same EDGE_SCROLL_TOTAL_PX
+    // (50_000 px) the phased path uses, capped at the per-platform
+    // safety ceiling so a bad screen size can't wedge the process.
+    expect(LIBNUT_FALLBACK_EDGE_DETENTS).toBeGreaterThanOrEqual(200);
+  });
+
+  it('rejects in-flight detents when the driver is destroyed mid-scroll', async () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, scrollMouse } = makeDriver();
+      const promise = driver.emitScrollDetents(0, -120, 5, 50);
+      // First call already happened.
+      expect(scrollMouse).toHaveBeenCalledTimes(1);
+      driver.destroy();
+      await expect(promise).rejects.toThrow(/destroyed/);
+      // No further calls after destroy().
+      await vi.advanceTimersByTimeAsync(500);
+      expect(scrollMouse).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Move the libnut-fallback per-detent loop into `ComputerInputDriver.emitScrollDetents` so scroll dispatch lives next to the rest of the input primitives.
- Emit exactly one platform-correct detent per `libnut.scrollMouse` call (120 on Windows = one `WHEEL_DELTA`, 1 elsewhere) and pace calls with `LIBNUT_FALLBACK_TICK_DELAY_MS` so blink doesn't coalesce them into a single tick.
- Add `input-driver-scroll.test.ts` covering per-call magnitude, pacing, horizontal pass-through, and destroy-mid-scroll rejection.

## Why

`libnut.scrollMouse(x, y)` is not a portable pixel API:

| Platform | `y` semantics |
|----------|---------------|
| macOS    | CG pixel scroll delta |
| Linux    | XButton4/5 press-release pairs (1 = one wheel notch) |
| Windows  | Forwarded directly to `MOUSEEVENTF_WHEEL`'s `mouseData`, where the unit is `WHEEL_DELTA` (= 120) per detent |

The old fallback computed `ticks = ceil(distance / 100)` and made a single `scrollMouse(0, ticks)` call. On Windows that sends `mouseData < 120` for any normal request — well below one detent — and Chromium's `WheelEventQueue` silently accumulates and drops it, which is exactly what we saw in Lark / Feishu Electron clients reporting "scroll did nothing". macOS still works because the `phased-scroll` helper takes the path; Linux happens to work because 1 detent ≈ 1 notch already.

Edge scrolls (`scrollToTop` etc.) had the same problem in the libnut path: the unit vector was hard-coded as `[0, 10]` etc. — fine on Linux as 10 notches, near-useless on Windows as `mouseData = 10`.

After this change, both the directional fallback and edge fallback go through `emitScrollDetents`, which fires `LIBNUT_FALLBACK_DETENT_AMOUNT` per call — `120` on Windows, `1` everywhere else — and the destroy-mid-scroll rejection wired into the pending-input-delay set keeps shutdown clean.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx test computer` — 53/53 passing, including 4 new tests in `input-driver-scroll.test.ts`
- [x] `npx nx build computer`
- [ ] Windows manual verification in Lark / Feishu Electron client (single scroll request now visibly moves the page)

## Related

- Pairs with #2574 (chmod self-heal). Both are scroll-reliability fixes in the libnut/phased-scroll path; this one is the Windows half.
- Supersedes branch `fix/computer-scroll-win-fallback` (commits `905124883`, `d020e1de4`) — those predated the `ComputerInputDriver` refactor on main; this PR is the rewrite.