### PR TITLE
fix(core): validate parsed locate results

### DIFF
--- a/packages/core/src/ai-model/shared/model-locate-result/factory.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/factory.ts
@@ -7,6 +7,7 @@ import type {
   LocateResultAdapterDefinition,
   LocateResultContext,
   LocateResultCoordinates,
+  LocateResultValue,
   PixelBbox,
   ResolvedLocateResultCoordinates,
   SectionLocatePixelBboxGroup,
@@ -60,6 +61,41 @@ function normalizeReferenceResults(input: unknown): unknown[] {
     return [];
   }
   return Array.isArray(input) ? input : [input];
+}
+
+function assertValidParsedLocateResult(result: LocateResultValue): void {
+  if (!result || typeof result !== 'object') {
+    throw new Error(
+      `invalid parsed locate result: expected object, got ${JSON.stringify(
+        result,
+      )}`,
+    );
+  }
+
+  const expectedLength =
+    result.type === 'bbox' ? 4 : result.type === 'point' ? 2 : 0;
+  if (!expectedLength) {
+    throw new Error(
+      `invalid parsed locate result: unsupported type ${JSON.stringify(
+        (result as { type?: unknown }).type,
+      )}`,
+    );
+  }
+
+  const coordinates = result.coordinates;
+  if (
+    !Array.isArray(coordinates) ||
+    coordinates.length !== expectedLength ||
+    !coordinates.every(
+      (value) => typeof value === 'number' && Number.isFinite(value),
+    )
+  ) {
+    throw new Error(
+      `invalid parsed locate result: ${result.type} coordinates must be ${expectedLength} finite numbers, got ${JSON.stringify(
+        coordinates,
+      )}`,
+    );
+  }
 }
 
 function pickRawLocateValue(
@@ -124,7 +160,11 @@ function createStandardLocateResultAdapterImplementation(
   const mapRawLocateValueToPixelBbox = (
     rawResult: unknown,
     ctx: LocateResultContext,
-  ) => mapLocateResultToPixelBbox(parseRawLocateValue(rawResult), ctx);
+  ) => {
+    const parsedResult = parseRawLocateValue(rawResult);
+    assertValidParsedLocateResult(parsedResult);
+    return mapLocateResultToPixelBbox(parsedResult, ctx);
+  };
   // Keep error semantics out of the adapter: callers may preserve, ignore, or
   // fail fast on `error` / `errors`, while this layer only extracts coordinates.
   const adaptRawLocateInputToPixelBbox = (

--- a/packages/core/tests/unit-test/locate-result-adapter.test.ts
+++ b/packages/core/tests/unit-test/locate-result-adapter.test.ts
@@ -194,6 +194,25 @@ describe('createLocateResultAdapter', () => {
     ).toThrow(/invalid bbox data/);
   });
 
+  it('rejects invalid parsed adapter results before coordinate range checks', () => {
+    const adapter = createLocateResultAdapter({
+      coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      parseRawLocateValue: () => ({
+        type: 'bbox',
+        coordinates: [652, '233; 713 251;'] as any,
+      }),
+    });
+
+    expect(() =>
+      adapter.adaptElementLocateResultToPixelBbox(
+        { bbox: [652, '233; 713 251;'] },
+        locateCtx(640, 360),
+      ),
+    ).toThrow(
+      /invalid parsed locate result: bbox coordinates must be 4 finite numbers, got \[652,"233; 713 251;"\]/,
+    );
+  });
+
   it('rejects non-array coordinate values before numeric parsing', () => {
     const adapter = createLocateResultAdapter({
       coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },


### PR DESCRIPTION
## Summary

- Add a shared runtime assertion for parsed locate results returned by standard model adapters.
- Fail fast when adapter parsing returns an invalid internal shape, such as non-finite or non-number bbox/point coordinates.
- Cover the regression where a mixed bbox like `[652, "233; 713 251;"]` should report an invalid parsed locate result instead of a misleading normalized range error.

## Root Cause

Model-specific `parseRawLocateValue` functions are trusted by TypeScript to return `LocateResultValue`, but adapter implementations can still return invalid runtime data. Those invalid values previously reached the coordinate mapper, where non-number values were grouped with range violations and surfaced as `exceed normalized range [0, 1000]`.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/locate-result-adapter.test.ts`

Lint was not run per local workflow preference.