### PR TITLE
feat(cli): export report videos with ffmpeg

### DIFF
--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -4,12 +4,7 @@ import { Alert, ConfigProvider, Empty, theme } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
-import {
-  GroupedActionDump,
-  dedupeExecutionsKeepLatest,
-  restoreImageReferences,
-} from '@midscene/core';
-import { antiEscapeScriptTag } from '@midscene/shared/utils';
+import type { GroupedActionDump } from '@midscene/core';
 import {
   Logo,
   Player,
@@ -31,36 +26,13 @@ import type {
 } from './types';
 import { formatModelBriefText } from './utils/model-brief';
 import {
+  groupDumpScriptElements,
+  parseDumpGroup,
+} from './utils/read-report-dumps';
+import {
   getEmptyDumpDescription,
   parseDumpAttributes,
 } from './utils/report-dump';
-
-// Shared image cache across all test cases — resolved images are cached by id
-const imageCache = new Map<string, string>();
-
-function resolveImageFromDom(
-  refOrId: string | { id: string; storage?: 'inline' | 'file'; path?: string },
-): string {
-  const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
-  const cached = imageCache.get(id);
-  if (cached) return cached;
-
-  const el = document.querySelector(
-    `script[type="midscene-image"][data-id="${CSS.escape(id)}"]`,
-  );
-  if (el?.textContent) {
-    const data = antiEscapeScriptTag(el.textContent);
-    imageCache.set(id, data);
-    return data;
-  }
-
-  if (typeof refOrId === 'object' && refOrId?.storage === 'file') {
-    return refOrId.path || `./screenshots/${id}.png`;
-  }
-
-  // Fallback to directory path
-  return `./screenshots/${id}.png`;
-}
 
 let globalRenderCount = 1;
 const SIDEBAR_WIDTH_KEY = 'midscene-sidebar-width';
@@ -361,74 +333,24 @@ export function App() {
   }
 
   function getDumpElements(): PlaywrightTasks[] {
-    const dumpElements = document.querySelectorAll(
-      'script[type="midscene_web_dump"]',
-    );
-    const validElements = Array.from(dumpElements).filter((el) => {
-      const textContent = el.textContent;
-      if (!textContent) {
-        console.warn('empty content in script tag', el);
-      }
-      return !!textContent;
-    });
-
-    // Group elements by data-group-id.
-    // For backward compatibility with older reports that lack data-group-id,
-    // each element without the attribute is treated as its own group.
-    const groupMap = new Map<string, Element[]>();
-    let ungroupedCounter = 0;
-
-    for (const el of validElements) {
-      const groupId = el.getAttribute('data-group-id');
-      const decodedGroupId = groupId
-        ? decodeURIComponent(groupId)
-        : `__ungrouped_${ungroupedCounter++}`;
-      if (!groupMap.has(decodedGroupId)) {
-        groupMap.set(decodedGroupId, []);
-      }
-      groupMap.get(decodedGroupId)!.push(el);
-    }
-
+    const groupMap = groupDumpScriptElements();
     const result: PlaywrightTasks[] = [];
 
-    // Process grouped dump tags — merge into one PlaywrightTasks per group
+    // Process grouped dump tags — merge into one PlaywrightTasks per group.
+    // Parsing is deferred until first access (reports can be large).
     for (const [, elements] of groupMap) {
       const attributes = parseAttributesFromElement(elements[0]);
       let cachedJsonContent: GroupedActionDump | null = null;
-      let isParsed = false;
 
       result.push({
         get: () => {
-          if (!isParsed) {
+          if (!cachedJsonContent) {
             console.time('parse_grouped_dump');
-            const allExecutions: any[] = [];
-            let baseDump: GroupedActionDump | null = null;
-
-            for (const el of elements) {
-              const content = antiEscapeScriptTag(el.textContent || '');
-              const parsed = JSON.parse(content);
-              const restored = restoreImageReferences(
-                parsed,
-                resolveImageFromDom,
-              );
-              const dump = GroupedActionDump.fromJSON(restored);
-              if (!baseDump) {
-                baseDump = dump;
-              }
-              allExecutions.push(...dump.executions);
-            }
-
-            // Deduplicate executions by id — keep only the last one.
-            // Only executions with a stable id are deduped; old-format entries
-            // without id are always kept (they may be distinct despite same name).
-            baseDump!.executions = dedupeExecutionsKeepLatest(allExecutions);
-            cachedJsonContent = baseDump!;
-
-            console.timeEnd('parse_grouped_dump');
+            cachedJsonContent = parseDumpGroup(elements);
             (cachedJsonContent as any).attributes = attributes;
-            isParsed = true;
+            console.timeEnd('parse_grouped_dump');
           }
-          return cachedJsonContent!;
+          return cachedJsonContent;
         },
         attributes,
       });

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -14,8 +14,10 @@ import type {
   ExecutionTaskPlanningLocate,
   IExecutionDump,
 } from '@midscene/core';
-import type { MarkdownAttachment } from '@midscene/core';
-import { executionToMarkdown } from '@midscene/core';
+import {
+  type MarkdownAttachment,
+  executionToMarkdown,
+} from '@midscene/core/report-markdown';
 import {
   Blackboard,
   Player,

--- a/apps/report/src/components/detail-panel/markdown-view.ts
+++ b/apps/report/src/components/detail-panel/markdown-view.ts
@@ -1,4 +1,4 @@
-import type { MarkdownAttachment } from '@midscene/core';
+import type { MarkdownAttachment } from '@midscene/core/report-markdown';
 
 type ExecutionMarkdown = {
   markdown: string;

--- a/apps/report/src/components/playground/index.tsx
+++ b/apps/report/src/components/playground/index.tsx
@@ -5,8 +5,8 @@ import type {
   ReportActionDump,
   UIContext,
 } from '@midscene/core';
-import { GroupedActionDump } from '@midscene/core';
 import { paramStr, typeStr } from '@midscene/core/agent';
+import { GroupedActionDump } from '@midscene/core/dump';
 import { type PlaygroundSDK, noReplayAPIs } from '@midscene/playground';
 import type { ServerResponse } from '@midscene/playground';
 import {

--- a/apps/report/src/headless-video-export.ts
+++ b/apps/report/src/headless-video-export.ts
@@ -1,0 +1,176 @@
+/**
+ * Headless video export hook.
+ *
+ * Exposes `window.__midscene_exportVideoToBase64` so the Midscene CLI can drive
+ * a headless browser, load a report HTML, and produce the replay video that the
+ * report UI would otherwise download via the "Export video" button — without any
+ * user interaction. See `@midscene/cli` `report-video` command.
+ */
+import {
+  type BrandedFrameRenderer,
+  allScriptsFromDump,
+  calculateFrameMap,
+  createBrandedFrameRenderer,
+  recordBrandedVideo,
+} from '@midscene/visualizer';
+import { readReportDumpGroups } from './utils/read-report-dumps';
+
+export interface HeadlessVideoExportOptions {
+  // Which dump group to render when the report contains multiple groups.
+  // Defaults to 0 (the first group).
+  index?: number;
+  autoZoom?: boolean;
+  scale?: number;
+}
+
+export interface HeadlessVideoFrameSessionInfo {
+  totalFrames: number;
+  fps: number;
+  width: number;
+  height: number;
+}
+
+export interface HeadlessVideoFrameRenderOptions {
+  type?: 'image/jpeg' | 'image/png';
+  quality?: number;
+}
+
+let activeFrameRenderer: BrandedFrameRenderer | null = null;
+
+function mountFrameCanvas(renderer: BrandedFrameRenderer): void {
+  const { canvas } = renderer;
+  canvas.setAttribute('data-midscene-video-frame-canvas', 'true');
+  Object.assign(canvas.style, {
+    position: 'fixed',
+    left: '0',
+    top: '0',
+    width: `${renderer.width}px`,
+    height: `${renderer.height}px`,
+    zIndex: '2147483647',
+    background: '#000',
+  });
+  if (!canvas.parentElement) {
+    document.body.appendChild(canvas);
+  }
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('failed to read video blob'));
+    reader.onload = () => {
+      const result = reader.result as string;
+      // strip the `data:<mime>;base64,` prefix
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+function resolveReportFrameMap(options?: HeadlessVideoExportOptions) {
+  const groups = readReportDumpGroups();
+  if (groups.length === 0) {
+    throw new Error('no dump data found in the report');
+  }
+  const index = options?.index ?? 0;
+  const dump = groups[index];
+  if (!dump) {
+    throw new Error(
+      `dump group index ${index} out of range (found ${groups.length} group(s))`,
+    );
+  }
+
+  const info = allScriptsFromDump(dump);
+  if (!info?.scripts?.length) {
+    throw new Error('no replayable scripts in the report');
+  }
+
+  return calculateFrameMap(info.scripts, {
+    imageWidth: info.width,
+    imageHeight: info.height,
+  });
+}
+
+export async function exportReportVideoToBase64(
+  options?: HeadlessVideoExportOptions,
+): Promise<string> {
+  const frameMap = resolveReportFrameMap(options);
+  const blob = await recordBrandedVideo(frameMap, {
+    autoZoom: options?.autoZoom ?? true,
+    headless: true,
+    scale: options?.scale,
+  });
+  return blobToBase64(blob);
+}
+
+export async function prepareReportVideoFrames(
+  options?: HeadlessVideoExportOptions,
+): Promise<HeadlessVideoFrameSessionInfo> {
+  disposeReportVideoFrames();
+  const frameMap = resolveReportFrameMap(options);
+  activeFrameRenderer = await createBrandedFrameRenderer(frameMap, {
+    autoZoom: options?.autoZoom ?? true,
+    scale: options?.scale,
+  });
+  mountFrameCanvas(activeFrameRenderer);
+  return {
+    totalFrames: activeFrameRenderer.totalFrames,
+    fps: activeFrameRenderer.fps,
+    width: activeFrameRenderer.width,
+    height: activeFrameRenderer.height,
+  };
+}
+
+export function renderReportVideoFrame(frameIndex: number): void {
+  if (!activeFrameRenderer) {
+    throw new Error('video frame renderer has not been prepared');
+  }
+  activeFrameRenderer.renderFrame(frameIndex);
+}
+
+export async function renderReportVideoFrameToBase64(
+  frameIndex: number,
+  options?: HeadlessVideoFrameRenderOptions,
+): Promise<string> {
+  if (!activeFrameRenderer) {
+    throw new Error('video frame renderer has not been prepared');
+  }
+  const dataURL = activeFrameRenderer.renderFrameToDataURL(
+    frameIndex,
+    options?.type ?? 'image/png',
+    options?.quality,
+  );
+  return dataURL.slice(dataURL.indexOf(',') + 1);
+}
+
+export function disposeReportVideoFrames(): void {
+  activeFrameRenderer?.canvas.remove();
+  activeFrameRenderer?.dispose();
+  activeFrameRenderer = null;
+}
+
+declare global {
+  interface Window {
+    __midscene_exportVideoToBase64?: (
+      options?: HeadlessVideoExportOptions,
+    ) => Promise<string>;
+    __midscene_prepareVideoFrames?: (
+      options?: HeadlessVideoExportOptions,
+    ) => Promise<HeadlessVideoFrameSessionInfo>;
+    __midscene_renderVideoFrameToBase64?: (
+      frameIndex: number,
+      options?: HeadlessVideoFrameRenderOptions,
+    ) => Promise<string>;
+    __midscene_renderVideoFrame?: (frameIndex: number) => void;
+    __midscene_disposeVideoFrames?: () => void;
+  }
+}
+
+export function installHeadlessVideoExport(): void {
+  if (typeof window === 'undefined') return;
+  window.__midscene_exportVideoToBase64 = exportReportVideoToBase64;
+  window.__midscene_prepareVideoFrames = prepareReportVideoFrames;
+  window.__midscene_renderVideoFrame = renderReportVideoFrame;
+  window.__midscene_renderVideoFrameToBase64 = renderReportVideoFrameToBase64;
+  window.__midscene_disposeVideoFrames = disposeReportVideoFrames;
+}

--- a/apps/report/src/index.tsx
+++ b/apps/report/src/index.tsx
@@ -1,5 +1,10 @@
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
+import { installHeadlessVideoExport } from './headless-video-export';
+
+// Installs window.__midscene_exportVideoToBase64 for the CLI headless exporter.
+// Called explicitly (not a bare side-effect import) so it survives tree-shaking.
+installHeadlessVideoExport();
 
 const rootEl = document.getElementById('root');
 

--- a/apps/report/src/utils/read-report-dumps.ts
+++ b/apps/report/src/utils/read-report-dumps.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared helpers for reading the dump data embedded in a report HTML.
+ *
+ * The report App renders these dumps lazily (with per-group attributes), while
+ * the headless video exporter reads them eagerly. Both go through the same
+ * grouping/parsing/dedupe logic here so the two paths cannot drift apart.
+ */
+import { GroupedActionDump, restoreImageReferences } from '@midscene/core/dump';
+import { antiEscapeScriptTag } from '@midscene/shared/utils';
+
+// Shared image cache across all callers — resolved images are cached by id.
+const imageCache = new Map<string, string>();
+
+function dedupeExecutionsKeepLatest<
+  T extends GroupedActionDump['executions'][number],
+>(executions: T[]): T[] {
+  let noIdCounter = 0;
+  const deduped = new Map<string, T>();
+  for (const exec of executions) {
+    const key = exec.id || `__no_id_${noIdCounter++}`;
+    deduped.set(key, exec);
+  }
+  return Array.from(deduped.values());
+}
+
+export function resolveImageFromDom(
+  refOrId: string | { id: string; storage?: 'inline' | 'file'; path?: string },
+): string {
+  const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
+  const cached = imageCache.get(id);
+  if (cached) return cached;
+
+  const el = document.querySelector(
+    `script[type="midscene-image"][data-id="${CSS.escape(id)}"]`,
+  );
+  if (el?.textContent) {
+    const data = antiEscapeScriptTag(el.textContent);
+    imageCache.set(id, data);
+    return data;
+  }
+
+  if (typeof refOrId === 'object' && refOrId?.storage === 'file') {
+    return refOrId.path || `./screenshots/${id}.png`;
+  }
+  // Fallback to directory path
+  return `./screenshots/${id}.png`;
+}
+
+/**
+ * Group the embedded `<script type="midscene_web_dump">` tags by their
+ * `data-group-id`. Current report templates always emit this attribute.
+ */
+export function groupDumpScriptElements(): Map<string, Element[]> {
+  const validElements = Array.from(
+    document.querySelectorAll('script[type="midscene_web_dump"]'),
+  ).filter((el) => !!el.textContent?.trim());
+
+  const groupMap = new Map<string, Element[]>();
+  for (const el of validElements) {
+    const groupId = el.getAttribute('data-group-id');
+    if (!groupId) {
+      throw new Error(
+        'report dump script is missing data-group-id; regenerate the report with the current Midscene template',
+      );
+    }
+    const decodedGroupId = decodeURIComponent(groupId);
+    if (!groupMap.has(decodedGroupId)) {
+      groupMap.set(decodedGroupId, []);
+    }
+    groupMap.get(decodedGroupId)!.push(el);
+  }
+  return groupMap;
+}
+
+/**
+ * Parse one group's dump elements into a single deduped {@link GroupedActionDump}.
+ * Executions with a stable id are deduplicated (keeping the latest); old-format
+ * entries without an id are always kept.
+ */
+export function parseDumpGroup(elements: Element[]): GroupedActionDump {
+  const allExecutions: GroupedActionDump['executions'] = [];
+  let baseDump: GroupedActionDump | null = null;
+
+  for (const el of elements) {
+    const content = antiEscapeScriptTag(el.textContent || '');
+    const restored = restoreImageReferences(
+      JSON.parse(content),
+      resolveImageFromDom,
+    );
+    const dump = GroupedActionDump.fromJSON(restored);
+    if (!baseDump) baseDump = dump;
+    allExecutions.push(...dump.executions);
+  }
+
+  if (!baseDump) {
+    throw new Error('parseDumpGroup: no dump elements to parse');
+  }
+  baseDump.executions = dedupeExecutionsKeepLatest(allExecutions);
+  return baseDump;
+}
+
+/** Read all embedded dumps as one {@link GroupedActionDump} per group. */
+export function readReportDumpGroups(): GroupedActionDump[] {
+  return Array.from(groupDumpScriptElements().values()).map(parseDumpGroup);
+}

--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -72,6 +72,40 @@ npx @midscene/web report-tool --action merge-html \
 
 Repeat `--htmlReport` once per source report. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
 
+## Generate A Replay Video From The CLI
+
+The report viewer has an "Export video" button that renders the replay as a `.webm` file. The `report-video` subcommand of `@midscene/cli` produces the replay video from the command line, without opening the report in a browser — handy for CI or batch jobs. It drives a headless browser internally and encodes frames with the bundled `@ffmpeg-installer/ffmpeg` binary by default, so it ships only in `@midscene/cli` (not in the per-platform CLIs).
+
+Generate a video from an existing report HTML. Directory-mode reports generated with `html-and-external-assets` are also supported; pass either the report directory or its `index.html`:
+
+```shell
+npx @midscene/cli report-video --input ./midscene_run/report/puppeteer-2026/index.html --output ./videos --name my-replay
+```
+
+You can also pass a dump JSON file instead of an HTML report:
+
+```shell
+npx @midscene/cli report-video --input ./output-data/some.execution.json --output ./videos
+```
+
+Options:
+
+- `--input, -i`: report HTML (file or directory) or a dump JSON file. Required.
+- `--output, -o`: output directory. Defaults to the Midscene report directory.
+- `--name`: output file name without extension. Defaults to `midscene_replay`.
+- `--index`: which dump group to render for a multi-group report. Defaults to `0`.
+- `--encoder`: `ffmpeg` (default) or `media-recorder`. The ffmpeg encoder renders frames offline and supports long replays more reliably.
+- `--format`: `webm` (default) or `mp4` when using the ffmpeg encoder.
+- `--fps`: output frame rate for the ffmpeg encoder. Defaults to `15` for faster export; pass `30` for the browser export cadence.
+- `--frame-format`: intermediate frame format for the ffmpeg encoder. Defaults to high-quality `jpeg` for speed; pass `png` for lossless intermediate frames.
+- `--concurrency`: parallel frame renderers for the ffmpeg encoder. Defaults to `4`.
+- `--scale`: output resolution scale for the ffmpeg encoder. Defaults to `1` (960×540); pass `2` for 1920×1080.
+- `--no-auto-zoom`: disable the auto-zoom camera animation.
+
+The default output is a WebM video (960×540) rendered at 15fps with high-quality JPEG intermediate frames and a 2Mbps VP8 bitrate. When `--scale` is increased, the WebM bitrate scales with the output pixel area (`--scale 2` uses 8Mbps). To produce MP4, pass `--format mp4` or a `--name` ending in `.mp4`. To prioritize smoothness over speed, pass `--fps 30`; to prioritize lossless intermediate frames over speed, pass `--frame-format png`; to prioritize sharpness over speed and file size, pass `--scale 2`.
+
+When the input is an HTML report, screenshots are preserved automatically; a dump JSON only renders embedded screenshots, so prefer the HTML input when screenshots are stored as separate files. The report must be generated with a current Midscene template that includes the video export hook; older report HTML files should be regenerated before exporting video.
+
 ## Parse With The JavaScript SDK
 
 If you prefer to control report parsing in code, use `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` from `@midscene/core`.

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -72,6 +72,40 @@ npx @midscene/web report-tool --action merge-html \
 
 每多合并一份报告就重复一次 `--htmlReport`。`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
 
+## 通过命令行生成回放视频
+
+报告页面有一个「导出视频」按钮，可以把回放渲染成 `.webm` 文件。`@midscene/cli` 的 `report-video` 子命令能在命令行直接产出回放视频，无需在浏览器中打开报告，适合 CI 或批处理场景。它内部会驱动一个无头浏览器，并默认使用随 CLI 安装的 `@ffmpeg-installer/ffmpeg` 二进制进行逐帧编码，因此只随 `@midscene/cli` 提供（不在各平台 CLI 中）。
+
+从已有的报告 HTML 生成视频。也支持 `html-and-external-assets` 生成的目录模式报告，可以传入报告目录或其中的 `index.html`：
+
+```shell
+npx @midscene/cli report-video --input ./midscene_run/report/puppeteer-2026/index.html --output ./videos --name my-replay
+```
+
+也可以传入 dump JSON 文件，而不是 HTML 报告：
+
+```shell
+npx @midscene/cli report-video --input ./output-data/some.execution.json --output ./videos
+```
+
+可用参数：
+
+- `--input, -i`:报告 HTML（文件或目录）或 dump JSON 文件，必填。
+- `--output, -o`:输出目录，留空时使用 Midscene 默认的报告目录。
+- `--name`:输出文件名（不含扩展名），默认为 `midscene_replay`。
+- `--index`:多分组报告中要渲染的 dump 分组序号，默认为 `0`。
+- `--encoder`:编码器，可选 `ffmpeg`（默认）或 `media-recorder`。ffmpeg 会离线逐帧编码，更适合较长回放。
+- `--format`:使用 ffmpeg 编码时的输出格式，可选 `webm`（默认）或 `mp4`。
+- `--fps`:使用 ffmpeg 编码时的输出帧率，默认为 `15` 以提升导出速度；如需接近浏览器导出的流畅度，可传入 `30`。
+- `--frame-format`:使用 ffmpeg 编码时的中间帧格式，默认为高质量 `jpeg` 以提升速度；如需无损中间帧，可传入 `png`。
+- `--concurrency`:使用 ffmpeg 编码时的并行帧渲染器数量，默认为 `4`。
+- `--scale`:使用 ffmpeg 编码时的输出分辨率倍率，默认为 `1`（960×540）；传入 `2` 可输出 1920×1080。
+- `--no-auto-zoom`:关闭自动缩放的镜头动画。
+
+默认输出为 WebM 视频（960×540），并以 15fps、高质量 JPEG 中间帧和 2Mbps VP8 码率渲染。当增大 `--scale` 时，WebM 码率会随输出像素面积同步增大（`--scale 2` 使用 8Mbps）。若需要 MP4，可传入 `--format mp4`，或让 `--name` 以 `.mp4` 结尾。若优先考虑流畅度而不是速度，可传入 `--fps 30`；若优先考虑无损中间帧而不是速度，可传入 `--frame-format png`；若优先考虑清晰度而不是速度和文件大小，可传入 `--scale 2`。
+
+当输入为 HTML 报告时会自动保留截图;而 dump JSON 只会渲染内嵌的截图，因此当截图以独立文件存储时，建议使用 HTML 输入。报告需要由包含视频导出 hook 的当前 Midscene 模板生成；旧版报告 HTML 请先重新生成再导出视频。
+
 ## 使用 JavaScript SDK 解析
 
 如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles`。

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "@midscene/shared": "workspace:*",
     "@midscene/web": "workspace:*",
     "@rstest/core": "0.10.3",
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "http-server": "14.1.1",
     "lodash.merge": "4.6.2",
     "puppeteer": "24.6.0"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,11 +8,17 @@ import { version } from '../package.json';
 import { matchYamlFiles, parseProcessArgs } from './cli-utils';
 import { createConfig, createFilesConfig } from './config-factory';
 import { runFrameworkTestConfig } from './framework';
+import { reportVideoCommand } from './report-video';
 
 Promise.resolve(
   (async () => {
     const rawArgs = process.argv.slice(2);
     const [firstArg] = rawArgs;
+    if (firstArg === 'report-video') {
+      const exitCode = await reportVideoCommand(rawArgs.slice(1));
+      // Ensure the process terminates even if a browser handle lingers.
+      process.exit(exitCode);
+    }
     if (firstArg === 'report-tool') {
       await runToolsCLI(
         {

--- a/packages/cli/src/report-video-args.ts
+++ b/packages/cli/src/report-video-args.ts
@@ -1,0 +1,263 @@
+import yargs from 'yargs/yargs';
+
+export interface ReportVideoOptions {
+  input: string;
+  output?: string;
+  name?: string;
+  index?: number;
+  autoZoom?: boolean;
+  encoder?: 'ffmpeg' | 'media-recorder';
+  format?: 'webm' | 'mp4';
+  fps?: number;
+  frameFormat?: 'jpeg' | 'png';
+  concurrency?: number;
+  scale?: number;
+}
+
+export type ReportVideoArgParseResult =
+  | { type: 'ok'; options: ReportVideoOptions }
+  | { type: 'help'; exitCode: 0 }
+  | { type: 'error'; exitCode: 1 };
+
+export const DEFAULT_FFMPEG_FPS = 15;
+export const DEFAULT_FFMPEG_FRAME_FORMAT = 'jpeg';
+export const DEFAULT_FFMPEG_CONCURRENCY = 4;
+export const DEFAULT_FFMPEG_SCALE = 1;
+const MAX_FFMPEG_FPS = 60;
+const MAX_FFMPEG_CONCURRENCY = 8;
+const MAX_FFMPEG_SCALE = 4;
+
+type ParsedReportVideoArgs = {
+  input?: string;
+  output?: string;
+  name?: string;
+  index?: number;
+  autoZoom?: boolean;
+  encoder: 'ffmpeg' | 'media-recorder';
+  format: 'webm' | 'mp4';
+  fps?: number;
+  frameFormat?: 'jpeg' | 'png';
+  concurrency: number;
+  scale: number;
+  'auto-zoom': boolean;
+  'frame-format': 'jpeg' | 'png';
+};
+
+export function printReportVideoHelp(): void {
+  console.log(`
+Usage: midscene report-video --input <report.html | dump.json> [options]
+
+Generate the replay video of a Midscene report from the command line,
+without opening the report in a browser.
+
+Options:
+  -i, --input <path>    Report HTML (file or directory) or a dump JSON file. (required)
+  -o, --output <dir>    Output directory. Defaults to the Midscene report directory.
+      --name <name>     Output file name without extension. Defaults to "midscene_replay".
+      --index <n>       Which dump group to render for multi-group reports. Defaults to 0.
+      --encoder <name>   Encoder to use: "ffmpeg" or "media-recorder". Defaults to "ffmpeg".
+      --format <format>  Output format for ffmpeg: "webm" or "mp4". Defaults to "webm".
+      --fps <n>          Output frame rate for ffmpeg. Defaults to ${DEFAULT_FFMPEG_FPS}; use 30 for full fidelity.
+      --frame-format <format>  Intermediate frame format for ffmpeg: "jpeg" or "png". Defaults to "${DEFAULT_FFMPEG_FRAME_FORMAT}" for speed.
+      --concurrency <n>  Parallel frame renderers for ffmpeg. Defaults to ${DEFAULT_FFMPEG_CONCURRENCY}.
+      --scale <n>        Output resolution scale for ffmpeg. Defaults to ${DEFAULT_FFMPEG_SCALE}; use 2 for 1920×1080.
+      --no-auto-zoom    Disable the auto-zoom camera animation.
+  -h, --help            Show this help.
+`);
+}
+
+// Returns null to signal "print help and stop" (missing input, --help, or a bad
+// flag value). yargs handles -i/-o aliases, --key=value and --no-auto-zoom.
+//
+// Kept free of heavy imports (@midscene/core, puppeteer) so it stays cheap to
+// unit-test in isolation.
+export function parseReportVideoArgs(
+  argv: string[],
+): ReportVideoOptions | null {
+  const result = parseReportVideoArgResult(argv);
+  return result.type === 'ok' ? result.options : null;
+}
+
+export function parseReportVideoArgResult(
+  argv: string[],
+): ReportVideoArgParseResult {
+  if (argv.includes('-h') || argv.includes('--help')) {
+    return { type: 'help', exitCode: 0 };
+  }
+
+  let parsed: ParsedReportVideoArgs;
+  try {
+    parsed = yargs(argv)
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error ?? new Error(message);
+      })
+      .help(false)
+      .showHelpOnFail(false)
+      .version(false)
+      .options({
+        input: {
+          alias: 'i',
+          type: 'string',
+          description:
+            'Report HTML (file or directory) or a dump JSON file. (required)',
+        },
+        output: {
+          alias: 'o',
+          type: 'string',
+          description:
+            'Output directory. Defaults to the Midscene report directory.',
+        },
+        name: {
+          type: 'string',
+          description:
+            'Output file name without extension. Defaults to "midscene_replay".',
+        },
+        index: {
+          type: 'number',
+          description:
+            'Which dump group to render for multi-group reports. Defaults to 0.',
+        },
+        encoder: {
+          choices: ['ffmpeg', 'media-recorder'] as const,
+          default: 'ffmpeg' as const,
+          description:
+            'Encoder to use. ffmpeg renders frames offline; media-recorder uses the browser recorder.',
+        },
+        format: {
+          choices: ['webm', 'mp4'] as const,
+          default: 'webm' as const,
+          description:
+            'Output format for the ffmpeg encoder. media-recorder only supports webm.',
+        },
+        fps: {
+          type: 'number',
+          description: `Output frame rate for the ffmpeg encoder. Defaults to ${DEFAULT_FFMPEG_FPS}.`,
+        },
+        'frame-format': {
+          choices: ['jpeg', 'png'] as const,
+          default: DEFAULT_FFMPEG_FRAME_FORMAT,
+          description:
+            'Intermediate frame format for the ffmpeg encoder. jpeg is faster; png is lossless.',
+        },
+        concurrency: {
+          type: 'number',
+          default: DEFAULT_FFMPEG_CONCURRENCY,
+          description: `Parallel frame renderers for the ffmpeg encoder. Defaults to ${DEFAULT_FFMPEG_CONCURRENCY}.`,
+        },
+        scale: {
+          type: 'number',
+          default: DEFAULT_FFMPEG_SCALE,
+          description: `Output resolution scale for the ffmpeg encoder. Defaults to ${DEFAULT_FFMPEG_SCALE}.`,
+        },
+        'auto-zoom': {
+          type: 'boolean',
+          default: true,
+          description:
+            'Auto-zoom camera animation. Use --no-auto-zoom to disable.',
+        },
+      })
+      .parseSync() as ParsedReportVideoArgs;
+  } catch (error) {
+    console.error(
+      `report-video: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (!parsed.input) {
+    console.error('report-video: --input is required');
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    parsed.index !== undefined &&
+    (!Number.isInteger(parsed.index) || parsed.index < 0)
+  ) {
+    console.error('report-video: --index must be a non-negative integer');
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (parsed.encoder === 'media-recorder' && parsed.format !== 'webm') {
+    console.error('report-video: --encoder media-recorder only supports webm');
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    parsed.fps !== undefined &&
+    (!Number.isInteger(parsed.fps) ||
+      parsed.fps <= 0 ||
+      parsed.fps > MAX_FFMPEG_FPS)
+  ) {
+    console.error(
+      `report-video: --fps must be a positive integer no greater than ${MAX_FFMPEG_FPS}`,
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (parsed.encoder === 'media-recorder' && parsed.fps !== undefined) {
+    console.error('report-video: --fps is only supported by --encoder ffmpeg');
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    parsed.encoder === 'media-recorder' &&
+    parsed['frame-format'] !== DEFAULT_FFMPEG_FRAME_FORMAT
+  ) {
+    console.error(
+      'report-video: --frame-format is only supported by --encoder ffmpeg',
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    !Number.isInteger(parsed.concurrency) ||
+    parsed.concurrency <= 0 ||
+    parsed.concurrency > MAX_FFMPEG_CONCURRENCY
+  ) {
+    console.error(
+      `report-video: --concurrency must be a positive integer no greater than ${MAX_FFMPEG_CONCURRENCY}`,
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    !Number.isInteger(parsed.scale) ||
+    parsed.scale <= 0 ||
+    parsed.scale > MAX_FFMPEG_SCALE
+  ) {
+    console.error(
+      `report-video: --scale must be a positive integer no greater than ${MAX_FFMPEG_SCALE}`,
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  if (
+    parsed.encoder === 'media-recorder' &&
+    parsed.scale !== DEFAULT_FFMPEG_SCALE
+  ) {
+    console.error(
+      'report-video: --scale is only supported by --encoder ffmpeg',
+    );
+    return { type: 'error', exitCode: 1 };
+  }
+
+  const frameFormat = parsed['frame-format'] as 'jpeg' | 'png';
+
+  return {
+    type: 'ok',
+    options: {
+      input: parsed.input,
+      output: parsed.output,
+      name: parsed.name,
+      index: parsed.index,
+      autoZoom: parsed['auto-zoom'],
+      encoder: parsed.encoder,
+      format: parsed.format,
+      fps: parsed.fps,
+      frameFormat,
+      concurrency: parsed.concurrency,
+      scale: parsed.scale,
+    },
+  };
+}

--- a/packages/cli/src/report-video-dump.ts
+++ b/packages/cli/src/report-video-dump.ts
@@ -1,0 +1,31 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function containsFileStoredScreenshotRef(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(containsFileStoredScreenshotRef);
+  }
+
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.storage === 'file' && typeof value.id === 'string') {
+    return true;
+  }
+
+  return Object.values(value).some(containsFileStoredScreenshotRef);
+}
+
+export function dumpJsonReferencesFileStoredScreenshots(
+  dumpString: string,
+): boolean {
+  try {
+    return containsFileStoredScreenshotRef(JSON.parse(dumpString));
+  } catch {
+    // Keep the warning best-effort. The actual JSON/template error is reported
+    // by the normal report generation path below.
+    return /"storage"\s*:\s*"file"/.test(dumpString);
+  }
+}

--- a/packages/cli/src/report-video-ffmpeg.ts
+++ b/packages/cli/src/report-video-ffmpeg.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+
+export const DEFAULT_JPEG_FRAME_QUALITY = 0.95;
+const DEFAULT_WEBM_VIDEO_BITRATE_MBPS = 2;
+const DEFAULT_MP4_CRF = '18';
+
+export function resolveVideoOutputPath(
+  outputDir: string,
+  name: string | undefined,
+  format: 'webm' | 'mp4',
+): string {
+  const basename = name ?? 'midscene_replay';
+  const ext = path.extname(basename).toLowerCase();
+  if (ext === '.webm' || ext === '.mp4') {
+    return path.join(outputDir, basename);
+  }
+  return path.join(outputDir, `${basename}.${format}`);
+}
+
+export function resolveVideoFormat(
+  name: string | undefined,
+  format: 'webm' | 'mp4' | undefined,
+): 'webm' | 'mp4' {
+  const ext = path.extname(name ?? '').toLowerCase();
+  if (ext === '.mp4') return 'mp4';
+  if (ext === '.webm') return 'webm';
+  return format ?? 'webm';
+}
+
+export function ffmpegArgs(
+  fps: number,
+  format: 'webm' | 'mp4',
+  framePattern: string,
+  outputPath: string,
+  scale: number,
+): string[] {
+  const common = [
+    '-y',
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-framerate',
+    String(fps),
+    '-start_number',
+    '0',
+    '-i',
+    framePattern,
+    '-an',
+  ];
+
+  if (format === 'mp4') {
+    return [
+      ...common,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-crf',
+      DEFAULT_MP4_CRF,
+      '-pix_fmt',
+      'yuv420p',
+      '-movflags',
+      '+faststart',
+      outputPath,
+    ];
+  }
+
+  return [
+    ...common,
+    '-c:v',
+    'libvpx',
+    '-b:v',
+    `${DEFAULT_WEBM_VIDEO_BITRATE_MBPS * scale * scale}M`,
+    '-pix_fmt',
+    'yuv420p',
+    outputPath,
+  ];
+}
+
+export function resolveFrameExtension(frameFormat: 'jpeg' | 'png'): string {
+  return frameFormat === 'jpeg' ? 'jpg' : 'png';
+}
+
+export function resolveFrameMimeType(
+  frameFormat: 'jpeg' | 'png',
+): 'image/jpeg' | 'image/png' {
+  return frameFormat === 'jpeg' ? 'image/jpeg' : 'image/png';
+}

--- a/packages/cli/src/report-video.ts
+++ b/packages/cli/src/report-video.ts
@@ -1,0 +1,751 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { reportHTMLContent } from '@midscene/core';
+import { getMidsceneRunSubDir } from '@midscene/shared/common';
+import { getDebug } from '@midscene/shared/logger';
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import {
+  DEFAULT_FFMPEG_CONCURRENCY,
+  DEFAULT_FFMPEG_FPS,
+  DEFAULT_FFMPEG_FRAME_FORMAT,
+  type ReportVideoOptions,
+  parseReportVideoArgResult,
+  printReportVideoHelp,
+} from './report-video-args';
+import { dumpJsonReferencesFileStoredScreenshots } from './report-video-dump';
+import {
+  DEFAULT_JPEG_FRAME_QUALITY,
+  ffmpegArgs,
+  resolveFrameExtension,
+  resolveFrameMimeType,
+  resolveVideoFormat,
+  resolveVideoOutputPath,
+} from './report-video-ffmpeg';
+
+const debug = getDebug('cli:report-video');
+// Warnings should also reach the console so users notice them.
+const warn = getDebug('cli:report-video', { console: true });
+
+// Upper bound for the legacy MediaRecorder path. The ffmpeg path renders one
+// frame per protocol call and is not subject to this total-video timeout.
+const MEDIA_RECORDER_TIMEOUT_MS = 8 * 60 * 1000;
+const FRAME_RENDER_TIMEOUT_MS = 30 * 1000;
+const FRAME_PREPARE_TIMEOUT_MS = 60 * 1000;
+// Keep one prepared report page alive for many frames. Preparing a page reloads
+// the full report and image cache, which dominates long-report export time.
+// If a page does become unhealthy, the per-frame retry path still restarts the
+// browser and resumes from the failed frame.
+const FFMPEG_FRAME_BATCH_SIZE = 500;
+const FFMPEG_FRAME_MAX_RETRIES = 3;
+const FRAME_DISPOSE_TIMEOUT_MS = 2 * 1000;
+const BROWSER_CLOSE_TIMEOUT_MS = 5 * 1000;
+const BATCH_PAGE_NAVIGATION_TIMEOUT_MS = 120 * 1000;
+
+interface ReportVideoTarget {
+  htmlPath: string;
+  url: string;
+  close: () => Promise<void>;
+}
+
+// Software-rendering flags so canvas.captureStream + MediaRecorder work in a
+// headless, GPU-less environment (e.g. CI). Without a timeslice on start()
+// headless Chromium also emits no data — that is handled in recordBrandedVideo.
+//
+// The disable-*-throttling/backgrounding flags are essential: a headless page
+// reports visibilityState='hidden', which pauses requestAnimationFrame. The
+// export render loop is driven by rAF, so without these the render stalls
+// indefinitely (CPU drops to ~0). These keep timers and rAF running full speed.
+const HEADLESS_VIDEO_ARGS = [
+  '--autoplay-policy=no-user-gesture-required',
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+  '--disable-background-timer-throttling',
+  '--disable-backgrounding-occluded-windows',
+  '--disable-renderer-backgrounding',
+  '--disable-features=CalculateNativeWinOcclusion',
+];
+
+function launchReportVideoBrowser(protocolTimeout?: number): Promise<Browser> {
+  return puppeteer.launch({
+    headless: true,
+    args: HEADLESS_VIDEO_ARGS,
+    protocolTimeout,
+  });
+}
+
+async function closeReportVideoBrowser(browser: Browser): Promise<void> {
+  const browserProcess = browser.process();
+  await Promise.race([
+    browser.close().catch(() => {}),
+    new Promise((resolve) => setTimeout(resolve, BROWSER_CLOSE_TIMEOUT_MS)),
+  ]);
+  browserProcess?.kill('SIGKILL');
+}
+
+function isDirectoryModeReportHtml(reportFilePath: string): boolean {
+  return (
+    path.basename(reportFilePath) === 'index.html' &&
+    existsSync(path.join(path.dirname(reportFilePath), 'screenshots'))
+  );
+}
+
+function contentTypeForFile(filePath: string): string {
+  switch (path.extname(filePath).toLowerCase()) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.wasm':
+      return 'application/wasm';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function createStaticReportServer(rootDir: string): Promise<{
+  origin: string;
+  close: () => Promise<void>;
+}> {
+  const root = path.resolve(rootDir);
+  const server = createServer((req, res) => {
+    try {
+      const reqUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const relativePath =
+        decodeURIComponent(reqUrl.pathname).replace(/^\/+/, '') || 'index.html';
+      const filePath = path.resolve(root, relativePath);
+      if (filePath !== root && !filePath.startsWith(`${root}${path.sep}`)) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
+      if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+      res.writeHead(200, {
+        'content-type': contentTypeForFile(filePath),
+        'cache-control': 'no-store',
+      });
+      createReadStream(filePath).pipe(res);
+    } catch (error) {
+      res.writeHead(500);
+      res.end(error instanceof Error ? error.message : 'Internal server error');
+    }
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('report-video: failed to start local report server');
+  }
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+interface VideoFrameSessionInfo {
+  totalFrames: number;
+  fps: number;
+  width: number;
+  height: number;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+// Resolve the input into a report HTML file.
+//
+// - dump JSON: wrapped straight into the current template.
+// - report HTML / directory: used as-is. Old report templates are intentionally
+//   not supported; regenerate the report so it includes the video export hooks.
+function resolveReportHtmlFile(input: string): string {
+  const resolved = path.resolve(input);
+  if (!existsSync(resolved)) {
+    throw new Error(`report-video: input does not exist: ${input}`);
+  }
+
+  if (input.toLowerCase().endsWith('.json')) {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'midscene-report-video-'));
+    const dumpString = readFileSync(resolved, 'utf-8');
+    // A dump JSON only carries the screenshots it embeds inline; screenshots
+    // stored as separate files (split reports) cannot be resolved here and
+    // would render blank. Surface that so it is not a silent surprise.
+    if (dumpJsonReferencesFileStoredScreenshots(dumpString)) {
+      warn(
+        'dump JSON references file-stored screenshots that will render blank; pass the report HTML instead to keep screenshots',
+      );
+    }
+    const html = reportHTMLContent(dumpString);
+    if (!html) {
+      throw new Error(
+        'report-video: failed to build report HTML from dump (report template missing)',
+      );
+    }
+    const htmlPath = path.join(tmpDir, 'report.html');
+    writeFileSync(htmlPath, html);
+    debug('built temp report html from dump json at %s', htmlPath);
+    return htmlPath;
+  }
+
+  // HTML file or directory-mode report
+  const sourceHtml =
+    !input.toLowerCase().endsWith('.html') && statSync(resolved).isDirectory()
+      ? path.join(resolved, 'index.html')
+      : resolved;
+  if (!existsSync(sourceHtml)) {
+    throw new Error(`report-video: cannot find report HTML at ${sourceHtml}`);
+  }
+
+  debug('using report html directly at %s', sourceHtml);
+  return sourceHtml;
+}
+
+async function prepareReportVideoTarget(
+  htmlPath: string,
+): Promise<ReportVideoTarget> {
+  if (!isDirectoryModeReportHtml(htmlPath)) {
+    return {
+      htmlPath,
+      url: pathToFileURL(htmlPath).href,
+      close: async () => {},
+    };
+  }
+
+  const rootDir = path.dirname(htmlPath);
+  const server = await createStaticReportServer(rootDir);
+  return {
+    htmlPath,
+    url: `${server.origin}/index.html`,
+    close: server.close,
+  };
+}
+
+async function resolveFfmpegPath(): Promise<string> {
+  try {
+    const mod = await import('@ffmpeg-installer/ffmpeg');
+    const ffmpegPackage = (mod.default ?? mod) as { path?: string };
+    if (!ffmpegPackage.path) {
+      throw new Error('ffmpeg installer did not expose a binary path');
+    }
+    return ffmpegPackage.path;
+  } catch (error) {
+    throw new Error(
+      `report-video: failed to load @ffmpeg-installer/ffmpeg. Reinstall @midscene/cli dependencies.${error instanceof Error ? `\n${error.message}` : ''}`,
+    );
+  }
+}
+
+function resolveTargetFps(
+  requestedFps: number | undefined,
+  sourceFps: number,
+): number {
+  const targetFps = requestedFps ?? Math.min(DEFAULT_FFMPEG_FPS, sourceFps);
+  if (targetFps > sourceFps) {
+    throw new Error(
+      `report-video: --fps (${targetFps}) cannot exceed the report source fps (${sourceFps})`,
+    );
+  }
+  return targetFps;
+}
+
+function sampledFrameCount(
+  session: VideoFrameSessionInfo,
+  targetFps: number,
+): number {
+  return Math.max(
+    1,
+    Math.ceil((session.totalFrames / session.fps) * targetFps),
+  );
+}
+
+function sourceFrameIndexForOutputFrame(
+  outputFrameIndex: number,
+  session: VideoFrameSessionInfo,
+  targetFps: number,
+): number {
+  return Math.min(
+    session.totalFrames - 1,
+    Math.floor((outputFrameIndex * session.fps) / targetFps),
+  );
+}
+
+async function waitForReportVideoHooks(
+  page: Page,
+  encoder: 'ffmpeg' | 'media-recorder',
+): Promise<void> {
+  const hookExpression =
+    encoder === 'ffmpeg'
+      ? 'typeof window.__midscene_prepareVideoFrames === "function" && typeof window.__midscene_renderVideoFrameToBase64 === "function"'
+      : 'typeof window.__midscene_exportVideoToBase64 === "function"';
+
+  try {
+    await page.waitForFunction(hookExpression, {
+      timeout: encoder === 'ffmpeg' ? BATCH_PAGE_NAVIGATION_TIMEOUT_MS : 30_000,
+    });
+  } catch {
+    throw new Error(
+      'report-video: the report did not expose the video export hook. ' +
+        'Rebuild @midscene/report so the current template is used.',
+    );
+  }
+}
+
+async function renderWithMediaRecorder(
+  page: Page,
+  opts: ReportVideoOptions,
+): Promise<Buffer> {
+  try {
+    const base64 = (await page.evaluate(
+      (o) =>
+        (
+          window as unknown as {
+            __midscene_exportVideoToBase64: (arg: unknown) => Promise<string>;
+          }
+        ).__midscene_exportVideoToBase64(o),
+      { index: opts.index, autoZoom: opts.autoZoom },
+    )) as string;
+
+    if (!base64) {
+      throw new Error('report-video: exporter returned no video data');
+    }
+    return Buffer.from(base64, 'base64');
+  } catch (e) {
+    if (e instanceof Error && /timed out/i.test(e.message)) {
+      throw new Error(
+        `report-video: MediaRecorder rendering did not finish within ${MEDIA_RECORDER_TIMEOUT_MS / 1000}s. Use the default ffmpeg encoder for long reports.`,
+      );
+    }
+    throw e;
+  }
+}
+
+async function renderWithFfmpeg(
+  target: ReportVideoTarget,
+  opts: ReportVideoOptions,
+  outputPath: string,
+  format: 'webm' | 'mp4',
+): Promise<void> {
+  const openPreparedPage = async (
+    browser: Browser,
+  ): Promise<{
+    page: Page;
+    session: VideoFrameSessionInfo;
+  }> => {
+    const page = await browser.newPage();
+    page.setDefaultNavigationTimeout(BATCH_PAGE_NAVIGATION_TIMEOUT_MS);
+    page.on('console', (msg) => debug('[page] %s', msg.text()));
+    page.on('pageerror', (err) => debug('[pageerror] %s', err.message));
+    await page.goto(target.url, {
+      waitUntil: 'domcontentloaded',
+    });
+    await waitForReportVideoHooks(page, 'ffmpeg');
+    const session = (await withTimeout(
+      page.evaluate(
+        (o) =>
+          (
+            window as unknown as {
+              __midscene_prepareVideoFrames: (
+                arg: unknown,
+              ) => Promise<VideoFrameSessionInfo>;
+            }
+          ).__midscene_prepareVideoFrames(o),
+        { index: opts.index, autoZoom: opts.autoZoom, scale: opts.scale },
+      ),
+      FRAME_PREPARE_TIMEOUT_MS,
+      `report-video: preparing video frames timed out after ${FRAME_PREPARE_TIMEOUT_MS / 1000}s`,
+    )) as VideoFrameSessionInfo;
+    await page.setViewport({
+      width: session.width,
+      height: session.height,
+      deviceScaleFactor: 1,
+    });
+    return { page, session };
+  };
+
+  const closeBatchPage = async (page: Page): Promise<void> => {
+    await withTimeout(
+      page
+        .evaluate(() =>
+          (
+            window as unknown as {
+              __midscene_disposeVideoFrames?: () => void;
+            }
+          ).__midscene_disposeVideoFrames?.(),
+        )
+        .catch(() => {}),
+      FRAME_DISPOSE_TIMEOUT_MS,
+      'report-video: disposing frame renderer timed out',
+    ).catch(() => {});
+    await Promise.race([
+      page.close().catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, BROWSER_CLOSE_TIMEOUT_MS)),
+    ]);
+  };
+
+  const ffmpegPath = await resolveFfmpegPath();
+  let firstBrowser: Browser | null = null;
+  let firstBatch: { page: Page; session: VideoFrameSessionInfo } | null = null;
+  let firstBrowserAssignedToWorker = false;
+  let frameDir: string | null = null;
+
+  try {
+    firstBrowser = await launchReportVideoBrowser();
+    firstBatch = await openPreparedPage(firstBrowser);
+    const { session } = firstBatch;
+    const targetFps = resolveTargetFps(opts.fps, session.fps);
+    const outputFrameCount = sampledFrameCount(session, targetFps);
+    const concurrency = Math.max(
+      1,
+      Math.min(
+        opts.concurrency ?? DEFAULT_FFMPEG_CONCURRENCY,
+        outputFrameCount,
+      ),
+    );
+    const frameFormat = opts.frameFormat ?? DEFAULT_FFMPEG_FRAME_FORMAT;
+    const frameMimeType = resolveFrameMimeType(frameFormat);
+    const frameQuality =
+      frameFormat === 'jpeg' ? DEFAULT_JPEG_FRAME_QUALITY : undefined;
+    frameDir = mkdtempSync(
+      path.join(tmpdir(), 'midscene-report-video-frames-'),
+    );
+    const frameDirPath = frameDir;
+    const frameExtension = resolveFrameExtension(frameFormat);
+    const framePattern = path.join(
+      frameDirPath,
+      `frame-%06d.${frameExtension}`,
+    );
+    const progressStep = Math.max(1, Math.floor(outputFrameCount / 10));
+    let nextOutputFrameIndex = 0;
+    let completedFrames = 0;
+    let nextProgressFrame = progressStep;
+    let aborted = false;
+
+    if (targetFps !== session.fps) {
+      console.log(
+        `   Sampling frames at ${targetFps}fps (source ${session.fps}fps)`,
+      );
+    }
+    if (opts.scale && opts.scale > 1) {
+      console.log(
+        `   Rendering at ${session.width}×${session.height} (scale ${opts.scale})`,
+      );
+    }
+    if (concurrency > 1) {
+      console.log(`   Rendering with ${concurrency} parallel workers`);
+    }
+
+    const assertStableSession = (
+      nextSession: VideoFrameSessionInfo,
+      context: string,
+    ) => {
+      if (
+        nextSession.totalFrames !== session.totalFrames ||
+        nextSession.fps !== session.fps
+      ) {
+        throw new Error(
+          `report-video: frame session changed between ${context}`,
+        );
+      }
+    };
+
+    const takeNextFrame = (): number | null => {
+      if (aborted || nextOutputFrameIndex >= outputFrameCount) return null;
+      const frameIndex = nextOutputFrameIndex;
+      nextOutputFrameIndex += 1;
+      return frameIndex;
+    };
+
+    const reportFrameRendered = () => {
+      completedFrames += 1;
+      if (
+        completedFrames === 1 ||
+        completedFrames === outputFrameCount ||
+        completedFrames >= nextProgressFrame
+      ) {
+        console.log(
+          `   Rendered frames: ${completedFrames}/${outputFrameCount}`,
+        );
+        debug('ffmpeg frame progress %d/%d', completedFrames, outputFrameCount);
+        while (nextProgressFrame <= completedFrames) {
+          nextProgressFrame += progressStep;
+        }
+      }
+    };
+
+    const renderFrameToFile = async (page: Page, outputFrameIndex: number) => {
+      const sourceFrameIndex = sourceFrameIndexForOutputFrame(
+        outputFrameIndex,
+        session,
+        targetFps,
+      );
+      const frameBase64 = await withTimeout(
+        page.evaluate(
+          (index, renderOptions) =>
+            (
+              window as unknown as {
+                __midscene_renderVideoFrameToBase64: (
+                  frameIndex: number,
+                  options?: {
+                    type?: 'image/jpeg' | 'image/png';
+                    quality?: number;
+                  },
+                ) => Promise<string>;
+              }
+            ).__midscene_renderVideoFrameToBase64(index, renderOptions),
+          sourceFrameIndex,
+          {
+            type: frameMimeType,
+            quality: frameQuality,
+          },
+        ),
+        FRAME_RENDER_TIMEOUT_MS,
+        `report-video: rendering frame ${outputFrameIndex + 1}/${outputFrameCount} timed out after ${FRAME_RENDER_TIMEOUT_MS / 1000}s`,
+      );
+
+      writeFileSync(
+        path.join(
+          frameDirPath,
+          `frame-${String(outputFrameIndex).padStart(6, '0')}.${frameExtension}`,
+        ),
+        Buffer.from(frameBase64, 'base64'),
+      );
+    };
+
+    const runWorker = async (
+      workerIndex: number,
+      initial?: {
+        browser: Browser;
+        page: Page;
+      },
+    ) => {
+      let browser = initial?.browser ?? (await launchReportVideoBrowser());
+      let page: Page | null = initial?.page ?? null;
+      let framesOnCurrentPage = page ? 0 : FFMPEG_FRAME_BATCH_SIZE;
+
+      const resetWorkerBrowser = async () => {
+        if (page) {
+          await closeBatchPage(page).catch(() => {});
+          page = null;
+        }
+        await closeReportVideoBrowser(browser).catch(() => {});
+        browser = await launchReportVideoBrowser();
+        framesOnCurrentPage = FFMPEG_FRAME_BATCH_SIZE;
+      };
+
+      const ensurePage = async () => {
+        if (page && framesOnCurrentPage < FFMPEG_FRAME_BATCH_SIZE) return;
+        if (page) {
+          await closeBatchPage(page);
+          page = null;
+        }
+        const nextBatch = await openPreparedPage(browser);
+        assertStableSession(nextBatch.session, 'batches');
+        page = nextBatch.page;
+        framesOnCurrentPage = 0;
+      };
+
+      try {
+        while (!aborted) {
+          const outputFrameIndex = takeNextFrame();
+          if (outputFrameIndex === null) break;
+
+          let retries = 0;
+          while (true) {
+            try {
+              await ensurePage();
+              await renderFrameToFile(page!, outputFrameIndex);
+              framesOnCurrentPage += 1;
+              reportFrameRendered();
+              break;
+            } catch (error) {
+              retries += 1;
+              if (retries > FFMPEG_FRAME_MAX_RETRIES) {
+                throw error;
+              }
+              console.log(
+                `   Retrying frame ${outputFrameIndex + 1}/${outputFrameCount} (${retries}/${FFMPEG_FRAME_MAX_RETRIES}, worker ${workerIndex + 1})`,
+              );
+              await resetWorkerBrowser();
+            }
+          }
+        }
+      } catch (error) {
+        aborted = true;
+        throw error;
+      } finally {
+        if (page) {
+          await closeBatchPage(page).catch(() => {});
+        }
+        await closeReportVideoBrowser(browser).catch(() => {});
+      }
+    };
+
+    const initialBrowser = firstBrowser;
+    const initialPage = firstBatch.page;
+    firstBrowserAssignedToWorker = true;
+    const workerResults = await Promise.allSettled(
+      Array.from({ length: concurrency }, (_, workerIndex) =>
+        runWorker(
+          workerIndex,
+          workerIndex === 0
+            ? { browser: initialBrowser, page: initialPage }
+            : undefined,
+        ),
+      ),
+    );
+    const failedWorker = workerResults.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failedWorker) {
+      throw failedWorker.reason;
+    }
+
+    console.log(`   Encoding ${format.toUpperCase()} with ffmpeg…`);
+    const ffmpegProcess = spawn(
+      ffmpegPath,
+      ffmpegArgs(targetFps, format, framePattern, outputPath, opts.scale ?? 1),
+      {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      },
+    );
+    let stderr = '';
+    ffmpegProcess.stderr.setEncoding('utf8');
+    ffmpegProcess.stderr.on('data', (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-4000);
+    });
+
+    const [code, signal] = (await once(ffmpegProcess, 'close')) as [
+      number | null,
+      NodeJS.Signals | null,
+    ];
+    if (code !== 0) {
+      throw new Error(
+        `report-video: ffmpeg exited with ${code ?? signal ?? 'unknown status'}${stderr ? `\n${stderr}` : ''}`,
+      );
+    }
+  } finally {
+    if (!firstBrowserAssignedToWorker) {
+      if (firstBatch) {
+        await closeBatchPage(firstBatch.page).catch(() => {});
+      }
+      if (firstBrowser) {
+        await closeReportVideoBrowser(firstBrowser).catch(() => {});
+      }
+    }
+    if (frameDir) {
+      rmSync(frameDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function runReportVideo(
+  opts: ReportVideoOptions,
+): Promise<string> {
+  const htmlPath = resolveReportHtmlFile(opts.input);
+  const encoder = opts.encoder ?? 'ffmpeg';
+  const format = resolveVideoFormat(opts.name, opts.format);
+  if (encoder === 'media-recorder' && format !== 'webm') {
+    throw new Error(
+      'report-video: --encoder media-recorder only supports webm',
+    );
+  }
+  const outputDir = opts.output
+    ? path.resolve(opts.output)
+    : getMidsceneRunSubDir('report');
+  mkdirSync(outputDir, { recursive: true });
+  const outputPath = resolveVideoOutputPath(outputDir, opts.name, format);
+  const target = await prepareReportVideoTarget(htmlPath);
+
+  console.log(`   Report: ${htmlPath}`);
+
+  try {
+    console.log(`   Rendering video with ${encoder}…`);
+    if (encoder === 'ffmpeg') {
+      await renderWithFfmpeg(target, opts, outputPath, format);
+      const bytes = statSync(outputPath).size;
+      console.log(
+        `   ✅ Video saved: ${outputPath} (${(bytes / 1024).toFixed(1)} KB)`,
+      );
+      return outputPath;
+    }
+
+    console.log('   Launching headless browser…');
+    const browser = await launchReportVideoBrowser(MEDIA_RECORDER_TIMEOUT_MS);
+    const page = await browser.newPage();
+    try {
+      page.on('console', (msg) => debug('[page] %s', msg.text()));
+      page.on('pageerror', (err) => debug('[pageerror] %s', err.message));
+
+      await page.goto(target.url, {
+        waitUntil: isDirectoryModeReportHtml(htmlPath)
+          ? 'domcontentloaded'
+          : 'networkidle0',
+      });
+      await waitForReportVideoHooks(page, encoder);
+
+      const buffer = await renderWithMediaRecorder(page, opts);
+      writeFileSync(outputPath, buffer);
+      console.log(
+        `   ✅ Video saved: ${outputPath} (${(buffer.length / 1024).toFixed(1)} KB)`,
+      );
+      return outputPath;
+    } finally {
+      await closeReportVideoBrowser(browser);
+    }
+  } finally {
+    await target.close();
+  }
+}
+
+export async function reportVideoCommand(argv: string[]): Promise<number> {
+  const result = parseReportVideoArgResult(argv);
+  if (result.type !== 'ok') {
+    printReportVideoHelp();
+    return result.exitCode;
+  }
+  await runReportVideo(result.options);
+  return 0;
+}

--- a/packages/cli/tests/unit-test/report-video.test.ts
+++ b/packages/cli/tests/unit-test/report-video.test.ts
@@ -1,0 +1,255 @@
+import {
+  parseReportVideoArgResult,
+  parseReportVideoArgs,
+} from '@/report-video-args';
+import { dumpJsonReferencesFileStoredScreenshots } from '@/report-video-dump';
+import { ffmpegArgs } from '@/report-video-ffmpeg';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('report-video arg parsing', () => {
+  test('parses required input and defaults', () => {
+    const opts = parseReportVideoArgs(['--input', 'report.html']);
+    expect(opts).toEqual({
+      input: 'report.html',
+      autoZoom: true,
+      encoder: 'ffmpeg',
+      format: 'webm',
+      frameFormat: 'jpeg',
+      concurrency: 4,
+      scale: 1,
+    });
+  });
+
+  test('parses short flags and output/name/index', () => {
+    const opts = parseReportVideoArgs([
+      '-i',
+      './r/index.html',
+      '-o',
+      './out',
+      '--name',
+      'clip',
+      '--index',
+      '2',
+    ]);
+    expect(opts).toMatchObject({
+      input: './r/index.html',
+      output: './out',
+      name: 'clip',
+      index: 2,
+      autoZoom: true,
+      encoder: 'ffmpeg',
+      format: 'webm',
+      frameFormat: 'jpeg',
+      concurrency: 4,
+      scale: 1,
+    });
+  });
+
+  test('supports --key=value style', () => {
+    const opts = parseReportVideoArgs([
+      '--input=dump.json',
+      '--output=/tmp/v',
+      '--name=foo',
+    ]);
+    expect(opts).toMatchObject({
+      input: 'dump.json',
+      output: '/tmp/v',
+      name: 'foo',
+    });
+  });
+
+  test('--no-auto-zoom disables auto zoom', () => {
+    const opts = parseReportVideoArgs(['-i', 'r.html', '--no-auto-zoom']);
+    expect(opts?.autoZoom).toBe(false);
+  });
+
+  test('returns null for --help', () => {
+    expect(parseReportVideoArgs(['--help'])).toBeNull();
+  });
+
+  test('distinguishes help from argument errors', () => {
+    expect(parseReportVideoArgResult(['--help'])).toEqual({
+      type: 'help',
+      exitCode: 0,
+    });
+    expect(parseReportVideoArgResult(['--name', 'x'])).toEqual({
+      type: 'error',
+      exitCode: 1,
+    });
+  });
+
+  test('returns null when input is missing', () => {
+    expect(parseReportVideoArgs(['--name', 'x'])).toBeNull();
+  });
+
+  test('returns null for a non-integer --index', () => {
+    expect(parseReportVideoArgs(['-i', 'r.html', '--index', 'abc'])).toBeNull();
+  });
+
+  test('returns null for a negative --index', () => {
+    expect(parseReportVideoArgs(['-i', 'r.html', '--index=-1'])).toBeNull();
+  });
+
+  test('parses ffmpeg mp4 output', () => {
+    const opts = parseReportVideoArgs([
+      '-i',
+      'r.html',
+      '--format',
+      'mp4',
+      '--encoder',
+      'ffmpeg',
+      '--fps',
+      '15',
+      '--frame-format',
+      'png',
+      '--concurrency',
+      '2',
+      '--scale',
+      '2',
+    ]);
+    expect(opts).toMatchObject({
+      encoder: 'ffmpeg',
+      format: 'mp4',
+      fps: 15,
+      frameFormat: 'png',
+      concurrency: 2,
+      scale: 2,
+    });
+  });
+
+  test('rejects mp4 with media-recorder', () => {
+    expect(
+      parseReportVideoArgs([
+        '-i',
+        'r.html',
+        '--encoder',
+        'media-recorder',
+        '--format',
+        'mp4',
+      ]),
+    ).toBeNull();
+  });
+
+  test('returns an error result for invalid choice values', () => {
+    expect(
+      parseReportVideoArgResult(['-i', 'r.html', '--encoder', 'bad']),
+    ).toEqual({
+      type: 'error',
+      exitCode: 1,
+    });
+  });
+
+  test('rejects invalid fps', () => {
+    expect(parseReportVideoArgs(['-i', 'r.html', '--fps', '0'])).toBeNull();
+    expect(parseReportVideoArgs(['-i', 'r.html', '--fps', '10.5'])).toBeNull();
+    expect(parseReportVideoArgs(['-i', 'r.html', '--fps', '61'])).toBeNull();
+  });
+
+  test('rejects fps with media-recorder', () => {
+    expect(
+      parseReportVideoArgs([
+        '-i',
+        'r.html',
+        '--encoder',
+        'media-recorder',
+        '--fps',
+        '15',
+      ]),
+    ).toBeNull();
+  });
+
+  test('rejects frame format with media-recorder', () => {
+    expect(
+      parseReportVideoArgs([
+        '-i',
+        'r.html',
+        '--encoder',
+        'media-recorder',
+        '--frame-format',
+        'png',
+      ]),
+    ).toBeNull();
+  });
+
+  test('rejects invalid concurrency', () => {
+    expect(
+      parseReportVideoArgs(['-i', 'r.html', '--concurrency', '0']),
+    ).toBeNull();
+    expect(
+      parseReportVideoArgs(['-i', 'r.html', '--concurrency', '1.5']),
+    ).toBeNull();
+    expect(
+      parseReportVideoArgs(['-i', 'r.html', '--concurrency', '9']),
+    ).toBeNull();
+  });
+
+  test('rejects invalid scale', () => {
+    expect(parseReportVideoArgs(['-i', 'r.html', '--scale', '0'])).toBeNull();
+    expect(parseReportVideoArgs(['-i', 'r.html', '--scale', '1.5'])).toBeNull();
+    expect(parseReportVideoArgs(['-i', 'r.html', '--scale', '5'])).toBeNull();
+  });
+
+  test('rejects scale with media-recorder', () => {
+    expect(
+      parseReportVideoArgs([
+        '-i',
+        'r.html',
+        '--encoder',
+        'media-recorder',
+        '--scale',
+        '2',
+      ]),
+    ).toBeNull();
+  });
+
+  test('detects file-stored screenshots in pretty dump json', () => {
+    expect(
+      dumpJsonReferencesFileStoredScreenshots(
+        JSON.stringify(
+          {
+            executions: [
+              {
+                tasks: [
+                  {
+                    screenshot: {
+                      id: 'screen-1',
+                      storage: 'file',
+                      path: './screenshots/screen-1.jpeg',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      dumpJsonReferencesFileStoredScreenshots(
+        JSON.stringify({ executions: [{ tasks: [{ screenshot: 'inline' }] }] }),
+      ),
+    ).toBe(false);
+  });
+
+  test('scales webm bitrate with output pixel area', () => {
+    const args = ffmpegArgs(
+      15,
+      'webm',
+      '/tmp/frame-%06d.jpg',
+      '/tmp/out.webm',
+      2,
+    );
+    expect(args).toContain('-b:v');
+    expect(args[args.indexOf('-b:v') + 1]).toBe('8M');
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/es/device/index.mjs",
       "require": "./dist/lib/device/index.js"
     },
+    "./dump": {
+      "types": "./dist/types/dump/index.d.ts",
+      "import": "./dist/es/dump/index.mjs",
+      "require": "./dist/lib/dump/index.js"
+    },
     "./agent": {
       "types": "./dist/types/agent/index.d.ts",
       "import": "./dist/es/agent/index.mjs",
@@ -49,6 +54,11 @@
       "import": "./dist/es/report.mjs",
       "require": "./dist/lib/report.js"
     },
+    "./report-markdown": {
+      "types": "./dist/types/report-markdown.d.ts",
+      "import": "./dist/es/report-markdown.mjs",
+      "require": "./dist/lib/report-markdown.js"
+    },
     "./skill": {
       "types": "./dist/types/skill/index.d.ts",
       "import": "./dist/es/skill/index.mjs",
@@ -62,8 +72,10 @@
       "ai-model": ["./dist/types/ai-model.d.ts"],
       "tree": ["./dist/types/tree.d.ts"],
       "device": ["./dist/types/device.d.ts"],
+      "dump": ["./dist/types/dump/index.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
+      "report-markdown": ["./dist/types/report-markdown.d.ts"],
       "mcp": ["./dist/types/skill/index.d.ts"]
     }
   },

--- a/packages/core/src/dump/index.ts
+++ b/packages/core/src/dump/index.ts
@@ -3,6 +3,8 @@
  */
 
 // Utilities
+export { GroupedActionDump } from './report-action-dump';
+export type { IExecutionDump, IReportActionDump } from '../types';
 export { restoreImageReferences } from './screenshot-restoration';
 export {
   escapeContent,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,7 @@ export {
 // Report generator
 export type { IReportGenerator } from './report-generator';
 export { ReportGenerator, nullReportGenerator } from './report-generator';
+export { reportHTMLContent } from './utils';
 export {
   collectDedupedExecutions,
   ReportMergingTool,

--- a/packages/visualizer/src/component/player/scenes/export-branded-video.ts
+++ b/packages/visualizer/src/component/player/scenes/export-branded-video.ts
@@ -369,35 +369,72 @@ function drawSteps(
 
 // ── main export function ──
 
-export async function exportBrandedVideo(
-  frameMap: FrameMap,
-  options?: {
-    autoZoom?: boolean;
-  },
-  onProgress?: (pct: number) => void,
-): Promise<void> {
-  if (activeExport) {
-    throw new Error('Video export is already in progress');
-  }
-  activeExport = true;
-  try {
-    await runExportBrandedVideo(frameMap, options, onProgress);
-  } finally {
-    activeExport = false;
-  }
+export interface RecordBrandedVideoOptions {
+  autoZoom?: boolean;
+  scale?: number;
+  // Render for a headless page (the Midscene CLI exporter) instead of an
+  // interactive tab. Disables the "tab hidden" and "render stalled" interruption
+  // guards: a headless page reports no visibility changes, and software
+  // rendering is legitimately slow, so neither signal indicates a real problem.
+  headless?: boolean;
 }
 
-async function runExportBrandedVideo(
-  frameMap: FrameMap,
-  options?: {
-    autoZoom?: boolean;
-  },
-  onProgress?: (pct: number) => void,
-): Promise<void> {
-  const { totalDurationInFrames: total, fps } = frameMap;
-  const autoZoom = options?.autoZoom ?? true;
+export interface BrandedFrameRendererOptions {
+  autoZoom?: boolean;
+  scale?: number;
+}
 
-  // 1. pre-load all images
+export interface BrandedFrameRenderer {
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+  fps: number;
+  totalFrames: number;
+  renderFrame: (frameIndex: number) => void;
+  renderFrameToBlob: (
+    frameIndex: number,
+    type?: string,
+    quality?: number,
+  ) => Promise<Blob>;
+  renderFrameToDataURL: (
+    frameIndex: number,
+    type?: string,
+    quality?: number,
+  ) => string;
+  dispose: () => void;
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type = 'image/png',
+  quality?: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('failed to encode canvas frame'));
+          return;
+        }
+        resolve(blob);
+      },
+      type,
+      quality,
+    );
+  });
+}
+
+export async function createBrandedFrameRenderer(
+  frameMap: FrameMap,
+  options?: BrandedFrameRendererOptions,
+): Promise<BrandedFrameRenderer> {
+  const { totalDurationInFrames: totalFrames, fps } = frameMap;
+  const autoZoom = options?.autoZoom ?? true;
+  const scale = options?.scale ?? 1;
+  if (!Number.isFinite(scale) || scale <= 0) {
+    throw new Error('video frame scale must be a positive number');
+  }
+
   const imgSrcs = new Set<string>();
   for (const sf of frameMap.scriptFrames) {
     if (sf.img) imgSrcs.add(sf.img);
@@ -436,12 +473,116 @@ async function runExportBrandedVideo(
     /* optional */
   }
 
-  // 2. canvas + recorder
   const canvas = document.createElement('canvas');
-  canvas.width = W;
-  canvas.height = H;
-  const ctx = canvas.getContext('2d')!;
+  canvas.width = Math.round(W * scale);
+  canvas.height = Math.round(H * scale);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('failed to create video canvas context');
+  }
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
 
+  const renderFrame = (frameIndex: number) => {
+    if (frameIndex < 0 || frameIndex >= totalFrames) {
+      throw new Error(
+        `video frame index ${frameIndex} out of range (0-${totalFrames - 1})`,
+      );
+    }
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.restore();
+    ctx.setTransform(scale, 0, 0, scale, 0, 0);
+    drawSteps(
+      ctx,
+      frameIndex,
+      frameMap,
+      imgCache,
+      pointerCache,
+      spinnerImg,
+      autoZoom,
+    );
+  };
+
+  return {
+    canvas,
+    width: canvas.width,
+    height: canvas.height,
+    fps,
+    totalFrames,
+    renderFrame,
+    renderFrameToBlob: (frameIndex, type, quality) => {
+      renderFrame(frameIndex);
+      return canvasToBlob(canvas, type, quality);
+    },
+    renderFrameToDataURL: (frameIndex, type, quality) => {
+      renderFrame(frameIndex);
+      return canvas.toDataURL(type ?? 'image/png', quality);
+    },
+    dispose: () => {
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      imgCache.clear();
+      pointerCache.clear();
+      spinnerImg = null;
+    },
+  };
+}
+
+// MediaRecorder must be started with a timeslice, otherwise headless Chromium
+// emits no `dataavailable` events and the resulting blob is empty.
+const RECORDER_TIMESLICE_MS = 100;
+
+export async function exportBrandedVideo(
+  frameMap: FrameMap,
+  options?: RecordBrandedVideoOptions,
+  onProgress?: (pct: number) => void,
+): Promise<void> {
+  const blob = await recordBrandedVideo(frameMap, options, onProgress);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'midscene_replay.webm';
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export async function recordBrandedVideo(
+  frameMap: FrameMap,
+  options?: RecordBrandedVideoOptions,
+  onProgress?: (pct: number) => void,
+): Promise<Blob> {
+  if (activeExport) {
+    throw new Error('Video export is already in progress');
+  }
+  activeExport = true;
+  try {
+    return await runRecordBrandedVideo(frameMap, options, onProgress);
+  } finally {
+    activeExport = false;
+  }
+}
+
+async function runRecordBrandedVideo(
+  frameMap: FrameMap,
+  options?: RecordBrandedVideoOptions,
+  onProgress?: (pct: number) => void,
+): Promise<Blob> {
+  const { totalDurationInFrames: total, fps } = frameMap;
+  const autoZoom = options?.autoZoom ?? true;
+  const headless = options?.headless ?? false;
+  const renderer = await createBrandedFrameRenderer(frameMap, {
+    autoZoom,
+    scale: options?.scale,
+  });
+  const { canvas } = renderer;
+
+  // captureStream(fps) lets the browser sample frames in lockstep with the
+  // compositor; the rAF-driven loop below advances the compositor, so every
+  // drawn frame is captured (this holds in headless too — rAF keeps running).
+  // We deliberately do NOT use captureStream(0)+requestFrame: forcing every
+  // drawn frame floods the software (swiftshader) encoder, which then drops
+  // frames nondeterministically.
   const stream = canvas.captureStream(fps);
   const recorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
   const chunks: BlobPart[] = [];
@@ -450,7 +591,7 @@ async function runExportBrandedVideo(
   };
 
   // 3. render loop
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<Blob>((resolve, reject) => {
     let stoppedByError: Error | null = null;
     let settled = false;
     let nextFrame = 0;
@@ -465,6 +606,7 @@ async function runExportBrandedVideo(
       if (renderTimer) clearTimeout(renderTimer);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       stream.getTracks().forEach((track) => track.stop());
+      renderer.dispose();
     };
 
     const finishWithError = (error: Error) => {
@@ -504,19 +646,18 @@ async function runExportBrandedVideo(
         reject(new Error('No video data'));
         return;
       }
-      const blob = new Blob(chunks, { type: 'video/webm' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'midscene_replay.webm';
-      a.click();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
-      resolve();
+      resolve(new Blob(chunks, { type: 'video/webm' }));
     };
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    recorder.start();
+    if (!headless) {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+    recorder.start(RECORDER_TIMESLICE_MS);
 
+    // The loop is rAF-driven in both modes: captureStream(fps) samples frames in
+    // lockstep with the compositor, and rAF is what advances the compositor, so
+    // every drawn frame is captured. (Headless pages keep rAF running at full
+    // rate.) setTimeout only paces frames to real time between rAF ticks.
     const scheduleNextFrame = () => {
       const delay = Math.max(0, nextFrameDueAt - performance.now());
       renderTimer = setTimeout(() => {
@@ -527,6 +668,7 @@ async function runExportBrandedVideo(
     const renderFrame = (timestamp: number) => {
       if (settled || recorder.state === 'inactive') return;
       if (
+        !headless &&
         nextFrame > 0 &&
         isExportRenderStalled(timestamp - lastFrameAt, frameDuration)
       ) {
@@ -537,16 +679,7 @@ async function runExportBrandedVideo(
       }
 
       lastFrameAt = timestamp;
-      ctx.clearRect(0, 0, W, H);
-      drawSteps(
-        ctx,
-        nextFrame,
-        frameMap,
-        imgCache,
-        pointerCache,
-        spinnerImg,
-        autoZoom,
-      );
+      renderer.renderFrame(nextFrame);
       onProgress?.((nextFrame + 1) / total);
 
       nextFrame += 1;

--- a/packages/visualizer/src/index.tsx
+++ b/packages/visualizer/src/index.tsx
@@ -34,6 +34,18 @@ export { ServiceModeControl } from './component/service-mode-control';
 export { ContextPreview } from './component/context-preview';
 export { PromptInput } from './component/prompt-input';
 export { Player } from './component/player';
+export {
+  createBrandedFrameRenderer,
+  exportBrandedVideo,
+  recordBrandedVideo,
+} from './component/player/scenes/export-branded-video';
+export type {
+  BrandedFrameRenderer,
+  BrandedFrameRendererOptions,
+  RecordBrandedVideoOptions,
+} from './component/player/scenes/export-branded-video';
+export { calculateFrameMap } from './component/player/scenes/frame-calculator';
+export type { FrameMap } from './component/player/scenes/frame-calculator';
 export { Blackboard } from './component/blackboard';
 export { default as ScreenshotViewer } from './component/screenshot-viewer';
 export type { ScreenshotViewerMode } from './component/screenshot-viewer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,6 +801,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@ffmpeg-installer/ffmpeg':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@midscene/android':
         specifier: workspace:*
         version: link:../android
@@ -13515,7 +13518,6 @@ snapshots:
       '@ffmpeg-installer/linux-x64': 4.1.0
       '@ffmpeg-installer/win32-ia32': 4.1.0
       '@ffmpeg-installer/win32-x64': 4.1.0
-    optional: true
 
   '@ffmpeg-installer/linux-arm64@4.1.4':
     optional: true


### PR DESCRIPTION
## Summary

- Add `midscene report-video` to export report replays from the CLI.
- Use the bundled `@ffmpeg-installer/ffmpeg` binary as the default encoder, with WebM/MP4 output, 15fps default sampling, 4 parallel frame renderers, and optional `--scale` for higher-resolution videos.
- Expose report-side headless frame hooks and shared dump-reading utilities so HTML reports, directory-mode `html-and-external-assets` reports, and dump JSON inputs can be rendered consistently.
- Harden the CLI path: invalid args now return non-zero exit codes, ffmpeg browser startup failures clean up correctly, file-stored screenshot refs are detected from parsed dump JSON, and the ffmpeg helpers are split into focused testable modules.
- Document the command in English and Chinese docs.

## Validation

- `pnpm run lint`
- `cd packages/cli && npx vitest run tests/unit-test/report-video.test.ts`
- `cd packages/cli && npx rslib build`
- `npx nx test @midscene/visualizer`
- CLI exit-code checks:
  - `node packages/cli/bin/midscene report-video --name x` exits `1`
  - `node packages/cli/bin/midscene report-video --help` exits `0`
- Exported and inspected sample videos:
  - `/tmp/midscene-video/optimized-final.webm` from a directory-mode `html-and-external-assets` report (`vp8`, `960x540`, `15fps`, `3` frames)
  - `/tmp/midscene-video/todo-dir-scale2-hq.webm` (`1920x1080`, `125` frames, `15fps`)
  - `/tmp/midscene-video/todo-dir-full-hq.webm` (`960x540`, `1233` frames, `15fps`)

## Notes

- The ffmpeg encoder is the default path. The existing browser `MediaRecorder` path remains available via `--encoder media-recorder`.
- `--scale 2` outputs 1920x1080 and increases WebM bitrate with output pixel area.
- This intentionally does not support old report templates; reports can be regenerated and the current template must expose the video export hooks.

## Dependency / License Note

- `@ffmpeg-installer/ffmpeg@1.1.0` is now a regular dependency of `@midscene/cli` (not optional) so users get a working ffmpeg binary after installing the CLI.
- The package declares `LGPL-2.1` and its platform packages bundle ffmpeg binaries. Please confirm this is acceptable for `@midscene/cli` distribution before marking the PR ready for review.
