### PR TITLE
fix(web-integration): stop capping longPress duration at 600ms

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -807,13 +807,12 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   async longPress(x: number, y: number, duration?: number) {
     duration = duration || 500;
-    const LONG_PRESS_THRESHOLD = 600;
-    const MIN_PRESS_THRESHOLD = 300;
-    if (duration > LONG_PRESS_THRESHOLD) {
-      duration = LONG_PRESS_THRESHOLD;
-    }
-    if (duration < MIN_PRESS_THRESHOLD) {
-      duration = MIN_PRESS_THRESHOLD;
+    // Keep a lower bound so the press is registered as a long press rather than
+    // a click, but never cap the upper bound: the duration is the caller's
+    // intent (e.g. "hold for 6 seconds").
+    const MIN_LONG_PRESS_DURATION = 300;
+    if (duration < MIN_LONG_PRESS_DURATION) {
+      duration = MIN_LONG_PRESS_DURATION;
     }
     await this.mouse.move(x, y);
 

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -962,13 +962,12 @@ export class Page<
   }
   async longPress(x: number, y: number, duration?: number) {
     duration = duration || 500;
-    const LONG_PRESS_THRESHOLD = 600;
-    const MIN_PRESS_THRESHOLD = 300;
-    if (duration > LONG_PRESS_THRESHOLD) {
-      duration = LONG_PRESS_THRESHOLD;
-    }
-    if (duration < MIN_PRESS_THRESHOLD) {
-      duration = MIN_PRESS_THRESHOLD;
+    // Keep a lower bound so the press is registered as a long press rather than
+    // a click, but never cap the upper bound: the duration is the caller's
+    // intent (e.g. "hold for 6 seconds").
+    const MIN_LONG_PRESS_DURATION = 300;
+    if (duration < MIN_LONG_PRESS_DURATION) {
+      duration = MIN_LONG_PRESS_DURATION;
     }
     debugPage(`mouse longPress at ${x}, ${y} for ${duration}ms`);
     if (this.interfaceType === 'puppeteer') {

--- a/packages/web-integration/tests/unit-test/base-page-long-press.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-long-press.test.ts
@@ -1,0 +1,82 @@
+import { Page } from '@/puppeteer/base-page';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+  logMsg: vi.fn(),
+}));
+
+vi.mock('@midscene/shared/node', () => ({
+  getElementInfosScriptContent: vi.fn(() => ''),
+  getExtraReturnLogic: vi.fn(() => Promise.resolve('() => ({})')),
+}));
+
+vi.mock('@/web-element', () => ({
+  WebPageContextParser: vi.fn(),
+}));
+
+vi.mock('@/web-page', () => ({
+  commonWebActionsForWebPage: vi.fn(() => []),
+}));
+
+const createMockPage = () => {
+  const mouse = { move: vi.fn(), down: vi.fn(), up: vi.fn() };
+  const underlyingPage = {
+    url: () => 'http://example.com',
+    mouse,
+    keyboard: { down: vi.fn(), up: vi.fn(), press: vi.fn(), type: vi.fn() },
+    evaluate: vi.fn(),
+  } as any;
+  return { underlyingPage, mouse };
+};
+
+describe('Page.longPress - duration handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Run the press immediately instead of actually waiting, and capture the
+  // requested delay so we can assert how long the button is held down.
+  const spyHeldDuration = () => {
+    const setTimeoutSpy = vi
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn: any) => {
+        fn();
+        return 0 as any;
+      });
+    return () =>
+      setTimeoutSpy.mock.calls.map((call) => call[1]).filter(Boolean);
+  };
+
+  it('holds for the full requested duration without capping (regression for #2544)', async () => {
+    const { underlyingPage, mouse } = createMockPage();
+    const page = new Page(underlyingPage, 'puppeteer');
+    const heldDurations = spyHeldDuration();
+
+    await page.longPress(10, 20, 6000);
+
+    expect(mouse.down).toHaveBeenCalledTimes(1);
+    expect(mouse.up).toHaveBeenCalledTimes(1);
+    expect(heldDurations()).toContain(6000);
+  });
+
+  it('raises a too-short duration to the long-press minimum', async () => {
+    const { underlyingPage } = createMockPage();
+    const page = new Page(underlyingPage, 'puppeteer');
+    const heldDurations = spyHeldDuration();
+
+    await page.longPress(10, 20, 100);
+
+    expect(heldDurations()).toContain(300);
+  });
+
+  it('falls back to the default duration when omitted', async () => {
+    const { underlyingPage } = createMockPage();
+    const page = new Page(underlyingPage, 'puppeteer');
+    const heldDurations = spyHeldDuration();
+
+    await page.longPress(10, 20);
+
+    expect(heldDurations()).toContain(500);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2544.

The web `longPress` action silently caps its duration at 600ms. Asking the model to "long-press for 6 seconds" (`duration: 6000`) only holds for 600ms.

## Root cause

`longPress` was introduced together with `swipe` in #1170 and its implementation was copied from `swipe`, inheriting `swipe`'s duration clamp — including the misleadingly named `LONG_PRESS_THRESHOLD` constant that appears *inside* the long-press method:

```js
const LONG_PRESS_THRESHOLD = 600; // copied from swipe, never meant for long press
const MIN_PRESS_THRESHOLD = 300;
if (duration > LONG_PRESS_THRESHOLD) duration = LONG_PRESS_THRESHOLD; // <- the bug
```

For `swipe`, capping the duration is defensible — duration there controls the gesture's animation speed. For `longPress`, the duration *is* the caller's intent, so capping it breaks the action and also diverges from the Android/iOS backends, which never cap (defaults 2000ms / 1000ms, no upper bound).

## Change

- Remove the upper bound in both backends:
  - `packages/web-integration/src/puppeteer/base-page.ts` (puppeteer / playwright)
  - `packages/web-integration/src/chrome-extension/page.ts` (CDP)
- Keep the 300ms lower bound so the gesture is still registered as a long press rather than a click.
- Rename the constant to `MIN_LONG_PRESS_DURATION` and add a comment explaining why the upper bound is intentionally gone.

`swipe`'s clamp is left untouched here; whether it should also drop its cap (and instead scale its fixed 30-step interpolation with duration) is a separate, higher-risk change worth its own issue.

## Tests

New `packages/web-integration/tests/unit-test/base-page-long-press.test.ts`:
- 6000ms passes through uncapped (regression for #2544)
- a too-short duration is raised to the 300ms minimum
- omitted duration falls back to the 500ms default

## Validation

- `npx nx test @midscene/web -- long-press` — 3 passed
- `pnpm run lint` — clean