### PR TITLE
Add verbose CLI progress events

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -12,6 +12,8 @@ import {
   type AgentAssertOpt,
   type AgentOpt,
   type AgentWaitForOpt,
+  type AiActProgressEvent,
+  type AiActProgressListener,
   type DeepThinkOption,
   type DeviceAction,
   ExecutionDump,
@@ -139,6 +141,8 @@ export class Agent<
   private dumpUpdateListeners: Array<
     (dump: string, executionDump?: ExecutionDump) => void
   > = [];
+
+  private aiActProgressListeners: AiActProgressListener[] = [];
 
   get onDumpUpdate():
     | ((dump: string, executionDump?: ExecutionDump) => void)
@@ -308,6 +312,9 @@ export class Agent<
               console.error('Error in onDumpUpdate listener', error);
             }
           }
+        },
+        onAiActProgress: async (event) => {
+          await this.notifyAiActProgressListeners(event);
         },
       },
     });
@@ -1269,6 +1276,49 @@ export class Agent<
    */
   clearDumpUpdateListeners(): void {
     this.dumpUpdateListeners = [];
+  }
+
+  /**
+   * Add an aiAct progress listener.
+   * @param listener Listener function
+   * @returns A remove function that can be called to remove this listener
+   */
+  addAiActProgressListener(listener: AiActProgressListener): () => void {
+    this.aiActProgressListeners.push(listener);
+
+    return () => {
+      this.removeAiActProgressListener(listener);
+    };
+  }
+
+  /**
+   * Remove an aiAct progress listener.
+   * @param listener The listener function to remove
+   */
+  removeAiActProgressListener(listener: AiActProgressListener): void {
+    const index = this.aiActProgressListeners.indexOf(listener);
+    if (index > -1) {
+      this.aiActProgressListeners.splice(index, 1);
+    }
+  }
+
+  /**
+   * Clear all aiAct progress listeners.
+   */
+  clearAiActProgressListeners(): void {
+    this.aiActProgressListeners = [];
+  }
+
+  private async notifyAiActProgressListeners(
+    event: AiActProgressEvent,
+  ): Promise<void> {
+    for (const listener of this.aiActProgressListeners) {
+      try {
+        await listener(event);
+      } catch (error) {
+        console.error('Error in onAiActProgress listener', error);
+      }
+    }
   }
 
   private notifyDumpUpdateListeners(executionDump?: ExecutionDump) {

--- a/packages/core/src/agent/ai-act-progress.ts
+++ b/packages/core/src/agent/ai-act-progress.ts
@@ -1,0 +1,451 @@
+import type {
+  AiActProgressAction,
+  ExecutionTask,
+  PlanningAIResponse,
+} from '@/types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactText(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    return json.length > 180 ? `${json.slice(0, 177)}...` : json;
+  } catch {
+    return String(value);
+  }
+}
+
+function compactProgressValue(value: unknown): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map(compactProgressValue);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactProgressValue(value.prompt);
+  }
+
+  if (!isRecord(value)) {
+    return String(value);
+  }
+
+  const entries = Object.entries(value).slice(0, 6);
+  return Object.fromEntries(
+    entries.map(([key, entryValue]) => [key, compactProgressValue(entryValue)]),
+  );
+}
+
+function summarizeParam(param: unknown): unknown {
+  if (!param || typeof param !== 'object') {
+    return compactProgressValue(param);
+  }
+
+  const record = param as Record<string, unknown>;
+  if (typeof record.prompt === 'string') {
+    return compactProgressValue(record.prompt);
+  }
+  if (
+    record.locate &&
+    typeof record.locate === 'object' &&
+    record.locate !== null
+  ) {
+    const locate = record.locate as Record<string, unknown>;
+    return {
+      locate: compactProgressValue(locate.prompt),
+      ...Object.fromEntries(
+        Object.entries(record)
+          .filter(([key]) => key !== 'locate')
+          .slice(0, 4)
+          .map(([key, value]) => [key, compactProgressValue(value)]),
+      ),
+    };
+  }
+
+  return compactProgressValue(record);
+}
+
+function summarizeUserInstruction(value: unknown): string {
+  if (typeof value === 'string') {
+    return compactText(value);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactText(value.prompt);
+  }
+
+  return compactText(value);
+}
+
+function summarizeSubGoals(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const goals = value
+    .slice(0, 6)
+    .map((goal) => {
+      if (!isRecord(goal)) {
+        return '';
+      }
+      const index = typeof goal.index === 'number' ? `${goal.index}. ` : '';
+      const status = typeof goal.status === 'string' ? `[${goal.status}] ` : '';
+      const description =
+        typeof goal.description === 'string' ? goal.description : '';
+      return `${index}${status}${description}`.trim();
+    })
+    .filter(Boolean);
+
+  return goals.length > 0 ? `sub-goals: ${goals.join('; ')}` : '';
+}
+
+function actionOutputText(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const action = value.find(isRecord);
+  if (!action) {
+    return '';
+  }
+
+  return (
+    compactText(action.log) ||
+    compactText(action.thought) ||
+    compactText(summarizeParam(action.param))
+  );
+}
+
+export function plannedTextForAiAct(
+  planResult: PlanningAIResponse | undefined,
+): string {
+  if (!planResult) {
+    return '';
+  }
+
+  return (
+    compactText(planResult.log) ||
+    compactText(planResult.thought) ||
+    summarizeSubGoals(planResult.updateSubGoals) ||
+    actionOutputText(planResult.actions) ||
+    compactText(planResult.output)
+  );
+}
+
+export function completeTextForAiAct(
+  planResult: PlanningAIResponse | undefined,
+): string {
+  if (!planResult) {
+    return '';
+  }
+
+  return (
+    compactText(planResult.output) ||
+    (planResult.shouldContinuePlanning === false
+      ? plannedTextForAiAct(planResult)
+      : '')
+  );
+}
+
+export function errorMessageForAiAct(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function integerText(value: number): string {
+  return String(Math.round(value));
+}
+
+function formatPoint(point: readonly [number, number]): string {
+  return `(${integerText(point[0])}, ${integerText(point[1])})`;
+}
+
+function formatBbox(bbox: readonly [number, number, number, number]): string {
+  return `(${bbox.map(integerText).join(',')})`;
+}
+
+function bboxArrayFromProperty(
+  value: Record<string, unknown>,
+  key: string,
+): [number, number, number, number] | undefined {
+  const bbox = value[key];
+  if (!Array.isArray(bbox) || bbox.length < 4) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(bbox[0]);
+  const top = numberFromUnknown(bbox[1]);
+  const right = numberFromUnknown(bbox[2]);
+  const bottom = numberFromUnknown(bbox[3]);
+  if (
+    left === undefined ||
+    top === undefined ||
+    right === undefined ||
+    bottom === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, right, bottom];
+}
+
+function centerPointFromBbox(
+  bbox: readonly [number, number, number, number],
+): [number, number] {
+  return [
+    Math.floor((bbox[0] + bbox[2]) / 2),
+    Math.floor((bbox[1] + bbox[3]) / 2),
+  ];
+}
+
+function pointFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number] | undefined {
+  const center = value.center;
+  if (Array.isArray(center) && center.length >= 2) {
+    const x = numberFromUnknown(center[0]);
+    const y = numberFromUnknown(center[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const point = value.point;
+  if (Array.isArray(point) && point.length >= 2) {
+    const x = numberFromUnknown(point[0]);
+    const y = numberFromUnknown(point[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return centerPointFromBbox(locatedPixelBbox);
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return centerPointFromBbox(bbox);
+  }
+
+  return undefined;
+}
+
+function bboxFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number, number, number] | undefined {
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return locatedPixelBbox;
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return bbox;
+  }
+
+  if (!isRecord(value.rect)) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(value.rect.left);
+  const top = numberFromUnknown(value.rect.top);
+  const width = numberFromUnknown(value.rect.width);
+  const height = numberFromUnknown(value.rect.height);
+  if (
+    left === undefined ||
+    top === undefined ||
+    width === undefined ||
+    height === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, left + width, top + height];
+}
+
+function targetTextFromLocateLike(value: Record<string, unknown>): string {
+  return (
+    compactText(value.description) ||
+    compactText(value.prompt) ||
+    summarizeUserInstruction(value)
+  );
+}
+
+function isLocateLike(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    'center' in value ||
+    'rect' in value ||
+    'point' in value ||
+    'bbox' in value ||
+    'prompt' in value ||
+    'description' in value
+  );
+}
+
+const locatorParamKeys = ['locate', 'from', 'to', 'start', 'end'];
+
+function firstLocateLikeParam(
+  param: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(param)) {
+    return undefined;
+  }
+
+  for (const key of locatorParamKeys) {
+    const value = param[key];
+    if (isLocateLike(value)) {
+      return value;
+    }
+  }
+
+  return Object.values(param).find(isLocateLike);
+}
+
+function hasUnresolvedLocateLikeParam(param: unknown): boolean {
+  if (!isRecord(param)) {
+    return false;
+  }
+
+  return Object.entries(param).some(([key, value]) => {
+    if (locatorParamKeys.includes(key) && typeof value === 'string') {
+      return true;
+    }
+
+    return (
+      isLocateLike(value) &&
+      !pointFromLocateLike(value) &&
+      !bboxFromLocateLike(value)
+    );
+  });
+}
+
+export interface AiActActionProgressText {
+  action: AiActProgressAction;
+  planned: string;
+  running: string;
+  done: string;
+}
+
+function sleepActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionProgressText | undefined {
+  if (actionName !== 'Sleep' || !isRecord(param)) {
+    return undefined;
+  }
+
+  const timeMs =
+    numberFromUnknown(param.timeMs) ??
+    numberFromUnknown(param.duration) ??
+    numberFromUnknown(param.timeoutMs);
+  const planned = timeMs ? `Sleep ${integerText(timeMs)}ms` : 'Sleep';
+  return {
+    action: { name: actionName },
+    planned,
+    running: planned,
+    done: 'Sleep',
+  };
+}
+
+function locateActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionProgressText | undefined {
+  const locate = firstLocateLikeParam(param);
+  if (!locate) {
+    return undefined;
+  }
+
+  const point = pointFromLocateLike(locate);
+  const bbox = bboxFromLocateLike(locate);
+  if (!point) {
+    return undefined;
+  }
+
+  const target = targetTextFromLocateLike(locate);
+  const targetSegment = target ? ` "${target}"` : '';
+  const pointSegment = ` at ${formatPoint(point)}`;
+  const bboxSegment = bbox ? `, bbox=${formatBbox(bbox)}` : '';
+  return {
+    action: {
+      name: actionName,
+      ...(target ? { target } : {}),
+      point,
+      ...(bbox ? { bbox } : {}),
+    },
+    planned: `${actionName}${targetSegment}${pointSegment}${bboxSegment}`,
+    running: `${actionName} at ${formatPoint(point)}`,
+    done: actionName,
+  };
+}
+
+function genericActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionProgressText | undefined {
+  if (hasUnresolvedLocateLikeParam(param)) {
+    return undefined;
+  }
+
+  const paramText = compactText(summarizeParam(param));
+  const planned = paramText ? `${actionName}: ${paramText}` : actionName;
+  return {
+    action: { name: actionName },
+    planned,
+    running: planned,
+    done: actionName,
+  };
+}
+
+export function actionProgressTextForAiAct(
+  task: ExecutionTask,
+): AiActActionProgressText | undefined {
+  if (task.type !== 'Action Space' || task.subType === 'Finished') {
+    return undefined;
+  }
+
+  const actionName =
+    typeof task.subType === 'string' && task.subType.length > 0
+      ? task.subType
+      : 'Action';
+  return (
+    sleepActionText(actionName, task.param) ||
+    locateActionText(actionName, task.param) ||
+    genericActionText(actionName, task.param)
+  );
+}

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -15,6 +15,8 @@ import type Service from '@/service';
 import type { TaskRunner } from '@/task-runner';
 import { TaskExecutionError } from '@/task-runner';
 import type {
+  AiActProgressEvent,
+  AiActProgressListener,
   DeviceAction,
   ExecutionTask,
   ExecutionTaskApply,
@@ -34,6 +36,12 @@ import type {
 import { ServiceError } from '@/types';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
+import {
+  actionProgressTextForAiAct,
+  completeTextForAiAct,
+  errorMessageForAiAct,
+  plannedTextForAiAct,
+} from './ai-act-progress';
 import { ExecutionSession } from './execution-session';
 import { TaskBuilder } from './task-builder';
 import type { TaskCache } from './task-cache';
@@ -55,6 +63,14 @@ interface TaskExecutorHooks {
     runner: TaskRunner,
     error?: TaskExecutionError,
   ) => Promise<void> | void;
+  onAiActProgress?: AiActProgressListener;
+}
+
+interface AiActActionProgressContext {
+  planIndex: number;
+  planLimit: number;
+  taskStartIndex: number;
+  emittedKeys: Set<string>;
 }
 
 export type ActionReportOptions = {
@@ -104,6 +120,8 @@ export class TaskExecutor {
 
   useDeviceTime?: boolean;
 
+  private aiActProgressSequence = 0;
+
   // @deprecated use .interface instead
   get page() {
     return this.interface;
@@ -142,7 +160,14 @@ export class TaskExecutor {
 
   private createExecutionSession(
     title: string,
-    options?: { tasks?: ExecutionTaskApply[]; uiContext?: UIContext },
+    options?: {
+      tasks?: ExecutionTaskApply[];
+      uiContext?: UIContext;
+      onTaskUpdate?: (
+        runner: TaskRunner,
+        error?: TaskExecutionError,
+      ) => Promise<void> | void;
+    },
   ) {
     return new ExecutionSession(
       title,
@@ -153,13 +178,109 @@ export class TaskExecutor {
       {
         onTaskStart: this.onTaskStartCallback,
         tasks: options?.tasks,
-        onTaskUpdate: this.hooks?.onTaskUpdate,
+        onTaskUpdate: async (runner, error) => {
+          await this.hooks?.onTaskUpdate?.(runner, error);
+          await options?.onTaskUpdate?.(runner, error);
+        },
       },
     );
   }
 
   private getActionSpace(): DeviceAction[] {
     return this.providedActionSpace;
+  }
+
+  private async emitAiActProgress(
+    event: Omit<AiActProgressEvent, 'type'>,
+  ): Promise<void> {
+    if (!this.hooks?.onAiActProgress) {
+      return;
+    }
+
+    try {
+      await this.hooks.onAiActProgress({
+        type: 'aiAct',
+        sequence: ++this.aiActProgressSequence,
+        ...event,
+      });
+    } catch (error) {
+      console.error('Error in onAiActProgress listener', error);
+    }
+  }
+
+  private async emitAiActActionProgress(
+    runner: TaskRunner,
+    context: AiActActionProgressContext,
+  ): Promise<void> {
+    const tasks = runner.tasks.slice(context.taskStartIndex);
+    for (const task of tasks) {
+      if (
+        task.type !== 'Action Space' ||
+        task.subType === 'Finished' ||
+        task.subType === 'Error'
+      ) {
+        continue;
+      }
+
+      const progressText = actionProgressTextForAiAct(task);
+      if (!progressText) {
+        continue;
+      }
+
+      const keyPrefix = `aiAct:${context.planIndex}:${task.taskId}`;
+      const emitOnce = async (
+        key: string,
+        event: Omit<AiActProgressEvent, 'type'>,
+      ) => {
+        const fullKey = `${keyPrefix}:${key}`;
+        if (context.emittedKeys.has(fullKey)) {
+          return;
+        }
+        context.emittedKeys.add(fullKey);
+        await this.emitAiActProgress(event);
+      };
+
+      await emitOnce('planned', {
+        event: 'plan_action',
+        planIndex: context.planIndex,
+        planLimit: context.planLimit,
+        message: progressText.planned,
+        action: progressText.action,
+      });
+
+      if (task.status === 'running') {
+        await emitOnce('running', {
+          event: 'action_running',
+          planIndex: context.planIndex,
+          planLimit: context.planLimit,
+          message: progressText.running,
+          action: progressText.action,
+        });
+      }
+
+      if (task.status === 'finished') {
+        await emitOnce('finished', {
+          event: 'action_done',
+          planIndex: context.planIndex,
+          planLimit: context.planLimit,
+          message: progressText.done,
+          action: progressText.action,
+          durationMs: task.timing?.cost,
+        });
+      }
+
+      if (task.status === 'failed') {
+        await emitOnce('failed', {
+          event: 'action_failed',
+          planIndex: context.planIndex,
+          planLimit: context.planLimit,
+          message: progressText.done,
+          action: progressText.action,
+          durationMs: task.timing?.cost,
+          error: task.errorMessage,
+        });
+      }
+    }
   }
 
   /**
@@ -413,12 +534,20 @@ export class TaskExecutor {
     }
 
     const conversationHistory = new ConversationHistory();
+    const promptDisplay =
+      reportOptions?.prompt || userPromptToString(userPrompt);
+    let activeAiActActionProgress: AiActActionProgressContext | undefined;
 
     const session = this.createExecutionSession(
-      taskTitleStr(
-        reportOptions?.type || 'Act',
-        reportOptions?.prompt || userPromptToString(userPrompt),
-      ),
+      taskTitleStr(reportOptions?.type || 'Act', promptDisplay),
+      {
+        onTaskUpdate: async (runner) => {
+          if (!activeAiActActionProgress) {
+            return;
+          }
+          await this.emitAiActActionProgress(runner, activeAiActActionProgress);
+        },
+      },
     );
     const runner = session.getRunner();
 
@@ -426,16 +555,42 @@ export class TaskExecutor {
     const yamlFlow: MidsceneYamlFlowItem[] = [];
     const replanningCycleLimit =
       replanningCycleLimitOverride ?? this.replanningCycleLimit;
-    assert(
-      replanningCycleLimit !== undefined,
-      'replanningCycleLimit is required for TaskExecutor.action',
-    );
+    if (replanningCycleLimit === undefined) {
+      throw new Error(
+        'replanningCycleLimit is required for TaskExecutor.action',
+      );
+    }
+
+    await this.emitAiActProgress({
+      event: 'start',
+      prompt: promptDisplay,
+      planLimit: replanningCycleLimit,
+    });
+
+    const appendFailedPlan = async (
+      errorMsg: string,
+      planIndex?: number,
+    ): Promise<{
+      output: undefined;
+      runner: TaskRunner;
+    }> => {
+      await this.emitAiActProgress({
+        event: 'failed',
+        ...(planIndex ? { planIndex } : {}),
+        planLimit: replanningCycleLimit,
+        error: errorMsg,
+        message: errorMsg,
+      });
+      return session.appendErrorPlan(errorMsg);
+    };
 
     let errorCountInOnePlanningLoop = 0; // count the number of errors in one planning loop
     let outputString: string | undefined;
+    let latestPlanResult: PlanningAIResponse | undefined;
+    let latestPlanIndex = 0;
 
     if (abortSignal?.aborted) {
-      return session.appendErrorPlan(
+      return appendFailedPlan(
         `Task aborted: ${abortSignal.reason || 'abort signal received'}`,
       );
     }
@@ -445,10 +600,14 @@ export class TaskExecutor {
 
     // Main planning loop - unified plan/replan logic
     while (true) {
+      const planIndex = replanCount + 1;
+      latestPlanIndex = planIndex;
+
       // Check abort signal before each planning cycle
       if (abortSignal?.aborted) {
-        return session.appendErrorPlan(
+        return appendFailedPlan(
           `Task aborted: ${abortSignal.reason || 'abort signal received'}`,
+          planIndex,
         );
       }
 
@@ -477,7 +636,14 @@ export class TaskExecutor {
           executor: async (param, executorContext) => {
             const { uiContext } = executorContext;
             assert(uiContext, 'uiContext is required for Planning task');
+            const planningUiContext = uiContext as UIContext;
             const timing = executorContext.task.timing;
+            await this.emitAiActProgress({
+              event: 'plan_thinking',
+              planIndex,
+              planLimit: replanningCycleLimit,
+              screenshot: planningUiContext.screenshot,
+            });
 
             const actionSpace = this.getActionSpace();
             debug(
@@ -500,7 +666,7 @@ export class TaskExecutor {
             try {
               setTimingFieldOnce(timing, 'callAiStart');
               planResult = await planImpl(param.userInstruction, {
-                context: uiContext,
+                context: planningUiContext,
                 actionContext: param.aiActContext,
                 actionSpace,
                 modelRuntime: planningModel,
@@ -524,6 +690,13 @@ export class TaskExecutor {
                   rawChoiceMessage: planError.rawChoiceMessage,
                 };
               }
+              await this.emitAiActProgress({
+                event: 'plan_failed',
+                planIndex,
+                planLimit: replanningCycleLimit,
+                error: errorMessageForAiAct(planError),
+                message: errorMessageForAiAct(planError),
+              });
               throw planError;
             } finally {
               setTimingFieldOnce(timing, 'callAiEnd');
@@ -565,16 +738,42 @@ export class TaskExecutor {
               updateSubGoals,
               markFinishedIndexes,
             };
-            executorContext.uiContext = uiContext;
+            executorContext.uiContext = planningUiContext;
+
+            const plannedText = plannedTextForAiAct(planResult);
+            if (plannedText) {
+              await this.emitAiActProgress({
+                event: 'plan_planned',
+                planIndex,
+                planLimit: replanningCycleLimit,
+                message: plannedText,
+              });
+            }
+
+            if (error) {
+              const errorMessage = `Failed to continue: ${error}\n${log || ''}`;
+              await this.emitAiActProgress({
+                event: 'plan_failed',
+                planIndex,
+                planLimit: replanningCycleLimit,
+                error: errorMessage,
+                message: errorMessage,
+              });
+            }
 
             assert(!error, `Failed to continue: ${error}\n${log || ''}`);
 
             // Check if task was finalized with failure
             if (finalizeSuccess === false) {
-              assert(
-                false,
-                `Task failed: ${finalizeMessage || 'No error message provided'}\n${log || ''}`,
-              );
+              const errorMessage = `Task failed: ${finalizeMessage || 'No error message provided'}\n${log || ''}`;
+              await this.emitAiActProgress({
+                event: 'plan_failed',
+                planIndex,
+                planLimit: replanningCycleLimit,
+                error: errorMessage,
+                message: errorMessage,
+              });
+              assert(false, errorMessage);
             }
 
             return {
@@ -590,6 +789,7 @@ export class TaskExecutor {
       );
 
       const planResult = result?.output as PlanningAIResponse | undefined;
+      latestPlanResult = planResult;
 
       // Execute planned actions
       const plans = planResult?.actions || [];
@@ -608,10 +808,11 @@ export class TaskExecutor {
           },
         );
       } catch (error) {
-        return session.appendErrorPlan(
-          `Error converting plans to executable tasks: ${error}, plans: ${JSON.stringify(
+        return appendFailedPlan(
+          `Error converting plans to executable tasks: ${errorMessageForAiAct(error)}, plans: ${JSON.stringify(
             plans,
           )}`,
+          planIndex,
         );
       }
       if (conversationHistory.pendingFeedbackMessage) {
@@ -625,6 +826,12 @@ export class TaskExecutor {
       const initialTimeString = await this.getTimeString();
 
       const taskCountBeforeRun = runner.tasks.length;
+      activeAiActActionProgress = {
+        planIndex,
+        planLimit: replanningCycleLimit,
+        taskStartIndex: taskCountBeforeRun,
+        emittedKeys: new Set(),
+      };
       try {
         await session.appendAndRun(executables.tasks);
         this.setPendingFeedbackMessage(
@@ -647,16 +854,22 @@ export class TaskExecutor {
           'current error count in one planning loop:',
           errorCountInOnePlanningLoop,
         );
+      } finally {
+        activeAiActActionProgress = undefined;
       }
 
       if (errorCountInOnePlanningLoop > maxErrorCountAllowedInOnePlanningLoop) {
-        return session.appendErrorPlan('Too many errors in one planning loop');
+        return appendFailedPlan(
+          'Too many errors in one planning loop',
+          planIndex,
+        );
       }
 
       // Check abort signal after executing actions
       if (abortSignal?.aborted) {
-        return session.appendErrorPlan(
+        return appendFailedPlan(
           `Task aborted: ${abortSignal.reason || 'abort signal received'}`,
+          planIndex,
         );
       }
 
@@ -679,7 +892,7 @@ export class TaskExecutor {
 
       if (replanCount > replanningCycleLimit) {
         const errorMsg = `Replanned ${replanningCycleLimit} times, exceeding the limit. Please configure a larger value for replanningCycleLimit (or use MIDSCENE_REPLANNING_CYCLE_LIMIT) to handle more complex tasks.`;
-        return session.appendErrorPlan(errorMsg);
+        return appendFailedPlan(errorMsg, planIndex);
       }
 
       if (!conversationHistory.pendingFeedbackMessage) {
@@ -687,6 +900,13 @@ export class TaskExecutor {
         conversationHistory.pendingFeedbackMessage = `Time: ${timeString}, I have finished the action previously planned.`;
       }
     }
+
+    await this.emitAiActProgress({
+      event: 'complete',
+      planIndex: latestPlanIndex,
+      planLimit: replanningCycleLimit,
+      message: outputString || completeTextForAiAct(latestPlanResult),
+    });
 
     return {
       output: {

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -467,6 +467,7 @@ export class TaskExecutor {
             ...(reportOptions?.prompt
               ? { userInstructionDisplay: reportOptions.prompt }
               : {}),
+            replanningCycleLimit,
             aiActContext,
             imagesIncludeCount,
             deepThink,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -603,6 +603,7 @@ task - planning
 export interface ExecutionTaskPlanningParam {
   userInstruction: TUserPrompt;
   userInstructionDisplay?: string;
+  replanningCycleLimit?: number;
   aiActContext?: string;
   imagesIncludeCount?: number;
   deepThink?: DeepThinkOption;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -382,6 +382,43 @@ export interface ExecutionTaskProgressOptions {
   onTaskStart?: (task: ExecutionTask) => Promise<void> | void;
 }
 
+export type AiActProgressEventName =
+  | 'start'
+  | 'plan_thinking'
+  | 'plan_planned'
+  | 'plan_action'
+  | 'plan_failed'
+  | 'action_running'
+  | 'action_done'
+  | 'action_failed'
+  | 'complete'
+  | 'failed';
+
+export interface AiActProgressAction {
+  name: string;
+  target?: string;
+  point?: [number, number];
+  bbox?: [number, number, number, number];
+}
+
+export interface AiActProgressEvent {
+  type: 'aiAct';
+  event: AiActProgressEventName;
+  sequence?: number;
+  prompt?: string;
+  planIndex?: number;
+  planLimit?: number;
+  screenshot?: ScreenshotItem;
+  message?: string;
+  action?: AiActProgressAction;
+  durationMs?: number;
+  error?: string;
+}
+
+export type AiActProgressListener = (
+  event: AiActProgressEvent,
+) => Promise<void> | void;
+
 export interface ExecutionRecorderItem {
   type: 'screenshot';
   ts: number;

--- a/packages/core/tests/unit-test/task-executor-concurrency.test.ts
+++ b/packages/core/tests/unit-test/task-executor-concurrency.test.ts
@@ -146,6 +146,74 @@ describe('TaskExecutor concurrency isolation', () => {
     await Promise.all([actionPromiseA, actionPromiseB]);
   });
 
+  it('emits semantic aiAct progress events from planning and action execution', async () => {
+    const progressEvents: string[] = [];
+    taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 3,
+      actionSpace: emptyParamActionSpace,
+      hooks: {
+        onAiActProgress: (event) => {
+          progressEvents.push(
+            [
+              event.event,
+              event.planIndex,
+              event.planLimit,
+              event.message,
+              event.action?.name,
+              event.durationMs === undefined
+                ? undefined
+                : Math.round(event.durationMs),
+            ]
+              .filter((item) => item !== undefined)
+              .join('|'),
+          );
+        },
+      },
+    });
+
+    vi.mocked(genericXmlPlan).mockResolvedValue({
+      actions: [
+        {
+          type: 'Noop',
+          param: {},
+        },
+      ],
+      yamlFlow: [],
+      shouldContinuePlanning: false,
+      log: 'Need to run the noop action.',
+      rawResponse: '',
+      finalizeSuccess: true,
+      finalizeMessage: 'Noop done.',
+    });
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable').mockResolvedValue({
+      tasks: [
+        {
+          type: 'Action Space',
+          subType: 'Noop',
+          executor: async () => undefined,
+        },
+      ],
+      yamlFlow: [],
+    } as any);
+
+    await taskExecutor.action(
+      'run noop',
+      planningModel(),
+      defaultModel(),
+      true,
+    );
+
+    expect(progressEvents).toEqual([
+      'start|3',
+      'plan_thinking|1|3',
+      'plan_planned|1|3|Need to run the noop action.',
+      'plan_action|1|3|Noop|Noop',
+      'action_running|1|3|Noop|Noop',
+      expect.stringMatching(/^action_done\|1\|3\|Noop\|Noop\|\d+$/),
+      'complete|1|3|Noop done.',
+    ]);
+  });
+
   it('should use device-local formatted time for replanning feedback', async () => {
     const seenPendingFeedback: string[] = [];
     mockInterface.getDeviceLocalTimeString = vi

--- a/packages/shared/src/agent-tools/tool-generator.ts
+++ b/packages/shared/src/agent-tools/tool-generator.ts
@@ -728,11 +728,15 @@ export function generateCommonTools(
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
-          emitCliVerboseEvent({
-            event: 'ai_act_start',
-            tool: 'act',
-            prompt,
-          });
+          const hasAiActProgressListener =
+            typeof agent.addAiActProgressListener === 'function';
+          if (!hasAiActProgressListener) {
+            emitCliVerboseEvent({
+              event: 'ai_act_start',
+              tool: 'act',
+              prompt,
+            });
+          }
           const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
             toolName: 'act',
           });

--- a/packages/shared/src/agent-tools/tool-generator.ts
+++ b/packages/shared/src/agent-tools/tool-generator.ts
@@ -728,6 +728,11 @@ export function generateCommonTools(
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
+          emitCliVerboseEvent({
+            event: 'ai_act_start',
+            tool: 'act',
+            prompt,
+          });
           const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
             toolName: 'act',
           });

--- a/packages/shared/src/agent-tools/tool-generator.ts
+++ b/packages/shared/src/agent-tools/tool-generator.ts
@@ -1,6 +1,10 @@
 import { parseBase64 } from '@midscene/shared/img';
 import { z } from 'zod';
 import {
+  attachCliVerboseDumpListener,
+  emitCliVerboseEvent,
+} from '../cli/verbose';
+import {
   getZodDescription,
   getZodTypeName,
   isMidsceneLocatorField,
@@ -570,41 +574,56 @@ export function generateToolsFromActionSpace(
       handler: async (args: Record<string, unknown>) => {
         try {
           const agent = await getAgent(args);
-          let normalizedArgs = normalizeActionArgs(
-            sanitizeArgs(args),
-            action.paramSchema,
-          );
-          if (toolDefaults.locate) {
-            normalizedArgs = applyLocateDefaults(
-              normalizedArgs,
-              action.paramSchema,
-              toolDefaults.locate,
-            );
-          }
-          let actionResult: unknown;
-
+          emitCliVerboseEvent({
+            event: 'agent_ready',
+            tool: action.name,
+          });
+          const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
+            toolName: action.name,
+          });
           try {
-            actionResult = await executeAction(
+            let normalizedArgs = normalizeActionArgs(
+              sanitizeArgs(args),
+              action.paramSchema,
+            );
+            if (toolDefaults.locate) {
+              normalizedArgs = applyLocateDefaults(
+                normalizedArgs,
+                action.paramSchema,
+                toolDefaults.locate,
+              );
+            }
+            let actionResult: unknown;
+
+            try {
+              actionResult = await executeAction(
+                agent,
+                action.name,
+                normalizedArgs,
+              );
+            } catch (error: unknown) {
+              const errorMessage = getErrorMessage(error);
+              console.error(
+                `Error executing action "${action.name}":`,
+                errorMessage,
+              );
+              // Return screenshot + warning instead of hard error,
+              // so the AI agent can see current state and decide to retry or adjust strategy
+              return await captureFailureResult(
+                agent,
+                action.name,
+                errorMessage,
+              );
+            }
+
+            return await captureScreenshotResult(
               agent,
               action.name,
-              normalizedArgs,
+              actionResult,
             );
-          } catch (error: unknown) {
-            const errorMessage = getErrorMessage(error);
-            console.error(
-              `Error executing action "${action.name}":`,
-              errorMessage,
-            );
-            // Return screenshot + warning instead of hard error,
-            // so the AI agent can see current state and decide to retry or adjust strategy
-            return await captureFailureResult(agent, action.name, errorMessage);
+          } finally {
+            unsubscribeVerbose();
           }
-
-          return await captureScreenshotResult(
-            agent,
-            action.name,
-            actionResult,
-          );
         } catch (error: unknown) {
           // Connection/agent errors are still hard errors
           const errorMessage = getErrorMessage(error);
@@ -640,17 +659,28 @@ export function generateCommonTools(
       ): Promise<ToolResult> => {
         try {
           const agent = await getAgent(args);
-          const screenshot = await agent.page?.screenshotBase64();
-          if (!screenshot) {
-            return createErrorResult('Screenshot not available');
-          }
-          await agent.recordToReport?.('take_screenshot', {
-            screenshotBase64: screenshot,
+          emitCliVerboseEvent({
+            event: 'agent_ready',
+            tool: 'take_screenshot',
           });
-          const { mimeType, body } = parseBase64(screenshot);
-          return {
-            content: [{ type: 'image', data: body, mimeType }],
-          };
+          const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
+            toolName: 'take_screenshot',
+          });
+          try {
+            const screenshot = await agent.page?.screenshotBase64();
+            if (!screenshot) {
+              return createErrorResult('Screenshot not available');
+            }
+            await agent.recordToReport?.('take_screenshot', {
+              screenshotBase64: screenshot,
+            });
+            const { mimeType, body } = parseBase64(screenshot);
+            return {
+              content: [{ type: 'image', data: body, mimeType }],
+            };
+          } finally {
+            unsubscribeVerbose();
+          }
         } catch (error: unknown) {
           const errorMessage = getErrorMessage(error);
           console.error('Error taking screenshot:', errorMessage);
@@ -691,23 +721,34 @@ export function generateCommonTools(
         const prompt = args.prompt as string;
         try {
           const agent = await getAgent(args);
+          emitCliVerboseEvent({
+            event: 'agent_ready',
+            tool: 'act',
+          });
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
-          // Start from the act defaults (deepThink off), overlay the server
-          // tool defaults, then let explicit per-call args win.
-          const actOptions: Record<string, unknown> = {
-            deepThink: false,
-            ...toolDefaults.act,
-          };
-          if (args.deepLocate !== undefined) {
-            actOptions.deepLocate = args.deepLocate;
+          const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
+            toolName: 'act',
+          });
+          try {
+            // Start from the act defaults (deepThink off), overlay the server
+            // tool defaults, then let explicit per-call args win.
+            const actOptions: Record<string, unknown> = {
+              deepThink: false,
+              ...toolDefaults.act,
+            };
+            if (args.deepLocate !== undefined) {
+              actOptions.deepLocate = args.deepLocate;
+            }
+            if (args.deepThink !== undefined) {
+              actOptions.deepThink = args.deepThink;
+            }
+            const result = await agent.aiAction(prompt, actOptions);
+            return await captureScreenshotResult(agent, 'act', result);
+          } finally {
+            unsubscribeVerbose();
           }
-          if (args.deepThink !== undefined) {
-            actOptions.deepThink = args.deepThink;
-          }
-          const result = await agent.aiAction(prompt, actOptions);
-          return await captureScreenshotResult(agent, 'act', result);
         } catch (error: unknown) {
           const errorMessage = getErrorMessage(error);
           console.error('Error executing act:', errorMessage);
@@ -742,19 +783,30 @@ export function generateCommonTools(
         const message = args.message as string | undefined;
         try {
           const agent = await getAgent(args);
+          emitCliVerboseEvent({
+            event: 'agent_ready',
+            tool: 'assert',
+          });
           if (!agent.aiAssert) {
             return createErrorResult('assert is not supported by this agent');
           }
-          const userPrompt = composeUserPrompt({
-            prompt,
-            image: args.image,
-            imageName: args.imageName,
-            convertHttpImage2Base64: args.convertHttpImage2Base64,
+          const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
+            toolName: 'assert',
           });
-          await agent.aiAssert(userPrompt, message);
-          return {
-            content: [{ type: 'text', text: 'Assertion passed.' }],
-          };
+          try {
+            const userPrompt = composeUserPrompt({
+              prompt,
+              image: args.image,
+              imageName: args.imageName,
+              convertHttpImage2Base64: args.convertHttpImage2Base64,
+            });
+            await agent.aiAssert(userPrompt, message);
+            return {
+              content: [{ type: 'text', text: 'Assertion passed.' }],
+            };
+          } finally {
+            unsubscribeVerbose();
+          }
         } catch (error: unknown) {
           const errorMessage = getErrorMessage(error);
           console.error('Error executing assert:', errorMessage);

--- a/packages/shared/src/agent-tools/tool-generator.ts
+++ b/packages/shared/src/agent-tools/tool-generator.ts
@@ -728,15 +728,6 @@ export function generateCommonTools(
           if (!agent.aiAction) {
             return createErrorResult('act is not supported by this agent');
           }
-          const hasAiActProgressListener =
-            typeof agent.addAiActProgressListener === 'function';
-          if (!hasAiActProgressListener) {
-            emitCliVerboseEvent({
-              event: 'ai_act_start',
-              tool: 'act',
-              prompt,
-            });
-          }
           const unsubscribeVerbose = attachCliVerboseDumpListener(agent, {
             toolName: 'act',
           });

--- a/packages/shared/src/agent-tools/types.ts
+++ b/packages/shared/src/agent-tools/types.ts
@@ -121,9 +121,13 @@ export interface RecordToReportOptions {
 export interface BaseAgent {
   getActionSpace(): Promise<ActionSpaceItem[]>;
   destroy?(): Promise<void>;
+  reportFile?: string | null;
   page?: {
     screenshotBase64(): Promise<string>;
   };
+  addDumpUpdateListener?: (
+    listener: (dump: string, executionDump?: unknown) => void,
+  ) => () => void;
   recordToReport?: (
     title?: string,
     opt?: RecordToReportOptions,

--- a/packages/shared/src/agent-tools/types.ts
+++ b/packages/shared/src/agent-tools/types.ts
@@ -113,6 +113,20 @@ export interface RecordToReportOptions {
   screenshots?: RecordToReportScreenshot[];
 }
 
+export interface BaseAiActProgressEvent {
+  type?: unknown;
+  event?: unknown;
+  sequence?: unknown;
+  prompt?: unknown;
+  planIndex?: unknown;
+  planLimit?: unknown;
+  screenshot?: unknown;
+  message?: unknown;
+  action?: unknown;
+  durationMs?: unknown;
+  error?: unknown;
+}
+
 /**
  * Base agent interface
  * Represents a platform-specific agent (Android, iOS, Web)
@@ -127,6 +141,9 @@ export interface BaseAgent {
   };
   addDumpUpdateListener?: (
     listener: (dump: string, executionDump?: unknown) => void,
+  ) => () => void;
+  addAiActProgressListener?: (
+    listener: (event: BaseAiActProgressEvent) => void,
   ) => () => void;
   recordToReport?: (
     title?: string,

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -3,13 +3,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import dotenv from 'dotenv';
 import type { BaseMidsceneTools } from '../agent-tools/base-tools';
-import { stripBehaviorFlags } from '../agent-tools/tool-defaults';
+import { getDebug } from '../logger';
+import {
+  TOOL_BEHAVIOR_FLAGS,
+  stripBehaviorFlags,
+} from '../agent-tools/tool-defaults';
 import type {
   ToolDefinition,
   ToolResult,
   ToolResultContent,
 } from '../agent-tools/types';
-import { getDebug } from '../logger';
 import {
   canonicalizeCliArgKeys,
   formatCliValidationError,
@@ -17,6 +20,14 @@ import {
   parseCliArgs,
 } from './cli-args';
 import { CLIError } from './cli-error';
+import {
+  cliVerboseErrorMessage,
+  cliVerboseFlag,
+  compactCliVerboseArgs,
+  emitCliVerboseEvent,
+  stripVerboseFlag,
+  withCliVerboseContext,
+} from './verbose';
 
 const debug = getDebug('cli-runner');
 
@@ -58,6 +69,12 @@ function outputContentItem(item: ToolResultContent, isError: boolean): void {
       const filepath = join(tmpdir(), filename);
       writeFileSync(filepath, Buffer.from(item.data, 'base64'));
       console.log(`Screenshot saved: ${filepath}`);
+      emitCliVerboseEvent({
+        event: 'artifact',
+        kind: 'screenshot',
+        path: filepath,
+        mimeType: item.mimeType,
+      });
       break;
     }
 
@@ -105,6 +122,8 @@ function printCommandHelp(scriptName: string, cmd: CLICommand): void {
       console.log(`  ${label.padEnd(optionWidth)} ${desc}${aliasText}`);
     }
   }
+
+  printGlobalOptions();
 }
 
 function printVersion(scriptName: string, version: string): void {
@@ -126,7 +145,28 @@ function printHelp(
     console.log(`  ${name.padEnd(30)} ${def.description}`);
   }
   console.log(`  ${'version'.padEnd(30)} Show CLI version`);
+  printGlobalOptions();
   console.log(`\nRun "${scriptName} <command> --help" for more info.`);
+}
+
+function printGlobalOptions(): void {
+  const options = [
+    {
+      flag: `--${cliVerboseFlag}`,
+      description:
+        'Print structured progress events while the command is running.',
+    },
+    ...TOOL_BEHAVIOR_FLAGS.map((flag) => ({
+      flag: `--${flag.cli}`,
+      description: flag.description,
+    })),
+  ];
+  const optionWidth = Math.max(...options.map((option) => option.flag.length));
+
+  console.log('\nGlobal Options:');
+  for (const option of options) {
+    console.log(`  ${option.flag.padEnd(optionWidth)} ${option.description}`);
+  }
 }
 
 type AnyMidsceneTools = BaseMidsceneTools<any, any>;
@@ -139,12 +179,14 @@ export async function runToolsCLI(
   const inputArgs = options?.argv ?? process.argv.slice(2);
   debug('CLI invoked: %s %s', scriptName, inputArgs.join(' '));
 
+  const { rawArgs: argsWithoutVerbose, verbose } = stripVerboseFlag(inputArgs);
+
   // Global behavior flags (e.g. `--deep-locate` / `--deep-think`) apply
   // regardless of which command runs. `stripBehaviorFlags` is the single place
   // that knows how they look on the command line: it resolves their defaults
   // and returns the remaining args so the per-command parser never sees them.
   // See https://github.com/web-infra-dev/midscene/issues/2446.
-  const { rawArgs, toolDefaults } = stripBehaviorFlags(inputArgs);
+  const { rawArgs, toolDefaults } = stripBehaviorFlags(argsWithoutVerbose);
   if (Object.keys(toolDefaults).length > 0) {
     tools.setToolDefaults?.(toolDefaults);
   }
@@ -235,15 +277,51 @@ export async function runToolsCLI(
 
   debug('command: %s, args: %s', match.name, JSON.stringify(handlerArgs));
 
-  const result = await match.def.handler(handlerArgs);
-  debug(
-    'command %s completed, isError: %s',
-    match.name,
-    result.isError ?? false,
+  await withCliVerboseContext(
+    {
+      enabled: verbose,
+      scriptName,
+      commandName: match.name,
+      startedAt: Date.now(),
+    },
+    async () => {
+      const startedAt = Date.now();
+      emitCliVerboseEvent({
+        event: 'command_start',
+        args: compactCliVerboseArgs(handlerArgs),
+      });
+
+      try {
+        const result = await match.def.handler(handlerArgs);
+        debug(
+          'command %s completed, isError: %s',
+          match.name,
+          result.isError ?? false,
+        );
+        outputResult(result);
+        emitCliVerboseEvent({
+          event: 'command_done',
+          status: result.isError ? 'error' : 'ok',
+          durationMs: Date.now() - startedAt,
+        });
+        if (result.isError) {
+          throw new CLIError('Command failed', 1);
+        }
+      } catch (error) {
+        if (
+          !(error instanceof CLIError && error.message === 'Command failed')
+        ) {
+          emitCliVerboseEvent({
+            event: 'command_done',
+            status: 'error',
+            durationMs: Date.now() - startedAt,
+            error: cliVerboseErrorMessage(error),
+          });
+        }
+        throw error;
+      } finally {
+        await tools.destroy();
+      }
+    },
   );
-  outputResult(result);
-  await tools.destroy();
-  if (result.isError) {
-    throw new CLIError('Command failed', 1);
-  }
 }

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -154,7 +154,7 @@ function printGlobalOptions(): void {
     {
       flag: `--${cliVerboseFlag}`,
       description:
-        'Print structured progress events while the command is running.',
+        'Print progress while the command is running. Use --verbose=jsonl for structured events.',
     },
     ...TOOL_BEHAVIOR_FLAGS.map((flag) => ({
       flag: `--${flag.cli}`,
@@ -179,7 +179,11 @@ export async function runToolsCLI(
   const inputArgs = options?.argv ?? process.argv.slice(2);
   debug('CLI invoked: %s %s', scriptName, inputArgs.join(' '));
 
-  const { rawArgs: argsWithoutVerbose, verbose } = stripVerboseFlag(inputArgs);
+  const {
+    rawArgs: argsWithoutVerbose,
+    verbose,
+    format: verboseFormat,
+  } = stripVerboseFlag(inputArgs);
 
   // Global behavior flags (e.g. `--deep-locate` / `--deep-think`) apply
   // regardless of which command runs. `stripBehaviorFlags` is the single place
@@ -280,6 +284,7 @@ export async function runToolsCLI(
   await withCliVerboseContext(
     {
       enabled: verbose,
+      format: verboseFormat,
       scriptName,
       commandName: match.name,
       startedAt: Date.now(),

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -2,7 +2,6 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import dotenv from 'dotenv';
 import type { BaseMidsceneTools } from '../agent-tools/base-tools';
-import { getDebug } from '../logger';
 import {
   TOOL_BEHAVIOR_FLAGS,
   stripBehaviorFlags,
@@ -12,6 +11,7 @@ import type {
   ToolResult,
   ToolResultContent,
 } from '../agent-tools/types';
+import { getDebug } from '../logger';
 import {
   canonicalizeCliArgKeys,
   formatCliValidationError,
@@ -155,7 +155,7 @@ function printGlobalOptions(): void {
     {
       flag: `--${cliVerboseFlag}`,
       description:
-        'Print progress while the command is running. Use --verbose=jsonl for structured events.',
+        'Print progress while the command is running. act prints readable progress by default. Use --verbose=jsonl for structured events.',
     },
     ...TOOL_BEHAVIOR_FLAGS.map((flag) => ({
       flag: `--${flag.cli}`,
@@ -282,9 +282,11 @@ export async function runToolsCLI(
 
   debug('command: %s, args: %s', match.name, JSON.stringify(handlerArgs));
 
+  const verboseEnabled = verbose || match.name === 'act';
+
   await withCliVerboseContext(
     {
-      enabled: verbose,
+      enabled: verboseEnabled,
       format: verboseFormat,
       scriptName,
       commandName: match.name,

--- a/packages/shared/src/cli/cli-runner.ts
+++ b/packages/shared/src/cli/cli-runner.ts
@@ -1,5 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import dotenv from 'dotenv';
 import type { BaseMidsceneTools } from '../agent-tools/base-tools';
@@ -20,6 +19,7 @@ import {
   parseCliArgs,
 } from './cli-args';
 import { CLIError } from './cli-error';
+import { writeCliScreenshotFile } from './screenshot-file';
 import {
   cliVerboseErrorMessage,
   cliVerboseFlag,
@@ -65,9 +65,10 @@ function outputContentItem(item: ToolResultContent, isError: boolean): void {
       break;
 
     case 'image': {
-      const filename = `screenshot-${Date.now()}.png`;
-      const filepath = join(tmpdir(), filename);
-      writeFileSync(filepath, Buffer.from(item.data, 'base64'));
+      const filepath = writeCliScreenshotFile(item.data, {
+        mimeType: item.mimeType,
+        filenamePrefix: 'screenshot',
+      });
       console.log(`Screenshot saved: ${filepath}`);
       emitCliVerboseEvent({
         event: 'artifact',

--- a/packages/shared/src/cli/index.ts
+++ b/packages/shared/src/cli/index.ts
@@ -2,3 +2,11 @@ export { CLIError, reportCLIError } from './cli-error';
 export { parseCliArgs, parseValue } from './cli-args';
 export { runToolsCLI, removePrefix } from './cli-runner';
 export type { CLIRunnerOptions, CLIExtraCommand } from './cli-runner';
+export {
+  attachCliVerboseDumpListener,
+  emitCliVerboseEvent,
+  getCliVerboseContext,
+  isCliVerboseEnabled,
+  stripVerboseFlag,
+  withCliVerboseContext,
+} from './verbose';

--- a/packages/shared/src/cli/screenshot-file.ts
+++ b/packages/shared/src/cli/screenshot-file.ts
@@ -6,6 +6,7 @@ export interface WriteCliScreenshotFileOptions {
   id?: unknown;
   mimeType?: unknown;
   extension?: unknown;
+  directoryPath?: string;
   directoryName?: string;
   filenamePrefix?: string;
   overwrite?: boolean;
@@ -37,9 +38,11 @@ export function writeCliScreenshotFile(
     options.mimeType,
     options.extension,
   );
-  const directory = options.directoryName
-    ? join(tmpdir(), options.directoryName)
-    : tmpdir();
+  const directory = options.directoryPath
+    ? options.directoryPath
+    : options.directoryName
+      ? join(tmpdir(), options.directoryName)
+      : tmpdir();
   if (!existsSync(directory)) {
     mkdirSync(directory, { recursive: true });
   }

--- a/packages/shared/src/cli/screenshot-file.ts
+++ b/packages/shared/src/cli/screenshot-file.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface WriteCliScreenshotFileOptions {
+  id?: unknown;
+  mimeType?: unknown;
+  extension?: unknown;
+  directoryName?: string;
+  filenamePrefix?: string;
+  overwrite?: boolean;
+}
+
+function safeScreenshotFilenamePart(value: unknown): string {
+  const text = typeof value === 'string' && value.length > 0 ? value : 'shot';
+  return text.replace(/[^a-zA-Z0-9._-]/g, '_') || 'shot';
+}
+
+function extensionFromImageMetadata(
+  mimeType: unknown,
+  extension: unknown,
+): 'png' | 'jpeg' {
+  if (extension === 'jpeg' || extension === 'jpg') {
+    return 'jpeg';
+  }
+  if (extension === 'png') {
+    return 'png';
+  }
+  return mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+}
+
+export function writeCliScreenshotFile(
+  rawBase64: string,
+  options: WriteCliScreenshotFileOptions = {},
+): string {
+  const extension = extensionFromImageMetadata(
+    options.mimeType,
+    options.extension,
+  );
+  const directory = options.directoryName
+    ? join(tmpdir(), options.directoryName)
+    : tmpdir();
+  if (!existsSync(directory)) {
+    mkdirSync(directory, { recursive: true });
+  }
+
+  const filename =
+    options.id !== undefined
+      ? `${safeScreenshotFilenamePart(options.id)}.${extension}`
+      : `${options.filenamePrefix ?? 'screenshot'}-${Date.now()}.${extension}`;
+  const filePath = join(directory, filename);
+
+  if (options.overwrite !== false || !existsSync(filePath)) {
+    writeFileSync(filePath, Buffer.from(rawBase64, 'base64'));
+  }
+
+  return filePath;
+}

--- a/packages/shared/src/cli/verbose-ai-act.ts
+++ b/packages/shared/src/cli/verbose-ai-act.ts
@@ -1,29 +1,32 @@
 import {
   type CliVerboseScreenshotCollectOptions,
-  latestScreenshotPathForAiAct,
+  collectScreenshotRefs,
+  pathForReportScreenshot,
 } from './verbose-screenshot';
-
-interface CliVerboseExecutionTaskLike {
-  taskId?: unknown;
-  type?: unknown;
-  subType?: unknown;
-  status?: unknown;
-  param?: unknown;
-  thought?: unknown;
-  output?: unknown;
-  errorMessage?: unknown;
-  timing?: {
-    cost?: unknown;
-  };
-}
-
-interface CliVerboseExecutionDumpLike {
-  tasks: CliVerboseExecutionTaskLike[];
-}
 
 export interface CliVerboseLine {
   key: string;
   text: string;
+}
+
+export interface CliAiActProgressEvent {
+  type?: unknown;
+  event?: unknown;
+  sequence?: unknown;
+  prompt?: unknown;
+  planIndex?: unknown;
+  planLimit?: unknown;
+  screenshot?: unknown;
+  message?: unknown;
+  action?: unknown;
+  durationMs?: unknown;
+  error?: unknown;
+}
+
+export interface CliAiActProgressPayload
+  extends Omit<CliAiActProgressEvent, 'screenshot'> {
+  screenshots?: Array<Record<string, unknown>>;
+  screenshotPath?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -51,571 +54,198 @@ function compactText(value: unknown): string {
   }
 }
 
-function compactCliVerboseValue(value: unknown): unknown {
-  if (value === undefined || value === null) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
-  }
-
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    return value.slice(0, 5).map(compactCliVerboseValue);
-  }
-
-  if (isRecord(value) && typeof value.prompt === 'string') {
-    return compactCliVerboseValue(value.prompt);
-  }
-
-  if (!isRecord(value)) {
-    return String(value);
-  }
-
-  const entries = Object.entries(value).slice(0, 6);
-  return Object.fromEntries(
-    entries.map(([key, entryValue]) => [
-      key,
-      compactCliVerboseValue(entryValue),
-    ]),
-  );
-}
-
-function summarizeParam(param: unknown): unknown {
-  if (!param || typeof param !== 'object') {
-    return compactCliVerboseValue(param);
-  }
-
-  const record = param as Record<string, unknown>;
-  if (typeof record.prompt === 'string') {
-    return compactCliVerboseValue(record.prompt);
-  }
-  if (
-    record.locate &&
-    typeof record.locate === 'object' &&
-    record.locate !== null
-  ) {
-    const locate = record.locate as Record<string, unknown>;
-    return {
-      locate: compactCliVerboseValue(locate.prompt),
-      ...Object.fromEntries(
-        Object.entries(record)
-          .filter(([key]) => key !== 'locate')
-          .slice(0, 4)
-          .map(([key, value]) => [key, compactCliVerboseValue(value)]),
-      ),
-    };
-  }
-
-  return compactCliVerboseValue(record);
-}
-
-function summarizeUserInstruction(value: unknown): string {
-  if (typeof value === 'string') {
-    return compactText(value);
-  }
-
-  if (isRecord(value) && typeof value.prompt === 'string') {
-    return compactText(value.prompt);
-  }
-
-  return compactText(value);
-}
-
-function summarizeSubGoals(value: unknown): string {
-  if (!Array.isArray(value) || value.length === 0) {
-    return '';
-  }
-
-  const goals = value
-    .slice(0, 6)
-    .map((goal) => {
-      if (!isRecord(goal)) {
-        return '';
-      }
-      const index = typeof goal.index === 'number' ? `${goal.index}. ` : '';
-      const status = typeof goal.status === 'string' ? `[${goal.status}] ` : '';
-      const description =
-        typeof goal.description === 'string' ? goal.description : '';
-      return `${index}${status}${description}`.trim();
-    })
-    .filter(Boolean);
-
-  return goals.length > 0 ? `sub-goals: ${goals.join('; ')}` : '';
-}
-
-function isCliVerboseExecutionDumpLike(
-  value: unknown,
-): value is CliVerboseExecutionDumpLike {
-  return isRecord(value) && Array.isArray(value.tasks);
-}
-
-function taskKey(task: CliVerboseExecutionTaskLike, fallback: string): string {
-  return typeof task.taskId === 'string' && task.taskId.length > 0
-    ? task.taskId
-    : fallback;
-}
-
-function numberFromUnknown(value: unknown): number | undefined {
+function numericValue(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
     ? value
     : undefined;
 }
 
-function integerText(value: number): string {
-  return String(Math.round(value));
-}
-
-function formatPoint(point: readonly [number, number]): string {
-  return `(${integerText(point[0])}, ${integerText(point[1])})`;
-}
-
-function formatBbox(bbox: readonly [number, number, number, number]): string {
-  return `(${bbox.map(integerText).join(',')})`;
-}
-
-function bboxArrayFromProperty(
-  value: Record<string, unknown>,
-  key: string,
-): [number, number, number, number] | undefined {
-  const bbox = value[key];
-  if (!Array.isArray(bbox) || bbox.length < 4) {
-    return undefined;
+function planPrefix(event: CliAiActProgressPayload): string {
+  const planIndex = numericValue(event.planIndex);
+  if (!planIndex) {
+    return '[Midscene][aiAct]';
   }
 
-  const left = numberFromUnknown(bbox[0]);
-  const top = numberFromUnknown(bbox[1]);
-  const right = numberFromUnknown(bbox[2]);
-  const bottom = numberFromUnknown(bbox[3]);
-  if (
-    left === undefined ||
-    top === undefined ||
-    right === undefined ||
-    bottom === undefined
-  ) {
-    return undefined;
-  }
-
-  return [left, top, right, bottom];
+  const planLimit = numericValue(event.planLimit);
+  return `[Midscene][aiAct][Plan ${Math.round(planIndex)}${
+    planLimit ? `/${Math.round(planLimit)}` : ''
+  }]`;
 }
 
-function centerPointFromBbox(
-  bbox: readonly [number, number, number, number],
-): [number, number] {
+function eventKey(event: CliAiActProgressPayload, suffix: string): string {
+  const sequence = numericValue(event.sequence);
+  if (sequence) {
+    return `aiAct:${sequence}:${suffix}`;
+  }
+
   return [
-    Math.floor((bbox[0] + bbox[2]) / 2),
-    Math.floor((bbox[1] + bbox[3]) / 2),
-  ];
+    'aiAct',
+    compactText(event.event),
+    compactText(event.planIndex),
+    compactText(event.message),
+    suffix,
+  ]
+    .filter(Boolean)
+    .join(':');
 }
 
-function planLimitText(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.param)) {
-    return '';
-  }
-  const limit = numberFromUnknown(task.param.replanningCycleLimit);
-  return limit && limit > 0 ? `/${integerText(limit)}` : '';
-}
-
-function planPrefix(
-  task: CliVerboseExecutionTaskLike,
-  planIndex: number,
-): string {
-  return `[Midscene][aiAct][Plan ${planIndex}${planLimitText(task)}]`;
-}
-
-function actionOutputText(value: unknown): string {
-  if (!Array.isArray(value) || value.length === 0) {
-    return '';
-  }
-
-  const action = value.find(isRecord);
-  if (!action) {
-    return '';
-  }
-
-  return (
-    compactText(action.log) ||
-    compactText(action.thought) ||
-    compactText(summarizeParam(action.param))
-  );
-}
-
-function plannedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.output)) {
-    return compactText(task.output) || compactText(task.thought);
-  }
-
-  return (
-    compactText(task.output.log) ||
-    compactText(task.output.thought) ||
-    compactText(task.thought) ||
-    summarizeSubGoals(task.output.updateSubGoals) ||
-    actionOutputText(task.output.actions) ||
-    compactText(task.output.output)
-  );
-}
-
-function completeTextForAiAct(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.output)) {
-    return '';
-  }
-
-  const output = compactText(task.output.output);
-  if (output) {
-    return output;
-  }
-
-  return task.output.shouldContinuePlanning === false
-    ? plannedTextForAiAct(task)
-    : '';
-}
-
-function failedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
-  if (typeof task.errorMessage === 'string' && task.errorMessage.length > 0) {
-    return compactText(task.errorMessage);
-  }
-
-  if (isRecord(task.output)) {
-    return (
-      compactText(task.output.output) ||
-      compactText(task.output.log) ||
-      compactText(task.output.thought)
-    );
-  }
-
-  return compactText(task.thought) || 'planning failed';
-}
-
-function pointFromLocateLike(
-  value: Record<string, unknown>,
-): [number, number] | undefined {
-  const center = value.center;
-  if (Array.isArray(center) && center.length >= 2) {
-    const x = numberFromUnknown(center[0]);
-    const y = numberFromUnknown(center[1]);
-    if (x !== undefined && y !== undefined) {
-      return [x, y];
-    }
-  }
-
-  const point = value.point;
-  if (Array.isArray(point) && point.length >= 2) {
-    const x = numberFromUnknown(point[0]);
-    const y = numberFromUnknown(point[1]);
-    if (x !== undefined && y !== undefined) {
-      return [x, y];
-    }
-  }
-
-  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
-  if (locatedPixelBbox) {
-    return centerPointFromBbox(locatedPixelBbox);
-  }
-
-  const bbox = bboxArrayFromProperty(value, 'bbox');
-  if (bbox) {
-    return centerPointFromBbox(bbox);
-  }
-
-  return undefined;
-}
-
-function bboxFromLocateLike(
-  value: Record<string, unknown>,
-): [number, number, number, number] | undefined {
-  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
-  if (locatedPixelBbox) {
-    return locatedPixelBbox;
-  }
-
-  const bbox = bboxArrayFromProperty(value, 'bbox');
-  if (bbox) {
-    return bbox;
-  }
-
-  if (!isRecord(value.rect)) {
-    return undefined;
-  }
-
-  const left = numberFromUnknown(value.rect.left);
-  const top = numberFromUnknown(value.rect.top);
-  const width = numberFromUnknown(value.rect.width);
-  const height = numberFromUnknown(value.rect.height);
-  if (
-    left === undefined ||
-    top === undefined ||
-    width === undefined ||
-    height === undefined
-  ) {
-    return undefined;
-  }
-
-  return [left, top, left + width, top + height];
-}
-
-function targetTextFromLocateLike(value: Record<string, unknown>): string {
-  return (
-    compactText(value.description) ||
-    compactText(value.prompt) ||
-    summarizeUserInstruction(value)
-  );
-}
-
-function isLocateLike(value: unknown): value is Record<string, unknown> {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  return (
-    'center' in value ||
-    'rect' in value ||
-    'point' in value ||
-    'bbox' in value ||
-    'prompt' in value ||
-    'description' in value
-  );
-}
-
-const locatorParamKeys = ['locate', 'from', 'to', 'start', 'end'];
-
-function firstLocateLikeParam(
-  param: unknown,
-): Record<string, unknown> | undefined {
-  if (!isRecord(param)) {
-    return undefined;
-  }
-
-  for (const key of locatorParamKeys) {
-    const value = param[key];
-    if (isLocateLike(value)) {
-      return value;
-    }
-  }
-
-  return Object.values(param).find(isLocateLike);
-}
-
-function hasUnresolvedLocateLikeParam(param: unknown): boolean {
-  if (!isRecord(param)) {
-    return false;
-  }
-
-  return Object.entries(param).some(([key, value]) => {
-    if (locatorParamKeys.includes(key) && typeof value === 'string') {
-      return true;
-    }
-
-    return (
-      isLocateLike(value) &&
-      !pointFromLocateLike(value) &&
-      !bboxFromLocateLike(value)
-    );
-  });
-}
-
-interface AiActActionText {
-  action: string;
-  running: string;
-  done: string;
-}
-
-function sleepActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  if (actionName !== 'Sleep' || !isRecord(param)) {
-    return undefined;
-  }
-
-  const timeMs =
-    numberFromUnknown(param.timeMs) ??
-    numberFromUnknown(param.duration) ??
-    numberFromUnknown(param.timeoutMs);
-  const action = timeMs ? `Sleep ${integerText(timeMs)}ms` : 'Sleep';
-  return {
-    action,
-    running: action,
-    done: 'Sleep',
-  };
-}
-
-function locateActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  const locate = firstLocateLikeParam(param);
-  if (!locate) {
-    return undefined;
-  }
-
-  const point = pointFromLocateLike(locate);
-  const bbox = bboxFromLocateLike(locate);
-  if (!point) {
-    return undefined;
-  }
-
-  const target = targetTextFromLocateLike(locate);
-  const targetSegment = target ? ` "${target}"` : '';
-  const pointSegment = ` at ${formatPoint(point)}`;
-  const bboxSegment = bbox ? `, bbox=${formatBbox(bbox)}` : '';
-  return {
-    action: `${actionName}${targetSegment}${pointSegment}${bboxSegment}`,
-    running: `${actionName} at ${formatPoint(point)}`,
-    done: actionName,
-  };
-}
-
-function genericActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  if (hasUnresolvedLocateLikeParam(param)) {
-    return undefined;
-  }
-
-  const paramText = compactText(summarizeParam(param));
-  const action = paramText ? `${actionName}: ${paramText}` : actionName;
-  return {
-    action,
-    running: action,
-    done: actionName,
-  };
-}
-
-function actionTextForAiAct(
-  task: CliVerboseExecutionTaskLike,
-): AiActActionText | undefined {
-  const actionName =
-    typeof task.subType === 'string' && task.subType.length > 0
-      ? task.subType
-      : 'Action';
-  return (
-    sleepActionText(actionName, task.param) ||
-    locateActionText(actionName, task.param) ||
-    genericActionText(actionName, task.param)
-  );
-}
-
-export function buildAiActTimelineLines(
-  executionDump: unknown,
+export function normalizeAiActProgressEventForCli(
+  event: unknown,
   screenshotOptions: CliVerboseScreenshotCollectOptions = {},
-): CliVerboseLine[] {
-  if (!isCliVerboseExecutionDumpLike(executionDump)) {
-    return [];
+): CliAiActProgressPayload | undefined {
+  if (!isRecord(event) || event.type !== 'aiAct') {
+    return undefined;
   }
 
-  const lines: CliVerboseLine[] = [];
-  let planIndex = 0;
-  let currentPlan:
-    | {
-        index: number;
-        prefix: string;
-      }
-    | undefined;
+  const screenshots = collectScreenshotRefs(
+    event.screenshot,
+    screenshotOptions,
+  );
+  const latestPath = screenshots
+    .slice()
+    .reverse()
+    .find(
+      (item) => typeof item.path === 'string' && item.path.length > 0,
+    )?.path;
+  const screenshotPath =
+    typeof latestPath === 'string'
+      ? pathForReportScreenshot(latestPath, screenshotOptions.reportFile)
+      : undefined;
 
-  executionDump.tasks.forEach((task, taskIndex) => {
-    const fallbackKey = String(taskIndex + 1);
-    if (task.type === 'Planning' && task.subType === 'Plan') {
-      planIndex += 1;
-      currentPlan = {
-        index: planIndex,
-        prefix: planPrefix(task, planIndex),
-      };
-      const keyPrefix = `aiAct:plan:${taskKey(task, fallbackKey)}`;
-      const screenshotPath = latestScreenshotPathForAiAct(
-        task,
-        screenshotOptions,
-      );
-      if (screenshotPath) {
-        lines.push({
-          key: `${keyPrefix}:thinking`,
-          text: `${currentPlan.prefix} Thinking with the latest screenshot: ${screenshotPath}`,
-        });
-      }
+  const {
+    type,
+    event: eventName,
+    sequence,
+    prompt,
+    planIndex,
+    planLimit,
+    message,
+    action,
+    durationMs,
+    error,
+  } = event;
 
-      if (task.status === 'finished') {
-        const plannedText = plannedTextForAiAct(task);
-        if (plannedText) {
-          lines.push({
-            key: `${keyPrefix}:planned`,
-            text: `${currentPlan.prefix} Planned: ${plannedText}`,
-          });
-        }
+  return {
+    type,
+    event: eventName,
+    sequence,
+    prompt,
+    planIndex,
+    planLimit,
+    message,
+    action,
+    durationMs,
+    error,
+    ...(screenshots.length > 0 ? { screenshots } : {}),
+    ...(screenshotPath ? { screenshotPath } : {}),
+  };
+}
 
-        const completeText = completeTextForAiAct(task);
-        if (completeText) {
-          lines.push({
-            key: `${keyPrefix}:complete`,
-            text: `[Midscene][aiAct] Complete: ${completeText}`,
-          });
-        }
-      }
+export function buildAiActProgressEventLines(
+  event: CliAiActProgressPayload,
+): CliVerboseLine[] {
+  const eventName = typeof event.event === 'string' ? event.event : '';
+  const prefix = planPrefix(event);
+  const message = compactText(event.message);
+  const error = compactText(event.error);
+  const duration =
+    typeof event.durationMs === 'number'
+      ? ` cost=${Math.round(event.durationMs)}ms`
+      : '';
 
-      if (task.status === 'failed') {
-        lines.push({
-          key: `${keyPrefix}:failed`,
-          text: `${currentPlan.prefix} Failed: ${failedTextForAiAct(task)}`,
-        });
-      }
-      return;
+  switch (eventName) {
+    case 'start': {
+      const prompt = compactText(event.prompt);
+      return [
+        {
+          key: `aiAct:start:${prompt}`,
+          text: prompt
+            ? `[Midscene][aiAct] Start: ${prompt}`
+            : '[Midscene][aiAct] Start',
+        },
+      ];
     }
-
-    if (
-      !currentPlan ||
-      task.type !== 'Action Space' ||
-      task.subType === 'Finished'
-    ) {
-      return;
-    }
-
-    const actionText = actionTextForAiAct(task);
-    if (!actionText) {
-      return;
-    }
-
-    const keyPrefix = `aiAct:action:${taskKey(task, fallbackKey)}`;
-    lines.push({
-      key: `${keyPrefix}:planned`,
-      text: `${currentPlan.prefix} Action: ${actionText.action}`,
-    });
-
-    if (task.status === 'running') {
-      lines.push({
-        key: `${keyPrefix}:running`,
-        text: `[Midscene][aiAct][Action] Running: ${actionText.running}`,
-      });
-    }
-
-    if (task.status === 'finished') {
-      const cost =
-        typeof task.timing?.cost === 'number'
-          ? ` cost=${integerText(task.timing.cost)}ms`
-          : '';
-      lines.push({
-        key: `${keyPrefix}:finished`,
-        text: `[Midscene][aiAct][Action] Done: ${actionText.done}${cost}`,
-      });
-    }
-
-    if (task.status === 'failed') {
-      const cost =
-        typeof task.timing?.cost === 'number'
-          ? ` cost=${integerText(task.timing.cost)}ms`
-          : '';
-      const error =
-        typeof task.errorMessage === 'string' && task.errorMessage.length > 0
-          ? ` error=${task.errorMessage}`
-          : '';
-      lines.push({
-        key: `${keyPrefix}:failed`,
-        text: `[Midscene][aiAct][Action] Failed: ${actionText.done}${cost}${error}`,
-      });
-    }
-  });
-
-  return lines;
+    case 'plan_thinking':
+      return event.screenshotPath
+        ? [
+            {
+              key: eventKey(event, 'thinking'),
+              text: `${prefix} Thinking with the latest screenshot: ${event.screenshotPath}`,
+            },
+          ]
+        : [
+            {
+              key: eventKey(event, 'thinking'),
+              text: `${prefix} Thinking with the latest screenshot`,
+            },
+          ];
+    case 'plan_planned':
+      return message
+        ? [
+            {
+              key: eventKey(event, 'planned'),
+              text: `${prefix} Planned: ${message}`,
+            },
+          ]
+        : [];
+    case 'plan_action':
+      return message
+        ? [
+            {
+              key: eventKey(event, 'action'),
+              text: `${prefix} Action: ${message}`,
+            },
+          ]
+        : [];
+    case 'plan_failed':
+      return [
+        {
+          key: eventKey(event, 'plan_failed'),
+          text: `${prefix} Failed${error || message ? `: ${error || message}` : ''}`,
+        },
+      ];
+    case 'action_running':
+      return message
+        ? [
+            {
+              key: eventKey(event, 'action_running'),
+              text: `[Midscene][aiAct][Action] Running: ${message}`,
+            },
+          ]
+        : [];
+    case 'action_done':
+      return message
+        ? [
+            {
+              key: eventKey(event, 'action_done'),
+              text: `[Midscene][aiAct][Action] Done: ${message}${duration}`,
+            },
+          ]
+        : [];
+    case 'action_failed':
+      return [
+        {
+          key: eventKey(event, 'action_failed'),
+          text: `[Midscene][aiAct][Action] Failed${message ? `: ${message}` : ''}${duration}${
+            error ? ` error=${error}` : ''
+          }`,
+        },
+      ];
+    case 'complete':
+      return [
+        {
+          key: eventKey(event, 'complete'),
+          text: `[Midscene][aiAct] Complete${message ? `: ${message}` : ''}`,
+        },
+      ];
+    case 'failed':
+      return [
+        {
+          key: eventKey(event, 'failed'),
+          text: `[Midscene][aiAct] Failed${error || message ? `: ${error || message}` : ''}`,
+        },
+      ];
+    default:
+      return [];
+  }
 }

--- a/packages/shared/src/cli/verbose-ai-act.ts
+++ b/packages/shared/src/cli/verbose-ai-act.ts
@@ -1,0 +1,621 @@
+import {
+  type CliVerboseScreenshotCollectOptions,
+  latestScreenshotPathForAiAct,
+} from './verbose-screenshot';
+
+interface CliVerboseExecutionTaskLike {
+  taskId?: unknown;
+  type?: unknown;
+  subType?: unknown;
+  status?: unknown;
+  param?: unknown;
+  thought?: unknown;
+  output?: unknown;
+  errorMessage?: unknown;
+  timing?: {
+    cost?: unknown;
+  };
+}
+
+interface CliVerboseExecutionDumpLike {
+  tasks: CliVerboseExecutionTaskLike[];
+}
+
+export interface CliVerboseLine {
+  key: string;
+  text: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactText(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    return json.length > 180 ? `${json.slice(0, 177)}...` : json;
+  } catch {
+    return String(value);
+  }
+}
+
+function compactCliVerboseValue(value: unknown): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map(compactCliVerboseValue);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactCliVerboseValue(value.prompt);
+  }
+
+  if (!isRecord(value)) {
+    return String(value);
+  }
+
+  const entries = Object.entries(value).slice(0, 6);
+  return Object.fromEntries(
+    entries.map(([key, entryValue]) => [
+      key,
+      compactCliVerboseValue(entryValue),
+    ]),
+  );
+}
+
+function summarizeParam(param: unknown): unknown {
+  if (!param || typeof param !== 'object') {
+    return compactCliVerboseValue(param);
+  }
+
+  const record = param as Record<string, unknown>;
+  if (typeof record.prompt === 'string') {
+    return compactCliVerboseValue(record.prompt);
+  }
+  if (
+    record.locate &&
+    typeof record.locate === 'object' &&
+    record.locate !== null
+  ) {
+    const locate = record.locate as Record<string, unknown>;
+    return {
+      locate: compactCliVerboseValue(locate.prompt),
+      ...Object.fromEntries(
+        Object.entries(record)
+          .filter(([key]) => key !== 'locate')
+          .slice(0, 4)
+          .map(([key, value]) => [key, compactCliVerboseValue(value)]),
+      ),
+    };
+  }
+
+  return compactCliVerboseValue(record);
+}
+
+function summarizeUserInstruction(value: unknown): string {
+  if (typeof value === 'string') {
+    return compactText(value);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactText(value.prompt);
+  }
+
+  return compactText(value);
+}
+
+function summarizeSubGoals(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const goals = value
+    .slice(0, 6)
+    .map((goal) => {
+      if (!isRecord(goal)) {
+        return '';
+      }
+      const index = typeof goal.index === 'number' ? `${goal.index}. ` : '';
+      const status = typeof goal.status === 'string' ? `[${goal.status}] ` : '';
+      const description =
+        typeof goal.description === 'string' ? goal.description : '';
+      return `${index}${status}${description}`.trim();
+    })
+    .filter(Boolean);
+
+  return goals.length > 0 ? `sub-goals: ${goals.join('; ')}` : '';
+}
+
+function isCliVerboseExecutionDumpLike(
+  value: unknown,
+): value is CliVerboseExecutionDumpLike {
+  return isRecord(value) && Array.isArray(value.tasks);
+}
+
+function taskKey(task: CliVerboseExecutionTaskLike, fallback: string): string {
+  return typeof task.taskId === 'string' && task.taskId.length > 0
+    ? task.taskId
+    : fallback;
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function integerText(value: number): string {
+  return String(Math.round(value));
+}
+
+function formatPoint(point: readonly [number, number]): string {
+  return `(${integerText(point[0])}, ${integerText(point[1])})`;
+}
+
+function formatBbox(bbox: readonly [number, number, number, number]): string {
+  return `(${bbox.map(integerText).join(',')})`;
+}
+
+function bboxArrayFromProperty(
+  value: Record<string, unknown>,
+  key: string,
+): [number, number, number, number] | undefined {
+  const bbox = value[key];
+  if (!Array.isArray(bbox) || bbox.length < 4) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(bbox[0]);
+  const top = numberFromUnknown(bbox[1]);
+  const right = numberFromUnknown(bbox[2]);
+  const bottom = numberFromUnknown(bbox[3]);
+  if (
+    left === undefined ||
+    top === undefined ||
+    right === undefined ||
+    bottom === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, right, bottom];
+}
+
+function centerPointFromBbox(
+  bbox: readonly [number, number, number, number],
+): [number, number] {
+  return [
+    Math.floor((bbox[0] + bbox[2]) / 2),
+    Math.floor((bbox[1] + bbox[3]) / 2),
+  ];
+}
+
+function planLimitText(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.param)) {
+    return '';
+  }
+  const limit = numberFromUnknown(task.param.replanningCycleLimit);
+  return limit && limit > 0 ? `/${integerText(limit)}` : '';
+}
+
+function planPrefix(
+  task: CliVerboseExecutionTaskLike,
+  planIndex: number,
+): string {
+  return `[Midscene][aiAct][Plan ${planIndex}${planLimitText(task)}]`;
+}
+
+function actionOutputText(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const action = value.find(isRecord);
+  if (!action) {
+    return '';
+  }
+
+  return (
+    compactText(action.log) ||
+    compactText(action.thought) ||
+    compactText(summarizeParam(action.param))
+  );
+}
+
+function plannedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.output)) {
+    return compactText(task.output) || compactText(task.thought);
+  }
+
+  return (
+    compactText(task.output.log) ||
+    compactText(task.output.thought) ||
+    compactText(task.thought) ||
+    summarizeSubGoals(task.output.updateSubGoals) ||
+    actionOutputText(task.output.actions) ||
+    compactText(task.output.output)
+  );
+}
+
+function completeTextForAiAct(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.output)) {
+    return '';
+  }
+
+  const output = compactText(task.output.output);
+  if (output) {
+    return output;
+  }
+
+  return task.output.shouldContinuePlanning === false
+    ? plannedTextForAiAct(task)
+    : '';
+}
+
+function failedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
+  if (typeof task.errorMessage === 'string' && task.errorMessage.length > 0) {
+    return compactText(task.errorMessage);
+  }
+
+  if (isRecord(task.output)) {
+    return (
+      compactText(task.output.output) ||
+      compactText(task.output.log) ||
+      compactText(task.output.thought)
+    );
+  }
+
+  return compactText(task.thought) || 'planning failed';
+}
+
+function pointFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number] | undefined {
+  const center = value.center;
+  if (Array.isArray(center) && center.length >= 2) {
+    const x = numberFromUnknown(center[0]);
+    const y = numberFromUnknown(center[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const point = value.point;
+  if (Array.isArray(point) && point.length >= 2) {
+    const x = numberFromUnknown(point[0]);
+    const y = numberFromUnknown(point[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return centerPointFromBbox(locatedPixelBbox);
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return centerPointFromBbox(bbox);
+  }
+
+  return undefined;
+}
+
+function bboxFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number, number, number] | undefined {
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return locatedPixelBbox;
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return bbox;
+  }
+
+  if (!isRecord(value.rect)) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(value.rect.left);
+  const top = numberFromUnknown(value.rect.top);
+  const width = numberFromUnknown(value.rect.width);
+  const height = numberFromUnknown(value.rect.height);
+  if (
+    left === undefined ||
+    top === undefined ||
+    width === undefined ||
+    height === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, left + width, top + height];
+}
+
+function targetTextFromLocateLike(value: Record<string, unknown>): string {
+  return (
+    compactText(value.description) ||
+    compactText(value.prompt) ||
+    summarizeUserInstruction(value)
+  );
+}
+
+function isLocateLike(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    'center' in value ||
+    'rect' in value ||
+    'point' in value ||
+    'bbox' in value ||
+    'prompt' in value ||
+    'description' in value
+  );
+}
+
+const locatorParamKeys = ['locate', 'from', 'to', 'start', 'end'];
+
+function firstLocateLikeParam(
+  param: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(param)) {
+    return undefined;
+  }
+
+  for (const key of locatorParamKeys) {
+    const value = param[key];
+    if (isLocateLike(value)) {
+      return value;
+    }
+  }
+
+  return Object.values(param).find(isLocateLike);
+}
+
+function hasUnresolvedLocateLikeParam(param: unknown): boolean {
+  if (!isRecord(param)) {
+    return false;
+  }
+
+  return Object.entries(param).some(([key, value]) => {
+    if (locatorParamKeys.includes(key) && typeof value === 'string') {
+      return true;
+    }
+
+    return (
+      isLocateLike(value) &&
+      !pointFromLocateLike(value) &&
+      !bboxFromLocateLike(value)
+    );
+  });
+}
+
+interface AiActActionText {
+  action: string;
+  running: string;
+  done: string;
+}
+
+function sleepActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  if (actionName !== 'Sleep' || !isRecord(param)) {
+    return undefined;
+  }
+
+  const timeMs =
+    numberFromUnknown(param.timeMs) ??
+    numberFromUnknown(param.duration) ??
+    numberFromUnknown(param.timeoutMs);
+  const action = timeMs ? `Sleep ${integerText(timeMs)}ms` : 'Sleep';
+  return {
+    action,
+    running: action,
+    done: 'Sleep',
+  };
+}
+
+function locateActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  const locate = firstLocateLikeParam(param);
+  if (!locate) {
+    return undefined;
+  }
+
+  const point = pointFromLocateLike(locate);
+  const bbox = bboxFromLocateLike(locate);
+  if (!point) {
+    return undefined;
+  }
+
+  const target = targetTextFromLocateLike(locate);
+  const targetSegment = target ? ` "${target}"` : '';
+  const pointSegment = ` at ${formatPoint(point)}`;
+  const bboxSegment = bbox ? `, bbox=${formatBbox(bbox)}` : '';
+  return {
+    action: `${actionName}${targetSegment}${pointSegment}${bboxSegment}`,
+    running: `${actionName} at ${formatPoint(point)}`,
+    done: actionName,
+  };
+}
+
+function genericActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  if (hasUnresolvedLocateLikeParam(param)) {
+    return undefined;
+  }
+
+  const paramText = compactText(summarizeParam(param));
+  const action = paramText ? `${actionName}: ${paramText}` : actionName;
+  return {
+    action,
+    running: action,
+    done: actionName,
+  };
+}
+
+function actionTextForAiAct(
+  task: CliVerboseExecutionTaskLike,
+): AiActActionText | undefined {
+  const actionName =
+    typeof task.subType === 'string' && task.subType.length > 0
+      ? task.subType
+      : 'Action';
+  return (
+    sleepActionText(actionName, task.param) ||
+    locateActionText(actionName, task.param) ||
+    genericActionText(actionName, task.param)
+  );
+}
+
+export function buildAiActTimelineLines(
+  executionDump: unknown,
+  screenshotOptions: CliVerboseScreenshotCollectOptions = {},
+): CliVerboseLine[] {
+  if (!isCliVerboseExecutionDumpLike(executionDump)) {
+    return [];
+  }
+
+  const lines: CliVerboseLine[] = [];
+  let planIndex = 0;
+  let currentPlan:
+    | {
+        index: number;
+        prefix: string;
+      }
+    | undefined;
+
+  executionDump.tasks.forEach((task, taskIndex) => {
+    const fallbackKey = String(taskIndex + 1);
+    if (task.type === 'Planning' && task.subType === 'Plan') {
+      planIndex += 1;
+      currentPlan = {
+        index: planIndex,
+        prefix: planPrefix(task, planIndex),
+      };
+      const keyPrefix = `aiAct:plan:${taskKey(task, fallbackKey)}`;
+      const screenshotPath = latestScreenshotPathForAiAct(
+        task,
+        screenshotOptions,
+      );
+      if (screenshotPath) {
+        lines.push({
+          key: `${keyPrefix}:thinking`,
+          text: `${currentPlan.prefix} Thinking with the latest screenshot: ${screenshotPath}`,
+        });
+      }
+
+      if (task.status === 'finished') {
+        const plannedText = plannedTextForAiAct(task);
+        if (plannedText) {
+          lines.push({
+            key: `${keyPrefix}:planned`,
+            text: `${currentPlan.prefix} Planned: ${plannedText}`,
+          });
+        }
+
+        const completeText = completeTextForAiAct(task);
+        if (completeText) {
+          lines.push({
+            key: `${keyPrefix}:complete`,
+            text: `[Midscene][aiAct] Complete: ${completeText}`,
+          });
+        }
+      }
+
+      if (task.status === 'failed') {
+        lines.push({
+          key: `${keyPrefix}:failed`,
+          text: `${currentPlan.prefix} Failed: ${failedTextForAiAct(task)}`,
+        });
+      }
+      return;
+    }
+
+    if (
+      !currentPlan ||
+      task.type !== 'Action Space' ||
+      task.subType === 'Finished'
+    ) {
+      return;
+    }
+
+    const actionText = actionTextForAiAct(task);
+    if (!actionText) {
+      return;
+    }
+
+    const keyPrefix = `aiAct:action:${taskKey(task, fallbackKey)}`;
+    lines.push({
+      key: `${keyPrefix}:planned`,
+      text: `${currentPlan.prefix} Action: ${actionText.action}`,
+    });
+
+    if (task.status === 'running') {
+      lines.push({
+        key: `${keyPrefix}:running`,
+        text: `[Midscene][aiAct][Action] Running: ${actionText.running}`,
+      });
+    }
+
+    if (task.status === 'finished') {
+      const cost =
+        typeof task.timing?.cost === 'number'
+          ? ` cost=${integerText(task.timing.cost)}ms`
+          : '';
+      lines.push({
+        key: `${keyPrefix}:finished`,
+        text: `[Midscene][aiAct][Action] Done: ${actionText.done}${cost}`,
+      });
+    }
+
+    if (task.status === 'failed') {
+      const cost =
+        typeof task.timing?.cost === 'number'
+          ? ` cost=${integerText(task.timing.cost)}ms`
+          : '';
+      const error =
+        typeof task.errorMessage === 'string' && task.errorMessage.length > 0
+          ? ` error=${task.errorMessage}`
+          : '';
+      lines.push({
+        key: `${keyPrefix}:failed`,
+        text: `[Midscene][aiAct][Action] Failed: ${actionText.done}${cost}${error}`,
+      });
+    }
+  });
+
+  return lines;
+}

--- a/packages/shared/src/cli/verbose-screenshot.ts
+++ b/packages/shared/src/cli/verbose-screenshot.ts
@@ -1,0 +1,269 @@
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { writeCliScreenshotFile } from './screenshot-file';
+
+export type CliVerboseScreenshotExportMode = 'none' | 'tmp' | 'report';
+
+export interface CliVerboseScreenshotCollectOptions {
+  reportFile?: unknown;
+  exportMode?: CliVerboseScreenshotExportMode;
+  cache?: Map<string, string>;
+}
+
+interface CliVerboseScreenshotRefLike {
+  type: 'midscene_screenshot_ref';
+  id?: unknown;
+  mimeType?: unknown;
+  storage?: unknown;
+  path?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCliVerboseScreenshotRefLike(
+  value: unknown,
+): value is CliVerboseScreenshotRefLike {
+  return isRecord(value) && value.type === 'midscene_screenshot_ref';
+}
+
+function toSerializableScreenshot(
+  value: unknown,
+): CliVerboseScreenshotRefLike | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const maybeSerializable = value as {
+    toSerializable?: () => unknown;
+  };
+  if (typeof maybeSerializable.toSerializable === 'function') {
+    try {
+      const serialized = maybeSerializable.toSerializable();
+      return isCliVerboseScreenshotRefLike(serialized) ? serialized : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return isCliVerboseScreenshotRefLike(value) ? value : null;
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  try {
+    const property = value[key];
+    return typeof property === 'string' && property.length > 0
+      ? property
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function screenshotRawBase64(value: unknown): string | undefined {
+  const rawBase64 = getStringProperty(value, 'rawBase64');
+  if (rawBase64) {
+    return rawBase64;
+  }
+
+  const base64 = getStringProperty(value, 'base64');
+  const match = base64?.match(/^data:image\/(?:png|jpeg|jpg);base64,(.+)$/);
+  return match?.[1];
+}
+
+function inlineScreenshotCacheKey(
+  rawBase64: string,
+  serialized: CliVerboseScreenshotRefLike,
+  directoryPath: string | undefined,
+  directoryName: string | undefined,
+  extension: string | undefined,
+): string {
+  return JSON.stringify([
+    serialized.id,
+    serialized.mimeType,
+    directoryPath,
+    directoryName,
+    extension,
+    rawBase64,
+  ]);
+}
+
+function exportInlineScreenshotForVerbose(
+  value: unknown,
+  serialized: CliVerboseScreenshotRefLike,
+  options: CliVerboseScreenshotCollectOptions,
+): string | undefined {
+  if (typeof serialized.path === 'string') {
+    return serialized.path;
+  }
+
+  const exportMode = options.exportMode ?? 'tmp';
+  if (exportMode === 'none') {
+    return undefined;
+  }
+
+  const rawBase64 = screenshotRawBase64(value);
+  if (!rawBase64) {
+    return undefined;
+  }
+
+  const directoryPath =
+    exportMode === 'report' &&
+    typeof options.reportFile === 'string' &&
+    options.reportFile.length > 0
+      ? join(dirname(options.reportFile), 'screenshots')
+      : undefined;
+  const directoryName = directoryPath ? undefined : 'midscene-cli-screenshots';
+  const extension = getStringProperty(value, 'extension');
+  const cacheKey = inlineScreenshotCacheKey(
+    rawBase64,
+    serialized,
+    directoryPath,
+    directoryName,
+    extension,
+  );
+  const cachedPath = options.cache?.get(cacheKey);
+  if (cachedPath) {
+    return cachedPath;
+  }
+
+  try {
+    const path = writeCliScreenshotFile(rawBase64, {
+      id: serialized.id,
+      mimeType: serialized.mimeType,
+      extension,
+      ...(directoryPath ? { directoryPath } : { directoryName }),
+      overwrite: false,
+    });
+    options.cache?.set(cacheKey, path);
+    return path;
+  } catch {
+    return undefined;
+  }
+}
+
+export function collectScreenshotRefs(
+  value: unknown,
+  options: CliVerboseScreenshotCollectOptions = {},
+): Array<Record<string, unknown>> {
+  const screenshots: Array<Record<string, unknown>> = [];
+  const visit = (candidate: unknown, timing?: unknown): void => {
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) {
+        visit(item, timing);
+      }
+      return;
+    }
+
+    const serialized = toSerializableScreenshot(candidate);
+    if (serialized?.type === 'midscene_screenshot_ref') {
+      const screenshot: Record<string, unknown> = {
+        id: serialized.id,
+        storage: serialized.storage,
+      };
+      const exportedPath = exportInlineScreenshotForVerbose(
+        candidate,
+        serialized,
+        options,
+      );
+      if (exportedPath) {
+        screenshot.path = exportedPath;
+        screenshot.file = basename(exportedPath);
+      }
+      if (typeof timing === 'string') {
+        screenshot.timing = timing;
+      }
+      screenshots.push(screenshot);
+      return;
+    }
+
+    if (!isRecord(candidate)) {
+      return;
+    }
+
+    const screenshotRecord = candidate.screenshot;
+    if (screenshotRecord) {
+      visit(screenshotRecord, candidate.timing);
+    }
+    if (candidate.recorder) {
+      visit(candidate.recorder);
+    }
+    if (isRecord(candidate.uiContext)) {
+      visit(candidate.uiContext.screenshot);
+    }
+  };
+
+  visit(value);
+  return screenshots;
+}
+
+export function pathForReportScreenshot(
+  path: string,
+  reportFile?: unknown,
+): string {
+  const resolvedPath =
+    typeof reportFile === 'string' &&
+    reportFile.length > 0 &&
+    (path.startsWith('./') || path.startsWith('../'))
+      ? join(dirname(reportFile), path)
+      : path;
+
+  if (!isAbsolute(resolvedPath)) {
+    return resolvedPath;
+  }
+
+  const relativePath = relative(process.cwd(), resolvedPath);
+  if (
+    relativePath &&
+    !relativePath.startsWith('..') &&
+    !isAbsolute(relativePath)
+  ) {
+    return relativePath;
+  }
+
+  return resolvedPath;
+}
+
+export function latestScreenshotPathForAiAct(
+  value: unknown,
+  options: CliVerboseScreenshotCollectOptions = {},
+): string {
+  const screenshot = collectScreenshotRefs(value, {
+    ...options,
+    exportMode: options.exportMode ?? 'report',
+  })
+    .slice()
+    .reverse()
+    .find((item) => typeof item.path === 'string' && item.path.length > 0);
+  const path = typeof screenshot?.path === 'string' ? screenshot.path : '';
+  return path ? pathForReportScreenshot(path, options.reportFile) : '';
+}
+
+export function renderScreenshotList(screenshots: unknown): string {
+  if (!Array.isArray(screenshots) || screenshots.length === 0) {
+    return '';
+  }
+
+  return screenshots
+    .map((item) => {
+      if (!isRecord(item)) {
+        return '';
+      }
+      const path =
+        typeof item.path === 'string'
+          ? item.path
+          : typeof item.file === 'string'
+            ? item.file
+            : typeof item.id === 'string'
+              ? item.id
+              : '';
+      const timing = typeof item.timing === 'string' ? item.timing : '';
+      return [timing, path].filter(Boolean).join(' ');
+    })
+    .filter(Boolean)
+    .join(', ');
+}

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,0 +1,393 @@
+import { basename } from 'node:path';
+
+export const cliVerboseFlag = 'verbose';
+
+const progressEventName = 'midscene_progress';
+const cliVerboseContextKey = '__midscene_cli_verbose_context__';
+
+export interface CliVerboseContext {
+  enabled: boolean;
+  scriptName?: string;
+  commandName?: string;
+  startedAt?: number;
+}
+
+export interface CliVerboseEvent {
+  event: string;
+  scriptName?: string;
+  command?: string;
+  status?: 'ok' | 'error';
+  durationMs?: number;
+  error?: string;
+  [key: string]: unknown;
+}
+
+type DumpUpdateAgent = {
+  addDumpUpdateListener?: (
+    listener: (dump: string, executionDump?: unknown) => void,
+  ) => () => void;
+  reportFile?: string | null;
+};
+
+interface CliVerboseScreenshotRefLike {
+  type: 'midscene_screenshot_ref';
+  id?: unknown;
+  storage?: unknown;
+  path?: string;
+}
+
+interface CliVerboseExecutionTaskLike {
+  taskId?: unknown;
+  type?: unknown;
+  subType?: unknown;
+  status?: unknown;
+  param?: unknown;
+  errorMessage?: unknown;
+  timing?: {
+    cost?: unknown;
+  };
+  recorder?: unknown;
+  uiContext?: {
+    screenshot?: unknown;
+  };
+}
+
+interface CliVerboseExecutionDumpLike {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+  tasks: CliVerboseExecutionTaskLike[];
+}
+
+const getGlobalContext = (): { current: CliVerboseContext } => {
+  const globalWithContext = globalThis as unknown as Record<
+    string,
+    { current: CliVerboseContext } | undefined
+  >;
+  if (!globalWithContext[cliVerboseContextKey]) {
+    globalWithContext[cliVerboseContextKey] = { current: { enabled: false } };
+  }
+  return globalWithContext[cliVerboseContextKey]!;
+};
+
+export function stripVerboseFlag(argv: readonly string[]): {
+  rawArgs: string[];
+  verbose: boolean;
+} {
+  const rawArgs: string[] = [];
+  let verbose = false;
+
+  for (const arg of argv) {
+    if (arg === `--${cliVerboseFlag}`) {
+      verbose = true;
+      continue;
+    }
+    rawArgs.push(arg);
+  }
+
+  return { rawArgs, verbose };
+}
+
+export async function withCliVerboseContext<T>(
+  context: CliVerboseContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const globalContext = getGlobalContext();
+  const previous = globalContext.current;
+  globalContext.current = context;
+  try {
+    return await fn();
+  } finally {
+    globalContext.current = previous;
+  }
+}
+
+export function getCliVerboseContext(): CliVerboseContext {
+  return getGlobalContext().current;
+}
+
+export function isCliVerboseEnabled(): boolean {
+  return getCliVerboseContext().enabled;
+}
+
+export function emitCliVerboseEvent(event: CliVerboseEvent): void {
+  const context = getCliVerboseContext();
+  if (!context.enabled) {
+    return;
+  }
+
+  const payload = {
+    type: progressEventName,
+    timestamp: new Date().toISOString(),
+    scriptName: context.scriptName,
+    command: context.commandName,
+    ...event,
+  };
+  console.log(JSON.stringify(payload));
+}
+
+function errorMessageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactPrimitiveCliVerboseValue(
+  value: unknown,
+): { handled: true; value: unknown } | { handled: false } {
+  if (value === undefined || value === null) {
+    return { handled: true, value };
+  }
+
+  if (typeof value === 'string') {
+    return {
+      handled: true,
+      value: value.length > 180 ? `${value.slice(0, 177)}...` : value,
+    };
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return { handled: true, value };
+  }
+
+  if (typeof value !== 'object') {
+    return { handled: true, value: String(value) };
+  }
+
+  return { handled: false };
+}
+
+function compactStructuredCliVerboseValue(value: unknown): unknown {
+  const primitive = compactPrimitiveCliVerboseValue(value);
+  if (primitive.handled) {
+    return primitive.value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map(compactStructuredCliVerboseValue);
+  }
+
+  if (!isRecord(value)) {
+    return String(value);
+  }
+
+  const entries = Object.entries(value).slice(0, 6);
+  return Object.fromEntries(
+    entries.map(([key, entryValue]) => [
+      key,
+      compactStructuredCliVerboseValue(entryValue),
+    ]),
+  );
+}
+
+export function compactCliVerboseValue(value: unknown): unknown {
+  const primitive = compactPrimitiveCliVerboseValue(value);
+  if (primitive.handled) {
+    return primitive.value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map(compactCliVerboseValue);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactCliVerboseValue(value.prompt);
+  }
+
+  if (!isRecord(value)) {
+    return String(value);
+  }
+
+  const entries = Object.entries(value).slice(0, 6);
+  return Object.fromEntries(
+    entries.map(([key, entryValue]) => [
+      key,
+      compactCliVerboseValue(entryValue),
+    ]),
+  );
+}
+
+export function compactCliVerboseArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(args)
+      .slice(0, 8)
+      .map(([key, value]) => [key, compactStructuredCliVerboseValue(value)]),
+  );
+}
+
+function summarizeParam(param: unknown): unknown {
+  if (!param || typeof param !== 'object') {
+    return compactCliVerboseValue(param);
+  }
+
+  const record = param as Record<string, unknown>;
+  if (typeof record.prompt === 'string') {
+    return compactCliVerboseValue(record.prompt);
+  }
+  if (
+    record.locate &&
+    typeof record.locate === 'object' &&
+    record.locate !== null
+  ) {
+    const locate = record.locate as Record<string, unknown>;
+    return {
+      locate: compactCliVerboseValue(locate.prompt),
+      ...Object.fromEntries(
+        Object.entries(record)
+          .filter(([key]) => key !== 'locate')
+          .slice(0, 4)
+          .map(([key, value]) => [key, compactCliVerboseValue(value)]),
+      ),
+    };
+  }
+
+  return compactCliVerboseValue(record);
+}
+
+function isCliVerboseScreenshotRefLike(
+  value: unknown,
+): value is CliVerboseScreenshotRefLike {
+  return isRecord(value) && value.type === 'midscene_screenshot_ref';
+}
+
+function toSerializableScreenshot(
+  value: unknown,
+): CliVerboseScreenshotRefLike | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const maybeSerializable = value as {
+    toSerializable?: () => unknown;
+  };
+  if (typeof maybeSerializable.toSerializable === 'function') {
+    try {
+      const serialized = maybeSerializable.toSerializable();
+      return isCliVerboseScreenshotRefLike(serialized) ? serialized : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return isCliVerboseScreenshotRefLike(value) ? value : null;
+}
+
+function collectScreenshotRefs(value: unknown): Array<Record<string, unknown>> {
+  const screenshots: Array<Record<string, unknown>> = [];
+  const visit = (candidate: unknown, timing?: unknown): void => {
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) {
+        visit(item, timing);
+      }
+      return;
+    }
+
+    const serialized = toSerializableScreenshot(candidate);
+    if (serialized?.type === 'midscene_screenshot_ref') {
+      const screenshot: Record<string, unknown> = {
+        id: serialized.id,
+        storage: serialized.storage,
+      };
+      if (typeof serialized.path === 'string') {
+        screenshot.path = serialized.path;
+        screenshot.file = basename(serialized.path);
+      }
+      if (typeof timing === 'string') {
+        screenshot.timing = timing;
+      }
+      screenshots.push(screenshot);
+      return;
+    }
+
+    if (!isRecord(candidate)) {
+      return;
+    }
+
+    const screenshotRecord = candidate.screenshot;
+    if (screenshotRecord) {
+      visit(screenshotRecord, candidate.timing);
+    }
+    if (candidate.recorder) {
+      visit(candidate.recorder);
+    }
+    if (isRecord(candidate.uiContext)) {
+      visit(candidate.uiContext.screenshot);
+    }
+  };
+
+  visit(value);
+  return screenshots;
+}
+
+function isCliVerboseExecutionDumpLike(
+  value: unknown,
+): value is CliVerboseExecutionDumpLike {
+  return isRecord(value) && Array.isArray(value.tasks);
+}
+
+function summarizeDumpUpdate(
+  executionDump: unknown,
+): Record<string, unknown> | undefined {
+  if (!isCliVerboseExecutionDumpLike(executionDump)) {
+    return undefined;
+  }
+
+  const tasks = executionDump.tasks;
+  const latestTask = tasks[tasks.length - 1];
+
+  return {
+    execution: {
+      id: executionDump.id,
+      name: executionDump.name,
+      description: compactCliVerboseValue(executionDump.description),
+      taskCount: tasks.length,
+    },
+    task: latestTask
+      ? {
+          id: latestTask.taskId,
+          index: tasks.length,
+          total: tasks.length,
+          type: latestTask.type,
+          subType: latestTask.subType,
+          status: latestTask.status,
+          param: summarizeParam(latestTask.param),
+          error: latestTask.errorMessage,
+          durationMs: latestTask.timing?.cost,
+        }
+      : undefined,
+    screenshots: latestTask
+      ? collectScreenshotRefs(latestTask).slice(-3)
+      : undefined,
+  };
+}
+
+export function attachCliVerboseDumpListener(
+  agent: DumpUpdateAgent,
+  options?: { toolName?: string },
+): () => void {
+  if (!isCliVerboseEnabled()) {
+    return () => {};
+  }
+  if (typeof agent.addDumpUpdateListener !== 'function') {
+    return () => {};
+  }
+
+  return agent.addDumpUpdateListener((_dump, executionDump) => {
+    const summary = summarizeDumpUpdate(executionDump);
+    if (!summary) {
+      return;
+    }
+    emitCliVerboseEvent({
+      event: 'dump_update',
+      tool: options?.toolName,
+      report: agent.reportFile || undefined,
+      ...summary,
+    });
+  });
+}
+
+export { errorMessageOf as cliVerboseErrorMessage };

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,4 +1,9 @@
-import { type CliVerboseLine, buildAiActTimelineLines } from './verbose-ai-act';
+import {
+  type CliAiActProgressEvent,
+  type CliVerboseLine,
+  buildAiActProgressEventLines,
+  normalizeAiActProgressEventForCli,
+} from './verbose-ai-act';
 import {
   type CliVerboseScreenshotCollectOptions,
   type CliVerboseScreenshotExportMode,
@@ -35,6 +40,9 @@ export interface CliVerboseEvent {
 type DumpUpdateAgent = {
   addDumpUpdateListener?: (
     listener: (dump: string, executionDump?: unknown) => void,
+  ) => () => void;
+  addAiActProgressListener?: (
+    listener: (event: CliAiActProgressEvent) => void,
   ) => () => void;
   reportFile?: string | null;
 };
@@ -531,6 +539,19 @@ function renderCliVerboseEventText(
   const tool = typeof event.tool === 'string' ? event.tool : undefined;
 
   switch (event.event) {
+    case 'ai_act_progress': {
+      if (!isActVerboseEvent(command, tool)) {
+        return undefined;
+      }
+      const progressEvent = isRecord(event.aiAct) ? event.aiAct : undefined;
+      if (!progressEvent) {
+        return undefined;
+      }
+      return renderLinesOnce(
+        context,
+        buildAiActProgressEventLines(progressEvent),
+      );
+    }
     case 'ai_act_start': {
       const prompt = compactText(event.prompt);
       const text = prompt
@@ -664,15 +685,37 @@ export function attachCliVerboseDumpListener(
   if (!isCliVerboseEnabled()) {
     return () => {};
   }
+
+  const isActTool = options?.toolName === 'act';
+  const screenshotExportCache = new Map<string, string>();
+
+  if (isActTool && typeof agent.addAiActProgressListener === 'function') {
+    return agent.addAiActProgressListener((aiActEvent) => {
+      const context = getCliVerboseContext();
+      const isTextMode = context.format !== 'jsonl';
+      const progress = normalizeAiActProgressEventForCli(aiActEvent, {
+        reportFile: agent.reportFile,
+        exportMode: isTextMode ? 'report' : 'none',
+        cache: screenshotExportCache,
+      });
+      if (!progress) {
+        return;
+      }
+      emitCliVerboseEvent({
+        event: 'ai_act_progress',
+        tool: options?.toolName,
+        aiAct: progress,
+      });
+    });
+  }
+
   if (typeof agent.addDumpUpdateListener !== 'function') {
     return () => {};
   }
 
-  const screenshotExportCache = new Map<string, string>();
   return agent.addDumpUpdateListener((_dump, executionDump) => {
     const context = getCliVerboseContext();
     const isTextMode = context.format !== 'jsonl';
-    const isActTool = options?.toolName === 'act';
     const summaryExportMode: CliVerboseScreenshotExportMode =
       isTextMode && !isActTool ? 'tmp' : 'none';
     const summary = summarizeDumpUpdate(executionDump, {
@@ -682,19 +725,10 @@ export function attachCliVerboseDumpListener(
     if (!summary) {
       return;
     }
-    const aiActTimeline =
-      isTextMode && isActTool
-        ? buildAiActTimelineLines(executionDump, {
-            reportFile: agent.reportFile,
-            exportMode: 'report',
-            cache: screenshotExportCache,
-          })
-        : undefined;
     emitCliVerboseEvent({
       event: 'dump_update',
       tool: options?.toolName,
       report: agent.reportFile || undefined,
-      ...(aiActTimeline ? { aiActTimeline } : {}),
       ...summary,
     });
   });

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -5,8 +5,11 @@ export const cliVerboseFlag = 'verbose';
 const progressEventName = 'midscene_progress';
 const cliVerboseContextKey = '__midscene_cli_verbose_context__';
 
+export type CliVerboseFormat = 'text' | 'jsonl';
+
 export interface CliVerboseContext {
   enabled: boolean;
+  format?: CliVerboseFormat;
   scriptName?: string;
   commandName?: string;
   startedAt?: number;
@@ -42,6 +45,9 @@ interface CliVerboseExecutionTaskLike {
   subType?: unknown;
   status?: unknown;
   param?: unknown;
+  thought?: unknown;
+  output?: unknown;
+  log?: unknown;
   errorMessage?: unknown;
   timing?: {
     cost?: unknown;
@@ -50,6 +56,20 @@ interface CliVerboseExecutionTaskLike {
   uiContext?: {
     screenshot?: unknown;
   };
+}
+
+interface CliVerboseStepSummary {
+  id?: unknown;
+  index: number;
+  total: number;
+  type?: unknown;
+  subType?: unknown;
+  status?: unknown;
+  param?: unknown;
+  message: string;
+  error?: unknown;
+  durationMs?: unknown;
+  screenshots?: Array<Record<string, unknown>>;
 }
 
 interface CliVerboseExecutionDumpLike {
@@ -70,22 +90,39 @@ const getGlobalContext = (): { current: CliVerboseContext } => {
   return globalWithContext[cliVerboseContextKey]!;
 };
 
+function parseVerboseFormat(rawFormat: string): CliVerboseFormat {
+  if (rawFormat === 'text' || rawFormat === 'jsonl') {
+    return rawFormat;
+  }
+
+  throw new Error(
+    `Unsupported --${cliVerboseFlag} format "${rawFormat}". Use "--${cliVerboseFlag}" or "--${cliVerboseFlag}=jsonl".`,
+  );
+}
+
 export function stripVerboseFlag(argv: readonly string[]): {
   rawArgs: string[];
   verbose: boolean;
+  format: CliVerboseFormat;
 } {
   const rawArgs: string[] = [];
   let verbose = false;
+  let format: CliVerboseFormat = 'text';
 
   for (const arg of argv) {
     if (arg === `--${cliVerboseFlag}`) {
       verbose = true;
       continue;
     }
+    if (arg.startsWith(`--${cliVerboseFlag}=`)) {
+      verbose = true;
+      format = parseVerboseFormat(arg.slice(`--${cliVerboseFlag}=`.length));
+      continue;
+    }
     rawArgs.push(arg);
   }
 
-  return { rawArgs, verbose };
+  return { rawArgs, verbose, format };
 }
 
 export async function withCliVerboseContext<T>(
@@ -123,7 +160,16 @@ export function emitCliVerboseEvent(event: CliVerboseEvent): void {
     command: context.commandName,
     ...event,
   };
-  console.log(JSON.stringify(payload));
+
+  if (context.format === 'jsonl') {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+
+  const text = renderCliVerboseEventText(payload);
+  if (text) {
+    console.log(text);
+  }
 }
 
 function errorMessageOf(error: unknown): string {
@@ -132,6 +178,27 @@ function errorMessageOf(error: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactText(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    return json.length > 180 ? `${json.slice(0, 177)}...` : json;
+  } catch {
+    return String(value);
+  }
 }
 
 function compactPrimitiveCliVerboseValue(
@@ -248,6 +315,114 @@ function summarizeParam(param: unknown): unknown {
   return compactCliVerboseValue(record);
 }
 
+function summarizeUserInstruction(value: unknown): string {
+  if (typeof value === 'string') {
+    return compactText(value);
+  }
+
+  if (isRecord(value) && typeof value.prompt === 'string') {
+    return compactText(value.prompt);
+  }
+
+  return compactText(value);
+}
+
+function summarizeTaskParamText(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.param)) {
+    return compactText(summarizeParam(task.param));
+  }
+
+  if (task.type === 'Planning' && task.subType !== 'Locate') {
+    if (task.param.userInstructionDisplay) {
+      return summarizeUserInstruction(task.param.userInstructionDisplay);
+    }
+    if (task.param.userInstruction) {
+      return summarizeUserInstruction(task.param.userInstruction);
+    }
+  }
+
+  if (task.param.dataDemand) {
+    return compactText(summarizeParam(task.param.dataDemand));
+  }
+
+  if (task.param.assertion) {
+    return compactText(summarizeParam(task.param.assertion));
+  }
+
+  return compactText(summarizeParam(task.param));
+}
+
+function summarizeSubGoals(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const goals = value
+    .slice(0, 6)
+    .map((goal) => {
+      if (!isRecord(goal)) {
+        return '';
+      }
+      const index = typeof goal.index === 'number' ? `${goal.index}. ` : '';
+      const status = typeof goal.status === 'string' ? `[${goal.status}] ` : '';
+      const description =
+        typeof goal.description === 'string' ? goal.description : '';
+      return `${index}${status}${description}`.trim();
+    })
+    .filter(Boolean);
+
+  return goals.length > 0 ? `sub-goals: ${goals.join('; ')}` : '';
+}
+
+function summarizeActions(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const actions = value
+    .slice(0, 5)
+    .map((action) => {
+      if (!isRecord(action)) {
+        return '';
+      }
+      const type = typeof action.type === 'string' ? action.type : 'Action';
+      const param = compactText(summarizeParam(action.param));
+      return param ? `${type}: ${param}` : type;
+    })
+    .filter(Boolean);
+
+  return actions.length > 0 ? `actions: ${actions.join('; ')}` : '';
+}
+
+function summarizeTaskOutputText(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.output)) {
+    return compactText(task.output);
+  }
+
+  return (
+    summarizeSubGoals(task.output.updateSubGoals) ||
+    compactText(task.output.log) ||
+    compactText(task.output.output) ||
+    summarizeActions(task.output.actions)
+  );
+}
+
+function summarizeTaskText(task: CliVerboseExecutionTaskLike): string {
+  const parts = [task.type, task.subType].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0,
+  );
+  const label = parts.length > 0 ? parts.join('/') : 'Task';
+  const status =
+    typeof task.status === 'string' && task.status.length > 0
+      ? task.status
+      : 'unknown';
+  const param = summarizeTaskParamText(task);
+  const output = summarizeTaskOutputText(task);
+  const thought = compactText(task.thought);
+  const detail = output || thought || param;
+  return detail ? `${label} ${status}: ${detail}` : `${label} ${status}`;
+}
+
 function isCliVerboseScreenshotRefLike(
   value: unknown,
 ): value is CliVerboseScreenshotRefLike {
@@ -338,6 +513,21 @@ function summarizeDumpUpdate(
 
   const tasks = executionDump.tasks;
   const latestTask = tasks[tasks.length - 1];
+  const steps = tasks.map(
+    (task, index): CliVerboseStepSummary => ({
+      id: task.taskId,
+      index: index + 1,
+      total: tasks.length,
+      type: task.type,
+      subType: task.subType,
+      status: task.status,
+      param: summarizeParam(task.param),
+      message: summarizeTaskText(task),
+      error: task.errorMessage,
+      durationMs: task.timing?.cost,
+      screenshots: collectScreenshotRefs(task).slice(-3),
+    }),
+  );
 
   return {
     execution: {
@@ -346,6 +536,7 @@ function summarizeDumpUpdate(
       description: compactCliVerboseValue(executionDump.description),
       taskCount: tasks.length,
     },
+    steps,
     task: latestTask
       ? {
           id: latestTask.taskId,
@@ -355,14 +546,128 @@ function summarizeDumpUpdate(
           subType: latestTask.subType,
           status: latestTask.status,
           param: summarizeParam(latestTask.param),
+          message: summarizeTaskText(latestTask),
           error: latestTask.errorMessage,
           durationMs: latestTask.timing?.cost,
         }
       : undefined,
-    screenshots: latestTask
-      ? collectScreenshotRefs(latestTask).slice(-3)
-      : undefined,
+    screenshots: collectScreenshotRefs(tasks).slice(-5),
   };
+}
+
+function stringifyArgs(args: unknown): string {
+  if (!isRecord(args) || Object.keys(args).length === 0) {
+    return '';
+  }
+
+  return Object.entries(args)
+    .map(([key, value]) => `${key}=${compactText(value)}`)
+    .join(', ');
+}
+
+function renderScreenshotList(screenshots: unknown): string {
+  if (!Array.isArray(screenshots) || screenshots.length === 0) {
+    return '';
+  }
+
+  return screenshots
+    .map((item) => {
+      if (!isRecord(item)) {
+        return '';
+      }
+      const path =
+        typeof item.path === 'string'
+          ? item.path
+          : typeof item.file === 'string'
+            ? item.file
+            : typeof item.id === 'string'
+              ? item.id
+              : '';
+      const timing = typeof item.timing === 'string' ? item.timing : '';
+      return [timing, path].filter(Boolean).join(' ');
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+function renderCliVerboseEventText(event: CliVerboseEvent): string | undefined {
+  const command = typeof event.command === 'string' ? event.command : 'command';
+  const tool = typeof event.tool === 'string' ? event.tool : undefined;
+
+  switch (event.event) {
+    case 'command_start': {
+      const args = stringifyArgs(event.args);
+      return args
+        ? `[Midscene] ${command} started (${args})`
+        : `[Midscene] ${command} started`;
+    }
+    case 'agent_ready':
+      return `[Midscene] ${tool ?? command} ready`;
+    case 'dump_update': {
+      const task = isRecord(event.task) ? event.task : undefined;
+      const steps = Array.isArray(event.steps)
+        ? event.steps.filter(isRecord)
+        : [];
+      const execution = isRecord(event.execution) ? event.execution : undefined;
+      const executionName =
+        typeof execution?.name === 'string' ? execution.name : 'execution';
+      const lines =
+        steps.length > 0
+          ? [
+              `[Midscene] Progress: ${executionName} (${steps.length} steps)`,
+              ...steps.map((step) => {
+                const index =
+                  typeof step.index === 'number' &&
+                  typeof step.total === 'number'
+                    ? `Step ${step.index}/${step.total}`
+                    : 'Step';
+                const message =
+                  typeof step.message === 'string'
+                    ? step.message
+                    : typeof step.status === 'string'
+                      ? step.status
+                      : 'updated';
+                return `[Midscene] ${index}: ${message}`;
+              }),
+            ]
+          : [
+              `[Midscene] Step: ${
+                typeof task?.message === 'string'
+                  ? task.message
+                  : typeof task?.status === 'string'
+                    ? task.status
+                    : 'updated'
+              }`,
+            ];
+      const screenshots = renderScreenshotList(event.screenshots);
+      if (screenshots) {
+        lines.push(`[Midscene] Screenshot: ${screenshots}`);
+      }
+      if (typeof event.report === 'string' && event.report.length > 0) {
+        lines.push(`[Midscene] Report: ${event.report}`);
+      }
+      return lines.join('\n');
+    }
+    case 'artifact': {
+      const kind = typeof event.kind === 'string' ? event.kind : 'artifact';
+      const path = typeof event.path === 'string' ? event.path : undefined;
+      return path
+        ? `[Midscene] ${kind} saved: ${path}`
+        : `[Midscene] ${kind} ready`;
+    }
+    case 'command_done': {
+      const status = event.status === 'error' ? 'failed' : 'finished';
+      const duration =
+        typeof event.durationMs === 'number' ? ` in ${event.durationMs}ms` : '';
+      const error =
+        event.status === 'error' && typeof event.error === 'string'
+          ? `: ${event.error}`
+          : '';
+      return `[Midscene] ${command} ${status}${duration}${error}`;
+    }
+    default:
+      return undefined;
+  }
 }
 
 export function attachCliVerboseDumpListener(

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,6 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename } from 'node:path';
+import { writeCliScreenshotFile } from './screenshot-file';
 
 export const cliVerboseFlag = 'verbose';
 
@@ -454,23 +453,6 @@ function toSerializableScreenshot(
   return isCliVerboseScreenshotRefLike(value) ? value : null;
 }
 
-function safeScreenshotId(value: unknown): string {
-  const id = typeof value === 'string' && value.length > 0 ? value : 'shot';
-  return id.replace(/[^a-zA-Z0-9._-]/g, '_') || 'shot';
-}
-
-function extensionFromScreenshot(
-  value: unknown,
-  serialized: CliVerboseScreenshotRefLike,
-): 'png' | 'jpeg' {
-  if (isRecord(value) && typeof value.extension === 'string') {
-    return value.extension === 'jpeg' || value.extension === 'jpg'
-      ? 'jpeg'
-      : 'png';
-  }
-  return serialized.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
-}
-
 function getStringProperty(value: unknown, key: string): string | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -511,19 +493,13 @@ function exportInlineScreenshotForVerbose(
   }
 
   try {
-    const screenshotDir = join(tmpdir(), 'midscene-cli-screenshots');
-    if (!existsSync(screenshotDir)) {
-      mkdirSync(screenshotDir, { recursive: true });
-    }
-
-    const filePath = join(
-      screenshotDir,
-      `${safeScreenshotId(serialized.id)}.${extensionFromScreenshot(value, serialized)}`,
-    );
-    if (!existsSync(filePath)) {
-      writeFileSync(filePath, Buffer.from(rawBase64, 'base64'));
-    }
-    return filePath;
+    return writeCliScreenshotFile(rawBase64, {
+      id: serialized.id,
+      mimeType: serialized.mimeType,
+      extension: getStringProperty(value, 'extension'),
+      directoryName: 'midscene-cli-screenshots',
+      overwrite: false,
+    });
   } catch {
     return undefined;
   }

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,5 +1,10 @@
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
-import { writeCliScreenshotFile } from './screenshot-file';
+import { type CliVerboseLine, buildAiActTimelineLines } from './verbose-ai-act';
+import {
+  type CliVerboseScreenshotCollectOptions,
+  type CliVerboseScreenshotExportMode,
+  collectScreenshotRefs,
+  renderScreenshotList,
+} from './verbose-screenshot';
 
 export const cliVerboseFlag = 'verbose';
 
@@ -33,14 +38,6 @@ type DumpUpdateAgent = {
   ) => () => void;
   reportFile?: string | null;
 };
-
-interface CliVerboseScreenshotRefLike {
-  type: 'midscene_screenshot_ref';
-  id?: unknown;
-  mimeType?: unknown;
-  storage?: unknown;
-  path?: string;
-}
 
 interface CliVerboseExecutionTaskLike {
   taskId?: unknown;
@@ -80,11 +77,6 @@ interface CliVerboseExecutionDumpLike {
   name?: unknown;
   description?: unknown;
   tasks: CliVerboseExecutionTaskLike[];
-}
-
-interface CliVerboseLine {
-  key: string;
-  text: string;
 }
 
 const getGlobalContext = (): { current: CliVerboseContext } => {
@@ -434,148 +426,6 @@ function summarizeTaskText(task: CliVerboseExecutionTaskLike): string {
   return detail ? `${label} ${status}: ${detail}` : `${label} ${status}`;
 }
 
-function isCliVerboseScreenshotRefLike(
-  value: unknown,
-): value is CliVerboseScreenshotRefLike {
-  return isRecord(value) && value.type === 'midscene_screenshot_ref';
-}
-
-function toSerializableScreenshot(
-  value: unknown,
-): CliVerboseScreenshotRefLike | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  const maybeSerializable = value as {
-    toSerializable?: () => unknown;
-  };
-  if (typeof maybeSerializable.toSerializable === 'function') {
-    try {
-      const serialized = maybeSerializable.toSerializable();
-      return isCliVerboseScreenshotRefLike(serialized) ? serialized : null;
-    } catch {
-      return null;
-    }
-  }
-
-  return isCliVerboseScreenshotRefLike(value) ? value : null;
-}
-
-function getStringProperty(value: unknown, key: string): string | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-
-  try {
-    const property = value[key];
-    return typeof property === 'string' && property.length > 0
-      ? property
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function screenshotRawBase64(value: unknown): string | undefined {
-  const rawBase64 = getStringProperty(value, 'rawBase64');
-  if (rawBase64) {
-    return rawBase64;
-  }
-
-  const base64 = getStringProperty(value, 'base64');
-  const match = base64?.match(/^data:image\/(?:png|jpeg|jpg);base64,(.+)$/);
-  return match?.[1];
-}
-
-function exportInlineScreenshotForVerbose(
-  value: unknown,
-  serialized: CliVerboseScreenshotRefLike,
-  reportFile?: unknown,
-): string | undefined {
-  if (typeof serialized.path === 'string') {
-    return serialized.path;
-  }
-
-  const rawBase64 = screenshotRawBase64(value);
-  if (!rawBase64) {
-    return undefined;
-  }
-
-  try {
-    const directoryPath =
-      typeof reportFile === 'string' && reportFile.length > 0
-        ? join(dirname(reportFile), 'screenshots')
-        : undefined;
-    return writeCliScreenshotFile(rawBase64, {
-      id: serialized.id,
-      mimeType: serialized.mimeType,
-      extension: getStringProperty(value, 'extension'),
-      ...(directoryPath
-        ? { directoryPath }
-        : { directoryName: 'midscene-cli-screenshots' }),
-      overwrite: false,
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-function collectScreenshotRefs(
-  value: unknown,
-  reportFile?: unknown,
-): Array<Record<string, unknown>> {
-  const screenshots: Array<Record<string, unknown>> = [];
-  const visit = (candidate: unknown, timing?: unknown): void => {
-    if (Array.isArray(candidate)) {
-      for (const item of candidate) {
-        visit(item, timing);
-      }
-      return;
-    }
-
-    const serialized = toSerializableScreenshot(candidate);
-    if (serialized?.type === 'midscene_screenshot_ref') {
-      const screenshot: Record<string, unknown> = {
-        id: serialized.id,
-        storage: serialized.storage,
-      };
-      const exportedPath = exportInlineScreenshotForVerbose(
-        candidate,
-        serialized,
-        reportFile,
-      );
-      if (exportedPath) {
-        screenshot.path = exportedPath;
-        screenshot.file = basename(exportedPath);
-      }
-      if (typeof timing === 'string') {
-        screenshot.timing = timing;
-      }
-      screenshots.push(screenshot);
-      return;
-    }
-
-    if (!isRecord(candidate)) {
-      return;
-    }
-
-    const screenshotRecord = candidate.screenshot;
-    if (screenshotRecord) {
-      visit(screenshotRecord, candidate.timing);
-    }
-    if (candidate.recorder) {
-      visit(candidate.recorder);
-    }
-    if (isRecord(candidate.uiContext)) {
-      visit(candidate.uiContext.screenshot);
-    }
-  };
-
-  visit(value);
-  return screenshots;
-}
-
 function isCliVerboseExecutionDumpLike(
   value: unknown,
 ): value is CliVerboseExecutionDumpLike {
@@ -584,6 +434,7 @@ function isCliVerboseExecutionDumpLike(
 
 function summarizeDumpUpdate(
   executionDump: unknown,
+  screenshotOptions: CliVerboseScreenshotCollectOptions = {},
 ): Record<string, unknown> | undefined {
   if (!isCliVerboseExecutionDumpLike(executionDump)) {
     return undefined;
@@ -603,7 +454,7 @@ function summarizeDumpUpdate(
       message: summarizeTaskText(task),
       error: task.errorMessage,
       durationMs: task.timing?.cost,
-      screenshots: collectScreenshotRefs(task).slice(-3),
+      screenshots: collectScreenshotRefs(task, screenshotOptions).slice(-3),
     }),
   );
 
@@ -629,7 +480,7 @@ function summarizeDumpUpdate(
           durationMs: latestTask.timing?.cost,
         }
       : undefined,
-    screenshots: collectScreenshotRefs(tasks).slice(-5),
+    screenshots: collectScreenshotRefs(tasks, screenshotOptions).slice(-5),
   };
 }
 
@@ -640,31 +491,6 @@ function stringifyArgs(args: unknown): string {
 
   return Object.entries(args)
     .map(([key, value]) => `${key}=${compactText(value)}`)
-    .join(', ');
-}
-
-function renderScreenshotList(screenshots: unknown): string {
-  if (!Array.isArray(screenshots) || screenshots.length === 0) {
-    return '';
-  }
-
-  return screenshots
-    .map((item) => {
-      if (!isRecord(item)) {
-        return '';
-      }
-      const path =
-        typeof item.path === 'string'
-          ? item.path
-          : typeof item.file === 'string'
-            ? item.file
-            : typeof item.id === 'string'
-              ? item.id
-              : '';
-      const timing = typeof item.timing === 'string' ? item.timing : '';
-      return [timing, path].filter(Boolean).join(' ');
-    })
-    .filter(Boolean)
     .join(', ');
 }
 
@@ -695,482 +521,6 @@ function renderLinesOnce(
   return pendingLines.length > 0
     ? pendingLines.map((line) => line.text).join('\n')
     : undefined;
-}
-
-function taskKey(task: CliVerboseExecutionTaskLike, fallback: string): string {
-  return typeof task.taskId === 'string' && task.taskId.length > 0
-    ? task.taskId
-    : fallback;
-}
-
-function numberFromUnknown(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
-function integerText(value: number): string {
-  return String(Math.round(value));
-}
-
-function formatPoint(point: readonly [number, number]): string {
-  return `(${integerText(point[0])}, ${integerText(point[1])})`;
-}
-
-function formatBbox(bbox: readonly [number, number, number, number]): string {
-  return `(${bbox.map(integerText).join(',')})`;
-}
-
-function bboxArrayFromProperty(
-  value: Record<string, unknown>,
-  key: string,
-): [number, number, number, number] | undefined {
-  const bbox = value[key];
-  if (!Array.isArray(bbox) || bbox.length < 4) {
-    return undefined;
-  }
-
-  const left = numberFromUnknown(bbox[0]);
-  const top = numberFromUnknown(bbox[1]);
-  const right = numberFromUnknown(bbox[2]);
-  const bottom = numberFromUnknown(bbox[3]);
-  if (
-    left === undefined ||
-    top === undefined ||
-    right === undefined ||
-    bottom === undefined
-  ) {
-    return undefined;
-  }
-
-  return [left, top, right, bottom];
-}
-
-function centerPointFromBbox(
-  bbox: readonly [number, number, number, number],
-): [number, number] {
-  return [
-    Math.floor((bbox[0] + bbox[2]) / 2),
-    Math.floor((bbox[1] + bbox[3]) / 2),
-  ];
-}
-
-function pathForReportScreenshot(path: string, reportFile?: unknown): string {
-  const resolvedPath =
-    typeof reportFile === 'string' &&
-    reportFile.length > 0 &&
-    (path.startsWith('./') || path.startsWith('../'))
-      ? join(dirname(reportFile), path)
-      : path;
-
-  if (!isAbsolute(resolvedPath)) {
-    return resolvedPath;
-  }
-
-  const relativePath = relative(process.cwd(), resolvedPath);
-  if (
-    relativePath &&
-    !relativePath.startsWith('..') &&
-    !isAbsolute(relativePath)
-  ) {
-    return relativePath;
-  }
-
-  return resolvedPath;
-}
-
-function latestScreenshotPathForAiAct(
-  value: unknown,
-  reportFile?: unknown,
-): string {
-  const screenshot = collectScreenshotRefs(value, reportFile)
-    .slice()
-    .reverse()
-    .find((item) => typeof item.path === 'string' && item.path.length > 0);
-  const path = typeof screenshot?.path === 'string' ? screenshot.path : '';
-  return path ? pathForReportScreenshot(path, reportFile) : '';
-}
-
-function planLimitText(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.param)) {
-    return '';
-  }
-  const limit = numberFromUnknown(task.param.replanningCycleLimit);
-  return limit && limit > 0 ? `/${integerText(limit)}` : '';
-}
-
-function planPrefix(
-  task: CliVerboseExecutionTaskLike,
-  planIndex: number,
-): string {
-  return `[Midscene][aiAct][Plan ${planIndex}${planLimitText(task)}]`;
-}
-
-function actionOutputText(value: unknown): string {
-  if (!Array.isArray(value) || value.length === 0) {
-    return '';
-  }
-
-  const action = value.find(isRecord);
-  if (!action) {
-    return '';
-  }
-
-  return (
-    compactText(action.log) ||
-    compactText(action.thought) ||
-    compactText(summarizeParam(action.param))
-  );
-}
-
-function plannedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.output)) {
-    return compactText(task.output) || compactText(task.thought);
-  }
-
-  return (
-    compactText(task.output.log) ||
-    compactText(task.output.thought) ||
-    compactText(task.thought) ||
-    summarizeSubGoals(task.output.updateSubGoals) ||
-    actionOutputText(task.output.actions) ||
-    compactText(task.output.output)
-  );
-}
-
-function completeTextForAiAct(task: CliVerboseExecutionTaskLike): string {
-  if (!isRecord(task.output)) {
-    return '';
-  }
-
-  const output = compactText(task.output.output);
-  if (output) {
-    return output;
-  }
-
-  return task.output.shouldContinuePlanning === false
-    ? plannedTextForAiAct(task)
-    : '';
-}
-
-function pointFromLocateLike(
-  value: Record<string, unknown>,
-): [number, number] | undefined {
-  const center = value.center;
-  if (Array.isArray(center) && center.length >= 2) {
-    const x = numberFromUnknown(center[0]);
-    const y = numberFromUnknown(center[1]);
-    if (x !== undefined && y !== undefined) {
-      return [x, y];
-    }
-  }
-
-  const point = value.point;
-  if (Array.isArray(point) && point.length >= 2) {
-    const x = numberFromUnknown(point[0]);
-    const y = numberFromUnknown(point[1]);
-    if (x !== undefined && y !== undefined) {
-      return [x, y];
-    }
-  }
-
-  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
-  if (locatedPixelBbox) {
-    return centerPointFromBbox(locatedPixelBbox);
-  }
-
-  const bbox = bboxArrayFromProperty(value, 'bbox');
-  if (bbox) {
-    return centerPointFromBbox(bbox);
-  }
-
-  return undefined;
-}
-
-function bboxFromLocateLike(
-  value: Record<string, unknown>,
-): [number, number, number, number] | undefined {
-  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
-  if (locatedPixelBbox) {
-    return locatedPixelBbox;
-  }
-
-  const bbox = bboxArrayFromProperty(value, 'bbox');
-  if (bbox) {
-    return bbox;
-  }
-
-  if (!isRecord(value.rect)) {
-    return undefined;
-  }
-
-  const left = numberFromUnknown(value.rect.left);
-  const top = numberFromUnknown(value.rect.top);
-  const width = numberFromUnknown(value.rect.width);
-  const height = numberFromUnknown(value.rect.height);
-  if (
-    left === undefined ||
-    top === undefined ||
-    width === undefined ||
-    height === undefined
-  ) {
-    return undefined;
-  }
-
-  return [left, top, left + width, top + height];
-}
-
-function targetTextFromLocateLike(value: Record<string, unknown>): string {
-  return (
-    compactText(value.description) ||
-    compactText(value.prompt) ||
-    summarizeUserInstruction(value)
-  );
-}
-
-function isLocateLike(value: unknown): value is Record<string, unknown> {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  return (
-    'center' in value ||
-    'rect' in value ||
-    'point' in value ||
-    'bbox' in value ||
-    'prompt' in value ||
-    'description' in value
-  );
-}
-
-const locatorParamKeys = ['locate', 'from', 'to', 'start', 'end'];
-
-function firstLocateLikeParam(
-  param: unknown,
-): Record<string, unknown> | undefined {
-  if (!isRecord(param)) {
-    return undefined;
-  }
-
-  for (const key of locatorParamKeys) {
-    const value = param[key];
-    if (isLocateLike(value)) {
-      return value;
-    }
-  }
-
-  return Object.values(param).find(isLocateLike);
-}
-
-function hasUnresolvedLocateLikeParam(param: unknown): boolean {
-  if (!isRecord(param)) {
-    return false;
-  }
-
-  return Object.entries(param).some(([key, value]) => {
-    if (locatorParamKeys.includes(key) && typeof value === 'string') {
-      return true;
-    }
-
-    return (
-      isLocateLike(value) &&
-      !pointFromLocateLike(value) &&
-      !bboxFromLocateLike(value)
-    );
-  });
-}
-
-interface AiActActionText {
-  action: string;
-  running: string;
-  done: string;
-}
-
-function sleepActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  if (actionName !== 'Sleep' || !isRecord(param)) {
-    return undefined;
-  }
-
-  const timeMs =
-    numberFromUnknown(param.timeMs) ??
-    numberFromUnknown(param.duration) ??
-    numberFromUnknown(param.timeoutMs);
-  const action = timeMs ? `Sleep ${integerText(timeMs)}ms` : 'Sleep';
-  return {
-    action,
-    running: action,
-    done: 'Sleep',
-  };
-}
-
-function locateActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  const locate = firstLocateLikeParam(param);
-  if (!locate) {
-    return undefined;
-  }
-
-  const point = pointFromLocateLike(locate);
-  const bbox = bboxFromLocateLike(locate);
-  if (!point) {
-    return undefined;
-  }
-
-  const target = targetTextFromLocateLike(locate);
-  const targetSegment = target ? ` "${target}"` : '';
-  const pointSegment = ` at ${formatPoint(point)}`;
-  const bboxSegment = bbox ? `, bbox=${formatBbox(bbox)}` : '';
-  return {
-    action: `${actionName}${targetSegment}${pointSegment}${bboxSegment}`,
-    running: `${actionName} at ${formatPoint(point)}`,
-    done: actionName,
-  };
-}
-
-function genericActionText(
-  actionName: string,
-  param: unknown,
-): AiActActionText | undefined {
-  if (hasUnresolvedLocateLikeParam(param)) {
-    return undefined;
-  }
-
-  const paramText = compactText(summarizeParam(param));
-  const action = paramText ? `${actionName}: ${paramText}` : actionName;
-  return {
-    action,
-    running: action,
-    done: actionName,
-  };
-}
-
-function actionTextForAiAct(
-  task: CliVerboseExecutionTaskLike,
-): AiActActionText | undefined {
-  const actionName =
-    typeof task.subType === 'string' && task.subType.length > 0
-      ? task.subType
-      : 'Action';
-  return (
-    sleepActionText(actionName, task.param) ||
-    locateActionText(actionName, task.param) ||
-    genericActionText(actionName, task.param)
-  );
-}
-
-function buildAiActTimelineLines(
-  executionDump: unknown,
-  reportFile?: unknown,
-): CliVerboseLine[] {
-  if (!isCliVerboseExecutionDumpLike(executionDump)) {
-    return [];
-  }
-
-  const lines: CliVerboseLine[] = [];
-  let planIndex = 0;
-  let currentPlan:
-    | {
-        index: number;
-        prefix: string;
-      }
-    | undefined;
-
-  executionDump.tasks.forEach((task, taskIndex) => {
-    const fallbackKey = String(taskIndex + 1);
-    if (task.type === 'Planning' && task.subType === 'Plan') {
-      planIndex += 1;
-      currentPlan = {
-        index: planIndex,
-        prefix: planPrefix(task, planIndex),
-      };
-      const keyPrefix = `aiAct:plan:${taskKey(task, fallbackKey)}`;
-      const screenshotPath = latestScreenshotPathForAiAct(task, reportFile);
-      if (screenshotPath) {
-        lines.push({
-          key: `${keyPrefix}:thinking`,
-          text: `${currentPlan.prefix} Thinking with the latest screenshot: ${screenshotPath}`,
-        });
-      }
-
-      if (task.status === 'finished') {
-        const plannedText = plannedTextForAiAct(task);
-        if (plannedText) {
-          lines.push({
-            key: `${keyPrefix}:planned`,
-            text: `${currentPlan.prefix} Planned: ${plannedText}`,
-          });
-        }
-
-        const completeText = completeTextForAiAct(task);
-        if (completeText) {
-          lines.push({
-            key: `${keyPrefix}:complete`,
-            text: `[Midscene][aiAct] Complete: ${completeText}`,
-          });
-        }
-      }
-      return;
-    }
-
-    if (
-      !currentPlan ||
-      task.type !== 'Action Space' ||
-      task.subType === 'Finished'
-    ) {
-      return;
-    }
-
-    const actionText = actionTextForAiAct(task);
-    if (!actionText) {
-      return;
-    }
-
-    const keyPrefix = `aiAct:action:${taskKey(task, fallbackKey)}`;
-    lines.push({
-      key: `${keyPrefix}:planned`,
-      text: `${currentPlan.prefix} Action: ${actionText.action}`,
-    });
-
-    if (task.status === 'running') {
-      lines.push({
-        key: `${keyPrefix}:running`,
-        text: `[Midscene][aiAct][Action] Running: ${actionText.running}`,
-      });
-    }
-
-    if (task.status === 'finished') {
-      const cost =
-        typeof task.timing?.cost === 'number'
-          ? ` cost=${integerText(task.timing.cost)}ms`
-          : '';
-      lines.push({
-        key: `${keyPrefix}:finished`,
-        text: `[Midscene][aiAct][Action] Done: ${actionText.done}${cost}`,
-      });
-    }
-
-    if (task.status === 'failed') {
-      const cost =
-        typeof task.timing?.cost === 'number'
-          ? ` cost=${integerText(task.timing.cost)}ms`
-          : '';
-      const error =
-        typeof task.errorMessage === 'string' && task.errorMessage.length > 0
-          ? ` error=${task.errorMessage}`
-          : '';
-      lines.push({
-        key: `${keyPrefix}:failed`,
-        text: `[Midscene][aiAct][Action] Failed: ${actionText.done}${cost}${error}`,
-      });
-    }
-  });
-
-  return lines;
 }
 
 function renderCliVerboseEventText(
@@ -1279,6 +629,18 @@ function renderCliVerboseEventText(
     }
     case 'command_done': {
       if (isActVerboseEvent(command, tool)) {
+        if (event.status === 'error') {
+          const error =
+            typeof event.error === 'string' && event.error.length > 0
+              ? `: ${event.error}`
+              : '';
+          return renderLinesOnce(context, [
+            {
+              key: `aiAct:command_failed:${event.error ?? 'unknown'}`,
+              text: `[Midscene][aiAct] Failed${error}`,
+            },
+          ]);
+        }
         return undefined;
       }
       const status = event.status === 'error' ? 'failed' : 'finished';
@@ -1306,15 +668,27 @@ export function attachCliVerboseDumpListener(
     return () => {};
   }
 
+  const screenshotExportCache = new Map<string, string>();
   return agent.addDumpUpdateListener((_dump, executionDump) => {
-    const summary = summarizeDumpUpdate(executionDump);
+    const context = getCliVerboseContext();
+    const isTextMode = context.format !== 'jsonl';
+    const isActTool = options?.toolName === 'act';
+    const summaryExportMode: CliVerboseScreenshotExportMode =
+      isTextMode && !isActTool ? 'tmp' : 'none';
+    const summary = summarizeDumpUpdate(executionDump, {
+      exportMode: summaryExportMode,
+      cache: screenshotExportCache,
+    });
     if (!summary) {
       return;
     }
-    const context = getCliVerboseContext();
     const aiActTimeline =
-      context.format !== 'jsonl' && options?.toolName === 'act'
-        ? buildAiActTimelineLines(executionDump, agent.reportFile)
+      isTextMode && isActTool
+        ? buildAiActTimelineLines(executionDump, {
+            reportFile: agent.reportFile,
+            exportMode: 'report',
+            cache: screenshotExportCache,
+          })
         : undefined;
     emitCliVerboseEvent({
       event: 'dump_update',

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import { writeCliScreenshotFile } from './screenshot-file';
 
 export const cliVerboseFlag = 'verbose';
@@ -14,6 +14,7 @@ export interface CliVerboseContext {
   scriptName?: string;
   commandName?: string;
   startedAt?: number;
+  renderedLineKeys?: Set<string>;
 }
 
 export interface CliVerboseEvent {
@@ -81,6 +82,11 @@ interface CliVerboseExecutionDumpLike {
   tasks: CliVerboseExecutionTaskLike[];
 }
 
+interface CliVerboseLine {
+  key: string;
+  text: string;
+}
+
 const getGlobalContext = (): { current: CliVerboseContext } => {
   const globalWithContext = globalThis as unknown as Record<
     string,
@@ -133,7 +139,10 @@ export async function withCliVerboseContext<T>(
 ): Promise<T> {
   const globalContext = getGlobalContext();
   const previous = globalContext.current;
-  globalContext.current = context;
+  globalContext.current = {
+    ...context,
+    renderedLineKeys: context.renderedLineKeys ?? new Set(),
+  };
   try {
     return await fn();
   } finally {
@@ -168,7 +177,7 @@ export function emitCliVerboseEvent(event: CliVerboseEvent): void {
     return;
   }
 
-  const text = renderCliVerboseEventText(payload);
+  const text = renderCliVerboseEventText(payload, context);
   if (text) {
     console.log(text);
   }
@@ -482,6 +491,7 @@ function screenshotRawBase64(value: unknown): string | undefined {
 function exportInlineScreenshotForVerbose(
   value: unknown,
   serialized: CliVerboseScreenshotRefLike,
+  reportFile?: unknown,
 ): string | undefined {
   if (typeof serialized.path === 'string') {
     return serialized.path;
@@ -493,11 +503,17 @@ function exportInlineScreenshotForVerbose(
   }
 
   try {
+    const directoryPath =
+      typeof reportFile === 'string' && reportFile.length > 0
+        ? join(dirname(reportFile), 'screenshots')
+        : undefined;
     return writeCliScreenshotFile(rawBase64, {
       id: serialized.id,
       mimeType: serialized.mimeType,
       extension: getStringProperty(value, 'extension'),
-      directoryName: 'midscene-cli-screenshots',
+      ...(directoryPath
+        ? { directoryPath }
+        : { directoryName: 'midscene-cli-screenshots' }),
       overwrite: false,
     });
   } catch {
@@ -505,7 +521,10 @@ function exportInlineScreenshotForVerbose(
   }
 }
 
-function collectScreenshotRefs(value: unknown): Array<Record<string, unknown>> {
+function collectScreenshotRefs(
+  value: unknown,
+  reportFile?: unknown,
+): Array<Record<string, unknown>> {
   const screenshots: Array<Record<string, unknown>> = [];
   const visit = (candidate: unknown, timing?: unknown): void => {
     if (Array.isArray(candidate)) {
@@ -524,6 +543,7 @@ function collectScreenshotRefs(value: unknown): Array<Record<string, unknown>> {
       const exportedPath = exportInlineScreenshotForVerbose(
         candidate,
         serialized,
+        reportFile,
       );
       if (exportedPath) {
         screenshot.path = exportedPath;
@@ -648,20 +668,561 @@ function renderScreenshotList(screenshots: unknown): string {
     .join(', ');
 }
 
-function renderCliVerboseEventText(event: CliVerboseEvent): string | undefined {
+function isActVerboseEvent(command?: string, tool?: string): boolean {
+  return command === 'act' || tool === 'act';
+}
+
+function renderLinesOnce(
+  context: CliVerboseContext,
+  lines: CliVerboseLine[],
+): string | undefined {
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  if (!context.renderedLineKeys) {
+    context.renderedLineKeys = new Set();
+  }
+  const renderedLineKeys = context.renderedLineKeys;
+  const pendingLines = lines.filter((line) => {
+    if (renderedLineKeys.has(line.key)) {
+      return false;
+    }
+    renderedLineKeys.add(line.key);
+    return true;
+  });
+
+  return pendingLines.length > 0
+    ? pendingLines.map((line) => line.text).join('\n')
+    : undefined;
+}
+
+function taskKey(task: CliVerboseExecutionTaskLike, fallback: string): string {
+  return typeof task.taskId === 'string' && task.taskId.length > 0
+    ? task.taskId
+    : fallback;
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function integerText(value: number): string {
+  return String(Math.round(value));
+}
+
+function formatPoint(point: readonly [number, number]): string {
+  return `(${integerText(point[0])}, ${integerText(point[1])})`;
+}
+
+function formatBbox(bbox: readonly [number, number, number, number]): string {
+  return `(${bbox.map(integerText).join(',')})`;
+}
+
+function bboxArrayFromProperty(
+  value: Record<string, unknown>,
+  key: string,
+): [number, number, number, number] | undefined {
+  const bbox = value[key];
+  if (!Array.isArray(bbox) || bbox.length < 4) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(bbox[0]);
+  const top = numberFromUnknown(bbox[1]);
+  const right = numberFromUnknown(bbox[2]);
+  const bottom = numberFromUnknown(bbox[3]);
+  if (
+    left === undefined ||
+    top === undefined ||
+    right === undefined ||
+    bottom === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, right, bottom];
+}
+
+function centerPointFromBbox(
+  bbox: readonly [number, number, number, number],
+): [number, number] {
+  return [
+    Math.floor((bbox[0] + bbox[2]) / 2),
+    Math.floor((bbox[1] + bbox[3]) / 2),
+  ];
+}
+
+function pathForReportScreenshot(path: string, reportFile?: unknown): string {
+  const resolvedPath =
+    typeof reportFile === 'string' &&
+    reportFile.length > 0 &&
+    (path.startsWith('./') || path.startsWith('../'))
+      ? join(dirname(reportFile), path)
+      : path;
+
+  if (!isAbsolute(resolvedPath)) {
+    return resolvedPath;
+  }
+
+  const relativePath = relative(process.cwd(), resolvedPath);
+  if (
+    relativePath &&
+    !relativePath.startsWith('..') &&
+    !isAbsolute(relativePath)
+  ) {
+    return relativePath;
+  }
+
+  return resolvedPath;
+}
+
+function latestScreenshotPathForAiAct(
+  value: unknown,
+  reportFile?: unknown,
+): string {
+  const screenshot = collectScreenshotRefs(value, reportFile)
+    .slice()
+    .reverse()
+    .find((item) => typeof item.path === 'string' && item.path.length > 0);
+  const path = typeof screenshot?.path === 'string' ? screenshot.path : '';
+  return path ? pathForReportScreenshot(path, reportFile) : '';
+}
+
+function planLimitText(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.param)) {
+    return '';
+  }
+  const limit = numberFromUnknown(task.param.replanningCycleLimit);
+  return limit && limit > 0 ? `/${integerText(limit)}` : '';
+}
+
+function planPrefix(
+  task: CliVerboseExecutionTaskLike,
+  planIndex: number,
+): string {
+  return `[Midscene][aiAct][Plan ${planIndex}${planLimitText(task)}]`;
+}
+
+function actionOutputText(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return '';
+  }
+
+  const action = value.find(isRecord);
+  if (!action) {
+    return '';
+  }
+
+  return (
+    compactText(action.log) ||
+    compactText(action.thought) ||
+    compactText(summarizeParam(action.param))
+  );
+}
+
+function plannedTextForAiAct(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.output)) {
+    return compactText(task.output) || compactText(task.thought);
+  }
+
+  return (
+    compactText(task.output.log) ||
+    compactText(task.output.thought) ||
+    compactText(task.thought) ||
+    summarizeSubGoals(task.output.updateSubGoals) ||
+    actionOutputText(task.output.actions) ||
+    compactText(task.output.output)
+  );
+}
+
+function completeTextForAiAct(task: CliVerboseExecutionTaskLike): string {
+  if (!isRecord(task.output)) {
+    return '';
+  }
+
+  const output = compactText(task.output.output);
+  if (output) {
+    return output;
+  }
+
+  return task.output.shouldContinuePlanning === false
+    ? plannedTextForAiAct(task)
+    : '';
+}
+
+function pointFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number] | undefined {
+  const center = value.center;
+  if (Array.isArray(center) && center.length >= 2) {
+    const x = numberFromUnknown(center[0]);
+    const y = numberFromUnknown(center[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const point = value.point;
+  if (Array.isArray(point) && point.length >= 2) {
+    const x = numberFromUnknown(point[0]);
+    const y = numberFromUnknown(point[1]);
+    if (x !== undefined && y !== undefined) {
+      return [x, y];
+    }
+  }
+
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return centerPointFromBbox(locatedPixelBbox);
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return centerPointFromBbox(bbox);
+  }
+
+  return undefined;
+}
+
+function bboxFromLocateLike(
+  value: Record<string, unknown>,
+): [number, number, number, number] | undefined {
+  const locatedPixelBbox = bboxArrayFromProperty(value, 'locatedPixelBbox');
+  if (locatedPixelBbox) {
+    return locatedPixelBbox;
+  }
+
+  const bbox = bboxArrayFromProperty(value, 'bbox');
+  if (bbox) {
+    return bbox;
+  }
+
+  if (!isRecord(value.rect)) {
+    return undefined;
+  }
+
+  const left = numberFromUnknown(value.rect.left);
+  const top = numberFromUnknown(value.rect.top);
+  const width = numberFromUnknown(value.rect.width);
+  const height = numberFromUnknown(value.rect.height);
+  if (
+    left === undefined ||
+    top === undefined ||
+    width === undefined ||
+    height === undefined
+  ) {
+    return undefined;
+  }
+
+  return [left, top, left + width, top + height];
+}
+
+function targetTextFromLocateLike(value: Record<string, unknown>): string {
+  return (
+    compactText(value.description) ||
+    compactText(value.prompt) ||
+    summarizeUserInstruction(value)
+  );
+}
+
+function isLocateLike(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    'center' in value ||
+    'rect' in value ||
+    'point' in value ||
+    'bbox' in value ||
+    'prompt' in value ||
+    'description' in value
+  );
+}
+
+const locatorParamKeys = ['locate', 'from', 'to', 'start', 'end'];
+
+function firstLocateLikeParam(
+  param: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(param)) {
+    return undefined;
+  }
+
+  for (const key of locatorParamKeys) {
+    const value = param[key];
+    if (isLocateLike(value)) {
+      return value;
+    }
+  }
+
+  return Object.values(param).find(isLocateLike);
+}
+
+function hasUnresolvedLocateLikeParam(param: unknown): boolean {
+  if (!isRecord(param)) {
+    return false;
+  }
+
+  return Object.entries(param).some(([key, value]) => {
+    if (locatorParamKeys.includes(key) && typeof value === 'string') {
+      return true;
+    }
+
+    return (
+      isLocateLike(value) &&
+      !pointFromLocateLike(value) &&
+      !bboxFromLocateLike(value)
+    );
+  });
+}
+
+interface AiActActionText {
+  action: string;
+  running: string;
+  done: string;
+}
+
+function sleepActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  if (actionName !== 'Sleep' || !isRecord(param)) {
+    return undefined;
+  }
+
+  const timeMs =
+    numberFromUnknown(param.timeMs) ??
+    numberFromUnknown(param.duration) ??
+    numberFromUnknown(param.timeoutMs);
+  const action = timeMs ? `Sleep ${integerText(timeMs)}ms` : 'Sleep';
+  return {
+    action,
+    running: action,
+    done: 'Sleep',
+  };
+}
+
+function locateActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  const locate = firstLocateLikeParam(param);
+  if (!locate) {
+    return undefined;
+  }
+
+  const point = pointFromLocateLike(locate);
+  const bbox = bboxFromLocateLike(locate);
+  if (!point) {
+    return undefined;
+  }
+
+  const target = targetTextFromLocateLike(locate);
+  const targetSegment = target ? ` "${target}"` : '';
+  const pointSegment = ` at ${formatPoint(point)}`;
+  const bboxSegment = bbox ? `, bbox=${formatBbox(bbox)}` : '';
+  return {
+    action: `${actionName}${targetSegment}${pointSegment}${bboxSegment}`,
+    running: `${actionName} at ${formatPoint(point)}`,
+    done: actionName,
+  };
+}
+
+function genericActionText(
+  actionName: string,
+  param: unknown,
+): AiActActionText | undefined {
+  if (hasUnresolvedLocateLikeParam(param)) {
+    return undefined;
+  }
+
+  const paramText = compactText(summarizeParam(param));
+  const action = paramText ? `${actionName}: ${paramText}` : actionName;
+  return {
+    action,
+    running: action,
+    done: actionName,
+  };
+}
+
+function actionTextForAiAct(
+  task: CliVerboseExecutionTaskLike,
+): AiActActionText | undefined {
+  const actionName =
+    typeof task.subType === 'string' && task.subType.length > 0
+      ? task.subType
+      : 'Action';
+  return (
+    sleepActionText(actionName, task.param) ||
+    locateActionText(actionName, task.param) ||
+    genericActionText(actionName, task.param)
+  );
+}
+
+function buildAiActTimelineLines(
+  executionDump: unknown,
+  reportFile?: unknown,
+): CliVerboseLine[] {
+  if (!isCliVerboseExecutionDumpLike(executionDump)) {
+    return [];
+  }
+
+  const lines: CliVerboseLine[] = [];
+  let planIndex = 0;
+  let currentPlan:
+    | {
+        index: number;
+        prefix: string;
+      }
+    | undefined;
+
+  executionDump.tasks.forEach((task, taskIndex) => {
+    const fallbackKey = String(taskIndex + 1);
+    if (task.type === 'Planning' && task.subType === 'Plan') {
+      planIndex += 1;
+      currentPlan = {
+        index: planIndex,
+        prefix: planPrefix(task, planIndex),
+      };
+      const keyPrefix = `aiAct:plan:${taskKey(task, fallbackKey)}`;
+      const screenshotPath = latestScreenshotPathForAiAct(task, reportFile);
+      if (screenshotPath) {
+        lines.push({
+          key: `${keyPrefix}:thinking`,
+          text: `${currentPlan.prefix} Thinking with the latest screenshot: ${screenshotPath}`,
+        });
+      }
+
+      if (task.status === 'finished') {
+        const plannedText = plannedTextForAiAct(task);
+        if (plannedText) {
+          lines.push({
+            key: `${keyPrefix}:planned`,
+            text: `${currentPlan.prefix} Planned: ${plannedText}`,
+          });
+        }
+
+        const completeText = completeTextForAiAct(task);
+        if (completeText) {
+          lines.push({
+            key: `${keyPrefix}:complete`,
+            text: `[Midscene][aiAct] Complete: ${completeText}`,
+          });
+        }
+      }
+      return;
+    }
+
+    if (
+      !currentPlan ||
+      task.type !== 'Action Space' ||
+      task.subType === 'Finished'
+    ) {
+      return;
+    }
+
+    const actionText = actionTextForAiAct(task);
+    if (!actionText) {
+      return;
+    }
+
+    const keyPrefix = `aiAct:action:${taskKey(task, fallbackKey)}`;
+    lines.push({
+      key: `${keyPrefix}:planned`,
+      text: `${currentPlan.prefix} Action: ${actionText.action}`,
+    });
+
+    if (task.status === 'running') {
+      lines.push({
+        key: `${keyPrefix}:running`,
+        text: `[Midscene][aiAct][Action] Running: ${actionText.running}`,
+      });
+    }
+
+    if (task.status === 'finished') {
+      const cost =
+        typeof task.timing?.cost === 'number'
+          ? ` cost=${integerText(task.timing.cost)}ms`
+          : '';
+      lines.push({
+        key: `${keyPrefix}:finished`,
+        text: `[Midscene][aiAct][Action] Done: ${actionText.done}${cost}`,
+      });
+    }
+
+    if (task.status === 'failed') {
+      const cost =
+        typeof task.timing?.cost === 'number'
+          ? ` cost=${integerText(task.timing.cost)}ms`
+          : '';
+      const error =
+        typeof task.errorMessage === 'string' && task.errorMessage.length > 0
+          ? ` error=${task.errorMessage}`
+          : '';
+      lines.push({
+        key: `${keyPrefix}:failed`,
+        text: `[Midscene][aiAct][Action] Failed: ${actionText.done}${cost}${error}`,
+      });
+    }
+  });
+
+  return lines;
+}
+
+function renderCliVerboseEventText(
+  event: CliVerboseEvent,
+  context: CliVerboseContext,
+): string | undefined {
   const command = typeof event.command === 'string' ? event.command : 'command';
   const tool = typeof event.tool === 'string' ? event.tool : undefined;
 
   switch (event.event) {
+    case 'ai_act_start': {
+      const prompt = compactText(event.prompt);
+      const text = prompt
+        ? `[Midscene][aiAct] Start: ${prompt}`
+        : '[Midscene][aiAct] Start';
+      return renderLinesOnce(context, [
+        {
+          key: `aiAct:start:${prompt}`,
+          text,
+        },
+      ]);
+    }
     case 'command_start': {
+      if (isActVerboseEvent(command, tool)) {
+        return undefined;
+      }
       const args = stringifyArgs(event.args);
       return args
         ? `[Midscene] ${command} started (${args})`
         : `[Midscene] ${command} started`;
     }
     case 'agent_ready':
+      if (isActVerboseEvent(command, tool)) {
+        return undefined;
+      }
       return `[Midscene] ${tool ?? command} ready`;
     case 'dump_update': {
+      if (isActVerboseEvent(command, tool)) {
+        const lines = Array.isArray(event.aiActTimeline)
+          ? event.aiActTimeline.filter(isRecord).flatMap((line) => {
+              if (
+                typeof line.key === 'string' &&
+                typeof line.text === 'string'
+              ) {
+                return [{ key: line.key, text: line.text }];
+              }
+              return [];
+            })
+          : [];
+        return renderLinesOnce(context, lines);
+      }
+
       const task = isRecord(event.task) ? event.task : undefined;
       const steps = Array.isArray(event.steps)
         ? event.steps.filter(isRecord)
@@ -707,6 +1268,9 @@ function renderCliVerboseEventText(event: CliVerboseEvent): string | undefined {
       return lines.join('\n');
     }
     case 'artifact': {
+      if (isActVerboseEvent(command, tool)) {
+        return undefined;
+      }
       const kind = typeof event.kind === 'string' ? event.kind : 'artifact';
       const path = typeof event.path === 'string' ? event.path : undefined;
       return path
@@ -714,6 +1278,9 @@ function renderCliVerboseEventText(event: CliVerboseEvent): string | undefined {
         : `[Midscene] ${kind} ready`;
     }
     case 'command_done': {
+      if (isActVerboseEvent(command, tool)) {
+        return undefined;
+      }
       const status = event.status === 'error' ? 'failed' : 'finished';
       const duration =
         typeof event.durationMs === 'number' ? ` in ${event.durationMs}ms` : '';
@@ -744,10 +1311,16 @@ export function attachCliVerboseDumpListener(
     if (!summary) {
       return;
     }
+    const context = getCliVerboseContext();
+    const aiActTimeline =
+      context.format !== 'jsonl' && options?.toolName === 'act'
+        ? buildAiActTimelineLines(executionDump, agent.reportFile)
+        : undefined;
     emitCliVerboseEvent({
       event: 'dump_update',
       tool: options?.toolName,
       report: agent.reportFile || undefined,
+      ...(aiActTimeline ? { aiActTimeline } : {}),
       ...summary,
     });
   });

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -552,18 +552,6 @@ function renderCliVerboseEventText(
         buildAiActProgressEventLines(progressEvent),
       );
     }
-    case 'ai_act_start': {
-      const prompt = compactText(event.prompt);
-      const text = prompt
-        ? `[Midscene][aiAct] Start: ${prompt}`
-        : '[Midscene][aiAct] Start';
-      return renderLinesOnce(context, [
-        {
-          key: `aiAct:start:${prompt}`,
-          text,
-        },
-      ]);
-    }
     case 'command_start': {
       if (isActVerboseEvent(command, tool)) {
         return undefined;
@@ -580,18 +568,7 @@ function renderCliVerboseEventText(
       return `[Midscene] ${tool ?? command} ready`;
     case 'dump_update': {
       if (isActVerboseEvent(command, tool)) {
-        const lines = Array.isArray(event.aiActTimeline)
-          ? event.aiActTimeline.filter(isRecord).flatMap((line) => {
-              if (
-                typeof line.key === 'string' &&
-                typeof line.text === 'string'
-              ) {
-                return [{ key: line.key, text: line.text }];
-              }
-              return [];
-            })
-          : [];
-        return renderLinesOnce(context, lines);
+        return undefined;
       }
 
       const task = isRecord(event.task) ? event.task : undefined;
@@ -707,6 +684,10 @@ export function attachCliVerboseDumpListener(
         aiAct: progress,
       });
     });
+  }
+
+  if (isActTool) {
+    return () => {};
   }
 
   if (typeof agent.addDumpUpdateListener !== 'function') {

--- a/packages/shared/src/cli/verbose.ts
+++ b/packages/shared/src/cli/verbose.ts
@@ -1,4 +1,6 @@
-import { basename } from 'node:path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
 
 export const cliVerboseFlag = 'verbose';
 
@@ -35,6 +37,7 @@ type DumpUpdateAgent = {
 interface CliVerboseScreenshotRefLike {
   type: 'midscene_screenshot_ref';
   id?: unknown;
+  mimeType?: unknown;
   storage?: unknown;
   path?: string;
 }
@@ -451,6 +454,81 @@ function toSerializableScreenshot(
   return isCliVerboseScreenshotRefLike(value) ? value : null;
 }
 
+function safeScreenshotId(value: unknown): string {
+  const id = typeof value === 'string' && value.length > 0 ? value : 'shot';
+  return id.replace(/[^a-zA-Z0-9._-]/g, '_') || 'shot';
+}
+
+function extensionFromScreenshot(
+  value: unknown,
+  serialized: CliVerboseScreenshotRefLike,
+): 'png' | 'jpeg' {
+  if (isRecord(value) && typeof value.extension === 'string') {
+    return value.extension === 'jpeg' || value.extension === 'jpg'
+      ? 'jpeg'
+      : 'png';
+  }
+  return serialized.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  try {
+    const property = value[key];
+    return typeof property === 'string' && property.length > 0
+      ? property
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function screenshotRawBase64(value: unknown): string | undefined {
+  const rawBase64 = getStringProperty(value, 'rawBase64');
+  if (rawBase64) {
+    return rawBase64;
+  }
+
+  const base64 = getStringProperty(value, 'base64');
+  const match = base64?.match(/^data:image\/(?:png|jpeg|jpg);base64,(.+)$/);
+  return match?.[1];
+}
+
+function exportInlineScreenshotForVerbose(
+  value: unknown,
+  serialized: CliVerboseScreenshotRefLike,
+): string | undefined {
+  if (typeof serialized.path === 'string') {
+    return serialized.path;
+  }
+
+  const rawBase64 = screenshotRawBase64(value);
+  if (!rawBase64) {
+    return undefined;
+  }
+
+  try {
+    const screenshotDir = join(tmpdir(), 'midscene-cli-screenshots');
+    if (!existsSync(screenshotDir)) {
+      mkdirSync(screenshotDir, { recursive: true });
+    }
+
+    const filePath = join(
+      screenshotDir,
+      `${safeScreenshotId(serialized.id)}.${extensionFromScreenshot(value, serialized)}`,
+    );
+    if (!existsSync(filePath)) {
+      writeFileSync(filePath, Buffer.from(rawBase64, 'base64'));
+    }
+    return filePath;
+  } catch {
+    return undefined;
+  }
+}
+
 function collectScreenshotRefs(value: unknown): Array<Record<string, unknown>> {
   const screenshots: Array<Record<string, unknown>> = [];
   const visit = (candidate: unknown, timing?: unknown): void => {
@@ -467,9 +545,13 @@ function collectScreenshotRefs(value: unknown): Array<Record<string, unknown>> {
         id: serialized.id,
         storage: serialized.storage,
       };
-      if (typeof serialized.path === 'string') {
-        screenshot.path = serialized.path;
-        screenshot.file = basename(serialized.path);
+      const exportedPath = exportInlineScreenshotForVerbose(
+        candidate,
+        serialized,
+      );
+      if (exportedPath) {
+        screenshot.path = exportedPath;
+        screenshot.file = basename(exportedPath);
       }
       if (typeof timing === 'string') {
         screenshot.timing = timing;

--- a/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
+++ b/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
@@ -13,6 +13,11 @@ Commands:
   tap                            Tap on a specific element or coordinate on the screen
   version                        Show CLI version
 
+Global Options:
+  --verbose     Print structured progress events while the command is running.
+  --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
+  --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower).
+
 Run "test-cli <command> --help" for more info."
 `;
 
@@ -24,5 +29,10 @@ Connect to a device for automation
 
 Options:
   --url                  The device URL to connect to
-  --timeout              Connection timeout in ms"
+  --timeout              Connection timeout in ms
+
+Global Options:
+  --verbose     Print structured progress events while the command is running.
+  --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
+  --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower)."
 `;

--- a/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
+++ b/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
@@ -14,7 +14,7 @@ Commands:
   version                        Show CLI version
 
 Global Options:
-  --verbose     Print structured progress events while the command is running.
+  --verbose     Print progress while the command is running. Use --verbose=jsonl for structured events.
   --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
   --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower).
 
@@ -32,7 +32,7 @@ Options:
   --timeout              Connection timeout in ms
 
 Global Options:
-  --verbose     Print structured progress events while the command is running.
+  --verbose     Print progress while the command is running. Use --verbose=jsonl for structured events.
   --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
   --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower)."
 `;

--- a/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
+++ b/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
@@ -14,7 +14,7 @@ Commands:
   version                        Show CLI version
 
 Global Options:
-  --verbose     Print progress while the command is running. Use --verbose=jsonl for structured events.
+  --verbose     Print progress while the command is running. act prints readable progress by default. Use --verbose=jsonl for structured events.
   --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
   --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower).
 
@@ -32,7 +32,7 @@ Options:
   --timeout              Connection timeout in ms
 
 Global Options:
-  --verbose     Print progress while the command is running. Use --verbose=jsonl for structured events.
+  --verbose     Print progress while the command is running. act prints readable progress by default. Use --verbose=jsonl for structured events.
   --deep-locate Force deep locate for every locating operation (better precision for small/ambiguous targets, a bit slower).
   --deep-think  Plan the act tool with deep thinking (richer context and sub-goal decomposition, a bit slower)."
 `;

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -641,6 +641,73 @@ describe('runToolsCLI', () => {
     consoleSpy.mockRestore();
   });
 
+  it('strips global --verbose and emits structured progress events', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'Connected' }],
+      isError: false,
+    });
+    const tools = createMockTools([{ name: 'connect', handler }]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: ['--verbose', 'connect', '--url', 'https://example.com'],
+    });
+
+    expect(handler).toHaveBeenCalledWith({ url: 'https://example.com' });
+    const progressEvents = consoleSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes('"type":"midscene_progress"'))
+      .map((message) => JSON.parse(message));
+    expect(progressEvents.map((event) => event.event)).toEqual([
+      'command_start',
+      'command_done',
+    ]);
+    expect(progressEvents[0]).toMatchObject({
+      scriptName: 'test-cli',
+      command: 'connect',
+      args: { url: 'https://example.com' },
+    });
+    expect(progressEvents[1]).toMatchObject({
+      scriptName: 'test-cli',
+      command: 'connect',
+      status: 'ok',
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('preserves structured command args in verbose progress events', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'Tapped' }],
+      isError: false,
+    });
+    const tools = createMockTools([{ name: 'tap', handler }]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', {
+      argv: [
+        '--verbose',
+        'tap',
+        '--locate',
+        '{"prompt":"Submit","deepLocate":true}',
+      ],
+    });
+
+    const progressEvents = consoleSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes('"type":"midscene_progress"'))
+      .map((message) => JSON.parse(message));
+    expect(progressEvents[0]).toMatchObject({
+      event: 'command_start',
+      args: {
+        locate: {
+          prompt: 'Submit',
+          deepLocate: true,
+        },
+      },
+    });
+    consoleSpy.mockRestore();
+  });
+
   it('strips platform prefix from command names', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'ok' }],
@@ -691,6 +758,21 @@ describe('runToolsCLI', () => {
     vi.restoreAllMocks();
   });
 
+  it('calls destroy when a command handler throws', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('boom'));
+    const tools = createMockTools([{ name: 'explode', handler }]);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      runToolsCLI(tools, 'test-cli', {
+        argv: ['--verbose', 'explode'],
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(tools.destroy).toHaveBeenCalledOnce();
+    vi.restoreAllMocks();
+  });
+
   it('matches commands case-insensitively', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'tapped' }],
@@ -735,7 +817,13 @@ describe('runToolsCLI', () => {
     expect(output).toContain('  tap');
     expect(output).toContain('  scroll');
     // Command names column should not have uppercase originals
-    const commandLines = output.split('\n').filter((l) => l.startsWith('  '));
+    const commandLines = output
+      .split('\n')
+      .slice(
+        output.split('\n').indexOf('Commands:') + 1,
+        output.split('\n').indexOf('Global Options:'),
+      )
+      .filter((l) => l.startsWith('  '));
     for (const line of commandLines) {
       const cmdName = line.trimStart().split(/\s{2,}/)[0];
       expect(cmdName).toBe(cmdName.toLowerCase());

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs';
 import {
   CLIError,
   parseCliArgs,
@@ -408,6 +409,27 @@ describe('runToolsCLI', () => {
 
     expect(tools.setToolDefaults).not.toHaveBeenCalled();
     expect(handler).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('writes image tool results with an extension matching the mime type', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'image', data: 'aGVsbG8=', mimeType: 'image/jpeg' }],
+      isError: false,
+    });
+    const tools = createMockTools([{ name: 'take_screenshot', handler }]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runToolsCLI(tools, 'test-cli', { argv: ['take_screenshot'] });
+
+    const message = consoleSpy.mock.calls
+      .map(([line]) => String(line))
+      .find((line) => line.startsWith('Screenshot saved: '));
+    expect(message).toMatch(/^Screenshot saved: .+screenshot-\d+\.jpeg$/);
+    const screenshotPath = message?.replace('Screenshot saved: ', '');
+    expect(screenshotPath).toBeDefined();
+    expect(existsSync(screenshotPath!)).toBe(true);
+    expect(readFileSync(screenshotPath!, 'utf8')).toBe('hello');
     consoleSpy.mockRestore();
   });
 

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -641,7 +641,7 @@ describe('runToolsCLI', () => {
     consoleSpy.mockRestore();
   });
 
-  it('strips global --verbose and emits structured progress events', async () => {
+  it('strips global --verbose and emits readable progress lines', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Connected' }],
       isError: false,
@@ -654,28 +654,16 @@ describe('runToolsCLI', () => {
     });
 
     expect(handler).toHaveBeenCalledWith({ url: 'https://example.com' });
-    const progressEvents = consoleSpy.mock.calls
-      .map(([message]) => String(message))
-      .filter((message) => message.includes('"type":"midscene_progress"'))
-      .map((message) => JSON.parse(message));
-    expect(progressEvents.map((event) => event.event)).toEqual([
-      'command_start',
-      'command_done',
+    const messages = consoleSpy.mock.calls.map(([message]) => String(message));
+    expect(messages).toEqual([
+      '[Midscene] connect started (url=https://example.com)',
+      'Connected',
+      expect.stringMatching(/^\[Midscene\] connect finished in \d+ms$/),
     ]);
-    expect(progressEvents[0]).toMatchObject({
-      scriptName: 'test-cli',
-      command: 'connect',
-      args: { url: 'https://example.com' },
-    });
-    expect(progressEvents[1]).toMatchObject({
-      scriptName: 'test-cli',
-      command: 'connect',
-      status: 'ok',
-    });
     consoleSpy.mockRestore();
   });
 
-  it('preserves structured command args in verbose progress events', async () => {
+  it('preserves structured command args in jsonl verbose progress events', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Tapped' }],
       isError: false,
@@ -685,7 +673,7 @@ describe('runToolsCLI', () => {
 
     await runToolsCLI(tools, 'test-cli', {
       argv: [
-        '--verbose',
+        '--verbose=jsonl',
         'tap',
         '--locate',
         '{"prompt":"Submit","deepLocate":true}',
@@ -698,6 +686,9 @@ describe('runToolsCLI', () => {
       .map((message) => JSON.parse(message));
     expect(progressEvents[0]).toMatchObject({
       event: 'command_start',
+      type: 'midscene_progress',
+      scriptName: 'test-cli',
+      command: 'tap',
       args: {
         locate: {
           prompt: 'Submit',

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -786,6 +786,23 @@ describe('runToolsCLI', () => {
     vi.restoreAllMocks();
   });
 
+  it('emits an aiAct failure line when a verbose act command throws', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('boom'));
+    const tools = createMockTools([{ name: 'act', handler }]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      runToolsCLI(tools, 'test-cli', {
+        argv: ['--verbose', 'act'],
+      }),
+    ).rejects.toThrow('boom');
+
+    const messages = consoleSpy.mock.calls.map(([message]) => String(message));
+    expect(messages).toContain('[Midscene][aiAct] Failed: boom');
+    expect(tools.destroy).toHaveBeenCalledOnce();
+    vi.restoreAllMocks();
+  });
+
   it('matches commands case-insensitively', async () => {
     const handler = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'tapped' }],

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -786,14 +786,14 @@ describe('runToolsCLI', () => {
     vi.restoreAllMocks();
   });
 
-  it('emits an aiAct failure line when a verbose act command throws', async () => {
+  it('emits an aiAct failure line when an act command throws by default', async () => {
     const handler = vi.fn().mockRejectedValue(new Error('boom'));
     const tools = createMockTools([{ name: 'act', handler }]);
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', {
-        argv: ['--verbose', 'act'],
+        argv: ['act'],
       }),
     ).rejects.toThrow('boom');
 

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1,3 +1,4 @@
+import { withCliVerboseContext } from '@/cli';
 import {
   generateCommonTools,
   generateToolsFromActionSpace,
@@ -741,6 +742,111 @@ describe('toolDefaults (deep locate / deep think)', () => {
       deepThink: false,
       deepLocate: true,
     });
+  });
+
+  it('emits verbose dump update events while act is running', async () => {
+    let dumpListener:
+      | ((dump: string, executionDump?: unknown) => void)
+      | undefined;
+    const unsubscribe = vi.fn();
+    const aiAction = vi.fn().mockImplementation(async () => {
+      dumpListener?.('{}', {
+        id: 'execution-1',
+        name: 'AI Action',
+        description: 'open settings',
+        tasks: [
+          {
+            taskId: 'task-1',
+            type: 'Planning',
+            subType: 'Locate',
+            status: 'running',
+            param: { prompt: 'open settings' },
+            timing: { cost: 12 },
+            recorder: [
+              {
+                timing: 'after-calling',
+                screenshot: {
+                  toSerializable: () => ({
+                    type: 'midscene_screenshot_ref',
+                    id: 'shot-1',
+                    storage: 'file',
+                    path: './screenshots/shot-1.png',
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      });
+      return 'done';
+    });
+    const addDumpUpdateListener = vi.fn((listener) => {
+      dumpListener = listener;
+      return unsubscribe;
+    });
+    const commonTools = generateCommonTools(async () => ({
+      aiAction,
+      addDumpUpdateListener,
+      reportFile: '/tmp/midscene-report.html',
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await withCliVerboseContext(
+      {
+        enabled: true,
+        scriptName: 'midscene-web',
+        commandName: 'act',
+      },
+      async () => {
+        await actTool?.handler({ prompt: 'open settings' });
+      },
+    );
+
+    const progressEvents = consoleSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes('"type":"midscene_progress"'))
+      .map((message) => JSON.parse(message));
+    expect(progressEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'agent_ready',
+        scriptName: 'midscene-web',
+        command: 'act',
+        tool: 'act',
+      }),
+    );
+    expect(progressEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'dump_update',
+        command: 'act',
+        tool: 'act',
+        report: '/tmp/midscene-report.html',
+        execution: expect.objectContaining({
+          id: 'execution-1',
+          name: 'AI Action',
+          taskCount: 1,
+        }),
+        task: expect.objectContaining({
+          id: 'task-1',
+          type: 'Planning',
+          subType: 'Locate',
+          status: 'running',
+          param: 'open settings',
+        }),
+        screenshots: [
+          expect.objectContaining({
+            id: 'shot-1',
+            storage: 'file',
+            path: './screenshots/shot-1.png',
+          }),
+        ],
+      }),
+    );
+    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
   });
 
   it('lets an explicit act deepLocate arg override the server default', async () => {

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -744,7 +744,110 @@ describe('toolDefaults (deep locate / deep think)', () => {
     });
   });
 
-  it('emits verbose dump update events while act is running', async () => {
+  it('emits readable verbose dump updates while act is running', async () => {
+    let dumpListener:
+      | ((dump: string, executionDump?: unknown) => void)
+      | undefined;
+    const unsubscribe = vi.fn();
+    const aiAction = vi.fn().mockImplementation(async () => {
+      dumpListener?.('{}', {
+        id: 'execution-1',
+        name: 'AI Action',
+        description: 'open settings',
+        tasks: [
+          {
+            taskId: 'plan-1',
+            type: 'Planning',
+            subType: 'Plan',
+            status: 'finished',
+            param: { userInstruction: 'open settings' },
+            output: {
+              updateSubGoals: [
+                {
+                  index: 1,
+                  status: 'finished',
+                  description: 'Open settings',
+                },
+                {
+                  index: 2,
+                  status: 'running',
+                  description: 'Locate submit button',
+                },
+              ],
+            },
+            timing: { cost: 20 },
+          },
+          {
+            taskId: 'task-2',
+            type: 'Planning',
+            subType: 'Locate',
+            status: 'running',
+            param: { prompt: 'Submit' },
+            timing: { cost: 12 },
+            recorder: [
+              {
+                timing: 'after-calling',
+                screenshot: {
+                  toSerializable: () => ({
+                    type: 'midscene_screenshot_ref',
+                    id: 'shot-1',
+                    storage: 'file',
+                    path: './screenshots/shot-1.png',
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      });
+      return 'done';
+    });
+    const addDumpUpdateListener = vi.fn((listener) => {
+      dumpListener = listener;
+      return unsubscribe;
+    });
+    const commonTools = generateCommonTools(async () => ({
+      aiAction,
+      addDumpUpdateListener,
+      reportFile: '/tmp/midscene-report.html',
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await withCliVerboseContext(
+      {
+        enabled: true,
+        scriptName: 'midscene-web',
+        commandName: 'act',
+      },
+      async () => {
+        await actTool?.handler({ prompt: 'open settings' });
+      },
+    );
+
+    const messages = consoleSpy.mock.calls.flatMap(([message]) =>
+      String(message).split('\n'),
+    );
+    expect(messages).toContain('[Midscene] act ready');
+    expect(messages).toContain('[Midscene] Progress: AI Action (2 steps)');
+    expect(messages).toContain(
+      '[Midscene] Step 1/2: Planning/Plan finished: sub-goals: 1. [finished] Open settings; 2. [running] Locate submit button',
+    );
+    expect(messages).toContain(
+      '[Midscene] Step 2/2: Planning/Locate running: Submit',
+    );
+    expect(messages).toContain(
+      '[Midscene] Screenshot: after-calling ./screenshots/shot-1.png',
+    );
+    expect(messages).toContain('[Midscene] Report: /tmp/midscene-report.html');
+    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
+  it('emits jsonl verbose dump update events while act is running', async () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
       | undefined;
@@ -797,6 +900,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
     await withCliVerboseContext(
       {
         enabled: true,
+        format: 'jsonl',
         scriptName: 'midscene-web',
         commandName: 'act',
       },
@@ -834,6 +938,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
           subType: 'Locate',
           status: 'running',
           param: 'open settings',
+          message: 'Planning/Locate running: open settings',
         }),
         screenshots: [
           expect.objectContaining({

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs';
 import { withCliVerboseContext } from '@/cli';
 import {
   generateCommonTools,
@@ -842,6 +843,89 @@ describe('toolDefaults (deep locate / deep think)', () => {
       '[Midscene] Screenshot: after-calling ./screenshots/shot-1.png',
     );
     expect(messages).toContain('[Midscene] Report: /tmp/midscene-report.html');
+    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
+  it('exports inline verbose dump screenshots to readable file paths', async () => {
+    let dumpListener:
+      | ((dump: string, executionDump?: unknown) => void)
+      | undefined;
+    const unsubscribe = vi.fn();
+    const aiAction = vi.fn().mockImplementation(async () => {
+      dumpListener?.('{}', {
+        id: 'execution-1',
+        name: 'AI Action',
+        tasks: [
+          {
+            taskId: 'task-1',
+            type: 'Planning',
+            subType: 'Locate',
+            status: 'running',
+            param: { prompt: 'Submit' },
+            recorder: [
+              {
+                timing: 'after-calling',
+                screenshot: {
+                  extension: 'png',
+                  rawBase64: 'Zm9v',
+                  toSerializable: () => ({
+                    type: 'midscene_screenshot_ref',
+                    id: 'inline-shot-1',
+                    capturedAt: 1000,
+                    mimeType: 'image/png',
+                    storage: 'inline',
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      });
+      return 'done';
+    });
+    const addDumpUpdateListener = vi.fn((listener) => {
+      dumpListener = listener;
+      return unsubscribe;
+    });
+    const commonTools = generateCommonTools(async () => ({
+      aiAction,
+      addDumpUpdateListener,
+      reportFile: '/tmp/midscene-report.html',
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await withCliVerboseContext(
+      {
+        enabled: true,
+        scriptName: 'midscene-web',
+        commandName: 'act',
+      },
+      async () => {
+        await actTool?.handler({ prompt: 'open settings' });
+      },
+    );
+
+    const messages = consoleSpy.mock.calls.flatMap(([message]) =>
+      String(message).split('\n'),
+    );
+    const screenshotMessage = messages.find((message) =>
+      message.includes('[Midscene] Screenshot: after-calling '),
+    );
+    expect(screenshotMessage).toMatch(
+      /^\[Midscene\] Screenshot: after-calling .+midscene-cli-screenshots\/inline-shot-1\.png$/,
+    );
+    const screenshotPath = screenshotMessage?.replace(
+      '[Midscene] Screenshot: after-calling ',
+      '',
+    );
+    expect(screenshotPath).toBeDefined();
+    expect(existsSync(screenshotPath!)).toBe(true);
+    expect(readFileSync(screenshotPath!, 'utf8')).toBe('foo');
     expect(addDumpUpdateListener).toHaveBeenCalledOnce();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1003,6 +1003,96 @@ describe('toolDefaults (deep locate / deep think)', () => {
     consoleSpy.mockRestore();
   });
 
+  it('emits human-readable aiAct planning failure details', async () => {
+    let dumpListener:
+      | ((dump: string, executionDump?: unknown) => void)
+      | undefined;
+    const unsubscribe = vi.fn();
+    const reportFile = join(
+      process.cwd(),
+      'midscene_run/report/midscene-report.html',
+    );
+    const aiAction = vi.fn().mockImplementation(async () => {
+      dumpListener?.('{}', {
+        id: 'execution-1',
+        name: 'Act - open settings',
+        description: 'open settings',
+        tasks: [
+          {
+            taskId: 'plan-failed',
+            type: 'Planning',
+            subType: 'Plan',
+            status: 'failed',
+            param: {
+              userInstruction: 'open settings',
+              replanningCycleLimit: 3,
+            },
+            uiContext: {
+              screenshot: {
+                toSerializable: () => ({
+                  type: 'midscene_screenshot_ref',
+                  id: 'failed-shot',
+                  storage: 'file',
+                  path: './screenshots/failed-shot.png',
+                }),
+              },
+            },
+            output: {
+              log: 'The settings entry is not visible.',
+              shouldContinuePlanning: false,
+            },
+            errorMessage: 'Task failed: The settings entry is not visible.',
+          },
+        ],
+      });
+      throw new Error('Task failed: The settings entry is not visible.');
+    });
+    const addDumpUpdateListener = vi.fn((listener) => {
+      dumpListener = listener;
+      return unsubscribe;
+    });
+    const commonTools = generateCommonTools(async () => ({
+      aiAction,
+      addDumpUpdateListener,
+      reportFile,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await withCliVerboseContext(
+      {
+        enabled: true,
+        scriptName: 'midscene-web',
+        commandName: 'act',
+      },
+      async () => actTool?.handler({ prompt: 'open settings' }),
+    );
+
+    const messages = consoleSpy.mock.calls.flatMap(([message]) =>
+      String(message).split('\n'),
+    );
+    expect(result?.isError).toBe(true);
+    expect(messages).toContain('[Midscene][aiAct] Start: open settings');
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 1/3] Thinking with the latest screenshot: midscene_run/report/screenshots/failed-shot.png',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 1/3] Failed: Task failed: The settings entry is not visible.',
+    );
+    expect(messages).not.toContain(
+      '[Midscene][aiAct] Complete: The settings entry is not visible.',
+    );
+    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
   it('exports inline verbose dump screenshots to readable file paths', async () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1114,6 +1114,41 @@ describe('toolDefaults (deep locate / deep think)', () => {
     consoleSpy.mockRestore();
   });
 
+  it('does not render aiAct dump progress without core progress listener', async () => {
+    const unsubscribe = vi.fn();
+    const aiAction = vi.fn().mockResolvedValue('Settings opened.');
+    const addDumpUpdateListener = vi.fn(() => unsubscribe);
+    const commonTools = generateCommonTools(async () => ({
+      aiAction,
+      addDumpUpdateListener,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+    const actTool = commonTools.find((tool) => tool.name === 'act');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await withCliVerboseContext(
+      {
+        enabled: true,
+        scriptName: 'midscene-web',
+        commandName: 'act',
+      },
+      async () => {
+        await actTool?.handler({ prompt: 'open settings' });
+      },
+    );
+
+    const messages = consoleSpy.mock.calls.flatMap(([message]) =>
+      String(message).split('\n'),
+    );
+    expect(
+      messages.some((message) => message.startsWith('[Midscene][aiAct]')),
+    ).toBe(false);
+    expect(addDumpUpdateListener).not.toHaveBeenCalled();
+    expect(unsubscribe).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   it('emits human-readable aiAct planning failure details', async () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
@@ -1351,48 +1386,37 @@ describe('toolDefaults (deep locate / deep think)', () => {
     consoleSpy.mockRestore();
   });
 
-  it('emits jsonl verbose dump update events while act is running', async () => {
-    let dumpListener:
-      | ((dump: string, executionDump?: unknown) => void)
+  it('emits jsonl aiAct progress events while act is running', async () => {
+    let progressListener:
+      | ((event: Record<string, unknown>) => void)
       | undefined;
     const unsubscribe = vi.fn();
     const aiAction = vi.fn().mockImplementation(async () => {
-      dumpListener?.('{}', {
-        id: 'execution-1',
-        name: 'AI Action',
-        description: 'open settings',
-        tasks: [
-          {
-            taskId: 'task-1',
-            type: 'Planning',
-            subType: 'Locate',
-            status: 'running',
-            param: { prompt: 'open settings' },
-            timing: { cost: 12 },
-            recorder: [
-              {
-                timing: 'after-calling',
-                screenshot: {
-                  toSerializable: () => ({
-                    type: 'midscene_screenshot_ref',
-                    id: 'shot-1',
-                    storage: 'file',
-                    path: './screenshots/shot-1.png',
-                  }),
-                },
-              },
-            ],
-          },
-        ],
+      progressListener?.({
+        type: 'aiAct',
+        sequence: 1,
+        event: 'plan_thinking',
+        planIndex: 1,
+        planLimit: 3,
+        screenshot: {
+          toSerializable: () => ({
+            type: 'midscene_screenshot_ref',
+            id: 'shot-1',
+            storage: 'file',
+            path: './screenshots/shot-1.png',
+          }),
+        },
       });
       return 'done';
     });
-    const addDumpUpdateListener = vi.fn((listener) => {
-      dumpListener = listener;
+    const addDumpUpdateListener = vi.fn(() => unsubscribe);
+    const addAiActProgressListener = vi.fn((listener) => {
+      progressListener = listener;
       return unsubscribe;
     });
     const commonTools = generateCommonTools(async () => ({
       aiAction,
+      addAiActProgressListener,
       addDumpUpdateListener,
       reportFile: '/tmp/midscene-report.html',
       getActionSpace: vi.fn().mockResolvedValue([]),
@@ -1427,33 +1451,27 @@ describe('toolDefaults (deep locate / deep think)', () => {
     );
     expect(progressEvents).toContainEqual(
       expect.objectContaining({
-        event: 'dump_update',
+        event: 'ai_act_progress',
         command: 'act',
         tool: 'act',
-        report: '/tmp/midscene-report.html',
-        execution: expect.objectContaining({
-          id: 'execution-1',
-          name: 'AI Action',
-          taskCount: 1,
+        aiAct: expect.objectContaining({
+          type: 'aiAct',
+          sequence: 1,
+          event: 'plan_thinking',
+          planIndex: 1,
+          planLimit: 3,
+          screenshots: [
+            expect.objectContaining({
+              id: 'shot-1',
+              storage: 'file',
+              path: './screenshots/shot-1.png',
+            }),
+          ],
         }),
-        task: expect.objectContaining({
-          id: 'task-1',
-          type: 'Planning',
-          subType: 'Locate',
-          status: 'running',
-          param: 'open settings',
-          message: 'Planning/Locate running: open settings',
-        }),
-        screenshots: [
-          expect.objectContaining({
-            id: 'shot-1',
-            storage: 'file',
-            path: './screenshots/shot-1.png',
-          }),
-        ],
       }),
     );
-    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(addAiActProgressListener).toHaveBeenCalledOnce();
+    expect(addDumpUpdateListener).not.toHaveBeenCalled();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
   });

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { withCliVerboseContext } from '@/cli';
 import {
   generateCommonTools,
   generateToolsFromActionSpace,
 } from '@/agent-tools/tool-generator';
 import { composeUserPrompt } from '@/agent-tools/user-prompt';
+import { withCliVerboseContext } from '@/cli';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -750,11 +750,30 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
       | undefined;
+    let progressListener:
+      | ((event: Record<string, unknown>) => void)
+      | undefined;
     const unsubscribe = vi.fn();
     const reportFile = join(
       process.cwd(),
       'midscene_run/report/midscene-report.html',
     );
+    let sequence = 1;
+    const emitProgress = (event: Record<string, unknown>) => {
+      progressListener?.({
+        type: 'aiAct',
+        sequence: sequence++,
+        ...event,
+      });
+    };
+    const progressScreenshot = (id: string) => ({
+      toSerializable: () => ({
+        type: 'midscene_screenshot_ref',
+        id,
+        storage: 'file',
+        path: `./screenshots/${id}.png`,
+      }),
+    });
     const plan1 = {
       taskId: 'plan-1',
       type: 'Planning',
@@ -915,6 +934,92 @@ describe('toolDefaults (deep locate / deep think)', () => {
       });
     };
     const aiAction = vi.fn().mockImplementation(async () => {
+      emitProgress({
+        event: 'start',
+        prompt: 'open settings',
+        planLimit: 10,
+      });
+      emitProgress({
+        event: 'plan_thinking',
+        planIndex: 1,
+        planLimit: 10,
+        screenshot: progressScreenshot('shot-1'),
+      });
+      emitProgress({
+        event: 'plan_planned',
+        planIndex: 1,
+        planLimit: 10,
+        message: 'Need to open settings first.',
+      });
+      emitProgress({
+        event: 'plan_action',
+        planIndex: 1,
+        planLimit: 10,
+        message: 'Tap "Submit button" at (100, 200), bbox=(80,180,120,220)',
+      });
+      emitProgress({
+        event: 'action_running',
+        planIndex: 1,
+        planLimit: 10,
+        message: 'Tap at (100, 200)',
+      });
+      emitProgress({
+        event: 'action_done',
+        planIndex: 1,
+        planLimit: 10,
+        message: 'Tap',
+        durationMs: 208,
+      });
+      emitProgress({
+        event: 'plan_thinking',
+        planIndex: 2,
+        planLimit: 10,
+        screenshot: progressScreenshot('shot-2'),
+      });
+      emitProgress({
+        event: 'plan_planned',
+        planIndex: 2,
+        planLimit: 10,
+        message: 'The page is still transitioning, so wait briefly.',
+      });
+      emitProgress({
+        event: 'plan_action',
+        planIndex: 2,
+        planLimit: 10,
+        message: 'Sleep 2000ms',
+      });
+      emitProgress({
+        event: 'action_running',
+        planIndex: 2,
+        planLimit: 10,
+        message: 'Sleep 2000ms',
+      });
+      emitProgress({
+        event: 'action_done',
+        planIndex: 2,
+        planLimit: 10,
+        message: 'Sleep',
+        durationMs: 2004,
+      });
+      emitProgress({
+        event: 'plan_thinking',
+        planIndex: 3,
+        planLimit: 10,
+        screenshot: progressScreenshot('shot-3'),
+      });
+      emitProgress({
+        event: 'plan_planned',
+        planIndex: 3,
+        planLimit: 10,
+        message:
+          'The selected page is open, so the requested task is complete.',
+      });
+      emitProgress({
+        event: 'complete',
+        planIndex: 3,
+        planLimit: 10,
+        message: 'Settings opened.',
+      });
       emitDump([plan1, tapStringPending]);
       emitDump([plan1, tapPending]);
       emitDump([plan1, locate1, tapRunning]);
@@ -928,8 +1033,13 @@ describe('toolDefaults (deep locate / deep think)', () => {
       dumpListener = listener;
       return unsubscribe;
     });
+    const addAiActProgressListener = vi.fn((listener) => {
+      progressListener = listener;
+      return unsubscribe;
+    });
     const commonTools = generateCommonTools(async () => ({
       aiAction,
+      addAiActProgressListener,
       addDumpUpdateListener,
       reportFile,
       getActionSpace: vi.fn().mockResolvedValue([]),
@@ -998,7 +1108,8 @@ describe('toolDefaults (deep locate / deep think)', () => {
         message.includes('[Midscene][aiAct][Plan 1/10] Action: Tap'),
       ),
     ).toHaveLength(1);
-    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(addAiActProgressListener).toHaveBeenCalledOnce();
+    expect(addDumpUpdateListener).not.toHaveBeenCalled();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
   });
@@ -1007,12 +1118,48 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
       | undefined;
+    let progressListener:
+      | ((event: Record<string, unknown>) => void)
+      | undefined;
     const unsubscribe = vi.fn();
     const reportFile = join(
       process.cwd(),
       'midscene_run/report/midscene-report.html',
     );
+    let sequence = 1;
+    const emitProgress = (event: Record<string, unknown>) => {
+      progressListener?.({
+        type: 'aiAct',
+        sequence: sequence++,
+        ...event,
+      });
+    };
     const aiAction = vi.fn().mockImplementation(async () => {
+      emitProgress({
+        event: 'start',
+        prompt: 'open settings',
+        planLimit: 3,
+      });
+      emitProgress({
+        event: 'plan_thinking',
+        planIndex: 1,
+        planLimit: 3,
+        screenshot: {
+          toSerializable: () => ({
+            type: 'midscene_screenshot_ref',
+            id: 'failed-shot',
+            storage: 'file',
+            path: './screenshots/failed-shot.png',
+          }),
+        },
+      });
+      emitProgress({
+        event: 'plan_failed',
+        planIndex: 1,
+        planLimit: 3,
+        message: 'Task failed: The settings entry is not visible.',
+        error: 'Task failed: The settings entry is not visible.',
+      });
       dumpListener?.('{}', {
         id: 'execution-1',
         name: 'Act - open settings',
@@ -1051,8 +1198,13 @@ describe('toolDefaults (deep locate / deep think)', () => {
       dumpListener = listener;
       return unsubscribe;
     });
+    const addAiActProgressListener = vi.fn((listener) => {
+      progressListener = listener;
+      return unsubscribe;
+    });
     const commonTools = generateCommonTools(async () => ({
       aiAction,
+      addAiActProgressListener,
       addDumpUpdateListener,
       reportFile,
       getActionSpace: vi.fn().mockResolvedValue([]),
@@ -1087,7 +1239,8 @@ describe('toolDefaults (deep locate / deep think)', () => {
     expect(messages).not.toContain(
       '[Midscene][aiAct] Complete: The settings entry is not visible.',
     );
-    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(addAiActProgressListener).toHaveBeenCalledOnce();
+    expect(addDumpUpdateListener).not.toHaveBeenCalled();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
     consoleErrorSpy.mockRestore();
@@ -1097,8 +1250,29 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
       | undefined;
+    let progressListener:
+      | ((event: Record<string, unknown>) => void)
+      | undefined;
     const unsubscribe = vi.fn();
+    const inlineScreenshot = {
+      extension: 'png',
+      rawBase64: 'Zm9v',
+      toSerializable: () => ({
+        type: 'midscene_screenshot_ref',
+        id: 'inline-shot-1',
+        capturedAt: 1000,
+        mimeType: 'image/png',
+        storage: 'inline',
+      }),
+    };
     const aiAction = vi.fn().mockImplementation(async () => {
+      progressListener?.({
+        type: 'aiAct',
+        sequence: 1,
+        event: 'plan_thinking',
+        planIndex: 1,
+        screenshot: inlineScreenshot,
+      });
       dumpListener?.('{}', {
         id: 'execution-1',
         name: 'Act - open settings',
@@ -1110,32 +1284,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
             status: 'running',
             param: { userInstruction: 'open settings' },
             uiContext: {
-              screenshot: {
-                extension: 'png',
-                rawBase64: 'Zm9v',
-                toSerializable: () => ({
-                  type: 'midscene_screenshot_ref',
-                  id: 'inline-shot-1',
-                  capturedAt: 1000,
-                  mimeType: 'image/png',
-                  storage: 'inline',
-                }),
-              },
+              screenshot: inlineScreenshot,
             },
             recorder: [
               {
                 timing: 'after-calling',
-                screenshot: {
-                  extension: 'png',
-                  rawBase64: 'Zm9v',
-                  toSerializable: () => ({
-                    type: 'midscene_screenshot_ref',
-                    id: 'inline-shot-1',
-                    capturedAt: 1000,
-                    mimeType: 'image/png',
-                    storage: 'inline',
-                  }),
-                },
+                screenshot: inlineScreenshot,
               },
             ],
           },
@@ -1147,8 +1301,13 @@ describe('toolDefaults (deep locate / deep think)', () => {
       dumpListener = listener;
       return unsubscribe;
     });
+    const addAiActProgressListener = vi.fn((listener) => {
+      progressListener = listener;
+      return unsubscribe;
+    });
     const commonTools = generateCommonTools(async () => ({
       aiAction,
+      addAiActProgressListener,
       addDumpUpdateListener,
       reportFile: '/tmp/midscene-report.html',
       getActionSpace: vi.fn().mockResolvedValue([]),
@@ -1186,7 +1345,8 @@ describe('toolDefaults (deep locate / deep think)', () => {
     expect(screenshotPath).toBeDefined();
     expect(existsSync(screenshotPath!)).toBe(true);
     expect(readFileSync(screenshotPath!, 'utf8')).toBe('foo');
-    expect(addDumpUpdateListener).toHaveBeenCalledOnce();
+    expect(addAiActProgressListener).toHaveBeenCalledOnce();
+    expect(addDumpUpdateListener).not.toHaveBeenCalled();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
   });

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { withCliVerboseContext } from '@/cli';
 import {
   generateCommonTools,
@@ -745,63 +746,183 @@ describe('toolDefaults (deep locate / deep think)', () => {
     });
   });
 
-  it('emits readable verbose dump updates while act is running', async () => {
+  it('emits human-readable aiAct verbose timeline while act is running', async () => {
     let dumpListener:
       | ((dump: string, executionDump?: unknown) => void)
       | undefined;
     const unsubscribe = vi.fn();
-    const aiAction = vi.fn().mockImplementation(async () => {
-      dumpListener?.('{}', {
-        id: 'execution-1',
-        name: 'AI Action',
-        description: 'open settings',
-        tasks: [
+    const reportFile = join(
+      process.cwd(),
+      'midscene_run/report/midscene-report.html',
+    );
+    const plan1 = {
+      taskId: 'plan-1',
+      type: 'Planning',
+      subType: 'Plan',
+      status: 'finished',
+      param: {
+        userInstruction: 'open settings',
+        replanningCycleLimit: 10,
+      },
+      uiContext: {
+        screenshot: {
+          toSerializable: () => ({
+            type: 'midscene_screenshot_ref',
+            id: 'shot-1',
+            storage: 'file',
+            path: './screenshots/shot-1.png',
+          }),
+        },
+      },
+      output: {
+        log: 'Need to open settings first.',
+        actions: [
           {
-            taskId: 'plan-1',
-            type: 'Planning',
-            subType: 'Plan',
-            status: 'finished',
-            param: { userInstruction: 'open settings' },
-            output: {
-              updateSubGoals: [
-                {
-                  index: 1,
-                  status: 'finished',
-                  description: 'Open settings',
-                },
-                {
-                  index: 2,
-                  status: 'running',
-                  description: 'Locate submit button',
-                },
-              ],
-            },
-            timing: { cost: 20 },
-          },
-          {
-            taskId: 'task-2',
-            type: 'Planning',
-            subType: 'Locate',
-            status: 'running',
-            param: { prompt: 'Submit' },
-            timing: { cost: 12 },
-            recorder: [
-              {
-                timing: 'after-calling',
-                screenshot: {
-                  toSerializable: () => ({
-                    type: 'midscene_screenshot_ref',
-                    id: 'shot-1',
-                    storage: 'file',
-                    path: './screenshots/shot-1.png',
-                  }),
-                },
-              },
-            ],
+            type: 'Tap',
+            param: { locate: { prompt: 'Submit button' } },
           },
         ],
+        shouldContinuePlanning: true,
+      },
+      timing: { cost: 20 },
+    };
+    const locate1 = {
+      taskId: 'locate-1',
+      type: 'Planning',
+      subType: 'Locate',
+      status: 'finished',
+      param: { prompt: 'Submit button' },
+      output: {
+        element: {
+          description: 'Submit button',
+          center: [100, 200],
+          rect: { left: 80, top: 180, width: 40, height: 40 },
+        },
+      },
+      timing: { cost: 12 },
+    };
+    const tapRunning = {
+      taskId: 'tap-1',
+      type: 'Action Space',
+      subType: 'Tap',
+      status: 'running',
+      param: {
+        locate: {
+          description: 'Submit button',
+          center: [100, 200],
+          rect: { left: 80, top: 180, width: 40, height: 40 },
+        },
+      },
+    };
+    const tapStringPending = {
+      taskId: 'tap-string',
+      type: 'Action Space',
+      subType: 'Tap',
+      status: 'pending',
+      param: { locate: 'Submit button' },
+    };
+    const tapPending = {
+      taskId: 'tap-1',
+      type: 'Action Space',
+      subType: 'Tap',
+      status: 'pending',
+      param: {
+        locate: {
+          prompt: 'Submit button',
+          bbox: [8, 18, 12, 22],
+          locatedPixelBbox: [80, 180, 120, 220],
+        },
+      },
+    };
+    const tapFinished = {
+      ...tapRunning,
+      status: 'finished',
+      timing: { cost: 208 },
+    };
+    const plan2 = {
+      taskId: 'plan-2',
+      type: 'Planning',
+      subType: 'Plan',
+      status: 'finished',
+      param: {
+        userInstruction: 'open settings',
+        replanningCycleLimit: 10,
+      },
+      uiContext: {
+        screenshot: {
+          toSerializable: () => ({
+            type: 'midscene_screenshot_ref',
+            id: 'shot-2',
+            storage: 'file',
+            path: './screenshots/shot-2.png',
+          }),
+        },
+      },
+      output: {
+        log: 'The page is still transitioning, so wait briefly.',
+        actions: [
+          {
+            type: 'Sleep',
+            param: { timeMs: 2000 },
+          },
+        ],
+        shouldContinuePlanning: true,
+      },
+    };
+    const sleepRunning = {
+      taskId: 'sleep-1',
+      type: 'Action Space',
+      subType: 'Sleep',
+      status: 'running',
+      param: { timeMs: 2000 },
+    };
+    const sleepFinished = {
+      ...sleepRunning,
+      status: 'finished',
+      timing: { cost: 2004 },
+    };
+    const plan3 = {
+      taskId: 'plan-3',
+      type: 'Planning',
+      subType: 'Plan',
+      status: 'finished',
+      param: {
+        userInstruction: 'open settings',
+        replanningCycleLimit: 10,
+      },
+      uiContext: {
+        screenshot: {
+          toSerializable: () => ({
+            type: 'midscene_screenshot_ref',
+            id: 'shot-3',
+            storage: 'file',
+            path: './screenshots/shot-3.png',
+          }),
+        },
+      },
+      output: {
+        log: 'The selected page is open, so the requested task is complete.',
+        output: 'Settings opened.',
+        shouldContinuePlanning: false,
+      },
+    };
+    const emitDump = (tasks: unknown[]) => {
+      dumpListener?.('{}', {
+        id: 'execution-1',
+        name: 'Act - open settings',
+        description: 'open settings',
+        tasks,
       });
-      return 'done';
+    };
+    const aiAction = vi.fn().mockImplementation(async () => {
+      emitDump([plan1, tapStringPending]);
+      emitDump([plan1, tapPending]);
+      emitDump([plan1, locate1, tapRunning]);
+      emitDump([plan1, locate1, tapFinished]);
+      emitDump([plan1, locate1, tapFinished, plan2, sleepRunning]);
+      emitDump([plan1, locate1, tapFinished, plan2, sleepFinished]);
+      emitDump([plan1, locate1, tapFinished, plan2, sleepFinished, plan3]);
+      return 'Settings opened.';
     });
     const addDumpUpdateListener = vi.fn((listener) => {
       dumpListener = listener;
@@ -810,7 +931,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
     const commonTools = generateCommonTools(async () => ({
       aiAction,
       addDumpUpdateListener,
-      reportFile: '/tmp/midscene-report.html',
+      reportFile,
       getActionSpace: vi.fn().mockResolvedValue([]),
       page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
     }));
@@ -831,18 +952,52 @@ describe('toolDefaults (deep locate / deep think)', () => {
     const messages = consoleSpy.mock.calls.flatMap(([message]) =>
       String(message).split('\n'),
     );
-    expect(messages).toContain('[Midscene] act ready');
-    expect(messages).toContain('[Midscene] Progress: AI Action (2 steps)');
+    expect(messages).toContain('[Midscene][aiAct] Start: open settings');
     expect(messages).toContain(
-      '[Midscene] Step 1/2: Planning/Plan finished: sub-goals: 1. [finished] Open settings; 2. [running] Locate submit button',
+      '[Midscene][aiAct][Plan 1/10] Thinking with the latest screenshot: midscene_run/report/screenshots/shot-1.png',
     );
     expect(messages).toContain(
-      '[Midscene] Step 2/2: Planning/Locate running: Submit',
+      '[Midscene][aiAct][Plan 1/10] Planned: Need to open settings first.',
     );
     expect(messages).toContain(
-      '[Midscene] Screenshot: after-calling ./screenshots/shot-1.png',
+      '[Midscene][aiAct][Plan 1/10] Action: Tap "Submit button" at (100, 200), bbox=(80,180,120,220)',
     );
-    expect(messages).toContain('[Midscene] Report: /tmp/midscene-report.html');
+    expect(messages).not.toContain(
+      '[Midscene][aiAct][Plan 1/10] Action: Tap: {"locate":"Submit button"}',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Action] Running: Tap at (100, 200)',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Action] Done: Tap cost=208ms',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 2/10] Thinking with the latest screenshot: midscene_run/report/screenshots/shot-2.png',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 2/10] Planned: The page is still transitioning, so wait briefly.',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 2/10] Action: Sleep 2000ms',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Action] Running: Sleep 2000ms',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Action] Done: Sleep cost=2004ms',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 3/10] Thinking with the latest screenshot: midscene_run/report/screenshots/shot-3.png',
+    );
+    expect(messages).toContain(
+      '[Midscene][aiAct][Plan 3/10] Planned: The selected page is open, so the requested task is complete.',
+    );
+    expect(messages).toContain('[Midscene][aiAct] Complete: Settings opened.');
+    expect(
+      messages.filter((message) =>
+        message.includes('[Midscene][aiAct][Plan 1/10] Action: Tap'),
+      ),
+    ).toHaveLength(1);
     expect(addDumpUpdateListener).toHaveBeenCalledOnce();
     expect(unsubscribe).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
@@ -856,14 +1011,27 @@ describe('toolDefaults (deep locate / deep think)', () => {
     const aiAction = vi.fn().mockImplementation(async () => {
       dumpListener?.('{}', {
         id: 'execution-1',
-        name: 'AI Action',
+        name: 'Act - open settings',
         tasks: [
           {
-            taskId: 'task-1',
+            taskId: 'plan-1',
             type: 'Planning',
-            subType: 'Locate',
+            subType: 'Plan',
             status: 'running',
-            param: { prompt: 'Submit' },
+            param: { userInstruction: 'open settings' },
+            uiContext: {
+              screenshot: {
+                extension: 'png',
+                rawBase64: 'Zm9v',
+                toSerializable: () => ({
+                  type: 'midscene_screenshot_ref',
+                  id: 'inline-shot-1',
+                  capturedAt: 1000,
+                  mimeType: 'image/png',
+                  storage: 'inline',
+                }),
+              },
+            },
             recorder: [
               {
                 timing: 'after-calling',
@@ -914,13 +1082,15 @@ describe('toolDefaults (deep locate / deep think)', () => {
       String(message).split('\n'),
     );
     const screenshotMessage = messages.find((message) =>
-      message.includes('[Midscene] Screenshot: after-calling '),
+      message.includes(
+        '[Midscene][aiAct][Plan 1] Thinking with the latest screenshot: ',
+      ),
     );
     expect(screenshotMessage).toMatch(
-      /^\[Midscene\] Screenshot: after-calling .+midscene-cli-screenshots\/inline-shot-1\.png$/,
+      /^\[Midscene\]\[aiAct\]\[Plan 1\] Thinking with the latest screenshot: .+screenshots\/inline-shot-1\.png$/,
     );
     const screenshotPath = screenshotMessage?.replace(
-      '[Midscene] Screenshot: after-calling ',
+      '[Midscene][aiAct][Plan 1] Thinking with the latest screenshot: ',
       '',
     );
     expect(screenshotPath).toBeDefined();


### PR DESCRIPTION
## Summary
- Add a global `--verbose` CLI flag that prints readable progress while Midscene commands are running.
- Make text-mode `aiAct` verbose output a clean human-readable timeline: start prompt, each plan's latest screenshot, planned reasoning, action details, action running/done status, timing, and final completion or failure text.
- Surface `aiAct` screenshot paths next to the report under `midscene_run/report/screenshots/`, so agents and humans can open the exact screenshot referenced by each plan step.
- Split verbose rendering responsibilities: generic event output stays in `verbose.ts`, `aiAct` timeline rendering lives in `verbose-ai-act.ts`, and screenshot reference/export logic lives in `verbose-screenshot.ts`.
- Avoid duplicate inline screenshot exports by using a per-command screenshot export cache and by skipping eager image writes for JSONL events.
- Preserve the generic verbose output for non-`act` commands and keep `--verbose=jsonl` as the structured machine-readable event stream.
- Document `--verbose` and `--verbose=jsonl` in the English and Chinese MCP docs.

## Example
Real stdout from `./packages/web-integration/bin/midscene-web --verbose act --prompt "click the blue Search button"` against `packages/web-integration/tests/ai/fixtures/input-test.html` on 2026-06-22:

```text
[Midscene][aiAct] Start: click the blue Search button
[Midscene][aiAct][Plan 1/20] Thinking with the latest screenshot: midscene_run/report/screenshots/16c4a092-f1b0-4830-8db9-0f06b60ea2db.jpeg
[Midscene][aiAct][Plan 1/20] Planned: Click the blue Search button
[Midscene][aiAct][Plan 1/20] Action: Tap "the blue Search button" at (893, 364), bbox=(832,340,955,389)
[Midscene][aiAct][Action] Running: Tap at (893, 364)
[Midscene][aiAct][Action] Done: Tap cost=787ms
[Midscene][aiAct][Plan 2/20] Thinking with the latest screenshot: midscene_run/report/screenshots/ebd3ca93-9033-4d31-ba9c-248d875485cb.jpeg
[Midscene][aiAct][Plan 2/20] Planned: The user's instruction was to "click the blue Search button", and the previous action has already executed that click. The current screenshot shows the same interface with no vi...
[Midscene][aiAct] Complete: The blue Search button has been clicked.
Action "act" completed.
Result: The blue Search button has been clicked.
```

## Validation
- `pnpm exec biome check packages/shared/src/cli/verbose.ts packages/shared/src/cli/verbose-ai-act.ts packages/shared/src/cli/verbose-screenshot.ts packages/shared/src/cli/screenshot-file.ts packages/shared/tests/unit-test/tool-generator.test.ts packages/shared/tests/unit-test/cli-runner.test.ts apps/site/docs/en/mcp.mdx apps/site/docs/zh/mcp.mdx`
- `pnpm --dir packages/shared exec vitest run tests/unit-test/tool-generator.test.ts -t "verbose|planning failure"`
- `pnpm --dir packages/shared exec vitest run tests/unit-test/cli-runner.test.ts -t "verbose|act command throws|image tool results"`
- `pnpm exec nx test @midscene/shared`
- `pnpm exec nx build @midscene/web`
- Real `midscene-web` run against local fixture: `./packages/web-integration/bin/midscene-web --verbose act --prompt "click the blue Search button"`; verified stdout includes `Start`, per-plan screenshot paths, `Planned`, `Action`, `Running`, `Done`, and `Complete` lines.
- `pnpm run lint` was run, but it fails locally on unrelated untracked files `packages/web-integration/swipe-verify.cjs` and `packages/web-integration/swipe-verify2.cjs` with `lint/style/useSingleVarDeclarator`; those files are not part of this PR.
