### PR TITLE
feat(web-integration): support custom HTTP headers in YAML web config

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -166,6 +166,12 @@ web:
   # Path to a JSON format browser cookie file, optional.
   cookie: <path-to-cookie-file>
 
+  # Extra HTTP headers sent with every request (Puppeteer only), optional.
+  # Useful when the server validates custom request headers.
+  extraHTTPHeaders:
+    X-Custom-Token: my-token
+    Accept-Language: en-US
+
   # The strategy for waiting for network idle in Puppeteer mode, optional.
   # `timeout` applies to the initial opening of `web.url` defined in YAML and to later actions such as `aiTap` and `aiInput`.
   # `continueOnNetworkIdleError` only applies to the initial opening of `web.url` defined in YAML.

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -168,6 +168,7 @@ web:
 
   # Extra HTTP headers sent with every request (Puppeteer only), optional.
   # Useful when the server validates custom request headers.
+  # Values must be strings; quote values YAML would treat as a boolean or number, e.g. "true".
   extraHTTPHeaders:
     X-Custom-Token: my-token
     Accept-Language: en-US

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -167,6 +167,7 @@ web:
 
   # 随每个请求发送的额外 HTTP 请求头（仅 Puppeteer 模式），可选
   # 适用于服务器会校验自定义请求头的场景
+  # 值必须是字符串；像 true、false、纯数字这类会被 YAML 解析为非字符串的值需加引号，如 "true"
   extraHTTPHeaders:
     X-Custom-Token: my-token
     Accept-Language: en-US

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -165,6 +165,12 @@ web:
   # JSON 格式的浏览器 Cookie 文件路径，可选
   cookie: <path-to-cookie-file>
 
+  # 随每个请求发送的额外 HTTP 请求头（仅 Puppeteer 模式），可选
+  # 适用于服务器会校验自定义请求头的场景
+  extraHTTPHeaders:
+    X-Custom-Token: my-token
+    Accept-Language: en-US
+
   # Puppeteer 模式下等待网络空闲的策略，可选
   # `timeout` 会作用于初始打开 YAML 中的 `web.url`，以及后续 `aiTap`、`aiInput` 等操作后的等待
   # `continueOnNetworkIdleError` 只作用于初始打开 YAML 中的 `web.url`

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -255,10 +255,11 @@ export async function createYamlPlayer(
           webTarget.deviceScaleFactor != null ||
           webTarget.waitForNetworkIdle ||
           webTarget.cookie ||
+          webTarget.extraHTTPHeaders ||
           webTarget.chromeArgs
         ) {
           console.warn(
-            'puppeteer options (userAgent, viewportWidth, viewportHeight, deviceScaleFactor, waitForNetworkIdle, cookie, chromeArgs) are not supported in bridge mode. They will be ignored.',
+            'puppeteer options (userAgent, viewportWidth, viewportHeight, deviceScaleFactor, waitForNetworkIdle, cookie, extraHTTPHeaders, chromeArgs) are not supported in bridge mode. They will be ignored.',
           );
         }
 

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -10,6 +10,7 @@ import type {
   MidsceneYamlScript,
   MidsceneYamlScriptAgentOpt,
   MidsceneYamlScriptEnv,
+  MidsceneYamlScriptWebEnv,
 } from '@midscene/core';
 import { createAgent, getReportFileName } from '@midscene/core/agent';
 import type { AbstractInterface } from '@midscene/core/device';
@@ -248,18 +249,22 @@ export async function createYamlPlayer(
           `bridgeMode config value must be either "newTabWithUrl" or "currentTab", but got ${webTarget.bridgeMode}`,
         );
 
-        if (
-          webTarget.userAgent ||
-          webTarget.viewportWidth != null ||
-          webTarget.viewportHeight != null ||
-          webTarget.deviceScaleFactor != null ||
-          webTarget.waitForNetworkIdle ||
-          webTarget.cookie ||
-          webTarget.extraHTTPHeaders ||
-          webTarget.chromeArgs
-        ) {
+        const bridgeUnsupportedKeys: (keyof MidsceneYamlScriptWebEnv)[] = [
+          'userAgent',
+          'viewportWidth',
+          'viewportHeight',
+          'deviceScaleFactor',
+          'waitForNetworkIdle',
+          'cookie',
+          'extraHTTPHeaders',
+          'chromeArgs',
+        ];
+        const ignoredKeys = bridgeUnsupportedKeys.filter(
+          (key) => webTarget[key] != null,
+        );
+        if (ignoredKeys.length > 0) {
           console.warn(
-            'puppeteer options (userAgent, viewportWidth, viewportHeight, deviceScaleFactor, waitForNetworkIdle, cookie, extraHTTPHeaders, chromeArgs) are not supported in bridge mode. They will be ignored.',
+            `puppeteer options (${ignoredKeys.join(', ')}) are not supported in bridge mode. They will be ignored.`,
           );
         }
 

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -148,6 +148,9 @@ export interface MidsceneYamlScriptWebEnv
    * Extra HTTP headers sent with every request (Puppeteer only, not supported
    * in bridge mode). Useful when the server validates custom request headers.
    *
+   * Header values must be strings. Quote values that YAML would otherwise parse
+   * as a boolean or number (e.g. `true`, `false`, `123`), such as `"true"`.
+   *
    * @example
    * ```yaml
    * web:

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -143,6 +143,22 @@ export interface MidsceneYamlScriptWebEnv
     continueOnNetworkIdleError?: boolean; // should continue if failed to wait for network idle, true for default
   };
   cookie?: string;
+
+  /**
+   * Extra HTTP headers sent with every request (Puppeteer only, not supported
+   * in bridge mode). Useful when the server validates custom request headers.
+   *
+   * @example
+   * ```yaml
+   * web:
+   *   url: https://example.com
+   *   extraHTTPHeaders:
+   *     X-Custom-Token: my-token
+   *     Accept-Language: en-US
+   * ```
+   */
+  extraHTTPHeaders?: Record<string, string>;
+
   forceSameTabNavigation?: boolean; // if track the newly opened tab, true for default in yaml script
 
   /**

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -286,7 +286,15 @@ export async function launchPuppeteerPage(
   }
 
   if (target.extraHTTPHeaders) {
-    await page.setExtraHTTPHeaders(target.extraHTTPHeaders);
+    // YAML may parse unquoted values into booleans/numbers (e.g. `yes` -> true),
+    // but Puppeteer requires string header values, so normalize them here.
+    const normalizedHeaders = Object.fromEntries(
+      Object.entries(target.extraHTTPHeaders).map(([key, value]) => [
+        key,
+        String(value),
+      ]),
+    );
+    await page.setExtraHTTPHeaders(normalizedHeaders);
   }
 
   if (viewportConfig) {

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -285,6 +285,10 @@ export async function launchPuppeteerPage(
     await page.setUserAgent(ua);
   }
 
+  if (target.extraHTTPHeaders) {
+    await page.setExtraHTTPHeaders(target.extraHTTPHeaders);
+  }
+
   if (viewportConfig) {
     await page.setViewport(viewportConfig);
   }

--- a/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
@@ -1,16 +1,37 @@
 import type { IncomingHttpHeaders } from 'node:http';
 import { type Server, createServer } from 'node:http';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { launchPage } from './utils';
+import { puppeteerAgentForTarget } from '@/puppeteer/agent-launcher';
+import type { MidsceneYamlScriptWebEnv } from '@midscene/core';
+import { ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
 
-// End-to-end check that `extraHTTPHeaders` from the web config actually reaches
-// the server. A mock-based unit test only proves we call `setExtraHTTPHeaders`;
-// this drives a real browser against a local server and inspects what arrived.
-describe('extraHTTPHeaders (puppeteer)', () => {
+// End-to-end check that `extraHTTPHeaders` declared in a YAML script actually
+// reaches the server. This drives the full user-facing path
+// (parseYamlScript -> ScriptPlayer -> puppeteerAgentForTarget -> real browser)
+// against a local server and inspects the headers that arrived — a mock-based
+// unit test only proves we call `setExtraHTTPHeaders`.
+describe('extraHTTPHeaders via YAML (puppeteer)', () => {
   let server: Server;
   let baseUrl: string;
   let received: IncomingHttpHeaders[] = [];
-  let resetFn: (() => Promise<void>) | undefined;
+
+  const runYaml = async (yamlString: string) => {
+    const script = parseYamlScript(yamlString);
+    const player = new ScriptPlayer<MidsceneYamlScriptWebEnv>(
+      script,
+      puppeteerAgentForTarget,
+    );
+    await player.run();
+    expect(player.status, player.errorInSetup?.message).toBe('done');
+  };
 
   beforeAll(async () => {
     server = createServer((req, res) => {
@@ -29,33 +50,37 @@ describe('extraHTTPHeaders (puppeteer)', () => {
     server?.close();
   });
 
-  afterEach(async () => {
+  beforeEach(() => {
     received = [];
-    if (resetFn) {
-      await resetFn();
-      resetFn = undefined;
-    }
   });
 
-  it('sends custom headers with the request', async () => {
-    const { reset } = await launchPage(baseUrl, {
-      targetOverrides: {
-        extraHTTPHeaders: {
-          'X-Custom-Token': 'my-secret-token',
-          'X-From-Midscene': 'yes',
-        },
-      },
-    });
-    resetFn = reset;
+  it('sends custom headers declared in the YAML web config', async () => {
+    await runYaml(`
+web:
+  url: ${baseUrl}
+  extraHTTPHeaders:
+    X-Custom-Token: my-secret-token
+    X-From-Midscene: "yes"
+tasks:
+  - name: noop
+    flow:
+      - sleep: 50
+`);
 
     const docReq = received.find((h) => h['x-custom-token'] !== undefined);
     expect(docReq?.['x-custom-token']).toBe('my-secret-token');
     expect(docReq?.['x-from-midscene']).toBe('yes');
   });
 
-  it('does not send custom headers when not configured', async () => {
-    const { reset } = await launchPage(baseUrl);
-    resetFn = reset;
+  it('does not send custom headers when the YAML omits them', async () => {
+    await runYaml(`
+web:
+  url: ${baseUrl}
+tasks:
+  - name: noop
+    flow:
+      - sleep: 50
+`);
 
     expect(received.length).toBeGreaterThan(0);
     expect(received.some((h) => h['x-custom-token'] !== undefined)).toBe(false);

--- a/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
@@ -55,12 +55,16 @@ describe('extraHTTPHeaders via YAML (puppeteer)', () => {
   });
 
   it('sends custom headers declared in the YAML web config', async () => {
+    // `X-Bool-Flag: true` / `X-Num-Flag: 123` are intentionally unquoted: YAML
+    // parses them to a boolean / number, and the launcher must normalize them
+    // to strings before they reach the server.
     await runYaml(`
 web:
   url: ${baseUrl}
   extraHTTPHeaders:
     X-Custom-Token: my-secret-token
-    X-From-Midscene: "yes"
+    X-Bool-Flag: true
+    X-Num-Flag: 123
 tasks:
   - name: noop
     flow:
@@ -69,7 +73,8 @@ tasks:
 
     const docReq = received.find((h) => h['x-custom-token'] !== undefined);
     expect(docReq?.['x-custom-token']).toBe('my-secret-token');
-    expect(docReq?.['x-from-midscene']).toBe('yes');
+    expect(docReq?.['x-bool-flag']).toBe('true');
+    expect(docReq?.['x-num-flag']).toBe('123');
   });
 
   it('does not send custom headers when the YAML omits them', async () => {

--- a/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/extra-http-headers.test.ts
@@ -1,0 +1,63 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import { type Server, createServer } from 'node:http';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { launchPage } from './utils';
+
+// End-to-end check that `extraHTTPHeaders` from the web config actually reaches
+// the server. A mock-based unit test only proves we call `setExtraHTTPHeaders`;
+// this drives a real browser against a local server and inspects what arrived.
+describe('extraHTTPHeaders (puppeteer)', () => {
+  let server: Server;
+  let baseUrl: string;
+  let received: IncomingHttpHeaders[] = [];
+  let resetFn: (() => Promise<void>) | undefined;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      received.push(req.headers);
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<html><body>ok</body></html>');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const { port } = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${port}/`;
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  afterEach(async () => {
+    received = [];
+    if (resetFn) {
+      await resetFn();
+      resetFn = undefined;
+    }
+  });
+
+  it('sends custom headers with the request', async () => {
+    const { reset } = await launchPage(baseUrl, {
+      targetOverrides: {
+        extraHTTPHeaders: {
+          'X-Custom-Token': 'my-secret-token',
+          'X-From-Midscene': 'yes',
+        },
+      },
+    });
+    resetFn = reset;
+
+    const docReq = received.find((h) => h['x-custom-token'] !== undefined);
+    expect(docReq?.['x-custom-token']).toBe('my-secret-token');
+    expect(docReq?.['x-from-midscene']).toBe('yes');
+  });
+
+  it('does not send custom headers when not configured', async () => {
+    const { reset } = await launchPage(baseUrl);
+    resetFn = reset;
+
+    expect(received.length).toBeGreaterThan(0);
+    expect(received.some((h) => h['x-custom-token'] !== undefined)).toBe(false);
+  });
+});

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -20,6 +20,7 @@ const browserMock = {
 
 const createPageMock = () => ({
   setUserAgent: vi.fn().mockResolvedValue(undefined),
+  setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
   setViewport: vi.fn().mockResolvedValue(undefined),
   goto: vi.fn().mockResolvedValue(undefined),
   waitForNetworkIdle: vi.fn().mockResolvedValue(undefined),
@@ -102,6 +103,25 @@ describe('launchPuppeteerPage', () => {
         deviceScaleFactor: 0,
       }),
     ).rejects.toThrow(/deviceScaleFactor must be > 0/);
+  });
+
+  it('applies extraHTTPHeaders to the page when provided', async () => {
+    const headers = {
+      'X-Custom-Token': 'my-token',
+      'Accept-Language': 'en-US',
+    };
+    await launchPuppeteerPage({
+      url: 'https://example.com',
+      extraHTTPHeaders: headers,
+    });
+
+    expect(pageMock.setExtraHTTPHeaders).toHaveBeenCalledWith(headers);
+  });
+
+  it('does not set extraHTTPHeaders when not provided', async () => {
+    await launchPuppeteerPage({ url: 'https://example.com' });
+
+    expect(pageMock.setExtraHTTPHeaders).not.toHaveBeenCalled();
   });
 
   it('passes yaml waitForNetworkIdle settings to the agent for later actions', async () => {

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -118,6 +118,19 @@ describe('launchPuppeteerPage', () => {
     expect(pageMock.setExtraHTTPHeaders).toHaveBeenCalledWith(headers);
   });
 
+  it('normalizes non-string extraHTTPHeaders values to strings', async () => {
+    await launchPuppeteerPage({
+      url: 'https://example.com',
+      // YAML may yield booleans/numbers for unquoted values
+      extraHTTPHeaders: { 'X-Flag': true, 'X-Num': 123 } as any,
+    });
+
+    expect(pageMock.setExtraHTTPHeaders).toHaveBeenCalledWith({
+      'X-Flag': 'true',
+      'X-Num': '123',
+    });
+  });
+
   it('does not set extraHTTPHeaders when not provided', async () => {
     await launchPuppeteerPage({ url: 'https://example.com' });
 


### PR DESCRIPTION
## What

Closes #2312.

Add an `extraHTTPHeaders` option to the YAML `web` config so that requests can carry custom HTTP headers. Some sites validate request headers (beyond cookies) for access control, which previously could not be configured from a YAML script.

```yaml
web:
  url: https://example.com
  extraHTTPHeaders:
    X-Custom-Token: my-token
    Accept-Language: en-US
```

## How

- **Type**: add `extraHTTPHeaders?: Record<string, string>` to `MidsceneYamlScriptWebEnv` (`packages/core/src/yaml.ts`), with doc comment and example.
- **Apply**: call `page.setExtraHTTPHeaders(target.extraHTTPHeaders)` in the Puppeteer launcher, right after `setUserAgent`, mirroring how `userAgent` / `cookie` are handled (`packages/web-integration/src/puppeteer/agent-launcher.ts`).
- **Bridge mode**: add `extraHTTPHeaders` to the existing "ignored in bridge mode" warning list (`packages/cli/src/create-yaml-player.ts`), consistent with `cookie` / `userAgent`.
- **Docs**: document the field in both `en` and `zh` `automate-with-scripts-in-yaml.mdx`.

## Scope note

Only the YAML path needs native support, because that is the only entry where Midscene itself launches the browser and owns the `page`. Programmatic entries (`new PuppeteerAgent(page)`, `new PlaywrightAgent(page)`, `PlaywrightAiFixture`, bridge mode) already hand Midscene a user-controlled `page`/browser, where headers are set directly via `page.setExtraHTTPHeaders()` or the framework config — wrapping that would just be a redundant pass-through, which is why `userAgent` / `cookie` / `viewport` are likewise YAML-only.

## Validation

- `npx nx test @midscene/web -- agent-launcher` — 7 passed (includes 2 new cases: header applied when provided, not called when absent).
- `pnpm run lint` — passed.