### PR TITLE
fix(core): handle fenced UI-TARS finish output

### DIFF
--- a/packages/core/src/ai-model/ui-tars-planning.ts
+++ b/packages/core/src/ai-model/ui-tars-planning.ts
@@ -240,7 +240,7 @@ export async function uiTarsPlanning(
       transformActions.push({
         type: 'Finished',
         param: {},
-        thought: action.thought || '',
+        thought: action.action_inputs.content || action.thought || '',
       });
     } else if (actionType === 'hotkey') {
       if (!action.action_inputs.key) {
@@ -360,8 +360,10 @@ function convertBboxToCoordinates(text: string): string {
     return `(${x},${y})`;
   }
 
-  // Remove [EOS] and replace <bbox> coordinates
-  const cleanedText = text.replace(/\[EOS\]/g, '');
+  // Remove common model wrappers before handing the response to UI-TARS parser.
+  const cleanedText = text
+    .replace(/\[EOS\]/g, '')
+    .replace(/```(?:[a-zA-Z0-9_-]+)?/g, '');
   return cleanedText.replace(pattern, replaceMatch).trim();
 }
 
@@ -436,7 +438,9 @@ interface ScrollAction extends BaseAction {
 
 interface FinishedAction extends BaseAction {
   action_type: 'finished';
-  action_inputs: Record<string, never>;
+  action_inputs: {
+    content?: string;
+  };
 }
 
 export type Action =

--- a/packages/core/tests/unit-test/ui-tars-planning.test.ts
+++ b/packages/core/tests/unit-test/ui-tars-planning.test.ts
@@ -1,0 +1,79 @@
+import { ConversationHistory } from '@/ai-model/conversation-history';
+import { callAIWithStringResponse } from '@/ai-model/service-caller/index';
+import { uiTarsPlanning } from '@/ai-model/ui-tars-planning';
+import type { UIContext } from '@/types';
+import { type IModelConfig, UITarsModelVersion } from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ai-model/service-caller/index', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/ai-model/service-caller/index')>();
+  return {
+    ...actual,
+    callAIWithStringResponse: vi.fn(),
+  };
+});
+
+const context: UIContext = {
+  screenshot: {
+    base64: 'data:image/png;base64,AA==',
+  } as any,
+  shotSize: {
+    width: 1000,
+    height: 800,
+  },
+  shrunkShotToLogicalRatio: 1,
+};
+
+const modelConfig: IModelConfig = {
+  modelName: 'ui-tars-test-model',
+  modelFamily: 'vlm-ui-tars',
+  modelDescription: 'ui-tars-test-model',
+  intent: 'planning',
+  slot: 'planning',
+  uiTarsModelVersion: UITarsModelVersion.V1_0,
+};
+
+function createPlanOptions() {
+  return {
+    context,
+    modelConfig,
+    conversationHistory: new ConversationHistory(),
+  };
+}
+
+function firstAction(result: Awaited<ReturnType<typeof uiTarsPlanning>>) {
+  expect(result.actions).toHaveLength(1);
+  const action = result.actions?.[0];
+  if (!action) {
+    throw new Error('expected ui-tars planning to return an action');
+  }
+  return action;
+}
+
+describe('uiTarsPlanning', () => {
+  beforeEach(() => {
+    vi.mocked(callAIWithStringResponse).mockReset();
+  });
+
+  it('transforms fenced finished content into a Finished action thought', async () => {
+    vi.mocked(callAIWithStringResponse).mockResolvedValueOnce({
+      content: `\`\`\`
+finished(content='已经将计数器加到3，任务完成。')
+\`\`\``,
+    });
+
+    const result = await uiTarsPlanning(
+      'increase counter to 3',
+      createPlanOptions(),
+    );
+    const action = firstAction(result);
+
+    expect(result.shouldContinuePlanning).toBe(false);
+    expect(action).toMatchObject({
+      type: 'Finished',
+      param: {},
+      thought: '已经将计数器加到3，任务完成。',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Strip Markdown code fences from UI-TARS planning responses before handing them to `@ui-tars/action-parser`.
- Preserve `finished(content='...')` as the `Finished` action thought.
- Add a regression unit test for the reported fenced `finished(content=...)` response shape.

## Why

UI-TARS can return task completion wrapped in a Markdown code fence, with `finished(content='已经将计数器加到3，任务完成。')` inside it. The parser does not handle the outer Markdown fence, so planning reported `No actions found in UI-TARS response.` even though the task was complete.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/ui-tars-planning.test.ts`

Note: I did not manually run lint. The repository pre-commit hook ran `lint-staged`, which invoked `npx biome check --diagnostic-level=info --fix` on the staged TS files during commit.