### PR TITLE
fix(core): expose raw OpenAI error bodies

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -45,6 +45,11 @@ import {
 } from './codex-app-server';
 import type { JsonParserSource } from './json';
 import {
+  type OpenAIErrorResponseContext,
+  formatOpenAIAPIErrorDetails,
+  wrapOpenAICompatibleFetch,
+} from './openai-error';
+import {
   buildRequestAbortSignal,
   isHardTimeoutError,
   resolveEffectiveTimeoutMs,
@@ -116,6 +121,7 @@ export async function createChatClient({
   modelName: string;
   modelDescription: string;
   modelFamily: TModelFamily | undefined;
+  openAIErrorResponseContext: OpenAIErrorResponseContext;
 }> {
   const {
     socksProxy,
@@ -223,6 +229,7 @@ export async function createChatClient({
   }
 
   const effectiveTimeoutMs = resolveEffectiveTimeoutMs({ timeout });
+  const openAIErrorResponseContext: OpenAIErrorResponseContext = {};
   const openAIOptions = {
     baseURL: openaiBaseURL,
     apiKey: openaiApiKey,
@@ -230,6 +237,7 @@ export async function createChatClient({
     // Note: Type assertion needed due to undici version mismatch between dependencies
     ...(proxyAgent ? { fetchOptions: { dispatcher: proxyAgent as any } } : {}),
     ...openaiExtraConfig,
+    fetch: wrapOpenAICompatibleFetch(openAIErrorResponseContext),
     // Midscene already handles retries in callAI(), so disable SDK-level retries
     // to avoid duplicate attempts and duplicated backoff latency.
     maxRetries: 0,
@@ -286,6 +294,7 @@ export async function createChatClient({
     modelName,
     modelDescription,
     modelFamily,
+    openAIErrorResponseContext,
   };
 }
 
@@ -318,10 +327,15 @@ export async function callAI(
     });
   }
 
-  const { completion, modelName, modelDescription, modelFamily } =
-    await createChatClient({
-      modelConfig,
-    });
+  const {
+    completion,
+    modelName,
+    modelDescription,
+    modelFamily,
+    openAIErrorResponseContext,
+  } = await createChatClient({
+    modelConfig,
+  });
   const effectiveTimeoutMs = resolveEffectiveTimeoutMs(modelConfig);
 
   const extraBody = modelConfig.extraBody;
@@ -656,7 +670,7 @@ export async function callAI(
     }
 
     const newError = new Error(
-      `failed to call ${isStreaming ? 'streaming ' : ''}AI model service (${modelName}): ${e.message}\nTrouble shooting: https://midscenejs.com/model-provider.html`,
+      `failed to call ${isStreaming ? 'streaming ' : ''}AI model service (${modelName}): ${e.message}${formatOpenAIAPIErrorDetails(e, openAIErrorResponseContext)}\nTrouble shooting: https://midscenejs.com/model-provider.html`,
       {
         cause: e,
       },

--- a/packages/core/src/ai-model/service-caller/openai-error.ts
+++ b/packages/core/src/ai-model/service-caller/openai-error.ts
@@ -1,0 +1,85 @@
+const MAX_ERROR_RESPONSE_BODY_LENGTH = 4000;
+
+export interface OpenAIErrorResponseContext {
+  rawResponseBodies?: Array<{
+    attempt: number;
+    body: string;
+  }>;
+}
+
+function truncateErrorResponseBody(body: string): string {
+  if (body.length <= MAX_ERROR_RESPONSE_BODY_LENGTH) {
+    return body;
+  }
+
+  return `${body.slice(0, MAX_ERROR_RESPONSE_BODY_LENGTH)}... [truncated, ${body.length} chars total]`;
+}
+
+// Mirrors OpenAI SDK's default fetch selection:
+// openai@6.3.0 src/client.ts sets `this.fetch = options.fetch ?? Shims.getDefaultFetch()`,
+// and src/internal/shims.ts resolves that default to global `fetch`.
+function getDefaultFetch(): typeof fetch {
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch;
+  }
+
+  throw new Error(
+    '`fetch` is not defined as a global; check that the runtime provides globalThis.fetch or polyfill it before creating the OpenAI client',
+  );
+}
+
+export function wrapOpenAICompatibleFetch(
+  context: OpenAIErrorResponseContext,
+): typeof fetch {
+  const baseFetch = getDefaultFetch();
+  let attempt = 0;
+
+  return async (input, init) => {
+    attempt += 1;
+    const response = await baseFetch(input, init);
+
+    if (!response.ok) {
+      // OpenAI SDK only exposes the `error` field for JSON error responses.
+      // Non-standard provider bodies like `{ err: 'xxx' }` would otherwise be
+      // hidden from Midscene's final error message.
+      const rawResponseBody = await response
+        .clone()
+        .text()
+        .catch(() => undefined);
+
+      if (rawResponseBody !== undefined) {
+        context.rawResponseBodies ??= [];
+        context.rawResponseBodies.push({
+          attempt,
+          body: rawResponseBody,
+        });
+      }
+    }
+
+    return response;
+  };
+}
+
+export function formatOpenAIAPIErrorDetails(
+  _error: unknown,
+  context: OpenAIErrorResponseContext,
+): string {
+  if (!context.rawResponseBodies?.length) {
+    return '';
+  }
+
+  if (context.rawResponseBodies.length === 1) {
+    return `\nOpenAI raw error response body: ${truncateErrorResponseBody(
+      context.rawResponseBodies[0].body,
+    )}`;
+  }
+
+  const details = context.rawResponseBodies
+    .map(
+      ({ attempt, body }) =>
+        `Attempt ${attempt}: ${truncateErrorResponseBody(body)}`,
+    )
+    .join('\n');
+
+  return `\nOpenAI raw error response bodies:\n${details}`;
+}

--- a/packages/core/tests/unit-test/service-caller-openai-error.test.ts
+++ b/packages/core/tests/unit-test/service-caller-openai-error.test.ts
@@ -1,0 +1,160 @@
+import type { IModelConfig } from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreate = vi.fn();
+const mockOpenAIConstructor = vi.fn().mockImplementation(() => ({
+  chat: {
+    completions: {
+      create: mockCreate,
+    },
+  },
+}));
+
+vi.mock('openai', () => ({
+  default: mockOpenAIConstructor,
+}));
+
+const baseConfig = (overrides: Partial<IModelConfig> = {}): IModelConfig =>
+  ({
+    modelName: 'gpt-4o',
+    openaiApiKey: 'test-key',
+    openaiBaseURL: 'https://api.openai.com/v1',
+    modelDescription: 'test model',
+    intent: 'default',
+    slot: 'default',
+    retryCount: 0,
+    ...overrides,
+  }) as IModelConfig;
+
+describe('service-caller OpenAI error handling', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('records non-2xx raw response body without changing the response', async () => {
+    const { wrapOpenAICompatibleFetch } = await import(
+      '@/ai-model/service-caller/openai-error'
+    );
+    const context = {};
+    const responseBody = JSON.stringify({
+      detail: 'model does not exist',
+      trace_id: 'trace_123',
+    });
+    const response = new Response(responseBody, {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': 'req_123',
+      },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(response);
+
+    const wrappedResponse = await wrapOpenAICompatibleFetch(context)(
+      'https://example.com/v1/chat/completions',
+      { method: 'POST' },
+    );
+
+    expect(wrappedResponse).toBe(response);
+    await expect(wrappedResponse.text()).resolves.toBe(responseBody);
+    expect(context).toEqual({
+      rawResponseBodies: [{ attempt: 1, body: responseBody }],
+    });
+  });
+
+  it('does not record successful response bodies', async () => {
+    const { wrapOpenAICompatibleFetch } = await import(
+      '@/ai-model/service-caller/openai-error'
+    );
+    const context = {};
+    const response = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      wrapOpenAICompatibleFetch(context)('https://example.com'),
+    ).resolves.toBe(response);
+    expect(context).toEqual({});
+  });
+
+  it('keeps raw response bodies from multiple failed requests', async () => {
+    const { wrapOpenAICompatibleFetch } = await import(
+      '@/ai-model/service-caller/openai-error'
+    );
+    const context = {};
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('first body', { status: 500 }))
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce(new Response('third body', { status: 502 }));
+    const wrappedFetch = wrapOpenAICompatibleFetch(context);
+
+    await expect(wrappedFetch('https://example.com')).resolves.toBeInstanceOf(
+      Response,
+    );
+    await expect(wrappedFetch('https://example.com')).rejects.toThrow(
+      'network error',
+    );
+    await expect(wrappedFetch('https://example.com')).resolves.toBeInstanceOf(
+      Response,
+    );
+
+    expect(context).toEqual({
+      rawResponseBodies: [
+        { attempt: 1, body: 'first body' },
+        { attempt: 3, body: 'third body' },
+      ],
+    });
+  });
+
+  it('exposes raw body fields that a bare OpenAI APIError drops', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+    const actualOpenAI =
+      await vi.importActual<typeof import('openai')>('openai');
+    const rawResponseBody = JSON.stringify({
+      detail: 'model does not exist',
+      trace_id: 'trace_123',
+    });
+    const bareOpenAIError = actualOpenAI.default.APIError.generate(
+      422,
+      JSON.parse(rawResponseBody),
+      'status code (no body)',
+      new Headers({ 'x-request-id': 'req_123' }),
+    );
+
+    expect(bareOpenAIError.message).toBe('422 status code (no body)');
+    expect(bareOpenAIError.message).not.toContain('model does not exist');
+    expect(bareOpenAIError.message).not.toContain('trace_123');
+    expect(bareOpenAIError.error).toBeUndefined();
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(rawResponseBody, {
+        status: 422,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    mockCreate.mockImplementation(async () => {
+      // The mocked SDK does not call fetch, so trigger the configured fetch to
+      // exercise Midscene's wrapper before throwing an SDK-shaped APIError.
+      await mockOpenAIConstructor.mock.calls
+        .at(-1)?.[0]
+        .fetch('https://example.com/v1/chat/completions');
+      throw bareOpenAIError;
+    });
+
+    const promise = callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime(baseConfig()),
+    );
+
+    await expect(promise).rejects.toThrow(
+      /OpenAI raw error response body: \{"detail":"model does not exist","trace_id":"trace_123"\}/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap the default OpenAI-compatible fetch to record raw non-2xx response bodies without consuming the SDK response.
- Include recorded raw OpenAI error response bodies in Midscene's final model-call error message.
- Add unit coverage showing bare OpenAI APIError drops non-standard JSON fields while Midscene preserves the raw body for diagnostics.

## Why

OpenAI SDK only exposes the top-level `error` field for JSON error responses. Providers or gateways that return bodies like `{ "err": "xxx" }` can otherwise produce `status code (no body)` at the Midscene layer, hiding useful provider diagnostics from users.

## Validation

- `node_modules/.bin/vitest --run tests/unit-test/service-caller-openai-error.test.ts --config vitest.config.ts`
- `node_modules/.bin/tsc -p tsconfig.json --noEmit`

Note: the commit hook also ran `lint-staged`/`biome check --fix` for the staged files.