### PR TITLE
Fix deeplocate report screenshots and labels

### DIFF
--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -16,7 +16,7 @@ import type {
   IExecutionDump,
 } from '@midscene/core';
 import type { MarkdownAttachment } from '@midscene/core';
-import { executionToMarkdown } from '@midscene/core';
+import { executionToMarkdown, getTaskSearchArea } from '@midscene/core';
 import {
   Blackboard,
   Player,
@@ -161,13 +161,6 @@ const DetailPanel = (): JSX.Element => {
   // Check if page context is frozen
   const isPageContextFrozen = Boolean(activeTask?.uiContext?._isFrozen);
 
-  const markdownResult = useMemo(() => {
-    return getExecutionMarkdownView(activeExecution, (execution) =>
-      executionToMarkdown(execution as ExecutionDump | IExecutionDump, {
-        screenshotBaseDir: './screenshots',
-      }),
-    );
-  }, [activeExecution]);
   const activeTaskJsonViewData = useMemo(() => {
     return activeTask ? sanitizeJsonViewData(activeTask) : null;
   }, [activeTask]);
@@ -176,6 +169,10 @@ const DetailPanel = (): JSX.Element => {
       ? JSON.stringify(activeTaskJsonViewData, undefined, 2)
       : '';
   }, [activeTaskJsonViewData]);
+  const activeTaskSearchArea = useMemo(
+    () => getTaskSearchArea(activeTask),
+    [activeTask],
+  );
 
   const hasReplay =
     activeTask?.type === 'Planning' &&
@@ -194,6 +191,16 @@ const DetailPanel = (): JSX.Element => {
     availableViewTypes.indexOf(preferredViewType) >= 0
       ? preferredViewType
       : availableViewTypes[0];
+  const markdownResult = useMemo(() => {
+    if (viewType !== VIEW_TYPE_MARKDOWN) {
+      return null;
+    }
+    return getExecutionMarkdownView(activeExecution, (execution) =>
+      executionToMarkdown(execution as ExecutionDump | IExecutionDump, {
+        screenshotBaseDir: './screenshots',
+      }),
+    );
+  }, [activeExecution, viewType]);
 
   let content;
   if (activeExecution && viewType === VIEW_TYPE_REPLAY) {
@@ -206,13 +213,13 @@ const DetailPanel = (): JSX.Element => {
       />
     );
   } else if (viewType === VIEW_TYPE_MARKDOWN) {
-    if (markdownResult.status === 'ready') {
+    if (markdownResult?.status === 'ready') {
       content = (
         <div className="markdown-view scrollable">
           <pre className="markdown-source">{markdownResult.markdown}</pre>
         </div>
       );
-    } else if (markdownResult.status === 'error') {
+    } else if (markdownResult?.status === 'error') {
       content = (
         <div>Failed to render markdown: {markdownResult.errorMessage}</div>
       );
@@ -272,7 +279,7 @@ const DetailPanel = (): JSX.Element => {
       activeTask.uiContext?.screenshot?.capturedAt,
     );
 
-    contextLocatorView = activeTask.uiContext?.shotSize ? (
+    contextLocatorView = activeTask.uiContext ? (
       <ScreenshotDisplay
         title={`${isPageContextFrozen ? 'UI Context (Frozen)' : 'UI Context'} / ${contextScreenshotAt}`}
       >
@@ -280,18 +287,21 @@ const DetailPanel = (): JSX.Element => {
           key={`${_contextLoadId}`}
           uiContext={activeTask.uiContext}
           highlightElements={highlightElements}
-          highlightRect={insightDump?.taskInfo?.searchArea}
+          highlightRect={
+            activeTaskSearchArea || insightDump?.taskInfo?.searchArea
+          }
         />
       </ScreenshotDisplay>
     ) : null;
 
     if (activeTask.recorder?.length) {
       for (const item of activeTask.recorder) {
-        if (item.screenshot?.base64) {
+        const screenshot = item.screenshot?.base64;
+        if (screenshot) {
           screenshotItems.push({
             timestamp: item.ts,
-            screenshotTimestamp: item.screenshot.capturedAt,
-            screenshot: item.screenshot.base64,
+            screenshotTimestamp: item.screenshot?.capturedAt,
+            screenshot,
             timing: item.timing,
           });
         }
@@ -394,27 +404,21 @@ const DetailPanel = (): JSX.Element => {
         />
 
         <div className="view-switcher-actions">
-          {viewType === VIEW_TYPE_MARKDOWN && markdownResult && (
-            <a
-              className="download-zip-link"
-              onClick={() =>
-                downloadMarkdownZip(
-                  // @ts-ignore Keep the existing Markdown download behavior for now.
-                  // markdownResult is a discriminated union, and only the "ready"
-                  // branch has markdown content. The historical condition did not
-                  // check status, and we have not confirmed whether empty/error
-                  // states intentionally still render this action.
-                  markdownResult.markdown,
-                  // @ts-ignore See the note above: preserve the current behavior
-                  // until the Markdown view UX expectation is clarified.
-                  markdownResult.attachments,
-                  safeName || 'report',
-                )
-              }
-            >
-              <DownloadOutlined /> Download ZIP
-            </a>
-          )}
+          {viewType === VIEW_TYPE_MARKDOWN &&
+            markdownResult?.status === 'ready' && (
+              <a
+                className="download-zip-link"
+                onClick={() =>
+                  downloadMarkdownZip(
+                    markdownResult.markdown,
+                    markdownResult.attachments,
+                    safeName || 'report',
+                  )
+                }
+              >
+                <DownloadOutlined /> Download ZIP
+              </a>
+            )}
           {viewType === VIEW_TYPE_JSON && activeTaskJsonText && (
             <a
               className="copy-json-link"

--- a/apps/report/src/components/store/index.tsx
+++ b/apps/report/src/components/store/index.tsx
@@ -3,12 +3,12 @@ import type { PlaywrightTaskAttributes } from '@/types';
 import type {
   ExecutionDump,
   ExecutionTask,
-  ExecutionTaskPlanningLocate,
   GroupedActionDump,
   LocateResultElement,
   ModelBrief,
   ServiceDump,
 } from '@midscene/core';
+import { getTaskServiceDump } from '@midscene/core';
 import type { AnimationScript } from '@midscene/visualizer';
 import {
   allScriptsFromDump,
@@ -209,7 +209,7 @@ export const useExecutionDump = create<DumpStoreType>((set, get) => {
         task.type === 'Insight' ||
         (task.type === 'Planning' && task.subType === 'Locate')
       ) {
-        const dump = (task as ExecutionTaskPlanningLocate).log;
+        const dump = getTaskServiceDump(task);
         set({
           insightDump: dump,
         });

--- a/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
@@ -16,11 +16,13 @@ const makeTask = (opts: TaskFixtureOptions): ExecutionTask =>
     uiContext: opts.uiContextScreenshot
       ? { screenshot: opts.uiContextScreenshot }
       : undefined,
-    recorder: opts.recorder?.map((r) => ({
-      type: 'screenshot',
-      ts: r.ts,
-      screenshot: r.base64 !== undefined ? { base64: r.base64 } : undefined,
-    })),
+    recorder: [
+      ...(opts.recorder?.map((r) => ({
+        type: 'screenshot',
+        ts: r.ts,
+        screenshot: r.base64 !== undefined ? { base64: r.base64 } : undefined,
+      })) ?? []),
+    ],
   }) as unknown as ExecutionTask;
 
 describe('buildTimelineScreenshots', () => {
@@ -190,8 +192,8 @@ describe('buildTimelineScreenshots', () => {
   });
 
   it('still uses dropped recorder ts to compute starting time', () => {
-    // legacy behaviour: a recorder with no screenshot still contributes its ts
-    // to startingTime so that surviving entries render at the right offset.
+    // A recorder with no screenshot still contributes its ts to startingTime so
+    // surviving entries render at the right offset.
     const taskA = makeTask({
       id: 'A',
       startTs: 5000,

--- a/apps/report/src/components/timeline/build-timeline-screenshots.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.ts
@@ -29,7 +29,7 @@ const collectScreenshotEntries = (
       entries.push({
         task,
         ts: task.timing.start,
-        base64: ctxScreenshot.base64 || '',
+        base64: ctxScreenshot.base64,
       });
     }
 
@@ -38,7 +38,7 @@ const collectScreenshotEntries = (
         entries.push({
           task,
           ts: recorder.ts,
-          base64: recorder.screenshot.base64 || '',
+          base64: recorder.screenshot.base64,
         });
       }
     }
@@ -47,9 +47,9 @@ const collectScreenshotEntries = (
   return entries;
 };
 
-// Note: matches the legacy behaviour where any recorder ts (even ones whose
-// screenshot was later filtered out) and any task.timing.start contribute to
-// the starting time. We keep this so the rendered offsets are unchanged.
+// Note: any recorder ts, even ones whose screenshot is later filtered out, and
+// any task.timing.start contribute to the starting time so rendered offsets are
+// unchanged.
 const computeStartingTime = (allTasks: ExecutionTask[]): number => {
   let starting = -1;
   const consider = (ts: number) => {

--- a/apps/report/src/utils/report-task-tags.ts
+++ b/apps/report/src/utils/report-task-tags.ts
@@ -22,6 +22,10 @@ export const consumedDumpFlagKeys = {
 
 export function hasDeepThinkFlag(task: ExecutionTask): boolean {
   // deepThink is an aiAct planning-phase flag, not a per-locate-task flag.
+  if (task.type !== 'Planning' || task.subType === 'Locate') {
+    return false;
+  }
+
   const param = task.param as Partial<DeepThinkParam> | undefined;
 
   return param?.[consumedDumpFlagKeys.deepThink] === true;

--- a/apps/report/tests/report-task-tags.test.ts
+++ b/apps/report/tests/report-task-tags.test.ts
@@ -38,6 +38,21 @@ describe('report task tag flags', () => {
     expect(hasDeepThinkFlag(task as ExecutionTask)).toBe(false);
   });
 
+  it('does not treat deprecated locate deepThink as aiAct deepThink', () => {
+    const task = {
+      type: 'Planning',
+      subType: 'Locate',
+      taskId: 'locate-old-alias',
+      status: 'finished',
+      param: {
+        prompt: 'target button',
+        deepThink: true,
+      },
+    };
+
+    expect(hasDeepThinkFlag(task as ExecutionTask)).toBe(false);
+  });
+
   it('consumes deepLocate from locate task dump params', () => {
     const task = {
       type: 'Planning',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,10 +34,10 @@
       "import": "./dist/es/device/index.mjs",
       "require": "./dist/lib/device/index.js"
     },
-    "./dump": {
-      "types": "./dist/types/dump/index.d.ts",
-      "import": "./dist/es/dump/index.mjs",
-      "require": "./dist/lib/dump/index.js"
+    "./dump/task-service-dump": {
+      "types": "./dist/types/dump/task-service-dump.d.ts",
+      "import": "./dist/es/dump/task-service-dump.mjs",
+      "require": "./dist/lib/dump/task-service-dump.js"
     },
     "./agent": {
       "types": "./dist/types/agent/index.d.ts",
@@ -67,7 +67,7 @@
       "ai-model": ["./dist/types/ai-model.d.ts"],
       "tree": ["./dist/types/tree.d.ts"],
       "device": ["./dist/types/device.d.ts"],
-      "dump": ["./dist/types/dump/index.d.ts"],
+      "dump/task-service-dump": ["./dist/types/dump/task-service-dump.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
       "mcp": ["./dist/types/skill/index.d.ts"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/es/device/index.mjs",
       "require": "./dist/lib/device/index.js"
     },
+    "./dump": {
+      "types": "./dist/types/dump/index.d.ts",
+      "import": "./dist/es/dump/index.mjs",
+      "require": "./dist/lib/dump/index.js"
+    },
     "./agent": {
       "types": "./dist/types/agent/index.d.ts",
       "import": "./dist/es/agent/index.mjs",
@@ -62,6 +67,7 @@
       "ai-model": ["./dist/types/ai-model.d.ts"],
       "tree": ["./dist/types/tree.d.ts"],
       "device": ["./dist/types/device.d.ts"],
+      "dump": ["./dist/types/dump/index.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
       "mcp": ["./dist/types/skill/index.d.ts"]

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -70,8 +70,25 @@ function invalidLocateElementReason(
   return undefined;
 }
 
+type LocateParamWithDeprecatedAlias = DetailedLocateParam & {
+  deepThink?: boolean;
+};
+
+function normalizeLocateParam(
+  param: string | DetailedLocateParam,
+): DetailedLocateParam {
+  if (typeof param === 'string') {
+    return { prompt: param };
+  }
+
+  const { deepThink, ...rest } = param as LocateParamWithDeprecatedAlias;
+  const deepLocate = rest.deepLocate ?? deepThink;
+
+  return deepLocate === undefined ? rest : { ...rest, deepLocate };
+}
+
 export function locatePlanForLocate(param: string | DetailedLocateParam) {
-  const locate = typeof param === 'string' ? { prompt: param } : param;
+  const locate = normalizeLocateParam(param);
   const locatePlan: PlanningAction<PlanningLocateParam> = {
     type: 'Locate',
     param: locate,
@@ -379,13 +396,7 @@ export class TaskBuilder {
   ): ExecutionTaskPlanningLocateApply {
     const { cacheable, defaultModel, deepLocate, abortSignal } = context;
 
-    let locateParam = detailedLocateParam;
-
-    if (typeof locateParam === 'string') {
-      locateParam = {
-        prompt: locateParam,
-      };
-    }
+    let locateParam = normalizeLocateParam(detailedLocateParam);
 
     if (cacheable !== undefined) {
       locateParam = {
@@ -452,6 +463,7 @@ export class TaskBuilder {
               dump.taskInfo?.searchAreaRawChoiceMessage,
           };
           task.usage = withUsageIntent(dump.taskInfo?.usage, 'default');
+          task.searchArea = dump.taskInfo?.searchArea;
           if (dump.taskInfo?.searchAreaUsage) {
             task.searchAreaUsage = dump.taskInfo.searchAreaUsage;
           }

--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -4,6 +4,11 @@ import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
 export const escapeContent = escapeScriptTag;
 export const unescapeContent = antiEscapeScriptTag;
 
+function htmlScriptCloseTag(): string {
+  // biome-ignore lint/style/useTemplate: keep this token runtime-built for inline report bundles
+  return String.fromCharCode(60) + '/script>';
+}
+
 /** Chunk size for streaming file operations (64KB) */
 export const STREAMING_CHUNK_SIZE = 64 * 1024;
 
@@ -104,7 +109,7 @@ export function extractImageByIdSync(
   imageId: string,
 ): string | null {
   const targetTag = `<script type="midscene-image" data-id="${imageId}">`;
-  const closeTag = '</script>';
+  const closeTag = htmlScriptCloseTag();
 
   let result: string | null = null;
 
@@ -129,7 +134,7 @@ export function streamImageScriptsToFile(
 ): void {
   const { appendFileSync } = require('node:fs');
   const openTag = '<script type="midscene-image"';
-  const closeTag = '</script>';
+  const closeTag = htmlScriptCloseTag();
 
   streamScanTags(srcFilePath, openTag, closeTag, (content) => {
     // Write complete tag immediately to destination, don't accumulate
@@ -147,7 +152,7 @@ export function streamImageScriptsToFile(
  */
 export function extractLastDumpScriptSync(filePath: string): string {
   const openTagPrefix = '<script type="midscene_web_dump"';
-  const closeTag = '</script>';
+  const closeTag = htmlScriptCloseTag();
 
   let lastContent = '';
 
@@ -251,7 +256,7 @@ export function streamDumpScriptsSync(
   onMatch: (dumpScript: { openTag: string; content: string }) => boolean,
 ): void {
   const openTagPrefix = '<script type="midscene_web_dump"';
-  const closeTag = '</script>';
+  const closeTag = htmlScriptCloseTag();
 
   const fd = openSync(filePath, 'r');
   const fileSize = statSync(filePath).size;
@@ -347,7 +352,7 @@ export function parseDumpScript(html: string): string {
   // Use string search instead of regex to avoid ReDoS vulnerability
   // Find the LAST dump script tag (template may contain similar patterns in bundled JS)
   const scriptOpenTag = '<script type="midscene_web_dump"';
-  const scriptCloseTag = '</script>';
+  const closeTag = htmlScriptCloseTag();
 
   // Find the last occurrence of the opening tag
   const lastOpenIndex = html.lastIndexOf(scriptOpenTag);
@@ -362,7 +367,7 @@ export function parseDumpScript(html: string): string {
   }
 
   // Find the closing tag after the opening tag
-  const closeIndex = html.indexOf(scriptCloseTag, tagEndIndex);
+  const closeIndex = html.indexOf(closeTag, tagEndIndex);
   if (closeIndex === -1) {
     throw new Error('No dump script found in HTML');
   }
@@ -398,13 +403,14 @@ export function parseDumpScriptAttributes(
 
 export function generateImageScriptTag(id: string, data: string): string {
   // Do not use template string here, will cause bundle error with <script
+  const closeTag = htmlScriptCloseTag();
   return (
     // biome-ignore lint/style/useTemplate: <explanation>
     '<script type="midscene-image" data-id="' +
     id +
     '">' +
     escapeContent(data) +
-    '</script>'
+    closeTag
   );
 }
 
@@ -420,24 +426,16 @@ export function generateImageScriptTag(id: string, data: string): string {
  */
 // Do not use template string here, will cause bundle error with <script
 //
-// The closing </script> tag is built at runtime via scriptClose() so that no
-// bundler (rslib, webpack, rsbuild) can ever see or inline a literal
-// '</script>' into JS source.  A literal '</script>' inside a <script> block
-// causes the HTML parser to prematurely close the block — which breaks the
-// report viewer when this module is bundled into the report HTML template.
+// The closing script tag is built at runtime so bundlers cannot inline the
+// token that would prematurely close the report template's inline app bundle.
 //
-// Do NOT replace this with a string constant, hex escape (\x3c), or simple
-// concatenation — bundlers will optimise / inline them and re-introduce the
-// literal '</script>'.
+// Do NOT replace this with a string constant, hex escape (\x3c), or literal
+// string concatenation. Bundlers may optimise those forms back to the unsafe
+// token.
 let _baseUrlFixScript: string;
 export function getBaseUrlFixScript(): string {
   if (!_baseUrlFixScript) {
-    // Closing </script> MUST be split so that no bundler (rslib / webpack /
-    // terser) can ever produce a literal '</script>' in bundle output.
-    // A literal '</script>' inside a <script> block causes the HTML parser
-    // to prematurely close the block, which breaks the report viewer when
-    // this module is bundled into the report template.
-    const close = '</' + 'script>';
+    const close = htmlScriptCloseTag();
     _baseUrlFixScript =
       // biome-ignore lint/style/useTemplate: see above
       '\n<script>(function(){' +
@@ -457,6 +455,7 @@ export function generateDumpScriptTag(
   json: string,
   attributes?: Record<string, string | number | boolean>,
 ): string {
+  const closeTag = htmlScriptCloseTag();
   let attrString = '';
   if (attributes && Object.keys(attributes).length > 0) {
     // Do not use template string here, will cause bundle error with <script
@@ -476,6 +475,6 @@ export function generateDumpScriptTag(
     attrString +
     '>' +
     escapeContent(json) +
-    '</script>'
+    closeTag
   );
 }

--- a/packages/core/src/dump/index.ts
+++ b/packages/core/src/dump/index.ts
@@ -13,3 +13,4 @@ export {
   generateImageScriptTag,
   generateDumpScriptTag,
 } from './html-utils';
+export { getTaskSearchArea, getTaskServiceDump } from './task-service-dump';

--- a/packages/core/src/dump/task-service-dump.ts
+++ b/packages/core/src/dump/task-service-dump.ts
@@ -1,0 +1,31 @@
+import type { ExecutionTask, Rect, ServiceDump } from '../types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isServiceDump(value: unknown): value is ServiceDump {
+  return (
+    isRecord(value) &&
+    typeof value.type === 'string' &&
+    isRecord(value.taskInfo)
+  );
+}
+
+export function getTaskServiceDump(
+  task?: ExecutionTask | null,
+): ServiceDump | null {
+  const log = task?.log as unknown;
+
+  if (isRecord(log) && isServiceDump(log.dump)) {
+    return log.dump;
+  }
+
+  return null;
+}
+
+export function getTaskSearchArea(
+  task?: ExecutionTask | null,
+): Rect | undefined {
+  return task?.searchArea ?? getTaskServiceDump(task)?.taskInfo?.searchArea;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,9 +69,11 @@ export {
   parseDumpScriptAttributes,
   generateImageScriptTag,
   generateDumpScriptTag,
+} from './dump';
+export {
   getTaskSearchArea,
   getTaskServiceDump,
-} from './dump';
+} from './dump/task-service-dump';
 
 // Report generator
 export type { IReportGenerator } from './report-generator';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,8 @@ export {
   parseDumpScriptAttributes,
   generateImageScriptTag,
   generateDumpScriptTag,
+  getTaskSearchArea,
+  getTaskServiceDump,
 } from './dump';
 
 // Report generator

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -468,6 +468,12 @@ export type ExecutionTask<
       cost?: number;
     };
     usage?: AIUsageInfo;
+    /**
+     * Pixel rect of the deepLocate first-stage search area in screenshot
+     * coordinates. Used by reports to explain the crop/zoom area that the
+     * final locate ran against.
+     */
+    searchArea?: Rect;
     searchAreaUsage?: AIUsageInfo;
     reasoning_content?: string;
   };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -29,6 +29,11 @@ export { appendFileSync } from 'node:fs';
 
 export const groupedActionDumpFileExt = 'web-dump.json';
 
+function htmlScriptCloseTag(): string {
+  // biome-ignore lint/style/useTemplate: keep this token runtime-built for inline report bundles
+  return String.fromCharCode(60) + '/script>';
+}
+
 /**
  * Process cache configuration with environment variable support and backward compatibility.
  *
@@ -157,6 +162,7 @@ export function reportHTMLContent(
   // if reportPath is set, it means we are in write to file mode
   const writeToFile = reportPath && !ifInBrowser;
   let dumpContent = '';
+  const closeTag = htmlScriptCloseTag();
 
   const resolveAutoGroupId = (): string => {
     if (!reportPath || !appendReport) {
@@ -182,7 +188,8 @@ export function reportHTMLContent(
       encodeURIComponent(groupId) +
       '">\n' +
       escapeScriptTag(dumpData) +
-      '\n</script>';
+      '\n' +
+      closeTag;
   } else {
     const { dumpString, attributes } = dumpData;
     const attributesArr = Object.entries(attributes || {})
@@ -200,7 +207,8 @@ export function reportHTMLContent(
       attributesArr.join(' ') +
       '>\n' +
       escapeScriptTag(dumpString) +
-      '\n</script>';
+      '\n' +
+      closeTag;
   }
 
   if (writeToFile) {

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -10,6 +10,19 @@ import {
 import { getTmpFile } from '../../src/utils';
 
 describe('html-utils', () => {
+  it('keeps report-bundled sources free of raw script close tokens', () => {
+    const unsafeCloseTag = [String.fromCharCode(60), '/script>'].join('');
+    const bundledSourceFiles = [
+      join(__dirname, '../../src/dump/html-utils.ts'),
+      join(__dirname, '../../src/utils.ts'),
+    ];
+
+    for (const sourceFile of bundledSourceFiles) {
+      const source = readFileSync(sourceFile, 'utf8');
+      expect(source).not.toContain(unsafeCloseTag);
+    }
+  });
+
   describe('extractImageByIdSync', () => {
     const fixturesDir = join(__dirname, '../fixtures/report-samples');
     const inlineSamplePath = join(fixturesDir, 'inline-sample.html');

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -1,4 +1,4 @@
-import { TaskBuilder } from '@/agent/task-builder';
+import { TaskBuilder, locatePlanForLocate } from '@/agent/task-builder';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
 import { AbstractInterface, defineActionSleep } from '@/device';
@@ -52,6 +52,19 @@ describe('TaskBuilder', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('normalizes the deprecated locate deepThink alias before task reporting', () => {
+    const plan = locatePlanForLocate({
+      prompt: 'cart icon',
+      deepThink: true,
+    } as any);
+
+    expect(plan.param).toEqual({
+      prompt: 'cart icon',
+      deepLocate: true,
+    });
+    expect(plan.param).not.toHaveProperty('deepThink');
   });
 
   it('dispatches plans using handler registry', async () => {

--- a/packages/core/tests/unit-test/task-service-dump.test.ts
+++ b/packages/core/tests/unit-test/task-service-dump.test.ts
@@ -1,0 +1,48 @@
+import { getTaskSearchArea, getTaskServiceDump } from '@/dump';
+import type { ExecutionTask, ServiceDump } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+const serviceDump = {
+  type: 'locate',
+  taskInfo: {
+    durationMs: 100,
+    searchArea: { left: 10, top: 20, width: 300, height: 200 },
+  },
+} as ServiceDump;
+
+describe('task service dump utilities', () => {
+  it('reads the wrapped service dump from task logs', () => {
+    const task = {
+      log: {
+        dump: serviceDump,
+      },
+    } as ExecutionTask;
+
+    expect(getTaskServiceDump(task)).toBe(serviceDump);
+    expect(getTaskSearchArea(task)).toEqual(serviceDump.taskInfo.searchArea);
+  });
+
+  it('prefers the explicit task searchArea when present', () => {
+    const task = {
+      searchArea: { left: 1, top: 2, width: 3, height: 4 },
+      log: {
+        dump: serviceDump,
+      },
+    } as ExecutionTask;
+
+    expect(getTaskSearchArea(task)).toEqual({
+      left: 1,
+      top: 2,
+      width: 3,
+      height: 4,
+    });
+  });
+
+  it('ignores direct service dump logs', () => {
+    const task = {
+      log: serviceDump,
+    } as ExecutionTask;
+
+    expect(getTaskServiceDump(task)).toBeNull();
+  });
+});

--- a/packages/visualizer/src/component/blackboard/index.tsx
+++ b/packages/visualizer/src/component/blackboard/index.tsx
@@ -14,7 +14,9 @@ export const Blackboard = (props: {
   const highlightElements: BaseElement[] = props.highlightElements || [];
   const highlightRect = props.highlightRect;
 
-  if (!props.uiContext?.shotSize) {
+  const shotSize = props.uiContext?.shotSize;
+
+  if (!shotSize) {
     return (
       <div className="blackboard">
         <div className="blackboard-main-content" style={{ padding: '20px' }}>
@@ -25,7 +27,6 @@ export const Blackboard = (props: {
   }
 
   const context = props.uiContext;
-  const { shotSize, screenshot } = context;
   const screenWidth = shotSize.width;
   const screenHeight = shotSize.height;
 
@@ -35,13 +36,8 @@ export const Blackboard = (props: {
   );
 
   const screenshotBase64 = React.useMemo(() => {
-    if (!screenshot) return '';
-    if (typeof screenshot === 'object' && 'base64' in screenshot) {
-      return (screenshot as { base64: string }).base64;
-    }
-    if (typeof screenshot === 'string') return screenshot;
-    return '';
-  }, [screenshot]);
+    return context?.screenshot?.base64 || '';
+  }, [context]);
 
   const highlightBoxes = highlightOverlays.map((highlight) =>
     getCenterHighlightBox(highlight),

--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -1,7 +1,7 @@
 'use client';
 import { mousePointer } from '@/utils';
 import { paramStr, typeStr } from '@midscene/core/agent';
-import { getTaskSearchArea } from '@midscene/core/dump';
+import { getTaskSearchArea } from '@midscene/core/dump/task-service-dump';
 import {
   getCenterHighlightBox,
   normalizeHighlightElementForReport,

--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -1,6 +1,7 @@
 'use client';
 import { mousePointer } from '@/utils';
 import { paramStr, typeStr } from '@midscene/core/agent';
+import { getTaskSearchArea } from '@midscene/core/dump';
 import {
   getCenterHighlightBox,
   normalizeHighlightElementForReport,
@@ -16,6 +17,7 @@ import type {
   ModelBrief,
   Rect,
   ReportActionDump,
+  ScreenshotItem,
   UIContext,
 } from '@midscene/core';
 
@@ -137,10 +139,13 @@ const resolveTaskShotSize = (
   task: Pick<ExecutionTask, 'uiContext'> | undefined,
   fallbackWidth: number,
   fallbackHeight: number,
-): { width: number; height: number } => ({
-  width: task?.uiContext?.shotSize?.width || fallbackWidth,
-  height: task?.uiContext?.shotSize?.height || fallbackHeight,
-});
+): { width: number; height: number } => {
+  const size = task?.uiContext?.shotSize;
+  return {
+    width: size?.width || fallbackWidth,
+    height: size?.height || fallbackHeight,
+  };
+};
 
 export const mergeTwoCameraState = (
   cameraState1: TargetCameraState,
@@ -226,9 +231,10 @@ const extractMetaFromNormalized = (
 
   normalizedDump.executions?.filter(Boolean).forEach((execution) => {
     execution.tasks.forEach((task) => {
-      if (task.uiContext?.shotSize?.width) {
-        const w = task.uiContext.shotSize.width;
-        const h = task.uiContext.shotSize.height;
+      const shotSize = task.uiContext?.shotSize;
+      if (shotSize) {
+        const w = shotSize.width;
+        const h = shotSize.height;
         if (!firstWidth) {
           firstWidth = w;
           firstHeight = h;
@@ -397,8 +403,8 @@ export const generateAnimationScripts = (
     };
   };
 
-  // Screenshot fields in ExecutionTask are typed loosely; this alias keeps casts in one place
-  type ScreenshotData = { base64: string } | undefined | null;
+  // Restored screenshot refs expose the same base64/capturedAt shape used by ScreenshotItem.
+  type ScreenshotData = Pick<ScreenshotItem, 'base64'> | undefined | null;
   const asScreenshot = (s: unknown): ScreenshotData => s as ScreenshotData;
 
   // Helper: create AnimationScript with lazy img getter that defers .base64 read
@@ -476,11 +482,14 @@ export const generateAnimationScripts = (
       const title = typeStr(task);
       const subTitle = paramStr(task);
       const context = task.uiContext;
-      if (context?.screenshot) {
+      const contextScreenshot = context?.screenshot;
+      if (context && contextScreenshot) {
         // show the original screenshot first
-        const width = context.shotSize?.width || imageWidth;
-        const height = context.shotSize?.height || imageHeight;
-        const contextScreenshot = asScreenshot(context.screenshot);
+        const { width, height } = resolveTaskShotSize(
+          task,
+          imageWidth,
+          imageHeight,
+        );
         scripts.push(
           createScript(
             {
@@ -492,7 +501,7 @@ export const generateAnimationScripts = (
               imageHeight: height,
               taskId: currentTaskId,
             },
-            contextScreenshot,
+            asScreenshot(contextScreenshot),
           ),
         );
 
@@ -515,16 +524,16 @@ export const generateAnimationScripts = (
                 context: context,
                 camera: newCameraState,
                 highlightElement,
-                searchArea: task.log?.taskInfo?.searchArea,
+                searchArea: getTaskSearchArea(task),
                 duration: locateDuration * 0.5,
                 insightCameraDuration: locateDuration,
                 title,
                 subTitle: highlightElement.description || subTitle,
-                imageWidth: context.shotSize?.width || imageWidth,
-                imageHeight: context.shotSize?.height || imageHeight,
+                imageWidth: width,
+                imageHeight: height,
                 taskId: currentTaskId,
               },
-              contextScreenshot,
+              asScreenshot(contextScreenshot),
             ),
           );
 
@@ -535,6 +544,11 @@ export const generateAnimationScripts = (
       const planningTask = task as ExecutionTaskPlanning;
       if (planningTask.recorder && planningTask.recorder.length > 0) {
         const screenshot = planningTask.recorder[0]?.screenshot;
+        const { width, height } = resolveTaskShotSize(
+          task,
+          imageWidth,
+          imageHeight,
+        );
         scripts.push(
           createScript(
             {
@@ -542,8 +556,8 @@ export const generateAnimationScripts = (
               duration: stillDuration,
               title: typeStr(task),
               subTitle: paramStr(task),
-              imageWidth: task.uiContext?.shotSize?.width || imageWidth,
-              imageHeight: task.uiContext?.shotSize?.height || imageHeight,
+              imageWidth: width,
+              imageHeight: height,
               taskId: currentTaskId,
             },
             asScreenshot(screenshot),

--- a/packages/visualizer/tests/replay-scripts-camera.test.ts
+++ b/packages/visualizer/tests/replay-scripts-camera.test.ts
@@ -1,4 +1,9 @@
-import type { ExecutionTaskAction, IExecutionDump } from '@midscene/core';
+import type {
+  ExecutionTaskAction,
+  ExecutionTaskPlanningLocate,
+  IExecutionDump,
+  ServiceDump,
+} from '@midscene/core';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@midscene/core/agent', () => ({
@@ -6,7 +11,10 @@ vi.mock('@midscene/core/agent', () => ({
   typeStr: (task: { type: string }) => task.type,
 }));
 
-import { generateAnimationScripts } from '../src/utils/replay-scripts';
+import {
+  extractDumpMetaInfo,
+  generateAnimationScripts,
+} from '../src/utils/replay-scripts';
 
 function createActionTask({
   height,
@@ -34,6 +42,43 @@ function createActionTask({
         height,
       },
     } as ExecutionTaskAction['uiContext'],
+  };
+}
+
+function createLocateTask(): ExecutionTaskPlanningLocate {
+  const serviceDump = {
+    type: 'locate',
+    taskInfo: {
+      durationMs: 100,
+      searchArea: { left: 10, top: 20, width: 300, height: 200 },
+    },
+  } as ServiceDump;
+
+  return {
+    type: 'Planning',
+    subType: 'Locate',
+    taskId: 'locate-1',
+    status: 'finished',
+    executor: () => undefined,
+    param: {
+      prompt: 'settings',
+      deepLocate: true,
+    },
+    output: {
+      element: {
+        description: 'settings',
+        center: [80, 100],
+        rect: { left: 70, top: 90, width: 20, height: 20 },
+      } as any,
+    },
+    log: {
+      dump: serviceDump,
+    } as any,
+    uiContext: {
+      shotSize: { width: 720, height: 1280 },
+      screenshot: { base64: 'frame-locate' },
+      shrunkShotToLogicalRatio: 1,
+    } as any,
   };
 }
 
@@ -67,5 +112,22 @@ describe('generateAnimationScripts', () => {
     expect(imageScripts?.[0].camera?.width).toBe(720);
     expect(imageScripts?.[1].imageWidth).toBe(1080);
     expect(imageScripts?.[1].camera?.width).toBe(1080);
+  });
+
+  it('keeps deepLocate search area overlays from wrapped service dumps', () => {
+    const execution = {
+      name: 'search-area-regression',
+      tasks: [createLocateTask()],
+    } as IExecutionDump;
+
+    const scripts = generateAnimationScripts(execution, -1, 720, 1280);
+    const insightScript = scripts?.find((script) => script.type === 'insight');
+
+    expect(insightScript?.searchArea).toEqual({
+      left: 10,
+      top: 20,
+      width: 300,
+      height: 200,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Render report and visualizer screenshots from the current `uiContext.screenshot` and recorder screenshot schema without legacy dump shims.
- Share service dump/search-area extraction through `@midscene/core/dump` and use it in report and replay rendering.
- Normalize the deprecated locate `deepThink` alias to `deepLocate` and prevent locate tasks from being tagged as aiAct DeepThink.
- Avoid raw script close tokens in report-bundled sources to prevent inline report syntax errors.

## Validation
- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/task-service-dump.test.ts tests/unit-test/task-builder.test.ts tests/unit-test/html-utils.test.ts`
- `pnpm exec nx test @midscene/report`
- `pnpm exec nx test @midscene/visualizer`
- `pnpm exec nx build @midscene/core`
- `pnpm exec nx build @midscene/visualizer`
- `pnpm exec nx build @midscene/report`
- `git diff --check`

## Manual report check
- Generated `midscene_run/report/midscene-deeplocate-report-2026-06-12_12-05-09-96098328.html`.
- Loaded it through `http://127.0.0.1:4174/`; no page errors or console errors were observed.
- Confirmed the report shows `DeepLocate`, does not show `No screenshot`, and contains `deepLocate: true`, `searchArea`, and screenshot refs.

## Note
- `pnpm exec nx test @midscene/core` was also attempted, but existing large report merge tests failed with timeout / oversized inline HTML behavior unrelated to this change.