### PR TITLE
feat(cli): support harmony target in yaml scripts

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -41,7 +41,7 @@ To execute YAML workflows from the command line, install the Midscene CLI. See [
 
 Script files use YAML format to describe automation tasks. It defines the target to be manipulated (like a webpage or an Android app) and the series of steps to perform.
 
-A standard `.yaml` script file includes a `web`, `android`, `ios`, or `computer` section to configure the environment, an optional `agent` section to configure AI agent behavior, and a `tasks` section to define the automation tasks.
+A standard `.yaml` script file includes a `web`, `android`, `ios`, `harmony`, or `computer` section to configure the environment, an optional `agent` section to configure AI agent behavior, and a `tasks` section to define the automation tasks.
 
 ```yaml
 web:
@@ -399,6 +399,79 @@ tasks:
   - name: Terminate Settings app
     flow:
       - terminate: com.apple.Preferences
+```
+
+### The `harmony` part
+
+The `harmony` section is used for HarmonyOS device automation via HDC. The device is connected with `hdc`, so make sure `hdc list targets` reports your device before running.
+
+```yaml
+harmony:
+  # The HarmonyOS device ID to connect to, optional, defaults to the first connected device.
+  deviceId: <device-id>
+
+  # The app to launch, optional, defaults to the device's current screen.
+  launch: <bundle-name>
+
+  # The path to the HDC executable, optional.
+  hdcPath: <path-to-hdc>
+
+  # Whether to auto dismiss keyboard after input, optional, defaults to false.
+  autoDismissKeyboard: <boolean>
+
+  # Custom mapping of app names to bundle names, optional. User-provided mappings take precedence over defaults.
+  appNameMapping:
+    <app-name>: <bundle-name>
+
+  # The path to the JSON file for outputting aiQuery/aiAssert results, optional.
+  output: <path-to-output-file>
+
+  # All other options supported by the HarmonyDevice constructor
+```
+
+#### HarmonyOS Platform-Specific Actions
+
+**`launch` - Launch App**
+
+Launch a HarmonyOS app by its bundle name.
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: Launch app
+    flow:
+      - launch: com.example.app
+```
+
+**`terminate` - Terminate App**
+
+Terminate (force-stop) a running HarmonyOS app by bundle name or mapped app name.
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: Terminate app
+    flow:
+      - terminate: com.example.app
+```
+
+**`runHdcShell` - Execute HDC Shell Command**
+
+Execute an HDC shell command on the HarmonyOS device.
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: Dump window info
+    flow:
+      - runHdcShell:
+          command: 'hidumper -s WindowManagerService -a'
 ```
 
 ### The `computer` part

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -41,7 +41,7 @@ tasks:
 
 脚本文件使用 YAML 格式来描述自动化任务。它定义了要操作的目标（如网页或安卓应用）以及一系列要执行的步骤。
 
-一个标准的 `.yaml` 脚本文件包含 `web`、`android`、`ios` 或 `computer` 部分配置环境，可选的 `agent` 部分配置 AI Agent 行为，以及一个 `tasks` 部分来定义自动化任务。
+一个标准的 `.yaml` 脚本文件包含 `web`、`android`、`ios`、`harmony` 或 `computer` 部分配置环境,可选的 `agent` 部分配置 AI Agent 行为,以及一个 `tasks` 部分来定义自动化任务。
 
 ```yaml
 web:
@@ -403,6 +403,79 @@ tasks:
   - name: 终止设置应用
     flow:
       - terminate: com.apple.Preferences
+```
+
+### `harmony` 部分
+
+`harmony` 部分用于通过 HDC 进行 HarmonyOS 设备自动化。设备通过 `hdc` 连接,运行前请先确认 `hdc list targets` 能列出你的设备。
+
+```yaml
+harmony:
+  # 要连接的 HarmonyOS 设备 ID,可选,默认使用第一个已连接的设备。
+  deviceId: <device-id>
+
+  # 要启动的应用,可选,默认使用设备当前屏幕。
+  launch: <bundle-name>
+
+  # HDC 可执行文件路径,可选。
+  hdcPath: <path-to-hdc>
+
+  # 输入完成后是否自动收起键盘,可选,默认为 false。
+  autoDismissKeyboard: <boolean>
+
+  # 应用名到 Bundle 名的自定义映射,可选。用户提供的映射优先级高于默认映射。
+  appNameMapping:
+    <app-name>: <bundle-name>
+
+  # 用于输出 aiQuery/aiAssert 结果的 JSON 文件路径,可选。
+  output: <path-to-output-file>
+
+  # HarmonyDevice 构造函数支持的其他所有选项
+```
+
+#### HarmonyOS 平台专属动作
+
+**`launch` - 启动应用**
+
+通过 Bundle 名启动 HarmonyOS 应用。
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: 启动应用
+    flow:
+      - launch: com.example.app
+```
+
+**`terminate` - 终止应用**
+
+通过 Bundle 名或映射的应用名终止(强制停止)正在运行的 HarmonyOS 应用。
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: 终止应用
+    flow:
+      - terminate: com.example.app
+```
+
+**`runHdcShell` - 执行 HDC Shell 命令**
+
+在 HarmonyOS 设备上执行 HDC shell 命令。
+
+```yaml
+harmony:
+  deviceId: 'test-device'
+
+tasks:
+  - name: 导出窗口信息
+    flow:
+      - runHdcShell:
+          command: 'hidumper -s WindowManagerService -a'
 ```
 
 ### `computer` 部分

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "@midscene/android": "workspace:*",
     "@midscene/computer": "workspace:*",
     "@midscene/core": "workspace:*",
+    "@midscene/harmony": "workspace:*",
     "@midscene/ios": "workspace:*",
     "@midscene/shared": "workspace:*",
     "@midscene/web": "workspace:*",

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -340,6 +340,31 @@ export async function createYamlPlayer(
         return { agent, freeFn };
       }
 
+      // handle harmony
+      if (typeof clonedYamlScript.harmony !== 'undefined') {
+        const harmonyTarget = clonedYamlScript.harmony;
+        const { agentFromHdcDevice } = await import('@midscene/harmony');
+        const agent = await agentFromHdcDevice(harmonyTarget?.deviceId, {
+          ...harmonyTarget, // Pass all HarmonyOS config options
+          ...buildAgentOptions(
+            clonedYamlScript.agent,
+            preference.reportFileName,
+            fileName,
+          ),
+        });
+
+        if (harmonyTarget?.launch) {
+          await agent.launch(harmonyTarget.launch);
+        }
+
+        freeFn.push({
+          name: 'destroy_harmony_agent',
+          fn: () => agent.destroy(),
+        });
+
+        return { agent, freeFn };
+      }
+
       // handle computer
       if (typeof clonedYamlScript.computer !== 'undefined') {
         const computerTarget = clonedYamlScript.computer;
@@ -424,7 +449,7 @@ export async function createYamlPlayer(
       }
 
       throw new Error(
-        'No valid interface configuration found in the yaml script, should be either "web", "android", "ios", "computer", or "interface"',
+        'No valid interface configuration found in the yaml script, should be either "web", "android", "ios", "harmony", "computer", or "interface"',
       );
     },
     undefined,

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -114,6 +114,7 @@ export async function createYamlPlayer(
         typeof webTarget !== 'undefined',
         typeof clonedYamlScript.android !== 'undefined',
         typeof clonedYamlScript.ios !== 'undefined',
+        typeof clonedYamlScript.harmony !== 'undefined',
         typeof clonedYamlScript.computer !== 'undefined',
         typeof clonedYamlScript.interface !== 'undefined',
       ].filter(Boolean).length;
@@ -123,6 +124,7 @@ export async function createYamlPlayer(
           typeof webTarget !== 'undefined' ? 'web' : null,
           typeof clonedYamlScript.android !== 'undefined' ? 'android' : null,
           typeof clonedYamlScript.ios !== 'undefined' ? 'ios' : null,
+          typeof clonedYamlScript.harmony !== 'undefined' ? 'harmony' : null,
           typeof clonedYamlScript.computer !== 'undefined' ? 'computer' : null,
           typeof clonedYamlScript.interface !== 'undefined'
             ? 'interface'
@@ -130,7 +132,7 @@ export async function createYamlPlayer(
         ].filter(Boolean);
 
         throw new Error(
-          `Only one target type can be specified, but found multiple: ${specifiedTargets.join(', ')}. Please specify only one of: web, android, ios, computer, or interface.`,
+          `Only one target type can be specified, but found multiple: ${specifiedTargets.join(', ')}. Please specify only one of: web, android, ios, harmony, computer, or interface.`,
         );
       }
 

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -1448,5 +1448,32 @@ describe('create-yaml-player', () => {
         'cdpEndpoint and bridgeMode are mutually exclusive',
       );
     });
+
+    test('should throw when harmony is combined with another target', async () => {
+      const mockScript: MidsceneYamlScript = {
+        web: { url: 'http://example.com' },
+        harmony: { deviceId: 'harmony-device-1' },
+        tasks: [],
+      };
+
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(readFileSync).mockReturnValue('mock yaml content');
+      vi.mocked(parseYamlScript).mockReturnValue(mockScript);
+
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+
+      // The setup function should reject because two targets are specified
+      await expect(setupFnCallback!()).rejects.toThrow(
+        /Only one target type can be specified, but found multiple: web, harmony/,
+      );
+    });
   });
 });

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -39,6 +39,10 @@ vi.mock('@midscene/ios', () => ({
   agentFromWebDriverAgent: vi.fn(),
 }));
 
+vi.mock('@midscene/harmony', () => ({
+  agentFromHdcDevice: vi.fn(),
+}));
+
 vi.mock('@midscene/web/bridge-mode', () => ({
   AgentOverChromeBridge: vi.fn(),
 }));
@@ -61,6 +65,7 @@ vi.mock('puppeteer', () => ({
 import { agentFromAdbDevice } from '@midscene/android';
 import { getReportFileName } from '@midscene/core/agent';
 import { ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
+import { agentFromHdcDevice } from '@midscene/harmony';
 import { agentFromWebDriverAgent } from '@midscene/ios';
 import { globalConfigManager } from '@midscene/shared/env';
 import { AgentOverChromeBridge } from '@midscene/web/bridge-mode';
@@ -533,6 +538,88 @@ describe('create-yaml-player', () => {
           launch: mockIOSOptions.launch,
         }),
       );
+    });
+
+    test('should pass all HarmonyOS device options from YAML to agentFromHdcDevice', async () => {
+      const mockHarmonyOptions = {
+        deviceId: 'harmony-device-1',
+        hdcPath: '/custom/path/to/hdc',
+        autoDismissKeyboard: true,
+        keyboardDismissStrategy: 'esc-first' as const,
+        appNameMapping: { 携程: 'com.ctrip.harmonynext' },
+        launch: 'com.example.app',
+      };
+
+      const mockScript: MidsceneYamlScript = {
+        harmony: mockHarmonyOptions,
+        tasks: [],
+      };
+
+      const mockAgent = { destroy: vi.fn(), launch: vi.fn() };
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(readFileSync).mockReturnValue('mock yaml content');
+      vi.mocked(parseYamlScript).mockReturnValue(mockScript);
+      vi.mocked(agentFromHdcDevice).mockResolvedValue(mockAgent as any);
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+
+      if (setupFnCallback) {
+        await setupFnCallback();
+      }
+
+      // Verify agentFromHdcDevice was called with deviceId and all options
+      expect(agentFromHdcDevice).toHaveBeenCalledWith(
+        mockHarmonyOptions.deviceId,
+        expect.objectContaining({
+          hdcPath: mockHarmonyOptions.hdcPath,
+          autoDismissKeyboard: mockHarmonyOptions.autoDismissKeyboard,
+          keyboardDismissStrategy: mockHarmonyOptions.keyboardDismissStrategy,
+          appNameMapping: mockHarmonyOptions.appNameMapping,
+          launch: mockHarmonyOptions.launch,
+        }),
+      );
+      // Verify launch was triggered
+      expect(mockAgent.launch).toHaveBeenCalledWith(mockHarmonyOptions.launch);
+    });
+
+    test('should connect first HarmonyOS device when deviceId is omitted', async () => {
+      const mockScript: MidsceneYamlScript = {
+        harmony: {},
+        tasks: [],
+      };
+
+      const mockAgent = { destroy: vi.fn(), launch: vi.fn() };
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(readFileSync).mockReturnValue('mock yaml content');
+      vi.mocked(parseYamlScript).mockReturnValue(mockScript);
+      vi.mocked(agentFromHdcDevice).mockResolvedValue(mockAgent as any);
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+
+      if (setupFnCallback) {
+        await setupFnCallback();
+      }
+
+      expect(agentFromHdcDevice).toHaveBeenCalledWith(
+        undefined,
+        expect.any(Object),
+      );
+      // No launch field, so launch should not be triggered
+      expect(mockAgent.launch).not.toHaveBeenCalled();
     });
 
     test('should handle Android config with minimal options', async () => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../core"
     },
     {
+      "path": "../harmony"
+    },
+    {
       "path": "../ios"
     },
     {

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -492,7 +492,9 @@ export function buildYamlFlowFromPlans(
         : action.name === 'Terminate' || action.interfaceAlias === 'terminate'
           ? 'uri'
           : action.name === 'RunAdbShell' ||
-              action.interfaceAlias === 'runAdbShell'
+              action.interfaceAlias === 'runAdbShell' ||
+              action.name === 'RunHdcShell' ||
+              action.interfaceAlias === 'runHdcShell'
             ? 'command'
             : undefined;
     const shortcutKeys = shortcutField ? Object.keys(flowParam) : [];

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -1,5 +1,9 @@
 import type { TMultimodalPrompt, TUserPrompt } from './common';
-import type { AndroidDeviceOpt, IOSDeviceOpt } from './device';
+import type {
+  AndroidDeviceOpt,
+  HarmonyDeviceOpt,
+  IOSDeviceOpt,
+} from './device';
 import type { AgentOpt, LocateResultElement, Rect } from './types';
 import type { UIContext } from './types';
 
@@ -54,6 +58,7 @@ export interface MidsceneYamlScript {
   web?: MidsceneYamlScriptWebEnv;
   android?: MidsceneYamlScriptAndroidEnv;
   ios?: MidsceneYamlScriptIOSEnv;
+  harmony?: MidsceneYamlScriptHarmonyEnv;
   computer?: MidsceneYamlScriptComputerEnv;
 
   interface?: MidsceneYamlScriptEnvGeneralInterface;
@@ -196,6 +201,19 @@ export interface MidsceneYamlScriptIOSEnv
   launch?: string;
 }
 
+export interface MidsceneYamlScriptHarmonyEnv
+  extends MidsceneYamlScriptConfig,
+    Omit<HarmonyDeviceOpt, 'customActions'> {
+  // The HarmonyOS device ID to connect to, optional, will use the first device if not specified
+  deviceId?: string;
+
+  // The app package to launch, optional, will use the current screen if not specified
+  launch?: string;
+
+  // Custom mapping of app names to bundle names, user-provided mappings take precedence over defaults
+  appNameMapping?: Record<string, string>;
+}
+
 export interface MidsceneYamlScriptComputerEnv
   extends MidsceneYamlScriptConfig {
   // The display ID to use, optional, will use the primary display if not specified
@@ -206,6 +224,7 @@ export type MidsceneYamlScriptEnv =
   | MidsceneYamlScriptWebEnv
   | MidsceneYamlScriptAndroidEnv
   | MidsceneYamlScriptIOSEnv
+  | MidsceneYamlScriptHarmonyEnv
   | MidsceneYamlScriptComputerEnv;
 
 export interface MidsceneYamlFlowItemAIAction {

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -121,7 +121,12 @@ const buildShortcutActionParam = (
     return { uri: value };
   }
 
-  if (actionName === 'RunAdbShell' || interfaceAlias === 'runAdbShell') {
+  if (
+    actionName === 'RunAdbShell' ||
+    interfaceAlias === 'runAdbShell' ||
+    actionName === 'RunHdcShell' ||
+    interfaceAlias === 'runHdcShell'
+  ) {
     return { command: value };
   }
 
@@ -696,12 +701,14 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
   }
 
   async run() {
-    const { target, web, android, ios, computer, tasks } = this.script;
+    const { target, web, android, ios, harmony, computer, tasks } = this.script;
     const webEnv = web || target;
     const androidEnv = android;
     const iosEnv = ios;
+    const harmonyEnv = harmony;
     const computerEnv = computer;
-    const platform = webEnv || androidEnv || iosEnv || computerEnv;
+    const platform =
+      webEnv || androidEnv || iosEnv || harmonyEnv || computerEnv;
 
     this.setPlayerStatus('running');
 

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -315,12 +315,16 @@ describe('llm planning - build yaml flow', () => {
     ]);
   });
 
-  it('inline single-string shortcut for Terminate/Launch/RunAdbShell', () => {
+  it('inline single-string shortcut for Terminate/Launch/RunAdbShell/RunHdcShell', () => {
     const flow = buildYamlFlowFromPlans(
       [
         { type: 'Terminate', param: { uri: 'com.mi.car.mobile' } },
         { type: 'Launch', param: { uri: 'com.mi.car.mobile' } },
         { type: 'RunAdbShell', param: { command: 'input keyevent 3' } },
+        {
+          type: 'RunHdcShell',
+          param: { command: 'hidumper -s WindowManagerService -a' },
+        },
       ],
       [
         {
@@ -341,12 +345,19 @@ describe('llm planning - build yaml flow', () => {
           paramSchema: z.object({ command: z.string() }),
           call: async () => {},
         },
+        {
+          name: 'RunHdcShell',
+          interfaceAlias: 'runHdcShell',
+          paramSchema: z.object({ command: z.string() }),
+          call: async () => {},
+        },
       ],
     );
     expect(flow).toEqual([
       { terminate: 'com.mi.car.mobile' },
       { launch: 'com.mi.car.mobile' },
       { runAdbShell: 'input keyevent 3' },
+      { runHdcShell: 'hidumper -s WindowManagerService -a' },
     ]);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,6 +810,9 @@ importers:
       '@midscene/core':
         specifier: workspace:*
         version: link:../core
+      '@midscene/harmony':
+        specifier: workspace:*
+        version: link:../harmony
       '@midscene/ios':
         specifier: workspace:*
         version: link:../ios
@@ -2304,19 +2307,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':


### PR DESCRIPTION
## Background

Running a HarmonyOS device through a YAML script failed with:

> Error: No valid interface configuration found in the yaml script, should be either "web", "android", "ios", "computer", or "interface"

The CLI YAML runner only recognized `web` / `android` / `ios` / `computer` / `interface` as top-level targets. The `@midscene/harmony` package existed (`HarmonyDevice`, `agentFromHdcDevice`, MCP server) but was never wired into the YAML runner, so `harmony:` / `harmonyos:` always errored. The only workaround was the generic `interface:` mechanism plus a hand-written adapter class, because `HarmonyDevice`'s constructor is `(deviceId, options)` while `interface:` calls `new Device(param)` with a single object.

## What this PR does

Adds native HarmonyOS support to the YAML runner so a top-level `harmony:` section just works, mirroring the existing `android` / `ios` branches.

- **core**: add `MidsceneYamlScriptHarmonyEnv` and the `harmony` field on `MidsceneYamlScript`; include it in the union and in the player's platform resolution; add the `runHdcShell` shortcut action param alongside `runAdbShell`.
- **cli**: handle the `harmony` target via `agentFromHdcDevice` (deviceId optional → first connected device), forward all device options, trigger `launch` when provided, and register cleanup. Update the no-target error message to include `harmony`. Add `@midscene/harmony` as a workspace dependency.
- **docs**: document the `harmony` section and its platform-specific actions (`launch` / `terminate` / `runHdcShell`) in both the English and Chinese YAML guides.
- **tests**: cover harmony option propagation and the first-device fallback.

## Example

```yaml
harmony:
  deviceId: your-device-id   # optional, defaults to the first connected device
  launch: com.example.app    # optional

agent:
  aiActionContext: ...

tasks:
  - name: demo
    flow:
      - ai: do something
```

## Validation

- `pnpm run lint`
- `npx nx build core`
- `npx nx build cli`
- `npx nx test core -- yaml`
- `npx nx test cli -- create-yaml-player`