### PR TITLE
docs(site): recommend Azure OpenAI v1 bearer config

### DIFF
--- a/apps/site/docs/en/faq.md
+++ b/apps/site/docs/en/faq.md
@@ -38,23 +38,20 @@ JSON.stringify({ defaultHeaders: { foo: 'bar' } })
 
 ## How do I use Azure OpenAI Service?
 
-First choose the model and model family from [Model configuration](./model-common-config). Azure only changes the provider URL and key:
+When using Azure OpenAI Service, first choose the model and fill in the regular model configuration from [Model configuration](./model-common-config). Azure only requires changing the model service URL and API Key to the Azure form:
 
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # Or https://<your-resource>.openai.azure.com/openai/v1
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
 MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
 ```
 
-This uses the normal OpenAI-compatible path and sends `POST /openai/v1/chat/completions` with `Authorization: Bearer ...`. Do not append `/chat/completions` to `MIDSCENE_MODEL_BASE_URL`, and do not add `api-version` for `/openai/v1` endpoints.
+In other words, other settings such as `MIDSCENE_MODEL_NAME` and `MIDSCENE_MODEL_FAMILY` should still follow the corresponding model section in [Model configuration](./model-common-config). Azure is only a model provider with different authentication, not a special model.
 
-`MIDSCENE_MODEL_FAMILY` is still configured according to the model you choose, not according to Azure. For example, use the GPT-5, Qwen, Gemini, or other model sections in [Model configuration](./model-common-config) as the source of truth.
+This uses the normal OpenAI-compatible path and sends `POST /openai/v1/chat/completions` with `Authorization: Bearer ...`. Do not append `/chat/completions` to `MIDSCENE_MODEL_BASE_URL`, and do not add `api-version` for `/openai/v1` endpoints.
 
 If an Azure-compatible gateway only accepts the `api-key` header, use this fallback:
 
 ```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```

--- a/apps/site/docs/en/faq.md
+++ b/apps/site/docs/en/faq.md
@@ -36,6 +36,33 @@ You can generate the JSON string with JSON serialization to avoid mistakes when 
 JSON.stringify({ defaultHeaders: { foo: 'bar' } })
 ```
 
+## How do I use Azure OpenAI Service?
+
+First choose the model and model family from [Model configuration](./model-common-config). Azure only changes the provider URL and key:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # Or https://<your-resource>.openai.azure.com/openai/v1
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
+```
+
+This uses the normal OpenAI-compatible path and sends `POST /openai/v1/chat/completions` with `Authorization: Bearer ...`. Do not append `/chat/completions` to `MIDSCENE_MODEL_BASE_URL`, and do not add `api-version` for `/openai/v1` endpoints.
+
+`MIDSCENE_MODEL_FAMILY` is still configured according to the model you choose, not according to Azure. For example, use the GPT-5, Qwen, Gemini, or other model sections in [Model configuration](./model-common-config) as the source of truth.
+
+If an Azure-compatible gateway only accepts the `api-key` header, use this fallback:
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="placeholder"
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+In this fallback, `MIDSCENE_MODEL_API_KEY="placeholder"` only satisfies the OpenAI SDK constructor check. The real key is sent through `defaultHeaders.api-key`.
+
+Azure AD / keyless auth (`DefaultAzureCredential`) is not supported. Use an API key.
+
 ## How to improve the running time?
 
 There are several ways to improve the running time:

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -246,36 +246,28 @@ Starting with version 1.0, Midscene no longer supports GPT-4o as the planning mo
 
 ## Using Azure OpenAI Service {#azure-openai}
 
-Midscene no longer ships a dedicated Azure client. Because Azure OpenAI exposes OpenAI-compatible APIs, you connect to it like any other OpenAI-compatible endpoint. The exact base URL depends on which Azure endpoint shape your resource provides.
+Midscene no longer ships a dedicated Azure client. Use Azure resources that expose an OpenAI-compatible `/openai/v1` Chat Completions endpoint the same way you use any other OpenAI-compatible provider.
 
-For the classic Azure OpenAI deployment endpoint, point `MIDSCENE_MODEL_BASE_URL` at your deployment and pass Azure's `api-version` query parameter and `api-key` header through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
+Use this configuration for endpoints such as `https://<your-resource>.openai.azure.com/openai/v1` or `https://<your-resource>.services.ai.azure.com/openai/v1`. Do not append `/chat/completions`; the OpenAI SDK adds that path.
 
 ```bash
-# Point at your deployment. Do NOT append /chat/completions — the SDK adds it.
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.openai.azure.com/openai/deployments/<your-deployment>"
-# Use the deployment name as the model name.
-MIDSCENE_MODEL_NAME="<your-deployment>"
-# Required by the OpenAI SDK constructor, but ignored by Azure when the api-key header is set below.
-MIDSCENE_MODEL_API_KEY="placeholder"
-# Azure auth uses an `api-key` header (not a Bearer token) and requires the api-version query param.
-MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-preview"},"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # Or https://<your-resource>.openai.azure.com/openai/v1
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
 ```
 
-This sends requests as `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview` with the `api-key` header, which is exactly what Azure OpenAI expects.
+This sends requests as `POST /openai/v1/chat/completions` with the `Authorization: Bearer ...` header. For GPT-5 series models, also set `MIDSCENE_MODEL_FAMILY="gpt-5"` as shown in the [GPT-5 Series](#gpt-5-4) section above.
 
-For Azure resources that expose the OpenAI-compatible `/openai/v1` endpoint, use the `/openai/v1` base URL and do not add `api-version`. Do not append `/chat/completions`; the OpenAI SDK adds that path.
+Some Azure-compatible gateways may only accept the `api-key` header. In that case, keep `MIDSCENE_MODEL_API_KEY` as a non-empty placeholder for the OpenAI SDK constructor and pass the real key through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
 
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
 MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-# Required by the OpenAI SDK constructor. Azure auth uses the api-key header below.
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```
 
-This sends requests as `POST /openai/v1/chat/completions` with the `api-key` header.
-
-Do not omit `MIDSCENE_MODEL_API_KEY` in this setup unless `OPENAI_API_KEY` is already set. The OpenAI SDK validates its constructor `apiKey` before sending the request; Azure still uses the `api-key` header above for authentication.
+For `/openai/v1` endpoints, do not add `api-version`. The base URL must stop at `/openai/v1`.
 
 :::warning Azure AD / keyless auth is not supported
 

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -244,37 +244,6 @@ Migration mapping:
 
 Starting with version 1.0, Midscene no longer supports GPT-4o as the planning model for UI operations. See [Model strategy](./model-strategy) for details.
 
-## Using Azure OpenAI Service {#azure-openai}
-
-Midscene no longer ships a dedicated Azure client. Use Azure resources that expose an OpenAI-compatible `/openai/v1` Chat Completions endpoint the same way you use any other OpenAI-compatible provider.
-
-Use this configuration for endpoints such as `https://<your-resource>.openai.azure.com/openai/v1` or `https://<your-resource>.services.ai.azure.com/openai/v1`. Do not append `/chat/completions`; the OpenAI SDK adds that path.
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # Or https://<your-resource>.openai.azure.com/openai/v1
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
-```
-
-This sends requests as `POST /openai/v1/chat/completions` with the `Authorization: Bearer ...` header. For GPT-5 series models, also set `MIDSCENE_MODEL_FAMILY="gpt-5"` as shown in the [GPT-5 Series](#gpt-5-4) section above.
-
-Some Azure-compatible gateways may only accept the `api-key` header. In that case, keep `MIDSCENE_MODEL_API_KEY` as a non-empty placeholder for the OpenAI SDK constructor and pass the real key through `MIDSCENE_MODEL_INIT_CONFIG_JSON`.
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-MIDSCENE_MODEL_API_KEY="placeholder"
-MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
-```
-
-For `/openai/v1` endpoints, do not add `api-version`. The base URL must stop at `/openai/v1`.
-
-:::warning Azure AD / keyless auth is not supported
-
-The previous `DefaultAzureCredential` (Azure AD token provider, a.k.a. keyless) mode has been removed. Use an API key as shown above.
-
-:::
-
 ## Multi-model example: GPT-5.4 for planning/insight + Qwen 3.5 for visual grounding {#gpt54-planning-insight-qwen35}
 
 For more information on combining multiple models, see [Advanced: Combining Multiple Models](./model-strategy#advanced-combining-multiple-models).

--- a/apps/site/docs/zh/faq.md
+++ b/apps/site/docs/zh/faq.md
@@ -36,6 +36,33 @@ MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"foo":"bar"}}'
 JSON.stringify({ defaultHeaders: { foo: 'bar' } })
 ```
 
+## 如何使用 Azure OpenAI Service？
+
+先从 [模型配置](./model-common-config) 里选择模型和对应的 Model Family。Azure 只影响服务 URL 和 key 的写法：
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # 或 https://<your-resource>.openai.azure.com/openai/v1
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
+```
+
+这会走普通 OpenAI-compatible 路径，以 `Authorization: Bearer ...` 请求头发送 `POST /openai/v1/chat/completions`。`MIDSCENE_MODEL_BASE_URL` 不要追加 `/chat/completions`，`/openai/v1` 端点也不要追加 `api-version`。
+
+`MIDSCENE_MODEL_FAMILY` 仍然按你选择的模型来配置，而不是按 Azure 来配置。例如 GPT-5、Qwen、Gemini 或其他模型，都以 [模型配置](./model-common-config) 里的对应章节为准。
+
+如果某个 Azure-compatible 网关只接受 `api-key` 请求头，可以使用下面的 fallback：
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="placeholder"
+MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+```
+
+在这个 fallback 里，`MIDSCENE_MODEL_API_KEY="placeholder"` 只用于满足 OpenAI SDK 构造器校验，真实 key 通过 `defaultHeaders.api-key` 发送。
+
+不支持 Azure AD / keyless 鉴权（`DefaultAzureCredential`）。请使用 API Key。
+
 ## 如何配置 midscene_run 目录？
 
 Midscene 会将运行产物（报告、日志、缓存等）保存在 `midscene_run` 目录下。默认情况下，该目录会创建在当前工作目录下。

--- a/apps/site/docs/zh/faq.md
+++ b/apps/site/docs/zh/faq.md
@@ -38,30 +38,27 @@ JSON.stringify({ defaultHeaders: { foo: 'bar' } })
 
 ## 如何使用 Azure OpenAI Service？
 
-先从 [模型配置](./model-common-config) 里选择模型和对应的 Model Family。Azure 只影响服务 URL 和 key 的写法：
+使用 Azure OpenAI Service 时，请先按 [模型配置](./model-common-config) 选择并填写对应模型的常规配置。Azure 只需要把模型服务地址和 API Key 换成 Azure 的写法：
 
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # 或 https://<your-resource>.openai.azure.com/openai/v1
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
 MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
 ```
 
+也就是说，`MIDSCENE_MODEL_NAME`、`MIDSCENE_MODEL_FAMILY` 等其他配置仍然按 [模型配置](./model-common-config) 中对应模型的说明填写；Azure 只是鉴权方式有所差异的模型供应商，而非一种特殊模型。
+
 这会走普通 OpenAI-compatible 路径，以 `Authorization: Bearer ...` 请求头发送 `POST /openai/v1/chat/completions`。`MIDSCENE_MODEL_BASE_URL` 不要追加 `/chat/completions`，`/openai/v1` 端点也不要追加 `api-version`。
 
-`MIDSCENE_MODEL_FAMILY` 仍然按你选择的模型来配置，而不是按 Azure 来配置。例如 GPT-5、Qwen、Gemini 或其他模型，都以 [模型配置](./model-common-config) 里的对应章节为准。
-
-如果某个 Azure-compatible 网关只接受 `api-key` 请求头，可以使用下面的 fallback：
+如果某个 Azure-compatible 网关只接受 `api-key` 请求头，可以额外添加下面的配置，通过 header 发送真实 API Key：
 
 ```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```
 
-在这个 fallback 里，`MIDSCENE_MODEL_API_KEY="placeholder"` 只用于满足 OpenAI SDK 构造器校验，真实 key 通过 `defaultHeaders.api-key` 发送。
+这里的 `MIDSCENE_MODEL_API_KEY="placeholder"` 只是为了满足 OpenAI SDK 的初始化要求，真实 API Key 会通过 `defaultHeaders.api-key` 发送。
 
-不支持 Azure AD / keyless 鉴权（`DefaultAzureCredential`）。请使用 API Key。
+Azure AD / keyless 鉴权（`DefaultAzureCredential`）的方式现在已经不再支持，请使用 API Key 的方式。
 
 ## 如何配置 midscene_run 目录？
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -248,36 +248,28 @@ MIDSCENE_MODEL_FAMILY="vlm-ui-tars-doubao-1.5"
 
 ## 使用 Azure OpenAI Service {#azure-openai}
 
-Midscene 不再内置专用的 Azure 客户端。由于 Azure OpenAI 提供 OpenAI 兼容接口，你可以像接入其他 OpenAI 兼容端点一样接入它。具体的 base URL 取决于你的 Azure 资源提供哪种端点格式。
+Midscene 不再内置专用的 Azure 客户端。对于提供 OpenAI 兼容 `/openai/v1` Chat Completions 端点的 Azure 资源，直接按普通 OpenAI-compatible provider 接入即可。
 
-对于经典的 Azure OpenAI deployment 端点，把 `MIDSCENE_MODEL_BASE_URL` 指向你的 deployment，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入 Azure 所需的 `api-version` 查询参数和 `api-key` 请求头。
+以下配置适用于 `https://<your-resource>.openai.azure.com/openai/v1` 或 `https://<your-resource>.services.ai.azure.com/openai/v1` 这类端点。不要在末尾加 `/chat/completions`，OpenAI SDK 会自动补全这个路径。
 
 ```bash
-# 指向你的 deployment。不要在末尾加 /chat/completions，SDK 会自动补全。
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.openai.azure.com/openai/deployments/<your-deployment>"
-# 用 deployment 名称作为模型名。
-MIDSCENE_MODEL_NAME="<your-deployment>"
-# OpenAI SDK 构造时必填，但当下方设置了 api-key 请求头后，Azure 会忽略它。
-MIDSCENE_MODEL_API_KEY="placeholder"
-# Azure 鉴权使用 `api-key` 请求头（而非 Bearer token），并且要求带上 api-version 查询参数。
-MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultQuery":{"api-version":"2024-08-01-preview"},"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
+MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # 或 https://<your-resource>.openai.azure.com/openai/v1
+MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
+MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
 ```
 
-这样发出的请求会是 `POST /openai/deployments/<your-deployment>/chat/completions?api-version=2024-08-01-preview`，并携带 `api-key` 请求头，正是 Azure OpenAI 所期望的格式。
+这样发出的请求会是 `POST /openai/v1/chat/completions`，并携带 `Authorization: Bearer ...` 请求头。如果使用 GPT-5 系列模型，还需要按上方 [GPT-5 Series](#gpt-5-4) 章节设置 `MIDSCENE_MODEL_FAMILY="gpt-5"`。
 
-对于提供 OpenAI 兼容 `/openai/v1` 端点的 Azure 资源，base URL 使用 `/openai/v1`，不要再追加 `api-version`。也不要在末尾加 `/chat/completions`，OpenAI SDK 会自动补全这个路径。
+少数 Azure-compatible 网关可能只接受 `api-key` 请求头。遇到这种情况时，保留非空的 `MIDSCENE_MODEL_API_KEY` 作为 OpenAI SDK 构造参数占位，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入真实 key。
 
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
 MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-# OpenAI SDK 构造时必填；Azure 实际鉴权使用下方 api-key 请求头。
 MIDSCENE_MODEL_API_KEY="placeholder"
 MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
 ```
 
-这样发出的请求会是 `POST /openai/v1/chat/completions`，并携带 `api-key` 请求头。
-
-除非已经设置了 `OPENAI_API_KEY`，否则这个配置里不要省略 `MIDSCENE_MODEL_API_KEY`。OpenAI SDK 会在发请求前校验构造器里的 `apiKey`；Azure 实际鉴权仍然使用上面的 `api-key` 请求头。
+对于 `/openai/v1` 端点，不要追加 `api-version`。base URL 应该停在 `/openai/v1`。
 
 :::warning 不再支持 Azure AD / keyless 鉴权
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -246,37 +246,6 @@ MIDSCENE_MODEL_FAMILY="vlm-ui-tars-doubao-1.5"
 
 从 1.0 版本开始，Midscene 不再支持使用 GPT-4o 作为 UI 操作的规划模型。详见：[模型策略](./model-strategy)。
 
-## 使用 Azure OpenAI Service {#azure-openai}
-
-Midscene 不再内置专用的 Azure 客户端。对于提供 OpenAI 兼容 `/openai/v1` Chat Completions 端点的 Azure 资源，直接按普通 OpenAI-compatible provider 接入即可。
-
-以下配置适用于 `https://<your-resource>.openai.azure.com/openai/v1` 或 `https://<your-resource>.services.ai.azure.com/openai/v1` 这类端点。不要在末尾加 `/chat/completions`，OpenAI SDK 会自动补全这个路径。
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1" # 或 https://<your-resource>.openai.azure.com/openai/v1
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-MIDSCENE_MODEL_API_KEY="<your-azure-api-key>"
-```
-
-这样发出的请求会是 `POST /openai/v1/chat/completions`，并携带 `Authorization: Bearer ...` 请求头。如果使用 GPT-5 系列模型，还需要按上方 [GPT-5 Series](#gpt-5-4) 章节设置 `MIDSCENE_MODEL_FAMILY="gpt-5"`。
-
-少数 Azure-compatible 网关可能只接受 `api-key` 请求头。遇到这种情况时，保留非空的 `MIDSCENE_MODEL_API_KEY` 作为 OpenAI SDK 构造参数占位，并通过 `MIDSCENE_MODEL_INIT_CONFIG_JSON` 传入真实 key。
-
-```bash
-MIDSCENE_MODEL_BASE_URL="https://<your-resource>.services.ai.azure.com/openai/v1"
-MIDSCENE_MODEL_NAME="<your-model-or-deployment-name>"
-MIDSCENE_MODEL_API_KEY="placeholder"
-MIDSCENE_MODEL_INIT_CONFIG_JSON='{"defaultHeaders":{"api-key":"<your-azure-api-key>"}}'
-```
-
-对于 `/openai/v1` 端点，不要追加 `api-version`。base URL 应该停在 `/openai/v1`。
-
-:::warning 不再支持 Azure AD / keyless 鉴权
-
-此前基于 `DefaultAzureCredential`（Azure AD token provider，即 keyless）的模式已被移除，请改用上面的 API Key 方式。
-
-:::
-
 ## 多模型示例：GPT-5.4 规划/理解 + Qwen 3.5 视觉定位 {#gpt54-planning-insight-qwen35}
 
 关于组合多个模型的更多信息，可查阅 [进阶：组合多个模型](./model-strategy#advanced-combining-multiple-models)。


### PR DESCRIPTION
## Summary

- Document Azure OpenAI-compatible `/openai/v1` as a FAQ because it is a provider URL/key setup, not a model-family setup.
- Recommend `MIDSCENE_MODEL_BASE_URL=.../openai/v1` with `MIDSCENE_MODEL_API_KEY=<your-azure-api-key>` as the default Azure configuration.
- Keep `MIDSCENE_MODEL_INIT_CONFIG_JSON` + `defaultHeaders.api-key` as a fallback only for gateways that require the `api-key` header.
- Remove the classic deployment endpoint from the verified/recommended docs path.

## Validation

- `pnpm run lint`
- `AI_TEST_TYPE=web pnpm --dir packages/web-integration exec vitest --run tests/ai/web/puppeteer/azure-openai-v1-bearer-report.temp.test.ts`
  - Generated Midscene report: `packages/web-integration/midscene_run/report/azure-openai-v1-bearer-report-2026-06-09_19-05-01-82a7db76.html`
  - The temporary test file was removed after verification and is not part of this PR.