### PR TITLE
fix(cli): honor explicit YAML report file names

### DIFF
--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -46,7 +46,8 @@ export const launchServer = async (
 /**
  * Resolves reportFileName with proper priority handling.
  * Priority: YAML reportFileName > CLI testId (legacy) > YAML testId (legacy) > fileName
- * The final name always includes a unique suffix to avoid overwriting.
+ * Explicit YAML reportFileName is treated as the exact output name. Generated
+ * legacy fallbacks include a unique suffix to avoid overwriting.
  */
 function resolveReportFileName(
   yamlReportFileName: string | undefined,
@@ -54,7 +55,10 @@ function resolveReportFileName(
   yamlTestId: string | undefined,
   fileName: string,
 ): string {
-  const baseName = yamlReportFileName ?? cliTestId ?? yamlTestId ?? fileName;
+  if (yamlReportFileName !== undefined) {
+    return yamlReportFileName;
+  }
+  const baseName = cliTestId ?? yamlTestId ?? fileName;
   return getReportFileName(baseName);
 }
 

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -985,7 +985,7 @@ describe('create-yaml-player', () => {
       }
 
       // Verify all agent options were passed
-      // Note: YAML testId takes precedence over fileName
+      // Explicit YAML reportFileName should be passed through unchanged.
       expect(puppeteerAgentForTarget).toHaveBeenCalledWith(
         expect.any(Object),
         expect.objectContaining({
@@ -993,7 +993,7 @@ describe('create-yaml-player', () => {
           groupDescription: 'Custom description',
           generateReport: true,
           autoPrintReportMsg: false,
-          reportFileName: 'custom-report-mock-report',
+          reportFileName: 'custom-report',
           replanningCycleLimit: 25,
           aiActionContext: 'Test context',
         }),
@@ -1075,7 +1075,7 @@ describe('create-yaml-player', () => {
 
       expect(agentFromWebDriverAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          reportFileName: 'ios-test-report-mock-report',
+          reportFileName: 'ios-test-report',
           autoPrintReportMsg: true,
         }),
       );

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -344,7 +344,7 @@ export class Agent<
     });
     this.dump = this.resetDump();
     this.reportFileName =
-      opts?.reportFileName ||
+      opts?.reportFileName ??
       // Keep deprecated testId behavior for generated report names until it is
       // fully removed from the public API.
       getReportFileName(opts?.testId || this.interface.interfaceType || 'web');

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -150,11 +150,11 @@ export class ReportGenerator implements IReportGenerator {
     },
   ): IReportGenerator {
     assertReportGenerationOptions(opts);
+    validateReportFileName(reportFileName);
     if (opts.generateReport === false) return nullReportGenerator;
 
     // In browser environment, file system is not available
     if (ifInBrowser) return nullReportGenerator;
-    validateReportFileName(reportFileName);
 
     const reportRootDir = getMidsceneRunSubDir('report');
     const outputDir = join(reportRootDir, reportFileName);

--- a/packages/core/tests/unit-test/agent-report-filename.test.ts
+++ b/packages/core/tests/unit-test/agent-report-filename.test.ts
@@ -30,4 +30,15 @@ describe('Agent reportFileName', () => {
         }),
     ).toThrow('reportFileName must be a non-empty string');
   });
+
+  it('rejects empty reportFileName even when report generation is disabled', () => {
+    expect(
+      () =>
+        new Agent(createMockInterface(), {
+          reportFileName: '',
+          generateReport: false,
+          modelConfig,
+        }),
+    ).toThrow('reportFileName must be a non-empty string');
+  });
 });

--- a/packages/core/tests/unit-test/agent-report-filename.test.ts
+++ b/packages/core/tests/unit-test/agent-report-filename.test.ts
@@ -1,0 +1,33 @@
+import { Agent } from '@/agent';
+import type { AbstractInterface } from '@/device';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_NAME,
+} from '@midscene/shared/env';
+import { describe, expect, it } from 'vitest';
+
+const modelConfig = {
+  [MIDSCENE_MODEL_NAME]: 'test-model',
+  [MIDSCENE_MODEL_API_KEY]: 'test-key',
+  [MIDSCENE_MODEL_BASE_URL]: 'https://api.test.com/v1',
+};
+
+function createMockInterface() {
+  return {
+    interfaceType: 'puppeteer',
+    actionSpace: () => [],
+  } as unknown as AbstractInterface;
+}
+
+describe('Agent reportFileName', () => {
+  it('rejects empty reportFileName when provided', () => {
+    expect(
+      () =>
+        new Agent(createMockInterface(), {
+          reportFileName: '',
+          modelConfig,
+        }),
+    ).toThrow('reportFileName must be a non-empty string');
+  });
+});

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -934,6 +934,14 @@ describe('ReportGenerator — append-only model', () => {
       expect(gen).toBe(nullReportGenerator);
     });
 
+    it('should reject empty reportFileName when generateReport is false', () => {
+      expect(() =>
+        ReportGenerator.create('', {
+          generateReport: false,
+        }),
+      ).toThrow('reportFileName must be a non-empty string');
+    });
+
     it('should throw when persistExecutionDump is true and generateReport is false', () => {
       expect(() =>
         ReportGenerator.create('test-invalid', {

--- a/packages/web-integration/tests/unit-test/agent.test.ts
+++ b/packages/web-integration/tests/unit-test/agent.test.ts
@@ -162,6 +162,16 @@ describe('PageAgent reportFileName', () => {
     expect(agent.reportFileName).toBe(customReportName);
   });
 
+  it('should reject empty reportFileName when provided', () => {
+    expect(
+      () =>
+        new PageAgent(mockPage, {
+          reportFileName: '',
+          modelConfig: mockedModelConfig,
+        }),
+    ).toThrow('reportFileName must be a non-empty string');
+  });
+
   it('should generate reportFileName when not provided', () => {
     const agent = new PageAgent(mockPage, {
       modelConfig: mockedModelConfig,


### PR DESCRIPTION
## Summary

- Preserve explicit YAML `agent.reportFileName` values as the exact report output name.
- Keep generated unique names for legacy `testId` and filename fallback paths.
- Reject explicitly empty `reportFileName` values, including when report generation is disabled.
- Update CLI, core, report generator, and web consumer unit coverage for report file name behavior.

## Validation

- `pnpm --filter @midscene/cli test -- tests/unit-test/create-yaml-player.test.ts`
- `pnpm --filter @midscene/core test -- tests/unit-test/agent-report-filename.test.ts tests/unit-test/report-generator.test.ts`
- `pnpm exec nx test @midscene/core -- tests/unit-test/agent-report-filename.test.ts tests/unit-test/report-generator.test.ts`
- `pnpm exec nx build @midscene/core`
- `pnpm --filter @midscene/web test -- tests/unit-test/agent.test.ts`
- `pnpm run lint`