### PR TITLE
Handle invalid Studio model env config

### DIFF
--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
@@ -225,11 +225,10 @@ export function ModelEnvConfigModal({
     () => resolveModelConnection(envValues),
     [envValues],
   );
-  const configError =
-    'error' in resolvedConnection ? resolvedConnection.error : null;
   const validationError =
-    configError && !configError.startsWith('Missing required keys:')
-      ? configError
+    'error' in resolvedConnection &&
+    resolvedConnection.kind === 'invalid-config'
+      ? resolvedConnection.error
       : null;
   const canRunConnectivityTest = !('error' in resolvedConnection);
   const isExpandedForm = tab === 'form';

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
@@ -225,27 +225,40 @@ export function ModelEnvConfigModal({
     () => resolveModelConnection(envValues),
     [envValues],
   );
+  const configError =
+    'error' in resolvedConnection ? resolvedConnection.error : null;
+  const validationError =
+    configError && !configError.startsWith('Missing required keys:')
+      ? configError
+      : null;
   const canRunConnectivityTest = !('error' in resolvedConnection);
   const isExpandedForm = tab === 'form';
   const hasTestStatus =
     testStatus.kind === 'success' || testStatus.kind === 'error';
-  const modalHeightClass =
-    isExpandedForm && hasTestStatus
-      ? 'h-[603px]'
-      : isExpandedForm
-        ? 'h-[563px]'
-        : hasTestStatus
-          ? 'h-[444px]'
-          : 'h-[404px]';
-  const modalVerticalOffsetClass =
-    isExpandedForm && hasTestStatus
-      ? 'translate-y-[99.5px]'
-      : isExpandedForm
-        ? 'translate-y-[79.5px]'
-        : hasTestStatus
-          ? 'translate-y-[20px]'
-          : '';
-  const descriptionMarginClass = hasTestStatus ? 'mt-[12px]' : 'mt-[16px]';
+  const statusKind = validationError
+    ? 'error'
+    : hasTestStatus
+      ? testStatus.kind
+      : null;
+  const hasStatusRow = statusKind !== null;
+  const hasValidationStatus = validationError !== null;
+  const modalHeightClass = (() => {
+    if (isExpandedForm && hasValidationStatus) return 'h-[683px]';
+    if (isExpandedForm && hasStatusRow) return 'h-[603px]';
+    if (isExpandedForm) return 'h-[563px]';
+    if (hasValidationStatus) return 'h-[524px]';
+    if (hasStatusRow) return 'h-[444px]';
+    return 'h-[404px]';
+  })();
+  const modalVerticalOffsetClass = (() => {
+    if (isExpandedForm && hasValidationStatus) return 'translate-y-[139.5px]';
+    if (isExpandedForm && hasStatusRow) return 'translate-y-[99.5px]';
+    if (isExpandedForm) return 'translate-y-[79.5px]';
+    if (hasValidationStatus) return 'translate-y-[60px]';
+    if (hasStatusRow) return 'translate-y-[20px]';
+    return '';
+  })();
+  const descriptionMarginClass = hasStatusRow ? 'mt-[12px]' : 'mt-[16px]';
 
   if (!open) {
     return null;
@@ -338,7 +351,12 @@ export function ModelEnvConfigModal({
           </div>
         ) : null}
 
-        {hasTestStatus ? <ModelEnvConfigStatus kind={testStatus.kind} /> : null}
+        {statusKind ? (
+          <ModelEnvConfigStatus
+            kind={statusKind}
+            message={validationError ?? undefined}
+          />
+        ) : null}
 
         <EnvModalFooter
           canRunConnectivityTest={canRunConnectivityTest}

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
@@ -2,6 +2,7 @@ type ModelEnvConfigStatusKind = 'success' | 'error';
 
 interface ModelEnvConfigStatusProps {
   kind: ModelEnvConfigStatusKind;
+  message?: string;
 }
 
 function ErrorStatusIcon() {
@@ -62,21 +63,29 @@ function SuccessStatusIcon() {
   );
 }
 
-export function ModelEnvConfigStatus({ kind }: ModelEnvConfigStatusProps) {
+export function ModelEnvConfigStatus({
+  kind,
+  message: customMessage,
+}: ModelEnvConfigStatusProps) {
   const isSuccess = kind === 'success';
   const statusClasses = isSuccess
     ? 'bg-status-success-bg text-status-success-fg'
     : 'bg-[#E13E37]/11 text-[#E13E37]';
-  const message = isSuccess ? 'Test passed.' : 'Test failed. Please try again.';
+  const message =
+    customMessage ??
+    (isSuccess ? 'Test passed.' : 'Test failed. Please try again.');
 
   return (
     <div className="relative z-10 mt-[12px] px-[21px]">
       <div
-        className={`box-border flex h-[32px] w-[360px] items-center justify-between rounded-[8px] px-[12px] py-[8px] ${statusClasses}`}
+        className={`box-border flex min-h-[32px] w-[360px] items-start justify-between rounded-[8px] px-[12px] py-[8px] ${statusClasses}`}
       >
-        <div className="flex items-center gap-[10px]">
+        <div className="flex min-w-0 flex-1 items-start gap-[10px]">
           {isSuccess ? <SuccessStatusIcon /> : <ErrorStatusIcon />}
-          <span className="overflow-hidden whitespace-nowrap font-sans text-[12px] font-normal leading-[14.5px]">
+          <span
+            className="min-w-0 flex-1 whitespace-normal break-words font-sans text-[12px] font-normal leading-[16px]"
+            title={message}
+          >
             {message}
           </span>
         </div>

--- a/apps/studio/src/renderer/components/ShellLayout/connectivity-env.ts
+++ b/apps/studio/src/renderer/components/ShellLayout/connectivity-env.ts
@@ -46,8 +46,13 @@ export const FIXED_MODEL_ENV_FIELDS: readonly ModelEnvField[] = [
  * saved env text may use compatible aliases such as OPENAI_API_KEY.
  */
 export function hasCompleteModelEnvConfig(text: string): boolean {
+  return getModelEnvConfigError(text) === null;
+}
+
+export function getModelEnvConfigError(text: string): string | null {
   const env = parseEnvText(text);
-  return !('error' in resolveModelConnection(env));
+  const resolved = resolveModelConnection(env);
+  return 'error' in resolved ? resolved.error : null;
 }
 
 /**

--- a/apps/studio/src/renderer/recorder/model-config.ts
+++ b/apps/studio/src/renderer/recorder/model-config.ts
@@ -12,6 +12,9 @@ function resolveModelConfigFromProvider(
 ): IModelConfig | null {
   const resolved = resolveModelConnectionWithConfig(provider);
   if ('error' in resolved) {
+    if (resolved.kind === 'invalid-config') {
+      throw new Error(resolved.error);
+    }
     return null;
   }
   return resolved.modelConfig;

--- a/apps/studio/src/shared/model-connection.ts
+++ b/apps/studio/src/shared/model-connection.ts
@@ -22,7 +22,12 @@ export interface ResolvedModelConnection extends ModelConnectionParams {
   modelConfig: IModelConfig;
 }
 
+export type ModelConnectionErrorKind =
+  | 'missing-required-keys'
+  | 'invalid-config';
+
 export interface ModelConnectionError {
+  kind: ModelConnectionErrorKind;
   error: string;
 }
 
@@ -65,7 +70,10 @@ export function resolveModelConnectionWithConfig(
   if (!model) missing.push(MIDSCENE_MODEL_NAME);
 
   if (missing.length > 0) {
-    return { error: `Missing required keys: ${missing.join(', ')}` };
+    return {
+      kind: 'missing-required-keys',
+      error: `Missing required keys: ${missing.join(', ')}`,
+    };
   }
 
   let modelConfig: IModelConfig;
@@ -76,6 +84,7 @@ export function resolveModelConnectionWithConfig(
     modelConfig = modelConfigManager.getModelConfig('default');
   } catch (error) {
     return {
+      kind: 'invalid-config',
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/apps/studio/src/shared/model-connection.ts
+++ b/apps/studio/src/shared/model-connection.ts
@@ -22,6 +22,10 @@ export interface ResolvedModelConnection extends ModelConnectionParams {
   modelConfig: IModelConfig;
 }
 
+export interface ModelConnectionError {
+  error: string;
+}
+
 export function connectivityRequestToModelConfig(
   request: ConnectivityTestRequest,
 ): TModelConfig {
@@ -34,7 +38,7 @@ export function connectivityRequestToModelConfig(
 
 export function resolveModelConnection(
   provider: Record<string, string | number | undefined>,
-): ModelConnectionParams | { error: string } {
+): ModelConnectionParams | ModelConnectionError {
   const resolved = resolveModelConnectionWithConfig(provider);
   if ('error' in resolved) {
     return resolved;
@@ -49,7 +53,7 @@ export function resolveModelConnection(
 
 export function resolveModelConnectionWithConfig(
   provider: Record<string, string | number | undefined>,
-): ResolvedModelConnection | { error: string } {
+): ResolvedModelConnection | ModelConnectionError {
   const normalizedProvider = normalizeStudioModelProvider(provider);
   const apiKey = normalizedProvider[MIDSCENE_MODEL_API_KEY]?.trim() || '';
   const baseUrl = normalizedProvider[MIDSCENE_MODEL_BASE_URL]?.trim() || '';
@@ -64,11 +68,17 @@ export function resolveModelConnectionWithConfig(
     return { error: `Missing required keys: ${missing.join(', ')}` };
   }
 
-  const modelConfigManager = new ModelConfigManager(
-    normalizedProvider as TModelConfig,
-  );
-  const modelConfig: IModelConfig =
-    modelConfigManager.getModelConfig('default');
+  let modelConfig: IModelConfig;
+  try {
+    const modelConfigManager = new ModelConfigManager(
+      normalizedProvider as TModelConfig,
+    );
+    modelConfig = modelConfigManager.getModelConfig('default');
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   return {
     apiKey,

--- a/apps/studio/tests/connectivity-env.test.ts
+++ b/apps/studio/tests/connectivity-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getModelEnvConfigError,
   hasCompleteModelEnvConfig,
   parseEnvEntries,
   parseEnvText,
@@ -115,6 +116,25 @@ describe('resolveModelConnection', () => {
     expect(result).toEqual({
       error: expect.stringContaining('OPENAI_BASE_URL'),
     });
+  });
+
+  it('reports invalid model family as a config error instead of throwing', () => {
+    const source = [
+      'MIDSCENE_MODEL_BASE_URL=https://example.com/v1',
+      'MIDSCENE_MODEL_API_KEY=sk-test',
+      'MIDSCENE_MODEL_NAME=qwen3-vl-plus',
+      'MIDSCENE_MODEL_FAMILY=1',
+    ].join('\n');
+
+    const result = resolveModelConnection(parseEnvText(source));
+
+    expect(result).toEqual({
+      error: expect.stringContaining('Invalid MIDSCENE_MODEL_FAMILY value: 1'),
+    });
+    expect(hasCompleteModelEnvConfig(source)).toBe(false);
+    expect(getModelEnvConfigError(source)).toContain(
+      'Invalid MIDSCENE_MODEL_FAMILY value: 1',
+    );
   });
 
   it('treats OpenAI-compatible env aliases as a complete Studio model config', () => {

--- a/apps/studio/tests/connectivity-env.test.ts
+++ b/apps/studio/tests/connectivity-env.test.ts
@@ -114,6 +114,7 @@ describe('resolveModelConnection', () => {
   it('reports missing required keys', () => {
     const result = resolveModelConnection({ OPENAI_API_KEY: 'sk' });
     expect(result).toEqual({
+      kind: 'missing-required-keys',
       error: expect.stringContaining('OPENAI_BASE_URL'),
     });
   });
@@ -129,6 +130,7 @@ describe('resolveModelConnection', () => {
     const result = resolveModelConnection(parseEnvText(source));
 
     expect(result).toEqual({
+      kind: 'invalid-config',
       error: expect.stringContaining('Invalid MIDSCENE_MODEL_FAMILY value: 1'),
     });
     expect(hasCompleteModelEnvConfig(source)).toBe(false);

--- a/apps/studio/tests/model-env-config-modal.test.tsx
+++ b/apps/studio/tests/model-env-config-modal.test.tsx
@@ -147,6 +147,31 @@ describe('ModelEnvConfigModal', () => {
     await unmountModal(validRender.root);
   });
 
+  it('shows invalid model family without crashing the modal', async () => {
+    const { container, root } = await renderModal(
+      [
+        'MIDSCENE_MODEL_BASE_URL=https://example.com/v1',
+        'MIDSCENE_MODEL_API_KEY=sk-test',
+        'MIDSCENE_MODEL_NAME=qwen3-vl-plus',
+        'MIDSCENE_MODEL_FAMILY=1',
+      ].join('\n'),
+    );
+
+    expect(getConnectivityButton(container).disabled).toBe(true);
+    expect(container.textContent).toContain(
+      'Invalid MIDSCENE_MODEL_FAMILY value: 1',
+    );
+    const errorMessage = Array.from(container.querySelectorAll('span')).find(
+      (item) =>
+        item.textContent?.includes('Invalid MIDSCENE_MODEL_FAMILY value: 1'),
+    );
+    expect(errorMessage?.className).toContain('whitespace-normal');
+    expect(errorMessage?.className).not.toContain('text-ellipsis');
+    expect(container.querySelector('.h-\\[524px\\]')).toBeTruthy();
+
+    await unmountModal(root);
+  });
+
   it('starts spinning only while the connectivity test is running', async () => {
     const { container, root } = await renderModal(VALID_ENV_TEXT);
     const runConnectivityTest = vi.fn(

--- a/apps/studio/tests/studio-recorder-model-config.test.ts
+++ b/apps/studio/tests/studio-recorder-model-config.test.ts
@@ -78,4 +78,49 @@ describe('resolveStudioRecorderModelConfig', () => {
       modelFamily: 'qwen3-vl',
     });
   });
+
+  it('falls back when the saved Studio env text is incomplete', async () => {
+    memoryStore['studio:model-env-text'] =
+      'MIDSCENE_MODEL_API_KEY=sk-incomplete';
+    visualizerState.config = {
+      MIDSCENE_MODEL_BASE_URL: 'https://example.com/v1',
+      MIDSCENE_MODEL_API_KEY: 'sk-test',
+      MIDSCENE_MODEL_NAME: 'qwen3-vl-plus',
+      MIDSCENE_MODEL_FAMILY: 'qwen3-vl',
+    };
+
+    const { resolveStudioRecorderModelConfig } = await import(
+      '../src/renderer/recorder/model-config'
+    );
+
+    expect(resolveStudioRecorderModelConfig()).toMatchObject({
+      modelName: 'qwen3-vl-plus',
+      openaiApiKey: 'sk-test',
+      openaiBaseURL: 'https://example.com/v1',
+      modelFamily: 'qwen3-vl',
+    });
+  });
+
+  it('throws instead of falling back when the saved Studio env text is invalid', async () => {
+    memoryStore['studio:model-env-text'] = [
+      'MIDSCENE_MODEL_BASE_URL=https://example.com/v1',
+      'MIDSCENE_MODEL_API_KEY=sk-invalid',
+      'MIDSCENE_MODEL_NAME=qwen3-vl-plus',
+      'MIDSCENE_MODEL_FAMILY=1',
+    ].join('\n');
+    visualizerState.config = {
+      MIDSCENE_MODEL_BASE_URL: 'https://example.com/v1',
+      MIDSCENE_MODEL_API_KEY: 'sk-test',
+      MIDSCENE_MODEL_NAME: 'qwen3-vl-plus',
+      MIDSCENE_MODEL_FAMILY: 'qwen3-vl',
+    };
+
+    const { resolveStudioRecorderModelConfig } = await import(
+      '../src/renderer/recorder/model-config'
+    );
+
+    expect(() => resolveStudioRecorderModelConfig()).toThrow(
+      'Invalid MIDSCENE_MODEL_FAMILY value: 1',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Convert Studio model connection validation failures from thrown exceptions into structured config errors.
- Show invalid `MIDSCENE_MODEL_FAMILY` values inside the Model Env Config modal instead of letting the renderer crash.
- Allow long validation errors to wrap in the modal and keep the connectivity test disabled while the config is invalid.

## Root Cause

Studio reused `ModelConfigManager.getModelConfig()` during render-time validation. When a saved or typed env value such as `MIDSCENE_MODEL_FAMILY=1` was invalid, `getModelConfig()` threw synchronously, which escaped React rendering and blanked the Studio UI.

## Validation

- `pnpm --filter studio test -- tests/connectivity-env.test.ts tests/model-env-config-modal.test.tsx tests/model-env-storage.test.ts tests/studio-recorder-model-config.test.ts`
- `pnpm run lint`
- `pnpm exec nx build studio`

Notes: lint completed with an existing Biome warning under `.claude/worktrees/...`; the Studio build completed with existing sharp/photon bundle warnings.