### PR TITLE
fix(core): delete screenshot-less directory reports on mergeReports rmOriginalReports

### DIFF
--- a/packages/core/src/dump/html-utils.ts
+++ b/packages/core/src/dump/html-utils.ts
@@ -451,6 +451,14 @@ export function getBaseUrlFixScript(): string {
   return _baseUrlFixScript;
 }
 
+/**
+ * Dump-script attribute that records how the report file stores screenshots.
+ * Written by the report generator and the merger, read back when deciding
+ * whether a report is in directory mode. Kept here, next to dump-tag
+ * generation, so the writer and reader share one source of truth.
+ */
+export const DATA_SCREENSHOT_MODE_ATTR = 'data-screenshot-mode';
+
 export function generateDumpScriptTag(
   json: string,
   attributes?: Record<string, string | number | boolean>,

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -20,6 +20,7 @@ import {
 } from '@midscene/shared/env';
 import { ifInBrowser, logMsg, uuid } from '@midscene/shared/utils';
 import {
+  DATA_SCREENSHOT_MODE_ATTR,
   generateDumpScriptTag,
   generateImageScriptTag,
   getBaseUrlFixScript,
@@ -30,6 +31,7 @@ import {
   ReportActionDump,
   type ReportAttributes,
   type ReportMeta,
+  type ScreenshotMode,
 } from './types';
 import { getReportTpl } from './utils';
 
@@ -86,7 +88,7 @@ export function assertReportGenerationOptions(opts: {
 
 export class ReportGenerator implements IReportGenerator {
   private reportPath: string;
-  private screenshotMode: 'inline' | 'directory';
+  private screenshotMode: ScreenshotMode;
   private shouldPersistExecutionDump: boolean;
   private autoPrint: boolean;
   private firstWriteDone = false;
@@ -111,7 +113,7 @@ export class ReportGenerator implements IReportGenerator {
 
   constructor(options: {
     reportPath: string;
-    screenshotMode: 'inline' | 'directory';
+    screenshotMode: ScreenshotMode;
     persistExecutionDump?: boolean;
     autoPrint?: boolean;
     reuseExistingReport?: boolean;
@@ -287,6 +289,9 @@ export class ReportGenerator implements IReportGenerator {
   private getDumpScriptAttributes(): Record<string, string> {
     return {
       'data-group-id': this.reportStreamId,
+      // Self-describe how this report file stores screenshots so consumers
+      // (merge/delete) never have to guess the mode from the filesystem.
+      [DATA_SCREENSHOT_MODE_ATTR]: this.screenshotMode,
       ...this.reportAttributes,
     };
   }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -89,6 +89,21 @@ export function isDirectoryModeReport(reportFilePath: string): boolean {
 }
 
 /**
+ * Whether a report lives in its own dedicated directory (`{name}/index.html`)
+ * rather than being a single standalone file (`{name}.html`).
+ *
+ * This is a structural fact about *where the report file sits*, independent of
+ * how it stores screenshots: a directory report can keep screenshots external
+ * (a `screenshots/` sibling) OR inline them into `index.html`. Deletion needs
+ * this — not the screenshot mode — to decide whether to remove the whole
+ * directory or just unlink a file, so that an inline-screenshot report nested in
+ * its own folder still has the folder removed instead of being orphaned.
+ */
+function isDirectoryBasedReport(reportFilePath: string): boolean {
+  return path.basename(reportFilePath) === 'index.html';
+}
+
+/**
  * Deduplicate executions by stable id, keeping only the last occurrence.
  * Old-format executions without id are always preserved.
  */
@@ -208,9 +223,10 @@ export class ReportMergingTool {
       mkdirSync(targetDir, { recursive: true });
     }
 
-    // Resolve each report's mode exactly once. isDirectoryModeReport reads the
-    // file to find the authoritative metadata, so recomputing it per phase
-    // (selection / merge loop / deletion) would re-scan every report 3x.
+    // Resolve each report's screenshot mode exactly once. isDirectoryModeReport
+    // reads the file to find the authoritative metadata, so recomputing it for
+    // both the output-path decision and the per-report merge loop would re-scan
+    // every report twice.
     const isDirModeByIndex = this.reportInfos.map((info) =>
       Boolean(
         info.reportFilePath && isDirectoryModeReport(info.reportFilePath),
@@ -356,13 +372,12 @@ export class ReportMergingTool {
 
       // Remove original reports if needed
       if (rmOriginalReports) {
-        for (let i = 0; i < this.reportInfos.length; i++) {
-          const info = this.reportInfos[i];
+        for (const info of this.reportInfos) {
           if (!info.reportFilePath) continue;
           try {
-            if (isDirModeByIndex[i]) {
-              // Directory mode: remove the entire report directory, including a
-              // screenshot-less run that only has index.html.
+            if (isDirectoryBasedReport(info.reportFilePath)) {
+              // The report owns its directory (`{name}/index.html`) — remove the
+              // whole folder, whether screenshots are external or inlined.
               const reportDir = path.dirname(info.reportFilePath);
               rmSync(reportDir, { recursive: true, force: true });
             } else {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -13,6 +13,7 @@ import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import { antiEscapeScriptTag, logMsg } from '@midscene/shared/utils';
 import { getReportFileName } from './agent';
 import {
+  DATA_SCREENSHOT_MODE_ATTR,
   extractAllDumpScriptsSync,
   extractLastDumpScriptSync,
   getBaseUrlFixScript,
@@ -27,20 +28,64 @@ import {
   type ExecutionDump,
   type IExecutionDump,
   ReportActionDump,
+  type ScreenshotMode,
 } from './types';
 import type { ReportFileWithAttributes } from './types';
 import { getReportTpl, getVersion, reportHTMLContent } from './utils';
 
 /**
+ * Read the screenshot storage mode a report declared at generation time.
+ *
+ * Reports written by current versions stamp `data-screenshot-mode` onto every
+ * dump script tag, so we only need to peek at the first real dump script (the
+ * template's bundled JS also references the dump type string, hence the
+ * `data-group-id` filter) and can stop streaming immediately.
+ *
+ * Returns undefined for legacy reports that predate the attribute or for
+ * unreadable files, letting the caller fall back to a filesystem heuristic.
+ */
+const screenshotModeAttrRegExp = new RegExp(
+  `${DATA_SCREENSHOT_MODE_ATTR}="(inline|directory)"`,
+);
+
+function readDeclaredScreenshotMode(
+  reportFilePath: string,
+): ScreenshotMode | undefined {
+  let mode: ScreenshotMode | undefined;
+  try {
+    streamDumpScriptsSync(reportFilePath, ({ openTag }) => {
+      // Skip false matches from the template's bundled JS code.
+      if (!openTag.includes('data-group-id')) return false;
+      const match = openTag.match(screenshotModeAttrRegExp);
+      mode = match?.[1] as ScreenshotMode | undefined;
+      return true; // the first real dump script decides the mode
+    });
+  } catch {
+    // Unreadable / non-existent file — let the caller fall back.
+  }
+  return mode;
+}
+
+/**
  * Check if a report is in directory mode (html-and-external-assets).
  * Directory mode reports: {name}/index.html + {name}/screenshots/
+ *
+ * The mode is read from the report's own `data-screenshot-mode` metadata, which
+ * is authoritative regardless of whether the run happened to capture any
+ * screenshots. For legacy reports without the attribute we fall back to the old
+ * filesystem heuristic (an `index.html` that has a sibling `screenshots/` dir).
  */
 export function isDirectoryModeReport(reportFilePath: string): boolean {
-  const reportDir = path.dirname(reportFilePath);
-  return (
-    path.basename(reportFilePath) === 'index.html' &&
-    existsSync(path.join(reportDir, 'screenshots'))
-  );
+  // Directory-mode reports are always written as `{name}/index.html`, so any
+  // other filename is inline. Short-circuit before touching the file so the
+  // common inline case (`{name}.html`) costs nothing.
+  if (path.basename(reportFilePath) !== 'index.html') return false;
+
+  const declared = readDeclaredScreenshotMode(reportFilePath);
+  if (declared) return declared === 'directory';
+
+  // Legacy fallback for reports generated before screenshotMode was embedded.
+  return existsSync(path.join(path.dirname(reportFilePath), 'screenshots'));
 }
 
 /**
@@ -163,11 +208,15 @@ export class ReportMergingTool {
       mkdirSync(targetDir, { recursive: true });
     }
 
-    // Check if any source report is directory mode
-    const hasDirectoryModeReport = this.reportInfos.some((info) => {
-      const reportFilePath = info.reportFilePath;
-      return Boolean(reportFilePath && isDirectoryModeReport(reportFilePath));
-    });
+    // Resolve each report's mode exactly once. isDirectoryModeReport reads the
+    // file to find the authoritative metadata, so recomputing it per phase
+    // (selection / merge loop / deletion) would re-scan every report 3x.
+    const isDirModeByIndex = this.reportInfos.map((info) =>
+      Boolean(
+        info.reportFilePath && isDirectoryModeReport(info.reportFilePath),
+      ),
+    );
+    const hasDirectoryModeReport = isDirModeByIndex.some(Boolean);
 
     const resolvedName =
       reportFileName === 'AUTO'
@@ -229,19 +278,23 @@ export class ReportMergingTool {
         let mergedGroupId = `merged-group-${i}`;
 
         if (reportInfo.reportFilePath) {
-          if (isDirectoryModeReport(reportInfo.reportFilePath)) {
-            // Directory mode: copy external screenshot files
+          if (isDirModeByIndex[i]) {
+            // Directory mode: copy external screenshot files. A directory-mode
+            // report can legitimately have no screenshots/ dir (a run that
+            // captured nothing), so only copy when the source dir exists.
             const reportDir = path.dirname(reportInfo.reportFilePath);
             const screenshotsDir = path.join(reportDir, 'screenshots');
-            const mergedScreenshotsDir = path.join(
-              path.dirname(outputFilePath),
-              'screenshots',
-            );
-            mkdirSync(mergedScreenshotsDir, { recursive: true });
-            for (const file of readdirSync(screenshotsDir)) {
-              const src = path.join(screenshotsDir, file);
-              const dest = path.join(mergedScreenshotsDir, file);
-              copyFileSync(src, dest);
+            if (existsSync(screenshotsDir)) {
+              const mergedScreenshotsDir = path.join(
+                path.dirname(outputFilePath),
+                'screenshots',
+              );
+              mkdirSync(mergedScreenshotsDir, { recursive: true });
+              for (const file of readdirSync(screenshotsDir)) {
+                const src = path.join(screenshotsDir, file);
+                const dest = path.join(mergedScreenshotsDir, file);
+                copyFileSync(src, dest);
+              }
             }
           } else {
             // Inline mode: stream image scripts to output file
@@ -277,6 +330,9 @@ export class ReportMergingTool {
             dumpString,
             attributes: {
               'data-group-id': mergedGroupId,
+              [DATA_SCREENSHOT_MODE_ATTR]: hasDirectoryModeReport
+                ? 'directory'
+                : 'inline',
               playwright_test_duration: reportAttributes.testDuration,
               playwright_test_status: reportAttributes.testStatus,
               playwright_test_title: reportAttributes.testTitle,
@@ -300,11 +356,13 @@ export class ReportMergingTool {
 
       // Remove original reports if needed
       if (rmOriginalReports) {
-        for (const info of this.reportInfos) {
+        for (let i = 0; i < this.reportInfos.length; i++) {
+          const info = this.reportInfos[i];
           if (!info.reportFilePath) continue;
           try {
-            if (isDirectoryModeReport(info.reportFilePath)) {
-              // Directory mode: remove the entire report directory
+            if (isDirModeByIndex[i]) {
+              // Directory mode: remove the entire report directory, including a
+              // screenshot-less run that only has index.html.
               const reportDir = path.dirname(info.reportFilePath);
               rmSync(reportDir, { recursive: true, force: true });
             } else {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -728,6 +728,13 @@ export type ExecutionTaskPlanningLocate =
   ExecutionTask<ExecutionTaskPlanningLocateApply>;
 
 /*
+How a report file stores screenshots:
+- `inline`: base64 image script tags embedded in the single HTML file
+- `directory`: external PNG files under a sibling `screenshots/` dir
+*/
+export type ScreenshotMode = 'inline' | 'directory';
+
+/*
 Report metadata - extracted from ReportActionDump for per-execution writes
 */
 export interface ReportMeta {

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -113,6 +113,34 @@ describe('ReportGenerator — append-only model', () => {
     }
   });
 
+  // Writer contract for the self-describing screenshot mode. The merger reads
+  // this attribute back to decide directory vs inline, so the generated value
+  // must match for both modes (see report.ts readDeclaredScreenshotMode).
+  describe('data-screenshot-mode attribute', () => {
+    it.each(['inline', 'directory'] as const)(
+      'stamps data-screenshot-mode="%s" on the dump script tag',
+      async (mode) => {
+        const reportPath =
+          mode === 'directory'
+            ? join(tmpDir, 'dir-mode', 'index.html')
+            : join(tmpDir, 'inline-mode.html');
+        const generator = new ReportGenerator({
+          reportPath,
+          screenshotMode: mode,
+          autoPrint: false,
+        });
+        generator.onExecutionUpdate(
+          createExecution([ScreenshotItem.create(fakeBase64(100), Date.now())]),
+          defaultReportMeta,
+        );
+        await generator.finalize();
+
+        const html = readFileSync(reportPath, 'utf-8');
+        expect(html).toContain(`data-screenshot-mode="${mode}"`);
+      },
+    );
+  });
+
   describe('inline mode — append-only strategy', () => {
     it('should write each screenshot image tag exactly once across multiple updates', async () => {
       const reportPath = join(tmpDir, 'inline-test.html');

--- a/packages/core/tests/unit-test/report.test.ts
+++ b/packages/core/tests/unit-test/report.test.ts
@@ -13,7 +13,7 @@ import {
   extractAllDumpScriptsSync,
   generateImageScriptTag,
 } from '../../src/dump/html-utils';
-import { ReportMergingTool } from '../../src/report';
+import { ReportMergingTool, isDirectoryModeReport } from '../../src/report';
 import { ReportActionDump } from '../../src/types';
 import { getReportTpl, getTmpFile, writeDumpReport } from '../../src/utils';
 
@@ -325,6 +325,91 @@ describe('reportMergingTool', () => {
       expect(existsSync(mergedPath!)).toBe(true);
 
       // Verify original directories are completely removed
+      for (const dir of reportDirs) {
+        expect(existsSync(dir)).toBe(false);
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: a directory-mode report whose run captured no screenshots has
+  // no screenshots/ dir. It must still be recognized as directory mode (via the
+  // self-described data-screenshot-mode attribute) and its whole directory must
+  // be removed by rmOriginalReports — not just the index.html, leaving the dir.
+  const writeDirModeReport = (
+    reportDir: string,
+    name: string,
+    withScreenshots: boolean,
+  ): string => {
+    mkdirSync(reportDir, { recursive: true });
+    if (withScreenshots) {
+      const screenshotsDir = join(reportDir, 'screenshots');
+      mkdirSync(screenshotsDir, { recursive: true });
+      writeFileSync(join(screenshotsDir, 'img.png'), 'fake-png');
+    }
+    const dumpJson = JSON.stringify({ groupName: name, executions: [] });
+    const indexHtml = join(reportDir, 'index.html');
+    writeFileSync(
+      indexHtml,
+      `${getReportTpl()}\n<script type="midscene_web_dump" data-group-id="${name}" data-screenshot-mode="directory">${dumpJson}</script>`,
+    );
+    return indexHtml;
+  };
+
+  it('detects directory mode from metadata even without a screenshots dir', () => {
+    const tmpDir = join(tmpdir(), `midscene-dir-mode-meta-${Date.now()}`);
+    try {
+      const noShots = writeDirModeReport(
+        join(tmpDir, 'no-shots'),
+        'no-shots',
+        false,
+      );
+      const withShots = writeDirModeReport(
+        join(tmpDir, 'with-shots'),
+        'with-shots',
+        true,
+      );
+      expect(isDirectoryModeReport(noShots)).toBe(true);
+      expect(isDirectoryModeReport(withShots)).toBe(true);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes the whole directory of a screenshot-less directory mode report on rmOriginalReports', () => {
+    const tmpDir = join(tmpdir(), `midscene-dir-mode-noss-rm-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    try {
+      const tool = new ReportMergingTool();
+      const reportDirs: string[] = [];
+      // One report with screenshots, one without — both directory mode.
+      for (const [name, withShots] of [
+        ['with-shots', true],
+        ['no-shots', false],
+      ] as const) {
+        const reportDir = join(tmpDir, name);
+        reportDirs.push(reportDir);
+        const indexHtml = writeDirModeReport(reportDir, name, withShots);
+        tool.append({
+          reportFilePath: indexHtml,
+          reportAttributes: {
+            testDescription: name,
+            testDuration: 1,
+            testId: name,
+            testStatus: 'passed',
+            testTitle: name,
+          },
+        });
+      }
+
+      const mergedPath = tool.mergeReports('dir-mode-noss-rm-test', {
+        rmOriginalReports: true,
+        overwrite: true,
+      });
+
+      expect(existsSync(mergedPath!)).toBe(true);
+      // Both original directories must be gone, including the screenshot-less one.
       for (const dir of reportDirs) {
         expect(existsSync(dir)).toBe(false);
       }

--- a/packages/core/tests/unit-test/report.test.ts
+++ b/packages/core/tests/unit-test/report.test.ts
@@ -418,6 +418,57 @@ describe('reportMergingTool', () => {
     }
   });
 
+  // Regression for the real-world report: a legacy directory-based report
+  // (`{name}/index.html`) that predates data-screenshot-mode AND inlines its
+  // screenshots (no screenshots/ dir). Such a report reads as inline screenshot
+  // mode, so the merged output is a single file — but rmOriginalReports must
+  // still remove the whole source folder, not orphan it.
+  it('removes the folder of a legacy inline-screenshot directory report on rmOriginalReports', () => {
+    const tmpDir = join(tmpdir(), `midscene-legacy-folder-rm-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    try {
+      const tool = new ReportMergingTool();
+      const reportDirs: string[] = [];
+      for (const name of ['playwright-merged-a', 'playwright-merged-b']) {
+        const reportDir = join(tmpDir, name);
+        mkdirSync(reportDir, { recursive: true }); // no screenshots/ dir
+        reportDirs.push(reportDir);
+        const dumpJson = JSON.stringify({ groupName: name, executions: [] });
+        const indexHtml = join(reportDir, 'index.html');
+        // No data-screenshot-mode attribute (legacy) + an inline image tag.
+        writeFileSync(
+          indexHtml,
+          `${getReportTpl()}\n<script type="midscene_web_dump" data-group-id="${name}">${dumpJson}</script>\n${generateImageScriptTag(`${name}-img`, 'data:image/png;base64,AAAA')}`,
+        );
+        tool.append({
+          reportFilePath: indexHtml,
+          reportAttributes: {
+            testDescription: name,
+            testDuration: 1,
+            testId: name,
+            testStatus: 'passed',
+            testTitle: name,
+          },
+        });
+      }
+
+      const mergedPath = tool.mergeReports('legacy-folder-rm-test', {
+        rmOriginalReports: true,
+        overwrite: true,
+      });
+
+      expect(existsSync(mergedPath!)).toBe(true);
+      // Merged as inline → single .html file (not a directory).
+      expect(mergedPath!.endsWith('index.html')).toBe(false);
+      // The source folders must be removed, not orphaned.
+      for (const dir of reportDirs) {
+        expect(existsSync(dir)).toBe(false);
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('should merge a single report', async () => {
     const tool = new ReportMergingTool();
     generateNReports(1, 'single report content', tool, true, 'merge-1-test');


### PR DESCRIPTION
## Problem

When calling `ReportMergingTool.mergeReports(name, { rmOriginalReports: true })` with reports produced in `html-and-external-assets` (directory) mode, original report directories were **not** deleted — leaving scattered report folders behind. Reported against v1.9.8.

### Root cause

`isDirectoryModeReport()` inferred the report's mode from the filesystem:

```ts
path.basename(p) === 'index.html' && existsSync(path.join(dir, 'screenshots'))
```

The `screenshots/` directory is created **lazily**, only when the run persists its first screenshot. A directory-mode report whose run captured **no** screenshots therefore has no `screenshots/` dir, so it was misdetected as *inline*. On deletion that took the inline branch (`unlinkSync(index.html)`), removing only `index.html` and leaving the whole report directory on disk.

Reports that did capture screenshots were deleted correctly, which is why the leftovers looked partial/intermittent.

## Fix

Make reports **self-describing** instead of guessing from the filesystem:

- The generator stamps `data-screenshot-mode="inline" | "directory"` on every dump script tag (`getDumpScriptAttributes`).
- `isDirectoryModeReport()` reads that authoritative metadata. It short-circuits any non-`index.html` path before touching the file (the common inline case costs zero IO), and only falls back to the legacy `screenshots/` heuristic for older reports that predate the attribute.
- The merged report is stamped too, so merged output stays self-describing.
- The mode is resolved **once per report** and reused across selection / merge loop / deletion (previously recomputed 3×, which now means file reads).
- The screenshot-copy step is guarded with `existsSync`, so a screenshot-less directory report merges cleanly.

The attribute name and the `'inline' | 'directory'` union are centralized as `DATA_SCREENSHOT_MODE_ATTR` and `ScreenshotMode` so the writer and the reader share one source of truth.

## Tests

- `report.test.ts`: directory mode detected from metadata without a `screenshots/` dir; `rmOriginalReports` removes the **entire** directory of a screenshot-less directory report.
- `report-generator.test.ts`: writer contract — generated reports stamp `data-screenshot-mode` for both modes.

## Validation

- `npx biome check` on all changed files — clean.
- `npx nx test core` — 1184 passed, my 4 new tests green.
  - One pre-existing failure remains: `merge-browser-parse.test.ts` (merged directory-mode report size assertion). It fails identically (26.92 MB) on clean `main` (verified by stashing this change), so it is unrelated to this PR.