### PR TITLE
chore(workflow): move pnpm config to workspace file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,1 @@
 registry=https://registry.npmjs.org/
-strict-peer-dependencies=false
-save-prefix=''
-save-workspace-protocol=rolling
-ignore-compatibility-db=true
-use-lockfile-v6=true
-puppeteer_download_base_url=https://cdn.npmmirror.com/binaries/chrome-for-testing

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - apps/*
   - packages/*
+
+strictPeerDependencies: false
+saveWorkspaceProtocol: rolling
+ignoreCompatibilityDb: true
+useLockfileV6: true
+savePrefix: ''


### PR DESCRIPTION
## Summary

- Move pnpm-only settings from `.npmrc` into `pnpm-workspace.yaml` using pnpm's workspace config keys.
- Move `save-prefix` to `savePrefix` in `pnpm-workspace.yaml`.
- Leave `.npmrc` with only the npm registry setting and remove the obsolete Puppeteer download base URL entry.

## Validation

- Not run, per project/user instruction to avoid lint for commits unless explicitly requested.
- Commit hook ran and reported no matching `lint-staged` tasks.