### PR TITLE
docs(shared): update common tools comment

### DIFF
--- a/packages/shared/src/agent-tools/base-tools.ts
+++ b/packages/shared/src/agent-tools/base-tools.ts
@@ -298,7 +298,7 @@ export abstract class BaseMidsceneTools<
       this.toolDefaults,
     );
 
-    // 4. Add common tools (screenshot, waitFor)
+    // 4. Add common tools (screenshot, act, assert)
     const commonTools = generateCommonTools(
       (args = {}) => this.ensureAgent(this.extractAgentInitParam(args)),
       this.getAgentInitArgSchema(),


### PR DESCRIPTION
## Summary

- Update the BaseMidsceneTools comment so the listed common tools match the current generateCommonTools output.

## Notes

- The current common tools are `take_screenshot`, `act`, and `assert`; `aiWaitFor` is available through Agent/YAML APIs but is not registered as a direct common tool.

## Validation

- Not run. Comment-only change.
- Commit hook ran `npx biome check --diagnostic-level=info --fix` automatically during commit.