### PR TITLE
fix(android): workaround multi-device scrcpy initialization failure

### DIFF
--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -111,6 +111,48 @@ export class ScrcpyDeviceAdapter {
       const adbClient = new AdbServerClient(
         new AdbServerNodeTcpConnector({ host: '127.0.0.1', port: 5037 }),
       );
+
+      // Workaround for @yume-chan/adb multi-device bug:
+      // getDeviceFeatures() uses a two-step protocol that fails when multiple
+      // devices are connected. Override it to use the one-shot format.
+      // See: https://github.com/yume-chan/ya-webadb/pull/849
+      const deviceId = this.deviceId;
+      const originalGetDeviceFeatures =
+        adbClient.getDeviceFeatures.bind(adbClient);
+      adbClient.getDeviceFeatures = async function (device: unknown) {
+        try {
+          return await originalGetDeviceFeatures(device);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            /more than one device\/emulator/i.test(error.message)
+          ) {
+            const service = AdbServerClient.formatDeviceService(
+              device as Parameters<
+                typeof AdbServerClient.formatDeviceService
+              >[0],
+              'features',
+            );
+            const connection = await adbClient.createConnection(service);
+            try {
+              const featuresString = await connection.readString();
+              const features = featuresString.split(',');
+              const devices = await adbClient.getDevices();
+              const info = devices.find(
+                (d: { serial: string }) => d.serial === deviceId,
+              );
+              return {
+                transportId: info?.transportId,
+                features,
+              };
+            } finally {
+              await connection.dispose();
+            }
+          }
+          throw error;
+        }
+      };
+
       const adb = new Adb(
         await adbClient.createTransport({ serial: this.deviceId }),
       );


### PR DESCRIPTION
## Summary

Fix `--useScrcpy` failing with `"more than one device/emulator"` when multiple Android devices are connected to the host machine.

## Problem

When 2+ devices are connected, scrcpy initialization fails:

```
[Midscene] Scrcpy unavailable, using ADB fallback (device: e986b63e): 
Failed to initialize Scrcpy for device e986b63e. 
Error: Error: more than one device/emulator
```

### Root Cause

The upstream `@yume-chan/adb` library's `getDeviceFeatures()` uses a two-step ADB protocol:
1. `host:transport-id:N` → OKAY (transport switch)
2. `host:features` → FAIL ❌ (ADB server doesn't inherit device context for host services)

The correct one-shot format (`host-serial:S:features`) works in all environments.

## Fix

Add a runtime workaround in `ScrcpyDeviceAdapter.ensureManager()` that catches the specific `"more than one device/emulator"` error and retries using the one-shot protocol format. This is a non-invasive try/catch wrapper around the original method — single-device environments are completely unaffected (the original path succeeds without triggering the fallback).

## Testing

Verified on Ubuntu 22.04 with 2 USB-connected Android devices:

```bash
# Before fix:
midscene-android connect --device-id e986b63e --useScrcpy
# → Scrcpy unavailable, using ADB fallback ❌

# After fix:
midscene-android connect --device-id e986b63e --useScrcpy
# → [midscene] Using scrcpy for screenshots (device: e986b63e) ✅

midscene-android connect --device-id fe40de17 --useScrcpy
# → [midscene] Using scrcpy for screenshots (device: fe40de17) ✅
```

## Upstream

The root cause fix has been submitted to `@yume-chan/ya-webadb`:  
https://github.com/yume-chan/ya-webadb/pull/849

This workaround can be removed once the upstream fix is released and the dependency is updated.

## Related

Closes #2662