### PR TITLE
Add v1.10 changelog

### DIFF
--- a/apps/site/docs/en/changelog.mdx
+++ b/apps/site/docs/en/changelog.mdx
@@ -1,5 +1,27 @@
 # Changelog
 
+## v1.10 - BDD-Style Scripts, Doubao-Seed-2.1, and MCP Retirement
+
+v1.10 adds BDD-style Gherkin script execution, upgrades the recommended Doubao model to Doubao-Seed-2.1, and formally retires MCP server packages. Going forward, use Skills and the platform CLIs when AI agents need to drive Midscene.
+
+### BDD-Style Scripts with Gherkin
+
+- Added `agent.runGherkinScenario()` for running Gherkin scenarios directly from JavaScript / TypeScript.
+- Added the `runGherkinScenario` step for YAML flows, so natural-language scenarios can be written as `Given` / `When` / `Then` steps and executed in order.
+- `Given` / `When` map to `aiAct`, while `Then` and following `And` / `But` steps map to `aiAssert`. This keeps test cases readable in natural language while giving them a stable step structure.
+- Midscene currently supports a single-`Scenario` subset of Gherkin. BDD-related capabilities are still in Beta. See: [BDD-Style Scripts with Gherkin](./advanced/bdd-style-scripts-with-gherkin)
+
+### New Model Support
+
+- Recommended and supported `Doubao-Seed-2.1-turbo`, which has very fast localization speed and strong localization quality in our current private evaluation set.
+- The Doubao Seed family now uses `MIDSCENE_MODEL_FAMILY="doubao-seed"`, while the legacy `doubao-vision` family remains compatible. See: [Common Model Configuration](./model-common-config#doubao-seed-model), [Model Strategy](./model-strategy)
+
+### MCP Retirement
+
+- Midscene no longer ships MCP server packages, including `@midscene/web-bridge-mcp`, `@midscene/android-mcp`, `@midscene/ios-mcp`, `@midscene/harmony-mcp`, `@midscene/computer-mcp`, and `@midscene/mcp`.
+- Use [Skills](./skills) and the platform CLIs when AI coding agents need to operate browsers, mobile devices, or desktop apps.
+- If you still depend on MCP servers, pin Midscene to `1.9.8`. This is the final version that includes MCP support. See: [MCP Integration Has Been Retired](./mcp)
+
 ## v1.9 - New Model Support, YAML Automation, and AndroidWorld Benchmark
 
 v1.9 expands model support, improves YAML automation, and makes reports, Android automation, Web input, and desktop automation more reliable.

--- a/apps/site/docs/zh/changelog.mdx
+++ b/apps/site/docs/zh/changelog.mdx
@@ -1,5 +1,27 @@
 # 更新日志
 
+## v1.10 - BDD 风格脚本、Doubao-Seed-2.1 与 MCP 下线
+
+v1.10 新增 BDD 风格的 Gherkin 脚本执行能力，升级推荐模型到 Doubao-Seed-2.1，并正式下线 MCP server 包，后续推荐通过 Skills 与各平台 CLI 让 AI Agent 驱动 Midscene。
+
+### BDD 风格脚本（Gherkin）
+
+- 新增 `agent.runGherkinScenario()`，可在 JavaScript / TypeScript 中直接运行 Gherkin 场景。
+- YAML flow 新增 `runGherkinScenario` 步骤，可把自然语言场景写成 `Given` / `When` / `Then` 结构并按步骤执行。
+- `Given` / `When` 会映射为 `aiAct`，`Then` 以及跟随它的 `And` / `But` 会映射为 `aiAssert`，让测试用例既保持自然语言可读性，又有稳定的步骤结构。
+- 当前支持围绕单个 `Scenario` 的 Gherkin 子集，BDD 相关能力仍处于 Beta 阶段。详见：[BDD 风格脚本（Gherkin）](./advanced/bdd-style-scripts-with-gherkin)
+
+### 新增模型支持
+
+- 推荐并支持 `Doubao-Seed-2.1-turbo`，在当前私有测评集中具备很快的定位速度和良好的定位效果。
+- 豆包 Seed 系列统一使用 `MIDSCENE_MODEL_FAMILY="doubao-seed"`，同时继续兼容旧的 `doubao-vision` family。详见：[常用模型配置](./model-common-config#doubao-seed-model)、[模型策略](./model-strategy)
+
+### MCP 下线
+
+- Midscene 不再发布 MCP server 包，包括 `@midscene/web-bridge-mcp`、`@midscene/android-mcp`、`@midscene/ios-mcp`、`@midscene/harmony-mcp`、`@midscene/computer-mcp` 和 `@midscene/mcp`。
+- 需要 AI 编程 Agent 操作浏览器、移动设备或桌面应用时，请改用 [Skills](./skills) 与各平台 CLI。
+- 如果仍依赖 MCP server，请将 Midscene 固定在 `1.9.8`。这是最后一个包含 MCP 支持的版本。详见：[MCP 集成已下线](./mcp)
+
 ## v1.9 - 新增模型支持、YAML 自动化与 AndroidWorld Benchmark
 
 v1.9 版本扩展了模型支持，改进了 YAML 自动化，并提升了报告查看、Android 自动化、Web 输入和桌面自动化的稳定性。

--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -1,4 +1,9 @@
-import type { DeviceAction, Point, UIContext } from '@midscene/core';
+import type {
+  DeviceAction,
+  Point,
+  ScreenshotRef,
+  UIContext,
+} from '@midscene/core';
 import type { AbstractInterface } from '@midscene/core/device';
 import {
   type InputPrimitives,
@@ -16,7 +21,7 @@ type SerializedStaticScreenshot = {
   base64?: unknown;
   _base64?: unknown;
   type?: unknown;
-};
+} & Partial<Omit<ScreenshotRef, 'type'>>;
 
 type StaticPageUIContext = Omit<
   UIContext,


### PR DESCRIPTION
## Summary
- Add a new v1.10 changelog section in English and Chinese.
- Cover BDD-style Gherkin scripts, Doubao-Seed-2.1 support, and MCP server package retirement.
- Link to the related BDD, model configuration, model strategy, MCP, and Skills documentation.

## Validation
- pnpm exec prettier --check apps/site/docs/en/changelog.mdx apps/site/docs/zh/changelog.mdx
- pnpm run lint
