### PR TITLE
chore(workflow): Mark internal UI packages private

### DIFF
--- a/packages/playground-app/package.json
+++ b/packages/playground-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@midscene/playground-app",
+  "private": true,
   "version": "1.10.0",
   "description": "Reusable React shell for Midscene playground applications",
   "repository": "https://github.com/web-infra-dev/midscene",
@@ -52,8 +53,5 @@
     "vitest": "3.0.5"
   },
   "sideEffects": ["**/*.css", "**/*.less", "**/*.sass", "**/*.scss"],
-  "publishConfig": {
-    "access": "public"
-  },
   "license": "MIT"
 }

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@midscene/recorder",
+  "private": true,
   "version": "1.10.0",
   "repository": {
     "type": "git",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@midscene/visualizer",
+  "private": true,
   "version": "1.10.0",
   "repository": "https://github.com/web-infra-dev/midscene",
   "homepage": "https://midscenejs.com/",
@@ -59,9 +60,6 @@
     "zustand": "4.5.2"
   },
   "sideEffects": ["**/*.css", "**/*.less", "**/*.sass", "**/*.scss"],
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "@ant-design/icons": "^5.3.1",
     "@midscene/core": "workspace:*",


### PR DESCRIPTION
## Summary

- Mark `@midscene/visualizer`, `@midscene/playground-app`, and `@midscene/recorder` as private packages.
- Remove public `publishConfig` from packages that previously declared public npm access.

## Why

These packages are only consumed by private apps or other private workspace packages, so they do not need to be published independently. Marking them private prevents accidental npm publication while preserving monorepo usage.

## Validation

- Confirmed all current package.json consumers of these three packages are private.
- Commit hook ran `biome check --diagnostic-level=info --fix` and `pnpm run check-dependency-version` during commit.
- Did not run full lint/build.