### PR TITLE
MID-5: support Web YAML downloadPath

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -166,6 +166,11 @@ web:
   # Path to a JSON format browser cookie file, optional.
   cookie: <path-to-cookie-file>
 
+  # Chrome download directory (Puppeteer only), optional.
+  # Relative paths are resolved from the current working directory.
+  # Not supported in bridge mode.
+  downloadPath: <path-to-download-directory>
+
   # Extra HTTP headers sent with every request (Puppeteer only), optional.
   # Useful when the server validates custom request headers.
   # Values must be strings; quote values YAML would treat as a boolean or number, e.g. "true".

--- a/apps/site/docs/en/bridge-mode.mdx
+++ b/apps/site/docs/en/bridge-mode.mdx
@@ -110,6 +110,9 @@ In bridge mode, these options will be ignored (they will follow your desktop bro
 - deviceScaleFactor
 - waitForNetworkIdle
 - cookie
+- extraHTTPHeaders
+- downloadPath
+- chromeArgs
 
 ## Remote Access Configuration
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -165,6 +165,11 @@ web:
   # JSON 格式的浏览器 Cookie 文件路径，可选
   cookie: <path-to-cookie-file>
 
+  # Chrome 下载目录（仅 Puppeteer 模式），可选
+  # 相对路径会基于当前工作目录解析
+  # bridgeMode 不支持该选项
+  downloadPath: <path-to-download-directory>
+
   # 随每个请求发送的额外 HTTP 请求头（仅 Puppeteer 模式），可选
   # 适用于服务器会校验自定义请求头的场景
   # 值必须是字符串；像 true、false、纯数字这类会被 YAML 解析为非字符串的值需加引号，如 "true"

--- a/apps/site/docs/zh/bridge-mode.mdx
+++ b/apps/site/docs/zh/bridge-mode.mdx
@@ -102,6 +102,9 @@ midscene ./bing.yaml
 - `deviceScaleFactor`
 - `waitForNetworkIdle`
 - `cookie`
+- `extraHTTPHeaders`
+- `downloadPath`
+- `chromeArgs`
 
 ## 远程访问配置
 

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -17,7 +17,10 @@ import type { AbstractInterface } from '@midscene/core/device';
 import { processCacheConfig } from '@midscene/core/utils';
 import { getDebug } from '@midscene/shared/logger';
 import { AgentOverChromeBridge } from '@midscene/web/bridge-mode';
-import { puppeteerAgentForTarget } from '@midscene/web/puppeteer-agent-launcher';
+import {
+  buildDownloadBehavior,
+  puppeteerAgentForTarget,
+} from '@midscene/web/puppeteer-agent-launcher';
 import type { Browser, Page } from 'puppeteer';
 import puppeteer from 'puppeteer';
 
@@ -187,6 +190,7 @@ export async function createYamlPlayer(
             (await puppeteer.connect({
               browserWSEndpoint: webTarget.cdpEndpoint,
               defaultViewport: null,
+              downloadBehavior: buildDownloadBehavior(webTarget.downloadPath),
             }));
 
           // Warn about options that don't apply to an already-running browser

--- a/packages/cli/src/create-yaml-player.ts
+++ b/packages/cli/src/create-yaml-player.ts
@@ -261,6 +261,7 @@ export async function createYamlPlayer(
           'waitForNetworkIdle',
           'cookie',
           'extraHTTPHeaders',
+          'downloadPath',
           'chromeArgs',
         ];
         const ignoredKeys = bridgeUnsupportedKeys.filter(

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -10,6 +10,7 @@ import type {
 import { type ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
 import {
   buildChromeArgs,
+  buildDownloadBehavior,
   defaultViewportHeight,
   defaultViewportWidth,
 } from '@midscene/web/puppeteer-agent-launcher';
@@ -127,6 +128,9 @@ class YamlBatchExecutor {
           browser = await puppeteer.connect({
             browserWSEndpoint: globalWebConfig.cdpEndpoint,
             defaultViewport: null,
+            downloadBehavior: buildDownloadBehavior(
+              globalWebConfig.downloadPath,
+            ),
           });
         } else {
           // Extract viewport dimensions from global config or use defaults
@@ -145,6 +149,9 @@ class YamlBatchExecutor {
           browser = await puppeteer.launch({
             headless: !headed,
             defaultViewport: headed ? null : { width, height },
+            downloadBehavior: buildDownloadBehavior(
+              globalWebConfig?.downloadPath,
+            ),
             args,
             acceptInsecureCerts: globalWebConfig?.acceptInsecureCerts,
           });

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -6,6 +6,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
+import path from 'node:path';
 import { BatchRunner } from '@/batch-runner';
 import { createYamlPlayer } from '@/create-yaml-player';
 import type {
@@ -61,7 +62,18 @@ vi.mock('@midscene/web/puppeteer-agent-launcher', async (importOriginal) => {
     await importOriginal<
       typeof import('@midscene/web/puppeteer-agent-launcher')
     >();
-  return { ...original };
+  return {
+    ...original,
+    buildDownloadBehavior: (downloadPath: string | undefined) =>
+      downloadPath
+        ? {
+            policy: 'allow',
+            downloadPath: downloadPath.startsWith('/')
+              ? downloadPath
+              : `${process.cwd()}/${downloadPath.replace(/^\.\//, '')}`,
+          }
+        : undefined,
+  };
 });
 vi.mock('@midscene/web/bridge-mode');
 vi.mock('@midscene/android');
@@ -213,6 +225,30 @@ describe('BatchRunner', () => {
       expect(launchCall).toHaveProperty('acceptInsecureCerts', true);
     });
 
+    test('should pass downloadPath to Puppeteer launch options when shareBrowserContext is true', async () => {
+      const config = {
+        ...mockBatchConfig,
+        shareBrowserContext: true,
+        files: ['web1.yml'],
+        globalConfig: {
+          web: {
+            url: 'http://example.com',
+            downloadPath: './downloads',
+          },
+        },
+      };
+      const runner = new BatchRunner(config);
+      await runner.run();
+
+      expect(puppeteer.launch).toHaveBeenCalledTimes(1);
+
+      const launchCall = vi.mocked(puppeteer.launch).mock.calls[0][0];
+      expect(launchCall).toHaveProperty('downloadBehavior', {
+        policy: 'allow',
+        downloadPath: path.resolve('./downloads'),
+      });
+    });
+
     test('should not create a shared browser instance when shareBrowserContext is false', async () => {
       const config = {
         ...mockBatchConfig,
@@ -273,9 +309,36 @@ describe('BatchRunner', () => {
       expect(puppeteer.connect).toHaveBeenCalledWith({
         browserWSEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
         defaultViewport: null,
+        downloadBehavior: undefined,
       });
       // Should NOT call launch
       expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    test('should pass downloadPath to Puppeteer connect options when shareBrowserContext uses CDP', async () => {
+      const config = {
+        ...mockBatchConfig,
+        shareBrowserContext: true,
+        files: ['web1.yml'],
+        globalConfig: {
+          web: {
+            url: 'http://example.com',
+            cdpEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
+            downloadPath: './downloads',
+          },
+        },
+      };
+      const runner = new BatchRunner(config);
+      await runner.run();
+
+      expect(puppeteer.connect).toHaveBeenCalledWith({
+        browserWSEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
+        defaultViewport: null,
+        downloadBehavior: {
+          policy: 'allow',
+          downloadPath: path.resolve('./downloads'),
+        },
+      });
     });
 
     test('should disconnect (not close) browser in CDP mode', async () => {

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { createYamlPlayer, launchServer } from '@/create-yaml-player';
 import type { MidsceneYamlScript, MidsceneYamlScriptEnv } from '@midscene/core';
 import { processCacheConfig } from '@midscene/core/utils';
@@ -47,9 +48,25 @@ vi.mock('@midscene/web/bridge-mode', () => ({
   AgentOverChromeBridge: vi.fn(),
 }));
 
-vi.mock('@midscene/web/puppeteer-agent-launcher', () => ({
-  puppeteerAgentForTarget: vi.fn(),
-}));
+vi.mock('@midscene/web/puppeteer-agent-launcher', async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import('@midscene/web/puppeteer-agent-launcher')
+    >();
+  return {
+    ...original,
+    buildDownloadBehavior: (downloadPath: string | undefined) =>
+      downloadPath
+        ? {
+            policy: 'allow',
+            downloadPath: downloadPath.startsWith('/')
+              ? downloadPath
+              : `${process.cwd()}/${downloadPath.replace(/^\.\//, '')}`,
+          }
+        : undefined,
+    puppeteerAgentForTarget: vi.fn(),
+  };
+});
 
 vi.mock('@midscene/web/puppeteer', () => ({
   PuppeteerAgent: vi.fn(),
@@ -1374,6 +1391,7 @@ describe('create-yaml-player', () => {
       expect(puppeteer.connect).toHaveBeenCalledWith({
         browserWSEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
         defaultViewport: null,
+        downloadBehavior: undefined,
       });
 
       // Should reuse puppeteerAgentForTarget (page setup: viewport, userAgent, etc.)
@@ -1383,6 +1401,53 @@ describe('create-yaml-player', () => {
         mockBrowser, // CDP browser passed as browser param
         undefined, // no shared page
       );
+    });
+
+    test('should configure download behavior via Puppeteer connect options in CDP mode', async () => {
+      const mockScript: MidsceneYamlScript = {
+        web: {
+          url: 'http://example.com',
+          cdpEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
+          downloadPath: './downloads',
+        },
+        tasks: [],
+      };
+
+      const mockBrowser = {
+        disconnect: vi.fn(),
+      };
+      const mockAgent = { destroy: vi.fn() };
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(readFileSync).mockReturnValue('mock yaml content');
+      vi.mocked(parseYamlScript).mockReturnValue(mockScript);
+
+      const puppeteer = (await import('puppeteer')).default;
+      vi.mocked(puppeteer.connect).mockResolvedValue(mockBrowser as any);
+
+      vi.mocked(puppeteerAgentForTarget).mockResolvedValue({
+        agent: mockAgent as any,
+        freeFn: [],
+      });
+
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+      await setupFnCallback?.();
+
+      expect(puppeteer.connect).toHaveBeenCalledWith({
+        browserWSEndpoint: 'ws://localhost:9222/devtools/browser/xxx',
+        defaultViewport: null,
+        downloadBehavior: {
+          policy: 'allow',
+          downloadPath: path.resolve('./downloads'),
+        },
+      });
     });
 
     test('should pass agent options in CDP mode via puppeteerAgentForTarget', async () => {

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -275,6 +275,42 @@ describe('create-yaml-player', () => {
 
       expect(result).toBe(mockPlayer);
     });
+
+    test('should pass web downloadPath to puppeteer agent launcher', async () => {
+      const mockScript: MidsceneYamlScript = {
+        web: {
+          url: 'http://example.com',
+          downloadPath: './downloads',
+        },
+        tasks: [],
+      };
+      const mockAgent = { destroy: vi.fn() };
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(puppeteerAgentForTarget).mockResolvedValue({
+        agent: mockAgent as any,
+        freeFn: [],
+      });
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+      await setupFnCallback?.();
+
+      expect(puppeteerAgentForTarget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'http://example.com',
+          downloadPath: './downloads',
+        }),
+        expect.any(Object),
+        undefined,
+        undefined,
+      );
+    });
   });
 
   describe('Cache configuration - Legacy compatibility mode', () => {
@@ -819,6 +855,44 @@ describe('create-yaml-player', () => {
           aiActionContext: 'This is a test context for bridge mode',
         }),
       );
+    });
+
+    test('should warn that downloadPath is ignored in bridge mode', async () => {
+      const mockScript: MidsceneYamlScript = {
+        web: {
+          url: 'http://example.com',
+          bridgeMode: 'newTabWithUrl',
+          downloadPath: './downloads',
+        },
+        tasks: [],
+      };
+
+      const mockAgent = {
+        destroy: vi.fn(),
+        connectNewTabWithUrl: vi.fn().mockResolvedValue(undefined),
+      };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      let setupFnCallback: (() => Promise<any>) | undefined;
+
+      vi.mocked(readFileSync).mockReturnValue('mock yaml content');
+      vi.mocked(parseYamlScript).mockReturnValue(mockScript);
+      vi.mocked(AgentOverChromeBridge).mockImplementation(
+        () => mockAgent as any,
+      );
+      vi.mocked(ScriptPlayer).mockImplementation((script, setupFn) => {
+        setupFnCallback = setupFn as () => Promise<any>;
+        return {
+          addCleanup: vi.fn(),
+        } as unknown as ScriptPlayer<MidsceneYamlScriptEnv>;
+      });
+
+      await createYamlPlayer(mockFilePath, mockScript);
+      await setupFnCallback?.();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('downloadPath'),
+      );
+      warnSpy.mockRestore();
     });
 
     test('should handle undefined aiActionContext gracefully for Android', async () => {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -165,6 +165,20 @@ export interface MidsceneYamlScriptWebEnv
   forceSameTabNavigation?: boolean; // if track the newly opened tab, true for default in yaml script
 
   /**
+   * Chrome download directory (Puppeteer only, not supported in bridge mode).
+   *
+   * Relative paths are resolved from the current working directory.
+   *
+   * @example
+   * ```yaml
+   * web:
+   *   url: https://example.com
+   *   downloadPath: ./downloads
+   * ```
+   */
+  downloadPath?: string;
+
+  /**
    * Custom Chrome launch arguments (Puppeteer only, not supported in bridge mode).
    *
    * Allows passing custom command-line arguments to Chrome/Chromium when launching the browser.

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -120,7 +120,6 @@ async function configureDownloadPath(
     behavior: 'allow',
     downloadPath: path.resolve(downloadPath),
   });
-  await cdpSession.detach();
 }
 
 export interface BuildChromeArgsOptions {

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 
@@ -105,6 +106,22 @@ interface FreeFn {
 }
 
 const launcherDebug = getDebug('puppeteer:launcher');
+
+async function configureDownloadPath(
+  page: Page,
+  downloadPath: string | undefined,
+): Promise<void> {
+  if (!downloadPath) {
+    return;
+  }
+
+  const cdpSession = await page.createCDPSession();
+  await cdpSession.send('Browser.setDownloadBehavior', {
+    behavior: 'allow',
+    downloadPath: path.resolve(downloadPath),
+  });
+  await cdpSession.detach();
+}
 
 export interface BuildChromeArgsOptions {
   userAgent?: string;
@@ -275,6 +292,8 @@ export async function launchPuppeteerPage(
     }
     page = await browserInstance.newPage();
   }
+
+  await configureDownloadPath(page, target.downloadPath);
 
   if (target.cookie) {
     const cookieFileContent = readFileSync(target.cookie, 'utf-8');

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -11,7 +11,11 @@ import {
 import { PuppeteerAgent } from '@/puppeteer/index';
 import type { AgentOpt, Cache, MidsceneYamlScriptWebEnv } from '@midscene/core';
 import { DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT } from '@midscene/shared/constants';
-import puppeteer, { type Browser, type Page } from 'puppeteer';
+import puppeteer, {
+  type Browser,
+  type DownloadBehavior,
+  type Page,
+} from 'puppeteer';
 
 export { defaultViewportWidth, defaultViewportHeight } from '@/common/viewport';
 
@@ -107,19 +111,17 @@ interface FreeFn {
 
 const launcherDebug = getDebug('puppeteer:launcher');
 
-async function configureDownloadPath(
-  page: Page,
+export function buildDownloadBehavior(
   downloadPath: string | undefined,
-): Promise<void> {
+): DownloadBehavior | undefined {
   if (!downloadPath) {
-    return;
+    return undefined;
   }
 
-  const cdpSession = await page.createCDPSession();
-  await cdpSession.send('Browser.setDownloadBehavior', {
-    behavior: 'allow',
+  return {
+    policy: 'allow',
     downloadPath: path.resolve(downloadPath),
-  });
+  };
 }
 
 export interface BuildChromeArgsOptions {
@@ -239,6 +241,7 @@ export async function launchPuppeteerPage(
       : undefined,
     chromeArgs: target.chromeArgs,
   });
+  const downloadBehavior = buildDownloadBehavior(target.downloadPath);
 
   launcherDebug(
     'launching browser with viewport, headed',
@@ -270,6 +273,7 @@ export async function launchPuppeteerPage(
       browserInstance = await puppeteer.launch({
         headless: !preference?.headed,
         defaultViewport: defaultViewportConfig,
+        downloadBehavior,
         args,
         acceptInsecureCerts: target.acceptInsecureCerts,
         ignoreDefaultArgs: preference?.ignoreDefaultArgs,
@@ -291,8 +295,6 @@ export async function launchPuppeteerPage(
     }
     page = await browserInstance.newPage();
   }
-
-  await configureDownloadPath(page, target.downloadPath);
 
   if (target.cookie) {
     const cookieFileContent = readFileSync(target.cookie, 'utf-8');

--- a/packages/web-integration/tests/ai/web/puppeteer/download-path.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/download-path.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+import { puppeteerAgentForTarget } from '@/puppeteer/agent-launcher';
+import type { MidsceneYamlScriptWebEnv } from '@midscene/core';
+import { ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// End-to-end check that `downloadPath` declared in a YAML script controls
+// Chrome's actual download location. A mock-based unit test only proves that
+// we send a CDP command; this verifies the user-visible file placement.
+describe('downloadPath via YAML (puppeteer)', () => {
+  let server: Server;
+  let baseUrl: string;
+  let downloadDir: string | undefined;
+  let fileName: string | undefined;
+
+  const runYaml = async (yamlString: string) => {
+    const script = parseYamlScript(yamlString);
+    const player = new ScriptPlayer<MidsceneYamlScriptWebEnv>(
+      script,
+      puppeteerAgentForTarget,
+    );
+    await player.run();
+    expect(player.status, player.errorInSetup?.message).toBe('done');
+  };
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      if (req.url === '/download') {
+        res.writeHead(200, {
+          'content-type': 'text/plain',
+          'content-disposition': `attachment; filename="${fileName}"`,
+        });
+        res.end('download-ok');
+        return;
+      }
+
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end(
+        '<html><body><a id="download" href="/download">Download</a></body></html>',
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const { port } = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${port}/`;
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  afterEach(() => {
+    if (fileName) {
+      rmSync(path.join(homedir(), 'Downloads', fileName), { force: true });
+    }
+    if (downloadDir) {
+      rmSync(downloadDir, { recursive: true, force: true });
+    }
+    downloadDir = undefined;
+    fileName = undefined;
+  });
+
+  it('downloads files into the YAML downloadPath directory', async () => {
+    downloadDir = mkdtempSync(path.join(tmpdir(), 'midscene-download-path-'));
+    fileName = `midscene-download-path-${Date.now()}.txt`;
+
+    await runYaml(`
+web:
+  url: ${baseUrl}
+  downloadPath: ${downloadDir}
+  waitForNetworkIdle:
+    timeout: 0
+tasks:
+  - name: download file
+    flow:
+      - javascript: document.querySelector("#download").click();
+      - sleep: 1200
+`);
+
+    const expectedFile = path.join(downloadDir, fileName);
+    expect(existsSync(expectedFile)).toBe(true);
+    expect(readFileSync(expectedFile, 'utf8')).toBe('download-ok');
+    expect(existsSync(path.join(homedir(), 'Downloads', fileName))).toBe(false);
+  });
+});

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -19,13 +19,7 @@ const browserMock = {
   close: vi.fn(),
 };
 
-const cdpSessionMock = {
-  send: vi.fn().mockResolvedValue(undefined),
-  detach: vi.fn().mockResolvedValue(undefined),
-};
-
 const createPageMock = () => ({
-  createCDPSession: vi.fn().mockResolvedValue(cdpSessionMock),
   setUserAgent: vi.fn().mockResolvedValue(undefined),
   setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
   setViewport: vi.fn().mockResolvedValue(undefined),
@@ -150,22 +144,70 @@ describe('launchPuppeteerPage', () => {
       downloadPath: './downloads',
     });
 
-    expect(pageMock.createCDPSession).toHaveBeenCalled();
-    expect(cdpSessionMock.send).toHaveBeenCalledWith(
-      'Browser.setDownloadBehavior',
-      {
-        behavior: 'allow',
-        downloadPath: path.resolve('./downloads'),
-      },
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downloadBehavior: {
+          policy: 'allow',
+          downloadPath: path.resolve('./downloads'),
+        },
+      }),
     );
-    expect(cdpSessionMock.detach).not.toHaveBeenCalled();
   });
 
   it('does not configure Chrome download behavior when downloadPath is omitted', async () => {
     await launchPuppeteerPage({ url: 'https://example.com' });
 
-    expect(pageMock.createCDPSession).not.toHaveBeenCalled();
-    expect(cdpSessionMock.send).not.toHaveBeenCalled();
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downloadBehavior: undefined,
+      }),
+    );
+  });
+
+  it('builds Chrome download behavior from a relative downloadPath', async () => {
+    const { buildDownloadBehavior } = await import(
+      '@/puppeteer/agent-launcher'
+    );
+
+    expect(buildDownloadBehavior('./downloads')).toEqual({
+      policy: 'allow',
+      downloadPath: path.resolve('./downloads'),
+    });
+  });
+
+  it('does not build Chrome download behavior when downloadPath is omitted', async () => {
+    const { buildDownloadBehavior } = await import(
+      '@/puppeteer/agent-launcher'
+    );
+
+    expect(buildDownloadBehavior(undefined)).toBeUndefined();
+  });
+
+  it('does not configure Chrome download behavior on an externally provided browser', async () => {
+    await launchPuppeteerPage(
+      {
+        url: 'https://example.com',
+        downloadPath: './downloads',
+      },
+      undefined,
+      browserMock as any,
+    );
+
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
+
+  it('does not configure Chrome download behavior on an externally provided page', async () => {
+    await launchPuppeteerPage(
+      {
+        url: 'https://example.com',
+        downloadPath: './downloads',
+      },
+      undefined,
+      browserMock as any,
+      pageMock as any,
+    );
+
+    expect(mockLaunch).not.toHaveBeenCalled();
   });
 
   it('passes yaml waitForNetworkIdle settings to the agent for later actions', async () => {

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   defaultViewportHeight,
   defaultViewportWidth,
@@ -18,7 +19,13 @@ const browserMock = {
   close: vi.fn(),
 };
 
+const cdpSessionMock = {
+  send: vi.fn().mockResolvedValue(undefined),
+  detach: vi.fn().mockResolvedValue(undefined),
+};
+
 const createPageMock = () => ({
+  createCDPSession: vi.fn().mockResolvedValue(cdpSessionMock),
   setUserAgent: vi.fn().mockResolvedValue(undefined),
   setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
   setViewport: vi.fn().mockResolvedValue(undefined),
@@ -135,6 +142,30 @@ describe('launchPuppeteerPage', () => {
     await launchPuppeteerPage({ url: 'https://example.com' });
 
     expect(pageMock.setExtraHTTPHeaders).not.toHaveBeenCalled();
+  });
+
+  it('configures Chrome download behavior when downloadPath is provided', async () => {
+    await launchPuppeteerPage({
+      url: 'https://example.com',
+      downloadPath: './downloads',
+    });
+
+    expect(pageMock.createCDPSession).toHaveBeenCalled();
+    expect(cdpSessionMock.send).toHaveBeenCalledWith(
+      'Browser.setDownloadBehavior',
+      {
+        behavior: 'allow',
+        downloadPath: path.resolve('./downloads'),
+      },
+    );
+    expect(cdpSessionMock.detach).toHaveBeenCalled();
+  });
+
+  it('does not configure Chrome download behavior when downloadPath is omitted', async () => {
+    await launchPuppeteerPage({ url: 'https://example.com' });
+
+    expect(pageMock.createCDPSession).not.toHaveBeenCalled();
+    expect(cdpSessionMock.send).not.toHaveBeenCalled();
   });
 
   it('passes yaml waitForNetworkIdle settings to the agent for later actions', async () => {

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -158,7 +158,7 @@ describe('launchPuppeteerPage', () => {
         downloadPath: path.resolve('./downloads'),
       },
     );
-    expect(cdpSessionMock.detach).toHaveBeenCalled();
+    expect(cdpSessionMock.detach).not.toHaveBeenCalled();
   });
 
   it('does not configure Chrome download behavior when downloadPath is omitted', async () => {


### PR DESCRIPTION
## Summary

- Add `web.downloadPath` to the Web YAML config type.
- Configure Chrome download behavior in Puppeteer-backed Web YAML runs via CDP before navigation.
- Warn that `downloadPath` is ignored in bridge mode.
- Cover YAML option forwarding, launcher download behavior, and bridge-mode warning with unit tests.

## Validation

- `pnpm --filter @midscene/web exec vitest --run tests/unit-test/puppeteer/agent-launcher.test.ts`
- `pnpm --filter @midscene/cli exec vitest --run tests/unit-test/create-yaml-player.test.ts`
- `pnpm run lint`

Closes MID-5
