### PR TITLE
fix(core): preserve raw response on parse failure

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -615,9 +615,19 @@ export async function callAIWithObjectResponse<T>(
     abortSignal: options?.abortSignal,
   });
   assert(response, 'empty response');
-  const jsonContent = adapter.jsonParser(response.content, {
-    source: options?.jsonParserSource ?? 'generic-object',
-  });
+  let jsonContent: unknown;
+  try {
+    jsonContent = adapter.jsonParser(response.content, {
+      source: options?.jsonParserSource ?? 'generic-object',
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new AIResponseParseError(
+      errorMessage,
+      response.content,
+      response.usage,
+    );
+  }
   if (typeof jsonContent !== 'object') {
     throw new AIResponseParseError(
       `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -1,5 +1,9 @@
 import { getModelRuntime } from '@/ai-model/models';
-import { callAI, callAIWithObjectResponse } from '@/ai-model/service-caller';
+import {
+  AIResponseParseError,
+  callAI,
+  callAIWithObjectResponse,
+} from '@/ai-model/service-caller';
 import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -133,6 +137,53 @@ describe('service-caller reasoning fallback', () => {
     expect(response.contentString).toBe(
       '{"type":"Tap","param":{"locate":{"prompt":"POI RichInfo tab"}}}',
     );
+  });
+
+  it('preserves raw model response when object JSON parsing fails', async () => {
+    const rawResponse = `\`\`\`json
+{
+  "bbox": 37, 313, 55, 324,
+  "errors": []
+}
+\`\`\``;
+
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: rawResponse,
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    });
+
+    const promise = callAIWithObjectResponse(
+      [{ role: 'user', content: 'locate element' }],
+      baseModelConfig,
+      { jsonParserSource: 'locate' },
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(AIResponseParseError);
+
+    try {
+      await promise;
+    } catch (error) {
+      const typedError = error as AIResponseParseError;
+      expect(typedError.message).toContain(
+        'failed to parse LLM response into JSON',
+      );
+      expect(typedError.rawResponse).toBe(rawResponse);
+      expect(typedError.usage).toMatchObject({
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      });
+    }
   });
 
   it('uses modelConfig reasoningEnabled by default in callAI', async () => {


### PR DESCRIPTION
## Summary

- Preserve the original model response when `callAIWithObjectResponse` fails to parse object JSON.
- Wrap parser failures as `AIResponseParseError` with `response.content` as `rawResponse`, so locate/report dumps no longer store the parser error message in the raw response field.
- Add a regression test for malformed locate JSON where the original markdown JSON block must be retained.

## Root Cause

`adapter.jsonParser(response.content)` could throw a plain `Error`. Downstream locate handling only preserves `rawResponse` for `AIResponseParseError`, so plain parser errors were converted into `error.message`, causing `rawResponse` in dumps to contain the parse error text instead of the raw model output.

## Validation

```bash
pnpm --filter @midscene/core test tests/unit-test/service-caller-reasoning-fallback.test.ts
```

Note: `git commit` also triggered the repository hook and ran `lint-staged` on the staged TypeScript files.