### PR TITLE
Support file upload in Chrome extension Bridge mode

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -164,7 +164,7 @@ function ai(prompt: string): Promise<string | undefined>; // shorthand form
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `deepThink?: 'unset' | true | false` - Controls how strongly Midscene guides `aiAct` to think during planning. When enabled, `aiAct` focuses more on task decomposition and separates task planning from UI element locating into different model calls. For compatibility, `'unset'` is accepted and treated the same as `false`. [Learn more about deepThink](./model-strategy#about-the-deepthink-option-in-aiact).
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
-    - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer).
+    - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
     - `abortSignal?: AbortSignal` - An optional [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that allows you to abort the `aiAct` execution. When the signal is triggered, Midscene will stop the current planning loop and throw an error. This is useful for implementing timeouts or user-initiated cancellations.
@@ -227,7 +227,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
-    - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer).
+    - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
 

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -167,6 +167,7 @@ function ai(prompt: string): Promise<string | undefined>; // shorthand form
     - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
+      - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `abortSignal?: AbortSignal` - An optional [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that allows you to abort the `aiAct` execution. When the signal is triggered, Midscene will stop the current planning loop and throw an error. This is useful for implementing timeouts or user-initiated cancellations.
 
 - Return Value:
@@ -230,6 +231,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
     - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
+      - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
 
 - Return Value:
 

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -670,7 +670,7 @@ tasks:
 
 Notes:
 
-- `fileChooserAccept` is only available for web pages (Playwright, Puppeteer).
+- `fileChooserAccept` is only available for web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
 - Relative paths are resolved from the current command working directory, not from the YAML file directory.
 - If a file does not exist, the script throws before the tap is executed.
 

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -673,6 +673,7 @@ Notes:
 - `fileChooserAccept` is only available for web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
 - Relative paths are resolved from the current command working directory, not from the YAML file directory.
 - If a file does not exist, the script throws before the tap is executed.
+- Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
 
 #### Prompting with images
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -166,7 +166,7 @@ function ai(prompt: string): Promise<string | undefined>; // 简写形式
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `deepThink?: 'unset' | true | false` - 控制 Midscene 在 `aiAct` 规划时引导模型思考的力度。开启后，`aiAct` 会更注重任务拆解，并将任务 Planning 和 UI 元素定位拆解为不同的模型调用。为了兼容旧写法，`'unset'` 仍然可以传入，并会被按 `false` 处理。[详情参阅 deepThink 说明](./model-strategy#关于-aiact-方法的-deepthink-参数)。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认值为 false。
-    - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer）中可用。
+    - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
@@ -225,7 +225,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
-    - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer）中可用。
+    - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
 - 返回值：

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -169,6 +169,7 @@ function ai(prompt: string): Promise<string | undefined>; // 简写形式
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
+      - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
 - 返回值：
@@ -228,6 +229,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
+      - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
 - 返回值：
 
   - `Promise<void>`

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -677,7 +677,7 @@ tasks:
 
 注意：
 
-- `fileChooserAccept` 仅在 web 页面（Playwright、Puppeteer）中可用。
+- `fileChooserAccept` 仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
 - 相对路径会基于当前命令执行目录解析，而不是基于 YAML 文件所在目录解析。
 - 如果文件不存在，脚本会在执行点击前直接报错。
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -680,6 +680,7 @@ tasks:
 - `fileChooserAccept` 仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
 - 相对路径会基于当前命令执行目录解析，而不是基于 YAML 文件所在目录解析。
 - 如果文件不存在，脚本会在执行点击前直接报错。
+- Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
 
 #### 使用图像提示
 

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -911,7 +911,7 @@ export async function withFileChooser<T>(
   try {
     const result = await action();
     // Check for errors that occurred during file chooser handling
-    const error = getError();
+    const error = await getError();
     if (error) {
       throw error;
     }

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -15,6 +15,11 @@ export interface FileChooserHandler {
   accept(files: string[]): Promise<void>;
 }
 
+export interface FileChooserRegistration {
+  dispose: () => void;
+  getError: () => Error | undefined | Promise<Error | undefined>;
+}
+
 export interface MjpegStreamFrame {
   /** Raw base64-encoded image bytes WITHOUT a `data:image/...;base64,` prefix. */
   data: string;
@@ -153,7 +158,7 @@ export abstract class AbstractInterface {
   // for web only
   registerFileChooserListener?(
     handler: (chooser: FileChooserHandler) => Promise<void>,
-  ): Promise<{ dispose: () => void; getError: () => Error | undefined }>;
+  ): Promise<FileChooserRegistration>;
 
   // @deprecated do NOT extend this method
   abstract getElementsNodeTree?: () => Promise<ElementNode>;

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -1,5 +1,6 @@
 import { Agent, type AgentOpt } from '@midscene/core/agent';
 import type { FileChooserHandler } from '@midscene/core/device';
+import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import { commonWebActionsForWebPage } from '../web-page';
 import type { KeyboardAction, MouseAction } from '../web-page';
@@ -27,6 +28,8 @@ type BridgeSerializedError = {
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const debug = getDebug('web:bridge:agent-cli-side');
 
 function deserializeBridgeError(error: BridgeSerializedError): Error {
   const result = new Error(error.message);
@@ -153,7 +156,12 @@ export const getBridgePageInCliSide = (options?: {
               fileChooserEnabled = false;
               server
                 .call(BridgeEvent.ClearFileChooserAccept, [], 5000)
-                .catch(() => {});
+                .catch((error) => {
+                  debug(
+                    'failed to clear bridge file chooser accept: %O',
+                    error,
+                  );
+                });
             },
             getError: () => fileChooserError,
           };

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -163,7 +163,10 @@ export const getBridgePageInCliSide = (options?: {
                   );
                 });
             },
-            getError: () => fileChooserError,
+            getError: async () => {
+              await syncFileChooserError();
+              return fileChooserError;
+            },
           };
         };
       }

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -1,4 +1,5 @@
 import { Agent, type AgentOpt } from '@midscene/core/agent';
+import type { FileChooserHandler } from '@midscene/core/device';
 import { assert } from '@midscene/shared/utils';
 import { commonWebActionsForWebPage } from '../web-page';
 import type { KeyboardAction, MouseAction } from '../web-page';
@@ -19,7 +20,20 @@ interface ChromeExtensionPageCliSide extends ExtensionBridgePageBrowserSide {
   showStatusMessage: (message: string) => Promise<void>;
 }
 
+type BridgeSerializedError = {
+  message: string;
+  name?: string;
+  stack?: string;
+};
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function deserializeBridgeError(error: BridgeSerializedError): Error {
+  const result = new Error(error.message);
+  result.name = error.name || 'Error';
+  result.stack = error.stack;
+  return result;
+}
 
 // actually, this is a proxy to the page in browser side
 export const getBridgePageInCliSide = (options?: {
@@ -40,10 +54,47 @@ export const getBridgePageInCliSide = (options?: {
   server.listen({
     timeout: options?.timeout,
   });
+
+  let fileChooserEnabled = false;
+  let fileChooserError: Error | undefined;
+
+  const fileChooserBridgeMethods = new Set<string>([
+    BridgeEvent.RegisterFileChooserAccept,
+    BridgeEvent.ClearFileChooserAccept,
+    BridgeEvent.GetFileChooserError,
+  ]);
+
+  const syncFileChooserError = async () => {
+    if (!fileChooserEnabled) return;
+    try {
+      const error = await server.call<BridgeSerializedError | undefined>(
+        BridgeEvent.GetFileChooserError,
+        [],
+        5000,
+      );
+      if (error) {
+        fileChooserError = deserializeBridgeError(error);
+      }
+    } catch (error) {
+      fileChooserError =
+        error instanceof Error ? error : new Error(String(error));
+    }
+  };
+
   const bridgeCaller = (method: string, timeout?: number) => {
     return async (...args: any[]) => {
-      const response = await server.call(method, args, timeout);
-      return response;
+      try {
+        const response = await server.call(method, args, timeout);
+        if (!fileChooserBridgeMethods.has(method)) {
+          await syncFileChooserError();
+        }
+        return response;
+      } catch (error) {
+        if (!fileChooserBridgeMethods.has(method)) {
+          await syncFileChooserError();
+        }
+        throw error;
+      }
     };
   };
   const page = {
@@ -74,6 +125,39 @@ export const getBridgePageInCliSide = (options?: {
 
       if (Object.keys(page).includes(prop)) {
         return page[prop as keyof typeof page];
+      }
+
+      if (prop === 'registerFileChooserListener') {
+        return async (
+          handler: (chooser: FileChooserHandler) => Promise<void>,
+        ) => {
+          fileChooserEnabled = true;
+          fileChooserError = undefined;
+          try {
+            await handler({
+              accept: async (files: string[]) => {
+                await server.call(BridgeEvent.RegisterFileChooserAccept, [
+                  files,
+                ]);
+              },
+            });
+          } catch (error) {
+            fileChooserEnabled = false;
+            fileChooserError =
+              error instanceof Error ? error : new Error(String(error));
+            throw fileChooserError;
+          }
+
+          return {
+            dispose: () => {
+              fileChooserEnabled = false;
+              server
+                .call(BridgeEvent.ClearFileChooserAccept, [], 5000)
+                .catch(() => {});
+            },
+            getError: () => fileChooserError,
+          };
+        };
       }
 
       if (prop === 'mouse') {

--- a/packages/web-integration/src/bridge-mode/common.ts
+++ b/packages/web-integration/src/bridge-mode/common.ts
@@ -32,6 +32,9 @@ export enum BridgeEvent {
   GetBrowserTabList = 'getBrowserTabList',
   SetDestroyOptions = 'setDestroyOptions',
   SetActiveTabId = 'setActiveTabId',
+  RegisterFileChooserAccept = 'registerFileChooserAccept',
+  ClearFileChooserAccept = 'clearFileChooserAccept',
+  GetFileChooserError = 'getFileChooserError',
 }
 
 export const BridgeSignalKill = 'MIDSCENE_BRIDGE_SIGNAL_KILL';

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -17,6 +17,7 @@ import type {
   AbstractInterface,
   DeviceAction,
   FileChooserHandler,
+  FileChooserRegistration,
 } from '@midscene/core/device';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { treeToList } from '@midscene/shared/extractor';
@@ -91,7 +92,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   private bridgeFileChooserDispose?: () => void;
 
-  private bridgeFileChooserGetError?: () => Error | undefined;
+  private bridgeFileChooserGetError?: FileChooserRegistration['getError'];
 
   private isMobileEmulation: boolean | null = null;
 
@@ -399,7 +400,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   async registerFileChooserListener(
     handler: (chooser: FileChooserHandler) => Promise<void>,
-  ): Promise<{ dispose: () => void; getError: () => Error | undefined }> {
+  ): Promise<FileChooserRegistration> {
     const registrationVersion = ++this.fileChooserRegistrationVersion;
     const tabId = await this.getTabIdOrConnectToCurrentTab();
 
@@ -415,10 +416,11 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     }
 
     let capturedError: Error | undefined;
+    let pendingFileChooserHandling = Promise.resolve();
 
     const fileChooserEventHandler: Parameters<
       typeof chrome.debugger.onEvent.addListener
-    >[0] = async (source, method, params) => {
+    >[0] = (source, method, params) => {
       if (source.tabId !== tabId || method !== 'Page.fileChooserOpened') {
         return;
       }
@@ -431,44 +433,51 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
         return;
       }
 
-      try {
-        await handler({
-          accept: async (files: string[]) => {
-            const { node } = await this.sendCommandToDebugger<
-              CDPTypes.DOM.DescribeNodeResponse,
-              CDPTypes.DOM.DescribeNodeRequest
-            >('DOM.describeNode', {
-              backendNodeId: event.backendNodeId,
-            });
+      const currentFileChooserHandling = (async () => {
+        try {
+          await handler({
+            accept: async (files: string[]) => {
+              const { node } = await this.sendCommandToDebugger<
+                CDPTypes.DOM.DescribeNodeResponse,
+                CDPTypes.DOM.DescribeNodeRequest
+              >('DOM.describeNode', {
+                backendNodeId: event.backendNodeId,
+              });
 
-            const hasWebkitDirectory =
-              hasFlatNodeAttribute(node.attributes, 'webkitdirectory') ||
-              hasFlatNodeAttribute(node.attributes, 'directory');
-            if (hasWebkitDirectory) {
-              throw new Error(
-                'Directory upload (webkitdirectory) is not supported in Chrome extension bridge mode. Please use Playwright instead, which supports directory upload since version 1.45.',
-              );
-            }
+              const hasWebkitDirectory =
+                hasFlatNodeAttribute(node.attributes, 'webkitdirectory') ||
+                hasFlatNodeAttribute(node.attributes, 'directory');
+              if (hasWebkitDirectory) {
+                throw new Error(
+                  'Directory upload (webkitdirectory) is not supported in Chrome extension bridge mode. Please use Playwright instead, which supports directory upload since version 1.45.',
+                );
+              }
 
-            if (
-              files.length > 1 &&
-              !hasFlatNodeAttribute(node.attributes, 'multiple')
-            ) {
-              throw new Error(
-                'Non-multiple file input can only accept single file',
-              );
-            }
+              if (
+                files.length > 1 &&
+                !hasFlatNodeAttribute(node.attributes, 'multiple')
+              ) {
+                throw new Error(
+                  'Non-multiple file input can only accept single file',
+                );
+              }
 
-            await this.sendCommandToDebugger('DOM.setFileInputFiles', {
-              files,
-              backendNodeId: event.backendNodeId,
-            });
-          },
-        });
-      } catch (error) {
-        capturedError =
-          error instanceof Error ? error : new Error(String(error));
-      }
+              await this.sendCommandToDebugger('DOM.setFileInputFiles', {
+                files,
+                backendNodeId: event.backendNodeId,
+              });
+            },
+          });
+        } catch (error) {
+          capturedError =
+            error instanceof Error ? error : new Error(String(error));
+        }
+      })();
+      const previousFileChooserHandling = pendingFileChooserHandling;
+      pendingFileChooserHandling = Promise.all([
+        previousFileChooserHandling,
+        currentFileChooserHandling,
+      ]).then(() => {});
     };
 
     this.fileChooserEventHandler = fileChooserEventHandler;
@@ -497,7 +506,10 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
             debug('failed to disable file chooser interception: %O', error);
           });
       },
-      getError: () => capturedError,
+      getError: async () => {
+        await pendingFileChooserHandling;
+        return capturedError;
+      },
     };
   }
 
@@ -518,10 +530,10 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     this.bridgeFileChooserGetError = undefined;
   }
 
-  getFileChooserError():
-    | { message: string; name?: string; stack?: string }
-    | undefined {
-    const error = this.bridgeFileChooserGetError?.();
+  async getFileChooserError(): Promise<
+    { message: string; name?: string; stack?: string } | undefined
+  > {
+    const error = await this.bridgeFileChooserGetError?.();
     return error ? serializeError(error) : undefined;
   }
 

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -13,7 +13,11 @@ import type {
   Rect,
   Size,
 } from '@midscene/core';
-import type { AbstractInterface, DeviceAction } from '@midscene/core/device';
+import type {
+  AbstractInterface,
+  DeviceAction,
+  FileChooserHandler,
+} from '@midscene/core/device';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { treeToList } from '@midscene/shared/extractor';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
@@ -45,6 +49,29 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function hasFlatNodeAttribute(
+  attributes: string[] | undefined,
+  name: string,
+): boolean {
+  if (!attributes) return false;
+  for (let i = 0; i < attributes.length; i += 2) {
+    if (attributes[i] === name) return true;
+  }
+  return false;
+}
+
+function serializeError(error: Error): {
+  message: string;
+  name?: string;
+  stack?: string;
+} {
+  return {
+    message: error.message,
+    name: error.name,
+    stack: error.stack,
+  };
+}
+
 export default class ChromeExtensionProxyPage implements AbstractInterface {
   interfaceType = 'chrome-extension-proxy';
 
@@ -55,6 +82,14 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   private activeTabId: number | null = null;
 
   private destroyed = false;
+
+  private fileChooserEventHandler?: Parameters<
+    typeof chrome.debugger.onEvent.addListener
+  >[0];
+
+  private bridgeFileChooserDispose?: () => void;
+
+  private bridgeFileChooserGetError?: () => Error | undefined;
 
   private isMobileEmulation: boolean | null = null;
 
@@ -358,6 +393,121 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
       expression: script,
       awaitPromise: true,
     });
+  }
+
+  async registerFileChooserListener(
+    handler: (chooser: FileChooserHandler) => Promise<void>,
+  ): Promise<{ dispose: () => void; getError: () => Error | undefined }> {
+    const tabId = await this.getTabIdOrConnectToCurrentTab();
+    await this.sendCommandToDebugger('Page.enable', {});
+    await this.sendCommandToDebugger('DOM.enable', {});
+    await this.sendCommandToDebugger('Page.setInterceptFileChooserDialog', {
+      enabled: true,
+    });
+
+    if (this.fileChooserEventHandler) {
+      chrome.debugger.onEvent.removeListener(this.fileChooserEventHandler);
+      this.fileChooserEventHandler = undefined;
+    }
+
+    let capturedError: Error | undefined;
+
+    const fileChooserEventHandler: Parameters<
+      typeof chrome.debugger.onEvent.addListener
+    >[0] = async (source, method, params) => {
+      if (source.tabId !== tabId || method !== 'Page.fileChooserOpened') {
+        return;
+      }
+
+      const event = params as CDPTypes.Page.FileChooserOpenedEvent;
+      if (event.backendNodeId === undefined) {
+        debug(
+          'chrome extension file chooser opened without backendNodeId, skip',
+        );
+        return;
+      }
+
+      try {
+        await handler({
+          accept: async (files: string[]) => {
+            const { node } = await this.sendCommandToDebugger<
+              CDPTypes.DOM.DescribeNodeResponse,
+              CDPTypes.DOM.DescribeNodeRequest
+            >('DOM.describeNode', {
+              backendNodeId: event.backendNodeId,
+            });
+
+            const hasWebkitDirectory =
+              hasFlatNodeAttribute(node.attributes, 'webkitdirectory') ||
+              hasFlatNodeAttribute(node.attributes, 'directory');
+            if (hasWebkitDirectory) {
+              throw new Error(
+                'Directory upload (webkitdirectory) is not supported in Chrome extension bridge mode. Please use Playwright instead, which supports directory upload since version 1.45.',
+              );
+            }
+
+            if (
+              files.length > 1 &&
+              !hasFlatNodeAttribute(node.attributes, 'multiple')
+            ) {
+              throw new Error(
+                'Non-multiple file input can only accept single file',
+              );
+            }
+
+            await this.sendCommandToDebugger('DOM.setFileInputFiles', {
+              files,
+              backendNodeId: event.backendNodeId,
+            });
+          },
+        });
+      } catch (error) {
+        capturedError =
+          error instanceof Error ? error : new Error(String(error));
+      }
+    };
+
+    this.fileChooserEventHandler = fileChooserEventHandler;
+    chrome.debugger.onEvent.addListener(fileChooserEventHandler);
+
+    return {
+      dispose: () => {
+        if (this.fileChooserEventHandler === fileChooserEventHandler) {
+          chrome.debugger.onEvent.removeListener(fileChooserEventHandler);
+          this.fileChooserEventHandler = undefined;
+        }
+        this.sendCommandToDebugger('Page.setInterceptFileChooserDialog', {
+          enabled: false,
+        }).catch((error) => {
+          debug('failed to disable file chooser interception: %O', error);
+        });
+      },
+      getError: () => capturedError,
+    };
+  }
+
+  async registerFileChooserAccept(files: string[]): Promise<void> {
+    this.clearFileChooserAccept();
+    const { dispose, getError } = await this.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(files);
+      },
+    );
+    this.bridgeFileChooserDispose = dispose;
+    this.bridgeFileChooserGetError = getError;
+  }
+
+  clearFileChooserAccept(): void {
+    this.bridgeFileChooserDispose?.();
+    this.bridgeFileChooserDispose = undefined;
+    this.bridgeFileChooserGetError = undefined;
+  }
+
+  getFileChooserError():
+    | { message: string; name?: string; stack?: string }
+    | undefined {
+    const error = this.bridgeFileChooserGetError?.();
+    return error ? serializeError(error) : undefined;
   }
 
   async beforeInvokeAction(): Promise<void> {
@@ -798,6 +948,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   async destroy(): Promise<void> {
     this.destroyed = true;
+    this.clearFileChooserAccept();
     const tabIdToDetach = this.activeTabId;
     this.activeTabId = null;
     if (tabIdToDetach) {

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -87,6 +87,8 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     typeof chrome.debugger.onEvent.addListener
   >[0];
 
+  private fileChooserRegistrationVersion = 0;
+
   private bridgeFileChooserDispose?: () => void;
 
   private bridgeFileChooserGetError?: () => Error | undefined;
@@ -398,7 +400,9 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   async registerFileChooserListener(
     handler: (chooser: FileChooserHandler) => Promise<void>,
   ): Promise<{ dispose: () => void; getError: () => Error | undefined }> {
+    const registrationVersion = ++this.fileChooserRegistrationVersion;
     const tabId = await this.getTabIdOrConnectToCurrentTab();
+
     await this.sendCommandToDebugger('Page.enable', {});
     await this.sendCommandToDebugger('DOM.enable', {});
     await this.sendCommandToDebugger('Page.setInterceptFileChooserDialog', {
@@ -472,15 +476,26 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
     return {
       dispose: () => {
-        if (this.fileChooserEventHandler === fileChooserEventHandler) {
-          chrome.debugger.onEvent.removeListener(fileChooserEventHandler);
-          this.fileChooserEventHandler = undefined;
+        if (this.fileChooserEventHandler !== fileChooserEventHandler) {
+          return;
         }
-        this.sendCommandToDebugger('Page.setInterceptFileChooserDialog', {
-          enabled: false,
-        }).catch((error) => {
-          debug('failed to disable file chooser interception: %O', error);
-        });
+        chrome.debugger.onEvent.removeListener(fileChooserEventHandler);
+        this.fileChooserEventHandler = undefined;
+        Promise.resolve()
+          .then(() => {
+            if (this.fileChooserRegistrationVersion !== registrationVersion) {
+              return;
+            }
+            return this.sendCommandToDebugger(
+              'Page.setInterceptFileChooserDialog',
+              {
+                enabled: false,
+              },
+            );
+          })
+          .catch((error) => {
+            debug('failed to disable file chooser interception: %O', error);
+          });
       },
       getError: () => capturedError,
     };

--- a/packages/web-integration/tests/ai/bridge/file-upload.test.ts
+++ b/packages/web-integration/tests/ai/bridge/file-upload.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { join } from 'node:path';
+import { getBridgePageInCliSide } from '@/bridge-mode/agent-cli-side';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({
+  testTimeout: 3 * 60 * 1000,
+});
+
+const describeIf = process.env.BRIDGE_MODE ? describe : describe.skip;
+
+const fixturePath = (filename: string) =>
+  join(__dirname, '../fixtures', filename);
+
+async function startFixtureServer(filename: string) {
+  const html = readFileSync(fixturePath(filename), 'utf8');
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(html);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+async function evaluateJson<T>(
+  page: ReturnType<typeof getBridgePageInCliSide>,
+  expression: string,
+): Promise<T> {
+  const response = await page.evaluateJavaScript(
+    `JSON.stringify((${expression})())`,
+  );
+  if (response.exceptionDetails) {
+    throw new Error(response.exceptionDetails.exception?.description);
+  }
+  return JSON.parse(response.result.value) as T;
+}
+
+describeIf('file upload in bridge mode', () => {
+  let page: ReturnType<typeof getBridgePageInCliSide> | undefined;
+  let closeServer: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    try {
+      await page?.destroy();
+    } finally {
+      page = undefined;
+    }
+
+    if (closeServer) {
+      await closeServer();
+      closeServer = undefined;
+    }
+  });
+
+  it('accepts files through the chrome extension bridge', async () => {
+    const fixtureServer = await startFixtureServer('file-upload.html');
+    closeServer = fixtureServer.close;
+    const testFile = fixturePath('test-file.txt');
+
+    page = getBridgePageInCliSide();
+    await page.connectNewTabWithUrl(fixtureServer.url);
+    await page.setDestroyOptions({ closeTab: true });
+
+    const buttonCenter = await evaluateJson<{ x: number; y: number }>(
+      page,
+      `() => {
+        const buttons = Array.from(document.querySelectorAll('.upload-btn'));
+        const button = buttons.find((element) =>
+          element.textContent.includes('Choose Single File')
+        );
+        if (!button) {
+          throw new Error('Choose Single File button not found');
+        }
+        const rect = button.getBoundingClientRect();
+        return {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        };
+      }`,
+    );
+
+    await page.registerFileChooserAccept([testFile]);
+    await page.mouse.click(buttonCenter.x, buttonCenter.y);
+    expect(await page.getFileChooserError()).toBeUndefined();
+
+    const selected = await evaluateJson<{
+      files: string[];
+      selectedText: string;
+    }>(
+      page,
+      `() => {
+        const input = document.querySelector('#single-file-input');
+        return {
+          files: Array.from(input.files || []).map((file) => file.name),
+          selectedText:
+            document.querySelector('#selected-files')?.textContent || '',
+        };
+      }`,
+    );
+
+    expect(selected.files).toEqual(['test-file.txt']);
+    expect(selected.selectedText).toContain('test-file.txt');
+    expect(selected.selectedText).toContain('single');
+  });
+});

--- a/packages/web-integration/tests/ai/bridge/file-upload.test.ts
+++ b/packages/web-integration/tests/ai/bridge/file-upload.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { join } from 'node:path';
-import { getBridgePageInCliSide } from '@/bridge-mode/agent-cli-side';
+import {
+  AgentOverChromeBridge,
+  type getBridgePageInCliSide,
+} from '@/bridge-mode/agent-cli-side';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.setConfig({
@@ -53,14 +56,14 @@ async function evaluateJson<T>(
 }
 
 describeIf('file upload in bridge mode', () => {
-  let page: ReturnType<typeof getBridgePageInCliSide> | undefined;
+  let agent: AgentOverChromeBridge | undefined;
   let closeServer: (() => Promise<void>) | undefined;
 
   afterEach(async () => {
     try {
-      await page?.destroy();
+      await agent?.destroy();
     } finally {
-      page = undefined;
+      agent = undefined;
     }
 
     if (closeServer) {
@@ -74,37 +77,21 @@ describeIf('file upload in bridge mode', () => {
     closeServer = fixtureServer.close;
     const testFile = fixturePath('test-file.txt');
 
-    page = getBridgePageInCliSide();
-    await page.connectNewTabWithUrl(fixtureServer.url);
-    await page.setDestroyOptions({ closeTab: true });
+    agent = new AgentOverChromeBridge({
+      closeNewTabsAfterDisconnect: true,
+    });
+    await agent.connectNewTabWithUrl(fixtureServer.url);
 
-    const buttonCenter = await evaluateJson<{ x: number; y: number }>(
-      page,
-      `() => {
-        const buttons = Array.from(document.querySelectorAll('.upload-btn'));
-        const button = buttons.find((element) =>
-          element.textContent.includes('Choose Single File')
-        );
-        if (!button) {
-          throw new Error('Choose Single File button not found');
-        }
-        const rect = button.getBoundingClientRect();
-        return {
-          x: rect.left + rect.width / 2,
-          y: rect.top + rect.height / 2,
-        };
-      }`,
-    );
-
-    await page.registerFileChooserAccept([testFile]);
-    await page.mouse.click(buttonCenter.x, buttonCenter.y);
-    expect(await page.getFileChooserError()).toBeUndefined();
+    await agent.aiTap('Choose Single File', {
+      xpath: '//*[@id="single-file-input"]/following-sibling::button[1]',
+      fileChooserAccept: [testFile],
+    });
 
     const selected = await evaluateJson<{
       files: string[];
       selectedText: string;
     }>(
-      page,
+      agent.page,
       `() => {
         const input = document.querySelector('#single-file-input');
         return {

--- a/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
@@ -64,7 +64,9 @@ describe('bridge file chooser adapter', () => {
     expect(
       calls.some((call) => call.method === BridgeEvent.GetFileChooserError),
     ).toBe(true);
-    expect(registration.getError()?.message).toBe('remote file chooser failed');
+    expect((await registration.getError())?.message).toBe(
+      'remote file chooser failed',
+    );
 
     registration.dispose();
     await sleep(50);

--- a/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
@@ -1,0 +1,75 @@
+import { getBridgePageInCliSide } from '@/bridge-mode/agent-cli-side';
+import { BridgeEvent, MouseEvent } from '@/bridge-mode/common';
+import { BridgeClient } from '@/bridge-mode/io-client';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const DEFAULT_HOST = '127.0.0.1';
+let testPort = 16376;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('bridge file chooser adapter', () => {
+  let client: BridgeClient | undefined;
+  let page: ReturnType<typeof getBridgePageInCliSide> | undefined;
+
+  afterEach(async () => {
+    try {
+      await page?.destroy();
+    } catch {}
+    client?.disconnect();
+    page = undefined;
+    client = undefined;
+  });
+
+  it('converts registerFileChooserListener into bridge file accept calls', async () => {
+    const port = testPort++;
+    const calls: { method: string; args: any[] }[] = [];
+    const remoteFileChooserError = {
+      message: 'remote file chooser failed',
+      name: 'Error',
+    };
+
+    page = getBridgePageInCliSide({ port, timeout: 2000 });
+    await sleep(50);
+
+    client = new BridgeClient(
+      `ws://${DEFAULT_HOST}:${port}`,
+      async (method, args) => {
+        calls.push({ method, args });
+        if (method === BridgeEvent.GetFileChooserError) {
+          return remoteFileChooserError;
+        }
+        return undefined;
+      },
+    );
+    await client.connect();
+
+    const registration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(['/tmp/upload.txt']);
+      },
+    );
+
+    expect(calls).toContainEqual({
+      method: BridgeEvent.RegisterFileChooserAccept,
+      args: [['/tmp/upload.txt']],
+    });
+
+    await page.mouse.click(10, 20);
+
+    expect(calls).toContainEqual({
+      method: MouseEvent.Click,
+      args: [10, 20],
+    });
+    expect(
+      calls.some((call) => call.method === BridgeEvent.GetFileChooserError),
+    ).toBe(true);
+    expect(registration.getError()?.message).toBe('remote file chooser failed');
+
+    registration.dispose();
+    await sleep(50);
+    expect(
+      calls.some((call) => call.method === BridgeEvent.ClearFileChooserAccept),
+    ).toBe(true);
+  });
+});

--- a/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/file-chooser.test.ts
@@ -74,4 +74,43 @@ describe('bridge file chooser adapter', () => {
       calls.some((call) => call.method === BridgeEvent.ClearFileChooserAccept),
     ).toBe(true);
   });
+
+  it('polls remote file chooser errors when getError is called', async () => {
+    const port = testPort++;
+    const calls: { method: string; args: any[] }[] = [];
+    const remoteFileChooserError = {
+      message: 'late remote file chooser failed',
+      name: 'Error',
+    };
+
+    page = getBridgePageInCliSide({ port, timeout: 2000 });
+    await sleep(50);
+
+    client = new BridgeClient(
+      `ws://${DEFAULT_HOST}:${port}`,
+      async (method, args) => {
+        calls.push({ method, args });
+        if (method === BridgeEvent.GetFileChooserError) {
+          return remoteFileChooserError;
+        }
+        return undefined;
+      },
+    );
+    await client.connect();
+
+    const registration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(['/tmp/upload.txt']);
+      },
+    );
+
+    expect((await registration.getError())?.message).toBe(
+      'late remote file chooser failed',
+    );
+    expect(
+      calls.some((call) => call.method === BridgeEvent.GetFileChooserError),
+    ).toBe(true);
+
+    registration.dispose();
+  });
 });

--- a/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAddListener = vi.fn();
+const mockRemoveListener = vi.fn();
+const mockSendCommand = vi.fn();
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    getURL: vi.fn((path: string) => path),
+  },
+  tabs: {
+    get: vi.fn(),
+    query: vi.fn(),
+    update: vi.fn(),
+  },
+  debugger: {
+    attach: vi.fn(),
+    detach: vi.fn(),
+    sendCommand: mockSendCommand,
+    onEvent: {
+      addListener: mockAddListener,
+      removeListener: mockRemoveListener,
+    },
+  },
+});
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../src/chrome-extension/dynamic-scripts', () => ({
+  getHtmlElementScript: vi.fn(async () => ''),
+  injectStopWaterFlowAnimation: vi.fn(async () => ''),
+  injectWaterFlowAnimation: vi.fn(async () => ''),
+}));
+
+import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
+
+describe('ChromeExtensionProxyPage file chooser support', () => {
+  let page: ChromeExtensionProxyPage;
+  let nodeAttributes: string[] | undefined;
+
+  const getFileChooserListener = () => {
+    const listener = mockAddListener.mock.calls.at(-1)?.[0];
+    expect(listener).toBeTypeOf('function');
+    return listener as (
+      source: chrome.debugger.Debuggee,
+      method: string,
+      params?: unknown,
+    ) => Promise<void>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nodeAttributes = [];
+    page = new ChromeExtensionProxyPage(false);
+    (page as any).activeTabId = 7;
+
+    vi.mocked(chrome.tabs.get).mockResolvedValue({
+      id: 7,
+      url: 'https://example.com',
+      status: 'complete',
+    } as chrome.tabs.Tab);
+
+    mockSendCommand.mockImplementation(async (_target, method: string) => {
+      if (method === 'DOM.describeNode') {
+        return {
+          node: {
+            attributes: nodeAttributes,
+          },
+        };
+      }
+
+      if (method === 'Runtime.evaluate') {
+        return { result: { value: true } };
+      }
+
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets accepted files when a file chooser opens', async () => {
+    const files = ['/tmp/a.txt', '/tmp/b.txt'];
+    nodeAttributes = ['type', 'file', 'multiple', ''];
+
+    const registration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(files);
+      },
+    );
+
+    const listener = getFileChooserListener();
+    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+      backendNodeId: 42,
+    });
+
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      { tabId: 7 },
+      'DOM.setFileInputFiles',
+      {
+        files,
+        backendNodeId: 42,
+      },
+    );
+    expect(registration.getError()).toBeUndefined();
+
+    registration.dispose();
+    expect(mockRemoveListener).toHaveBeenCalledWith(listener);
+  });
+
+  it('captures an error when multiple files target a single-file input', async () => {
+    const registration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(['/tmp/a.txt', '/tmp/b.txt']);
+      },
+    );
+
+    const listener = getFileChooserListener();
+    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+      backendNodeId: 42,
+    });
+
+    expect(registration.getError()?.message).toBe(
+      'Non-multiple file input can only accept single file',
+    );
+    expect(mockSendCommand).not.toHaveBeenCalledWith(
+      { tabId: 7 },
+      'DOM.setFileInputFiles',
+      expect.anything(),
+    );
+  });
+
+  it('captures an error for directory upload inputs', async () => {
+    nodeAttributes = ['type', 'file', 'webkitdirectory', ''];
+
+    await page.registerFileChooserAccept(['/tmp/upload-dir']);
+    const listener = getFileChooserListener();
+    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+      backendNodeId: 42,
+    });
+
+    expect(page.getFileChooserError()?.message).toContain(
+      'Directory upload (webkitdirectory) is not supported in Chrome extension bridge mode',
+    );
+  });
+});

--- a/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
@@ -47,7 +47,7 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
       source: chrome.debugger.Debuggee,
       method: string,
       params?: unknown,
-    ) => Promise<void>;
+    ) => void;
   };
 
   const getInterceptFileChooserCalls = (enabled: boolean) =>
@@ -101,9 +101,10 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
     );
 
     const listener = getFileChooserListener();
-    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+    listener({ tabId: 7 }, 'Page.fileChooserOpened', {
       backendNodeId: 42,
     });
+    const error = await registration.getError();
 
     expect(mockSendCommand).toHaveBeenCalledWith(
       { tabId: 7 },
@@ -113,7 +114,7 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
         backendNodeId: 42,
       },
     );
-    expect(registration.getError()).toBeUndefined();
+    expect(error).toBeUndefined();
 
     registration.dispose();
     expect(mockRemoveListener).toHaveBeenCalledWith(listener);
@@ -147,11 +148,11 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
     );
 
     const listener = getFileChooserListener();
-    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+    listener({ tabId: 7 }, 'Page.fileChooserOpened', {
       backendNodeId: 42,
     });
 
-    expect(registration.getError()?.message).toBe(
+    expect((await registration.getError())?.message).toBe(
       'Non-multiple file input can only accept single file',
     );
     expect(mockSendCommand).not.toHaveBeenCalledWith(
@@ -161,16 +162,56 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
     );
   });
 
+  it('waits for asynchronous file chooser errors before reporting them', async () => {
+    let resolveDescribeNode:
+      | ((value: { node: { attributes: string[] } }) => void)
+      | undefined;
+    mockSendCommand.mockImplementation(async (_target, method: string) => {
+      if (method === 'DOM.describeNode') {
+        return new Promise<{ node: { attributes: string[] } }>((resolve) => {
+          resolveDescribeNode = resolve;
+        });
+      }
+
+      if (method === 'Runtime.evaluate') {
+        return { result: { value: true } };
+      }
+
+      return {};
+    });
+
+    const registration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(['/tmp/a.txt', '/tmp/b.txt']);
+      },
+    );
+    const listener = getFileChooserListener();
+
+    listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+      backendNodeId: 42,
+    });
+
+    const errorPromise = registration.getError();
+    await Promise.resolve();
+    expect(resolveDescribeNode).toBeTypeOf('function');
+
+    resolveDescribeNode?.({ node: { attributes: [] } });
+
+    await expect(errorPromise).resolves.toMatchObject({
+      message: 'Non-multiple file input can only accept single file',
+    });
+  });
+
   it('captures an error for directory upload inputs', async () => {
     nodeAttributes = ['type', 'file', 'webkitdirectory', ''];
 
     await page.registerFileChooserAccept(['/tmp/upload-dir']);
     const listener = getFileChooserListener();
-    await listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+    listener({ tabId: 7 }, 'Page.fileChooserOpened', {
       backendNodeId: 42,
     });
 
-    expect(page.getFileChooserError()?.message).toContain(
+    expect((await page.getFileChooserError())?.message).toContain(
       'Directory upload (webkitdirectory) is not supported in Chrome extension bridge mode',
     );
   });

--- a/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
@@ -202,6 +202,27 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
     });
   });
 
+  it('accepts files registered through chrome extension bridge mode', async () => {
+    const files = ['/tmp/bridge-upload.txt'];
+
+    await page.registerFileChooserAccept(files);
+    const listener = getFileChooserListener();
+    listener({ tabId: 7 }, 'Page.fileChooserOpened', {
+      backendNodeId: 42,
+    });
+    const error = await page.getFileChooserError();
+
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      { tabId: 7 },
+      'DOM.setFileInputFiles',
+      {
+        files,
+        backendNodeId: 42,
+      },
+    );
+    expect(error).toBeUndefined();
+  });
+
   it('captures an error for directory upload inputs', async () => {
     nodeAttributes = ['type', 'file', 'webkitdirectory', ''];
 

--- a/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-file-chooser.test.ts
@@ -50,6 +50,13 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
     ) => Promise<void>;
   };
 
+  const getInterceptFileChooserCalls = (enabled: boolean) =>
+    mockSendCommand.mock.calls.filter(
+      ([, method, params]) =>
+        method === 'Page.setInterceptFileChooserDialog' &&
+        (params as { enabled?: boolean }).enabled === enabled,
+    );
+
   beforeEach(() => {
     vi.clearAllMocks();
     nodeAttributes = [];
@@ -110,6 +117,26 @@ describe('ChromeExtensionProxyPage file chooser support', () => {
 
     registration.dispose();
     expect(mockRemoveListener).toHaveBeenCalledWith(listener);
+  });
+
+  it('does not let stale dispose disable a newer registration', async () => {
+    const firstRegistration = await page.registerFileChooserListener(
+      async (chooser) => {
+        await chooser.accept(['/tmp/first.txt']);
+      },
+    );
+    const firstListener = getFileChooserListener();
+
+    firstRegistration.dispose();
+
+    await page.registerFileChooserListener(async (chooser) => {
+      await chooser.accept(['/tmp/second.txt']);
+    });
+    await Promise.resolve();
+
+    expect(mockRemoveListener).toHaveBeenCalledWith(firstListener);
+    expect(getInterceptFileChooserCalls(true)).toHaveLength(2);
+    expect(getInterceptFileChooserCalls(false)).toHaveLength(0);
   });
 
   it('captures an error when multiple files target a single-file input', async () => {


### PR DESCRIPTION
## Summary

This PR adds `fileChooserAccept` support for Chrome extension Bridge mode. The CLI-side bridge adapter now consumes the core `registerFileChooserListener` callback locally and forwards accepted file paths through explicit bridge events, because callback functions cannot be serialized over the Socket.IO bridge.

On the browser side, the Chrome extension registers a DevTools Protocol file chooser interception handler and uses `DOM.setFileInputFiles` when `Page.fileChooserOpened` fires. The implementation also tracks asynchronous browser-side errors so `getError()` can surface failures back to the core flow.

## Behavior

- Adds bridge events for registering accepted file paths, clearing the registration, and reading file chooser errors.
- Supports regular `<input type="file">` uploads in Chrome extension Bridge mode.
- Rejects multiple files for non-`multiple` inputs.
- Rejects `webkitdirectory` / directory upload inputs in Bridge mode and asks users to use Playwright for that case.
- Cleans up file chooser interception when the bridge page is disposed.
- Updates English and Chinese docs to mention Bridge mode support.

## Validation

- `pnpm --dir packages/web-integration test -- tests/unit-test/chrome-extension-file-chooser.test.ts tests/unit-test/bridge/file-chooser.test.ts`
- `pnpm exec nx build @midscene/web`
- `pnpm exec nx test @midscene/web`
- `pnpm run lint`
