### PR TITLE
fix(cli): resolve @rstest/core from the CLI package, not process.argv[1]

### DIFF
--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -10,7 +10,20 @@ export interface RunRstestYamlProjectOptions {
   stdio?: 'inherit' | 'pipe';
 }
 
-const requireFromCliEntry = () => {
+// `@rstest/core` and `@rsbuild/core` are direct dependencies of `@midscene/cli`,
+// so they always sit on the resolution path of the CLI's own files. Anchor the
+// lookup to this module's location (`__dirname` of the bundled output) rather
+// than `process.argv[1]`: the command-line entry can be a wrapper script, a
+// symlinked bin, an `npx` cache path, or some other launcher whose `node_modules`
+// chain does not include `@rstest/core`. Anchoring on `process.argv[1]` is what
+// caused YAML runs to fail with "Cannot find module '@rstest/core/package.json'"
+// in environments where the launcher differs from the install location.
+const requireFromCliPackage = () => {
+  if (typeof __dirname !== 'undefined') {
+    return createRequire(join(__dirname, 'index.js'));
+  }
+  // ESM consumers of the bundled output have no `__dirname`; fall back to the
+  // command-line entry so programmatic usage keeps working.
   const entry = process.argv[1]
     ? resolve(process.argv[1])
     : join(process.cwd(), 'midscene-cli.js');
@@ -18,13 +31,13 @@ const requireFromCliEntry = () => {
 };
 
 const resolvePackageFromRstestCore = (packageName: string): string => {
-  const require = requireFromCliEntry();
+  const require = requireFromCliPackage();
   const rstestPackageJsonPath = require.resolve('@rstest/core/package.json');
   return createRequire(rstestPackageJsonPath).resolve(packageName);
 };
 
 export function resolveRstestCoreImportPath(): string {
-  const require = requireFromCliEntry();
+  const require = requireFromCliPackage();
   const packageJsonPath = require.resolve('@rstest/core/package.json');
   return join(dirname(packageJsonPath), 'dist', 'index.js');
 }

--- a/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
@@ -1,17 +1,46 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   resolveRstestCoreImportPath,
   runRstestYamlProject,
 } from '@/framework/rstest-runner';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 describe('rstest runner', () => {
   test('resolves the bundled Rstest core import path', () => {
     expect(resolveRstestCoreImportPath()).toMatch(
       /@rstest[/\\]core[/\\]dist[/\\]index\.js$/,
     );
+  });
+
+  describe('dependency resolution anchor', () => {
+    const originalEntry = process.argv[1];
+    let isolatedRoot: string | undefined;
+
+    afterEach(() => {
+      process.argv[1] = originalEntry;
+      if (isolatedRoot) {
+        rmSync(isolatedRoot, { recursive: true, force: true });
+        isolatedRoot = undefined;
+      }
+    });
+
+    test('resolves @rstest/core independently of process.argv[1]', () => {
+      // Simulate a launcher (wrapper script, symlinked bin, npx cache, Docker
+      // entrypoint) whose node_modules chain does NOT contain @rstest/core.
+      // Resolution must still succeed because it is anchored on the CLI module
+      // location, not on the command-line entry. This is the regression that
+      // caused "Cannot find module '@rstest/core/package.json'".
+      isolatedRoot = mkdtempSync(join(tmpdir(), 'midscene-bogus-entry-'));
+      const fakeEntry = join(isolatedRoot, 'midscene-cli.js');
+      writeFileSync(fakeEntry, '');
+      process.argv[1] = fakeEntry;
+
+      expect(resolveRstestCoreImportPath()).toMatch(
+        /@rstest[/\\]core[/\\]dist[/\\]index\.js$/,
+      );
+    });
   });
 
   test('limits virtual YAML files with the configured worker concurrency', async () => {


### PR DESCRIPTION
## Problem

Running YAML scripts fails with:

```
Cannot find module '@rstest/core/package.json'
```

even though `@rstest/core` is a declared dependency of `@midscene/cli`. The same logic written in TypeScript keeps working. Users hit this after rebuilding a Docker image, with no source change of their own.

## Root cause

Since 1.8.8 (`Run YAML cases through Rstest`, #2537), the YAML path resolves `@rstest/core` and `@rsbuild/core` at runtime via `require.resolve`. The lookup was anchored on **`process.argv[1]`** — the command-line entry — in `packages/cli/src/framework/rstest-runner.ts`:

```ts
const requireFromCliEntry = () => {
  const entry = process.argv[1] ? resolve(process.argv[1]) : join(process.cwd(), 'midscene-cli.js');
  return createRequire(entry);
};
```

When the launcher differs from the install location — a Docker entrypoint, a wrapper script, a relocated/symlinked bin, or an `npx` cache path — the `node_modules` chain walked up from `process.argv[1]` does not contain `@rstest/core`, so resolution throws. TypeScript scripts never touch this code path, which is why TS kept working while YAML broke.

## Fix

Anchor the lookup on **this module's own location** (`__dirname` of the bundled output) instead of `process.argv[1]`. `@rstest/core` and `@rsbuild/core` are direct dependencies of `@midscene/cli`, so they always sit on the CLI package's own resolution path, regardless of how the CLI is launched. ESM consumers of the bundled output (which have no `__dirname`) fall back to the previous behaviour.

## Reproduction & verification

Against the published **1.9.0**, launching the CLI through a wrapper located outside the install tree reproduces the exact error:

```
Error: Cannot find module '@rstest/core/package.json'
    at resolvePackageFromRstestCore (.../@midscene/cli/dist/lib/index.js)
```

With the `__dirname` anchor, the same invocation resolves and runs to the execution summary.

## Validation

- `npx biome check` on the changed files — clean
- `npx vitest --run tests/unit-test/framework/rstest-runner.test.ts -t anchor` — passing (new regression test: resolution succeeds even when `process.argv[1]` points outside the install tree)

Note: a full `nx build cli` currently fails in this workspace on an unrelated pre-existing `@midscene/harmony` declaration-resolution error (reproduces on a clean `main` checkout), not introduced by this change.