### PR TITLE
fix(computer): capture Windows screenshots via PowerShell (#2150)

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -232,6 +232,64 @@ function sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
 }
 
 // Lazy load libnut with fallback
+const POWERSHELL_TIMEOUT_MS = 15_000;
+// CopyFromScreen output can be several MB once base64-encoded.
+const POWERSHELL_MAX_BUFFER = 64 * 1024 * 1024;
+
+function escapePowershellSingleQuoted(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Run a PowerShell script and return its stdout. The script is passed via
+ * `-EncodedCommand` (UTF-16LE base64) to avoid any shell quoting/escaping and
+ * the Git Bash argument mangling that breaks screenshot-desktop (#2150).
+ * `powershell.exe` (Windows PowerShell 5.x) is used because it ships with
+ * System.Windows.Forms / System.Drawing out of the box.
+ */
+function runPowershell(script: string): string {
+  const encoded = Buffer.from(script, 'utf16le').toString('base64');
+  return execFileSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-EncodedCommand',
+      encoded,
+    ],
+    {
+      encoding: 'utf8',
+      timeout: POWERSHELL_TIMEOUT_MS,
+      maxBuffer: POWERSHELL_MAX_BUFFER,
+      windowsHide: true,
+    },
+  );
+}
+
+/** Enumerate Windows monitors via PowerShell (screenshot-desktop's .bat-based
+ * listDisplays is broken under Claude Code — see #2150). */
+function listWindowsDisplays(): DisplayInfo[] {
+  const script = `
+Add-Type -AssemblyName System.Windows.Forms
+$s = [System.Windows.Forms.Screen]::AllScreens | ForEach-Object {
+  [PSCustomObject]@{ id = $_.DeviceName; name = $_.DeviceName; primary = $_.Primary }
+}
+ConvertTo-Json @($s) -Compress
+`.trim();
+  const parsed = JSON.parse(runPowershell(script).trim()) as Array<{
+    id: string;
+    name?: string;
+    primary?: boolean;
+  }>;
+  return parsed.map((d) => ({
+    id: String(d.id),
+    name: d.name || String(d.id),
+    primary: d.primary || false,
+  }));
+}
+
 let libnut: LibNut | null = null;
 let libnutLoadError: Error | null = null;
 
@@ -835,6 +893,11 @@ export class ComputerDevice implements AbstractInterface {
    */
   static async listDisplays(): Promise<DisplayInfo[]> {
     try {
+      // screenshot-desktop's Windows listDisplays uses the same broken polyglot
+      // .bat as its capture path (#2150); enumerate via PowerShell instead.
+      if (process.platform === 'win32') {
+        return listWindowsDisplays();
+      }
       const displays: ScreenshotDisplay[] = await screenshot.listDisplays();
       return displays.map((d) => ({
         id: String(d.id),
@@ -1030,6 +1093,18 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     }
     debugDevice('Taking screenshot', { displayId: this.displayId });
 
+    // Windows: screenshot-desktop captures through a polyglot .bat that
+    // self-compiles via csc.exe and then re-launches the compiled exe. That
+    // chain breaks under the POSIX-flavored environment Claude Code / Git Bash
+    // inject (PATH/SystemRoot/COMSPEC), so the capture fails even though the
+    // host can screenshot fine from a plain terminal (issue #2150). Capture
+    // through PowerShell instead — System.Drawing.CopyFromScreen works in
+    // virtual-desktop coordinates, so it captures any monitor (including
+    // secondary displays at negative offsets) without csc/.bat/.NET source.
+    if (process.platform === 'win32') {
+      return this.screenshotViaPowershell();
+    }
+
     const options: ScreenshotOptions = { format: 'png' };
     if (this.displayId !== undefined) {
       // On macOS: displayId is screenshot-desktop's screen index.
@@ -1096,6 +1171,62 @@ Original error: ${lastRawMessage}`,
       );
     }
     throw new Error(`Failed to take screenshot: ${lastRawMessage}`);
+  }
+
+  /**
+   * Windows screenshot path that bypasses screenshot-desktop's polyglot .bat
+   * (see screenshotBase64 for the rationale). Captures via PowerShell +
+   * System.Drawing, which honors `displayId` by matching the monitor's
+   * DeviceName and captures in virtual-desktop coordinates, so secondary
+   * displays — including those at negative offsets — are supported.
+   *
+   * Note: the script makes the process system-DPI-aware (SetProcessDPIAware)
+   * so captures return physical pixels. On mixed-DPI multi-monitor setups a
+   * non-primary monitor may still be off by its per-monitor scale factor;
+   * system DPI awareness covers the common single-scale and uniform-scale
+   * cases that #2150 reports.
+   */
+  private screenshotViaPowershell(): string {
+    const deviceName = this.displayId ? String(this.displayId) : '';
+    const target = deviceName
+      ? `[System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.DeviceName -eq '${escapePowershellSingleQuoted(deviceName)}' } | Select-Object -First 1`
+      : '$null';
+    const script = `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class NutDpi { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }
+"@
+[NutDpi]::SetProcessDPIAware() | Out-Null
+$screen = ${target}
+if (-not $screen) { $screen = [System.Windows.Forms.Screen]::PrimaryScreen }
+$b = $screen.Bounds
+$bmp = New-Object System.Drawing.Bitmap($b.Width, $b.Height)
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($b.X, $b.Y, 0, 0, $bmp.Size)
+$ms = New-Object System.IO.MemoryStream
+$bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+[Console]::Out.Write([Convert]::ToBase64String($ms.ToArray()))
+$g.Dispose(); $bmp.Dispose(); $ms.Dispose()
+`.trim();
+
+    let stdout: string;
+    try {
+      stdout = runPowershell(script);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to take screenshot on Windows: ${message}`);
+    }
+
+    const body = stdout.trim();
+    if (!body) {
+      throw new Error(
+        'Failed to take screenshot on Windows: PowerShell returned no image data',
+      );
+    }
+    return createImgBase64ByFormat('png', body);
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -246,19 +246,16 @@ function escapePowershellSingleQuoted(value: string): string {
  * the Git Bash argument mangling that breaks screenshot-desktop (#2150).
  * `powershell.exe` (Windows PowerShell 5.x) is used because it ships with
  * System.Windows.Forms / System.Drawing out of the box.
+ *
+ * No `-ExecutionPolicy Bypass`: execution policy only gates `.ps1` script
+ * files, not inline `-EncodedCommand`/`-Command` input, so it would be a
+ * no-op here while making the invocation look more privileged to auditing.
  */
 function runPowershell(script: string): string {
   const encoded = Buffer.from(script, 'utf16le').toString('base64');
   return execFileSync(
     'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-EncodedCommand',
-      encoded,
-    ],
+    ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
     {
       encoding: 'utf8',
       timeout: POWERSHELL_TIMEOUT_MS,
@@ -1180,11 +1177,15 @@ Original error: ${lastRawMessage}`,
    * DeviceName and captures in virtual-desktop coordinates, so secondary
    * displays — including those at negative offsets — are supported.
    *
-   * Note: the script makes the process system-DPI-aware (SetProcessDPIAware)
-   * so captures return physical pixels. On mixed-DPI multi-monitor setups a
-   * non-primary monitor may still be off by its per-monitor scale factor;
-   * system DPI awareness covers the common single-scale and uniform-scale
-   * cases that #2150 reports.
+   * Note: the process is left at its default (DPI-unaware) state on purpose.
+   * Making it DPI-aware would require a runtime `Add-Type` C# compile (csc) —
+   * the exact .NET-compiler dependency this PR removes by dropping
+   * screenshot-desktop's polyglot .bat — so it is intentionally avoided here.
+   * As a result, captures on a scaled display come back at logical (scaled)
+   * resolution. That is sufficient for the #2150 fix (the health check only
+   * needs a successful capture). Per-monitor DPI / coordinate accuracy is a
+   * separate Windows concern to be addressed in a follow-up with real-device
+   * verification.
    */
   private screenshotViaPowershell(): string {
     const deviceName = this.displayId ? String(this.displayId) : '';
@@ -1200,12 +1201,6 @@ if (-not $screen) { throw "Requested display not found: $dn" }`
     const script = `
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.Windows.Forms, System.Drawing
-Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-public class NutDpi { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }
-"@
-[NutDpi]::SetProcessDPIAware() | Out-Null
 ${selectScreen}
 $b = $screen.Bounds
 $bmp = New-Object System.Drawing.Bitmap($b.Width, $b.Height)

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -1188,9 +1188,15 @@ Original error: ${lastRawMessage}`,
    */
   private screenshotViaPowershell(): string {
     const deviceName = this.displayId ? String(this.displayId) : '';
-    const target = deviceName
-      ? `[System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.DeviceName -eq '${escapePowershellSingleQuoted(deviceName)}' } | Select-Object -First 1`
-      : '$null';
+    // A requested displayId that cannot be matched (stale saved id, unplugged
+    // monitor) must fail fast rather than silently capturing the primary
+    // display — otherwise downstream coordinates/actions land on the wrong
+    // monitor. Only fall back to primary when no displayId was supplied.
+    const selectScreen = deviceName
+      ? `$dn = '${escapePowershellSingleQuoted(deviceName)}'
+$screen = [System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.DeviceName -eq $dn } | Select-Object -First 1
+if (-not $screen) { throw "Requested display not found: $dn" }`
+      : '$screen = [System.Windows.Forms.Screen]::PrimaryScreen';
     const script = `
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.Windows.Forms, System.Drawing
@@ -1200,8 +1206,7 @@ using System.Runtime.InteropServices;
 public class NutDpi { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }
 "@
 [NutDpi]::SetProcessDPIAware() | Out-Null
-$screen = ${target}
-if (-not $screen) { $screen = [System.Windows.Forms.Screen]::PrimaryScreen }
+${selectScreen}
 $b = $screen.Bounds
 $bmp = New-Object System.Drawing.Bitmap($b.Width, $b.Height)
 $g = [System.Drawing.Graphics]::FromImage($bmp)

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -3,7 +3,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockState = vi.hoisted(() => {
   const execSync = vi.fn();
-  const execFileSync = vi.fn();
+  // 1x1 PNG, base64-encoded — what the Windows PowerShell capture prints.
+  const FAKE_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+  // Windows screenshot/listDisplays go through `powershell.exe -EncodedCommand`
+  // now (issue #2150); answer based on which script is being run.
+  const execFileSync = vi.fn((file?: string, args?: string[]) => {
+    if (file === 'powershell.exe' && args) {
+      const idx = args.indexOf('-EncodedCommand');
+      const script =
+        idx >= 0
+          ? Buffer.from(args[idx + 1], 'base64').toString('utf16le')
+          : '';
+      if (script.includes('CopyFromScreen')) {
+        return FAKE_PNG_BASE64;
+      }
+      return JSON.stringify([
+        { id: '\\\\.\\DISPLAY1', name: '\\\\.\\DISPLAY1', primary: true },
+      ]);
+    }
+    return undefined;
+  });
 
   const screenshot = vi.fn(async () => Buffer.from('png')) as ReturnType<
     typeof vi.fn
@@ -40,7 +60,8 @@ const mockState = vi.hoisted(() => {
   const reset = () => {
     mousePos = { x: 10, y: 20 };
     execSync.mockReset();
-    execFileSync.mockReset();
+    // mockClear (not mockReset) so the powershell-aware implementation survives.
+    execFileSync.mockClear();
     screenshot.mockClear();
     screenshot.listDisplays.mockClear();
     libnut.getScreenSize.mockClear();

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -8,22 +8,30 @@ const mockState = vi.hoisted(() => {
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
   // Windows screenshot/listDisplays go through `powershell.exe -EncodedCommand`
   // now (issue #2150); answer based on which script is being run.
-  const execFileSync = vi.fn((file?: string, args?: string[]) => {
-    if (file === 'powershell.exe' && args) {
-      const idx = args.indexOf('-EncodedCommand');
-      const script =
-        idx >= 0
-          ? Buffer.from(args[idx + 1], 'base64').toString('utf16le')
-          : '';
-      if (script.includes('CopyFromScreen')) {
-        return FAKE_PNG_BASE64;
+  const execFileSync = vi.fn(
+    (
+      file?: string,
+      args?: string[],
+      // Return type stays wide (string | Buffer) so other tests can stub
+      // Buffer outputs (e.g. the frontmost-app osascript probe) via
+      // mockReturnValueOnce.
+    ): string | Buffer | undefined => {
+      if (file === 'powershell.exe' && args) {
+        const idx = args.indexOf('-EncodedCommand');
+        const script =
+          idx >= 0
+            ? Buffer.from(args[idx + 1], 'base64').toString('utf16le')
+            : '';
+        if (script.includes('CopyFromScreen')) {
+          return FAKE_PNG_BASE64;
+        }
+        return JSON.stringify([
+          { id: '\\\\.\\DISPLAY1', name: '\\\\.\\DISPLAY1', primary: true },
+        ]);
       }
-      return JSON.stringify([
-        { id: '\\\\.\\DISPLAY1', name: '\\\\.\\DISPLAY1', primary: true },
-      ]);
-    }
-    return undefined;
-  });
+      return undefined;
+    },
+  );
 
   const screenshot = vi.fn(async () => Buffer.from('png')) as ReturnType<
     typeof vi.fn

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -41,12 +41,23 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     expect(execFileSync.mock.calls[0][0]).toBe('powershell.exe');
     expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
 
+    // ExecutionPolicy only gates .ps1 files, not -EncodedCommand input, so it
+    // must not be passed.
+    const args = execFileSync.mock.calls[0][1] as string[];
+    expect(args).not.toContain('-ExecutionPolicy');
+    expect(args).not.toContain('Bypass');
+
     // Without a displayId the script falls back to the primary screen and
     // never does a lookup that could fail.
     const script = decodeEncodedCommand(execFileSync.mock.calls[0]);
     expect(script).toContain('CopyFromScreen');
     expect(script).toContain('PrimaryScreen');
     expect(script).not.toContain('throw');
+
+    // No runtime C# compile: this PR's whole point is to drop the .NET
+    // compiler dependency, so the DPI Add-Type/csc path must not reappear.
+    expect(script).not.toContain('SetProcessDPIAware');
+    expect(script).not.toContain('DllImport');
   });
 
   it('targets the requested display by DeviceName and fails fast if missing', async () => {

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -1,0 +1,71 @@
+import { Buffer } from 'node:buffer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// A 1x1 PNG, base64-encoded, as PowerShell's CopyFromScreen path would print
+// to stdout.
+const FAKE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const execFileSync = vi.fn(() => FAKE_PNG_BASE64);
+
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => execFileSync(...args),
+  execSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+/** Decode the -EncodedCommand argument back to the PowerShell script. */
+function decodeEncodedCommand(call: unknown[]): string {
+  const args = call[1] as string[];
+  const idx = args.indexOf('-EncodedCommand');
+  return Buffer.from(args[idx + 1], 'base64').toString('utf16le');
+}
+
+describe('Windows screenshot via PowerShell (issue #2150)', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    execFileSync.mockClear();
+    vi.resetModules();
+  });
+
+  it('captures through powershell.exe and returns a PNG data URI', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const { ComputerDevice } = await import('../../src/device');
+
+    const device = new ComputerDevice({});
+    const base64 = await device.screenshotBase64();
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync.mock.calls[0][0]).toBe('powershell.exe');
+    expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
+
+    // Without a displayId the script falls back to the primary screen.
+    const script = decodeEncodedCommand(execFileSync.mock.calls[0]);
+    expect(script).toContain('CopyFromScreen');
+    expect(script).toContain('PrimaryScreen');
+  });
+
+  it('targets the requested display by DeviceName', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const { ComputerDevice } = await import('../../src/device');
+
+    const device = new ComputerDevice({ displayId: '\\\\.\\DISPLAY2' });
+    await device.screenshotBase64();
+
+    const script = decodeEncodedCommand(execFileSync.mock.calls[0]);
+    expect(script).toContain("DeviceName -eq '\\\\.\\DISPLAY2'");
+  });
+
+  it('throws when PowerShell returns no image data', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    execFileSync.mockReturnValueOnce('   ');
+    const { ComputerDevice } = await import('../../src/device');
+
+    const device = new ComputerDevice({});
+    await expect(device.screenshotBase64()).rejects.toThrow(
+      /returned no image data/,
+    );
+  });
+});

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -41,13 +41,15 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     expect(execFileSync.mock.calls[0][0]).toBe('powershell.exe');
     expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
 
-    // Without a displayId the script falls back to the primary screen.
+    // Without a displayId the script falls back to the primary screen and
+    // never does a lookup that could fail.
     const script = decodeEncodedCommand(execFileSync.mock.calls[0]);
     expect(script).toContain('CopyFromScreen');
     expect(script).toContain('PrimaryScreen');
+    expect(script).not.toContain('throw');
   });
 
-  it('targets the requested display by DeviceName', async () => {
+  it('targets the requested display by DeviceName and fails fast if missing', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const { ComputerDevice } = await import('../../src/device');
 
@@ -55,7 +57,11 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     await device.screenshotBase64();
 
     const script = decodeEncodedCommand(execFileSync.mock.calls[0]);
-    expect(script).toContain("DeviceName -eq '\\\\.\\DISPLAY2'");
+    expect(script).toContain('DeviceName -eq $dn');
+    expect(script).toContain("$dn = '\\\\.\\DISPLAY2'");
+    // A requested-but-missing display must throw, not fall back to primary.
+    expect(script).toContain('throw "Requested display not found');
+    expect(script).not.toContain('PrimaryScreen');
   });
 
   it('throws when PowerShell returns no image data', async () => {

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -6,17 +6,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const FAKE_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-const execFileSync = vi.fn(() => FAKE_PNG_BASE64);
+// Typed params so `mock.calls[i]` is a `[file, args, options]` tuple the type
+// checker can index into.
+const execFileSync = vi.fn(
+  (_file: string, _args: string[], _options?: unknown): string =>
+    FAKE_PNG_BASE64,
+);
 
 vi.mock('node:child_process', () => ({
-  execFileSync: (...args: unknown[]) => execFileSync(...args),
+  execFileSync: (file: string, args: string[], options?: unknown) =>
+    execFileSync(file, args, options),
   execSync: vi.fn(),
   spawnSync: vi.fn(),
 }));
 
 /** Decode the -EncodedCommand argument back to the PowerShell script. */
-function decodeEncodedCommand(call: unknown[]): string {
-  const args = call[1] as string[];
+function decodeEncodedCommand(call: [string, string[], unknown?]): string {
+  const args = call[1];
   const idx = args.indexOf('-EncodedCommand');
   return Buffer.from(args[idx + 1], 'base64').toString('utf16le');
 }


### PR DESCRIPTION
## Summary

Fixes #2150. On Windows, `@midscene/computer connect` fails inside Claude Code (but works in a standalone terminal) because the health-check screenshot cannot be taken.

### Root cause

`screenshot-desktop` captures on Windows through a polyglot `.bat` that self-compiles via `csc.exe` and then re-launches the compiled exe. That chain breaks under the POSIX-flavored environment Claude Code / Git Bash inject (`PATH` / `SystemRoot` / `COMSPEC`), so the capture throws, the health check fails, and `connect` aborts. The reporter confirmed that calling the already-compiled exe directly works — i.e. the `.bat` wrapper is what breaks, not the capture itself.

### Fix

Replace the Windows capture path entirely with PowerShell + System.Drawing, which never touches the `.bat`/`csc` chain:

- **Screenshot** — on `win32`, `screenshotBase64` runs `System.Drawing.CopyFromScreen` via `powershell.exe -EncodedCommand`, spawned through `execFileSync` (no shell). This avoids both the polyglot bat and Git Bash argument mangling. The PNG is returned as base64 over stdout (no temp file).
- **Multi-monitor** — capture uses virtual-desktop coordinates, so any monitor is supported, including secondary displays at negative offsets. `displayId` is honored by matching the monitor `DeviceName`.
- **listDisplays** — on `win32`, monitors are enumerated via `[System.Windows.Forms.Screen]::AllScreens` (the previous screenshot-desktop path used the same broken `.bat`).

macOS / Linux paths are unchanged.

### Known limitation

The script makes the process system-DPI-aware (`SetProcessDPIAware`) so captures return physical pixels. On mixed-DPI multi-monitor setups a non-primary monitor may still be off by its per-monitor scale factor (would need per-monitor-v2 awareness).

## Test plan

- [x] `pnpm run lint`
- [x] `npx nx test computer` (82 passed) — incl. new `windows-screenshot.test.ts` covering the PowerShell path, displayId targeting, and empty-output error; `device-security.test.ts` updated to mock the PowerShell calls
- [x] `npx nx test shared` (401 passed)
- [x] `npx nx build computer` / `npx nx build shared`
- [ ] **Real-device verification still required** — must run on Windows **inside Claude Code** (the bug only reproduces in that environment). Validate: `connect` succeeds, health-check screenshot passes, monitors are listed, and per-display capture works for a secondary monitor (including one at a negative offset). A prepatch will be published for this.

> Note: validated logic via mocks on macOS; the maintainer's CLI host cannot exercise the real Windows PowerShell path.