### PR TITLE
fix(core): include retry attempts in AI request errors

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -64,6 +64,49 @@ function stringifyForDebug(value: unknown): string {
   }
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function normalizeRetryCount(retryCount: unknown): number {
+  if (typeof retryCount !== 'number' || !Number.isFinite(retryCount)) {
+    return 1;
+  }
+
+  return Math.max(0, Math.floor(retryCount));
+}
+
+function appendAIRequestFailureSummary<T extends Error>(
+  error: T,
+  attemptErrors: Array<{ attempt: number; error: unknown }>,
+  maxAttempts: number,
+): T {
+  const failedAttempts = attemptErrors.length;
+  const retries = Math.max(0, failedAttempts - 1);
+  const retryLabel = retries === 1 ? 'retry' : 'retries';
+  const originalMessage = error.message;
+  const previousAttemptErrors = attemptErrors.slice(0, -1);
+
+  error.message = `AI model request failed after ${retries} ${retryLabel} (${failedAttempts}/${maxAttempts} attempts). Last error: ${originalMessage}`;
+
+  if (previousAttemptErrors.length === 0) {
+    return error;
+  }
+
+  const details = previousAttemptErrors
+    .map(
+      ({ attempt, error }) => `Attempt ${attempt}: ${getErrorMessage(error)}`,
+    )
+    .join('\n');
+
+  error.message = `${error.message}\nPrevious AI call attempt errors:\n${details}`;
+  return error;
+}
+
 export async function createChatClient({
   modelConfig,
 }: {
@@ -479,11 +522,12 @@ export async function callAI(
       );
     } else {
       // Non-streaming with retry logic
-      const retryCount = modelConfig.retryCount ?? 1;
+      const retryCount = normalizeRetryCount(modelConfig.retryCount);
       const retryInterval = modelConfig.retryInterval ?? 2000;
       const maxAttempts = retryCount + 1; // retryCount=1 means 2 total attempts (1 initial + 1 retry)
 
       let lastError: Error | undefined;
+      const attemptErrors: Array<{ attempt: number; error: unknown }> = [];
 
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         const { signal: attemptSignal, cleanup: cleanupAttemptSignal } =
@@ -542,7 +586,8 @@ export async function callAI(
 
           break; // Success, exit retry loop
         } catch (error) {
-          lastError = error as Error;
+          lastError = toError(error);
+          attemptErrors.push({ attempt, error });
           const wasHardTimeout = isHardTimeoutError(lastError);
           if (wasHardTimeout) {
             warnCall(
@@ -565,7 +610,15 @@ export async function callAI(
       }
 
       if (!content) {
-        throw lastError;
+        assert(
+          lastError,
+          'AI model request failed without recording an attempt error',
+        );
+        throw appendAIRequestFailureSummary(
+          lastError,
+          attemptErrors,
+          maxAttempts,
+        );
       }
     }
 

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -193,6 +193,83 @@ describe('service-caller request timeout', () => {
     expect(mockCreate).toHaveBeenCalledTimes(2);
   });
 
+  it('includes previous attempt errors when all retry attempts fail', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+
+    mockCreate
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockRejectedValueOnce(new Error('second failure'));
+
+    const promise = callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime(baseConfig({ retryCount: 1, retryInterval: 0 })),
+    );
+
+    await expect(promise).rejects.toThrow(/second failure/);
+    await expect(promise).rejects.toThrow(
+      /AI model request failed after 1 retry \(2\/2 attempts\)/,
+    );
+    await expect(promise).rejects.toThrow(/Previous AI call attempt errors/);
+    await expect(promise).rejects.toThrow(/Attempt 1: first failure/);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes negative retryCount to zero retries', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+
+    mockCreate.mockRejectedValueOnce(new Error('single failure'));
+
+    const promise = callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime(baseConfig({ retryCount: -1, retryInterval: 0 })),
+    );
+
+    await expect(promise).rejects.toThrow(
+      /AI model request failed after 0 retries \(1\/1 attempts\)/,
+    );
+    await expect(promise).rejects.toThrow(/single failure/);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { retryCount: Number.NaN, expectedRetries: 1, expectedAttempts: 2 },
+    {
+      retryCount: Number.POSITIVE_INFINITY,
+      expectedRetries: 1,
+      expectedAttempts: 2,
+    },
+    { retryCount: 2.9, expectedRetries: 2, expectedAttempts: 3 },
+  ])(
+    'normalizes retryCount $retryCount to $expectedRetries retries',
+    async ({ retryCount, expectedRetries, expectedAttempts }) => {
+      const { callAI } = await import('@/ai-model/service-caller');
+      const { getModelRuntime } = await import('@/ai-model/models');
+
+      for (let i = 1; i <= expectedAttempts; i++) {
+        mockCreate.mockRejectedValueOnce(new Error(`failure ${i}`));
+      }
+
+      const promise = callAI(
+        [{ role: 'user', content: 'hello' }],
+        getModelRuntime(baseConfig({ retryCount, retryInterval: 0 })),
+      );
+
+      await expect(promise).rejects.toThrow(
+        new RegExp(
+          `AI model request failed after ${expectedRetries} ${
+            expectedRetries === 1 ? 'retry' : 'retries'
+          } \\(${expectedAttempts}\\/${expectedAttempts} attempts\\)`,
+        ),
+      );
+      await expect(promise).rejects.toThrow(
+        new RegExp(`failure ${expectedAttempts}`),
+      );
+      expect(mockCreate).toHaveBeenCalledTimes(expectedAttempts);
+    },
+  );
+
   it('disables the hard timeout when modelConfig.timeout is 0', async () => {
     const { callAI } = await import('@/ai-model/service-caller');
     const { getModelRuntime } = await import('@/ai-model/models');


### PR DESCRIPTION
## Summary

- Add retry attempt summaries to non-streaming AI request failures.
- Preserve previous failed attempt messages alongside the final error.
- Normalize invalid `retryCount` values so negative counts still perform one initial attempt.

## Why

When all AI request attempts failed, the final thrown error only showed the last failure. This made it hard to diagnose cases where the first attempt failed for a different reason, such as a 429 followed by a timeout.

## Validation

- `pnpm --filter @midscene/core test tests/unit-test/service-caller-timeout.test.ts`
- `git diff --check`

Lint was not run per local workflow preference.