### PR TITLE
feat(core): expose aggregated LLM usage metrics on agent (#1084)

### DIFF
--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1324,13 +1324,13 @@ console.log(logContent);
 ## LLM usage metrics
 
 Midscene records the token usage of every LLM call. You can read the aggregated
-totals from the agent at runtime, which is useful for cost observability and
-per-spec tracking with tools like Langfuse.
+totals from the agent at runtime, which is useful for cost observability with
+tools like Langfuse.
 
 ### `agent.metrics`
 
 A getter that returns a snapshot of the LLM usage accumulated by the agent since
-it was created or since the last `resetMetrics()` call.
+it was created.
 
 - Type
 
@@ -1362,32 +1362,6 @@ interface MidsceneUsageMetrics {
 await agent.aiAct('search for headphones');
 const usage = agent.metrics;
 console.log(usage.totalTokens, usage.byIntent, usage.byModel);
-```
-
-### `agent.resetMetrics()`
-
-Clears the accumulated metrics. Call it at the start of a logical unit (such as
-a test spec) to measure only the usage that follows. Call it between actions,
-not while one is in flight, so an in-progress action is not counted twice.
-
-- Type
-
-```typescript
-function resetMetrics(): void;
-```
-
-- Example: per-spec cost tracking
-
-```typescript
-beforeEach(() => agent.resetMetrics());
-
-afterEach(() => {
-  const usage = agent.metrics;
-  langfuse.track('MidsceneUsage', {
-    value: usage.totalTokens,
-    metadata: usage,
-  });
-});
 ```
 
 ### `onLLMUsage` option

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1321,6 +1321,88 @@ const logContent = agent._unstableLogContent();
 console.log(logContent);
 ```
 
+## LLM usage metrics
+
+Midscene records the token usage of every LLM call. You can read the aggregated
+totals from the agent at runtime, which is useful for cost observability and
+per-spec tracking with tools like Langfuse.
+
+### `agent.metrics`
+
+A getter that returns a snapshot of the LLM usage accumulated by the agent since
+it was created or since the last `resetMetrics()` call.
+
+- Type
+
+```typescript
+interface UsageBucket {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  calls: number;
+}
+
+interface MidsceneUsageMetrics {
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  totalTokens: number;
+  totalCachedInput: number;
+  totalTimeCostMs: number;
+  calls: number;
+  // Breakdown by call intent: `planning`, `insight`, `default`.
+  byIntent: Record<string, UsageBucket>;
+  // Breakdown by model name.
+  byModel: Record<string, UsageBucket>;
+}
+```
+
+- Example
+
+```typescript
+await agent.aiAct('search for headphones');
+const usage = agent.metrics;
+console.log(usage.totalTokens, usage.byIntent, usage.byModel);
+```
+
+### `agent.resetMetrics()`
+
+Clears the accumulated metrics. Call it at the start of a logical unit (such as
+a test spec) to measure only the usage that follows. Call it between actions,
+not while one is in flight, so an in-progress action is not counted twice.
+
+- Type
+
+```typescript
+function resetMetrics(): void;
+```
+
+- Example: per-spec cost tracking
+
+```typescript
+beforeEach(() => agent.resetMetrics());
+
+afterEach(() => {
+  const usage = agent.metrics;
+  langfuse.track('MidsceneUsage', {
+    value: usage.totalTokens,
+    metadata: usage,
+  });
+});
+```
+
+### `onLLMUsage` option
+
+For real-time tracking, pass an `onLLMUsage` callback when constructing the
+agent. It is invoked once per LLM call as soon as the usage is available, with
+the raw usage info (token counts, model name, intent, request id, etc.).
+
+```typescript
+const agent = new PuppeteerAgent(page, {
+  onLLMUsage: (usage) => {
+    langfuse.event({ name: usage.intent, value: usage.total_tokens });
+  },
+});
+```
 
 ## Deep Locate (deepLocate)
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1310,6 +1310,82 @@ const logContent = agent._unstableLogContent();
 console.log(logContent);
 ```
 
+## 大模型用量指标
+
+Midscene 会记录每一次大模型调用的 token 用量。你可以在运行时从 agent 读取聚合后的总量,这对于成本可观测性以及配合 Langfuse 等工具按用例(spec)追踪非常有用。
+
+### `agent.metrics`
+
+一个 getter,返回自 agent 创建以来(或自上次调用 `resetMetrics()` 以来)累计的大模型用量快照。
+
+- 类型
+
+```typescript
+interface UsageBucket {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  calls: number;
+}
+
+interface MidsceneUsageMetrics {
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  totalTokens: number;
+  totalCachedInput: number;
+  totalTimeCostMs: number;
+  calls: number;
+  // 按调用意图拆分:`planning`、`insight`、`default`。
+  byIntent: Record<string, UsageBucket>;
+  // 按模型名称拆分。
+  byModel: Record<string, UsageBucket>;
+}
+```
+
+- 示例
+
+```typescript
+await agent.aiAct('搜索耳机');
+const usage = agent.metrics;
+console.log(usage.totalTokens, usage.byIntent, usage.byModel);
+```
+
+### `agent.resetMetrics()`
+
+清空已累计的指标。在一个逻辑单元(例如一个测试 spec)开始时调用,即可只统计此后产生的用量。请在两次操作之间调用,不要在某个操作执行途中调用,否则进行中的操作可能被重复计数。
+
+- 类型
+
+```typescript
+function resetMetrics(): void;
+```
+
+- 示例:按 spec 追踪成本
+
+```typescript
+beforeEach(() => agent.resetMetrics());
+
+afterEach(() => {
+  const usage = agent.metrics;
+  langfuse.track('MidsceneUsage', {
+    value: usage.totalTokens,
+    metadata: usage,
+  });
+});
+```
+
+### `onLLMUsage` 选项
+
+如需实时追踪,可在构造 agent 时传入 `onLLMUsage` 回调。每次大模型调用的用量一旦就绪即触发一次,回调参数为原始用量信息(token 数、模型名、意图、请求 id 等)。
+
+```typescript
+const agent = new PuppeteerAgent(page, {
+  onLLMUsage: (usage) => {
+    langfuse.event({ name: usage.intent, value: usage.total_tokens });
+  },
+});
+```
+
 ## 属性
 
 ### `.reportFile`

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1312,11 +1312,11 @@ console.log(logContent);
 
 ## 大模型用量指标
 
-Midscene 会记录每一次大模型调用的 token 用量。你可以在运行时从 agent 读取聚合后的总量,这对于成本可观测性以及配合 Langfuse 等工具按用例(spec)追踪非常有用。
+Midscene 会记录每一次大模型调用的 token 用量。你可以在运行时从 agent 读取聚合后的总量,这对于配合 Langfuse 等工具做成本可观测性非常有用。
 
 ### `agent.metrics`
 
-一个 getter,返回自 agent 创建以来(或自上次调用 `resetMetrics()` 以来)累计的大模型用量快照。
+一个 getter,返回自 agent 创建以来累计的大模型用量快照。
 
 - 类型
 
@@ -1348,30 +1348,6 @@ interface MidsceneUsageMetrics {
 await agent.aiAct('搜索耳机');
 const usage = agent.metrics;
 console.log(usage.totalTokens, usage.byIntent, usage.byModel);
-```
-
-### `agent.resetMetrics()`
-
-清空已累计的指标。在一个逻辑单元(例如一个测试 spec)开始时调用,即可只统计此后产生的用量。请在两次操作之间调用,不要在某个操作执行途中调用,否则进行中的操作可能被重复计数。
-
-- 类型
-
-```typescript
-function resetMetrics(): void;
-```
-
-- 示例:按 spec 追踪成本
-
-```typescript
-beforeEach(() => agent.resetMetrics());
-
-afterEach(() => {
-  const usage = agent.metrics;
-  langfuse.track('MidsceneUsage', {
-    value: usage.totalTokens,
-    metadata: usage,
-  });
-});
 ```
 
 ### `onLLMUsage` 选项

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -481,20 +481,10 @@ export class Agent<
   }
 
   /**
-   * Aggregated LLM usage accumulated by this agent since creation or the last
-   * {@link resetMetrics}. Use with `resetMetrics()` for per-spec cost tracking.
+   * Aggregated LLM usage accumulated by this agent since it was created.
    */
   get metrics(): MidsceneUsageMetrics {
     return this.metricsCollector.snapshot();
-  }
-
-  /**
-   * Clear accumulated usage metrics. Call at the start of a logical unit (e.g.
-   * a test spec) to measure only the usage that follows.
-   */
-  resetMetrics() {
-    this.metricsCollector.reset();
-    this.countedUsageKeys.clear();
   }
 
   dumpDataString(opt?: { inlineScreenshots?: boolean }) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7,6 +7,7 @@ import Service from '../service/index';
 // DO NOT import from '../index' as it creates a circular dependency:
 // index.ts -> agent/index.ts -> agent/agent.ts -> index.ts
 import {
+  type AIUsageInfo,
   type ActionParam,
   type ActionReturn,
   type AgentAssertOpt,
@@ -64,6 +65,7 @@ import { getDebug } from '@midscene/shared/logger';
 import { assert, ifInBrowser, uuid } from '@midscene/shared/utils';
 import { defineActionSleep } from '../device';
 import { validateAgentCacheInput } from './cache-config';
+import { MetricsCollector, type MidsceneUsageMetrics } from './metrics';
 import { AgentProgressBus } from './progress';
 import { buildPromptWithContext } from './prompt-context';
 import { normalizeRecordToReportScreenshot } from './record-to-report';
@@ -143,6 +145,12 @@ export class Agent<
   onTaskStartTip?: OnTaskStartTip;
 
   taskCache?: TaskCache;
+
+  private readonly metricsCollector = new MetricsCollector();
+
+  // Usage values already folded into `metricsCollector`, keyed by
+  // `${taskId}:${field}` so re-emitted snapshots never double-count.
+  private readonly countedUsageKeys = new Set<string>();
 
   private dumpUpdateListeners: Array<
     (dump: string, executionDump?: ExecutionDump) => void
@@ -305,6 +313,7 @@ export class Agent<
         onSnapshotChange: async (runner) => {
           const executionDump = runner.dump();
           this.appendExecutionDump(executionDump, runner);
+          this.collectUsageMetrics(executionDump);
 
           // Persist report updates before notifying listeners so screenshot
           // payloads can be released from memory and serialized as references.
@@ -442,6 +451,50 @@ export class Agent<
       return;
     }
     currentDump.executions.push(execution);
+  }
+
+  /**
+   * Fold any not-yet-counted task usage from an execution dump into the
+   * instance metrics. Snapshots are re-emitted as tasks progress, so each
+   * usage value is keyed by `${taskId}:${field}` and counted at most once.
+   */
+  private collectUsageMetrics(execution: ExecutionDump) {
+    for (const task of execution.tasks) {
+      this.consumeUsage(task.usage, `${task.taskId}:usage`);
+      this.consumeUsage(task.searchAreaUsage, `${task.taskId}:searchAreaUsage`);
+    }
+  }
+
+  private consumeUsage(usage: AIUsageInfo | undefined, key: string) {
+    if (!usage || this.countedUsageKeys.has(key)) {
+      return;
+    }
+    this.countedUsageKeys.add(key);
+    this.metricsCollector.add(usage);
+    if (this.opts.onLLMUsage) {
+      try {
+        this.opts.onLLMUsage(usage);
+      } catch (error) {
+        warn(`onLLMUsage listener threw, ignoring: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * Aggregated LLM usage accumulated by this agent since creation or the last
+   * {@link resetMetrics}. Use with `resetMetrics()` for per-spec cost tracking.
+   */
+  get metrics(): MidsceneUsageMetrics {
+    return this.metricsCollector.snapshot();
+  }
+
+  /**
+   * Clear accumulated usage metrics. Call at the start of a logical unit (e.g.
+   * a test spec) to measure only the usage that follows.
+   */
+  resetMetrics() {
+    this.metricsCollector.reset();
+    this.countedUsageKeys.clear();
   }
 
   dumpDataString(opt?: { inlineScreenshots?: boolean }) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -148,6 +148,10 @@ export class Agent<
 
   private readonly metricsCollector = new MetricsCollector();
 
+  // Monotonic counter for generating unique dedup keys when a usage has no
+  // request_id (e.g. estimated streaming usage).
+  private usageCallCounter = 0;
+
   // Usage values already folded into `metricsCollector`, keyed by
   // `${taskId}:${field}` so re-emitted snapshots never double-count.
   private readonly countedUsageKeys = new Set<string>();
@@ -238,7 +242,24 @@ export class Agent<
   }
 
   private resolveModelRuntime(intent: TIntent): ModelRuntime {
-    return getModelRuntime(this.modelConfigManager.getModelConfig(intent));
+    const runtime = getModelRuntime(
+      this.modelConfigManager.getModelConfig(intent),
+    );
+    return {
+      ...runtime,
+      onUsage: (usage) => {
+        this.usageCallCounter += 1;
+        // buildUsageInfo leaves intent undefined; fill it from the model
+        // config slot so metrics.byIntent has a meaningful category.
+        const enriched = usage.intent
+          ? usage
+          : { ...usage, intent: usage.slot };
+        this.consumeUsage(
+          enriched,
+          `callai:${usage.request_id ?? this.usageCallCounter}`,
+        );
+      },
+    };
   }
 
   constructor(interfaceInstance: InterfaceType, opts?: AgentOpt) {
@@ -466,10 +487,17 @@ export class Agent<
   }
 
   private consumeUsage(usage: AIUsageInfo | undefined, key: string) {
-    if (!usage || this.countedUsageKeys.has(key)) {
+    if (!usage) {
       return;
     }
-    this.countedUsageKeys.add(key);
+    // Prefer request_id for dedup because it is stable across collection paths
+    // (onUsage callback and task-dump-based collectUsageMetrics both see the
+    // same request_id from the underlying model call).
+    const dedupKey = usage.request_id ? `req:${usage.request_id}` : key;
+    if (this.countedUsageKeys.has(dedupKey)) {
+      return;
+    }
+    this.countedUsageKeys.add(dedupKey);
     this.metricsCollector.add(usage);
     if (this.opts.onLLMUsage) {
       try {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,4 +1,5 @@
 import { type ModelRuntime, getModelRuntime } from '@/ai-model/models';
+import { INTERNAL_CALL_ID_FIELD } from '@/ai-model/service-caller';
 import yaml from 'js-yaml';
 import type { TUserPrompt } from '../ai-model/index';
 import { ScreenshotItem } from '../screenshot-item';
@@ -490,10 +491,19 @@ export class Agent<
     if (!usage) {
       return;
     }
-    // Prefer request_id for dedup because it is stable across collection paths
-    // (onUsage callback and task-dump-based collectUsageMetrics both see the
-    // same request_id from the underlying model call).
-    const dedupKey = usage.request_id ? `req:${usage.request_id}` : key;
+    // Dedup key priority:
+    // 1. request_id — provider-issued, stable across onUsage and task dump paths
+    // 2. INTERNAL_CALL_ID_FIELD — callAI-generated internal id, covers
+    //    providers that don't return a request_id
+    // 3. caller-provided key (taskId:field or callai:counter)
+    let dedupKey: string;
+    if (usage.request_id) {
+      dedupKey = `req:${usage.request_id}`;
+    } else if ((usage as any)[INTERNAL_CALL_ID_FIELD]) {
+      dedupKey = `int:${(usage as any)[INTERNAL_CALL_ID_FIELD]}`;
+    } else {
+      dedupKey = key;
+    }
     if (this.countedUsageKeys.has(dedupKey)) {
       return;
     }

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -13,6 +13,7 @@ export { type LocateCache, type PlanningCache, TaskCache } from './task-cache';
 export { cacheFileExt } from './task-cache';
 
 export { TaskExecutor } from './tasks';
+export type { MidsceneUsageMetrics, UsageBucket } from './metrics';
 export type {
   GherkinStepKeyword,
   RunGherkinScenarioOptions,

--- a/packages/core/src/agent/metrics.ts
+++ b/packages/core/src/agent/metrics.ts
@@ -1,0 +1,131 @@
+import type { AIUsageInfo } from '@/types';
+
+/**
+ * Aggregated usage for a single grouping key (intent or model).
+ */
+export interface UsageBucket {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  calls: number;
+}
+
+/**
+ * Instance-level snapshot of LLM usage accumulated by an Agent.
+ *
+ * Designed for cost observability: reset at the start of a logical unit
+ * (e.g. a test spec) and read back at the end, then push to tools like
+ * Langfuse. `byIntent` / `byModel` provide free breakdowns derived from the
+ * usage data Midscene already records per call.
+ */
+export interface MidsceneUsageMetrics {
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  totalTokens: number;
+  totalCachedInput: number;
+  totalTimeCostMs: number;
+  calls: number;
+  byIntent: Record<string, UsageBucket>;
+  byModel: Record<string, UsageBucket>;
+}
+
+const emptyBucket = (): UsageBucket => ({
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  calls: 0,
+});
+
+const addToBucket = (
+  map: Record<string, UsageBucket>,
+  key: string,
+  prompt: number,
+  completion: number,
+  total: number,
+): void => {
+  if (!map[key]) {
+    map[key] = emptyBucket();
+  }
+  const bucket = map[key];
+  bucket.promptTokens += prompt;
+  bucket.completionTokens += completion;
+  bucket.totalTokens += total;
+  bucket.calls += 1;
+};
+
+/**
+ * Pure accumulator for {@link AIUsageInfo}. Deduplication of calls is the
+ * caller's responsibility; every `add` counts as one call.
+ */
+export class MetricsCollector {
+  private totalPromptTokens = 0;
+  private totalCompletionTokens = 0;
+  private totalTokens = 0;
+  private totalCachedInput = 0;
+  private totalTimeCostMs = 0;
+  private calls = 0;
+  private byIntent: Record<string, UsageBucket> = {};
+  private byModel: Record<string, UsageBucket> = {};
+
+  add(usage: AIUsageInfo): void {
+    const prompt = usage.prompt_tokens ?? 0;
+    const completion = usage.completion_tokens ?? 0;
+    const total = usage.total_tokens ?? 0;
+
+    this.totalPromptTokens += prompt;
+    this.totalCompletionTokens += completion;
+    this.totalTokens += total;
+    this.totalCachedInput += usage.cached_input ?? 0;
+    this.totalTimeCostMs += usage.time_cost ?? 0;
+    this.calls += 1;
+
+    addToBucket(
+      this.byIntent,
+      usage.intent ?? 'unknown',
+      prompt,
+      completion,
+      total,
+    );
+    addToBucket(
+      this.byModel,
+      usage.model_name ?? 'unknown',
+      prompt,
+      completion,
+      total,
+    );
+  }
+
+  snapshot(): MidsceneUsageMetrics {
+    const cloneBuckets = (
+      map: Record<string, UsageBucket>,
+    ): Record<string, UsageBucket> => {
+      const out: Record<string, UsageBucket> = {};
+      for (const [key, bucket] of Object.entries(map)) {
+        out[key] = { ...bucket };
+      }
+      return out;
+    };
+
+    return {
+      totalPromptTokens: this.totalPromptTokens,
+      totalCompletionTokens: this.totalCompletionTokens,
+      totalTokens: this.totalTokens,
+      totalCachedInput: this.totalCachedInput,
+      totalTimeCostMs: this.totalTimeCostMs,
+      calls: this.calls,
+      byIntent: cloneBuckets(this.byIntent),
+      byModel: cloneBuckets(this.byModel),
+    };
+  }
+
+  reset(): void {
+    this.totalPromptTokens = 0;
+    this.totalCompletionTokens = 0;
+    this.totalTokens = 0;
+    this.totalCachedInput = 0;
+    this.totalTimeCostMs = 0;
+    this.calls = 0;
+    this.byIntent = {};
+    this.byModel = {};
+  }
+}

--- a/packages/core/src/agent/metrics.ts
+++ b/packages/core/src/agent/metrics.ts
@@ -13,10 +13,9 @@ export interface UsageBucket {
 /**
  * Instance-level snapshot of LLM usage accumulated by an Agent.
  *
- * Designed for cost observability: reset at the start of a logical unit
- * (e.g. a test spec) and read back at the end, then push to tools like
- * Langfuse. `byIntent` / `byModel` provide free breakdowns derived from the
- * usage data Midscene already records per call.
+ * Designed for cost observability: read it back after a logical unit of work
+ * and push to tools like Langfuse. `byIntent` / `byModel` provide free
+ * breakdowns derived from the usage data Midscene already records per call.
  */
 export interface MidsceneUsageMetrics {
   totalPromptTokens: number;
@@ -118,6 +117,10 @@ export class MetricsCollector {
     };
   }
 
+  /**
+   * Clear all accumulated state. Not wired to a public Agent API yet; kept for
+   * a future per-unit reset (e.g. resetting metrics at the start of a spec).
+   */
   reset(): void {
     this.totalPromptTokens = 0;
     this.totalCompletionTokens = 0;

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -461,7 +461,12 @@ export class TaskBuilder {
           task.usage = withUsageIntent(dump.taskInfo?.usage, 'default');
           task.searchArea = dump.taskInfo?.searchArea;
           if (dump.taskInfo?.searchAreaUsage) {
-            task.searchAreaUsage = dump.taskInfo.searchAreaUsage;
+            // The deepLocate search-area call belongs to the same locate task,
+            // so it shares the companion usage intent.
+            task.searchAreaUsage = withUsageIntent(
+              dump.taskInfo.searchAreaUsage,
+              'default',
+            );
           }
           if (dump.taskInfo?.reasoning_content) {
             task.reasoning_content = dump.taskInfo.reasoning_content;

--- a/packages/core/src/ai-model/model-adapter/types.ts
+++ b/packages/core/src/ai-model/model-adapter/types.ts
@@ -1,4 +1,5 @@
 import type { PixelBbox, PlanningAction } from '@/types';
+import type { AIUsageInfo } from '@/types';
 import type {
   IModelConfig,
   TIntent,
@@ -210,6 +211,13 @@ export interface ModelAdapter {
 export interface ModelRuntime {
   config: IModelConfig;
   adapter: ModelAdapter;
+  /**
+   * Optional callback fired after every underlying model call with the shaped
+   * usage info. Provides a single collection point for callers that want to
+   * aggregate usage across all model invocations (including auxiliary calls
+   * such as order-sensitive judging and deep-locate search-area calls).
+   */
+  onUsage?: (usage: AIUsageInfo) => void;
 }
 
 export interface ModelAdapterDefinition {

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -310,12 +310,16 @@ export async function callAI(
   const { config: modelConfig, adapter } = modelRuntime;
 
   if (isCodexAppServerProvider(modelConfig.openaiBaseURL)) {
-    return callAIWithCodexAppServer(messages, modelConfig, {
+    const codexResult = await callAIWithCodexAppServer(messages, modelConfig, {
       stream: options?.stream,
       onChunk: options?.onChunk,
       reasoningEnabled: modelConfig.reasoningEnabled,
       abortSignal: options?.abortSignal,
     });
+    if (codexResult.usage && modelRuntime.onUsage) {
+      modelRuntime.onUsage(codexResult.usage);
+    }
+    return codexResult;
   }
 
   const { completion, modelName, modelDescription, modelFamily } =
@@ -359,6 +363,9 @@ export async function callAI(
   let timeCost: number | undefined;
   let requestId: string | null | undefined;
   let responseModelName: string | undefined;
+  // Tracks whether onUsage has already been fired for this call (e.g. from
+  // the streaming final-chunk handler), so the final return does not double-fire.
+  let usageReported = false;
 
   const hasUsableText = (value: string | null | undefined): value is string =>
     typeof value === 'string' && value.trim().length > 0;
@@ -384,7 +391,10 @@ export async function callAI(
       model_description: modelDescription,
       response_model_name: responseModelName,
       slot: modelConfig.slot,
-      // Agent task layers fill semantic intent after the raw model call.
+      // Left undefined at the raw call layer. The agent's onUsage callback
+      // fills it from modelConfig.slot for metrics collection, and task
+      // layers use withUsageIntent() to stamp a more specific semantic
+      // intent (e.g. 'planning', 'insight') when attaching usage to tasks.
       intent: undefined,
       request_id: requestId ?? undefined,
     } satisfies AIUsageInfo;
@@ -504,12 +514,17 @@ export async function callAI(
             }
 
             // Send final chunk
+            const finalUsage = buildUsageInfo(usage, requestId);
+            if (finalUsage && modelRuntime.onUsage) {
+              modelRuntime.onUsage(finalUsage);
+              usageReported = true;
+            }
             const finalChunk: CodeGenerationChunk = {
               content: '',
               accumulated,
               reasoning_content: '',
               isComplete: true,
-              usage: buildUsageInfo(usage, requestId),
+              usage: finalUsage,
             };
             options.onChunk!(finalChunk);
             break;
@@ -578,10 +593,14 @@ export async function callAI(
           }
 
           if (!hasUsableText(content)) {
+            const errorUsage = buildUsageInfo(usage, requestId);
+            if (errorUsage && modelRuntime.onUsage) {
+              modelRuntime.onUsage(errorUsage);
+            }
             throw new AIResponseParseError(
               'empty content from AI model',
               JSON.stringify(result),
-              buildUsageInfo(usage, requestId),
+              errorUsage,
               rawChoiceMessage,
             );
           }
@@ -641,11 +660,18 @@ export async function callAI(
       } as OpenAI.CompletionUsage;
     }
 
+    const finalUsage = buildUsageInfo(usage, requestId);
+    // Report usage to the runtime-level collector if not already reported
+    // (e.g. from the streaming final-chunk handler).
+    if (!usageReported && finalUsage && modelRuntime.onUsage) {
+      modelRuntime.onUsage(finalUsage);
+    }
+
     return {
       content: content || '',
       reasoning_content: accumulatedReasoning || undefined,
       rawChoiceMessage,
-      usage: buildUsageInfo(usage, requestId),
+      usage: finalUsage,
       isStreamed: !!isStreaming,
     };
   } catch (e: any) {

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -56,6 +56,18 @@ export {
 } from './json';
 export type { JsonParser } from './json';
 
+/**
+ * Internal field name stamped onto every AIUsageInfo shaped by callAI().
+ * Used for cross-path dedup when the provider does not return a request_id.
+ */
+export const INTERNAL_CALL_ID_FIELD = '_midscene_call_id';
+
+let internalCallIdCounter = 0;
+function nextInternalCallId(): string {
+  internalCallIdCounter += 1;
+  return `call_${internalCallIdCounter}`;
+}
+
 function stringifyForDebug(value: unknown): string {
   try {
     return JSON.stringify(value);
@@ -309,6 +321,11 @@ export async function callAI(
 }> {
   const { config: modelConfig, adapter } = modelRuntime;
 
+  // Stable internal ID for this call, used by the agent to deduplicate usage
+  // across the onUsage callback and the task-dump-based collectUsageMetrics()
+  // path when the provider does not return a request_id.
+  const internalCallId = nextInternalCallId();
+
   if (isCodexAppServerProvider(modelConfig.openaiBaseURL)) {
     const codexResult = await callAIWithCodexAppServer(messages, modelConfig, {
       stream: options?.stream,
@@ -316,8 +333,11 @@ export async function callAI(
       reasoningEnabled: modelConfig.reasoningEnabled,
       abortSignal: options?.abortSignal,
     });
-    if (codexResult.usage && modelRuntime.onUsage) {
-      modelRuntime.onUsage(codexResult.usage);
+    if (codexResult.usage) {
+      (codexResult.usage as any)[INTERNAL_CALL_ID_FIELD] = internalCallId;
+      if (modelRuntime.onUsage) {
+        modelRuntime.onUsage(codexResult.usage);
+      }
     }
     return codexResult;
   }
@@ -397,6 +417,8 @@ export async function callAI(
       // intent (e.g. 'planning', 'insight') when attaching usage to tasks.
       intent: undefined,
       request_id: requestId ?? undefined,
+      // Internal stable ID for cross-path dedup when request_id is absent.
+      [INTERNAL_CALL_ID_FIELD]: internalCallId,
     } satisfies AIUsageInfo;
   };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,7 +61,9 @@ export {
   type AgentOpt,
   type AiActOptions,
   type GherkinStepKeyword,
+  type MidsceneUsageMetrics,
   type RunGherkinScenarioOptions,
+  type UsageBucket,
   createAgent,
 } from './agent';
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -996,6 +996,16 @@ export interface AgentOpt {
    * ```
    */
   createOpenAIClient?: CreateOpenAIClientFn;
+
+  /**
+   * Called once per LLM call as soon as its usage is available, with the raw
+   * {@link AIUsageInfo} (token counts, model name, intent, request id, etc.).
+   *
+   * Use this for real-time, per-spec cost observability — e.g. push each call
+   * to Langfuse without waiting for the run to finish. For aggregated totals,
+   * read `agent.metrics` instead.
+   */
+  onLLMUsage?: (usage: AIUsageInfo) => void;
 }
 
 export type TestStatus =

--- a/packages/core/tests/unit-test/agent-metrics.test.ts
+++ b/packages/core/tests/unit-test/agent-metrics.test.ts
@@ -115,17 +115,6 @@ describe('MetricsCollector', () => {
     expect(first.totalTokens).toBe(10);
     expect(first.byIntent.planning.calls).toBe(1);
   });
-
-  it('clears all accumulated state on reset', () => {
-    const collector = new MetricsCollector();
-    collector.add(usage({ total_tokens: 10 }));
-    collector.reset();
-    const snapshot = collector.snapshot();
-    expect(snapshot.totalTokens).toBe(0);
-    expect(snapshot.calls).toBe(0);
-    expect(snapshot.byIntent).toEqual({});
-    expect(snapshot.byModel).toEqual({});
-  });
 });
 
 describe('Agent usage metrics', () => {
@@ -192,30 +181,6 @@ describe('Agent usage metrics', () => {
     );
     expect(agent.metrics.calls).toBe(1);
     expect(agent.metrics.totalTokens).toBe(30);
-
-    await agent.destroy();
-  });
-
-  it('resetMetrics clears totals and re-allows previously counted tasks', async () => {
-    const agent = new Agent(createMockInterface(), {
-      modelConfig,
-      generateReport: false,
-    });
-
-    const task = {
-      taskId: 't1',
-      usage: usage({ total_tokens: 50, intent: 'planning' }),
-    };
-    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
-    expect(agent.metrics.totalTokens).toBe(50);
-
-    agent.resetMetrics();
-    expect(agent.metrics.totalTokens).toBe(0);
-    expect(agent.metrics.calls).toBe(0);
-
-    // After reset, the dedup memory is cleared so a fresh run is counted again.
-    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
-    expect(agent.metrics.totalTokens).toBe(50);
 
     await agent.destroy();
   });

--- a/packages/core/tests/unit-test/agent-metrics.test.ts
+++ b/packages/core/tests/unit-test/agent-metrics.test.ts
@@ -1,0 +1,245 @@
+import { Agent } from '@/agent';
+import { MetricsCollector } from '@/agent/metrics';
+import type { AIUsageInfo, ExecutionDump } from '@/types';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_NAME,
+} from '@midscene/shared/env';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('openai');
+
+const modelConfig = {
+  [MIDSCENE_MODEL_NAME]: 'test-model',
+  [MIDSCENE_MODEL_API_KEY]: 'test-key',
+  [MIDSCENE_MODEL_BASE_URL]: 'https://api.test.com/v1',
+};
+
+function createMockInterface() {
+  return {
+    interfaceType: 'puppeteer',
+    actionSpace: () => [],
+    describe: () => 'test page',
+    size: async () => ({ width: 1280, height: 720 }),
+    screenshotBase64: async () =>
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+  } as any;
+}
+
+function usage(overrides: Partial<AIUsageInfo>): AIUsageInfo {
+  return {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    cached_input: 0,
+    time_cost: 0,
+    model_name: undefined,
+    model_description: undefined,
+    response_model_name: undefined,
+    intent: undefined,
+    slot: undefined,
+    request_id: undefined,
+    ...overrides,
+  };
+}
+
+function dumpWithTasks(tasks: any[]): ExecutionDump {
+  return { id: 'exec', name: 'exec', tasks } as unknown as ExecutionDump;
+}
+
+describe('MetricsCollector', () => {
+  it('aggregates totals and breaks down by intent and model', () => {
+    const collector = new MetricsCollector();
+    collector.add(
+      usage({
+        prompt_tokens: 100,
+        completion_tokens: 40,
+        total_tokens: 140,
+        cached_input: 10,
+        time_cost: 500,
+        intent: 'planning',
+        model_name: 'model-a',
+      }),
+    );
+    collector.add(
+      usage({
+        prompt_tokens: 60,
+        completion_tokens: 20,
+        total_tokens: 80,
+        cached_input: 5,
+        time_cost: 300,
+        intent: 'insight',
+        model_name: 'model-a',
+      }),
+    );
+
+    const snapshot = collector.snapshot();
+    expect(snapshot.totalPromptTokens).toBe(160);
+    expect(snapshot.totalCompletionTokens).toBe(60);
+    expect(snapshot.totalTokens).toBe(220);
+    expect(snapshot.totalCachedInput).toBe(15);
+    expect(snapshot.totalTimeCostMs).toBe(800);
+    expect(snapshot.calls).toBe(2);
+
+    expect(snapshot.byIntent.planning).toEqual({
+      promptTokens: 100,
+      completionTokens: 40,
+      totalTokens: 140,
+      calls: 1,
+    });
+    expect(snapshot.byIntent.insight.calls).toBe(1);
+    expect(snapshot.byModel['model-a']).toEqual({
+      promptTokens: 160,
+      completionTokens: 60,
+      totalTokens: 220,
+      calls: 2,
+    });
+  });
+
+  it('treats missing token fields as zero and missing labels as "unknown"', () => {
+    const collector = new MetricsCollector();
+    collector.add(usage({}));
+    const snapshot = collector.snapshot();
+    expect(snapshot.totalTokens).toBe(0);
+    expect(snapshot.calls).toBe(1);
+    expect(snapshot.byIntent.unknown.calls).toBe(1);
+    expect(snapshot.byModel.unknown.calls).toBe(1);
+  });
+
+  it('returns an independent snapshot that does not mutate on further adds', () => {
+    const collector = new MetricsCollector();
+    collector.add(usage({ total_tokens: 10, intent: 'planning' }));
+    const first = collector.snapshot();
+    collector.add(usage({ total_tokens: 10, intent: 'planning' }));
+    expect(first.totalTokens).toBe(10);
+    expect(first.byIntent.planning.calls).toBe(1);
+  });
+
+  it('clears all accumulated state on reset', () => {
+    const collector = new MetricsCollector();
+    collector.add(usage({ total_tokens: 10 }));
+    collector.reset();
+    const snapshot = collector.snapshot();
+    expect(snapshot.totalTokens).toBe(0);
+    expect(snapshot.calls).toBe(0);
+    expect(snapshot.byIntent).toEqual({});
+    expect(snapshot.byModel).toEqual({});
+  });
+});
+
+describe('Agent usage metrics', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('counts each task usage once across re-emitted snapshots', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    const task = {
+      taskId: 't1',
+      usage: usage({ total_tokens: 50, intent: 'planning' }),
+    };
+
+    // Same task surfaces in multiple snapshots; usage must not double-count.
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+
+    expect(agent.metrics.totalTokens).toBe(50);
+    expect(agent.metrics.calls).toBe(1);
+
+    await agent.destroy();
+  });
+
+  it('counts both usage and searchAreaUsage of a task', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    (agent as any).collectUsageMetrics(
+      dumpWithTasks([
+        {
+          taskId: 't1',
+          usage: usage({ total_tokens: 50, intent: 'insight' }),
+          searchAreaUsage: usage({ total_tokens: 20, intent: 'insight' }),
+        },
+      ]),
+    );
+
+    expect(agent.metrics.totalTokens).toBe(70);
+    expect(agent.metrics.calls).toBe(2);
+
+    await agent.destroy();
+  });
+
+  it('counts usage that is filled in on a later snapshot', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    (agent as any).collectUsageMetrics(
+      dumpWithTasks([{ taskId: 't1', usage: undefined }]),
+    );
+    expect(agent.metrics.calls).toBe(0);
+
+    (agent as any).collectUsageMetrics(
+      dumpWithTasks([{ taskId: 't1', usage: usage({ total_tokens: 30 }) }]),
+    );
+    expect(agent.metrics.calls).toBe(1);
+    expect(agent.metrics.totalTokens).toBe(30);
+
+    await agent.destroy();
+  });
+
+  it('resetMetrics clears totals and re-allows previously counted tasks', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    const task = {
+      taskId: 't1',
+      usage: usage({ total_tokens: 50, intent: 'planning' }),
+    };
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+    expect(agent.metrics.totalTokens).toBe(50);
+
+    agent.resetMetrics();
+    expect(agent.metrics.totalTokens).toBe(0);
+    expect(agent.metrics.calls).toBe(0);
+
+    // After reset, the dedup memory is cleared so a fresh run is counted again.
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+    expect(agent.metrics.totalTokens).toBe(50);
+
+    await agent.destroy();
+  });
+
+  it('invokes the onLLMUsage callback once per usage', async () => {
+    const onLLMUsage = vi.fn();
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+      onLLMUsage,
+    });
+
+    const task = {
+      taskId: 't1',
+      usage: usage({ total_tokens: 50, intent: 'planning' }),
+    };
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+    (agent as any).collectUsageMetrics(dumpWithTasks([task]));
+
+    expect(onLLMUsage).toHaveBeenCalledTimes(1);
+    expect(onLLMUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ total_tokens: 50, intent: 'planning' }),
+    );
+
+    await agent.destroy();
+  });
+});

--- a/packages/core/tests/unit-test/agent-metrics.test.ts
+++ b/packages/core/tests/unit-test/agent-metrics.test.ts
@@ -208,3 +208,156 @@ describe('Agent usage metrics', () => {
     await agent.destroy();
   });
 });
+
+describe('Agent usage via ModelRuntime.onUsage (real lifecycle)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('collects usage reported through the model runtime onUsage callback', async () => {
+    const onLLMUsage = vi.fn();
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+      onLLMUsage,
+    });
+
+    // Simulate what callAI() does: after a model call it invokes
+    // modelRuntime.onUsage(usageInfo). The agent attaches this callback
+    // to every ModelRuntime it resolves via resolveModelRuntime().
+    const runtime = (agent as any).resolveModelRuntime('default');
+    expect(runtime.onUsage).toBeTypeOf('function');
+
+    runtime.onUsage(
+      usage({
+        total_tokens: 42,
+        prompt_tokens: 30,
+        completion_tokens: 12,
+        model_name: 'test-model',
+        intent: 'planning',
+        request_id: 'req-abc-123',
+      }),
+    );
+
+    expect(agent.metrics.totalTokens).toBe(42);
+    expect(agent.metrics.totalPromptTokens).toBe(30);
+    expect(agent.metrics.totalCompletionTokens).toBe(12);
+    expect(agent.metrics.calls).toBe(1);
+    expect(agent.metrics.byModel['test-model'].calls).toBe(1);
+    expect(onLLMUsage).toHaveBeenCalledTimes(1);
+    expect(onLLMUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ total_tokens: 42, request_id: 'req-abc-123' }),
+    );
+
+    await agent.destroy();
+  });
+
+  it('deduplicates by request_id when onUsage fires twice', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    const runtime = (agent as any).resolveModelRuntime('default');
+    const u = usage({ total_tokens: 42, request_id: 'req-dedup-1' });
+
+    // Simulate the same model call being reported twice (e.g. streaming
+    // final-chunk + final-return both fire onUsage — guarded by
+    // usageReported flag in callAI, but test the dedup directly).
+    runtime.onUsage(u);
+    runtime.onUsage(u);
+
+    expect(agent.metrics.totalTokens).toBe(42);
+    expect(agent.metrics.calls).toBe(1);
+
+    await agent.destroy();
+  });
+
+  it('deduplicates across onUsage and collectUsageMetrics paths by request_id', async () => {
+    const onLLMUsage = vi.fn();
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+      onLLMUsage,
+    });
+
+    const sharedUsage = usage({
+      total_tokens: 55,
+      intent: 'locate',
+      model_name: 'test-model',
+      request_id: 'req-cross-path-1',
+    });
+
+    // 1. Model call completes; callAI fires onUsage first.
+    const runtime = (agent as any).resolveModelRuntime('default');
+    runtime.onUsage(sharedUsage);
+
+    // 2. Later, the task dump is emitted with the same usage (same request_id).
+    //    collectUsageMetrics must NOT double-count.
+    (agent as any).collectUsageMetrics(
+      dumpWithTasks([
+        {
+          taskId: 'task-1',
+          usage: { ...sharedUsage },
+        },
+      ]),
+    );
+
+    expect(agent.metrics.totalTokens).toBe(55);
+    expect(agent.metrics.calls).toBe(1);
+    expect(onLLMUsage).toHaveBeenCalledTimes(1);
+
+    await agent.destroy();
+  });
+
+  it('collects auxiliary model calls (e.g. order-sensitive judge) that never attach to a task', async () => {
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+    });
+
+    const runtime = (agent as any).resolveModelRuntime('default');
+
+    // Simulate AiJudgeOrderSensitive → callAIWithObjectResponse → callAI
+    // firing onUsage. This usage never appears in any task dump, so
+    // without the callAI-level collector it would be invisible.
+    runtime.onUsage(
+      usage({
+        total_tokens: 15,
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        model_name: 'test-model',
+        intent: 'default',
+        request_id: 'req-order-sensitive-1',
+      }),
+    );
+
+    expect(agent.metrics.totalTokens).toBe(15);
+    expect(agent.metrics.calls).toBe(1);
+
+    await agent.destroy();
+  });
+
+  it('isolates onLLMUsage listener errors from metrics collection', async () => {
+    const onLLMUsage = vi.fn(() => {
+      throw new Error('listener boom');
+    });
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+      onLLMUsage,
+    });
+
+    const runtime = (agent as any).resolveModelRuntime('default');
+
+    // Should not throw even though the listener throws.
+    runtime.onUsage(usage({ total_tokens: 10, request_id: 'req-err-1' }));
+    runtime.onUsage(usage({ total_tokens: 20, request_id: 'req-err-2' }));
+
+    expect(agent.metrics.totalTokens).toBe(30);
+    expect(agent.metrics.calls).toBe(2);
+    expect(onLLMUsage).toHaveBeenCalledTimes(2);
+
+    await agent.destroy();
+  });
+});

--- a/packages/core/tests/unit-test/agent-metrics.test.ts
+++ b/packages/core/tests/unit-test/agent-metrics.test.ts
@@ -1,5 +1,6 @@
 import { Agent } from '@/agent';
 import { MetricsCollector } from '@/agent/metrics';
+import { INTERNAL_CALL_ID_FIELD } from '@/ai-model/service-caller';
 import type { AIUsageInfo, ExecutionDump } from '@/types';
 import {
   MIDSCENE_MODEL_API_KEY,
@@ -294,6 +295,46 @@ describe('Agent usage via ModelRuntime.onUsage (real lifecycle)', () => {
 
     // 2. Later, the task dump is emitted with the same usage (same request_id).
     //    collectUsageMetrics must NOT double-count.
+    (agent as any).collectUsageMetrics(
+      dumpWithTasks([
+        {
+          taskId: 'task-1',
+          usage: { ...sharedUsage },
+        },
+      ]),
+    );
+
+    expect(agent.metrics.totalTokens).toBe(55);
+    expect(agent.metrics.calls).toBe(1);
+    expect(onLLMUsage).toHaveBeenCalledTimes(1);
+
+    await agent.destroy();
+  });
+
+  it('deduplicates across paths by internal call id when request_id is absent', async () => {
+    const onLLMUsage = vi.fn();
+    const agent = new Agent(createMockInterface(), {
+      modelConfig,
+      generateReport: false,
+      onLLMUsage,
+    });
+
+    // Simulate a provider that doesn't return request_id. callAI() stamps
+    // INTERNAL_CALL_ID_FIELD onto every usage it shapes.
+    const sharedUsage = usage({
+      total_tokens: 55,
+      intent: 'locate',
+      model_name: 'test-model',
+      request_id: undefined,
+    });
+    (sharedUsage as any)[INTERNAL_CALL_ID_FIELD] = 'call_42';
+
+    // 1. onUsage fires first (from callAI return path).
+    const runtime = (agent as any).resolveModelRuntime('default');
+    runtime.onUsage(sharedUsage);
+
+    // 2. Later, task dump emits with the same usage (same internal call id).
+    //    Without INTERNAL_CALL_ID_FIELD dedup, this would double-count.
     (agent as any).collectUsageMetrics(
       dumpWithTasks([
         {


### PR DESCRIPTION
## What & Why

Closes #1084. Previously the only way to access LLM token usage was the `DEBUG=midscene:ai:profile:stats` env var or log files, which cannot be tracked per spec or pushed to observability tools in real time. This adds a runtime API on the agent.

## Changes

- **`agent.metrics`** — getter returning aggregated usage accumulated **since the agent was created**: `totalPromptTokens`, `totalCompletionTokens`, `totalTokens`, `totalCachedInput`, `totalTimeCostMs`, `calls`, plus `byIntent` and `byModel` breakdowns.
- **`onLLMUsage` agent option** — fires once per LLM call as soon as usage is available, with the raw `AIUsageInfo` (token counts, model name, intent, request id, etc.), for real-time push to tools like Langfuse.

## Design

- A standalone `MetricsCollector` owns all aggregation logic (`add` / `snapshot`); `snapshot()` returns a deep copy for immutability.
- **Two collection paths** ensure complete coverage:
  1. **`ModelRuntime.onUsage` callback** — attached by the agent to every resolved model runtime, fired from `callAI()` / `callAIWithObjectResponse()` after every model call. This catches auxiliary calls that never attach to a task dump (e.g. `AiJudgeOrderSensitive` during cache feature extraction, failed deepLocate search-area calls).
  2. **`onSnapshotChange` hook → `collectUsageMetrics()`** — scans each task's `usage` and `searchAreaUsage` from the execution dump. Acts as a safety net for custom adapters that may not go through `callAI`.
- Cross-path deduplication uses `request_id` when available, so the same model call reported through both paths is counted exactly once.
- All `@midscene/web`, Android, iOS, etc. agents extend the core `Agent`, so they inherit this with no extra changes.

## Tests & Docs

- New `agent-metrics.test.ts`: collector aggregation, zero/`unknown` fallbacks, snapshot independence; agent-level dedup across re-emitted snapshots, `usage` + `searchAreaUsage`, late-filled usage, `onLLMUsage` firing once per call, **real lifecycle via `ModelRuntime.onUsage`**, request_id cross-path dedup, auxiliary call coverage, listener error isolation.
- Bilingual API docs (`apps/site/docs/{en,zh}/api.mdx`) with a Langfuse per-spec example.

## Validation

- `pnpm run lint` — pass
- `npx nx build core` — pass
- `npx nx test core` — 1198 passed, 8 skipped

## Example

Per-spec tracking: create a fresh agent per spec (or reset by creating a new agent instance):

```ts
let agent: Agent;
beforeEach(() => { agent = new PuppeteerAgent(page); });
afterEach(() => {
  const usage = agent.metrics;
  langfuse.track('MidsceneUsage', { value: usage.totalTokens, metadata: usage });
});

// or real-time, per call:
const agent = new PuppeteerAgent(page, {
  onLLMUsage: (u) => langfuse.event({ name: u.intent ?? 'unknown', value: u.total_tokens }),
});
```