### PR TITLE
fix(core): enable default reasoning content fallback

### DIFF
--- a/packages/core/src/ai-model/models/default.ts
+++ b/packages/core/src/ai-model/models/default.ts
@@ -7,5 +7,9 @@ export const defaultOpenAICompatibleAdapterConfig: ModelAdapterDefinition = {
       'reasoningEffort',
       'reasoningBudget',
     ],
+    // Users may omit modelFamily when using an OpenAI-compatible endpoint.
+    // Many models expose useful assistant output through reasoning_content, so
+    // the default adapter should still recover when content is empty.
+    useReasoningAsContentFallback: true,
   },
 };

--- a/packages/core/tests/unit-test/model-adapter.test.ts
+++ b/packages/core/tests/unit-test/model-adapter.test.ts
@@ -31,6 +31,7 @@ describe('model adapter registry', () => {
       'reasoningEffort',
       'reasoningBudget',
     ]);
+    expect(adapter.chatCompletion.useReasoningAsContentFallback).toBe(true);
   });
 
   it('resolves every supported model family', () => {
@@ -63,7 +64,7 @@ describe('model adapter registry', () => {
     }
   });
 
-  it('enables reasoning-as-content fallback only for supported model families', () => {
+  it('enables reasoning-as-content fallback for default and supported model families', () => {
     const enabledFamilies: TModelFamily[] = [
       'doubao-vision',
       'doubao-seed',
@@ -85,7 +86,7 @@ describe('model adapter registry', () => {
     }
 
     expect(getModelAdapter().chatCompletion.useReasoningAsContentFallback).toBe(
-      false,
+      true,
     );
   });
 


### PR DESCRIPTION
## Summary

- Enable reasoning-content fallback for the default OpenAI-compatible adapter.
- Cover the default adapter fallback behavior in model adapter registry tests.

## Why

Users may omit `modelFamily` when using an OpenAI-compatible endpoint. Some providers return useful assistant output in `reasoning_content` while leaving `content` empty, so the default adapter should recover from that response shape instead of failing with `empty content from AI model`.

## Validation

- `node_modules/.bin/vitest --run tests/unit-test/model-adapter.test.ts --config vitest.config.ts`