### PR TITLE
fix(cli): keep browser open and show live progress with --keep-window

### DIFF
--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -1,9 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
-import type { BatchRunnerConfig } from '../batch-runner';
+import { BatchRunner, type BatchRunnerConfig } from '../batch-runner';
 import {
   createNotExecutedYamlResult,
+  getSummaryAbsolutePath,
   printExecutionFinished,
   printExecutionPlan,
   printExecutionSummary,
@@ -30,6 +31,38 @@ export interface FrameworkTestCommandOptions extends WebRuntimeOptions {
   frameworkImport?: string;
   stdio?: 'inherit' | 'pipe';
   rstestRunner?: typeof runRstestYamlProject;
+  /**
+   * In-process executor used for the `keepWindow` path. Injectable so tests can
+   * exercise the routing without launching a real browser. Defaults to the
+   * legacy {@link BatchRunner}.
+   */
+  inProcessRunner?: (
+    config: BatchRunnerConfig,
+  ) => Promise<MidsceneYamlConfigResult[]>;
+}
+
+const defaultInProcessRunner = (
+  config: BatchRunnerConfig,
+): Promise<MidsceneYamlConfigResult[]> => new BatchRunner(config).run();
+
+// `keepWindow` keeps the browser open after the run finishes, which is only
+// possible when the browser is owned by this long-lived CLI process. The Rstest
+// framework runs each case in a disposable worker whose teardown kills the
+// browser, so route keepWindow (a debug-only flow) through the in-process batch
+// executor instead. It owns the browser in this process and renders the live
+// per-step progress that the Rstest path does not surface — the two reasons to
+// pass --keep-window in the first place.
+async function runConfigInMainProcess(
+  config: BatchRunnerConfig,
+  commandOptions: FrameworkTestCommandOptions,
+): Promise<number> {
+  const runner = commandOptions.inProcessRunner ?? defaultInProcessRunner;
+  const results = await runner(config);
+  const success = printExecutionSummary(
+    results,
+    getSummaryAbsolutePath(config.summary),
+  );
+  return success ? 0 : 1;
 }
 
 const createCaseOptions = (
@@ -75,6 +108,10 @@ export async function runFrameworkTestConfig(
   config: BatchRunnerConfig,
   commandOptions: FrameworkTestCommandOptions = {},
 ): Promise<number> {
+  if (config.keepWindow) {
+    return runConfigInMainProcess(config, commandOptions);
+  }
+
   printExecutionPlan(config);
 
   const projectDir = resolve(commandOptions.projectDir || process.cwd());

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -696,6 +696,118 @@ export function defineYamlCaseTest(test: any, options: any) {
     }
   });
 
+  test('routes keepWindow through the in-process runner instead of Rstest', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    let rstestCalled = false;
+    let inProcessConfig: { keepWindow: boolean } | undefined;
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yaml],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: true,
+          keepWindow: true,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: '@test/framework',
+          stdio: 'pipe',
+          rstestRunner: async () => {
+            rstestCalled = true;
+            return 0;
+          },
+          inProcessRunner: async (config) => {
+            inProcessConfig = config;
+            return [
+              {
+                file: yaml,
+                success: true,
+                executed: true,
+                duration: 1,
+                resultType: 'success',
+              },
+            ];
+          },
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(rstestCalled).toBe(false);
+      expect(inProcessConfig?.keepWindow).toBe(true);
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('returns a non-zero exit code when a keepWindow run fails', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const yaml = join(root, 'case.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          files: [yaml],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: true,
+          keepWindow: true,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          stdio: 'pipe',
+          rstestRunner: async () => 0,
+          inProcessRunner: async () => [
+            {
+              file: yaml,
+              success: false,
+              executed: true,
+              duration: 1,
+              resultType: 'failed',
+              error: 'boom',
+            },
+          ],
+        },
+      );
+
+      expect(exitCode).toBe(1);
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('records shared browser batch setup failures for every YAML case', async () => {
     const root = createTempDir();
     const runDir = join(root, 'midscene-run');


### PR DESCRIPTION
## Problem

After upgrading the CLI to 1.9.x, two regressions appear when debugging with
`--keep-window` (e.g. `midscene path/to/case.yaml --headed --keep-window`):

1. **`--keep-window` no longer keeps the browser open.** The flag is still
   honored at the Puppeteer launcher level (it skips `browser.close()`), but
   since #2537 ("Run YAML cases through Rstest") the browser is launched inside
   a **disposable Rstest worker**. When `runRstest()` finishes, the worker pool
   is torn down and the worker's Chrome child process is killed with it. The
   main CLI process then enters the `keepWindow` `setInterval` hang and prints
   "browser is still running", but the window is already gone.

2. **No live execution records.** The Rstest runner is configured with
   `reporters: []`, and the per-step plan / pass-fail status comes from the
   player's `taskStatusList`, which previously was rendered live by the
   in-process `TTYWindowRenderer` in `yaml-batch-executor.ts`. The Rstest path
   bypasses it, so there is no per-step progress during a run.

Both symptoms share one root cause: execution was moved into a throwaway
worker, while `keepWindow` fundamentally requires the browser to be owned by
the long-lived CLI process.

## Fix

When `keepWindow` is set (a debug-only flow), bypass Rstest and run through the
still-present in-process `BatchRunner` (`runYamlBatch`):

- It launches and owns the browser in the main process, so after the run the
  `index.ts` hang keeps a real window open.
- It restores the live per-step `TTYWindowRenderer` progress.
- It still honors `keepWindow` in browser teardown.

Non-`keepWindow` runs keep using the Rstest framework (parallelism, retry,
isolation) unchanged.

The in-process runner is injectable (`inProcessRunner`) so the routing is unit
tested without launching a real browser.

## Tests

- `npx nx test cli` — 193 passed (incl. 2 new tests covering the keepWindow
  routing and its exit code).
- `pnpm run lint`
- `npx nx build cli`