### PR TITLE
refactor(shared): share the in-process Rstest runner between cli + testing-framework

### DIFF
--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
-import type { RstestUserConfig, TestRunResult } from '@rstest/core/api';
+import { runRstestWithVirtualModules } from '@midscene/shared/rstest';
+import type { TestRunResult } from '@rstest/core/api';
 import type { GeneratedRstestYamlProject } from './rstest-project';
 
 export interface RunRstestYamlProjectOptions {
@@ -36,43 +36,27 @@ const formatRunError = (
 export async function runRstestYamlProject(
   options: RunRstestYamlProjectOptions,
 ): Promise<number> {
-  const [{ runRstest }, { rspack }] = await Promise.all([
-    import('@rstest/core/api'),
-    import(pathToFileURL(resolvePackageFromRstestCore('@rsbuild/core')).href),
-  ]);
   const { project } = options;
-  const maxConcurrency =
-    project.maxConcurrency !== undefined
-      ? Math.max(1, project.maxConcurrency)
-      : undefined;
-  const inlineConfig: RstestUserConfig = {
+  // The CLI bundles its own `@rstest/core`, so `@rsbuild/core` is resolved
+  // relative to it. The actual `runRstest` wiring is shared with
+  // `@midscene/testing-framework` via `@midscene/shared/rstest`.
+  const result = await runRstestWithVirtualModules({
+    cwd: options.cwd || project.projectDir,
     root: project.projectDir,
     include: project.include,
-    testEnvironment: 'node',
+    virtualModules: project.virtualModules,
+    rsbuildEntry: resolvePackageFromRstestCore('@rsbuild/core'),
     testTimeout: project.testTimeout,
-    ...(maxConcurrency !== undefined ? { maxConcurrency } : {}),
-    ...(maxConcurrency !== undefined
-      ? { pool: { maxWorkers: maxConcurrency, minWorkers: maxConcurrency } }
-      : {}),
-    ...(project.bail !== undefined ? { bail: project.bail } : {}),
+    maxConcurrency: project.maxConcurrency,
+    bail: project.bail,
     reporters: [],
-    tools: {
-      rspack: (_config, { appendPlugins }) => {
-        appendPlugins(
-          new rspack.experiments.VirtualModulesPlugin(project.virtualModules),
-        );
-      },
-    },
-  };
-
-  const result = await runRstest({
-    cwd: options.cwd || project.projectDir,
-    inlineConfig,
   });
 
-  if (!result.ok && options.stdio !== 'pipe' && result.unhandledErrors.length) {
+  const unhandledErrors = (result.unhandledErrors ??
+    []) as TestRunResult['unhandledErrors'];
+  if (!result.ok && options.stdio !== 'pipe' && unhandledErrors.length) {
     console.error(
-      result.unhandledErrors.map((error) => formatRunError(error)).join('\n'),
+      unhandledErrors.map((error) => formatRunError(error)).join('\n'),
     );
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -72,6 +72,11 @@
       "import": "./dist/es/logger.mjs",
       "require": "./dist/lib/logger.js"
     },
+    "./rstest": {
+      "types": "./dist/types/rstest.d.ts",
+      "import": "./dist/es/rstest.mjs",
+      "require": "./dist/lib/rstest.js"
+    },
     "./*": {
       "types": "./dist/types/*.d.ts",
       "import": "./dist/es/*.mjs",
@@ -103,6 +108,7 @@
   },
   "devDependencies": {
     "@rslib/core": "^0.18.3",
+    "@rstest/core": "0.10.3",
     "@types/debug": "4.1.12",
     "@types/express": "^4.17.21",
     "@types/node": "^18.0.0",

--- a/packages/shared/src/rstest.ts
+++ b/packages/shared/src/rstest.ts
@@ -1,0 +1,116 @@
+import { pathToFileURL } from 'node:url';
+
+/**
+ * The slice of `@rsbuild/core` the helper needs. Loosely typed so
+ * `@midscene/shared` does not take a hard dependency on `@rstest/core` /
+ * `@rsbuild/core` (both are resolved at runtime by the caller).
+ */
+export interface RsbuildLike {
+  rspack: {
+    experiments: {
+      VirtualModulesPlugin: new (modules: Record<string, string>) => unknown;
+    };
+  };
+}
+
+export interface RstestRunResultLike {
+  ok?: boolean;
+  [key: string]: unknown;
+}
+
+export interface RunRstestWithVirtualModulesOptions {
+  /** Working directory passed to Rstest. */
+  cwd: string;
+  /** Project root. */
+  root: string;
+  /** Rstest `include` entries (typically the virtual module ids). */
+  include: string[];
+  /** Virtual test modules to register with the bundler. */
+  virtualModules: Record<string, string>;
+  /**
+   * Absolute path to the `@rsbuild/core` entry. The caller resolves it from the
+   * right base — the user project for `@midscene/testing-framework`, the bundled
+   * copy for `@midscene/cli` — so this helper stays free of a hard
+   * `@rstest/core` / `@rsbuild/core` dependency.
+   */
+  rsbuildEntry: string;
+  testTimeout?: number;
+  maxConcurrency?: number;
+  bail?: number;
+  reporters?: unknown[];
+}
+
+/**
+ * Build the Rstest `inlineConfig` that registers `virtualModules` as test files
+ * through `@rsbuild/core`'s `VirtualModulesPlugin`. Pure (no I/O) so it can be
+ * unit tested directly; {@link runRstestWithVirtualModules} wires it to the real
+ * `runRstest`.
+ */
+export function buildRstestInlineConfig(
+  options: RunRstestWithVirtualModulesOptions,
+  rsbuild: RsbuildLike,
+): Record<string, unknown> {
+  const maxConcurrency =
+    options.maxConcurrency !== undefined
+      ? Math.max(1, options.maxConcurrency)
+      : undefined;
+
+  return {
+    root: options.root,
+    include: options.include,
+    testEnvironment: 'node',
+    ...(options.testTimeout !== undefined
+      ? { testTimeout: options.testTimeout }
+      : {}),
+    ...(maxConcurrency !== undefined
+      ? {
+          maxConcurrency,
+          pool: { maxWorkers: maxConcurrency, minWorkers: maxConcurrency },
+        }
+      : {}),
+    ...(options.bail !== undefined ? { bail: options.bail } : {}),
+    ...(options.reporters !== undefined
+      ? { reporters: options.reporters }
+      : {}),
+    tools: {
+      rspack: (
+        _config: unknown,
+        { appendPlugins }: { appendPlugins: (plugin: unknown) => void },
+      ) => {
+        appendPlugins(
+          new rsbuild.rspack.experiments.VirtualModulesPlugin(
+            options.virtualModules,
+          ),
+        );
+      },
+    },
+  };
+}
+
+/**
+ * Run an in-process Rstest pass whose test files are supplied as virtual
+ * modules. Shared by `@midscene/cli` and `@midscene/testing-framework`: each
+ * resolves `@rstest/core` + `@rsbuild/core` from its own base and passes the
+ * resolved `@rsbuild/core` entry path in.
+ */
+export async function runRstestWithVirtualModules(
+  options: RunRstestWithVirtualModulesOptions,
+): Promise<RstestRunResultLike> {
+  // `@rstest/core` is a dev-only dependency here (types); at runtime it resolves
+  // from the caller's context — the CLI's bundled copy or the user project's
+  // peer dependency — never from `@midscene/shared` itself.
+  const [rstestApi, rsbuild] = await Promise.all([
+    import('@rstest/core/api') as Promise<{
+      runRstest: (args: {
+        cwd: string;
+        inlineConfig: Record<string, unknown>;
+      }) => Promise<RstestRunResultLike>;
+    }>,
+    import(pathToFileURL(options.rsbuildEntry).href) as Promise<RsbuildLike>,
+  ]);
+
+  return rstestApi.runRstest({
+    cwd: options.cwd,
+    inlineConfig: buildRstestInlineConfig(options, rsbuild),
+  });
+}

--- a/packages/shared/tests/unit-test/rstest.test.ts
+++ b/packages/shared/tests/unit-test/rstest.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type RsbuildLike,
+  type RunRstestWithVirtualModulesOptions,
+  buildRstestInlineConfig,
+} from '../../src/rstest';
+
+const createFakeRsbuild = () => {
+  const created: Record<string, string>[] = [];
+  const rsbuild: RsbuildLike = {
+    rspack: {
+      experiments: {
+        VirtualModulesPlugin: class {
+          constructor(modules: Record<string, string>) {
+            created.push(modules);
+          }
+        },
+      },
+    },
+  };
+  return { rsbuild, created };
+};
+
+const base: RunRstestWithVirtualModulesOptions = {
+  cwd: '/proj',
+  root: '/proj',
+  include: ['virtual:a.test.ts'],
+  virtualModules: { 'virtual:a.test.ts': 'export {};' },
+  rsbuildEntry: '/proj/node_modules/@rsbuild/core',
+};
+
+describe('buildRstestInlineConfig', () => {
+  it('registers the virtual modules via VirtualModulesPlugin under a node env', () => {
+    const { rsbuild, created } = createFakeRsbuild();
+    const config = buildRstestInlineConfig(base, rsbuild);
+
+    expect(config.testEnvironment).toBe('node');
+    expect(config.include).toEqual(['virtual:a.test.ts']);
+
+    const appended: unknown[] = [];
+    (
+      config.tools as {
+        rspack: (
+          c: unknown,
+          h: { appendPlugins: (p: unknown) => void },
+        ) => void;
+      }
+    ).rspack({}, { appendPlugins: (p) => appended.push(p) });
+
+    expect(appended).toHaveLength(1);
+    expect(created).toEqual([{ 'virtual:a.test.ts': 'export {};' }]);
+  });
+
+  it('omits optional run-level keys when unset', () => {
+    const { rsbuild } = createFakeRsbuild();
+    const config = buildRstestInlineConfig(base, rsbuild);
+    for (const key of [
+      'testTimeout',
+      'maxConcurrency',
+      'pool',
+      'bail',
+      'reporters',
+    ]) {
+      expect(key in config).toBe(false);
+    }
+  });
+
+  it('maps maxConcurrency to a single-sized pool and forwards run-level options', () => {
+    const { rsbuild } = createFakeRsbuild();
+    const config = buildRstestInlineConfig(
+      { ...base, testTimeout: 0, maxConcurrency: 2, bail: 1, reporters: [] },
+      rsbuild,
+    );
+    expect(config.testTimeout).toBe(0);
+    expect(config.maxConcurrency).toBe(2);
+    expect(config.pool).toEqual({ maxWorkers: 2, minWorkers: 2 });
+    expect(config.bail).toBe(1);
+    expect(config.reporters).toEqual([]);
+  });
+});

--- a/packages/testing-framework/src/runner.ts
+++ b/packages/testing-framework/src/runner.ts
@@ -1,8 +1,7 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
-import type { RstestUserConfig } from '@rstest/core/api';
+import { runRstestWithVirtualModules } from '@midscene/shared/rstest';
 import { resolveMidsceneConfigPath } from './config';
 import { SUITE_SUMMARY_FILENAME, emptySuiteSummary } from './result';
 import { createBootstrapModuleSource } from './runtime/source';
@@ -39,39 +38,29 @@ export interface RunMidsceneTestOptions {
 }
 
 /**
- * Default in-process Rstest driver. Unlike the previous forked worker, this
- * runs `runRstest` directly in the current process: the runner never imports
- * the user's `midscene.config` (only the Rstest worker that loads the bootstrap
- * module does), so the Playwright `@vitest/expect` global never collides with
- * Rstest's own copy. `@rsbuild/core` is resolved relative to `@rstest/core` so
- * the `VirtualModulesPlugin` matches the bundler Rstest actually uses.
+ * Default in-process Rstest driver. It runs `runRstest` directly in the current
+ * process: the runner never imports the user's `midscene.config` (only the
+ * Rstest worker that loads the bootstrap module does), so the Playwright
+ * `@vitest/expect` global never collides with Rstest's own copy. `@rsbuild/core`
+ * is resolved relative to the *project's* `@rstest/core` (a peer dependency) so
+ * the `VirtualModulesPlugin` matches the bundler Rstest actually uses. The
+ * `runRstest` wiring itself is shared with `@midscene/cli` via
+ * `@midscene/shared/rstest`.
  */
 const defaultBootstrapRunner: FrameworkBootstrapRunner = async (project) => {
   const projectRequire = createRequire(resolve(project.root, 'package.json'));
   const rstestPkgJson = projectRequire.resolve('@rstest/core/package.json');
   const rsbuildEntry = createRequire(rstestPkgJson).resolve('@rsbuild/core');
 
-  const [{ runRstest }, { rspack }] = await Promise.all([
-    import('@rstest/core/api'),
-    import(pathToFileURL(rsbuildEntry).href),
-  ]);
-
-  const inlineConfig: RstestUserConfig = {
+  const result = await runRstestWithVirtualModules({
+    cwd: project.root,
     root: project.root,
     include: project.include,
-    testEnvironment: 'node',
+    virtualModules: project.virtualModules,
+    rsbuildEntry,
     testTimeout: 0,
-    pool: { maxWorkers: 1, minWorkers: 1 },
-    tools: {
-      rspack: (_config, { appendPlugins }) => {
-        appendPlugins(
-          new rspack.experiments.VirtualModulesPlugin(project.virtualModules),
-        );
-      },
-    },
-  };
-
-  const result = await runRstest({ cwd: project.root, inlineConfig });
+    maxConcurrency: 1,
+  });
 
   return { ok: Boolean(result?.ok) };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,6 +1591,9 @@ importers:
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.62))(typescript@5.8.3)
+      '@rstest/core':
+        specifier: 0.10.3
+        version: 0.10.3(core-js@3.47.0)(jsdom@29.0.2)
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -2353,19 +2356,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':


### PR DESCRIPTION
Stacked on #2582 (base = `codex/testing-framework-native-rstest`).

## What
`@midscene/cli` (`runRstestYamlProject`) and `@midscene/testing-framework` (`defaultBootstrapRunner`) had the same ~15-line kernel: build an Rstest `inlineConfig` that registers virtual test modules via `@rsbuild/core`'s `VirtualModulesPlugin`, then call `runRstest`. This extracts that kernel to **`@midscene/shared/rstest`** and points both at it.

- `buildRstestInlineConfig(options, rsbuild)` — pure, unit-tested config builder.
- `runRstestWithVirtualModules(options)` — resolves `@rstest/core/api` at runtime + calls `runRstest`.

## Why it's safe (no cycle, no new runtime dep)
- `@midscene/shared` is already a dependency of both packages, so there's no cycle.
- Each caller keeps its **own** resolution strategy and passes the resolved `@rsbuild/core` entry in: the framework resolves from the **user project** (`@rstest/core` peer dep), the CLI from its **bundled** copy. So `@midscene/shared` only needs `@rstest/core` as a **dev-only** dependency (types) — it never ships a runtime dependency on it; at runtime the module resolves from the caller's context.

## Validation
- `nx build shared|testing-framework|cli` all pass; `check-dependency-version` clean; `pnpm lint` clean.
- New `packages/shared/tests/unit-test/rstest.test.ts` (3 tests) for the pure builder.
- `testing-framework` 58 unit tests pass; all `cli` framework tests pass — including the `reporters: []` assertion and the real `runRstest` virtual-module runs now routed through the shared helper.

Draft — review after #2582.