### PR TITLE
refactor: simplify MarkdownAttachment schema and remove redundant filePath

### DIFF
--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -74,18 +74,7 @@ function writeAttachmentFromReport(
 
   const absolutePath = path.join(opts.screenshotsDir, suggestedFileName);
 
-  const sourceRef = attachment.sourcePath
-    ? {
-        type: 'midscene_screenshot_ref' as const,
-        id,
-        capturedAt: 0,
-        mimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',
-        storage: 'file' as const,
-        path: attachment.sourcePath,
-      }
-    : null;
-
-  const resolved = resolveScreenshotSource(sourceRef, {
+  const resolved = resolveScreenshotSource(attachment.sourceRef ?? null, {
     reportPath: opts.htmlPath,
     fallbackId: id,
     fallbackMimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -9,24 +9,24 @@ import type {
   IReportActionDump,
   ReportActionDump,
 } from '@/types';
+import type { ScreenshotRef } from './dump/screenshot-store';
 import { normalizeScreenshotRef } from './dump/screenshot-store';
 
 export interface MarkdownAttachment {
   id: string;
+  /**
+   * Stable, prefixed file name for the exported copy. The markdown image link
+   * always points at `${screenshotBaseDir}/${suggestedFileName}`, so consumers
+   * write the screenshot under this name to keep links in sync. See #2392.
+   */
   suggestedFileName: string;
   mimeType?: string;
   /**
-   * Path referenced from the markdown file. Always points at the exported copy
-   * (`${screenshotBaseDir}/${suggestedFileName}`) so the markdown links stay in
-   * sync with the files actually written to disk.
+   * Reference to the screenshot in the source report, used to locate the
+   * original bytes when copying them to the exported name. Absent for in-memory
+   * screenshots, which carry their data in `base64Data` instead.
    */
-  filePath: string;
-  /**
-   * Original on-disk location of the screenshot in the source report (a
-   * ScreenshotRef `path`). Used only to locate the source file when copying it
-   * to the exported name; never referenced from the markdown. See issue #2392.
-   */
-  sourcePath?: string;
+  sourceRef?: ScreenshotRef;
   executionIndex: number;
   taskIndex: number;
   /** Populated when screenshot data is available in memory (e.g. browser context). */
@@ -196,13 +196,11 @@ function screenshotAttachment(
   if (screenshot instanceof ScreenshotItem) {
     const ext = screenshot.extension;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${screenshot.id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: screenshot.id,
         suggestedFileName,
-        filePath,
         mimeType: `image/${ext === 'jpeg' ? 'jpeg' : 'png'}`,
         executionIndex,
         taskIndex,
@@ -215,14 +213,12 @@ function screenshotAttachment(
   if (ref) {
     const ext = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${ref.id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: ref.id,
         suggestedFileName,
-        filePath,
-        sourcePath: ref.path,
+        sourceRef: ref,
         mimeType: ref.mimeType,
         executionIndex,
         taskIndex,
@@ -236,13 +232,11 @@ function screenshotAttachment(
     const ext = base64.startsWith('data:image/jpeg') ? 'jpeg' : 'png';
     const id = `restored-${executionIndex + 1}-${taskIndex + 1}`;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${id}.${ext}`;
-    const filePath = `${screenshotBaseDir}/${suggestedFileName}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${filePath})`,
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id,
         suggestedFileName,
-        filePath,
         mimeType: `image/${ext}`,
         executionIndex,
         taskIndex,

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -70,8 +70,10 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('timing=after click');
     expect(result.markdown).toContain('Screen size: 1280 x 720');
     expect(result.attachments).toHaveLength(2);
-    expect(result.attachments[0].filePath).toContain('./screenshots/');
     expect(result.attachments[0].suggestedFileName).toContain('.png');
+    expect(result.markdown).toContain(
+      `./screenshots/${result.attachments[0].suggestedFileName}`,
+    );
   });
 
   it('merges all executions into one markdown and keeps file snapshot', async () => {


### PR DESCRIPTION
## Summary

Refactored the `MarkdownAttachment` interface to remove redundant `filePath` field and improve the schema for screenshot references. The `filePath` was being computed inline in markdown generation, making it unnecessary to store. Additionally, replaced the `sourcePath` string field with a `sourceRef` object that carries the full `ScreenshotRef` context, eliminating the need to reconstruct screenshot references in consumers.

## Key Changes

- **MarkdownAttachment interface**: Removed `filePath` field and replaced `sourcePath?: string` with `sourceRef?: ScreenshotRef`
- **Markdown generation**: Inlined `filePath` computation directly in template strings (e.g., `` `${screenshotBaseDir}/${suggestedFileName}` ``)
- **Screenshot reference handling**: Changed from storing only the file path string to storing the complete `ScreenshotRef` object, allowing consumers like `report-cli.ts` to use it directly without reconstruction
- **Test updates**: Updated assertions to verify the markdown contains the correct screenshot path and removed assertions on the removed `filePath` field

## Implementation Details

- The `sourceRef` field is now optional and only populated for screenshots sourced from disk (ScreenshotItem references); in-memory screenshots (with `base64Data`) have `sourceRef` absent
- Updated `report-cli.ts` to use `attachment.sourceRef ?? null` directly instead of reconstructing a `ScreenshotRef` object from `attachment.sourcePath`
- Improved JSDoc comments to clarify the purpose of each field and reference issue #2392

## Validation

- `pnpm run lint` (formatting and linting)
- `npx nx test core` (unit tests for report-markdown and report-cli)

https://claude.ai/code/session_01XNJMMfqu2g21BR1RqYqX8w