### PR TITLE
fix(web-integration): clear inputs via cdp select all

### DIFF
--- a/apps/site/docs/en/integrate-with-playwright.mdx
+++ b/apps/site/docs/en/integrate-with-playwright.mdx
@@ -275,6 +275,12 @@ const mid = new PlaywrightAgent(page, {
 });
 ```
 
+### Browser support
+
+Some Midscene web automation features rely on Chrome DevTools Protocol (CDP), which is provided by Chromium-based browsers. These include browser-level events, touch gestures, and CDP fallback paths used by specific interactions.
+
+When using Playwright, Chromium is the recommended browser engine. Firefox and WebKit may work for basic Playwright-native operations, but Midscene features that depend on CDP may report errors on those engines.
+
 ### Connect Midscene Agent to a Remote Playwright Browser
 
 :::info Example Project

--- a/apps/site/docs/en/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/en/integrate-with-puppeteer.mdx
@@ -114,6 +114,12 @@ const mid = new PuppeteerAgent(page, {
 });
 ```
 
+### Browser support
+
+Some Midscene web automation features rely on Chrome DevTools Protocol (CDP), which is provided by Chromium-based browsers. These include browser-level events, touch gestures, and CDP fallback paths used by specific interactions.
+
+When using Puppeteer, Chrome, Chromium, or another Chromium-based browser is recommended. Browsers that do not provide compatible CDP support may report errors when Midscene uses CDP-backed features.
+
 ### Connect Midscene Agent to a Remote Puppeteer Browser
 
 :::info Example Project

--- a/apps/site/docs/zh/integrate-with-playwright.mdx
+++ b/apps/site/docs/zh/integrate-with-playwright.mdx
@@ -274,6 +274,12 @@ const mid = new PlaywrightAgent(page, {
 });
 ```
 
+### 浏览器支持说明
+
+Midscene 的部分 Web 自动化能力依赖 Chromium-based browser 提供的 Chrome DevTools Protocol（CDP），例如浏览器级事件、触摸手势，以及一些交互操作中使用的 CDP fallback 路径。
+
+使用 Playwright 时，推荐使用 Chromium。Firefox 和 WebKit 可能可以覆盖基础的 Playwright-native 操作，但依赖 CDP 的 Midscene 能力可能会在这些浏览器内核上报错。
+
 ### 连接远程 Playwright 浏览器并接入 Midscene Agent
 
 :::info 示例项目

--- a/apps/site/docs/zh/integrate-with-puppeteer.mdx
+++ b/apps/site/docs/zh/integrate-with-puppeteer.mdx
@@ -114,6 +114,12 @@ const mid = new PuppeteerAgent(page, {
 });
 ```
 
+### 浏览器支持说明
+
+Midscene 的部分 Web 自动化能力依赖 Chromium-based browser 提供的 Chrome DevTools Protocol（CDP），例如浏览器级事件、触摸手势，以及一些交互操作中使用的 CDP fallback 路径。
+
+使用 Puppeteer 时，推荐使用 Chrome、Chromium 或其他 Chromium-based browser。不提供兼容 CDP 能力的浏览器，可能会在 Midscene 使用 CDP-backed features 时报错。
+
 ### 连接远程 Puppeteer 浏览器并接入 Midscene Agent
 
 :::info 示例项目

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -61,9 +61,12 @@ type ScreencastFrameEvent = {
   sessionId: number;
 };
 
-type ScreencastCdpSession = {
+type PageCdpSession = {
   send(method: string, params?: Record<string, unknown>): Promise<unknown>;
   detach(): Promise<void>;
+};
+
+type ScreencastCdpSession = PageCdpSession & {
   on(
     event: 'Page.screencastFrame',
     handler: (event: ScreencastFrameEvent) => void,
@@ -76,11 +79,6 @@ type ScreencastCdpSession = {
     event: 'Page.screencastFrame',
     handler: (event: ScreencastFrameEvent) => void,
   ): void;
-};
-
-type InputCdpSession = {
-  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
-  detach(): Promise<void>;
 };
 
 function isClosedPageError(error: unknown) {
@@ -388,11 +386,7 @@ export class Page<
           'playwright screenshot failed, trying CDP fallback: %s',
           error,
         );
-        base64 = await this.screenshotBase64ByPlaywrightCdp(
-          page,
-          imgType,
-          quality,
-        );
+        base64 = await this.screenshotBase64ByPlaywrightCdp(imgType, quality);
       }
     } else {
       throw new Error('Unsupported page type for screenshot');
@@ -403,18 +397,10 @@ export class Page<
   }
 
   private async screenshotBase64ByPlaywrightCdp(
-    page: PlaywrightPage,
     imgType: 'jpeg' | 'png',
     quality?: number,
   ) {
-    const browserName = page.context().browser()?.browserType().name();
-    if (browserName && browserName !== 'chromium') {
-      throw new Error(
-        `CDP screenshot fallback requires Chromium-based browser, but current browser is "${browserName}".`,
-      );
-    }
-
-    const client = await page.context().newCDPSession(page);
+    const client = await this.createPageCdpSession('CDP screenshot fallback');
     try {
       const result = (await new Promise<{
         data: string;
@@ -449,20 +435,43 @@ export class Page<
     }
   }
 
-  private async createScreencastCdpSession(): Promise<ScreencastCdpSession> {
+  private async createPageCdpSession(
+    featureName: string,
+  ): Promise<PageCdpSession> {
     if (this.interfaceType === 'puppeteer') {
       const page = this.underlyingPage as PuppeteerPage;
-      return (await page.target().createCDPSession()) as ScreencastCdpSession;
+      // Puppeteer has exposed CDP sessions through both page.createCDPSession()
+      // and the historical page.target().createCDPSession() API. Support both
+      // here so CDP-backed actions work across Puppeteer versions and wrapped
+      // page objects that may only expose one of the two shapes.
+      const pageWithCdp = page as PuppeteerPage & {
+        createCDPSession?: () => Promise<unknown>;
+      };
+      if (typeof pageWithCdp.createCDPSession === 'function') {
+        return (await pageWithCdp.createCDPSession()) as unknown as PageCdpSession;
+      }
+
+      const target = page.target?.();
+      if (typeof target?.createCDPSession === 'function') {
+        return (await target.createCDPSession()) as unknown as PageCdpSession;
+      }
+
+      throw new Error(
+        `${featureName} requires a browser page with CDP session support.`,
+      );
     }
 
     const page = this.underlyingPage as PlaywrightPage;
     const browserName = page.context().browser()?.browserType().name();
     if (browserName && browserName !== 'chromium') {
       throw new Error(
-        `CDP screencast requires Chromium-based browser, but current browser is "${browserName}".`,
+        `${featureName} requires Chromium-based browser, but current browser is "${browserName}".`,
       );
     }
-    return (await page.context().newCDPSession(page)) as ScreencastCdpSession;
+
+    return (await page
+      .context()
+      .newCDPSession(page)) as unknown as PageCdpSession;
   }
 
   async waitForDomQuiet(opts?: {
@@ -578,7 +587,9 @@ export class Page<
     if (typeof this.underlyingPage.bringToFront === 'function') {
       await this.underlyingPage.bringToFront();
     }
-    const client = await this.createScreencastCdpSession();
+    const client = (await this.createPageCdpSession(
+      'CDP screencast',
+    )) as ScreencastCdpSession;
     let stopped = false;
     const streamToken = Symbol('mjpeg-stream');
 
@@ -803,22 +814,8 @@ export class Page<
     };
   }
 
-  private async createInputCdpSession(): Promise<InputCdpSession> {
-    if (this.interfaceType === 'puppeteer') {
-      const page = this.underlyingPage as PuppeteerPage;
-      return (await (typeof page.createCDPSession === 'function'
-        ? page.createCDPSession()
-        : page.target().createCDPSession())) as unknown as InputCdpSession;
-    }
-
-    const page = this.underlyingPage as PlaywrightPage;
-    return (await page
-      .context()
-      .newCDPSession(page)) as unknown as InputCdpSession;
-  }
-
   private async selectAllByCdp(): Promise<void> {
-    const client = await this.createInputCdpSession();
+    const client = await this.createPageCdpSession('clearInput');
     try {
       // Use the browser editing command instead of Modifier+A. Playwright's
       // Chromium input layer derives the browser platform from
@@ -851,13 +848,12 @@ export class Page<
     try {
       await this.selectAllByCdp();
       await backspace();
-      debugPage('clearInput end');
-      return;
     } catch (error) {
-      debugPage('clearInput cdp selectAll failed, fallback to shortcut', error);
+      debugPage('clearInput cdp selectAll failed', error);
+      throw error;
+    } finally {
+      debugPage('clearInput end');
     }
-
-    debugPage('clearInput end');
   }
 
   private everMoved = false;
@@ -968,9 +964,7 @@ export class Page<
   async stopLoading(): Promise<void> {
     debugPage('stop loading');
     if (this.interfaceType === 'puppeteer') {
-      const client = await (this.underlyingPage as PuppeteerPage)
-        .target()
-        .createCDPSession();
+      const client = await this.createPageCdpSession('stopLoading');
       try {
         await client.send('Page.stopLoading');
       } finally {
@@ -1109,23 +1103,9 @@ export class Page<
       detach(): Promise<void>;
     };
 
-    let client: TouchClient;
-    if (this.interfaceType === 'puppeteer') {
-      const page = this.underlyingPage as PuppeteerPage;
-      client = (await page.target().createCDPSession()) as TouchClient;
-    } else if (this.interfaceType === 'playwright') {
-      const page = this.underlyingPage as PlaywrightPage;
-      // CDP is Chromium-only; Firefox/WebKit do not support it
-      const browserName = page.context().browser()?.browserType().name();
-      if (browserName && browserName !== 'chromium') {
-        throw new Error(
-          `Pinch gesture requires Chromium-based browser, but current browser is "${browserName}". CDP touch events are not supported in Firefox/WebKit.`,
-        );
-      }
-      client = (await page.context().newCDPSession(page)) as TouchClient;
-    } else {
-      return;
-    }
+    const client = (await this.createPageCdpSession(
+      'Pinch gesture',
+    )) as TouchClient;
 
     try {
       await client.send('Input.dispatchTouchEvent', {
@@ -1165,13 +1145,13 @@ export class Page<
     }
   }
 
-  private async ensurePuppeteerFileChooserSession(
-    page: PuppeteerPage,
-  ): Promise<CDPSession> {
+  private async ensurePuppeteerFileChooserSession(): Promise<CDPSession> {
     if (this.puppeteerFileChooserSession) {
       return this.puppeteerFileChooserSession;
     }
-    const session = await page.target().createCDPSession();
+    const session = (await this.createPageCdpSession(
+      'Puppeteer file chooser',
+    )) as unknown as CDPSession;
     await session.send('Page.enable');
     await session.send('DOM.enable');
     await session.send('Page.setInterceptFileChooserDialog', { enabled: true });
@@ -1190,8 +1170,7 @@ export class Page<
       );
     }
 
-    const page = this.underlyingPage as PuppeteerPage;
-    const session = await this.ensurePuppeteerFileChooserSession(page);
+    const session = await this.ensurePuppeteerFileChooserSession();
     if (this.puppeteerFileChooserHandler) {
       session.off('Page.fileChooserOpened', this.puppeteerFileChooserHandler);
     }

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -78,6 +78,11 @@ type ScreencastCdpSession = {
   ): void;
 };
 
+type InputCdpSession = {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  detach(): Promise<void>;
+};
+
 function isClosedPageError(error: unknown) {
   if (!(error instanceof Error)) {
     return false;
@@ -798,36 +803,54 @@ export class Page<
     };
   }
 
+  private async createInputCdpSession(): Promise<InputCdpSession> {
+    if (this.interfaceType === 'puppeteer') {
+      const page = this.underlyingPage as PuppeteerPage;
+      return (await (typeof page.createCDPSession === 'function'
+        ? page.createCDPSession()
+        : page.target().createCDPSession())) as unknown as InputCdpSession;
+    }
+
+    const page = this.underlyingPage as PlaywrightPage;
+    return (await page
+      .context()
+      .newCDPSession(page)) as unknown as InputCdpSession;
+  }
+
+  private async selectAllByCdp(): Promise<void> {
+    const client = await this.createInputCdpSession();
+    try {
+      await client.send('Input.dispatchKeyEvent', {
+        type: 'rawKeyDown',
+
+        commands: ['selectAll'],
+      });
+      await client.send('Input.dispatchKeyEvent', {
+        type: 'keyUp',
+      });
+    } finally {
+      await client.detach().catch(() => undefined);
+    }
+  }
+
   async clearInput(element?: ElementInfo): Promise<void> {
     const backspace = async () => {
       await sleep(100);
       await this.keyboard.press([{ key: 'Backspace' }]);
     };
 
-    const isMac = process.platform === 'darwin';
     debugPage('clearInput begin');
-    if (isMac) {
-      if (this.interfaceType === 'puppeteer') {
-        // https://github.com/segment-boneyard/nightmare/issues/810#issuecomment-452669866
-        element &&
-          (await this.mouse.click(element.center[0], element.center[1], {
-            count: 3,
-          }));
-        await backspace();
-      }
 
-      element && (await this.mouse.click(element.center[0], element.center[1]));
-      await this.underlyingPage.keyboard.down('Meta');
-      await this.underlyingPage.keyboard.press('a');
-      await this.underlyingPage.keyboard.up('Meta');
+    element && (await this.mouse.click(element.center[0], element.center[1]));
+    try {
+      await this.selectAllByCdp();
       await backspace();
-    } else {
-      element && (await this.mouse.click(element.center[0], element.center[1]));
-      await this.underlyingPage.keyboard.down('Control');
-      await this.underlyingPage.keyboard.press('a');
-      await this.underlyingPage.keyboard.up('Control');
-      await backspace();
+      debugPage('clearInput end');
+      return;
+    } catch (error) {
+      debugPage('clearInput cdp selectAll failed, fallback to shortcut', error);
     }
+
     debugPage('clearInput end');
   }
 

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -820,6 +820,12 @@ export class Page<
   private async selectAllByCdp(): Promise<void> {
     const client = await this.createInputCdpSession();
     try {
+      // Use the browser editing command instead of Modifier+A. Playwright's
+      // Chromium input layer derives the browser platform from
+      // Browser.getVersion().userAgent, while Modifier+A shortcuts are often
+      // chosen from local process.platform. If a Linux browser is launched with
+      // a macOS browser-level UA, Chromium treats select-all as Cmd+A instead
+      // of Ctrl+A, so the local-platform shortcut can fail.
       await client.send('Input.dispatchKeyEvent', {
         type: 'rawKeyDown',
 

--- a/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
@@ -1,0 +1,104 @@
+import { WebPage as PlaywrightWebPage } from '@/playwright/page';
+import { PuppeteerWebPage } from '@/puppeteer/page';
+import { type Browser as PlaywrightBrowser, chromium } from 'playwright';
+import puppeteer, { type Browser as PuppeteerBrowser } from 'puppeteer';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+const TEST_TIMEOUT_MS = 120_000;
+
+const PAGE_HTML = `
+  <!DOCTYPE html>
+  <html>
+    <body style="padding: 24px;">
+      <input id="target" value="value to clear" style="width: 240px; padding: 8px;" />
+    </body>
+  </html>
+`;
+
+async function puppeteerInputCenter(page: any): Promise<[number, number]> {
+  return page.$eval('#target', (el: HTMLInputElement) => {
+    const rect = el.getBoundingClientRect();
+    return [rect.left + rect.width / 2, rect.top + rect.height / 2];
+  });
+}
+
+async function playwrightInputCenter(page: any): Promise<[number, number]> {
+  return page.locator('#target').evaluate((el: HTMLInputElement) => {
+    const rect = el.getBoundingClientRect();
+    return [rect.left + rect.width / 2, rect.top + rect.height / 2];
+  });
+}
+
+describe('BasePage clearInput CDP selectAll', () => {
+  describe('Puppeteer', () => {
+    let browser: PuppeteerBrowser;
+
+    beforeAll(async () => {
+      browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      });
+    }, TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      await browser?.close();
+    }, TEST_TIMEOUT_MS);
+
+    test(
+      'clears the focused input',
+      async () => {
+        const page = await browser.newPage();
+        await page.setContent(PAGE_HTML);
+
+        const webPage = new PuppeteerWebPage(page);
+        const center = await puppeteerInputCenter(page);
+
+        await webPage.clearInput({ center } as any);
+
+        const value = await page.$eval(
+          '#target',
+          (el) => (el as HTMLInputElement).value,
+        );
+        await page.close();
+
+        expect(value).toBe('');
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
+
+  describe('Playwright', () => {
+    let browser: PlaywrightBrowser;
+
+    beforeAll(async () => {
+      browser = await chromium.launch({
+        headless: true,
+      });
+    }, TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      await browser?.close();
+    }, TEST_TIMEOUT_MS);
+
+    test(
+      'clears the focused input',
+      async () => {
+        const page = await browser.newPage();
+        await page.setContent(PAGE_HTML);
+
+        const webPage = new PlaywrightWebPage(page);
+        const center = await playwrightInputCenter(page);
+
+        await webPage.clearInput({ center } as any);
+
+        const value = await page.locator('#target').evaluate((el) => {
+          return (el as HTMLInputElement).value;
+        });
+        await page.close();
+
+        expect(value).toBe('');
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
+});

--- a/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
@@ -73,6 +73,9 @@ describe('BasePage clearInput CDP selectAll', () => {
     beforeAll(async () => {
       browser = await chromium.launch({
         headless: true,
+        // CI installs Puppeteer's Chrome cache, but not Playwright's browser
+        // bundle because dependencies are installed with --ignore-scripts.
+        executablePath: puppeteer.executablePath(),
       });
     }, TEST_TIMEOUT_MS);
 

--- a/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-clear-input-cdp.test.ts
@@ -29,6 +29,20 @@ async function playwrightInputCenter(page: any): Promise<[number, number]> {
   });
 }
 
+async function playwrightInputValue(page: any): Promise<string> {
+  return page.locator('#target').evaluate((el: HTMLInputElement) => el.value);
+}
+
+async function playwrightBrowserUserAgent(page: any): Promise<string> {
+  const client = await page.context().newCDPSession(page);
+  try {
+    const version = await client.send('Browser.getVersion');
+    return version.userAgent;
+  } finally {
+    await client.detach().catch(() => undefined);
+  }
+}
+
 describe('BasePage clearInput CDP selectAll', () => {
   describe('Puppeteer', () => {
     let browser: PuppeteerBrowser;
@@ -76,6 +90,7 @@ describe('BasePage clearInput CDP selectAll', () => {
         // CI installs Puppeteer's Chrome cache, but not Playwright's browser
         // bundle because dependencies are installed with --ignore-scripts.
         executablePath: puppeteer.executablePath(),
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
     }, TEST_TIMEOUT_MS);
 
@@ -94,14 +109,89 @@ describe('BasePage clearInput CDP selectAll', () => {
 
         await webPage.clearInput({ center } as any);
 
-        const value = await page.locator('#target').evaluate((el) => {
-          return (el as HTMLInputElement).value;
-        });
+        const value = await playwrightInputValue(page);
         await page.close();
 
         expect(value).toBe('');
       },
       TEST_TIMEOUT_MS,
     );
+
+    describe('with spoofed browser-level user agent', () => {
+      const linuxUserAgent =
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36';
+      const macUserAgent =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36';
+      const spoofedUserAgent =
+        process.platform === 'darwin' ? linuxUserAgent : macUserAgent;
+      const spoofedUserAgentMarker =
+        process.platform === 'darwin' ? 'X11; Linux x86_64' : 'Macintosh';
+      const localSelectAllModifier =
+        process.platform === 'darwin' ? 'Meta' : 'Control';
+
+      let spoofedBrowser: PlaywrightBrowser;
+
+      beforeAll(async () => {
+        spoofedBrowser = await chromium.launch({
+          headless: true,
+          executablePath: puppeteer.executablePath(),
+          args: [
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            `--user-agent=${spoofedUserAgent}`,
+          ],
+        });
+      }, TEST_TIMEOUT_MS);
+
+      afterAll(async () => {
+        await spoofedBrowser?.close();
+      }, TEST_TIMEOUT_MS);
+
+      test(
+        'clears input with CDP selectAll when browser platform is changed by UA',
+        async () => {
+          const page = await spoofedBrowser.newPage();
+          await page.setContent(PAGE_HTML);
+
+          const browserUserAgent = await playwrightBrowserUserAgent(page);
+          expect(browserUserAgent).toContain(spoofedUserAgentMarker);
+
+          const webPage = new PlaywrightWebPage(page);
+          const center = await playwrightInputCenter(page);
+
+          await webPage.clearInput({ center } as any);
+
+          const value = await playwrightInputValue(page);
+          await page.close();
+
+          expect(value).toBe('');
+        },
+        TEST_TIMEOUT_MS,
+      );
+
+      test(
+        'does not clear input with local-platform modifier+A when browser platform is changed by UA',
+        async () => {
+          const page = await spoofedBrowser.newPage();
+          await page.setContent(PAGE_HTML);
+
+          const browserUserAgent = await playwrightBrowserUserAgent(page);
+          expect(browserUserAgent).toContain(spoofedUserAgentMarker);
+
+          const center = await playwrightInputCenter(page);
+          await page.mouse.click(center[0], center[1]);
+          await page.keyboard.down(localSelectAllModifier);
+          await page.keyboard.press('a');
+          await page.keyboard.up(localSelectAllModifier);
+          await page.keyboard.press('Backspace');
+
+          const value = await playwrightInputValue(page);
+          await page.close();
+
+          expect(value).not.toBe('');
+        },
+        TEST_TIMEOUT_MS,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Use CDP `Input.dispatchKeyEvent` with `selectAll` for web `clearInput` before deleting text.
- Add Puppeteer and Playwright unit coverage that verifies `clearInput` empties a focused input.

## Validation
- `pnpm --filter @midscene/web test -- tests/unit-test/base-page-clear-input-cdp.test.ts`