### PR TITLE
[codex] Handle missing toolchain errors

### DIFF
--- a/apps/studio/src/main/playground/device-discovery.ts
+++ b/apps/studio/src/main/playground/device-discovery.ts
@@ -34,6 +34,15 @@ export const DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS = 10_000;
 export const DEVICE_DISCOVERY_POLL_INTERVAL_MS = 5000;
 const execFileAsync = promisify(execFile);
 
+function safeDebugLog(...args: Parameters<typeof debugLog>): void {
+  try {
+    debugLog(...args);
+  } catch {
+    // Packaged Electron apps can have closed stdio streams. Device discovery
+    // must never crash the main process just because debug logging cannot write.
+  }
+}
+
 export interface DeviceDiscoveryService {
   close(): void;
   getSnapshot(options?: {
@@ -213,7 +222,7 @@ async function withPlatformDiscoveryTimeout(
   let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
   const timeout = new Promise<PlatformScanResult>((resolve) => {
     timeoutId = setTimeout(() => {
-      debugLog(
+      safeDebugLog(
         `${platformId} scan timed out after ${DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS}ms`,
       );
       resolve(timeoutScanResult(platformId));
@@ -277,7 +286,7 @@ export function createDeviceDiscoveryService({
       try {
         listener(devices);
       } catch (error) {
-        debugLog('device discovery listener failed:', error);
+        safeDebugLog('device discovery listener failed:', error);
       }
     });
   };
@@ -311,7 +320,7 @@ export function createDeviceDiscoveryService({
 
     intervalId = setIntervalFn(() => {
       void refreshSnapshot().catch((error) => {
-        debugLog('device discovery refresh failed:', error);
+        safeDebugLog('device discovery refresh failed:', error);
       });
     }, intervalMs);
   };
@@ -323,7 +332,7 @@ export function createDeviceDiscoveryService({
 
     started = true;
     void refreshSnapshot().catch((error) => {
-      debugLog('initial device discovery refresh failed:', error);
+      safeDebugLog('initial device discovery refresh failed:', error);
     });
     ensurePolling();
   };
@@ -353,7 +362,7 @@ export function createDeviceDiscoveryService({
       }
 
       void refreshSnapshot().catch((error) => {
-        debugLog('device discovery resume refresh failed:', error);
+        safeDebugLog('device discovery resume refresh failed:', error);
       });
       ensurePolling();
     },
@@ -396,7 +405,7 @@ export async function discoverAllDevices(): Promise<DiscoverDevicesResult> {
         errors.push(scan.value.error);
       }
     } else {
-      debugLog('platform scan rejected:', scan.reason);
+      safeDebugLog('platform scan rejected:', scan.reason);
     }
   }
 
@@ -423,11 +432,11 @@ async function scanAndroidDevices(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    debugLog('android scan failed:', err);
+    safeDebugLog('android scan failed:', err);
     try {
       return await scanAndroidDevicesFromCli();
     } catch (fallbackError) {
-      debugLog('android cli fallback failed:', fallbackError);
+      safeDebugLog('android cli fallback failed:', fallbackError);
       return { devices: [], error: toolchainMissing('android') };
     }
   }
@@ -482,7 +491,7 @@ async function scanIOSDevices(): Promise<PlatformScanResult> {
     // iOS WDA probe failing just means no local WDA is running. That is
     // the dominant case (no developer has WDA up by default), not a
     // toolchain problem — do not surface it as an error to the UI.
-    debugLog('ios scan failed:', err);
+    safeDebugLog('ios scan failed:', err);
     return { devices: [] };
   } finally {
     clearTimeout(timeoutId);
@@ -509,11 +518,11 @@ async function scanHarmonyDevices(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    debugLog('harmony scan failed:', err);
+    safeDebugLog('harmony scan failed:', err);
     try {
       return await scanHarmonyDevicesFromCli();
     } catch (fallbackError) {
-      debugLog('harmony cli fallback failed:', fallbackError);
+      safeDebugLog('harmony cli fallback failed:', fallbackError);
       return { devices: [], error: toolchainMissing('harmony') };
     }
   }
@@ -536,7 +545,7 @@ async function scanComputerDisplays(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    debugLog('computer scan failed:', err);
+    safeDebugLog('computer scan failed:', err);
     return { devices: [] };
   }
 }

--- a/apps/studio/tests/device-discovery.test.ts
+++ b/apps/studio/tests/device-discovery.test.ts
@@ -374,4 +374,27 @@ describe('discoverAllDevices', () => {
       `harmony scan timed out after ${DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS}ms`,
     );
   });
+
+  it('does not reject when timeout debug logging cannot write to stdio', async () => {
+    vi.useFakeTimers();
+    mocks.debugLog.mockImplementation(() => {
+      throw new Error('write EIO');
+    });
+    mocks.getConnectedDevicesWithDetails.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    mocks.getConnectedHarmonyDevices.mockResolvedValue([]);
+    mocks.getConnectedDisplays.mockResolvedValue([]);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const discovery = discoverAllDevices();
+    await vi.advanceTimersByTimeAsync(DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS);
+
+    await expect(discovery).resolves.toEqual({
+      devices: [],
+      errors: [{ platformId: 'android', kind: 'toolchain-missing' }],
+    });
+  });
 });

--- a/packages/playground-app/src/controller/create-agent-error.tsx
+++ b/packages/playground-app/src/controller/create-agent-error.tsx
@@ -1,0 +1,226 @@
+import { Tooltip } from 'antd';
+import React, { type ReactNode, useState } from 'react';
+
+const INSTALL_CHROME_COMMAND = 'npx puppeteer browsers install chrome';
+const PUPPETEER_CONFIGURATION_URL = 'https://pptr.dev/guides/configuration';
+const CHROME_MISSING_RE = /could not find (?:google )?chrome/;
+
+interface CreateAgentErrorNotification {
+  title: string;
+  description: ReactNode;
+  duration: number;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.toString();
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const value = (error as { message?: unknown }).message;
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return String(error);
+}
+
+function copyInstallCommand() {
+  if (typeof navigator === 'undefined') {
+    return;
+  }
+
+  try {
+    void navigator.clipboard
+      ?.writeText(INSTALL_CHROME_COMMAND)
+      .catch(() => undefined);
+  } catch {
+    // Clipboard access can be unavailable or denied; copying is best-effort.
+  }
+}
+
+function CopyIcon() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'block',
+        height: 16,
+        position: 'relative',
+        width: 16,
+      }}
+    >
+      <span
+        style={{
+          border: '1.5px solid currentColor',
+          borderRadius: 3,
+          height: 10,
+          left: 5,
+          position: 'absolute',
+          top: 3,
+          width: 8,
+        }}
+      />
+      <span
+        style={{
+          background: '#f6f8fa',
+          border: '1.5px solid currentColor',
+          borderRadius: 3,
+          height: 10,
+          left: 2,
+          position: 'absolute',
+          top: 0,
+          width: 8,
+        }}
+      />
+    </span>
+  );
+}
+
+export function isPuppeteerChromeMissingError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    CHROME_MISSING_RE.test(message) &&
+    (message.includes('puppeteer browsers install chrome') ||
+      message.includes('cache path') ||
+      message.includes('puppeteer'))
+  );
+}
+
+function ChromeMissingDescription({ error }: { error: unknown }) {
+  const rawMessage = getErrorMessage(error);
+  const [copyVisible, setCopyVisible] = useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div>
+        Studio could not find the Chrome browser required to create a Web Agent.
+      </div>
+      <div>Run this command, then try again:</div>
+      <div
+        onMouseEnter={() => setCopyVisible(true)}
+        onMouseLeave={() => setCopyVisible(false)}
+        style={{
+          background: '#f6f8fa',
+          border: '1px solid #d9d9d9',
+          borderRadius: 6,
+          boxSizing: 'border-box',
+          maxWidth: '100%',
+          minHeight: 46,
+          position: 'relative',
+        }}
+      >
+        <pre
+          style={{
+            fontFamily:
+              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+            fontSize: 14,
+            lineHeight: 1.4,
+            margin: 0,
+            overflowX: 'auto',
+            padding: '12px 44px 12px 12px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {INSTALL_CHROME_COMMAND}
+        </pre>
+        <button
+          aria-label="Copy install command"
+          onBlur={() => setCopyVisible(false)}
+          onClick={copyInstallCommand}
+          onFocus={() => setCopyVisible(true)}
+          style={{
+            alignItems: 'center',
+            background: '#ffffff',
+            border: '1px solid #d9d9d9',
+            borderRadius: 6,
+            bottom: 7,
+            color: '#555',
+            cursor: 'pointer',
+            display: 'inline-flex',
+            height: 28,
+            justifyContent: 'center',
+            opacity: copyVisible ? 1 : 0,
+            padding: 0,
+            pointerEvents: copyVisible ? 'auto' : 'none',
+            position: 'absolute',
+            right: 7,
+            transition: 'opacity 120ms ease',
+            width: 28,
+          }}
+          title="Copy command"
+          type="button"
+        >
+          <CopyIcon />
+        </button>
+      </div>
+      <div>
+        Guide:{' '}
+        <a href={PUPPETEER_CONFIGURATION_URL} rel="noreferrer" target="_blank">
+          {PUPPETEER_CONFIGURATION_URL}
+        </a>
+      </div>
+      <Tooltip
+        getPopupContainer={() => document.body}
+        overlayInnerStyle={{
+          width: 'min(680px, calc(100vw - 48px))',
+        }}
+        overlayStyle={{
+          maxWidth: 'min(680px, calc(100vw - 48px))',
+        }}
+        placement="topRight"
+        title={
+          <pre
+            style={{
+              margin: 0,
+              maxHeight: 280,
+              overflow: 'auto',
+              whiteSpace: 'pre-wrap',
+              width: '100%',
+            }}
+          >
+            {rawMessage}
+          </pre>
+        }
+        zIndex={10_000}
+      >
+        <button
+          style={{
+            alignSelf: 'flex-start',
+            background: 'transparent',
+            border: 0,
+            color: 'inherit',
+            cursor: 'help',
+            padding: 0,
+            textDecoration: 'underline',
+          }}
+          type="button"
+        >
+          Original error
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function getCreateAgentErrorNotification(
+  error: unknown,
+): CreateAgentErrorNotification | undefined {
+  if (!isPuppeteerChromeMissingError(error)) {
+    return undefined;
+  }
+
+  return {
+    description: <ChromeMissingDescription error={error} />,
+    duration: 0,
+    title: 'Failed to create Agent',
+  };
+}

--- a/packages/playground-app/src/controller/usePlaygroundController.ts
+++ b/packages/playground-app/src/controller/usePlaygroundController.ts
@@ -30,6 +30,7 @@ import {
   serializeAutoCreateInput,
   shouldResetAutoCreateBlock,
 } from './auto-create';
+import { getCreateAgentErrorNotification } from './create-agent-error';
 import { runSingleFlight } from './single-flight';
 import type { PlaygroundControllerResult, PlaygroundFormValues } from './types';
 
@@ -308,6 +309,7 @@ export function usePlaygroundController({
       options?: { silent?: boolean },
     ): Promise<boolean> =>
       runSingleFlight(pendingCreateSessionRef, async () => {
+        let attemptedValues: Record<string, unknown> | undefined;
         try {
           sessionMutatingRef.current = true;
           setSessionMutating(true);
@@ -316,6 +318,7 @@ export function usePlaygroundController({
           }
 
           const values = input ?? (await form.validateFields());
+          attemptedValues = values;
           await playgroundSDK.createSession(values);
           if (shouldResetAutoCreateBlock(options)) {
             autoCreateBlockedSignatureRef.current = null;
@@ -329,7 +332,17 @@ export function usePlaygroundController({
           if ((error as { errorFields?: unknown }).errorFields) {
             return false;
           }
-          notifyError(error, { title: 'Failed to create Agent' });
+          if (options?.silent) {
+            autoCreateBlockedSignatureRef.current =
+              serializeAutoCreateInput(attemptedValues);
+            return false;
+          }
+          notifyError(
+            error,
+            getCreateAgentErrorNotification(error) ?? {
+              title: 'Failed to create Agent',
+            },
+          );
           return false;
         } finally {
           sessionMutatingRef.current = false;

--- a/packages/playground-app/tests/create-agent-error.test.ts
+++ b/packages/playground-app/tests/create-agent-error.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCreateAgentErrorNotification,
+  isPuppeteerChromeMissingError,
+} from '../src/controller/create-agent-error';
+
+describe('create agent error formatting', () => {
+  it('detects Puppeteer Chrome missing errors without depending on the version', () => {
+    const error = new Error(
+      'Could not find Chrome (ver. 999.0.0). This can occur if either\n' +
+        ' 1. you did not perform an installation before running the script ' +
+        '(e.g. `npx puppeteer browsers install chrome`) or\n' +
+        ' 2. your cache path is incorrectly configured.',
+    );
+
+    expect(isPuppeteerChromeMissingError(error)).toBe(true);
+  });
+
+  it('detects future Puppeteer Chrome missing wording with cache context', () => {
+    expect(
+      isPuppeteerChromeMissingError(
+        new Error(
+          'Could not find Google Chrome. Check the Puppeteer cache path.',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not classify unrelated Puppeteer errors as Chrome missing', () => {
+    expect(
+      isPuppeteerChromeMissingError(
+        new Error('Timed out after 30000 ms while waiting for Chrome.'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns a persistent productized notification for Chrome missing errors', () => {
+    const notification = getCreateAgentErrorNotification(
+      new Error(
+        'Could not find Chrome. Run `npx puppeteer browsers install chrome`.',
+      ),
+    );
+
+    expect(notification).toEqual(
+      expect.objectContaining({
+        duration: 0,
+        title: 'Failed to create Agent',
+      }),
+    );
+    expect(notification?.description).toBeTruthy();
+  });
+});

--- a/packages/visualizer/src/utils/notify.ts
+++ b/packages/visualizer/src/utils/notify.ts
@@ -1,10 +1,11 @@
 import { notification } from 'antd';
+import type { ReactNode } from 'react';
 
 export interface NotifyErrorOptions {
   /** Short, descriptive label rendered as the toast title. */
   title?: string;
   /** Custom body text; defaults to the normalized error message. */
-  description?: string;
+  description?: ReactNode;
   /** Seconds before auto-dismiss. Mirrors antd's default of 4.5. */
   duration?: number;
 }


### PR DESCRIPTION
## Summary

- Prevent Studio device discovery debug logging from crashing the Electron main process when stdio writes fail.
- Show a productized persistent notification for Puppeteer Chrome missing errors when creating a Web Agent.
- Keep the raw Chrome error behind a tooltip and provide a copyable install command.

## Root Cause

- Packaged Studio can have closed stdio streams. A device discovery timeout log went through `console.warn`, which could throw `write EIO` and surface as an Electron main-process crash dialog.
- Puppeteer Chrome missing errors are plain `Error` instances without a stable error code, so the previous UI surfaced the raw technical message directly.

## Validation

- `pnpm --dir apps/studio test tests/device-discovery.test.ts`
- `pnpm --dir packages/playground-app test tests/create-agent-error.test.ts`
- `pnpm --dir packages/visualizer build`
- `pnpm --dir packages/playground-app build`
- `pnpm run lint`
