### PR TITLE
feat(core): support Gemini thinking content

### DIFF
--- a/packages/core/src/ai-model/models/chat-content.ts
+++ b/packages/core/src/ai-model/models/chat-content.ts
@@ -1,0 +1,22 @@
+import type { ChatCompletionContentSource, ContentAndReasoning } from './types';
+
+export function defaultExtractContentAndReasoning(
+  message: ChatCompletionContentSource | undefined,
+): ContentAndReasoning {
+  if (!message) {
+    return {
+      content: '',
+      reasoning_content: '',
+    };
+  }
+
+  const messageReasoning =
+    typeof message.reasoning_content === 'string'
+      ? message.reasoning_content
+      : '';
+
+  return {
+    content: typeof message.content === 'string' ? message.content : '',
+    reasoning_content: messageReasoning,
+  };
+}

--- a/packages/core/src/ai-model/models/gemini.ts
+++ b/packages/core/src/ai-model/models/gemini.ts
@@ -1,22 +1,176 @@
 import type { TModelFamily } from '@midscene/shared/env';
+import type OpenAI from 'openai';
+import { defaultExtractContentAndReasoning } from './chat-content';
 import type {
   ChatCompletionCallContext,
+  ChatCompletionContentSource,
   ChatCompletionParamsResult,
+  ContentAndReasoning,
   ModelAdapterDefinition,
 } from './types';
+
+type GeminiContentPart = Record<string, unknown> & {
+  text?: string;
+  thought?: boolean;
+};
+
+type GeminiContentExtension = {
+  content: string | null | GeminiContentPart[];
+  reasoning_content?: string;
+  extra_content?: unknown;
+};
+
+type GeminiContentSource =
+  | ChatCompletionContentSource
+  | (Omit<OpenAI.Chat.Completions.ChatCompletionMessage, 'content'> &
+      GeminiContentExtension)
+  | (Omit<OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta, 'content'> &
+      GeminiContentExtension);
 
 const buildGeminiChatCompletionParams = (
   input: ChatCompletionCallContext,
 ): ChatCompletionParamsResult => {
-  const { midsceneDefaults, userConfig } = input;
+  const { midsceneDefaults, userConfig, intent } = input;
   const { reasoningEffort } = userConfig;
   const config: Record<string, unknown> = {
     temperature: userConfig.temperature ?? midsceneDefaults.temperature,
+  };
+
+  if (intent === 'insight') {
+    config.extra_body = {
+      google: {
+        thinking_config: {
+          // In real Gemini tests, insight calls need `include_thoughts` to get
+          // the model's thinking, and Gemini puts that thinking into `content`.
+          include_thoughts: true,
+        },
+      },
+    };
+  }
+
+  if (reasoningEffort) {
+    config.extra_body = {
+      google: {
+        thinking_config: {
+          thinking_level: reasoningEffort,
+          include_thoughts: true,
+        },
+      },
+    };
+  } else {
     // Gemini 3.x cannot fully disable native thinking, so use the lowest
     // supported effort unless the user explicitly requests another level.
-    reasoning_effort: reasoningEffort || 'minimal',
-  };
+    config.reasoning_effort = 'minimal';
+  }
   return { config };
+};
+
+const extractInlineThought = (content: string): string | undefined => {
+  const match = content.match(/<thought>([\s\S]*?)<\/thought>/i);
+  return match?.[1]?.trim() || undefined;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+type GeminiExtractedContent = {
+  content: string;
+  geminiReasoningContent: string;
+};
+
+const formatReasoningContent = ({
+  geminiReasoningContent,
+  providerReasoningContent,
+}: {
+  geminiReasoningContent: string;
+  providerReasoningContent: string;
+}): string => {
+  if (geminiReasoningContent && providerReasoningContent) {
+    return `thoughtParts：${geminiReasoningContent}; reasoning_content：${providerReasoningContent}`;
+  }
+
+  return geminiReasoningContent || providerReasoningContent || '';
+};
+
+const extractGeminiThoughtParts = (
+  content: GeminiContentPart[],
+): GeminiExtractedContent => {
+  const contentParts: string[] = [];
+  const reasoningParts: string[] = [];
+
+  for (const part of content) {
+    if (!isRecord(part)) {
+      continue;
+    }
+
+    const text = typeof part.text === 'string' ? part.text : undefined;
+    if (!text) {
+      continue;
+    }
+
+    if (part.thought === true) {
+      reasoningParts.push(text);
+    } else {
+      contentParts.push(text);
+    }
+  }
+
+  return {
+    content: contentParts.join(''),
+    geminiReasoningContent: reasoningParts.join(''),
+  };
+};
+
+export const extractGeminiContentAndReasoning = (
+  message: GeminiContentSource | undefined,
+): ContentAndReasoning => {
+  // Gemini native API exposes thought summaries in
+  // `response.candidates[0].content.parts`, where each text part can carry
+  // `thought: true`. Some OpenAI-compatible adapters may pass through a
+  // native-like content-parts shape, even though the Gemini OpenAI
+  // compatibility docs do not guarantee it.
+  // Docs: https://ai.google.dev/gemini-api/docs/thinking#thought-summaries
+
+  if (!message) {
+    return {
+      content: '',
+      reasoning_content: '',
+    };
+  }
+
+  if (Array.isArray(message.content)) {
+    const extracted = extractGeminiThoughtParts(message.content);
+
+    return {
+      content: extracted.content,
+      reasoning_content: formatReasoningContent({
+        geminiReasoningContent: extracted.geminiReasoningContent,
+        providerReasoningContent:
+          typeof message.reasoning_content === 'string'
+            ? message.reasoning_content
+            : '',
+      }),
+    };
+  }
+
+  const result = defaultExtractContentAndReasoning(
+    message as ChatCompletionContentSource,
+  );
+  // In real Gemini OpenAI-compatible responses we observed that
+  // `include_thoughts` can still return a plain string `message.content`,
+  // with the thought summary prepended as `<thought>...</thought>` before the
+  // visible answer. Keep content unchanged, but extract that leading thought
+  // text for report display.
+  const geminiReasoningContent = extractInlineThought(result.content) || '';
+
+  return {
+    content: result.content,
+    reasoning_content: formatReasoningContent({
+      geminiReasoningContent,
+      providerReasoningContent: result.reasoning_content,
+    }),
+  };
 };
 
 export const geminiAdapters = {
@@ -24,6 +178,7 @@ export const geminiAdapters = {
     chatCompletion: {
       unsupportedUserConfig: ['reasoningEnabled', 'reasoningBudget'],
       buildChatCompletionParams: buildGeminiChatCompletionParams,
+      extractContentAndReasoning: extractGeminiContentAndReasoning,
     },
     locate: {
       resultAdapter: {

--- a/packages/core/src/ai-model/models/resolved.ts
+++ b/packages/core/src/ai-model/models/resolved.ts
@@ -1,6 +1,7 @@
 import { normalJsonParser } from '../service-caller/json';
 import { createLocateResultAdapter } from '../shared/model-locate-result/factory';
 import type { LocateResultAdapterDefinition } from '../shared/model-locate-result/types';
+import { defaultExtractContentAndReasoning } from './chat-content';
 import type {
   ChatCompletionAdapter,
   ChatCompletionCallContext,
@@ -57,6 +58,9 @@ function resolveChatCompletion(
   const resolveImageDetail =
     chatCompletion?.resolveImageDetail ?? defaultImageDetail;
   const unsupportedUserConfig = chatCompletion?.unsupportedUserConfig ?? [];
+  const extractContentAndReasoning =
+    chatCompletion?.extractContentAndReasoning ??
+    defaultExtractContentAndReasoning;
 
   return {
     unsupportedUserConfig,
@@ -74,6 +78,7 @@ function resolveChatCompletion(
         userConfig: input.userConfig ?? {},
         midsceneDefaults: midsceneChatCompletionDefaults,
       }),
+    extractContentAndReasoning,
   };
 }
 

--- a/packages/core/src/ai-model/models/types.ts
+++ b/packages/core/src/ai-model/models/types.ts
@@ -1,4 +1,5 @@
 import type { IModelConfig, TIntent } from '@midscene/shared/env';
+import type OpenAI from 'openai';
 import type {
   JsonParser,
   JsonParserContext,
@@ -57,12 +58,30 @@ export interface ChatCompletionCallContext {
 
 export type ImageDetail = 'auto' | 'low' | 'high' | 'original';
 
+export interface ContentAndReasoning {
+  content: string;
+  reasoning_content: string;
+}
+
+export type ChatCompletionContentSource =
+  | (OpenAI.Chat.Completions.ChatCompletionMessage & {
+      reasoning_content?: string;
+    })
+  | (OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
+      reasoning_content?: string;
+    });
+
+export type ExtractContentAndReasoning = (
+  message: ChatCompletionContentSource | undefined,
+) => ContentAndReasoning;
+
 export interface ChatCompletionAdapter {
   unsupportedUserConfig: ChatCompletionUnsupportedUserConfig[];
   buildChatCompletionParams(
     input: ChatCompletionCallInput,
   ): ChatCompletionParamsResult;
   resolveImageDetail(input: ChatCompletionCallInput): ImageDetail | undefined;
+  extractContentAndReasoning: ExtractContentAndReasoning;
 }
 
 export interface ChatCompletionDefinition {
@@ -73,6 +92,7 @@ export interface ChatCompletionDefinition {
   resolveImageDetail?: (
     input: ChatCompletionCallContext,
   ) => ImageDetail | undefined;
+  extractContentAndReasoning?: ExtractContentAndReasoning;
 }
 
 export type ImagePreprocessDefinition = Partial<ImagePreprocessPolicy>;

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -398,9 +398,11 @@ export async function callAI(
         requestId = stream._request_id;
 
         for await (const chunk of stream) {
-          const content = chunk.choices?.[0]?.delta?.content || '';
-          const reasoning_content =
-            (chunk.choices?.[0]?.delta as any)?.reasoning_content || '';
+          const parsedChunk = adapter.chatCompletion.extractContentAndReasoning(
+            chunk.choices?.[0]?.delta,
+          );
+          const content = parsedChunk.content || '';
+          const reasoning_content = parsedChunk.reasoning_content || '';
 
           // Check for usage info in any chunk (OpenAI provides usage in separate chunks)
           if (chunk.usage) {
@@ -495,9 +497,12 @@ export async function callAI(
             );
           }
 
-          content = result.choices[0].message.content!;
-          accumulatedReasoning =
-            (result.choices[0].message as any)?.reasoning_content || '';
+          const parsedMessage =
+            adapter.chatCompletion.extractContentAndReasoning(
+              result.choices[0].message,
+            );
+          content = parsedMessage.content;
+          accumulatedReasoning = parsedMessage.reasoning_content;
           usage = result.usage;
           requestId = result._request_id;
 

--- a/packages/core/tests/unit-test/model-adapter/chat-content.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/chat-content.test.ts
@@ -1,0 +1,37 @@
+import { defaultExtractContentAndReasoning } from '@/ai-model/models/chat-content';
+import { describe, expect, it } from 'vitest';
+
+describe('chat content extraction', () => {
+  it('returns empty strings for undefined input', () => {
+    expect(defaultExtractContentAndReasoning(undefined)).toEqual({
+      content: '',
+      reasoning_content: '',
+    });
+  });
+
+  it('extracts string content and reasoning_content', () => {
+    expect(
+      defaultExtractContentAndReasoning({
+        content: 'visible response',
+        reasoning_content: 'reasoning response',
+      }),
+    ).toEqual({
+      content: 'visible response',
+      reasoning_content: 'reasoning response',
+    });
+  });
+
+  it('returns empty content for null content', () => {
+    expect(
+      defaultExtractContentAndReasoning({
+        role: 'assistant',
+        content: null,
+        refusal: null,
+        reasoning_content: 'top-level reasoning. ',
+      }),
+    ).toEqual({
+      content: '',
+      reasoning_content: 'top-level reasoning. ',
+    });
+  });
+});

--- a/packages/core/tests/unit-test/model-adapter/gemini.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/gemini.test.ts
@@ -1,4 +1,7 @@
-import { geminiAdapters } from '@/ai-model/models/gemini';
+import {
+  extractGeminiContentAndReasoning,
+  geminiAdapters,
+} from '@/ai-model/models/gemini';
 import { ResolvedModelAdapter } from '@/ai-model/models/resolved';
 import { describe, expect, it } from 'vitest';
 
@@ -28,7 +31,24 @@ describe('gemini model adapter', () => {
     });
   });
 
-  it('passes reasoning effort through for gemini', () => {
+  it('enables thought summaries for insight intent', () => {
+    const result = geminiAdapter.chatCompletion.buildChatCompletionParams({
+      intent: 'insight',
+    });
+    expect(result.config).toEqual({
+      temperature: 0,
+      extra_body: {
+        google: {
+          thinking_config: {
+            include_thoughts: true,
+          },
+        },
+      },
+      reasoning_effort: 'minimal',
+    });
+  });
+
+  it('uses thinking config for gemini when reasoning effort is set', () => {
     const result = geminiAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {
         reasoningEffort: 'high',
@@ -36,7 +56,14 @@ describe('gemini model adapter', () => {
     });
     expect(result.config).toEqual({
       temperature: 0,
-      reasoning_effort: 'high',
+      extra_body: {
+        google: {
+          thinking_config: {
+            thinking_level: 'high',
+            include_thoughts: true,
+          },
+        },
+      },
     });
   });
 
@@ -50,6 +77,103 @@ describe('gemini model adapter', () => {
     expect(result.config).toEqual({
       temperature: 0,
       reasoning_effort: 'minimal',
+    });
+  });
+
+  it('extracts inline thought XML from string content', () => {
+    const result = extractGeminiContentAndReasoning({
+      content:
+        '<thought>I should locate the add button.</thought>```json\n' +
+        '{"bbox":[128,284,151,298]}\n' +
+        '```',
+      extra_content: {
+        google: {
+          thought: true,
+          thought_signature: 'signature',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      content:
+        '<thought>I should locate the add button.</thought>```json\n' +
+        '{"bbox":[128,284,151,298]}\n' +
+        '```',
+      reasoning_content: 'I should locate the add button.',
+    });
+  });
+
+  it('extracts thought parts into reasoning_content', () => {
+    const result = extractGeminiContentAndReasoning({
+      content: [
+        {
+          text: 'I need to locate the add button.',
+          thought: true,
+        },
+        {
+          text: '{"bbox":[124,281,157,302]}',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      content: '{"bbox":[124,281,157,302]}',
+      reasoning_content: 'I need to locate the add button.',
+    });
+  });
+
+  it('combines thought parts with provider reasoning_content', () => {
+    const result = extractGeminiContentAndReasoning({
+      content: [
+        {
+          text: 'I need to locate the add button.',
+          thought: true,
+        },
+        {
+          text: '{"bbox":[124,281,157,302]}',
+        },
+      ],
+      reasoning_content: 'provider reasoning',
+    });
+
+    expect(result).toEqual({
+      content: '{"bbox":[124,281,157,302]}',
+      reasoning_content:
+        'thoughtParts：I need to locate the add button.; reasoning_content：provider reasoning',
+    });
+  });
+
+  it('keeps visible content when Gemini parts do not include thought summaries', () => {
+    const result = extractGeminiContentAndReasoning({
+      content: [
+        {
+          text: '{"bbox":[124,281,157,302]}',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      content: '{"bbox":[124,281,157,302]}',
+      reasoning_content: '',
+    });
+  });
+
+  it('combines inline thought XML with provider reasoning_content', () => {
+    const result = extractGeminiContentAndReasoning({
+      content:
+        '<thought>I should locate the add button.</thought>```json\n' +
+        '{"bbox":[128,284,151,298]}\n' +
+        '```',
+      reasoning_content: 'provider reasoning',
+    });
+
+    expect(result).toEqual({
+      content:
+        '<thought>I should locate the add button.</thought>```json\n' +
+        '{"bbox":[128,284,151,298]}\n' +
+        '```',
+      reasoning_content:
+        'thoughtParts：I should locate the add button.; reasoning_content：provider reasoning',
     });
   });
 


### PR DESCRIPTION
## Summary

- Move chat completion content/reasoning extraction into model adapters with a default extractor.
- Add Gemini-specific extraction for native thought parts and observed OpenAI-compatible `<thought>...</thought>` content.
- Enable Gemini `include_thoughts` for insight calls so report reasoning can be populated.
- Add focused unit coverage for default and Gemini extraction behavior.

## Validation

- `pnpm --filter @midscene/core test tests/unit-test/model-adapter/chat-content.test.ts tests/unit-test/model-adapter/gemini.test.ts tests/unit-test/service-caller-reasoning-fallback.test.ts`

Note: lint was not run.