### PR TITLE
fix(core): support locate coordinate metadata and kimi pixel coordinates

### DIFF
--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -14,8 +14,20 @@ import {
 } from '../service-caller/json';
 import {
   type LocateResultValue,
+  createLocateResultValue,
   unwrapCoordinateListLikeInput,
 } from '../shared/model-locate-result';
+
+const doubaoBboxCoordinatesMeta = {
+  shape: 'bbox',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
+const doubaoPointCoordinatesMeta = {
+  shape: 'point',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
 
 export function normalizeDoubaoJsonObject(
   obj: any,
@@ -105,15 +117,12 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
     );
     const splitted = bbox.split(' ');
     if (splitted.length === 4) {
-      return {
-        type: 'bbox',
-        coordinates: [
-          Number(splitted[0]),
-          Number(splitted[1]),
-          Number(splitted[2]),
-          Number(splitted[3]),
-        ],
-      };
+      return createLocateResultValue(doubaoBboxCoordinatesMeta, [
+        Number(splitted[0]),
+        Number(splitted[1]),
+        Number(splitted[2]),
+        Number(splitted[3]),
+      ]);
     }
     throw new Error(`invalid bbox data string for doubao-vision mode: ${bbox}`);
   }
@@ -136,10 +145,12 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
   }
 
   if (bboxList.length === 4 || bboxList.length === 5) {
-    return {
-      type: 'bbox',
-      coordinates: [bboxList[0], bboxList[1], bboxList[2], bboxList[3]],
-    };
+    return createLocateResultValue(doubaoBboxCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+      bboxList[2],
+      bboxList[3],
+    ]);
   }
 
   if (
@@ -148,14 +159,19 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
     bboxList.length === 3 ||
     bboxList.length === 7
   ) {
-    return { type: 'point', coordinates: [bboxList[0], bboxList[1]] };
+    return createLocateResultValue(doubaoPointCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+    ]);
   }
 
   if (bbox.length === 8) {
-    return {
-      type: 'bbox',
-      coordinates: [bboxList[0], bboxList[1], bboxList[4], bboxList[5]],
-    };
+    return createLocateResultValue(doubaoBboxCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+      bboxList[4],
+      bboxList[5],
+    ]);
   }
 
   const msg = `invalid bbox data for doubao-vision mode: ${JSON.stringify(bbox)} `;
@@ -202,7 +218,7 @@ const doubaoVisionAdapter: ModelAdapterDefinition = {
   },
   locate: {
     resultAdapter: {
-      coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      coordinates: doubaoBboxCoordinatesMeta,
       parseRawLocateValue: parseDoubaoRawLocateValue,
     },
   },

--- a/packages/core/src/ai-model/models/kimi.ts
+++ b/packages/core/src/ai-model/models/kimi.ts
@@ -4,6 +4,36 @@ import type {
   ChatCompletionParamsResult,
   ModelAdapterDefinition,
 } from '../model-adapter/types';
+import {
+  type LocateResultValue,
+  createLocateResultValue,
+  parseCoordinateList,
+} from '../shared/model-locate-result';
+
+const kimiNormalizedPointCoordinatesMeta = {
+  shape: 'point',
+  order: 'xy',
+  normalizedBy: 1,
+} as const;
+const kimiPixelPointCoordinatesMeta = {
+  shape: 'point',
+  order: 'xy',
+} as const;
+
+function parseKimiRawLocateValue(input: unknown): LocateResultValue {
+  const point = parseCoordinateList(input, 'point');
+  if (point.length < 2) {
+    throw new Error(`invalid point data: ${JSON.stringify(input)} `);
+  }
+  const [x, y] = point;
+  // Keep this compatible with OSWorld's Kimi adapter: values <= 1 are
+  // normalized coordinates, otherwise they are treated as screenshot pixels.
+  const coordinatesMeta =
+    x <= 1 && y <= 1
+      ? kimiNormalizedPointCoordinatesMeta
+      : kimiPixelPointCoordinatesMeta;
+  return createLocateResultValue(coordinatesMeta, [x, y]);
+}
 
 const buildKimiChatCompletionParams = (
   input: ChatCompletionCallContext,
@@ -40,7 +70,8 @@ export const kimiAdapters = {
     },
     locate: {
       resultAdapter: {
-        coordinates: { shape: 'point', order: 'xy', normalizedBy: 1 },
+        coordinates: kimiNormalizedPointCoordinatesMeta,
+        parseRawLocateValue: parseKimiRawLocateValue,
       },
     },
   },

--- a/packages/core/src/ai-model/models/qwen.ts
+++ b/packages/core/src/ai-model/models/qwen.ts
@@ -7,10 +7,25 @@ import type {
 import {
   type LocateResultValue,
   type PixelBbox,
+  createLocateResultValue,
+  isBboxLocateResultValue,
   unwrapCoordinateListLikeInput,
 } from '../shared/model-locate-result';
 
 const defaultBboxSize = 20;
+const qwen25BboxCoordinatesMeta = {
+  shape: 'bbox',
+  order: 'xy',
+} as const;
+const qwen25PointCoordinatesMeta = {
+  shape: 'point',
+  order: 'xy',
+} as const;
+const qwen3BboxCoordinatesMeta = {
+  shape: 'bbox',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
 
 function topLeftPointToPixelBbox(x: number, y: number): PixelBbox {
   return [
@@ -29,28 +44,35 @@ function parseQwen25RawLocateValue(input: unknown): LocateResultValue {
   }
 
   if (typeof bbox[2] === 'number' && typeof bbox[3] === 'number') {
-    return {
-      type: 'bbox',
-      coordinates: [bbox[0], bbox[1], bbox[2], bbox[3]],
-    };
+    return createLocateResultValue(qwen25BboxCoordinatesMeta, [
+      bbox[0],
+      bbox[1],
+      bbox[2],
+      bbox[3],
+    ]);
   }
 
-  return { type: 'point', coordinates: [bbox[0], bbox[1]] };
+  return createLocateResultValue(qwen25PointCoordinatesMeta, [
+    bbox[0],
+    bbox[1],
+  ]);
 }
 
 function normalizeQwen25ResultToPixelBbox(
   result: LocateResultValue,
 ): PixelBbox {
-  if (result.type === 'bbox') {
+  if (isBboxLocateResultValue(result)) {
+    const { coordinates } = result;
     return [
-      Math.round(result.coordinates[0]),
-      Math.round(result.coordinates[1]),
-      Math.round(result.coordinates[2]),
-      Math.round(result.coordinates[3]),
+      Math.round(coordinates[0]),
+      Math.round(coordinates[1]),
+      Math.round(coordinates[2]),
+      Math.round(coordinates[3]),
     ];
   }
 
-  return topLeftPointToPixelBbox(result.coordinates[0], result.coordinates[1]);
+  const { coordinates } = result;
+  return topLeftPointToPixelBbox(coordinates[0], coordinates[1]);
 }
 
 const buildQwenChatCompletionParams = (
@@ -118,7 +140,7 @@ const qwen3Adapter: ModelAdapterDefinition = {
   },
   locate: {
     resultAdapter: {
-      coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      coordinates: qwen3BboxCoordinatesMeta,
     },
   },
 };
@@ -138,7 +160,7 @@ export const qwenAdapters = {
     },
     locate: {
       resultAdapter: {
-        coordinates: { shape: 'bbox', order: 'xy' },
+        coordinates: qwen25BboxCoordinatesMeta,
         parseRawLocateValue: parseQwen25RawLocateValue,
         mapLocateResultToPixelBbox: normalizeQwen25ResultToPixelBbox,
       },

--- a/packages/core/src/ai-model/models/ui-tars/adapter.ts
+++ b/packages/core/src/ai-model/models/ui-tars/adapter.ts
@@ -12,11 +12,22 @@ import {
 } from '../../service-caller/json';
 import {
   type LocateResultValue,
+  createLocateResultValue,
   unwrapCoordinateListLikeInput,
 } from '../../shared/model-locate-result';
 import { createUiTarsPlanner } from './planning';
 
 const defaultVlmUiTarsReplanningCycleLimit = 40;
+const uiTarsBboxCoordinatesMeta = {
+  shape: 'bbox',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
+const uiTarsPointCoordinatesMeta = {
+  shape: 'point',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
 
 function normalizeJsonObject(
   obj: any,
@@ -106,15 +117,12 @@ function parseUiTarsRawLocateValue(input: unknown): LocateResultValue {
     );
     const splitted = bbox.split(' ');
     if (splitted.length === 4) {
-      return {
-        type: 'bbox',
-        coordinates: [
-          Number(splitted[0]),
-          Number(splitted[1]),
-          Number(splitted[2]),
-          Number(splitted[3]),
-        ],
-      };
+      return createLocateResultValue(uiTarsBboxCoordinatesMeta, [
+        Number(splitted[0]),
+        Number(splitted[1]),
+        Number(splitted[2]),
+        Number(splitted[3]),
+      ]);
     }
     throw new Error(`invalid bbox data string for ui-tars mode: ${bbox}`);
   }
@@ -137,10 +145,12 @@ function parseUiTarsRawLocateValue(input: unknown): LocateResultValue {
   }
 
   if (bboxList.length === 4 || bboxList.length === 5) {
-    return {
-      type: 'bbox',
-      coordinates: [bboxList[0], bboxList[1], bboxList[2], bboxList[3]],
-    };
+    return createLocateResultValue(uiTarsBboxCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+      bboxList[2],
+      bboxList[3],
+    ]);
   }
 
   if (
@@ -149,14 +159,19 @@ function parseUiTarsRawLocateValue(input: unknown): LocateResultValue {
     bboxList.length === 3 ||
     bboxList.length === 7
   ) {
-    return { type: 'point', coordinates: [bboxList[0], bboxList[1]] };
+    return createLocateResultValue(uiTarsPointCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+    ]);
   }
 
   if (bbox.length === 8) {
-    return {
-      type: 'bbox',
-      coordinates: [bboxList[0], bboxList[1], bboxList[4], bboxList[5]],
-    };
+    return createLocateResultValue(uiTarsBboxCoordinatesMeta, [
+      bboxList[0],
+      bboxList[1],
+      bboxList[4],
+      bboxList[5],
+    ]);
   }
 
   const msg = `invalid bbox data for ui-tars mode: ${JSON.stringify(bbox)} `;
@@ -197,7 +212,7 @@ function createUiTarsAdapter(
     },
     locate: {
       resultAdapter: {
-        coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinates: uiTarsBboxCoordinatesMeta,
         parseRawLocateValue: parseUiTarsRawLocateValue,
       },
     },

--- a/packages/core/src/ai-model/shared/model-locate-result/factory.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/factory.ts
@@ -72,12 +72,17 @@ function assertValidParsedLocateResult(result: LocateResultValue): void {
     );
   }
 
+  const coordinatesMeta = result.coordinatesMeta;
   const expectedLength =
-    result.type === 'bbox' ? 4 : result.type === 'point' ? 2 : 0;
+    coordinatesMeta?.shape === 'bbox'
+      ? 4
+      : coordinatesMeta?.shape === 'point'
+        ? 2
+        : 0;
   if (!expectedLength) {
     throw new Error(
-      `invalid parsed locate result: unsupported type ${JSON.stringify(
-        (result as { type?: unknown }).type,
+      `invalid parsed locate result: unsupported coordinatesMeta.shape ${JSON.stringify(
+        coordinatesMeta?.shape,
       )}`,
     );
   }
@@ -91,7 +96,7 @@ function assertValidParsedLocateResult(result: LocateResultValue): void {
     )
   ) {
     throw new Error(
-      `invalid parsed locate result: ${result.type} coordinates must be ${expectedLength} finite numbers, got ${JSON.stringify(
+      `invalid parsed locate result: ${coordinatesMeta.shape} coordinates must be ${expectedLength} finite numbers, got ${JSON.stringify(
         coordinates,
       )}`,
     );
@@ -150,12 +155,7 @@ function createStandardLocateResultAdapterImplementation(
     ((input) => parseNumericLocateResult(resolvedCoordinates, input));
   const mapLocateResultToPixelBbox =
     config.mapLocateResultToPixelBbox ??
-    ((result, ctx) =>
-      mapLocateResultToPixelBboxByCoordinates(
-        result,
-        ctx,
-        resolvedCoordinates,
-      ));
+    ((result, ctx) => mapLocateResultToPixelBboxByCoordinates(result, ctx));
 
   const mapRawLocateValueToPixelBbox = (
     rawResult: unknown,

--- a/packages/core/src/ai-model/shared/model-locate-result/index.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/index.ts
@@ -10,6 +10,7 @@ export {
 export type { CoordinateDistanceAxis } from './coordinate-distance';
 export {
   createLocateResultValue,
+  parseCoordinateList,
   unwrapCoordinateListLikeInput,
 } from './parse';
 export type {

--- a/packages/core/src/ai-model/shared/model-locate-result/index.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/index.ts
@@ -3,8 +3,15 @@ export {
   resolveLocateResultCoordinates,
 } from './factory';
 export { createCoordinateDistanceToPixels } from './coordinate-distance';
+export {
+  isBboxLocateResultValue,
+  isPointLocateResultValue,
+} from './types';
 export type { CoordinateDistanceAxis } from './coordinate-distance';
-export { unwrapCoordinateListLikeInput } from './parse';
+export {
+  createLocateResultValue,
+  unwrapCoordinateListLikeInput,
+} from './parse';
 export type {
   LocateResultBbox,
   PixelBbox,

--- a/packages/core/src/ai-model/shared/model-locate-result/parse.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/parse.ts
@@ -1,5 +1,11 @@
 import type {
+  BboxLocateResultCoordinates,
+  BboxLocateResultValue,
+  LocateResultBbox,
+  LocateResultPoint,
   LocateResultValue,
+  PointLocateResultCoordinates,
+  PointLocateResultValue,
   ResolvedLocateResultCoordinates,
 } from './types';
 
@@ -48,6 +54,36 @@ function parseCoordinateList(input: unknown, label: string): number[] {
   return numericValues;
 }
 
+export function createLocateResultValue(
+  coordinatesMeta: PointLocateResultCoordinates,
+  coordinates: number[],
+): PointLocateResultValue;
+export function createLocateResultValue(
+  coordinatesMeta: BboxLocateResultCoordinates,
+  coordinates: number[],
+): BboxLocateResultValue;
+export function createLocateResultValue(
+  coordinatesMeta: ResolvedLocateResultCoordinates,
+  coordinates: number[],
+): LocateResultValue {
+  if (coordinatesMeta.shape === 'point') {
+    return {
+      coordinates: [coordinates[0], coordinates[1]] as LocateResultPoint,
+      coordinatesMeta,
+    };
+  }
+
+  return {
+    coordinates: [
+      coordinates[0],
+      coordinates[1],
+      coordinates[2],
+      coordinates[3],
+    ] as LocateResultBbox,
+    coordinatesMeta,
+  };
+}
+
 export function parseNumericLocateResult(
   resolvedCoordinates: ResolvedLocateResultCoordinates,
   input: unknown,
@@ -57,7 +93,7 @@ export function parseNumericLocateResult(
     if (point.length < 2) {
       throw new Error(`invalid point data: ${JSON.stringify(input)} `);
     }
-    return { type: 'point', coordinates: [point[0], point[1]] };
+    return createLocateResultValue(resolvedCoordinates, point);
   }
 
   const bbox = parseCoordinateList(input, 'bbox');
@@ -65,8 +101,5 @@ export function parseNumericLocateResult(
     throw new Error(`invalid bbox data: ${JSON.stringify(input)} `);
   }
 
-  return {
-    type: 'bbox',
-    coordinates: [bbox[0], bbox[1], bbox[2], bbox[3]],
-  };
+  return createLocateResultValue(resolvedCoordinates, bbox);
 }

--- a/packages/core/src/ai-model/shared/model-locate-result/parse.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/parse.ts
@@ -27,7 +27,7 @@ export function unwrapCoordinateListLikeInput(
   return coordinateList as string;
 }
 
-function parseCoordinateList(input: unknown, label: string): number[] {
+export function parseCoordinateList(input: unknown, label: string): number[] {
   const unwrapped = unwrapCoordinateListLikeInput(
     input as CoordinateListLikeInput,
   );

--- a/packages/core/src/ai-model/shared/model-locate-result/pixel-bbox-mapper.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/pixel-bbox-mapper.ts
@@ -16,16 +16,16 @@ const defaultBboxSize = 20; // must be even number
 
 function resolveCoordinateLimits(
   result: LocateResultValue,
-  resolvedCoordinates: ResolvedLocateResultCoordinates,
   width: number,
   height: number,
 ): number[] {
+  const resolvedCoordinates = result.coordinatesMeta;
   const normalizedBy = resolvedCoordinates.normalizedBy;
   if (normalizedBy !== undefined) {
     return result.coordinates.map(() => normalizedBy);
   }
 
-  if (result.type === 'bbox') {
+  if (resolvedCoordinates.shape === 'bbox') {
     return resolvedCoordinates.order === 'yx'
       ? [height, width, height, width]
       : [width, height, width, height];
@@ -36,17 +36,12 @@ function resolveCoordinateLimits(
 
 function assertLocateResultCoordinates(
   result: LocateResultValue,
-  resolvedCoordinates: ResolvedLocateResultCoordinates,
   width: number,
   height: number,
 ) {
+  const resolvedCoordinates = result.coordinatesMeta;
   const normalizedBy = resolvedCoordinates.normalizedBy;
-  const limits = resolveCoordinateLimits(
-    result,
-    resolvedCoordinates,
-    width,
-    height,
-  );
+  const limits = resolveCoordinateLimits(result, width, height);
   const outOfRange = result.coordinates.some((value, index) => {
     const limit = limits[index];
     return (
@@ -110,13 +105,13 @@ function reorderCoordinatesToXy(
 export function mapLocateResultToPixelBboxByCoordinates(
   result: LocateResultValue,
   { preparedSize }: { preparedSize: { width: number; height: number } },
-  resolvedCoordinates: ResolvedLocateResultCoordinates,
 ): PixelBbox {
-  // The parsed result type decides whether this maps a bbox or expands a point.
-  // `resolvedCoordinates` describes coordinate order and normalization only.
+  // The parsed result metadata decides whether this maps a bbox or expands a
+  // point, and how to interpret coordinate order and normalization.
   const { width, height } = preparedSize;
+  const resolvedCoordinates = result.coordinatesMeta;
   const normalizedBy = resolvedCoordinates.normalizedBy;
-  assertLocateResultCoordinates(result, resolvedCoordinates, width, height);
+  assertLocateResultCoordinates(result, width, height);
 
   const xyCoordinates = reorderCoordinatesToXy(
     result.coordinates,

--- a/packages/core/src/ai-model/shared/model-locate-result/types.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/types.ts
@@ -6,9 +6,44 @@ export type PixelBbox = Bbox;
 export type NonEmptyArray<T> = [T, ...T[]];
 export type RawLocateValue = unknown;
 
+export type LocateResultPoint = [number, number];
+export type PointLocateResultCoordinates = ResolvedLocateResultCoordinates & {
+  shape: 'point';
+};
+export type BboxLocateResultCoordinates = ResolvedLocateResultCoordinates & {
+  shape: 'bbox';
+};
+
 export type LocateResultValue =
-  | { type: 'bbox'; coordinates: LocateResultBbox }
-  | { type: 'point'; coordinates: [number, number] };
+  | {
+      coordinates: LocateResultPoint;
+      coordinatesMeta: PointLocateResultCoordinates;
+    }
+  | {
+      coordinates: LocateResultBbox;
+      coordinatesMeta: BboxLocateResultCoordinates;
+    };
+
+export type PointLocateResultValue = Extract<
+  LocateResultValue,
+  { coordinatesMeta: { shape: 'point' } }
+>;
+export type BboxLocateResultValue = Extract<
+  LocateResultValue,
+  { coordinatesMeta: { shape: 'bbox' } }
+>;
+
+export function isBboxLocateResultValue(
+  result: LocateResultValue,
+): result is BboxLocateResultValue {
+  return result.coordinatesMeta.shape === 'bbox';
+}
+
+export function isPointLocateResultValue(
+  result: LocateResultValue,
+): result is PointLocateResultValue {
+  return result.coordinatesMeta.shape === 'point';
+}
 
 export type LocateResultShape = 'bbox' | 'point';
 
@@ -69,11 +104,17 @@ export interface LocateResultCoordinates {
   normalizedBy?: number;
 }
 
-export interface ResolvedLocateResultCoordinates {
-  shape: LocateResultShape;
-  order: 'xy' | 'yx';
-  normalizedBy?: number;
-}
+export type ResolvedLocateResultCoordinates =
+  | {
+      shape: 'point';
+      order: 'xy' | 'yx';
+      normalizedBy?: number;
+    }
+  | {
+      shape: 'bbox';
+      order: 'xy' | 'yx';
+      normalizedBy?: number;
+    };
 
 export type RawLocateValueParser = (input: RawLocateValue) => LocateResultValue;
 export type LocateResultPixelBboxMapper = (
@@ -89,9 +130,9 @@ export type LocateResultPixelBboxMapper = (
  *    raw result parser, and a default pixel bbox mapper.
  * 2. `parseRawLocateValue` converts that raw result value into Midscene's
  *    internal `LocateResultValue` shape:
- *    `{ type: 'bbox' | 'point', coordinates: ... }`. Omit it when the model
- *    returns a plain numeric bbox/point matching `coordinates`; provide it when the
- *    model needs repair or fallback handling.
+ *    `{ coordinates, coordinatesMeta }`. Omit it when the model returns a
+ *    plain numeric bbox/point matching `coordinates`; provide it when the
+ *    model needs repair, fallback handling, or per-result coordinate metadata.
  * 3. `mapLocateResultToPixelBbox` converts the parsed result into a pixel bbox
  *    `[left, top, right, bottom]`. Omit it when `coordinates` is enough to describe
  *    the coordinate system and order; provide it only for model-specific
@@ -132,13 +173,13 @@ export type LocateResultPixelBboxMapper = (
  * resultAdapter: {
  *   coordinates: { shape: 'bbox', order: 'xy' },
  *   parseRawLocateValue: (raw) => ({
- *     type: 'bbox',
  *     coordinates: [
  *       Number((raw as any).left),
  *       Number((raw as any).top),
  *       Number((raw as any).right),
  *       Number((raw as any).bottom),
  *     ],
+ *     coordinatesMeta: { shape: 'bbox', order: 'xy' },
  *   }),
  *   mapLocateResultToPixelBbox: (result) => result.coordinates,
  * }
@@ -154,8 +195,8 @@ export type StandardLocateResultAdapterDefinition = {
   coordinates: LocateResultCoordinates;
   /**
    * Parses the picked raw value into a `LocateResultValue`. This function
-   * should handle response repair and bbox-vs-point fallback only;
-   * coordinate-system conversion should stay in `mapLocateResultToPixelBbox`.
+   * should handle response repair, bbox-vs-point fallback, and the coordinate
+   * metadata that describes the parsed coordinates.
    */
   parseRawLocateValue?: RawLocateValueParser;
   /**

--- a/packages/core/tests/unit-test/locate-result-adapter.test.ts
+++ b/packages/core/tests/unit-test/locate-result-adapter.test.ts
@@ -198,8 +198,8 @@ describe('createLocateResultAdapter', () => {
     const adapter = createLocateResultAdapter({
       coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
       parseRawLocateValue: () => ({
-        type: 'bbox',
         coordinates: [652, '233; 713 251;'] as any,
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
       }),
     });
 
@@ -374,8 +374,8 @@ describe('createLocateResultAdapter', () => {
 
   it('allows custom parsing and mapping in standard definition', () => {
     const parseRawLocateValue = vi.fn(() => ({
-      type: 'point' as const,
       coordinates: [3, 4] as [number, number],
+      coordinatesMeta: { shape: 'point' as const, order: 'xy' as const },
     }));
     const mapLocateResultToPixelBbox = vi.fn(
       (): [number, number, number, number] => [1, 2, 3, 4],
@@ -401,7 +401,10 @@ describe('createLocateResultAdapter', () => {
     expect(parseRawLocateValue).toHaveBeenCalledWith({ x: 3, y: 4 });
     expect(parseRawLocateValue).toHaveBeenCalledWith({ x: 5, y: 6 });
     expect(mapLocateResultToPixelBbox).toHaveBeenCalledWith(
-      { type: 'point', coordinates: [3, 4] },
+      {
+        coordinates: [3, 4],
+        coordinatesMeta: { shape: 'point', order: 'xy' },
+      },
       locateCtx(100, 100),
     );
   });

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -302,12 +302,12 @@ describe('doubao model adapter', () => {
 
   it('parses raw Doubao locate values directly', () => {
     expect(parseDoubaoRawLocateValue('100 200 300 400')).toEqual({
-      type: 'bbox',
       coordinates: [100, 200, 300, 400],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
     });
     expect(parseDoubaoRawLocateValue(['100', '200', '300', '400'])).toEqual({
-      type: 'bbox',
       coordinates: [100, 200, 300, 400],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
     });
     expect(() => parseDoubaoRawLocateValue('100 200 300 400 ')).toThrow(
       /invalid bbox data string/,

--- a/packages/core/tests/unit-test/model-adapter/kimi.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/kimi.test.ts
@@ -20,6 +20,51 @@ describe('kimi model adapter', () => {
     expect(result).toEqual([693, 142, 731, 171]);
   });
 
+  it('accepts pixel xy point coordinates for kimi locate results', () => {
+    const locateAdapter = kimiAdapter.locate;
+    expect(locateAdapter.kind).toBe('standard');
+    if (locateAdapter.kind !== 'standard') {
+      throw new Error('kimi should use standard locate adapter');
+    }
+
+    const result =
+      locateAdapter.resultAdapter.adaptElementLocateResultToPixelBbox(
+        [960, 540],
+        { preparedSize: { width: 1920, height: 1080 } },
+      );
+    expect(result).toEqual([950, 530, 970, 550]);
+  });
+
+  it('accepts pixel xy point strings for kimi locate results', () => {
+    const locateAdapter = kimiAdapter.locate;
+    expect(locateAdapter.kind).toBe('standard');
+    if (locateAdapter.kind !== 'standard') {
+      throw new Error('kimi should use standard locate adapter');
+    }
+
+    const result =
+      locateAdapter.resultAdapter.adaptElementLocateResultToPixelBbox(
+        '960 540',
+        { preparedSize: { width: 1920, height: 1080 } },
+      );
+    expect(result).toEqual([950, 530, 970, 550]);
+  });
+
+  it('rejects out-of-range kimi pixel point coordinates', () => {
+    const locateAdapter = kimiAdapter.locate;
+    expect(locateAdapter.kind).toBe('standard');
+    if (locateAdapter.kind !== 'standard') {
+      throw new Error('kimi should use standard locate adapter');
+    }
+
+    expect(() =>
+      locateAdapter.resultAdapter.adaptElementLocateResultToPixelBbox(
+        [2000, 540],
+        { preparedSize: { width: 1920, height: 1080 } },
+      ),
+    ).toThrow(/exceed image size/);
+  });
+
   it('defaults kimi thinking to disabled when reasoning config is unset', () => {
     const result = kimiAdapter.chatCompletion.buildChatCompletionParams({
       userConfig: {},


### PR DESCRIPTION
## Summary

- Add `coordinatesMeta` to locate result values and let coordinate mapping use the parsed result metadata.
- Update Doubao, Qwen, UI-TARS, and shared locate parsing/tests for the new locate result shape.
- Add Kimi compatibility for point coordinates returned as either normalized OSWorld-style values (`<= 1`) or screenshot pixel coordinates.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/kimi.test.ts tests/unit-test/locate-result-adapter.test.ts`
- `pnpm --filter @midscene/core build`
- `git diff --check`