### PR TITLE
docs(site): clarify remoteAdbHost points to adb server, not adbd

### DIFF
--- a/apps/site/docs/en/integrate-with-android.mdx
+++ b/apps/site/docs/en/integrate-with-android.mdx
@@ -376,3 +376,11 @@ const device = new AndroidDevice('s4ey59', {
   remoteAdbPort: 5037,
 });
 ```
+
+:::info This refers to the adb server, not the device's adbd
+`remoteAdbHost` / `remoteAdbPort` (and their environment variables) point to the **adb server**, equivalent to `adb -H <host> -P <port>` (default port `5037`). They do **not** refer to the device's own adbd, nor to the `ip:port` of a device in `adb connect <ip:port>`.
+
+Note: these two options only take effect on an `AndroidDevice` instance. `getConnectedDevices()` (used to list devices) always connects to the local default adb server and is not affected by them.
+
+To drive a cloud / remote real device, the usual approach is: run `adb connect <device-ip:port>` in your terminal first to attach the device to your local adb server, then go through the normal `getConnectedDevices()` / `new AndroidDevice(deviceId)` flow — no `remoteAdbHost` needed. Only set `remoteAdbHost` / `remoteAdbPort` when the device is exposed through a **remote adb server**, pointing them at that remote adb server.
+:::

--- a/apps/site/docs/zh/integrate-with-android.mdx
+++ b/apps/site/docs/zh/integrate-with-android.mdx
@@ -523,3 +523,13 @@ const device = new AndroidDevice('s4ey59', {
   remoteAdbPort: 5037,
 });
 ```
+
+:::info 这里指的是 adb server，不是设备的 adbd
+`remoteAdbHost` / `remoteAdbPort`(以及对应的环境变量)指向的是 **adb server** 的地址，等价于 `adb -H <host> -P <port>`，默认端口 `5037`。它**不是**设备本身的 adbd 地址，也不是 `adb connect <ip:port>` 里设备的 ip:port。
+
+需要注意:这两个参数只对 `AndroidDevice` 实例生效；而 `getConnectedDevices()`(用于列举设备)始终连接本地默认的 adb server，不受这两个参数影响。
+
+**什么时候需要设置 `remoteAdbHost`?** 只有当云真机 / 远程设备是通过一个独立的**远端 adb server** 暴露时才需要——此时把 `remoteAdbHost` / `remoteAdbPort` 指向那个远端 adb server。
+
+如果云真机是挂在本地 adb server 上(即先在终端执行 `adb connect <设备ip:port>`)，则**不需要**设置 `remoteAdbHost`，直接走正常的 `getConnectedDevices()` / `new AndroidDevice(deviceId)` 流程即可。
+:::


### PR DESCRIPTION
## What

Adds a clarifying note (both EN and ZH) to the Android "custom adb path / remote adb host" FAQ in `integrate-with-android.mdx`, explaining what `remoteAdbHost` / `remoteAdbPort` actually refer to.

## Why

The options name is ambiguous — users assume `remoteAdbHost` is the device's `adbd` address (or the `ip:port` used in `adb connect`). In fact these options are passed straight through to `appium-adb` and become `adb -H <host> -P <port>`, i.e. the **adb server** host/port (default `5037`), not the device's adbd.

Reference in code:
- `packages/android/src/device.ts:356-371` — options forwarded to the `ADB` constructor.
- `appium-adb` `adb.js:301-310` — `remoteAdbHost`/`remoteAdbPort` become `-H` / `-P`.
- `packages/android/src/utils.ts:65` — `getConnectedDevices()` always uses the local default adb server and ignores these options.

## Notes added

- `remoteAdbHost` / `remoteAdbPort` target the **adb server**, equivalent to `adb -H <host> -P <port>`; not the device's adbd.
- These options only affect an `AndroidDevice` instance; `getConnectedDevices()` always talks to the local adb server.
- Guidance for cloud / remote devices: the common path is `adb connect <device-ip:port>` to attach the device to the local adb server, then use the normal `getConnectedDevices()` / `new AndroidDevice(deviceId)` flow — no `remoteAdbHost` needed. Only set `remoteAdbHost` when the device is exposed through a separate remote adb server.

## Validation

- `pnpm run lint` — passed.
- Docs-only change (EN + ZH kept in sync).