### PR TITLE
fix(core): replace stale locate cache entry on replanning (#2529)

### DIFF
--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -67,6 +67,11 @@ export class TaskCache {
 
   private matchedCacheIndices: Set<string> = new Set(); // Track matched records
 
+  // Track, per `${type}:${promptStr}`, the in-memory indices of cache entries
+  // consumed by matchCache (most recent last). Used to replace a stale entry
+  // in place during replanning instead of appending a duplicate.
+  private consumedCacheIndices: Map<string, number[]> = new Map();
+
   constructor(
     cacheId: string,
     isCacheResultUsed: boolean,
@@ -161,6 +166,10 @@ export class TaskCache {
           }
         }
         this.matchedCacheIndices.add(key);
+        const consumeKey = `${type}:${promptStr}`;
+        const consumed = this.consumedCacheIndices.get(consumeKey) ?? [];
+        consumed.push(i);
+        this.consumedCacheIndices.set(consumeKey, consumed);
         debug(
           'cache found and marked as used, type: %s, prompt: %s, index: %d',
           type,
@@ -414,7 +423,53 @@ export class TaskCache {
         });
       }
     } else {
-      this.appendCache(newRecord);
+      // No live MatchCacheResult was passed. During replanning a previous
+      // locate may have consumed (marked-used) a cache entry for this prompt
+      // that pointed at the wrong element; matchCache then returns undefined on
+      // the retry, so we land here. Replace that consumed (stale) entry in
+      // place instead of appending a duplicate — otherwise the stale entry is
+      // matched first on the next run and re-triggers replanning forever.
+      const promptStr =
+        typeof newRecord.prompt === 'string'
+          ? newRecord.prompt
+          : JSON.stringify(newRecord.prompt);
+      const consumeKey = `${newRecord.type}:${promptStr}`;
+      const consumed = this.consumedCacheIndices.get(consumeKey);
+      const staleIndex = consumed?.pop();
+      if (staleIndex !== undefined && this.cache.caches[staleIndex]) {
+        debug(
+          'replacing consumed stale cache entry in place, type: %s, prompt: %s, index: %d',
+          newRecord.type,
+          newRecord.prompt,
+          staleIndex,
+        );
+        this.replaceCacheRecord(staleIndex, newRecord);
+      } else {
+        this.appendCache(newRecord);
+      }
     }
+  }
+
+  private replaceCacheRecord(
+    index: number,
+    newRecord: PlanningCache | LocateCache,
+  ) {
+    const target = this.cache.caches[index];
+    if (newRecord.type === 'plan') {
+      (target as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
+    } else {
+      const locateCache = target as LocateCache;
+      locateCache.cache = newRecord.cache;
+      if ('xpaths' in locateCache) {
+        locateCache.xpaths = undefined;
+      }
+    }
+
+    if (this.readOnlyMode) {
+      debug('read-only mode, cache replaced in memory but not flushed to file');
+      return;
+    }
+
+    this.flushCacheToFile();
   }
 }

--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -146,8 +146,7 @@ export class TaskCache {
       return undefined;
     }
     // Find the first unused matching cache
-    const promptStr =
-      typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
+    const promptStr = this.promptKey(prompt);
     for (let i = 0; i < this.cacheOriginalLength; i++) {
       const item = this.cache.caches[i];
       const key = `${type}:${promptStr}:${i}`;
@@ -403,25 +402,40 @@ export class TaskCache {
     }
   }
 
+  // Single source of truth for turning a prompt into a stable string key.
+  // matchCache and updateOrAppendCacheRecord must agree on this, otherwise a
+  // consumed entry can never be found again for in-place replacement.
+  private promptKey(prompt: TUserPrompt): string {
+    return typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
+  }
+
+  // Copy the mutable payload of `newRecord` into an existing cache entry.
+  // Shared by the live-record update path and replaceCacheRecord so the field
+  // list lives in exactly one place. Caller guarantees same `type`.
+  private applyRecordInto(
+    target: PlanningCache | LocateCache,
+    newRecord: PlanningCache | LocateCache,
+  ) {
+    if (newRecord.type === 'plan') {
+      (target as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
+    } else {
+      const locateCache = target as LocateCache;
+      locateCache.cache = newRecord.cache;
+      if ('xpaths' in locateCache) {
+        locateCache.xpaths = undefined;
+      }
+    }
+  }
+
   updateOrAppendCacheRecord(
     newRecord: PlanningCache | LocateCache,
     cachedRecord?: MatchCacheResult<PlanningCache | LocateCache>,
   ) {
     if (cachedRecord) {
       // update existing record
-      if (newRecord.type === 'plan') {
-        cachedRecord.updateFn((cache) => {
-          (cache as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
-        });
-      } else {
-        cachedRecord.updateFn((cache) => {
-          const locateCache = cache as LocateCache;
-          locateCache.cache = newRecord.cache;
-          if ('xpaths' in locateCache) {
-            locateCache.xpaths = undefined;
-          }
-        });
-      }
+      cachedRecord.updateFn((cache) => {
+        this.applyRecordInto(cache, newRecord);
+      });
     } else {
       // No live MatchCacheResult was passed. During replanning a previous
       // locate may have consumed (marked-used) a cache entry for this prompt
@@ -429,11 +443,19 @@ export class TaskCache {
       // the retry, so we land here. Replace that consumed (stale) entry in
       // place instead of appending a duplicate — otherwise the stale entry is
       // matched first on the next run and re-triggers replanning forever.
-      const promptStr =
-        typeof newRecord.prompt === 'string'
-          ? newRecord.prompt
-          : JSON.stringify(newRecord.prompt);
-      const consumeKey = `${newRecord.type}:${promptStr}`;
+      //
+      // Known limitation: if the same prompt is located more times in one run
+      // than there are cached entries for it (e.g. the script added an extra
+      // same-prompt locate), the extra locate is a genuine cache miss but still
+      // finds a consumed index here and overwrites a still-valid entry instead
+      // of appending. This layer cannot tell that case apart from real
+      // poisoning, because both arrive as "consumed, then undefined match". The
+      // robust fix is to have the caller signal which entry actually failed; we
+      // accept the narrow overwrite for now since perpetual poisoning is the
+      // more common and more harmful failure. See the regression test
+      // "overwrites a consumed entry when the same prompt overflows" which pins
+      // this behavior.
+      const consumeKey = `${newRecord.type}:${this.promptKey(newRecord.prompt)}`;
       const consumed = this.consumedCacheIndices.get(consumeKey);
       const staleIndex = consumed?.pop();
       if (staleIndex !== undefined && this.cache.caches[staleIndex]) {
@@ -455,15 +477,14 @@ export class TaskCache {
     newRecord: PlanningCache | LocateCache,
   ) {
     const target = this.cache.caches[index];
-    if (newRecord.type === 'plan') {
-      (target as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
-    } else {
-      const locateCache = target as LocateCache;
-      locateCache.cache = newRecord.cache;
-      if ('xpaths' in locateCache) {
-        locateCache.xpaths = undefined;
-      }
-    }
+    // Consumed indices are recorded per `${type}:${prompt}` in matchCache, which
+    // only stores entries whose `item.type === type`, so the target must share
+    // newRecord's type. Assert it to make the invariant explicit and fail fast.
+    assert(
+      target.type === newRecord.type,
+      `cache record type mismatch on replace: expected ${newRecord.type}, got ${target.type}`,
+    );
+    this.applyRecordInto(target, newRecord);
 
     if (this.readOnlyMode) {
       debug('read-only mode, cache replaced in memory but not flushed to file');

--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -67,10 +67,17 @@ export class TaskCache {
 
   private matchedCacheIndices: Set<string> = new Set(); // Track matched records
 
-  // Track, per `${type}:${promptStr}`, the in-memory indices of cache entries
-  // consumed by matchCache (most recent last). Used to replace a stale entry
-  // in place during replanning instead of appending a duplicate.
+  // Per `${type}:${promptStr}`, the in-memory indices of cache entries consumed
+  // by matchCache this run (most recent last). markLocateCacheStale() drains
+  // from here into staleCacheIndices when the consumed entry's element is
+  // rejected by a failed action.
   private consumedCacheIndices: Map<string, number[]> = new Map();
+
+  // Per `${type}:${promptStr}`, indices of consumed entries whose backing
+  // element was rejected (the action using it failed and the run replanned).
+  // Only these are replaced in place on the re-locate; every other write
+  // appends, so legitimately repeated prompts keep one entry per occurrence.
+  private staleCacheIndices: Map<string, number[]> = new Map();
 
   constructor(
     cacheId: string,
@@ -437,30 +444,17 @@ export class TaskCache {
         this.applyRecordInto(cache, newRecord);
       });
     } else {
-      // No live MatchCacheResult was passed. During replanning a previous
-      // locate may have consumed (marked-used) a cache entry for this prompt
-      // that pointed at the wrong element; matchCache then returns undefined on
-      // the retry, so we land here. Replace that consumed (stale) entry in
-      // place instead of appending a duplicate — otherwise the stale entry is
-      // matched first on the next run and re-triggers replanning forever.
-      //
-      // Known limitation: if the same prompt is located more times in one run
-      // than there are cached entries for it (e.g. the script added an extra
-      // same-prompt locate), the extra locate is a genuine cache miss but still
-      // finds a consumed index here and overwrites a still-valid entry instead
-      // of appending. This layer cannot tell that case apart from real
-      // poisoning, because both arrive as "consumed, then undefined match". The
-      // robust fix is to have the caller signal which entry actually failed; we
-      // accept the narrow overwrite for now since perpetual poisoning is the
-      // more common and more harmful failure. See the regression test
-      // "overwrites a consumed entry when the same prompt overflows" which pins
-      // this behavior.
+      // No live MatchCacheResult was passed. This is either a genuine first-time
+      // miss or a replanning re-locate after the previously matched entry was
+      // rejected. Only replace an entry that was explicitly marked stale (its
+      // element caused a failed action); otherwise append. Without this gate a
+      // legitimately repeated prompt — located more times than it has cached
+      // entries — would overwrite a still-valid entry instead of appending.
       const consumeKey = `${newRecord.type}:${this.promptKey(newRecord.prompt)}`;
-      const consumed = this.consumedCacheIndices.get(consumeKey);
-      const staleIndex = consumed?.pop();
+      const staleIndex = this.staleCacheIndices.get(consumeKey)?.pop();
       if (staleIndex !== undefined && this.cache.caches[staleIndex]) {
         debug(
-          'replacing consumed stale cache entry in place, type: %s, prompt: %s, index: %d',
+          'replacing stale cache entry in place, type: %s, prompt: %s, index: %d',
           newRecord.type,
           newRecord.prompt,
           staleIndex,
@@ -470,6 +464,32 @@ export class TaskCache {
         this.appendCache(newRecord);
       }
     }
+  }
+
+  /**
+   * Mark the most recently consumed locate cache entry for `prompt` as stale.
+   * Call this when an action that used the cache-hit element failed and the run
+   * is about to replan: the subsequent re-locate then replaces this entry in
+   * place instead of appending a duplicate, which would otherwise be matched
+   * first on the next run and re-trigger replanning forever (#2529).
+   *
+   * No-op when nothing was consumed for the prompt, so a plain first-time miss
+   * (and any repeated prompt that never failed) still appends normally.
+   */
+  markLocateCacheStale(prompt: TUserPrompt) {
+    const consumeKey = `locate:${this.promptKey(prompt)}`;
+    const index = this.consumedCacheIndices.get(consumeKey)?.pop();
+    if (index === undefined) {
+      return;
+    }
+    const stale = this.staleCacheIndices.get(consumeKey) ?? [];
+    stale.push(index);
+    this.staleCacheIndices.set(consumeKey, stale);
+    debug(
+      'marked locate cache entry as stale, prompt: %s, index: %d',
+      prompt,
+      index,
+    );
   }
 
   private replaceCacheRecord(

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -288,10 +288,16 @@ export class TaskExecutor {
   }
 
   /**
-   * After a failed plan-execution batch, mark every cache-hit locate task in
-   * that batch (tasks at index >= fromIndex) as stale, so the upcoming replan's
-   * re-locate replaces the bad entry in place instead of appending a duplicate
-   * that would re-poison the cache on the next run (#2529).
+   * Called when the task is about to replan. Marks every cache-hit locate task
+   * in the just-run batch (tasks at index >= fromIndex) as stale: that batch
+   * did not finish the task, so the element each cache hit produced is suspect.
+   * The upcoming re-locate of the same prompt then replaces the bad entry in
+   * place instead of appending a duplicate that would re-poison the cache on the
+   * next run (#2529).
+   *
+   * Marking a locate that was actually fine is harmless: the step is only ever
+   * replaced if the same prompt is located again (i.e. the step is redone),
+   * which does not happen for a locate that already succeeded.
    */
   private invalidateFailedCacheHitLocates(
     runner: TaskRunner,
@@ -538,11 +544,6 @@ export class TaskExecutor {
       } catch (error: any) {
         // errorFlag = true;
         errorCountInOnePlanningLoop++;
-        // The just-run batch failed and we are about to replan. Any locate task
-        // in it that was served from cache produced an element the action then
-        // rejected, so mark those cache entries stale; the re-locate will then
-        // replace them in place instead of appending a poisoning duplicate.
-        this.invalidateFailedCacheHitLocates(runner, taskCountBeforeRun);
         const timeString = await this.getTimeString();
         conversationHistory.pendingFeedbackMessage = `Time: ${timeString}, Error executing running tasks: ${error?.message || String(error)}`;
         debug(
@@ -568,6 +569,15 @@ export class TaskExecutor {
       if (!planResult?.shouldContinuePlanning) {
         break;
       }
+
+      // We are about to replan, which means the batch we just ran did not finish
+      // the task. Any locate task in that batch that was served from cache
+      // produced an element that failed to complete the step (the action threw,
+      // or it clicked the wrong element and the goal was not reached). Mark those
+      // cache entries stale so the re-locate of the same prompt replaces them in
+      // place instead of appending a poisoning duplicate that would be matched
+      // first on the next run (#2529).
+      this.invalidateFailedCacheHitLocates(runner, taskCountBeforeRun);
 
       // Increment replan count for next iteration
       ++replanCount;

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -27,6 +27,7 @@ import type {
   PlanningAIResponse,
   PlanningAction,
   PlanningActionParamWaitFor,
+  PlanningLocateParam,
   ServiceDump,
   ServiceExtractOption,
   ServiceExtractParam,
@@ -286,6 +287,34 @@ export class TaskExecutor {
     });
   }
 
+  /**
+   * After a failed plan-execution batch, mark every cache-hit locate task in
+   * that batch (tasks at index >= fromIndex) as stale, so the upcoming replan's
+   * re-locate replaces the bad entry in place instead of appending a duplicate
+   * that would re-poison the cache on the next run (#2529).
+   */
+  private invalidateFailedCacheHitLocates(
+    runner: TaskRunner,
+    fromIndex: number,
+  ) {
+    if (!this.taskCache) {
+      return;
+    }
+    for (let i = fromIndex; i < runner.tasks.length; i++) {
+      const task = runner.tasks[i];
+      if (
+        task.type === 'Planning' &&
+        task.subType === 'Locate' &&
+        task.hitBy?.from === 'Cache'
+      ) {
+        const prompt = (task.param as PlanningLocateParam | undefined)?.prompt;
+        if (prompt) {
+          this.taskCache.markLocateCacheStale(prompt);
+        }
+      }
+    }
+  }
+
   private async runAction(
     userPrompt: string,
     modelConfigForPlanning: IModelConfig,
@@ -503,11 +532,17 @@ export class TaskExecutor {
       const initialTimeString = await this.getTimeString();
       conversationHistory.pendingFeedbackMessage += `Current time: ${initialTimeString}`;
 
+      const taskCountBeforeRun = runner.tasks.length;
       try {
         await session.appendAndRun(executables.tasks);
       } catch (error: any) {
         // errorFlag = true;
         errorCountInOnePlanningLoop++;
+        // The just-run batch failed and we are about to replan. Any locate task
+        // in it that was served from cache produced an element the action then
+        // rejected, so mark those cache entries stale; the re-locate will then
+        // replace them in place instead of appending a poisoning duplicate.
+        this.invalidateFailedCacheHitLocates(runner, taskCountBeforeRun);
         const timeString = await this.getTimeString();
         conversationHistory.pendingFeedbackMessage = `Time: ${timeString}, Error executing running tasks: ${error?.message || String(error)}`;
         debug(

--- a/packages/core/tests/unit-test/task-cache-poisoning.test.ts
+++ b/packages/core/tests/unit-test/task-cache-poisoning.test.ts
@@ -26,7 +26,7 @@ function seedStaleLocate(taskCache: TaskCache, prompt: string, xpath: string) {
 }
 
 describe('locate cache poisoning regression (#2529)', () => {
-  it('replaces a consumed stale locate entry in place during replanning instead of appending', () => {
+  it('replaces a stale locate entry in place when the consumed hit was rejected', () => {
     const cache = new TaskCache(uuid(), true);
     seedStaleLocate(cache, 'click submit', 'wrong/xpath');
 
@@ -35,12 +35,14 @@ describe('locate cache poisoning regression (#2529)', () => {
     expect(matched).toBeDefined();
     expect(matched?.cacheContent.cache?.xpaths).toEqual(['wrong/xpath']);
 
+    // The action using that element failed -> the replan loop marks it stale.
+    cache.markLocateCacheStale('click submit');
+
     // Replanning re-locates the same prompt; the entry was already consumed,
     // so matchLocateCache now returns undefined.
-    const rematched = cache.matchLocateCache('click submit');
-    expect(rematched).toBeUndefined();
+    expect(cache.matchLocateCache('click submit')).toBeUndefined();
 
-    // The corrected locate result must replace the stale entry, not append.
+    // The corrected locate result replaces the stale entry, not append.
     cache.updateOrAppendCacheRecord(
       {
         type: 'locate',
@@ -53,6 +55,30 @@ describe('locate cache poisoning regression (#2529)', () => {
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(1);
     expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+  });
+
+  it('appends (does not replace) a consumed entry that was never marked stale', () => {
+    // Without a stale mark, a re-locate after a consumed hit must append, not
+    // overwrite — the prior hit may have been correct.
+    const cache = new TaskCache(uuid(), true);
+    seedStaleLocate(cache, 'click submit', 'first/xpath');
+
+    expect(cache.matchLocateCache('click submit')).toBeDefined();
+    expect(cache.matchLocateCache('click submit')).toBeUndefined();
+
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'click submit',
+        cache: { xpaths: ['second/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(2);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['first/xpath']);
+    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['second/xpath']);
   });
 
   it('appends a new entry when nothing was consumed for the prompt', () => {
@@ -76,11 +102,12 @@ describe('locate cache poisoning regression (#2529)', () => {
     const cache = new TaskCache(uuid(), true);
     seedStaleLocate(cache, 'click submit', 'wrong/xpath');
 
-    // Consume the stale entry for "click submit".
+    // Consume and mark the stale entry for "click submit".
     expect(cache.matchLocateCache('click submit')).toBeDefined();
+    cache.markLocateCacheStale('click submit');
 
-    // A write for a different prompt must append, leaving the consumed entry
-    // untouched.
+    // A write for a different prompt must append, leaving the stale-marked
+    // entry untouched (the stale mark is keyed by prompt).
     cache.updateOrAppendCacheRecord(
       {
         type: 'locate',
@@ -117,11 +144,10 @@ describe('locate cache poisoning regression (#2529)', () => {
     expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
   });
 
-  it('overwrites a consumed entry when the same prompt overflows (known limitation)', () => {
-    // Documents the accepted trade-off in updateOrAppendCacheRecord: when a
-    // prompt is located more times in one run than it has cached entries, the
-    // extra (genuine) miss overwrites the most recently consumed entry instead
-    // of appending. This layer cannot distinguish it from real poisoning.
+  it('appends instead of overwriting when the same prompt overflows without failure', () => {
+    // Same prompt located more times than it has cached entries, and no hit was
+    // rejected: the extra miss must append a new entry, never overwrite a still
+    // valid one. This is the case Codex flagged (P2).
     const cache = new TaskCache(uuid(), true);
     const internal = getTaskCacheInternal(cache);
     internal.cache.caches.push(
@@ -144,10 +170,31 @@ describe('locate cache poisoning regression (#2529)', () => {
       undefined,
     );
 
-    // The most recently consumed entry (index 1) is overwritten, not appended.
-    expect(internal.cache.caches).toHaveLength(2);
+    // Both original entries are preserved; the third occurrence is appended.
+    expect(internal.cache.caches).toHaveLength(3);
     expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/3']);
+    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
+    expect(internal.cache.caches[2].cache?.xpaths).toEqual(['row/3']);
+  });
+
+  it('markLocateCacheStale is a no-op when nothing was consumed', () => {
+    const cache = new TaskCache(uuid(), true);
+    seedStaleLocate(cache, 'click submit', 'wrong/xpath');
+
+    // No matchLocateCache call -> nothing consumed -> marking is a no-op, so the
+    // following write appends rather than replaces.
+    cache.markLocateCacheStale('click submit');
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'click submit',
+        cache: { xpaths: ['correct/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(2);
   });
 
   it('replaces in memory but does not flush to file in read-only mode', () => {
@@ -156,6 +203,7 @@ describe('locate cache poisoning regression (#2529)', () => {
     seedStaleLocate(cache, 'click submit', 'wrong/xpath');
 
     expect(cache.matchLocateCache('click submit')).toBeDefined();
+    cache.markLocateCacheStale('click submit');
     expect(cache.matchLocateCache('click submit')).toBeUndefined();
 
     cache.updateOrAppendCacheRecord(

--- a/packages/core/tests/unit-test/task-cache-poisoning.test.ts
+++ b/packages/core/tests/unit-test/task-cache-poisoning.test.ts
@@ -1,0 +1,116 @@
+import { type LocateCache, TaskCache } from '@/agent';
+import { uuid } from '@midscene/shared/utils';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Access internal cache state for testing
+ */
+function getTaskCacheInternal(taskCache: TaskCache) {
+  return taskCache as unknown as {
+    cache: { caches: LocateCache[] };
+    cacheOriginalLength: number;
+  };
+}
+
+function seedStaleLocate(taskCache: TaskCache, prompt: string, xpath: string) {
+  const internal = getTaskCacheInternal(taskCache);
+  internal.cache.caches.push({
+    type: 'locate',
+    prompt,
+    cache: { xpaths: [xpath] },
+  });
+  internal.cacheOriginalLength = internal.cache.caches.length;
+}
+
+describe('locate cache poisoning regression (#2529)', () => {
+  it('replaces a consumed stale locate entry in place during replanning instead of appending', () => {
+    const cache = new TaskCache(uuid(), true);
+    seedStaleLocate(cache, 'click submit', 'wrong/xpath');
+
+    // First locate consumes the stale entry (cache hit on the wrong element).
+    const matched = cache.matchLocateCache('click submit');
+    expect(matched).toBeDefined();
+    expect(matched?.cacheContent.cache?.xpaths).toEqual(['wrong/xpath']);
+
+    // Replanning re-locates the same prompt; the entry was already consumed,
+    // so matchLocateCache now returns undefined.
+    const rematched = cache.matchLocateCache('click submit');
+    expect(rematched).toBeUndefined();
+
+    // The corrected locate result must replace the stale entry, not append.
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'click submit',
+        cache: { xpaths: ['correct/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(1);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+  });
+
+  it('appends a new entry when nothing was consumed for the prompt', () => {
+    const cache = new TaskCache(uuid(), true);
+
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'fresh prompt',
+        cache: { xpaths: ['some/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(1);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['some/xpath']);
+  });
+
+  it('does not cross-replace entries for different prompts', () => {
+    const cache = new TaskCache(uuid(), true);
+    seedStaleLocate(cache, 'click submit', 'wrong/xpath');
+
+    // Consume the stale entry for "click submit".
+    expect(cache.matchLocateCache('click submit')).toBeDefined();
+
+    // A write for a different prompt must append, leaving the consumed entry
+    // untouched.
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'click cancel',
+        cache: { xpaths: ['cancel/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(2);
+    expect(internal.cache.caches[0].prompt).toBe('click submit');
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['wrong/xpath']);
+    expect(internal.cache.caches[1].prompt).toBe('click cancel');
+  });
+
+  it('appends a second entry for a repeated prompt that was never consumed', () => {
+    // Two distinct locate occurrences of the same prompt in one run, both
+    // cache misses: each should append its own entry.
+    const cache = new TaskCache(uuid(), true);
+
+    cache.updateOrAppendCacheRecord(
+      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
+      undefined,
+    );
+    cache.updateOrAppendCacheRecord(
+      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    expect(internal.cache.caches).toHaveLength(2);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
+    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
+  });
+});

--- a/packages/core/tests/unit-test/task-cache-poisoning.test.ts
+++ b/packages/core/tests/unit-test/task-cache-poisoning.test.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { type LocateCache, TaskCache } from '@/agent';
 import { uuid } from '@midscene/shared/utils';
 import { describe, expect, it } from 'vitest';
@@ -112,5 +115,63 @@ describe('locate cache poisoning regression (#2529)', () => {
     expect(internal.cache.caches).toHaveLength(2);
     expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
     expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
+  });
+
+  it('overwrites a consumed entry when the same prompt overflows (known limitation)', () => {
+    // Documents the accepted trade-off in updateOrAppendCacheRecord: when a
+    // prompt is located more times in one run than it has cached entries, the
+    // extra (genuine) miss overwrites the most recently consumed entry instead
+    // of appending. This layer cannot distinguish it from real poisoning.
+    const cache = new TaskCache(uuid(), true);
+    const internal = getTaskCacheInternal(cache);
+    internal.cache.caches.push(
+      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
+      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+    );
+    internal.cacheOriginalLength = 2;
+
+    // Three occurrences in one run: the first two hit, the third misses.
+    expect(
+      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
+    ).toEqual(['row/1']);
+    expect(
+      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
+    ).toEqual(['row/2']);
+    expect(cache.matchLocateCache('row action')).toBeUndefined();
+
+    cache.updateOrAppendCacheRecord(
+      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/3'] } },
+      undefined,
+    );
+
+    // The most recently consumed entry (index 1) is overwritten, not appended.
+    expect(internal.cache.caches).toHaveLength(2);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
+    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/3']);
+  });
+
+  it('replaces in memory but does not flush to file in read-only mode', () => {
+    const filePath = join(tmpdir(), `mid-cache-${uuid()}.cache.yaml`);
+    const cache = new TaskCache(uuid(), true, filePath, { readOnly: true });
+    seedStaleLocate(cache, 'click submit', 'wrong/xpath');
+
+    expect(cache.matchLocateCache('click submit')).toBeDefined();
+    expect(cache.matchLocateCache('click submit')).toBeUndefined();
+
+    cache.updateOrAppendCacheRecord(
+      {
+        type: 'locate',
+        prompt: 'click submit',
+        cache: { xpaths: ['correct/xpath'] },
+      },
+      undefined,
+    );
+
+    const internal = getTaskCacheInternal(cache);
+    // In-memory entry is replaced in place...
+    expect(internal.cache.caches).toHaveLength(1);
+    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+    // ...but nothing is written to disk in read-only mode.
+    expect(existsSync(filePath)).toBe(false);
   });
 });

--- a/packages/web-integration/tests/ai/fixtures/cache-poisoning.html
+++ b/packages/web-integration/tests/ai/fixtures/cache-poisoning.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cache Poisoning Repro</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 48px;
+        color: #222;
+      }
+      h1 {
+        font-size: 26px;
+      }
+      #submit {
+        font-size: 20px;
+        padding: 14px 28px;
+        margin-top: 16px;
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+      }
+      #result {
+        margin-top: 28px;
+        font-size: 24px;
+        font-weight: 600;
+        color: #16a34a;
+        min-height: 32px;
+      }
+      /* A small, unobtrusive decoy element that exists and is clickable but
+         does NOT complete the task. The poisoned cache xpath points here. */
+      #decoy {
+        position: fixed;
+        bottom: 12px;
+        right: 16px;
+        font-size: 12px;
+        color: #9ca3af;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Demo Order Page</h1>
+    <p>Click the primary blue button to submit your order.</p>
+    <button id="submit">Submit Order</button>
+    <div id="result"></div>
+    <a href="#" id="decoy">Help</a>
+    <script>
+      document.getElementById('submit').addEventListener('click', function () {
+        document.getElementById('result').textContent =
+          'Order submitted successfully';
+      });
+      // The decoy intentionally does nothing meaningful when clicked.
+      document.getElementById('decoy').addEventListener('click', function (e) {
+        e.preventDefault();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-integration/tests/ai/web/puppeteer/cache-poisoning.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/cache-poisoning.test.ts
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import { isDeepStrictEqual } from 'node:util';
+import { PuppeteerAgent } from '@/puppeteer';
+import { sleep } from '@midscene/core/utils';
+import { uuid } from '@midscene/shared/utils';
+import yaml from 'js-yaml';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getFixturePath } from './test-utils';
+import { launchPage } from './utils';
+
+const DECOY_XPATH = '//*[@id="decoy"]';
+
+type LooseCache = {
+  type: 'plan' | 'locate';
+  prompt: unknown;
+  cache?: { xpaths?: string[] };
+  xpaths?: string[];
+  yamlWorkflow?: string;
+};
+type LooseCacheFile = { caches: LooseCache[] };
+
+function readCacheFile(path: string): LooseCacheFile {
+  return yaml.load(fs.readFileSync(path, 'utf-8')) as LooseCacheFile;
+}
+
+/**
+ * Reproduce locate cache poisoning (#2529) end-to-end against a real model, and
+ * verify the fix.
+ *
+ * Setup:
+ *  - Run 1 (read-write): aiAct genuinely locates and clicks the real button, so
+ *    a correct plan + locate cache is written.
+ *  - Poison: rewrite every locate entry's xpath to point at a decoy element that
+ *    exists (so the cache hit resolves) but does NOT complete the task, and drop
+ *    the plan cache so Run 2 re-plans (a plan-cache hit would run the cached
+ *    yaml and bypass the replanning path that detects the bad hit).
+ *  - Run 2 (read-write, same cache id): the poisoned locate is hit -> the decoy
+ *    is actioned -> the goal is not reached -> aiAct replans -> the consumed
+ *    cache entry is marked stale -> the re-locate REPLACES it in place.
+ *
+ * Before the fix the re-locate appended a second entry, leaving [stale, correct]
+ * so the stale entry was matched first on every later run (perpetual replanning).
+ *
+ * Note: this is a real-model e2e test, so it depends on the model regenerating a
+ * matching locate prompt on Run 2. CI retries AI tests once to absorb flakiness.
+ */
+describe(
+  'locate cache poisoning (#2529)',
+  () => {
+    let agent1: PuppeteerAgent | undefined;
+    let agent2: PuppeteerAgent | undefined;
+    let reset1: (() => Promise<void>) | undefined;
+    let reset2: (() => Promise<void>) | undefined;
+    let cacheFileToCleanup: string | undefined;
+
+    afterEach(async () => {
+      for (const a of [agent1, agent2]) {
+        if (a) {
+          try {
+            await a.destroy();
+          } catch (e) {
+            console.warn('agent destroy error', e);
+          }
+        }
+      }
+      for (const r of [reset1, reset2]) {
+        if (r) {
+          await r();
+        }
+      }
+      if (cacheFileToCleanup && fs.existsSync(cacheFileToCleanup)) {
+        fs.unlinkSync(cacheFileToCleanup);
+      }
+      agent1 = agent2 = undefined;
+      reset1 = reset2 = undefined;
+      cacheFileToCleanup = undefined;
+    });
+
+    it(
+      'replaces the poisoned locate entry on replanning instead of appending a duplicate',
+      async () => {
+        const fixture = `file://${getFixturePath('cache-poisoning.html')}`;
+        const cacheId = `locate-poison-${uuid()}`;
+        const actPrompt =
+          'Click the blue "Submit Order" button to submit the order';
+        const assertPrompt =
+          'the page shows the text "Order submitted successfully"';
+
+        // --- Run 1: produce a genuine, correct cache ---------------------------
+        const run1 = await launchPage(fixture);
+        reset1 = run1.reset;
+        agent1 = new PuppeteerAgent(run1.originPage, {
+          cache: { id: cacheId },
+        });
+        // deepThink disables inline-bbox planning, so the locate step actually
+        // consults the locate cache (otherwise a single-model plan returns a
+        // bbox directly and the locate cache is never read).
+        await agent1.aiAct(actPrompt, { deepThink: true });
+        await agent1.aiAssert(assertPrompt);
+        await sleep(1000);
+
+        const cacheFile = agent1.taskCache?.cacheFilePath;
+        expect(cacheFile).toBeDefined();
+        cacheFileToCleanup = cacheFile;
+
+        const beforeCache = readCacheFile(cacheFile!);
+        const locateEntriesBefore = beforeCache.caches.filter(
+          (c) => c.type === 'locate',
+        );
+        console.log(
+          'run1 locate prompts:',
+          JSON.stringify(locateEntriesBefore.map((c) => c.prompt)),
+        );
+        // Run 1 must have produced at least one locate cache entry to poison.
+        expect(locateEntriesBefore.length).toBeGreaterThanOrEqual(1);
+        const poisonedPrompts = locateEntriesBefore.map((c) => c.prompt);
+        const locateCountBefore = locateEntriesBefore.length;
+
+        // --- Poison: point every locate at the decoy, drop plan caches ---------
+        const poisoned: LooseCacheFile = {
+          ...beforeCache,
+          caches: beforeCache.caches
+            .filter((c) => c.type === 'locate')
+            .map((c) => ({
+              type: 'locate' as const,
+              prompt: c.prompt,
+              cache: { xpaths: [DECOY_XPATH] },
+            })),
+        };
+        fs.writeFileSync(cacheFile!, yaml.dump(poisoned));
+
+        // --- Run 2: hit the poisoned cache, expect replanning + in-place fix ---
+        const run2 = await launchPage(fixture);
+        reset2 = run2.reset;
+        agent2 = new PuppeteerAgent(run2.originPage, {
+          cache: { id: cacheId },
+        });
+        const staleSpy = vi.spyOn(agent2.taskCache!, 'markLocateCacheStale');
+        const matchSpy = vi.spyOn(agent2.taskCache!, 'matchLocateCache');
+
+        await agent2.aiAct(actPrompt, { deepThink: true });
+        await agent2.aiAssert(assertPrompt);
+        await sleep(1000);
+
+        console.log(
+          'run2 matchLocateCache hits:',
+          matchSpy.mock.results.filter((r) => r.value !== undefined).length,
+          '/ calls:',
+          matchSpy.mock.calls.length,
+        );
+        console.log(
+          'run2 markLocateCacheStale calls:',
+          staleSpy.mock.calls.length,
+        );
+
+        // The poisoned hit was detected and its entry was marked stale.
+        expect(staleSpy).toHaveBeenCalled();
+
+        const afterCache = readCacheFile(cacheFile!);
+        const locateEntriesAfter = afterCache.caches.filter(
+          (c) => c.type === 'locate',
+        );
+
+        // No locate entry still points at the decoy — the stale entry was
+        // refreshed in place, not left behind.
+        const stillDecoy = locateEntriesAfter.filter((c) =>
+          isDeepStrictEqual(c.cache?.xpaths, [DECOY_XPATH]),
+        );
+        expect(stillDecoy).toHaveLength(0);
+
+        // For each poisoned prompt, there is at most one locate entry — the fix
+        // replaced rather than appended a duplicate ([stale, correct]).
+        for (const prompt of poisonedPrompts) {
+          const samePrompt = locateEntriesAfter.filter((c) =>
+            isDeepStrictEqual(c.prompt, prompt),
+          );
+          expect(samePrompt.length).toBeLessThanOrEqual(1);
+        }
+
+        // The locate cache did not grow beyond what Run 1 produced.
+        expect(locateEntriesAfter.length).toBeLessThanOrEqual(
+          locateCountBefore,
+        );
+      },
+      6 * 60 * 1000,
+    );
+  },
+  6 * 60 * 1000,
+);


### PR DESCRIPTION
## Problem

Closes #2529.

When a VLM locate lands on the wrong DOM element (e.g. an adjacent one), the wrong element's XPath gets cached. On subsequent runs the cache poisons itself:

1. The stale entry is matched first (`isCacheHit = true`).
2. The cache write block is skipped because of the `!isCacheHit` guard, so the stale entry never gets corrected.
3. The action fails on the wrong element.
4. `aiAct` replanning re-locates correctly, but in a **rebuilt** task whose `matchLocateCache` now returns `undefined` (the entry was already consumed this run). `updateOrAppendCacheRecord(correct, undefined)` therefore **appends** the corrected result instead of overwriting the stale one.
5. The cache becomes `[stale, correct]`. On the next run the stale entry is matched first again → wrong element → replanning → another appended duplicate. This repeats forever.

The root cause is in `packages/core/src/agent/task-cache.ts`: when `updateOrAppendCacheRecord` is called without a live `MatchCacheResult` (because the stale entry was already consumed), it falls through to `appendCache()` instead of replacing the consumed entry.

## Fix

- Track the in-memory indices of consumed cache entries per `${type}:${prompt}` in a new `consumedCacheIndices` map, recorded in `matchCache`.
- In `updateOrAppendCacheRecord`, when no live `MatchCacheResult` is passed but a consumed entry exists for the prompt, replace that stale entry **in place** (new private `replaceCacheRecord`, honoring `readOnlyMode`) instead of appending a duplicate.

Healthy paths are preserved: a plain cache miss with nothing consumed still appends, and two distinct misses for the same prompt in one run still append their own entries. The only behavior change is that a consumed-then-rewritten entry is overwritten rather than duplicated.

## Tests

New regression suite `packages/core/tests/unit-test/task-cache-poisoning.test.ts`:

- Replaces a consumed stale locate entry in place during replanning instead of appending (this fails on `main`, reproducing the bug).
- Appends a new entry when nothing was consumed for the prompt.
- Does not cross-replace entries for different prompts.
- Appends a second entry for a repeated prompt that was never consumed.

## Validation

- `npx vitest run` for `task-cache-poisoning`, `task-cache-empty-flow`, `bbox-locate-cache`, `aiaction-cacheable`, `agent-cache-config` — all pass.
- `pnpm run lint` (biome) — clean.