### PR TITLE
fix(playground): point package entries to bin outputs

### DIFF
--- a/packages/harmony-playground/package.json
+++ b/packages/harmony-playground/package.json
@@ -7,9 +7,9 @@
     "directory": "packages/harmony-playground"
   },
   "description": "HarmonyOS playground for Midscene",
-  "main": "./dist/lib/index.js",
-  "types": "./dist/types/index.d.ts",
-  "module": "./dist/es/index.mjs",
+  "main": "./dist/lib/bin.js",
+  "types": "./dist/types/bin.d.ts",
+  "module": "./dist/es/bin.mjs",
   "files": ["dist", "bin", "README.md"],
   "bin": {
     "midscene-harmony-playground": "./bin/harmony-playground",

--- a/packages/ios-playground/package.json
+++ b/packages/ios-playground/package.json
@@ -7,9 +7,9 @@
     "directory": "packages/ios-playground"
   },
   "description": "iOS playground for Midscene",
-  "main": "./dist/lib/index.js",
-  "types": "./dist/types/index.d.ts",
-  "module": "./dist/es/index.mjs",
+  "main": "./dist/lib/bin.js",
+  "types": "./dist/types/bin.d.ts",
+  "module": "./dist/es/bin.mjs",
   "files": ["dist", "bin", "README.md"],
   "bin": {
     "midscene-ios-playground": "./bin/ios-playground",


### PR DESCRIPTION
## Summary
- update `@midscene/harmony-playground` package entrypoints to the built `bin` outputs
- update `@midscene/ios-playground` package entrypoints to the built `bin` outputs

## Why
Both packages build `src/bin.ts` as `dist/lib/bin.js`, `dist/es/bin.mjs`, and `dist/types/bin.d.ts`. The published package.json files currently point `main`, `module`, and `types` at `index` files that are not shipped in the npm tarballs.

## Validation
- `npm pack @midscene/harmony-playground@1.9.8` and verified patched `main`/`module`/`types` targets exist in the tarball
- `npm pack @midscene/ios-playground@1.9.8` and verified patched `main`/`module`/`types` targets exist in the tarball
- `pnpm run lint` not run: `pnpm` is not installed in this environment