### PR TITLE
docs(site): document Azure OpenAI via OpenAI-compatible endpoint

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -246,7 +246,9 @@ Starting with version 1.0, Midscene no longer supports GPT-4o as the planning mo
 
 ## Using Azure OpenAI Service {#azure-openai}
 
-Midscene no longer ships a dedicated Azure client. Because Azure OpenAI exposes an OpenAI-compatible API, you connect to it like any other OpenAI-compatible endpoint: point `MIDSCENE_MODEL_BASE_URL` at your deployment and pass Azure's `api-version` query parameter and `api-key` header through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
+Midscene no longer ships a dedicated Azure client. Because Azure OpenAI exposes OpenAI-compatible APIs, you connect to it like any other OpenAI-compatible endpoint. The exact base URL depends on which Azure endpoint shape your resource provides.
+
+For the classic Azure OpenAI deployment endpoint, point `MIDSCENE_MODEL_BASE_URL` at your deployment and pass Azure's `api-version` query parameter and `api-key` header through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
 
 ```bash
 # Point at your deployment. Do NOT append /chat/completions — the SDK adds it.
@@ -260,6 +262,17 @@ MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-prev
 ```
 
 This sends requests as `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview` with the `api-key` header, which is exactly what Azure OpenAI expects.
+
+For Azure resources that expose the OpenAI-compatible `/openai/v1` endpoint, use the `/openai/v1` base URL and do not add `api-version`. Do not append `/chat/completions`; the OpenAI SDK adds that path.
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="placeholder"
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+This sends requests as `POST /openai/v1/chat/completions` with the `api-key` header.
 
 :::warning Azure AD / keyless auth is not supported
 

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -244,6 +244,29 @@ Migration mapping:
 
 Starting with version 1.0, Midscene no longer supports GPT-4o as the planning model for UI operations. See [Model strategy](./model-strategy) for details.
 
+## Using Azure OpenAI Service {#azure-openai}
+
+Midscene no longer ships a dedicated Azure client. Because Azure OpenAI exposes an OpenAI-compatible API, you connect to it like any other OpenAI-compatible endpoint: point `MIDSCENE_MODEL_BASE_URL` at your deployment and pass Azure's `api-version` query parameter and `api-key` header through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
+
+```bash
+# Point at your deployment. Do NOT append /chat/completions — the SDK adds it.
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.openai.azure.com/openai/deployments/<your-deployment>"
+# Use the deployment name as the model name.
+MIDSCENE_MODEL_NAME="<your-deployment>"
+# Required by the OpenAI SDK constructor, but ignored by Azure when the api-key header is set below.
+MIDSCENE_MODEL_API_KEY="placeholder"
+# Azure auth uses an `api-key` header (not a Bearer token) and requires the api-version query param.
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-preview"},"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+This sends requests as `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview` with the `api-key` header, which is exactly what Azure OpenAI expects.
+
+:::warning Azure AD / keyless auth is not supported
+
+The previous `DefaultAzureCredential` (Azure AD token provider, a.k.a. keyless) mode has been removed. Use an API key as shown above.
+
+:::
+
 ## Multi-model example: GPT-5.4 for planning/insight + Qwen 3.5 for visual grounding {#gpt54-planning-insight-qwen35}
 
 For more information on combining multiple models, see [Advanced: Combining Multiple Models](./model-strategy#advanced-combining-multiple-models).

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -268,11 +268,14 @@ For Azure resources that expose the OpenAI-compatible `/openai/v1` endpoint, use
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
 MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+# Required by the OpenAI SDK constructor. Azure auth uses the api-key header below.
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```
 
 This sends requests as `POST /openai/v1/chat/completions` with the `api-key` header.
+
+Do not omit `MIDSCENE_MODEL_API_KEY` in this setup unless `OPENAI_API_KEY` is already set. The OpenAI SDK validates its constructor `apiKey` before sending the request; Azure still uses the `api-key` header above for authentication.
 
 :::warning Azure AD / keyless auth is not supported
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -270,11 +270,14 @@ MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-prev
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
 MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+# OpenAI SDK 构造时必填；Azure 实际鉴权使用下方 api-key 请求头。
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```
 
 这样发出的请求会是 `POST /openai/v1/chat/completions`，并携带 `api-key` 请求头。
+
+除非已经设置了 `OPENAI_API_KEY`，否则这个配置里不要省略 `MIDSCENE_MODEL_API_KEY`。OpenAI SDK 会在发请求前校验构造器里的 `apiKey`；Azure 实际鉴权仍然使用上面的 `api-key` 请求头。
 
 :::warning 不再支持 Azure AD / keyless 鉴权
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -248,7 +248,9 @@ MIDSCENE_MODEL_FAMILY="vlm-ui-tars-doubao-1.5"
 
 ## 使用 Azure OpenAI Service {#azure-openai}
 
-Midscene 不再内置专用的 Azure 客户端。由于 Azure OpenAI 提供的是 OpenAI 兼容接口，你只需像接入其他 OpenAI 兼容端点一样接入它：把 `MIDSCENE_MODEL_BASE_URL` 指向你的 deployment，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入 Azure 所需的 `api-version` 查询参数和 `api-key` 请求头。
+Midscene 不再内置专用的 Azure 客户端。由于 Azure OpenAI 提供 OpenAI 兼容接口，你可以像接入其他 OpenAI 兼容端点一样接入它。具体的 base URL 取决于你的 Azure 资源提供哪种端点格式。
+
+对于经典的 Azure OpenAI deployment 端点，把 `MIDSCENE_MODEL_BASE_URL` 指向你的 deployment，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入 Azure 所需的 `api-version` 查询参数和 `api-key` 请求头。
 
 ```bash
 # 指向你的 deployment。不要在末尾加 /chat/completions，SDK 会自动补全。
@@ -262,6 +264,17 @@ MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-prev
 ```
 
 这样发出的请求会是 `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview`，并携带 `api-key` 请求头，正是 Azure OpenAI 所期望的格式。
+
+对于提供 OpenAI 兼容 `/openai/v1` 端点的 Azure 资源，base URL 使用 `/openai/v1`，不要再追加 `api-version`。也不要在末尾加 `/chat/completions`，OpenAI SDK 会自动补全这个路径。
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="placeholder"
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+这样发出的请求会是 `POST /openai/v1/chat/completions`，并携带 `api-key` 请求头。
 
 :::warning 不再支持 Azure AD / keyless 鉴权
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -246,6 +246,29 @@ MIDSCENE_MODEL_FAMILY="vlm-ui-tars-doubao-1.5"
 
 从 1.0 版本开始，Midscene 不再支持使用 GPT-4o 作为 UI 操作的规划模型。详见：[模型策略](./model-strategy)。
 
+## 使用 Azure OpenAI Service {#azure-openai}
+
+Midscene 不再内置专用的 Azure 客户端。由于 Azure OpenAI 提供的是 OpenAI 兼容接口，你只需像接入其他 OpenAI 兼容端点一样接入它：把 `MIDSCENE_MODEL_BASE_URL` 指向你的 deployment，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入 Azure 所需的 `api-version` 查询参数和 `api-key` 请求头。
+
+```bash
+# 指向你的 deployment。不要在末尾加 /chat/completions，SDK 会自动补全。
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.openai.azure.com/openai/deployments/<your-deployment>"
+# 用 deployment 名称作为模型名。
+MIDSCENE_MODEL_NAME="<your-deployment>"
+# OpenAI SDK 构造时必填，但当下方设置了 api-key 请求头后，Azure 会忽略它。
+MIDSCENE_MODEL_API_KEY="placeholder"
+# Azure 鉴权使用 `api-key` 请求头（而非 Bearer token），并且要求带上 api-version 查询参数。
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-preview"},"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+这样发出的请求会是 `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview`，并携带 `api-key` 请求头，正是 Azure OpenAI 所期望的格式。
+
+:::warning 不再支持 Azure AD / keyless 鉴权
+
+此前基于 `DefaultAzureCredential`（Azure AD token provider，即 keyless）的模式已被移除，请改用上面的 API Key 方式。
+
+:::
+
 ## 多模型示例：GPT-5.4 规划/理解 + Qwen 3.5 视觉定位 {#gpt54-planning-insight-qwen35}
 
 关于组合多个模型的更多信息，可查阅 [进阶：组合多个模型](./model-strategy#advanced-combining-multiple-models)。


### PR DESCRIPTION
## What

Adds a dedicated **"Using Azure OpenAI Service"** section (anchor `#azure-openai`) to the model configuration docs, in both English and Chinese.

## Why

Issue #2460 reports that Azure configuration is missing from the docs and that the config referenced in a previously-closed issue no longer works. The dedicated Azure client was intentionally removed in #1325 (`refactor(core): remove non-OpenAI SDK support and upgrade to OpenAI 6.x`), but no replacement guidance was documented — leaving users stranded.

## How

Since Azure OpenAI exposes an OpenAI-compatible API, it is now connected like any other OpenAI-compatible endpoint:

- `MIDSCENE_MODEL_BASE_URL` points at the Azure deployment.
- Azure's required `api-version` query param and `api-key` header are passed through `MIDSCENE_MODEL_INIT_CONFIG_JSON` (`defaultQuery` / `defaultHeaders`).
- A warning notes that Azure AD / keyless (`DefaultAzureCredential`) auth is no longer supported.

## Verification

I verified this path end-to-end before documenting it: a local HTTP server simulating an Azure deployment endpoint received Midscene's real `callAI` request and confirmed the exact Azure wire format — `POST /openai/deployments/<deployment>/chat/completions?api-version=...` with the `api-key` header and the deployment name as the request body `model`. The response was parsed back correctly.

## Validation commands

- `pnpm run lint` — passed (1178 files checked, no fixes)

Docs-only change; no code or build wiring touched.

Closes #2460
