### PR TITLE
Fix report playground server origin and context spacing

### DIFF
--- a/apps/report/src/utils/report-playground-utils.ts
+++ b/apps/report/src/utils/report-playground-utils.ts
@@ -1,5 +1,4 @@
 import { type AgentFactory, PlaygroundSDK } from '@midscene/playground';
-import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
 
 export type ServiceModeType = 'Server' | 'In-Browser' | 'In-Browser-Extension';
 
@@ -20,7 +19,6 @@ export function getReportPlaygroundSDK(
   if (serviceMode === 'Server') {
     return new PlaygroundSDK({
       type: 'remote-execution',
-      serverUrl: `http://localhost:${PLAYGROUND_SERVER_PORT}`,
     });
   }
   // For In-Browser and In-Browser-Extension modes, use local execution

--- a/apps/report/tests/report-playground-utils.test.ts
+++ b/apps/report/tests/report-playground-utils.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { playgroundSDKMock } = vi.hoisted(() => ({
+  playgroundSDKMock: vi.fn(),
+}));
+
+vi.mock('@midscene/playground', () => ({
+  PlaygroundSDK: playgroundSDKMock,
+}));
+
+import { getReportPlaygroundSDK } from '../src/utils/report-playground-utils';
+
+describe('getReportPlaygroundSDK', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets PlaygroundSDK resolve the remote server URL in Server mode', () => {
+    getReportPlaygroundSDK('Server');
+
+    expect(playgroundSDKMock).toHaveBeenCalledWith({
+      type: 'remote-execution',
+    });
+  });
+
+  it('throws when local execution has no agent factory', () => {
+    expect(() => getReportPlaygroundSDK('In-Browser')).toThrow(
+      'Agent or agentFactory is required for local execution mode',
+    );
+  });
+
+  it('uses local execution with agent factory outside Server mode', () => {
+    const agentFactory = vi.fn();
+
+    getReportPlaygroundSDK('In-Browser', undefined, agentFactory);
+
+    expect(playgroundSDKMock).toHaveBeenCalledWith({
+      type: 'local-execution',
+      agentFactory,
+    });
+  });
+});

--- a/packages/visualizer/src/component/context-preview/index.less
+++ b/packages/visualizer/src/component/context-preview/index.less
@@ -1,0 +1,3 @@
+.context-panel {
+  padding-bottom: 12px;
+}

--- a/packages/visualizer/src/component/context-preview/index.tsx
+++ b/packages/visualizer/src/component/context-preview/index.tsx
@@ -4,6 +4,7 @@ import type React from 'react';
 import Blackboard from '../blackboard';
 import { iconForStatus } from '../misc';
 import DemoData from '../playground/playground-demo-ui-context.json';
+import './index.less';
 
 interface ContextPreviewProps {
   uiContextPreview: UIContext | undefined;


### PR DESCRIPTION
## Summary
- Let report Playground Server mode use the SDK default server origin instead of forcing localhost.
- Add unit coverage for report Playground SDK setup.
- Add bottom spacing under the UI context preview before the action toolbar.

## Validation
- `pnpm run lint`
- `pnpm --filter @midscene/report test`
- `fnm exec --using 20.20.2 pnpm exec nx build @midscene/report --skip-nx-cache`