### PR TITLE
feat(report): add agent markdown export view

### DIFF
--- a/apps/report/src/App.less
+++ b/apps/report/src/App.less
@@ -154,29 +154,36 @@ footer.mt-8 {
       }
     }
 
-    .report-view-mode-switch {
-      flex-shrink: 0;
-
-      .ant-segmented-item-label {
-        min-height: 26px;
-        line-height: 26px;
-        padding-inline: 12px;
-      }
-    }
-
-    .report-markdown-actions {
-      display: flex;
+    .report-view-mode-dropdown {
+      display: inline-flex;
       align-items: center;
       gap: 6px;
-      min-width: 0;
+      height: 32px;
+      padding: 0 8px;
+      border: none;
+      border-radius: 6px;
+      background: transparent;
+      color: #262626;
+      font-size: 14px;
+      line-height: 32px;
+      cursor: pointer;
+      flex-shrink: 0;
 
-      .ant-btn {
-        height: 28px;
+      &:hover,
+      &:focus,
+      &:active {
+        background: transparent;
+        color: #262626;
+        outline: none;
       }
 
-      .ant-btn:not(.ant-btn-icon-only) {
-        padding-inline: 10px;
-        font-size: 13px;
+      .anticon {
+        color: #595959;
+        font-size: 12px;
+      }
+
+      span {
+        white-space: nowrap;
       }
     }
   }
@@ -230,12 +237,8 @@ footer.mt-8 {
     .page-nav-left {
       gap: 8px;
 
-      .report-view-mode-switch .ant-segmented-item-label {
-        padding-inline: 8px;
-      }
-
-      .report-markdown-actions .ant-btn:not(.ant-btn-icon-only) {
-        max-width: 148px;
+      .report-view-mode-dropdown span {
+        max-width: 128px;
         overflow: hidden;
         text-overflow: ellipsis;
       }
@@ -350,6 +353,21 @@ footer.mt-8 {
   .page-nav {
     .page-nav-title {
       color: #f8fafd;
+    }
+
+    .report-view-mode-dropdown {
+      color: #f8fafd;
+
+      &:hover,
+      &:focus,
+      &:active {
+        background: transparent;
+        color: #f8fafd;
+      }
+
+      .anticon {
+        color: rgba(255, 255, 255, 0.65);
+      }
     }
   }
 

--- a/apps/report/src/App.less
+++ b/apps/report/src/App.less
@@ -137,6 +137,9 @@ footer.mt-8 {
   .page-nav-left {
     display: flex;
     flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
 
     .page-nav-title {
       padding-left: 4px;
@@ -148,6 +151,32 @@ footer.mt-8 {
         font-weight: normal;
         color: #808080;
         font-size: 12px;
+      }
+    }
+
+    .report-view-mode-switch {
+      flex-shrink: 0;
+
+      .ant-segmented-item-label {
+        min-height: 26px;
+        line-height: 26px;
+        padding-inline: 12px;
+      }
+    }
+
+    .report-markdown-actions {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+
+      .ant-btn {
+        height: 28px;
+      }
+
+      .ant-btn:not(.ant-btn-icon-only) {
+        padding-inline: 10px;
+        font-size: 13px;
       }
     }
   }
@@ -191,6 +220,24 @@ footer.mt-8 {
       svg {
         width: 20px;
         height: 20px;
+      }
+    }
+  }
+}
+
+@media (max-width: 960px) {
+  .page-nav {
+    .page-nav-left {
+      gap: 8px;
+
+      .report-view-mode-switch .ant-segmented-item-label {
+        padding-inline: 8px;
+      }
+
+      .report-markdown-actions .ant-btn:not(.ant-btn-icon-only) {
+        max-width: 148px;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
   }

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -1,14 +1,12 @@
 import './App.less';
 
-import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
+import { DownOutlined } from '@ant-design/icons';
 import {
   Alert,
   App as AntdApp,
-  Button,
   ConfigProvider,
+  Dropdown,
   Empty,
-  Segmented,
-  Tooltip,
   message,
   theme,
 } from 'antd';
@@ -48,7 +46,6 @@ import {
   downloadMarkdownZip,
   getReportMarkdownView,
   markdownArchiveBaseName,
-  markdownZipDownloadTooltip,
 } from './utils/markdown-export';
 import { formatModelBriefText } from './utils/model-brief';
 import { getPlayerViewOptions } from './utils/player-only';
@@ -123,6 +120,8 @@ function Visualizer(props: VisualizerProps): JSX.Element {
   const dump = useExecutionDump((store) => store.dump);
   const [timelineCollapsed, setTimelineCollapsed] = useState(false);
   const [reportViewMode, setReportViewMode] = useState<ReportViewMode>('human');
+  const [reportViewModeDropdownOpen, setReportViewModeDropdownOpen] =
+    useState(false);
   const [selectedMarkdownImagePath, setSelectedMarkdownImagePath] = useState<
     string | null
   >(null);
@@ -202,6 +201,16 @@ function Visualizer(props: VisualizerProps): JSX.Element {
     () => markdownArchiveBaseName(dump),
     [dump],
   );
+  const reportViewModeLabel =
+    reportViewMode === 'markdown' ? 'Markdown View' : 'Human View';
+  const handleReportViewModeChange = (mode: ReportViewMode) => {
+    if (mode === reportViewMode) {
+      return;
+    }
+    setReportViewMode(mode);
+    setSelectedMarkdownImagePath(null);
+    setSelectedMarkdownImageRequestId(0);
+  };
 
   const handleCopyReportMarkdown = async () => {
     if (!readyReportMarkdown) {
@@ -334,6 +343,11 @@ function Visualizer(props: VisualizerProps): JSX.Element {
             reportViewMode={reportViewMode}
             reportMarkdownView={reportMarkdownView}
             onMarkdownImageClick={handleMarkdownImageClick}
+            reportMarkdownActionsDisabled={!readyReportMarkdown}
+            onCopyReportMarkdown={() => void handleCopyReportMarkdown()}
+            onDownloadReportMarkdownZip={() =>
+              void handleDownloadReportMarkdownZip()
+            }
           />
         </div>
         <div
@@ -477,44 +491,31 @@ function Visualizer(props: VisualizerProps): JSX.Element {
                 <div className="page-nav-left">
                   <Logo />
                   {executionDump && (
-                    <Segmented
-                      size="small"
-                      className="report-view-mode-switch"
-                      value={reportViewMode}
-                      options={[
-                        { label: 'Human View', value: 'human' },
-                        { label: 'Markdown View', value: 'markdown' },
-                      ]}
-                      onChange={(value) => {
-                        setReportViewMode(value as ReportViewMode);
-                        setSelectedMarkdownImagePath(null);
-                        setSelectedMarkdownImageRequestId(0);
+                    <Dropdown
+                      trigger={['click']}
+                      placement="bottomLeft"
+                      open={reportViewModeDropdownOpen}
+                      onOpenChange={setReportViewModeDropdownOpen}
+                      menu={{
+                        items: [
+                          { key: 'human', label: 'Human View' },
+                          { key: 'markdown', label: 'Markdown View' },
+                        ],
+                        onClick: ({ key }) => {
+                          handleReportViewModeChange(key as ReportViewMode);
+                          setReportViewModeDropdownOpen(false);
+                        },
                       }}
-                    />
-                  )}
-                  {reportViewMode === 'markdown' && (
-                    <div className="report-markdown-actions">
-                      <Tooltip title="Copy report.md markdown">
-                        <Button
-                          type="text"
-                          size="small"
-                          icon={<CopyOutlined />}
-                          disabled={!readyReportMarkdown}
-                          onClick={() => void handleCopyReportMarkdown()}
-                          aria-label="Copy report markdown"
-                        />
-                      </Tooltip>
-                      <Tooltip title={markdownZipDownloadTooltip}>
-                        <Button
-                          type="text"
-                          size="small"
-                          icon={<DownloadOutlined />}
-                          disabled={!readyReportMarkdown}
-                          onClick={() => void handleDownloadReportMarkdownZip()}
-                          aria-label="Download markdown and images ZIP"
-                        />
-                      </Tooltip>
-                    </div>
+                    >
+                      <button
+                        type="button"
+                        className="report-view-mode-dropdown"
+                        aria-expanded={reportViewModeDropdownOpen}
+                      >
+                        <span>{reportViewModeLabel}</span>
+                        <DownOutlined />
+                      </button>
+                    </Dropdown>
                   )}
                 </div>
                 <div className="page-nav-right">

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -203,13 +203,16 @@ function Visualizer(props: VisualizerProps): JSX.Element {
   );
   const reportViewModeLabel =
     reportViewMode === 'markdown' ? 'Markdown View' : 'Human View';
+  const resetMarkdownImageSelection = () => {
+    setSelectedMarkdownImagePath(null);
+    setSelectedMarkdownImageRequestId(0);
+  };
   const handleReportViewModeChange = (mode: ReportViewMode) => {
     if (mode === reportViewMode) {
       return;
     }
     setReportViewMode(mode);
-    setSelectedMarkdownImagePath(null);
-    setSelectedMarkdownImageRequestId(0);
+    resetMarkdownImageSelection();
   };
 
   const handleCopyReportMarkdown = async () => {
@@ -348,6 +351,7 @@ function Visualizer(props: VisualizerProps): JSX.Element {
             onDownloadReportMarkdownZip={() =>
               void handleDownloadReportMarkdownZip()
             }
+            onReportCaseChange={resetMarkdownImageSelection}
           />
         </div>
         <div

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -1,12 +1,24 @@
 import './App.less';
 
-import { Alert, App as AntdApp, ConfigProvider, Empty, theme } from 'antd';
+import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  App as AntdApp,
+  Button,
+  ConfigProvider,
+  Empty,
+  Segmented,
+  Tooltip,
+  message,
+  theme,
+} from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 import {
   GroupedActionDump,
   dedupeExecutionsKeepLatest,
+  reportToMarkdown,
   restoreImageReferences,
 } from '@midscene/core';
 import { antiEscapeScriptTag } from '@midscene/shared/utils';
@@ -16,6 +28,7 @@ import {
   globalThemeConfig,
   useGlobalPreference,
 } from '@midscene/visualizer';
+import AgentScreenshotView from './components/agent-screenshot-view';
 import DetailPanel from './components/detail-panel';
 import DetailSide from './components/detail-side';
 import GlobalHoverPreview from './components/global-hover-preview';
@@ -28,8 +41,15 @@ import ThemeLightIcon from './icons/theme-light.svg?react';
 import type {
   PlaywrightTaskAttributes,
   PlaywrightTasks,
+  ReportViewMode,
   VisualizerProps,
 } from './types';
+import {
+  downloadMarkdownZip,
+  getReportMarkdownView,
+  markdownArchiveBaseName,
+  markdownZipDownloadTooltip,
+} from './utils/markdown-export';
 import { formatModelBriefText } from './utils/model-brief';
 import { getPlayerViewOptions } from './utils/player-only';
 import {
@@ -102,6 +122,12 @@ function Visualizer(props: VisualizerProps): JSX.Element {
   });
   const dump = useExecutionDump((store) => store.dump);
   const [timelineCollapsed, setTimelineCollapsed] = useState(false);
+  const [reportViewMode, setReportViewMode] = useState<ReportViewMode>('human');
+  const [selectedMarkdownImagePath, setSelectedMarkdownImagePath] = useState<
+    string | null
+  >(null);
+  const [selectedMarkdownImageRequestId, setSelectedMarkdownImageRequestId] =
+    useState(0);
   const {
     modelCallDetailsEnabled: proModeEnabled,
     setModelCallDetailsEnabled: setProModeEnabled,
@@ -164,6 +190,62 @@ function Visualizer(props: VisualizerProps): JSX.Element {
       dumps.every((d) => d.attributes?.playwright_test_status === 'skipped'),
     [dumps],
   );
+  const reportMarkdownView = useMemo(() => {
+    if (reportViewMode !== 'markdown') {
+      return null;
+    }
+    return getReportMarkdownView(dump, reportToMarkdown);
+  }, [dump, reportViewMode]);
+  const readyReportMarkdown =
+    reportMarkdownView?.status === 'ready' ? reportMarkdownView : null;
+  const reportArchiveBaseName = useMemo(
+    () => markdownArchiveBaseName(dump),
+    [dump],
+  );
+
+  const handleCopyReportMarkdown = async () => {
+    if (!readyReportMarkdown) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(readyReportMarkdown.markdown);
+      message.success('Markdown copied');
+    } catch {
+      message.error('Copy failed');
+    }
+  };
+
+  const handleDownloadReportMarkdownZip = async () => {
+    if (!readyReportMarkdown) {
+      return;
+    }
+
+    try {
+      const result = await downloadMarkdownZip(
+        readyReportMarkdown.markdown,
+        readyReportMarkdown.attachments,
+        reportArchiveBaseName,
+      );
+      if (result.missingAttachmentCount > 0) {
+        message.warning(
+          `${result.missingAttachmentCount} screenshot link${
+            result.missingAttachmentCount === 1 ? '' : 's'
+          } kept as markdown reference${
+            result.missingAttachmentCount === 1 ? '' : 's'
+          } but not packaged.`,
+        );
+      } else {
+        message.success('Markdown and images downloaded');
+      }
+    } catch {
+      message.error('Download failed');
+    }
+  };
+  const handleMarkdownImageClick = (markdownPath: string) => {
+    setSelectedMarkdownImagePath(markdownPath);
+    setSelectedMarkdownImageRequestId((current) => current + 1);
+  };
 
   const renderContent = () => {
     if (dump && dump.executions.length === 0) {
@@ -249,6 +331,9 @@ function Visualizer(props: VisualizerProps): JSX.Element {
             onProModeChange={setProModeEnabled}
             replayAllScripts={replayAllScripts}
             setReplayAllMode={setReplayAllMode}
+            reportViewMode={reportViewMode}
+            reportMarkdownView={reportMarkdownView}
+            onMarkdownImageClick={handleMarkdownImageClick}
           />
         </div>
         <div
@@ -273,28 +358,38 @@ function Visualizer(props: VisualizerProps): JSX.Element {
           }}
         />
         <div className="main-right">
-          <div
-            className="main-right-header"
-            onClick={() => setTimelineCollapsed(!timelineCollapsed)}
-            style={{ cursor: 'pointer', userSelect: 'none' }}
-          >
-            <span
-              className="timeline-collapse-icon"
-              style={{
-                display: 'inline-block',
-                marginRight: 8,
-                transition: 'transform 0.2s',
-                transform: timelineCollapsed
-                  ? 'rotate(-90deg)'
-                  : 'rotate(0deg)',
-              }}
-            >
-              ▼
-            </span>
-            Record
-          </div>
-          {!timelineCollapsed && <Timeline key={mainLayoutChangeFlag} />}
-          <div className="main-content">{content}</div>
+          {reportViewMode === 'markdown' ? (
+            <AgentScreenshotView
+              markdownView={reportMarkdownView}
+              selectedMarkdownImagePath={selectedMarkdownImagePath}
+              selectedMarkdownImageRequestId={selectedMarkdownImageRequestId}
+            />
+          ) : (
+            <>
+              <div
+                className="main-right-header"
+                onClick={() => setTimelineCollapsed(!timelineCollapsed)}
+                style={{ cursor: 'pointer', userSelect: 'none' }}
+              >
+                <span
+                  className="timeline-collapse-icon"
+                  style={{
+                    display: 'inline-block',
+                    marginRight: 8,
+                    transition: 'transform 0.2s',
+                    transform: timelineCollapsed
+                      ? 'rotate(-90deg)'
+                      : 'rotate(0deg)',
+                  }}
+                >
+                  ▼
+                </span>
+                Record
+              </div>
+              {!timelineCollapsed && <Timeline key={mainLayoutChangeFlag} />}
+              <div className="main-content">{content}</div>
+            </>
+          )}
         </div>
       </div>
     );
@@ -381,6 +476,46 @@ function Visualizer(props: VisualizerProps): JSX.Element {
               <div className="page-nav">
                 <div className="page-nav-left">
                   <Logo />
+                  {executionDump && (
+                    <Segmented
+                      size="small"
+                      className="report-view-mode-switch"
+                      value={reportViewMode}
+                      options={[
+                        { label: 'Human View', value: 'human' },
+                        { label: 'Markdown View', value: 'markdown' },
+                      ]}
+                      onChange={(value) => {
+                        setReportViewMode(value as ReportViewMode);
+                        setSelectedMarkdownImagePath(null);
+                        setSelectedMarkdownImageRequestId(0);
+                      }}
+                    />
+                  )}
+                  {reportViewMode === 'markdown' && (
+                    <div className="report-markdown-actions">
+                      <Tooltip title="Copy report.md markdown">
+                        <Button
+                          type="text"
+                          size="small"
+                          icon={<CopyOutlined />}
+                          disabled={!readyReportMarkdown}
+                          onClick={() => void handleCopyReportMarkdown()}
+                          aria-label="Copy report markdown"
+                        />
+                      </Tooltip>
+                      <Tooltip title={markdownZipDownloadTooltip}>
+                        <Button
+                          type="text"
+                          size="small"
+                          icon={<DownloadOutlined />}
+                          disabled={!readyReportMarkdown}
+                          onClick={() => void handleDownloadReportMarkdownZip()}
+                          aria-label="Download markdown and images ZIP"
+                        />
+                      </Tooltip>
+                    </div>
+                  )}
                 </div>
                 <div className="page-nav-right">
                   <div className="page-nav-version">

--- a/apps/report/src/components/agent-screenshot-view/index.less
+++ b/apps/report/src/components/agent-screenshot-view/index.less
@@ -1,0 +1,188 @@
+@import '../common.less';
+
+.agent-screenshot-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+  background: #fff;
+}
+
+.agent-screenshot-header {
+  height: 50px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  padding: 0 16px 0 17px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid @border-color;
+}
+
+.agent-screenshot-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.agent-screenshot-count {
+  min-width: 20px;
+  height: 20px;
+  box-sizing: border-box;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: #f2f4f7;
+  color: #595959;
+  font-size: 12px;
+  line-height: 20px;
+  text-align: center;
+}
+
+.agent-screenshot-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.agent-screenshot-item {
+  margin: 0;
+  border: 1px solid @border-color;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  flex-shrink: 0;
+  transition:
+    border-color 0.18s,
+    box-shadow 0.18s;
+
+  &.selected {
+    border-color: #1677ff;
+    box-shadow: 0 0 0 2px rgba(22, 119, 255, 0.18);
+  }
+
+  figcaption {
+    min-height: 54px;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 8px;
+    align-items: center;
+    color: #595959;
+    font-size: 12px;
+    border-bottom: 1px solid @border-color;
+    background: #fafafa;
+  }
+
+  .agent-screenshot-index {
+    color: #8c8c8c;
+    font-weight: 600;
+  }
+
+  .agent-screenshot-file {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .agent-screenshot-file-name,
+  .agent-screenshot-path {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-screenshot-file-name {
+    color: #262626;
+    font-weight: 500;
+  }
+
+  .agent-screenshot-path {
+    color: #667085;
+    font-family:
+      'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Fira Mono',
+      'Roboto Mono', monospace;
+    font-size: 11px;
+    line-height: 16px;
+  }
+
+  .agent-screenshot-image-frame {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #f8fafc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .agent-screenshot-preview-missing {
+    color: #8c8c8c;
+    font-size: 12px;
+  }
+}
+
+.agent-screenshot-empty {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+[data-theme='dark'] {
+  .agent-screenshot-view {
+    background: #1f1f1f;
+  }
+
+  .agent-screenshot-header,
+  .agent-screenshot-item,
+  .agent-screenshot-item figcaption {
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .agent-screenshot-count,
+  .agent-screenshot-item figcaption {
+    background: #2c2e31;
+    color: #f8fafd;
+  }
+
+  .agent-screenshot-file-name {
+    color: #f8fafd;
+  }
+
+  .agent-screenshot-path,
+  .agent-screenshot-preview-missing {
+    color: rgba(248, 250, 253, 0.7);
+  }
+
+  .agent-screenshot-item {
+    background: #1f1f1f;
+
+    &.selected {
+      border-color: #69b1ff;
+      box-shadow: 0 0 0 2px rgba(105, 177, 255, 0.22);
+    }
+  }
+
+  .agent-screenshot-image-frame {
+    background: #141414;
+  }
+}

--- a/apps/report/src/components/agent-screenshot-view/index.tsx
+++ b/apps/report/src/components/agent-screenshot-view/index.tsx
@@ -1,0 +1,111 @@
+import './index.less';
+
+import { Empty } from 'antd';
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  type MarkdownView,
+  getMarkdownAttachmentDisplayItems,
+} from '../../utils/markdown-export';
+
+interface AgentScreenshotViewProps {
+  markdownView?: MarkdownView | null;
+  selectedMarkdownImagePath?: string | null;
+  selectedMarkdownImageRequestId?: number;
+}
+
+const AgentScreenshotView = ({
+  markdownView,
+  selectedMarkdownImagePath,
+  selectedMarkdownImageRequestId,
+}: AgentScreenshotViewProps): JSX.Element => {
+  const readyMarkdown =
+    markdownView?.status === 'ready' ? markdownView : undefined;
+  const itemRefs = useRef(new Map<string, HTMLElement>());
+
+  const screenshots = useMemo(
+    () =>
+      readyMarkdown
+        ? getMarkdownAttachmentDisplayItems(readyMarkdown.attachments)
+        : [],
+    [readyMarkdown],
+  );
+
+  useEffect(() => {
+    if (!selectedMarkdownImagePath) {
+      return;
+    }
+
+    const selectedItem = itemRefs.current.get(selectedMarkdownImagePath);
+    selectedItem?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  }, [selectedMarkdownImagePath, selectedMarkdownImageRequestId]);
+
+  return (
+    <div className="agent-screenshot-view">
+      <div className="agent-screenshot-header">
+        <div className="agent-screenshot-title">
+          Screenshots
+          <span className="agent-screenshot-count">{screenshots.length}</span>
+        </div>
+      </div>
+      {screenshots.length ? (
+        <div className="agent-screenshot-list">
+          {screenshots.map((screenshot, index) => (
+            <figure
+              className={`agent-screenshot-item ${
+                selectedMarkdownImagePath === screenshot.markdownPath
+                  ? 'selected'
+                  : ''
+              }`}
+              key={screenshot.key}
+              data-markdown-path={screenshot.markdownPath}
+              ref={(node) => {
+                if (node) {
+                  itemRefs.current.set(screenshot.markdownPath, node);
+                } else {
+                  itemRefs.current.delete(screenshot.markdownPath);
+                }
+              }}
+            >
+              <figcaption>
+                <span className="agent-screenshot-index">#{index + 1}</span>
+                <span className="agent-screenshot-file">
+                  <span
+                    className="agent-screenshot-file-name"
+                    title={screenshot.fileName}
+                  >
+                    {screenshot.fileName}
+                  </span>
+                  <code
+                    className="agent-screenshot-path"
+                    title={screenshot.markdownPath}
+                  >
+                    {screenshot.markdownPath}
+                  </code>
+                </span>
+              </figcaption>
+              <div className="agent-screenshot-image-frame">
+                {screenshot.previewSrc ? (
+                  <img
+                    src={screenshot.previewSrc}
+                    alt={screenshot.markdownPath}
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="agent-screenshot-preview-missing">
+                    Preview unavailable
+                  </div>
+                )}
+              </div>
+            </figure>
+          ))}
+        </div>
+      ) : (
+        <div className="agent-screenshot-empty">
+          <Empty description="No screenshots available" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AgentScreenshotView;

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -15,17 +15,20 @@ import type {
   ExecutionTaskPlanningLocate,
   IExecutionDump,
 } from '@midscene/core';
-import type { MarkdownAttachment } from '@midscene/core';
 import { executionToMarkdown, getTaskSearchArea } from '@midscene/core';
 import {
   Blackboard,
   Player,
   fullTimeStrWithMilliseconds,
 } from '@midscene/visualizer';
-import { Segmented, message } from 'antd';
+import { Segmented, Tooltip, message } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { JsonView, allExpanded } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
+import {
+  downloadMarkdownZip,
+  markdownZipDownloadTooltip,
+} from '../../utils/markdown-export';
 import OpenInPlayground from '../open-in-playground';
 import { sanitizeJsonViewData } from './json-view-data';
 import { getExecutionMarkdownView } from './markdown-view';
@@ -72,39 +75,6 @@ const jsonViewStyles = {
   quotesForFieldNames: true,
   stringifyStringValues: true,
 };
-
-async function downloadMarkdownZip(
-  markdown: string,
-  attachments: MarkdownAttachment[],
-  fileName: string,
-): Promise<void> {
-  const { zipSync, strToU8 } = await import('fflate');
-
-  const files: Record<string, Uint8Array> = {};
-  files['report.md'] = strToU8(markdown);
-
-  for (const att of attachments) {
-    if (!att.base64Data) continue;
-    const raw = att.base64Data.replace(/^data:image\/[a-zA-Z+]+;base64,/, '');
-    const binary = atob(raw);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    files[`screenshots/${att.suggestedFileName}`] = bytes;
-  }
-
-  const zipped = zipSync(files);
-  const blob = new Blob([zipped], { type: 'application/zip' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${fileName}.zip`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
 
 // Helper function to recursively extract all elements from param
 const extractElementsFromParam = (param: any): any[] => {
@@ -412,18 +382,20 @@ const DetailPanel = ({
         <div className="view-switcher-actions">
           {viewType === VIEW_TYPE_MARKDOWN &&
             markdownResult?.status === 'ready' && (
-              <a
-                className="download-zip-link"
-                onClick={() =>
-                  downloadMarkdownZip(
-                    markdownResult.markdown,
-                    markdownResult.attachments,
-                    safeName || 'report',
-                  )
-                }
-              >
-                <DownloadOutlined /> Download ZIP
-              </a>
+              <Tooltip title={markdownZipDownloadTooltip}>
+                <a
+                  className="download-zip-link"
+                  onClick={() =>
+                    void downloadMarkdownZip(
+                      markdownResult.markdown,
+                      markdownResult.attachments,
+                      safeName || 'report',
+                    )
+                  }
+                >
+                  <DownloadOutlined /> Download ZIP
+                </a>
+              </Tooltip>
             )}
           {viewType === VIEW_TYPE_JSON && activeTaskJsonText && (
             <a

--- a/apps/report/src/components/detail-panel/markdown-view.ts
+++ b/apps/report/src/components/detail-panel/markdown-view.ts
@@ -1,34 +1,4 @@
-import type { MarkdownAttachment } from '@midscene/core';
-
-type ExecutionMarkdown = {
-  markdown: string;
-  attachments: MarkdownAttachment[];
-};
-
-export type ExecutionMarkdownView =
-  | ({ status: 'ready' } & ExecutionMarkdown)
-  | { status: 'empty' }
-  | { status: 'error'; errorMessage: string };
-
-export function getExecutionMarkdownView(
-  activeExecution: unknown,
-  toMarkdown: (activeExecution: unknown) => ExecutionMarkdown,
-): ExecutionMarkdownView {
-  if (!activeExecution) {
-    return { status: 'empty' };
-  }
-
-  try {
-    return {
-      status: 'ready',
-      ...toMarkdown(activeExecution),
-    };
-  } catch (error) {
-    console.warn('Failed to render markdown view', error);
-
-    return {
-      status: 'error',
-      errorMessage: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
+export {
+  getExecutionMarkdownView,
+  type MarkdownView as ExecutionMarkdownView,
+} from '@/utils/markdown-export';

--- a/apps/report/src/components/playwright-case-selector/index.tsx
+++ b/apps/report/src/components/playwright-case-selector/index.tsx
@@ -26,6 +26,7 @@ interface PlaywrightCaseSelectorProps {
   dumps?: PlaywrightTasks[];
   selected?: GroupedActionDump | null;
   onSelect?: (dump: GroupedActionDump) => void;
+  onCaseChange?: () => void;
 }
 
 const STATUS_DISPLAY_LABEL: Partial<
@@ -130,6 +131,7 @@ function PlaywrightCaseTitle(props: {
 
 export function PlaywrightCaseSelector({
   dumps,
+  onCaseChange,
 }: PlaywrightCaseSelectorProps): JSX.Element | null {
   if (!dumps || dumps.length === 0) return null;
   if (dumps.length === 1 && !dumps[0].attributes?.is_merged) return null;
@@ -249,6 +251,7 @@ export function PlaywrightCaseSelector({
 
   const handlePlaywrightTaskSelect = async (dump: PlaywrightTasks) => {
     await setGroupedDump(dump.get(), dump.attributes);
+    onCaseChange?.();
     setIsExpanded(false);
   };
 

--- a/apps/report/src/components/report-overview/index.tsx
+++ b/apps/report/src/components/report-overview/index.tsx
@@ -16,6 +16,7 @@ const ReportOverview = (props: {
   proModeEnabled?: boolean;
   onProModeChange?: (enabled: boolean) => void;
   dumps?: PlaywrightTasks[];
+  onCaseChange?: () => void;
 }): JSX.Element => {
   const testStats = useMemo(() => {
     const stats = {
@@ -124,7 +125,10 @@ const ReportOverview = (props: {
   return (
     <div className="report-overview">
       {testStatsEl}
-      <PlaywrightCaseSelector dumps={props.dumps} />
+      <PlaywrightCaseSelector
+        dumps={props.dumps}
+        onCaseChange={props.onCaseChange}
+      />
     </div>
   );
 };

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -48,8 +48,18 @@
       .page-nav-toolbar {
         display: flex;
         align-items: center;
-        gap: 16px;
+        gap: 6px;
         flex-shrink: 0;
+
+        .ant-btn {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 28px;
+          height: 28px;
+          padding: 0;
+          border-radius: 8px;
+        }
 
         .icon-button {
           cursor: pointer;
@@ -64,6 +74,10 @@
             background: #e6e8eb;
           }
         }
+      }
+
+      .report-markdown-sidebar-actions {
+        margin-left: auto;
       }
     }
   }
@@ -578,13 +592,24 @@
       background: #1f1f1f;
 
       .page-nav-left {
-        .page-nav-toolbar .icon-button {
-          &:hover {
-            background: #2c2e31;
+        .page-nav-toolbar {
+          .ant-btn:not(:disabled) {
+            color: #f8fafd;
+
+            &:hover {
+              background: #2c2e31;
+              color: #f8fafd;
+            }
           }
 
-          svg {
-            color: #f8fafd;
+          .icon-button {
+            &:hover {
+              background: #2c2e31;
+            }
+
+            svg {
+              color: #f8fafd;
+            }
           }
         }
 

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -7,7 +7,7 @@
   width: 100%;
   height: 100%;
   min-width: 270px;
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: hidden;
   box-sizing: border-box;
   border-radius: 16px;
@@ -27,11 +27,29 @@
       align-items: center;
       justify-content: space-between;
       width: 100%;
+      min-width: 0;
+
+      .page-nav-top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        width: 100%;
+        min-width: 0;
+      }
+
+      .page-nav-title {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
 
       .page-nav-toolbar {
         display: flex;
         align-items: center;
         gap: 16px;
+        flex-shrink: 0;
 
         .icon-button {
           cursor: pointer;
@@ -46,6 +64,82 @@
             background: #e6e8eb;
           }
         }
+      }
+    }
+  }
+
+  .agent-markdown-sidebar {
+    flex: 1;
+    min-height: 0;
+    padding: 0 12px 12px;
+    overflow: hidden;
+
+    &.empty {
+      padding: 20px;
+      color: #808080;
+      font-size: 12px;
+    }
+  }
+
+  .agent-markdown-source {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 12px;
+    overflow: auto;
+    border: 1px solid @border-color;
+    border-radius: 8px;
+    background: #f8fafc;
+    color: #1f2937;
+    font-family:
+      'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Fira Mono',
+      'Roboto Mono', monospace;
+    font-size: 12px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+
+    .agent-markdown-line {
+      min-height: 19px;
+    }
+
+    .line-heading {
+      color: #0969da;
+      font-weight: 600;
+    }
+
+    .line-table {
+      color: #8250df;
+    }
+
+    .line-list {
+      color: #0550ae;
+    }
+
+    .line-code,
+    .line-fence {
+      color: #57606a;
+      background: rgba(175, 184, 193, 0.12);
+    }
+
+    .line-image {
+      color: #1f883d;
+    }
+
+    .agent-markdown-image-link {
+      display: inline;
+      margin: 0;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: #1677ff;
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
       }
     }
   }
@@ -506,6 +600,35 @@
 
     .side-sub-title {
       color: #f8fafd;
+    }
+
+    .agent-markdown-source {
+      border-color: rgba(255, 255, 255, 0.12);
+      background: #141414;
+      color: #f8fafd;
+
+      .line-heading {
+        color: #69b1ff;
+      }
+
+      .line-table {
+        color: #d3adf7;
+      }
+
+      .line-list {
+        color: #91caff;
+      }
+
+      .line-code,
+      .line-fence {
+        color: rgba(248, 250, 253, 0.72);
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .line-image,
+      .agent-markdown-image-link {
+        color: #95de64;
+      }
     }
 
     .tasks-table {

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -9,18 +9,20 @@ import {
   iconForStatus,
   timeCostStrElement,
 } from '@midscene/visualizer';
-import { Checkbox, Tag, Tooltip } from 'antd';
+import { Alert, Checkbox, Tag, Tooltip } from 'antd';
 import { useEffect, useMemo } from 'react';
 import CameraIcon from '../../icons/camera.svg?react';
 import MessageIcon from '../../icons/message.svg?react';
 import PlayIcon from '../../icons/play.svg?react';
-import type { PlaywrightTasks } from '../../types';
+import type { PlaywrightTasks, ReportViewMode } from '../../types';
+import type { MarkdownView } from '../../utils/markdown-export';
 import {
   hasDeepLocateFlag,
   hasDeepThinkFlag,
 } from '../../utils/report-task-tags';
 import { anchorIdForTask } from '../../utils/task-anchor';
 import ReportOverview from '../report-overview';
+import MarkdownSource from './markdown-source';
 
 // Extended task type with searchAreaUsage
 type ExecutionTaskWithSearchAreaUsage = ExecutionTask & {
@@ -42,6 +44,9 @@ interface SidebarProps {
   replayAllScripts?: AnimationScript[] | null;
   replayAllMode?: boolean;
   setReplayAllMode?: (mode: boolean) => void;
+  reportViewMode?: ReportViewMode;
+  reportMarkdownView?: MarkdownView | null;
+  onMarkdownImageClick?: (markdownPath: string) => void;
 }
 
 const Sidebar = (props: SidebarProps = {}): JSX.Element => {
@@ -50,6 +55,9 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     proModeEnabled = false,
     onProModeChange,
     setReplayAllMode,
+    reportViewMode = 'human',
+    reportMarkdownView,
+    onMarkdownImageClick,
   } = props;
   const groupedDump = useExecutionDump((store) => store.dump);
   const playwrightAttributes = useExecutionDump(
@@ -68,7 +76,6 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
   const currentSelectedIndex = allTasks?.findIndex(
     (task) => task === activeTask,
   );
-
   // Prepare table data source
   const tableData = useMemo<TableRowData[]>(() => {
     if (!groupedDump) return [];
@@ -893,30 +900,60 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     </div>
   ) : null;
 
+  let agentMarkdownContent: JSX.Element;
+  if (reportMarkdownView?.status === 'ready') {
+    agentMarkdownContent = (
+      <div className="agent-markdown-sidebar">
+        <MarkdownSource
+          markdown={reportMarkdownView.markdown}
+          onImageClick={onMarkdownImageClick}
+        />
+      </div>
+    );
+  } else if (reportMarkdownView?.status === 'error') {
+    agentMarkdownContent = (
+      <div className="agent-markdown-sidebar">
+        <Alert
+          type="error"
+          showIcon
+          message="Failed to render markdown"
+          description={reportMarkdownView.errorMessage}
+        />
+      </div>
+    );
+  } else {
+    agentMarkdownContent = (
+      <div className="agent-markdown-sidebar empty">No report markdown</div>
+    );
+  }
+
   return (
     <div className="side-bar">
       <div className="page-nav">
         <div className="page-nav-left">
-          <div className="page-nav-title">
-            Report
-            <span className="page-nav-title-hint">
-              Switch: Command + Up / Down
-            </span>
-          </div>
-          <div className="page-nav-toolbar">
-            <div
-              className="icon-button"
-              onClick={() => {
-                setReplayAllMode?.(true);
-              }}
-            >
-              <PlayIcon />
+          <div className="page-nav-top">
+            <div className="page-nav-title">Report</div>
+            <div className="page-nav-toolbar">
+              <div
+                className="icon-button"
+                onClick={() => {
+                  setReplayAllMode?.(true);
+                }}
+              >
+                <PlayIcon />
+              </div>
             </div>
           </div>
         </div>
       </div>
-      {sideList}
-      {executionContent}
+      {reportViewMode === 'markdown' ? (
+        agentMarkdownContent
+      ) : (
+        <>
+          {sideList}
+          {executionContent}
+        </>
+      )}
     </div>
   );
 };

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -54,6 +54,7 @@ interface SidebarProps {
   reportMarkdownActionsDisabled?: boolean;
   onCopyReportMarkdown?: () => void;
   onDownloadReportMarkdownZip?: () => void;
+  onReportCaseChange?: () => void;
 }
 
 const Sidebar = (props: SidebarProps = {}): JSX.Element => {
@@ -68,6 +69,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     reportMarkdownActionsDisabled = true,
     onCopyReportMarkdown,
     onDownloadReportMarkdownZip,
+    onReportCaseChange,
   } = props;
   const groupedDump = useExecutionDump((store) => store.dump);
   const playwrightAttributes = useExecutionDump(
@@ -586,7 +588,11 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     [groupedDump].map((group, groupIndex) => {
       return (
         <div key={groupIndex}>
-          <ReportOverview title={group.groupName} dumps={dumps} />
+          <ReportOverview
+            title={group.groupName}
+            dumps={dumps}
+            onCaseChange={onReportCaseChange}
+          />
         </div>
       );
     })
@@ -984,14 +990,8 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
           </div>
         </div>
       </div>
-      {reportViewMode === 'markdown' ? (
-        agentMarkdownContent
-      ) : (
-        <>
-          {sideList}
-          {executionContent}
-        </>
-      )}
+      {sideList}
+      {reportViewMode === 'markdown' ? agentMarkdownContent : executionContent}
     </div>
   );
 };

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -1,5 +1,6 @@
 import './index.less';
 import { useAllCurrentTasks, useExecutionDump } from '@/components/store';
+import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
 import type { AIUsageInfo, ExecutionTask } from '@midscene/core';
 import { deriveTaskStatus } from '@midscene/core';
 import { typeStr } from '@midscene/core/agent';
@@ -9,13 +10,16 @@ import {
   iconForStatus,
   timeCostStrElement,
 } from '@midscene/visualizer';
-import { Alert, Checkbox, Tag, Tooltip } from 'antd';
+import { Alert, Button, Checkbox, Tag, Tooltip } from 'antd';
 import { useEffect, useMemo } from 'react';
 import CameraIcon from '../../icons/camera.svg?react';
 import MessageIcon from '../../icons/message.svg?react';
 import PlayIcon from '../../icons/play.svg?react';
 import type { PlaywrightTasks, ReportViewMode } from '../../types';
-import type { MarkdownView } from '../../utils/markdown-export';
+import {
+  type MarkdownView,
+  markdownZipDownloadTooltip,
+} from '../../utils/markdown-export';
 import {
   hasDeepLocateFlag,
   hasDeepThinkFlag,
@@ -47,6 +51,9 @@ interface SidebarProps {
   reportViewMode?: ReportViewMode;
   reportMarkdownView?: MarkdownView | null;
   onMarkdownImageClick?: (markdownPath: string) => void;
+  reportMarkdownActionsDisabled?: boolean;
+  onCopyReportMarkdown?: () => void;
+  onDownloadReportMarkdownZip?: () => void;
 }
 
 const Sidebar = (props: SidebarProps = {}): JSX.Element => {
@@ -58,6 +65,9 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     reportViewMode = 'human',
     reportMarkdownView,
     onMarkdownImageClick,
+    reportMarkdownActionsDisabled = true,
+    onCopyReportMarkdown,
+    onDownloadReportMarkdownZip,
   } = props;
   const groupedDump = useExecutionDump((store) => store.dump);
   const playwrightAttributes = useExecutionDump(
@@ -927,22 +937,50 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     );
   }
 
+  const pageNavToolbar =
+    reportViewMode === 'markdown' ? (
+      <div className="page-nav-toolbar report-markdown-sidebar-actions">
+        <Tooltip title="Copy report.md markdown">
+          <Button
+            type="text"
+            size="small"
+            icon={<CopyOutlined />}
+            disabled={reportMarkdownActionsDisabled}
+            onClick={onCopyReportMarkdown}
+            aria-label="Copy report markdown"
+          />
+        </Tooltip>
+        <Tooltip title={markdownZipDownloadTooltip}>
+          <Button
+            type="text"
+            size="small"
+            icon={<DownloadOutlined />}
+            disabled={reportMarkdownActionsDisabled}
+            onClick={onDownloadReportMarkdownZip}
+            aria-label="Download markdown and images ZIP"
+          />
+        </Tooltip>
+      </div>
+    ) : (
+      <div className="page-nav-toolbar">
+        <div
+          className="icon-button"
+          onClick={() => {
+            setReplayAllMode?.(true);
+          }}
+        >
+          <PlayIcon />
+        </div>
+      </div>
+    );
+
   return (
     <div className="side-bar">
       <div className="page-nav">
         <div className="page-nav-left">
           <div className="page-nav-top">
             <div className="page-nav-title">Report</div>
-            <div className="page-nav-toolbar">
-              <div
-                className="icon-button"
-                onClick={() => {
-                  setReplayAllMode?.(true);
-                }}
-              >
-                <PlayIcon />
-              </div>
-            </div>
+            {pageNavToolbar}
           </div>
         </div>
       </div>

--- a/apps/report/src/components/sidebar/markdown-source.tsx
+++ b/apps/report/src/components/sidebar/markdown-source.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+interface MarkdownSourceProps {
+  markdown: string;
+  onImageClick?: (markdownPath: string) => void;
+}
+
+type MarkdownLineKind =
+  | 'blank'
+  | 'code'
+  | 'fence'
+  | 'heading'
+  | 'image'
+  | 'list'
+  | 'table'
+  | 'text';
+
+interface MarkdownLine {
+  text: string;
+  kind: MarkdownLineKind;
+}
+
+const imageLinkPattern = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+function buildMarkdownLines(markdown: string): MarkdownLine[] {
+  let inCodeBlock = false;
+
+  return markdown.split('\n').map((text) => {
+    const trimmed = text.trim();
+
+    if (trimmed.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      return { text, kind: 'fence' };
+    }
+
+    if (inCodeBlock) {
+      return { text, kind: 'code' };
+    }
+
+    if (!trimmed) {
+      return { text, kind: 'blank' };
+    }
+
+    if (/^#{1,6}\s+/.test(trimmed)) {
+      return { text, kind: 'heading' };
+    }
+
+    if (imageLinkPattern.test(text)) {
+      imageLinkPattern.lastIndex = 0;
+      return { text, kind: 'image' };
+    }
+    imageLinkPattern.lastIndex = 0;
+
+    if (/^\|.*\|$/.test(trimmed)) {
+      return { text, kind: 'table' };
+    }
+
+    if (/^[-*]\s+/.test(trimmed) || /^\d+\.\s+/.test(trimmed)) {
+      return { text, kind: 'list' };
+    }
+
+    return { text, kind: 'text' };
+  });
+}
+
+function renderLineContent(
+  line: string,
+  onImageClick?: (markdownPath: string) => void,
+): ReactNode {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  imageLinkPattern.lastIndex = 0;
+
+  for (const match of line.matchAll(imageLinkPattern)) {
+    const matchIndex = match.index ?? 0;
+    const [raw, altText, markdownPath] = match;
+
+    if (matchIndex > cursor) {
+      nodes.push(line.slice(cursor, matchIndex));
+    }
+
+    nodes.push(
+      <button
+        type="button"
+        className="agent-markdown-image-link"
+        key={`${markdownPath}-${matchIndex}`}
+        title={markdownPath}
+        onClick={() => onImageClick?.(markdownPath)}
+      >
+        ![{altText}]({markdownPath})
+      </button>,
+    );
+    cursor = matchIndex + raw.length;
+  }
+
+  if (cursor < line.length) {
+    nodes.push(line.slice(cursor));
+  }
+
+  return nodes.length ? nodes : line || '\u00a0';
+}
+
+const MarkdownSource = ({
+  markdown,
+  onImageClick,
+}: MarkdownSourceProps): JSX.Element => {
+  const lines = useMemo(() => buildMarkdownLines(markdown), [markdown]);
+
+  return (
+    <div className="agent-markdown-source" role="document">
+      {lines.map((line, index) => (
+        <div
+          className={`agent-markdown-line line-${line.kind}`}
+          key={`${index}-${line.kind}`}
+        >
+          {renderLineContent(line.text, onImageClick)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MarkdownSource;

--- a/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
@@ -2,11 +2,14 @@ import type { ExecutionTask } from '@midscene/core';
 import { describe, expect, it } from 'vitest';
 import { buildTimelineScreenshots } from './build-timeline-screenshots';
 
+const onePixelPngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lz8yrwAAAABJRU5ErkJggg==';
+
 interface TaskFixtureOptions {
   id: string;
   startTs?: number;
-  uiContextScreenshot?: { base64: string };
-  recorder?: { ts: number; base64?: string }[];
+  uiContextScreenshot?: { base64: string } | string;
+  recorder?: { ts: number; base64?: string; screenshot?: string }[];
 }
 
 const makeTask = (opts: TaskFixtureOptions): ExecutionTask =>
@@ -20,7 +23,9 @@ const makeTask = (opts: TaskFixtureOptions): ExecutionTask =>
       ...(opts.recorder?.map((r) => ({
         type: 'screenshot',
         ts: r.ts,
-        screenshot: r.base64 !== undefined ? { base64: r.base64 } : undefined,
+        screenshot:
+          r.screenshot ??
+          (r.base64 !== undefined ? { base64: r.base64 } : undefined),
       })) ?? []),
     ],
   }) as unknown as ExecutionTask;
@@ -81,6 +86,34 @@ describe('buildTimelineScreenshots', () => {
     expect(startingTime).toBe(1800);
     expect(allScreenshots.map((s) => s.timeOffset)).toEqual([0, 700, 1200]);
     expect(allScreenshots.map((s) => s.img)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('accepts recorder screenshots stored as raw base64 strings', () => {
+    const task = makeTask({
+      id: 'raw-recorder',
+      startTs: 1000,
+      recorder: [{ ts: 1200, screenshot: onePixelPngBase64 }],
+    });
+
+    const { allScreenshots } = buildTimelineScreenshots([task]);
+
+    expect(allScreenshots).toHaveLength(1);
+    expect(allScreenshots[0].img).toBe(
+      `data:image/png;base64,${onePixelPngBase64}`,
+    );
+  });
+
+  it('keeps already-prefixed data URLs unchanged', () => {
+    const dataUrl = `data:image/png;base64,${onePixelPngBase64}`;
+    const task = makeTask({
+      id: 'data-url-recorder',
+      startTs: 1000,
+      recorder: [{ ts: 1200, screenshot: dataUrl }],
+    });
+
+    const { allScreenshots } = buildTimelineScreenshots([task]);
+
+    expect(allScreenshots[0].img).toBe(dataUrl);
   });
 
   it('orders screenshots from multiple tasks by absolute time', () => {

--- a/apps/report/src/components/timeline/build-timeline-screenshots.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.ts
@@ -18,6 +18,41 @@ interface RawScreenshotEntry {
   base64: string;
 }
 
+const rawBase64BodyPattern = /^[a-zA-Z0-9+/=\s]+$/;
+
+const imageSrcFromString = (value: string): string => {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('data:')) {
+    return trimmed;
+  }
+  if (trimmed.length < 32 || !rawBase64BodyPattern.test(trimmed)) {
+    return value;
+  }
+
+  const body = trimmed.replace(/\s/g, '');
+  const mimeType = body.startsWith('/9j/')
+    ? 'image/jpeg'
+    : body.startsWith('UklGR')
+      ? 'image/webp'
+      : 'image/png';
+  return `data:${mimeType};base64,${body}`;
+};
+
+const screenshotBase64 = (screenshot: unknown): string | undefined => {
+  if (typeof screenshot === 'string') {
+    return imageSrcFromString(screenshot);
+  }
+  if (
+    screenshot &&
+    typeof screenshot === 'object' &&
+    'base64' in screenshot &&
+    typeof screenshot.base64 === 'string'
+  ) {
+    return imageSrcFromString(screenshot.base64);
+  }
+  return undefined;
+};
+
 const collectScreenshotEntries = (
   allTasks: ExecutionTask[],
 ): RawScreenshotEntry[] => {
@@ -25,20 +60,22 @@ const collectScreenshotEntries = (
 
   for (const task of allTasks) {
     const ctxScreenshot = task.uiContext?.screenshot;
-    if (ctxScreenshot && task.timing?.start) {
+    const ctxBase64 = screenshotBase64(ctxScreenshot);
+    if (ctxBase64 && task.timing?.start) {
       entries.push({
         task,
         ts: task.timing.start,
-        base64: ctxScreenshot.base64,
+        base64: ctxBase64,
       });
     }
 
     for (const recorder of task.recorder ?? []) {
-      if (recorder.screenshot) {
+      const recorderBase64 = screenshotBase64(recorder.screenshot);
+      if (recorderBase64) {
         entries.push({
           task,
           ts: recorder.ts,
-          base64: recorder.screenshot.base64,
+          base64: recorderBase64,
         });
       }
     }

--- a/apps/report/src/types.ts
+++ b/apps/report/src/types.ts
@@ -20,6 +20,8 @@ export interface PlaywrightTasks {
   attributes: PlaywrightTaskAttributes;
 }
 
+export type ReportViewMode = 'human' | 'markdown';
+
 export interface VisualizerProps {
   logoAction?: () => void;
   dumps?: PlaywrightTasks[];

--- a/apps/report/src/utils/markdown-export.test.ts
+++ b/apps/report/src/utils/markdown-export.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildMarkdownArchiveFiles,
+  buildMarkdownArchiveFilesForDownload,
+  countPackageableMarkdownAttachments,
+  getMarkdownAttachmentDisplayItems,
+  getReportMarkdownView,
+  markdownArchiveBaseName,
+  markdownAttachmentPath,
+} from './markdown-export';
+
+describe('markdown-export helpers', () => {
+  it('returns empty when report is missing', () => {
+    expect(
+      getReportMarkdownView(undefined, () => ({
+        markdown: '',
+        attachments: [],
+      })),
+    ).toEqual({
+      status: 'empty',
+    });
+  });
+
+  it('returns report markdown when generation succeeds', () => {
+    const result = getReportMarkdownView(
+      {
+        groupName: 'report',
+        sdkVersion: '1.0.0',
+        modelBriefs: [],
+        executions: [],
+      },
+      () => ({
+        markdown: '# report',
+        attachments: [],
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 'ready',
+      markdown: '# report',
+      attachments: [],
+    });
+  });
+
+  it('returns the error message and warns when report markdown generation fails', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = getReportMarkdownView(
+      {
+        groupName: 'report',
+        sdkVersion: '1.0.0',
+        modelBriefs: [],
+        executions: [],
+      },
+      () => {
+        throw new Error('boom');
+      },
+    );
+
+    expect(result).toEqual({
+      status: 'error',
+      errorMessage: 'boom',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to render report markdown view',
+      expect.any(Error),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('builds safe archive names from report group names', () => {
+    expect(markdownArchiveBaseName({ groupName: 'Checkout flow #1' })).toBe(
+      'Checkout-flow-1',
+    );
+    expect(markdownArchiveBaseName({ groupName: '***' })).toBe(
+      'midscene-report',
+    );
+  });
+
+  it('packages markdown and only in-memory screenshot attachments', () => {
+    const files = buildMarkdownArchiveFiles('# report', [
+      {
+        id: 'inline',
+        suggestedFileName: 'inline.png',
+        executionIndex: 0,
+        taskIndex: 0,
+        base64Data: `data:image/png;base64,${btoa('image-bytes')}`,
+      },
+      {
+        id: 'file-backed',
+        suggestedFileName: 'file-backed.png',
+        executionIndex: 0,
+        taskIndex: 1,
+      },
+    ]);
+
+    expect(Object.keys(files).sort()).toEqual([
+      'report.md',
+      'screenshots/inline.png',
+    ]);
+    expect(new TextDecoder().decode(files['report.md'])).toBe('# report');
+    expect(new TextDecoder().decode(files['screenshots/inline.png'])).toBe(
+      'image-bytes',
+    );
+  });
+
+  it('builds display items from markdown attachment names and paths', () => {
+    const items = getMarkdownAttachmentDisplayItems([
+      {
+        id: 'shot',
+        suggestedFileName: 'execution-1-task-2-shot.png',
+        executionIndex: 0,
+        taskIndex: 1,
+        base64Data: 'data:image/png;base64,AA==',
+      },
+    ]);
+
+    expect(items).toEqual([
+      {
+        key: '0-1-shot-execution-1-task-2-shot.png-0',
+        fileName: 'execution-1-task-2-shot.png',
+        markdownPath: './screenshots/execution-1-task-2-shot.png',
+        previewSrc: 'data:image/png;base64,AA==',
+        executionIndex: 0,
+        taskIndex: 1,
+      },
+    ]);
+    expect(
+      markdownAttachmentPath({
+        suggestedFileName: items[0].fileName,
+      }),
+    ).toBe('./screenshots/execution-1-task-2-shot.png');
+  });
+
+  it('uses file paths for preview without treating them as packageable base64', () => {
+    const attachment = {
+      id: 'file-shot',
+      suggestedFileName: 'execution-1-task-1-file-shot.png',
+      executionIndex: 0,
+      taskIndex: 0,
+      base64Data: './screenshots/file-shot.png',
+    };
+
+    expect(getMarkdownAttachmentDisplayItems([attachment])[0]).toMatchObject({
+      fileName: 'execution-1-task-1-file-shot.png',
+      markdownPath: './screenshots/execution-1-task-1-file-shot.png',
+      previewSrc: './screenshots/file-shot.png',
+    });
+    expect(countPackageableMarkdownAttachments([attachment])).toBe(0);
+    expect(
+      Object.keys(buildMarkdownArchiveFiles('# report', [attachment])),
+    ).toEqual(['report.md']);
+  });
+
+  it('packages fetchable file-backed attachments under their markdown names', async () => {
+    const fileBytes = new TextEncoder().encode('file-bytes');
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => fileBytes.buffer,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await buildMarkdownArchiveFilesForDownload('# report', [
+      {
+        id: 'file-shot',
+        suggestedFileName: 'execution-1-task-1-file-shot.png',
+        executionIndex: 0,
+        taskIndex: 0,
+        base64Data: './screenshots/file-shot.png',
+        sourceRef: {
+          type: 'midscene_screenshot_ref',
+          id: 'file-shot',
+          capturedAt: 1710000000000,
+          mimeType: 'image/png',
+          storage: 'file',
+          path: './screenshots/file-shot.png',
+        },
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith('./screenshots/file-shot.png');
+    expect(Object.keys(result.files).sort()).toEqual([
+      'report.md',
+      'screenshots/execution-1-task-1-file-shot.png',
+    ]);
+    expect(
+      new TextDecoder().decode(
+        result.files['screenshots/execution-1-task-1-file-shot.png'],
+      ),
+    ).toBe('file-bytes');
+    expect(result.packagedAttachmentCount).toBe(1);
+    expect(result.missingAttachmentCount).toBe(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('counts packageable attachments by base64 availability', () => {
+    expect(
+      countPackageableMarkdownAttachments([
+        {
+          id: 'inline',
+          suggestedFileName: 'inline.png',
+          executionIndex: 0,
+          taskIndex: 0,
+          base64Data: 'data:image/png;base64,AA==',
+        },
+        {
+          id: 'file-backed',
+          suggestedFileName: 'file-backed.png',
+          executionIndex: 0,
+          taskIndex: 1,
+        },
+      ]),
+    ).toBe(1);
+  });
+});

--- a/apps/report/src/utils/markdown-export.ts
+++ b/apps/report/src/utils/markdown-export.ts
@@ -1,0 +1,262 @@
+import type { MarkdownAttachment } from '@midscene/core';
+
+const defaultScreenshotBaseDir = './screenshots';
+const dataUrlBase64Pattern = /^data:image\/(?:png|jpeg|jpg);base64,/i;
+const rawBase64Pattern = /^[a-zA-Z0-9+/=\s]+$/;
+
+type MarkdownExport = {
+  markdown: string;
+  attachments: MarkdownAttachment[];
+};
+
+export type MarkdownAttachmentDisplayItem = {
+  key: string;
+  fileName: string;
+  markdownPath: string;
+  previewSrc?: string;
+  executionIndex: number;
+  taskIndex: number;
+};
+
+export const markdownZipDownloadTooltip =
+  'Downloads report.md and referenced screenshots as a ZIP that can be shared with an agent for analysis.';
+
+export interface MarkdownArchiveBuildResult {
+  files: Record<string, Uint8Array>;
+  packagedAttachmentCount: number;
+  missingAttachmentCount: number;
+}
+
+export type MarkdownView =
+  | ({ status: 'ready' } & MarkdownExport)
+  | { status: 'empty' }
+  | { status: 'error'; errorMessage: string };
+
+export function getMarkdownView<T>(
+  source: T | null | undefined,
+  toMarkdown: (source: T) => MarkdownExport,
+  warningMessage: string,
+): MarkdownView {
+  if (!source) {
+    return { status: 'empty' };
+  }
+
+  try {
+    return {
+      status: 'ready',
+      ...toMarkdown(source),
+    };
+  } catch (error) {
+    console.warn(warningMessage, error);
+
+    return {
+      status: 'error',
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function getExecutionMarkdownView(
+  activeExecution: unknown,
+  toMarkdown: (activeExecution: unknown) => MarkdownExport,
+): MarkdownView {
+  return getMarkdownView(
+    activeExecution,
+    toMarkdown,
+    'Failed to render markdown view',
+  );
+}
+
+export function getReportMarkdownView<T>(
+  report: T | null | undefined,
+  toMarkdown: (report: T) => MarkdownExport,
+): MarkdownView {
+  return getMarkdownView(
+    report,
+    toMarkdown,
+    'Failed to render report markdown view',
+  );
+}
+
+export function markdownArchiveBaseName(
+  report: { groupName?: string } | null | undefined,
+): string {
+  const safeName = (report?.groupName || 'midscene-report')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zA-Z0-9-_]/g, '');
+
+  return safeName || 'midscene-report';
+}
+
+function normalizeBaseDir(baseDir: string): string {
+  const trimmed = baseDir.trim().replace(/\/+$/, '');
+  return trimmed || defaultScreenshotBaseDir;
+}
+
+export function markdownAttachmentPath(
+  attachment: Pick<MarkdownAttachment, 'suggestedFileName'>,
+  screenshotBaseDir = defaultScreenshotBaseDir,
+): string {
+  return `${normalizeBaseDir(screenshotBaseDir)}/${attachment.suggestedFileName}`;
+}
+
+function isPackageableBase64Data(
+  base64Data: string | undefined,
+): base64Data is string {
+  if (!base64Data) return false;
+  const raw = base64Data.replace(dataUrlBase64Pattern, '').replace(/\s/g, '');
+  return Boolean(raw) && rawBase64Pattern.test(raw);
+}
+
+function previewSourceForAttachment(
+  attachment: MarkdownAttachment,
+): string | undefined {
+  const base64Data = attachment.base64Data?.trim();
+  if (base64Data) {
+    if (dataUrlBase64Pattern.test(base64Data)) {
+      return base64Data;
+    }
+    if (rawBase64Pattern.test(base64Data)) {
+      return `data:${attachment.mimeType || 'image/png'};base64,${base64Data.replace(/\s/g, '')}`;
+    }
+    return base64Data;
+  }
+
+  return attachment.sourceRef?.path;
+}
+
+export function getMarkdownAttachmentDisplayItems(
+  attachments: MarkdownAttachment[],
+  screenshotBaseDir = defaultScreenshotBaseDir,
+): MarkdownAttachmentDisplayItem[] {
+  return attachments.map((attachment, index) => ({
+    key: `${attachment.executionIndex}-${attachment.taskIndex}-${attachment.id}-${attachment.suggestedFileName}-${index}`,
+    fileName: attachment.suggestedFileName,
+    markdownPath: markdownAttachmentPath(attachment, screenshotBaseDir),
+    previewSrc: previewSourceForAttachment(attachment),
+    executionIndex: attachment.executionIndex,
+    taskIndex: attachment.taskIndex,
+  }));
+}
+
+function base64ToUint8Array(base64Data: string): Uint8Array {
+  const raw = base64Data.replace(/^data:[^;]+;base64,/, '');
+  const binary = atob(raw);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function attachmentPathSource(
+  attachment: MarkdownAttachment,
+): string | undefined {
+  const base64Data = attachment.base64Data?.trim();
+  if (base64Data && !isPackageableBase64Data(base64Data)) {
+    return base64Data;
+  }
+
+  return attachment.sourceRef?.path;
+}
+
+async function fetchAttachmentBytes(
+  attachment: MarkdownAttachment,
+): Promise<Uint8Array | undefined> {
+  const base64Data = attachment.base64Data;
+  if (isPackageableBase64Data(base64Data)) {
+    return base64ToUint8Array(base64Data);
+  }
+
+  const source = attachmentPathSource(attachment);
+  if (!source) {
+    return undefined;
+  }
+
+  try {
+    const response = await fetch(source);
+    if (!response.ok) {
+      return undefined;
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  } catch {
+    return undefined;
+  }
+}
+
+export function countPackageableMarkdownAttachments(
+  attachments: MarkdownAttachment[],
+): number {
+  return attachments.filter((attachment) =>
+    isPackageableBase64Data(attachment.base64Data),
+  ).length;
+}
+
+export function buildMarkdownArchiveFiles(
+  markdown: string,
+  attachments: MarkdownAttachment[],
+): Record<string, Uint8Array> {
+  const files: Record<string, Uint8Array> = {
+    'report.md': new TextEncoder().encode(markdown),
+  };
+
+  for (const attachment of attachments) {
+    const base64Data = attachment.base64Data;
+    if (!isPackageableBase64Data(base64Data)) {
+      continue;
+    }
+    files[`screenshots/${attachment.suggestedFileName}`] =
+      base64ToUint8Array(base64Data);
+  }
+
+  return files;
+}
+
+export async function buildMarkdownArchiveFilesForDownload(
+  markdown: string,
+  attachments: MarkdownAttachment[],
+): Promise<MarkdownArchiveBuildResult> {
+  const files: Record<string, Uint8Array> = {
+    'report.md': new TextEncoder().encode(markdown),
+  };
+  let packagedAttachmentCount = 0;
+
+  for (const attachment of attachments) {
+    const bytes = await fetchAttachmentBytes(attachment);
+    if (!bytes) {
+      continue;
+    }
+    files[`screenshots/${attachment.suggestedFileName}`] = bytes;
+    packagedAttachmentCount += 1;
+  }
+
+  return {
+    files,
+    packagedAttachmentCount,
+    missingAttachmentCount: attachments.length - packagedAttachmentCount,
+  };
+}
+
+export async function downloadMarkdownZip(
+  markdown: string,
+  attachments: MarkdownAttachment[],
+  fileName: string,
+): Promise<MarkdownArchiveBuildResult> {
+  const { zipSync } = await import('fflate');
+  const result = await buildMarkdownArchiveFilesForDownload(
+    markdown,
+    attachments,
+  );
+  const zipped = zipSync(result.files);
+  const blob = new Blob([zipped], { type: 'application/zip' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `${fileName}.zip`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+  return result;
+}

--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -41,8 +41,10 @@ function formatUsageModelForAgent(source: string, usage: AIUsageInfo): string {
 
 function collectUsageModelsForAgent(report: IReportActionDump): string {
   const models = new Map<string, string>();
-  for (const execution of report.executions) {
-    for (const task of execution.tasks) {
+  const executions = Array.isArray(report.executions) ? report.executions : [];
+  for (const execution of executions) {
+    const tasks = Array.isArray(execution.tasks) ? execution.tasks : [];
+    for (const task of tasks) {
       const taskWithUsage = task as {
         usage?: AIUsageInfo;
         searchAreaUsage?: AIUsageInfo;
@@ -81,7 +83,7 @@ export function generateAgentReportComment(report: IReportActionDump): string {
     `Report: ${cleanHtmlCommentValue(report.groupName)}`,
     `SDK: ${cleanHtmlCommentValue(report.sdkVersion)}`,
     `Device: ${cleanHtmlCommentValue(report.deviceType)}`,
-    `Executions: ${report.executions.length}; Tasks: ${taskCount}`,
+    `Executions: ${executions.length}; Tasks: ${taskCount}`,
     `Models: ${cleanHtmlCommentValue(modelBriefs)}`,
     'Structured report JSON is stored in script[type="midscene_web_dump"] tags near this comment.',
     'Screenshots are stored as script[type="midscene-image"] tags or files referenced by screenshot refs.',

--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -1,8 +1,96 @@
 import { closeSync, openSync, readSync, statSync } from 'node:fs';
 import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
+import type { AIUsageInfo, IReportActionDump, ModelBrief } from '../types';
 
 export const escapeContent = escapeScriptTag;
 export const unescapeContent = antiEscapeScriptTag;
+
+function cleanHtmlCommentValue(value: unknown): string {
+  return String(value ?? 'N/A')
+    .replace(/\0/g, '')
+    .replace(/--/g, '- -');
+}
+
+function formatModelBriefForAgent(brief: ModelBrief): string {
+  const intent = brief.intent || 'default';
+  const model = brief.name || 'unknown';
+  const description = brief.modelDescription
+    ? ` (${brief.modelDescription})`
+    : '';
+  return `${intent}: ${model}${description}`;
+}
+
+function hasUsageModelInfo(usage?: AIUsageInfo): usage is AIUsageInfo {
+  return Boolean(
+    usage &&
+      (usage.model_name ||
+        usage.response_model_name ||
+        usage.model_description ||
+        usage.intent),
+  );
+}
+
+function formatUsageModelForAgent(source: string, usage: AIUsageInfo): string {
+  const intent = usage.intent || source;
+  const model = usage.model_name || usage.response_model_name || 'unknown';
+  const description = usage.model_description
+    ? ` (${usage.model_description})`
+    : '';
+  return `${intent}: ${model}${description}`;
+}
+
+function collectUsageModelsForAgent(report: IReportActionDump): string {
+  const models = new Map<string, string>();
+  for (const execution of report.executions) {
+    for (const task of execution.tasks) {
+      const taskWithUsage = task as {
+        usage?: AIUsageInfo;
+        searchAreaUsage?: AIUsageInfo;
+      };
+      const usages: Array<[string, AIUsageInfo | undefined]> = [
+        ['main', taskWithUsage.usage],
+        ['searchArea', taskWithUsage.searchAreaUsage],
+      ];
+
+      for (const [source, usage] of usages) {
+        if (!hasUsageModelInfo(usage)) {
+          continue;
+        }
+        const formatted = formatUsageModelForAgent(source, usage);
+        models.set(formatted, formatted);
+      }
+    }
+  }
+
+  return Array.from(models.values()).join('; ');
+}
+
+export function generateAgentReportComment(report: IReportActionDump): string {
+  const executions = Array.isArray(report.executions) ? report.executions : [];
+  const taskCount = executions.reduce(
+    (sum, execution) =>
+      sum + (Array.isArray(execution.tasks) ? execution.tasks.length : 0),
+    0,
+  );
+  const modelBriefs = report.modelBriefs?.length
+    ? report.modelBriefs.map(formatModelBriefForAgent).join('; ')
+    : collectUsageModelsForAgent(report) || 'No model metadata recorded';
+
+  const lines = [
+    'For Agent Analysis:',
+    `Report: ${cleanHtmlCommentValue(report.groupName)}`,
+    `SDK: ${cleanHtmlCommentValue(report.sdkVersion)}`,
+    `Device: ${cleanHtmlCommentValue(report.deviceType)}`,
+    `Executions: ${report.executions.length}; Tasks: ${taskCount}`,
+    `Models: ${cleanHtmlCommentValue(modelBriefs)}`,
+    'Structured report JSON is stored in script[type="midscene_web_dump"] tags near this comment.',
+    'Screenshots are stored as script[type="midscene-image"] tags or files referenced by screenshot refs.',
+    'For AI analysis, inspect each execution task for type, status, timing, param, output, usage, searchAreaUsage, recorder, and screenshot refs.',
+    'Use the Markdown export when available; it contains the same report context plus image links for agent review.',
+  ];
+
+  return `\n<!--\n${lines.join('\n')}\n-->\n`;
+}
 
 function htmlScriptCloseTag(): string {
   // biome-ignore lint/style/useTemplate: keep this token runtime-built for inline report bundles

--- a/packages/core/src/dump/screenshot-restoration.ts
+++ b/packages/core/src/dump/screenshot-restoration.ts
@@ -3,7 +3,7 @@ import { type ScreenshotRef, normalizeScreenshotRef } from './screenshot-store';
 /**
  * Recursively restore image references in parsed data.
  * Replaces ScreenshotRef with lazy
- * { get base64() {...}, capturedAt } objects.
+ * { get base64() {...}, capturedAt, sourceRef } objects.
  * The resolver is only called when .base64 is first accessed.
  */
 export function restoreImageReferences<T>(
@@ -22,8 +22,17 @@ export function restoreImageReferences<T>(
     const refLike = normalizeScreenshotRef(data);
     if (refLike) {
       let resolved: string | null = null;
-      const lazy: { base64: string; capturedAt?: number } =
-        Object.defineProperties({} as { base64: string; capturedAt?: number }, {
+      const lazy: {
+        base64: string;
+        capturedAt?: number;
+        sourceRef: ScreenshotRef;
+      } = Object.defineProperties(
+        {} as {
+          base64: string;
+          capturedAt?: number;
+          sourceRef: ScreenshotRef;
+        },
+        {
           base64: {
             get() {
               if (resolved === null) {
@@ -34,7 +43,9 @@ export function restoreImageReferences<T>(
             enumerable: true,
           },
           capturedAt: { value: refLike.capturedAt, enumerable: true },
-        });
+          sourceRef: { value: { ...refLike }, enumerable: true },
+        },
+      );
       return lazy as T;
     }
 

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -21,6 +21,7 @@ import {
 import { ifInBrowser, logMsg, uuid } from '@midscene/shared/utils';
 import {
   DATA_SCREENSHOT_MODE_ATTR,
+  generateAgentReportComment,
   generateDumpScriptTag,
   generateImageScriptTag,
   getBaseUrlFixScript,
@@ -105,7 +106,11 @@ export class ReportGenerator implements IReportGenerator {
   // Tracks the last execution + groupMeta for re-writing on finalize
   private lastExecution?: ExecutionDump;
   private lastReportMeta?: ReportMeta;
+  private executionsByKey = new Map<string, ExecutionDump>();
+  private executionCommentKeyByObject = new WeakMap<ExecutionDump, string>();
+  private executionCommentKeyIndex = 0;
   private reportAttributes: Record<string, string> = {};
+  private agentCommentWritten = false;
 
   // write queue for serial execution
   private writeQueue: Promise<void> = Promise.resolve();
@@ -182,6 +187,7 @@ export class ReportGenerator implements IReportGenerator {
   ): void {
     this.lastExecution = execution;
     this.lastReportMeta = reportMeta;
+    this.executionsByKey.set(this.getExecutionCommentKey(execution), execution);
     this.mergeReportAttributes(attributes);
     this.writeQueue = this.writeQueue.then(async () => {
       if (this.destroyed) return;
@@ -206,6 +212,7 @@ export class ReportGenerator implements IReportGenerator {
       return undefined;
     }
 
+    await this.appendAgentReportComment();
     return this.reportPath;
   }
 
@@ -381,6 +388,30 @@ export class ReportGenerator implements IReportGenerator {
     );
   }
 
+  private async appendAgentReportComment(): Promise<void> {
+    if (
+      this.agentCommentWritten ||
+      !this.lastReportMeta ||
+      this.executionsByKey.size === 0
+    ) {
+      return;
+    }
+
+    const reportDump = new ReportActionDump({
+      sdkVersion: this.lastReportMeta.sdkVersion,
+      groupName: this.lastReportMeta.groupName,
+      groupDescription: this.lastReportMeta.groupDescription,
+      modelBriefs: this.lastReportMeta.modelBriefs,
+      deviceType: this.lastReportMeta.deviceType,
+      executions: Array.from(this.executionsByKey.values()),
+    });
+    await appendFileAsync(
+      this.reportPath,
+      `\n${generateAgentReportComment(reportDump)}`,
+    );
+    this.agentCommentWritten = true;
+  }
+
   private getExecutionLogKey(execution: ExecutionDump): string {
     if (!execution.id) {
       throw new Error(
@@ -388,6 +419,21 @@ export class ReportGenerator implements IReportGenerator {
       );
     }
     return `id:${execution.id}`;
+  }
+
+  private getExecutionCommentKey(execution: ExecutionDump): string {
+    if (execution.id) {
+      return `id:${execution.id}`;
+    }
+
+    const existingKey = this.executionCommentKeyByObject.get(execution);
+    if (existingKey) {
+      return existingKey;
+    }
+
+    const key = `no-id:${this.executionCommentKeyIndex++}`;
+    this.executionCommentKeyByObject.set(execution, key);
+    return key;
   }
 
   private async persistExecutionDumpToFile(

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -1,16 +1,36 @@
-import { basename } from 'node:path';
 import { extractInsightParam, paramStr, typeStr } from '@/agent/ui-utils';
 import { ScreenshotItem } from '@/screenshot-item';
 import type {
+  AIUsageInfo,
   ExecutionDump,
   ExecutionRecorderItem,
   ExecutionTask,
   IExecutionDump,
   IReportActionDump,
+  ModelBrief,
   ReportActionDump,
 } from '@/types';
 import type { ScreenshotRef } from './dump/screenshot-store';
 import { normalizeScreenshotRef } from './dump/screenshot-store';
+
+const screenshotDataUrlPattern =
+  /^data:image\/(png|jpeg|jpg);base64,([\s\S]*)$/i;
+const rawBase64BodyPattern = /^[a-zA-Z0-9+/=\s]+$/;
+const jsonContextMaxStringLength = 12_000;
+
+type ExecutionTaskWithExtraUsage = ExecutionTask & {
+  searchAreaUsage?: AIUsageInfo;
+  reasoning_content?: string;
+};
+
+interface UsageTotals {
+  calls: number;
+  prompt: number;
+  cachedInput: number;
+  completion: number;
+  total: number;
+  timeCost: number;
+}
 
 export interface MarkdownAttachment {
   id: string;
@@ -84,6 +104,255 @@ function formatTime(ts?: number): string {
     return 'N/A';
   }
   return new Date(ts).toISOString();
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return 'N/A';
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : 'N/A';
+  }
+  return String(value);
+}
+
+function escapeTableCell(value: unknown): string {
+  return formatValue(value).replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+}
+
+function markdownTable(headers: string[], rows: unknown[][]): string[] {
+  return [
+    `| ${headers.map(escapeTableCell).join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.map(escapeTableCell).join(' | ')} |`),
+  ];
+}
+
+function modelBriefRows(modelBriefs: ModelBrief[]): unknown[][] {
+  return modelBriefs.map((brief) => [
+    brief.intent || 'default',
+    brief.name || 'N/A',
+    brief.modelDescription || 'N/A',
+  ]);
+}
+
+function modelRowsFromUsage(report: IReportActionDump): unknown[][] {
+  const rows = new Map<string, unknown[]>();
+  const addUsage = (source: string, usage?: AIUsageInfo) => {
+    if (!hasUsage(usage)) return;
+    const intent = usage.intent || source;
+    const model = usage.model_name || usage.response_model_name;
+    const description = usage.model_description;
+    const key = `${intent}\0${model || ''}\0${description || ''}`;
+    if (rows.has(key)) {
+      return;
+    }
+    rows.set(key, [intent, model || 'N/A', description || 'N/A']);
+  };
+
+  for (const execution of report.executions) {
+    for (const task of execution.tasks) {
+      const taskWithUsage = task as ExecutionTaskWithExtraUsage;
+      addUsage('main', taskWithUsage.usage);
+      addUsage('searchArea', taskWithUsage.searchAreaUsage);
+    }
+  }
+
+  return Array.from(rows.values());
+}
+
+function usageValue(usage: AIUsageInfo | undefined, key: string): number {
+  const value = usage?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function hasUsage(usage: AIUsageInfo | undefined): usage is AIUsageInfo {
+  if (!usage) return false;
+  return [
+    'intent',
+    'model_name',
+    'model_description',
+    'prompt_tokens',
+    'cached_input',
+    'completion_tokens',
+    'total_tokens',
+    'time_cost',
+    'request_id',
+  ].some((key) => usage[key] !== undefined && usage[key] !== null);
+}
+
+function usageTotalTokens(usage: AIUsageInfo): number {
+  const explicitTotal = usageValue(usage, 'total_tokens');
+  if (explicitTotal > 0) {
+    return explicitTotal;
+  }
+  return (
+    usageValue(usage, 'prompt_tokens') + usageValue(usage, 'completion_tokens')
+  );
+}
+
+function usageModelName(usage: AIUsageInfo): string {
+  return (
+    usage.model_name ||
+    usage.response_model_name ||
+    usage.model_description ||
+    usage.intent ||
+    'Unknown'
+  );
+}
+
+function usageRowsForTask(task: ExecutionTask): unknown[][] {
+  const taskWithUsage = task as ExecutionTaskWithExtraUsage;
+  const rows: unknown[][] = [];
+  const appendUsage = (source: string, usage?: AIUsageInfo) => {
+    if (!hasUsage(usage)) return;
+    rows.push([
+      source,
+      usage.intent,
+      usage.model_name || usage.response_model_name,
+      usage.model_description,
+      usageValue(usage, 'prompt_tokens'),
+      usageValue(usage, 'cached_input'),
+      usageValue(usage, 'completion_tokens'),
+      usageTotalTokens(usage),
+      usageValue(usage, 'time_cost'),
+      usage.request_id,
+    ]);
+  };
+
+  appendUsage('main', taskWithUsage.usage);
+  appendUsage('searchArea', taskWithUsage.searchAreaUsage);
+  return rows;
+}
+
+function collectUsageTotals(
+  report: IReportActionDump,
+): Map<string, UsageTotals> {
+  const totalsByModel = new Map<string, UsageTotals>();
+  const addUsage = (usage?: AIUsageInfo) => {
+    if (!hasUsage(usage)) return;
+    const modelName = usageModelName(usage);
+    const current = totalsByModel.get(modelName) ?? {
+      calls: 0,
+      prompt: 0,
+      cachedInput: 0,
+      completion: 0,
+      total: 0,
+      timeCost: 0,
+    };
+
+    totalsByModel.set(modelName, {
+      calls: current.calls + 1,
+      prompt: current.prompt + usageValue(usage, 'prompt_tokens'),
+      cachedInput: current.cachedInput + usageValue(usage, 'cached_input'),
+      completion: current.completion + usageValue(usage, 'completion_tokens'),
+      total: current.total + usageTotalTokens(usage),
+      timeCost: current.timeCost + usageValue(usage, 'time_cost'),
+    });
+  };
+
+  for (const execution of report.executions) {
+    for (const task of execution.tasks) {
+      const taskWithUsage = task as ExecutionTaskWithExtraUsage;
+      addUsage(taskWithUsage.usage);
+      addUsage(taskWithUsage.searchAreaUsage);
+    }
+  }
+
+  return totalsByModel;
+}
+
+function sanitizeJsonForMarkdown(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (typeof value === 'string') {
+    if (
+      screenshotDataUrlPattern.test(value) ||
+      value.length > 1_000_000 ||
+      /^[a-zA-Z0-9+/=\s]{100000,}$/.test(value)
+    ) {
+      return `[omitted image/base64 string, length=${value.length}]`;
+    }
+    if (value.length > jsonContextMaxStringLength) {
+      return `${value.slice(0, jsonContextMaxStringLength)}\n[truncated, original length=${value.length}]`;
+    }
+    return value;
+  }
+
+  if (
+    value === null ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'function') {
+    return '[omitted function]';
+  }
+
+  if (typeof value !== 'object' || value === undefined) {
+    return undefined;
+  }
+
+  if (seen.has(value)) {
+    return '[omitted circular reference]';
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeJsonForMarkdown(item, seen));
+  }
+
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(input)) {
+    if (entry === undefined || typeof entry === 'function') {
+      continue;
+    }
+    if (
+      typeof entry === 'string' &&
+      /(^|_|-)(base64|screenshotBase64|imageBase64)$/i.test(key)
+    ) {
+      output[key] = `[omitted base64 string, length=${entry.length}]`;
+      continue;
+    }
+    output[key] = sanitizeJsonForMarkdown(entry, seen);
+  }
+  seen.delete(value);
+  return output;
+}
+
+function appendJsonSection(
+  lines: string[],
+  title: string,
+  value: unknown,
+): void {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+  const sanitized = sanitizeJsonForMarkdown(value);
+  if (sanitized === undefined) {
+    return;
+  }
+
+  lines.push('', `### ${title}`, '', '```json');
+  lines.push(JSON.stringify(sanitized, null, 2));
+  lines.push('```');
+}
+
+function appendTextSection(
+  lines: string[],
+  title: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'string' || !value.trim()) {
+    return;
+  }
+  lines.push('', `### ${title}`, '', '```text');
+  lines.push(value.replace(/```/g, '` ` `'));
+  lines.push('```');
 }
 
 function resolveTaskTiming(task: ExecutionTask): {
@@ -179,6 +448,29 @@ function extractLocateCenter(
 }
 
 function tryExtractBase64(screenshot: unknown): string | undefined {
+  if (typeof screenshot === 'string') {
+    const trimmedScreenshot = screenshot.trim();
+    const dataUrlMatch = trimmedScreenshot.match(screenshotDataUrlPattern);
+    if (dataUrlMatch) {
+      const format = dataUrlMatch[1].toLowerCase() === 'jpg' ? 'jpeg' : 'png';
+      const base64Body = dataUrlMatch[2].replace(/\s/g, '');
+      if (!base64Body) {
+        return undefined;
+      }
+      return `data:image/${format};base64,${base64Body}`;
+    }
+
+    if (
+      trimmedScreenshot.startsWith('data:') ||
+      !rawBase64BodyPattern.test(trimmedScreenshot)
+    ) {
+      return undefined;
+    }
+
+    const base64Body = trimmedScreenshot.replace(/\s/g, '');
+    return base64Body ? `data:image/png;base64,${base64Body}` : undefined;
+  }
+
   if (!screenshot || typeof screenshot !== 'object') return undefined;
   const s = screenshot as Record<string, unknown>;
   if (typeof s.base64 === 'string' && s.base64.length > 0) {
@@ -187,11 +479,23 @@ function tryExtractBase64(screenshot: unknown): string | undefined {
   return undefined;
 }
 
+function restoredSourceRef(screenshot: unknown): ScreenshotRef | undefined {
+  if (!screenshot || typeof screenshot !== 'object') {
+    return undefined;
+  }
+
+  const sourceRef = (screenshot as Record<string, unknown>).sourceRef;
+  return normalizeScreenshotRef(sourceRef) ?? undefined;
+}
+
 function screenshotAttachment(
   screenshot: unknown,
   screenshotBaseDir: string,
   executionIndex: number,
   taskIndex: number,
+  options?: {
+    fallbackIdSuffix?: string;
+  },
 ): { markdown: string; attachment: MarkdownAttachment } {
   if (screenshot instanceof ScreenshotItem) {
     const ext = screenshot.extension;
@@ -227,10 +531,31 @@ function screenshotAttachment(
     };
   }
 
+  const sourceRef = restoredSourceRef(screenshot);
+  if (sourceRef) {
+    const ext = sourceRef.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+    const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${sourceRef.id}.${ext}`;
+    return {
+      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
+      attachment: {
+        id: sourceRef.id,
+        suggestedFileName,
+        sourceRef,
+        mimeType: sourceRef.mimeType,
+        executionIndex,
+        taskIndex,
+        base64Data: tryExtractBase64(screenshot),
+      },
+    };
+  }
+
   const base64 = tryExtractBase64(screenshot);
   if (base64) {
     const ext = base64.startsWith('data:image/jpeg') ? 'jpeg' : 'png';
-    const id = `restored-${executionIndex + 1}-${taskIndex + 1}`;
+    const idSuffix = options?.fallbackIdSuffix
+      ? `-${options.fallbackIdSuffix}`
+      : '';
+    const id = `restored-${executionIndex + 1}-${taskIndex + 1}${idSuffix}`;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${id}.${ext}`;
     return {
       markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
@@ -280,6 +605,7 @@ function recorderMarkdownSection(
       screenshotBaseDir,
       executionIndex,
       taskIndex,
+      { fallbackIdSuffix: `recorder-${recorderIndex + 1}` },
     );
 
     lines.push(imageResult.markdown);
@@ -307,6 +633,9 @@ function renderExecution(
 
   lines.push('', `- Execution start: ${formatTime(execution.logTime)}`);
   lines.push(`- Task count: ${execution.tasks.length}`);
+  if (execution.aiActContext) {
+    appendTextSection(lines, 'AI Action Context', execution.aiActContext);
+  }
 
   execution.tasks.forEach((task, taskIndex) => {
     const title = typeStr(task);
@@ -317,6 +646,9 @@ function renderExecution(
       '',
       `## ${taskIndex + 1}. ${title}${detail ? ` - ${detail}` : ''}`,
     );
+    lines.push(`- Task ID: ${task.taskId || 'N/A'}`);
+    lines.push(`- Type: ${task.type || 'N/A'}`);
+    lines.push(`- SubType: ${task.subType || 'N/A'}`);
     lines.push(`- Status: ${task.status || 'unknown'}`);
     lines.push(`- Start: ${formatTime(time.start)}`);
     lines.push(`- End: ${formatTime(time.end)}`);
@@ -337,6 +669,38 @@ function renderExecution(
     if (task.errorMessage) {
       lines.push(`- Error: ${task.errorMessage}`);
     }
+
+    const usageRows = usageRowsForTask(task);
+    if (usageRows.length) {
+      lines.push('', '### Model Usage');
+      lines.push(
+        ...markdownTable(
+          [
+            'Source',
+            'Intent',
+            'Model',
+            'Description',
+            'Prompt Tokens',
+            'Cached Input',
+            'Completion Tokens',
+            'Total Tokens',
+            'Time Cost(ms)',
+            'Request ID',
+          ],
+          usageRows,
+        ),
+      );
+    }
+
+    appendJsonSection(lines, 'Param', task.param);
+    appendJsonSection(lines, 'Output', task.output);
+    appendJsonSection(lines, 'Log', task.log);
+    appendTextSection(lines, 'Thought', task.thought);
+    appendTextSection(
+      lines,
+      'Reasoning Content',
+      (task as ExecutionTaskWithExtraUsage).reasoning_content,
+    );
 
     if (task.uiContext?.screenshot) {
       const imageResult = screenshotAttachment(
@@ -368,18 +732,6 @@ function renderExecution(
   };
 }
 
-function reportFileName(
-  execution: IExecutionDump,
-  executionIndex: number,
-): string {
-  const safeName =
-    execution.name
-      .trim()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-zA-Z0-9-_]/g, '') || `execution-${executionIndex + 1}`;
-  return `${executionIndex + 1}-${basename(safeName)}.md`;
-}
-
 export function executionToMarkdown(
   execution: ExecutionDump | IExecutionDump,
   options?: ExecutionMarkdownOptions,
@@ -395,25 +747,58 @@ export function reportToMarkdown(
   const executionResults = reportDump.executions.map((execution, index) => {
     const rendered = renderExecution(execution, index);
     return {
-      executionIndex: index,
-      executionName: execution.name,
       markdown: rendered.markdown,
       attachments: rendered.attachments,
-      suggestedFileName: reportFileName(execution, index),
     };
   });
 
   const attachments = executionResults.flatMap((item) => item.attachments);
+  const usageTotals = collectUsageTotals(reportDump);
+  const modelRows = reportDump.modelBriefs?.length
+    ? modelBriefRows(reportDump.modelBriefs)
+    : modelRowsFromUsage(reportDump);
+
+  const modelInfoLines = [
+    '\n## Model Info',
+    ...(modelRows.length
+      ? markdownTable(['Intent', 'Model', 'Description'], modelRows)
+      : ['- No model metadata recorded.']),
+  ];
+
+  const tokenSummaryLines = [
+    '\n## Token Usage Summary',
+    ...(usageTotals.size
+      ? markdownTable(
+          [
+            'Model',
+            'Calls',
+            'Prompt Tokens',
+            'Cached Input',
+            'Completion Tokens',
+            'Total Tokens',
+            'Time Cost(ms)',
+          ],
+          Array.from(usageTotals.entries()).map(([modelName, totals]) => [
+            modelName,
+            totals.calls,
+            totals.prompt,
+            totals.cachedInput,
+            totals.completion,
+            totals.total,
+            totals.timeCost,
+          ]),
+        )
+      : ['- No token usage recorded.']),
+  ];
 
   const header = [
     `# ${reportDump.groupName}`,
     reportDump.groupDescription ? `\n${reportDump.groupDescription}` : '',
     `\n- SDK Version: ${reportDump.sdkVersion}`,
+    reportDump.deviceType ? `- Device Type: ${reportDump.deviceType}` : '',
     `- Execution count: ${reportDump.executions.length}`,
-    '\n## Suggested execution markdown files',
-    ...executionResults.map(
-      (item) => `- ${item.suggestedFileName} (${item.executionName})`,
-    ),
+    ...modelInfoLines,
+    ...tokenSummaryLines,
   ]
     .filter(Boolean)
     .join('\n');

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -3,7 +3,6 @@ import { ScreenshotItem } from '@/screenshot-item';
 import type {
   AIUsageInfo,
   ExecutionDump,
-  ExecutionRecorderItem,
   ExecutionTask,
   IExecutionDump,
   IReportActionDump,
@@ -495,13 +494,16 @@ function screenshotAttachment(
   taskIndex: number,
   options?: {
     fallbackIdSuffix?: string;
+    label?: string;
   },
 ): { markdown: string; attachment: MarkdownAttachment } {
+  const markdownLabel = options?.label || `task-${taskIndex + 1}`;
+
   if (screenshot instanceof ScreenshotItem) {
     const ext = screenshot.extension;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${screenshot.id}.${ext}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
+      markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: screenshot.id,
         suggestedFileName,
@@ -518,7 +520,7 @@ function screenshotAttachment(
     const ext = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${ref.id}.${ext}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
+      markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: ref.id,
         suggestedFileName,
@@ -536,7 +538,7 @@ function screenshotAttachment(
     const ext = sourceRef.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${sourceRef.id}.${ext}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
+      markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id: sourceRef.id,
         suggestedFileName,
@@ -558,7 +560,7 @@ function screenshotAttachment(
     const id = `restored-${executionIndex + 1}-${taskIndex + 1}${idSuffix}`;
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${id}.${ext}`;
     return {
-      markdown: `\n![task-${taskIndex + 1}](${screenshotBaseDir}/${suggestedFileName})`,
+      markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
       attachment: {
         id,
         suggestedFileName,
@@ -575,44 +577,78 @@ function screenshotAttachment(
   );
 }
 
-function recorderMarkdownSection(
-  recorder: ExecutionRecorderItem[] | undefined,
+function imageLabelSuffix(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'screenshot'
+  );
+}
+
+function screenshotsMarkdownSection(
+  task: ExecutionTask,
   screenshotBaseDir: string,
   executionIndex: number,
   taskIndex: number,
 ): { lines: string[]; attachments: MarkdownAttachment[] } {
-  if (!recorder?.length) {
-    return { lines: [], attachments: [] };
+  const lines: string[] = ['', '### Screenshots'];
+  const attachments: MarkdownAttachment[] = [];
+  let screenshotIndex = 0;
+
+  if (task.uiContext?.screenshot) {
+    const imageResult = screenshotAttachment(
+      task.uiContext.screenshot,
+      screenshotBaseDir,
+      executionIndex,
+      taskIndex,
+      {
+        fallbackIdSuffix: 'ui-context',
+        label: `task-${taskIndex + 1}-ui-context`,
+      },
+    );
+    const time = resolveTaskTiming(task);
+    screenshotIndex += 1;
+    lines.push(
+      `- #${screenshotIndex} type=ui-context, ts=${formatTime(time.start)}, timing=ui-context`,
+    );
+    lines.push(imageResult.markdown);
+    attachments.push(imageResult.attachment);
   }
 
-  const lines: string[] = ['', '### Recorder'];
-  const attachments: MarkdownAttachment[] = [];
-
-  recorder.forEach((item, recorderIndex) => {
-    const descriptionText = item.description
-      ? `, description=${item.description}`
-      : '';
-    lines.push(
-      `- #${recorderIndex + 1} type=${item.type}, ts=${formatTime(item.ts)}, timing=${item.timing || 'N/A'}${descriptionText}`,
-    );
-
+  task.recorder?.forEach((item, recorderIndex) => {
     if (!item.screenshot) {
       return;
     }
+
+    const descriptionText = item.description
+      ? `, description=${item.description}`
+      : '';
+    const timing = item.timing || 'N/A';
+    screenshotIndex += 1;
+    lines.push(
+      `- #${screenshotIndex} type=${item.type}, ts=${formatTime(item.ts)}, timing=${timing}${descriptionText}`,
+    );
 
     const imageResult = screenshotAttachment(
       item.screenshot,
       screenshotBaseDir,
       executionIndex,
       taskIndex,
-      { fallbackIdSuffix: `recorder-${recorderIndex + 1}` },
+      {
+        fallbackIdSuffix: `recorder-${recorderIndex + 1}`,
+        label: `task-${taskIndex + 1}-${imageLabelSuffix(timing)}`,
+      },
     );
 
     lines.push(imageResult.markdown);
     attachments.push(imageResult.attachment);
   });
 
-  return { lines, attachments };
+  return screenshotIndex > 0
+    ? { lines, attachments }
+    : { lines: [], attachments };
 }
 
 function renderExecution(
@@ -702,27 +738,15 @@ function renderExecution(
       (task as ExecutionTaskWithExtraUsage).reasoning_content,
     );
 
-    if (task.uiContext?.screenshot) {
-      const imageResult = screenshotAttachment(
-        task.uiContext.screenshot,
-        screenshotBaseDir,
-        executionIndex,
-        taskIndex,
-      );
-
-      lines.push(imageResult.markdown);
-      attachments.push(imageResult.attachment);
-    }
-
-    const recorderSection = recorderMarkdownSection(
-      task.recorder,
+    const screenshotsSection = screenshotsMarkdownSection(
+      task,
       screenshotBaseDir,
       executionIndex,
       taskIndex,
     );
-    if (recorderSection.lines.length) {
-      lines.push(...recorderSection.lines);
-      attachments.push(...recorderSection.attachments);
+    if (screenshotsSection.lines.length) {
+      lines.push(...screenshotsSection.lines);
+      attachments.push(...screenshotsSection.attachments);
     }
   });
 

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -16,6 +16,7 @@ import {
   DATA_SCREENSHOT_MODE_ATTR,
   extractAllDumpScriptsSync,
   extractLastDumpScriptSync,
+  generateAgentReportComment,
   getBaseUrlFixScript,
   streamDumpScriptsSync,
   streamImageScriptsToFile,
@@ -135,6 +136,41 @@ function peekReportSdkVersion(reportFilePath: string): string | undefined {
 }
 
 const warnedMismatchedVersions = new Set<string>();
+
+function tryParseAgentReportDump(dumpString: string): ReportActionDump | null {
+  const trimmed = dumpString.trimStart();
+  if (!trimmed.startsWith('{') || !trimmed.includes('"executions"')) {
+    return null;
+  }
+
+  try {
+    return ReportActionDump.fromSerializedString(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function mergedAgentReportComment(reports: ReportActionDump[]): string {
+  if (reports.length === 0) {
+    return '';
+  }
+  if (reports.length === 1) {
+    return generateAgentReportComment(reports[0]);
+  }
+
+  const deviceTypes = Array.from(
+    new Set(reports.map((report) => report.deviceType).filter(Boolean)),
+  );
+  const mergedReport = new ReportActionDump({
+    sdkVersion: reports[0].sdkVersion || getVersion(),
+    groupName: 'Merged Midscene Report',
+    groupDescription: 'Agent-readable summary for merged report HTML',
+    modelBriefs: reports.flatMap((report) => report.modelBriefs ?? []),
+    deviceType: deviceTypes.length === 1 ? deviceTypes[0] : 'mixed',
+    executions: reports.flatMap((report) => report.executions ?? []),
+  });
+  return generateAgentReportComment(mergedReport);
+}
 
 export class ReportMergingTool {
   private reportInfos: ReportFileWithAttributes[] = [];
@@ -281,6 +317,8 @@ export class ReportMergingTool {
         appendFileSync(outputFilePath, getBaseUrlFixScript());
       }
 
+      const agentReports: ReportActionDump[] = [];
+
       // Process all reports one by one
       for (let i = 0; i < this.reportInfos.length; i++) {
         const reportInfo = this.reportInfos[i];
@@ -341,6 +379,11 @@ export class ReportMergingTool {
           }
         }
 
+        const agentReport = tryParseAgentReportDump(dumpString);
+        if (agentReport) {
+          agentReports.push(agentReport);
+        }
+
         const reportHtmlStr = `${reportHTMLContent(
           {
             dumpString,
@@ -363,6 +406,11 @@ export class ReportMergingTool {
         )}\n`;
 
         appendFileSync(outputFilePath, reportHtmlStr);
+      }
+
+      const agentComment = mergedAgentReportComment(agentReports);
+      if (agentComment) {
+        appendFileSync(outputFilePath, agentComment);
       }
 
       // Close the HTML document

--- a/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
+++ b/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
@@ -34,12 +34,13 @@
 }
 ```
 
-![task-1](./screenshots/execution-1-task-1-shot-exec-1.png)
+### Screenshots
+- #1 type=ui-context, ts=2024-03-09T16:00:00.000Z, timing=ui-context
 
-### Recorder
-- #1 type=screenshot, ts=2024-03-09T16:00:00.060Z, timing=record-step-1
+![task-1-ui-context](./screenshots/execution-1-task-1-shot-exec-1.png)
+- #2 type=screenshot, ts=2024-03-09T16:00:00.060Z, timing=record-step-1
 
-![task-1](./screenshots/execution-1-task-1-shot-recorder-exec-1.png)
+![task-1-record-step-1](./screenshots/execution-1-task-1-shot-recorder-exec-1.png)
 
 ---
 
@@ -82,4 +83,7 @@
 }
 ```
 
-![task-1](./screenshots/execution-2-task-1-shot-exec-2.png)
+### Screenshots
+- #1 type=ui-context, ts=2024-03-09T16:00:00.000Z, timing=ui-context
+
+![task-1-ui-context](./screenshots/execution-2-task-1-shot-exec-2.png)

--- a/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
+++ b/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
@@ -3,9 +3,11 @@
 - SDK Version: 1.0.0
 - Execution count: 2
 
-## Suggested execution markdown files
-- 1-exec-1.md (exec-1)
-- 2-exec-2.md (exec-2)
+## Model Info
+- No model metadata recorded.
+
+## Token Usage Summary
+- No token usage recorded.
 
 # exec-1
 
@@ -13,11 +15,24 @@
 - Task count: 1
 
 ## 1. Tap - Submit
+- Task ID: task-1
+- Type: Action Space
+- SubType: Tap
 - Status: finished
 - Start: 2024-03-09T16:00:00.000Z
 - End: 2024-03-09T16:00:00.100Z
 - Cost(ms): 100
 - Screen size: 1440 x 900
+
+### Param
+
+```json
+{
+  "locate": {
+    "prompt": "Submit"
+  }
+}
+```
 
 ![task-1](./screenshots/execution-1-task-1-shot-exec-1.png)
 
@@ -34,11 +49,37 @@
 - Task count: 1
 
 ## 1. Locate - Submit
+- Task ID: task-2
+- Type: Action Space
+- SubType: Locate
 - Status: finished
 - Start: 2024-03-09T16:00:00.000Z
 - End: 2024-03-09T16:00:00.100Z
 - Cost(ms): 100
 - Screen size: 1024 x 768
 - Locate center: (512, 333)
+
+### Param
+
+```json
+{
+  "locate": {
+    "prompt": "Submit"
+  }
+}
+```
+
+### Output
+
+```json
+{
+  "element": {
+    "center": [
+      512,
+      333
+    ]
+  }
+}
+```
 
 ![task-1](./screenshots/execution-2-task-1-shot-exec-2.png)

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractImageByIdSync,
   extractLastDumpScriptSync,
+  generateAgentReportComment,
   generateImageScriptTag,
   streamImageScriptsToFile,
 } from '../../src/dump/html-utils';
@@ -21,6 +22,75 @@ describe('html-utils', () => {
       const source = readFileSync(sourceFile, 'utf8');
       expect(source).not.toContain(unsafeCloseTag);
     }
+  });
+
+  it('generates a compact agent analysis comment for report HTML', () => {
+    const comment = generateAgentReportComment({
+      sdkVersion: '1.0.0',
+      groupName: 'checkout -- flow',
+      modelBriefs: [
+        {
+          intent: 'planning',
+          name: 'gpt-4o',
+          modelDescription: 'vision planner',
+        },
+      ],
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'exec',
+          tasks: [
+            {
+              taskId: 'task-1',
+              type: 'Action Space',
+              subType: 'Tap',
+              status: 'finished',
+              executor: async () => {},
+            } as any,
+          ],
+        },
+      ],
+    });
+
+    expect(comment).toContain('For Agent Analysis');
+    expect(comment).toContain('script[type="midscene_web_dump"]');
+    expect(comment).toContain('script[type="midscene-image"]');
+    expect(comment).toContain('planning: gpt-4o (vision planner)');
+    expect(comment).toContain('checkout - - flow');
+    expect(comment).not.toContain('checkout -- flow');
+  });
+
+  it('falls back agent comment model info to task usage', () => {
+    const comment = generateAgentReportComment({
+      sdkVersion: '1.0.0',
+      groupName: 'usage model report',
+      modelBriefs: [],
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'exec',
+          tasks: [
+            {
+              taskId: 'task-1',
+              type: 'Planning',
+              subType: 'Plan',
+              status: 'finished',
+              usage: {
+                intent: 'planning',
+                model_name: 'openai_qwen3.5-plus',
+                model_description: 'qwen3.5 mode',
+              },
+              executor: async () => {},
+            } as any,
+          ],
+        },
+      ],
+    });
+
+    expect(comment).toContain(
+      'Models: planning: openai_qwen3.5-plus (qwen3.5 mode)',
+    );
+    expect(comment).not.toContain('No report-level model metadata recorded');
   });
 
   describe('extractImageByIdSync', () => {

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -93,6 +93,23 @@ describe('html-utils', () => {
     expect(comment).not.toContain('No report-level model metadata recorded');
   });
 
+  it('keeps agent analysis comments optional for incomplete execution dumps', () => {
+    const comment = generateAgentReportComment({
+      sdkVersion: '1.0.0',
+      groupName: 'incomplete report',
+      modelBriefs: [],
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'exec',
+        } as any,
+      ],
+    });
+
+    expect(comment).toContain('Executions: 1; Tasks: 0');
+    expect(comment).toContain('Models: No model metadata recorded');
+  });
+
   describe('extractImageByIdSync', () => {
     const fixturesDir = join(__dirname, '../fixtures/report-samples');
     const inlineSamplePath = join(fixturesDir, 'inline-sample.html');

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -374,7 +374,7 @@ describe('createReportCliCommands', () => {
     expect(mdContent).toContain('# markdown-test');
     expect(mdContent).toContain('# execution-exec-md-1');
     expect(mdContent).toContain('# execution-exec-md-2');
-    expect(mdContent).toContain('Suggested execution markdown files');
+    expect(mdContent).not.toContain('Suggested execution markdown files');
 
     expect(existsSync(join(outputDir, 'screenshots'))).toBe(true);
   });

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -1243,6 +1243,51 @@ describe('ReportGenerator — append-only model', () => {
       await generator.finalize();
       expect(() => s1.base64).not.toThrow();
       expect(() => s2.base64).not.toThrow();
+
+      const html = readFileSync(reportPath, 'utf-8');
+      const agentCommentCount = (html.match(/<!--\nFor Agent Analysis:/g) ?? [])
+        .length;
+      expect(agentCommentCount).toBe(1);
+      expect(html).toContain('Executions: 2; Tasks: 2');
+    });
+
+    it('keeps same-name executions without id in the agent comment', async () => {
+      const reportPath = join(tmpDir, 'no-id-same-name.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'inline',
+        autoPrint: false,
+      });
+      const createNoIdExecution = (taskId: string) =>
+        new ExecutionDump({
+          logTime: Date.now(),
+          name: 'same execution name',
+          tasks: [
+            {
+              taskId,
+              type: 'Insight',
+              subType: 'Locate',
+              param: { prompt: taskId },
+              executor: async () => undefined,
+              recorder: [],
+              status: 'finished',
+            } as any,
+          ],
+        });
+
+      generator.onExecutionUpdate(
+        createNoIdExecution('task-a'),
+        defaultReportMeta,
+      );
+      generator.onExecutionUpdate(
+        createNoIdExecution('task-b'),
+        defaultReportMeta,
+      );
+
+      await generator.finalize();
+
+      const html = readFileSync(reportPath, 'utf-8');
+      expect(html).toContain('Executions: 2; Tasks: 2');
     });
 
     it('should work correctly in directory mode with lazy loading', async () => {

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -153,7 +153,7 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('# report-group');
     expect(result.markdown).toContain('# exec-1');
     expect(result.markdown).toContain('# exec-2');
-    expect(result.markdown).toContain('Suggested execution markdown files');
+    expect(result.markdown).not.toContain('Suggested execution markdown files');
     expect(result.markdown).toContain('timing=record-step-1');
     expect(result.markdown).toContain('Screen size: 1440 x 900');
     expect(result.markdown).toContain('Screen size: 1024 x 768');
@@ -197,6 +197,206 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('Cost(ms): 8');
     expect(result.markdown).toContain('Screen size: 800 x 600');
     expect(result.attachments).toHaveLength(1);
+  });
+
+  it('preserves restored screenshot source refs for file-backed export', () => {
+    const execution: IExecutionDump = {
+      logTime: 1710000000000,
+      name: 'restored file screenshot',
+      tasks: [
+        createTask({
+          uiContext: {
+            screenshot: {
+              base64: './screenshots/original-shot.png',
+              capturedAt: 1710000000000,
+              sourceRef: {
+                type: 'midscene_screenshot_ref',
+                id: 'original-shot',
+                capturedAt: 1710000000000,
+                mimeType: 'image/png',
+                storage: 'file',
+                path: './screenshots/original-shot.png',
+              },
+            },
+          },
+        }),
+      ],
+    };
+
+    const result = executionToMarkdown(execution);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      id: 'original-shot',
+      suggestedFileName: 'execution-1-task-1-original-shot.png',
+      base64Data: './screenshots/original-shot.png',
+      sourceRef: {
+        path: './screenshots/original-shot.png',
+      },
+    });
+    expect(result.markdown).toContain(
+      './screenshots/execution-1-task-1-original-shot.png',
+    );
+  });
+
+  it('includes model metadata, token usage, and task context for agent analysis', () => {
+    const report: IReportActionDump = {
+      sdkVersion: '1.0.0',
+      groupName: 'agent-ready-report',
+      modelBriefs: [
+        {
+          intent: 'planning',
+          name: 'gpt-4o',
+          modelDescription: 'vision planner',
+        },
+      ],
+      deviceType: 'web',
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'agent execution',
+          aiActContext: 'Complete checkout.',
+          tasks: [
+            createTask({
+              taskId: 'task-agent-context',
+              usage: {
+                intent: 'planning',
+                model_name: 'gpt-4o',
+                model_description: 'vision planner',
+                prompt_tokens: 100,
+                cached_input: 20,
+                completion_tokens: 30,
+                total_tokens: 130,
+                time_cost: 456,
+                request_id: 'req-main',
+              },
+              searchAreaUsage: {
+                intent: 'insight',
+                model_name: 'gpt-4o-mini',
+                prompt_tokens: 10,
+                completion_tokens: 3,
+                total_tokens: 13,
+                time_cost: 123,
+                request_id: 'req-search',
+              },
+              output: {
+                result: 'clicked',
+              },
+              log: {
+                note: 'button matched',
+              },
+              thought: 'Submit button is visible.',
+              reasoning_content: 'Clicking submit completes the form.',
+            }),
+          ],
+        },
+      ],
+    };
+
+    const result = reportToMarkdown(report);
+
+    expect(result.markdown).toContain('## Model Info');
+    expect(result.markdown).toContain('| planning | gpt-4o | vision planner |');
+    expect(result.markdown).toContain('## Token Usage Summary');
+    expect(result.markdown).toContain(
+      '| gpt-4o | 1 | 100 | 20 | 30 | 130 | 456 |',
+    );
+    expect(result.markdown).toContain(
+      '| gpt-4o-mini | 1 | 10 | 0 | 3 | 13 | 123 |',
+    );
+    expect(result.markdown).toContain('### Model Usage');
+    expect(result.markdown).toContain('req-main');
+    expect(result.markdown).toContain('req-search');
+    expect(result.markdown).toContain('### AI Action Context');
+    expect(result.markdown).toContain('Complete checkout.');
+    expect(result.markdown).toContain('### Param');
+    expect(result.markdown).toContain('"prompt": "Submit"');
+    expect(result.markdown).toContain('### Output');
+    expect(result.markdown).toContain('"result": "clicked"');
+    expect(result.markdown).toContain('### Log');
+    expect(result.markdown).toContain('"note": "button matched"');
+    expect(result.markdown).toContain('### Thought');
+    expect(result.markdown).toContain('Submit button is visible.');
+    expect(result.markdown).toContain('### Reasoning Content');
+    expect(result.markdown).toContain('Clicking submit completes the form.');
+  });
+
+  it('falls back report model info to task usage when model briefs are missing', () => {
+    const report: IReportActionDump = {
+      sdkVersion: '1.0.0',
+      groupName: 'usage-model-report',
+      modelBriefs: [],
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'usage execution',
+          tasks: [
+            createTask({
+              usage: {
+                intent: 'planning',
+                model_name: 'openai_qwen3.5-plus',
+                model_description: 'qwen3.5 mode',
+                prompt_tokens: 100,
+                completion_tokens: 20,
+              },
+            }),
+          ],
+        },
+      ],
+    };
+
+    const result = reportToMarkdown(report);
+
+    expect(result.markdown).toContain('## Model Info');
+    expect(result.markdown).toContain(
+      '| planning | openai_qwen3.5-plus | qwen3.5 mode |',
+    );
+    expect(result.markdown).not.toContain(
+      'No report-level model metadata recorded',
+    );
+  });
+
+  it('handles recorder screenshots stored as base64 strings', () => {
+    const execution: IExecutionDump = {
+      logTime: 1710000000000,
+      name: 'recorder string screenshot',
+      tasks: [
+        createTask({
+          taskId: 'task-recorder-string',
+          uiContext: {
+            screenshot: {
+              base64: 'data:image/png;base64,bWFpbg==',
+              capturedAt: 1710000000000,
+            },
+            shotSize: { width: 800, height: 600 },
+          },
+          recorder: [
+            {
+              type: 'screenshot',
+              ts: 1710000000050,
+              timing: 'after action',
+              screenshot: 'data:image/png;base64,cmVjb3JkZXI=',
+            },
+          ],
+        }),
+      ],
+    };
+
+    const result = executionToMarkdown(execution);
+
+    expect(result.markdown).toContain('### Recorder');
+    expect(result.markdown).toContain('timing=after action');
+    expect(result.attachments).toHaveLength(2);
+    expect(result.attachments[0].base64Data).toBe(
+      'data:image/png;base64,bWFpbg==',
+    );
+    expect(result.attachments[1].base64Data).toBe(
+      'data:image/png;base64,cmVjb3JkZXI=',
+    );
+    expect(result.attachments[1].suggestedFileName).toContain('recorder-1');
+    expect(result.attachments[1].suggestedFileName).not.toBe(
+      result.attachments[0].suggestedFileName,
+    );
   });
 
   it('throws with invalid input', () => {

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -66,11 +66,18 @@ describe('report-markdown', () => {
 
     expect(result.markdown).toContain('# single execution');
     expect(result.markdown).toContain('Tap - Submit');
-    expect(result.markdown).toContain('![task-1](./screenshots/');
-    expect(result.markdown).toContain('### Recorder');
+    expect(result.markdown).toContain('### Screenshots');
+    expect(result.markdown).toContain(
+      '- #1 type=ui-context, ts=2024-03-09T16:00:00.000Z, timing=ui-context',
+    );
+    expect(result.markdown).toContain('![task-1-ui-context](./screenshots/');
+    expect(result.markdown).toContain('![task-1-after-click](./screenshots/');
     expect(result.markdown).toContain('timing=after click');
     expect(result.markdown).toContain('description=Post-click state');
     expect(result.markdown).toContain('Screen size: 1280 x 720');
+    expect(result.markdown.indexOf('### Screenshots')).toBeLessThan(
+      result.markdown.indexOf('![task-1-ui-context](./screenshots/'),
+    );
     expect(result.attachments).toHaveLength(2);
     expect(result.attachments[0].suggestedFileName).toContain('.png');
     expect(result.markdown).toContain(
@@ -384,7 +391,8 @@ describe('report-markdown', () => {
 
     const result = executionToMarkdown(execution);
 
-    expect(result.markdown).toContain('### Recorder');
+    expect(result.markdown).toContain('### Screenshots');
+    expect(result.markdown).toContain('timing=ui-context');
     expect(result.markdown).toContain('timing=after action');
     expect(result.attachments).toHaveLength(2);
     expect(result.attachments[0].base64Data).toBe(

--- a/packages/core/tests/unit-test/report.test.ts
+++ b/packages/core/tests/unit-test/report.test.ts
@@ -153,7 +153,7 @@ describe('reportMergingTool', () => {
 
   it(
     'should merge 100 mocked reports, and delete original reports after that.',
-    { timeout: 30 * 1000 },
+    { timeout: 60 * 1000 },
     async () => {
       const tool = new ReportMergingTool();
       let mergedReportPath: string | null = null;
@@ -562,6 +562,13 @@ describe('reportMergingTool', () => {
     const mergedReportContent = readFileSync(mergedReportPath!, 'utf-8');
     expect(mergedReportContent).toContain('playwright_test_id="all-skipped-1"');
     expect(mergedReportContent).toContain('playwright_test_id="all-skipped-2"');
+    expect(mergedReportContent).toContain('For Agent Analysis:');
+    expect(
+      mergedReportContent.match(/<!--\nFor Agent Analysis:/g),
+    ).toHaveLength(1);
+    expect(mergedReportContent).toContain(
+      'Structured report JSON is stored in script[type="midscene_web_dump"] tags near this comment.',
+    );
 
     const dumpScripts = extractAllDumpScriptsSync(mergedReportPath!).filter(
       (script) => script.openTag.includes('playwright_test_id='),

--- a/packages/core/tests/unit-test/service-describe.test.ts
+++ b/packages/core/tests/unit-test/service-describe.test.ts
@@ -341,7 +341,7 @@ describe('service.describe', () => {
     expect(mockCallAIWithObjectResponse).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
+  const edgePointCases: Array<[string, [number, number]]> = [
     ['top-left corner', [4, 6]],
     ['top-right corner', [1916, 6]],
     ['bottom-left corner', [4, 1074]],
@@ -350,7 +350,9 @@ describe('service.describe', () => {
     ['right edge', [1916, 540]],
     ['top edge', [960, 6]],
     ['bottom edge', [960, 1074]],
-  ] as const)(
+  ];
+
+  it.each(edgePointCases)(
     'keeps crop-local point markers anchored to the original click point near the %s',
     async (_name, point) => {
       mockCallAIWithObjectResponse.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Add a report-level Markdown View for agent analysis with syntax-highlighted markdown in the left sidebar and a screenshot timeline on the right.
- Add icon-only copy/download actions for report markdown and a ZIP containing report.md plus referenced screenshots.
- Include model and token usage context in markdown/HTML agent metadata, preserve file-backed screenshot refs, and keep markdown screenshot links aligned with exported image names.

## Validation
- pnpm --dir apps/report test src/utils/markdown-export.test.ts
- pnpm --dir packages/core test tests/unit-test/report-markdown.test.ts tests/unit-test/html-utils.test.ts tests/unit-test/report-generator.test.ts tests/unit-test/report-cli.test.ts
- pnpm run lint
- pnpm exec nx build @midscene/report
- pnpm --dir apps/report generate-demo
- Browser DOM validation for Markdown View switching, icon-only download button, screenshot rendering, markdown image jump-to-screenshot behavior, and restored sidebar header layout