### PR TITLE
refactor(report): rename copy JSON link class and update styling

### DIFF
--- a/apps/report/src/components/detail-panel/index.less
+++ b/apps/report/src/components/detail-panel/index.less
@@ -42,6 +42,18 @@
     }
   }
 
+  .copy-json-link {
+    font-size: 13px;
+    color: @main-text;
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
   .detail-content {
     box-sizing: border-box;
     justify-content: center;
@@ -262,6 +274,14 @@
 
     &:hover {
       color: #69b1ff;
+    }
+  }
+
+  .copy-json-link {
+    color: #e8eaed;
+
+    &:hover {
+      opacity: 0.7;
     }
   }
 

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -417,7 +417,7 @@ const DetailPanel = (): JSX.Element => {
           )}
           {viewType === VIEW_TYPE_JSON && activeTaskJsonText && (
             <a
-              className="download-zip-link"
+              className="copy-json-link"
               onClick={() => {
                 navigator.clipboard
                   .writeText(activeTaskJsonText)


### PR DESCRIPTION
## Summary
Updated the detail panel component to use a more semantically accurate class name for the JSON copy functionality and added corresponding dark mode styling.

## Changes
- Renamed CSS class from `download-zip-link` to `copy-json-link` to better reflect the actual functionality (copying JSON text to clipboard rather than downloading)
- Added base styling for `.copy-json-link` with appropriate font size, color, cursor, and hover effects
- Added dark mode variant styling for `.copy-json-link` in the dark theme section
- Updated the JSX element to use the new `copy-json-link` class name

## Implementation Details
The change improves code clarity by using a class name that accurately describes the button's behavior. The styling is consistent with the existing design patterns in the component, including hover opacity effects for both light and dark modes.

## Validation
- `pnpm run lint` (to verify code style compliance)

https://claude.ai/code/session_01T1txHmSVbV7drWuhKDprqS