### PR TITLE
fix(core): keep aiAssert context out of the report prompt

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1163,6 +1163,12 @@ export class Agent<
     const { textPrompt, multimodalPrompt } = parsePrompt(assertionWithContext);
     const assertionText =
       typeof assertion === 'string' ? assertion : assertion.prompt;
+    // The context is folded into `textPrompt` so the model receives it, but the
+    // report should display only the clean assertion (mirroring how aiAct keeps
+    // its context out of the displayed prompt). Skip the override when no
+    // context was added so the report keeps the original demand verbatim.
+    const reportDescription =
+      textPrompt === assertionText ? undefined : assertionText;
 
     try {
       const { output, thought } =
@@ -1175,6 +1181,7 @@ export class Agent<
           {
             abortSignal: opt?.abortSignal,
           },
+          reportDescription,
         );
 
       const pass = Boolean(output);

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -695,7 +695,12 @@ export class TaskExecutor {
     executionOptions?: {
       abortSignal?: AbortSignal;
     },
+    // Clean text shown in the report instead of the model-facing `demand`.
+    // Used when `demand` carries extra context (e.g. aiAssert context) that
+    // should reach the model but stay out of the report for readability.
+    reportDescription?: string,
   ) {
+    const displayDemand = reportDescription ?? demand;
     const queryTask: ExecutionTaskInsightQueryApply = {
       type: 'Insight',
       subType: type,
@@ -703,10 +708,10 @@ export class TaskExecutor {
         domIncluded: opt?.domIncluded,
         dataDemand: multimodalPrompt
           ? ({
-              demand,
+              demand: displayDemand,
               multimodalPrompt,
             } as never)
-          : demand, // for user param presentation in report right sidebar
+          : displayDemand, // for user param presentation in report right sidebar
       },
       executor: async (param, taskContext) => {
         const { task } = taskContext;
@@ -828,11 +833,14 @@ export class TaskExecutor {
     executionOptions?: {
       abortSignal?: AbortSignal;
     },
+    // Clean text shown in the report instead of the model-facing `demand`.
+    reportDescription?: string,
   ): Promise<ExecutionResult<T>> {
     const session = this.createExecutionSession(
       taskTitleStr(
         type,
-        typeof demand === 'string' ? demand : JSON.stringify(demand),
+        reportDescription ??
+          (typeof demand === 'string' ? demand : JSON.stringify(demand)),
       ),
     );
 
@@ -843,6 +851,7 @@ export class TaskExecutor {
       opt,
       multimodalPrompt,
       executionOptions,
+      reportDescription,
     );
 
     const runner = session.getRunner();

--- a/packages/core/tests/unit-test/agent-context-option.test.ts
+++ b/packages/core/tests/unit-test/agent-context-option.test.ts
@@ -113,6 +113,8 @@ describe('Agent per-call context option', () => {
       {
         abortSignal: undefined,
       },
+      // report keeps the clean assertion, not the context-augmented prompt
+      'The success toast is visible',
     );
     expect(result).toEqual({
       pass: true,
@@ -141,6 +143,8 @@ describe('Agent per-call context option', () => {
       {
         abortSignal: abortController.signal,
       },
+      // no context added, so no separate report description
+      undefined,
     );
   });
 });

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -679,6 +679,56 @@ describe('TaskExecutor - Null Data Handling', () => {
       });
     });
 
+    it('shows reportDescription in the report while sending demand to the model', async () => {
+      const mockInsight = {
+        contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
+        extract: vi.fn(async () => ({
+          data: { StatementIsTruthy: true },
+          usage: { totalTokens: 100 },
+          thought: 'looks good',
+          dump: createMockDump({ StatementIsTruthy: true }, 'looks good', {
+            totalTokens: 100,
+          }),
+        })),
+        onceDumpUpdatedFn: undefined,
+      } as any;
+
+      const mockModelConfig: IModelConfig = {
+        modelName: 'mock-model',
+        modelDescription: 'mock-model-description',
+        intent: 'default',
+        slot: 'default',
+      };
+
+      const taskExecutor = new TaskExecutor({} as any, mockInsight, {
+        actionSpace: [],
+      });
+
+      const queryTask = await (taskExecutor as any).createTypeQueryTask(
+        'Assert',
+        'Context for this request:\nThe user is a buyer.\n\nthe cart is empty',
+        getModelRuntime(mockModelConfig),
+        {},
+        undefined,
+        undefined,
+        // clean assertion shown in the report
+        'the cart is empty',
+      );
+
+      // report sidebar shows the clean assertion, not the context blob
+      expect(queryTask.param.dataDemand).toBe('the cart is empty');
+
+      await queryTask.executor({}, {
+        task: queryTask,
+        uiContext: await createEmptyUIContext(),
+      } as any);
+
+      // the model still receives the context-augmented demand
+      const [demandArg] = mockInsight.extract.mock.calls[0];
+      expect(demandArg.StatementIsTruthy).toContain('The user is a buyer.');
+      expect(demandArg.StatementIsTruthy).toContain('the cart is empty');
+    });
+
     it('should handle null data for Number type query', async () => {
       const mockInsight = {
         contextRetrieverFn: vi.fn(async () => await createMockUIContext()),


### PR DESCRIPTION
aiAssert folded the per-call context into the assertion text via buildPromptWithContext, and that combined string became both the model demand and the report title/sidebar. Unlike aiAct, which keeps its context out of the displayed prompt, this made Gherkin "Then" steps (and any aiAssert with context) render a long, noisy "Context for this request: ..." blob in the report.

Thread a clean reportDescription through createTypeQueryExecution and createTypeQueryTask so the model still receives the context-augmented demand while the report shows only the original assertion, matching how aiAct handles context.


Claude-Session: https://claude.ai/code/session_01FvtJ5BDVoxKLi4cnesEKCJ