### PR TITLE
docs(site): clarify deepLocate docs

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1245,11 +1245,15 @@ await agent.aiTap('Shopping cart icon in the top right', { deepLocate: true });
 
 :::note
 
-This parameter was originally named `deepThink` in single-step action methods such as `aiTap` and `aiHover` other than `aiAct`. Since v1.5.1, it has been renamed to `deepLocate`, but the old `deepThink` parameter remains compatible.
+Historically, the name `deepThink` has carried two different meanings across APIs:
 
-The `deepThink` parameter in `aiAct()` still keeps the `deepThink` semantics. It controls the **planning mode** and guides task decomposition and planning-focused reasoning. See [aiAct deepThink documentation](./model-strategy#about-the-deepthink-option-in-aiact) for details.
+- In `aiAct()`, `deepThink` has always meant **planning mode**, guiding task decomposition and planning-focused reasoning. See [aiAct deepThink documentation](./model-strategy#about-the-deepthink-option-in-aiact) for details.
+- In single-step action methods such as `aiTap` and `aiHover`, the old `deepThink` meant **enhanced element location**, equivalent to today's `deepLocate`.
 
-In single-step action methods such as `aiTap` and `aiHover`, use the clearer `deepLocate` parameter instead of the old `deepThink` parameter when you need to improve location precision.
+To separate these two meanings, `deepThink` has been reserved for planning mode since v1.5.1, while enhanced element location is consistently named `deepLocate`.
+
+- For `aiAct()`, you can use both `deepThink` and `deepLocate`: `deepThink` controls planning mode, while `deepLocate` controls the Deep Locate behavior described in this section.
+- For single-step action methods such as `aiTap` and `aiHover`, use the clearer `deepLocate` parameter when you need to improve location precision. The old `deepThink` parameter remains compatible and is equivalent to `deepLocate`.
 
 :::
 

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1232,12 +1232,11 @@ console.log(logContent);
 
 ## Deep Locate (deepLocate)
 
-`deepLocate` is an optional parameter available on all APIs that require element location (`aiTap`, `aiHover`, `aiInput`, `aiKeyboardPress`, `aiScroll`, `aiDoubleClick`, `aiRightClick`, `aiLocate`, etc.).
+`deepLocate` is an optional parameter available on all APIs that require element location (`aiAct`, `aiTap`, `aiHover`, `aiInput`, `aiKeyboardPress`, `aiScroll`, `aiDoubleClick`, `aiRightClick`, `aiLocate`, etc.).
 
-When enabled, Midscene will call the AI model twice to precisely locate the element, which can improve accuracy. This is especially useful when the target element is small or hard to distinguish from its surroundings. For newer models (e.g. Qwen3 / Doubao 1.6 / Gemini 3), the gain is less noticeable in most cases, so enable it only when needed.
+When enabled, Midscene will call the AI model twice to precisely locate the element, which can improve accuracy. This is especially useful when the target element is small or hard to distinguish from its surroundings. For newer models (e.g. Qwen3.x / Doubao 2.0 / Gemini 3.5), the gain is less noticeable in most cases, so enable it only when needed.
 
 - **Default**: `false`
-- **Parameter renamed**: Previously named `deepThink`, renamed to `deepLocate` since v1.5.1. The old `deepThink` parameter remains compatible.
 
 ```typescript
 // Enable deepLocate to precisely locate hard-to-identify elements
@@ -1246,12 +1245,11 @@ await agent.aiTap('Shopping cart icon in the top right', { deepLocate: true });
 
 :::note
 
-`deepThink` in `aiAct()` and `deepLocate` here are completely different features:
+This parameter was originally named `deepThink` in single-step action methods such as `aiTap` and `aiHover` other than `aiAct`. Since v1.5.1, it has been renamed to `deepLocate`, but the old `deepThink` parameter remains compatible.
 
-- `deepLocate`: Controls the **precision of element location** by making Midscene run two locate passes to improve accuracy.
-- `deepThink` in `aiAct()`: Controls the **planning mode** by guiding task decomposition and planning-only reasoning.
+The `deepThink` parameter in `aiAct()` still keeps the `deepThink` semantics. It controls the **planning mode** and guides task decomposition and planning-focused reasoning. See [aiAct deepThink documentation](./model-strategy#about-the-deepthink-option-in-aiact) for details.
 
-[See aiAct deepThink documentation](./model-strategy#about-the-deepthink-option-in-aiact)
+In single-step action methods such as `aiTap` and `aiHover`, use the clearer `deepLocate` parameter instead of the old `deepThink` parameter when you need to improve location precision.
 
 :::
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1248,12 +1248,11 @@ overrideAIConfig({
 
 ## 深度定位（deepLocate）
 
-`deepLocate` 是一个可选参数，适用于所有需要元素定位的 API（`aiTap`、`aiHover`、`aiInput`、`aiKeyboardPress`、`aiScroll`、`aiDoubleClick`、`aiRightClick`、`aiLocate` 等）。
+`deepLocate` 是一个可选参数，适用于所有需要元素定位的 API（`aiAct`、`aiTap`、`aiHover`、`aiInput`、`aiKeyboardPress`、`aiScroll`、`aiDoubleClick`、`aiRightClick`、`aiLocate` 等）。
 
-开启后，Midscene 会调用 AI 模型两次以精确定位元素，从而提升准确性。这在目标元素面积较小、难以和周围元素区分时非常有用。对于新一代模型（如 Qwen3 / Doubao 1.6 / Gemini 3），大多数场景下带来的收益不明显，建议按需开启。
+开启后，Midscene 会调用 AI 模型两次以精确定位元素，从而提升准确性。这在目标元素面积较小、难以和周围元素区分时非常有用。对于新一代模型（如 Qwen3.x / Doubao 2.0 / Gemini 3.5），大多数场景下带来的收益不明显，建议按需开启。
 
 - **默认值**：`false`
-- **参数更名**：该参数原来叫 `deepThink`，自 v1.5.1 起更名为 `deepLocate`，旧的 `deepThink` 参数仍然兼容。
 
 ```typescript
 // 开启 deepLocate 精确定位较难识别的元素
@@ -1262,13 +1261,11 @@ await agent.aiTap('右上角购物车图标', { deepLocate: true });
 
 :::note
 
-`aiAct()` 中的 `deepThink` 参数与此处的 `deepLocate` 是完全不同的功能：
+该参数最早曾在 `aiTap`、`aiHover` 等单步操作方法（也就是除了 `aiAct`）中命名为 `deepThink`；自 v1.5.1 起更名为 `deepLocate`，但旧的 `deepThink` 参数仍然兼容。
 
-- `deepLocate`：控制元素**定位**时的二次确认策略，用于提升定位精度。
-- `aiAct()` 中的 `deepThink`：控制**规划模式**，用于引导任务拆解和专注规划的思考过程。
+而 `aiAct()` 中的 `deepThink` 参数依然保持了 `deepThink` 的语义，控制**规划模式**，用于引导任务拆解和专注规划的思考过程。详情请参考 [aiAct deepThink 说明](./model-strategy#关于-aiact-方法的-deepthink-参数)。
 
-[参阅 aiAct deepThink 说明](./model-strategy#关于-aiact-方法的-deepthink-参数)
-
+在 `aiTap`、`aiHover` 等单步操作方法中，如果需要提升定位精确度，推荐使用语义更清晰的 `deepLocate` 参数，而不是旧的 `deepThink` 参数。
 :::
 
 ## 使用图片作为提示词

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1261,11 +1261,15 @@ await agent.aiTap('右上角购物车图标', { deepLocate: true });
 
 :::note
 
-该参数最早曾在 `aiTap`、`aiHover` 等单步操作方法（也就是除了 `aiAct`）中命名为 `deepThink`；自 v1.5.1 起更名为 `deepLocate`，但旧的 `deepThink` 参数仍然兼容。
+历史上，`deepThink` 这个名字在不同 API 中承担过两种含义：
 
-而 `aiAct()` 中的 `deepThink` 参数依然保持了 `deepThink` 的语义，控制**规划模式**，用于引导任务拆解和专注规划的思考过程。详情请参考 [aiAct deepThink 说明](./model-strategy#关于-aiact-方法的-deepthink-参数)。
+- 在 `aiAct()` 中，`deepThink` 从一开始就表示**规划模式**，用于引导任务拆解和专注规划的思考过程。详情请参考 [aiAct deepThink 说明](./model-strategy#关于-aiact-方法的-deepthink-参数)。
+- 在 `aiTap`、`aiHover` 等单步操作方法中，旧的 `deepThink` 表示**定位增强**，等同于现在的 `deepLocate`。
 
-在 `aiTap`、`aiHover` 等单步操作方法中，如果需要提升定位精确度，推荐使用语义更清晰的 `deepLocate` 参数，而不是旧的 `deepThink` 参数。
+为了区分这两种语义，自 v1.5.1 起，`deepThink` 只用于表示规划模式，定位增强统一命名为 `deepLocate`。
+
+- 对于 `aiAct()`，可以同时使用 `deepThink` 和 `deepLocate`：`deepThink` 控制规划模式，`deepLocate` 控制本节描述的深度定位。
+- 对于 `aiTap`、`aiHover` 等单步操作方法，如果需要提升定位精确度，推荐使用语义更清晰的 `deepLocate` 参数；旧的 `deepThink` 参数仍然兼容，语义等同于 `deepLocate`。
 :::
 
 ## 使用图片作为提示词


### PR DESCRIPTION
## Summary

- Clarify that `deepLocate` applies to APIs that require element location, including `aiAct`.
- Update the newer model examples in the Deep Locate section.
- Align the English and Chinese notes around the historical `deepThink` name and the separate `aiAct.deepThink` planning semantics.

## Validation

- Not run. Docs-only change; lint intentionally skipped per local workflow preference.