### PR TITLE
fix(core): keep markdown image paths in sync with exported screenshots (#2392)

### DIFF
--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -74,18 +74,16 @@ function writeAttachmentFromReport(
 
   const absolutePath = path.join(opts.screenshotsDir, suggestedFileName);
 
-  const outputRelativePath = `./screenshots/${suggestedFileName}`;
-  const sourceRef =
-    attachment.filePath !== outputRelativePath
-      ? {
-          type: 'midscene_screenshot_ref' as const,
-          id,
-          capturedAt: 0,
-          mimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',
-          storage: 'file' as const,
-          path: attachment.filePath,
-        }
-      : null;
+  const sourceRef = attachment.sourcePath
+    ? {
+        type: 'midscene_screenshot_ref' as const,
+        id,
+        capturedAt: 0,
+        mimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',
+        storage: 'file' as const,
+        path: attachment.sourcePath,
+      }
+    : null;
 
   const resolved = resolveScreenshotSource(sourceRef, {
     reportPath: opts.htmlPath,

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -74,18 +74,7 @@ function writeAttachmentFromReport(
 
   const absolutePath = path.join(opts.screenshotsDir, suggestedFileName);
 
-  const sourceRef = attachment.sourcePath
-    ? {
-        type: 'midscene_screenshot_ref' as const,
-        id,
-        capturedAt: 0,
-        mimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',
-        storage: 'file' as const,
-        path: attachment.sourcePath,
-      }
-    : null;
-
-  const resolved = resolveScreenshotSource(sourceRef, {
+  const resolved = resolveScreenshotSource(attachment.sourceRef ?? null, {
     reportPath: opts.htmlPath,
     fallbackId: id,
     fallbackMimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -15,7 +15,18 @@ export interface MarkdownAttachment {
   id: string;
   suggestedFileName: string;
   mimeType?: string;
+  /**
+   * Path referenced from the markdown file. Always points at the exported copy
+   * (`${screenshotBaseDir}/${suggestedFileName}`) so the markdown links stay in
+   * sync with the files actually written to disk.
+   */
   filePath: string;
+  /**
+   * Original on-disk location of the screenshot in the source report (a
+   * ScreenshotRef `path`). Used only to locate the source file when copying it
+   * to the exported name; never referenced from the markdown. See issue #2392.
+   */
+  sourcePath?: string;
   executionIndex: number;
   taskIndex: number;
   /** Populated when screenshot data is available in memory (e.g. browser context). */
@@ -204,13 +215,14 @@ function screenshotAttachment(
   if (ref) {
     const ext = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${ref.id}.${ext}`;
-    const filePath = ref.path || `${screenshotBaseDir}/${suggestedFileName}`;
+    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
       markdown: `\n![task-${taskIndex + 1}](${filePath})`,
       attachment: {
         id: ref.id,
         suggestedFileName,
         filePath,
+        sourcePath: ref.path,
         mimeType: ref.mimeType,
         executionIndex,
         taskIndex,

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -9,24 +9,24 @@ import type {
   IReportActionDump,
   ReportActionDump,
 } from '@/types';
+import type { ScreenshotRef } from './dump/screenshot-store';
 import { normalizeScreenshotRef } from './dump/screenshot-store';
 
 export interface MarkdownAttachment {
   id: string;
+  /**
+   * Stable, prefixed file name for the exported copy. The markdown image link
+   * always points at `${screenshotBaseDir}/${suggestedFileName}`, so consumers
+   * write the screenshot under this name to keep links in sync. See #2392.
+   */
   suggestedFileName: string;
   mimeType?: string;
   /**
-   * Path referenced from the markdown file. Always points at the exported copy
-   * (`${screenshotBaseDir}/${suggestedFileName}`) so the markdown links stay in
-   * sync with the files actually written to disk.
+   * Reference to the screenshot in the source report, used to locate the
+   * original bytes when copying them to the exported name. Absent for in-memory
+   * screenshots, which carry their data in `base64Data` instead.
    */
-  filePath: string;
-  /**
-   * Original on-disk location of the screenshot in the source report (a
-   * ScreenshotRef `path`). Used only to locate the source file when copying it
-   * to the exported name; never referenced from the markdown. See issue #2392.
-   */
-  sourcePath?: string;
+  sourceRef?: ScreenshotRef;
   executionIndex: number;
   taskIndex: number;
   /** Populated when screenshot data is available in memory (e.g. browser context). */
@@ -196,13 +196,11 @@ function screenshotAttachment(
   if (screenshot instanceof ScreenshotItem) {
     const ext = screenshot.extension;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${screenshot.id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: screenshot.id,
         suggestedFileName,
-        filePath,
         mimeType: `image/${ext === 'jpeg' ? 'jpeg' : 'png'}`,
         executionIndex,
         taskIndex,
@@ -215,14 +213,12 @@ function screenshotAttachment(
   if (ref) {
     const ext = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${ref.id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: ref.id,
         suggestedFileName,
-        filePath,
-        sourcePath: ref.path,
+        sourceRef: ref,
         mimeType: ref.mimeType,
         executionIndex,
         taskIndex,
@@ -236,13 +232,11 @@ function screenshotAttachment(
     const ext = base64.startsWith('data:image/jpeg') ? 'jpeg' : 'png';
     const id = `restored-${executionIndex + 1}-${taskIndex + 1}`;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id,
         suggestedFileName,
-        filePath,
         mimeType: `image/${ext}`,
         executionIndex,
         taskIndex,

--- a/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
+++ b/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
@@ -19,12 +19,12 @@
 - Cost(ms): 100
 - Screen size: 1440 x 900
 
-![task-1](./screenshots/shot-exec-1.png)
+![task-1](./screenshots/execution-1-task-1-shot-exec-1.png)
 
 ### Recorder
 - #1 type=screenshot, ts=2024-03-09T16:00:00.060Z, timing=record-step-1
 
-![task-1](./screenshots/shot-recorder-exec-1.png)
+![task-1](./screenshots/execution-1-task-1-shot-recorder-exec-1.png)
 
 ---
 
@@ -41,4 +41,4 @@
 - Screen size: 1024 x 768
 - Locate center: (512, 333)
 
-![task-1](./screenshots/shot-exec-2.png)
+![task-1](./screenshots/execution-2-task-1-shot-exec-2.png)

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -473,6 +473,76 @@ describe('createReportCliCommands', () => {
     expect(readFileSync(exportedScreenshot)).toEqual(
       readFileSync(sourceScreenshotPath),
     );
+
+    // The markdown must reference the exported (prefixed) file name, not the
+    // original source path. See issue #2392.
+    const mdContent = readFileSync(join(outputDir, 'report.md'), 'utf-8');
+    expect(mdContent).toContain(
+      './screenshots/execution-1-task-1-file-shot.png',
+    );
+    expect(mdContent).not.toContain(sourceScreenshotPath);
+  });
+
+  it('references the exported file name for report-relative screenshots', async () => {
+    // Reproduces the exact issue #2392 scenario: the android
+    // html-and-external-assets mode stores screenshots as
+    // ./screenshots/<id>.png relative to the report file. The exported markdown
+    // must point at the prefixed copy, not the original relative path.
+    const reportDir = join(tmpDir, 'input-report-md-rel');
+    const reportPath = join(reportDir, 'index.html');
+    const sourceScreenshotsDir = join(reportDir, 'screenshots');
+    mkdirSync(sourceScreenshotsDir, { recursive: true });
+
+    const sourceScreenshotPath = join(sourceScreenshotsDir, 'rel-shot.png');
+    writeFileSync(sourceScreenshotPath, Buffer.from('png-binary-rel'));
+
+    const screenshotRef: ScreenshotRef = {
+      type: 'midscene_screenshot_ref',
+      id: 'rel-shot',
+      capturedAt: Date.now(),
+      mimeType: 'image/png',
+      storage: 'file',
+      path: './screenshots/rel-shot.png',
+    };
+    const dump = new ReportActionDump({
+      groupName: 'markdown-rel-file-test',
+      groupDescription: 'markdown export relative file ref test',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createExecution('exec-md-rel', screenshotRef)],
+    });
+
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(dump.serialize(), { 'data-group-id': 'group-1' }),
+      'utf-8',
+    );
+
+    const outputDir = join(tmpDir, 'output-md-rel');
+    const [command] = createReportCliCommands();
+    await command.def.handler({
+      htmlPath: reportPath,
+      outputDir,
+      action: 'to-markdown',
+    });
+
+    const exportedScreenshot = join(
+      outputDir,
+      'screenshots',
+      'execution-1-task-1-rel-shot.png',
+    );
+    expect(existsSync(exportedScreenshot)).toBe(true);
+    expect(readFileSync(exportedScreenshot)).toEqual(
+      readFileSync(sourceScreenshotPath),
+    );
+
+    // Markdown references the exported copy; the original relative path
+    // ./screenshots/rel-shot.png must no longer appear on its own.
+    const mdContent = readFileSync(join(outputDir, 'report.md'), 'utf-8');
+    expect(mdContent).toContain(
+      './screenshots/execution-1-task-1-rel-shot.png',
+    );
+    expect(mdContent).not.toContain('(./screenshots/rel-shot.png)');
   });
 
   function writeFakeReport(

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -70,8 +70,10 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('timing=after click');
     expect(result.markdown).toContain('Screen size: 1280 x 720');
     expect(result.attachments).toHaveLength(2);
-    expect(result.attachments[0].filePath).toContain('./screenshots/');
     expect(result.attachments[0].suggestedFileName).toContain('.png');
+    expect(result.markdown).toContain(
+      `./screenshots/${result.attachments[0].suggestedFileName}`,
+    );
   });
 
   it('merges all executions into one markdown and keeps file snapshot', async () => {


### PR DESCRIPTION
## Summary

Fixes #2392. When `report-tool --action to-markdown` runs against a report generated in `html-and-external-assets` mode, the exported markdown referenced broken image paths.

File-backed screenshots are copied to a task-prefixed name (`execution-N-task-M-<id>.<ext>`), but the markdown still pointed at the original un-prefixed `ScreenshotRef.path` (e.g. `./screenshots/<id>.png`), so none of the image links resolved.

## Root cause

`MarkdownAttachment.filePath` was overloaded for two conflicting purposes:

1. the path **referenced from the markdown** (display), and
2. the path used to **locate the source file** when copying it.

In the `ScreenshotRef` branch, `filePath` was set to `ref.path || …`. When `ref.path` existed, the markdown linked to the original location while `writeAttachmentFromReport` always wrote the file under the prefixed `suggestedFileName` — the two never matched.

## Fix

Split the two responsibilities:

- `filePath` now **always** points at the exported copy (`${screenshotBaseDir}/${suggestedFileName}`), which is exactly what gets written to disk, so the markdown links stay correct.
- A new optional `sourcePath` carries the original `ScreenshotRef.path`, used **only** to locate the source file during copy.

This also removes the fragile `filePath !== './screenshots/<name>'` string comparison in `writeAttachmentFromReport`, which had hard-coded the `./screenshots/` prefix and could misfire for a non-default `screenshotBaseDir`. The new design uses an explicit `sourcePath` field instead of inferring intent from a string match.

`ScreenshotItem` / inline-ref / base64 paths are unchanged: they carry no `sourcePath` and continue to resolve via the report's inline image data.

## Tests

- Extended the existing "copies file-backed screenshots during markdown export" test to also assert the markdown references the exported (prefixed) name and not the original source path.
- Added a new test reproducing the exact issue scenario: a **report-relative** `./screenshots/<id>.png` ref, asserting both the exported file and the markdown link use the prefixed name.
- Updated `report-markdown.output.md` snapshot to reflect the corrected links.

## Validation

- `npx vitest run tests/unit-test/report-cli.test.ts tests/unit-test/report-markdown.test.ts` — 26 passed
- `npx nx build core` — success (public `MarkdownAttachment` type adds an optional field; backward compatible)
- `npx biome check` on the touched files — clean
- `pnpm run lint` — no errors

> Note: a pre-existing failure in `report-merge-count.test.ts` ("merging 10 inline reports", V8 string-length limit) is unrelated to this change and reproduces on `main`.

## Known gap (out of scope)

The bare-base64 branch of `screenshotAttachment` does not set `sourcePath` and `writeAttachmentFromReport` does not consume `base64Data`; it relies on inline resolution from the report. Serialized reports don't surface bare base64 screenshots, so this path is not reachable from the CLI today. Left as a follow-up.