### PR TITLE
fix(shared): guard console debug logging

### DIFF
--- a/apps/studio/src/main/playground/device-discovery.ts
+++ b/apps/studio/src/main/playground/device-discovery.ts
@@ -34,15 +34,6 @@ export const DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS = 10_000;
 export const DEVICE_DISCOVERY_POLL_INTERVAL_MS = 5000;
 const execFileAsync = promisify(execFile);
 
-function safeDebugLog(...args: Parameters<typeof debugLog>): void {
-  try {
-    debugLog(...args);
-  } catch {
-    // Packaged Electron apps can have closed stdio streams. Device discovery
-    // must never crash the main process just because debug logging cannot write.
-  }
-}
-
 export interface DeviceDiscoveryService {
   close(): void;
   getSnapshot(options?: {
@@ -222,7 +213,7 @@ async function withPlatformDiscoveryTimeout(
   let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
   const timeout = new Promise<PlatformScanResult>((resolve) => {
     timeoutId = setTimeout(() => {
-      safeDebugLog(
+      debugLog(
         `${platformId} scan timed out after ${DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS}ms`,
       );
       resolve(timeoutScanResult(platformId));
@@ -286,7 +277,7 @@ export function createDeviceDiscoveryService({
       try {
         listener(devices);
       } catch (error) {
-        safeDebugLog('device discovery listener failed:', error);
+        debugLog('device discovery listener failed:', error);
       }
     });
   };
@@ -320,7 +311,7 @@ export function createDeviceDiscoveryService({
 
     intervalId = setIntervalFn(() => {
       void refreshSnapshot().catch((error) => {
-        safeDebugLog('device discovery refresh failed:', error);
+        debugLog('device discovery refresh failed:', error);
       });
     }, intervalMs);
   };
@@ -332,7 +323,7 @@ export function createDeviceDiscoveryService({
 
     started = true;
     void refreshSnapshot().catch((error) => {
-      safeDebugLog('initial device discovery refresh failed:', error);
+      debugLog('initial device discovery refresh failed:', error);
     });
     ensurePolling();
   };
@@ -362,7 +353,7 @@ export function createDeviceDiscoveryService({
       }
 
       void refreshSnapshot().catch((error) => {
-        safeDebugLog('device discovery resume refresh failed:', error);
+        debugLog('device discovery resume refresh failed:', error);
       });
       ensurePolling();
     },
@@ -405,7 +396,7 @@ export async function discoverAllDevices(): Promise<DiscoverDevicesResult> {
         errors.push(scan.value.error);
       }
     } else {
-      safeDebugLog('platform scan rejected:', scan.reason);
+      debugLog('platform scan rejected:', scan.reason);
     }
   }
 
@@ -432,11 +423,11 @@ async function scanAndroidDevices(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    safeDebugLog('android scan failed:', err);
+    debugLog('android scan failed:', err);
     try {
       return await scanAndroidDevicesFromCli();
     } catch (fallbackError) {
-      safeDebugLog('android cli fallback failed:', fallbackError);
+      debugLog('android cli fallback failed:', fallbackError);
       return { devices: [], error: toolchainMissing('android') };
     }
   }
@@ -491,7 +482,7 @@ async function scanIOSDevices(): Promise<PlatformScanResult> {
     // iOS WDA probe failing just means no local WDA is running. That is
     // the dominant case (no developer has WDA up by default), not a
     // toolchain problem — do not surface it as an error to the UI.
-    safeDebugLog('ios scan failed:', err);
+    debugLog('ios scan failed:', err);
     return { devices: [] };
   } finally {
     clearTimeout(timeoutId);
@@ -518,11 +509,11 @@ async function scanHarmonyDevices(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    safeDebugLog('harmony scan failed:', err);
+    debugLog('harmony scan failed:', err);
     try {
       return await scanHarmonyDevicesFromCli();
     } catch (fallbackError) {
-      safeDebugLog('harmony cli fallback failed:', fallbackError);
+      debugLog('harmony cli fallback failed:', fallbackError);
       return { devices: [], error: toolchainMissing('harmony') };
     }
   }
@@ -545,7 +536,7 @@ async function scanComputerDisplays(): Promise<PlatformScanResult> {
       })),
     };
   } catch (err) {
-    safeDebugLog('computer scan failed:', err);
+    debugLog('computer scan failed:', err);
     return { devices: [] };
   }
 }

--- a/apps/studio/tests/device-discovery.test.ts
+++ b/apps/studio/tests/device-discovery.test.ts
@@ -374,27 +374,4 @@ describe('discoverAllDevices', () => {
       `harmony scan timed out after ${DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS}ms`,
     );
   });
-
-  it('does not reject when timeout debug logging cannot write to stdio', async () => {
-    vi.useFakeTimers();
-    mocks.debugLog.mockImplementation(() => {
-      throw new Error('write EIO');
-    });
-    mocks.getConnectedDevicesWithDetails.mockImplementation(
-      () => new Promise(() => undefined),
-    );
-    mocks.getConnectedHarmonyDevices.mockResolvedValue([]);
-    mocks.getConnectedDisplays.mockResolvedValue([]);
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-    } as Response);
-
-    const discovery = discoverAllDevices();
-    await vi.advanceTimersByTimeAsync(DEVICE_PLATFORM_DISCOVERY_TIMEOUT_MS);
-
-    await expect(discovery).resolves.toEqual({
-      devices: [],
-      errors: [{ platformId: 'android', kind: 'toolchain-missing' }],
-    });
-  });
 });

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -65,7 +65,12 @@ export function getDebug(
       const baseFn = getDebug(topic);
       const wrapper = (...args: unknown[]): void => {
         baseFn(...args);
-        console.warn('[Midscene]', ...args);
+        try {
+          console.warn('[Midscene]', ...args);
+        } catch {
+          // Packaged Electron apps can have closed stdio streams. Debug logging
+          // must not crash callers just because console output cannot write.
+        }
       };
       debugInstances.set(cacheKey, wrapper);
     } else {

--- a/packages/shared/tests/unit-test/logger.test.ts
+++ b/packages/shared/tests/unit-test/logger.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  debugFn: vi.fn(),
+}));
+
+vi.mock('debug', () => ({
+  default: vi.fn(() => mocks.debugFn),
+}));
+
+vi.mock('../../src/utils', () => ({
+  ifInNode: false,
+}));
+
+import { getDebug } from '../../src/logger';
+
+describe('getDebug', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.debugFn.mockClear();
+  });
+
+  it('does not throw when console logging cannot write', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      throw new Error('write EIO');
+    });
+    const debugLog = getDebug('logger:test', { console: true });
+
+    expect(() => {
+      debugLog('android scan failed:', new Error('adb unavailable'));
+    }).not.toThrow();
+
+    expect(mocks.debugFn).toHaveBeenCalledWith(
+      'android scan failed:',
+      expect.any(Error),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Midscene]',
+      'android scan failed:',
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Guard the console output path in getDebug(..., { console: true }) so closed Electron stdio streams do not crash callers.
- Remove the now-duplicated device-discovery safeDebugLog wrapper and rely on the shared logger behavior.
- Add a shared logger unit test for console.warn write failures.

## Tests / verification
- pnpm --dir packages/shared test tests/unit-test/logger.test.ts
- pnpm --dir apps/studio test tests/device-discovery.test.ts
- pnpm run lint

## Notes
- Created on a fresh branch to avoid force-pushing the previous divergent PR branch.