### PR TITLE
feat(ios): source frameSequence frames from WDA MJPEG stream

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -459,6 +459,46 @@ export class Agent<
     const { count, intervalMs } =
       this.normalizeFrameSequenceOption(frameSequence);
 
+    // Fast path: devices with a continuous frame stream (e.g. iOS WDA MJPEG)
+    // sample recent frames far faster than repeated screenshotBase64() calls.
+    // We pull the earlier frames from the stream and capture the representative
+    // (last) frame with a normal full-quality screenshot.
+    const fastCapture = this.interface.captureFrameSequence?.bind(
+      this.interface,
+    );
+    if (fastCapture) {
+      try {
+        const earlier = await fastCapture({
+          count: count - 1,
+          intervalMs,
+          abortSignal,
+        });
+        abortSignal?.throwIfAborted();
+        const representative = await this.getUIContext('assert');
+        const frames = [
+          ...earlier.map((frame) =>
+            ScreenshotItem.create(frame.base64, frame.capturedAt),
+          ),
+          representative.screenshot,
+        ];
+        if (frames.length > 1) {
+          return {
+            ...representative,
+            screenshotSequence: frames,
+          };
+        }
+        // Stream yielded no earlier frames; fall through to sequential capture.
+      } catch (error) {
+        if (abortSignal?.aborted) {
+          throw error;
+        }
+        debug(
+          'frame sequence fast path failed, falling back to sequential capture: %s',
+          error,
+        );
+      }
+    }
+
     const frames: ScreenshotItem[] = [];
     let lastContext: UIContext | undefined;
     for (let i = 0; i < count; i++) {

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -141,6 +141,17 @@ export type IOSDeviceOpt = {
   useWDA?: boolean;
   /** WDA MJPEG server port for real-time screen streaming (default: 9100) */
   wdaMjpegPort?: number;
+  /**
+   * Use WDA's MJPEG stream as a fast frame source for `frameSequence` capture.
+   * Disabled by default (opt-in), mirroring Android scrcpy. When disabled,
+   * `frameSequence` falls back to sequential `screenshotBase64()` capture.
+   *
+   * For multi-device concurrency, set a distinct `wdaMjpegPort` per device
+   * (just like `wdaPort`) so each device streams from its own port.
+   */
+  wdaMjpegFrameSource?: {
+    enabled?: boolean;
+  };
 } & IOSDeviceInputOpt;
 
 /**

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -181,6 +181,23 @@ export abstract class AbstractInterface {
   mjpegStreamUrl?: string;
 
   /**
+   * Optional fast multi-frame capture for transient-UI observation
+   * (`frameSequence`). Devices that maintain a continuous frame stream — e.g.
+   * iOS sampling WDA's MJPEG server — implement this to sample recent frames far
+   * faster than repeated `screenshotBase64()` calls, so short-lived UI (toasts,
+   * carousels) is not missed.
+   *
+   * Returns frames in temporal order (earliest first). Each `base64` is a full
+   * `data:image/...;base64,` data URL. May return fewer frames than requested
+   * (e.g. the stream is not ready yet); callers should degrade gracefully.
+   */
+  captureFrameSequence?(opt: {
+    count: number;
+    intervalMs: number;
+    abortSignal?: AbortSignal;
+  }): Promise<Array<{ base64: string; capturedAt: number }>>;
+
+  /**
    * Optional in-process MJPEG frame producer. Implementations can push raw
    * base64 frames here when there is no standalone native MJPEG URL, e.g.
    * Chromium CDP Page.startScreencast for web previews.

--- a/packages/core/tests/unit-test/agent-frame-sequence.test.ts
+++ b/packages/core/tests/unit-test/agent-frame-sequence.test.ts
@@ -15,7 +15,9 @@ const fakeContext = (tag: string): UIContext =>
     shrunkShotToLogicalRatio: 1,
   }) as UIContext;
 
-const createAgentStub = () => {
+const createAgentStub = (
+  opts: { captureFrameSequence?: (...args: any[]) => any } = {},
+) => {
   const agent = Object.create(Agent.prototype) as Agent<any>;
   const createTypeQueryExecution = vi.fn(async () => ({
     output: true,
@@ -24,6 +26,10 @@ const createAgentStub = () => {
   (agent as any).opts = {};
   (agent as any).taskExecutor = { createTypeQueryExecution };
   (agent as any).resolveModelRuntime = vi.fn(() => defaultModel);
+  // The interface is consulted for an optional fast frame-sequence source.
+  (agent as any).interface = opts.captureFrameSequence
+    ? { captureFrameSequence: opts.captureFrameSequence }
+    : {};
 
   let counter = 0;
   const getUIContext = vi.fn(async () => fakeContext(`frame-${counter++}`));
@@ -122,5 +128,43 @@ describe('Agent frame sequence switch', () => {
 
     // Should bail out long before capturing all 6 frames.
     expect(getUIContext.mock.calls.length).toBeLessThan(6);
+  });
+
+  it('uses the device fast frame source when available', async () => {
+    const captureFrameSequence = vi.fn(async ({ count }: { count: number }) =>
+      Array.from({ length: count }, (_, i) => ({
+        base64: `data:image/jpeg;base64,stream-${i}`,
+        capturedAt: 1000 + i,
+      })),
+    );
+    const { agent, getUIContext } = createAgentStub({ captureFrameSequence });
+
+    await agent.aiAssert('a toast appeared', undefined, {
+      keepRawResponse: true,
+      frameSequence: { count: 5, intervalMs: 100 },
+    });
+
+    // Earlier frames come from the stream (count - 1)...
+    expect(captureFrameSequence).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 4, intervalMs: 100 }),
+    );
+    // ...and exactly one representative is captured via the normal screenshot.
+    expect(getUIContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to sequential capture when the fast source fails', async () => {
+    const captureFrameSequence = vi.fn(async () => {
+      throw new Error('stream unavailable');
+    });
+    const { agent, getUIContext } = createAgentStub({ captureFrameSequence });
+
+    await agent.aiAssert('a toast appeared', undefined, {
+      keepRawResponse: true,
+      frameSequence: { count: 4, intervalMs: 0 },
+    });
+
+    expect(captureFrameSequence).toHaveBeenCalledTimes(1);
+    // Fallback path captures all 4 frames sequentially via screenshots.
+    expect(getUIContext).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/ios/src/agent-tools.ts
+++ b/packages/ios/src/agent-tools.ts
@@ -38,13 +38,25 @@ const iosInitArgShape = {
     .number()
     .optional()
     .describe('WebDriverAgent MJPEG streaming port'),
+  wdaMjpegFrameSource: z
+    .object({ enabled: z.boolean().optional() })
+    .optional()
+    .describe(
+      'Opt-in: use the WDA MJPEG stream as a fast frameSequence frame source (default off)',
+    ),
   ...agentBehaviorInitArgShape,
 };
 
 type IOSInitArgs = AgentBehaviorInitArgs &
   Pick<
     IOSDeviceOpt,
-    'deviceId' | 'wdaHost' | 'wdaPort' | 'sessionId' | 'useWDA' | 'wdaMjpegPort'
+    | 'deviceId'
+    | 'wdaHost'
+    | 'wdaPort'
+    | 'sessionId'
+    | 'useWDA'
+    | 'wdaMjpegPort'
+    | 'wdaMjpegFrameSource'
   >;
 
 function getTargetIdentity(initArgs?: IOSInitArgs): string {

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -24,6 +24,7 @@ import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison } from '@midscene/shared/utils';
 import { WDAManager } from '@midscene/webdriver';
 import { IOSWebDriverClient as WebDriverAgentBackend } from './ios-webdriver-client';
+import { MjpegFrameSource } from './mjpeg-frame-source';
 
 // Re-export IOSDeviceOpt and IOSDeviceInputOpt for backward compatibility
 export type { IOSDeviceOpt, IOSDeviceInputOpt } from '@midscene/core/device';
@@ -49,6 +50,8 @@ export class IOSDevice implements AbstractInterface {
   private wdaManager: WDAManager;
   /** URL of WDA's native MJPEG server for real-time streaming */
   mjpegStreamUrl: string;
+  /** Lazily-started consumer of the WDA MJPEG stream, used by frameSequence. */
+  private mjpegFrameSource: MjpegFrameSource | null = null;
   private appNameMapping: Record<string, string> = {};
   interfaceType: InterfaceType = 'ios';
   uri: string | undefined;
@@ -423,6 +426,79 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
       debugDevice(`Screenshot failed: ${error}`);
       throw new Error(`Failed to take screenshot: ${error}`);
     }
+  }
+
+  /**
+   * Fast multi-frame capture sourced from WDA's MJPEG stream. WDA's
+   * `takeScreenshot` is too slow to sample a short time window densely, so for
+   * `frameSequence` we pull the most recent frame from the continuously-running
+   * MJPEG stream instead — pulling is near-instant, so frames land at the
+   * requested cadence. Throws if the stream is unavailable; the caller falls
+   * back to sequential `screenshotBase64()` capture.
+   */
+  async captureFrameSequence(opt: {
+    count: number;
+    intervalMs: number;
+    abortSignal?: AbortSignal;
+  }): Promise<Array<{ base64: string; capturedAt: number }>> {
+    const { count, intervalMs, abortSignal } = opt;
+    const source = await this.ensureMjpegFrameSource();
+
+    const frames: Array<{ base64: string; capturedAt: number }> = [];
+    for (let i = 0; i < count; i++) {
+      abortSignal?.throwIfAborted();
+      if (i > 0 && intervalMs > 0) {
+        await this.interruptibleSleep(intervalMs, abortSignal);
+      }
+      const frame = source.getLatest();
+      if (frame) {
+        frames.push(frame);
+      }
+    }
+    debugDevice(
+      `captureFrameSequence collected ${frames.length}/${count} frames`,
+    );
+    return frames;
+  }
+
+  private async ensureMjpegFrameSource(): Promise<MjpegFrameSource> {
+    assert(
+      !this.destroyed,
+      `IOSDevice ${this.deviceId} has been destroyed and cannot stream frames`,
+    );
+    if (!this.mjpegFrameSource) {
+      this.mjpegFrameSource = new MjpegFrameSource(this.mjpegStreamUrl);
+    }
+    try {
+      await this.mjpegFrameSource.ensureStarted();
+    } catch (error) {
+      // Drop the failed source so a later call can retry from a clean state.
+      this.mjpegFrameSource.stop();
+      this.mjpegFrameSource = null;
+      throw error;
+    }
+    return this.mjpegFrameSource;
+  }
+
+  private interruptibleSleep(
+    ms: number,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (abortSignal?.aborted) {
+        reject(abortSignal.reason);
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(abortSignal?.reason);
+      };
+      const timer = setTimeout(() => {
+        abortSignal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 
   async clearInput(element?: ElementInfo): Promise<void> {
@@ -952,6 +1028,10 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     }
 
     try {
+      // Stop the MJPEG frame source if it was started.
+      this.mjpegFrameSource?.stop();
+      this.mjpegFrameSource = null;
+
       // Delete WDA session
       await this.wdaBackend.deleteSession();
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -52,6 +52,12 @@ export class IOSDevice implements AbstractInterface {
   mjpegStreamUrl: string;
   /** Lazily-started consumer of the WDA MJPEG stream, used by frameSequence. */
   private mjpegFrameSource: MjpegFrameSource | null = null;
+  /**
+   * Fast frame-sequence capability. Only wired up when the MJPEG frame source
+   * is opt-in enabled; otherwise left undefined so frameSequence falls back to
+   * sequential screenshots.
+   */
+  captureFrameSequence?: AbstractInterface['captureFrameSequence'];
   private appNameMapping: Record<string, string> = {};
   interfaceType: InterfaceType = 'ios';
   uri: string | undefined;
@@ -235,6 +241,14 @@ export class IOSDevice implements AbstractInterface {
     });
     this.wdaManager = WDAManager.getInstance(wdaPort, wdaHost);
     this.mjpegStreamUrl = `http://${wdaHost}:${mjpegPort}`;
+
+    // Opt-in (default off), mirroring Android scrcpy: only expose the fast
+    // MJPEG frame-source capability when explicitly enabled. When off,
+    // frameSequence falls back to sequential screenshotBase64() capture.
+    if (options?.wdaMjpegFrameSource?.enabled) {
+      this.captureFrameSequence = (frameOpt) =>
+        this.captureFrameSequenceImpl(frameOpt);
+    }
   }
 
   describe(): string {
@@ -435,8 +449,11 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
    * MJPEG stream instead — pulling is near-instant, so frames land at the
    * requested cadence. Throws if the stream is unavailable; the caller falls
    * back to sequential `screenshotBase64()` capture.
+   *
+   * Opt-in: only wired up as the `captureFrameSequence` capability (in the
+   * constructor) when `wdaMjpegFrameSource.enabled` is set, mirroring scrcpy.
    */
-  async captureFrameSequence(opt: {
+  private async captureFrameSequenceImpl(opt: {
     count: number;
     intervalMs: number;
     abortSignal?: AbortSignal;

--- a/packages/ios/src/mjpeg-frame-source.ts
+++ b/packages/ios/src/mjpeg-frame-source.ts
@@ -1,0 +1,169 @@
+import { getDebug } from '@midscene/shared/logger';
+
+const debug = getDebug('ios:mjpeg');
+
+// JPEG markers.
+const SOI_0 = 0xff;
+const SOI_1 = 0xd8;
+const EOI_1 = 0xd9;
+
+export interface ExtractedFrames {
+  /** Complete JPEG frames found in the buffer, in order. */
+  frames: Buffer[];
+  /** Bytes after the last complete frame, to be prepended to the next chunk. */
+  rest: Buffer;
+}
+
+/**
+ * Extract complete JPEG frames from a (possibly partial) MJPEG byte buffer by
+ * scanning for SOI (`FF D8`) / EOI (`FF D9`) markers. Boundary headers between
+ * parts are ignored — anything before the first SOI is discarded. The trailing
+ * incomplete bytes are returned as `rest` so they can be prepended to the next
+ * chunk.
+ */
+export function extractJpegFrames(buffer: Buffer): ExtractedFrames {
+  const frames: Buffer[] = [];
+  let searchStart = 0;
+
+  while (true) {
+    // Find the next SOI marker.
+    let soi = -1;
+    for (let i = searchStart; i + 1 < buffer.length; i++) {
+      if (buffer[i] === SOI_0 && buffer[i + 1] === SOI_1) {
+        soi = i;
+        break;
+      }
+    }
+    if (soi === -1) {
+      // No start marker in the unconsumed region. Discard boundary/garbage, but
+      // keep a trailing 0xFF that might be the first half of a split SOI marker.
+      const last = buffer.length - 1;
+      const rest =
+        last >= searchStart && buffer[last] === SOI_0
+          ? buffer.subarray(last)
+          : Buffer.alloc(0);
+      return { frames, rest };
+    }
+
+    // Find the matching EOI marker after the SOI.
+    let eoi = -1;
+    for (let i = soi + 2; i + 1 < buffer.length; i++) {
+      if (buffer[i] === SOI_0 && buffer[i + 1] === EOI_1) {
+        eoi = i;
+        break;
+      }
+    }
+    if (eoi === -1) {
+      // Incomplete frame; carry everything from the SOI forward.
+      return { frames, rest: buffer.subarray(soi) };
+    }
+
+    frames.push(buffer.subarray(soi, eoi + 2));
+    searchStart = eoi + 2;
+  }
+}
+
+interface LatestFrame {
+  /** JPEG data URL. */
+  base64: string;
+  capturedAt: number;
+}
+
+/**
+ * Subscribes to a WDA MJPEG server and keeps the most recently decoded JPEG
+ * frame. Pulling the latest frame is near-instant, which lets `frameSequence`
+ * sample at the requested cadence instead of paying WDA's slow per-screenshot
+ * cost. Lazily connected; auto-reconnects on stream errors until stopped.
+ */
+export class MjpegFrameSource {
+  private latest: LatestFrame | null = null;
+  private abortController: AbortController | null = null;
+  private runPromise: Promise<void> | null = null;
+  private stopped = false;
+  private readonly nowFn: () => number;
+
+  constructor(
+    private readonly url: string,
+    nowFn: () => number = Date.now,
+  ) {
+    this.nowFn = nowFn;
+  }
+
+  /**
+   * Ensure the stream is connected and at least one frame has arrived.
+   * Resolves once a frame is available, or rejects on timeout.
+   */
+  async ensureStarted(timeoutMs = 3000): Promise<void> {
+    if (this.stopped) {
+      throw new Error('MjpegFrameSource has been stopped');
+    }
+    if (!this.runPromise) {
+      this.abortController = new AbortController();
+      this.runPromise = this.run(this.abortController.signal);
+    }
+    if (this.latest) {
+      return;
+    }
+    const start = this.nowFn();
+    // Poll for the first frame.
+    while (this.nowFn() - start < timeoutMs) {
+      if (this.latest) return;
+      if (this.stopped) throw new Error('MjpegFrameSource has been stopped');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    }
+    throw new Error(
+      `MjpegFrameSource: no frame received from ${this.url} within ${timeoutMs}ms`,
+    );
+  }
+
+  /** Latest decoded frame as a JPEG data URL, or null if none yet. */
+  getLatest(): { base64: string; capturedAt: number } | null {
+    if (!this.latest) return null;
+    return { base64: this.latest.base64, capturedAt: this.latest.capturedAt };
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abortController?.abort();
+    this.abortController = null;
+    this.runPromise = null;
+    this.latest = null;
+  }
+
+  private async run(signal: AbortSignal): Promise<void> {
+    while (!this.stopped && !signal.aborted) {
+      try {
+        const response = await fetch(this.url, { signal });
+        if (!response.ok || !response.body) {
+          throw new Error(`MJPEG stream responded with ${response.status}`);
+        }
+        let pending: Buffer = Buffer.alloc(0);
+        // response.body is a WHATWG ReadableStream in Node 18+.
+        for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+          if (this.stopped || signal.aborted) break;
+          pending = Buffer.concat([pending, Buffer.from(chunk)]);
+          const { frames, rest } = extractJpegFrames(pending);
+          if (frames.length > 0) {
+            this.latest = {
+              base64: `data:image/jpeg;base64,${frames[frames.length - 1].toString('base64')}`,
+              capturedAt: this.nowFn(),
+            };
+          }
+          pending = rest;
+          // Guard against unbounded growth if markers never match.
+          if (pending.length > 8 * 1024 * 1024) {
+            pending = pending.subarray(pending.length - 1024);
+          }
+        }
+      } catch (error) {
+        if (this.stopped || signal.aborted) return;
+        debug('MJPEG stream error, will retry: %s', error);
+      }
+      // Back off before reconnecting, whether the stream errored or ended
+      // cleanly, so a short-lived connection cannot busy-spin reconnects.
+      if (!this.stopped && !signal.aborted) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+  }
+}

--- a/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
+++ b/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { IOSDevice } from '../../src/device';
 import {
   MjpegFrameSource,
   extractJpegFrames,
@@ -63,6 +64,28 @@ describe('extractJpegFrames', () => {
     );
     expect(frames).toHaveLength(1);
     expect([...rest]).toEqual([0xff]);
+  });
+});
+
+describe('IOSDevice MJPEG frame source opt-in', () => {
+  it('does not expose captureFrameSequence by default', () => {
+    const device = new IOSDevice({ wdaMjpegPort: 9123 });
+    expect(device.captureFrameSequence).toBeUndefined();
+  });
+
+  it('exposes captureFrameSequence when explicitly enabled', () => {
+    const device = new IOSDevice({
+      wdaMjpegPort: 9123,
+      wdaMjpegFrameSource: { enabled: true },
+    });
+    expect(typeof device.captureFrameSequence).toBe('function');
+  });
+
+  it('builds the stream URL from the per-device wdaMjpegPort (multi-device)', () => {
+    const a = new IOSDevice({ wdaHost: '127.0.0.1', wdaMjpegPort: 9101 });
+    const b = new IOSDevice({ wdaHost: '127.0.0.1', wdaMjpegPort: 9102 });
+    expect(a.mjpegStreamUrl).toBe('http://127.0.0.1:9101');
+    expect(b.mjpegStreamUrl).toBe('http://127.0.0.1:9102');
   });
 });
 

--- a/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
+++ b/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MjpegFrameSource,
+  extractJpegFrames,
+} from '../../src/mjpeg-frame-source';
+
+// A minimal "JPEG": SOI (FF D8) + a tag byte + EOI (FF D9).
+const jpeg = (tag: number): Buffer =>
+  Buffer.from([0xff, 0xd8, tag, 0xff, 0xd9]);
+
+describe('extractJpegFrames', () => {
+  it('extracts a single complete frame and leaves no remainder', () => {
+    const { frames, rest } = extractJpegFrames(jpeg(0x01));
+    expect(frames).toHaveLength(1);
+    expect([...frames[0]]).toEqual([0xff, 0xd8, 0x01, 0xff, 0xd9]);
+    expect(rest).toHaveLength(0);
+  });
+
+  it('extracts multiple frames in order', () => {
+    const buf = Buffer.concat([jpeg(0x01), jpeg(0x02), jpeg(0x03)]);
+    const { frames, rest } = extractJpegFrames(buf);
+    expect(frames).toHaveLength(3);
+    expect(frames.map((f) => f[2])).toEqual([0x01, 0x02, 0x03]);
+    expect(rest).toHaveLength(0);
+  });
+
+  it('ignores boundary/header bytes before the SOI', () => {
+    const boundary = Buffer.from(
+      '--BoundaryString\r\nContent-Type: image/jpeg\r\n\r\n',
+    );
+    const { frames, rest } = extractJpegFrames(
+      Buffer.concat([boundary, jpeg(0x07)]),
+    );
+    expect(frames).toHaveLength(1);
+    expect(frames[0][2]).toBe(0x07);
+    expect(rest).toHaveLength(0);
+  });
+
+  it('carries an incomplete frame (SOI without EOI) into rest', () => {
+    const partial = Buffer.from([0xff, 0xd8, 0xaa, 0xbb]); // no EOI yet
+    const { frames, rest } = extractJpegFrames(partial);
+    expect(frames).toHaveLength(0);
+    expect([...rest]).toEqual([0xff, 0xd8, 0xaa, 0xbb]);
+  });
+
+  it('reassembles a frame split across two chunks', () => {
+    const full = jpeg(0x42);
+    const chunkA = full.subarray(0, 3); // FF D8 42
+    const chunkB = full.subarray(3); // FF D9
+
+    const first = extractJpegFrames(chunkA);
+    expect(first.frames).toHaveLength(0);
+
+    const second = extractJpegFrames(Buffer.concat([first.rest, chunkB]));
+    expect(second.frames).toHaveLength(1);
+    expect(second.frames[0][2]).toBe(0x42);
+    expect(second.rest).toHaveLength(0);
+  });
+
+  it('keeps a trailing 0xFF that may begin a split SOI marker', () => {
+    const { frames, rest } = extractJpegFrames(
+      Buffer.concat([jpeg(0x01), Buffer.from([0xff])]),
+    );
+    expect(frames).toHaveLength(1);
+    expect([...rest]).toEqual([0xff]);
+  });
+});
+
+describe('MjpegFrameSource', () => {
+  it('decodes frames from a streamed MJPEG response and exposes the latest', async () => {
+    const full = Buffer.concat([jpeg(0x01), jpeg(0x02)]);
+    const body = {
+      async *[Symbol.asyncIterator]() {
+        yield new Uint8Array(full.subarray(0, 4));
+        yield new Uint8Array(full.subarray(4));
+      },
+    };
+    const fetchMock = async () =>
+      ({ ok: true, status: 200, body }) as unknown as Response;
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+
+    try {
+      let t = 1000;
+      const source = new MjpegFrameSource('http://localhost:9100', () => t++);
+      await source.ensureStarted(2000);
+      const latest = source.getLatest();
+      expect(latest).not.toBeNull();
+      expect(latest?.base64.startsWith('data:image/jpeg;base64,')).toBe(true);
+      // last frame in the stream is jpeg(0x02)
+      const decoded = Buffer.from(
+        latest!.base64.replace('data:image/jpeg;base64,', ''),
+        'base64',
+      );
+      expect(decoded[2]).toBe(0x02);
+      source.stop();
+    } finally {
+      (globalThis as any).fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Background

`frameSequence` works well on Android because its `screenshotBase64()` pulls the latest frame from a continuously-running **scrcpy** video stream (near-instant). On **iOS**, `screenshotBase64()` goes through WDA's `takeScreenshot()` — a full per-call capture that is too slow to sample a short time window densely, so the effective frame spacing becomes `captureLatency + intervalMs` and short-lived UI (toasts) slips through the gaps.

Key point: iOS **already runs WDA's native MJPEG server** (`mjpegStreamUrl`, with `mjpegServerFramerate`/`mjpegServerScreenshotQuality` configured) — the iOS analog of scrcpy. It just wasn't wired into frame capture. This PR consumes it as a fast frame source.

Targets `feat/frame-sequence-transient-ui` (the frameSequence feature branch).

## What this PR does

- **core (device)**: add an optional `AbstractInterface.captureFrameSequence({count, intervalMs, abortSignal})` — a fast multi-frame capture implemented by devices that maintain a continuous frame stream. Returns data-URL frames in temporal order; may return fewer than requested.
- **core (agent)**: `captureUIContextSequence` prefers `captureFrameSequence` for the earlier frames and captures the representative (last) frame with a normal full-quality screenshot. If the fast source throws or yields nothing, it falls back to the existing sequential `screenshotBase64()` loop. Abort is honored throughout.
- **ios**: `MjpegFrameSource` consumes the WDA MJPEG stream (lazy-started, auto-reconnecting with backoff, stopped on `destroy()`) and keeps the latest decoded JPEG. `IOSDevice.captureFrameSequence` samples it at the requested cadence — pulling is near-instant, so frames land at `intervalMs` instead of `intervalMs + slowScreenshot`.

`screenshotBase64()` (normal locate/asserts) is unchanged — it still uses full-quality `takeScreenshot()`. The MJPEG stream is only used for the multi-frame sampling.

## Why this design

- Mirrors what already makes Android fast (continuous stream → instant latest-frame), instead of optimizing the slow per-call path.
- The fast path is an **optional** capability: Android/web don't implement it and keep working (Android is already fast; web could later implement it over CDP screencast). No behavior change for devices without it.
- Graceful degradation: any stream failure falls back to sequential capture, so correctness is preserved even if the MJPEG server is unavailable.

## Tests

- `packages/ios/tests/unit-test/mjpeg-frame-source.test.ts` — `extractJpegFrames` (single/multiple frames, boundary/header bytes, incomplete frame, split-across-chunks, trailing-FF), plus a streamed `MjpegFrameSource` decoding the latest frame from a mocked fetch stream. 7/7 pass.
- `packages/core/tests/unit-test/agent-frame-sequence.test.ts` — fast-path is used when the device exposes `captureFrameSequence` (earlier frames from stream + one representative screenshot), and falls back to sequential capture when it fails.

## Validation

- `npx tsc --noEmit` for `@midscene/core` and `@midscene/ios` — clean
- `npx nx build core` and `npx nx build ios` — pass
- Core frameSequence suites (20 tests) + iOS `device.test.ts` (54) + new MJPEG tests — pass
- biome lint clean

Note: end-to-end behavior was verified on Android/web in the base PR; the iOS path here is covered by unit tests (no physical iOS device in CI).