### PR TITLE
feat(cli): add "midscene emit" command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "@midscene/core": "workspace:*",
     "@midscene/ios": "workspace:*",
     "@midscene/shared": "workspace:*",
+    "@midscene/testing-framework": "workspace:*",
     "@midscene/web": "workspace:*",
     "@rstest/core": "0.10.3",
     "http-server": "14.1.1",

--- a/packages/cli/src/emit-command.ts
+++ b/packages/cli/src/emit-command.ts
@@ -1,29 +1,83 @@
 import { emitRstestProject } from '@midscene/testing-framework';
+import { dependencies } from '../package.json';
 
 export interface EmitCommandDeps {
   emit: typeof emitRstestProject;
+  rstestVersion?: string;
 }
 
-const readFlag = (args: string[], name: string): string | undefined => {
-  const index = args.indexOf(name);
-  return index !== -1 && index + 1 < args.length ? args[index + 1] : undefined;
+interface ParsedEmitArgs {
+  outDir?: string;
+  configPath?: string;
+  error?: string;
+  help?: boolean;
+}
+
+const usage = 'Usage: midscene emit <out-dir> [--config <path>]';
+const help = `${usage}
+
+Options:
+  --config <path>  Path to the source midscene.config file
+  -h, --help       Show this help message`;
+
+const normalizePackageVersion = (
+  packageVersion: string | undefined,
+  fallbackVersion: string,
+): string => {
+  if (!packageVersion || packageVersion.startsWith('workspace:')) {
+    return fallbackVersion;
+  }
+  return packageVersion;
 };
 
-const firstPositional = (args: string[]): string | undefined => {
+const defaultRstestVersion = normalizePackageVersion(
+  dependencies['@rstest/core'],
+  'latest',
+);
+
+const parseEmitArgs = (args: string[]): ParsedEmitArgs => {
+  let outDir: string | undefined;
+  let configPath: string | undefined;
+
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg.startsWith('-')) {
-      // `--flag value` consumes the following token as its value, so skip it
-      // (but not `--flag=value`, which is self-contained).
-      const next = args[index + 1];
-      if (!arg.includes('=') && next !== undefined && !next.startsWith('-')) {
-        index += 1;
+
+    if (arg === '--help' || arg === '-h') {
+      return { help: true };
+    }
+
+    if (arg === '--config') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('-')) {
+        return { error: '--config requires a path value' };
       }
+      configPath = value;
+      index += 1;
       continue;
     }
-    return arg;
+
+    if (arg.startsWith('--config=')) {
+      const value = arg.slice('--config='.length);
+      if (!value) {
+        return { error: '--config requires a path value' };
+      }
+      configPath = value;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      return { error: `Unknown option: ${arg}` };
+    }
+
+    if (!outDir) {
+      outDir = arg;
+      continue;
+    }
+
+    return { error: `Unexpected argument: ${arg}` };
   }
-  return undefined;
+
+  return { outDir, configPath };
 };
 
 /**
@@ -36,15 +90,31 @@ export async function runEmitCommand(
   args: string[],
   deps: EmitCommandDeps = { emit: emitRstestProject },
 ): Promise<number> {
-  const outDir = firstPositional(args);
+  const {
+    outDir,
+    configPath,
+    error,
+    help: shouldShowHelp,
+  } = parseEmitArgs(args);
+  if (shouldShowHelp) {
+    console.log(help);
+    return 0;
+  }
+
+  if (error) {
+    console.error(`${error}\n${usage}`);
+    return 1;
+  }
+
   if (!outDir) {
-    console.error('Usage: midscene emit <out-dir> [--config <path>]');
+    console.error(usage);
     return 1;
   }
 
   const result = await deps.emit({
     outDir,
-    configPath: readFlag(args, '--config'),
+    configPath,
+    rstestVersion: deps.rstestVersion ?? defaultRstestVersion,
   });
   console.log(
     `Emitted native Rstest project to ${result.outDir} (${result.caseFiles.length} case(s))`,

--- a/packages/cli/src/emit-command.ts
+++ b/packages/cli/src/emit-command.ts
@@ -1,0 +1,53 @@
+import { emitRstestProject } from '@midscene/testing-framework';
+
+export interface EmitCommandDeps {
+  emit: typeof emitRstestProject;
+}
+
+const readFlag = (args: string[], name: string): string | undefined => {
+  const index = args.indexOf(name);
+  return index !== -1 && index + 1 < args.length ? args[index + 1] : undefined;
+};
+
+const firstPositional = (args: string[]): string | undefined => {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.startsWith('-')) {
+      // `--flag value` consumes the following token as its value, so skip it
+      // (but not `--flag=value`, which is self-contained).
+      const next = args[index + 1];
+      if (!arg.includes('=') && next !== undefined && !next.startsWith('-')) {
+        index += 1;
+      }
+      continue;
+    }
+    return arg;
+  }
+  return undefined;
+};
+
+/**
+ * `midscene emit <out-dir> [--config <path>]` — export a self-contained native
+ * Rstest project (`rstest.config.ts` + `e2e/*.test.ts` + `package.json`) from a
+ * `midscene.config.ts`. Thin CLI wrapper around `@midscene/testing-framework`'s
+ * `emitRstestProject`.
+ */
+export async function runEmitCommand(
+  args: string[],
+  deps: EmitCommandDeps = { emit: emitRstestProject },
+): Promise<number> {
+  const outDir = firstPositional(args);
+  if (!outDir) {
+    console.error('Usage: midscene emit <out-dir> [--config <path>]');
+    return 1;
+  }
+
+  const result = await deps.emit({
+    outDir,
+    configPath: readFlag(args, '--config'),
+  });
+  console.log(
+    `Emitted native Rstest project to ${result.outDir} (${result.caseFiles.length} case(s))`,
+  );
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import dotenv from 'dotenv';
 import { version } from '../package.json';
 import { matchYamlFiles, parseProcessArgs } from './cli-utils';
 import { createConfig, createFilesConfig } from './config-factory';
+import { runEmitCommand } from './emit-command';
 import { runFrameworkTestConfig } from './framework';
 
 Promise.resolve(
@@ -28,6 +29,12 @@ Promise.resolve(
         },
       );
       return;
+    }
+
+    if (firstArg === 'emit') {
+      console.log(`\nWelcome to @midscene/cli v${version}\n`);
+      const exitCode = await runEmitCommand(rawArgs.slice(1));
+      process.exit(exitCode);
     }
 
     const { options, path, files: cmdFiles } = await parseProcessArgs();

--- a/packages/cli/tests/unit-test/emit-command.test.ts
+++ b/packages/cli/tests/unit-test/emit-command.test.ts
@@ -1,0 +1,50 @@
+import type { EmitRstestProjectResult } from '@midscene/testing-framework';
+import { describe, expect, it, vi } from 'vitest';
+import { runEmitCommand } from '../../src/emit-command';
+
+const fakeResult = (
+  overrides: Partial<EmitRstestProjectResult> = {},
+): EmitRstestProjectResult => ({
+  outDir: '/abs/out',
+  configFile: '/abs/out/midscene.config.ts',
+  rstestConfigFile: '/abs/out/rstest.config.ts',
+  packageJsonFile: '/abs/out/package.json',
+  caseFiles: ['/abs/out/e2e/a.test.ts'],
+  yamlFiles: ['/abs/out/e2e/a.yaml'],
+  userTestFiles: [],
+  ...overrides,
+});
+
+describe('runEmitCommand', () => {
+  it('returns 1 and does not emit when the out-dir is missing', async () => {
+    const emit = vi.fn();
+    const code = await runEmitCommand(['--config', './midscene.config.ts'], {
+      emit,
+    });
+    expect(code).toBe(1);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('emits to the positional out-dir with the --config path', async () => {
+    const emit = vi.fn(async () => fakeResult());
+    const code = await runEmitCommand(
+      ['./out', '--config', './midscene.config.ts'],
+      { emit },
+    );
+    expect(code).toBe(0);
+    expect(emit).toHaveBeenCalledWith({
+      outDir: './out',
+      configPath: './midscene.config.ts',
+    });
+  });
+
+  it('defaults configPath to undefined when --config is omitted', async () => {
+    const emit = vi.fn(async () => fakeResult({ caseFiles: [] }));
+    const code = await runEmitCommand(['./out'], { emit });
+    expect(code).toBe(0);
+    expect(emit).toHaveBeenCalledWith({
+      outDir: './out',
+      configPath: undefined,
+    });
+  });
+});

--- a/packages/cli/tests/unit-test/emit-command.test.ts
+++ b/packages/cli/tests/unit-test/emit-command.test.ts
@@ -1,5 +1,6 @@
 import type { EmitRstestProjectResult } from '@midscene/testing-framework';
 import { describe, expect, it, vi } from 'vitest';
+import { dependencies } from '../../package.json';
 import { runEmitCommand } from '../../src/emit-command';
 
 const fakeResult = (
@@ -15,7 +16,18 @@ const fakeResult = (
   ...overrides,
 });
 
+const emitVersions = {
+  rstestVersion: '0.10.3',
+};
+
 describe('runEmitCommand', () => {
+  it('returns 0 and does not emit when help is requested', async () => {
+    const emit = vi.fn();
+    const code = await runEmitCommand(['--help'], { emit });
+    expect(code).toBe(0);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
   it('returns 1 and does not emit when the out-dir is missing', async () => {
     const emit = vi.fn();
     const code = await runEmitCommand(['--config', './midscene.config.ts'], {
@@ -29,22 +41,70 @@ describe('runEmitCommand', () => {
     const emit = vi.fn(async () => fakeResult());
     const code = await runEmitCommand(
       ['./out', '--config', './midscene.config.ts'],
-      { emit },
+      { emit, ...emitVersions },
     );
     expect(code).toBe(0);
     expect(emit).toHaveBeenCalledWith({
       outDir: './out',
       configPath: './midscene.config.ts',
+      ...emitVersions,
     });
+  });
+
+  it('supports --config=<path>', async () => {
+    const emit = vi.fn(async () => fakeResult());
+    const code = await runEmitCommand(
+      ['./out', '--config=./midscene.config.ts'],
+      { emit, ...emitVersions },
+    );
+    expect(code).toBe(0);
+    expect(emit).toHaveBeenCalledWith({
+      outDir: './out',
+      configPath: './midscene.config.ts',
+      ...emitVersions,
+    });
+  });
+
+  it('returns 1 and does not emit when --config is missing a value', async () => {
+    const emit = vi.fn();
+    const code = await runEmitCommand(['./out', '--config'], { emit });
+    expect(code).toBe(1);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 and does not emit when --config= is empty', async () => {
+    const emit = vi.fn();
+    const code = await runEmitCommand(['./out', '--config='], { emit });
+    expect(code).toBe(1);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 and does not emit unknown options', async () => {
+    const emit = vi.fn();
+    const code = await runEmitCommand(['./out', '--unknown'], { emit });
+    expect(code).toBe(1);
+    expect(emit).not.toHaveBeenCalled();
   });
 
   it('defaults configPath to undefined when --config is omitted', async () => {
     const emit = vi.fn(async () => fakeResult({ caseFiles: [] }));
+    const code = await runEmitCommand(['./out'], { emit, ...emitVersions });
+    expect(code).toBe(0);
+    expect(emit).toHaveBeenCalledWith({
+      outDir: './out',
+      configPath: undefined,
+      ...emitVersions,
+    });
+  });
+
+  it('pins the emitted Rstest version from CLI package metadata by default', async () => {
+    const emit = vi.fn(async () => fakeResult());
     const code = await runEmitCommand(['./out'], { emit });
     expect(code).toBe(0);
     expect(emit).toHaveBeenCalledWith({
       outDir: './out',
       configPath: undefined,
+      rstestVersion: dependencies['@rstest/core'],
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,6 +816,9 @@ importers:
       '@midscene/shared':
         specifier: workspace:*
         version: link:../shared
+      '@midscene/testing-framework':
+        specifier: workspace:*
+        version: link:../testing-framework
       '@midscene/web':
         specifier: workspace:*
         version: link:../web-integration


### PR DESCRIPTION
Stacked on #2582 (base = `codex/testing-framework-native-rstest`).

## What
Adds the doc-facing `midscene emit <out-dir> [--config <path>]` command to `@midscene/cli`, exporting a self-contained native Rstest project (`rstest.config.ts` + `e2e/*.test.ts` + `package.json`) from a `midscene.config.ts`.

## How
- Thin dispatch branch in the CLI entry (next to `report-tool`) → `runEmitCommand`, a small wrapper over `@midscene/testing-framework`'s `emitRstestProject` (injectable for tests).
- Adds `@midscene/testing-framework` as a `@midscene/cli` dependency. Direction is **cli → testing-framework** (testing-framework stays self-contained and never imports the CLI), so there is no dependency cycle.

## Validation
- New unit tests for arg parsing (`tests/unit-test/emit-command.test.ts`): missing out-dir → exit 1; positional out-dir + `--config` forwarded; `--config` value is not mistaken for the out-dir.
- `npx nx test cli`, `npx nx build cli`, `pnpm run lint` all pass.
- End-to-end: `node packages/cli/bin/midscene emit ./out --config ./midscene.config.ts` emits `midscene.config.ts` + `e2e/*.{yaml,test.ts}` + `rstest.config.ts` + `package.json`.

Draft — review after #2582.