### PR TITLE
fix(web-integration): handle serialized static screenshots

### DIFF
--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -12,7 +12,43 @@ const ThrowNotImplemented = (methodName: string) => {
   );
 };
 
-type StaticPageUIContext = Omit<UIContext, 'deprecatedDpr'>;
+type StaticPageUIContext = Omit<
+  UIContext,
+  'deprecatedDpr' | 'screenshot'
+> & {
+  screenshot: unknown;
+};
+
+function screenshotBase64FromContext(screenshot: unknown): string {
+  if (typeof screenshot === 'string') {
+    return screenshot;
+  }
+
+  if (!screenshot || typeof screenshot !== 'object') {
+    throw new Error('StaticPage screenshot must be a base64 string');
+  }
+
+  const record = screenshot as Record<string, unknown>;
+  if (typeof record.base64 === 'string') {
+    return record.base64;
+  }
+
+  // Server-mode report playback sends UIContext through JSON. ScreenshotItem
+  // instances lose their getter there, but keep the in-memory payload here.
+  if (typeof record._base64 === 'string') {
+    return record._base64;
+  }
+
+  if (record.type === 'midscene_screenshot_ref') {
+    throw new Error(
+      'StaticPage screenshot is a serialized reference without base64 data',
+    );
+  }
+
+  throw new Error(
+    'StaticPage screenshot must include base64 data before execution',
+  );
+}
 
 export default class StaticPage implements AbstractInterface {
   interfaceType = 'static';
@@ -78,11 +114,7 @@ export default class StaticPage implements AbstractInterface {
   }
 
   async screenshotBase64() {
-    const screenshot = this.uiContext.screenshot;
-    if (typeof screenshot === 'object' && 'base64' in screenshot) {
-      return (screenshot as { base64: string }).base64;
-    }
-    return screenshot as unknown as string;
+    return screenshotBase64FromContext(this.uiContext.screenshot);
   }
 
   async url() {

--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -24,22 +24,16 @@ function screenshotBase64FromContext(screenshot: unknown): string {
     return screenshot;
   }
 
-  if (!screenshot || typeof screenshot !== 'object') {
-    throw new Error('StaticPage screenshot must be a base64 string');
+  const record =
+    screenshot && typeof screenshot === 'object'
+      ? (screenshot as Record<string, unknown>)
+      : undefined;
+  const base64 = record?.base64 ?? record?._base64;
+  if (typeof base64 === 'string') {
+    return base64;
   }
 
-  const record = screenshot as Record<string, unknown>;
-  if (typeof record.base64 === 'string') {
-    return record.base64;
-  }
-
-  // Server-mode report playback sends UIContext through JSON. ScreenshotItem
-  // instances lose their getter there, but keep the in-memory payload here.
-  if (typeof record._base64 === 'string') {
-    return record._base64;
-  }
-
-  if (record.type === 'midscene_screenshot_ref') {
+  if (record?.type === 'midscene_screenshot_ref') {
     throw new Error(
       'StaticPage screenshot is a serialized reference without base64 data',
     );

--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -12,28 +12,29 @@ const ThrowNotImplemented = (methodName: string) => {
   );
 };
 
+type SerializedStaticScreenshot = {
+  base64?: unknown;
+  _base64?: unknown;
+  type?: unknown;
+};
+
 type StaticPageUIContext = Omit<
   UIContext,
   'deprecatedDpr' | 'screenshot'
 > & {
-  screenshot: unknown;
+  screenshot: UIContext['screenshot'] | SerializedStaticScreenshot;
 };
 
-function screenshotBase64FromContext(screenshot: unknown): string {
-  if (typeof screenshot === 'string') {
-    return screenshot;
-  }
-
-  const record =
-    screenshot && typeof screenshot === 'object'
-      ? (screenshot as Record<string, unknown>)
-      : undefined;
-  const base64 = record?.base64 ?? record?._base64;
+function screenshotBase64FromContext(
+  screenshot: StaticPageUIContext['screenshot'],
+): string {
+  const record = screenshot as SerializedStaticScreenshot;
+  const base64 = record.base64 ?? record._base64;
   if (typeof base64 === 'string') {
     return base64;
   }
 
-  if (record?.type === 'midscene_screenshot_ref') {
+  if (record.type === 'midscene_screenshot_ref') {
     throw new Error(
       'StaticPage screenshot is a serialized reference without base64 data',
     );

--- a/packages/web-integration/tests/ai/web/static/static-page.test.ts
+++ b/packages/web-integration/tests/ai/web/static/static-page.test.ts
@@ -9,7 +9,7 @@ const dumpFilePath = join(__dirname, '../../fixtures/ui-context.json');
 const context = readFileSync(dumpFilePath, { encoding: 'utf-8' });
 const contextJson = JSON.parse(context);
 
-contextJson.screenshot = contextJson.screenshotBase64;
+contextJson.screenshot = { base64: contextJson.screenshotBase64 };
 
 describe(
   'static page agent',

--- a/packages/web-integration/tests/unit-test/playground-server.test.ts
+++ b/packages/web-integration/tests/unit-test/playground-server.test.ts
@@ -1,7 +1,7 @@
 import { ScreenshotItem } from '@midscene/core';
 import { PlaygroundServer } from '@midscene/playground';
-import { StaticPage, StaticPageAgent } from '@midscene/web/static';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { StaticPage, StaticPageAgent } from '../../src/static';
 
 describe('Playground Server', () => {
   let server: PlaygroundServer;
@@ -43,5 +43,33 @@ describe('Playground Server', () => {
     const context = await contextRes.json();
     expect(context).toBeDefined();
     expect(context.context).toBe(contextValue);
+  });
+
+  it('updates static context with a JSON-serialized ScreenshotItem', async () => {
+    const screenshotBase64 = 'data:image/png;base64,abc123';
+    const serializedScreenshot = JSON.parse(
+      JSON.stringify(ScreenshotItem.create(screenshotBase64, Date.now())),
+    );
+
+    const res = await fetch(`${serverBase}/action-space`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        context: {
+          shotSize: { width: 800, height: 600 },
+          shrunkShotToLogicalRatio: 1,
+          screenshot: serializedScreenshot,
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const screenshotRes = await fetch(`${serverBase}/screenshot`);
+    expect(screenshotRes.status).toBe(200);
+    const screenshot = await screenshotRes.json();
+    expect(screenshot.screenshot).toBe(screenshotBase64);
   });
 });

--- a/packages/web-integration/tests/unit-test/static-page.test.ts
+++ b/packages/web-integration/tests/unit-test/static-page.test.ts
@@ -1,0 +1,50 @@
+import { ScreenshotItem } from '@midscene/core';
+import { describe, expect, it } from 'vitest';
+import { StaticPage } from '../../src/static';
+
+const screenshotBase64 = 'data:image/png;base64,abc123';
+
+function createContext(
+  screenshot: unknown,
+): ConstructorParameters<typeof StaticPage>[0] {
+  return {
+    shotSize: { width: 800, height: 600 },
+    shrunkShotToLogicalRatio: 1,
+    screenshot,
+  } as ConstructorParameters<typeof StaticPage>[0];
+}
+
+describe('StaticPage', () => {
+  it('returns base64 from a ScreenshotItem instance', async () => {
+    const page = new StaticPage(
+      createContext(ScreenshotItem.create(screenshotBase64, Date.now())),
+    );
+
+    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+  });
+
+  it('returns base64 from a JSON-serialized ScreenshotItem', async () => {
+    const serializedScreenshot = JSON.parse(
+      JSON.stringify(ScreenshotItem.create(screenshotBase64, Date.now())),
+    );
+    const page = new StaticPage(createContext(serializedScreenshot));
+
+    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+  });
+
+  it('rejects screenshot refs that do not include base64 data', async () => {
+    const page = new StaticPage(
+      createContext({
+        type: 'midscene_screenshot_ref',
+        id: 'screenshot-id',
+        capturedAt: Date.now(),
+        mimeType: 'image/png',
+        storage: 'inline',
+      }),
+    );
+
+    await expect(page.screenshotBase64()).rejects.toThrow(
+      'serialized reference without base64 data',
+    );
+  });
+});

--- a/packages/web-integration/tests/unit-test/static-page.test.ts
+++ b/packages/web-integration/tests/unit-test/static-page.test.ts
@@ -5,13 +5,13 @@ import { StaticPage } from '../../src/static';
 const screenshotBase64 = 'data:image/png;base64,abc123';
 
 function createContext(
-  screenshot: unknown,
+  screenshot: ConstructorParameters<typeof StaticPage>[0]['screenshot'],
 ): ConstructorParameters<typeof StaticPage>[0] {
   return {
     shotSize: { width: 800, height: 600 },
     shrunkShotToLogicalRatio: 1,
     screenshot,
-  } as ConstructorParameters<typeof StaticPage>[0];
+  };
 }
 
 describe('StaticPage', () => {
@@ -19,6 +19,12 @@ describe('StaticPage', () => {
     const page = new StaticPage(
       createContext(ScreenshotItem.create(screenshotBase64, Date.now())),
     );
+
+    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+  });
+
+  it('returns base64 from a restored report screenshot object', async () => {
+    const page = new StaticPage(createContext({ base64: screenshotBase64 }));
 
     await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
   });


### PR DESCRIPTION
## Summary

- Handle `StaticPage` screenshots that arrive as JSON-serialized `ScreenshotItem` objects from Playground Server mode.
- Preserve support for normal `ScreenshotItem` instances and string/base64 screenshots, while throwing a clearer error for screenshot refs without inline base64 data.
- Add focused `StaticPage` coverage and a Playground Server regression test for JSON-serialized screenshots.

## Root Cause

The first introducing change was `8e02e9a292db73c2b9c29f24ffff9b1580433f11` (`refactor(core): replace StorageProvider with ReportGenerator protocol`, #1823) on 2026-02-03. That refactor removed the `ScreenshotItem.toJSON()` path that serialized screenshots as `{ base64 }`. In report Playground Server mode, `UIContext` is sent through JSON to `/execute`; the server middleware then updates the static page context with a plain object containing internal screenshot fields such as `_base64`. `StaticPage.screenshotBase64()` only recognized a public `base64` property and otherwise returned the whole object, which later reached `imageInfoOfBase64()` and produced `imageBase64.replace is not a function`.

`9a84b5bfd6e8b8dee8c5f5f965453bf6c166fdfe` (#1994) later kept the same fallback while removing legacy context compatibility, but it was not the first introducing commit for this error shape.

## Validation

- `pnpm --dir packages/web-integration exec vitest --run tests/unit-test/static-page.test.ts tests/unit-test/playground-server.test.ts`
- `npx nx test @midscene/web -- tests/unit-test/static-page.test.ts tests/unit-test/playground-server.test.ts`
- `npx nx build @midscene/web`
- `pnpm run lint`
- `git diff --check`
