### PR TITLE
fix(cli): degrade to plain logs on standard non-interactive signals

### DIFF
--- a/packages/cli/src/printer.ts
+++ b/packages/cli/src/printer.ts
@@ -12,9 +12,35 @@ export interface MidsceneYamlFileContext {
   player: ScriptPlayer<MidsceneYamlScriptEnv>;
 }
 
-export const isTTY = process.env.MIDSCENE_CLI_LOG_ON_NON_TTY
-  ? false
-  : process.stdout.isTTY;
+/**
+ * Decide whether the interactive (spinner / in-place redraw) renderer is safe
+ * to use. Besides a real TTY, we honor well-known "I'm not an interactive
+ * terminal" signals so that CI pipelines and Kubernetes pods do not get their
+ * stream-based log collectors (Fluentd / Filebeat) flooded with raw
+ * `\x1b[1A\x1b[2K` cursor-control sequences.
+ *
+ * - `MIDSCENE_CLI_LOG_ON_NON_TTY`: explicit opt-out (existing flag).
+ * - `NO_COLOR`: https://no-color.org convention.
+ * - `TERM=dumb`: terminal that cannot handle cursor movement.
+ * - `CI`: generic CI flag set by virtually every CI provider; relevant when the
+ *   environment still allocates a pseudo-TTY (e.g. `kubectl exec -t`).
+ */
+export function resolveIsTTY(
+  env: NodeJS.ProcessEnv = process.env,
+  stdoutIsTTY: boolean | undefined = process.stdout.isTTY,
+): boolean {
+  if (
+    env.MIDSCENE_CLI_LOG_ON_NON_TTY ||
+    env.NO_COLOR ||
+    env.TERM === 'dumb' ||
+    env.CI
+  ) {
+    return false;
+  }
+  return Boolean(stdoutIsTTY);
+}
+
+export const isTTY = resolveIsTTY();
 export const indent = '  ';
 export const spinnerInterval = 80;
 export const spinnerFrames = ['◰', '◳', '◲', '◱']; // https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json

--- a/packages/cli/tests/unit-test/printer.test.ts
+++ b/packages/cli/tests/unit-test/printer.test.ts
@@ -1,0 +1,29 @@
+import { resolveIsTTY } from '@/printer';
+import { describe, expect, it } from 'vitest';
+
+describe('resolveIsTTY', () => {
+  it('returns true on a real interactive TTY', () => {
+    expect(resolveIsTTY({}, true)).toBe(true);
+  });
+
+  it('returns false when stdout is not a TTY', () => {
+    expect(resolveIsTTY({}, undefined)).toBe(false);
+    expect(resolveIsTTY({}, false)).toBe(false);
+  });
+
+  it('falls back to non-TTY for the explicit opt-out flag', () => {
+    expect(resolveIsTTY({ MIDSCENE_CLI_LOG_ON_NON_TTY: '1' }, true)).toBe(
+      false,
+    );
+  });
+
+  it('honors standard non-interactive signals even with an allocated TTY', () => {
+    expect(resolveIsTTY({ NO_COLOR: '1' }, true)).toBe(false);
+    expect(resolveIsTTY({ TERM: 'dumb' }, true)).toBe(false);
+    expect(resolveIsTTY({ CI: 'true' }, true)).toBe(false);
+  });
+
+  it('does not treat TERM=xterm as non-interactive', () => {
+    expect(resolveIsTTY({ TERM: 'xterm-256color' }, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Background

Refs #2689.

The issue reports raw `\x1b[1A\x1b[2K` ANSI cursor-control sequences polluting logs in non-TTY Kubernetes / CI environments.

### Root cause assessment

The bug report attributes the noise to `@midscene/web` running AI tasks inside `worker_threads` where `process.stdout.isTTY` is `undefined`. After investigation this is **not** the actual cause:

- There is no `worker_threads`/`Worker` usage anywhere in the codebase.
- The `\x1b[1A\x1b[2K步骤...` lines come from **Playwright's own `list` reporter** (`reporters/list.js` emits `\x1B[2K\x1B[0G` plus cursor-up; `步骤N…` is the user's `test.step` name). Midscene's only cursor renderer emits `\x1B[K`, never `\x1B[2K`. The Playwright reporter runs in the main process, so worker TTY state is irrelevant. That part is configured via Playwright (`PLAYWRIGHT_FORCE_TTY=0`, `CI=1`, non-live reporter) and is out of Midscene's control.

### What this PR fixes

Midscene's **own** CLI yaml runner has the same class of problem: `TTYWindowRenderer` is gated solely on `process.stdout.isTTY` (plus the `MIDSCENE_CLI_LOG_ON_NON_TTY` opt-out). A CI pipeline or Kubernetes pod that allocates a pseudo-TTY (e.g. `kubectl exec -t`) still gets the in-place spinner, flooding stream-based log collectors (Fluentd/Filebeat) with raw cursor-control sequences.

This PR hardens the TTY detection in `packages/cli/src/printer.ts`, matching the issue's suggested fix:

- Extracted the logic into a testable `resolveIsTTY()` helper.
- In addition to the existing `MIDSCENE_CLI_LOG_ON_NON_TTY` flag, it now honors the standard non-interactive signals `NO_COLOR`, `TERM=dumb` and `CI`, falling back to line-by-line `console.log`.

## Changes

- `packages/cli/src/printer.ts`: add `resolveIsTTY()` honoring `NO_COLOR` / `TERM=dumb` / `CI`.
- `packages/cli/tests/unit-test/printer.test.ts`: unit coverage for the resolver.

## Validation

- `npx vitest --run printer` (packages/cli) → 5 passed
- `pnpm run lint` → pass
