### PR TITLE
fix(core): record response model name in usage

### DIFF
--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -730,6 +730,7 @@ class CodexAppServerConnection {
       time_cost: Date.now() - startTime,
       model_name: modelConfig.modelName,
       model_description: modelConfig.modelDescription,
+      response_model_name: undefined,
       slot: modelConfig.slot,
       intent: undefined,
       request_id: turnId,

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -300,6 +300,7 @@ export async function callAI(
   let usage: OpenAI.CompletionUsage | undefined;
   let timeCost: number | undefined;
   let requestId: string | null | undefined;
+  let responseModelName: string | undefined;
 
   const hasUsableText = (value: string | null | undefined): value is string =>
     typeof value === 'string' && value.trim().length > 0;
@@ -323,6 +324,7 @@ export async function callAI(
       time_cost: timeCost ?? 0,
       model_name: modelName,
       model_description: modelDescription,
+      response_model_name: responseModelName,
       slot: modelConfig.slot,
       // Agent task layers fill semantic intent after the raw model call.
       intent: undefined,
@@ -407,6 +409,9 @@ export async function callAI(
           // Check for usage info in any chunk (OpenAI provides usage in separate chunks)
           if (chunk.usage) {
             usage = chunk.usage;
+          }
+          if (chunk.model) {
+            responseModelName = chunk.model;
           }
 
           if (content || reasoning_content) {
@@ -505,6 +510,7 @@ export async function callAI(
           accumulatedReasoning = parsedMessage.reasoning_content;
           usage = result.usage;
           requestId = result._request_id;
+          responseModelName = result.model;
 
           if (!hasUsableText(content) && hasUsableText(accumulatedReasoning)) {
             warnCall('empty content from AI model, using reasoning content');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,6 +42,10 @@ export type AIUsageInfo = Record<string, any> & {
   model_name: string | undefined;
   model_description: string | undefined;
   /**
+   * Raw top-level `.model` value returned by the model service response.
+   */
+  response_model_name: string | undefined;
+  /**
    * Semantic intent of the model call, such as default, planning, or insight.
    */
   intent: string | undefined;

--- a/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
+++ b/packages/core/tests/unit-test/ai-judge-order-sensitive.test.ts
@@ -23,6 +23,7 @@ describe('AiJudgeOrderSensitive', () => {
       time_cost: undefined,
       model_name: undefined,
       model_description: undefined,
+      response_model_name: undefined,
       intent: undefined,
       slot: undefined,
       request_id: undefined,

--- a/packages/core/tests/unit-test/service-caller-empty-content.test.ts
+++ b/packages/core/tests/unit-test/service-caller-empty-content.test.ts
@@ -34,6 +34,7 @@ describe('service-caller empty content handling', () => {
           cached_tokens: 7,
         },
       },
+      model: 'gpt-4o-2024-08-06',
       _request_id: 'req_test_123',
     });
 
@@ -67,6 +68,7 @@ describe('service-caller empty content handling', () => {
         },
         model_name: 'gpt-4o',
         model_description: 'test model',
+        response_model_name: 'gpt-4o-2024-08-06',
         slot: 'default',
         request_id: 'req_test_123',
       });

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -68,6 +68,37 @@ describe('service-caller reasoning fallback', () => {
     expect(response.reasoning_content).toContain('POI RichInfo tab');
   });
 
+  it('records the raw response model name in usage metadata', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: 'ok',
+          },
+        },
+      ],
+      model: 'doubao-seed-2-0-lite-260215',
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    });
+
+    const response = await callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime({
+        ...baseModelConfig,
+        modelName: 'ep-20260402170055-hm5ng',
+      }),
+    );
+
+    expect(response.usage).toMatchObject({
+      model_name: 'ep-20260402170055-hm5ng',
+      response_model_name: 'doubao-seed-2-0-lite-260215',
+    });
+  });
+
   it('parses object responses from reasoning_content when content is blank', async () => {
     mockCreate.mockResolvedValue({
       choices: [

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -42,6 +42,7 @@ const createMockUsage = (totalTokens: number): AIUsageInfo => ({
   time_cost: undefined,
   model_name: undefined,
   model_description: undefined,
+  response_model_name: undefined,
   intent: undefined,
   slot: undefined,
   request_id: undefined,


### PR DESCRIPTION
## Summary

- Add `response_model_name` to AI usage metadata to capture the raw top-level `.model` value returned by model providers.
- Preserve existing `model_name` semantics as the configured/requested model name.
- Populate the new field for non-streaming responses and streaming chunks when available; leave it undefined for Codex app server usage where no equivalent raw response field is available.
- Add unit coverage for successful model-name divergence and parse-error usage preservation.

## Validation

- `pnpm --dir packages/core test -- tests/unit-test/service-caller-reasoning-fallback.test.ts tests/unit-test/service-caller-empty-content.test.ts`

Lint was not run per local workflow preference.