### PR TITLE
feat(report): map each sidebar task node to a url hash anchor

### DIFF
--- a/apps/report/e2e/sidebar-navigation.yaml
+++ b/apps/report/e2e/sidebar-navigation.yaml
@@ -86,6 +86,80 @@ tasks:
           })()
         name: assertSecondTaskSelected
 
+  - name: selected task row maps to a url hash anchor
+    flow:
+      - javascript: |
+          (function () {
+            const rows = Array.from(
+              document.querySelectorAll('.tasks-table .task-row'),
+            );
+            const firstRow = rows[0];
+            if (!(firstRow instanceof HTMLElement)) {
+              throw new Error('First sidebar task row not found');
+            }
+            if (!firstRow.id) {
+              throw new Error('Task row is missing an anchor id');
+            }
+            firstRow.click();
+            return { anchorId: firstRow.id };
+          })()
+        name: clickRowForHash
+      - sleep: 500
+      - javascript: |
+          (function () {
+            const selectedRow = document.querySelector(
+              '.tasks-table .task-row.selected',
+            );
+            if (!(selectedRow instanceof HTMLElement)) {
+              throw new Error('No selected task row after click');
+            }
+            const expectedHash = '#' + selectedRow.id;
+            if (window.location.hash !== expectedHash) {
+              throw new Error(
+                'Expected url hash ' +
+                  expectedHash +
+                  ', found ' +
+                  window.location.hash,
+              );
+            }
+            return { hash: window.location.hash };
+          })()
+        name: assertHashMatchesSelectedRow
+      - javascript: |
+          (function () {
+            const rows = Array.from(
+              document.querySelectorAll('.tasks-table .task-row'),
+            );
+            const targetRow = rows[1];
+            if (!(targetRow instanceof HTMLElement) || !targetRow.id) {
+              throw new Error('Second sidebar task row with id not found');
+            }
+            // Drive selection purely through the url hash.
+            window.location.hash = targetRow.id;
+            return { navigatedTo: targetRow.id };
+          })()
+        name: navigateViaHash
+      - sleep: 1000
+      - javascript: |
+          (function () {
+            const selectedRow = document.querySelector(
+              '.tasks-table .task-row.selected',
+            );
+            if (!(selectedRow instanceof HTMLElement)) {
+              throw new Error('No selected task row after hash navigation');
+            }
+            if ('#' + selectedRow.id !== window.location.hash) {
+              throw new Error(
+                'Hash navigation did not select the matching row; selected ' +
+                  selectedRow.id +
+                  ', hash ' +
+                  window.location.hash,
+              );
+            }
+            return { selectedTaskId: selectedRow.getAttribute('data-task-id') };
+          })()
+        name: assertHashSelectsRow
+
   - name: toggle model call details
     flow:
       - javascript: |

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -21,6 +21,7 @@ import DetailSide from './components/detail-side';
 import GlobalHoverPreview from './components/global-hover-preview';
 import Sidebar from './components/sidebar';
 import { type DumpStoreType, useExecutionDump } from './components/store';
+import { useTaskHashAnchor } from './components/store/use-task-hash-anchor';
 import Timeline from './components/timeline';
 import ThemeDarkIcon from './icons/theme-dark.svg?react';
 import ThemeLightIcon from './icons/theme-light.svg?react';
@@ -103,6 +104,9 @@ function Visualizer(props: VisualizerProps): JSX.Element {
     darkModeEnabled: isDarkMode,
     setDarkModeEnabled: setIsDarkMode,
   } = useGlobalPreference();
+
+  // Keep the URL hash in sync with the selected sidebar task (deep-linking).
+  useTaskHashAnchor();
 
   useEffect(() => {
     document.documentElement.setAttribute(

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -18,6 +18,7 @@ import {
   hasDeepLocateFlag,
   hasDeepThinkFlag,
 } from '../../utils/report-task-tags';
+import { anchorIdForTask } from '../../utils/task-anchor';
 import ReportOverview from '../report-overview';
 
 // Extended task type with searchAreaUsage
@@ -680,8 +681,14 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
           <div className="table-body">
             {tableData.map((record) => {
               if (record.isGroupHeader) {
+                // Group headers are not selectable; the id only makes them a
+                // plain `#group-<index>` scroll target, with no hash sync.
                 return (
-                  <div key={record.key} className="group-header-row">
+                  <div
+                    key={record.key}
+                    id={record.key}
+                    className="group-header-row"
+                  >
                     <div className="side-sub-title">{record.groupName}</div>
                   </div>
                 );
@@ -691,10 +698,14 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
               const isSelected = task === activeTask;
               const isPlaying = task === playingTask;
               const taskId = task.taskId;
+              // Single source of truth for the anchor format so the row id,
+              // the hash we write, and the hash we resolve never drift apart.
+              const anchorId = anchorIdForTask(task);
 
               return (
                 <div
                   key={record.key}
+                  id={anchorId}
                   data-task-id={taskId}
                   className={`task-row ${isSelected ? 'selected' : ''} ${isPlaying ? 'playing' : ''}`}
                   onClick={() => {

--- a/apps/report/src/components/store/use-task-hash-anchor.ts
+++ b/apps/report/src/components/store/use-task-hash-anchor.ts
@@ -1,0 +1,50 @@
+import { anchorIdForTask, findTaskByAnchor } from '@/utils/task-anchor';
+import { useEffect } from 'react';
+import { useExecutionDump } from './index';
+
+/**
+ * Keep the URL hash and the active sidebar task in sync:
+ * - On load (and whenever the hash changes), select the task the hash points at
+ *   and scroll its sidebar row into view, so reports are deep-linkable.
+ * - When the active task changes, reflect it into the hash via `replaceState`
+ *   (no extra history entries, and it does not re-trigger the hash listener).
+ */
+export function useTaskHashAnchor(): void {
+  const dump = useExecutionDump((store) => store.dump);
+  const activeTask = useExecutionDump((store) => store.activeTask);
+  const replayAllMode = useExecutionDump((store) => store.replayAllMode);
+  const setActiveTask = useExecutionDump((store) => store.setActiveTask);
+
+  // Hash -> active task (initial deep-link + manual hash navigation).
+  useEffect(() => {
+    if (!dump) return;
+
+    const applyHash = () => {
+      const hash = window.location.hash;
+      if (!hash || hash === '#') return;
+      const task = findTaskByAnchor(dump, hash);
+      if (!task) return;
+      setActiveTask(task);
+      // Scroll the matching row into view once it has been rendered.
+      requestAnimationFrame(() => {
+        document
+          .getElementById(hash.slice(1))
+          ?.scrollIntoView({ block: 'nearest' });
+      });
+    };
+
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => window.removeEventListener('hashchange', applyHash);
+  }, [dump, setActiveTask]);
+
+  // Active task -> hash. Skip while replaying all so the play-all view keeps
+  // whatever anchor was last shared.
+  useEffect(() => {
+    if (!dump || replayAllMode || !activeTask) return;
+    const target = `#${anchorIdForTask(activeTask)}`;
+    if (window.location.hash !== target) {
+      window.history.replaceState(null, '', target);
+    }
+  }, [dump, activeTask, replayAllMode]);
+}

--- a/apps/report/src/utils/task-anchor.test.ts
+++ b/apps/report/src/utils/task-anchor.test.ts
@@ -1,0 +1,49 @@
+import type {
+  ExecutionDump,
+  ExecutionTask,
+  GroupedActionDump,
+} from '@midscene/core';
+import { describe, expect, it } from 'vitest';
+import { anchorIdForTask, findTaskByAnchor } from './task-anchor';
+
+const makeTask = (id: string): ExecutionTask =>
+  ({ taskId: id }) as unknown as ExecutionTask;
+
+const makeDump = (executionTasks: ExecutionTask[][]): GroupedActionDump =>
+  ({
+    groupName: 'group',
+    groupDescription: 'desc',
+    executions: executionTasks.map(
+      (tasks, index) =>
+        ({ name: `exec-${index}`, tasks }) as unknown as ExecutionDump,
+    ),
+  }) as unknown as GroupedActionDump;
+
+describe('anchorIdForTask', () => {
+  it('builds the anchor from the taskId', () => {
+    expect(anchorIdForTask(makeTask('abc-123'))).toBe('task-abc-123');
+  });
+
+  it('throws when the task has no taskId', () => {
+    expect(() => anchorIdForTask({} as unknown as ExecutionTask)).toThrow(
+      /taskId/,
+    );
+  });
+});
+
+describe('findTaskByAnchor', () => {
+  it('matches by taskId, accepting a leading #', () => {
+    const target = makeTask('uuid-with-dashes-1');
+    const dump = makeDump([[makeTask('other'), target]]);
+    expect(findTaskByAnchor(dump, '#task-uuid-with-dashes-1')).toBe(target);
+    expect(findTaskByAnchor(dump, 'task-uuid-with-dashes-1')).toBe(target);
+  });
+
+  it('returns null for unknown or malformed anchors', () => {
+    const dump = makeDump([[makeTask('a')]]);
+    expect(findTaskByAnchor(dump, '#task-missing')).toBeNull();
+    expect(findTaskByAnchor(dump, '#group-0')).toBeNull();
+    expect(findTaskByAnchor(dump, '')).toBeNull();
+    expect(findTaskByAnchor(null, '#task-a')).toBeNull();
+  });
+});

--- a/apps/report/src/utils/task-anchor.ts
+++ b/apps/report/src/utils/task-anchor.ts
@@ -1,0 +1,42 @@
+import type { ExecutionTask, GroupedActionDump } from '@midscene/core';
+
+// Every selectable sidebar node (a task row) maps to a URL hash anchor so the
+// currently viewed task can be deep-linked and restored on reload. The anchor
+// is `task-<taskId>`; taskId is a uuid that is always assigned and serialized
+// into the report.
+const ANCHOR_PREFIX = 'task-';
+
+/** Build the hash anchor id for a task. */
+export function anchorIdForTask(task: ExecutionTask): string {
+  if (!task.taskId) {
+    throw new Error('Cannot build a hash anchor for a task without a taskId');
+  }
+  return `${ANCHOR_PREFIX}${task.taskId}`;
+}
+
+/**
+ * Resolve the task referenced by a hash anchor within the given dump. Accepts a
+ * hash with or without the leading `#`. Returns `null` when the anchor does not
+ * point at a task in this dump (e.g. it belongs to another case).
+ */
+export function findTaskByAnchor(
+  dump: GroupedActionDump | null,
+  hashOrAnchor: string,
+): ExecutionTask | null {
+  if (!dump || !hashOrAnchor) return null;
+  const anchor = hashOrAnchor.startsWith('#')
+    ? hashOrAnchor.slice(1)
+    : hashOrAnchor;
+  if (!anchor.startsWith(ANCHOR_PREFIX)) return null;
+  const taskId = anchor.slice(ANCHOR_PREFIX.length);
+
+  for (const execution of dump.executions) {
+    for (const task of execution.tasks) {
+      if (task.taskId === taskId) {
+        return task;
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## What

Make every selectable task node in the report sidebar addressable via a URL hash, so a report can be deep-linked to a specific step and restored on reload.

The anchor format is `#task-<taskId>` (taskId is a uuid that is always serialized into the dump).

## Why

Previously the report had no hash routing at all — there was no way to share a link that points at a specific step, and reloading always reset to the default replay-all view. This adds shareable, restorable per-node anchors.

## How

- **`apps/report/src/utils/task-anchor.ts`** (new): `anchorIdForTask` / `findTaskByAnchor` are the single source of truth for the anchor format. `anchorIdForTask` fails fast when a task has no `taskId` instead of emitting a malformed `task-undefined` id.
- **`apps/report/src/components/store/use-task-hash-anchor.ts`** (new): syncs both directions.
  - hash → active task: on load and on `hashchange`, select the referenced task and scroll its row into view.
  - active task → hash: written via `history.replaceState` (no history pollution, and it does not re-enter the `hashchange` listener). Skipped while replaying all so the play-all view keeps whatever anchor was last shared.
- **`apps/report/src/components/sidebar/index.tsx`**: each task row gets an `id` produced by `anchorIdForTask(task)`; group headers get a plain `#group-<index>` scroll-target id (no hash sync).
- **`apps/report/src/App.tsx`**: mount the hook in `Visualizer`.

## Behavior notes

- Click a node → URL hash becomes `#task-<taskId>` (no extra browser history entries).
- Open/edit a deep link → the matching node is selected and scrolled into view; reload keeps that node instead of falling back to replay-all.
- Group headers are addressable for native scroll only; they are not selectable and do not participate in hash sync.

## Validation

- `npx nx test report` — 51 passed (incl. new `task-anchor.test.ts`, covering the taskId match, malformed/unknown anchors, and the fail-fast throw).
- `npx nx build report` — succeeds.
- `pnpm run lint` — clean.
- Manually verified against a real generated report (14 task nodes, all with taskId): click→hash, hash→selection + scroll, and reload persistence all work. New e2e steps added to `apps/report/e2e/sidebar-navigation.yaml` assert click→hash and hash→selection.