### PR TITLE
feat(core): add frameSequence option to observe transient UI

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -726,6 +726,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 
 - Return Value:
 
@@ -756,6 +757,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 
 - Return Value:
 
@@ -805,6 +807,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 - Return Value:
 
   - Returns a `Promise<boolean>` when AI returns a boolean value.
@@ -835,6 +838,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 - Return Value:
 
   - Returns a `Promise<number>` when AI returns a number value.
@@ -868,6 +872,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 - Return Value:
 
   - Returns a `Promise<string>` when AI returns a string value.
@@ -906,6 +911,7 @@ function aiAssert(
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
 
 - Return Value:
 

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -726,7 +726,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 
 - Return Value:
 
@@ -757,7 +757,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 
 - Return Value:
 
@@ -807,7 +807,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 - Return Value:
 
   - Returns a `Promise<boolean>` when AI returns a boolean value.
@@ -838,7 +838,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 - Return Value:
 
   - Returns a `Promise<number>` when AI returns a number value.
@@ -872,7 +872,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 - Return Value:
 
   - Returns a `Promise<string>` when AI returns a string value.
@@ -911,7 +911,7 @@ function aiAssert(
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`.
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - Capture a short sequence of frames over a time window and send them all to the model instead of a single screenshot, so it can observe transient UI such as toasts, carousel banners, or auto-hiding controls. Off by default. Set `true` for defaults (4 frames at 1s intervals; `count` is clamped to 2–8), or pass an object to tune `count` / `intervalMs`. Costs more tokens, and has no effect when `screenshotIncluded` is `false`. The captured frames are shown in the report timeline.
 
 - Return Value:
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -715,6 +715,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 
@@ -745,6 +746,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 
@@ -796,6 +798,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 
@@ -828,6 +831,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 
@@ -862,6 +866,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 
@@ -901,6 +906,7 @@ function aiAssert(
   - options?: Object - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
 
 - 返回值：
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -715,7 +715,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 
@@ -746,7 +746,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 
@@ -798,7 +798,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 
@@ -831,7 +831,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 
@@ -866,7 +866,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 
@@ -906,7 +906,7 @@ function aiAssert(
   - options?: Object - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
-    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。
+    - `frameSequence?: boolean | { count?: number; intervalMs?: number }` - 在一小段时间窗口内连续采集多帧,并一起发送给模型(而不是单张截图),让模型能观察到瞬时 UI,例如 toast 提示、轮播 banner、自动隐藏的控件。默认关闭。传 `true` 使用默认值(间隔 1 秒采集 4 帧,`count` 会被限制在 2~8),或传对象自定义 `count` / `intervalMs`。会增加 token 消耗;当 `screenshotIncluded` 为 `false` 时该选项不生效。采集到的连续帧会显示在报告的时间线中。
 
 - 返回值：
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -393,6 +393,7 @@ export class Agent<
   private static readonly FRAME_SEQUENCE_MIN_COUNT = 2;
   private static readonly FRAME_SEQUENCE_MAX_COUNT = 8;
   private static readonly FRAME_SEQUENCE_DEFAULT_INTERVAL_MS = 1000;
+  private static readonly FRAME_SEQUENCE_MAX_INTERVAL_MS = 10000;
 
   private normalizeFrameSequenceOption(
     frameSequence: boolean | FrameSequenceOption,
@@ -405,9 +406,9 @@ export class Agent<
         Math.round(raw.count ?? Agent.FRAME_SEQUENCE_DEFAULT_COUNT),
       ),
     );
-    const intervalMs = Math.max(
-      0,
-      raw.intervalMs ?? Agent.FRAME_SEQUENCE_DEFAULT_INTERVAL_MS,
+    const intervalMs = Math.min(
+      Agent.FRAME_SEQUENCE_MAX_INTERVAL_MS,
+      Math.max(0, raw.intervalMs ?? Agent.FRAME_SEQUENCE_DEFAULT_INTERVAL_MS),
     );
     return { count, intervalMs };
   }
@@ -1255,7 +1256,7 @@ export class Agent<
       typeof assertion === 'string' ? assertion : assertion.prompt;
 
     const executionOptions = await this.buildExtractExecutionOptions(
-      { ...serviceOpt, frameSequence: opt?.frameSequence },
+      opt,
       opt?.abortSignal,
     );
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -18,6 +18,7 @@ import {
   type ExecutionRecorderItem,
   type ExecutionTask,
   type ExecutionTaskLog,
+  type FrameSequenceOption,
   type LocateOption,
   type LocateResultElement,
   type OnTaskStartTip,
@@ -386,6 +387,87 @@ export class Agent<
 
   async _snapshotContext(): Promise<UIContext> {
     return await this.getUIContext('locate');
+  }
+
+  private static readonly FRAME_SEQUENCE_DEFAULT_COUNT = 4;
+  private static readonly FRAME_SEQUENCE_MIN_COUNT = 2;
+  private static readonly FRAME_SEQUENCE_MAX_COUNT = 8;
+  private static readonly FRAME_SEQUENCE_DEFAULT_INTERVAL_MS = 1000;
+
+  private normalizeFrameSequenceOption(
+    frameSequence: boolean | FrameSequenceOption,
+  ): { count: number; intervalMs: number } {
+    const raw = typeof frameSequence === 'object' ? frameSequence : {};
+    const count = Math.min(
+      Agent.FRAME_SEQUENCE_MAX_COUNT,
+      Math.max(
+        Agent.FRAME_SEQUENCE_MIN_COUNT,
+        Math.round(raw.count ?? Agent.FRAME_SEQUENCE_DEFAULT_COUNT),
+      ),
+    );
+    const intervalMs = Math.max(
+      0,
+      raw.intervalMs ?? Agent.FRAME_SEQUENCE_DEFAULT_INTERVAL_MS,
+    );
+    return { count, intervalMs };
+  }
+
+  /**
+   * Capture a sequence of screenshots over a short time window and return a
+   * UIContext whose `screenshot` is the latest frame and whose
+   * `screenshotSequence` holds every captured frame in temporal order. Used by
+   * extract/assert flows to let the model observe transient UI.
+   */
+  private async captureUIContextSequence(
+    frameSequence: boolean | FrameSequenceOption,
+  ): Promise<UIContext> {
+    // A frozen context never changes between frames, so a sequence is pointless.
+    if (this.frozenUIContext) {
+      return this.frozenUIContext;
+    }
+
+    const { count, intervalMs } =
+      this.normalizeFrameSequenceOption(frameSequence);
+
+    const frames: ScreenshotItem[] = [];
+    let lastContext: UIContext | undefined;
+    for (let i = 0; i < count; i++) {
+      if (i > 0 && intervalMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+      lastContext = await this.getUIContext('assert');
+      frames.push(lastContext.screenshot);
+    }
+
+    assert(lastContext, 'failed to capture any frame for frame sequence');
+    return {
+      ...lastContext,
+      screenshotSequence: frames,
+    };
+  }
+
+  /**
+   * Build the execution options for extract/assert flows. When the caller
+   * enables `frameSequence` (and screenshots are not disabled), capture a frame
+   * sequence up front and pass it down as the UIContext so the model observes
+   * transient UI.
+   */
+  private async buildExtractExecutionOptions(
+    opt?: ServiceExtractOption,
+    abortSignal?: AbortSignal,
+  ): Promise<{ abortSignal?: AbortSignal; uiContext?: UIContext }> {
+    const executionOptions: {
+      abortSignal?: AbortSignal;
+      uiContext?: UIContext;
+    } = { abortSignal };
+
+    if (opt?.frameSequence && opt?.screenshotIncluded !== false) {
+      executionOptions.uiContext = await this.captureUIContextSequence(
+        opt.frameSequence,
+      );
+    }
+
+    return executionOptions;
   }
 
   /**
@@ -1037,11 +1119,14 @@ export class Agent<
     opt: ServiceExtractOption = defaultServiceExtractOption,
   ): Promise<ReturnType> {
     const modelRuntime = this.resolveModelRuntime('insight');
+    const executionOptions = await this.buildExtractExecutionOptions(opt);
     const { output } = await this.taskExecutor.createTypeQueryExecution(
       'Query',
       demand,
       modelRuntime,
       opt,
+      undefined,
+      executionOptions,
     );
     return output as ReturnType;
   }
@@ -1053,12 +1138,14 @@ export class Agent<
     const modelRuntime = this.resolveModelRuntime('insight');
 
     const { textPrompt, multimodalPrompt } = parsePrompt(prompt);
+    const executionOptions = await this.buildExtractExecutionOptions(opt);
     const { output } = await this.taskExecutor.createTypeQueryExecution(
       'Boolean',
       textPrompt,
       modelRuntime,
       opt,
       multimodalPrompt,
+      executionOptions,
     );
     return output as boolean;
   }
@@ -1070,12 +1157,14 @@ export class Agent<
     const modelRuntime = this.resolveModelRuntime('insight');
 
     const { textPrompt, multimodalPrompt } = parsePrompt(prompt);
+    const executionOptions = await this.buildExtractExecutionOptions(opt);
     const { output } = await this.taskExecutor.createTypeQueryExecution(
       'Number',
       textPrompt,
       modelRuntime,
       opt,
       multimodalPrompt,
+      executionOptions,
     );
     return output as number;
   }
@@ -1087,12 +1176,14 @@ export class Agent<
     const modelRuntime = this.resolveModelRuntime('insight');
 
     const { textPrompt, multimodalPrompt } = parsePrompt(prompt);
+    const executionOptions = await this.buildExtractExecutionOptions(opt);
     const { output } = await this.taskExecutor.createTypeQueryExecution(
       'String',
       textPrompt,
       modelRuntime,
       opt,
       multimodalPrompt,
+      executionOptions,
     );
     return output as string;
   }
@@ -1163,6 +1254,11 @@ export class Agent<
     const assertionText =
       typeof assertion === 'string' ? assertion : assertion.prompt;
 
+    const executionOptions = await this.buildExtractExecutionOptions(
+      { ...serviceOpt, frameSequence: opt?.frameSequence },
+      opt?.abortSignal,
+    );
+
     try {
       const { output, thought } =
         await this.taskExecutor.createTypeQueryExecution<boolean>(
@@ -1171,9 +1267,7 @@ export class Agent<
           modelRuntime,
           serviceOpt,
           multimodalPrompt,
-          {
-            abortSignal: opt?.abortSignal,
-          },
+          executionOptions,
         );
 
       const pass = Boolean(output);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -414,13 +414,42 @@ export class Agent<
   }
 
   /**
+   * Sleep for `ms`, but reject early if `abortSignal` fires so a cancelled
+   * frame-sequence capture does not keep waiting out the interval.
+   */
+  private interruptibleSleep(
+    ms: number,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (abortSignal?.aborted) {
+        reject(abortSignal.reason);
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(abortSignal?.reason);
+      };
+      const timer = setTimeout(() => {
+        abortSignal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  /**
    * Capture a sequence of screenshots over a short time window and return a
    * UIContext whose `screenshot` is the latest frame and whose
    * `screenshotSequence` holds every captured frame in temporal order. Used by
    * extract/assert flows to let the model observe transient UI.
+   *
+   * Honors `abortSignal` between frames so a cancelled assertion stops
+   * capturing promptly instead of waiting out the whole window.
    */
   private async captureUIContextSequence(
     frameSequence: boolean | FrameSequenceOption,
+    abortSignal?: AbortSignal,
   ): Promise<UIContext> {
     // A frozen context never changes between frames, so a sequence is pointless.
     if (this.frozenUIContext) {
@@ -433,9 +462,11 @@ export class Agent<
     const frames: ScreenshotItem[] = [];
     let lastContext: UIContext | undefined;
     for (let i = 0; i < count; i++) {
+      abortSignal?.throwIfAborted();
       if (i > 0 && intervalMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        await this.interruptibleSleep(intervalMs, abortSignal);
       }
+      abortSignal?.throwIfAborted();
       lastContext = await this.getUIContext('assert');
       frames.push(lastContext.screenshot);
     }
@@ -465,6 +496,7 @@ export class Agent<
     if (opt?.frameSequence && opt?.screenshotIncluded !== false) {
       executionOptions.uiContext = await this.captureUIContextSequence(
         opt.frameSequence,
+        abortSignal,
       );
     }
 

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -16,6 +16,7 @@ import type { TaskRunner } from '@/task-runner';
 import { TaskExecutionError } from '@/task-runner';
 import type {
   DeviceAction,
+  ExecutionRecorderItem,
   ExecutionTask,
   ExecutionTaskApply,
   ExecutionTaskInsightQueryApply,
@@ -775,13 +776,9 @@ export class TaskExecutor {
           }
           throw error;
         } finally {
-          // A frame sequence is a transient model input: it is not persisted in
-          // the report. Release the extra frames once the model call is done so
-          // their base64 is not retained for the lifetime of the dump. The
-          // representative `screenshot` is kept.
-          if (uiContext?.screenshotSequence) {
-            uiContext.screenshotSequence = undefined;
-          }
+          // Surface the captured frame sequence in the report, then release it
+          // from the UIContext so its base64 is not retained twice.
+          recordAndReleaseFrameSequence(task, uiContext);
         }
 
         const { data, thought, dump } = extractResult;
@@ -968,6 +965,46 @@ export class TaskExecutor {
     }
 
     return session.appendErrorPlan(`waitFor timeout: ${errorThought}`);
+  }
+}
+
+/**
+ * Surface a captured frame sequence in the report timeline, then release it
+ * from the UIContext.
+ *
+ * When `frameSequence` is enabled, the extra frames live on
+ * `uiContext.screenshotSequence` only as a transient model input. This attaches
+ * them to the task recorder so the report renders the full sequence the model
+ * saw (the report timeline builds one screenshot per recorder item), then drops
+ * the field from the UIContext so its base64 is not retained twice for the
+ * lifetime of the dump.
+ *
+ * The last frame is the representative `uiContext.screenshot`, already shown in
+ * the report, so only the earlier frames are recorded to avoid duplication.
+ */
+export function recordAndReleaseFrameSequence(
+  task: ExecutionTask,
+  uiContext: UIContext | undefined,
+): void {
+  const frames = uiContext?.screenshotSequence;
+  if (frames && frames.length > 1) {
+    const recorderItems: ExecutionRecorderItem[] = [];
+    for (let i = 0; i < frames.length - 1; i++) {
+      const frame = frames[i];
+      recorderItems.push({
+        type: 'screenshot',
+        ts: frame.capturedAt,
+        screenshot: frame,
+        description: `Frame sequence ${i + 1}/${frames.length}`,
+        timing: 'frame-sequence',
+      });
+    }
+    task.recorder = task.recorder
+      ? [...task.recorder, ...recorderItems]
+      : recorderItems;
+  }
+  if (uiContext?.screenshotSequence) {
+    uiContext.screenshotSequence = undefined;
   }
 }
 

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -827,6 +827,7 @@ export class TaskExecutor {
     multimodalPrompt?: TMultimodalPrompt,
     executionOptions?: {
       abortSignal?: AbortSignal;
+      uiContext?: UIContext;
     },
   ): Promise<ExecutionResult<T>> {
     const session = this.createExecutionSession(
@@ -834,6 +835,9 @@ export class TaskExecutor {
         type,
         typeof demand === 'string' ? demand : JSON.stringify(demand),
       ),
+      executionOptions?.uiContext
+        ? { uiContext: executionOptions.uiContext }
+        : undefined,
     );
 
     const queryTask = await this.createTypeQueryTask(

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -774,6 +774,14 @@ export class TaskExecutor {
             applyDump(error.dump);
           }
           throw error;
+        } finally {
+          // A frame sequence is a transient model input: it is not persisted in
+          // the report. Release the extra frames once the model call is done so
+          // their base64 is not retained for the lifetime of the dump. The
+          // representative `screenshot` is kept.
+          if (uiContext?.screenshotSequence) {
+            uiContext.screenshotSequence = undefined;
+          }
         }
 
         const { data, thought, dump } = extractResult;
@@ -884,8 +892,17 @@ export class TaskExecutor {
       checkIntervalMs,
       domIncluded,
       screenshotIncluded,
+      frameSequence,
       ...restOpt
     } = opt;
+    if (frameSequence) {
+      // waitFor is itself a polling loop, so it already re-samples the screen
+      // over time. The single-shot frameSequence capture does not apply here;
+      // ignore it explicitly instead of letting it silently no-op.
+      warnLog(
+        'frameSequence is ignored by aiWaitFor (it already polls over time). Use aiAssert with { frameSequence } for a one-shot multi-frame check.',
+      );
+    }
     const serviceExtractOpt: ServiceExtractOption = {
       domIncluded,
       screenshotIncluded,

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -530,7 +530,7 @@ export async function AiExtractElementInfo<T>(options: {
     if (screenshotSequence && screenshotSequence.length > 1) {
       userContent.push({
         type: 'text',
-        text: `The following ${screenshotSequence.length} images are consecutive screenshots captured over a short time window, ordered from earliest to latest. They may reveal transient UI (such as toasts, carousel banners, or auto-hiding controls) that is visible in only some frames. Consider all of them when answering; the last image is the most recent state. Unless <DATA_DEMAND> explicitly asks for comparison or matching against reference images, base your answer on these screenshots and their contents.`,
+        text: `The following ${screenshotSequence.length} images are consecutive screenshots captured over a short time window (a few seconds), ordered from earliest to latest. Treat them together as a SINGLE observation of that time window, not as separate states to judge independently. Transient UI such as toasts, banners, flashes, or auto-hiding controls may appear in only some frames and already be gone by the last frame. When the statement or question is about whether something appears, pops up, is shown, or happens (an event), answer based on whether it holds in ANY of the frames — treat it as TRUE even if it is no longer visible in the last frame; do NOT require it to remain visible in the final frame. Only restrict your answer to the last (most recent) frame when the statement is explicitly about the current or final state. Unless <DATA_DEMAND> explicitly asks for comparison or matching against reference images, base your answer on these screenshots and their contents.`,
       });
 
       screenshotSequence.forEach((frame, index) => {

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -526,18 +526,40 @@ export async function AiExtractElementInfo<T>(options: {
   const userContent: ChatCompletionUserMessageParam['content'] = [];
 
   if (extractOption?.screenshotIncluded !== false) {
-    userContent.push({
-      type: 'text',
-      text: 'This is the current screenshot to evaluate. Unless <DATA_DEMAND> explicitly asks for comparison or matching against reference images, base your answer on this screenshot and its contents when provided.',
-    });
+    const screenshotSequence = context.screenshotSequence;
+    if (screenshotSequence && screenshotSequence.length > 1) {
+      userContent.push({
+        type: 'text',
+        text: `The following ${screenshotSequence.length} images are consecutive screenshots captured over a short time window, ordered from earliest to latest. They may reveal transient UI (such as toasts, carousel banners, or auto-hiding controls) that is visible in only some frames. Consider all of them when answering; the last image is the most recent state. Unless <DATA_DEMAND> explicitly asks for comparison or matching against reference images, base your answer on these screenshots and their contents.`,
+      });
 
-    userContent.push({
-      type: 'image_url',
-      image_url: {
-        url: screenshotBase64,
-        detail: 'high',
-      },
-    });
+      screenshotSequence.forEach((frame, index) => {
+        userContent.push({
+          type: 'text',
+          text: `Frame ${index + 1}/${screenshotSequence.length}`,
+        });
+        userContent.push({
+          type: 'image_url',
+          image_url: {
+            url: frame.base64,
+            detail: 'high',
+          },
+        });
+      });
+    } else {
+      userContent.push({
+        type: 'text',
+        text: 'This is the current screenshot to evaluate. Unless <DATA_DEMAND> explicitly asks for comparison or matching against reference images, base your answer on this screenshot and its contents when provided.',
+      });
+
+      userContent.push({
+        type: 'image_url',
+        image_url: {
+          url: screenshotBase64,
+          detail: 'high',
+        },
+      });
+    }
   }
 
   userContent.push({

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -19,6 +19,12 @@ import { ScreenshotStore } from './screenshot-store';
  * Replacer function for JSON serialization that handles Page, Browser objects and ScreenshotItem
  */
 function replacerForDumpSerialization(_key: string, value: any): any {
+  // screenshotSequence is a transient model input (multi-frame capture). Its
+  // frames are not persisted by collectScreenshots, so serializing them would
+  // emit dangling screenshot refs. The representative `screenshot` is kept.
+  if (_key === 'screenshotSequence') {
+    return undefined;
+  }
   if (value && value.constructor?.name === 'Page') {
     return '[Page object]';
   }
@@ -187,10 +193,11 @@ export class ReportActionDump implements IReportActionDump {
         return obj.map(processValue);
       }
       if (obj && typeof obj === 'object') {
-        const entries = Object.entries(obj).map(([key, value]) => [
-          key,
-          processValue(value),
-        ]);
+        const entries = Object.entries(obj)
+          // screenshotSequence is a transient multi-frame model input whose
+          // frames are not persisted; skip it to avoid inlining large base64.
+          .filter(([key]) => key !== 'screenshotSequence')
+          .map(([key, value]) => [key, processValue(value)]);
         return Object.fromEntries(entries);
       }
       return obj;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -136,6 +136,15 @@ export abstract class UIContext {
   abstract screenshot: ScreenshotItem;
 
   /**
+   * Optional sequence of screenshots captured over a short time window, in
+   * temporal order (earliest first, latest last). When present with more than
+   * one frame, extract/assert flows submit all frames to the model so it can
+   * observe transient UI (toasts, carousels, auto-hiding controls). The last
+   * frame is the same state as {@link screenshot}.
+   */
+  abstract screenshotSequence?: ScreenshotItem[];
+
+  /**
    * screenshot size after shrinking
    */
   abstract shotSize: Size;

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -18,9 +18,25 @@ export interface LocateOption extends Partial<TMultimodalPrompt> {
   fileChooserAccept?: string | string[]; // file path(s) to upload when tapping triggers a file chooser
 }
 
+export interface FrameSequenceOption {
+  /** Number of frames to capture. Default 4, clamped to [2, 8]. */
+  count?: number;
+  /** Interval between consecutive frames in ms. Default 1000. */
+  intervalMs?: number;
+}
+
 export interface ServiceExtractOption {
   domIncluded?: boolean | 'visible-only';
   screenshotIncluded?: boolean;
+  /**
+   * Capture a short sequence of frames over a time window and submit them all
+   * to the model, instead of a single screenshot. Lets the model observe
+   * transient UI (toasts, carousels, auto-hiding controls) that appears in only
+   * some frames. Default: off. Trade-off: more tokens.
+   *
+   * Pass `true` for defaults, or an object to tune count/interval.
+   */
+  frameSequence?: boolean | FrameSequenceOption;
   [key: string]: unknown;
 }
 

--- a/packages/core/tests/unit-test/agent-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/agent-frame-sequence.test.ts
@@ -86,4 +86,41 @@ describe('Agent frame sequence switch', () => {
 
     expect(getUIContext).not.toHaveBeenCalled();
   });
+
+  it('does not capture any frame when the signal is already aborted', async () => {
+    const { agent, getUIContext } = createAgentStub();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      agent.aiAssert('a toast appeared', undefined, {
+        keepRawResponse: true,
+        abortSignal: controller.signal,
+        frameSequence: true,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(getUIContext).not.toHaveBeenCalled();
+  });
+
+  it('stops capturing promptly when aborted mid-sequence', async () => {
+    const { agent, getUIContext } = createAgentStub();
+    const controller = new AbortController();
+    // Abort right after the first frame is captured.
+    getUIContext.mockImplementationOnce(async () => {
+      controller.abort();
+      return fakeContext('frame-0');
+    });
+
+    await expect(
+      agent.aiAssert('a toast appeared', undefined, {
+        keepRawResponse: true,
+        abortSignal: controller.signal,
+        frameSequence: { count: 6, intervalMs: 50 },
+      }),
+    ).rejects.toBeDefined();
+
+    // Should bail out long before capturing all 6 frames.
+    expect(getUIContext.mock.calls.length).toBeLessThan(6);
+  });
 });

--- a/packages/core/tests/unit-test/agent-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/agent-frame-sequence.test.ts
@@ -1,0 +1,89 @@
+import { Agent } from '@/agent';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { UIContext } from '@/types';
+import { describe, expect, it, vi } from 'vitest';
+
+const defaultModel = { config: { slot: 'default' } };
+
+const fakeContext = (tag: string): UIContext =>
+  ({
+    screenshot: ScreenshotItem.create(
+      `data:image/png;base64,iVBORw0KGgo-${tag}`,
+      Date.now(),
+    ),
+    shotSize: { width: 100, height: 100 },
+    shrunkShotToLogicalRatio: 1,
+  }) as UIContext;
+
+const createAgentStub = () => {
+  const agent = Object.create(Agent.prototype) as Agent<any>;
+  const createTypeQueryExecution = vi.fn(async () => ({
+    output: true,
+    thought: 'ok',
+  }));
+  (agent as any).opts = {};
+  (agent as any).taskExecutor = { createTypeQueryExecution };
+  (agent as any).resolveModelRuntime = vi.fn(() => defaultModel);
+
+  let counter = 0;
+  const getUIContext = vi.fn(async () => fakeContext(`frame-${counter++}`));
+  (agent as any).getUIContext = getUIContext;
+
+  return { agent, createTypeQueryExecution, getUIContext };
+};
+
+describe('Agent frame sequence switch', () => {
+  it('is off by default: no extra captures, no screenshotSequence', async () => {
+    const { agent, createTypeQueryExecution, getUIContext } = createAgentStub();
+
+    await agent.aiAssert('a toast appeared', undefined, {
+      keepRawResponse: true,
+    });
+
+    expect(getUIContext).not.toHaveBeenCalled();
+    const executionOptions = (
+      createTypeQueryExecution.mock.calls[0] as any[]
+    )[5];
+    expect(executionOptions).toEqual({ abortSignal: undefined });
+    expect(executionOptions.uiContext).toBeUndefined();
+  });
+
+  it('captures a frame sequence when enabled and passes it as uiContext', async () => {
+    const { agent, createTypeQueryExecution, getUIContext } = createAgentStub();
+
+    await agent.aiAssert('a toast appeared', undefined, {
+      keepRawResponse: true,
+      frameSequence: { count: 3, intervalMs: 0 },
+    });
+
+    expect(getUIContext).toHaveBeenCalledTimes(3);
+    const executionOptions = (
+      createTypeQueryExecution.mock.calls[0] as any[]
+    )[5];
+    expect(executionOptions.uiContext).toBeDefined();
+    expect(executionOptions.uiContext.screenshotSequence).toHaveLength(3);
+  });
+
+  it('clamps frame count into the supported range', async () => {
+    const { agent, getUIContext } = createAgentStub();
+
+    await agent.aiAssert('a toast appeared', undefined, {
+      keepRawResponse: true,
+      frameSequence: { count: 99, intervalMs: 0 },
+    });
+
+    // max count is 8
+    expect(getUIContext).toHaveBeenCalledTimes(8);
+  });
+
+  it('skips capture when screenshots are disabled', async () => {
+    const { agent, getUIContext } = createAgentStub();
+
+    await agent.aiQuery('whatever', {
+      screenshotIncluded: false,
+      frameSequence: true,
+    });
+
+    expect(getUIContext).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/unit-test/dump-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/dump-frame-sequence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ScreenshotItem } from '../../src/screenshot-item';
+import {
+  ExecutionDump,
+  type IExecutionDump,
+  type IReportActionDump,
+  ReportActionDump,
+} from '../../src/types';
+
+/**
+ * The `frameSequence` feature attaches a `screenshotSequence` (a transient
+ * multi-frame model input) to `task.uiContext`. Those frames are NOT persisted
+ * by collectScreenshots, so dump serialization must drop the field to avoid
+ * dangling screenshot refs and base64 bloat. The representative `screenshot`
+ * must still be serialized.
+ */
+describe('dump serialization drops screenshotSequence', () => {
+  const FRAME_A = 'data:image/png;base64,iVBORw0KGgoAAAA-FRAME-A';
+  const FRAME_B = 'data:image/png;base64,iVBORw0KGgoAAAA-FRAME-B';
+  const FRAME_C = 'data:image/png;base64,iVBORw0KGgoAAAA-FRAME-C';
+
+  const buildExecutionDumpData = (): IExecutionDump => {
+    const representative = ScreenshotItem.create(FRAME_C, 3);
+    return {
+      logTime: 1,
+      name: 'frame-sequence-dump',
+      tasks: [
+        {
+          type: 'Insight',
+          subType: 'Assert',
+          status: 'finished',
+          param: {},
+          timing: { start: 1, end: 2, cost: 1 },
+          executor: async () => {},
+          uiContext: {
+            screenshot: representative,
+            screenshotSequence: [
+              ScreenshotItem.create(FRAME_A, 1),
+              ScreenshotItem.create(FRAME_B, 2),
+              representative,
+            ],
+            shotSize: { width: 100, height: 100 },
+            shrunkShotToLogicalRatio: 1,
+          },
+        } as any,
+      ],
+    };
+  };
+
+  it('omits screenshotSequence from ExecutionDump.serialize() (ref mode)', () => {
+    const serialized = new ExecutionDump(buildExecutionDumpData()).serialize();
+
+    expect(serialized).not.toContain('screenshotSequence');
+    // The early frames must not leak their base64 either.
+    expect(serialized).not.toContain('FRAME-A');
+    expect(serialized).not.toContain('FRAME-B');
+    // The representative screenshot is still serialized (as a ref).
+    expect(serialized).toContain('screenshot');
+  });
+
+  it('omits screenshotSequence from serializeWithInlineScreenshots() (inline mode)', () => {
+    const reportData: IReportActionDump = {
+      sdkVersion: '1.0.0',
+      groupName: 'frame-sequence',
+      modelBriefs: [],
+      executions: [buildExecutionDumpData()],
+    };
+    const serialized = new ReportActionDump(
+      reportData,
+    ).serializeWithInlineScreenshots();
+
+    expect(serialized).not.toContain('screenshotSequence');
+    // Inline mode would embed each frame's base64; the sequence frames must be
+    // dropped so only the representative frame is inlined.
+    expect(serialized).not.toContain('FRAME-A');
+    expect(serialized).not.toContain('FRAME-B');
+    expect(serialized).toContain('FRAME-C');
+  });
+});

--- a/packages/core/tests/unit-test/frame-sequence-recorder.test.ts
+++ b/packages/core/tests/unit-test/frame-sequence-recorder.test.ts
@@ -1,0 +1,77 @@
+import { recordAndReleaseFrameSequence } from '@/agent/tasks';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { ExecutionTask, UIContext } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+const makeUiContext = (frameCount: number): UIContext => {
+  const frames = Array.from({ length: frameCount }, (_, i) =>
+    ScreenshotItem.create(`data:image/png;base64,iVBORw0KGgo-${i}`, 1000 + i),
+  );
+  return {
+    screenshot: frames[frameCount - 1],
+    screenshotSequence: frames,
+    shotSize: { width: 100, height: 100 },
+    shrunkShotToLogicalRatio: 1,
+  } as UIContext;
+};
+
+const makeTask = (recorder?: ExecutionTask['recorder']): ExecutionTask =>
+  ({ recorder }) as ExecutionTask;
+
+describe('recordAndReleaseFrameSequence', () => {
+  it('records the earlier frames and releases the sequence from the uiContext', () => {
+    const task = makeTask();
+    const uiContext = makeUiContext(4);
+    const representative = uiContext.screenshot;
+
+    recordAndReleaseFrameSequence(task, uiContext);
+
+    // 4 frames -> 3 recorder items (the last is the representative screenshot)
+    expect(task.recorder).toHaveLength(3);
+    task.recorder?.forEach((item, i) => {
+      expect(item.type).toBe('screenshot');
+      expect(item.timing).toBe('frame-sequence');
+      expect(item.description).toBe(`Frame sequence ${i + 1}/4`);
+      expect(item.ts).toBe(1000 + i);
+    });
+
+    // the representative (last) frame must not be duplicated into the recorder
+    expect(
+      task.recorder?.some((item) => item.screenshot === representative),
+    ).toBe(false);
+
+    // the transient sequence is released so its base64 is not retained twice
+    expect(uiContext.screenshotSequence).toBeUndefined();
+  });
+
+  it('appends to an existing recorder without dropping prior items', () => {
+    const existing = {
+      type: 'screenshot' as const,
+      ts: 5,
+      screenshot: ScreenshotItem.create(
+        'data:image/png;base64,iVBORw0KGgo-x',
+        5,
+      ),
+      timing: 'after-calling',
+    };
+    const task = makeTask([existing]);
+
+    recordAndReleaseFrameSequence(task, makeUiContext(3));
+
+    expect(task.recorder?.[0]).toBe(existing);
+    expect(task.recorder).toHaveLength(1 + 2);
+  });
+
+  it('is a no-op when there is no frame sequence', () => {
+    const task = makeTask();
+    const uiContext = {
+      screenshot: ScreenshotItem.create('data:image/png;base64,iVBORw0KGgo', 1),
+      shotSize: { width: 10, height: 10 },
+      shrunkShotToLogicalRatio: 1,
+    } as UIContext;
+
+    recordAndReleaseFrameSequence(task, uiContext);
+
+    expect(task.recorder).toBeUndefined();
+  });
+});

--- a/packages/core/tests/unit-test/inspect-extract-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-frame-sequence.test.ts
@@ -1,0 +1,115 @@
+import { getModelRuntime } from '@/ai-model/models';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { UIContext } from '@/types';
+import type { IModelConfig } from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFakeContext } from '../utils';
+
+vi.mock('@/ai-model/service-caller/index', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/ai-model/service-caller/index')
+  >('@/ai-model/service-caller/index');
+  return {
+    ...actual,
+    AIResponseParseError: class AIResponseParseError extends Error {},
+    callAI: vi.fn(),
+    callAIWithObjectResponse: vi.fn(),
+    callAIWithStringResponse: vi.fn(),
+  };
+});
+
+import { callAI } from '@/ai-model/service-caller/index';
+import { AiExtractElementInfo } from '@/ai-model/workflows/inspect';
+
+describe('AiExtractElementInfo frame sequence', () => {
+  const modelConfig: IModelConfig = {
+    modelFamily: 'qwen2.5-vl',
+    modelName: 'test-model',
+    modelDescription: 'test-model-desc',
+    intent: 'insight',
+    slot: 'insight',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(callAI).mockResolvedValue({
+      content:
+        '<thought>Saw the toast.</thought><data-json>{"result":true}</data-json>',
+      usage: undefined,
+      reasoning_content: undefined,
+    } as any);
+  });
+
+  const withSequence = (frameCount: number): UIContext => {
+    const base = createFakeContext();
+    const sequence = Array.from({ length: frameCount }, () =>
+      ScreenshotItem.create(base.screenshot.base64, Date.now()),
+    );
+    return {
+      ...base,
+      screenshot: sequence[frameCount - 1],
+      screenshotSequence: sequence,
+    };
+  };
+
+  it('submits every frame plus a sequence note when more than one frame is present', async () => {
+    const context = withSequence(3);
+
+    await AiExtractElementInfo<{ result: boolean }>({
+      context,
+      dataQuery: {
+        StatementIsTruthy: 'Boolean, whether a success toast briefly appeared',
+      },
+      modelRuntime: getModelRuntime(modelConfig),
+    });
+
+    const msgs = vi.mocked(callAI).mock.calls[0]?.[0];
+    const userContent = msgs?.[1]?.content as Array<Record<string, any>>;
+
+    const imageParts = userContent.filter((p) => p.type === 'image_url');
+    expect(imageParts).toHaveLength(3);
+
+    const sequenceNote = userContent.find(
+      (p) =>
+        p.type === 'text' &&
+        typeof p.text === 'string' &&
+        p.text.includes('consecutive screenshots'),
+    );
+    expect(sequenceNote).toBeDefined();
+
+    // single-frame note must not be present in sequence mode
+    const singleNote = userContent.find(
+      (p) =>
+        p.type === 'text' &&
+        typeof p.text === 'string' &&
+        p.text.includes('This is the current screenshot to evaluate.'),
+    );
+    expect(singleNote).toBeUndefined();
+  });
+
+  it('falls back to the single-screenshot path when only one frame is present', async () => {
+    const context = withSequence(1);
+
+    await AiExtractElementInfo<{ result: boolean }>({
+      context,
+      dataQuery: {
+        StatementIsTruthy: 'Boolean, whether a success toast briefly appeared',
+      },
+      modelRuntime: getModelRuntime(modelConfig),
+    });
+
+    const msgs = vi.mocked(callAI).mock.calls[0]?.[0];
+    const userContent = msgs?.[1]?.content as Array<Record<string, any>>;
+
+    const imageParts = userContent.filter((p) => p.type === 'image_url');
+    expect(imageParts).toHaveLength(1);
+
+    const singleNote = userContent.find(
+      (p) =>
+        p.type === 'text' &&
+        typeof p.text === 'string' &&
+        p.text.includes('This is the current screenshot to evaluate.'),
+    );
+    expect(singleNote).toBeDefined();
+  });
+});

--- a/packages/core/tests/unit-test/inspect-extract-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-frame-sequence.test.ts
@@ -77,6 +77,14 @@ describe('AiExtractElementInfo frame sequence', () => {
     );
     expect(sequenceNote).toBeDefined();
 
+    // The note must establish "any frame" event semantics so a transient toast
+    // that is gone by the last frame is still judged true (not anchored to the
+    // most recent frame).
+    expect((sequenceNote as any).text).toContain('ANY of the frames');
+    expect((sequenceNote as any).text).not.toContain(
+      'the last image is the most recent state',
+    );
+
     // single-frame note must not be present in sequence mode
     const singleNote = userContent.find(
       (p) =>

--- a/packages/web-integration/tests/ai/fixtures/transient-toast.html
+++ b/packages/web-integration/tests/ai/fixtures/transient-toast.html
@@ -3,20 +3,47 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Transient Toast</title>
+    <title>Sign in</title>
     <style>
       body {
         font-family: -apple-system, Segoe UI, Roboto, sans-serif;
         margin: 0;
-        height: 100vh;
+        min-height: 100vh;
         display: flex;
         align-items: center;
         justify-content: center;
         background: #f4f4f5;
       }
-      #submit {
-        padding: 16px 36px;
+      .card {
+        width: 320px;
+        padding: 32px;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
+      }
+      .card h1 {
         font-size: 22px;
+        margin: 0 0 8px;
+      }
+      .card label {
+        display: block;
+        font-size: 13px;
+        color: #555;
+        margin: 16px 0 6px;
+      }
+      .card input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 10px 12px;
+        font-size: 15px;
+        border: 1px solid #d4d4d8;
+        border-radius: 8px;
+      }
+      #signin {
+        width: 100%;
+        margin-top: 24px;
+        padding: 12px;
+        font-size: 16px;
         border: none;
         border-radius: 8px;
         background: #2563eb;
@@ -25,14 +52,14 @@
       }
       #toast {
         position: fixed;
-        top: 48px;
+        top: 40px;
         left: 50%;
         transform: translateX(-50%);
         background: #d92d20;
         color: #fff;
-        padding: 18px 30px;
+        padding: 16px 28px;
         border-radius: 8px;
-        font-size: 24px;
+        font-size: 20px;
         font-weight: 600;
         box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
         display: none;
@@ -44,37 +71,41 @@
     </style>
   </head>
   <body>
-    <button id="submit">Submit</button>
+    <form class="card" id="login" onsubmit="return false">
+      <h1>Sign in</h1>
+      <label for="username">Username</label>
+      <input id="username" type="text" autocomplete="off" />
+      <label for="password">Password</label>
+      <input id="password" type="password" autocomplete="off" />
+      <button id="signin" type="submit">Sign in</button>
+    </form>
     <div id="toast" role="alert">Login failed: incorrect password</div>
     <script>
       (function () {
         var toast = document.getElementById('toast');
         var timers = [];
-        function clearTimers() {
-          timers.forEach(clearTimeout);
-          timers = [];
-        }
-        // Show the toast after `appearDelay` ms, then auto-hide after
-        // `visibleMs` ms. This mimics an async server response whose toast is
-        // short-lived: a screenshot taken too early (before it appears) or too
-        // late (after it hides) misses it entirely.
-        window.flashToast = function (appearDelay, visibleMs) {
-          clearTimers();
-          toast.classList.remove('show');
-          timers.push(
-            setTimeout(function () {
-              toast.classList.add('show');
-              timers.push(
-                setTimeout(function () {
-                  toast.classList.remove('show');
-                }, visibleMs),
-              );
-            }, appearDelay),
-          );
-        };
-        document.getElementById('submit').addEventListener('click', function () {
-          window.flashToast(1500, 1200);
-        });
+        // Real page behavior: clicking "Sign in" kicks off an async auth check
+        // and, ~1.5s later, shows a short-lived error toast that auto-hides
+        // after ~1.8s. A screenshot taken too early (before it appears) or too
+        // late (after it hides) misses it entirely — exactly the transient-UI
+        // problem behind issues #1653 / #2100 / #2272.
+        document
+          .getElementById('signin')
+          .addEventListener('click', function () {
+            timers.forEach(clearTimeout);
+            timers = [];
+            toast.classList.remove('show');
+            timers.push(
+              setTimeout(function () {
+                toast.classList.add('show');
+                timers.push(
+                  setTimeout(function () {
+                    toast.classList.remove('show');
+                  }, 1800),
+                );
+              }, 1500),
+            );
+          });
       })();
     </script>
   </body>

--- a/packages/web-integration/tests/ai/fixtures/transient-toast.html
+++ b/packages/web-integration/tests/ai/fixtures/transient-toast.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Transient Toast</title>
+    <style>
+      body {
+        font-family: -apple-system, Segoe UI, Roboto, sans-serif;
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f4f4f5;
+      }
+      #submit {
+        padding: 16px 36px;
+        font-size: 22px;
+        border: none;
+        border-radius: 8px;
+        background: #2563eb;
+        color: #fff;
+        cursor: pointer;
+      }
+      #toast {
+        position: fixed;
+        top: 48px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: #d92d20;
+        color: #fff;
+        padding: 18px 30px;
+        border-radius: 8px;
+        font-size: 24px;
+        font-weight: 600;
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+        display: none;
+        z-index: 9999;
+      }
+      #toast.show {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="submit">Submit</button>
+    <div id="toast" role="alert">Login failed: incorrect password</div>
+    <script>
+      (function () {
+        var toast = document.getElementById('toast');
+        var timers = [];
+        function clearTimers() {
+          timers.forEach(clearTimeout);
+          timers = [];
+        }
+        // Show the toast after `appearDelay` ms, then auto-hide after
+        // `visibleMs` ms. This mimics an async server response whose toast is
+        // short-lived: a screenshot taken too early (before it appears) or too
+        // late (after it hides) misses it entirely.
+        window.flashToast = function (appearDelay, visibleMs) {
+          clearTimers();
+          toast.classList.remove('show');
+          timers.push(
+            setTimeout(function () {
+              toast.classList.add('show');
+              timers.push(
+                setTimeout(function () {
+                  toast.classList.remove('show');
+                }, visibleMs),
+              );
+            }, appearDelay),
+          );
+        };
+        document.getElementById('submit').addEventListener('click', function () {
+          window.flashToast(1500, 1200);
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/web-integration/tests/ai/web/puppeteer/frame-sequence.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/frame-sequence.test.ts
@@ -11,19 +11,17 @@ import { launchPage } from './utils';
 const modelConfig = globalModelConfigManager.getModelConfig('default');
 const canRunAiTest = !!modelConfig.modelFamily && !!modelConfig.openaiApiKey;
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-declare global {
-  interface Window {
-    flashToast: (appearDelay: number, visibleMs: number) => void;
-  }
-}
-
 /**
- * Reproduces issues #1653 / #2100 / #2272: a short-lived toast appears after an
- * action and auto-hides. A single screenshot easily misses it, while the
- * `frameSequence` switch captures several frames over a time window so the
- * model can observe the transient toast.
+ * Real-world reproduction of issues #1653 / #2100 / #2272.
+ *
+ * A user signs in and the page shows a short-lived "Login failed" toast that
+ * appears ~1.5s after the click and auto-hides ~1.8s later. The whole flow is
+ * driven by real agent actions (aiTap / aiInput / aiBoolean) against the page's
+ * natural behavior:
+ *  - a single screenshot, captured right after the click (before the toast
+ *    appears), misses it;
+ *  - the `frameSequence` switch captures several frames across the window, so
+ *    the model observes the transient toast.
  */
 describe(
   'puppeteer integration - frameSequence (transient toast)',
@@ -31,7 +29,7 @@ describe(
     const ctx = createTestContext();
 
     it.skipIf(!canRunAiTest)(
-      'observes a transient toast that a single screenshot misses',
+      'observes a transient login-failed toast triggered by a real click',
       async () => {
         const htmlPath = getFixturePath('transient-toast.html');
         const { originPage, reset } = await launchPage(`file://${htmlPath}`, {
@@ -43,25 +41,25 @@ describe(
         ctx.resetFn = reset;
         ctx.agent = new PuppeteerAgent(originPage);
 
+        // Real form interaction.
+        await ctx.agent.aiInput('the username field', { value: 'test-user' });
+        await ctx.agent.aiInput('the password field', { value: 'wrong-pass' });
+
         // --- Control: single screenshot (switch OFF) ---
-        // Trigger the toast: it appears ~1.5s later and stays for ~1.2s. The
-        // default single-frame capture happens immediately (well before the
-        // toast appears), so the model should not see any toast right now.
-        await originPage.evaluate(() => window.flashToast(1500, 1200));
+        // Click "Sign in". The page reveals the error toast ~1.5s later. The
+        // default single-frame check captures right after the click, before the
+        // toast appears, so the model does not see it.
+        await ctx.agent.aiTap('the Sign in button');
         const seenWithSingleFrame = await ctx.agent.aiBoolean(
-          'an error toast or notification message is visible on the page right now',
+          'an error toast or "login failed" message is visible on the page right now',
         );
 
-        // Let the toast fully disappear before the next round.
-        await sleep(3000);
-
         // --- Frame sequence: switch ON ---
-        // Trigger the same toast and capture 7 frames at 500ms intervals
-        // (~3s window). Some frames fall inside the toast's visible window, so
-        // the model can observe it.
-        await originPage.evaluate(() => window.flashToast(1500, 1200));
+        // Click "Sign in" again to trigger a fresh toast and observe a sequence
+        // of frames across the toast's visible window (7 frames at 500ms).
+        await ctx.agent.aiTap('the Sign in button');
         const seenWithFrameSequence = await ctx.agent.aiBoolean(
-          'an error toast or notification message appears in any of these frames',
+          'a "login failed" error toast appears in any of these frames',
           { frameSequence: { count: 7, intervalMs: 500 } },
         );
 

--- a/packages/web-integration/tests/ai/web/puppeteer/frame-sequence.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/frame-sequence.test.ts
@@ -1,0 +1,77 @@
+import { PuppeteerAgent } from '@/puppeteer';
+import { globalModelConfigManager } from '@midscene/shared/env';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_TEST_TIMEOUT,
+  createTestContext,
+  getFixturePath,
+} from './test-utils';
+import { launchPage } from './utils';
+
+const modelConfig = globalModelConfigManager.getModelConfig('default');
+const canRunAiTest = !!modelConfig.modelFamily && !!modelConfig.openaiApiKey;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+declare global {
+  interface Window {
+    flashToast: (appearDelay: number, visibleMs: number) => void;
+  }
+}
+
+/**
+ * Reproduces issues #1653 / #2100 / #2272: a short-lived toast appears after an
+ * action and auto-hides. A single screenshot easily misses it, while the
+ * `frameSequence` switch captures several frames over a time window so the
+ * model can observe the transient toast.
+ */
+describe(
+  'puppeteer integration - frameSequence (transient toast)',
+  () => {
+    const ctx = createTestContext();
+
+    it.skipIf(!canRunAiTest)(
+      'observes a transient toast that a single screenshot misses',
+      async () => {
+        const htmlPath = getFixturePath('transient-toast.html');
+        const { originPage, reset } = await launchPage(`file://${htmlPath}`, {
+          viewport: {
+            width: 1280,
+            height: 720,
+          },
+        });
+        ctx.resetFn = reset;
+        ctx.agent = new PuppeteerAgent(originPage);
+
+        // --- Control: single screenshot (switch OFF) ---
+        // Trigger the toast: it appears ~1.5s later and stays for ~1.2s. The
+        // default single-frame capture happens immediately (well before the
+        // toast appears), so the model should not see any toast right now.
+        await originPage.evaluate(() => window.flashToast(1500, 1200));
+        const seenWithSingleFrame = await ctx.agent.aiBoolean(
+          'an error toast or notification message is visible on the page right now',
+        );
+
+        // Let the toast fully disappear before the next round.
+        await sleep(3000);
+
+        // --- Frame sequence: switch ON ---
+        // Trigger the same toast and capture 7 frames at 500ms intervals
+        // (~3s window). Some frames fall inside the toast's visible window, so
+        // the model can observe it.
+        await originPage.evaluate(() => window.flashToast(1500, 1200));
+        const seenWithFrameSequence = await ctx.agent.aiBoolean(
+          'an error toast or notification message appears in any of these frames',
+          { frameSequence: { count: 7, intervalMs: 500 } },
+        );
+
+        // The switch lets the model catch the transient toast...
+        expect(seenWithFrameSequence).toBe(true);
+        // ...whereas a single screenshot taken before it appears misses it.
+        expect(seenWithSingleFrame).toBe(false);
+      },
+      DEFAULT_TEST_TIMEOUT,
+    );
+  },
+  DEFAULT_TEST_TIMEOUT,
+);


### PR DESCRIPTION
## Background

Midscene perceives the UI from a **single static screenshot** taken at one moment. Any UI that is **transient / time-sensitive** — it appears, changes, or disappears between capture and the model call — cannot be reliably observed. This is the shared root cause behind several reports:

- #962 — [Feature] aiAssert should support dynamic scenarios (animations etc.) by sampling several screenshots over a `duration`/`frameRate` — this PR implements exactly that as the `frameSequence` option
- #1653 — toast disappears before the next screenshot reaches the model
- #1728 — carousel banner rotates before the click lands
- #2100 — H5 (non-native) toast on Android not detected
- #2272 — auto-hiding video controls (gone after ~5s)

Tracked in #2712.

## What this PR does

Adds an **opt-in** `frameSequence` switch to the extract/assert APIs. When enabled, a short sequence of frames is captured over a time window and **all frames are submitted to the model together**, so it can observe the transition instead of a single moment. **Off by default**; costs more tokens.

Applies to `aiAssert`, `aiQuery`, `aiBoolean`, `aiNumber`, `aiString` (and `aiAsk`). YAML `aiAssert` / `aiWaitFor` inherit it via `ServiceExtractOption`.

```ts
// default: single screenshot, behavior unchanged
await agent.aiAssert('a success toast appeared after submit');

// switch on: capture 4 frames @ 1s by default
await agent.aiAssert('a success toast appeared after submit', undefined, {
  frameSequence: true,
});

// tune count (clamped 2-8) and interval
await agent.aiBoolean('an error toast briefly flashed', {
  frameSequence: { count: 6, intervalMs: 500 },
});
```

## Design

- **types**: optional `screenshotSequence` on `UIContext`; `frameSequence?: boolean | { count?; intervalMs? }` on `ServiceExtractOption` (defaults: 4 frames @ 1000ms, `count` clamped to 2–8).
- **agent**: capture the sequence up front via the existing `getUIContext` pipeline (so shrink factor / sizing stay consistent) and pass it down as the UIContext. Skips when the context is frozen or `screenshotIncluded: false`.
- **inspect**: when more than one frame is present, submit every frame with a note that they are consecutive screenshots; single-frame path is unchanged.
- **dump**: `screenshotSequence` is dropped from report serialization (both inline and directory modes) to avoid dangling screenshot refs and base64 bloat. The representative (last) frame is still shown.

## Tests

- `packages/core/tests/unit-test/agent-frame-sequence.test.ts` — switch off by default, capture happens when on, count clamping, skip when screenshots disabled.
- `packages/core/tests/unit-test/inspect-extract-frame-sequence.test.ts` — multi-frame submits every frame + sequence note; single-frame falls back to the original path.
- `packages/web-integration/tests/ai/web/puppeteer/frame-sequence.test.ts` (+ `fixtures/transient-toast.html`) — AI e2e reproducing a transient toast that a single screenshot misses but `frameSequence` catches. Verified against a real model (2/2 passes).

## Validation

- `pnpm run lint` — clean
- `npx tsc --noEmit` for `@midscene/core` and `@midscene/web` — clean
- `npx nx build core` — passes
- `npx nx test core` (unit) — new + existing suites pass (3 pre-existing report-merge perf failures are unrelated, confirmed failing on clean `main`)
- `AI_TEST_TYPE=web` puppeteer AI test — 2/2 passes against a real model

## Docs

`apps/site/docs/{en,zh}/api.mdx` — `frameSequence` documented under every extract/assert API (bilingual).
