### PR TITLE
fix(ios): paste text through WDA clipboard

### DIFF
--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -113,12 +113,18 @@ export type IOSDeviceInputOpt = {
   /** Automatically dismiss the keyboard after input is completed */
   autoDismissKeyboard?: boolean;
   /**
-   * Per-character delay (ms) used when typing into iOS input fields. When set
-   * to a positive number, characters are dispatched to WebDriverAgent one at a
-   * time with this gap between them, which prevents app-side reaction windows
-   * (re-render, predictive bar, autocorrect) from swallowing a contiguous
-   * block of keystrokes. Set to 0 to send the whole string in a single
-   * `/wda/keys` request (faster, but lossy on slow-reacting inputs).
+   * Strategy used to enter text into iOS input fields. `paste` writes the text
+   * to the iOS pasteboard and triggers a paste shortcut, avoiding occasional
+   * character loss from WebDriverAgent key typing on longer inputs. `type`
+   * keeps the old `/wda/keys` delivery path.
+   * @default 'paste'
+   */
+  keyboardInputStrategy?: 'paste' | 'type';
+  /**
+   * Per-character delay (ms) used by the `type` strategy and by the fallback
+   * path when paste is not supported by the active WebDriverAgent/iOS runtime.
+   * When set to a positive number, characters are dispatched to
+   * WebDriverAgent one at a time with this gap between them.
    * @default 80
    */
   keyboardTypeDelay?: number;

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -112,6 +112,16 @@ export type AndroidDeviceOpt = {
 export type IOSDeviceInputOpt = {
   /** Automatically dismiss the keyboard after input is completed */
   autoDismissKeyboard?: boolean;
+  /**
+   * Per-character delay (ms) used when typing into iOS input fields. When set
+   * to a positive number, characters are dispatched to WebDriverAgent one at a
+   * time with this gap between them, which prevents app-side reaction windows
+   * (re-render, predictive bar, autocorrect) from swallowing a contiguous
+   * block of keystrokes. Set to 0 to send the whole string in a single
+   * `/wda/keys` request (faster, but lossy on slow-reacting inputs).
+   * @default 80
+   */
+  keyboardTypeDelay?: number;
 };
 
 /**

--- a/packages/core/tests/unit-test/device-options.test.ts
+++ b/packages/core/tests/unit-test/device-options.test.ts
@@ -87,6 +87,7 @@ describe('Device Options Type Definitions', () => {
     test('IOSDeviceInputOpt should include keyboard options', () => {
       const inputOptions: IOSDeviceInputOpt = {
         autoDismissKeyboard: true,
+        keyboardTypeDelay: 80,
       };
 
       expect(inputOptions).toBeDefined();

--- a/packages/core/tests/unit-test/device-options.test.ts
+++ b/packages/core/tests/unit-test/device-options.test.ts
@@ -62,6 +62,7 @@ describe('Device Options Type Definitions', () => {
         sessionId: 'external-session-id',
         useWDA: true,
         autoDismissKeyboard: true,
+        keyboardInputStrategy: 'paste',
       };
 
       // Type check - this will fail at compile time if types are incorrect
@@ -87,6 +88,7 @@ describe('Device Options Type Definitions', () => {
     test('IOSDeviceInputOpt should include keyboard options', () => {
       const inputOptions: IOSDeviceInputOpt = {
         autoDismissKeyboard: true,
+        keyboardInputStrategy: 'type',
         keyboardTypeDelay: 80,
       };
 
@@ -161,6 +163,7 @@ describe('Device Options Type Definitions', () => {
         sessionId: 'external-session-id',
         useWDA: true,
         autoDismissKeyboard: true,
+        keyboardInputStrategy: 'paste',
 
         // YAML-specific
         launch: 'com.example.app',

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -470,16 +470,33 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
 
     const delayMs =
       options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay ?? 80;
+    const keyboardInputStrategy =
+      options?.keyboardInputStrategy ??
+      this.options?.keyboardInputStrategy ??
+      'paste';
 
-    debugDevice(`Typing text: "${text}" (delayMs=${delayMs})`);
+    debugDevice(
+      `Input text: "${text}" (strategy=${keyboardInputStrategy}, delayMs=${delayMs})`,
+    );
 
     try {
       // Wait a bit to ensure keyboard is ready
       await sleep(200);
-      await this.wdaBackend.typeText(text, { delayMs });
+      if (keyboardInputStrategy === 'type') {
+        await this.wdaBackend.typeText(text, { delayMs });
+      } else {
+        try {
+          await this.wdaBackend.pasteText(text);
+        } catch (pasteError) {
+          debugDevice(
+            `Failed to paste text with WDA, falling back to typing: ${pasteError}`,
+          );
+          await this.wdaBackend.typeText(text, { delayMs });
+        }
+      }
       await sleep(300); // Give more time for text to appear
     } catch (error) {
-      debugDevice(`Failed to type text with WDA: ${error}`);
+      debugDevice(`Failed to input text with WDA: ${error}`);
       throw error;
     }
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -468,12 +468,15 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     const shouldAutoDismissKeyboard =
       options?.autoDismissKeyboard ?? this.options?.autoDismissKeyboard ?? true;
 
-    debugDevice(`Typing text: "${text}"`);
+    const delayMs =
+      options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay ?? 80;
+
+    debugDevice(`Typing text: "${text}" (delayMs=${delayMs})`);
 
     try {
       // Wait a bit to ensure keyboard is ready
       await sleep(200);
-      await this.wdaBackend.typeText(text);
+      await this.wdaBackend.typeText(text, { delayMs });
       await sleep(300); // Give more time for text to appear
     } catch (error) {
       debugDevice(`Failed to type text with WDA: ${error}`);

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -8,6 +8,7 @@ const debugIOS = getDebug('webdriver:ios');
 const WDA_MJPEG_SCREENSHOT_QUALITY = 50;
 const WDA_MJPEG_FRAMERATE = 30;
 const WDA_MJPEG_SCALING_FACTOR = 50;
+const XCUI_KEY_MODIFIER_COMMAND = 1 << 4;
 
 export class IOSWebDriverClient extends WebDriverClient {
   async launchApp(bundleId: string): Promise<void> {
@@ -303,6 +304,56 @@ export class IOSWebDriverClient extends WebDriverClient {
       debugIOS(`Failed to dismiss keyboard: ${error}`);
       return false;
     }
+  }
+
+  async pasteText(text: string): Promise<void> {
+    this.ensureSession();
+
+    // Keep the same surrounding-whitespace behavior as typeText.
+    const cleanText = text.trim();
+    if (!cleanText) {
+      return;
+    }
+
+    try {
+      await this.setPasteboardText(cleanText);
+      await this.sendPasteShortcut();
+      debugIOS(`Pasted text: "${text}"`);
+    } catch (error) {
+      debugIOS(`Failed to paste text "${text}": ${error}`);
+      throw new Error(`Failed to paste text: ${error}`);
+    }
+  }
+
+  private async setPasteboardText(text: string): Promise<void> {
+    this.ensureSession();
+
+    await this.makeRequest(
+      'POST',
+      `/session/${this.sessionId}/wda/setPasteboard`,
+      {
+        content: Buffer.from(text, 'utf8').toString('base64'),
+        contentType: 'plaintext',
+      },
+    );
+  }
+
+  private async sendPasteShortcut(): Promise<void> {
+    this.ensureSession();
+
+    const elementId = (await this.getActiveElement()) ?? '0';
+    await this.makeRequest(
+      'POST',
+      `/session/${this.sessionId}/wda/element/${elementId}/keyboardInput`,
+      {
+        keys: [
+          {
+            key: 'v',
+            modifierFlags: XCUI_KEY_MODIFIER_COMMAND,
+          },
+        ],
+      },
+    );
   }
 
   async typeText(text: string, options?: { delayMs?: number }): Promise<void> {

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -1,3 +1,4 @@
+import { sleep } from '@midscene/core/utils';
 import { getDebug } from '@midscene/shared/logger';
 import { WebDriverClient } from '@midscene/webdriver';
 
@@ -304,17 +305,42 @@ export class IOSWebDriverClient extends WebDriverClient {
     }
   }
 
-  async typeText(text: string): Promise<void> {
+  async typeText(text: string, options?: { delayMs?: number }): Promise<void> {
     this.ensureSession();
 
+    // Clean the text to avoid unwanted trailing spaces
+    const cleanText = text.trim();
+    if (!cleanText) {
+      return;
+    }
+
+    const chars = Array.from(cleanText);
+    const delayMs = options?.delayMs ?? 0;
+
     try {
-      // Clean the text to avoid unwanted trailing spaces
-      const cleanText = text.trim();
-      // Use WebDriverAgent's keys endpoint with array value
-      await this.makeRequest('POST', `/session/${this.sessionId}/wda/keys`, {
-        value: cleanText.split(''), // Must be an array of characters
-      });
-      debugIOS(`Typed text: "${text}"`);
+      if (delayMs > 0) {
+        // Per-character sends with an inter-key gap prevent a single app-side
+        // reaction window (re-render, predictive bar, autocorrect) from
+        // swallowing a contiguous block of keystrokes.
+        for (let i = 0; i < chars.length; i++) {
+          await this.makeRequest(
+            'POST',
+            `/session/${this.sessionId}/wda/keys`,
+            {
+              value: [chars[i]],
+            },
+          );
+          if (i < chars.length - 1) {
+            await sleep(delayMs);
+          }
+        }
+      } else {
+        // Use WebDriverAgent's keys endpoint with array value
+        await this.makeRequest('POST', `/session/${this.sessionId}/wda/keys`, {
+          value: chars, // Must be an array of characters
+        });
+      }
+      debugIOS(`Typed text: "${text}" (delayMs=${delayMs})`);
     } catch (error) {
       debugIOS(`Failed to type text "${text}": ${error}`);
       throw new Error(`Failed to type text: ${error}`);

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -317,6 +317,7 @@ export class IOSWebDriverClient extends WebDriverClient {
 
     try {
       await this.setPasteboardText(cleanText);
+      await this.verifyPasteboardText(cleanText);
       await this.sendPasteShortcut();
       debugIOS(`Pasted text: "${text}"`);
     } catch (error) {
@@ -336,6 +337,62 @@ export class IOSWebDriverClient extends WebDriverClient {
         contentType: 'plaintext',
       },
     );
+  }
+
+  private async verifyPasteboardText(expectedText: string): Promise<void> {
+    const actualText = await this.getPasteboardText(expectedText);
+    if (actualText !== expectedText) {
+      throw new Error(
+        `WDA pasteboard verification failed: expected ${this.formatTextForError(
+          expectedText,
+        )}, got ${this.formatTextForError(actualText)}`,
+      );
+    }
+  }
+
+  private async getPasteboardText(expectedText: string): Promise<string> {
+    this.ensureSession();
+
+    const response = await this.makeRequest(
+      'POST',
+      `/session/${this.sessionId}/wda/getPasteboard`,
+      {
+        contentType: 'plaintext',
+      },
+    );
+    const value = response?.value ?? response;
+    if (typeof value !== 'string') {
+      throw new Error(
+        `Unexpected WDA pasteboard response: ${JSON.stringify(response)}`,
+      );
+    }
+    return this.decodePasteboardText(value, expectedText);
+  }
+
+  private decodePasteboardText(value: string, expectedText: string): string {
+    if (!value) {
+      return '';
+    }
+    if (value === expectedText) {
+      return value;
+    }
+
+    const normalized = value.trim();
+    try {
+      const decoded = Buffer.from(normalized, 'base64');
+      const reencoded = decoded.toString('base64').replace(/=+$/, '');
+      if (reencoded === normalized.replace(/=+$/, '')) {
+        return decoded.toString('utf8');
+      }
+    } catch {
+      // Some WDA versions return plaintext directly.
+    }
+    return value;
+  }
+
+  private formatTextForError(text: string): string {
+    const preview = text.length > 80 ? `${text.slice(0, 80)}...` : text;
+    return `${JSON.stringify(preview)} (length=${text.length})`;
   }
 
   private async sendPasteShortcut(): Promise<void> {

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -248,8 +248,43 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.tap).toHaveBeenNthCalledWith(1, 10, 20);
       expect(mockWdaClient.tap).toHaveBeenNthCalledWith(2, 30, 40);
       expect(mockWdaClient.clearActiveElement).toHaveBeenCalledTimes(2);
-      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(1, 'from action');
-      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(2, 'from pointer');
+      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(1, 'from action', {
+        delayMs: 80,
+      });
+      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(
+        2,
+        'from pointer',
+        { delayMs: 80 },
+      );
+    });
+
+    it('forwards keyboardTypeDelay from per-call options to the WDA backend', async () => {
+      await device.inputPrimitives.keyboard.typeText('per call', {
+        autoDismissKeyboard: false,
+        keyboardTypeDelay: 25,
+      } as any);
+
+      expect(mockWdaClient.typeText).toHaveBeenLastCalledWith('per call', {
+        delayMs: 25,
+      });
+    });
+
+    it('falls back to device-level keyboardTypeDelay when the call omits it', async () => {
+      const deviceWithDelay = new IOSDevice({
+        wdaPort: DEFAULT_WDA_PORT,
+        wdaHost: 'localhost',
+        keyboardTypeDelay: 0,
+      });
+
+      await deviceWithDelay.inputPrimitives.keyboard.typeText('default delay', {
+        autoDismissKeyboard: false,
+      } as any);
+
+      expect(mockWdaClient.typeText).toHaveBeenLastCalledWith('default delay', {
+        delayMs: 0,
+      });
+
+      await deviceWithDelay.destroy();
     });
   });
 
@@ -396,7 +431,9 @@ describe('IOSDevice', () => {
       await device.connect();
 
       await getInternalTextInput(device).typeText('Hello World');
-      expect(mockWdaClient.typeText).toHaveBeenCalledWith('Hello World');
+      expect(mockWdaClient.typeText).toHaveBeenCalledWith('Hello World', {
+        delayMs: 80,
+      });
     });
 
     it('should press home button', async () => {
@@ -601,7 +638,9 @@ describe('IOSDevice', () => {
       await getInternalTextInput(deviceWithAutoDismiss).typeText('test text');
 
       // Should call typeText and swipe (for keyboard dismiss)
-      expect(mockBackend.typeText).toHaveBeenCalledWith('test text');
+      expect(mockBackend.typeText).toHaveBeenCalledWith('test text', {
+        delayMs: 80,
+      });
       expect(mockBackend.swipe).toHaveBeenCalled();
     });
   });

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -39,6 +39,7 @@ describe('IOSDevice', () => {
       longPress: vi.fn().mockResolvedValue(undefined),
       swipe: vi.fn().mockResolvedValue(undefined),
       pinch: vi.fn().mockResolvedValue(undefined),
+      pasteText: vi.fn().mockResolvedValue(undefined),
       typeText: vi.fn().mockResolvedValue(undefined),
       clearActiveElement: vi.fn().mockResolvedValue(true),
       pressKey: vi.fn().mockResolvedValue(undefined),
@@ -248,31 +249,42 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.tap).toHaveBeenNthCalledWith(1, 10, 20);
       expect(mockWdaClient.tap).toHaveBeenNthCalledWith(2, 30, 40);
       expect(mockWdaClient.clearActiveElement).toHaveBeenCalledTimes(2);
-      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(1, 'from action', {
-        delayMs: 80,
-      });
-      expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(
+      expect(mockWdaClient.pasteText).toHaveBeenNthCalledWith(1, 'from action');
+      expect(mockWdaClient.pasteText).toHaveBeenNthCalledWith(
         2,
         'from pointer',
-        { delayMs: 80 },
       );
+      expect(mockWdaClient.typeText).not.toHaveBeenCalled();
     });
 
-    it('forwards keyboardTypeDelay from per-call options to the WDA backend', async () => {
-      await device.inputPrimitives.keyboard.typeText('per call', {
-        autoDismissKeyboard: false,
-        keyboardTypeDelay: 25,
-      } as any);
+    it('forwards keyboardTypeDelay from per-call options when using type strategy', async () => {
+      const deviceWithTypeStrategy = new IOSDevice({
+        wdaPort: DEFAULT_WDA_PORT,
+        wdaHost: 'localhost',
+        keyboardInputStrategy: 'type',
+      });
+
+      await deviceWithTypeStrategy.inputPrimitives.keyboard.typeText(
+        'per call',
+        {
+          autoDismissKeyboard: false,
+          keyboardTypeDelay: 25,
+        } as any,
+      );
 
       expect(mockWdaClient.typeText).toHaveBeenLastCalledWith('per call', {
         delayMs: 25,
       });
+      expect(mockWdaClient.pasteText).not.toHaveBeenCalled();
+
+      await deviceWithTypeStrategy.destroy();
     });
 
-    it('falls back to device-level keyboardTypeDelay when the call omits it', async () => {
+    it('falls back to device-level keyboardTypeDelay when using type strategy', async () => {
       const deviceWithDelay = new IOSDevice({
         wdaPort: DEFAULT_WDA_PORT,
         wdaHost: 'localhost',
+        keyboardInputStrategy: 'type',
         keyboardTypeDelay: 0,
       });
 
@@ -285,6 +297,21 @@ describe('IOSDevice', () => {
       });
 
       await deviceWithDelay.destroy();
+    });
+
+    it('falls back to WDA typing when paste input is unavailable', async () => {
+      mockWdaClient.pasteText = vi
+        .fn()
+        .mockRejectedValue(new Error('Paste not supported'));
+
+      await device.inputPrimitives.keyboard.typeText('fallback text', {
+        autoDismissKeyboard: false,
+      } as any);
+
+      expect(mockWdaClient.pasteText).toHaveBeenCalledWith('fallback text');
+      expect(mockWdaClient.typeText).toHaveBeenLastCalledWith('fallback text', {
+        delayMs: 80,
+      });
     });
   });
 
@@ -427,13 +454,12 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.swipe).toHaveBeenCalledWith(100, 200, 300, 400, 500);
     });
 
-    it('should type text', async () => {
+    it('should paste text by default', async () => {
       await device.connect();
 
       await getInternalTextInput(device).typeText('Hello World');
-      expect(mockWdaClient.typeText).toHaveBeenCalledWith('Hello World', {
-        delayMs: 80,
-      });
+      expect(mockWdaClient.pasteText).toHaveBeenCalledWith('Hello World');
+      expect(mockWdaClient.typeText).not.toHaveBeenCalled();
     });
 
     it('should press home button', async () => {
@@ -566,6 +592,9 @@ describe('IOSDevice', () => {
 
     it('should handle text input failure', async () => {
       await device.connect();
+      mockWdaClient.pasteText = vi
+        .fn()
+        .mockRejectedValue(new Error('Paste text failed'));
       mockWdaClient.typeText = vi
         .fn()
         .mockRejectedValue(new Error('Type text failed'));
@@ -619,6 +648,7 @@ describe('IOSDevice', () => {
       const mockBackend = {
         ...mockWdaClient,
         createSession: vi.fn().mockResolvedValue({ sessionId: 'test-session' }),
+        pasteText: vi.fn().mockResolvedValue(undefined),
         typeText: vi.fn().mockResolvedValue(undefined),
         dismissKeyboard: vi
           .fn()
@@ -637,10 +667,9 @@ describe('IOSDevice', () => {
       await deviceWithAutoDismiss.connect();
       await getInternalTextInput(deviceWithAutoDismiss).typeText('test text');
 
-      // Should call typeText and swipe (for keyboard dismiss)
-      expect(mockBackend.typeText).toHaveBeenCalledWith('test text', {
-        delayMs: 80,
-      });
+      // Should call pasteText and swipe (for keyboard dismiss)
+      expect(mockBackend.pasteText).toHaveBeenCalledWith('test text');
+      expect(mockBackend.typeText).not.toHaveBeenCalled();
       expect(mockBackend.swipe).toHaveBeenCalled();
     });
   });

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -81,6 +81,66 @@ describe('IOSWebDriverClient.typeText delivery modes', () => {
   });
 });
 
+describe('IOSWebDriverClient.pasteText', () => {
+  it('sets the iOS pasteboard and sends Command+V to the active element', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockImplementation(async (_method, path) => {
+      if (path === '/session/session-under-test/element/active') {
+        return { value: { ELEMENT: 'active-element-id' } };
+      }
+      return undefined;
+    });
+
+    await client.pasteText('Hello 世界');
+
+    expect(makeRequest).toHaveBeenCalledTimes(3);
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      1,
+      'POST',
+      '/session/session-under-test/wda/setPasteboard',
+      {
+        content: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+        contentType: 'plaintext',
+      },
+    );
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      2,
+      'GET',
+      '/session/session-under-test/element/active',
+    );
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      3,
+      'POST',
+      '/session/session-under-test/wda/element/active-element-id/keyboardInput',
+      {
+        keys: [{ key: 'v', modifierFlags: 16 }],
+      },
+    );
+  });
+
+  it('falls back to the active application when no active element is available', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.pasteText('Hello');
+
+    expect(makeRequest).toHaveBeenLastCalledWith(
+      'POST',
+      '/session/session-under-test/wda/element/0/keyboardInput',
+      {
+        keys: [{ key: 'v', modifierFlags: 16 }],
+      },
+    );
+  });
+
+  it('trims surrounding whitespace and skips empty input', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.pasteText('   ');
+
+    expect(makeRequest).not.toHaveBeenCalled();
+  });
+});
+
 describe('IOSWebDriverClient - Simple Tests', () => {
   describe('Module Structure', () => {
     it('should export IOSWebDriverClient class', async () => {
@@ -117,6 +177,7 @@ describe('IOSWebDriverClient - Simple Tests', () => {
         'tap',
         'swipe',
         'typeText',
+        'pasteText',
         'pressKey',
         'launchApp',
         'openUrl',

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -82,9 +82,14 @@ describe('IOSWebDriverClient.typeText delivery modes', () => {
 });
 
 describe('IOSWebDriverClient.pasteText', () => {
-  it('sets the iOS pasteboard and sends Command+V to the active element', async () => {
+  it('sets and verifies the iOS pasteboard before sending Command+V to the active element', async () => {
     const { client, makeRequest } = createClientWithSession();
     makeRequest.mockImplementation(async (_method, path) => {
+      if (path === '/session/session-under-test/wda/getPasteboard') {
+        return {
+          value: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+        };
+      }
       if (path === '/session/session-under-test/element/active') {
         return { value: { ELEMENT: 'active-element-id' } };
       }
@@ -93,7 +98,7 @@ describe('IOSWebDriverClient.pasteText', () => {
 
     await client.pasteText('Hello 世界');
 
-    expect(makeRequest).toHaveBeenCalledTimes(3);
+    expect(makeRequest).toHaveBeenCalledTimes(4);
     expect(makeRequest).toHaveBeenNthCalledWith(
       1,
       'POST',
@@ -105,11 +110,19 @@ describe('IOSWebDriverClient.pasteText', () => {
     );
     expect(makeRequest).toHaveBeenNthCalledWith(
       2,
+      'POST',
+      '/session/session-under-test/wda/getPasteboard',
+      {
+        contentType: 'plaintext',
+      },
+    );
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      3,
       'GET',
       '/session/session-under-test/element/active',
     );
     expect(makeRequest).toHaveBeenNthCalledWith(
-      3,
+      4,
       'POST',
       '/session/session-under-test/wda/element/active-element-id/keyboardInput',
       {
@@ -118,8 +131,53 @@ describe('IOSWebDriverClient.pasteText', () => {
     );
   });
 
+  it('accepts plaintext pasteboard readback from WDA variants that do not return base64', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockImplementation(async (_method, path) => {
+      if (path === '/session/session-under-test/wda/getPasteboard') {
+        return { value: 'test' };
+      }
+      return undefined;
+    });
+
+    await client.pasteText('test');
+
+    expect(makeRequest).toHaveBeenLastCalledWith(
+      'POST',
+      '/session/session-under-test/wda/element/0/keyboardInput',
+      {
+        keys: [{ key: 'v', modifierFlags: 16 }],
+      },
+    );
+  });
+
+  it('throws before Command+V when WDA reports a mismatched pasteboard value', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockImplementation(async (_method, path) => {
+      if (path === '/session/session-under-test/wda/getPasteboard') {
+        return { value: '' };
+      }
+      return undefined;
+    });
+
+    await expect(client.pasteText('Hello')).rejects.toThrow(
+      'WDA pasteboard verification failed',
+    );
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/element/0/keyboardInput',
+      expect.anything(),
+    );
+  });
+
   it('falls back to the active application when no active element is available', async () => {
     const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockImplementation(async (_method, path) => {
+      if (path === '/session/session-under-test/wda/getPasteboard') {
+        return { value: Buffer.from('Hello', 'utf8').toString('base64') };
+      }
+      return undefined;
+    });
 
     await client.pasteText('Hello');
 

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -1,6 +1,85 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
 import type { IOSWebDriverClient as IOSWebDriverClientType } from '../../src/ios-webdriver-client';
+
+function createClientWithSession() {
+  const client = new IOSWebDriverClient({
+    port: DEFAULT_WDA_PORT,
+    host: 'localhost',
+  });
+  // Bypass createSession() — we only want to observe outbound HTTP calls.
+  (client as any).sessionId = 'session-under-test';
+  const makeRequest = vi
+    .spyOn(client as any, 'makeRequest')
+    .mockResolvedValue(undefined);
+  return { client, makeRequest };
+}
+
+describe('IOSWebDriverClient.typeText delivery modes', () => {
+  it('sends the whole string in one /wda/keys request when delayMs is 0 (default)', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.typeText('Al is amazing');
+
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/keys',
+      {
+        value: [
+          'A',
+          'l',
+          ' ',
+          'i',
+          's',
+          ' ',
+          'a',
+          'm',
+          'a',
+          'z',
+          'i',
+          'n',
+          'g',
+        ],
+      },
+    );
+  });
+
+  it('emits one /wda/keys request per character when delayMs > 0', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.typeText('Hi!', { delayMs: 1 });
+
+    expect(makeRequest).toHaveBeenCalledTimes(3);
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      1,
+      'POST',
+      '/session/session-under-test/wda/keys',
+      { value: ['H'] },
+    );
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/session/session-under-test/wda/keys',
+      { value: ['i'] },
+    );
+    expect(makeRequest).toHaveBeenNthCalledWith(
+      3,
+      'POST',
+      '/session/session-under-test/wda/keys',
+      { value: ['!'] },
+    );
+  });
+
+  it('trims surrounding whitespace and skips empty input', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.typeText('   ');
+
+    expect(makeRequest).not.toHaveBeenCalled();
+  });
+});
 
 describe('IOSWebDriverClient - Simple Tests', () => {
   describe('Module Structure', () => {


### PR DESCRIPTION
## Summary

Split from #2518. This PR contains only the iOS input changes.

- Add `keyboardInputStrategy` and `keyboardTypeDelay` to the iOS device input options.
- Default iOS text input to `paste`, using the WDA pasteboard plus a Cmd+V keyboard shortcut.
- Keep the old `/wda/keys` path behind `keyboardInputStrategy: "type"`.
- Fall back to delayed per-character typing when paste is unavailable.
- Cover paste, type strategy, fallback, and option forwarding in core/iOS unit tests.

## Why

WDA key typing can drop characters on longer or reactive iOS inputs. Pasting the full text through the pasteboard avoids that contiguous key-delivery failure mode while preserving an explicit type strategy for compatibility.

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx test ios`
- [x] `npx nx test core`
