### PR TITLE
feat(core): support reasoning default mode

### DIFF
--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -45,9 +45,9 @@ If you configure a dedicated Insight or Planning model, model-related `MIDSCENE_
 | `MIDSCENE_MODEL_TEMPERATURE` | Sampling temperature for model responses |
 | `MIDSCENE_MODEL_RETRY_COUNT` | Number of retries when AI call fails, default 1 (i.e., retry once after failure) |
 | `MIDSCENE_MODEL_RETRY_INTERVAL` | Interval between retries in milliseconds, default 2000 |
-| `MIDSCENE_MODEL_REASONING_ENABLED` | Enable or disable model-native reasoning/thinking. Set to `"true"` or `"false"`. For supported model families, Midscene disables or reduces model-native thinking by default when this variable is unset. Gemini 3.x series does not support turning off model-native thinking; use `MIDSCENE_MODEL_REASONING_EFFORT` to control its thinking effort. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode). Explicit reasoning config requires a supported `MIDSCENE_MODEL_FAMILY` |
-| `MIDSCENE_MODEL_REASONING_EFFORT` | Reasoning effort level string. Passed through as `reasoning_effort` for doubao and Gemini OpenAI-compatible endpoints, and as `effort` for Codex app-server. Common values: `low`, `medium`, `high`; Gemini 3.x series defaults to `minimal` |
-| `MIDSCENE_MODEL_REASONING_BUDGET` | Thinking token budget (number). Passed through as `thinking_budget` for qwen. Explicit reasoning config requires a supported `MIDSCENE_MODEL_FAMILY` |
+| `MIDSCENE_MODEL_REASONING_ENABLED` | Controls whether model-native thinking is enabled. Midscene disables it by default. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode) |
+| `MIDSCENE_MODEL_REASONING_EFFORT` | Controls model-native thinking effort, supported by some models. Common values: `low`, `medium`, `high`. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode) |
+| `MIDSCENE_MODEL_REASONING_BUDGET` | Thinking token budget (number), supported by some models. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode) |
 | `MIDSCENE_MODEL_HTTP_PROXY` | HTTP/HTTPS proxy, e.g., `http://127.0.0.1:8080` or `https://proxy.example.com:8080`. Takes precedence over `MIDSCENE_MODEL_SOCKS_PROXY` |
 | `MIDSCENE_MODEL_SOCKS_PROXY` | SOCKS proxy, e.g., `socks5://127.0.0.1:1080` |
 | `MIDSCENE_MODEL_INIT_CONFIG_JSON` | JSON blob that overrides the OpenAI SDK initialization config. Use `defaultHeaders` for custom auth headers; `extra_headers` and `extraHeaders` are accepted as aliases |

--- a/apps/site/docs/en/model-strategy.mdx
+++ b/apps/site/docs/en/model-strategy.mdx
@@ -137,11 +137,18 @@ Note: The implementation behind `deepThink` may change in the future as Midscene
 
 ### Model-Native Thinking Mode
 
-Some model providers enable model-native thinking by default. In Midscene UI automation, we found that model-native thinking often significantly increases task latency while providing limited improvement for execution quality. For the model families that Midscene knows how to control, Midscene disables model-native thinking by default to get the best execution speed and stability.
+Midscene disables model-native thinking by default to get better execution speed and stability. If the model itself does not support disabling native thinking, Midscene reduces model-native thinking as much as possible by controlling thinking granularity or limiting the thinking budget.
 
-If you need model-native thinking, set `MIDSCENE_MODEL_REASONING_ENABLED="true"` explicitly. Some model families also support extra controls such as `MIDSCENE_MODEL_REASONING_BUDGET` or `MIDSCENE_MODEL_REASONING_EFFORT`; see [Common Model Configuration](./model-common-config) for model-specific examples and [Advanced settings](./model-config#advanced-settings-optional) for the full environment variable reference.
+You can control model-native thinking with the following reasoning settings.
 
-Reasoning controls are model-family specific. If the configured model family does not support a reasoning option, Midscene ignores that option instead of guessing provider-specific reasoning parameters.
+- `MIDSCENE_MODEL_REASONING_ENABLED`: Explicitly controls whether model-native thinking is enabled.
+  - `false`: Force-disable model-native thinking (Midscene's default behavior).
+  - `true`: Force-enable model-native thinking.
+  - `default`: Follow the model's default behavior. Midscene will not send any setting that enables or disables thinking. In this case, explicitly configured `MIDSCENE_MODEL_REASONING_BUDGET` and `MIDSCENE_MODEL_REASONING_EFFORT` will also be ignored.
+- `MIDSCENE_MODEL_REASONING_BUDGET`: Controls the model's thinking budget (supported by some models). See [Common Model Configuration](./model-common-config) for examples.
+- `MIDSCENE_MODEL_REASONING_EFFORT`: Controls the model's thinking effort (supported by some models). See [Common Model Configuration](./model-common-config) for examples.
+
+Note: Different model providers use different parameters to control model-native thinking. If an explicit reasoning setting is not supported by the current model, Midscene ignores that setting instead of guessing provider-specific private parameters.
 
 ### "MIDSCENE_MODEL_FAMILY is not set to a multimodal model" error
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -43,9 +43,9 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 | `MIDSCENE_MODEL_TEMPERATURE` | 模型采样温度 |
 | `MIDSCENE_MODEL_RETRY_COUNT` | AI 调用失败时的重试次数，默认 1（即失败后重试 1 次）|
 | `MIDSCENE_MODEL_RETRY_INTERVAL` | AI 调用重试间隔毫秒数，默认 2000 |
-| `MIDSCENE_MODEL_REASONING_ENABLED` | 开启或关闭模型原生推理/思考。设为 `"true"` 或 `"false"`。对于已适配的模型系列，如果不配置该变量，Midscene 会默认关闭或降低模型原生思考。Gemini 3.x 系列不支持关闭模型原生 thinking，需通过 `MIDSCENE_MODEL_REASONING_EFFORT` 控制思考力度。见[模型原生的思考模式](./model-strategy#模型原生的思考模式)。显式配置 reasoning 时必须使用已支持的 `MIDSCENE_MODEL_FAMILY` |
-| `MIDSCENE_MODEL_REASONING_EFFORT` | 推理力度字符串。透传为豆包和 Gemini OpenAI-compatible 接口的 `reasoning_effort`，以及 Codex app-server 的 `effort`。常用值：`low`、`medium`、`high`；Gemini 3.x 系列默认使用 `minimal` |
-| `MIDSCENE_MODEL_REASONING_BUDGET` | 思考 token 预算（数字）。透传为千问的 `thinking_budget`。显式配置 reasoning 时必须使用已支持的 `MIDSCENE_MODEL_FAMILY` |
+| `MIDSCENE_MODEL_REASONING_ENABLED` | 控制是否启用模型的原生思考能力，Midscene 默认关闭。详见[模型原生的思考模式](./model-strategy#模型原生的思考模式) |
+| `MIDSCENE_MODEL_REASONING_EFFORT` | 控制模型的原生思考力度，部分模型支持。常用值：`low`、`medium`、`high`。详见[模型原生的思考模式](./model-strategy#模型原生的思考模式) |
+| `MIDSCENE_MODEL_REASONING_BUDGET` | 思考 token 预算（数字），部分模型支持。详见[模型原生的思考模式](./model-strategy#模型原生的思考模式) |
 | `MIDSCENE_MODEL_HTTP_PROXY` | HTTP/HTTPS 代理配置，如 `http://127.0.0.1:8080` 或 `https://proxy.example.com:8080`，优先级高于 `MIDSCENE_MODEL_SOCKS_PROXY` |
 | `MIDSCENE_MODEL_SOCKS_PROXY` | SOCKS 代理配置，如 `socks5://127.0.0.1:1080` |
 | `MIDSCENE_MODEL_INIT_CONFIG_JSON` | 覆盖 OpenAI SDK 初始化配置的 JSON。自定义鉴权 header 请使用 `defaultHeaders`；`extra_headers` 和 `extraHeaders` 也会作为别名兼容 |

--- a/apps/site/docs/zh/model-strategy.mdx
+++ b/apps/site/docs/zh/model-strategy.mdx
@@ -138,11 +138,19 @@ Midscene 提供了基于页面理解的数据处理接口，如 AI 断言（`aiA
 
 ### 模型原生的思考模式
 
-一些模型服务商会默认开启模型原生思考。在 Midscene 的 UI 自动化场景中，我们注意到模型原生思考通常会明显增加任务耗时，而对执行质量的提升有限。对于 Midscene 已经适配控制方式的模型系列，Midscene 会默认关闭模型原生思考，以获得更好的执行速度和稳定性。
+Midscene 会默认关闭模型原生思考，以获得更好的执行速度和稳定性。如果模型自身不支持关闭原生思考，Midscene 会通过控制思考粒度或限制思考额度的方式，尽可能减少模型的原生思考。
 
-如果你需要模型原生思考，请显式设置 `MIDSCENE_MODEL_REASONING_ENABLED="true"`。部分模型系列还支持 `MIDSCENE_MODEL_REASONING_BUDGET` 或 `MIDSCENE_MODEL_REASONING_EFFORT` 等额外控制项。具体示例请参考[常用模型配置](./model-common-config)，完整环境变量说明请参考[高阶配置](./model-config#高阶配置可选)。
+你可以通过下面的 reasoning 配置控制模型的原生思考。
 
-reasoning 控制项与模型系列相关。如果当前模型系列不支持某个 reasoning 配置，Midscene 会忽略该配置，而不会猜测服务商的私有参数。
+- `MIDSCENE_MODEL_REASONING_ENABLED`：显式控制是否开启模型原生思考。
+  - `false`：强制关闭模型原生思考（Midscene 默认行为）。
+  - `true`：强制开启模型原生思考。
+  - `default`：遵循模型的默认行为，Midscene 将不会向模型发送任何开启或关闭思考的配置。此时，显式配置的 `MIDSCENE_MODEL_REASONING_BUDGET` 和 `MIDSCENE_MODEL_REASONING_EFFORT` 也会被忽略。
+- `MIDSCENE_MODEL_REASONING_BUDGET`：控制模型的思考限额（部分模型支持），具体示例请参考[常用模型配置](./model-common-config)。
+- `MIDSCENE_MODEL_REASONING_EFFORT`：控制模型的思考力度（部分模型支持），具体示例请参考[常用模型配置](./model-common-config)。
+
+
+注意：不同模型厂商控制模型原生思考方式的参数各不相同。如果某个显式的 reasoning 配置不被当前模型支持，Midscene 会忽略该配置，而不会猜测服务商的私有参数。
 
 ### "MIDSCENE_MODEL_FAMILY is not set to a multimodal model" 错误
 

--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -167,21 +167,21 @@ const buildDoubaoChatCompletionParams = (
 ): ChatCompletionParamsResult => {
   const { midsceneDefaults, userConfig } = input;
   const { reasoningEnabled, reasoningEffort } = userConfig;
-  const effectiveReasoningEnabled = reasoningEnabled ?? false;
   const commonOverrideConfig: Record<string, unknown> = {};
 
   if (userConfig.temperature !== undefined) {
     commonOverrideConfig.temperature = userConfig.temperature;
   }
 
-  const modelSpecificConfig: Record<string, unknown> = {
-    thinking: {
-      type: effectiveReasoningEnabled ? 'enabled' : 'disabled',
-    },
-  };
+  const modelSpecificConfig: Record<string, unknown> = {};
 
-  if (reasoningEffort) {
-    modelSpecificConfig.reasoning_effort = reasoningEffort;
+  if (reasoningEnabled !== 'default') {
+    modelSpecificConfig.thinking = {
+      type: (reasoningEnabled ?? false) ? 'enabled' : 'disabled',
+    };
+    if (reasoningEffort) {
+      modelSpecificConfig.reasoning_effort = reasoningEffort;
+    }
   }
 
   return {

--- a/packages/core/src/ai-model/models/gemini.ts
+++ b/packages/core/src/ai-model/models/gemini.ts
@@ -31,7 +31,7 @@ const buildGeminiChatCompletionParams = (
   input: ChatCompletionCallContext,
 ): ChatCompletionParamsResult => {
   const { midsceneDefaults, userConfig, intent } = input;
-  const { reasoningEffort } = userConfig;
+  const { reasoningEnabled, reasoningEffort } = userConfig;
   const commonOverrideConfig: Record<string, unknown> = {};
 
   if (userConfig.temperature !== undefined) {
@@ -47,31 +47,33 @@ const buildGeminiChatCompletionParams = (
     reasoning_effort?: unknown;
   } = {};
 
-  if (intent === 'insight') {
-    modelSpecificConfig.extra_body = {
-      google: {
-        thinking_config: {
-          // In real Gemini tests, insight calls need `include_thoughts` to get
-          // the model's thinking, and Gemini puts that thinking into `content`.
-          include_thoughts: true,
+  if (reasoningEnabled !== 'default') {
+    if (reasoningEffort) {
+      modelSpecificConfig.extra_body = {
+        google: {
+          thinking_config: {
+            thinking_level: reasoningEffort,
+            include_thoughts: true,
+          },
         },
-      },
-    };
-  }
+      };
+    } else {
+      if (intent === 'insight') {
+        modelSpecificConfig.extra_body = {
+          google: {
+            thinking_config: {
+              // In real Gemini tests, insight calls need `include_thoughts` to get
+              // the model's thinking, and Gemini puts that thinking into `content`.
+              include_thoughts: true,
+            },
+          },
+        };
+      }
 
-  if (reasoningEffort) {
-    modelSpecificConfig.extra_body = {
-      google: {
-        thinking_config: {
-          thinking_level: reasoningEffort,
-          include_thoughts: true,
-        },
-      },
-    };
-  } else {
-    // Gemini 3.x cannot fully disable native thinking, so use the lowest
-    // supported effort unless the user explicitly requests another level.
-    modelSpecificConfig.reasoning_effort = 'minimal';
+      // Gemini 3.x cannot fully disable native thinking, so use the lowest
+      // supported effort unless the user explicitly requests another level.
+      modelSpecificConfig.reasoning_effort = 'minimal';
+    }
   }
 
   return {

--- a/packages/core/src/ai-model/models/glm.ts
+++ b/packages/core/src/ai-model/models/glm.ts
@@ -10,18 +10,19 @@ const buildGlmChatCompletionParams = (
 ): ChatCompletionParamsResult => {
   const { midsceneDefaults, userConfig } = input;
   const { reasoningEnabled } = userConfig;
-  const effectiveReasoningEnabled = reasoningEnabled ?? false;
   const commonOverrideConfig: Record<string, unknown> = {};
 
   if (userConfig.temperature !== undefined) {
     commonOverrideConfig.temperature = userConfig.temperature;
   }
 
-  const modelSpecificConfig = {
-    thinking: {
-      type: effectiveReasoningEnabled ? 'enabled' : 'disabled',
-    },
-  };
+  const modelSpecificConfig: Record<string, unknown> = {};
+
+  if (reasoningEnabled !== 'default') {
+    modelSpecificConfig.thinking = {
+      type: (reasoningEnabled ?? false) ? 'enabled' : 'disabled',
+    };
+  }
 
   return {
     config: {

--- a/packages/core/src/ai-model/models/qwen.ts
+++ b/packages/core/src/ai-model/models/qwen.ts
@@ -65,12 +65,13 @@ const buildQwenChatCompletionParams = (
     commonOverrideConfig.temperature = userConfig.temperature;
   }
 
-  const modelSpecificConfig: Record<string, unknown> = {
-    enable_thinking: reasoningEnabled ?? false,
-  };
+  const modelSpecificConfig: Record<string, unknown> = {};
 
-  if (reasoningBudget !== undefined) {
-    modelSpecificConfig.thinking_budget = reasoningBudget;
+  if (reasoningEnabled !== 'default') {
+    modelSpecificConfig.enable_thinking = reasoningEnabled ?? false;
+    if (reasoningBudget !== undefined) {
+      modelSpecificConfig.thinking_budget = reasoningBudget;
+    }
   }
 
   return {

--- a/packages/core/src/ai-model/models/types.ts
+++ b/packages/core/src/ai-model/models/types.ts
@@ -1,4 +1,8 @@
-import type { IModelConfig, TIntent } from '@midscene/shared/env';
+import type {
+  IModelConfig,
+  TIntent,
+  TModelReasoningEnabled,
+} from '@midscene/shared/env';
 import type OpenAI from 'openai';
 import type {
   JsonParser,
@@ -23,7 +27,7 @@ export type {
 export type JsonParserPreset = 'lenient-json';
 
 export interface ReasoningInput {
-  reasoningEnabled?: boolean;
+  reasoningEnabled?: TModelReasoningEnabled;
   reasoningEffort?: string;
   reasoningBudget?: number;
 }

--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -3,7 +3,10 @@ import type {
   CodeGenerationChunk,
   StreamingCallback,
 } from '@/types';
-import type { IModelConfig } from '@midscene/shared/env';
+import type {
+  IModelConfig,
+  TModelReasoningEnabled,
+} from '@midscene/shared/env';
 import { getDebug } from '@midscene/shared/logger';
 import { ifInBrowser } from '@midscene/shared/utils';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
@@ -259,11 +262,12 @@ export const resolveCodexReasoningEffort = ({
   reasoningEnabled,
   modelConfig,
 }: {
-  reasoningEnabled?: boolean;
+  reasoningEnabled?: TModelReasoningEnabled;
   modelConfig: IModelConfig;
 }): CodexReasoningEffort | undefined => {
   if (reasoningEnabled === true) return 'high';
   if (reasoningEnabled === false) return 'none';
+  if (reasoningEnabled === 'default') return undefined;
 
   const normalized = modelConfig.reasoningEffort?.trim().toLowerCase();
   if (
@@ -400,7 +404,7 @@ class CodexAppServerConnection {
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: boolean;
+    reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
   }): Promise<CodexTurnResult> {
     const startTime = Date.now();
@@ -935,7 +939,7 @@ class CodexAppServerConnectionManager {
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: boolean;
+    reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
   }): Promise<CodexTurnResult> {
     return this.runner.run(async () => {
@@ -987,7 +991,7 @@ export async function callAIWithCodexAppServer(
   options?: {
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: boolean;
+    reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
   },
 ): Promise<CodexTurnResult> {

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -116,6 +116,16 @@ describe('codex app-server provider helper', () => {
         },
       }),
     ).toBe('none');
+
+    expect(
+      resolveCodexReasoningEffort({
+        reasoningEnabled: 'default',
+        modelConfig: {
+          ...baseModelConfig,
+          reasoningEffort: 'medium',
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it('converts chat messages into codex turn payload', () => {

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -135,6 +135,18 @@ describe('doubao model adapter', () => {
     });
   });
 
+  it('follows provider default and ignores effort for doubao when reasoningEnabled=default', () => {
+    const result = doubaoSeedAdapter.chatCompletion.buildChatCompletionParams({
+      userConfig: {
+        reasoningEnabled: 'default',
+        reasoningEffort: 'high',
+      },
+    });
+    expect(result.config).toEqual({
+      temperature: 0,
+    });
+  });
+
   it('ignores reasoningBudget for doubao', () => {
     const result = doubaoSeedAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {

--- a/packages/core/tests/unit-test/model-adapter/gemini.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/gemini.test.ts
@@ -86,6 +86,18 @@ describe('gemini model adapter', () => {
     });
   });
 
+  it('follows provider default and ignores effort for gemini when reasoningEnabled=default', () => {
+    const result = geminiAdapter.chatCompletion.buildChatCompletionParams({
+      userConfig: {
+        reasoningEnabled: 'default',
+        reasoningEffort: 'high',
+      },
+    });
+    expect(result.config).toEqual({
+      temperature: 0,
+    });
+  });
+
   it('ignores unsupported reasoning fields for gemini', () => {
     const result = geminiAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {

--- a/packages/core/tests/unit-test/model-adapter/glm.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/glm.test.ts
@@ -64,6 +64,17 @@ describe('glm model adapter', () => {
     });
   });
 
+  it('follows provider default for glm-v when reasoningEnabled=default', () => {
+    const result = glmAdapter.chatCompletion.buildChatCompletionParams({
+      userConfig: {
+        reasoningEnabled: 'default',
+      },
+    });
+    expect(result.config).toEqual({
+      temperature: 0,
+    });
+  });
+
   it('ignores unsupported reasoning fields for glm-v', () => {
     const result = glmAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {

--- a/packages/core/tests/unit-test/model-adapter/qwen.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/qwen.test.ts
@@ -261,6 +261,18 @@ describe('qwen model adapter', () => {
     });
   });
 
+  it('follows provider default and ignores budget for qwen when reasoningEnabled=default', () => {
+    const result = qwen3VlAdapter.chatCompletion.buildChatCompletionParams({
+      userConfig: {
+        reasoningEnabled: 'default',
+        reasoningBudget: 16384,
+      },
+    });
+    expect(result.config).toEqual({
+      temperature: 0,
+    });
+  });
+
   it('ignores reasoningEffort for qwen because it is not a supported param', () => {
     const result = qwen3VlAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {

--- a/packages/shared/src/env/parse-model-config.ts
+++ b/packages/shared/src/env/parse-model-config.ts
@@ -279,6 +279,7 @@ export const parseOpenaiSdkConfig = ({
       const val = provider[keys.reasoningEnabled]?.trim()?.toLowerCase();
       if (val === 'true' || val === '1') return true;
       if (val === 'false' || val === '0') return false;
+      if (val === 'default') return 'default';
       return undefined;
     })(),
     reasoningBudget: (() => {

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -35,6 +35,8 @@ export const MIDSCENE_MODEL_REASONING_ENABLED =
 export const MIDSCENE_MODEL_REASONING_BUDGET =
   'MIDSCENE_MODEL_REASONING_BUDGET';
 
+export type TModelReasoningEnabled = boolean | 'default';
+
 /**
  * @deprecated Use MIDSCENE_MODEL_API_KEY instead. This is kept for backward compatibility.
  */
@@ -380,7 +382,7 @@ export interface IModelConfigForDefault {
   [MIDSCENE_MODEL_TEMPERATURE]?: string;
   // reasoning effort
   [MIDSCENE_MODEL_REASONING_EFFORT]?: string;
-  // enable reasoning (boolean as string)
+  // enable reasoning (boolean/default as string)
   [MIDSCENE_MODEL_REASONING_ENABLED]?: string;
   // reasoning budget (number as string)
   [MIDSCENE_MODEL_REASONING_BUDGET]?: string;
@@ -499,8 +501,9 @@ export interface IModelConfig {
   /**
    * Enable/disable reasoning for the model.
    * Passed through to model-family-specific parameters (e.g., enable_thinking for qwen, thinking.type for doubao/glm-v).
+   * "default" means following the model provider's default without sending reasoning controls.
    */
-  reasoningEnabled?: boolean;
+  reasoningEnabled?: TModelReasoningEnabled;
   /**
    * Reasoning token budget for the model.
    * Passed through to model-family-specific parameters (e.g., thinking_budget for qwen).

--- a/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
@@ -223,6 +223,17 @@ describe('ModelConfigManager', () => {
     expect(config.reasoningEnabled).toBe(false);
   });
 
+  it('parses reasoningEnabled=default as default', () => {
+    const configWithDefaultReasoning = {
+      ...baseMap,
+      [MIDSCENE_MODEL_REASONING_ENABLED]: 'default',
+    };
+    const manager = new ModelConfigManager(configWithDefaultReasoning);
+
+    const config = manager.getModelConfig('default');
+    expect(config.reasoningEnabled).toBe('default');
+  });
+
   it('reasoningEnabled is undefined when not set', () => {
     const manager = new ModelConfigManager(baseMap);
 


### PR DESCRIPTION
## Summary

- Add explicit `MIDSCENE_MODEL_REASONING_ENABLED=default` support so Midscene can follow provider-native reasoning defaults without sending enable/disable controls.
- Update Qwen, Doubao, GLM, Gemini, and Codex app-server reasoning adapter behavior to ignore effort/budget when `default` is selected.
- Refresh reasoning docs in English and Chinese and add focused unit coverage.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/qwen.test.ts tests/unit-test/model-adapter/doubao.test.ts tests/unit-test/model-adapter/glm.test.ts tests/unit-test/model-adapter/gemini.test.ts tests/unit-test/codex-app-server-provider.test.ts`
- `pnpm --filter @midscene/shared test -- tests/unit-test/env/modle-config-manager.test.ts`
- `pnpm --filter @midscene/shared build`
- `pnpm --filter @midscene/core build`
- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/qwen.test.ts`
- `git diff --check`

Lint was not run per local workflow preference.