### PR TITLE
docs(site): refresh recommended model list to latest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,26 @@ should point here instead of duplicating rules.
   It already documents translation constraints such as keeping `API Key` and
   `Agent` untranslated in Chinese where appropriate.
 
+### Upgrading recommended models
+
+`apps/site/docs/{en,zh}/model-strategy.mdx` and
+`apps/site/docs/{en,zh}/model-common-config.mdx` are the source of truth for
+which models we recommend and the exact model/family strings. When the
+recommended models or their versions change (e.g. `qwen3-vl` → `qwen3.x`,
+`gemini-3-flash` → `gemini-3.5-flash`), update the strategy/config docs first,
+then propagate the new model names to every place that markets the supported
+model list:
+
+- `README.md` and `README.zh.md` (the "Driven by Visual Language Model"
+  section).
+- `apps/site/docs/en/introduction.mdx` and
+  `apps/site/docs/zh/introduction.mdx` (same section).
+
+Keep all four spots in sync and consistent with the strategy/config docs.
+Leave historical references in `changelog.mdx` alone, and keep illustrative
+"newer beats older" comparisons in `faq.md` intact. Remember README and
+introduction are bilingual: update the en/zh counterparts in the same change.
+
 ## Validation Guidance
 
 - Docs-only change: usually `pnpm run lint` is enough.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Use [Midscene Skills](https://github.com/web-infra-dev/midscene-skills) to contr
 
 ## ✨ Driven by Visual Language Model
 
-Midscene.js is all-in on the pure-vision route for UI actions: element localization and interactions are based on screenshots only. It supports visual-language models like `Qwen3-VL`, `Doubao-1.6-vision`, `gemini-3-pro`, and `UI-TARS`. For data extraction and page understanding, you can still opt in to include DOM when needed.
+Midscene.js is all-in on the pure-vision route for UI actions: element localization and interactions are based on screenshots only. It supports visual-language models like `Qwen3.x`, `Doubao-Seed-2.0`, `GLM-4.6V`, `gemini-3.5-flash`, and `UI-TARS`. For data extraction and page understanding, you can still opt in to include DOM when needed.
 
 * Pure-vision localization for UI actions; the DOM extraction mode is removed.
 * Works across web, mobile, desktop, and even `<canvas>` surfaces.

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,7 +73,7 @@
 
 ## ✨ 视觉语言模型驱动
 
-Midscene.js 在 UI 操作上完全采用纯视觉路线：元素定位与交互仅基于截图。它支持 `Qwen3-VL`、`Doubao-1.6-vision`、`gemini-3-pro`、`UI-TARS` 等视觉语言模型。在数据提取与页面理解场景中，你仍可按需选择携带 DOM。
+Midscene.js 在 UI 操作上完全采用纯视觉路线：元素定位与交互仅基于截图。它支持 `Qwen3.x`、`Doubao-Seed-2.0`、`GLM-4.6V`、`gemini-3.5-flash`、`UI-TARS` 等视觉语言模型。在数据提取与页面理解场景中，你仍可按需选择携带 DOM。
 
 * UI 操作使用纯视觉定位；不再保留 DOM 提取模式。
 * 支持 Web、移动端、桌面端，甚至 `<canvas>` 场景。

--- a/apps/site/docs/en/introduction.mdx
+++ b/apps/site/docs/en/introduction.mdx
@@ -45,7 +45,7 @@ Plus these real-world showcases:
 
 ## Driven by Visual Language Model
 
-Midscene.js is all-in on the pure-vision route for UI actions: element localization and interactions are based on screenshots only. It supports visual-language models like `Qwen3-VL`, `Doubao-1.6-vision`, `gemini-3-flash`, and `UI-TARS`. For data extraction and page understanding, you can still opt in to include DOM when needed.
+Midscene.js is all-in on the pure-vision route for UI actions: element localization and interactions are based on screenshots only. It supports visual-language models like `Qwen3.x`, `Doubao-Seed-2.0`, `GLM-4.6V`, `gemini-3.5-flash`, and `UI-TARS`. For data extraction and page understanding, you can still opt in to include DOM when needed.
 
 * Pure-vision localization for UI actions; the DOM extraction mode is removed.
 * Works across web, mobile, desktop, and even `<canvas>` surfaces.

--- a/apps/site/docs/zh/introduction.mdx
+++ b/apps/site/docs/zh/introduction.mdx
@@ -43,7 +43,7 @@
 
 ## 视觉语言模型驱动
 
-Midscene.js 在 UI 操作上采用纯视觉（pure-vision）路线：元素定位和交互只基于截图完成。支持视觉语言模型，例如 `Qwen3-VL`、`Doubao-1.6-vision`、`gemini-3-pro`、`gemini-3-flash` 和 `UI-TARS`。在数据提取和页面理解场景中，需要时仍可选择附带 DOM 信息。
+Midscene.js 在 UI 操作上采用纯视觉（pure-vision）路线：元素定位和交互只基于截图完成。支持视觉语言模型，例如 `Qwen3.x`、`Doubao-Seed-2.0`、`GLM-4.6V`、`gemini-3.5-flash` 和 `UI-TARS`。在数据提取和页面理解场景中，需要时仍可选择附带 DOM 信息。
 
 * UI 操作采用纯视觉定位，不再提供 DOM 提取兼容模式。
 * 适用于 Web、移动端、桌面应用，甚至 `<canvas>` 场景。


### PR DESCRIPTION
Update the marketed visual-language model list in README (en/zh) and the introduction pages (en/zh) to match the source-of-truth model-strategy / model-common-config docs: Qwen3.x, Doubao-Seed-2.0, GLM-4.6V, gemini-3.5-flash, UI-TARS (was Qwen3-VL / Doubao-1.6-vision / gemini-3-pro / gemini-3-flash).

Add an AGENTS.md note listing which docs to update when upgrading recommended models.