### PR TITLE
fix(playground): respect screenshotIncluded request param for dump/report

### DIFF
--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -2790,8 +2790,9 @@ class PlaygroundServer {
       }
 
       try {
+        const inlineScreenshots = screenshotIncluded !== false;
         const dumpString = agent.dumpDataString({
-          inlineScreenshots: true,
+          inlineScreenshots,
         });
         if (dumpString) {
           const groupedDump = ReportActionDump.fromSerializedString(dumpString);
@@ -2800,7 +2801,7 @@ class PlaygroundServer {
           response.dump = null;
         }
         response.reportHTML =
-          agent.reportHTMLString({ inlineScreenshots: true }) || null;
+          agent.reportHTMLString({ inlineScreenshots }) || null;
 
         agent.writeOutActionDumps();
         agent.resetDump();


### PR DESCRIPTION
## Problem

The `/execute` endpoint hardcodes `inlineScreenshots: true` when generating `dump` and `reportHTML` response fields. After multiple actions, the response can exceed 50MB, causing `JSON.stringify` to throw `RangeError: Invalid string length`.

The `screenshotIncluded` field is already destructured from the request body and respected during action execution, but ignored when building the response.

## Fix

Respect the `screenshotIncluded` parameter from the request body when generating dump and reportHTML:

- When `screenshotIncluded: false` is sent, dump and reportHTML are generated **without** inline base64 screenshots, keeping the response size manageable.
- When `screenshotIncluded` is not provided (or `true`), the existing behavior is preserved (default `true` for backward compatibility).

## Related Issue

Fixes #2539