### PR TITLE
docs(site): document Android IME text input workaround

### DIFF
--- a/apps/site/docs/en/android-getting-started.mdx
+++ b/apps/site/docs/en/android-getting-started.mdx
@@ -348,6 +348,33 @@ With auto dismiss disabled, the keyboard will remain visible and may cover a lar
 - Using `aiAct` to manually dismiss the keyboard, e.g. `await agent.aiAct('tap the collapse button on the keyboard')`
 - Installing and switching to [ADBKeyBoard](https://github.com/senzhk/ADBKeyBoard) — a minimal virtual keyboard that takes up very little screen space, so it barely affects screen interactions even when visible
 
+### English text is rewritten by the Android keyboard
+
+If the report shows the correct input parameter, but the app receives different text, missing text, or Chinese/pinyin candidates, the active Android input method may be rewriting the text. This can happen when pure ASCII text goes through the native `adb input text` path while a Chinese keyboard or autocorrect keyboard is active.
+
+Use the existing `imeStrategy` option and force all text input through yadb:
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  imeStrategy: 'always-yadb',
+});
+```
+
+For YAML scripts:
+
+```yaml
+android:
+  imeStrategy: always-yadb
+```
+
+Or set the environment variable:
+
+```bash
+export MIDSCENE_ANDROID_IME_STRATEGY=always-yadb
+```
+
+This is different from text being cleared after typing. If the text is entered correctly and then disappears, check `keyboardDismissStrategy` or `autoDismissKeyboard` instead.
+
 ### How do I use a custom adb path or remote adb server?
 
 Set the environment variables first:

--- a/apps/site/docs/en/integrate-with-android.mdx
+++ b/apps/site/docs/en/integrate-with-android.mdx
@@ -360,6 +360,33 @@ With auto dismiss disabled, the keyboard will remain visible and may cover a lar
 - Using `aiAct` to manually dismiss the keyboard, e.g. `await agent.aiAct('dismiss the keyboard')`
 - Installing and switching to [ADBKeyBoard](https://github.com/senzhk/ADBKeyBoard) — a minimal virtual keyboard that takes up very little screen space, so it barely affects screen interactions even when visible
 
+### English text is rewritten by the Android keyboard
+
+If the report shows the correct input parameter, but the app receives different text, missing text, or Chinese/pinyin candidates, the active Android input method may be rewriting the text. This can happen when pure ASCII text goes through the native `adb input text` path while a Chinese keyboard or autocorrect keyboard is active.
+
+Use the existing `imeStrategy` option and force all text input through yadb:
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  imeStrategy: 'always-yadb',
+});
+```
+
+For YAML scripts:
+
+```yaml
+android:
+  imeStrategy: always-yadb
+```
+
+Or set the environment variable:
+
+```bash
+export MIDSCENE_ANDROID_IME_STRATEGY=always-yadb
+```
+
+This is different from text being cleared after typing. If the text is entered correctly and then disappears, check `keyboardDismissStrategy` or `autoDismissKeyboard` instead.
+
 ### How to use a custom adb path, remote adb host and port?
 
 You can use the `MIDSCENE_ADB_PATH` environment variable to specify the path to the adb executable, `MIDSCENE_ADB_REMOTE_HOST` environment variable to specify the remote adb host, `MIDSCENE_ADB_REMOTE_PORT` environment variable to specify the remote adb port.

--- a/apps/site/docs/zh/android-getting-started.mdx
+++ b/apps/site/docs/zh/android-getting-started.mdx
@@ -245,6 +245,33 @@ const device = new AndroidDevice('device-id', {
 - 使用 `aiAct` 指令手动隐藏键盘，例如 `await agent.aiAct('点击键盘上的收起按钮')`
 - 安装并切换到 [ADBKeyBoard](https://github.com/senzhk/ADBKeyBoard)——这是一款极小面积的虚拟键盘，即使不隐藏也几乎不影响屏幕操作
 
+### 英文文本被 Android 输入法改写
+
+如果报告中显示的输入参数是正确的，但 App 实际收到的是不同文本、缺字，或被改成中文/拼音候选词，通常是当前 Android 输入法改写了输入内容。纯 ASCII 文本如果走原生 `adb input text` 路径，在中文输入法或带自动纠错的输入法下就可能出现这个问题。
+
+使用已有的 `imeStrategy` 选项，将所有文本输入强制改为 yadb：
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  imeStrategy: 'always-yadb',
+});
+```
+
+YAML 脚本中可以这样配置：
+
+```yaml
+android:
+  imeStrategy: always-yadb
+```
+
+也可以通过环境变量设置：
+
+```bash
+export MIDSCENE_ANDROID_IME_STRATEGY=always-yadb
+```
+
+这和“输入后被清空”不是同一个问题。如果文本先正确输入、随后消失，请优先检查 `keyboardDismissStrategy` 或 `autoDismissKeyboard`。
+
 ### 如何使用自定义的 adb 路径或远程 adb 服务器？
 
 通过环境变量设置：

--- a/apps/site/docs/zh/integrate-with-android.mdx
+++ b/apps/site/docs/zh/integrate-with-android.mdx
@@ -507,6 +507,33 @@ const device = new AndroidDevice('device-id', {
 - 使用 `aiAct` 指令手动隐藏键盘，例如 `await agent.aiAct('隐藏键盘')`
 - 安装并切换到 [ADBKeyBoard](https://github.com/senzhk/ADBKeyBoard)——这是一款极小面积的虚拟键盘，即使不隐藏也几乎不影响屏幕操作
 
+### 英文文本被 Android 输入法改写
+
+如果报告中显示的输入参数是正确的，但 App 实际收到的是不同文本、缺字，或被改成中文/拼音候选词，通常是当前 Android 输入法改写了输入内容。纯 ASCII 文本如果走原生 `adb input text` 路径，在中文输入法或带自动纠错的输入法下就可能出现这个问题。
+
+使用已有的 `imeStrategy` 选项，将所有文本输入强制改为 yadb：
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  imeStrategy: 'always-yadb',
+});
+```
+
+YAML 脚本中可以这样配置：
+
+```yaml
+android:
+  imeStrategy: always-yadb
+```
+
+也可以通过环境变量设置：
+
+```bash
+export MIDSCENE_ANDROID_IME_STRATEGY=always-yadb
+```
+
+这和“输入后被清空”不是同一个问题。如果文本先正确输入、随后消失，请优先检查 `keyboardDismissStrategy` 或 `autoDismissKeyboard`。
+
 ### 如何使用自定义的 adb 路径、远程 adb 主机和端口？
 
 你可以使用 `MIDSCENE_ADB_PATH` 环境变量来指定 adb 可执行文件的路径，`MIDSCENE_ADB_REMOTE_HOST` 环境变量来指定远程 adb 主机，`MIDSCENE_ADB_REMOTE_PORT` 环境变量来指定远程 adb 端口。


### PR DESCRIPTION
## Summary
- Add Android FAQ entries explaining why English text can be rewritten by active Android IMEs when native adb text input is used.
- Document the existing workaround: set `imeStrategy: 'always-yadb'` in JavaScript, YAML, or `MIDSCENE_ANDROID_IME_STRATEGY`.
- Keep the workaround separate from keyboard-dismiss issues so users can distinguish IME rewriting from text being cleared after input.

## Validation
- `pnpm run lint`