### PR TITLE
fix(harmony-mcp): externalize photon and sharp to fix WASM init failure

### DIFF
--- a/packages/harmony-mcp/package.json
+++ b/packages/harmony-mcp/package.json
@@ -15,6 +15,11 @@
     "build:watch": "rslib build --watch --no-clean",
     "mcp-playground": "npx @modelcontextprotocol/inspector node ./dist/index.js"
   },
+  "dependencies": {
+    "@silvia-odwyer/photon": "0.3.3",
+    "@silvia-odwyer/photon-node": "0.3.3",
+    "sharp": "^0.34.3"
+  },
   "devDependencies": {
     "@midscene/harmony": "workspace:*",
     "@midscene/core": "workspace:*",
@@ -25,7 +30,6 @@
     "@rslib/core": "^0.18.3",
     "@rspack/core": "1.6.6",
     "@types/node": "^18.0.0",
-    "sharp": "^0.34.3",
     "typescript": "^5.8.3"
   },
   "license": "MIT"

--- a/packages/harmony-mcp/rslib.config.ts
+++ b/packages/harmony-mcp/rslib.config.ts
@@ -15,7 +15,16 @@ export default defineConfig({
     },
   },
   output: {
-    externals: ['@modelcontextprotocol/sdk'],
+    externals: [
+      // Keep the image libraries external. Bundling photon-node rewrites its
+      // `readFileSync(__dirname, 'photon_rs_bg.wasm')` to the dist dir, where
+      // the .wasm is never emitted, so the WASM module fails to initialize
+      // ("Cannot read properties of undefined (reading '__wbindgen_malloc')").
+      // Resolving from node_modules keeps the asset next to the module.
+      '@silvia-odwyer/photon',
+      '@silvia-odwyer/photon-node',
+      '@modelcontextprotocol/sdk',
+    ],
   },
   plugins: [createTypeCheckPlugin(), injectReportHtmlFromCore(__dirname)],
   tools: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1210,6 +1210,16 @@ importers:
         version: 3.25.76
 
   packages/harmony-mcp:
+    dependencies:
+      '@silvia-odwyer/photon':
+        specifier: 0.3.3
+        version: 0.3.3
+      '@silvia-odwyer/photon-node':
+        specifier: 0.3.3
+        version: 0.3.3
+      sharp:
+        specifier: ^0.34.3
+        version: 0.34.3
     devDependencies:
       '@midscene/core':
         specifier: workspace:*
@@ -1238,9 +1248,6 @@ importers:
       '@types/node':
         specifier: ^18.0.0
         version: 18.19.118
-      sharp:
-        specifier: ^0.34.3
-        version: 0.34.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1394,7 +1401,7 @@ importers:
         version: link:../web-integration
       '@modelcontextprotocol/inspector':
         specifier: ^0.16.3
-        version: 0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)
+        version: 0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.5)
       '@modelcontextprotocol/sdk':
         specifier: 1.10.2
         version: 1.10.2
@@ -2304,19 +2311,16 @@ packages:
   '@computer-use/libnut-darwin@2.7.1':
     resolution: {integrity: sha512-7B/aPcIYS4a4S7D3IYIHSpZ4B4m8Z3CjlYq0efTr+/JYmEu+LlO67ZhPvisLKifhagxf7goqEfnphg1F4jq5jw==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-linux@2.7.1':
     resolution: {integrity: sha512-QJD5URTFJ/2+JwBwRyajRF2BB+3eXpd4+t5btGeRVeiRQLKQ4lgorbMHySo6IrfAbSfnU1OVOrxAUygGxj0cFg==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut-win32@2.7.1':
     resolution: {integrity: sha512-nDvH5kP1zoO2cBtFYWV0om9xtTu523cc1LIk8r/wizqPrIAm0wCizTU+odF3Fi42zcKJWT6J+Pguy8fKrZyIuA==}
     engines: {node: '>=10.15.3'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
 
   '@computer-use/libnut@4.2.0':
@@ -14545,7 +14549,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(typescript@5.8.3)':
+  '@modelcontextprotocol/inspector@0.16.3(@types/node@18.19.62)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.5)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.16.3
       '@modelcontextprotocol/inspector-client': 0.16.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)


### PR DESCRIPTION
## Summary

Fixes #2549.

`harmony-mcp` was the **only** MCP package that did not externalize the image
libraries. As a result, `@silvia-odwyer/photon-node` and `sharp` were bundled
into `dist`, which breaks them at runtime:

- **photon-node**: bundling rewrites its
  `readFileSync(__dirname, 'photon_rs_bg.wasm')` to point at the `dist`
  directory, where the `.wasm` is never emitted. The WASM module fails to
  initialize, leaving the module-level `wasm` binding `undefined`, so the first
  image call throws `Cannot read properties of undefined (reading '__wbindgen_malloc')`.
- **sharp**: only its JS is bundled — the native `@img/sharp-{platform}/sharp.node`
  binary cannot be packed into a single file and is not shipped, so Sharp fails to
  load and falls back to the already-broken Photon path, surfacing the same error.

## Changes

- `packages/harmony-mcp/rslib.config.ts`: add `@silvia-odwyer/photon` and
  `@silvia-odwyer/photon-node` to `externals`.
- `packages/harmony-mcp/package.json`: declare `@silvia-odwyer/photon`,
  `@silvia-odwyer/photon-node` and `sharp` as runtime `dependencies` (move `sharp`
  out of `devDependencies`).

This matches how every other MCP package (`android-mcp`, `ios-mcp`,
`computer-mcp`, `web-bridge-mcp`) is already configured. With the modules
external + declared as dependencies, the package manager installs them (and the
correct platform-specific `@img/sharp-*` native package) so Node resolves them
from `node_modules`, with the `.wasm` / native binaries sitting next to the
modules.

## Validation

- `pnpm run lint` — pass, no changes.
- `npx nx build harmony-mcp` — pass. Verified the rebuilt bundle now uses external
  `import("@silvia-odwyer/photon-node")` / `import("sharp")`, contains no
  executable WASM `readFileSync` (only the harmless embedded report-viewer HTML
  string remains, identical to `ios-mcp`), and `dist` shrank from ~50 MB to ~28 MB.
