### PR TITLE
Support custom recordToReport screenshots

### DIFF
--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -244,6 +244,7 @@ const DetailPanel = (): JSX.Element => {
       timestamp?: number;
       screenshotTimestamp?: number;
       screenshot: string;
+      description?: string;
       timing?: string;
     }[] = [];
 
@@ -302,6 +303,7 @@ const DetailPanel = (): JSX.Element => {
             timestamp: item.ts,
             screenshotTimestamp: item.screenshot?.capturedAt,
             screenshot,
+            description: item.description,
             timing: item.timing,
           });
         }
@@ -313,7 +315,8 @@ const DetailPanel = (): JSX.Element => {
         <div className="screenshot-item-wrapper scrollable">
           {contextLocatorView && <div>{contextLocatorView}</div>}
           {screenshotItems.map((item) => {
-            const timeText = item.timing || 'unknown-timing';
+            const timeText =
+              item.description || item.timing || 'unknown-timing';
             const screenshotAt = capturedAtText(item.screenshotTimestamp);
             const title = `${timeText} / ${screenshotAt}`;
             return (

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1136,6 +1136,9 @@ interface RecordToReportOptions {
   /** @deprecated Use screenshots instead. */
   screenshotBase64?: string;
   screenshots?: {
+    /**
+     * PNG/JPEG data URI, or raw PNG base64 body.
+     */
     base64: string;
     description?: string;
   }[];
@@ -1153,7 +1156,7 @@ function recordToReport(
   - `title?: string` - Optional, the title of the screenshot, if not provided, the title will be 'untitled'.
   - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
-    - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically.
+    - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically. `base64` should be a PNG/JPEG data URI such as `data:image/png;base64,...`; a raw base64 body is also accepted and treated as PNG.
     - `subType?: string` - Custom display label for this log entry. The underlying report task type remains `Log`.
 
 - Compatibility:

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1142,7 +1142,6 @@ interface RecordToReportOptions {
     base64: string;
     description?: string;
   }[];
-  subType?: string;
 }
 
 function recordToReport(
@@ -1157,7 +1156,6 @@ function recordToReport(
   - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
     - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically. `base64` should be a PNG/JPEG data URI such as `data:image/png;base64,...`; a raw base64 body is also accepted and treated as PNG.
-    - `subType?: string` - Custom display label for this log entry. The underlying report task type remains `Log`.
 
 - Compatibility:
 
@@ -1180,7 +1178,6 @@ const before = await page.screenshot({ encoding: 'base64' });
 const after = await page.screenshot({ encoding: 'base64' });
 await agent.recordToReport('Checkout comparison', {
   content: 'Compare the state before and after submit.',
-  subType: 'Checkpoint',
   screenshots: [
     {
       base64: `data:image/png;base64,${before}`,

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1125,13 +1125,15 @@ console.log(result);
 
 ### `agent.recordToReport()`
 
-Log the current screenshot with a description in the report file.
+Log the current screenshot with a description in the report file by default, or
+record screenshots provided by the caller.
 
 - Type
 
 ```typescript
 interface RecordToReportOptions {
   content?: string;
+  /** @deprecated Use screenshots instead. */
   screenshotBase64?: string;
   screenshots?: {
     base64: string;
@@ -1155,10 +1157,16 @@ function recordToReport(
   - `title?: string` - Optional, the title of the screenshot, if not provided, the title will be 'untitled'.
   - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
-    - `screenshotBase64?: string` - Use the provided screenshot data instead of capturing the current page automatically.
     - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically.
     - `customScreenshotData?: Array<{ base64: string; description?: string }>` - Alias of `screenshots` for compatibility.
     - `subType?: string` - Custom display label for this log entry. The underlying report task type remains `Log`.
+
+- Compatibility:
+
+  `screenshotBase64?: string` is still accepted as a backward-compatible
+  single-screenshot override. Prefer `screenshots: [{ base64 }]` for new code.
+  Provide only one of `screenshots`, `customScreenshotData`, or
+  `screenshotBase64`.
 
 - Return Value:
 

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1139,10 +1139,6 @@ interface RecordToReportOptions {
     base64: string;
     description?: string;
   }[];
-  customScreenshotData?: {
-    base64: string;
-    description?: string;
-  }[];
   subType?: string;
 }
 
@@ -1158,15 +1154,13 @@ function recordToReport(
   - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
     - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically.
-    - `customScreenshotData?: Array<{ base64: string; description?: string }>` - Alias of `screenshots` for compatibility.
     - `subType?: string` - Custom display label for this log entry. The underlying report task type remains `Log`.
 
 - Compatibility:
 
   `screenshotBase64?: string` is still accepted as a backward-compatible
   single-screenshot override. Prefer `screenshots: [{ base64 }]` for new code.
-  Provide only one of `screenshots`, `customScreenshotData`, or
-  `screenshotBase64`.
+  Provide only one of `screenshots` or `screenshotBase64`.
 
 - Return Value:
 

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1130,14 +1130,35 @@ Log the current screenshot with a description in the report file.
 - Type
 
 ```typescript
-function recordToReport(title?: string, options?: Object): Promise<void>;
+interface RecordToReportOptions {
+  content?: string;
+  screenshotBase64?: string;
+  screenshots?: {
+    base64: string;
+    description?: string;
+  }[];
+  customScreenshotData?: {
+    base64: string;
+    description?: string;
+  }[];
+  subType?: string;
+}
+
+function recordToReport(
+  title?: string,
+  options?: RecordToReportOptions,
+): Promise<void>;
 ```
 
 - Parameters:
 
   - `title?: string` - Optional, the title of the screenshot, if not provided, the title will be 'untitled'.
-  - `options?: Object` - Optional, a configuration object containing:
+  - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
+    - `screenshotBase64?: string` - Use the provided screenshot data instead of capturing the current page automatically.
+    - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically.
+    - `customScreenshotData?: Array<{ base64: string; description?: string }>` - Alias of `screenshots` for compatibility.
+    - `subType?: string` - Custom display label for this log entry. The underlying report task type remains `Log`.
 
 - Return Value:
 
@@ -1148,6 +1169,23 @@ function recordToReport(title?: string, options?: Object): Promise<void>;
 ```typescript
 await agent.recordToReport('Login page', {
   content: 'User A',
+});
+
+const before = await page.screenshot({ encoding: 'base64' });
+const after = await page.screenshot({ encoding: 'base64' });
+await agent.recordToReport('Checkout comparison', {
+  content: 'Compare the state before and after submit.',
+  subType: 'Checkpoint',
+  screenshots: [
+    {
+      base64: `data:image/png;base64,${before}`,
+      description: 'Before submit',
+    },
+    {
+      base64: `data:image/png;base64,${after}`,
+      description: 'After submit',
+    },
+  ],
 });
 ```
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1126,6 +1126,9 @@ interface RecordToReportOptions {
   /** @deprecated 请改用 screenshots。 */
   screenshotBase64?: string;
   screenshots?: {
+    /**
+     * PNG/JPEG data URI，或裸 PNG base64 body。
+     */
     base64: string;
     description?: string;
   }[];
@@ -1143,7 +1146,7 @@ function recordToReport(
   - `title?: string` - 可选，截图的标题，如果未提供，则标题为 'untitled'。
   - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
-    - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。
+    - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。`base64` 推荐使用 PNG/JPEG data URI，例如 `data:image/png;base64,...`；也可以传裸 base64 body，此时会按 PNG 处理。
     - `subType?: string` - 这个日志条目的自定义展示标签。底层报告任务类型仍然是 `Log`。
 
 - 兼容性：

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1129,10 +1129,6 @@ interface RecordToReportOptions {
     base64: string;
     description?: string;
   }[];
-  customScreenshotData?: {
-    base64: string;
-    description?: string;
-  }[];
   subType?: string;
 }
 
@@ -1148,14 +1144,12 @@ function recordToReport(
   - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
     - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。
-    - `customScreenshotData?: Array<{ base64: string; description?: string }>` - `screenshots` 的兼容别名。
     - `subType?: string` - 这个日志条目的自定义展示标签。底层报告任务类型仍然是 `Log`。
 
 - 兼容性：
 
   `screenshotBase64?: string` 仍然作为向后兼容的单截图覆盖参数被接受。新代码建议使用
-  `screenshots: [{ base64 }]`。`screenshots`、`customScreenshotData` 和
-  `screenshotBase64` 三者只能传入一个。
+  `screenshots: [{ base64 }]`。`screenshots` 和 `screenshotBase64` 二者只能传入一个。
 
 - 返回值：
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1121,14 +1121,35 @@ console.log(result);
 - 类型
 
 ```typescript
-function recordToReport(title?: string, options?: Object): Promise<void>;
+interface RecordToReportOptions {
+  content?: string;
+  screenshotBase64?: string;
+  screenshots?: {
+    base64: string;
+    description?: string;
+  }[];
+  customScreenshotData?: {
+    base64: string;
+    description?: string;
+  }[];
+  subType?: string;
+}
+
+function recordToReport(
+  title?: string,
+  options?: RecordToReportOptions,
+): Promise<void>;
 ```
 
 - 参数：
 
   - `title?: string` - 可选，截图的标题，如果未提供，则标题为 'untitled'。
-  - `options?: Object` - 可选，一个配置对象，包含：
+  - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
+    - `screenshotBase64?: string` - 使用传入的截图数据，而不是自动截取当前页面。
+    - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。
+    - `customScreenshotData?: Array<{ base64: string; description?: string }>` - `screenshots` 的兼容别名。
+    - `subType?: string` - 这个日志条目的自定义展示标签。底层报告任务类型仍然是 `Log`。
 
 - 返回值：
 
@@ -1139,6 +1160,23 @@ function recordToReport(title?: string, options?: Object): Promise<void>;
 ```typescript
 await agent.recordToReport('登录页面', {
   content: '用户 A',
+});
+
+const before = await page.screenshot({ encoding: 'base64' });
+const after = await page.screenshot({ encoding: 'base64' });
+await agent.recordToReport('结算页对比', {
+  content: '对比提交前后的页面状态。',
+  subType: 'Checkpoint',
+  screenshots: [
+    {
+      base64: `data:image/png;base64,${before}`,
+      description: '提交前',
+    },
+    {
+      base64: `data:image/png;base64,${after}`,
+      description: '提交后',
+    },
+  ],
 });
 ```
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1132,7 +1132,6 @@ interface RecordToReportOptions {
     base64: string;
     description?: string;
   }[];
-  subType?: string;
 }
 
 function recordToReport(
@@ -1147,7 +1146,6 @@ function recordToReport(
   - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
     - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。`base64` 推荐使用 PNG/JPEG data URI，例如 `data:image/png;base64,...`；也可以传裸 base64 body，此时会按 PNG 处理。
-    - `subType?: string` - 这个日志条目的自定义展示标签。底层报告任务类型仍然是 `Log`。
 
 - 兼容性：
 
@@ -1169,7 +1167,6 @@ const before = await page.screenshot({ encoding: 'base64' });
 const after = await page.screenshot({ encoding: 'base64' });
 await agent.recordToReport('结算页对比', {
   content: '对比提交前后的页面状态。',
-  subType: 'Checkpoint',
   screenshots: [
     {
       base64: `data:image/png;base64,${before}`,

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1116,13 +1116,14 @@ console.log(result);
 
 ### `agent.recordToReport()`
 
-在报告文件中记录当前截图，并添加描述。
+默认在报告文件中记录当前截图并添加描述，也可以记录调用方传入的截图。
 
 - 类型
 
 ```typescript
 interface RecordToReportOptions {
   content?: string;
+  /** @deprecated 请改用 screenshots。 */
   screenshotBase64?: string;
   screenshots?: {
     base64: string;
@@ -1146,10 +1147,15 @@ function recordToReport(
   - `title?: string` - 可选，截图的标题，如果未提供，则标题为 'untitled'。
   - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
-    - `screenshotBase64?: string` - 使用传入的截图数据，而不是自动截取当前页面。
     - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。
     - `customScreenshotData?: Array<{ base64: string; description?: string }>` - `screenshots` 的兼容别名。
     - `subType?: string` - 这个日志条目的自定义展示标签。底层报告任务类型仍然是 `Log`。
+
+- 兼容性：
+
+  `screenshotBase64?: string` 仍然作为向后兼容的单截图覆盖参数被接受。新代码建议使用
+  `screenshots: [{ base64 }]`。`screenshots`、`customScreenshotData` 和
+  `screenshotBase64` 三者只能传入一个。
 
 - 返回值：
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -215,10 +215,6 @@ export interface RecordToReportOptions {
    */
   screenshots?: RecordToReportScreenshot[];
   /**
-   * Alias for the API shape proposed in issue #1998.
-   */
-  customScreenshotData?: RecordToReportScreenshot[];
-  /**
    * Custom display label for this log task. The underlying task type stays Log.
    */
   subType?: string;
@@ -1566,23 +1562,13 @@ export class Agent<
   async recordToReport(title?: string, opt?: RecordToReportOptions) {
     const now = Date.now();
     const hasScreenshots = Array.isArray(opt?.screenshots);
-    const hasCustomScreenshotData = Array.isArray(opt?.customScreenshotData);
     const hasScreenshotBase64 = typeof opt?.screenshotBase64 === 'string';
-    const screenshotSourceCount = [
-      hasScreenshots,
-      hasCustomScreenshotData,
-      hasScreenshotBase64,
-    ].filter(Boolean).length;
-    if (screenshotSourceCount > 1) {
+    if (hasScreenshots && hasScreenshotBase64) {
       throw new Error(
-        'recordToReport: provide only one of screenshots, customScreenshotData, or screenshotBase64',
+        'recordToReport: provide only one of screenshots or screenshotBase64',
       );
     }
-    const customScreenshots = hasScreenshots
-      ? opt!.screenshots
-      : hasCustomScreenshotData
-        ? opt!.customScreenshotData
-        : undefined;
+    const customScreenshots = hasScreenshots ? opt!.screenshots : undefined;
     if (customScreenshots && customScreenshots.length === 0) {
       throw new Error('recordToReport: screenshots cannot be empty');
     }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -200,6 +200,9 @@ type AiActInternalOptions = AiActOptions & {
 };
 
 export interface RecordToReportScreenshot {
+  /**
+   * PNG/JPEG data URI, or raw PNG base64 body.
+   */
   base64: string;
   description?: string;
 }
@@ -220,19 +223,65 @@ export interface RecordToReportOptions {
   subType?: string;
 }
 
-function assertRecordToReportScreenshot(
-  screenshot: RecordToReportScreenshot,
+const supportedScreenshotDataUriPattern =
+  /^data:image\/(png|jpe?g);base64,([\s\S]*)$/i;
+const rawBase64BodyPattern = /^[A-Za-z0-9+/=\s]+$/;
+
+function createRecordToReportImageDataUri(
+  format: 'png' | 'jpeg',
+  body: string,
+): string {
+  return `data:image/${format};base64,${body.replace(/\s/g, '')}`;
+}
+
+function normalizeRecordToReportScreenshotBase64(
+  base64: string,
   index: number,
-) {
-  if (!screenshot || typeof screenshot.base64 !== 'string') {
+): string {
+  const trimmedBase64 = base64.trim();
+  if (!trimmedBase64) {
     throw new Error(
-      `recordToReport: screenshot #${index + 1} must include a base64 string`,
+      `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
     );
   }
 
-  if (!screenshot.base64.trim()) {
+  const dataUriMatch = trimmedBase64.match(supportedScreenshotDataUriPattern);
+  if (dataUriMatch) {
+    const imageFormat: 'png' | 'jpeg' =
+      dataUriMatch[1].toLowerCase() === 'jpg'
+        ? 'jpeg'
+        : (dataUriMatch[1].toLowerCase() as 'png' | 'jpeg');
+    const body = dataUriMatch[2];
+    if (!body.replace(/\s/g, '')) {
+      throw new Error(
+        `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
+      );
+    }
+    return createRecordToReportImageDataUri(imageFormat, body);
+  }
+
+  if (trimmedBase64.startsWith('data:')) {
     throw new Error(
-      `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
+      `recordToReport: screenshot #${index + 1} base64 must be a PNG/JPEG data URI or raw PNG base64 string`,
+    );
+  }
+
+  if (!rawBase64BodyPattern.test(trimmedBase64)) {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} base64 must be a PNG/JPEG data URI or raw PNG base64 string`,
+    );
+  }
+
+  return createRecordToReportImageDataUri('png', trimmedBase64);
+}
+
+function normalizeRecordToReportScreenshot(
+  screenshot: RecordToReportScreenshot,
+  index: number,
+): RecordToReportScreenshot {
+  if (!screenshot || typeof screenshot.base64 !== 'string') {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} must include a base64 string`,
     );
   }
 
@@ -244,6 +293,11 @@ function assertRecordToReportScreenshot(
       `recordToReport: screenshot #${index + 1} description must be a string`,
     );
   }
+
+  return {
+    base64: normalizeRecordToReportScreenshotBase64(screenshot.base64, index),
+    description: screenshot.description,
+  };
 }
 
 export class Agent<
@@ -1561,33 +1615,50 @@ export class Agent<
 
   async recordToReport(title?: string, opt?: RecordToReportOptions) {
     const now = Date.now();
-    const hasScreenshots = Array.isArray(opt?.screenshots);
-    const hasScreenshotBase64 = typeof opt?.screenshotBase64 === 'string';
+    const screenshots = opt?.screenshots;
+    const screenshotBase64 = opt?.screenshotBase64;
+    const hasScreenshots = screenshots !== undefined;
+    const hasScreenshotBase64 = screenshotBase64 !== undefined;
+    if (hasScreenshots && !Array.isArray(screenshots)) {
+      throw new Error('recordToReport: screenshots must be an array');
+    }
+    if (hasScreenshotBase64 && typeof screenshotBase64 !== 'string') {
+      throw new Error('recordToReport: screenshotBase64 must be a string');
+    }
     if (hasScreenshots && hasScreenshotBase64) {
       throw new Error(
         'recordToReport: provide only one of screenshots or screenshotBase64',
       );
     }
-    const customScreenshots = hasScreenshots ? opt!.screenshots : undefined;
+    if (opt?.subType !== undefined && typeof opt.subType !== 'string') {
+      throw new Error('recordToReport: subType must be a string');
+    }
+    const customScreenshots = hasScreenshots ? screenshots : undefined;
     if (customScreenshots && customScreenshots.length === 0) {
       throw new Error('recordToReport: screenshots cannot be empty');
     }
     const screenshotInputs: RecordToReportScreenshot[] =
       customScreenshots ??
       (hasScreenshotBase64
-        ? [{ base64: opt!.screenshotBase64! }]
+        ? [{ base64: screenshotBase64 }]
         : [{ base64: await this.interface.screenshotBase64() }]);
 
     // 1. build recorder
     const recorder: ExecutionRecorderItem[] = screenshotInputs.map(
       (screenshotInput, index) => {
-        assertRecordToReportScreenshot(screenshotInput, index);
+        const normalizedScreenshotInput = normalizeRecordToReportScreenshot(
+          screenshotInput,
+          index,
+        );
         const ts = now + index;
         return {
           type: 'screenshot',
           ts,
-          screenshot: ScreenshotItem.create(screenshotInput.base64, ts),
-          description: screenshotInput.description,
+          screenshot: ScreenshotItem.create(
+            normalizedScreenshotInput.base64,
+            ts,
+          ),
+          description: normalizedScreenshotInput.description,
         };
       },
     );

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -25,6 +25,8 @@ import {
   type LocatorValidatorOption,
   type OnTaskStartTip,
   type PlanningAction,
+  type RecordToReportOptions,
+  type RecordToReportScreenshot,
   type Rect,
   ReportActionDump,
   type ReportMeta,
@@ -67,6 +69,7 @@ import { getDebug } from '@midscene/shared/logger';
 import { assert, ifInBrowser, uuid } from '@midscene/shared/utils';
 import { defineActionSleep } from '../device';
 import { validateAgentCacheInput } from './cache-config';
+import { normalizeRecordToReportScreenshot } from './record-to-report';
 import { markdownToAiActPrompt } from './run-markdown';
 import { TaskCache } from './task-cache';
 import {
@@ -86,6 +89,7 @@ import {
   commonContextParser,
   createScreenshotBoundUIContext,
   getReportFileName,
+  normalizeScrollType,
   parsePrompt,
 } from './utils';
 
@@ -160,30 +164,6 @@ const defaultServiceExtractOption: ServiceExtractOption = {
   screenshotIncluded: true,
 };
 
-const legacyScrollTypeMap = {
-  once: 'singleAction',
-  untilBottom: 'scrollToBottom',
-  untilTop: 'scrollToTop',
-  untilRight: 'scrollToRight',
-  untilLeft: 'scrollToLeft',
-} as const;
-
-type LegacyScrollType = keyof typeof legacyScrollTypeMap;
-
-const normalizeScrollType = (
-  scrollType: ScrollParam['scrollType'] | LegacyScrollType | undefined,
-): ScrollParam['scrollType'] | undefined => {
-  if (!scrollType) {
-    return scrollType;
-  }
-
-  if (scrollType in legacyScrollTypeMap) {
-    return legacyScrollTypeMap[scrollType as LegacyScrollType];
-  }
-
-  return scrollType as ScrollParam['scrollType'];
-};
-
 export type AiActOptions = {
   cacheable?: boolean;
   fileChooserAccept?: string | string[];
@@ -198,107 +178,6 @@ type AiActInternalOptions = AiActOptions & {
     prompt?: string;
   };
 };
-
-export interface RecordToReportScreenshot {
-  /**
-   * PNG/JPEG data URI, or raw PNG base64 body.
-   */
-  base64: string;
-  description?: string;
-}
-
-export interface RecordToReportOptions {
-  content?: string;
-  /**
-   * @deprecated Use `screenshots: [{ base64 }]` instead.
-   */
-  screenshotBase64?: string;
-  /**
-   * Custom screenshots to display under a single report entry.
-   */
-  screenshots?: RecordToReportScreenshot[];
-  /**
-   * Custom display label for this log task. The underlying task type stays Log.
-   */
-  subType?: string;
-}
-
-const supportedScreenshotDataUriPattern =
-  /^data:image\/(png|jpe?g);base64,([\s\S]*)$/i;
-const rawBase64BodyPattern = /^[A-Za-z0-9+/=\s]+$/;
-
-function createRecordToReportImageDataUri(
-  format: 'png' | 'jpeg',
-  body: string,
-): string {
-  return `data:image/${format};base64,${body.replace(/\s/g, '')}`;
-}
-
-function normalizeRecordToReportScreenshotBase64(
-  base64: string,
-  index: number,
-): string {
-  const trimmedBase64 = base64.trim();
-  if (!trimmedBase64) {
-    throw new Error(
-      `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
-    );
-  }
-
-  const dataUriMatch = trimmedBase64.match(supportedScreenshotDataUriPattern);
-  if (dataUriMatch) {
-    const imageFormat: 'png' | 'jpeg' =
-      dataUriMatch[1].toLowerCase() === 'jpg'
-        ? 'jpeg'
-        : (dataUriMatch[1].toLowerCase() as 'png' | 'jpeg');
-    const body = dataUriMatch[2];
-    if (!body.replace(/\s/g, '')) {
-      throw new Error(
-        `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
-      );
-    }
-    return createRecordToReportImageDataUri(imageFormat, body);
-  }
-
-  if (trimmedBase64.startsWith('data:')) {
-    throw new Error(
-      `recordToReport: screenshot #${index + 1} base64 must be a PNG/JPEG data URI or raw PNG base64 string`,
-    );
-  }
-
-  if (!rawBase64BodyPattern.test(trimmedBase64)) {
-    throw new Error(
-      `recordToReport: screenshot #${index + 1} base64 must be a PNG/JPEG data URI or raw PNG base64 string`,
-    );
-  }
-
-  return createRecordToReportImageDataUri('png', trimmedBase64);
-}
-
-function normalizeRecordToReportScreenshot(
-  screenshot: RecordToReportScreenshot,
-  index: number,
-): RecordToReportScreenshot {
-  if (!screenshot || typeof screenshot.base64 !== 'string') {
-    throw new Error(
-      `recordToReport: screenshot #${index + 1} must include a base64 string`,
-    );
-  }
-
-  if (
-    screenshot.description !== undefined &&
-    typeof screenshot.description !== 'string'
-  ) {
-    throw new Error(
-      `recordToReport: screenshot #${index + 1} description must be a string`,
-    );
-  }
-
-  return {
-    base64: normalizeRecordToReportScreenshotBase64(screenshot.base64, index),
-    description: screenshot.description,
-  };
-}
 
 export class Agent<
   InterfaceType extends AbstractInterface = AbstractInterface,
@@ -976,10 +855,7 @@ export class Agent<
 
     if (opt) {
       const normalizedScrollType = normalizeScrollType(
-        (opt as ScrollParam).scrollType as
-          | ScrollParam['scrollType']
-          | LegacyScrollType
-          | undefined,
+        (opt as ScrollParam).scrollType,
       );
 
       if (normalizedScrollType !== (opt as ScrollParam).scrollType) {
@@ -1630,8 +1506,8 @@ export class Agent<
         'recordToReport: provide only one of screenshots or screenshotBase64',
       );
     }
-    if (opt?.subType !== undefined && typeof opt.subType !== 'string') {
-      throw new Error('recordToReport: subType must be a string');
+    if (opt && 'subType' in opt) {
+      throw new Error('recordToReport: subType is not supported');
     }
     const customScreenshots = hasScreenshots ? screenshots : undefined;
     if (customScreenshots && customScreenshots.length === 0) {
@@ -1662,15 +1538,11 @@ export class Agent<
         };
       },
     );
-    const customSubType = opt?.subType?.trim();
-    const taskSubType = customSubType || 'Screenshot';
-    const executionTypeLabel = customSubType || 'Log';
-
     // 2. build ExecutionTaskLog
     const task: ExecutionTaskLog = {
       taskId: uuid(),
       type: 'Log',
-      subType: taskSubType,
+      subType: 'Screenshot',
       status: 'finished',
       recorder,
       timing: {
@@ -1687,7 +1559,7 @@ export class Agent<
     const executionDump = new ExecutionDump({
       id: uuid(),
       logTime: now,
-      name: `${executionTypeLabel} - ${title || 'untitled'}`,
+      name: `Log - ${title || 'untitled'}`,
       description: opt?.content || '',
       tasks: [task],
     });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -207,7 +207,7 @@ export interface RecordToReportScreenshot {
 export interface RecordToReportOptions {
   content?: string;
   /**
-   * Backward-compatible single screenshot override.
+   * @deprecated Use `screenshots: [{ base64 }]` instead.
    */
   screenshotBase64?: string;
   /**
@@ -1565,18 +1565,31 @@ export class Agent<
 
   async recordToReport(title?: string, opt?: RecordToReportOptions) {
     const now = Date.now();
-    const customScreenshots = Array.isArray(opt?.screenshots)
-      ? opt.screenshots
-      : Array.isArray(opt?.customScreenshotData)
-        ? opt.customScreenshotData
+    const hasScreenshots = Array.isArray(opt?.screenshots);
+    const hasCustomScreenshotData = Array.isArray(opt?.customScreenshotData);
+    const hasScreenshotBase64 = typeof opt?.screenshotBase64 === 'string';
+    const screenshotSourceCount = [
+      hasScreenshots,
+      hasCustomScreenshotData,
+      hasScreenshotBase64,
+    ].filter(Boolean).length;
+    if (screenshotSourceCount > 1) {
+      throw new Error(
+        'recordToReport: provide only one of screenshots, customScreenshotData, or screenshotBase64',
+      );
+    }
+    const customScreenshots = hasScreenshots
+      ? opt!.screenshots
+      : hasCustomScreenshotData
+        ? opt!.customScreenshotData
         : undefined;
     if (customScreenshots && customScreenshots.length === 0) {
       throw new Error('recordToReport: screenshots cannot be empty');
     }
     const screenshotInputs: RecordToReportScreenshot[] =
       customScreenshots ??
-      (opt?.screenshotBase64
-        ? [{ base64: opt.screenshotBase64 }]
+      (hasScreenshotBase64
+        ? [{ base64: opt!.screenshotBase64! }]
         : [{ base64: await this.interface.screenshotBase64() }]);
 
     // 1. build recorder

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -199,6 +199,57 @@ type AiActInternalOptions = AiActOptions & {
   };
 };
 
+export interface RecordToReportScreenshot {
+  base64: string;
+  description?: string;
+}
+
+export interface RecordToReportOptions {
+  content?: string;
+  /**
+   * Backward-compatible single screenshot override.
+   */
+  screenshotBase64?: string;
+  /**
+   * Custom screenshots to display under a single report entry.
+   */
+  screenshots?: RecordToReportScreenshot[];
+  /**
+   * Alias for the API shape proposed in issue #1998.
+   */
+  customScreenshotData?: RecordToReportScreenshot[];
+  /**
+   * Custom display label for this log task. The underlying task type stays Log.
+   */
+  subType?: string;
+}
+
+function assertRecordToReportScreenshot(
+  screenshot: RecordToReportScreenshot,
+  index: number,
+) {
+  if (!screenshot || typeof screenshot.base64 !== 'string') {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} must include a base64 string`,
+    );
+  }
+
+  if (!screenshot.base64.trim()) {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} base64 cannot be empty`,
+    );
+  }
+
+  if (
+    screenshot.description !== undefined &&
+    typeof screenshot.description !== 'string'
+  ) {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} description must be a string`,
+    );
+  }
+}
+
 export class Agent<
   InterfaceType extends AbstractInterface = AbstractInterface,
 > {
@@ -1512,31 +1563,44 @@ export class Agent<
     }
   }
 
-  async recordToReport(
-    title?: string,
-    opt?: {
-      content?: string;
-      screenshotBase64?: string;
-    },
-  ) {
-    // 1. screenshot
-    const base64 =
-      opt?.screenshotBase64 ?? (await this.interface.screenshotBase64());
+  async recordToReport(title?: string, opt?: RecordToReportOptions) {
     const now = Date.now();
-    const screenshot = ScreenshotItem.create(base64, now);
-    // 2. build recorder
-    const recorder: ExecutionRecorderItem[] = [
-      {
-        type: 'screenshot',
-        ts: now,
-        screenshot,
+    const customScreenshots = Array.isArray(opt?.screenshots)
+      ? opt.screenshots
+      : Array.isArray(opt?.customScreenshotData)
+        ? opt.customScreenshotData
+        : undefined;
+    if (customScreenshots && customScreenshots.length === 0) {
+      throw new Error('recordToReport: screenshots cannot be empty');
+    }
+    const screenshotInputs: RecordToReportScreenshot[] =
+      customScreenshots ??
+      (opt?.screenshotBase64
+        ? [{ base64: opt.screenshotBase64 }]
+        : [{ base64: await this.interface.screenshotBase64() }]);
+
+    // 1. build recorder
+    const recorder: ExecutionRecorderItem[] = screenshotInputs.map(
+      (screenshotInput, index) => {
+        assertRecordToReportScreenshot(screenshotInput, index);
+        const ts = now + index;
+        return {
+          type: 'screenshot',
+          ts,
+          screenshot: ScreenshotItem.create(screenshotInput.base64, ts),
+          description: screenshotInput.description,
+        };
       },
-    ];
-    // 3. build ExecutionTaskLog
+    );
+    const customSubType = opt?.subType?.trim();
+    const taskSubType = customSubType || 'Screenshot';
+    const executionTypeLabel = customSubType || 'Log';
+
+    // 2. build ExecutionTaskLog
     const task: ExecutionTaskLog = {
       taskId: uuid(),
       type: 'Log',
-      subType: 'Screenshot',
+      subType: taskSubType,
       status: 'finished',
       recorder,
       timing: {
@@ -1549,15 +1613,15 @@ export class Agent<
       },
       executor: async () => {},
     };
-    // 4. build ExecutionDump
+    // 3. build ExecutionDump
     const executionDump = new ExecutionDump({
       id: uuid(),
       logTime: now,
-      name: `Log - ${title || 'untitled'}`,
+      name: `${executionTypeLabel} - ${title || 'untitled'}`,
       description: opt?.content || '',
       tasks: [task],
     });
-    // 5. append to execution dump
+    // 4. append to execution dump
     this.appendExecutionDump(executionDump);
 
     this.writeOutActionDumps(executionDump);

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -18,10 +18,9 @@ export { cacheFileExt } from './task-cache';
 export { TaskExecutor } from './tasks';
 
 export type { AgentOpt } from '../types';
+export type { RecordToReportOptions, RecordToReportScreenshot } from '../types';
 export type {
   AiActOptions,
   DescribeElementAtPointOptions,
   DescribeElementCoordinateSpace,
-  RecordToReportOptions,
-  RecordToReportScreenshot,
 } from './agent';

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -22,4 +22,6 @@ export type {
   AiActOptions,
   DescribeElementAtPointOptions,
   DescribeElementCoordinateSpace,
+  RecordToReportOptions,
+  RecordToReportScreenshot,
 } from './agent';

--- a/packages/core/src/agent/record-to-report.ts
+++ b/packages/core/src/agent/record-to-report.ts
@@ -1,0 +1,29 @@
+import type { RecordToReportScreenshot } from '@/types';
+import { normalizeScreenshotBase64 } from '@midscene/shared/img';
+
+export function normalizeRecordToReportScreenshot(
+  screenshot: RecordToReportScreenshot,
+  index: number,
+): RecordToReportScreenshot {
+  if (!screenshot || typeof screenshot.base64 !== 'string') {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} must include a base64 string`,
+    );
+  }
+
+  if (
+    screenshot.description !== undefined &&
+    typeof screenshot.description !== 'string'
+  ) {
+    throw new Error(
+      `recordToReport: screenshot #${index + 1} description must be a string`,
+    );
+  }
+
+  return {
+    base64: normalizeScreenshotBase64(screenshot.base64, {
+      label: `recordToReport: screenshot #${index + 1} base64`,
+    }),
+    description: screenshot.description,
+  };
+}

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -9,6 +9,7 @@ import type {
   PlanningLocateParam,
   PlanningLocateParamWithLocatedPixelBbox,
   Rect,
+  ScrollParam,
   Size,
   UIContext,
 } from '@/types';
@@ -32,6 +33,28 @@ import type { TaskCache } from './task-cache';
 import { debug as cacheDebug } from './task-cache';
 
 const agentDebug = getDebug('agent');
+
+const legacyScrollTypeMap = {
+  once: 'singleAction',
+  untilBottom: 'scrollToBottom',
+  untilTop: 'scrollToTop',
+  untilRight: 'scrollToRight',
+  untilLeft: 'scrollToLeft',
+} as const;
+
+export const normalizeScrollType = (
+  scrollType: string | undefined,
+): ScrollParam['scrollType'] | undefined => {
+  if (!scrollType) {
+    return undefined;
+  }
+
+  if (scrollType in legacyScrollTypeMap) {
+    return legacyScrollTypeMap[scrollType as keyof typeof legacyScrollTypeMap];
+  }
+
+  return scrollType as ScrollParam['scrollType'];
+};
 
 export async function commonContextParser(
   interfaceInstance: AbstractInterface,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,8 +61,6 @@ export {
   Agent,
   type AgentOpt,
   type AiActOptions,
-  type RecordToReportOptions,
-  type RecordToReportScreenshot,
   createAgent,
 } from './agent';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,14 @@ export type {
   DetailedLocateParam,
 } from './yaml';
 
-export { Agent, type AgentOpt, type AiActOptions, createAgent } from './agent';
+export {
+  Agent,
+  type AgentOpt,
+  type AiActOptions,
+  type RecordToReportOptions,
+  type RecordToReportScreenshot,
+  createAgent,
+} from './agent';
 
 // Dump utilities
 export {

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -264,8 +264,11 @@ function recorderMarkdownSection(
   const attachments: MarkdownAttachment[] = [];
 
   recorder.forEach((item, recorderIndex) => {
+    const descriptionText = item.description
+      ? `, description=${item.description}`
+      : '';
     lines.push(
-      `- #${recorderIndex + 1} type=${item.type}, ts=${formatTime(item.ts)}, timing=${item.timing || 'N/A'}`,
+      `- #${recorderIndex + 1} type=${item.type}, ts=${formatTime(item.ts)}, timing=${item.timing || 'N/A'}${descriptionText}`,
     );
 
     if (!item.screenshot) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -387,6 +387,26 @@ export interface ExecutionRecorderItem {
   timing?: string;
 }
 
+export interface RecordToReportScreenshot {
+  /**
+   * PNG/JPEG data URI, or raw PNG base64 body.
+   */
+  base64: string;
+  description?: string;
+}
+
+export interface RecordToReportOptions {
+  content?: string;
+  /**
+   * @deprecated Use `screenshots: [{ base64 }]` instead.
+   */
+  screenshotBase64?: string;
+  /**
+   * Custom screenshots to display under a single report entry.
+   */
+  screenshots?: RecordToReportScreenshot[];
+}
+
 export type ExecutionTaskType = 'Planning' | 'Insight' | 'Action Space' | 'Log';
 
 export interface ExecutorContext {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -383,6 +383,7 @@ export interface ExecutionRecorderItem {
   type: 'screenshot';
   ts: number;
   screenshot?: ScreenshotItem;
+  description?: string;
   timing?: string;
 }
 

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -198,52 +198,6 @@ describe('Agent dump update screenshot serialization', () => {
     await agent.destroy();
   });
 
-  it('accepts customScreenshotData as a recordToReport alias', async () => {
-    const screenshotBase64 = vi
-      .fn()
-      .mockRejectedValue(new Error('should not capture again'));
-    const agent = new Agent(
-      {
-        ...createMockInterface(),
-        screenshotBase64,
-      } as any,
-      {
-        modelConfig,
-        generateReport: false,
-      },
-    );
-
-    const reportGeneratorStub = {
-      onExecutionUpdate: vi.fn(),
-      flush: vi.fn(async () => {}),
-      finalize: vi.fn(async () => undefined),
-      getReportPath: vi.fn(() => undefined),
-    };
-
-    (agent as any).reportGenerator = reportGeneratorStub;
-
-    const screenshot = 'data:image/png;base64,from-issue-api';
-    await agent.recordToReport('issue api', {
-      customScreenshotData: [
-        { base64: screenshot, description: 'Issue API screenshot' },
-      ],
-    });
-
-    expect(screenshotBase64).not.toHaveBeenCalled();
-    const execution = reportGeneratorStub.onExecutionUpdate.mock
-      .calls[0][0] as ExecutionDump;
-    expect(execution.name).toBe('Log - issue api');
-    expect(execution.tasks[0].subType).toBe('Screenshot');
-    expect(execution.tasks[0].recorder?.[0].description).toBe(
-      'Issue API screenshot',
-    );
-    expect(execution.tasks[0].recorder?.[0].screenshot?.base64).toBe(
-      screenshot,
-    );
-
-    await agent.destroy();
-  });
-
   it('rejects an empty custom screenshot list', async () => {
     const screenshotBase64 = vi
       .fn()
@@ -310,7 +264,7 @@ describe('Agent dump update screenshot serialization', () => {
         screenshots: [{ base64: 'data:image/png;base64,custom' }],
       }),
     ).rejects.toThrow(
-      'recordToReport: provide only one of screenshots, customScreenshotData, or screenshotBase64',
+      'recordToReport: provide only one of screenshots or screenshotBase64',
     );
 
     expect(screenshotBase64).not.toHaveBeenCalled();

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -166,7 +166,6 @@ describe('Agent dump update screenshot serialization', () => {
     const afterScreenshot = 'data:image/jpg;base64,after';
     await agent.recordToReport('comparison', {
       content: 'before and after state',
-      subType: 'Checkpoint',
       screenshots: [
         { base64: beforeScreenshot, description: 'Before click' },
         { base64: afterScreenshot, description: 'After click' },
@@ -178,12 +177,12 @@ describe('Agent dump update screenshot serialization', () => {
 
     const execution = reportGeneratorStub.onExecutionUpdate.mock
       .calls[0][0] as ExecutionDump;
-    expect(execution.name).toBe('Checkpoint - comparison');
+    expect(execution.name).toBe('Log - comparison');
     expect(execution.description).toBe('before and after state');
 
     const task = execution.tasks[0];
     expect(task.type).toBe('Log');
-    expect(task.subType).toBe('Checkpoint');
+    expect(task.subType).toBe('Screenshot');
     expect(task.recorder).toHaveLength(2);
     expect(task.recorder?.map((item) => item.description)).toEqual([
       'Before click',
@@ -229,7 +228,7 @@ describe('Agent dump update screenshot serialization', () => {
       agent.recordToReport('invalid subType', {
         subType: 123,
       } as any),
-    ).rejects.toThrow('recordToReport: subType must be a string');
+    ).rejects.toThrow('recordToReport: subType is not supported');
 
     expect(screenshotBase64).not.toHaveBeenCalled();
 

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -138,6 +138,148 @@ describe('Agent dump update screenshot serialization', () => {
     await agent.destroy();
   });
 
+  it('records multiple provided screenshots in one report entry', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    const reportGeneratorStub = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {}),
+      finalize: vi.fn(async () => undefined),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    (agent as any).reportGenerator = reportGeneratorStub;
+
+    const beforeScreenshot = 'data:image/png;base64,before';
+    const afterScreenshot = 'data:image/png;base64,after';
+    await agent.recordToReport('comparison', {
+      content: 'before and after state',
+      subType: 'Checkpoint',
+      screenshots: [
+        { base64: beforeScreenshot, description: 'Before click' },
+        { base64: afterScreenshot, description: 'After click' },
+      ],
+    });
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    expect(reportGeneratorStub.onExecutionUpdate).toHaveBeenCalledTimes(1);
+
+    const execution = reportGeneratorStub.onExecutionUpdate.mock
+      .calls[0][0] as ExecutionDump;
+    expect(execution.name).toBe('Checkpoint - comparison');
+    expect(execution.description).toBe('before and after state');
+
+    const task = execution.tasks[0];
+    expect(task.type).toBe('Log');
+    expect(task.subType).toBe('Checkpoint');
+    expect(task.recorder).toHaveLength(2);
+    expect(task.recorder?.map((item) => item.description)).toEqual([
+      'Before click',
+      'After click',
+    ]);
+    expect(task.recorder?.map((item) => item.screenshot?.base64)).toEqual([
+      beforeScreenshot,
+      afterScreenshot,
+    ]);
+    expect(task.recorder?.[0].ts ?? 0).toBeLessThan(task.recorder?.[1].ts ?? 0);
+
+    await agent.destroy();
+  });
+
+  it('accepts customScreenshotData as a recordToReport alias', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    const reportGeneratorStub = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {}),
+      finalize: vi.fn(async () => undefined),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    (agent as any).reportGenerator = reportGeneratorStub;
+
+    const screenshot = 'data:image/png;base64,from-issue-api';
+    await agent.recordToReport('issue api', {
+      customScreenshotData: [
+        { base64: screenshot, description: 'Issue API screenshot' },
+      ],
+    });
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    const execution = reportGeneratorStub.onExecutionUpdate.mock
+      .calls[0][0] as ExecutionDump;
+    expect(execution.name).toBe('Log - issue api');
+    expect(execution.tasks[0].subType).toBe('Screenshot');
+    expect(execution.tasks[0].recorder?.[0].description).toBe(
+      'Issue API screenshot',
+    );
+    expect(execution.tasks[0].recorder?.[0].screenshot?.base64).toBe(
+      screenshot,
+    );
+
+    await agent.destroy();
+  });
+
+  it('rejects an empty custom screenshot list', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    const reportGeneratorStub = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {}),
+      finalize: vi.fn(async () => undefined),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    (agent as any).reportGenerator = reportGeneratorStub;
+
+    await expect(
+      agent.recordToReport('empty screenshots', {
+        screenshots: [],
+      }),
+    ).rejects.toThrow('recordToReport: screenshots cannot be empty');
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    expect(reportGeneratorStub.onExecutionUpdate).not.toHaveBeenCalled();
+
+    await agent.destroy();
+  });
+
   it('records failed log entries for runner-level errors', async () => {
     const agent = new Agent(createMockInterface(), {
       modelConfig,

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -280,6 +280,45 @@ describe('Agent dump update screenshot serialization', () => {
     await agent.destroy();
   });
 
+  it('rejects multiple custom screenshot sources', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    const reportGeneratorStub = {
+      onExecutionUpdate: vi.fn(),
+      flush: vi.fn(async () => {}),
+      finalize: vi.fn(async () => undefined),
+      getReportPath: vi.fn(() => undefined),
+    };
+
+    (agent as any).reportGenerator = reportGeneratorStub;
+
+    await expect(
+      agent.recordToReport('conflicting screenshots', {
+        screenshotBase64: 'data:image/png;base64,legacy',
+        screenshots: [{ base64: 'data:image/png;base64,custom' }],
+      }),
+    ).rejects.toThrow(
+      'recordToReport: provide only one of screenshots, customScreenshotData, or screenshotBase64',
+    );
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    expect(reportGeneratorStub.onExecutionUpdate).not.toHaveBeenCalled();
+
+    await agent.destroy();
+  });
+
   it('records failed log entries for runner-level errors', async () => {
     const agent = new Agent(createMockInterface(), {
       modelConfig,

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -162,8 +162,8 @@ describe('Agent dump update screenshot serialization', () => {
 
     (agent as any).reportGenerator = reportGeneratorStub;
 
-    const beforeScreenshot = 'data:image/png;base64,before';
-    const afterScreenshot = 'data:image/png;base64,after';
+    const beforeScreenshot = 'before';
+    const afterScreenshot = 'data:image/jpg;base64,after';
     await agent.recordToReport('comparison', {
       content: 'before and after state',
       subType: 'Checkpoint',
@@ -190,10 +190,76 @@ describe('Agent dump update screenshot serialization', () => {
       'After click',
     ]);
     expect(task.recorder?.map((item) => item.screenshot?.base64)).toEqual([
-      beforeScreenshot,
-      afterScreenshot,
+      'data:image/png;base64,before',
+      'data:image/jpeg;base64,after',
     ]);
     expect(task.recorder?.[0].ts ?? 0).toBeLessThan(task.recorder?.[1].ts ?? 0);
+
+    await agent.destroy();
+  });
+
+  it('rejects invalid recordToReport option types before capturing screenshots', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    await expect(
+      agent.recordToReport('invalid screenshots', {
+        screenshots: { base64: 'data:image/png;base64,custom' },
+      } as any),
+    ).rejects.toThrow('recordToReport: screenshots must be an array');
+
+    await expect(
+      agent.recordToReport('invalid screenshotBase64', {
+        screenshotBase64: 123,
+      } as any),
+    ).rejects.toThrow('recordToReport: screenshotBase64 must be a string');
+
+    await expect(
+      agent.recordToReport('invalid subType', {
+        subType: 123,
+      } as any),
+    ).rejects.toThrow('recordToReport: subType must be a string');
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+
+    await agent.destroy();
+  });
+
+  it('rejects unsupported custom screenshot data URI formats', async () => {
+    const screenshotBase64 = vi
+      .fn()
+      .mockRejectedValue(new Error('should not capture again'));
+    const agent = new Agent(
+      {
+        ...createMockInterface(),
+        screenshotBase64,
+      } as any,
+      {
+        modelConfig,
+        generateReport: false,
+      },
+    );
+
+    await expect(
+      agent.recordToReport('svg screenshot', {
+        screenshots: [{ base64: 'data:image/svg+xml;base64,custom' }],
+      }),
+    ).rejects.toThrow(
+      'recordToReport: screenshot #1 base64 must be a PNG/JPEG data URI or raw PNG base64 string',
+    );
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
 
     await agent.destroy();
   });

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -47,6 +47,7 @@ describe('report-markdown', () => {
               type: 'screenshot',
               ts: 1710000000050,
               timing: 'after click',
+              description: 'Post-click state',
               screenshot: {
                 type: 'midscene_screenshot_ref',
                 id: 'shot-recorder-single',
@@ -68,6 +69,7 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('![task-1](./screenshots/');
     expect(result.markdown).toContain('### Recorder');
     expect(result.markdown).toContain('timing=after click');
+    expect(result.markdown).toContain('description=Post-click state');
     expect(result.markdown).toContain('Screen size: 1280 x 720');
     expect(result.attachments).toHaveLength(2);
     expect(result.attachments[0].suggestedFileName).toContain('.png');

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -21,6 +21,8 @@ export {
   createImgBase64ByFormat,
   inferBase64ImageFormat,
   normalizeBase64Image,
+  normalizeScreenshotBase64,
+  type NormalizeScreenshotBase64Options,
 } from './transform';
 export {
   processImageElementInfo,

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -157,6 +157,9 @@ export async function resizeAndConvertImgBuffer(
 export const normalizeBase64Body = (body: string) => body.replace(/\s/g, '');
 
 const base64ImageDataUrlPattern = /^data:image\/[a-zA-Z0-9.+-]+;base64,/i;
+const supportedScreenshotDataUriPattern =
+  /^data:image\/(png|jpe?g);base64,([\s\S]*)$/i;
+const rawBase64BodyPattern = /^[A-Za-z0-9+/=\s]+$/;
 
 export const inferBase64ImageFormat = (base64Body: string) => {
   if (base64Body.startsWith('iVBORw0KGgo')) {
@@ -205,6 +208,48 @@ function detectImageMimeTypeFromBuffer(buffer: Buffer): string | undefined {
 
 export const createImgBase64ByFormat = (format: string, body: string) => {
   return `data:image/${format};base64,${normalizeBase64Body(body)}`;
+};
+
+export interface NormalizeScreenshotBase64Options {
+  label?: string;
+}
+
+export const normalizeScreenshotBase64 = (
+  base64: string,
+  options?: NormalizeScreenshotBase64Options,
+) => {
+  const label = options?.label ?? 'screenshot base64';
+  const trimmedBase64 = base64.trim();
+  if (!trimmedBase64) {
+    throw new Error(`${label} cannot be empty`);
+  }
+
+  const dataUriMatch = trimmedBase64.match(supportedScreenshotDataUriPattern);
+  if (dataUriMatch) {
+    const imageFormat =
+      dataUriMatch[1].toLowerCase() === 'jpg'
+        ? 'jpeg'
+        : dataUriMatch[1].toLowerCase();
+    const body = dataUriMatch[2];
+    if (!normalizeBase64Body(body)) {
+      throw new Error(`${label} cannot be empty`);
+    }
+    return createImgBase64ByFormat(imageFormat, body);
+  }
+
+  if (trimmedBase64.startsWith('data:')) {
+    throw new Error(
+      `${label} must be a PNG/JPEG data URI or raw PNG base64 string`,
+    );
+  }
+
+  if (!rawBase64BodyPattern.test(trimmedBase64)) {
+    throw new Error(
+      `${label} must be a PNG/JPEG data URI or raw PNG base64 string`,
+    );
+  }
+
+  return createImgBase64ByFormat('png', trimmedBase64);
 };
 
 export const normalizeBase64Image = (base64: string) => {

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -100,6 +100,19 @@ export type UserPromptLike =
       convertHttpImage2Base64?: boolean;
     };
 
+export interface RecordToReportScreenshot {
+  base64: string;
+  description?: string;
+}
+
+export interface RecordToReportOptions {
+  content?: string;
+  screenshotBase64?: string;
+  screenshots?: RecordToReportScreenshot[];
+  customScreenshotData?: RecordToReportScreenshot[];
+  subType?: string;
+}
+
 /**
  * Base agent interface
  * Represents a platform-specific agent (Android, iOS, Web)
@@ -113,7 +126,7 @@ export interface BaseAgent {
   };
   recordToReport?: (
     title?: string,
-    opt?: { content?: string; screenshotBase64?: string },
+    opt?: RecordToReportOptions,
   ) => Promise<void>;
   callActionInActionSpace?: (
     actionName: string,

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -101,6 +101,9 @@ export type UserPromptLike =
     };
 
 export interface RecordToReportScreenshot {
+  /**
+   * PNG/JPEG data URI, or raw PNG base64 body.
+   */
   base64: string;
   description?: string;
 }

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -115,7 +115,6 @@ export interface RecordToReportOptions {
    */
   screenshotBase64?: string;
   screenshots?: RecordToReportScreenshot[];
-  subType?: string;
 }
 
 /**

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -107,6 +107,9 @@ export interface RecordToReportScreenshot {
 
 export interface RecordToReportOptions {
   content?: string;
+  /**
+   * @deprecated Use `screenshots: [{ base64 }]` instead.
+   */
   screenshotBase64?: string;
   screenshots?: RecordToReportScreenshot[];
   customScreenshotData?: RecordToReportScreenshot[];

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -112,7 +112,6 @@ export interface RecordToReportOptions {
    */
   screenshotBase64?: string;
   screenshots?: RecordToReportScreenshot[];
-  customScreenshotData?: RecordToReportScreenshot[];
   subType?: string;
 }
 

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   inferBase64ImageFormat,
   normalizeBase64Image,
+  normalizeScreenshotBase64,
   preProcessImageUrl,
   scaleImage,
 } from '../../src/img/transform';
@@ -92,6 +93,43 @@ describe('normalizeBase64Image', () => {
   it('wraps bare non-png base64 as jpeg for compatibility', () => {
     expect(normalizeBase64Image(' /9j/4AAQ SkZJRg== ')).toBe(
       'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+    );
+  });
+});
+
+describe('normalizeScreenshotBase64', () => {
+  it('accepts PNG and JPEG data urls', () => {
+    expect(
+      normalizeScreenshotBase64(' data:image/png;base64,aaa\r\nbbb '),
+    ).toBe('data:image/png;base64,aaabbb');
+    expect(normalizeScreenshotBase64('data:image/jpeg;base64,/9j/4AAQ')).toBe(
+      'data:image/jpeg;base64,/9j/4AAQ',
+    );
+  });
+
+  it('normalizes jpg data urls to jpeg', () => {
+    expect(normalizeScreenshotBase64('data:image/jpg;base64,/9j/4AAQ')).toBe(
+      'data:image/jpeg;base64,/9j/4AAQ',
+    );
+  });
+
+  it('wraps raw base64 as PNG', () => {
+    expect(normalizeScreenshotBase64(' iVBORw0KGgo aaa\r\nbbb ')).toBe(
+      'data:image/png;base64,iVBORw0KGgoaaabbb',
+    );
+  });
+
+  it('uses the provided label in validation errors', () => {
+    expect(() =>
+      normalizeScreenshotBase64(' ', { label: 'custom screenshot' }),
+    ).toThrow('custom screenshot cannot be empty');
+
+    expect(() =>
+      normalizeScreenshotBase64('data:image/svg+xml;base64,aaa', {
+        label: 'custom screenshot',
+      }),
+    ).toThrow(
+      'custom screenshot must be a PNG/JPEG data URI or raw PNG base64 string',
     );
   });
 });


### PR DESCRIPTION
## Summary

- Extend `agent.recordToReport()` with structured `screenshots` and `subType` display labels.
- Keep `screenshotBase64` as a backward-compatible legacy single-screenshot override, and reject calls that provide both screenshot sources at once.
- Harden `recordToReport()` input handling with fail-fast validation for invalid option shapes, unsupported screenshot data URI formats, and non-string `subType` values.
- Keep report task records typed as `Log` while storing per-screenshot descriptions on recorder items.
- Show custom screenshot descriptions in the report detail panel and Markdown export.
- Document the expanded API in both English and Chinese docs.

## Validation

- `pnpm run lint`
- `pnpm --dir packages/core test tests/unit-test/agent-dump-update.test.ts tests/unit-test/report-markdown.test.ts`
- `pnpm run clean`
- `npx nx run-many --target=build --projects=@midscene/shared,@midscene/core,@midscene/report --verbose --skip-nx-cache`

Closes #1998.
