### PR TITLE
feat(shared): forward custom failure message in assert CLI/MCP tool

### DIFF
--- a/packages/shared/src/mcp/tool-generator.ts
+++ b/packages/shared/src/mcp/tool-generator.ts
@@ -718,6 +718,12 @@ export function generateCommonTools(
           .describe(
             'Natural language assertion to verify, e.g. "there is a login button visible"',
           ),
+        message: z
+          .string()
+          .optional()
+          .describe(
+            'Custom error message to throw when the assertion fails, e.g. "the login button should be visible".',
+          ),
         ...promptInputExtraSchema,
         ...initArgSchema,
       },
@@ -726,6 +732,7 @@ export function generateCommonTools(
         args: Record<string, unknown> = {},
       ): Promise<ToolResult> => {
         const prompt = args.prompt as string;
+        const message = args.message as string | undefined;
         try {
           const agent = await getAgent(args);
           if (!agent.aiAssert) {
@@ -737,7 +744,7 @@ export function generateCommonTools(
             imageName: args.imageName,
             convertHttpImage2Base64: args.convertHttpImage2Base64,
           });
-          await agent.aiAssert(userPrompt);
+          await agent.aiAssert(userPrompt, message);
           return {
             content: [{ type: 'text', text: 'Assertion passed.' }],
           };

--- a/packages/shared/tests/unit-test/cli-report-session.test.ts
+++ b/packages/shared/tests/unit-test/cli-report-session.test.ts
@@ -156,6 +156,7 @@ describe('CLI report session', () => {
     expect(assertTools.createdReportGroupIds).toEqual([firstReportFileName]);
     expect(assertTools.aiAssert).toHaveBeenCalledWith(
       'The login page shows both email and password input fields',
+      undefined,
     );
   });
 

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -509,7 +509,27 @@ describe('generateCommonTools — assert image prompts', () => {
     const assert = tools.find((t) => t.name === 'assert')!;
     await assert.handler({ prompt: 'login button visible' });
 
-    expect(aiAssert).toHaveBeenCalledWith('login button visible');
+    expect(aiAssert).toHaveBeenCalledWith('login button visible', undefined);
+  });
+
+  it('forwards the custom failure message to aiAssert', async () => {
+    const aiAssert = vi.fn().mockResolvedValue(undefined);
+    const tools = generateCommonTools(async () => ({
+      aiAssert,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+
+    const assert = tools.find((t) => t.name === 'assert')!;
+    await assert.handler({
+      prompt: 'login button visible',
+      message: 'the login button should be visible',
+    });
+
+    expect(aiAssert).toHaveBeenCalledWith(
+      'login button visible',
+      'the login button should be visible',
+    );
   });
 
   it('forwards images to aiAssert as a TUserPrompt-style object', async () => {
@@ -527,10 +547,13 @@ describe('generateCommonTools — assert image prompts', () => {
       imageName: 'target',
     });
 
-    expect(aiAssert).toHaveBeenCalledWith({
-      prompt: 'the visible badge matches the reference image',
-      images: [{ name: 'target', url: 'https://example.com/btn.png' }],
-    });
+    expect(aiAssert).toHaveBeenCalledWith(
+      {
+        prompt: 'the visible badge matches the reference image',
+        images: [{ name: 'target', url: 'https://example.com/btn.png' }],
+      },
+      undefined,
+    );
   });
 
   it('forwards a local-path url verbatim so core can resolve it', async () => {
@@ -548,10 +571,13 @@ describe('generateCommonTools — assert image prompts', () => {
       imageName: 'badge',
     });
 
-    expect(aiAssert).toHaveBeenCalledWith({
-      prompt: 'the visible badge matches the supplied image',
-      images: [{ name: 'badge', url: './fixtures/badge.png' }],
-    });
+    expect(aiAssert).toHaveBeenCalledWith(
+      {
+        prompt: 'the visible badge matches the supplied image',
+        images: [{ name: 'badge', url: './fixtures/badge.png' }],
+      },
+      undefined,
+    );
   });
 
   it('exposes images and convertHttpImage2Base64 on the assert schema (no imageFiles flag)', () => {
@@ -562,6 +588,7 @@ describe('generateCommonTools — assert image prompts', () => {
 
     const assertSchema = tools.find((t) => t.name === 'assert')!.schema;
     expect(assertSchema).toHaveProperty('prompt');
+    expect(assertSchema).toHaveProperty('message');
     expect(assertSchema).toHaveProperty('image');
     expect(assertSchema).toHaveProperty('imageName');
     expect(assertSchema).toHaveProperty('convertHttpImage2Base64');


### PR DESCRIPTION
## Background

Closes #2351.

`Agent#aiAssert` has long been available in YAML flows, and #2425 / #2499
exposed an `assert` tool (backed by `aiAssert`) in the CLI and MCP / Skills
contexts. However, only `--prompt` (and image flags) were wired up — the
second argument of `aiAssert(assertion, msg?)`, the **custom failure
message**, was not reachable from the CLI or MCP.

This matters because the failure message is what an AI coding agent (or a
human reading CI output) sees when an assertion fails. Without it, every
failed assertion surfaces a generic, model-generated reason instead of the
caller's intent.

## What changed

- Add an optional `message` field to the `assert` tool schema in
  `generateCommonTools`. As a camelCase key it is exposed on the CLI as
  `--message`, matching the API requested in the issue:

  ```bash
  midscene-ios assert --prompt "the order is submitted" \
    --message "the order should be submitted after tapping pay"
  ```

- Forward it to `agent.aiAssert(userPrompt, message)`. When omitted it is
  `undefined`, preserving existing behavior.

## Tests

- `packages/shared/tests/unit-test/tool-generator.test.ts`
  - New case: the custom failure message is forwarded to `aiAssert`.
  - Updated existing cases to assert the second (`message`) argument.
  - Schema-presence test now checks for `message`.

## Validation

- `npx nx test shared -- tool-generator` — 36 passed
- `npx nx build shared`
- `pnpm run lint`
