### PR TITLE
fix(cli): surface real YAML run errors instead of silent "not executed"

### DIFF
--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -51,12 +51,15 @@ jobs:
         cache: 'pnpm'
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install puppeteer dependencies
       run: |
         cd packages/web-integration
         npx puppeteer browsers install chrome
+
+    - name: Build project
+      run: pnpm run build
     
     - name: Run tests with coverage
       run: pnpm run test:ai:coverage

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -55,7 +55,7 @@ jobs:
           ${{ runner.os }}-playwright-
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Playwright dependencies
       run: |
@@ -70,6 +70,9 @@ jobs:
       run: |
         cd packages/web-integration
         npx puppeteer browsers install chrome
+
+    - name: Build project
+      run: pnpm run build
 
     - name: Run e2e tests
       run: pnpm run e2e
@@ -148,7 +151,7 @@ jobs:
           ${{ runner.os }}-playwright-
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Playwright dependencies
       run: |
@@ -163,6 +166,9 @@ jobs:
       run: |
         cd packages/web-integration
         npx puppeteer browsers install chrome
+
+    - name: Build project
+      run: pnpm run build
 
     - name: Run apps/report e2e tests
       run: cd apps/report && pnpm run e2e

--- a/packages/android/scripts/download-retry.mjs
+++ b/packages/android/scripts/download-retry.mjs
@@ -1,0 +1,59 @@
+export const DEFAULT_DOWNLOAD_MAX_RETRIES = 6;
+export const DEFAULT_DOWNLOAD_RETRY_DELAY_MS = 2000;
+export const MAX_DOWNLOAD_RETRY_DELAY_MS = 30000;
+
+export function getDownloadMaxRetries(env = process.env) {
+  const value = Number.parseInt(
+    env.MIDSCENE_ANDROID_DOWNLOAD_RETRIES ?? '',
+    10,
+  );
+  return Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_DOWNLOAD_MAX_RETRIES;
+}
+
+export function getDownloadRetryDelayMs(
+  attempt,
+  baseDelayMs = DEFAULT_DOWNLOAD_RETRY_DELAY_MS,
+  maxDelayMs = MAX_DOWNLOAD_RETRY_DELAY_MS,
+) {
+  const normalizedAttempt = Math.max(1, attempt);
+  return Math.min(maxDelayMs, baseDelayMs * 2 ** (normalizedAttempt - 1));
+}
+
+export function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function retryDownload({
+  download,
+  label,
+  log = console.log,
+  maxRetries = DEFAULT_DOWNLOAD_MAX_RETRIES,
+  sleepImpl = sleep,
+}) {
+  const attempts = Math.max(1, Math.floor(maxRetries));
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await download();
+      return;
+    } catch (error) {
+      if (attempt === attempts) {
+        throw error;
+      }
+
+      const delayMs = getDownloadRetryDelayMs(attempt);
+      log(
+        `[${label}] Download attempt ${attempt}/${attempts} failed: ${getErrorMessage(error)}, retrying in ${
+          delayMs / 1000
+        }s...`,
+      );
+      await sleepImpl(delayMs);
+    }
+  }
+}

--- a/packages/android/scripts/download-scrcpy-server.mjs
+++ b/packages/android/scripts/download-scrcpy-server.mjs
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getDownloadMaxRetries, retryDownload } from './download-retry.mjs';
 import { createLoggedProxyDispatcher } from './proxy-dispatcher.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -143,29 +144,24 @@ export async function main() {
 
   await fs.mkdir(binDir, { recursive: true });
 
-  const maxRetries = 3;
+  const maxRetries = getDownloadMaxRetries();
   const downloadedFile = path.join(binDir, `scrcpy-server-${SCRCPY_VERSION}`);
   await fs.rm(downloadedFile, { force: true });
   const dispatcher = createLoggedProxyDispatcher({
     logPrefix: 'scrcpy',
   });
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
+  await retryDownload({
+    label: 'scrcpy',
+    maxRetries,
+    download: async () => {
       await downloadScrcpyServerReleaseAsset({
         destinationPath: downloadedFile,
         dispatcher,
         version: SCRCPY_VERSION,
       });
-      break;
-    } catch (err) {
-      if (attempt === maxRetries) throw err;
-      console.log(
-        `[scrcpy] Download attempt ${attempt} failed: ${err.message}, retrying in ${attempt * 2}s...`,
-      );
-      await new Promise((r) => setTimeout(r, attempt * 2000));
-    }
-  }
+    },
+  });
 
   await installDownloadedScrcpyServer({
     serverBinPath,

--- a/packages/android/scripts/download-scrcpy-server.mjs
+++ b/packages/android/scripts/download-scrcpy-server.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { Buffer } from 'node:buffer';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getDownloadMaxRetries, retryDownload } from './download-retry.mjs';
+import { downloadGitHubReleaseAssetWithApiFallback } from './github-release-asset.mjs';
 import { createLoggedProxyDispatcher } from './proxy-dispatcher.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -74,18 +74,17 @@ export async function downloadScrcpyServerReleaseAsset({
   version = SCRCPY_VERSION,
   dispatcher,
 }) {
-  const response = await fetchImpl(getScrcpyServerDownloadUrl(version), {
-    ...(dispatcher ? { dispatcher } : {}),
+  await downloadGitHubReleaseAssetWithApiFallback({
+    assetName: `scrcpy-server-${version}`,
+    destinationPath,
+    directUrl: getScrcpyServerDownloadUrl(version),
+    dispatcher,
+    fetchImpl,
+    fsApi,
+    owner: 'Genymobile',
+    repo: 'scrcpy',
+    version,
   });
-
-  if (!response.ok) {
-    throw new Error(
-      `Response code ${response.status} (${response.statusText})`,
-    );
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  await fsApi.writeFile(destinationPath, Buffer.from(arrayBuffer));
 }
 
 export async function main() {

--- a/packages/android/scripts/download-yadb.mjs
+++ b/packages/android/scripts/download-yadb.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { Buffer } from 'node:buffer';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getDownloadMaxRetries, retryDownload } from './download-retry.mjs';
+import { downloadGitHubReleaseAssetWithApiFallback } from './github-release-asset.mjs';
 import { createLoggedProxyDispatcher } from './proxy-dispatcher.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -21,18 +21,17 @@ export async function downloadYadbReleaseAsset({
   version = YADB_VERSION,
   dispatcher,
 }) {
-  const response = await fetchImpl(getYadbDownloadUrl(version), {
-    ...(dispatcher ? { dispatcher } : {}),
+  await downloadGitHubReleaseAssetWithApiFallback({
+    assetName: 'yadb',
+    destinationPath,
+    directUrl: getYadbDownloadUrl(version),
+    dispatcher,
+    fetchImpl,
+    fsApi,
+    owner: 'ysbing',
+    repo: 'YADB',
+    version,
   });
-
-  if (!response.ok) {
-    throw new Error(
-      `Response code ${response.status} (${response.statusText})`,
-    );
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  await fsApi.writeFile(destinationPath, Buffer.from(arrayBuffer));
 }
 
 export async function main() {

--- a/packages/android/scripts/download-yadb.mjs
+++ b/packages/android/scripts/download-yadb.mjs
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getDownloadMaxRetries, retryDownload } from './download-retry.mjs';
 import { createLoggedProxyDispatcher } from './proxy-dispatcher.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -62,27 +63,22 @@ export async function main() {
 
   await fs.mkdir(binDir, { recursive: true });
 
-  const maxRetries = 3;
+  const maxRetries = getDownloadMaxRetries();
   const dispatcher = createLoggedProxyDispatcher({
     logPrefix: 'yadb',
   });
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
+  await retryDownload({
+    label: 'yadb',
+    maxRetries,
+    download: async () => {
       await downloadYadbReleaseAsset({
         destinationPath: yadbPath,
         dispatcher,
         version: YADB_VERSION,
       });
-      break;
-    } catch (err) {
-      if (attempt === maxRetries) throw err;
-      console.log(
-        `[yadb] Download attempt ${attempt} failed: ${err.message}, retrying in ${attempt * 2}s...`,
-      );
-      await new Promise((r) => setTimeout(r, attempt * 2000));
-    }
-  }
+    },
+  });
 
   // Write version marker for future upgrade detection
   await fs.writeFile(versionFile, YADB_VERSION);

--- a/packages/android/scripts/github-release-asset.mjs
+++ b/packages/android/scripts/github-release-asset.mjs
@@ -1,0 +1,125 @@
+import { Buffer } from 'node:buffer';
+import { promises as fs } from 'node:fs';
+
+export function getGitHubReleaseMetadataUrl({ owner, repo, version }) {
+  return `https://api.github.com/repos/${owner}/${repo}/releases/tags/${version}`;
+}
+
+function getResponseErrorMessage(response) {
+  return `Response code ${response.status} (${response.statusText})`;
+}
+
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function downloadUrlToFile({
+  destinationPath,
+  dispatcher,
+  fetchImpl = fetch,
+  fsApi = fs,
+  headers,
+  url,
+}) {
+  const response = await fetchImpl(url, {
+    ...(dispatcher ? { dispatcher } : {}),
+    ...(headers ? { headers } : {}),
+  });
+
+  if (!response.ok) {
+    throw new Error(getResponseErrorMessage(response));
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  await fsApi.writeFile(destinationPath, Buffer.from(arrayBuffer));
+}
+
+export async function getGitHubReleaseAssetApiUrl({
+  assetName,
+  dispatcher,
+  fetchImpl = fetch,
+  owner,
+  repo,
+  version,
+}) {
+  const metadataUrl = getGitHubReleaseMetadataUrl({ owner, repo, version });
+  const response = await fetchImpl(metadataUrl, {
+    ...(dispatcher ? { dispatcher } : {}),
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(getResponseErrorMessage(response));
+  }
+
+  const release = await response.json();
+  const asset = Array.isArray(release.assets)
+    ? release.assets.find((item) => item?.name === assetName)
+    : undefined;
+
+  if (!asset?.url) {
+    throw new Error(
+      `Release asset ${assetName} not found in ${owner}/${repo}@${version}`,
+    );
+  }
+
+  return asset.url;
+}
+
+export async function downloadGitHubReleaseAssetWithApiFallback({
+  assetName,
+  destinationPath,
+  directUrl,
+  dispatcher,
+  fetchImpl = fetch,
+  fsApi = fs,
+  owner,
+  repo,
+  version,
+}) {
+  try {
+    await downloadUrlToFile({
+      destinationPath,
+      dispatcher,
+      fetchImpl,
+      fsApi,
+      url: directUrl,
+    });
+    return;
+  } catch (directError) {
+    let assetApiUrl;
+    try {
+      assetApiUrl = await getGitHubReleaseAssetApiUrl({
+        assetName,
+        dispatcher,
+        fetchImpl,
+        owner,
+        repo,
+        version,
+      });
+    } catch (fallbackError) {
+      throw new Error(
+        `Failed to download ${assetName}: browser download failed: ${getErrorMessage(
+          directError,
+        )}; API metadata fallback failed: ${getErrorMessage(fallbackError)}`,
+      );
+    }
+
+    try {
+      await downloadUrlToFile({
+        destinationPath,
+        dispatcher,
+        fetchImpl,
+        fsApi,
+        headers: { Accept: 'application/octet-stream' },
+        url: assetApiUrl,
+      });
+    } catch (fallbackError) {
+      throw new Error(
+        `Failed to download ${assetName}: browser download failed: ${getErrorMessage(
+          directError,
+        )}; API asset fallback failed: ${getErrorMessage(fallbackError)}`,
+      );
+    }
+  }
+}

--- a/packages/android/tests/unit-test/download-retry.test.ts
+++ b/packages/android/tests/unit-test/download-retry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_DOWNLOAD_MAX_RETRIES,
+  getDownloadMaxRetries,
+  getDownloadRetryDelayMs,
+  retryDownload,
+} from '../../scripts/download-retry.mjs';
+
+describe('download retry helper', () => {
+  it('uses six attempts by default for CI release asset downloads', () => {
+    expect(getDownloadMaxRetries({} as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_DOWNLOAD_MAX_RETRIES,
+    );
+    expect(DEFAULT_DOWNLOAD_MAX_RETRIES).toBe(6);
+  });
+
+  it('allows overriding the attempt count from the environment', () => {
+    expect(
+      getDownloadMaxRetries({
+        MIDSCENE_ANDROID_DOWNLOAD_RETRIES: '8',
+      } as NodeJS.ProcessEnv),
+    ).toBe(8);
+  });
+
+  it('caps exponential retry delays', () => {
+    expect(getDownloadRetryDelayMs(1)).toBe(2000);
+    expect(getDownloadRetryDelayMs(2)).toBe(4000);
+    expect(getDownloadRetryDelayMs(6)).toBe(30000);
+  });
+
+  it('retries transient failures before resolving', async () => {
+    const download = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Response code 504 (Gateway Time-out)'))
+      .mockRejectedValueOnce(new Error('Response code 502 (Bad Gateway)'))
+      .mockResolvedValue(undefined);
+    const sleepImpl = vi.fn(async () => undefined);
+    const log = vi.fn();
+
+    await retryDownload({
+      download,
+      label: 'scrcpy',
+      log,
+      maxRetries: 6,
+      sleepImpl,
+    });
+
+    expect(download).toHaveBeenCalledTimes(3);
+    expect(sleepImpl).toHaveBeenNthCalledWith(1, 2000);
+    expect(sleepImpl).toHaveBeenNthCalledWith(2, 4000);
+    expect(log).toHaveBeenCalledWith(
+      '[scrcpy] Download attempt 1/6 failed: Response code 504 (Gateway Time-out), retrying in 2s...',
+    );
+  });
+
+  it('throws the final download error after all attempts fail', async () => {
+    const error = new Error('Response code 504 (Gateway Time-out)');
+
+    await expect(
+      retryDownload({
+        download: vi.fn().mockRejectedValue(error),
+        label: 'scrcpy',
+        log: vi.fn(),
+        maxRetries: 2,
+        sleepImpl: vi.fn(async () => undefined),
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  it('always attempts the download at least once', async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+
+    await retryDownload({
+      download,
+      label: 'scrcpy',
+      log: vi.fn(),
+      maxRetries: 0,
+      sleepImpl: vi.fn(async () => undefined),
+    });
+
+    expect(download).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/android/tests/unit-test/scrcpy-server-version.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-server-version.test.ts
@@ -76,6 +76,74 @@ describe('scrcpy server version helper', () => {
     );
   });
 
+  it('falls back to the GitHub asset API when the browser download URL fails', async () => {
+    const dirPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-scrcpy-server-'),
+    );
+    tempDirs.push(dirPath);
+
+    const destinationPath = path.join(dirPath, 'scrcpy-server-v3.3.3');
+    const apiAssetUrl =
+      'https://api.github.com/repos/Genymobile/scrcpy/releases/assets/123';
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (
+        url ===
+        'https://github.com/Genymobile/scrcpy/releases/download/v3.3.3/scrcpy-server-v3.3.3'
+      ) {
+        return {
+          ok: false,
+          status: 504,
+          statusText: 'Gateway Time-out',
+        };
+      }
+
+      if (
+        url ===
+        'https://api.github.com/repos/Genymobile/scrcpy/releases/tags/v3.3.3'
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            assets: [{ name: 'scrcpy-server-v3.3.3', url: apiAssetUrl }],
+          }),
+          status: 200,
+          statusText: 'OK',
+        };
+      }
+
+      if (url === apiAssetUrl) {
+        return {
+          ok: true,
+          arrayBuffer: async () =>
+            new TextEncoder().encode('server-binary').buffer,
+          status: 200,
+          statusText: 'OK',
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await downloadScrcpyServerReleaseAsset({
+      dispatcher: undefined,
+      destinationPath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      version: 'v3.3.3',
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/Genymobile/scrcpy/releases/tags/v3.3.3',
+      { headers: { Accept: 'application/vnd.github+json' } },
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(3, apiAssetUrl, {
+      headers: { Accept: 'application/octet-stream' },
+    });
+    await expect(fs.readFile(destinationPath, 'utf8')).resolves.toBe(
+      'server-binary',
+    );
+  });
+
   it('replaces the cached server only after the new download is ready', async () => {
     const dirPath = await fs.mkdtemp(
       path.join(os.tmpdir(), 'midscene-scrcpy-server-'),

--- a/packages/android/tests/unit-test/yadb-download.test.ts
+++ b/packages/android/tests/unit-test/yadb-download.test.ts
@@ -54,7 +54,71 @@ describe('yadb download script', () => {
     );
   });
 
-  it('throws on non-2xx responses', async () => {
+  it('falls back to the GitHub asset API when the browser download URL fails', async () => {
+    const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'midscene-yadb-'));
+    tempDirs.push(dirPath);
+
+    const destinationPath = path.join(dirPath, 'yadb');
+    const apiAssetUrl =
+      'https://api.github.com/repos/ysbing/YADB/releases/assets/392259748';
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (
+        url === 'https://github.com/ysbing/YADB/releases/download/v1.1.1/yadb'
+      ) {
+        return {
+          ok: false,
+          status: 504,
+          statusText: 'Gateway Time-out',
+        };
+      }
+
+      if (
+        url === 'https://api.github.com/repos/ysbing/YADB/releases/tags/v1.1.1'
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            assets: [{ name: 'yadb', url: apiAssetUrl }],
+          }),
+          status: 200,
+          statusText: 'OK',
+        };
+      }
+
+      if (url === apiAssetUrl) {
+        return {
+          ok: true,
+          arrayBuffer: async () =>
+            new TextEncoder().encode('yadb-binary').buffer,
+          status: 200,
+          statusText: 'OK',
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await downloadYadbReleaseAsset({
+      dispatcher: undefined,
+      destinationPath,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      version: YADB_VERSION,
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/ysbing/YADB/releases/tags/v1.1.1',
+      { headers: { Accept: 'application/vnd.github+json' } },
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(3, apiAssetUrl, {
+      headers: { Accept: 'application/octet-stream' },
+    });
+    await expect(fs.readFile(destinationPath, 'utf8')).resolves.toBe(
+      'yadb-binary',
+    );
+  });
+
+  it('throws when the browser URL and API metadata fallback both fail', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: false,
       status: 502,
@@ -67,6 +131,8 @@ describe('yadb download script', () => {
         destinationPath: path.join(os.tmpdir(), 'midscene-yadb-should-fail'),
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
-    ).rejects.toThrow('Response code 502 (Bad Gateway)');
+    ).rejects.toThrow(
+      'Failed to download yadb: browser download failed: Response code 502 (Bad Gateway); API metadata fallback failed: Response code 502 (Bad Gateway)',
+    );
   });
 });

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -122,21 +122,23 @@ defineYamlBatchTest(${JSON.stringify(testOptions, null, 2)});
 `;
 };
 
-const resolveDefaultFrameworkImport = (): string => {
-  // Anchor the framework entry on this bundle's own directory rather than
-  // `process.argv[1]`. The command-line entry can be a `.bin` symlink, an
-  // `npx` cache path, or a wrapper script whose directory does not lead to the
-  // compiled `framework/index.js`. In those cases the argv-based lookup below
-  // falls through to the bare specifier `@midscene/cli/dist/lib/framework/
-  // index.js`, which the generated virtual test module then fails to resolve
-  // from the user's CWD ("Cannot find module ..."), silently turning every run
-  // into "not executed". `__dirname` always points at the installed CLI output
-  // (this mirrors `requireFromCliPackage` in rstest-runner.ts). Resolve to an
-  // absolute path so the virtual module imports it regardless of CWD.
+// Anchor the framework entry on this bundle's own directory rather than
+// `process.argv[1]`. The command-line entry can be a `.bin` symlink, an
+// `npx` cache path, or a wrapper script whose directory does not lead to the
+// compiled `framework/index.js`. In those cases the argv-based lookup below
+// falls through to the bare specifier `@midscene/cli/dist/lib/framework/
+// index.js`, which the generated virtual test module then fails to resolve
+// from the user's CWD ("Cannot find module ..."), silently turning every run
+// into "not executed". `__dirname` always points at the installed CLI output
+// (this mirrors `requireFromCliPackage` in rstest-runner.ts). Resolve to an
+// absolute path so the virtual module imports it regardless of CWD.
+// `moduleDir` is injectable so tests can exercise the resolution order without
+// depending on the dist layout.
+export const resolveDefaultFrameworkImport = (moduleDir?: string): string => {
+  const anchorDir =
+    moduleDir ?? (typeof __dirname !== 'undefined' ? __dirname : undefined);
   const candidates = [
-    typeof __dirname !== 'undefined'
-      ? join(__dirname, 'framework', 'index.js')
-      : '',
+    anchorDir ? join(anchorDir, 'framework', 'index.js') : '',
   ];
 
   const entry = process.argv[1] ? resolve(process.argv[1]) : '';

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -23,6 +23,9 @@ export type WebYamlRuntimeOptions = Pick<
 >;
 
 export const DEFAULT_YAML_TEST_TIMEOUT = 0;
+export const RSTEST_YAML_BATCH_TEST_MODULE =
+  'virtual:midscene-yaml/batch.test.ts';
+export const RSTEST_YAML_BATCH_TEST_NAME = 'midscene yaml batch';
 
 export interface CreateRstestYamlProjectOptions {
   files: string[];
@@ -45,6 +48,11 @@ export interface GeneratedYamlTestCase {
   testName: string;
 }
 
+export interface GeneratedYamlBatchTest {
+  testModule: string;
+  testName: string;
+}
+
 export interface GeneratedRstestYamlProject {
   projectDir: string;
   outputDir: string;
@@ -52,6 +60,7 @@ export interface GeneratedRstestYamlProject {
   include: string[];
   virtualModules: Record<string, string>;
   cases: GeneratedYamlTestCase[];
+  batchTest?: GeneratedYamlBatchTest;
   maxConcurrency?: number;
   testTimeout: number;
   bail?: number;
@@ -189,24 +198,28 @@ export function createRstestYamlProject(
   });
 
   if (options.batchConfig) {
-    const batchModule = 'virtual:midscene-yaml/batch.test.ts';
     const resultFiles = Object.fromEntries(
       cases.map((item) => [item.yamlFile, item.resultFile]),
     );
+    const batchTest = {
+      testModule: RSTEST_YAML_BATCH_TEST_MODULE,
+      testName: RSTEST_YAML_BATCH_TEST_NAME,
+    };
     return {
       projectDir,
       outputDir,
       resultDir,
-      include: [batchModule],
+      include: [batchTest.testModule],
       virtualModules: {
-        [batchModule]: createGeneratedBatchTestContent({
+        [batchTest.testModule]: createGeneratedBatchTestContent({
           frameworkImport,
-          testName: 'midscene yaml batch',
+          testName: batchTest.testName,
           config: options.batchConfig,
           resultFiles,
         }),
       },
       cases,
+      batchTest,
       maxConcurrency: 1,
       testTimeout,
       bail: options.bail,

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -123,15 +123,33 @@ defineYamlBatchTest(${JSON.stringify(testOptions, null, 2)});
 };
 
 const resolveDefaultFrameworkImport = (): string => {
-  const entry = process.argv[1] ? resolve(process.argv[1]) : '';
+  // Anchor the framework entry on this bundle's own directory rather than
+  // `process.argv[1]`. The command-line entry can be a `.bin` symlink, an
+  // `npx` cache path, or a wrapper script whose directory does not lead to the
+  // compiled `framework/index.js`. In those cases the argv-based lookup below
+  // falls through to the bare specifier `@midscene/cli/dist/lib/framework/
+  // index.js`, which the generated virtual test module then fails to resolve
+  // from the user's CWD ("Cannot find module ..."), silently turning every run
+  // into "not executed". `__dirname` always points at the installed CLI output
+  // (this mirrors `requireFromCliPackage` in rstest-runner.ts). Resolve to an
+  // absolute path so the virtual module imports it regardless of CWD.
   const candidates = [
-    entry ? join(dirname(entry), 'framework', 'index.js') : '',
-    entry
-      ? join(dirname(entry), '..', 'dist', 'lib', 'framework', 'index.js')
+    typeof __dirname !== 'undefined'
+      ? join(__dirname, 'framework', 'index.js')
       : '',
-  ].filter(Boolean);
+  ];
 
-  const matched = candidates.find((candidate) => existsSync(candidate));
+  const entry = process.argv[1] ? resolve(process.argv[1]) : '';
+  if (entry) {
+    candidates.push(join(dirname(entry), 'framework', 'index.js'));
+    candidates.push(
+      join(dirname(entry), '..', 'dist', 'lib', 'framework', 'index.js'),
+    );
+  }
+
+  const matched = candidates
+    .filter(Boolean)
+    .find((candidate) => existsSync(candidate));
   return matched || '@midscene/cli/dist/lib/framework/index.js';
 };
 

--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -104,6 +104,11 @@ const mapRunErrorsToCases = (
       errors.set(item.yamlFile, message);
     }
   };
+  const addAll = (message: string) => {
+    for (const item of project.cases) {
+      add(item, message);
+    }
+  };
   const matchFileCase = (
     file: TestRunResult['files'][number],
   ): GeneratedYamlTestCase | undefined => {
@@ -116,18 +121,51 @@ const mapRunErrorsToCases = (
     }
     return undefined;
   };
+  const isBatchFile = (file: TestRunResult['files'][number]): boolean => {
+    if (!project.batchTest) return false;
+    for (const key of [file.name, file.testPath]) {
+      if (
+        key &&
+        (key === project.batchTest.testModule ||
+          key.includes(project.batchTest.testModule))
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const isBatchTest = (testName: string): boolean =>
+    testName === project.batchTest?.testName;
 
   for (const file of result.files ?? []) {
     const fileCase = matchFileCase(file);
     for (const error of file.errors ?? []) {
-      add(fileCase, errorMessage(error));
+      const message = errorMessage(error);
+      if (isBatchFile(file)) {
+        addAll(message);
+      } else {
+        add(fileCase, message);
+      }
     }
     for (const testResult of file.results ?? []) {
       const item = byTestName.get(testResult.name) ?? fileCase;
       for (const error of testResult.errors ?? []) {
-        add(item, errorMessage(error));
+        const message = errorMessage(error);
+        if (isBatchTest(testResult.name) || isBatchFile(file)) {
+          addAll(message);
+        } else {
+          add(item, message);
+        }
       }
     }
+  }
+
+  if (
+    project.batchTest &&
+    errors.size === 0 &&
+    result.unhandledErrors?.length
+  ) {
+    addAll(errorMessage(result.unhandledErrors[0]));
   }
 
   // A single-case run whose failure rstest could not pin to a file/test (e.g. a

--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -1,8 +1,13 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { MidsceneYamlConfigResult } from '@midscene/core';
 import type { RstestUserConfig, TestRunResult } from '@rstest/core/api';
-import type { GeneratedRstestYamlProject } from './rstest-project';
+import type {
+  GeneratedRstestYamlProject,
+  GeneratedYamlTestCase,
+} from './rstest-project';
 
 export interface RunRstestYamlProjectOptions {
   project: GeneratedRstestYamlProject;
@@ -46,6 +51,128 @@ const formatRunError = (
   error: TestRunResult['unhandledErrors'][number],
 ): string => error.stack || `${error.name}: ${error.message}`;
 
+// Collect every failure rstest surfaced, not just `unhandledErrors`. A failing
+// YAML case shows up as a file-level error (e.g. a module that cannot be
+// loaded) or a test-level error under `files[].results[]`; `unhandledErrors`
+// only covers worker crashes and config-load failures. Reporting just the
+// latter is why a failed run printed nothing and looked like "not executed".
+const collectRunErrors = (result: TestRunResult): string[] => {
+  const messages: string[] = [];
+  const push = (
+    error: TestRunResult['unhandledErrors'][number],
+    label?: string,
+  ) => {
+    const formatted = formatRunError(error);
+    messages.push(label ? `${label}: ${formatted}` : formatted);
+  };
+
+  for (const file of result.files ?? []) {
+    for (const error of file.errors ?? []) {
+      push(error, file.name || file.testPath);
+    }
+    for (const testResult of file.results ?? []) {
+      for (const error of testResult.errors ?? []) {
+        push(error, testResult.name);
+      }
+    }
+  }
+  for (const error of result.unhandledErrors ?? []) {
+    push(error);
+  }
+
+  return Array.from(new Set(messages));
+};
+
+const errorMessage = (
+  error: TestRunResult['unhandledErrors'][number],
+): string => error.message || error.name || 'YAML case failed';
+
+// Attribute each rstest failure back to the YAML case it came from, keyed by the
+// resolved YAML file path. A test-level failure matches on the test name (which
+// equals the case's `testName`); a file-level failure (e.g. the test module
+// could not be loaded) matches on the generated virtual module id.
+const mapRunErrorsToCases = (
+  project: GeneratedRstestYamlProject,
+  result: TestRunResult,
+): Map<string, string> => {
+  const byTestName = new Map(
+    project.cases.map((item) => [item.testName, item]),
+  );
+  const errors = new Map<string, string>();
+  const add = (item: GeneratedYamlTestCase | undefined, message: string) => {
+    if (item && message && !errors.has(item.yamlFile)) {
+      errors.set(item.yamlFile, message);
+    }
+  };
+  const matchFileCase = (
+    file: TestRunResult['files'][number],
+  ): GeneratedYamlTestCase | undefined => {
+    for (const key of [file.name, file.testPath]) {
+      if (!key) continue;
+      const matched = project.cases.find(
+        (item) => key === item.testModule || key.includes(item.testModule),
+      );
+      if (matched) return matched;
+    }
+    return undefined;
+  };
+
+  for (const file of result.files ?? []) {
+    const fileCase = matchFileCase(file);
+    for (const error of file.errors ?? []) {
+      add(fileCase, errorMessage(error));
+    }
+    for (const testResult of file.results ?? []) {
+      const item = byTestName.get(testResult.name) ?? fileCase;
+      for (const error of testResult.errors ?? []) {
+        add(item, errorMessage(error));
+      }
+    }
+  }
+
+  // A single-case run whose failure rstest could not pin to a file/test (e.g. a
+  // worker crash surfaced only via `unhandledErrors`) still belongs to that one
+  // case — otherwise its real error would be lost to a blank "not executed".
+  if (
+    project.cases.length === 1 &&
+    errors.size === 0 &&
+    result.unhandledErrors?.length
+  ) {
+    add(project.cases[0], errorMessage(result.unhandledErrors[0]));
+  }
+
+  return errors;
+};
+
+// When a case fails before it can write its own result file (module load
+// failure, crash before `writeResultFile`, ...), the batch reader would treat
+// it as "not executed" with no error. Persist a failed result carrying the real
+// error so the failure — and its cause — is visible in the summary JSON.
+const recordUnreportedCaseFailures = (
+  project: GeneratedRstestYamlProject,
+  result: TestRunResult,
+): void => {
+  if (!project.cases.length) return;
+  const caseErrors = mapRunErrorsToCases(project, result);
+  for (const item of project.cases) {
+    if (existsSync(item.resultFile)) continue;
+    const error = caseErrors.get(item.yamlFile);
+    if (!error) continue;
+    const failure: MidsceneYamlConfigResult = {
+      file: item.yamlFile,
+      success: false,
+      executed: true,
+      output: undefined,
+      report: undefined,
+      duration: 0,
+      resultType: 'failed',
+      error,
+    };
+    mkdirSync(dirname(item.resultFile), { recursive: true });
+    writeFileSync(item.resultFile, JSON.stringify(failure, null, 2));
+  }
+};
+
 export async function runRstestYamlProject(
   options: RunRstestYamlProjectOptions,
 ): Promise<number> {
@@ -83,10 +210,14 @@ export async function runRstestYamlProject(
     inlineConfig,
   });
 
-  if (!result.ok && options.stdio !== 'pipe' && result.unhandledErrors.length) {
-    console.error(
-      result.unhandledErrors.map((error) => formatRunError(error)).join('\n'),
-    );
+  if (!result.ok) {
+    recordUnreportedCaseFailures(project, result);
+    if (options.stdio !== 'pipe') {
+      const runErrors = collectRunErrors(result);
+      if (runErrors.length) {
+        console.error(`\nYAML execution failed:\n${runErrors.join('\n\n')}`);
+      }
+    }
   }
 
   return result.ok ? 0 : 1;

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -697,4 +697,77 @@ export function defineYamlCaseTest(options: any) {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('records shared browser batch setup failures for every YAML case', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yamlA = join(root, 'login.yaml');
+    const yamlB = join(root, 'check-login.yaml');
+    const framework = join(root, 'framework.ts');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    const failureMessage =
+      'Model configuration is incomplete: model name (MIDSCENE_MODEL_NAME) is required.';
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yamlA, 'web:\n  url: about:blank\ntasks: []\n');
+    writeFileSync(yamlB, 'web:\n  url: about:blank\ntasks: []\n');
+    writeFileSync(
+      framework,
+      `import { test } from '@rstest/core';
+export function defineYamlBatchTest(options: any) {
+  test(options.testName, async () => {
+    throw new Error(${JSON.stringify(failureMessage)});
+  });
+}
+`,
+    );
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yamlA, yamlB],
+          concurrent: 2,
+          continueOnError: true,
+          summary: 'summary.json',
+          shareBrowserContext: true,
+          globalConfig: {},
+          headed: false,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: framework,
+          stdio: 'pipe',
+        },
+      );
+
+      expect(exitCode).toBe(1);
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary).toMatchObject({
+        failed: 2,
+        notExecuted: 0,
+      });
+      expect(summary.results).toHaveLength(2);
+      expect(summary.results[0]).toMatchObject({
+        resultType: 'failed',
+        error: expect.stringContaining(failureMessage),
+      });
+      expect(summary.results[1]).toMatchObject({
+        resultType: 'failed',
+        error: expect.stringContaining(failureMessage),
+      });
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -576,4 +576,71 @@ export function defineYamlCaseTest(options: any) {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('records the real error in the summary when a case fails before writing its result', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const framework = join(root, 'framework.ts');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    const failureMessage =
+      'Model configuration is incomplete: model name (MIDSCENE_MODEL_NAME) is required.';
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: https://file.example\ntasks: []\n');
+    // The case throws before writing its own result file, mimicking a module /
+    // setup failure inside the worker. The summary must still surface the real
+    // error instead of a blank "not executed".
+    writeFileSync(
+      framework,
+      `import { test } from '@rstest/core';
+export function defineYamlCaseTest(options: any) {
+  test(options.testName, async () => {
+    throw new Error(${JSON.stringify(failureMessage)});
+  });
+}
+`,
+    );
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yaml],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: false,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: framework,
+          stdio: 'pipe',
+        },
+      );
+
+      expect(exitCode).toBe(1);
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary).toMatchObject({
+        failed: 1,
+        notExecuted: 0,
+      });
+      expect(summary.results[0].resultType).toBe('failed');
+      expect(summary.results[0].error).toContain(failureMessage);
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -643,4 +643,58 @@ export function defineYamlCaseTest(options: any) {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('records a module load failure in the summary instead of a blank "not executed"', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      // The generated virtual module imports the framework entry. Point it at an
+      // unresolvable specifier so the test module fails to load ("Cannot find
+      // module") — exactly the failure shape of the original bug, where no
+      // result file was ever written. The summary must still carry the real
+      // error instead of a blank "not executed".
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yaml],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: false,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: '@midscene/__nonexistent_framework_entry__',
+          stdio: 'pipe',
+        },
+      );
+
+      expect(exitCode).toBe(1);
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary.notExecuted).toBe(0);
+      expect(summary.results[0].resultType).toBe('failed');
+      expect(summary.results[0].error).toBeTruthy();
+      expect(summary.results[0].error).not.toContain('Not executed');
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import {
   DEFAULT_YAML_TEST_TIMEOUT,
   createRstestYamlProject,
+  resolveDefaultFrameworkImport,
   resolveTestName,
 } from '@/framework/rstest-project';
 import { describe, expect, test } from 'vitest';
@@ -150,6 +151,33 @@ describe('rstest yaml project generation', () => {
     const yamlFile = '/tmp/other/script.yaml';
 
     expect(resolveTestName(projectDir, yamlFile)).toBe(yamlFile);
+  });
+
+  test('resolves the framework entry from the CLI module dir, not process.argv[1]', () => {
+    // Installed layout: the CLI module directory contains framework/index.js.
+    const moduleDir = createTempDir();
+    mkdirSync(join(moduleDir, 'framework'), { recursive: true });
+    writeFileSync(join(moduleDir, 'framework', 'index.js'), 'export {};');
+
+    // process.argv[1] points at a launcher whose directory does NOT lead to the
+    // framework entry (a .bin symlink / npx cache / wrapper). The original bug
+    // derived the path from argv[1] and fell back to the bare specifier
+    // `@midscene/cli/dist/lib/framework/index.js`, which the virtual test module
+    // then could not resolve from the user's CWD. The fix must anchor on the
+    // module directory instead and return an existing absolute path.
+    const originalEntry = process.argv[1];
+    const bogusLauncherDir = createTempDir();
+    process.argv[1] = join(bogusLauncherDir, 'midscene');
+
+    try {
+      const resolved = resolveDefaultFrameworkImport(moduleDir);
+      expect(resolved).toBe(join(moduleDir, 'framework', 'index.js'));
+      expect(resolved).not.toBe('@midscene/cli/dist/lib/framework/index.js');
+    } finally {
+      process.argv[1] = originalEntry;
+      rmSync(moduleDir, { recursive: true, force: true });
+      rmSync(bogusLauncherDir, { recursive: true, force: true });
+    }
   });
 
   test('generates a single batch virtual entry for shared browser context', () => {

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -213,6 +213,10 @@ describe('rstest yaml project generation', () => {
       });
 
       expect(project.include).toEqual(['virtual:midscene-yaml/batch.test.ts']);
+      expect(project.batchTest).toEqual({
+        testModule: 'virtual:midscene-yaml/batch.test.ts',
+        testName: 'midscene yaml batch',
+      });
       expect(project.cases).toHaveLength(2);
       expect(project.maxConcurrency).toBe(1);
       const generated = project.virtualModules[project.include[0]];


### PR DESCRIPTION
## Problem

Running a YAML script with the CLI could finish with a summary like this — `failed: 0` yet `notExecuted: 1`, and **no error message at all**:

```json
{ "summary": { "failed": 0, "notExecuted": 1 },
  "results": [{ "resultType": "notExecuted",
                "error": "Not executed (previous task failed)" }] }
```

The real failure was completely hidden, so there was nothing to act on.

## Root causes

1. **Framework module could not be resolved (the actual trigger).** The generated virtual test module imported the framework entry by the bare specifier `@midscene/cli/dist/lib/framework/index.js`. rstest resolves that import from the user's **CWD**. Under a global install, `npx`, or a symlinked `.bin`, `@midscene/cli` is not on the CWD resolution path, so the test module failed to load with `Cannot find module …`. The case never wrote its result file and collapsed to `not executed`.

   `resolveDefaultFrameworkImport` derived candidate paths from `process.argv[1]`, which points at the `.bin` symlink and never reaches the compiled `framework/index.js`, so it fell through to that unresolvable bare specifier.

2. **The error was swallowed.** The runner only printed `unhandledErrors` (worker crash / config load) and ignored file-level and test-level failures. Any case without a result file was unconditionally reported as `not executed (previous task failed)` — misleading when there is no previous task at all.

## Changes

- **`rstest-project.ts`** — anchor the framework entry on `__dirname` (the installed CLI output) and resolve to an absolute path, so the virtual module loads regardless of CWD. Mirrors the existing `@rstest/core` resolution in `rstest-runner.ts`. Falls back to the previous `argv[1]` candidates, then the bare specifier.
- **`rstest-runner.ts`** — collect **every** rstest error (file-level, test-level, unhandled) and print them to stderr; and persist a `failed` result carrying the real error for cases that failed before writing their own result file, so the cause appears in the summary JSON. Cases genuinely skipped by `bail` keep `not executed`.

## Result

Same scenario now yields an actionable summary:

```
❌ Failed files
   bing-search.yaml
     Error: Model configuration is incomplete: model name (MIDSCENE_MODEL_NAME) is required.
```

```json
{ "summary": { "failed": 1, "notExecuted": 0 },
  "results": [{ "resultType": "failed",
                "error": "Model configuration is incomplete: model name (MIDSCENE_MODEL_NAME) is required." }] }
```

## Validation

- `pnpm run lint`
- `npx nx build cli`
- `vitest run` on `framework/*`, `execution-summary`, `share-browser-context` (30+ tests, incl. a new end-to-end test asserting the real error reaches the summary JSON)
- Manual end-to-end: ran a YAML script from a CWD without `@midscene/cli` in `node_modules`; before, silent `not executed`; after, the real error is shown and recorded in the summary JSON.