### PR TITLE
feat(web-integration): add BrowserAgent page selection actions

### DIFF
--- a/apps/site/docs/en/web-api-reference.mdx
+++ b/apps/site/docs/en/web-api-reference.mdx
@@ -84,6 +84,7 @@ const agent = new PuppeteerBrowserAgent(browser, page, {
 - `newPage()` &mdash; Create a new page and make it active.
 - `setActivePage(page: Page)` &mdash; Explicitly set which Puppeteer page the Browser Agent controls next.
 - `waitForNewPage(action?, options?)` &mdash; Wait for a newly opened page without implicitly switching the active page.
+- AI page selection actions &mdash; Browser Agent exposes `ListBrowserPages` and `SetActivePage` in its action space, so AI plans can inspect open tabs and switch the active page by index, title, or URL. These actions are not available on Page Agent.
 
 ### Examples
 
@@ -195,6 +196,7 @@ const agent = new PlaywrightBrowserAgent(context, page, {
 - `newPage()` &mdash; Create a new page and make it active.
 - `setActivePage(page: Page)` &mdash; Explicitly set which Playwright page the Browser Agent controls next.
 - `waitForNewPage(action?, options?)` &mdash; Wait for a newly opened page without implicitly switching the active page.
+- AI page selection actions &mdash; Browser Agent exposes `ListBrowserPages` and `SetActivePage` in its action space, so AI plans can inspect open tabs and switch the active page by index, title, or URL. These actions are not available on Page Agent.
 
 ### Examples
 

--- a/apps/site/docs/zh/web-api-reference.mdx
+++ b/apps/site/docs/zh/web-api-reference.mdx
@@ -84,6 +84,7 @@ const agent = new PuppeteerBrowserAgent(browser, page, {
 - `newPage()` —— 创建新页面并将其设为 active page。
 - `setActivePage(page: Page)` —— 显式指定 Browser Agent 接下来控制哪个 Puppeteer 页面。
 - `waitForNewPage(action?, options?)` —— 等待新打开的页面，但不会隐式切换 active page。
+- AI 页面选择 action —— Browser Agent 会在 actionSpace 中暴露 `ListBrowserPages` 和 `SetActivePage`，AI 计划可以先查看已打开的标签页，再按 index、title 或 URL 切换 active page。这些 action 不会出现在 Page Agent 上。
 
 ### 示例
 
@@ -195,6 +196,7 @@ const agent = new PlaywrightBrowserAgent(context, page, {
 - `newPage()` —— 创建新页面并将其设为 active page。
 - `setActivePage(page: Page)` —— 显式指定 Browser Agent 接下来控制哪个 Playwright 页面。
 - `waitForNewPage(action?, options?)` —— 等待新打开的页面，但不会隐式切换 active page。
+- AI 页面选择 action —— Browser Agent 会在 actionSpace 中暴露 `ListBrowserPages` 和 `SetActivePage`，AI 计划可以先查看已打开的标签页，再按 index、title 或 URL 切换 active page。这些 action 不会出现在 Page Agent 上。
 
 ### 示例
 

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -32,6 +32,9 @@ vi.mock('@midscene/core/yaml', async (importOriginal) => {
 });
 
 vi.mock('@midscene/core/agent', () => ({
+  Agent: class MockAgent {
+    async destroy() {}
+  },
   createAgent: vi.fn(),
   getReportFileName: vi.fn((tag: string) => `${tag}-mock-report`),
 }));

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -118,7 +118,8 @@
     "semver": "7.5.2",
     "socket.io": "^4.8.1",
     "socket.io-client": "4.8.1",
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "zod": "^3.25.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0",

--- a/packages/web-integration/src/common/browser-agent.ts
+++ b/packages/web-integration/src/common/browser-agent.ts
@@ -1,7 +1,8 @@
-import type { AgentOpt } from '@midscene/core';
+import type { AgentOpt, DeviceAction } from '@midscene/core';
 import { Agent as CoreAgent } from '@midscene/core/agent';
 import type { AbstractInterface } from '@midscene/core/device';
 import type { DebugFunction } from '@midscene/shared/logger';
+import { z } from 'zod';
 
 export type BrowserAgentPageScope = 'page' | 'browser';
 
@@ -10,6 +11,8 @@ export type BrowserAgentAdapter<Page, NewPageEvent> = {
   newPage(): Promise<Page>;
   isPageClosed(page: Page): boolean;
   bringToFront(page: Page): Promise<void> | void;
+  pageTitle(page: Page): Promise<string> | string;
+  pageUrl(page: Page): string;
   onNewPage(handler: (event: NewPageEvent) => void): void;
   offNewPage(handler: (event: NewPageEvent) => void): void;
   resolveNewPage(event: NewPageEvent): Page | Promise<Page | null> | null;
@@ -113,6 +116,51 @@ export abstract class BrowserAwareAgent<
   }
 }
 
+export type BrowserAgentPageSummary = {
+  index: number;
+  active: boolean;
+  title: string;
+  url: string;
+};
+
+const setActivePageParamSchema = z.object({
+  index: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('0-based page/tab index returned by ListBrowserPages.'),
+  title: z
+    .string()
+    .optional()
+    .describe('Case-insensitive page title substring to match.'),
+  url: z
+    .string()
+    .optional()
+    .describe('Case-insensitive page URL substring to match.'),
+});
+
+export type SetActivePageParam = z.infer<typeof setActivePageParamSchema>;
+
+const normalizeOptionalText = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+};
+
+const describeSelector = (selector: SetActivePageParam) => {
+  const parts: string[] = [];
+  if (selector.index !== undefined) {
+    parts.push(`index ${selector.index}`);
+  }
+  if (selector.title?.trim()) {
+    parts.push(`title "${selector.title.trim()}"`);
+  }
+  if (selector.url?.trim()) {
+    parts.push(`url "${selector.url.trim()}"`);
+  }
+  return parts.join(', ');
+};
+
 export class BrowserAgentPageController<Page, NewPageEvent> {
   private readonly agentName: string;
   private readonly adapter: BrowserAgentAdapter<Page, NewPageEvent>;
@@ -146,6 +194,17 @@ export class BrowserAgentPageController<Page, NewPageEvent> {
     return this.adapter.pages();
   }
 
+  async pageSummaries(): Promise<BrowserAgentPageSummary[]> {
+    const pages = await this.adapter.pages();
+    const activePage = this.activePage;
+
+    return Promise.all(
+      pages.map((page, index) =>
+        this.pageSummary(page, index, page === activePage),
+      ),
+    );
+  }
+
   async newPage() {
     const page = await this.adapter.newPage();
     await this.setActivePage(page);
@@ -167,6 +226,68 @@ export class BrowserAgentPageController<Page, NewPageEvent> {
     }
   }
 
+  async setActivePageBySelector(
+    selector: SetActivePageParam,
+  ): Promise<BrowserAgentPageSummary> {
+    const hasIndex = selector.index !== undefined;
+    const title = normalizeOptionalText(selector.title);
+    const url = normalizeOptionalText(selector.url);
+
+    if (!hasIndex && !title && !url) {
+      throw new Error(
+        `[midscene] SetActivePage requires index, title, or url for ${this.agentName}.`,
+      );
+    }
+
+    const pages = await this.adapter.pages();
+
+    if (hasIndex) {
+      const page = pages[selector.index as number];
+      if (!page || this.adapter.isPageClosed(page)) {
+        throw new Error(
+          `[midscene] Cannot find ${this.agentName} page with index ${selector.index}. Available page indexes: ${pages
+            .map((_, index) => index)
+            .join(', ')}`,
+        );
+      }
+
+      await this.setActivePage(page);
+      return this.pageSummary(page, selector.index as number, true);
+    }
+
+    const matchedPages: Array<{ page: Page; index: number }> = [];
+    for (let index = 0; index < pages.length; index++) {
+      const page = pages[index];
+      if (this.adapter.isPageClosed(page)) {
+        continue;
+      }
+
+      const summary = await this.pageSummary(page, index, false);
+      const matchedTitle =
+        !title || summary.title.toLowerCase().includes(title);
+      const matchedUrl = !url || summary.url.toLowerCase().includes(url);
+      if (matchedTitle && matchedUrl) {
+        matchedPages.push({ page, index });
+      }
+    }
+
+    if (matchedPages.length === 0) {
+      throw new Error(
+        `[midscene] Cannot find ${this.agentName} page matching ${describeSelector(selector)}.`,
+      );
+    }
+
+    if (matchedPages.length > 1) {
+      throw new Error(
+        `[midscene] Multiple ${this.agentName} pages matched ${describeSelector(selector)}. Use ListBrowserPages and pass an index to SetActivePage.`,
+      );
+    }
+
+    const { page, index } = matchedPages[0];
+    await this.setActivePage(page);
+    return this.pageSummary(page, index, true);
+  }
+
   async waitForNewPage(
     action?: () => Promise<unknown> | unknown,
     opts?: { timeout?: number },
@@ -184,6 +305,34 @@ export class BrowserAgentPageController<Page, NewPageEvent> {
 
   destroy() {
     this.adapter.offNewPage(this.newPageHandler);
+  }
+
+  private async pageSummary(
+    page: Page,
+    index: number,
+    active: boolean,
+  ): Promise<BrowserAgentPageSummary> {
+    let title = '';
+    let url = '';
+
+    try {
+      title = await this.adapter.pageTitle(page);
+    } catch (error) {
+      this.debug(`failed to read page title: ${error}`);
+    }
+
+    try {
+      url = this.adapter.pageUrl(page);
+    } catch (error) {
+      this.debug(`failed to read page url: ${error}`);
+    }
+
+    return {
+      index,
+      active,
+      title,
+      url,
+    };
   }
 
   private async followNewPage(event: NewPageEvent) {
@@ -257,3 +406,41 @@ export class BrowserAgentPageController<Page, NewPageEvent> {
     return { promise, dispose };
   }
 }
+
+export const createBrowserAgentPageActions = <Page, NewPageEvent>(options: {
+  agentName: string;
+  getPageController: () => BrowserAgentPageController<Page, NewPageEvent>;
+}): DeviceAction<any>[] => [
+  {
+    name: 'ListBrowserPages',
+    description:
+      'List all open browser pages/tabs and show which one is currently active. Use this before switching pages when a task refers to another tab or window.',
+    call: async () => options.getPageController().pageSummaries(),
+  },
+  {
+    name: 'SetActivePage',
+    description:
+      'Set the active browser page/tab by 0-based index, title substring, or URL substring. Use index from ListBrowserPages when more than one page could match.',
+    paramSchema: setActivePageParamSchema,
+    sample: {
+      index: 1,
+    },
+    call: async (param) =>
+      options.getPageController().setActivePageBySelector(param),
+  },
+];
+
+export const appendBrowserAgentPageActions = (
+  customActions: DeviceAction<any>[] | undefined,
+  browserActions: DeviceAction<any>[],
+) => {
+  if (!customActions?.length) {
+    return browserActions;
+  }
+
+  const customActionNames = new Set(customActions.map((action) => action.name));
+  return [
+    ...customActions,
+    ...browserActions.filter((action) => !customActionNames.has(action.name)),
+  ];
+};

--- a/packages/web-integration/src/playwright/browser-agent.ts
+++ b/packages/web-integration/src/playwright/browser-agent.ts
@@ -2,6 +2,8 @@ import {
   type BrowserAgentAdapter,
   BrowserAgentPageController,
   BrowserAwareAgent,
+  appendBrowserAgentPageActions,
+  createBrowserAgentPageActions,
   resolveBrowserAgentRuntimeOptions,
 } from '@/common/browser-agent';
 import {
@@ -25,6 +27,8 @@ const createPlaywrightBrowserAdapter = (
   newPage: () => context.newPage(),
   isPageClosed: (page) => page.isClosed(),
   bringToFront: (page) => page.bringToFront(),
+  pageTitle: (page) => page.title(),
+  pageUrl: (page) => page.url(),
   onNewPage: (handler) => context.on('page', handler),
   offNewPage: (handler) => context.off('page', handler),
   resolveNewPage: (page) => page,
@@ -84,9 +88,28 @@ export class PlaywrightBrowserAgent extends BrowserAwareAgent<
       newPageTimeout,
     });
     const { forceChromeSelectRendering } = agentOpts;
+    const pageControllerRef: {
+      current?: BrowserAgentPageController<PlaywrightPage, PlaywrightPage>;
+    } = {};
+    const getPageController = () => {
+      if (!pageControllerRef.current) {
+        throw new Error(
+          '[midscene] PlaywrightBrowserAgent page controller is not initialized.',
+        );
+      }
+      return pageControllerRef.current;
+    };
+    const browserActions = createBrowserAgentPageActions({
+      agentName: 'PlaywrightBrowserAgent',
+      getPageController,
+    });
     const webPage = new PlaywrightWebPage(initialPage, {
       ...agentOpts,
       forceSameTabNavigation: runtimeOptions.forceSameTabNavigation,
+      customActions: appendBrowserAgentPageActions(
+        agentOpts.customActions,
+        browserActions,
+      ),
     });
     const pageController = new BrowserAgentPageController({
       agentName: 'PlaywrightBrowserAgent',
@@ -99,6 +122,7 @@ export class PlaywrightBrowserAgent extends BrowserAwareAgent<
       newPageTimeout: runtimeOptions.newPageTimeout,
       debug,
     });
+    pageControllerRef.current = pageController;
     super(webPage, agentOpts, pageController);
 
     applyForceChromeSelectRendering(

--- a/packages/web-integration/src/puppeteer/browser-agent.ts
+++ b/packages/web-integration/src/puppeteer/browser-agent.ts
@@ -2,6 +2,8 @@ import {
   type BrowserAgentAdapter,
   BrowserAgentPageController,
   BrowserAwareAgent,
+  appendBrowserAgentPageActions,
+  createBrowserAgentPageActions,
   resolveBrowserAgentRuntimeOptions,
 } from '@/common/browser-agent';
 import {
@@ -26,6 +28,8 @@ const createPuppeteerBrowserAdapter = (
   newPage: () => browser.newPage(),
   isPageClosed: (page) => page.isClosed(),
   bringToFront: (page) => page.bringToFront(),
+  pageTitle: (page) => page.title(),
+  pageUrl: (page) => page.url(),
   onNewPage: (handler) => browser.on('targetcreated', handler),
   offNewPage: (handler) => browser.off('targetcreated', handler),
   isNewPageEvent: (target) => target.type() === 'page',
@@ -86,9 +90,28 @@ export class PuppeteerBrowserAgent extends BrowserAwareAgent<
       newPageTimeout,
     });
     const { forceChromeSelectRendering } = agentOpts;
+    const pageControllerRef: {
+      current?: BrowserAgentPageController<PuppeteerPage, PuppeteerTarget>;
+    } = {};
+    const getPageController = () => {
+      if (!pageControllerRef.current) {
+        throw new Error(
+          '[midscene] PuppeteerBrowserAgent page controller is not initialized.',
+        );
+      }
+      return pageControllerRef.current;
+    };
+    const browserActions = createBrowserAgentPageActions({
+      agentName: 'PuppeteerBrowserAgent',
+      getPageController,
+    });
     const webPage = new PuppeteerWebPage(initialPage, {
       ...agentOpts,
       forceSameTabNavigation: runtimeOptions.forceSameTabNavigation,
+      customActions: appendBrowserAgentPageActions(
+        agentOpts.customActions,
+        browserActions,
+      ),
     });
     const pageController = new BrowserAgentPageController({
       agentName: 'PuppeteerBrowserAgent',
@@ -101,6 +124,7 @@ export class PuppeteerBrowserAgent extends BrowserAwareAgent<
       newPageTimeout: runtimeOptions.newPageTimeout,
       debug,
     });
+    pageControllerRef.current = pageController;
     super(webPage, agentOpts, pageController);
 
     applyForceChromeSelectRendering(

--- a/packages/web-integration/tests/unit-test/browser-agent-page-controller.test.ts
+++ b/packages/web-integration/tests/unit-test/browser-agent-page-controller.test.ts
@@ -1,11 +1,15 @@
 import {
   BrowserAgentPageController,
+  appendBrowserAgentPageActions,
+  createBrowserAgentPageActions,
   resolveBrowserAgentRuntimeOptions,
 } from '@/common/browser-agent';
 import { describe, expect, it, vi } from 'vitest';
 
 type PageMock = {
   id: string;
+  title: string;
+  url: string;
   closed?: boolean;
   bringToFront: ReturnType<typeof vi.fn>;
 };
@@ -15,19 +19,31 @@ type NewPageEvent = {
   page?: PageMock | null;
 };
 
-const createPage = (id: string): PageMock => ({
+const createPage = (
+  id: string,
+  options?: {
+    title?: string;
+    url?: string;
+  },
+): PageMock => ({
   id,
+  title: options?.title ?? id,
+  url: options?.url ?? `https://example.com/${id}`,
   bringToFront: vi.fn(),
 });
 
 function createController(options?: {
   autoFollowNewPage?: boolean;
   newPage?: PageMock;
+  pages?: PageMock[];
+  activePage?: PageMock;
 }) {
-  let activePage = createPage('initial');
+  let activePage =
+    options?.activePage ?? options?.pages?.[0] ?? createPage('initial');
   const handlers = new Set<(event: NewPageEvent) => void>();
   const debug = vi.fn();
   const newPage = options?.newPage ?? createPage('created');
+  const pages = options?.pages ?? [activePage];
 
   const controller = new BrowserAgentPageController<PageMock, NewPageEvent>({
     agentName: 'TestBrowserAgent',
@@ -39,10 +55,15 @@ function createController(options?: {
       activePage = page;
     },
     adapter: {
-      pages: () => [activePage],
-      newPage: async () => newPage,
+      pages: () => pages,
+      newPage: async () => {
+        pages.push(newPage);
+        return newPage;
+      },
       isPageClosed: (page) => Boolean(page.closed),
       bringToFront: (page) => page.bringToFront(),
+      pageTitle: (page) => page.title,
+      pageUrl: (page) => page.url,
       onNewPage: (handler) => {
         handlers.add(handler);
       },
@@ -79,6 +100,140 @@ describe('BrowserAgentPageController', () => {
     expect(page.id).toBe('created');
     expect(ctx.activePage).toBe(page);
     expect(page.bringToFront).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists browser pages with the active page marker', async () => {
+    const initial = createPage('initial', {
+      title: 'Home',
+      url: 'https://example.com/home',
+    });
+    const docs = createPage('docs', {
+      title: 'Docs',
+      url: 'https://example.com/docs',
+    });
+    const ctx = createController({
+      pages: [initial, docs],
+      activePage: docs,
+    });
+
+    await expect(ctx.controller.pageSummaries()).resolves.toEqual([
+      {
+        index: 0,
+        active: false,
+        title: 'Home',
+        url: 'https://example.com/home',
+      },
+      {
+        index: 1,
+        active: true,
+        title: 'Docs',
+        url: 'https://example.com/docs',
+      },
+    ]);
+  });
+
+  it('sets the active page by selector', async () => {
+    const initial = createPage('initial', {
+      title: 'Home',
+      url: 'https://example.com/home',
+    });
+    const docs = createPage('docs', {
+      title: 'Docs',
+      url: 'https://example.com/docs',
+    });
+    const ctx = createController({ pages: [initial, docs] });
+
+    const summary = await ctx.controller.setActivePageBySelector({
+      title: 'docs',
+    });
+
+    expect(ctx.activePage).toBe(docs);
+    expect(summary).toEqual({
+      index: 1,
+      active: true,
+      title: 'Docs',
+      url: 'https://example.com/docs',
+    });
+    expect(docs.bringToFront).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects ambiguous title or url selectors', async () => {
+    const first = createPage('first', {
+      title: 'Docs',
+      url: 'https://example.com/docs',
+    });
+    const second = createPage('second', {
+      title: 'API Docs',
+      url: 'https://example.com/api',
+    });
+    const ctx = createController({ pages: [first, second] });
+
+    await expect(
+      ctx.controller.setActivePageBySelector({ title: 'docs' }),
+    ).rejects.toThrow(
+      '[midscene] Multiple TestBrowserAgent pages matched title "docs". Use ListBrowserPages and pass an index to SetActivePage.',
+    );
+  });
+
+  it('creates browser page actions for AI page selection', async () => {
+    const initial = createPage('initial', {
+      title: 'Home',
+      url: 'https://example.com/home',
+    });
+    const docs = createPage('docs', {
+      title: 'Docs',
+      url: 'https://example.com/docs',
+    });
+    const ctx = createController({ pages: [initial, docs] });
+    const actions = createBrowserAgentPageActions({
+      agentName: 'TestBrowserAgent',
+      getPageController: () => ctx.controller,
+    });
+
+    expect(actions.map((action) => action.name)).toEqual([
+      'ListBrowserPages',
+      'SetActivePage',
+    ]);
+    await expect(actions[0].call(undefined, {} as any)).resolves.toEqual([
+      {
+        index: 0,
+        active: true,
+        title: 'Home',
+        url: 'https://example.com/home',
+      },
+      {
+        index: 1,
+        active: false,
+        title: 'Docs',
+        url: 'https://example.com/docs',
+      },
+    ]);
+
+    await actions[1].call({ index: 1 }, {} as any);
+    expect(ctx.activePage).toBe(docs);
+  });
+
+  it('keeps custom actions ahead of browser page actions', () => {
+    const customAction = {
+      name: 'SetActivePage',
+      description: 'custom action',
+      call: vi.fn(),
+    };
+    const browserActions = createBrowserAgentPageActions({
+      agentName: 'TestBrowserAgent',
+      getPageController: () => createController().controller,
+    });
+
+    const actions = appendBrowserAgentPageActions(
+      [customAction],
+      browserActions,
+    );
+
+    expect(actions.map((action) => action.name)).toEqual([
+      'SetActivePage',
+      'ListBrowserPages',
+    ]);
+    expect(actions[0]).toBe(customAction);
   });
 
   it('auto-follows matching new page events', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,6 +1489,9 @@ importers:
       ws:
         specifier: ^8.18.1
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      zod:
+        specifier: ^3.25.1
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.45.0


### PR DESCRIPTION
## Summary
- add BrowserAgent-only `ListBrowserPages` and `SetActivePage` actions so AI plans can inspect open tabs and switch the active page by index/title/url
- reuse the shared BrowserAgent page controller for page summaries and selector-based active page changes, including ambiguity errors for title/url matches
- document the new BrowserAgent actionSpace behavior in EN/ZH API reference and declare `zod` as a direct `@midscene/web` dependency for the action param schema

## Validation
- `fnm exec --using v20.20.2 pnpm install --frozen-lockfile --ignore-scripts`
- `NODE_OPTIONS=--max-old-space-size=4096 fnm exec --using v20.20.2 pnpm --dir packages/web-integration test -- tests/unit-test/browser-agent-page-controller.test.ts`
- `fnm exec --using v20.20.2 npx nx build @midscene/web --skip-nx-cache`
- `fnm exec --using v20.20.2 pnpm run lint`
- `git diff --check`

## Note
- The first focused web build hit `RangeError: Invalid string length` because an ignored generated `apps/report/dist/index.html` from a previous root prepare run was 485MB. I removed that generated dist directory and reran the focused web build successfully.