### PR TITLE
fix(cli): lazy-load Rstest core in CLI framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build project
       run: pnpm run build
 
-    - name: Check CLI CJS bundle on Node 20
+    - name: Check CLI CJS bundle on minimum supported Node
       run: |
         node - <<'EOF'
         const { readdirSync, readFileSync, statSync } = require('node:fs');
@@ -99,7 +99,7 @@ jobs:
           }
         }
         EOF
-        npx -y node@20.9.0 packages/cli/dist/lib/index.js --version
+        npx -y node@20.19.0 packages/cli/dist/lib/index.js --version
 
     - name: Type check tests
       run: pnpm run type-check:tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,24 @@ jobs:
     - name: Build project
       run: pnpm run build
 
+    - name: Check CLI CJS bundle on Node 20
+      run: |
+        node - <<'EOF'
+        const { readFileSync } = require('node:fs');
+        const files = [
+          'packages/cli/dist/lib/index.js',
+          'packages/cli/dist/lib/framework/index.js',
+        ];
+        const staticRstestRequire = /require\((['"])@rstest\/core\1\)/;
+        for (const file of files) {
+          const content = readFileSync(file, 'utf8');
+          if (staticRstestRequire.test(content)) {
+            throw new Error(`${file} contains a static require("@rstest/core")`);
+          }
+        }
+        EOF
+        npx -y node@20.9.0 packages/cli/dist/lib/index.js --version
+
     - name: Type check tests
       run: pnpm run type-check:tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,40 @@ jobs:
     - name: Check CLI CJS bundle on Node 20
       run: |
         node - <<'EOF'
-        const { readFileSync } = require('node:fs');
-        const files = [
-          'packages/cli/dist/lib/index.js',
-          'packages/cli/dist/lib/framework/index.js',
+        const { readdirSync, readFileSync, statSync } = require('node:fs');
+        const { join } = require('node:path');
+
+        const root = 'packages/cli/dist/lib';
+        const files = [];
+        const collectJsFiles = (dir) => {
+          for (const entry of readdirSync(dir)) {
+            const file = join(dir, entry);
+            if (statSync(file).isDirectory()) {
+              collectJsFiles(file);
+            } else if (file.endsWith('.js')) {
+              files.push(file);
+            }
+          }
+        };
+        collectJsFiles(root);
+
+        const staticRequirePatterns = [
+          {
+            name: '@rstest/core',
+            pattern: /require\((['"])@rstest\/core(?:\/[^'"]*)?\1\)/,
+          },
+          {
+            name: '@rsbuild/core',
+            pattern: /require\((['"])@rsbuild\/core(?:\/[^'"]*)?\1\)/,
+          },
         ];
-        const staticRstestRequire = /require\((['"])@rstest\/core\1\)/;
+
         for (const file of files) {
           const content = readFileSync(file, 'utf8');
-          if (staticRstestRequire.test(content)) {
-            throw new Error(`${file} contains a static require("@rstest/core")`);
+          for (const { name, pattern } of staticRequirePatterns) {
+            if (pattern.test(content)) {
+              throw new Error(`${file} contains a static require("${name}")`);
+            }
           }
         }
         EOF

--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -51,6 +51,8 @@ Notes:
 
 ### Install the CLI
 
+Before installing the CLI, make sure the terminal that runs `midscene` uses Node.js `20.19+`, `22.12+`, or `24+`. Some CLI execution paths use the Rstest/Rspack toolchain, which rejects older Node 20 patch versions such as `20.17.0`. If you see an `Unsupported Node.js version` message from Rspack, upgrade Node.js and reinstall the global CLI or project dependencies.
+
 Install `@midscene/cli` globally (recommended for first-time users):
 
 ```bash

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -54,6 +54,8 @@ MIDSCENE_MODEL_FAMILY="替换为你的模型系列"
 
 ### 安装命令行工具
 
+安装 CLI 前，请确认运行 `midscene` 的终端使用 Node.js `20.19+`、`22.12+` 或 `24+`。CLI 的部分执行路径会使用 Rstest/Rspack 工具链，这些依赖会拒绝 `20.17.0` 这类较旧的 Node 20 patch 版本。如果看到 Rspack 抛出的 `Unsupported Node.js version` 提示，请升级 Node.js 后重新安装全局 CLI 或项目依赖。
+
 全局安装 `@midscene/cli` （推荐新手使用）：
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "yargs": "17.7.2"
   },
   "engines": {
-    "node": ">=18.19.0"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/src/framework/rstest-dependencies.ts
+++ b/packages/cli/src/framework/rstest-dependencies.ts
@@ -1,0 +1,34 @@
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+
+// `@rstest/core` and `@rsbuild/core` are direct dependencies of `@midscene/cli`,
+// so they always sit on the resolution path of the CLI's own files. Anchor the
+// lookup to this module's location (`__dirname` of the bundled output) rather
+// than `process.argv[1]`: the command-line entry can be a wrapper script, a
+// symlinked bin, an `npx` cache path, or some other launcher whose `node_modules`
+// chain does not include `@rstest/core`. Anchoring on `process.argv[1]` is what
+// caused YAML runs to fail with "Cannot find module '@rstest/core/package.json'"
+// in environments where the launcher differs from the install location.
+const requireFromCliPackage = () => {
+  if (typeof __dirname !== 'undefined') {
+    return createRequire(join(__dirname, 'index.js'));
+  }
+  // ESM consumers of the bundled output have no `__dirname`; fall back to the
+  // command-line entry so programmatic usage keeps working.
+  const entry = process.argv[1]
+    ? resolve(process.argv[1])
+    : join(process.cwd(), 'midscene-cli.js');
+  return createRequire(entry);
+};
+
+export const resolvePackageFromRstestCore = (packageName: string): string => {
+  const require = requireFromCliPackage();
+  const rstestPackageJsonPath = require.resolve('@rstest/core/package.json');
+  return createRequire(rstestPackageJsonPath).resolve(packageName);
+};
+
+export function resolveRstestCoreImportPath(): string {
+  const require = requireFromCliPackage();
+  const packageJsonPath = require.resolve('@rstest/core/package.json');
+  return join(dirname(packageJsonPath), 'dist', 'index.js');
+}

--- a/packages/cli/src/framework/rstest-dependencies.ts
+++ b/packages/cli/src/framework/rstest-dependencies.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 // `@rstest/core` and `@rsbuild/core` are direct dependencies of `@midscene/cli`,
 // so they always sit on the resolution path of the CLI's own files. Anchor the
@@ -29,6 +29,5 @@ export const resolvePackageFromRstestCore = (packageName: string): string => {
 
 export function resolveRstestCoreImportPath(): string {
   const require = requireFromCliPackage();
-  const packageJsonPath = require.resolve('@rstest/core/package.json');
-  return join(dirname(packageJsonPath), 'dist', 'index.js');
+  return require.resolve('@rstest/core');
 }

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -102,16 +102,7 @@ const createRuntimeFailureResult = (
   error: errorMessageOf(error),
 });
 
-let rstestCorePromise: Promise<{ test: RstestTest }> | undefined;
-
-const loadRstestTest = async (): Promise<RstestTest> => {
-  if (!rstestCorePromise) {
-    rstestCorePromise = import('@rstest/core');
-  }
-  return (await rstestCorePromise).test;
-};
-
-const registerYamlCaseTest = (
+export const defineYamlCaseTest = (
   test: RstestTest,
   options: DefineYamlCaseTestOptions,
 ) => {
@@ -145,32 +136,7 @@ const registerYamlCaseTest = (
   });
 };
 
-export function defineYamlCaseTest(
-  test: RstestTest,
-  options: DefineYamlCaseTestOptions,
-): void;
-/**
- * @deprecated Prefer passing Rstest's `test` API explicitly so test registration
- * stays synchronous. This overload is kept for custom framework compatibility.
- */
-export function defineYamlCaseTest(
-  options: DefineYamlCaseTestOptions,
-): Promise<void>;
-export function defineYamlCaseTest(
-  testOrOptions: RstestTest | DefineYamlCaseTestOptions,
-  maybeOptions?: DefineYamlCaseTestOptions,
-): void | Promise<void> {
-  if (maybeOptions) {
-    registerYamlCaseTest(testOrOptions as RstestTest, maybeOptions);
-    return;
-  }
-
-  return loadRstestTest().then((test) => {
-    registerYamlCaseTest(test, testOrOptions as DefineYamlCaseTestOptions);
-  });
-}
-
-const registerYamlBatchTest = (
+export const defineYamlBatchTest = (
   test: RstestTest,
   options: DefineYamlBatchTestOptions,
 ) => {
@@ -181,28 +147,3 @@ const registerYamlBatchTest = (
     });
   });
 };
-
-export function defineYamlBatchTest(
-  test: RstestTest,
-  options: DefineYamlBatchTestOptions,
-): void;
-/**
- * @deprecated Prefer passing Rstest's `test` API explicitly so test registration
- * stays synchronous. This overload is kept for custom framework compatibility.
- */
-export function defineYamlBatchTest(
-  options: DefineYamlBatchTestOptions,
-): Promise<void>;
-export function defineYamlBatchTest(
-  testOrOptions: RstestTest | DefineYamlBatchTestOptions,
-  maybeOptions?: DefineYamlBatchTestOptions,
-): void | Promise<void> {
-  if (maybeOptions) {
-    registerYamlBatchTest(testOrOptions as RstestTest, maybeOptions);
-    return;
-  }
-
-  return loadRstestTest().then((test) => {
-    registerYamlBatchTest(test, testOrOptions as DefineYamlBatchTestOptions);
-  });
-}

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -149,6 +149,10 @@ export function defineYamlCaseTest(
   test: RstestTest,
   options: DefineYamlCaseTestOptions,
 ): void;
+/**
+ * @deprecated Prefer passing Rstest's `test` API explicitly so test registration
+ * stays synchronous. This overload is kept for custom framework compatibility.
+ */
 export function defineYamlCaseTest(
   options: DefineYamlCaseTestOptions,
 ): Promise<void>;
@@ -182,6 +186,10 @@ export function defineYamlBatchTest(
   test: RstestTest,
   options: DefineYamlBatchTestOptions,
 ): void;
+/**
+ * @deprecated Prefer passing Rstest's `test` API explicitly so test registration
+ * stays synchronous. This overload is kept for custom framework compatibility.
+ */
 export function defineYamlBatchTest(
   options: DefineYamlBatchTestOptions,
 ): Promise<void>;

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -4,7 +4,7 @@ import type {
   MidsceneYamlConfigAttempt,
   MidsceneYamlConfigResult,
 } from '@midscene/core';
-import { test } from '@rstest/core';
+import type { test as rstestTest } from '@rstest/core';
 import type { BatchRunnerConfig } from '../batch-runner';
 import { runYamlBatchInRstest } from './yaml-batch';
 import {
@@ -12,6 +12,8 @@ import {
   createYamlCaseFailure,
   runYamlCaseResult,
 } from './yaml-case';
+
+export type RstestTest = typeof rstestTest;
 
 export interface DefineYamlCaseTestOptions {
   testName: string;
@@ -100,7 +102,19 @@ const createRuntimeFailureResult = (
   error: errorMessageOf(error),
 });
 
-export function defineYamlCaseTest(options: DefineYamlCaseTestOptions) {
+let rstestCorePromise: Promise<{ test: RstestTest }> | undefined;
+
+const loadRstestTest = async (): Promise<RstestTest> => {
+  if (!rstestCorePromise) {
+    rstestCorePromise = import('@rstest/core');
+  }
+  return (await rstestCorePromise).test;
+};
+
+const registerYamlCaseTest = (
+  test: RstestTest,
+  options: DefineYamlCaseTestOptions,
+) => {
   test(options.testName, async () => {
     const file = resolve(options.yamlFile);
     const startTime = Date.now();
@@ -129,13 +143,58 @@ export function defineYamlCaseTest(options: DefineYamlCaseTestOptions) {
       throw error;
     }
   });
+};
+
+export function defineYamlCaseTest(
+  test: RstestTest,
+  options: DefineYamlCaseTestOptions,
+): void;
+export function defineYamlCaseTest(
+  options: DefineYamlCaseTestOptions,
+): Promise<void>;
+export function defineYamlCaseTest(
+  testOrOptions: RstestTest | DefineYamlCaseTestOptions,
+  maybeOptions?: DefineYamlCaseTestOptions,
+): void | Promise<void> {
+  if (maybeOptions) {
+    registerYamlCaseTest(testOrOptions as RstestTest, maybeOptions);
+    return;
+  }
+
+  return loadRstestTest().then((test) => {
+    registerYamlCaseTest(test, testOrOptions as DefineYamlCaseTestOptions);
+  });
 }
 
-export function defineYamlBatchTest(options: DefineYamlBatchTestOptions) {
+const registerYamlBatchTest = (
+  test: RstestTest,
+  options: DefineYamlBatchTestOptions,
+) => {
   test(options.testName, async () => {
     await runYamlBatchInRstest({
       config: options.config,
       resultFiles: options.resultFiles,
     });
+  });
+};
+
+export function defineYamlBatchTest(
+  test: RstestTest,
+  options: DefineYamlBatchTestOptions,
+): void;
+export function defineYamlBatchTest(
+  options: DefineYamlBatchTestOptions,
+): Promise<void>;
+export function defineYamlBatchTest(
+  testOrOptions: RstestTest | DefineYamlBatchTestOptions,
+  maybeOptions?: DefineYamlBatchTestOptions,
+): void | Promise<void> {
+  if (maybeOptions) {
+    registerYamlBatchTest(testOrOptions as RstestTest, maybeOptions);
+    return;
+  }
+
+  return loadRstestTest().then((test) => {
+    registerYamlBatchTest(test, testOrOptions as DefineYamlBatchTestOptions);
   });
 }

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -10,6 +10,7 @@ import {
 } from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import type { BatchRunnerConfig } from '../batch-runner';
+import { resolveRstestCoreImportPath } from './rstest-dependencies';
 import type { RunYamlCaseOptions } from './yaml-case';
 
 export type RstestYamlCaseOptions = Omit<
@@ -40,6 +41,7 @@ export interface CreateRstestYamlProjectOptions {
   bail?: number;
   retry?: number;
   batchConfig?: BatchRunnerConfig;
+  rstestCoreImport?: string;
 }
 
 export interface GeneratedYamlTestCase {
@@ -92,6 +94,7 @@ export const resolveTestName = (
 };
 
 const createGeneratedTestContent = (options: {
+  rstestCoreImport: string;
   frameworkImport: string;
   yamlFile: string;
   resultFile: string;
@@ -109,13 +112,21 @@ const createGeneratedTestContent = (options: {
       : {}),
   };
 
-  return `import { defineYamlCaseTest } from ${toImportLiteral(options.frameworkImport)};
+  return `import { test } from ${toImportLiteral(options.rstestCoreImport)};
+import { defineYamlCaseTest } from ${toImportLiteral(options.frameworkImport)};
 
-defineYamlCaseTest(${JSON.stringify(testOptions, null, 2)});
+const testOptions = ${JSON.stringify(testOptions, null, 2)};
+
+if (defineYamlCaseTest.length >= 2) {
+  defineYamlCaseTest(test, testOptions);
+} else {
+  defineYamlCaseTest(testOptions);
+}
 `;
 };
 
 const createGeneratedBatchTestContent = (options: {
+  rstestCoreImport: string;
   frameworkImport: string;
   testName: string;
   config: BatchRunnerConfig;
@@ -127,9 +138,16 @@ const createGeneratedBatchTestContent = (options: {
     resultFiles: options.resultFiles,
   };
 
-  return `import { defineYamlBatchTest } from ${toImportLiteral(options.frameworkImport)};
+  return `import { test } from ${toImportLiteral(options.rstestCoreImport)};
+import { defineYamlBatchTest } from ${toImportLiteral(options.frameworkImport)};
 
-defineYamlBatchTest(${JSON.stringify(testOptions, null, 2)});
+const testOptions = ${JSON.stringify(testOptions, null, 2)};
+
+if (defineYamlBatchTest.length >= 2) {
+  defineYamlBatchTest(test, testOptions);
+} else {
+  defineYamlBatchTest(testOptions);
+}
 `;
 };
 
@@ -176,6 +194,8 @@ export function createRstestYamlProject(
   const resultDir = options.resultDir || join(outputDir, 'results');
   const frameworkImport =
     options.frameworkImport || resolveDefaultFrameworkImport();
+  const rstestCoreImport =
+    options.rstestCoreImport || resolveRstestCoreImportPath();
   const testTimeout = options.testTimeout ?? DEFAULT_YAML_TEST_TIMEOUT;
 
   rmSync(outputDir, { recursive: true, force: true });
@@ -189,6 +209,7 @@ export function createRstestYamlProject(
     const resultFile = join(resultDir, `${fileStem}.json`);
     const testModule = toVirtualModuleId(fileStem);
     virtualModules[testModule] = createGeneratedTestContent({
+      rstestCoreImport,
       frameworkImport,
       yamlFile,
       resultFile,
@@ -214,6 +235,7 @@ export function createRstestYamlProject(
       include: [batchTest.testModule],
       virtualModules: {
         [batchTest.testModule]: createGeneratedBatchTestContent({
+          rstestCoreImport,
           frameworkImport,
           testName: batchTest.testName,
           config: options.batchConfig,

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -117,11 +117,7 @@ import { defineYamlCaseTest } from ${toImportLiteral(options.frameworkImport)};
 
 const testOptions = ${JSON.stringify(testOptions, null, 2)};
 
-if (defineYamlCaseTest.length >= 2) {
-  defineYamlCaseTest(test, testOptions);
-} else {
-  await defineYamlCaseTest(testOptions);
-}
+defineYamlCaseTest(test, testOptions);
 `;
 };
 
@@ -143,11 +139,7 @@ import { defineYamlBatchTest } from ${toImportLiteral(options.frameworkImport)};
 
 const testOptions = ${JSON.stringify(testOptions, null, 2)};
 
-if (defineYamlBatchTest.length >= 2) {
-  defineYamlBatchTest(test, testOptions);
-} else {
-  await defineYamlBatchTest(testOptions);
-}
+defineYamlBatchTest(test, testOptions);
 `;
 };
 

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -120,7 +120,7 @@ const testOptions = ${JSON.stringify(testOptions, null, 2)};
 if (defineYamlCaseTest.length >= 2) {
   defineYamlCaseTest(test, testOptions);
 } else {
-  defineYamlCaseTest(testOptions);
+  await defineYamlCaseTest(testOptions);
 }
 `;
 };
@@ -146,7 +146,7 @@ const testOptions = ${JSON.stringify(testOptions, null, 2)};
 if (defineYamlBatchTest.length >= 2) {
   defineYamlBatchTest(test, testOptions);
 } else {
-  defineYamlBatchTest(testOptions);
+  await defineYamlBatchTest(testOptions);
 }
 `;
 };

--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -1,50 +1,20 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
 import type { RstestUserConfig, TestRunResult } from '@rstest/core/api';
+import { resolvePackageFromRstestCore } from './rstest-dependencies';
 import type {
   GeneratedRstestYamlProject,
   GeneratedYamlTestCase,
 } from './rstest-project';
 
+export { resolveRstestCoreImportPath } from './rstest-dependencies';
+
 export interface RunRstestYamlProjectOptions {
   project: GeneratedRstestYamlProject;
   cwd?: string;
   stdio?: 'inherit' | 'pipe';
-}
-
-// `@rstest/core` and `@rsbuild/core` are direct dependencies of `@midscene/cli`,
-// so they always sit on the resolution path of the CLI's own files. Anchor the
-// lookup to this module's location (`__dirname` of the bundled output) rather
-// than `process.argv[1]`: the command-line entry can be a wrapper script, a
-// symlinked bin, an `npx` cache path, or some other launcher whose `node_modules`
-// chain does not include `@rstest/core`. Anchoring on `process.argv[1]` is what
-// caused YAML runs to fail with "Cannot find module '@rstest/core/package.json'"
-// in environments where the launcher differs from the install location.
-const requireFromCliPackage = () => {
-  if (typeof __dirname !== 'undefined') {
-    return createRequire(join(__dirname, 'index.js'));
-  }
-  // ESM consumers of the bundled output have no `__dirname`; fall back to the
-  // command-line entry so programmatic usage keeps working.
-  const entry = process.argv[1]
-    ? resolve(process.argv[1])
-    : join(process.cwd(), 'midscene-cli.js');
-  return createRequire(entry);
-};
-
-const resolvePackageFromRstestCore = (packageName: string): string => {
-  const require = requireFromCliPackage();
-  const rstestPackageJsonPath = require.resolve('@rstest/core/package.json');
-  return createRequire(rstestPackageJsonPath).resolve(packageName);
-};
-
-export function resolveRstestCoreImportPath(): string {
-  const require = requireFromCliPackage();
-  const packageJsonPath = require.resolve('@rstest/core/package.json');
-  return join(dirname(packageJsonPath), 'dist', 'index.js');
 }
 
 const formatRunError = (

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -30,8 +30,7 @@ describe('framework test command', () => {
       framework,
       `import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { test } from '@rstest/core';
-export function defineYamlCaseTest(options: any) {
+export function defineYamlCaseTest(test: any, options: any) {
   test(options.testName, async () => {
   mkdirSync(dirname(options.resultFile), { recursive: true });
   writeFileSync(${JSON.stringify(marker)}, JSON.stringify({
@@ -594,8 +593,7 @@ export function defineYamlCaseTest(options: any) {
     // error instead of a blank "not executed".
     writeFileSync(
       framework,
-      `import { test } from '@rstest/core';
-export function defineYamlCaseTest(options: any) {
+      `export function defineYamlCaseTest(test: any, options: any) {
   test(options.testName, async () => {
     throw new Error(${JSON.stringify(failureMessage)});
   });
@@ -714,8 +712,7 @@ export function defineYamlCaseTest(options: any) {
     writeFileSync(yamlB, 'web:\n  url: about:blank\ntasks: []\n');
     writeFileSync(
       framework,
-      `import { test } from '@rstest/core';
-export function defineYamlBatchTest(options: any) {
+      `export function defineYamlBatchTest(test: any, options: any) {
   test(options.testName, async () => {
     throw new Error(${JSON.stringify(failureMessage)});
   });

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { defineYamlCaseTest } from '@/framework/rstest-entry';
+import { type RstestTest, defineYamlCaseTest } from '@/framework/rstest-entry';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -27,6 +27,8 @@ vi.mock('@/framework/yaml-case', () => ({
 
 const createTempDir = () =>
   mkdtempSync(join(tmpdir(), 'midscene-rstest-entry-'));
+
+const injectedRstestTest = () => mocks.rstestTest as unknown as RstestTest;
 
 describe('defineYamlCaseTest', () => {
   beforeEach(() => {
@@ -79,7 +81,7 @@ describe('defineYamlCaseTest', () => {
       });
 
     try {
-      defineYamlCaseTest(mocks.rstestTest, {
+      defineYamlCaseTest(injectedRstestTest(), {
         testName: 'case',
         yamlFile: yaml,
         resultFile,
@@ -127,7 +129,7 @@ describe('defineYamlCaseTest', () => {
     });
 
     try {
-      defineYamlCaseTest(mocks.rstestTest, {
+      defineYamlCaseTest(injectedRstestTest(), {
         testName: 'case',
         yamlFile: yaml,
         resultFile,

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -11,12 +11,12 @@ import { defineYamlCaseTest } from '@/framework/rstest-entry';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  test: vi.fn(),
+  rstestTest: vi.fn(),
   runYamlCaseResult: vi.fn(),
 }));
 
 vi.mock('@rstest/core', () => ({
-  test: mocks.test,
+  test: mocks.rstestTest,
 }));
 
 vi.mock('@/framework/yaml-case', () => ({
@@ -31,6 +31,26 @@ const createTempDir = () =>
 describe('defineYamlCaseTest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test('loads Rstest dynamically for single-argument callers', async () => {
+    const root = createTempDir();
+    const yaml = join(root, 'case.yaml');
+    const resultFile = join(root, 'results', 'case.json');
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      await defineYamlCaseTest({
+        testName: 'case',
+        yamlFile: yaml,
+        resultFile,
+      });
+
+      expect(mocks.rstestTest).toHaveBeenCalledTimes(1);
+      expect(mocks.rstestTest.mock.calls[0][0]).toBe('case');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('preserves failed attempts when Rstest retries a YAML case', async () => {
@@ -59,13 +79,13 @@ describe('defineYamlCaseTest', () => {
       });
 
     try {
-      defineYamlCaseTest({
+      defineYamlCaseTest(mocks.rstestTest, {
         testName: 'case',
         yamlFile: yaml,
         resultFile,
       });
 
-      const [, runCase] = mocks.test.mock.calls[0];
+      const [, runCase] = mocks.rstestTest.mock.calls[0];
       await expect(runCase()).rejects.toThrow('first attempt failed');
       await expect(runCase()).resolves.toBeUndefined();
 
@@ -107,13 +127,13 @@ describe('defineYamlCaseTest', () => {
     });
 
     try {
-      defineYamlCaseTest({
+      defineYamlCaseTest(mocks.rstestTest, {
         testName: 'case',
         yamlFile: yaml,
         resultFile,
       });
 
-      const [, runCase] = mocks.test.mock.calls[0];
+      const [, runCase] = mocks.rstestTest.mock.calls[0];
       await expect(runCase()).rejects.toThrow(
         'task failed with continue-on-error',
       );

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -35,26 +35,6 @@ describe('defineYamlCaseTest', () => {
     vi.clearAllMocks();
   });
 
-  test('loads Rstest dynamically for single-argument callers', async () => {
-    const root = createTempDir();
-    const yaml = join(root, 'case.yaml');
-    const resultFile = join(root, 'results', 'case.json');
-    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
-
-    try {
-      await defineYamlCaseTest({
-        testName: 'case',
-        yamlFile: yaml,
-        resultFile,
-      });
-
-      expect(mocks.rstestTest).toHaveBeenCalledTimes(1);
-      expect(mocks.rstestTest.mock.calls[0][0]).toBe('case');
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   test('preserves failed attempts when Rstest retries a YAML case', async () => {
     const root = createTempDir();
     const yaml = join(root, 'case.yaml');

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -33,6 +33,7 @@ describe('rstest yaml project generation', () => {
         projectDir: root,
         outputDir,
         frameworkImport: '@test/framework',
+        rstestCoreImport: '@test/rstest-core',
         maxConcurrency: 2,
       });
 
@@ -52,10 +53,12 @@ describe('rstest yaml project generation', () => {
       expect(project.testTimeout).toBe(DEFAULT_YAML_TEST_TIMEOUT);
 
       const generated = project.virtualModules[project.cases[1].testModule];
+      expect(generated).toContain('import { test } from "@test/rstest-core"');
       expect(generated).toContain(
         'import { defineYamlCaseTest } from "@test/framework"',
       );
-      expect(generated).toContain('defineYamlCaseTest');
+      expect(generated).toContain('defineYamlCaseTest(test, testOptions)');
+      expect(generated).toContain('defineYamlCaseTest(testOptions)');
       expect(generated).toContain(JSON.stringify(yamlB));
       expect(generated).not.toContain('runYamlCaseInChildProcess');
       expect(generated).not.toContain('webRuntimeOptions');
@@ -76,6 +79,7 @@ describe('rstest yaml project generation', () => {
         projectDir: root,
         outputDir,
         frameworkImport: '@test/framework',
+        rstestCoreImport: '@test/rstest-core',
         caseOptions: {
           [yaml]: {
             globalConfig: {
@@ -214,6 +218,7 @@ describe('rstest yaml project generation', () => {
         projectDir: root,
         outputDir,
         frameworkImport: '@test/framework',
+        rstestCoreImport: '@test/rstest-core',
         batchConfig: {
           files: [yamlA, yamlB],
           concurrent: 1,
@@ -240,10 +245,12 @@ describe('rstest yaml project generation', () => {
       expect(project.cases).toHaveLength(2);
       expect(project.maxConcurrency).toBe(1);
       const generated = project.virtualModules[project.include[0]];
+      expect(generated).toContain('import { test } from "@test/rstest-core"');
       expect(generated).toContain(
         'import { defineYamlBatchTest } from "@test/framework"',
       );
-      expect(generated).toContain('defineYamlBatchTest');
+      expect(generated).toContain('defineYamlBatchTest(test, testOptions)');
+      expect(generated).toContain('defineYamlBatchTest(testOptions)');
       expect(generated).toContain('"shareBrowserContext": true');
       expect(generated).toContain(JSON.stringify(yamlA));
       expect(generated).toContain(JSON.stringify(yamlB));

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -58,7 +58,7 @@ describe('rstest yaml project generation', () => {
         'import { defineYamlCaseTest } from "@test/framework"',
       );
       expect(generated).toContain('defineYamlCaseTest(test, testOptions)');
-      expect(generated).toContain('defineYamlCaseTest(testOptions)');
+      expect(generated).toContain('await defineYamlCaseTest(testOptions)');
       expect(generated).toContain(JSON.stringify(yamlB));
       expect(generated).not.toContain('runYamlCaseInChildProcess');
       expect(generated).not.toContain('webRuntimeOptions');
@@ -250,7 +250,7 @@ describe('rstest yaml project generation', () => {
         'import { defineYamlBatchTest } from "@test/framework"',
       );
       expect(generated).toContain('defineYamlBatchTest(test, testOptions)');
-      expect(generated).toContain('defineYamlBatchTest(testOptions)');
+      expect(generated).toContain('await defineYamlBatchTest(testOptions)');
       expect(generated).toContain('"shareBrowserContext": true');
       expect(generated).toContain(JSON.stringify(yamlA));
       expect(generated).toContain(JSON.stringify(yamlB));

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -58,7 +58,7 @@ describe('rstest yaml project generation', () => {
         'import { defineYamlCaseTest } from "@test/framework"',
       );
       expect(generated).toContain('defineYamlCaseTest(test, testOptions)');
-      expect(generated).toContain('await defineYamlCaseTest(testOptions)');
+      expect(generated).not.toContain('defineYamlCaseTest(testOptions)');
       expect(generated).toContain(JSON.stringify(yamlB));
       expect(generated).not.toContain('runYamlCaseInChildProcess');
       expect(generated).not.toContain('webRuntimeOptions');
@@ -250,7 +250,7 @@ describe('rstest yaml project generation', () => {
         'import { defineYamlBatchTest } from "@test/framework"',
       );
       expect(generated).toContain('defineYamlBatchTest(test, testOptions)');
-      expect(generated).toContain('await defineYamlBatchTest(testOptions)');
+      expect(generated).not.toContain('defineYamlBatchTest(testOptions)');
       expect(generated).toContain('"shareBrowserContext": true');
       expect(generated).toContain(JSON.stringify(yamlA));
       expect(generated).toContain(JSON.stringify(yamlB));


### PR DESCRIPTION
## Summary
- Remove the runtime static import of `@rstest/core` from the CLI framework entry so the CommonJS CLI no longer loads Rstest for unrelated commands such as `--version`.
- Generate YAML Rstest virtual modules with an explicit Rstest `test` import and pass `test` into the framework helpers.
- Remove the legacy one-argument `defineYamlCaseTest` / `defineYamlBatchTest` fallback; generated modules now always use the injected `test` API.
- Share the CLI-anchored Rstest dependency resolution between the project generator and runner without hard-coding Rstest's internal `dist` layout.
- Align `@midscene/cli`'s package-level Node.js engines with the Rstest/Rspack dependency floor: `^20.19.0 || ^22.12.0 || >=24.0.0`.
- Add a CI smoke gate that recursively checks the built CLI CJS bundle for static Rstest/Rsbuild requires and runs the CJS entry on the minimum supported Node 20 patch version, Node 20.19.0.
- Document the CLI/Rstest/Rspack Node.js version guidance in the English and Chinese YAML script runner docs.

## Root Cause
The published CJS bundle loaded `packages/cli/src/framework/index.ts` for every CLI invocation, including `--version`. That barrel exported `rstest-entry.ts`, which statically imported `@rstest/core`. Because `@rstest/core` is ESM-only, older Node 20 versions failed during module loading with `ERR_REQUIRE_ESM` before the CLI could print its version.

## Side Effects / Risk Assessment
- Generated virtual test modules now import Rstest's `test` API directly and pass it to Midscene's framework helpers. This keeps the normal CLI-generated path synchronous for Rstest workers.
- The old one-argument helper shape is no longer supported. These helpers are internal to the generated CLI framework modules rather than a documented user API, so removing the compatibility branch keeps the contract smaller and avoids async registration during Rstest collection.
- The shared dependency-resolution helper preserves the existing CLI-package anchoring, so `npx`/bin-wrapper resolution behavior should remain unchanged, while relying on package resolution instead of Rstest's internal file layout.
- `@midscene/cli` now advertises the same Node.js floor as its Rstest/Rspack dependency path. This can surface earlier npm engine warnings or `engine-strict` install failures on Node 18 and older Node 20 patch versions, but it matches the package's real published dependency constraints and avoids a misleading support claim.
- The root workspace engine remains `>=18.19.0`; this PR only narrows the published CLI package. SDK-only packages are not being declared as requiring Node 20.19+ by this change.
- The CI gate still scans the full CLI CJS output for static `require()` calls to `@rstest/core` / `@rsbuild/core`, and the runtime smoke now uses Node 20.19.0 because that is the CLI package's declared minimum supported Node 20 patch.
- Registry smoke testing should use the public npm registry for immediately published beta versions; internal mirrors may lag behind the npmjs registry.

## Published Prepatch
- Published beta version: `1.9.5-beta-20260612074801.0`
- Release workflow: https://github.com/web-infra-dev/midscene/actions/runs/27401144193

## Validation
- Reproduced before the fix with: `npx -y node@20.9.0 packages/cli/dist/lib/index.js --version`
- `pnpm run lint`
- `pnpm run check-dependency-version`
- `pnpm run type-check:tests`
- `pnpm --filter @midscene/cli exec vitest --run tests/unit-test/framework/rstest-entry.test.ts tests/unit-test/framework/rstest-project.test.ts tests/unit-test/framework/rstest-runner.test.ts tests/unit-test/framework/command.test.ts`
- `npx nx test @midscene/cli`
- `npx nx build @midscene/cli`
- Verified after the fix: `npx -y node@20.19.0 packages/cli/dist/lib/index.js --version` outputs `1.9.4`
- Confirmed the built CJS output no longer contains static `require()` calls for `@rstest/core` / `@rsbuild/core`
- Ran the updated CI gate command locally with Node 20.19.0
- Verified npm dist-tag `beta` points to `1.9.5-beta-20260612074801.0`
