### PR TITLE
fix(core): derive real case status when merging reports

### DIFF
--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -1,6 +1,7 @@
 import './index.less';
 import { useAllCurrentTasks, useExecutionDump } from '@/components/store';
 import type { AIUsageInfo, ExecutionTask } from '@midscene/core';
+import { deriveTaskStatus } from '@midscene/core';
 import { typeStr } from '@midscene/core/agent';
 import {
   type AnimationScript,
@@ -125,28 +126,12 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
 
   // Helper functions for rendering
   const getStatusIcon = (task: ExecutionTaskWithSearchAreaUsage) => {
-    const isFinished = task.status === 'finished';
-    const isError = isFinished && (task.error || task.errorMessage);
-
-    if (isError) {
-      return iconForStatus('failed');
-    }
-
-    const isAssertFinishedWithWarning =
-      isFinished && task.subType === 'WaitFor' && task.output === false;
-
-    if (isAssertFinishedWithWarning) {
-      return iconForStatus('finishedWithWarning');
-    }
-
-    const isAssertFailed =
-      task.subType === 'Assert' && isFinished && task.output === false;
-
-    if (isAssertFailed) {
-      return iconForStatus('failed');
-    }
-
-    return iconForStatus(task.status);
+    // Share the same failure semantics as the merged-report status derivation
+    // (deriveTaskStatus) so step icons and merged Passed/Failed never diverge.
+    const status = deriveTaskStatus(task);
+    // `warning` maps to the dedicated warning icon; every other value is a
+    // status string iconForStatus already understands.
+    return iconForStatus(status === 'warning' ? 'finishedWithWarning' : status);
   };
 
   const getTitleIcon = (task: ExecutionTaskWithSearchAreaUsage) => {

--- a/packages/core/src/dump/index.ts
+++ b/packages/core/src/dump/index.ts
@@ -14,3 +14,9 @@ export {
   generateDumpScriptTag,
 } from './html-utils';
 export { getTaskSearchArea, getTaskServiceDump } from './task-service-dump';
+export {
+  deriveTaskStatus,
+  deriveCaseStatus,
+  type TaskStatusFields,
+  type DerivedTaskStatus,
+} from './task-status';

--- a/packages/core/src/dump/task-status.ts
+++ b/packages/core/src/dump/task-status.ts
@@ -1,0 +1,93 @@
+/**
+ * Single source of truth for turning raw task/execution dump data into a
+ * semantic status.
+ *
+ * Both the report sidebar (per-step status icon) and the merged-report
+ * status aggregation must agree on what "failed" means, otherwise a merged
+ * report can mark a failing case as passed. Keeping the rules here — as pure
+ * functions over plain dump fields — lets the front-end icons and the backend
+ * `mergeReportFiles` attribute derivation share the exact same logic.
+ */
+import type { TestStatus } from '../types';
+
+/**
+ * Minimal structural shape of a task needed to derive its status. Declared
+ * loosely so both the full `ExecutionTask` and the front-end task variants
+ * (which carry extra fields) satisfy it without coupling to a concrete type.
+ */
+export interface TaskStatusFields {
+  status?: 'pending' | 'running' | 'finished' | 'failed' | 'cancelled';
+  subType?: string;
+  error?: unknown;
+  errorMessage?: string;
+  output?: unknown;
+}
+
+export type DerivedTaskStatus =
+  | 'passed'
+  | 'failed'
+  | 'warning'
+  | 'pending'
+  | 'running'
+  | 'cancelled';
+
+/**
+ * Derive a single task's semantic status from its raw dump fields. Mirrors the
+ * historical `getStatusIcon` logic in the report sidebar so icons and merged
+ * status never diverge.
+ */
+export function deriveTaskStatus(task: TaskStatusFields): DerivedTaskStatus {
+  const isFinished = task.status === 'finished';
+
+  // Hard failure: the task threw / was aborted (status === 'failed', e.g. a
+  // failed Assert which throws `Assertion failed`, or a locate failure), or it
+  // finished but still carries an error.
+  if (task.status === 'failed') {
+    return 'failed';
+  }
+  if (isFinished && (task.error || task.errorMessage)) {
+    return 'failed';
+  }
+
+  // A `WaitFor` that finished falsy is a warning, not a hard failure.
+  if (isFinished && task.subType === 'WaitFor' && task.output === false) {
+    return 'warning';
+  }
+
+  // An `Assert` that finished with a falsy result is a failure. This is a
+  // legacy fallback: modern asserts throw and are caught above.
+  if (task.subType === 'Assert' && isFinished && task.output === false) {
+    return 'failed';
+  }
+
+  if (task.status === 'pending') return 'pending';
+  if (task.status === 'running') return 'running';
+  if (task.status === 'cancelled') return 'cancelled';
+
+  // finished, no error
+  return 'passed';
+}
+
+/**
+ * Aggregate the tasks of one case (a list of executions) into a single
+ * `TestStatus`. A case is `failed` when any of its tasks derives to `failed`;
+ * otherwise it is `passed`. Warnings, pending/running/cancelled steps do not by
+ * themselves fail a case.
+ *
+ * This only ever produces `passed` / `failed`; the finer `timedOut` /
+ * `skipped` / `interrupted` statuses can only come from a source report that
+ * already recorded them (e.g. a Playwright run), which callers should prefer
+ * when available.
+ */
+export function deriveCaseStatus(
+  executions: Array<{ tasks?: TaskStatusFields[] }>,
+): TestStatus {
+  for (const execution of executions) {
+    for (const task of execution.tasks ?? []) {
+      if (deriveTaskStatus(task) === 'failed') {
+        return 'failed';
+      }
+    }
+  }
+  return 'passed';
+}

--- a/packages/core/src/dump/task-status.ts
+++ b/packages/core/src/dump/task-status.ts
@@ -8,20 +8,21 @@
  * functions over plain dump fields — lets the front-end icons and the backend
  * `mergeReportFiles` attribute derivation share the exact same logic.
  */
-import type { TestStatus } from '../types';
+import type { ExecutionTask, TestStatus } from '../types';
 
 /**
- * Minimal structural shape of a task needed to derive its status. Declared
- * loosely so both the full `ExecutionTask` and the front-end task variants
- * (which carry extra fields) satisfy it without coupling to a concrete type.
+ * The subset of a task's fields needed to derive its status, picked from
+ * `ExecutionTask` so the field names/types stay defined in one place. It is a
+ * structural subset, so both the full `ExecutionTask` and the front-end task
+ * variants (which carry extra fields) satisfy it.
  */
-export interface TaskStatusFields {
-  status?: 'pending' | 'running' | 'finished' | 'failed' | 'cancelled';
-  subType?: string;
-  error?: unknown;
-  errorMessage?: string;
-  output?: unknown;
-}
+export type TaskStatusFields = Partial<
+  Pick<ExecutionTask, 'status' | 'subType' | 'error' | 'errorMessage'> & {
+    // `output` is only ever compared to `false`; keep it `unknown` rather than
+    // the picked generic `any` so the field stays type-safe for callers.
+    output: unknown;
+  }
+>;
 
 export type DerivedTaskStatus =
   | 'passed'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,7 +86,10 @@ export {
   parseDumpScriptAttributes,
   generateImageScriptTag,
   generateDumpScriptTag,
+  deriveTaskStatus,
+  deriveCaseStatus,
 } from './dump';
+export type { TaskStatusFields, DerivedTaskStatus } from './dump';
 export {
   getTaskSearchArea,
   getTaskServiceDump,

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -7,7 +7,9 @@ import {
 } from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
+import { extractAllDumpScriptsSync } from './dump/html-utils';
 import { resolveScreenshotSource } from './dump/screenshot-store';
+import { deriveCaseStatus } from './dump/task-status';
 import {
   ReportMergingTool,
   collectDedupedExecutions,
@@ -203,19 +205,63 @@ export async function reportFileToMarkdown(
   return markdownFromReport(resolvedHtmlPath, outputDir);
 }
 
+const TEST_STATUS_VALUES: ReadonlySet<TestStatus> = new Set<TestStatus>([
+  'passed',
+  'failed',
+  'timedOut',
+  'skipped',
+  'interrupted',
+]);
+
+const FAILING_TEST_STATUSES: ReadonlySet<TestStatus> = new Set<TestStatus>([
+  'failed',
+  'timedOut',
+  'interrupted',
+]);
+
+/**
+ * Reuse a `playwright_test_status` already recorded on the source report's dump
+ * scripts (e.g. a Playwright-generated report carries the precise
+ * timedOut/skipped/interrupted status). Returns undefined when the source has
+ * no such attribute, so the caller can fall back to deriving from the dump.
+ *
+ * A single source report may bundle several executions (e.g. an already-merged
+ * report), so surface a failing status if any execution failed — mirroring
+ * `deriveCaseStatus`'s any-failure-wins semantics rather than taking the first
+ * script's status and masking later failures.
+ */
+function readSourceTestStatus(htmlPath: string): TestStatus | undefined {
+  const recorded: TestStatus[] = [];
+  for (const { openTag } of extractAllDumpScriptsSync(htmlPath)) {
+    const match = openTag.match(/playwright_test_status="([^"]*)"/);
+    if (!match) continue;
+    const status = decodeURIComponent(match[1]) as TestStatus;
+    if (TEST_STATUS_VALUES.has(status)) {
+      recorded.push(status);
+    }
+  }
+  if (recorded.length === 0) return undefined;
+  return recorded.find((s) => FAILING_TEST_STATUSES.has(s)) ?? recorded[0];
+}
+
 function deriveReportAttributesFromHtml(
   htmlPath: string,
   index: number,
 ): ReportFileAttributes {
   const fallbackId = `${path.basename(path.dirname(htmlPath)) || path.basename(htmlPath, path.extname(htmlPath))}-${index + 1}`;
   try {
-    const { baseDump } = collectDedupedExecutions(htmlPath);
+    const { baseDump, executions } = collectDedupedExecutions(htmlPath);
+    // Prefer a status the source report already recorded (keeps Playwright's
+    // precise timedOut/skipped/interrupted); otherwise infer it from the dump
+    // so a failing case is not silently merged in as passed.
+    const testStatus =
+      readSourceTestStatus(htmlPath) ?? deriveCaseStatus(executions);
     return {
       testId: fallbackId,
       testTitle: baseDump.groupName || fallbackId,
       testDescription: baseDump.groupDescription ?? '',
       testDuration: 0,
-      testStatus: 'passed' as TestStatus,
+      testStatus,
     };
   } catch {
     return {

--- a/packages/core/tests/unit-test/report-merge-status.test.ts
+++ b/packages/core/tests/unit-test/report-merge-status.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression test for the merged-report status bug.
+ *
+ * `mergeReportFiles` used to hardcode every merged case to `passed`, so a
+ * report bundling a passing case and a failing case showed both as Passed in
+ * the overview sidebar. The merged HTML must instead reflect each case's real
+ * status, derived from its dump (or reused from a source report that already
+ * recorded a precise Playwright status).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateDumpScriptTag, generateImageScriptTag } from '../../src/dump';
+import { mergeReportFiles } from '../../src/report-cli';
+import { ScreenshotItem } from '../../src/screenshot-item';
+import {
+  ExecutionDump,
+  ReportActionDump,
+  type TestStatus,
+} from '../../src/types';
+
+function fakeBase64(sizeBytes: number): string {
+  return `data:image/png;base64,${'A'.repeat(sizeBytes)}`;
+}
+
+type TaskShape = {
+  status: 'pending' | 'running' | 'finished' | 'failed' | 'cancelled';
+  subType?: string;
+  errorMessage?: string;
+  output?: unknown;
+};
+
+function buildExecution(id: string, tasks: TaskShape[]): ExecutionDump {
+  const screenshot = ScreenshotItem.create(fakeBase64(80), Date.now());
+  return new ExecutionDump({
+    id,
+    logTime: Date.now(),
+    name: `execution-${id}`,
+    tasks: tasks.map((task, index) => ({
+      taskId: `task-${id}-${index}`,
+      type: 'Insight',
+      subType: task.subType ?? 'Locate',
+      param: { prompt: 'find something' },
+      uiContext: {
+        screenshot,
+        shotSize: { width: 1920, height: 1080 },
+        shrunkShotToLogicalRatio: 1,
+      },
+      executor: async () => undefined,
+      recorder: [],
+      status: task.status,
+      ...(task.errorMessage ? { errorMessage: task.errorMessage } : {}),
+      ...('output' in task ? { output: task.output } : {}),
+    })) as any,
+  });
+}
+
+/** Extract `playwright_test_status` for every merged dump, in document order. */
+function mergedStatuses(html: string): string[] {
+  const statuses: string[] = [];
+  const openPattern = '<script type="midscene_web_dump"';
+  let pos = 0;
+  while (true) {
+    const openIdx = html.indexOf(openPattern, pos);
+    if (openIdx === -1) break;
+    const tagEndIdx = html.indexOf('>', openIdx);
+    if (tagEndIdx === -1) break;
+    const openTag = html.substring(openIdx, tagEndIdx + 1);
+    pos = tagEndIdx + 1;
+    // Only merged dumps carry playwright_test_id; skip template false-positives.
+    if (!/playwright_test_id="[^"]*"/.test(openTag)) continue;
+    const match = openTag.match(/playwright_test_status="([^"]*)"/);
+    statuses.push(match ? decodeURIComponent(match[1]) : '');
+  }
+  return statuses;
+}
+
+describe('mergeReportFiles status derivation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `midscene-merge-status-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function writeReport(
+    dirName: string,
+    groupName: string,
+    execution: ExecutionDump,
+    extraAttributes: Record<string, string> = {},
+  ): string {
+    const reportPath = join(tmpDir, dirName, 'index.html');
+    mkdirSync(join(tmpDir, dirName), { recursive: true });
+    const screenshot = ScreenshotItem.create(fakeBase64(80), Date.now());
+    const dump = new ReportActionDump({
+      groupName,
+      groupDescription: `${groupName}-desc`,
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    const html = [
+      generateImageScriptTag(screenshot.id, screenshot.base64),
+      generateDumpScriptTag(dump.serialize(), {
+        'data-group-id': `group-${groupName}`,
+        ...extraAttributes,
+      }),
+    ].join('\n');
+    writeFileSync(reportPath, html, 'utf-8');
+    return reportPath;
+  }
+
+  it('marks a failing case as failed and a passing case as passed', () => {
+    // A real failed Assert throws, leaving the task status === 'failed' with an
+    // errorMessage; the passing case finishes cleanly.
+    const passReport = writeReport(
+      'pass-report',
+      'passing-case',
+      buildExecution('pass', [{ status: 'finished' }, { status: 'finished' }]),
+    );
+    const failReport = writeReport(
+      'fail-report',
+      'failing-case',
+      buildExecution('fail', [
+        { status: 'finished' },
+        {
+          status: 'failed',
+          subType: 'Assert',
+          errorMessage: 'Assertion failed: element not found',
+        },
+      ]),
+    );
+
+    const { mergedReportPath } = mergeReportFiles({
+      htmlPaths: [passReport, failReport],
+      outputDir: join(tmpDir, 'merged'),
+      outputName: 'merged',
+    });
+
+    const html = readFileSync(mergedReportPath, 'utf-8');
+    expect(mergedStatuses(html)).toEqual(['passed', 'failed']);
+  });
+
+  it('preserves a precise status already recorded on the source report', () => {
+    // A Playwright-sourced report carries playwright_test_status="timedOut".
+    // Even though the dump tasks look finished, the precise status wins.
+    const timedOutReport = writeReport(
+      'timeout-report',
+      'timeout-case',
+      buildExecution('timeout', [{ status: 'finished' }]),
+      { playwright_test_status: 'timedOut' as TestStatus },
+    );
+
+    const { mergedReportPath } = mergeReportFiles({
+      htmlPaths: [timedOutReport],
+      outputDir: join(tmpDir, 'merged-timeout'),
+      outputName: 'merged-timeout',
+    });
+
+    const html = readFileSync(mergedReportPath, 'utf-8');
+    expect(mergedStatuses(html)).toEqual(['timedOut']);
+  });
+
+  it('aggregates a failure across a multi-execution source report', () => {
+    // A source report that itself bundles a passing and a failing execution,
+    // each carrying its own recorded status. The merged case must surface the
+    // failure instead of the first (passing) script's status.
+    const reportPath = join(tmpDir, 'bundled-report', 'index.html');
+    mkdirSync(join(tmpDir, 'bundled-report'), { recursive: true });
+    const screenshot = ScreenshotItem.create(fakeBase64(80), Date.now());
+    const buildDump = (groupName: string, exec: ExecutionDump) =>
+      new ReportActionDump({
+        groupName,
+        groupDescription: `${groupName}-desc`,
+        sdkVersion: '1.0.0-test',
+        modelBriefs: [],
+        executions: [exec],
+      });
+    const html = [
+      generateImageScriptTag(screenshot.id, screenshot.base64),
+      generateDumpScriptTag(
+        buildDump(
+          'bundled',
+          buildExecution('ok', [{ status: 'finished' }]),
+        ).serialize(),
+        { 'data-group-id': 'group-bundled', playwright_test_status: 'passed' },
+      ),
+      generateDumpScriptTag(
+        buildDump(
+          'bundled',
+          buildExecution('bad', [{ status: 'failed', subType: 'Assert' }]),
+        ).serialize(),
+        { 'data-group-id': 'group-bundled', playwright_test_status: 'failed' },
+      ),
+    ].join('\n');
+    writeFileSync(reportPath, html, 'utf-8');
+
+    const { mergedReportPath } = mergeReportFiles({
+      htmlPaths: [reportPath],
+      outputDir: join(tmpDir, 'merged-bundled'),
+      outputName: 'merged-bundled',
+    });
+
+    const merged = readFileSync(mergedReportPath, 'utf-8');
+    expect(mergedStatuses(merged)).toEqual(['failed']);
+  });
+});

--- a/packages/core/tests/unit-test/task-status.test.ts
+++ b/packages/core/tests/unit-test/task-status.test.ts
@@ -1,0 +1,96 @@
+import { deriveCaseStatus, deriveTaskStatus } from '@/dump/task-status';
+import { describe, expect, it } from 'vitest';
+
+describe('deriveTaskStatus', () => {
+  it('treats a thrown / failed task as failed', () => {
+    expect(
+      deriveTaskStatus({
+        status: 'failed',
+        errorMessage: 'Assertion failed: button not visible',
+      }),
+    ).toBe('failed');
+  });
+
+  it('treats a finished task carrying an error as failed', () => {
+    expect(
+      deriveTaskStatus({ status: 'finished', error: new Error('x') }),
+    ).toBe('failed');
+    expect(deriveTaskStatus({ status: 'finished', errorMessage: 'boom' })).toBe(
+      'failed',
+    );
+  });
+
+  it('treats a finished WaitFor with falsy output as a warning', () => {
+    expect(
+      deriveTaskStatus({
+        status: 'finished',
+        subType: 'WaitFor',
+        output: false,
+      }),
+    ).toBe('warning');
+  });
+
+  it('treats a finished Assert with falsy output as failed (legacy fallback)', () => {
+    expect(
+      deriveTaskStatus({
+        status: 'finished',
+        subType: 'Assert',
+        output: false,
+      }),
+    ).toBe('failed');
+  });
+
+  it('treats a clean finished task as passed', () => {
+    expect(deriveTaskStatus({ status: 'finished' })).toBe('passed');
+    expect(
+      deriveTaskStatus({ status: 'finished', subType: 'Assert', output: true }),
+    ).toBe('passed');
+  });
+
+  it('passes through lifecycle statuses', () => {
+    expect(deriveTaskStatus({ status: 'pending' })).toBe('pending');
+    expect(deriveTaskStatus({ status: 'running' })).toBe('running');
+    expect(deriveTaskStatus({ status: 'cancelled' })).toBe('cancelled');
+  });
+});
+
+describe('deriveCaseStatus', () => {
+  it('returns passed when every task passed', () => {
+    expect(
+      deriveCaseStatus([
+        { tasks: [{ status: 'finished' }, { status: 'finished' }] },
+      ]),
+    ).toBe('passed');
+  });
+
+  it('returns failed when any task failed', () => {
+    expect(
+      deriveCaseStatus([
+        {
+          tasks: [
+            { status: 'finished' },
+            { status: 'failed', errorMessage: 'Assertion failed' },
+          ],
+        },
+      ]),
+    ).toBe('failed');
+  });
+
+  it('does not fail a case for a WaitFor warning alone', () => {
+    expect(
+      deriveCaseStatus([
+        {
+          tasks: [
+            { status: 'finished' },
+            { status: 'finished', subType: 'WaitFor', output: false },
+          ],
+        },
+      ]),
+    ).toBe('passed');
+  });
+
+  it('handles empty / task-less executions', () => {
+    expect(deriveCaseStatus([])).toBe('passed');
+    expect(deriveCaseStatus([{}])).toBe('passed');
+  });
+});


### PR DESCRIPTION
## Problem

`mergeReportFiles` hardcoded every merged case to `passed`. When merging a passing report and a failing report, the merged report's overview sidebar showed **both cases as Passed**, hiding the real failure.

Root cause: `deriveReportAttributesFromHtml` in `report-cli.ts` always returned `testStatus: 'passed'`, and the front-end overview computes Total/Passed/Failed purely from each dump's `playwright_test_status` attribute.

## Fix

- **New single source of truth** — `packages/core/src/dump/task-status.ts` exposes `deriveTaskStatus` / `deriveCaseStatus`, mirroring the report sidebar's `getStatusIcon` failure semantics (a thrown/failed task, a finished task carrying an error, or a finished `Assert` with a falsy output ⇒ `failed`; a finished `WaitFor` with a falsy output ⇒ `warning`).
- **`mergeReportFiles`** now prefers a precise status the source report already recorded (keeps Playwright's `timedOut` / `skipped` / `interrupted`), and otherwise infers `passed` / `failed` from the dump. When a source bundles multiple executions, a failure in any of them wins, matching `deriveCaseStatus`.
- **Report sidebar** reuses `deriveTaskStatus`, so per-step icons and the merged Passed/Failed counts can never diverge.

## Tests

- `packages/core/tests/unit-test/task-status.test.ts` — unit coverage for `deriveTaskStatus` / `deriveCaseStatus` (failed / Assert / WaitFor-warning / lifecycle / aggregation).
- `packages/core/tests/unit-test/report-merge-status.test.ts` — regression: merging a passing + a failing report yields `['passed', 'failed']`; a recorded `timedOut` is preserved; a failure inside a multi-execution source report is surfaced.

## Validation

- `npx vitest --run tests/unit-test/task-status.test.ts tests/unit-test/report-merge-status.test.ts` — 13 passed
- `npx nx build core` — green (declaration + type check)
- `npx biome check` on all changed files — clean