### PR TITLE
feat(bdd): [agent]/[no-ai] bracket annotations replacing @-style comment markers

### DIFF
--- a/apps/bdd-dashboard/src/components/HealthView.tsx
+++ b/apps/bdd-dashboard/src/components/HealthView.tsx
@@ -40,12 +40,17 @@ const KIND_META: Record<HealthKind, KindMeta> = {
   'detached-annotation': {
     label: 'Detached annotation comments (ignored)',
     severity: 'warn',
-    desc: 'An annotation comment (# @agent, # @no-ai, …) is not directly above a step, so it silently has no effect.',
+    desc: 'An annotation comment (# [agent], # [no-ai], …) is not directly above a step, so it silently has no effect.',
+  },
+  'legacy-annotation': {
+    label: 'Legacy @-style markers (ignored)',
+    severity: 'warn',
+    desc: 'A comment uses the retired # @agent / # @no-ai / # @soft syntax, which no longer routes — write # [agent], # [no-ai], # [soft] instead.',
   },
   'tag-level-agent': {
     label: 'Tag-level @agent (ignored)',
     severity: 'warn',
-    desc: '@agent only works as a comment directly above a step — as a tag on a scenario it is ignored.',
+    desc: 'Agent routing only works as a # [agent] comment directly above a step — @agent as a tag on a scenario is ignored.',
   },
   'unused-flow': {
     label: 'Unused flows',

--- a/apps/bdd-dashboard/src/components/HealthView.tsx
+++ b/apps/bdd-dashboard/src/components/HealthView.tsx
@@ -45,7 +45,7 @@ const KIND_META: Record<HealthKind, KindMeta> = {
   'legacy-annotation': {
     label: 'Legacy @-style markers (ignored)',
     severity: 'warn',
-    desc: 'A comment uses the retired # @agent / # @no-ai / # @soft syntax, which no longer routes — write # [agent], # [no-ai], # [soft] instead.',
+    desc: 'A comment uses the retired @-marker syntax (# @agent, …), which no longer routes — write the bracket form (# [agent], …) instead.',
   },
   'tag-level-agent': {
     label: 'Tag-level @agent (ignored)',

--- a/apps/bdd-dashboard/src/components/HelpPanel.tsx
+++ b/apps/bdd-dashboard/src/components/HelpPanel.tsx
@@ -82,8 +82,9 @@ const GLOSSARY: [string, string][] = [
   [
     'Step routing',
     'Where a step executes. Unmarked steps run on the Midscene UI agent; an ' +
-      '"agent" badge (# @agent or a $skill token) sends the step to a ' +
-      'general coding agent; "no-ai" runs a classic user-registered callback.',
+      '"agent" badge (a # [agent] comment or a $skill token) sends the step ' +
+      'to a general coding agent; "no-ai" runs a classic user-registered ' +
+      'callback.',
   ],
   [
     'soft',

--- a/apps/bdd-dashboard/src/fixtures/example-explore-model.ts
+++ b/apps/bdd-dashboard/src/fixtures/example-explore-model.ts
@@ -11,7 +11,7 @@
 import type { ExploreModel } from '../model/types';
 
 export const exampleExploreModel: ExploreModel = {
-  generatedAt: '2026-06-11T21:40:26.899Z',
+  generatedAt: '2026-06-12T19:26:26.165Z',
   baseDir: '/home/zack/projects/midscene/packages/bdd/example',
   features: [
     {
@@ -43,9 +43,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 7,
               flowCall: {
                 flowId: 'flow:I am logged in as {string}',
-                args: {
-                  role: 'guest',
-                },
+                args: { role: 'guest' },
               },
             },
             {
@@ -62,9 +60,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 8,
               flowCall: {
                 flowId: 'flow:I have added {string} to the cart',
-                args: {
-                  product: 'Camp Mug',
-                },
+                args: { product: 'Camp Mug' },
               },
             },
             {
@@ -139,9 +135,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 6,
               flowCall: {
                 flowId: 'flow:I am logged in as {string}',
-                args: {
-                  role: 'admin',
-                },
+                args: { role: 'admin' },
               },
             },
             {
@@ -158,9 +152,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 7,
               flowCall: {
                 flowId: 'flow:I have added {string} to the cart',
-                args: {
-                  product: 'Trail Backpack',
-                },
+                args: { product: 'Trail Backpack' },
               },
             },
             {
@@ -338,15 +330,22 @@ export const exampleExploreModel: ExploreModel = {
       relPath: 'features/gherkin-tour/01-steps-and-comments.feature',
       name: 'Gherkin tour — steps and comments',
       description:
-        'Everything indented under the `Feature:` line (until the first Scenario,\n  Background, or Rule) is the feature DESCRIPTION: free-form prose for human\n  readers. Cucumber parses but never executes it. Descriptions are also\n  allowed under Scenario, Rule, and Examples headers.\n\n  With @midscene/bdd, the steps themselves are plain natural language: by\n  default each one is sent to the Midscene vision agent, which drives the\n  page (Given/When) or judges an assertion against it (Then, fail-closed).',
+        'Everything indented under the `Feature:` line (until the first Scenario,\n' +
+        '  Background, or Rule) is the feature DESCRIPTION: free-form prose for human\n' +
+        '  readers. Cucumber parses but never executes it. Descriptions are also\n' +
+        '  allowed under Scenario, Rule, and Examples headers.\n' +
+        '\n' +
+        '  With @midscene/bdd, the steps themselves are plain natural language: by\n' +
+        '  default each one is sent to the Midscene vision agent, which drives the\n' +
+        '  page (Given/When) or judges an assertion against it (Then, fail-closed).',
       tags: ['@tour'],
       scenarios: [
         {
-          id: 'scenario:features/gherkin-tour/01-steps-and-comments.feature#32',
+          id: 'scenario:features/gherkin-tour/01-steps-and-comments.feature#34',
           name: 'Given/When/Then/And/But cover one shopping round-trip',
           tags: [],
           uri: 'features/gherkin-tour/01-steps-and-comments.feature',
-          line: 32,
+          line: 34,
           isOutline: false,
           steps: [
             {
@@ -360,7 +359,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 33,
+              line: 35,
             },
             {
               keyword: 'When ',
@@ -373,7 +372,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 34,
+              line: 36,
             },
             {
               keyword: 'Then ',
@@ -386,7 +385,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 35,
+              line: 37,
             },
             {
               keyword: 'And ',
@@ -399,7 +398,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 36,
+              line: 38,
             },
             {
               keyword: 'But ',
@@ -412,16 +411,16 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 37,
+              line: 39,
             },
           ],
         },
         {
-          id: 'scenario:features/gherkin-tour/01-steps-and-comments.feature#42',
+          id: 'scenario:features/gherkin-tour/01-steps-and-comments.feature#44',
           name: 'The * keyword writes steps as a bullet list',
           tags: [],
           uri: 'features/gherkin-tour/01-steps-and-comments.feature',
-          line: 42,
+          line: 44,
           isOutline: false,
           steps: [
             {
@@ -435,7 +434,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 43,
+              line: 45,
             },
             {
               keyword: '* ',
@@ -448,7 +447,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 44,
+              line: 46,
             },
             {
               keyword: '* ',
@@ -461,7 +460,7 @@ export const exampleExploreModel: ExploreModel = {
                 skills: [],
               },
               route: 'ui',
-              line: 45,
+              line: 47,
             },
           ],
         },
@@ -473,7 +472,10 @@ export const exampleExploreModel: ExploreModel = {
       relPath: 'features/gherkin-tour/02-background-and-rules.feature',
       name: 'Gherkin tour — Background and Rules',
       description:
-        'A `Background:` lists steps that run before EACH scenario in its scope; a\n  `Rule:` groups related scenarios under one business rule and may carry its\n  own (additional) Background. Tags on a Rule are inherited by every\n  scenario inside it, exactly like feature tags.',
+        'A `Background:` lists steps that run before EACH scenario in its scope; a\n' +
+        '  `Rule:` groups related scenarios under one business rule and may carry its\n' +
+        '  own (additional) Background. Tags on a Rule are inherited by every\n' +
+        '  scenario inside it, exactly like feature tags.',
       tags: ['@tour'],
       scenarios: [
         {
@@ -511,9 +513,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 23,
               flowCall: {
                 flowId: 'flow:I have added {string} to the cart',
-                args: {
-                  product: 'Trail Backpack',
-                },
+                args: { product: 'Trail Backpack' },
               },
             },
             {
@@ -592,9 +592,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 23,
               flowCall: {
                 flowId: 'flow:I have added {string} to the cart',
-                args: {
-                  product: 'Trail Backpack',
-                },
+                args: { product: 'Trail Backpack' },
               },
             },
             {
@@ -633,7 +631,12 @@ export const exampleExploreModel: ExploreModel = {
       relPath: 'features/gherkin-tour/03-scenario-outlines.feature',
       name: 'Gherkin tour — Scenario Outlines',
       description:
-        "An outline's steps may contain `<placeholders>`. Gherkin substitutes them\n  at COMPILE time from each `Examples:` row, producing one concrete scenario\n  per row. The same `<x>` substitution is reused for this framework's @flow\n  scenarios, bound from their `@param:` declarations (see features/flows/) —\n  and that is the ONLY variable mechanism here: there is deliberately no\n  runtime capture/remember syntax.",
+        "An outline's steps may contain `<placeholders>`. Gherkin substitutes them\n" +
+        '  at COMPILE time from each `Examples:` row, producing one concrete scenario\n' +
+        "  per row. The same `<x>` substitution is reused for this framework's @flow\n" +
+        '  scenarios, bound from their `@param:` declarations (see features/flows/) —\n' +
+        '  and that is the ONLY variable mechanism here: there is deliberately no\n' +
+        '  runtime capture/remember syntax.',
       tags: ['@tour'],
       scenarios: [
         {
@@ -659,9 +662,7 @@ export const exampleExploreModel: ExploreModel = {
               line: 23,
               flowCall: {
                 flowId: 'flow:I am logged in as {string}',
-                args: {
-                  role: 'admin',
-                },
+                args: { role: 'admin' },
               },
             },
             {
@@ -875,7 +876,9 @@ export const exampleExploreModel: ExploreModel = {
               },
               route: 'ui',
               dataTable:
-                '| product | quantity |\n| Camp Mug | 2 |\n| Trail Backpack | 1 |',
+                '| product | quantity |\n' +
+                '| Camp Mug | 2 |\n' +
+                '| Trail Backpack | 1 |',
               line: 10,
             },
             {
@@ -926,7 +929,9 @@ export const exampleExploreModel: ExploreModel = {
               },
               route: 'ui',
               docString:
-                'Restock plan:\n- Trail Backpack arrives Friday\n- Camp Mug is selling fast',
+                'Restock plan:\n' +
+                '- Trail Backpack arrives Friday\n' +
+                '- Camp Mug is selling fast',
               line: 23,
             },
             {
@@ -1031,12 +1036,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'When ',
           text: 'I open the login page',
           stepType: 'action',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 12,
         },
@@ -1044,12 +1044,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'And ',
           text: 'I sign in as the "<role>" user with the demo password shown on the login form',
           stepType: 'action',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 13,
           paramUses: ['role'],
@@ -1058,12 +1053,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'Then ',
           text: 'the dashboard for the "<role>" role is visible',
           stepType: 'outcome',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 14,
           paramUses: ['role'],
@@ -1086,12 +1076,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'When ',
           text: 'I go to the home page',
           stepType: 'action',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 8,
         },
@@ -1099,12 +1084,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'And ',
           text: 'I add the "<product>" product to the cart',
           stepType: 'action',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 9,
           paramUses: ['product'],
@@ -1113,12 +1093,7 @@ export const exampleExploreModel: ExploreModel = {
           keyword: 'Then ',
           text: 'the cart shows the "<product>" product',
           stepType: 'outcome',
-          annotations: {
-            agent: false,
-            noAi: false,
-            soft: false,
-            skills: [],
-          },
+          annotations: { agent: false, noAi: false, soft: false, skills: [] },
           route: 'ui',
           line: 10,
           paramUses: ['product'],
@@ -1137,57 +1112,43 @@ export const exampleExploreModel: ExploreModel = {
       from: 'scenario:features/cart.feature#6',
       to: 'flow:I am logged in as {string}',
       stepIndex: 0,
-      args: {
-        role: 'guest',
-      },
+      args: { role: 'guest' },
     },
     {
       from: 'scenario:features/cart.feature#6',
       to: 'flow:I have added {string} to the cart',
       stepIndex: 1,
-      args: {
-        product: 'Camp Mug',
-      },
+      args: { product: 'Camp Mug' },
     },
     {
       from: 'scenario:features/checkout.feature#5',
       to: 'flow:I am logged in as {string}',
       stepIndex: 0,
-      args: {
-        role: 'admin',
-      },
+      args: { role: 'admin' },
     },
     {
       from: 'scenario:features/checkout.feature#5',
       to: 'flow:I have added {string} to the cart',
       stepIndex: 1,
-      args: {
-        product: 'Trail Backpack',
-      },
+      args: { product: 'Trail Backpack' },
     },
     {
       from: 'scenario:features/gherkin-tour/02-background-and-rules.feature#30',
       to: 'flow:I have added {string} to the cart',
       stepIndex: 1,
-      args: {
-        product: 'Trail Backpack',
-      },
+      args: { product: 'Trail Backpack' },
     },
     {
       from: 'scenario:features/gherkin-tour/02-background-and-rules.feature#35',
       to: 'flow:I have added {string} to the cart',
       stepIndex: 1,
-      args: {
-        product: 'Trail Backpack',
-      },
+      args: { product: 'Trail Backpack' },
     },
     {
       from: 'scenario:features/gherkin-tour/03-scenario-outlines.feature#22',
       to: 'flow:I am logged in as {string}',
       stepIndex: 0,
-      args: {
-        role: 'admin',
-      },
+      args: { role: 'admin' },
     },
   ],
   health: [],

--- a/apps/bdd-dashboard/src/model/copy.ts
+++ b/apps/bdd-dashboard/src/model/copy.ts
@@ -4,8 +4,8 @@
  * the wording from drifting between the three.
  */
 
-export const AGENT_MARKER_HINT = 'marked with # @agent or a $skill token';
-export const NOAI_MARKER_HINT = 'marked with # @no-ai';
+export const AGENT_MARKER_HINT = 'marked with # [agent] or a $skill token';
+export const NOAI_MARKER_HINT = 'marked with # [no-ai]';
 
 export const AGENT_ROUTE_LABEL = 'general coding agent (e.g. Codex)';
 export const NOAI_ROUTE_LABEL =

--- a/apps/bdd-dashboard/src/model/indices.ts
+++ b/apps/bdd-dashboard/src/model/indices.ts
@@ -26,14 +26,14 @@ export interface ModelIndices {
   haystack: Map<string, string>;
 }
 
-// Routing markers are searchable ("@agent", "@no-ai", "$skill") even when
+// Routing markers are searchable ("[agent]", "[no-ai]", "$skill") even when
 // they live in comment lines the step text does not contain.
 function buildHaystack(item: StoryItem): string {
   const tags = 'tags' in item ? item.tags : [];
   const parts: string[] = [item.name, ...tags];
   for (const step of item.steps) {
     parts.push(step.text);
-    if (step.route !== 'ui') parts.push(`@${step.route}`);
+    if (step.route !== 'ui') parts.push(`[${step.route}]`);
     for (const skill of step.annotations.skills) parts.push(`$${skill}`);
   }
   return parts.join('\n').toLowerCase();

--- a/apps/bdd-dashboard/src/model/types.ts
+++ b/apps/bdd-dashboard/src/model/types.ts
@@ -9,6 +9,7 @@ export type HealthKind =
   | 'unknown-flow-sugar'
   | 'undeclared-param'
   | 'detached-annotation'
+  | 'legacy-annotation'
   | 'tag-level-agent'
   | 'missing-skill'
   | 'flow-depth';

--- a/packages/bdd/README.md
+++ b/packages/bdd/README.md
@@ -231,7 +231,7 @@ Everything cucumber gives you keeps working — this package adds exactly three 
 | | Mechanism | Prior art / rationale |
 | --- | --- | --- |
 | **100% standard** | `Background`, `Scenario Outline` + `Examples`, `Rule`, tags, data tables, doc strings, hooks, formatters, parallel workers, tag expressions, `cucumber.js` profiles | Plain cucumber-js — this package is one catch-all step definition plus a config preset |
-| **Extension 1** | `# [agent]` / `# [no-ai]` / `# [soft]` comment lines directly above a step | Gherkin has no step-level tags, so per-step routing lives in comment annotations (the established workaround in the Gherkin ecosystem); square brackets keep markers visually distinct from cucumber tags |
+| **Extension 1** | `# [agent]` / `# [no-ai]` / `# [soft]` comment lines directly above a step | Gherkin has no step-level tags, so per-step routing lives in comment annotations (the established workaround in the Gherkin ecosystem) |
 | **Extension 2** | `$skill-name` tokens in step text | Shell-style `$` references; a token both routes the statement to the general agent and loads the skill |
 | **Extension 3** | `@flow` / `@param:x` scenario tags | Karate's `call` model for reusable sub-scenarios, expressed through standard Gherkin tags; `<param>` substitution inside the flow body mirrors Scenario Outline placeholders |
 

--- a/packages/bdd/README.md
+++ b/packages/bdd/README.md
@@ -26,8 +26,8 @@ Every statement is routed to exactly one executor:
 | Rule | Marker | Who executes the statement |
 | --- | --- | --- |
 | **Default** | none | Midscene UI agent — the vision model drives the page (`aiAct`) for Given/When and judges Then steps (`aiAssert`, fail-closed) |
-| **Agent** | `# @agent` comment directly above the line, or a `$skill-name` token in it | A general-purpose coding agent (Codex app-server via `codex login`, or any OpenAI-compatible endpoint) — for behavior you cannot see in the browser: server logs, files, databases. Then steps must return a JSON verdict; a missing verdict fails (fail-closed) |
-| **No AI** | `# @no-ai` comment above the line (or `@no-ai` scenario/feature tag) | Classic BDD: a callback registered with `Given`/`When`/`Then`/`defineStep` from `@midscene/bdd` must match. An unimplemented step fails with a ready-to-paste snippet |
+| **Agent** | `# [agent]` comment directly above the line, or a `$skill-name` token in it | A general-purpose coding agent (Codex app-server via `codex login`, or any OpenAI-compatible endpoint) — for behavior you cannot see in the browser: server logs, files, databases. Then steps must return a JSON verdict; a missing verdict fails (fail-closed) |
+| **No AI** | `# [no-ai]` comment above the line (or `@no-ai` scenario/feature tag) | Classic BDD: a callback registered with `Given`/`When`/`Then`/`defineStep` from `@midscene/bdd` must match. An unimplemented step fails with a ready-to-paste snippet |
 
 All three in one scenario:
 
@@ -38,11 +38,13 @@ Feature: Failed login reporting
     Given I open the login page of the demo shop
     When I try to sign in as the "admin" user with a wrong password
     Then an error toast shows on the screen
-    # @agent
+    # [agent]
     Then the server log contains a failed-login warning, per $check-logs
-    # @no-ai
+    # [no-ai]
     Then the login attempt counter increments
 ```
+
+The comment markers use square brackets (`# [agent]`, not `# @agent`) so they cannot be mistaken for cucumber's `@`-prefixed tag syntax — tags live on the line above a `Feature:`/`Scenario:` header, markers live in a comment directly above a single step.
 
 The first three lines run through Midscene against the page. The fourth bails out to the coding agent, loading the `check-logs` skill into its prompt. The last requires a registered callback:
 
@@ -111,7 +113,7 @@ midscene.config.ts
 cucumber.js
 features/
   *.feature
-  step_definitions/   # classic callbacks for @no-ai steps (optional)
+  step_definitions/   # classic callbacks for [no-ai] steps (optional)
   skills/             # markdown skills for $tokens (optional)
 ```
 
@@ -229,11 +231,11 @@ Everything cucumber gives you keeps working — this package adds exactly three 
 | | Mechanism | Prior art / rationale |
 | --- | --- | --- |
 | **100% standard** | `Background`, `Scenario Outline` + `Examples`, `Rule`, tags, data tables, doc strings, hooks, formatters, parallel workers, tag expressions, `cucumber.js` profiles | Plain cucumber-js — this package is one catch-all step definition plus a config preset |
-| **Extension 1** | `# @agent` / `# @no-ai` / `# @soft` comment lines directly above a step | Gherkin has no step-level tags, so per-step routing lives in comment annotations (the established workaround in the Gherkin ecosystem) |
+| **Extension 1** | `# [agent]` / `# [no-ai]` / `# [soft]` comment lines directly above a step | Gherkin has no step-level tags, so per-step routing lives in comment annotations (the established workaround in the Gherkin ecosystem); square brackets keep markers visually distinct from cucumber tags |
 | **Extension 2** | `$skill-name` tokens in step text | Shell-style `$` references; a token both routes the statement to the general agent and loads the skill |
 | **Extension 3** | `@flow` / `@param:x` scenario tags | Karate's `call` model for reusable sub-scenarios, expressed through standard Gherkin tags; `<param>` substitution inside the flow body mirrors Scenario Outline placeholders |
 
-Data tables and doc strings on AI-routed steps are appended to the prompt verbatim. `@no-ai` and `@soft` may also be applied as ordinary scenario/feature tags (inherited per normal Gherkin semantics); `@agent` is deliberately per-line only.
+Data tables and doc strings on AI-routed steps are appended to the prompt verbatim. `@no-ai` and `@soft` may also be applied as ordinary scenario/feature tags (inherited per normal Gherkin semantics); agent routing is deliberately per-line only, so there is no `@agent` tag.
 
 Callback registration is the cucumber shape — `Given`/`When`/`Then` take `(pattern, fn)` where `pattern` is a cucumber expression string or a RegExp, and captures arrive as function arguments. Per cucumber convention the keyword is documentation only: matching ignores it, and `defineStep` is the keyword-agnostic alias. Two deliberate divergences from standard cucumber:
 
@@ -246,9 +248,9 @@ cucumber-js drives the run; `@midscene/bdd/register` contributes a single catch-
 
 ```mermaid
 flowchart TD
-    S[Statement] --> A{"# @no-ai?"}
+    S[Statement] --> A{"# [no-ai]?"}
     A -- yes --> CB[registered callback<br/>or fail with snippet]
-    A -- no --> B{"# @agent or $skill?"}
+    A -- no --> B{"# [agent] or $skill?"}
     B -- yes --> GA[general coding agent<br/>Then needs JSON verdict, fail-closed]
     B -- no --> C{matches a @flow?}
     C -- yes --> FL[execute flow steps<br/>&lt;param&gt; substituted, depth ≤ 2]
@@ -257,9 +259,9 @@ flowchart TD
     E -- Given / When --> ACT[aiAct]
 ```
 
-- **Soft checks:** `# @soft` above a Then step (or a `@soft` tag) downgrades an assertion failure to a logged warning attached to the report — the step never fails. There is no native cucumber "soft" status, so the scenario stays green by design.
+- **Soft checks:** `# [soft]` above a Then step (or a `@soft` tag) downgrades an assertion failure to a logged warning attached to the report — the step never fails. There is no native cucumber "soft" status, so the scenario stays green by design.
 - **Outlines:** a Scenario Outline's pickle steps point at the outline's step node, so an annotation comment above an outline step applies to every Examples row.
-- **Laziness:** the browser launches only when the first UI-routed step runs, and the general agent connects only on the first `@agent`/`$skill` step. The general agent receives the current page screenshot only if a UI session already exists — it never launches a browser.
+- **Laziness:** the browser launches only when the first UI-routed step runs, and the general agent connects only on the first `[agent]`/`$skill` step. The general agent receives the current page screenshot only if a UI session already exists — it never launches a browser.
 
 ## Status
 

--- a/packages/bdd/example/README.md
+++ b/packages/bdd/example/README.md
@@ -32,7 +32,7 @@ skill paths use the defaults (`features/**/*.feature`, `features/skills`).
 | `features/flows/add-to-cart.feature` | A second flow, parameterized over the product name. |
 | `features/cart.feature` | Calling both flows declaratively, then asserting against what the page shows. |
 | `features/checkout.feature` | A coupon journey; asserts the 10% discount visually. |
-| `features/error-reporting.feature` | All three routing rules in one scenario, including a plain `# @agent` step and a `# @no-ai` step (see below). |
+| `features/error-reporting.feature` | All three routing rules in one scenario, including a plain `# [agent]` step and a `# [no-ai]` step (see below). |
 | `features/gherkin-tour/*.feature` | The full standard Gherkin grammar (descriptions, Background, Rule, outlines, data tables, doc strings, tags, `# language:`), one commented file per theme — written for readers new to Cucumber/BDD. |
 
 ## The three routing rules
@@ -40,8 +40,8 @@ skill paths use the defaults (`features/**/*.feature`, `features/skills`).
 | Rule | Marker | Who executes the step |
 | --- | --- | --- |
 | Default | none | Midscene UI agent (vision model drives/asserts the page) |
-| Agent | `# @agent` comment above the step, or a `$skill` token in it | General coding agent (can read files, run commands; Then steps need a pass/fail verdict). Skills live in `features/skills/*.md`. |
-| No AI | `# @no-ai` comment above the step | A classic callback registered with `Given`/`When`/`Then`/`defineStep` (see `features/step_definitions/`) |
+| Agent | `# [agent]` comment above the step, or a `$skill` token in it | General coding agent (can read files, run commands; Then steps need a pass/fail verdict). Skills live in `features/skills/*.md`. |
+| No AI | `# [no-ai]` comment above the step | A classic callback registered with `Given`/`When`/`Then`/`defineStep` (see `features/step_definitions/`) |
 
 ## Flows
 

--- a/packages/bdd/example/features/error-reporting.feature
+++ b/packages/bdd/example/features/error-reporting.feature
@@ -1,12 +1,12 @@
 # Showcase of the three routing rules:
 # 1. Default — steps run through the Midscene UI agent (vision model drives
 #    and asserts against the live page).
-# 2. `# @agent` — the single statement below the comment bails out to a
+# 2. `# [agent]` — the single statement below the comment bails out to a
 #    general coding agent, which can read files, run commands, and must
 #    return a pass/fail verdict for Then steps. Adding a `$skill` token
 #    (e.g. `$check-logs`) also routes to the agent and loads the named
 #    skill from features/skills/ into its prompt.
-# 3. `# @no-ai` — the statement must match a classic callback registered with
+# 3. `# [no-ai]` — the statement must match a classic callback registered with
 #    Given/When/Then/defineStep (see features/step_definitions/).
 Feature: Failed login reporting
 
@@ -14,9 +14,9 @@ Feature: Failed login reporting
     Given I open the login page of the demo shop
     When I try to sign in as the "admin" user with a wrong password
     Then an error toast shows on the screen
-    # @agent
+    # [agent]
     Then the demo app source in demo-app/index.html counts failed sign-ins in a window.__loginAttempts counter
-    # @agent
+    # [agent]
     Then the server log contains a failed-login warning, per $check-logs
-    # @no-ai
+    # [no-ai]
     Then the login attempt counter increments

--- a/packages/bdd/example/features/gherkin-tour/01-steps-and-comments.feature
+++ b/packages/bdd/example/features/gherkin-tour/01-steps-and-comments.feature
@@ -5,9 +5,11 @@
 # Lines starting with `#` are COMMENTS — the only comment form Gherkin has,
 # and they must be full lines (no end-of-line comments). Cucumber ignores
 # them. This framework adds ONE documented extension on top: a comment that
-# consists only of markers (`# @agent`, `# @no-ai`, `# @soft`, `# $skill`)
+# consists only of markers (`# [agent]`, `# [no-ai]`, `# [soft]`, `# $skill`)
 # placed DIRECTLY above a step changes how that one step is executed — see
 # features/error-reporting.feature for all three routing rules in action.
+# The square brackets are deliberate: `@`-prefixed names are cucumber TAG
+# syntax (like @tour below), and comment markers are not tags.
 #
 # The line below names the feature. Tags placed above it (like @tour) apply
 # to every scenario inside; run a subset with e.g. `npx cucumber-js --tags

--- a/packages/bdd/example/features/step_definitions/counters.steps.js
+++ b/packages/bdd/example/features/step_definitions/counters.steps.js
@@ -1,6 +1,6 @@
 const { defineStep } = require('@midscene/bdd');
 
-// A classic `# @no-ai` step: deterministic code, no AI involved. Must be a
+// A classic `# [no-ai]` step: deterministic code, no AI involved. Must be a
 // regular `function` (not an arrow) so `this` is the step context, which
 // exposes `getUiAgent`, `attach`, `log`, `dataTable`, and `docString`.
 defineStep('the login attempt counter increments', async function () {

--- a/packages/bdd/scripts/gen-scale-fixture.mjs
+++ b/packages/bdd/scripts/gen-scale-fixture.mjs
@@ -16,13 +16,14 @@
  * including one fan-out smoke scenario calling 5 flows and two story-arc
  * features whose scenarios climb the pipeline/support chains level by level.
  * Flow bodies use declared <param> placeholders, step annotations
- * (# @agent / # @no-ai / @soft / $skill — including routed steps inside two
- * flow bodies so the graph's routing markers light up), two Scenario
+ * (# [agent] / # [no-ai] / @soft / $skill — including routed steps inside
+ * two flow bodies so the graph's routing markers light up), two Scenario
  * Outlines, and seeded imperfections so the HEALTH panel has content:
  *   - 2 unused flows
  *   - 1 undeclared <placeholder> in a flow body
- *   - 1 detached "# @agent" annotation comment (blank line before the step)
+ *   - 1 detached "# [agent]" annotation comment (blank line before the step)
  *   - 1 tag-level @agent tag (ignored by routing)
+ *   - 1 legacy "# @agent" marker (retired @-syntax, ignored by routing)
  *   - 1 $missing-skill reference
  *   - many flow-depth findings (every flow nested deeper than MAX_FLOW_DEPTH)
  *
@@ -277,7 +278,7 @@ const SUPPORT_FLOWS = `Feature: Shared support flows
     When I open the ticket actions menu
     And I click archive ticket
     Then the ticket disappears from the open queue
-    # @no-ai
+    # [no-ai]
     Then the archived-ticket counter increments
 `;
 
@@ -334,7 +335,7 @@ const pick = (arr, n) => arr[n % arr.length];
 
 // Scenario templates: each returns gherkin lines for scenario index n.
 // Together they exercise 1-5 flow calls, deep-chain entry points at every
-// level, data tables, and @soft / # @agent / # @no-ai annotations.
+// level, data tables, and @soft / # [agent] / # [no-ai] annotations.
 const TEMPLATES = [
   (n) => [
     `  Scenario: Basket total reflects the ${pick(PRODUCTS, n)} price`,
@@ -353,13 +354,13 @@ const TEMPLATES = [
   (n) => [
     `  Scenario: Search for ${pick(TERMS, n)} shows a counter`,
     `    Given I have searched the catalog for "${pick(TERMS, n)}"`,
-    '    # @no-ai',
+    '    # [no-ai]',
     '    Then the result counter matches the visible list length',
   ],
   (n) => [
     `  Scenario: Visiting the ${pick(SECTIONS, n)} section is logged`,
     `    Given I have opened the "${pick(SECTIONS, n)}" section`,
-    '    # @agent',
+    '    # [agent]',
     '    Then the server log notes the visit, per $check-logs',
   ],
   (n) => [
@@ -470,12 +471,13 @@ const OUTLINE = [
 // Seeded imperfections, placed at fixed (file, scenario) coordinates. The
 // detached annotation has a blank line between the marker comment and its
 // step (so it never attaches); the tag-level @agent is silently ignored by
-// routing (only "# @agent" comments route).
+// routing (only "# [agent]" comments route); the legacy annotation uses the
+// retired "# @agent" syntax, which no longer routes either.
 const SEEDED = {
   detachedAnnotation: [
     '  Scenario: Audit visit is reported (seeded detached annotation)',
     '    Given I have opened the "billing" section',
-    '    # @agent',
+    '    # [agent]',
     '',
     '    Then the server log notes the visit, per $check-logs',
   ],
@@ -485,10 +487,16 @@ const SEEDED = {
     '    Given I am signed in as "auditor"',
     '    Then the session report lists the sign-in',
   ],
+  legacyAnnotation: [
+    '  Scenario: Sign-in audit is appended (seeded legacy @-marker)',
+    '    Given I am signed in as "manager"',
+    '    # @agent',
+    '    Then the audit log notes the sign-in, per $check-logs',
+  ],
   missingSkill: [
     '  Scenario: Audit trail is appended (seeded missing skill)',
     `    Given I have opened the "billing" section`,
-    '    # @agent',
+    '    # [agent]',
     '    Then the audit trail records the visit, per $audit-trail',
   ],
 };
@@ -507,6 +515,8 @@ for (let f = 0; f < 30; f++) {
       blocks.push(SEEDED.detachedAnnotation.join('\n'));
     else if (f === 12 && s === 2) blocks.push(SEEDED.tagLevelAgent.join('\n'));
     else if (f === 21 && s === 1) blocks.push(SEEDED.missingSkill.join('\n'));
+    else if (f === 26 && s === 2)
+      blocks.push(SEEDED.legacyAnnotation.join('\n'));
     else blocks.push(TEMPLATES[n % TEMPLATES.length](n).join('\n'));
     scenarioTotal++;
   }
@@ -591,7 +601,7 @@ const SUPPORT_FEATURE = `Feature: Suite 33 — support desk
 
   Scenario: Escalation pings the on-call channel
     Given I have an escalated support ticket
-    # @agent
+    # [agent]
     Then the on-call channel mentions the ticket, per $check-logs
 
   Scenario: Resolution note is shown to the customer
@@ -616,10 +626,10 @@ for (const [name, body, count] of ARC_FEATURES) {
 
 const allContent = featureBodies.join('\n');
 const countMatches = (re) => (allContent.match(re) ?? []).length;
-const agentMarkers = countMatches(/^\s*# @agent$/gm);
-const noAiMarkers = countMatches(/^\s*# @no-ai$/gm);
+const agentMarkers = countMatches(/^\s*# \[agent\]$/gm);
+const noAiMarkers = countMatches(/^\s*# \[no-ai\]$/gm);
 const skillRefs = countMatches(/\$[A-Za-z][A-Za-z0-9_-]*/g);
 
 console.log(
-  `Wrote scale fixture to ${base}: 39 feature files (33 suites + 6 shared-flow files), ${scenarioTotal} scenarios, 30 flows (2 unused; deepest chain nests 7 flows: report → run → pipeline → data source → project → workspace → sign-in), seeded health findings (undeclared <placeholder>, detached annotation, tag-level @agent, missing $skill), routing markers: ${agentMarkers} × "# @agent", ${noAiMarkers} × "# @no-ai", ${skillRefs} × $skill references.`,
+  `Wrote scale fixture to ${base}: 39 feature files (33 suites + 6 shared-flow files), ${scenarioTotal} scenarios, 30 flows (2 unused; deepest chain nests 7 flows: report → run → pipeline → data source → project → workspace → sign-in), seeded health findings (undeclared <placeholder>, detached annotation, tag-level @agent, legacy @-marker, missing $skill), routing markers: ${agentMarkers} × "# [agent]", ${noAiMarkers} × "# [no-ai]", ${skillRefs} × $skill references.`,
 );

--- a/packages/bdd/scripts/gen-scale-fixture.mjs
+++ b/packages/bdd/scripts/gen-scale-fixture.mjs
@@ -628,6 +628,7 @@ const allContent = featureBodies.join('\n');
 const countMatches = (re) => (allContent.match(re) ?? []).length;
 const agentMarkers = countMatches(/^\s*# \[agent\]$/gm);
 const noAiMarkers = countMatches(/^\s*# \[no-ai\]$/gm);
+// Stats-only heuristic; mirrors SKILL_NAME in packages/bdd/src/annotations.ts.
 const skillRefs = countMatches(/\$[A-Za-z][A-Za-z0-9_-]*/g);
 
 console.log(

--- a/packages/bdd/src/agents/general-agent.ts
+++ b/packages/bdd/src/agents/general-agent.ts
@@ -1,5 +1,5 @@
 /**
- * General coding agent for `# @agent` / `$skill` steps.
+ * General coding agent for `# [agent]` / `$skill` steps.
  *
  * Exports: `VERDICT_INSTRUCTIONS`, `buildGeneralPrompt`, `extractVerdict`,
  * `CallAiGeneralAgent`. Built on core's `callAI`, so any OpenAI-compatible

--- a/packages/bdd/src/annotations.ts
+++ b/packages/bdd/src/annotations.ts
@@ -2,9 +2,12 @@
  * Step-level annotation resolution for @midscene/bdd.
  *
  * Gherkin has no step-level tags, so per-step routing markers live in `#`
- * comment lines directly above the step (`@agent`, `@no-ai`, `@soft`, and
- * `$skill` tokens). Scenario/feature-level `@no-ai` / `@soft` tags are
- * inherited via the pickle's tags; `@agent` is intentionally per-line only.
+ * comment lines directly above the step (`[agent]`, `[no-ai]`, `[soft]`, and
+ * `$skill` tokens). The bracket form is deliberate: `@`-prefixed markers
+ * would look like cucumber's native tag syntax (`@flow`, scenario-level
+ * `@no-ai`), which lives on header lines, not comments. Scenario/feature
+ * level `@no-ai` / `@soft` tags are inherited via the pickle's tags; agent
+ * routing is intentionally per-line only.
  */
 import type {
   GherkinDocument,
@@ -22,22 +25,33 @@ import type { RouterContext, StepAnnotations, StepType } from './types';
 const SKILL_TOKEN_RE = /\$([A-Za-z][A-Za-z0-9_-]*)/g;
 /**
  * An annotation comment line must consist ONLY of markers/tokens after `#`
- * (e.g. `# @agent $check-logs`). Prose comments that merely mention a marker
- * ("# TODO: make this @no-ai later") must not flip routing.
+ * (e.g. `# [agent] $check-logs`). Prose comments that merely mention a marker
+ * ("# TODO: make this [no-ai] later") must not flip routing.
  */
 const ANNOTATION_LINE_RE =
-  /^(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s+(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*))*$/;
-const AGENT_MARKER_RE = /@agent\b/;
-const NO_AI_MARKER_RE = /@no-ai\b/;
-const SOFT_MARKER_RE = /@soft\b/;
+  /^(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s+(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*))*$/;
+const AGENT_MARKER_RE = /\[agent\]/;
+const NO_AI_MARKER_RE = /\[no-ai\]/;
+const SOFT_MARKER_RE = /\[soft\]/;
 /**
  * A comment body that STARTS with a routing marker but is not marker-only
- * (`# @agent check the logs`) was likely intended to route — it is silently
+ * (`# [agent] check the logs`) was likely intended to route — it is silently
  * inert, so the footgun audit flags it. Prose that merely mentions a marker
- * mid-line ("# TODO: make this @no-ai later") stays un-flagged.
+ * mid-line ("# TODO: make this [no-ai] later") stays un-flagged.
  */
 const MARKER_AT_START_RE =
-  /^(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s|$)/;
+  /^(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s|$)/;
+/**
+ * The pre-release `@`-prefixed marker syntax (`# @agent`, `# @no-ai`,
+ * `# @soft`, optionally mixed with `$skill` tokens). It no longer routes —
+ * it was replaced with brackets so comment markers cannot be confused with
+ * cucumber's native tag syntax — but the footgun audit still recognizes the
+ * shape and tells authors to migrate. Requires at least one `@` marker:
+ * `$skill`-only lines are valid CURRENT syntax and never legacy.
+ */
+const LEGACY_MARKER_LINE_RE =
+  /^(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s+(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*))*$/;
+const LEGACY_MARKER_RE = /@(agent|no-ai|soft)\b/;
 
 /**
  * The single definition of "this comment line is a routing marker": strip
@@ -210,18 +224,21 @@ export function resolveStepAnnotations(input: {
 }
 
 /**
- * Audit a parsed document for the two silent annotation footguns and return
+ * Audit a parsed document for the silent annotation footguns and return
  * one human-readable warning per occurrence (callers decide how to emit):
  *
- * 1. A marker-only comment block (`# @agent`, `# @no-ai`, `# @soft`,
+ * 1. A marker-only comment block (`# [agent]`, `# [no-ai]`, `# [soft]`,
  *    `# $skill`) that is NOT directly above a step — e.g. separated by a
  *    blank line — never attaches to anything and silently does not route.
  * 2. An `@agent` Gherkin tag at feature/rule/scenario/examples level —
- *    `@no-ai` and `@soft` are inherited via pickle tags, but `@agent` is
- *    deliberately per-line only, so the tag is silently ignored.
+ *    `@no-ai` and `@soft` are inherited via pickle tags, but agent routing
+ *    is deliberately per-line only, so the tag is silently ignored.
  * 3. A comment line that STARTS with a routing marker but mixes in prose
- *    (`# @agent check the logs`) — only marker-only lines route, so the
+ *    (`# [agent] check the logs`) — only marker-only lines route, so the
  *    line is silently inert despite almost certainly being intended.
+ * 4. A marker-only comment in the retired `@`-prefixed syntax (`# @agent`,
+ *    `# @no-ai`, `# @soft`) — it never routes anymore; authors must switch
+ *    to the bracket form.
  */
 export function collectAnnotationFootguns(document: GherkinDocument): string[] {
   const warnings: string[] = [];
@@ -235,12 +252,22 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
 
   for (const [line, rawText] of commentTextByLine) {
     if (markerBody(rawText) === undefined) {
-      // Marker-at-start prose ("# @agent check the logs") is inert despite
-      // almost certainly being intended to route.
       const body = rawText.trim().replace(/^#/, '').trim();
+      // The retired `@`-marker syntax: marker-only shape, but with the old
+      // `@` prefix. Checked before the prose rule — a legacy line also
+      // "starts with" nothing the new grammar knows, and the migration hint
+      // is the actionable message.
+      if (LEGACY_MARKER_LINE_RE.test(body) && LEGACY_MARKER_RE.test(body)) {
+        warnings.push(
+          `annotation comment "${rawText.trim()}" at ${uri}:${line} uses the retired @-marker syntax and is ignored — write square-bracket markers instead (\`# @agent\` → \`# [agent]\`, \`# @no-ai\` → \`# [no-ai]\`, \`# @soft\` → \`# [soft]\`); brackets keep comment markers visually distinct from cucumber tags`,
+        );
+        continue;
+      }
+      // Marker-at-start prose ("# [agent] check the logs") is inert despite
+      // almost certainly being intended to route.
       if (MARKER_AT_START_RE.test(body)) {
         warnings.push(
-          `annotation comment "${rawText.trim()}" at ${uri}:${line} starts with a routing marker but mixes in prose, so the whole line is ignored — keep marker lines marker-only (e.g. "# @agent") and put prose in a separate comment`,
+          `annotation comment "${rawText.trim()}" at ${uri}:${line} starts with a routing marker but mixes in prose, so the whole line is ignored — keep marker lines marker-only (e.g. "# [agent]") and put prose in a separate comment`,
         );
       }
       continue;
@@ -265,7 +292,7 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
     for (const tag of tags) {
       if (tag.name === '@agent') {
         warnings.push(
-          `tag "@agent" at ${uri}:${tag.location.line} is ignored: @agent routes only as a "# @agent" comment directly above a step (feature/scenario tags support @no-ai, @soft, @flow, @param:*)`,
+          `tag "@agent" at ${uri}:${tag.location.line} is ignored: agent routing is per-step only — put a "# [agent]" comment directly above the step (feature/scenario tags support @no-ai, @soft, @flow, @param:*)`,
         );
       }
     }

--- a/packages/bdd/src/annotations.ts
+++ b/packages/bdd/src/annotations.ts
@@ -20,16 +20,25 @@ import { PickleStepType } from '@cucumber/messages';
 import { ERROR_PREFIX } from './types';
 import type { RouterContext, StepAnnotations, StepType } from './types';
 
+// One source for every grammar fragment: the marker names, the skill-token
+// name shape, and the line grammars all derive from these.
+const MARKER_NAMES = ['agent', 'no-ai', 'soft'] as const;
+const MARKER_NAMES_ALT = MARKER_NAMES.join('|');
 // Skill tokens must start with a letter: a leading digit would make money
 // amounts in step text ("the total is $42.50") hijack routing to the agent.
-const SKILL_TOKEN_RE = /\$([A-Za-z][A-Za-z0-9_-]*)/g;
-const SKILL_TOKEN = /\$[A-Za-z][A-Za-z0-9_-]*/.source;
-const MARKER = /\[(?:agent|no-ai|soft)\]/.source;
-const LEGACY_MARKER = /@(?:agent|no-ai|soft)/.source;
+// (Deliberately NOT types.ts IDENT_RE_SOURCE — skills allow hyphens and
+// forbid a leading underscore.)
+const SKILL_NAME = '[A-Za-z][A-Za-z0-9_-]*';
+const SKILL_TOKEN_RE = new RegExp(`\\$(${SKILL_NAME})`, 'g');
+const SKILL_TOKEN = `\\$${SKILL_NAME}`;
+const MARKER = `\\[(?:${MARKER_NAMES_ALT})\\]`;
+const LEGACY_MARKER = `@(?:${MARKER_NAMES_ALT})`;
 const markerOnlyLineRe = (marker: string) =>
   new RegExp(
     `^(?:${marker}|${SKILL_TOKEN})(?:\\s+(?:${marker}|${SKILL_TOKEN}))*$`,
   );
+const markerAtStartRe = (marker: string) =>
+  new RegExp(`^(?:${marker}|${SKILL_TOKEN})(?:\\s|$)`);
 /**
  * An annotation comment line must consist ONLY of markers/tokens after `#`
  * (e.g. `# [agent] $check-logs`). Prose comments that merely mention a marker
@@ -45,14 +54,19 @@ const SOFT_MARKER_RE = /\[soft\]/;
  * inert, so the footgun audit flags it. Prose that merely mentions a marker
  * mid-line ("# TODO: make this [no-ai] later") stays un-flagged.
  */
-const MARKER_AT_START_RE = new RegExp(`^(?:${MARKER}|${SKILL_TOKEN})(?:\\s|$)`);
+const MARKER_AT_START_RE = markerAtStartRe(MARKER);
 /**
- * Marker-only lines in the pre-release `@`-prefixed syntax (`# @agent`,
- * `# @no-ai`, `# @soft`, optionally mixed with `$skill` tokens). They no
- * longer route; the footgun audit recognizes the shape and tells authors
- * to migrate.
+ * The pre-release `@`-prefixed syntax (`# @agent`, marker-only or
+ * marker-at-start). It no longer routes; the footgun audit recognizes both
+ * shapes and tells authors to migrate.
  */
 const LEGACY_MARKER_LINE_RE = markerOnlyLineRe(LEGACY_MARKER);
+const LEGACY_MARKER_AT_START_RE = new RegExp(`^${LEGACY_MARKER}(?:\\s|$)`);
+
+/** Strip `# ` framing from a comment line; shared by resolver and audit. */
+function commentBody(rawText: string): string {
+  return rawText.trim().replace(/^#/, '').trim();
+}
 
 /**
  * The single definition of "this comment line is a routing marker": strip
@@ -61,7 +75,7 @@ const LEGACY_MARKER_LINE_RE = markerOnlyLineRe(LEGACY_MARKER);
  * through here so the two can never disagree on what routes.
  */
 function markerBody(rawText: string): string | undefined {
-  const text = rawText.trim().replace(/^#/, '').trim();
+  const text = commentBody(rawText);
   return ANNOTATION_LINE_RE.test(text) ? text : undefined;
 }
 
@@ -237,12 +251,27 @@ export function resolveStepAnnotations(input: {
  * 3. A comment line that STARTS with a routing marker but mixes in prose
  *    (`# [agent] check the logs`) — only marker-only lines route, so the
  *    line is silently inert despite almost certainly being intended.
- * 4. A marker-only comment in the retired `@`-prefixed syntax (`# @agent`,
- *    `# @no-ai`, `# @soft`) — it never routes anymore; authors must switch
- *    to the bracket form.
+ * 4. The retired `@`-prefixed syntax (`# @agent`, marker-only or
+ *    marker-at-start) — it never routes anymore; authors must switch to
+ *    the bracket form.
  */
-export function collectAnnotationFootguns(document: GherkinDocument): string[] {
-  const warnings: string[] = [];
+export type AnnotationFootgunKind =
+  | 'detached'
+  | 'marker-prose'
+  | 'legacy'
+  | 'tag-level-agent';
+
+export interface AnnotationFootgun {
+  kind: AnnotationFootgunKind;
+  line: number;
+  /** Human-readable warning, already carrying `uri:line`. */
+  message: string;
+}
+
+export function collectAnnotationFootguns(
+  document: GherkinDocument,
+): AnnotationFootgun[] {
+  const footguns: AnnotationFootgun[] = [];
   const uri = document.uri ?? '(unknown feature)';
 
   const { stepById, commentTextByLine } = indexDocument(document);
@@ -253,24 +282,32 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
 
   for (const [line, rawText] of commentTextByLine) {
     if (markerBody(rawText) === undefined) {
-      const body = rawText.trim().replace(/^#/, '').trim();
-      // Retired `@`-marker lines get the migration hint, checked before the
-      // prose rule so mixed lines like "# $skill @agent" are not misreported
-      // as marker-plus-prose. `$skill`-only lines match the legacy shape too,
-      // but they are valid current syntax, so markerBody() already accepted
-      // them and they never reach this branch.
-      if (LEGACY_MARKER_LINE_RE.test(body)) {
-        warnings.push(
-          `annotation comment "${rawText.trim()}" at ${uri}:${line} uses the retired @-marker syntax and is ignored — write bracket markers instead (e.g. "# @agent" → "# [agent]")`,
-        );
+      const body = commentBody(rawText);
+      // Retired `@`-marker lines (marker-only OR marker-at-start prose like
+      // "# @agent check the logs") get the migration hint, checked before
+      // the prose rule so mixed lines like "# $skill @agent" are not
+      // misreported as marker-plus-prose. `$skill`-only lines match the
+      // legacy line shape too, but they are valid current syntax, so
+      // markerBody() already accepted them and they never reach this branch.
+      if (
+        LEGACY_MARKER_LINE_RE.test(body) ||
+        LEGACY_MARKER_AT_START_RE.test(body)
+      ) {
+        footguns.push({
+          kind: 'legacy',
+          line,
+          message: `annotation comment "${rawText.trim()}" at ${uri}:${line} uses the retired @-marker syntax and is ignored — write bracket markers instead (e.g. "# @agent" → "# [agent]")`,
+        });
         continue;
       }
       // Marker-at-start prose ("# [agent] check the logs") is inert despite
       // almost certainly being intended to route.
       if (MARKER_AT_START_RE.test(body)) {
-        warnings.push(
-          `annotation comment "${rawText.trim()}" at ${uri}:${line} starts with a routing marker but mixes in prose, so the whole line is ignored — keep marker lines marker-only (e.g. "# [agent]") and put prose in a separate comment`,
-        );
+        footguns.push({
+          kind: 'marker-prose',
+          line,
+          message: `annotation comment "${rawText.trim()}" at ${uri}:${line} starts with a routing marker but mixes in prose, so the whole line is ignored — keep marker lines marker-only (e.g. "# [agent]") and put prose in a separate comment`,
+        });
       }
       continue;
     }
@@ -283,9 +320,11 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
     if (stepLines.has(runEnd + 1)) {
       continue;
     }
-    warnings.push(
-      `annotation comment "${rawText.trim()}" at ${uri}:${line} is not directly above a step (blank line or non-step content in between), so it will not affect routing — move it to the line right above its step`,
-    );
+    footguns.push({
+      kind: 'detached',
+      line,
+      message: `annotation comment "${rawText.trim()}" at ${uri}:${line} is not directly above a step (blank line or non-step content in between), so it will not affect routing — move it to the line right above its step`,
+    });
   }
 
   // Same explicit feature/rule/scenario walk as indexDocument, plus the
@@ -293,9 +332,11 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
   const checkTags = (tags: readonly Tag[]) => {
     for (const tag of tags) {
       if (tag.name === '@agent') {
-        warnings.push(
-          `tag "@agent" at ${uri}:${tag.location.line} is ignored: agent routing is per-step only — put a "# [agent]" comment directly above the step (feature/scenario tags support @no-ai, @soft, @flow, @param:*)`,
-        );
+        footguns.push({
+          kind: 'tag-level-agent',
+          line: tag.location.line,
+          message: `tag "@agent" at ${uri}:${tag.location.line} is ignored: agent routing is per-step only — put a "# [agent]" comment directly above the step (feature/scenario tags support @no-ai, @soft, @flow, @param:*)`,
+        });
       }
     }
   };
@@ -317,7 +358,7 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
     }
   }
 
-  return warnings;
+  return footguns;
 }
 
 /** Render a pickle data table as `| cell | cell |` lines for prompts. */

--- a/packages/bdd/src/annotations.ts
+++ b/packages/bdd/src/annotations.ts
@@ -23,13 +23,19 @@ import type { RouterContext, StepAnnotations, StepType } from './types';
 // Skill tokens must start with a letter: a leading digit would make money
 // amounts in step text ("the total is $42.50") hijack routing to the agent.
 const SKILL_TOKEN_RE = /\$([A-Za-z][A-Za-z0-9_-]*)/g;
+const SKILL_TOKEN = /\$[A-Za-z][A-Za-z0-9_-]*/.source;
+const MARKER = /\[(?:agent|no-ai|soft)\]/.source;
+const LEGACY_MARKER = /@(?:agent|no-ai|soft)/.source;
+const markerOnlyLineRe = (marker: string) =>
+  new RegExp(
+    `^(?:${marker}|${SKILL_TOKEN})(?:\\s+(?:${marker}|${SKILL_TOKEN}))*$`,
+  );
 /**
  * An annotation comment line must consist ONLY of markers/tokens after `#`
  * (e.g. `# [agent] $check-logs`). Prose comments that merely mention a marker
  * ("# TODO: make this [no-ai] later") must not flip routing.
  */
-const ANNOTATION_LINE_RE =
-  /^(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s+(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*))*$/;
+const ANNOTATION_LINE_RE = markerOnlyLineRe(MARKER);
 const AGENT_MARKER_RE = /\[agent\]/;
 const NO_AI_MARKER_RE = /\[no-ai\]/;
 const SOFT_MARKER_RE = /\[soft\]/;
@@ -39,19 +45,14 @@ const SOFT_MARKER_RE = /\[soft\]/;
  * inert, so the footgun audit flags it. Prose that merely mentions a marker
  * mid-line ("# TODO: make this [no-ai] later") stays un-flagged.
  */
-const MARKER_AT_START_RE =
-  /^(?:\[(?:agent|no-ai|soft)\]|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s|$)/;
+const MARKER_AT_START_RE = new RegExp(`^(?:${MARKER}|${SKILL_TOKEN})(?:\\s|$)`);
 /**
- * The pre-release `@`-prefixed marker syntax (`# @agent`, `# @no-ai`,
- * `# @soft`, optionally mixed with `$skill` tokens). It no longer routes —
- * it was replaced with brackets so comment markers cannot be confused with
- * cucumber's native tag syntax — but the footgun audit still recognizes the
- * shape and tells authors to migrate. Requires at least one `@` marker:
- * `$skill`-only lines are valid CURRENT syntax and never legacy.
+ * Marker-only lines in the pre-release `@`-prefixed syntax (`# @agent`,
+ * `# @no-ai`, `# @soft`, optionally mixed with `$skill` tokens). They no
+ * longer route; the footgun audit recognizes the shape and tells authors
+ * to migrate.
  */
-const LEGACY_MARKER_LINE_RE =
-  /^(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*)(?:\s+(?:@(?:agent|no-ai|soft)|\$[A-Za-z][A-Za-z0-9_-]*))*$/;
-const LEGACY_MARKER_RE = /@(agent|no-ai|soft)\b/;
+const LEGACY_MARKER_LINE_RE = markerOnlyLineRe(LEGACY_MARKER);
 
 /**
  * The single definition of "this comment line is a routing marker": strip
@@ -253,13 +254,14 @@ export function collectAnnotationFootguns(document: GherkinDocument): string[] {
   for (const [line, rawText] of commentTextByLine) {
     if (markerBody(rawText) === undefined) {
       const body = rawText.trim().replace(/^#/, '').trim();
-      // The retired `@`-marker syntax: marker-only shape, but with the old
-      // `@` prefix. Checked before the prose rule — a legacy line also
-      // "starts with" nothing the new grammar knows, and the migration hint
-      // is the actionable message.
-      if (LEGACY_MARKER_LINE_RE.test(body) && LEGACY_MARKER_RE.test(body)) {
+      // Retired `@`-marker lines get the migration hint, checked before the
+      // prose rule so mixed lines like "# $skill @agent" are not misreported
+      // as marker-plus-prose. `$skill`-only lines match the legacy shape too,
+      // but they are valid current syntax, so markerBody() already accepted
+      // them and they never reach this branch.
+      if (LEGACY_MARKER_LINE_RE.test(body)) {
         warnings.push(
-          `annotation comment "${rawText.trim()}" at ${uri}:${line} uses the retired @-marker syntax and is ignored — write square-bracket markers instead (\`# @agent\` → \`# [agent]\`, \`# @no-ai\` → \`# [no-ai]\`, \`# @soft\` → \`# [soft]\`); brackets keep comment markers visually distinct from cucumber tags`,
+          `annotation comment "${rawText.trim()}" at ${uri}:${line} uses the retired @-marker syntax and is ignored — write bracket markers instead (e.g. "# @agent" → "# [agent]")`,
         );
         continue;
       }

--- a/packages/bdd/src/assets.ts
+++ b/packages/bdd/src/assets.ts
@@ -114,8 +114,8 @@ export async function scanAssets(
   // silent by design at resolution time — surface them loudly once per scan.
   const warnFootgun = getDebug('bdd:annotations', { console: true });
   for (const { document } of parsed) {
-    for (const message of collectAnnotationFootguns(document)) {
-      warnFootgun(message);
+    for (const footgun of collectAnnotationFootguns(document)) {
+      warnFootgun(footgun.message);
     }
   }
 

--- a/packages/bdd/src/explore/model.ts
+++ b/packages/bdd/src/explore/model.ts
@@ -17,6 +17,7 @@ import type {
   Step,
 } from '@cucumber/messages';
 import {
+  type AnnotationFootgunKind,
   collectAnnotationFootguns,
   renderDataTable,
   resolveStepAnnotations,
@@ -480,24 +481,25 @@ export async function buildExploreModel(
   }
 
   // Annotation footguns (detached marker comments, legacy @-style markers,
-  // tag-level @agent) are silent no-ops at runtime — exactly the hygiene the
-  // Health panel exists for. Reuse the runtime collector and lift its
-  // `uri:line` into fields.
+  // tag-level @agent) are silent no-ops at runtime — exactly the hygiene
+  // the Health panel exists for. The collector returns structured findings,
+  // so kinds map directly instead of being sniffed out of message prose.
+  const FOOTGUN_KIND: Record<AnnotationFootgunKind, HealthKind> = {
+    detached: 'detached-annotation',
+    // Marker-plus-prose lines share the detached bucket: both are "the
+    // comment exists but does not route".
+    'marker-prose': 'detached-annotation',
+    legacy: 'legacy-annotation',
+    'tag-level-agent': 'tag-level-agent',
+  };
   for (const { document, uri } of parsed) {
     const relPath = path.relative(config.baseDir, uri);
-    for (const warning of collectAnnotationFootguns(document)) {
-      const loc = new RegExp(
-        ` at ${uri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(\\d+) `,
-      ).exec(warning);
+    for (const footgun of collectAnnotationFootguns(document)) {
       ctx.health.push({
-        kind: warning.startsWith('tag "@agent"')
-          ? 'tag-level-agent'
-          : warning.includes('retired @-marker syntax')
-            ? 'legacy-annotation'
-            : 'detached-annotation',
-        message: warning.split(`${uri}:`).join(`${relPath}:`),
+        kind: FOOTGUN_KIND[footgun.kind],
+        message: footgun.message.split(`${uri}:`).join(`${relPath}:`),
         uri: relPath,
-        line: loc ? Number(loc[1]) : undefined,
+        line: footgun.line,
       });
     }
   }

--- a/packages/bdd/src/explore/model.ts
+++ b/packages/bdd/src/explore/model.ts
@@ -40,6 +40,7 @@ export type HealthKind =
   | 'unknown-flow-sugar'
   | 'undeclared-param'
   | 'detached-annotation'
+  | 'legacy-annotation'
   | 'tag-level-agent'
   | 'missing-skill'
   | 'flow-depth';
@@ -137,9 +138,9 @@ export interface ExploreStats {
   flows: number;
   steps: number;
   edges: number;
-  /** Steps routed to the general coding agent (`# @agent` / `$skill`). */
+  /** Steps routed to the general coding agent (`# [agent]` / `$skill`). */
   agentSteps: number;
-  /** Steps routed to a user-registered classic callback (`# @no-ai`). */
+  /** Steps routed to a user-registered classic callback (`# [no-ai]`). */
   noAiSteps: number;
 }
 
@@ -166,6 +167,7 @@ const KIND_ORDER: HealthKind[] = [
   'undeclared-param',
   'missing-skill',
   'detached-annotation',
+  'legacy-annotation',
   'tag-level-agent',
   'unused-flow',
 ];
@@ -477,9 +479,10 @@ export async function buildExploreModel(
     });
   }
 
-  // Annotation footguns (detached marker comments, tag-level @agent) are
-  // silent no-ops at runtime — exactly the hygiene the Health panel exists
-  // for. Reuse the runtime collector and lift its `uri:line` into fields.
+  // Annotation footguns (detached marker comments, legacy @-style markers,
+  // tag-level @agent) are silent no-ops at runtime — exactly the hygiene the
+  // Health panel exists for. Reuse the runtime collector and lift its
+  // `uri:line` into fields.
   for (const { document, uri } of parsed) {
     const relPath = path.relative(config.baseDir, uri);
     for (const warning of collectAnnotationFootguns(document)) {
@@ -489,7 +492,9 @@ export async function buildExploreModel(
       ctx.health.push({
         kind: warning.startsWith('tag "@agent"')
           ? 'tag-level-agent'
-          : 'detached-annotation',
+          : warning.includes('retired @-marker syntax')
+            ? 'legacy-annotation'
+            : 'detached-annotation',
         message: warning.split(`${uri}:`).join(`${relPath}:`),
         uri: relPath,
         line: loc ? Number(loc[1]) : undefined,

--- a/packages/bdd/src/no-ai.ts
+++ b/packages/bdd/src/no-ai.ts
@@ -1,5 +1,5 @@
 /**
- * Classic-BDD escape hatch for `# @no-ai` steps.
+ * Classic-BDD escape hatch for `# [no-ai]` steps.
  *
  * Users register plain cucumber-style callbacks via `Given` / `When` / `Then`
  * / `defineStep`. Per cucumber convention the keyword is documentation only:
@@ -27,7 +27,7 @@ interface RegisteredStep {
  * The package ships dual-format (dist/lib CJS + dist/es ESM), and one process
  * routinely loads BOTH copies: cucumber imports the register entry as CJS
  * while an ESM user project imports `@midscene/bdd` as ESM. Module-level
- * state would give each copy its own registry and `# @no-ai` lookups would
+ * state would give each copy its own registry and `# [no-ai]` lookups would
  * never see the user's callbacks — so the registry is a process-wide
  * singleton stored on `globalThis`.
  */

--- a/packages/bdd/src/router.ts
+++ b/packages/bdd/src/router.ts
@@ -1,8 +1,8 @@
 /**
  * Step router for @midscene/bdd.
  *
- * Routing model (design doc): Midscene UI agent by default; `# @agent` /
- * `$skill` bails a single statement out to the general agent; `# @no-ai`
+ * Routing model (design doc): Midscene UI agent by default; `# [agent]` /
+ * `$skill` bails a single statement out to the general agent; `# [no-ai]`
  * requires a classic user-registered callback. Exact precedence:
  *
  *   1. @no-ai callback

--- a/packages/bdd/src/types.ts
+++ b/packages/bdd/src/types.ts
@@ -3,8 +3,8 @@
  *
  * Every module implements against these types; see each module's header for
  * its exact export surface. Routing model (design doc): Midscene UI agent by
- * default; `# @agent` / `$skill` bails a single statement out to a general
- * coding agent; `# @no-ai` requires a classic user-registered callback.
+ * default; `# [agent]` / `$skill` bails a single statement out to a general
+ * coding agent; `# [no-ai]` requires a classic user-registered callback.
  */
 import type { GherkinDocument, Pickle } from '@cucumber/messages';
 
@@ -104,11 +104,11 @@ export interface ResolvedBddConfig {
  * step (Gherkin has no step-level tags) plus scenario/feature-level tags.
  */
 export interface StepAnnotations {
-  /** `# @agent` above the step, or any `$skill` token present. */
+  /** `# [agent]` above the step, or any `$skill` token present. */
   agent: boolean;
-  /** `# @no-ai` above the step, or `@no-ai` scenario/feature tag. */
+  /** `# [no-ai]` above the step, or `@no-ai` scenario/feature tag. */
   noAi: boolean;
-  /** `# @soft` above the step, or `@soft` scenario/feature tag. */
+  /** `# [soft]` above the step, or `@soft` scenario/feature tag. */
   soft: boolean;
   /** `$skill-name` tokens from the step text and annotation comments. */
   skills: string[];

--- a/packages/bdd/tests/integration/fixtures/features/agent-skill.feature
+++ b/packages/bdd/tests/integration/fixtures/features/agent-skill.feature
@@ -8,3 +8,7 @@ Feature: Agent route with skills
 
   Scenario: unknown skill token
     Then everything is fine per $nope
+
+  Scenario: bracket marker routes without a skill
+    # [agent]
+    Then the disk usage is under quota

--- a/packages/bdd/tests/integration/fixtures/features/no-ai.feature
+++ b/packages/bdd/tests/integration/fixtures/features/no-ai.feature
@@ -1,9 +1,9 @@
 Feature: No-AI classic callbacks
 
   Scenario: matched user callback
-    # @no-ai
+    # [no-ai]
     Given the counter is reset to "5"
 
   Scenario: unmatched user callback
-    # @no-ai
+    # [no-ai]
     Given some step nobody implemented yet

--- a/packages/bdd/tests/integration/fixtures/features/soft.feature
+++ b/packages/bdd/tests/integration/fixtures/features/soft.feature
@@ -2,5 +2,5 @@ Feature: Soft checks
 
   Scenario: soft assertion failure is downgraded to a warning
     Given I open the demo shop
-    # @soft
+    # [soft]
     Then the promo banner is in SOFT_FAIL state

--- a/packages/bdd/tests/integration/run-cucumber.test.ts
+++ b/packages/bdd/tests/integration/run-cucumber.test.ts
@@ -323,6 +323,23 @@ describe('@agent / $skill general agent', () => {
     expect(result.error?.message).toContain('probe found errors');
   });
 
+  it('routes a "# [agent]" marker step to the general agent without skills', async () => {
+    const parsed = loadFeature('features/agent-skill.feature');
+    const result = await runScenario(
+      parsed.document,
+      pickleByName(parsed, 'bracket marker routes without a skill'),
+    );
+
+    expect(result.status).toBe('passed');
+    expect(generalCalls).toHaveLength(1);
+    expect(generalCalls[0].kind).toBe('assert');
+    expect(generalCalls[0].prompt).toContain('the disk usage is under quota');
+    expect(generalCalls[0].skills).toEqual([]);
+    // The marker bails the step out of the UI route entirely.
+    expect(uiRecord().calls).toEqual([]);
+    expect(uiRecord().factoryCalls).toBe(0);
+  });
+
   it('fails an unknown $skill token listing the available skills', async () => {
     const parsed = loadFeature('features/agent-skill.feature');
     const result = await runScenario(

--- a/packages/bdd/tests/real-cucumber/fixture-esm/features/main.feature
+++ b/packages/bdd/tests/real-cucumber/fixture-esm/features/main.feature
@@ -2,5 +2,5 @@ Feature: ESM project smoke
 
   Scenario: An ESM-registered no-ai callback executes
     Given I open the demo shop
-    # @no-ai
+    # [no-ai]
     Then the esm marker step writes "ESM_MARKER"

--- a/packages/bdd/tests/real-cucumber/fixture/features/main.feature
+++ b/packages/bdd/tests/real-cucumber/fixture/features/main.feature
@@ -20,14 +20,14 @@ Feature: Real-cucumber smoke over the stub UI agent
 
   Scenario: Soft assertion failure stays green
     Given I open the demo shop
-    # @soft
+    # [soft]
     Then the promo banner is in SOFT_FAIL state
 
   Scenario: No-ai marker callback
-    # @no-ai
+    # [no-ai]
     Then the marker step writes "MARKER_42"
 
   @must-fail
   Scenario: Unmatched no-ai step fails with a snippet
-    # @no-ai
+    # [no-ai]
     Then nobody ever implemented this step

--- a/packages/bdd/tests/unit-test/annotations.test.ts
+++ b/packages/bdd/tests/unit-test/annotations.test.ts
@@ -424,11 +424,34 @@ Feature: f
 });
 
 describe('collectAnnotationFootguns', () => {
-  function footguns(source: string, uri = 'probe.feature'): string[] {
+  function structuredFootguns(source: string, uri = 'probe.feature') {
     const { document } = parse(source);
     document.uri = uri;
     return collectAnnotationFootguns(document);
   }
+
+  /** Message-only view; most cases assert on the human-readable warning. */
+  function footguns(source: string, uri = 'probe.feature'): string[] {
+    return structuredFootguns(source, uri).map((footgun) => footgun.message);
+  }
+
+  it('returns structured kinds and lines, not just prose', () => {
+    const found = structuredFootguns(`@agent
+Feature: f
+  Scenario: s
+    # [agent]
+
+    # @no-ai
+    # [soft] but with prose
+    When I do a thing
+`);
+    expect(found.map(({ kind, line }) => ({ kind, line }))).toEqual([
+      { kind: 'detached', line: 4 },
+      { kind: 'legacy', line: 6 },
+      { kind: 'marker-prose', line: 7 },
+      { kind: 'tag-level-agent', line: 1 },
+    ]);
+  });
 
   it('warns on a marker comment detached from its step by a blank line', () => {
     const warnings = footguns(`Feature: f
@@ -563,9 +586,10 @@ Feature: f
     expect(warnings[0]).toContain('retired @-marker syntax');
   });
 
-  it('does not flag legacy markers mixed with prose or mid-line mentions', () => {
-    // Only marker-ONLY legacy lines get the migration warning; prose that
-    // mentions the old syntax stays silent, mirroring the new-syntax rule.
+  it('flags legacy markers at line start, ignores mid-line mentions', () => {
+    // `# @agent check the logs` routed before the syntax change, so it gets
+    // the migration hint (same start-of-line rule as the bracket prose
+    // footgun). Prose that mentions the old syntax mid-line stays silent.
     const warnings = footguns(`Feature: f
   Scenario: s
     # @agent check the logs
@@ -573,7 +597,9 @@ Feature: f
     # we used to write @no-ai here
     Then it worked
 `);
-    expect(warnings).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"# @agent check the logs"');
+    expect(warnings[0]).toContain('retired @-marker syntax');
   });
 
   it('stays silent for attached markers, prose comments, and consumed tags', () => {

--- a/packages/bdd/tests/unit-test/annotations.test.ts
+++ b/packages/bdd/tests/unit-test/annotations.test.ts
@@ -108,7 +108,7 @@ describe('resolveStepAnnotations', () => {
   it('reads markers from the comment block directly above the step', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @agent
+    # [agent]
     When I do a thing
 `);
     expect(resolve(parsed, 'I do a thing')).toEqual({
@@ -121,7 +121,7 @@ describe('resolveStepAnnotations', () => {
 
   it('does not leak a comment above the Scenario header into step 1', () => {
     const parsed = parse(`Feature: f
-  # @agent @soft $sneaky
+  # [agent] [soft] $sneaky
   Scenario: s
     When I do a thing
 `);
@@ -136,7 +136,7 @@ describe('resolveStepAnnotations', () => {
   it('parses multiple markers on a single comment line', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @agent @soft $skill-a
+    # [agent] [soft] $skill-a
     When I do a thing
 `);
     expect(resolve(parsed, 'I do a thing')).toEqual({
@@ -150,8 +150,8 @@ describe('resolveStepAnnotations', () => {
   it('collects a contiguous multi-line comment block (marker-only lines)', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @no-ai
-    # @soft
+    # [no-ai]
+    # [soft]
     # $first $second
     When I do a thing
     Then nothing leaked here
@@ -195,7 +195,7 @@ describe('resolveStepAnnotations', () => {
   it('drops the annotation when a blank line separates it from the step', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @no-ai
+    # [no-ai]
 
     When I do a thing
 `);
@@ -212,9 +212,9 @@ describe('resolveStepAnnotations', () => {
   it('stops the block at a non-comment line in between', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @no-ai
+    # [no-ai]
     Given an earlier step
-    # @soft
+    # [soft]
     When I do a thing
 `);
     expect(resolve(parsed, 'I do a thing')).toEqual({
@@ -228,7 +228,7 @@ describe('resolveStepAnnotations', () => {
   it('resolves annotations on Background steps', () => {
     const parsed = parse(`Feature: f
   Background:
-    # @agent
+    # [agent]
     Given a setup step
   Scenario: s
     When an action step
@@ -251,10 +251,10 @@ describe('resolveStepAnnotations', () => {
     const parsed = parse(`Feature: f
   Rule: r
     Background:
-      # @no-ai
+      # [no-ai]
       Given a rule setup
     Scenario: s
-      # @soft
+      # [soft]
       When a rule action
 `);
     expect(resolve(parsed, 'a rule setup')).toEqual({
@@ -274,7 +274,7 @@ describe('resolveStepAnnotations', () => {
   it('shares outline step annotations across all example expansions', () => {
     const parsed = parse(`Feature: f
   Scenario Outline: s
-    # @agent
+    # [agent]
     When I use <x>
 
     Examples:
@@ -395,7 +395,23 @@ Feature: f
   it('does not match marker prefixes of longer words', () => {
     const parsed = parse(`Feature: f
   Scenario: s
-    # @agents @softer @no-aim
+    # [agents] [softer] [no-aim]
+    When I do a thing
+`);
+    expect(resolve(parsed, 'I do a thing')).toEqual({
+      agent: false,
+      noAi: false,
+      soft: false,
+      skills: [],
+    });
+  });
+
+  it('does not route the retired @-marker syntax', () => {
+    // Clean break: `# @agent` was the pre-release syntax and is now plain
+    // prose for the resolver (the footgun audit warns about it separately).
+    const parsed = parse(`Feature: f
+  Scenario: s
+    # @agent @no-ai @soft
     When I do a thing
 `);
     expect(resolve(parsed, 'I do a thing')).toEqual({
@@ -417,35 +433,35 @@ describe('collectAnnotationFootguns', () => {
   it('warns on a marker comment detached from its step by a blank line', () => {
     const warnings = footguns(`Feature: f
   Scenario: s
-    # @agent
+    # [agent]
 
     When I do a thing
 `);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('"# @agent"');
+    expect(warnings[0]).toContain('"# [agent]"');
     expect(warnings[0]).toContain('probe.feature:3');
     expect(warnings[0]).toContain('not directly above a step');
   });
 
   it('warns on a marker comment block stranded above a Scenario header', () => {
     const warnings = footguns(`Feature: f
-  # @no-ai $probe
+  # [no-ai] $probe
   Scenario: s
     When I do a thing
 `);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('"# @no-ai $probe"');
+    expect(warnings[0]).toContain('"# [no-ai] $probe"');
     expect(warnings[0]).toContain('probe.feature:2');
   });
 
   it('warns once per detached marker line, none for the attached block', () => {
     const warnings = footguns(`Feature: f
   Scenario: s
-    # @soft
-    # @agent
+    # [soft]
+    # [agent]
 
     Given an earlier step
-    # @no-ai
+    # [no-ai]
     # $probe
     When I do a thing
 `);
@@ -488,13 +504,13 @@ Feature: f
   it('warns on a comment that starts with a marker but mixes in prose', () => {
     const warnings = footguns(`Feature: f
   Scenario: s
-    # @agent check the logs
+    # [agent] check the logs
     When I do a thing
     # $check-logs after deploying
     Then it worked
 `);
     expect(warnings).toHaveLength(2);
-    expect(warnings[0]).toContain('"# @agent check the logs"');
+    expect(warnings[0]).toContain('"# [agent] check the logs"');
     expect(warnings[0]).toContain('probe.feature:3');
     expect(warnings[0]).toContain('starts with a routing marker');
     expect(warnings[1]).toContain('"# $check-logs after deploying"');
@@ -504,9 +520,57 @@ Feature: f
   it('does not flag prose that merely mentions a marker mid-line', () => {
     const warnings = footguns(`Feature: f
   Scenario: s
-    # TODO: make this @no-ai later
+    # TODO: make this [no-ai] later
     When I do a thing
-    # @agents is not a marker
+    # @agents is not a marker, and neither is [agents]
+    Then it worked
+`);
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns on marker-only comments in the retired @-syntax', () => {
+    const warnings = footguns(`Feature: f
+  Scenario: s
+    # @agent
+    When I do a thing
+    # @no-ai @soft
+    Then it worked
+    # @agent $check-logs
+    Then the logs are clean
+`);
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain('"# @agent"');
+    expect(warnings[0]).toContain('probe.feature:3');
+    expect(warnings[0]).toContain('retired @-marker syntax');
+    expect(warnings[0]).toContain('# [agent]');
+    expect(warnings[1]).toContain('"# @no-ai @soft"');
+    expect(warnings[1]).toContain('probe.feature:5');
+    expect(warnings[2]).toContain('"# @agent $check-logs"');
+    expect(warnings[2]).toContain('probe.feature:7');
+  });
+
+  it('warns the legacy way even when the @-marker comment is detached', () => {
+    // The legacy warning wins over the detached-annotation warning: the
+    // line would not route even if it were attached, so the migration hint
+    // is the actionable message.
+    const warnings = footguns(`Feature: f
+  Scenario: s
+    # @agent
+
+    When I do a thing
+`);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('retired @-marker syntax');
+  });
+
+  it('does not flag legacy markers mixed with prose or mid-line mentions', () => {
+    // Only marker-ONLY legacy lines get the migration warning; prose that
+    // mentions the old syntax stays silent, mirroring the new-syntax rule.
+    const warnings = footguns(`Feature: f
+  Scenario: s
+    # @agent check the logs
+    When I do a thing
+    # we used to write @no-ai here
     Then it worked
 `);
     expect(warnings).toEqual([]);
@@ -518,7 +582,7 @@ Feature: f
   # this prose comment mentions @agent but is not marker-only
   @soft @flow @param:x @must-fail
   Scenario: s
-    # @agent
+    # [agent]
     When I do a thing
 `);
     expect(warnings).toEqual([]);

--- a/packages/bdd/tests/unit-test/explore.test.ts
+++ b/packages/bdd/tests/unit-test/explore.test.ts
@@ -124,14 +124,14 @@ describe('buildExploreModel', () => {
 
   Scenario: Mixed routing
     Given I open the page
-    # @agent
+    # [agent]
     When the coding agent rotates the API key
     Then the server log notes the rotation, per $check-logs
-    # @no-ai
+    # [no-ai]
     Then the counter increments
-    # @soft
+    # [soft]
     Then the banner is visible
-    # @no-ai @agent
+    # [no-ai] [agent]
     Then conflicting markers prefer the callback
 `,
     });
@@ -141,15 +141,15 @@ describe('buildExploreModel', () => {
     // Default → Midscene UI agent.
     expect(steps[0].route).toBe('ui');
     expect(steps[0].annotations.soft).toBe(false);
-    // # @agent comment → general coding agent.
+    // # [agent] comment → general coding agent.
     expect(steps[1].route).toBe('agent');
     expect(steps[1].annotations.skills).toEqual([]);
     // Inline $skill token implies agent and carries the skill name.
     expect(steps[2].route).toBe('agent');
     expect(steps[2].annotations.skills).toEqual(['check-logs']);
-    // # @no-ai → user-registered classic callback.
+    // # [no-ai] → user-registered classic callback.
     expect(steps[3].route).toBe('no-ai');
-    // # @soft is captured but does not change the route.
+    // # [soft] is captured but does not change the route.
     expect(steps[4].route).toBe('ui');
     expect(steps[4].annotations.soft).toBe(true);
     // no-ai beats agent, exactly like the runtime router.
@@ -179,15 +179,15 @@ describe('buildExploreModel', () => {
       'features/main.feature': `Feature: Main
 
   Scenario: Annotated steps skip the flow registry
-    # @agent
+    # [agent]
     Given I am logged in as "admin"
-    # @no-ai
+    # [no-ai]
     And I am logged in as "guest"
     # the next step would be an ambiguous flow match if it were unannotated
-    # @agent
+    # [agent]
     When I do "special" thing
     # ...and this one an unknown-flow-sugar error
-    # @no-ai
+    # [no-ai]
     And I run the "nope" flow
 `,
     });
@@ -368,11 +368,13 @@ Feature: Main
   Scenario: Triggers findings
     When I do "special" thing
     And I run the "nope" flow
-    # @agent
+    # [agent]
 
     Then the detached marker above is ignored
-    # @agent
+    # [agent]
     And the audit log is appended, per $ghost-skill
+    # @agent
+    And the retired @-marker above is flagged as legacy
 `,
     });
     const model = await buildExploreModel(config);
@@ -398,7 +400,7 @@ Feature: Main
       }),
     ]);
 
-    // The "# @agent" comment separated from its step by a blank line never
+    // The "# [agent]" comment separated from its step by a blank line never
     // attaches — surfaced with the file:line of the dangling comment.
     expect(kinds('detached-annotation')).toEqual([
       expect.objectContaining({ uri: 'features/main.feature', line: 7 }),
@@ -411,6 +413,15 @@ Feature: Main
     expect(kinds('tag-level-agent')).toEqual([
       expect.objectContaining({ uri: 'features/main.feature', line: 1 }),
     ]);
+
+    // The retired "# @agent" syntax no longer routes — surfaced as its own
+    // health kind with the migration hint.
+    expect(kinds('legacy-annotation')).toEqual([
+      expect.objectContaining({ uri: 'features/main.feature', line: 12 }),
+    ]);
+    expect(kinds('legacy-annotation')[0].message).toContain(
+      'retired @-marker syntax',
+    );
 
     expect(kinds('missing-skill')).toEqual([
       expect.objectContaining({ subject: 'ghost-skill', line: 11 }),


### PR DESCRIPTION
## Motivation

Review/user feedback: the `# @agent` / `# @no-ai` / `# @soft` comment markers look exactly like cucumber's native `@`-prefixed tag syntax (`@flow`, scenario-level `@no-ai`), which is confusing — a marker is a comment-line extension, not a tag. Comment markers now use square brackets so the two syntaxes can never be mistaken for each other. Applied to all three markers for consistency.

## Syntax change

| Old (retired) | New |
| --- | --- |
| `# @agent` | `# [agent]` |
| `# @no-ai` | `# [no-ai]` |
| `# @soft` | `# [soft]` |
| `# @agent $check-logs` | `# [agent] $check-logs` |

Unchanged: real Gherkin tags (`@flow`, `@param:*`, scenario/feature-level `@no-ai` / `@soft`) and `$skill` tokens (still valid alone on marker lines and inline in step text).

Clean break — the package is unreleased, so the old comment syntax no longer routes and there is no legacy support.

## Legacy-syntax footgun

`collectAnnotationFootguns` now recognizes marker-only comments in the retired `@`-style shape (`# @agent`, `# @no-ai @soft`, `# @agent $skill`) and warns with a migration hint ("uses the retired @-marker syntax … write square-bracket markers instead"). The warning is surfaced:

- at runtime via the existing footgun audit in `scanAssets`
- in the explore model / dashboard Health panel as a new `legacy-annotation` finding kind (seeded into the scale fixture generator so it shows on the scale dashboard)

The legacy warning takes precedence over the detached-annotation warning for the same line; prose mentioning the old syntax mid-line stays silent, mirroring the marker-prose rule (which now applies to the new bracket syntax: `# [agent] check the logs` is flagged as inert).

## Scope of updates

- **Runtime** (`packages/bdd/src`): `ANNOTATION_LINE_RE`, marker regexes, `MARKER_AT_START_RE` rewritten for brackets; new `LEGACY_MARKER_LINE_RE` footgun; footgun message wording (incl. the tag-level `@agent` warning now pointing at `# [agent]`); doc comments across `types.ts`, `router.ts`, `no-ai.ts`, `general-agent.ts`, `explore/model.ts`
- **Explore model**: new `legacy-annotation` `HealthKind` + ordering + message-prefix mapping
- **Feature files**: example suite (error-reporting, gherkin-tour explainer prose), unit/integration/real-cucumber fixtures, `gen-scale-fixture.mjs` (markers + new seeded legacy case)
- **Tests**: annotations/explore unit tests updated + new legacy-footgun and bracket-routing cases; new integration test proving a bare `# [agent]` marker routes to the general agent; existing integration/real-cucumber suites prove `# [no-ai]` / `# [soft]` routing with the new syntax
- **Dashboard** (`apps/bdd-dashboard`): `HealthKind` union, `KIND_META` (new legacy section + reworded descriptions), routing-copy hints, Help glossary, search haystack (`[agent]` / `[no-ai]` instead of `@agent` / `@no-ai`), regenerated typed dev fixture
- **Docs**: `packages/bdd/README.md` (routing table, examples, mermaid router diagram, conventions) and `example/README.md`

## Validation

- `npx vitest run` in `packages/bdd` — 13 files, 200 passed / 1 skipped
- `npx tsc --noEmit` in `packages/bdd` — clean
- `npx rslib build` / `npx nx build bdd` — clean
- `npx nx build bdd-dashboard --skip-nx-cache` — clean (includes app typecheck; template mirrored)
- example `npx midscene-bdd --dry-run` — 15 scenarios / 79 steps, all matched
- regenerated `/tmp/bdd-scale-fixture` via the generator and rendered both dashboards; verified the scale payload health kinds: `{flow-depth:10, undeclared-param:1, missing-skill:1, detached-annotation:1, legacy-annotation:1, tag-level-agent:1, unused-flow:2}` (no servers were live on :18801/:18802, so no in-browser spot-check)
- `npx biome check --fix` + root `pnpm run lint` — clean