### PR TITLE
feat(shared): expose deep-locate / deep-think via CLI flags for MCP and skill

### DIFF
--- a/apps/site/docs/en/mcp.mdx
+++ b/apps/site/docs/en/mcp.mdx
@@ -190,10 +190,6 @@ midscene-android --deep-locate tap --locate "the login button"
 
 A per-call value always wins over the startup flag: action tools accept `locate.deepLocate`, and the `act` tool accepts top-level `deepLocate` and `deepThink` booleans, so an individual call can opt in or out regardless of the startup setting.
 
-:::tip
-Deep locate only takes effect with a visual-language (VL) model. See [Model strategy](./model-strategy) for the supported models.
-:::
-
 ## Implement your own MCP
 
 If you want to integrate Midscene tools into your own MCP service, you can use the `mcpKitForAgent` function to get tool definitions and expose your own MCP service as needed.

--- a/apps/site/docs/en/mcp.mdx
+++ b/apps/site/docs/en/mcp.mdx
@@ -155,6 +155,45 @@ Add the Midscene Computer MCP server (`@midscene/computer-mcp`) in your MCP clie
 }
 ```
 
+## Improve precision (deep locate / deep think)
+
+Two independent startup flags help when the MCP service struggles with a task:
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when actions tap or interact with the wrong spot (location drift / offset). It applies to every operation that locates an element (action tools such as `Tap`, `Input`, `Scroll`, and the locating that happens inside `act`).
+- `--deep-think` — plans the `act` tool with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions. It only affects planning, so it has no effect on the single-step action tools.
+
+Both trade a little speed for better results, and you can combine them. Once a flag is on, the relevant tools default to it without having to pass a parameter on every call.
+
+For an MCP server, add the flag(s) to `args`:
+
+```json
+{
+  "mcpServers": {
+    "midscene-android": {
+      "command": "npx",
+      "args": ["-y", "@midscene/android-mcp", "--deep-locate", "--deep-think"],
+      "env": {
+        "MIDSCENE_MODEL_BASE_URL": "replace with your model service URL",
+        "MIDSCENE_MODEL_API_KEY": "replace with your API Key",
+        "MIDSCENE_MODEL_NAME": "replace with your model name"
+      }
+    }
+  }
+}
+```
+
+The same flags work for the Agent Skill / device CLIs (`midscene-android`, `midscene-web`, `midscene-ios`, etc.), since they share the same tool definitions:
+
+```bash
+midscene-android --deep-locate tap --locate "the login button"
+```
+
+A per-call value always wins over the startup flag: action tools accept `locate.deepLocate`, and the `act` tool accepts top-level `deepLocate` and `deepThink` booleans, so an individual call can opt in or out regardless of the startup setting.
+
+:::tip
+Deep locate only takes effect with a visual-language (VL) model. See [Model strategy](./model-strategy) for the supported models.
+:::
+
 ## Implement your own MCP
 
 If you want to integrate Midscene tools into your own MCP service, you can use the `mcpKitForAgent` function to get tool definitions and expose your own MCP service as needed.

--- a/apps/site/docs/zh/mcp.mdx
+++ b/apps/site/docs/zh/mcp.mdx
@@ -155,6 +155,45 @@ open report_file_name.html
 }
 ```
 
+## 提升精度（深度定位 / 深度思考）
+
+有两个相互独立的启动参数,可在 MCP 服务处理任务遇到困难时使用:
+
+- `--deep-locate`(深度定位)——额外进行一轮视觉推理来精确定位目标元素。当操作点击或交互到错误位置(定位漂移 / 偏移)时使用。它作用于所有需要定位元素的操作(`Tap`、`Input`、`Scroll` 等 Action 工具,以及 `act` 内部发生的定位)。
+- `--deep-think`(深度思考)——让 `act` 工具以更深的推理来规划(更丰富的上下文与子目标拆解)。适用于复杂、多步的 `act` 指令。它只影响规划,因此对单步的 Action 工具无效。
+
+两者都用少量速度换取更好的效果,且可以同时开启。开启后,相关工具会默认使用对应能力,无需在每次调用时单独传参。
+
+对于 MCP server,把参数加到 `args` 中:
+
+```json
+{
+  "mcpServers": {
+    "midscene-android": {
+      "command": "npx",
+      "args": ["-y", "@midscene/android-mcp", "--deep-locate", "--deep-think"],
+      "env": {
+        "MIDSCENE_MODEL_BASE_URL": "replace with your model service URL",
+        "MIDSCENE_MODEL_API_KEY": "replace with your API Key",
+        "MIDSCENE_MODEL_NAME": "replace with your model name"
+      }
+    }
+  }
+}
+```
+
+同样的参数对 Agent Skill / 设备 CLI(`midscene-android`、`midscene-web`、`midscene-ios` 等)同样生效,因为它们共用同一套工具定义:
+
+```bash
+midscene-android --deep-locate tap --locate "登录按钮"
+```
+
+单次调用的取值始终优先于启动参数:Action 工具支持 `locate.deepLocate`,`act` 工具支持顶层的 `deepLocate` 与 `deepThink` 布尔参数,因此任意单次调用都可以无视启动设置自行开启或关闭。
+
+:::tip
+深度定位仅在视觉语言（VL）模型下生效。支持的模型详见[模型选择策略](./model-strategy)。
+:::
+
 ## 实现自己的 MCP
 
 如果你想在自己的 MCP 服务中集成 Midscene 工具，可以使用 `mcpKitForAgent` 函数来获取工具定义，继而自己按需暴露 MCP 服务。

--- a/apps/site/docs/zh/mcp.mdx
+++ b/apps/site/docs/zh/mcp.mdx
@@ -190,10 +190,6 @@ midscene-android --deep-locate tap --locate "登录按钮"
 
 单次调用的取值始终优先于启动参数:Action 工具支持 `locate.deepLocate`,`act` 工具支持顶层的 `deepLocate` 与 `deepThink` 布尔参数,因此任意单次调用都可以无视启动设置自行开启或关闭。
 
-:::tip
-深度定位仅在视觉语言（VL）模型下生效。支持的模型详见[模型选择策略](./model-strategy)。
-:::
-
 ## 实现自己的 MCP
 
 如果你想在自己的 MCP 服务中集成 Midscene 工具，可以使用 `mcpKitForAgent` 函数来获取工具定义，继而自己按需暴露 MCP 服务。

--- a/packages/android-mcp/src/index.ts
+++ b/packages/android-mcp/src/index.ts
@@ -1,19 +1,14 @@
 import { parseArgs } from 'node:util';
 import { AndroidMCPServer } from '@midscene/android/mcp-server';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
 const args = values as CLIArgs;
 
 const server = new AndroidMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);

--- a/packages/computer-mcp/src/index.ts
+++ b/packages/computer-mcp/src/index.ts
@@ -1,19 +1,14 @@
 import { parseArgs } from 'node:util';
 import { ComputerMCPServer } from '@midscene/computer/mcp-server';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
 const args = values as CLIArgs;
 
 const server = new ComputerMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);

--- a/packages/harmony-mcp/src/index.ts
+++ b/packages/harmony-mcp/src/index.ts
@@ -1,19 +1,14 @@
 import { parseArgs } from 'node:util';
 import { HarmonyMCPServer } from '@midscene/harmony/mcp-server';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
 const args = values as CLIArgs;
 
 const server = new HarmonyMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);

--- a/packages/ios-mcp/src/index.ts
+++ b/packages/ios-mcp/src/index.ts
@@ -1,19 +1,14 @@
 import { parseArgs } from 'node:util';
 import { IOSMCPServer } from '@midscene/ios/mcp-server';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
 const args = values as CLIArgs;
 
 const server = new IOSMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 import { DeprecatedMCPServer } from './server.js';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
@@ -8,13 +12,4 @@ const args = values as CLIArgs;
 
 const server = new DeprecatedMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import dotenv from 'dotenv';
 import { getDebug } from '../logger';
 import type { BaseMidsceneTools } from '../mcp/base-tools';
+import { TOOL_BEHAVIOR_FLAGS, resolveToolDefaults } from '../mcp/tool-defaults';
 import type {
   ToolDefinition,
   ToolResult,
@@ -135,8 +136,29 @@ export async function runToolsCLI(
   scriptName: string,
   options?: CLIRunnerOptions,
 ): Promise<void> {
-  const rawArgs = options?.argv ?? process.argv.slice(2);
-  debug('CLI invoked: %s %s', scriptName, rawArgs.join(' '));
+  const inputArgs = options?.argv ?? process.argv.slice(2);
+  debug('CLI invoked: %s %s', scriptName, inputArgs.join(' '));
+
+  // Global behavior flags (e.g. `--deep-locate` / `--deep-think`) apply
+  // regardless of which command runs. Driven by TOOL_BEHAVIOR_FLAGS, stripped
+  // here so the per-command parser never sees them.
+  // See https://github.com/web-infra-dev/midscene/issues/2446.
+  const isFlag = (arg: string, cli: string) =>
+    arg === `--${cli}` ||
+    arg === `--${cli.replace(/-([a-z])/g, (_, c) => c.toUpperCase())}`;
+  const enabledFlags = new Set(
+    TOOL_BEHAVIOR_FLAGS.filter((flag) =>
+      inputArgs.some((arg) => isFlag(arg, flag.cli)),
+    ).map((flag) => flag.cli),
+  );
+  const rawArgs = inputArgs.filter(
+    (arg) => !TOOL_BEHAVIOR_FLAGS.some((flag) => isFlag(arg, flag.cli)),
+  );
+  if (enabledFlags.size > 0) {
+    tools.setToolDefaults?.(
+      resolveToolDefaults((cli) => enabledFlags.has(cli)),
+    );
+  }
 
   // Load .env from cwd before any tool initialization
   const envFile = join(process.cwd(), '.env');

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import dotenv from 'dotenv';
 import { getDebug } from '../logger';
 import type { BaseMidsceneTools } from '../mcp/base-tools';
-import { TOOL_BEHAVIOR_FLAGS, resolveToolDefaults } from '../mcp/tool-defaults';
+import { stripBehaviorFlags } from '../mcp/tool-defaults';
 import type {
   ToolDefinition,
   ToolResult,
@@ -140,24 +140,13 @@ export async function runToolsCLI(
   debug('CLI invoked: %s %s', scriptName, inputArgs.join(' '));
 
   // Global behavior flags (e.g. `--deep-locate` / `--deep-think`) apply
-  // regardless of which command runs. Driven by TOOL_BEHAVIOR_FLAGS, stripped
-  // here so the per-command parser never sees them.
+  // regardless of which command runs. `stripBehaviorFlags` is the single place
+  // that knows how they look on the command line: it resolves their defaults
+  // and returns the remaining args so the per-command parser never sees them.
   // See https://github.com/web-infra-dev/midscene/issues/2446.
-  const isFlag = (arg: string, cli: string) =>
-    arg === `--${cli}` ||
-    arg === `--${cli.replace(/-([a-z])/g, (_, c) => c.toUpperCase())}`;
-  const enabledFlags = new Set(
-    TOOL_BEHAVIOR_FLAGS.filter((flag) =>
-      inputArgs.some((arg) => isFlag(arg, flag.cli)),
-    ).map((flag) => flag.cli),
-  );
-  const rawArgs = inputArgs.filter(
-    (arg) => !TOOL_BEHAVIOR_FLAGS.some((flag) => isFlag(arg, flag.cli)),
-  );
-  if (enabledFlags.size > 0) {
-    tools.setToolDefaults?.(
-      resolveToolDefaults((cli) => enabledFlags.has(cli)),
-    );
+  const { rawArgs, toolDefaults } = stripBehaviorFlags(inputArgs);
+  if (Object.keys(toolDefaults).length > 0) {
+    tools.setToolDefaults?.(toolDefaults);
   }
 
   // Load .env from cwd before any tool initialization

--- a/packages/shared/src/mcp/base-server.ts
+++ b/packages/shared/src/mcp/base-server.ts
@@ -10,6 +10,12 @@ import express, {
   type Response,
 } from 'express';
 import { getErrorMessage } from './error-formatter';
+import {
+  TOOL_BEHAVIOR_FLAGS,
+  type ToolDefaults,
+  mergeToolDefaults,
+  resolveToolDefaults,
+} from './tool-defaults';
 import type { IMidsceneTools } from './types';
 
 export interface BaseMCPServerConfig {
@@ -47,18 +53,25 @@ interface SessionData {
 }
 
 /**
- * CLI argument configuration for MCP servers
+ * CLI argument configuration for MCP servers. Behavior flags (e.g.
+ * `--deep-locate`) are generated from {@link TOOL_BEHAVIOR_FLAGS}, so adding a
+ * new flag there exposes it here automatically.
  */
 export const CLI_ARGS_CONFIG: ParseArgsConfig['options'] = {
   mode: { type: 'string', default: 'stdio' },
   port: { type: 'string', default: '3000' },
   host: { type: 'string', default: 'localhost' },
+  ...Object.fromEntries(
+    TOOL_BEHAVIOR_FLAGS.map((flag) => [flag.cli, { type: 'boolean' as const }]),
+  ),
 };
 
 export interface CLIArgs {
   mode?: string;
   port?: string;
   host?: string;
+  /** Behavior flags such as `deep-locate` / `deep-think` (see TOOL_BEHAVIOR_FLAGS). */
+  [flag: string]: string | boolean | undefined;
 }
 
 /**
@@ -69,6 +82,7 @@ export function launchMCPServer(
   server: BaseMCPServer,
   args: CLIArgs,
 ): Promise<LaunchMCPServerResult> {
+  server.setToolDefaults(resolveToolDefaults((cli) => args[cli] === true));
   if (args.mode === 'http') {
     return server.launchHttp({
       port: Number.parseInt(args.port || '3000', 10),
@@ -91,6 +105,7 @@ export abstract class BaseMCPServer {
   protected toolsManager?: IMidsceneTools;
   protected config: BaseMCPServerConfig;
   protected providedToolsManager?: IMidsceneTools;
+  protected toolDefaults: ToolDefaults = {};
 
   constructor(config: BaseMCPServerConfig, toolsManager?: IMidsceneTools) {
     this.config = config;
@@ -100,6 +115,16 @@ export abstract class BaseMCPServer {
       description: config.description,
     });
     this.providedToolsManager = toolsManager;
+  }
+
+  /**
+   * Set the default options injected into generated tool calls (e.g. forced
+   * deep locate / deep think). Must be called before `launch()` /
+   * `launchHttp()` so they are applied to the tools manager before its tools
+   * are generated. Merges with any previously set defaults.
+   */
+  public setToolDefaults(toolDefaults: ToolDefaults): void {
+    this.toolDefaults = mergeToolDefaults(this.toolDefaults, toolDefaults);
   }
 
   /**
@@ -116,6 +141,10 @@ export abstract class BaseMCPServer {
 
     // Use provided tools manager if available, otherwise create new one
     this.toolsManager = this.providedToolsManager || this.createToolsManager();
+
+    // Apply the tool defaults before tools are generated so they are baked
+    // into the generated tool handlers.
+    this.toolsManager.setToolDefaults?.(this.toolDefaults);
 
     try {
       await this.toolsManager.initTools();

--- a/packages/shared/src/mcp/base-tools.ts
+++ b/packages/shared/src/mcp/base-tools.ts
@@ -14,6 +14,7 @@ import {
   extractNamespacedArgs,
   sanitizeNamespacedArgs,
 } from './init-arg-utils';
+import { type ToolDefaults, mergeToolDefaults } from './tool-defaults';
 import {
   generateCommonTools,
   generateToolsFromActionSpace,
@@ -73,6 +74,14 @@ export abstract class BaseMidsceneTools<
   protected mcpServer?: McpServer;
   protected agent?: TAgent;
   protected toolDefinitions: ToolDefinition[] = [];
+
+  /**
+   * Default options injected into every generated tool call (e.g. forced deep
+   * locate / deep think). Set from server/CLI behavior flags before
+   * `initTools()` so they are baked into the generated tool handlers.
+   * See https://github.com/web-infra-dev/midscene/issues/2446.
+   */
+  protected toolDefaults: ToolDefaults = {};
 
   /**
    * Declarative init-arg spec. Subclasses that accept CLI/MCP init args should
@@ -289,6 +298,7 @@ export abstract class BaseMidsceneTools<
       (args = {}) => this.sanitizeToolArgs(args),
       this.getAgentInitArgSchema(),
       this.getAgentInitArgCliMetadata(),
+      this.toolDefaults,
     );
 
     // 4. Add common tools (screenshot, waitFor)
@@ -296,6 +306,7 @@ export abstract class BaseMidsceneTools<
       (args = {}) => this.ensureAgent(this.extractAgentInitParam(args)),
       this.getAgentInitArgSchema(),
       this.getAgentInitArgCliMetadata(),
+      this.toolDefaults,
     );
     this.toolDefinitions.push(...actionTools, ...commonTools);
 
@@ -343,6 +354,15 @@ export abstract class BaseMidsceneTools<
    */
   public setAgent(agent: TAgent): void {
     this.agent = agent;
+  }
+
+  /**
+   * Set the default options injected into generated tool calls. Must be called
+   * before `initTools()` because the values are captured into the generated
+   * tool handlers. Merges with any previously set defaults.
+   */
+  public setToolDefaults(toolDefaults: ToolDefaults): void {
+    this.toolDefaults = mergeToolDefaults(this.toolDefaults, toolDefaults);
   }
 
   /**

--- a/packages/shared/src/mcp/index.ts
+++ b/packages/shared/src/mcp/index.ts
@@ -1,5 +1,6 @@
 export * from './base-server';
 export * from './base-tools';
+export * from './tool-defaults';
 export * from './init-arg-utils';
 export * from './error-formatter';
 export * from './tool-generator';

--- a/packages/shared/src/mcp/tool-defaults.ts
+++ b/packages/shared/src/mcp/tool-defaults.ts
@@ -1,0 +1,87 @@
+/**
+ * Unified, declarative mechanism for "force a default option on every tool
+ * call" behaviors exposed by MCP servers and the device / Agent Skill CLIs.
+ *
+ * Adding a new behavior flag (e.g. `--deep-search`) is a one-line change to
+ * {@link TOOL_BEHAVIOR_FLAGS}: declare which default-option "bag" it fills.
+ * The tool generator, servers, tools managers and CLI parsing are all generic
+ * over {@link ToolDefaults} and never need to learn about individual flags.
+ *
+ * See https://github.com/web-infra-dev/midscene/issues/2446.
+ */
+
+/**
+ * Default options injected into generated tool calls. Each field is an
+ * injection point; an explicit per-call value always wins over these defaults.
+ */
+export interface ToolDefaults {
+  /**
+   * Merged into every locate field of action tools (`Tap`, `Input`, ...).
+   * e.g. `{ deepLocate: true }`.
+   */
+  locate?: Record<string, unknown>;
+  /**
+   * Merged into the `act` tool's `aiAction` options.
+   * e.g. `{ deepLocate: true, deepThink: true }`.
+   */
+  act?: Record<string, unknown>;
+}
+
+export interface ToolBehaviorFlag {
+  /** Kebab-case CLI flag name, e.g. `deep-locate` (exposed as `--deep-locate`). */
+  cli: string;
+  /** One-line description for help output. */
+  description: string;
+  /** Default-option bags this flag turns on when present. */
+  defaults: ToolDefaults;
+}
+
+/**
+ * The single source of truth for behavior flags. Add a row to support a new
+ * `--flag`; nothing else in the pipeline needs to change.
+ */
+export const TOOL_BEHAVIOR_FLAGS: readonly ToolBehaviorFlag[] = [
+  {
+    cli: 'deep-locate',
+    description:
+      'Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).',
+    defaults: { locate: { deepLocate: true }, act: { deepLocate: true } },
+  },
+  {
+    cli: 'deep-think',
+    description:
+      'Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower).',
+    defaults: { act: { deepThink: true } },
+  },
+];
+
+/** Merge two {@link ToolDefaults}, with `b` taking precedence over `a`. */
+export function mergeToolDefaults(
+  a: ToolDefaults,
+  b: ToolDefaults,
+): ToolDefaults {
+  const locate = { ...a.locate, ...b.locate };
+  const act = { ...a.act, ...b.act };
+  const result: ToolDefaults = {};
+  if (Object.keys(locate).length > 0) {
+    result.locate = locate;
+  }
+  if (Object.keys(act).length > 0) {
+    result.act = act;
+  }
+  return result;
+}
+
+/**
+ * Resolve the active {@link ToolDefaults} from a predicate that says whether a
+ * given flag (by its `cli` name) is enabled.
+ */
+export function resolveToolDefaults(
+  isEnabled: (cli: string) => boolean,
+): ToolDefaults {
+  return TOOL_BEHAVIOR_FLAGS.reduce<ToolDefaults>(
+    (acc, flag) =>
+      isEnabled(flag.cli) ? mergeToolDefaults(acc, flag.defaults) : acc,
+    {},
+  );
+}

--- a/packages/shared/src/mcp/tool-defaults.ts
+++ b/packages/shared/src/mcp/tool-defaults.ts
@@ -85,3 +85,36 @@ export function resolveToolDefaults(
     {},
   );
 }
+
+/**
+ * Split argv into the resolved {@link ToolDefaults} and the remaining args.
+ *
+ * Behavior flags (e.g. `--deep-locate`) are global: they may appear anywhere
+ * in argv and are not tied to a specific sub-command. They are recognized by
+ * exact kebab-case match — the same surface the MCP `parseArgs` config exposes
+ * — and removed so a strict per-command parser never sees them. Every other
+ * token is returned untouched and in order for that per-command parser.
+ *
+ * This is the single place that knows how a behavior flag looks on the command
+ * line; both the device / Agent Skill CLI and the MCP launch path resolve their
+ * defaults from {@link TOOL_BEHAVIOR_FLAGS} through here / {@link resolveToolDefaults}.
+ */
+export function stripBehaviorFlags(argv: readonly string[]): {
+  rawArgs: string[];
+  toolDefaults: ToolDefaults;
+} {
+  const enabled = new Set<string>();
+  const rawArgs: string[] = [];
+  for (const arg of argv) {
+    const flag = TOOL_BEHAVIOR_FLAGS.find((f) => arg === `--${f.cli}`);
+    if (flag) {
+      enabled.add(flag.cli);
+    } else {
+      rawArgs.push(arg);
+    }
+  }
+  return {
+    rawArgs,
+    toolDefaults: resolveToolDefaults((cli) => enabled.has(cli)),
+  };
+}

--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -7,6 +7,7 @@ import {
   unwrapZodField,
 } from '../zod-schema-utils';
 import { getErrorMessage } from './error-formatter';
+import type { ToolDefaults } from './tool-defaults';
 import type {
   ActionSpaceItem,
   BaseAgent,
@@ -291,6 +292,62 @@ function normalizeActionArgs(
 }
 
 /**
+ * Merge `defaults` into a single locate object without overwriting values the
+ * caller set explicitly. `deepThink` is a deprecated alias for `deepLocate`,
+ * so an explicit `deepThink` counts as `deepLocate` already being set.
+ */
+function mergeLocateDefaults(
+  locate: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+): Record<string, unknown> {
+  let merged: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(defaults)) {
+    if (locate[key] !== undefined) {
+      continue;
+    }
+    if (key === 'deepLocate' && locate.deepThink !== undefined) {
+      continue;
+    }
+    merged = merged ?? { ...locate };
+    merged[key] = value;
+  }
+  return merged ?? locate;
+}
+
+/**
+ * Apply `locateDefaults` to every locate-like field of an action's args.
+ * Generic over the default keys, so new behaviors need no changes here.
+ */
+function applyLocateDefaults(
+  args: Record<string, unknown>,
+  paramSchema: z.ZodTypeAny | undefined,
+  locateDefaults: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!paramSchema || Object.keys(locateDefaults).length === 0) {
+    return args;
+  }
+
+  const shape = getZodObjectShape(paramSchema);
+  if (!shape) {
+    return args;
+  }
+
+  return Object.fromEntries(
+    Object.entries(args).map(([key, value]) => {
+      const fieldSchema = shape[key] as z.ZodTypeAny | undefined;
+      if (
+        fieldSchema &&
+        isMidsceneLocatorField(fieldSchema) &&
+        isRecord(value)
+      ) {
+        return [key, mergeLocateDefaults(value, locateDefaults)];
+      }
+      return [key, value];
+    }),
+  );
+}
+
+/**
  * Serialize args to human-readable description for AI action
  */
 function serializeArgsToDescription(args: Record<string, unknown>): string {
@@ -490,6 +547,7 @@ export function generateToolsFromActionSpace(
   ) => args,
   initArgSchema: ToolSchema = {},
   initArgCliMetadata?: ToolCliMetadata,
+  toolDefaults: ToolDefaults = {},
 ): ToolDefinition[] {
   return actionSpace.map((action) => {
     const schema = {
@@ -505,10 +563,17 @@ export function generateToolsFromActionSpace(
       handler: async (args: Record<string, unknown>) => {
         try {
           const agent = await getAgent(args);
-          const normalizedArgs = normalizeActionArgs(
+          let normalizedArgs = normalizeActionArgs(
             sanitizeArgs(args),
             action.paramSchema,
           );
+          if (toolDefaults.locate) {
+            normalizedArgs = applyLocateDefaults(
+              normalizedArgs,
+              action.paramSchema,
+              toolDefaults.locate,
+            );
+          }
           let actionResult: unknown;
 
           try {
@@ -553,6 +618,7 @@ export function generateCommonTools(
   getAgent: (args?: Record<string, unknown>) => Promise<BaseAgent>,
   initArgSchema: ToolSchema = {},
   initArgCliMetadata?: ToolCliMetadata,
+  toolDefaults: ToolDefaults = {},
 ): ToolDefinition[] {
   return [
     {
@@ -597,6 +663,18 @@ export function generateCommonTools(
           .describe(
             'Natural language description of the action to perform, e.g. "press Command+Space, type Safari, press Enter"',
           ),
+        deepLocate: z
+          .boolean()
+          .optional()
+          .describe(
+            'Use deep locate for every element this action targets. Improves precision for small or ambiguous targets at the cost of speed. Defaults to the server --deep-locate setting.',
+          ),
+        deepThink: z
+          .boolean()
+          .optional()
+          .describe(
+            'Plan this action with deep thinking (richer context and sub-goal decomposition). Helps with complex multi-step instructions at the cost of speed. Defaults to the server --deep-think setting.',
+          ),
         ...initArgSchema,
       },
       cli: mergeToolCliMetadata(undefined, initArgCliMetadata),
@@ -609,7 +687,19 @@ export function generateCommonTools(
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
-          const result = await agent.aiAction(prompt, { deepThink: false });
+          // Start from the act defaults (deepThink off), overlay the server
+          // tool defaults, then let explicit per-call args win.
+          const actOptions: Record<string, unknown> = {
+            deepThink: false,
+            ...toolDefaults.act,
+          };
+          if (args.deepLocate !== undefined) {
+            actOptions.deepLocate = args.deepLocate;
+          }
+          if (args.deepThink !== undefined) {
+            actOptions.deepThink = args.deepThink;
+          }
+          const result = await agent.aiAction(prompt, actOptions);
           return await captureScreenshotResult(agent, 'act', result);
         } catch (error: unknown) {
           const errorMessage = getErrorMessage(error);

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from 'zod';
+import type { ToolDefaults } from './tool-defaults';
 
 // Avoid circular dependency: don't import from @midscene/core
 // Instead, use generic types that will be provided by implementation
@@ -148,4 +149,5 @@ export interface IMidsceneTools {
   attachToServer(server: McpServer): void;
   initTools(): Promise<void>;
   destroy?(): Promise<void>;
+  setToolDefaults?(toolDefaults: ToolDefaults): void;
 }

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -352,6 +352,104 @@ describe('runToolsCLI', () => {
     consoleSpy.mockRestore();
   });
 
+  it('strips a global --deep-locate flag and applies deep locate defaults', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tools = createMockTools([{ name: 'tap', handler }]);
+    tools.setToolDefaults = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // The flag is placed before the command; it must be removed so 'tap'
+    // resolves as the command instead of being treated as unknown.
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['--deep-locate', 'tap', '--locate', 'btn'],
+    });
+
+    expect(tools.setToolDefaults).toHaveBeenCalledWith({
+      locate: { deepLocate: true },
+      act: { deepLocate: true },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('strips --deep-locate even when it follows the command', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tools = createMockTools([{ name: 'tap', handler }]);
+    tools.setToolDefaults = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['tap', '--deep-locate', '--locate', 'btn'],
+    });
+
+    expect(tools.setToolDefaults).toHaveBeenCalledWith({
+      locate: { deepLocate: true },
+      act: { deepLocate: true },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('does not set tool defaults without a behavior flag', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tools = createMockTools([{ name: 'tap', handler }]);
+    tools.setToolDefaults = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['tap', '--locate', 'btn'],
+    });
+
+    expect(tools.setToolDefaults).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('strips a global --deep-think flag and applies act defaults', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tools = createMockTools([{ name: 'act', handler }]);
+    tools.setToolDefaults = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['--deep-think', 'act', '--prompt', 'open settings'],
+    });
+
+    expect(tools.setToolDefaults).toHaveBeenCalledWith({
+      act: { deepThink: true },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('merges defaults when both flags are present', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tools = createMockTools([{ name: 'act', handler }]);
+    tools.setToolDefaults = vi.fn();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['act', '--deep-locate', '--deep-think', '--prompt', 'go'],
+    });
+
+    expect(tools.setToolDefaults).toHaveBeenCalledWith({
+      locate: { deepLocate: true },
+      act: { deepLocate: true, deepThink: true },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
   function createDetailedMockTools() {
     return {
       initTools: vi.fn().mockResolvedValue(undefined),

--- a/packages/shared/tests/unit-test/tool-defaults.test.ts
+++ b/packages/shared/tests/unit-test/tool-defaults.test.ts
@@ -1,0 +1,114 @@
+import {
+  TOOL_BEHAVIOR_FLAGS,
+  mergeToolDefaults,
+  resolveToolDefaults,
+  stripBehaviorFlags,
+} from '@/mcp/tool-defaults';
+import { describe, expect, it } from 'vitest';
+
+describe('mergeToolDefaults', () => {
+  it('merges locate and act bags with b winning', () => {
+    expect(
+      mergeToolDefaults(
+        { locate: { deepLocate: true }, act: { deepThink: true } },
+        { locate: { deepLocate: false }, act: { deepLocate: true } },
+      ),
+    ).toEqual({
+      locate: { deepLocate: false },
+      act: { deepThink: true, deepLocate: true },
+    });
+  });
+
+  it('omits empty bags', () => {
+    expect(mergeToolDefaults({}, {})).toEqual({});
+    expect(mergeToolDefaults({ act: { deepThink: true } }, {})).toEqual({
+      act: { deepThink: true },
+    });
+  });
+});
+
+describe('resolveToolDefaults', () => {
+  it('returns empty defaults when nothing is enabled', () => {
+    expect(resolveToolDefaults(() => false)).toEqual({});
+  });
+
+  it('resolves a single flag from the registry', () => {
+    expect(resolveToolDefaults((cli) => cli === 'deep-locate')).toEqual({
+      locate: { deepLocate: true },
+      act: { deepLocate: true },
+    });
+  });
+
+  it('merges every enabled flag', () => {
+    expect(resolveToolDefaults(() => true)).toEqual({
+      locate: { deepLocate: true },
+      act: { deepLocate: true, deepThink: true },
+    });
+  });
+});
+
+describe('stripBehaviorFlags', () => {
+  it('returns empty defaults and untouched args when no flag is present', () => {
+    expect(stripBehaviorFlags(['tap', '--locate', 'btn'])).toEqual({
+      rawArgs: ['tap', '--locate', 'btn'],
+      toolDefaults: {},
+    });
+  });
+
+  it('strips a leading behavior flag and resolves its defaults', () => {
+    expect(
+      stripBehaviorFlags(['--deep-locate', 'tap', '--locate', 'btn']),
+    ).toEqual({
+      rawArgs: ['tap', '--locate', 'btn'],
+      toolDefaults: { locate: { deepLocate: true }, act: { deepLocate: true } },
+    });
+  });
+
+  it('strips a behavior flag that follows the command, preserving order', () => {
+    expect(
+      stripBehaviorFlags(['tap', '--deep-locate', '--locate', 'btn']),
+    ).toEqual({
+      rawArgs: ['tap', '--locate', 'btn'],
+      toolDefaults: { locate: { deepLocate: true }, act: { deepLocate: true } },
+    });
+  });
+
+  it('merges defaults when several behavior flags are present', () => {
+    expect(
+      stripBehaviorFlags([
+        'act',
+        '--deep-locate',
+        '--deep-think',
+        '--prompt',
+        'go',
+      ]),
+    ).toEqual({
+      rawArgs: ['act', '--prompt', 'go'],
+      toolDefaults: {
+        locate: { deepLocate: true },
+        act: { deepLocate: true, deepThink: true },
+      },
+    });
+  });
+
+  it('only recognizes exact kebab-case flags (not camelCase or value forms)', () => {
+    const camel = stripBehaviorFlags(['--deepLocate', 'tap']);
+    expect(camel.toolDefaults).toEqual({});
+    expect(camel.rawArgs).toEqual(['--deepLocate', 'tap']);
+
+    const valued = stripBehaviorFlags(['--deep-locate=true', 'tap']);
+    expect(valued.toolDefaults).toEqual({});
+    expect(valued.rawArgs).toEqual(['--deep-locate=true', 'tap']);
+  });
+
+  it('covers every registered flag', () => {
+    for (const flag of TOOL_BEHAVIOR_FLAGS) {
+      const { rawArgs, toolDefaults } = stripBehaviorFlags([
+        `--${flag.cli}`,
+        'cmd',
+      ]);
+      expect(rawArgs).toEqual(['cmd']);
+      expect(toolDefaults).toEqual(flag.defaults);
+    }
+  });
+});

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -23,6 +23,7 @@ const locateSchema = z
   .object({
     prompt: z.union([z.string(), multimodalPromptSchema]),
     deepLocate: z.boolean().optional(),
+    deepThink: z.boolean().optional(),
     cacheable: z.boolean().optional(),
     xpath: z.union([z.string(), z.boolean()]).optional(),
   })
@@ -573,5 +574,212 @@ describe('generateCommonTools — assert image prompts', () => {
     expect(actSchema).toHaveProperty('prompt');
     expect(actSchema).not.toHaveProperty('images');
     expect(actSchema).not.toHaveProperty('imageFiles');
+  });
+});
+
+describe('toolDefaults (deep locate / deep think)', () => {
+  it('defaults locate.deepLocate to true for action tools when enabled', async () => {
+    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const [tool] = generateToolsFromActionSpace(
+      actionSpace,
+      async () => ({
+        callActionInActionSpace,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      undefined,
+      { locate: { deepLocate: true } },
+    );
+
+    await tool.handler({ locate: 'the login button' });
+
+    expect(callActionInActionSpace).toHaveBeenCalledWith('Tap', {
+      locate: {
+        prompt: 'the login button',
+        deepLocate: true,
+      },
+    });
+  });
+
+  it('keeps an explicit locate.deepLocate=false even when forced', async () => {
+    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const [tool] = generateToolsFromActionSpace(
+      actionSpace,
+      async () => ({
+        callActionInActionSpace,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      undefined,
+      { locate: { deepLocate: true } },
+    );
+
+    await tool.handler({
+      locate: { prompt: 'the login button', deepLocate: false },
+    });
+
+    expect(callActionInActionSpace).toHaveBeenCalledWith('Tap', {
+      locate: {
+        prompt: 'the login button',
+        deepLocate: false,
+      },
+    });
+  });
+
+  it('treats an explicit deepThink alias as deepLocate already set', async () => {
+    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const [tool] = generateToolsFromActionSpace(
+      actionSpace,
+      async () => ({
+        callActionInActionSpace,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      undefined,
+      { locate: { deepLocate: true } },
+    );
+
+    await tool.handler({
+      locate: { prompt: 'the login button', deepThink: false },
+    });
+
+    expect(callActionInActionSpace).toHaveBeenCalledWith('Tap', {
+      locate: {
+        prompt: 'the login button',
+        deepThink: false,
+      },
+    });
+  });
+
+  it('does not inject deepLocate for action tools when disabled', async () => {
+    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const [tool] = generateToolsFromActionSpace(actionSpace, async () => ({
+      callActionInActionSpace,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+
+    await tool.handler({ locate: 'the login button' });
+
+    expect(callActionInActionSpace).toHaveBeenCalledWith('Tap', {
+      locate: { prompt: 'the login button' },
+    });
+  });
+
+  it('passes deepLocate to the act tool when enabled', async () => {
+    const aiAction = vi.fn().mockResolvedValue('done');
+    const commonTools = generateCommonTools(
+      async () => ({
+        aiAction,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      { act: { deepLocate: true } },
+    );
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+
+    await actTool?.handler({ prompt: 'open settings' });
+
+    expect(aiAction).toHaveBeenCalledWith('open settings', {
+      deepThink: false,
+      deepLocate: true,
+    });
+  });
+
+  it('lets an explicit act deepLocate arg override the server default', async () => {
+    const aiAction = vi.fn().mockResolvedValue('done');
+    const commonTools = generateCommonTools(
+      async () => ({
+        aiAction,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      { act: { deepLocate: true } },
+    );
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+
+    await actTool?.handler({ prompt: 'open settings', deepLocate: false });
+
+    expect(aiAction).toHaveBeenCalledWith('open settings', {
+      deepThink: false,
+      deepLocate: false,
+    });
+  });
+
+  it('plans the act tool with deepThink when enabled', async () => {
+    const aiAction = vi.fn().mockResolvedValue('done');
+    const commonTools = generateCommonTools(
+      async () => ({
+        aiAction,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      { act: { deepThink: true } },
+    );
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+
+    await actTool?.handler({ prompt: 'open settings' });
+
+    expect(aiAction).toHaveBeenCalledWith('open settings', {
+      deepThink: true,
+    });
+  });
+
+  it('lets an explicit act deepThink arg override the server default', async () => {
+    const aiAction = vi.fn().mockResolvedValue('done');
+    const commonTools = generateCommonTools(
+      async () => ({
+        aiAction,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      { act: { deepThink: true } },
+    );
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+
+    await actTool?.handler({ prompt: 'open settings', deepThink: false });
+
+    expect(aiAction).toHaveBeenCalledWith('open settings', {
+      deepThink: false,
+    });
+  });
+
+  it('applies both locate and act defaults together', async () => {
+    const aiAction = vi.fn().mockResolvedValue('done');
+    const commonTools = generateCommonTools(
+      async () => ({
+        aiAction,
+        getActionSpace: vi.fn().mockResolvedValue([]),
+        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      }),
+      undefined,
+      undefined,
+      {
+        locate: { deepLocate: true },
+        act: { deepLocate: true, deepThink: true },
+      },
+    );
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+
+    await actTool?.handler({ prompt: 'open settings' });
+
+    expect(aiAction).toHaveBeenCalledWith('open settings', {
+      deepThink: true,
+      deepLocate: true,
+    });
   });
 });

--- a/packages/web-bridge-mcp/src/index.ts
+++ b/packages/web-bridge-mcp/src/index.ts
@@ -1,5 +1,9 @@
 import { parseArgs } from 'node:util';
-import { type CLIArgs, CLI_ARGS_CONFIG } from '@midscene/shared/mcp';
+import {
+  type CLIArgs,
+  CLI_ARGS_CONFIG,
+  launchMCPServer,
+} from '@midscene/shared/mcp';
 import { WebMCPServer } from '@midscene/web/mcp-server';
 
 const { values } = parseArgs({ options: CLI_ARGS_CONFIG });
@@ -7,13 +11,4 @@ const args = values as CLIArgs;
 
 const server = new WebMCPServer();
 
-if (args.mode === 'http') {
-  server
-    .launchHttp({
-      port: Number.parseInt(args.port || '3000', 10),
-      host: args.host || 'localhost',
-    })
-    .catch(console.error);
-} else {
-  server.launch().catch(console.error);
-}
+launchMCPServer(server, args).catch(console.error);


### PR DESCRIPTION
## Summary

Resolves the location drift reported in [#2446](https://github.com/web-infra-dev/midscene/issues/2446) by letting both **MCP servers** and the **skill CLI** enable *deep locate* / *deep think* through startup flags — no environment variables required.

- `--deep-locate` forces deep element location on every locate field (and the act tool), fixing offset/drift. Requires a VL model.
- `--deep-think` forces deep think (planning) on the act tool.

Both work in `mcp.json` `args` and in the device CLIs (skill), since MCP and skill share the same tool definitions.

## Design — unified & extensible

A new `packages/shared/src/mcp/tool-defaults.ts` introduces:

- `TOOL_BEHAVIOR_FLAGS` — a declarative registry mapping a CLI flag to the defaults it injects.
- `ToolDefaults` — a two-bag shape (`locate` / `act`) merged generically by the generators, where explicit per-call values always win.
- `mergeToolDefaults` / `resolveToolDefaults` helpers.

Adding a future flag only requires **one registry entry** — no per-flag plumbing through generators, servers, and the CLI.

## Changes

- **shared**: `tool-defaults` registry; `tool-generator`, `base-tools`, `base-server`, `types`, `index` wiring; `cli-runner` strips behavior flags before the per-command parser.
- **mcp entry packages** (`mcp`, `android-mcp`, `ios-mcp`, `computer-mcp`, `harmony-mcp`, `web-bridge-mcp`): route launch through the shared `launchMCPServer`.
- **site**: document the new flags (en + zh).

## Validation

- `pnpm run lint` — clean
- `npx nx test shared` — 366 passed (tool-generator 35, cli-runner 69)
- Builds: shared, android-mcp, web-bridge-mcp, core

Refs: https://github.com/web-infra-dev/midscene/issues/2446