### PR TITLE
fix(report): unify json key font weight

### DIFF
--- a/apps/report/src/components/detail-panel/index.less
+++ b/apps/report/src/components/detail-panel/index.less
@@ -127,6 +127,8 @@
   }
 
   .report-json-clickable-label {
+    font-weight: 600;
+    margin-right: 5px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
## Summary

- Set JSON View clickable keys to the same `font-weight: 600` as regular keys.
- Add matching right spacing for clickable JSON keys so expanded object/array keys align with leaf keys.

## Why

`react-json-view-lite` renders expandable object/array keys with `clickableLabel` when `clickToExpandNode` is enabled, while leaf keys use `label`. Only `label` had the report key font weight and spacing, so expandable keys looked inconsistent.

## Validation

- Not run, per repo/user workflow preference for this small style-only change.
- Commit hook ran staged-file `prettier --write` during commit.