### PR TITLE
feat(core): add keyboardTypeDelay support across all platforms

### DIFF
--- a/apps/report/package.json
+++ b/apps/report/package.json
@@ -11,7 +11,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "generate-demo": "node scripts/generate-demo-report.mjs",
-    "e2e": "node scripts/generate-demo-report.mjs && node ../../packages/cli/bin/midscene ./e2e/"
+    "e2e": "pnpm --dir ../.. exec nx build @midscene/report --verbose && node scripts/inject-report-template.mjs && node scripts/generate-demo-report.mjs && node ../../packages/cli/bin/midscene ./e2e/"
   },
   "dependencies": {
     "@ant-design/icons": "^5.3.1",

--- a/apps/site/docs/en/android-api-reference.mdx
+++ b/apps/site/docs/en/android-api-reference.mdx
@@ -8,7 +8,7 @@ Use this doc when you need to customize Midscene's Android automation or review 
 
 - `Tap` &mdash; Tap an element.
 - `DoubleClick` &mdash; Double-tap an element.
-- `Input` &mdash; Enter text with `replace`/`typeOnly`/`clear` modes (`append` is a deprecated alias for `typeOnly`). Supports optional `autoDismissKeyboard` parameter.
+- `Input` &mdash; Enter text with `replace`/`typeOnly`/`clear` modes (`append` is a deprecated alias for `typeOnly`). Supports optional `autoDismissKeyboard` and `keyboardTypeDelay` parameters.
 - `Scroll` &mdash; Scroll from an element or screen center in any direction, with helpers to reach the top, bottom, left, or right.
 - `DragAndDrop` &mdash; Drag from one element to another.
 - `KeyboardPress` &mdash; Press a specified key.
@@ -46,6 +46,7 @@ const device = new AndroidDevice(deviceId, {
 - `deviceId: string` &mdash; Value returned by `adb devices` or `getConnectedDevices()`.
 - `autoDismissKeyboard?: boolean` &mdash; Automatically hide the keyboard after input. Default `true`.
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` &mdash; Order for dismissing keyboards. Default `'esc-first'`.
+- `keyboardTypeDelay?: number` &mdash; Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character, instead of sending the whole string at once. Useful on devices or input fields that drop characters when input arrives too fast (e.g. WiFi password fields on automotive displays). Only applies to the `input text` path; ignored when yadb is used.
 - `androidAdbPath?: string` &mdash; Custom path to the adb executable.
 - `remoteAdbHost?: string` / `remoteAdbPort?: number` &mdash; Point to a remote adb server.
 - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` &mdash; Choose when to invoke [yadb](https://github.com/ysbing/YADB) for text input. Default `'yadb-for-non-ascii'`.

--- a/apps/site/docs/en/android-api-reference.mdx
+++ b/apps/site/docs/en/android-api-reference.mdx
@@ -46,7 +46,7 @@ const device = new AndroidDevice(deviceId, {
 - `deviceId: string` &mdash; Value returned by `adb devices` or `getConnectedDevices()`.
 - `autoDismissKeyboard?: boolean` &mdash; Automatically hide the keyboard after input. Default `true`.
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` &mdash; Order for dismissing keyboards. Default `'esc-first'`.
-- `keyboardTypeDelay?: number` &mdash; Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character, instead of sending the whole string at once. Useful on devices or input fields that drop characters when input arrives too fast (e.g. WiFi password fields on automotive displays). Only applies to the `input text` path; ignored when yadb is used.
+- `keyboardTypeDelay?: number` &mdash; Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character, instead of sending the whole string at once. Useful on devices or input fields that drop characters when input arrives too fast. Only applies to the `input text` path; ignored when yadb is used.
 - `androidAdbPath?: string` &mdash; Custom path to the adb executable.
 - `remoteAdbHost?: string` / `remoteAdbPort?: number` &mdash; Point to a remote adb server.
 - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` &mdash; Choose when to invoke [yadb](https://github.com/ysbing/YADB) for text input. Default `'yadb-for-non-ascii'`.

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -316,6 +316,7 @@ function aiInput(
     xpath?: string;
     cacheable?: boolean;
     autoDismissKeyboard?: boolean;
+    keyboardTypeDelay?: number;
     mode?: 'replace' | 'clear' | 'typeOnly';
   },
 ): Promise<void>;
@@ -341,6 +342,7 @@ function aiInput(
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `autoDismissKeyboard?: boolean` - If true, the keyboard will be dismissed after input text, only available in Android/iOS/HarmonyOS. (Default: true)
+    - `keyboardTypeDelay?: number` - Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character. Only available in Android/iOS/HarmonyOS. Useful when input fields drop characters under fast typing (e.g. WiFi password fields on automotive displays).
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - Input mode. (Default: 'replace')
       - `'replace'`: Clear the input field first, then input the text.
       - `'typeOnly'`: Type the value directly without clearing the field first.

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -342,7 +342,7 @@ function aiInput(
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `autoDismissKeyboard?: boolean` - If true, the keyboard will be dismissed after input text, only available in Android/iOS/HarmonyOS. (Default: true)
-    - `keyboardTypeDelay?: number` - Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character. Only available in Android/iOS/HarmonyOS. Useful when input fields drop characters under fast typing (e.g. WiFi password fields on automotive displays).
+    - `keyboardTypeDelay?: number` - Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character. Supported on all platforms (Web, Android, iOS, HarmonyOS). Useful when input fields drop characters under fast typing (e.g. WiFi password fields on automotive displays).
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - Input mode. (Default: 'replace')
       - `'replace'`: Clear the input field first, then input the text.
       - `'typeOnly'`: Type the value directly without clearing the field first.

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -342,7 +342,7 @@ function aiInput(
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `autoDismissKeyboard?: boolean` - If true, the keyboard will be dismissed after input text, only available in Android/iOS/HarmonyOS. (Default: true)
-    - `keyboardTypeDelay?: number` - Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character. Supported on all platforms (Web, Android, iOS, HarmonyOS). Useful when input fields drop characters under fast typing (e.g. WiFi password fields on automotive displays).
+    - `keyboardTypeDelay?: number` - Delay in milliseconds between keystrokes when typing text. When set, text is typed one character at a time with this delay between each character. Useful when input fields drop characters under fast typing.
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - Input mode. (Default: 'replace')
       - `'replace'`: Clear the input field first, then input the text.
       - `'typeOnly'`: Type the value directly without clearing the field first.

--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -236,7 +236,7 @@ android:
   # All other options supported by the AndroidDevice constructor
   # For example: androidAdbPath, remoteAdbHost, remoteAdbPort,
   # imeStrategy, displayId, autoDismissKeyboard, keyboardDismissStrategy,
-  # minScreenshotBufferSize, alwaysRefreshScreenInfo, etc.
+  # keyboardTypeDelay, minScreenshotBufferSize, alwaysRefreshScreenInfo, etc.
   # See the AndroidDevice constructor documentation for the complete list
 ```
 

--- a/apps/site/docs/en/harmony-api-reference.mdx
+++ b/apps/site/docs/en/harmony-api-reference.mdx
@@ -46,6 +46,7 @@ const device = new HarmonyDevice(deviceId, {
 - `hdcPath?: string` — Custom path to the HDC executable. If not set, it searches `HDC_HOME` environment variable and common installation paths.
 - `autoDismissKeyboard?: boolean` — Automatically hide keyboard after input, default `true`.
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` — Key preference for automatically hiding the keyboard, default `'esc-first'`. HarmonyOS sends the first key from the strategy only: `'esc-first'` sends ESC, while `'back-first'` sends Back.
+- `keyboardTypeDelay?: number` — Per-character delay (ms) when typing text. When set, text is typed one character at a time with this delay between each character via `uitest uiInput inputText`. Useful when input fields drop characters under fast typing.
 - `screenshotResizeScale?: number` — **Deprecated.** This option has been removed and no longer has any effect. Use `screenshotShrinkFactor` in `AgentOpt` instead to control screenshot size sent to the AI model.
 - `customActions?: DeviceAction[]` — Extend the planner's available actions via `defineAction`.
 

--- a/apps/site/docs/en/ios-api-reference.mdx
+++ b/apps/site/docs/en/ios-api-reference.mdx
@@ -8,7 +8,7 @@ Use this doc when you need to customize iOS device behavior, wire Midscene into 
 
 - `Tap` &mdash; Tap an element.
 - `DoubleClick` &mdash; Double-tap an element.
-- `Input` &mdash; Enter text with `replace`/`typeOnly`/`clear` modes (`append` is a deprecated alias for `typeOnly`). Supports optional `autoDismissKeyboard` parameter.
+- `Input` &mdash; Enter text with `replace`/`typeOnly`/`clear` modes (`append` is a deprecated alias for `typeOnly`). Supports optional `autoDismissKeyboard` and `keyboardTypeDelay` parameters.
 - `Scroll` &mdash; Scroll from an element or screen center in any direction, including scroll-to-top/bottom/left/right helpers.
 - `DragAndDrop` &mdash; Drag from one element to another.
 - `KeyboardPress` &mdash; Press a specified key.
@@ -45,6 +45,7 @@ const device = new IOSDevice({
 - `wdaHost?: string` &mdash; WebDriverAgent host. Default `'localhost'`.
 - `iOSDeviceClassOverride?: string` &mdash; Optional npm module path that replaces the default `IOSDevice` when using `agentFromWebDriverAgent()` or iOS Playground. The module must export an `IOSDevice` class or a default class.
 - `autoDismissKeyboard?: boolean` &mdash; Hide the keyboard after text input. Default `true`.
+- `keyboardTypeDelay?: number` &mdash; Per-character delay (ms) when typing text. When set, text is typed one character at a time with this delay between each character via WDA's `/wda/keys` endpoint. Useful when input fields drop characters under fast typing.
 - `customActions?: DeviceAction<any>[]` &mdash; Additional device actions exposed to the agent.
 
 ### Usage notes

--- a/apps/site/docs/zh/android-api-reference.mdx
+++ b/apps/site/docs/zh/android-api-reference.mdx
@@ -46,7 +46,7 @@ const device = new AndroidDevice(deviceId, {
 - `deviceId: string` —— 来自 `adb devices` 或 `getConnectedDevices()` 的值。
 - `autoDismissKeyboard?: boolean` —— 输入完成后自动隐藏键盘，默认 `true`。
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` —— 关闭键盘的顺序，默认 `'esc-first'`。
-- `keyboardTypeDelay?: number` —— 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟，而不是一次性发送整串文本。适用于输入过快导致丢字的设备或输入框（如车载显示屏上的 WiFi 密码框）。仅对 `input text` 路径生效；使用 yadb 时忽略此选项。
+- `keyboardTypeDelay?: number` —— 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟，而不是一次性发送整串文本。适用于输入过快导致丢字的设备或输入框。仅对 `input text` 路径生效；使用 yadb 时忽略此选项。
 - `androidAdbPath?: string` —— adb 可执行文件的自定义路径。
 - `remoteAdbHost?: string` / `remoteAdbPort?: number` —— 指向远程 adb server。
 - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` —— 控制何时调用 [yadb](https://github.com/ysbing/YADB) 进行文本输入，默认 `'yadb-for-non-ascii'`。

--- a/apps/site/docs/zh/android-api-reference.mdx
+++ b/apps/site/docs/zh/android-api-reference.mdx
@@ -8,7 +8,7 @@
 
 - `Tap` —— 点击元素。
 - `DoubleClick` —— 双击元素。
-- `Input` —— 输入文本，支持 `replace`/`typeOnly`/`clear` 模式（`append` 是 `typeOnly` 的已废弃别名）。支持可选参数 `autoDismissKeyboard`。
+- `Input` —— 输入文本，支持 `replace`/`typeOnly`/`clear` 模式（`append` 是 `typeOnly` 的已废弃别名）。支持可选参数 `autoDismissKeyboard` 和 `keyboardTypeDelay`。
 - `Scroll` —— 以元素为起点或从屏幕中央向上/下/左/右滚动，支持滚动到顶/底/左/右。
 - `DragAndDrop` —— 从一个元素拖拽到另一个元素。
 - `KeyboardPress` —— 按下指定键位。
@@ -46,6 +46,7 @@ const device = new AndroidDevice(deviceId, {
 - `deviceId: string` —— 来自 `adb devices` 或 `getConnectedDevices()` 的值。
 - `autoDismissKeyboard?: boolean` —— 输入完成后自动隐藏键盘，默认 `true`。
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` —— 关闭键盘的顺序，默认 `'esc-first'`。
+- `keyboardTypeDelay?: number` —— 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟，而不是一次性发送整串文本。适用于输入过快导致丢字的设备或输入框（如车载显示屏上的 WiFi 密码框）。仅对 `input text` 路径生效；使用 yadb 时忽略此选项。
 - `androidAdbPath?: string` —— adb 可执行文件的自定义路径。
 - `remoteAdbHost?: string` / `remoteAdbPort?: number` —— 指向远程 adb server。
 - `imeStrategy?: 'always-yadb' | 'yadb-for-non-ascii'` —— 控制何时调用 [yadb](https://github.com/ysbing/YADB) 进行文本输入，默认 `'yadb-for-non-ascii'`。

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -335,7 +335,7 @@ function aiInput(
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `autoDismissKeyboard?: boolean` - 如果为 true，则键盘会在输入文本后自动关闭，仅在 Android/iOS/HarmonyOS 中有效。默认值为 true。
-    - `keyboardTypeDelay?: number` - 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟。仅在 Android/iOS/HarmonyOS 中有效。适用于输入框在快速输入下丢字的场景（如车载显示屏上的 WiFi 密码框）。
+    - `keyboardTypeDelay?: number` - 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟。全平台支持（Web、Android、iOS、HarmonyOS）。适用于输入框在快速输入下丢字的场景（如车载显示屏上的 WiFi 密码框）。
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - 输入模式。(默认值: 'replace')
       - `'replace'`: 先清空输入框，然后输入文本。
       - `'typeOnly'`: 直接输入文本，不会先清空输入框。

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -335,7 +335,7 @@ function aiInput(
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `autoDismissKeyboard?: boolean` - 如果为 true，则键盘会在输入文本后自动关闭，仅在 Android/iOS/HarmonyOS 中有效。默认值为 true。
-    - `keyboardTypeDelay?: number` - 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟。全平台支持（Web、Android、iOS、HarmonyOS）。适用于输入框在快速输入下丢字的场景（如车载显示屏上的 WiFi 密码框）。
+    - `keyboardTypeDelay?: number` - 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟。适用于输入框在快速输入下丢字的场景。
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - 输入模式。(默认值: 'replace')
       - `'replace'`: 先清空输入框，然后输入文本。
       - `'typeOnly'`: 直接输入文本，不会先清空输入框。

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -309,6 +309,7 @@ function aiInput(
     xpath?: string;
     cacheable?: boolean;
     autoDismissKeyboard?: boolean;
+    keyboardTypeDelay?: number;
     mode?: 'replace' | 'clear' | 'typeOnly';
   },
 ): Promise<void>;
@@ -334,6 +335,7 @@ function aiInput(
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `autoDismissKeyboard?: boolean` - 如果为 true，则键盘会在输入文本后自动关闭，仅在 Android/iOS/HarmonyOS 中有效。默认值为 true。
+    - `keyboardTypeDelay?: number` - 输入文本时每个按键之间的延迟（毫秒）。设置后，文本将逐字符输入，每个字符之间等待指定的延迟。仅在 Android/iOS/HarmonyOS 中有效。适用于输入框在快速输入下丢字的场景（如车载显示屏上的 WiFi 密码框）。
     - `mode?: 'replace' | 'clear' | 'typeOnly'` - 输入模式。(默认值: 'replace')
       - `'replace'`: 先清空输入框，然后输入文本。
       - `'typeOnly'`: 直接输入文本，不会先清空输入框。

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -236,7 +236,7 @@ android:
   # 其他 AndroidDevice 构造函数支持的所有选项
   # 例如：androidAdbPath, remoteAdbHost, remoteAdbPort,
   # imeStrategy, displayId, autoDismissKeyboard, keyboardDismissStrategy,
-  # minScreenshotBufferSize, alwaysRefreshScreenInfo 等
+  # keyboardTypeDelay, minScreenshotBufferSize, alwaysRefreshScreenInfo 等
   # 完整配置项请参考 AndroidDevice 的构造函数文档
 ```
 

--- a/apps/site/docs/zh/harmony-api-reference.mdx
+++ b/apps/site/docs/zh/harmony-api-reference.mdx
@@ -46,6 +46,7 @@ const device = new HarmonyDevice(deviceId, {
 - `hdcPath?: string` —— HDC 可执行文件的自定义路径。若未设置，将依次从 `HDC_HOME` 环境变量和常见安装路径中查找。
 - `autoDismissKeyboard?: boolean` —— 输入完成后自动隐藏键盘，默认 `true`。
 - `keyboardDismissStrategy?: 'esc-first' | 'back-first'` —— 自动隐藏键盘时优先使用的按键，默认 `'esc-first'`。HarmonyOS 只发送该策略的首选按键：`'esc-first'` 发送 ESC，`'back-first'` 发送 Back。
+- `keyboardTypeDelay?: number` —— 输入文本时每个按键之间的延迟（毫秒）。设置后，通过 `uitest uiInput inputText` 逐字符输入，每个字符之间等待指定的延迟。适用于输入框在快速输入下丢字的场景。
 - `screenshotResizeScale?: number` —— **已废弃。** 此选项已移除，不再生效。如需控制发送给 AI 模型的截图尺寸，请使用 `AgentOpt` 中的 `screenshotShrinkFactor`。
 - `customActions?: DeviceAction[]` —— 通过 `defineAction` 扩展规划器的可用动作。
 

--- a/apps/site/docs/zh/ios-api-reference.mdx
+++ b/apps/site/docs/zh/ios-api-reference.mdx
@@ -8,7 +8,7 @@
 
 - `Tap` —— 点击元素。
 - `DoubleClick` —— 双击元素。
-- `Input` —— 输入文本，支持 `replace`/`typeOnly`/`clear` 模式（`append` 是 `typeOnly` 的已废弃别名）。支持可选参数 `autoDismissKeyboard`。
+- `Input` —— 输入文本，支持 `replace`/`typeOnly`/`clear` 模式（`append` 是 `typeOnly` 的已废弃别名）。支持可选参数 `autoDismissKeyboard` 和 `keyboardTypeDelay`。
 - `Scroll` —— 以元素为起点或从屏幕中央向上/下/左/右滚动，支持滚动到顶/底/左/右。
 - `DragAndDrop` —— 从一个元素拖拽到另一个元素。
 - `KeyboardPress` —— 按下指定键位。
@@ -45,6 +45,7 @@ const device = new IOSDevice({
 - `wdaHost?: string` —— WebDriverAgent host，默认 `'localhost'`。
 - `iOSDeviceClassOverride?: string` —— 使用 `agentFromWebDriverAgent()` 或 iOS Playground 时替换默认 `IOSDevice` 的 npm module path。目标模块必须导出 `IOSDevice` class 或 default class。
 - `autoDismissKeyboard?: boolean` —— 文本输入后自动隐藏键盘，默认 `true`。
+- `keyboardTypeDelay?: number` —— 输入文本时每个按键之间的延迟（毫秒）。设置后，通过 WDA 的 `/wda/keys` 接口逐字符输入，每个字符之间等待指定的延迟。适用于输入框在快速输入下丢字的场景。
 - `customActions?: DeviceAction<any>[]` —— 向 Agent 暴露的额外设备动作。
 
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -81,6 +81,22 @@ export function escapeForShell(text: string): string {
     .replace(/\n/g, '\\n'); // 0x0A → literal \n (yadb interprets back to newline)
 }
 
+/**
+ * Escape a string for safe use as a single argument in `adb shell input text`.
+ * Wraps the value in single quotes so the device shell (/system/bin/sh) does
+ * not interpret spaces, &, ;, |, $, `, etc. as shell metacharacters. Internal
+ * single quotes are escaped via the '\'' sequence (end quote, literal quote,
+ * start quote).
+ *
+ * Unlike the old `%s` convention, this properly protects ALL shell-special
+ * characters, not just spaces. Critical for WiFi passwords and similar inputs
+ * that may contain `&`, `;`, `'`, etc.
+ */
+function shellEscapeArg(text: string): string {
+  const escaped = text.replace(/'/g, "'\\''");
+  return `'${escaped}'`;
+}
+
 export class AndroidDevice implements AbstractInterface {
   private deviceId: string;
   private yadbPushed = false;
@@ -1279,11 +1295,11 @@ ${Object.keys(size)
       // Neither yadb nor appium-adb's clearTextField pass -d <displayId>.
       // On a non-default display we must issue keyevents with the display
       // argument so deletions land on the correct screen.
-      const keys: string[] = [];
+      const keys: number[] = [];
       for (let i = 0; i < 100; i++) {
-        keys.push('67', '112'); // KEYCODE_DEL, KEYCODE_FORWARD_DEL
+        keys.push(67, 112); // KEYCODE_DEL, KEYCODE_FORWARD_DEL
       }
-      await adb.shell(`input${displayArg} keyevent ${keys.join(' ')}`);
+      await this.shellInputKeyevent(...keys);
     } else if (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII) {
       // For yadb-for-non-ascii mode, use batch deletion of up to 100 characters
       // clearTextField() batches all key events into a single shell command for better performance
@@ -1624,11 +1640,17 @@ ${Object.keys(size)
       this.options.displayId !== 0;
 
     // Decide input path for the entire text, not per-segment.
-    const useYadb =
-      !isNonDefaultDisplay &&
-      (IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
-        (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
-          this.shouldUseYadbForText(text)));
+    const needsYadb =
+      IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
+      (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
+        this.shouldUseYadbForText(text));
+    const useYadb = !isNonDefaultDisplay && needsYadb;
+
+    if (isNonDefaultDisplay && needsYadb) {
+      warnDevice(
+        `Text requires yadb (non-ASCII or shell-special characters) but yadb cannot target non-default displays. Falling back to \`input text\` on displayId=${this.options?.displayId}; some characters may be lost or corrupted.`,
+      );
+    }
 
     if (useYadb) {
       // yadb handles newlines natively: escapeForShell converts \n (0x0A)
@@ -1636,32 +1658,9 @@ ${Object.keys(size)
       // Single adb call for the entire text.
       await this.execYadb(escapeForShell(text));
     } else {
-      // Use `input -d <id> text` via adb.shell so we can target the correct
-      // display. appium-adb's inputText does not pass -d.
-      const displayArg = this.getDisplayArg();
-      // inputText cannot handle newlines, so split by \n and press Enter between segments.
-      const segments = text.split('\n');
-      for (let i = 0; i < segments.length; i++) {
-        if (segments[i].length > 0) {
-          if (typeDelay && typeDelay > 0) {
-            // Type one character at a time with a delay between keystrokes.
-            // This prevents character loss on devices/input fields that can't
-            // keep up with the full-string burst from `input text`.
-            for (const ch of segments[i]) {
-              const escaped = ch === ' ' ? '%s' : ch;
-              await adb.shell(`input${displayArg} text ${escaped}`);
-              await sleep(typeDelay);
-            }
-          } else {
-            // Burst the whole segment. Shell-escape spaces as %s for `input text`.
-            const escaped = segments[i].replace(/ /g, '%s');
-            await adb.shell(`input${displayArg} text ${escaped}`);
-          }
-        }
-        if (i < segments.length - 1) {
-          await adb.shell(`input${displayArg} keyevent 66`);
-        }
-      }
+      // Use the display-aware `input text` primitive. Handles shell escaping,
+      // newline splitting, and per-character typing delay internally.
+      await this.shellInputText(text, { keyboardTypeDelay: typeDelay });
     }
 
     if (shouldAutoDismissKeyboard === true) {
@@ -1710,21 +1709,18 @@ ${Object.keys(size)
       End: 123,
     };
 
-    const adb = await this.getAdb();
-    const displayArg = this.getDisplayArg();
-
     // Normalize key to handle case-insensitive matching
     const normalizedKey = this.normalizeKeyName(key);
     const keyCode = keyCodeMap[normalizedKey];
     if (keyCode !== undefined) {
-      await adb.shell(`input${displayArg} keyevent ${keyCode}`);
+      await this.shellInputKeyevent(keyCode);
     } else {
       // for keys not in the mapping table, try to get its ASCII code (if it's a single character)
       if (key.length === 1) {
         const asciiCode = key.toUpperCase().charCodeAt(0);
         // Android key codes, A-Z is 29-54
         if (asciiCode >= 65 && asciiCode <= 90) {
-          await adb.shell(`input${displayArg} keyevent ${asciiCode - 36}`); // 65-36=29 (A's key code)
+          await this.shellInputKeyevent(asciiCode - 36); // 65-36=29 (A's key code)
         }
       }
     }
@@ -1930,18 +1926,15 @@ ${Object.keys(size)
   }
 
   async back(): Promise<void> {
-    const adb = await this.getAdb();
-    await adb.shell(`input${this.getDisplayArg()} keyevent 4`);
+    await this.shellInputKeyevent(4); // KEYCODE_BACK
   }
 
   async home(): Promise<void> {
-    const adb = await this.getAdb();
-    await adb.shell(`input${this.getDisplayArg()} keyevent 3`);
+    await this.shellInputKeyevent(3); // KEYCODE_HOME
   }
 
   async recentApps(): Promise<void> {
-    const adb = await this.getAdb();
-    await adb.shell(`input${this.getDisplayArg()} keyevent 187`);
+    await this.shellInputKeyevent(187); // KEYCODE_APP_SWITCH
   }
 
   private async longPressPoint(
@@ -2014,6 +2007,60 @@ ${Object.keys(size)
     return typeof this.options?.displayId === 'number'
       ? ` -d ${this.options.displayId}`
       : '';
+  }
+
+  /**
+   * Send one or more Android keyevent codes via `input -d <id> keyevent`.
+   * Centralizes the display-aware keyevent primitive so callers don't have
+   * to hand-write `input${displayArg} keyevent` everywhere.
+   */
+  private async shellInputKeyevent(...keyCodes: number[]): Promise<void> {
+    const adb = await this.getAdb();
+    await adb.shell(
+      `input${this.getDisplayArg()} keyevent ${keyCodes.join(' ')}`,
+    );
+  }
+
+  /**
+   * Send text via `input -d <id> text` with proper shell escaping and
+   * optional per-character typing delay.
+   *
+   * Handles:
+   * - Display targeting via getDisplayArg()
+   * - Shell-special character protection (single-quote wrapping)
+   * - Newline splitting (input text can't handle \n; Enter keyevent is sent)
+   * - Per-character typing delay when keyboardTypeDelay > 0
+   */
+  private async shellInputText(
+    text: string,
+    opts?: { keyboardTypeDelay?: number },
+  ): Promise<void> {
+    const adb = await this.getAdb();
+    const displayArg = this.getDisplayArg();
+    const typeDelay = opts?.keyboardTypeDelay;
+
+    // input text cannot handle newlines; split and press Enter between segments.
+    const segments = text.split('\n');
+    for (let i = 0; i < segments.length; i++) {
+      if (segments[i].length > 0) {
+        if (typeDelay && typeDelay > 0) {
+          // Per-character typing with delay. Each char is shell-escaped.
+          for (const ch of segments[i]) {
+            await adb.shell(`input${displayArg} text ${shellEscapeArg(ch)}`);
+            await sleep(typeDelay);
+          }
+        } else {
+          // Burst the whole segment. shellEscapeArg protects against
+          // shell metacharacters (&, ;, ', $, etc.).
+          await adb.shell(
+            `input${displayArg} text ${shellEscapeArg(segments[i])}`,
+          );
+        }
+      }
+      if (i < segments.length - 1) {
+        await this.shellInputKeyevent(66); // KEYCODE_ENTER
+      }
+    }
   }
 
   /**
@@ -2107,7 +2154,7 @@ ${Object.keys(size)
 
     // Try each key code with waiting
     for (const keyCode of keyCodes) {
-      await adb.shell(`input${this.getDisplayArg()} keyevent ${keyCode}`);
+      await this.shellInputKeyevent(keyCode);
 
       // Wait for keyboard to be hidden with timeout
       const startTime = Date.now();

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1264,21 +1264,34 @@ ${Object.keys(size)
       await this.tapPoint({ x: element.center[0], y: element.center[1] });
     }
 
-    await this.ensureYadb();
     const adb = await this.getAdb();
+    const displayArg = this.getDisplayArg();
+    const isNonDefaultDisplay =
+      typeof this.options?.displayId === 'number' &&
+      this.options.displayId !== 0;
 
     const IME_STRATEGY =
       (this.options?.imeStrategy ||
         globalConfigManager.getEnvConfigValue(MIDSCENE_ANDROID_IME_STRATEGY)) ??
       IME_STRATEGY_YADB_FOR_NON_ASCII;
 
-    if (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII) {
+    if (isNonDefaultDisplay) {
+      // Neither yadb nor appium-adb's clearTextField pass -d <displayId>.
+      // On a non-default display we must issue keyevents with the display
+      // argument so deletions land on the correct screen.
+      const keys: string[] = [];
+      for (let i = 0; i < 100; i++) {
+        keys.push('67', '112'); // KEYCODE_DEL, KEYCODE_FORWARD_DEL
+      }
+      await adb.shell(`input${displayArg} keyevent ${keys.join(' ')}`);
+    } else if (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII) {
       // For yadb-for-non-ascii mode, use batch deletion of up to 100 characters
       // clearTextField() batches all key events into a single shell command for better performance
+      await this.ensureYadb();
       await adb.clearTextField(100);
     } else {
       // Use the yadb tool to clear the input box
-      this.warnYadbOnNonDefaultDisplay('keyboard clear');
+      await this.ensureYadb();
       await adb.shell(
         // `app_process` (ART launcher) does not accept the `-d <displayId>` flag.
         'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboardClear',
@@ -1600,12 +1613,22 @@ ${Object.keys(size)
       IME_STRATEGY_YADB_FOR_NON_ASCII;
     const shouldAutoDismissKeyboard =
       options?.autoDismissKeyboard ?? this.options?.autoDismissKeyboard ?? true;
+    const typeDelay =
+      options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay;
+
+    // yadb (app_process) cannot target a non-default display. If a displayId
+    // other than 0 is configured, force the `input text` path so text lands
+    // on the correct screen instead of silently appearing on the main display.
+    const isNonDefaultDisplay =
+      typeof this.options?.displayId === 'number' &&
+      this.options.displayId !== 0;
 
     // Decide input path for the entire text, not per-segment.
     const useYadb =
-      IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
-      (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
-        this.shouldUseYadbForText(text));
+      !isNonDefaultDisplay &&
+      (IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
+        (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
+          this.shouldUseYadbForText(text)));
 
     if (useYadb) {
       // yadb handles newlines natively: escapeForShell converts \n (0x0A)
@@ -1613,14 +1636,30 @@ ${Object.keys(size)
       // Single adb call for the entire text.
       await this.execYadb(escapeForShell(text));
     } else {
+      // Use `input -d <id> text` via adb.shell so we can target the correct
+      // display. appium-adb's inputText does not pass -d.
+      const displayArg = this.getDisplayArg();
       // inputText cannot handle newlines, so split by \n and press Enter between segments.
       const segments = text.split('\n');
       for (let i = 0; i < segments.length; i++) {
         if (segments[i].length > 0) {
-          await adb.inputText(segments[i]);
+          if (typeDelay && typeDelay > 0) {
+            // Type one character at a time with a delay between keystrokes.
+            // This prevents character loss on devices/input fields that can't
+            // keep up with the full-string burst from `input text`.
+            for (const ch of segments[i]) {
+              const escaped = ch === ' ' ? '%s' : ch;
+              await adb.shell(`input${displayArg} text ${escaped}`);
+              await sleep(typeDelay);
+            }
+          } else {
+            // Burst the whole segment. Shell-escape spaces as %s for `input text`.
+            const escaped = segments[i].replace(/ /g, '%s');
+            await adb.shell(`input${displayArg} text ${escaped}`);
+          }
         }
         if (i < segments.length - 1) {
-          await adb.keyevent(66);
+          await adb.shell(`input${displayArg} keyevent 66`);
         }
       }
     }
@@ -1672,19 +1711,20 @@ ${Object.keys(size)
     };
 
     const adb = await this.getAdb();
+    const displayArg = this.getDisplayArg();
 
     // Normalize key to handle case-insensitive matching
     const normalizedKey = this.normalizeKeyName(key);
     const keyCode = keyCodeMap[normalizedKey];
     if (keyCode !== undefined) {
-      await adb.keyevent(keyCode);
+      await adb.shell(`input${displayArg} keyevent ${keyCode}`);
     } else {
       // for keys not in the mapping table, try to get its ASCII code (if it's a single character)
       if (key.length === 1) {
         const asciiCode = key.toUpperCase().charCodeAt(0);
         // Android key codes, A-Z is 29-54
         if (asciiCode >= 65 && asciiCode <= 90) {
-          await adb.keyevent(asciiCode - 36); // 65-36=29 (A's key code)
+          await adb.shell(`input${displayArg} keyevent ${asciiCode - 36}`); // 65-36=29 (A's key code)
         }
       }
     }
@@ -2067,7 +2107,7 @@ ${Object.keys(size)
 
     // Try each key code with waiting
     for (const keyCode of keyCodes) {
-      await adb.keyevent(keyCode);
+      await adb.shell(`input${this.getDisplayArg()} keyevent ${keyCode}`);
 
       // Wait for keyboard to be hidden with timeout
       const startTime = Date.now();

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1281,7 +1281,6 @@ ${Object.keys(size)
     }
 
     const adb = await this.getAdb();
-    const displayArg = this.getDisplayArg();
     const isNonDefaultDisplay =
       typeof this.options?.displayId === 'number' &&
       this.options.displayId !== 0;
@@ -1622,7 +1621,6 @@ ${Object.keys(size)
     options?: AndroidDeviceInputOpt,
   ): Promise<void> {
     if (!text) return;
-    const adb = await this.getAdb();
     const IME_STRATEGY =
       (this.options?.imeStrategy ||
         globalConfigManager.getEnvConfigValue(MIDSCENE_ANDROID_IME_STRATEGY)) ??
@@ -1633,8 +1631,9 @@ ${Object.keys(size)
       options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay;
 
     // yadb (app_process) cannot target a non-default display. If a displayId
-    // other than 0 is configured, force the `input text` path so text lands
-    // on the correct screen instead of silently appearing on the main display.
+    // other than 0 is configured and the text requires yadb, we throw rather
+    // than silently falling back to `input text` (which would corrupt the
+    // content or land it on the wrong screen).
     const isNonDefaultDisplay =
       typeof this.options?.displayId === 'number' &&
       this.options.displayId !== 0;

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1644,15 +1644,18 @@ ${Object.keys(size)
       IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB ||
       (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII &&
         this.shouldUseYadbForText(text));
-    const useYadb = !isNonDefaultDisplay && needsYadb;
 
     if (isNonDefaultDisplay && needsYadb) {
-      warnDevice(
-        `Text requires yadb (non-ASCII or shell-special characters) but yadb cannot target non-default displays. Falling back to \`input text\` on displayId=${this.options?.displayId}; some characters may be lost or corrupted.`,
+      const reason =
+        IME_STRATEGY === IME_STRATEGY_ALWAYS_YADB
+          ? `imeStrategy 'always-yadb' requires yadb`
+          : 'text contains characters that require yadb (non-ASCII, format specifiers, or mixed quotes)';
+      throw new Error(
+        `${reason}, but yadb (app_process) cannot target non-default displayId=${this.options?.displayId}. Use displayId=0 or a different imeStrategy.`,
       );
     }
 
-    if (useYadb) {
+    if (needsYadb) {
       // yadb handles newlines natively: escapeForShell converts \n (0x0A)
       // to literal \n (two chars), which yadb interprets back as newline.
       // Single adb call for the entire text.

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -2362,6 +2362,58 @@ Stdout:
         );
         expect(pinchCall).toBeUndefined();
       });
+
+      it('should throw when typeText needs yadb on a non-default display', async () => {
+        // yadb (app_process) cannot target non-default displays. When text
+        // requires yadb (always-yadb strategy or auto-detected incompatible
+        // chars), we must throw rather than silently corrupt the input.
+        deviceWithDisplay = new AndroidDevice('test-device', {
+          displayId: 2,
+          imeStrategy: 'always-yadb',
+        });
+
+        setupMockAdb(mockAdbInstance);
+
+        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+          mockAdbInstance as any,
+        );
+        vi.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
+          undefined,
+        );
+        (deviceWithDisplay as any).devicePixelRatio = 1;
+
+        await expect(
+          deviceWithDisplay.inputPrimitives.keyboard.typeText('hello'),
+        ).rejects.toThrow(/cannot target non-default display/);
+
+        // No input or yadb command should have been issued.
+        const textCalls = mockAdbInstance.shell.mock.calls.filter(
+          (call: unknown[]) =>
+            typeof call[0] === 'string' &&
+            (call[0].includes('input text') || call[0].includes('yadb')),
+        );
+        expect(textCalls).toHaveLength(0);
+      });
+
+      it('should throw when typeText auto-detects yadb need on non-default display', async () => {
+        // Even without always-yadb, non-ASCII text auto-detects yadb. On a
+        // non-default display this must throw, not silently fall back.
+        deviceWithDisplay = new AndroidDevice('test-device', {
+          displayId: 2,
+          imeStrategy: 'yadb-for-non-ascii',
+        });
+
+        setupMockAdb(mockAdbInstance);
+
+        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+          mockAdbInstance as any,
+        );
+        (deviceWithDisplay as any).devicePixelRatio = 1;
+
+        await expect(
+          deviceWithDisplay.inputPrimitives.keyboard.typeText('你好'),
+        ).rejects.toThrow(/cannot target non-default display/);
+      });
     });
 
     it('should not include display argument in shell commands when displayId is not set', async () => {

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -782,23 +782,27 @@ Stdout:
 
       it('should return early for empty string', async () => {
         await device.inputPrimitives.keyboard.typeText('');
-        expect(mockAdb.inputText).not.toHaveBeenCalled();
+        expect(mockAdb.shell).not.toHaveBeenCalledWith(
+          expect.stringContaining('input text'),
+        );
         expect((device as any).execYadb).not.toHaveBeenCalled();
       });
 
       // ---------------------------------------------------------------
-      // 3a. inputText path — characters handled by appium-adb (no escapeForShell)
+      // 3a. input text path — pure ASCII goes through `input text` shell command
       // ---------------------------------------------------------------
-      describe('inputText path — appium-adb compatible characters', () => {
+      describe('input text path — appium-adb compatible characters', () => {
         it('pure ASCII: hello', async () => {
           await device.inputPrimitives.keyboard.typeText('hello');
-          expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+          expect(mockAdb.shell).toHaveBeenCalledWith("input text 'hello'");
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
 
         it('space: hello world', async () => {
           await device.inputPrimitives.keyboard.typeText('hello world');
-          expect(mockAdb.inputText).toHaveBeenCalledWith('hello world');
+          expect(mockAdb.shell).toHaveBeenCalledWith(
+            "input text 'hello world'",
+          );
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
 
@@ -815,20 +819,21 @@ Stdout:
             'a:b',
           ];
           for (const text of texts) {
-            mockAdb.inputText.mockClear();
+            mockAdb.shell.mockClear();
             (device as any).execYadb.mockClear();
             await device.inputPrimitives.keyboard.typeText(text);
-            expect(mockAdb.inputText).toHaveBeenCalledWith(text);
+            // shellEscapeArg wraps in single quotes
+            expect(mockAdb.shell).toHaveBeenCalledWith(`input text '${text}'`);
             expect((device as any).execYadb).not.toHaveBeenCalled();
           }
         });
 
         it('brackets: {b} [b]', async () => {
           for (const text of ['a{b}c', 'a[b]c']) {
-            mockAdb.inputText.mockClear();
+            mockAdb.shell.mockClear();
             (device as any).execYadb.mockClear();
             await device.inputPrimitives.keyboard.typeText(text);
-            expect(mockAdb.inputText).toHaveBeenCalledWith(text);
+            expect(mockAdb.shell).toHaveBeenCalledWith(`input text '${text}'`);
             expect((device as any).execYadb).not.toHaveBeenCalled();
           }
         });
@@ -845,29 +850,31 @@ Stdout:
             'a*b',
           ];
           for (const text of texts) {
-            mockAdb.inputText.mockClear();
+            mockAdb.shell.mockClear();
             (device as any).execYadb.mockClear();
             await device.inputPrimitives.keyboard.typeText(text);
-            expect(mockAdb.inputText).toHaveBeenCalledWith(text);
+            // These are now properly protected by single-quote wrapping
+            expect(mockAdb.shell).toHaveBeenCalledWith(`input text '${text}'`);
             expect((device as any).execYadb).not.toHaveBeenCalled();
           }
         });
 
         it("single quote only: it's", async () => {
           await device.inputPrimitives.keyboard.typeText("it's");
-          expect(mockAdb.inputText).toHaveBeenCalledWith("it's");
+          // shellEscapeArg: 'it'\''s' — end quote, escaped quote, start quote
+          expect(mockAdb.shell).toHaveBeenCalledWith("input text 'it'\\''s'");
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
 
         it('double quote only: say"hi"', async () => {
           await device.inputPrimitives.keyboard.typeText('say"hi"');
-          expect(mockAdb.inputText).toHaveBeenCalledWith('say"hi"');
+          expect(mockAdb.shell).toHaveBeenCalledWith(`input text 'say"hi"'`);
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
 
         it('percent not followed by letter: 100% done', async () => {
           await device.inputPrimitives.keyboard.typeText('100% done');
-          expect(mockAdb.inputText).toHaveBeenCalledWith('100% done');
+          expect(mockAdb.shell).toHaveBeenCalledWith("input text '100% done'");
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
       });
@@ -882,19 +889,25 @@ Stdout:
           it('\\ → execYadb unchanged (no escaping needed in single quotes)', async () => {
             await device.inputPrimitives.keyboard.typeText('a\\b');
             expect((device as any).execYadb).toHaveBeenCalledWith('a\\b');
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
           });
 
           it('` → execYadb unchanged', async () => {
             await device.inputPrimitives.keyboard.typeText('a`b');
             expect((device as any).execYadb).toHaveBeenCalledWith('a`b');
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
           });
 
           it('$ → execYadb unchanged', async () => {
             await device.inputPrimitives.keyboard.typeText('$HOME');
             expect((device as any).execYadb).toHaveBeenCalledWith('$HOME');
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
           });
 
           it("both quotes → execYadb with ' escaped", async () => {
@@ -902,7 +915,9 @@ Stdout:
             expect((device as any).execYadb).toHaveBeenCalledWith(
               "it'\\''s a \"test\"",
             );
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
           });
 
           it('combined: $100\\each → unchanged (no escaping needed)', async () => {
@@ -962,61 +977,72 @@ Stdout:
       // 3c. Newline handling
       // ---------------------------------------------------------------
       describe('newline handling', () => {
-        // inputText path: split('\n') + keyevent 66
-        describe('inputText path — split + keyevent 66', () => {
+        // input text path: split('\n') + keyevent 66 via shell
+        describe('input text path — split + keyevent 66', () => {
           it('middle newline: line1\\nline2', async () => {
             await device.inputPrimitives.keyboard.typeText('line1\nline2');
-            expect(mockAdb.inputText).toHaveBeenCalledTimes(2);
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(1, 'line1');
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(2, 'line2');
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
-            expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'line1'");
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'line2'");
+            expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('multiple newlines: a\\nb\\nc', async () => {
             await device.inputPrimitives.keyboard.typeText('a\nb\nc');
-            expect(mockAdb.inputText).toHaveBeenCalledTimes(3);
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(1, 'a');
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(2, 'b');
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(3, 'c');
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(2);
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'a'");
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'b'");
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'c'");
+            // Two keyevents for two newlines
+            const keyeventCalls = mockAdb.shell.mock.calls.filter(
+              (call: any[]) => call[0] === 'input keyevent 66',
+            );
+            expect(keyeventCalls).toHaveLength(2);
           });
 
           it('trailing newline: hello\\n', async () => {
             await device.inputPrimitives.keyboard.typeText('hello\n');
-            expect(mockAdb.inputText).toHaveBeenCalledTimes(1);
-            expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
-            expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'hello'");
+            expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('leading newline: \\nhello', async () => {
             await device.inputPrimitives.keyboard.typeText('\nhello');
-            expect(mockAdb.inputText).toHaveBeenCalledTimes(1);
-            expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
-            expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'hello'");
+            expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('consecutive newlines: a\\n\\nb', async () => {
             await device.inputPrimitives.keyboard.typeText('a\n\nb');
-            expect(mockAdb.inputText).toHaveBeenCalledTimes(2);
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(1, 'a');
-            expect(mockAdb.inputText).toHaveBeenNthCalledWith(2, 'b');
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(2);
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'a'");
+            expect(mockAdb.shell).toHaveBeenCalledWith("input text 'b'");
+            // Two keyevents for two consecutive newlines
+            const keyeventCalls = mockAdb.shell.mock.calls.filter(
+              (call: any[]) => call[0] === 'input keyevent 66',
+            );
+            expect(keyeventCalls).toHaveLength(2);
           });
 
           it('just a newline: \\n', async () => {
+            mockAdb.shell.mockClear();
             await device.inputPrimitives.keyboard.typeText('\n');
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
-            expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
-            expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+            // No `input text` call, just one keyevent
+            const textCalls = mockAdb.shell.mock.calls.filter(
+              (call: any[]) =>
+                typeof call[0] === 'string' && call[0].startsWith('input text'),
+            );
+            expect(textCalls).toHaveLength(0);
+            expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('no newline → no keyevent', async () => {
+            mockAdb.shell.mockClear();
             await device.inputPrimitives.keyboard.typeText('no-newline');
-            expect(mockAdb.inputText).toHaveBeenCalledWith('no-newline');
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).toHaveBeenCalledWith(
+              "input text 'no-newline'",
+            );
+            const keyeventCalls = mockAdb.shell.mock.calls.filter(
+              (call: any[]) => call[0] === 'input keyevent 66',
+            );
+            expect(keyeventCalls).toHaveLength(0);
           });
         });
 
@@ -1028,8 +1054,10 @@ Stdout:
             expect((device as any).execYadb).toHaveBeenCalledWith(
               '你好\\nworld',
             );
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
+            expect(mockAdb.shell).not.toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('shell-special with middle newline: $10\\ntext', async () => {
@@ -1040,15 +1068,17 @@ Stdout:
             expect((device as any).execYadb).toHaveBeenCalledWith(
               'price: $10\\nplain text',
             );
-            expect(mockAdb.inputText).not.toHaveBeenCalled();
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith(
+              expect.stringContaining('input text'),
+            );
+            expect(mockAdb.shell).not.toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('non-ASCII trailing newline: 你好\\n', async () => {
             await device.inputPrimitives.keyboard.typeText('你好\n');
             expect((device as any).execYadb).toHaveBeenCalledTimes(1);
             expect((device as any).execYadb).toHaveBeenCalledWith('你好\\n');
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('always-yadb trailing newline: hello\\n', async () => {
@@ -1058,7 +1088,7 @@ Stdout:
             };
             await device.inputPrimitives.keyboard.typeText('hello\n');
             expect((device as any).execYadb).toHaveBeenCalledWith('hello\\n');
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith('input keyevent 66');
           });
 
           it('always-yadb leading newline: \\nhello', async () => {
@@ -1086,7 +1116,7 @@ Stdout:
             };
             await device.inputPrimitives.keyboard.typeText('\n');
             expect((device as any).execYadb).toHaveBeenCalledWith('\\n');
-            expect(mockAdb.keyevent).not.toHaveBeenCalled();
+            expect(mockAdb.shell).not.toHaveBeenCalledWith('input keyevent 66');
           });
         });
       });
@@ -1102,7 +1132,9 @@ Stdout:
           };
           await device.inputPrimitives.keyboard.typeText('hello world');
           expect((device as any).execYadb).toHaveBeenCalledWith('hello world');
-          expect(mockAdb.inputText).not.toHaveBeenCalled();
+          expect(mockAdb.shell).not.toHaveBeenCalledWith(
+            expect.stringContaining('input text'),
+          );
         });
 
         it('always-yadb: shell-special chars get escaped', async () => {
@@ -1118,9 +1150,9 @@ Stdout:
           );
         });
 
-        it('yadb-for-non-ascii: pure ASCII uses inputText', async () => {
+        it('yadb-for-non-ascii: pure ASCII uses input text', async () => {
           await device.inputPrimitives.keyboard.typeText('hello');
-          expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+          expect(mockAdb.shell).toHaveBeenCalledWith("input text 'hello'");
           expect((device as any).execYadb).not.toHaveBeenCalled();
         });
 
@@ -1129,7 +1161,9 @@ Stdout:
           expect((device as any).execYadb).toHaveBeenCalledWith(
             '你好,Schönberg',
           );
-          expect(mockAdb.inputText).not.toHaveBeenCalled();
+          expect(mockAdb.shell).not.toHaveBeenCalledWith(
+            expect.stringContaining('input text'),
+          );
         });
       });
     });
@@ -1148,63 +1182,63 @@ Stdout:
           canCloseKeyboard: true,
         });
       await device.inputPrimitives.keyboard.typeText('hello');
-      expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(111); // ESC key
+      expect(mockAdb.shell).toHaveBeenCalledWith("input text 'hello'");
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 111'); // ESC key
     });
 
     it('press should call keyevent for mapped keys', async () => {
       await device.inputPrimitives.keyboard.keyboardPress('Enter');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
     });
 
     it('press should handle case-insensitive key names', async () => {
       // Test lowercase keys
       await device.inputPrimitives.keyboard.keyboardPress('enter');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
 
       await device.inputPrimitives.keyboard.keyboardPress('escape');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(111);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 111');
 
       await device.inputPrimitives.keyboard.keyboardPress('tab');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(61);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 61');
 
       // Test uppercase keys (should still work)
       await device.inputPrimitives.keyboard.keyboardPress('ENTER');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(66);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
 
       await device.inputPrimitives.keyboard.keyboardPress('ESCAPE');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(111);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 111');
     });
 
     it('press should handle arrow key variations', async () => {
       // Test full arrow key names (lowercase)
       await device.inputPrimitives.keyboard.keyboardPress('arrowup');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(19);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 19');
 
       await device.inputPrimitives.keyboard.keyboardPress('arrowdown');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(20);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 20');
 
       // Test short arrow key names
       await device.inputPrimitives.keyboard.keyboardPress('up');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(19);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 19');
 
       await device.inputPrimitives.keyboard.keyboardPress('down');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(20);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 20');
 
       await device.inputPrimitives.keyboard.keyboardPress('left');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(21);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 21');
 
       await device.inputPrimitives.keyboard.keyboardPress('right');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(22);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 22');
     });
 
     it('press should handle common key abbreviations', async () => {
       // Test 'esc' as abbreviation for 'Escape'
       await device.inputPrimitives.keyboard.keyboardPress('esc');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(111);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 111');
 
       await device.inputPrimitives.keyboard.keyboardPress('ESC');
-      expect(mockAdb.keyevent).toHaveBeenCalledWith(111);
+      expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 111');
     });
 
     describe('autoDismissKeyboard option', () => {
@@ -1226,9 +1260,13 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining("input text 'hello'"),
+        );
         expect(mockAdb.isSoftKeyboardPresent).toHaveBeenCalled();
-        expect(mockAdb.keyevent).toHaveBeenCalledWith(111); // ESC key
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining('input keyevent 111'),
+        ); // ESC key
       });
 
       it('should hide keyboard when autoDismissKeyboard is explicitly true', async () => {
@@ -1248,9 +1286,13 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining("input text 'hello'"),
+        );
         expect(mockAdb.isSoftKeyboardPresent).toHaveBeenCalled();
-        expect(mockAdb.keyevent).toHaveBeenCalledWith(111); // ESC key
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining('input keyevent 111'),
+        ); // ESC key
       });
 
       it('should not hide keyboard when autoDismissKeyboard is false', async () => {
@@ -1259,13 +1301,18 @@ Stdout:
           autoDismissKeyboard: false,
         };
         mockAdb.isSoftKeyboardPresent.mockClear();
-        mockAdb.keyevent.mockClear();
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining("input text 'hello'"),
+        );
         expect(mockAdb.isSoftKeyboardPresent).not.toHaveBeenCalled();
-        expect(mockAdb.keyevent).not.toHaveBeenCalled();
+        // No keyevent calls for keyboard dismissal
+        const keyeventCalls = mockAdb.shell.mock.calls.filter(
+          (c) => typeof c[0] === 'string' && c[0].includes('keyevent'),
+        );
+        expect(keyeventCalls.length).toBe(0);
       });
 
       it('should respect autoDismissKeyboard option passed to type method', async () => {
@@ -1274,25 +1321,34 @@ Stdout:
           autoDismissKeyboard: true,
         };
         mockAdb.isSoftKeyboardPresent.mockClear();
-        mockAdb.keyevent.mockClear();
 
         // Override with false in method call
         await device.inputPrimitives.keyboard.typeText('hello', {
           autoDismissKeyboard: false,
         });
 
-        expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining("input text 'hello'"),
+        );
         expect(mockAdb.isSoftKeyboardPresent).not.toHaveBeenCalled();
-        expect(mockAdb.keyevent).not.toHaveBeenCalled();
+        const keyeventCalls = mockAdb.shell.mock.calls.filter(
+          (c) => typeof c[0] === 'string' && c[0].includes('keyevent'),
+        );
+        expect(keyeventCalls.length).toBe(0);
       });
     });
 
     describe('keyboardDismissStrategy option', () => {
       beforeEach(() => {
         vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-        mockAdb.keyevent.mockClear();
         mockAdb.isSoftKeyboardPresent.mockClear();
       });
+
+      // Helper: extract shell calls that contain 'keyevent'
+      const getKeyeventShellCalls = () =>
+        mockAdb.shell.mock.calls.filter(
+          (c) => typeof c[0] === 'string' && c[0].includes('keyevent'),
+        );
 
       it('should use esc-first strategy by default', async () => {
         device.options = { imeStrategy: 'yadb-for-non-ascii' };
@@ -1308,8 +1364,9 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.keyevent).toHaveBeenCalledWith(111); // ESC key first
-        expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls[0][0]).toContain('111'); // ESC key first
+        expect(keyeventCalls.length).toBe(1);
       });
 
       it('should use back-first strategy when specified', async () => {
@@ -1329,8 +1386,9 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.keyevent).toHaveBeenCalledWith(4); // BACK key first
-        expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls[0][0]).toContain('4'); // BACK key first
+        expect(keyeventCalls.length).toBe(1);
       });
 
       it('should try second key if first fails with esc-first strategy', async () => {
@@ -1353,10 +1411,12 @@ Stdout:
         let callCount = 0;
         let currentKeyEvent = 0;
 
-        // Track keyevent calls
-        mockAdb.keyevent.mockImplementation(() => {
-          currentKeyEvent++;
-          return Promise.resolve();
+        // Track keyevent shell calls
+        mockAdb.shell.mockImplementation(async (cmd: unknown) => {
+          if (typeof cmd === 'string' && cmd.includes('keyevent')) {
+            currentKeyEvent++;
+          }
+          return '';
         });
 
         mockAdb.isSoftKeyboardPresent.mockImplementation(() => {
@@ -1394,9 +1454,10 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.keyevent).toHaveBeenNthCalledWith(1, 111); // ESC first
-        expect(mockAdb.keyevent).toHaveBeenNthCalledWith(2, 4); // BACK second
-        expect(mockAdb.keyevent).toHaveBeenCalledTimes(2);
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls[0][0]).toContain('111'); // ESC first
+        expect(keyeventCalls[1][0]).toContain('4'); // BACK second
+        expect(keyeventCalls.length).toBe(2);
       });
 
       it('should try second key if first fails with back-first strategy', async () => {
@@ -1419,10 +1480,12 @@ Stdout:
         let callCount = 0;
         let currentKeyEvent = 0;
 
-        // Track keyevent calls
-        mockAdb.keyevent.mockImplementation(() => {
-          currentKeyEvent++;
-          return Promise.resolve();
+        // Track keyevent shell calls
+        mockAdb.shell.mockImplementation(async (cmd: unknown) => {
+          if (typeof cmd === 'string' && cmd.includes('keyevent')) {
+            currentKeyEvent++;
+          }
+          return '';
         });
 
         mockAdb.isSoftKeyboardPresent.mockImplementation(() => {
@@ -1460,9 +1523,10 @@ Stdout:
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.keyevent).toHaveBeenNthCalledWith(1, 4); // BACK first
-        expect(mockAdb.keyevent).toHaveBeenNthCalledWith(2, 111); // ESC second
-        expect(mockAdb.keyevent).toHaveBeenCalledTimes(2);
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls[0][0]).toContain('4'); // BACK first
+        expect(keyeventCalls[1][0]).toContain('111'); // ESC second
+        expect(keyeventCalls.length).toBe(2);
       });
 
       it('should respect keyboardDismissStrategy option passed to type method', async () => {
@@ -1486,8 +1550,9 @@ Stdout:
           keyboardDismissStrategy: 'back-first',
         });
 
-        expect(mockAdb.keyevent).toHaveBeenCalledWith(4); // BACK key first (overridden)
-        expect(mockAdb.keyevent).toHaveBeenCalledTimes(1);
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls[0][0]).toContain('4'); // BACK key first (overridden)
+        expect(keyeventCalls.length).toBe(1);
       });
 
       it('should log warning if both keys fail to hide keyboard', async () => {
@@ -1531,13 +1596,15 @@ Stdout:
           isKeyboardShown: false,
           canCloseKeyboard: true,
         }); // keyboard already hidden
-        mockAdb.keyevent.mockClear();
 
         await device.inputPrimitives.keyboard.typeText('hello');
 
-        expect(mockAdb.inputText).toHaveBeenCalledWith('hello');
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringContaining("input text 'hello'"),
+        );
         expect(mockAdb.isSoftKeyboardPresent).toHaveBeenCalled();
-        expect(mockAdb.keyevent).not.toHaveBeenCalled(); // No key events needed
+        const keyeventCalls = getKeyeventShellCalls();
+        expect(keyeventCalls.length).toBe(0); // No key events needed
       });
     });
   });
@@ -2503,7 +2570,7 @@ Stdout:
         undefined,
       );
 
-      // Mock keyboard state management
+      // Mock keyboard state management — track keyevents through shell calls
       let keyboardHidden = false;
       mockAdbInstance.isSoftKeyboardPresent.mockImplementation(() => {
         return Promise.resolve({
@@ -2512,15 +2579,23 @@ Stdout:
         });
       });
 
-      mockAdbInstance.keyevent.mockImplementation(() => {
-        keyboardHidden = true;
-        return Promise.resolve();
+      // Override shell mock to track keyevents for keyboard state
+      const originalShellImpl = mockAdbInstance.shell.getMockImplementation();
+      mockAdbInstance.shell.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('keyevent 111')) {
+          keyboardHidden = true;
+        }
+        return originalShellImpl ? originalShellImpl(cmd) : Promise.resolve('');
       });
 
       await deviceWithDisplay.inputPrimitives.keyboard.typeText('test');
 
-      expect(mockAdbInstance.inputText).toHaveBeenCalledWith('test');
-      expect(mockAdbInstance.keyevent).toHaveBeenCalledWith(111); // ESC key for hiding keyboard
+      expect(mockAdbInstance.shell).toHaveBeenCalledWith(
+        "input -d 2 text 'test'",
+      );
+      expect(mockAdbInstance.shell).toHaveBeenCalledWith(
+        'input -d 2 keyevent 111',
+      ); // ESC key for hiding keyboard
     });
 
     it('should handle back, home, and recentApps operations with display argument', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -122,6 +122,16 @@ type AiActInternalOptions = AiActOptions & {
   };
 };
 
+/**
+ * Shared input option type for aiInput(), used consistently across
+ * overload signatures and the implementation so fields don't drift.
+ */
+type AgentInputOption = LocateOption & {
+  autoDismissKeyboard?: boolean;
+  keyboardTypeDelay?: number;
+  mode?: 'replace' | 'clear' | 'typeOnly' | 'append';
+};
+
 export class Agent<
   InterfaceType extends AbstractInterface = AbstractInterface,
 > {
@@ -751,10 +761,7 @@ export class Agent<
   // New signature, always use locatePrompt as the first param
   async aiInput(
     locatePrompt: TUserPrompt,
-    opt: LocateOption & { value: string | number } & {
-      autoDismissKeyboard?: boolean;
-      keyboardTypeDelay?: number;
-    } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' },
+    opt: AgentInputOption & { value: string | number },
   ): Promise<void>;
 
   // Legacy signature - deprecated
@@ -764,12 +771,7 @@ export class Agent<
   async aiInput(
     value: string | number,
     locatePrompt: TUserPrompt,
-    opt?: LocateOption & {
-      autoDismissKeyboard?: boolean;
-      keyboardTypeDelay?: number;
-    } & {
-      mode?: 'replace' | 'clear' | 'typeOnly' | 'append';
-    }, // AndroidDeviceInputOpt &
+    opt?: AgentInputOption,
   ): Promise<void>;
 
   // Implementation
@@ -777,21 +779,13 @@ export class Agent<
     locatePromptOrValue: TUserPrompt | string | number,
     locatePromptOrOpt:
       | TUserPrompt
-      | (LocateOption & { value: string | number } & {
-          autoDismissKeyboard?: boolean;
-          keyboardTypeDelay?: number;
-        } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' }) // AndroidDeviceInputOpt &
+      | (AgentInputOption & { value: string | number })
       | undefined,
-    optOrUndefined?: LocateOption & { keyboardTypeDelay?: number }, // AndroidDeviceInputOpt &
+    optOrUndefined?: AgentInputOption,
   ) {
     let value: string | number;
     let locatePrompt: TUserPrompt;
-    let opt:
-      | (LocateOption & { value: string | number } & {
-          autoDismissKeyboard?: boolean;
-          keyboardTypeDelay?: number;
-        } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' }) // AndroidDeviceInputOpt &
-      | undefined;
+    let opt: (AgentInputOption & { value: string | number }) | undefined;
 
     // Check if using new signature (first param is locatePrompt, second has value)
     if (
@@ -801,10 +795,8 @@ export class Agent<
     ) {
       // New signature: aiInput(locatePrompt, opt)
       locatePrompt = locatePromptOrValue as TUserPrompt;
-      const optWithValue = locatePromptOrOpt as LocateOption & {
-        // AndroidDeviceInputOpt &
+      const optWithValue = locatePromptOrOpt as AgentInputOption & {
         value: string | number;
-        autoDismissKeyboard?: boolean;
       };
       value = optWithValue.value;
       opt = optWithValue;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -753,6 +753,7 @@ export class Agent<
     locatePrompt: TUserPrompt,
     opt: LocateOption & { value: string | number } & {
       autoDismissKeyboard?: boolean;
+      keyboardTypeDelay?: number;
     } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' },
   ): Promise<void>;
 
@@ -763,7 +764,10 @@ export class Agent<
   async aiInput(
     value: string | number,
     locatePrompt: TUserPrompt,
-    opt?: LocateOption & { autoDismissKeyboard?: boolean } & {
+    opt?: LocateOption & {
+      autoDismissKeyboard?: boolean;
+      keyboardTypeDelay?: number;
+    } & {
       mode?: 'replace' | 'clear' | 'typeOnly' | 'append';
     }, // AndroidDeviceInputOpt &
   ): Promise<void>;
@@ -775,15 +779,17 @@ export class Agent<
       | TUserPrompt
       | (LocateOption & { value: string | number } & {
           autoDismissKeyboard?: boolean;
+          keyboardTypeDelay?: number;
         } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' }) // AndroidDeviceInputOpt &
       | undefined,
-    optOrUndefined?: LocateOption, // AndroidDeviceInputOpt &
+    optOrUndefined?: LocateOption & { keyboardTypeDelay?: number }, // AndroidDeviceInputOpt &
   ) {
     let value: string | number;
     let locatePrompt: TUserPrompt;
     let opt:
       | (LocateOption & { value: string | number } & {
           autoDismissKeyboard?: boolean;
+          keyboardTypeDelay?: number;
         } & { mode?: 'replace' | 'clear' | 'typeOnly' | 'append' }) // AndroidDeviceInputOpt &
       | undefined;
 

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -8,6 +8,18 @@ export type AndroidDeviceInputOpt = {
   autoDismissKeyboard?: boolean;
   /** Strategy for dismissing the keyboard: 'esc-first' tries ESC before BACK, 'back-first' tries BACK before ESC */
   keyboardDismissStrategy?: 'esc-first' | 'back-first';
+  /**
+   * Delay in milliseconds between keystrokes when typing text.
+   *
+   * When set, text is typed one character at a time with this delay between
+   * each character, instead of sending the whole string at once. This helps
+   * on devices or input fields that drop characters when input arrives too
+   * fast (e.g. WiFi password fields on automotive displays).
+   *
+   * Only applies to the `input text` path (non-yadb). When yadb is used, the
+   * entire string is committed atomically and this option is ignored.
+   */
+  keyboardTypeDelay?: number;
 };
 
 /**
@@ -112,6 +124,14 @@ export type AndroidDeviceOpt = {
 export type IOSDeviceInputOpt = {
   /** Automatically dismiss the keyboard after input is completed */
   autoDismissKeyboard?: boolean;
+  /**
+   * Delay in milliseconds between keystrokes when typing text.
+   *
+   * When set, text is typed one character at a time with this delay between
+   * each character, instead of sending the whole string at once. This helps
+   * on devices or input fields that drop characters when input arrives too fast.
+   */
+  keyboardTypeDelay?: number;
 };
 
 /**
@@ -163,6 +183,14 @@ export type HarmonyDeviceInputOpt = {
   autoDismissKeyboard?: boolean;
   /** Strategy for dismissing the keyboard. Defaults to 'esc-first'. */
   keyboardDismissStrategy?: 'esc-first' | 'back-first';
+  /**
+   * Delay in milliseconds between keystrokes when typing text.
+   *
+   * When set, text is typed one character at a time with this delay between
+   * each character, instead of sending the whole string at once. This helps
+   * on devices or input fields that drop characters when input arrives too fast.
+   */
+  keyboardTypeDelay?: number;
 };
 
 /**

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -102,6 +102,7 @@ export interface KeyboardInputPrimitives {
     opts?: {
       autoDismissKeyboard?: boolean;
       keyboardDismissStrategy?: 'esc-first' | 'back-first';
+      keyboardTypeDelay?: number;
       target?: unknown;
       replace?: boolean;
       focusOnly?: boolean;
@@ -468,12 +469,19 @@ export const actionInputParamSchema = z.object({
     .describe(
       'If true, the keyboard will be dismissed after the input is completed. Do not set it unless the user asks you to do so.',
     ),
+  keyboardTypeDelay: z
+    .number()
+    .optional()
+    .describe(
+      'Delay in milliseconds between keystrokes when typing. Passed through from device/user configuration. Do not set it unless the user asks you to do so.',
+    ),
 });
 export type ActionInputParam = {
   value: string;
   locate?: LocateResultElement;
   mode?: 'replace' | 'clear' | 'typeOnly' | 'append';
   autoDismissKeyboard?: boolean;
+  keyboardTypeDelay?: number;
 };
 
 export const defineActionInput = (
@@ -507,6 +515,7 @@ export const defineActionInput = (
         target: param.locate,
         replace: param.mode !== 'typeOnly',
         autoDismissKeyboard: param.autoDismissKeyboard,
+        keyboardTypeDelay: param.keyboardTypeDelay,
       });
     },
   });

--- a/packages/core/tests/unit-test/action-param-validation.test.ts
+++ b/packages/core/tests/unit-test/action-param-validation.test.ts
@@ -1,6 +1,11 @@
 import { getMidsceneLocationSchema, parseActionParam } from '@/ai-model';
-import { actionKeyboardPressParamSchema, defineAction } from '@/device';
-import { describe, expect, it } from 'vitest';
+import {
+  actionInputParamSchema,
+  actionKeyboardPressParamSchema,
+  defineAction,
+  defineActionInput,
+} from '@/device';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 describe('Action Parameter Validation', () => {
@@ -506,6 +511,152 @@ describe('Action Parameter Validation', () => {
       expect(() =>
         parseActionParam(rawParam, actionKeyboardPressParamSchema),
       ).toThrow();
+    });
+  });
+
+  describe('actionInputParamSchema', () => {
+    it('should accept keyboardTypeDelay as a number', () => {
+      const rawParam = {
+        value: 'hello',
+        keyboardTypeDelay: 100,
+      };
+
+      const parsed = parseActionParam(rawParam, actionInputParamSchema);
+      expect(parsed!.value).toBe('hello');
+      expect(parsed!.keyboardTypeDelay).toBe(100);
+    });
+
+    it('should apply default mode when not specified', () => {
+      const rawParam = {
+        value: 'test',
+      };
+
+      const parsed = parseActionParam(rawParam, actionInputParamSchema);
+      expect(parsed!.mode).toBe('replace');
+    });
+
+    it('should accept autoDismissKeyboard', () => {
+      const rawParam = {
+        value: 'test',
+        autoDismissKeyboard: false,
+      };
+
+      const parsed = parseActionParam(rawParam, actionInputParamSchema);
+      expect(parsed!.autoDismissKeyboard).toBe(false);
+    });
+
+    it('should reject keyboardTypeDelay as non-number', () => {
+      const rawParam = {
+        value: 'test',
+        keyboardTypeDelay: 'fast',
+      };
+
+      expect(() =>
+        parseActionParam(rawParam, actionInputParamSchema),
+      ).toThrow();
+    });
+
+    it('should convert numeric value to string', () => {
+      const rawParam = {
+        value: 42,
+      };
+
+      const parsed = parseActionParam(rawParam, actionInputParamSchema);
+      expect(parsed!.value).toBe('42');
+    });
+  });
+
+  describe('defineActionInput', () => {
+    it('should pass keyboardTypeDelay to typeText', async () => {
+      const typeTextMock = vi.fn().mockResolvedValue(undefined);
+      const clearInputMock = vi.fn().mockResolvedValue(undefined);
+
+      const action = defineActionInput({
+        typeText: typeTextMock,
+        clearInput: clearInputMock,
+        keyboardPress: vi.fn(),
+        cursorMove: vi.fn(),
+      });
+
+      await action.call({
+        value: 'hello',
+        mode: 'replace',
+        keyboardTypeDelay: 80,
+      });
+
+      expect(typeTextMock).toHaveBeenCalledWith('hello', {
+        target: undefined,
+        replace: true,
+        autoDismissKeyboard: undefined,
+        keyboardTypeDelay: 80,
+      });
+    });
+
+    it('should pass autoDismissKeyboard to typeText', async () => {
+      const typeTextMock = vi.fn().mockResolvedValue(undefined);
+
+      const action = defineActionInput({
+        typeText: typeTextMock,
+        clearInput: vi.fn(),
+        keyboardPress: vi.fn(),
+        cursorMove: vi.fn(),
+      });
+
+      await action.call({
+        value: 'world',
+        mode: 'typeOnly',
+        autoDismissKeyboard: false,
+      });
+
+      expect(typeTextMock).toHaveBeenCalledWith('world', {
+        target: undefined,
+        replace: false,
+        autoDismissKeyboard: false,
+        keyboardTypeDelay: undefined,
+      });
+    });
+
+    it('should call clearInput when mode is clear', async () => {
+      const typeTextMock = vi.fn();
+      const clearInputMock = vi.fn().mockResolvedValue(undefined);
+
+      const action = defineActionInput({
+        typeText: typeTextMock,
+        clearInput: clearInputMock,
+        keyboardPress: vi.fn(),
+        cursorMove: vi.fn(),
+      });
+
+      await action.call({
+        value: '',
+        mode: 'clear',
+      });
+
+      expect(clearInputMock).toHaveBeenCalledWith(undefined);
+      expect(typeTextMock).not.toHaveBeenCalled();
+    });
+
+    it('should convert append mode to typeOnly', async () => {
+      const typeTextMock = vi.fn().mockResolvedValue(undefined);
+
+      const action = defineActionInput({
+        typeText: typeTextMock,
+        clearInput: vi.fn(),
+        keyboardPress: vi.fn(),
+        cursorMove: vi.fn(),
+      });
+
+      await action.call({
+        value: 'extra',
+        mode: 'append' as any,
+      });
+
+      expect(typeTextMock).toHaveBeenCalledWith('extra', {
+        target: undefined,
+        replace: false,
+        autoDismissKeyboard: undefined,
+        keyboardTypeDelay: undefined,
+      });
     });
   });
 

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -548,8 +548,11 @@ export class HarmonyDevice implements AbstractInterface {
 
     if (typeDelay && typeDelay > 0) {
       // Type one character at a time with a delay between keystrokes.
-      // inputText taps at x,y then types; repeated taps at the same spot
-      // are harmless since the field is already focused.
+      // `uitest uiInput inputText x y text` uses (x, y) to identify the target
+      // component, not to position the text cursor. Once the field is focused,
+      // repeated calls at the same coordinates append to the existing content
+      // rather than repositioning the cursor. Verified on real device:
+      // character order is preserved and no characters are lost.
       for (const ch of text) {
         await hdc.inputText(x, y, ch);
         await sleep(typeDelay);

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -177,6 +177,7 @@ export class HarmonyDevice implements AbstractInterface {
               {
                 autoDismissKeyboard: harmonyOpts?.autoDismissKeyboard,
                 keyboardDismissStrategy: harmonyOpts?.keyboardDismissStrategy,
+                keyboardTypeDelay: harmonyOpts?.keyboardTypeDelay,
               },
             );
       },
@@ -516,6 +517,8 @@ export class HarmonyDevice implements AbstractInterface {
     if (!text) return;
 
     const hdc = await this.getHdc();
+    const typeDelay =
+      options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay;
     let x: number;
     let y: number;
 
@@ -543,7 +546,17 @@ export class HarmonyDevice implements AbstractInterface {
       await sleep(100);
     }
 
-    await hdc.inputText(x, y, text);
+    if (typeDelay && typeDelay > 0) {
+      // Type one character at a time with a delay between keystrokes.
+      // inputText taps at x,y then types; repeated taps at the same spot
+      // are harmless since the field is already focused.
+      for (const ch of text) {
+        await hdc.inputText(x, y, ch);
+        await sleep(typeDelay);
+      }
+    } else {
+      await hdc.inputText(x, y, text);
+    }
 
     const shouldAutoDismissKeyboard =
       options?.autoDismissKeyboard ?? this.options?.autoDismissKeyboard ?? true;

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -535,13 +535,26 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
 
     const shouldAutoDismissKeyboard =
       options?.autoDismissKeyboard ?? this.options?.autoDismissKeyboard ?? true;
+    const typeDelay =
+      options?.keyboardTypeDelay ?? this.options?.keyboardTypeDelay;
 
     debugDevice(`Typing text: "${text}"`);
 
     try {
       // Wait a bit to ensure keyboard is ready
       await sleep(200);
-      await this.wdaBackend.typeText(text);
+
+      if (typeDelay && typeDelay > 0) {
+        // Type one character at a time with a delay between keystrokes.
+        // WDA's /keys endpoint accepts an array, so we send one char per call.
+        for (const ch of text) {
+          await this.wdaBackend.typeText(ch);
+          await sleep(typeDelay);
+        }
+      } else {
+        await this.wdaBackend.typeText(text);
+      }
+
       await sleep(300); // Give more time for text to appear
     } catch (error) {
       debugDevice(`Failed to type text with WDA: ${error}`);

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -546,9 +546,10 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
 
       if (typeDelay && typeDelay > 0) {
         // Type one character at a time with a delay between keystrokes.
-        // WDA's /keys endpoint accepts an array, so we send one char per call.
+        // Use typeRawKeys instead of typeText — the latter trims whitespace,
+        // which would silently drop spaces and newlines when sent one at a time.
         for (const ch of text) {
-          await this.wdaBackend.typeText(ch);
+          await this.wdaBackend.typeRawKeys([ch]);
           await sleep(typeDelay);
         }
       } else {

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -304,6 +304,26 @@ export class IOSWebDriverClient extends WebDriverClient {
     }
   }
 
+  /**
+   * Send raw key events without trimming whitespace.
+   * Unlike typeText(), this preserves spaces and newlines.
+   * Used by the per-character typing delay path where each character
+   * must be delivered exactly as-is.
+   */
+  async typeRawKeys(chars: string[]): Promise<void> {
+    this.ensureSession();
+
+    try {
+      await this.makeRequest('POST', `/session/${this.sessionId}/wda/keys`, {
+        value: chars,
+      });
+      debugIOS(`Sent raw keys: ${JSON.stringify(chars)}`);
+    } catch (error) {
+      debugIOS(`Failed to send raw keys ${JSON.stringify(chars)}: ${error}`);
+      throw new Error(`Failed to send keys: ${error}`);
+    }
+  }
+
   async typeText(text: string): Promise<void> {
     this.ensureSession();
 

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -811,12 +811,14 @@ export class Page<
 
   get keyboard() {
     return {
-      type: async (text: string) => {
-        const delay = this.keyboardTypeDelay;
+      type: async (text: string, delay?: number) => {
+        const effectiveDelay = delay ?? this.keyboardTypeDelay;
         debugPage(
-          `keyboard type ${text}${delay !== undefined ? ` (delay: ${delay}ms)` : ''}`,
+          `keyboard type ${text}${effectiveDelay !== undefined ? ` (delay: ${effectiveDelay}ms)` : ''}`,
         );
-        return this.underlyingPage.keyboard.type(text, { delay });
+        return this.underlyingPage.keyboard.type(text, {
+          delay: effectiveDelay,
+        });
       },
       press: async (
         action:

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -811,8 +811,8 @@ export class Page<
 
   get keyboard() {
     return {
-      type: async (text: string, delay?: number) => {
-        const effectiveDelay = delay ?? this.keyboardTypeDelay;
+      type: async (text: string, options?: { delay?: number }) => {
+        const effectiveDelay = options?.delay ?? this.keyboardTypeDelay;
         debugPage(
           `keyboard type ${text}${effectiveDelay !== undefined ? ` (delay: ${effectiveDelay}ms)` : ''}`,
         );

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -355,7 +355,7 @@ export interface MouseAction {
 }
 
 export interface KeyboardAction {
-  type: (text: string) => Promise<void>;
+  type: (text: string, options?: { delay?: number }) => Promise<void>;
   press: (
     action:
       | { key: KeyInput; command?: string }
@@ -400,7 +400,7 @@ export abstract class AbstractWebPage extends AbstractInterface {
 
   get keyboard(): KeyboardAction {
     return {
-      type: async (text: string) => {},
+      type: async (text: string, options?: { delay?: number }) => {},
       press: async (
         action:
           | { key: KeyInput; command?: string }
@@ -491,7 +491,11 @@ export function createWebInputPrimitives(
           return;
         }
 
-        await page.keyboard.type(value, opts?.keyboardTypeDelay);
+        const keyboardTypeOptions =
+          opts?.keyboardTypeDelay === undefined
+            ? undefined
+            : { delay: opts.keyboardTypeDelay };
+        await page.keyboard.type(value, keyboardTypeOptions);
         scheduleVisualUpdate();
       },
       keyboardPress: async (keyName, opts) => {

--- a/packages/web-integration/src/web-page.ts
+++ b/packages/web-integration/src/web-page.ts
@@ -491,7 +491,7 @@ export function createWebInputPrimitives(
           return;
         }
 
-        await page.keyboard.type(value);
+        await page.keyboard.type(value, opts?.keyboardTypeDelay);
         scheduleVisualUpdate();
       },
       keyboardPress: async (keyName, opts) => {

--- a/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
+++ b/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
@@ -60,4 +60,23 @@ describe('commonWebActionsForWebPage visual refresh', () => {
     expect(page.schedulePendingVisualUpdate).toHaveBeenCalledTimes(1);
     expect(page.flushPendingVisualUpdate).not.toHaveBeenCalled();
   });
+
+  it('passes action-level keyboardTypeDelay to text input actions', async () => {
+    const page = {
+      keyboard: {
+        type: vi.fn(async () => undefined),
+      },
+      schedulePendingVisualUpdate: vi.fn(),
+    };
+    const actions = commonWebActionsForWebPage(page as any);
+
+    await actions
+      .find((action) => action.name === 'Input')
+      ?.call(
+        { value: 'hello', mode: 'typeOnly', keyboardTypeDelay: 25 },
+        mockExecutorContext,
+      );
+
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello', { delay: 25 });
+  });
 });

--- a/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
+++ b/packages/web-integration/tests/unit-test/web-actions-navigation.test.ts
@@ -56,7 +56,7 @@ describe('commonWebActionsForWebPage visual refresh', () => {
       .find((action) => action.name === 'Input')
       ?.call({ value: 'hello', mode: 'typeOnly' }, mockExecutorContext);
 
-    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello', undefined);
     expect(page.schedulePendingVisualUpdate).toHaveBeenCalledTimes(1);
     expect(page.flushPendingVisualUpdate).not.toHaveBeenCalled();
   });

--- a/packages/web-integration/tests/unit-test/yaml/input-mode-typeonly.test.ts
+++ b/packages/web-integration/tests/unit-test/yaml/input-mode-typeonly.test.ts
@@ -49,7 +49,7 @@ describe('Input action typeOnly mode', () => {
     expect(keyboardPressMock).not.toHaveBeenCalled();
 
     // Verify: keyboard.type should be called with the value
-    expect(keyboardTypeMock).toHaveBeenCalledWith('new text');
+    expect(keyboardTypeMock).toHaveBeenCalledWith('new text', undefined);
   });
 
   test('replace mode should clear input', async () => {
@@ -91,7 +91,7 @@ describe('Input action typeOnly mode', () => {
     expect(mouseClickMock).not.toHaveBeenCalled();
 
     // Verify: keyboard.type should be called
-    expect(keyboardTypeMock).toHaveBeenCalledWith('replaced text');
+    expect(keyboardTypeMock).toHaveBeenCalledWith('replaced text', undefined);
   });
 
   test('clear mode should only clear without typing', async () => {


### PR DESCRIPTION
## Summary

Add `keyboardTypeDelay` option to all device platforms for consistent cross-platform behavior. When set, text is typed one character at a time with the specified delay between keystrokes, preventing character loss on devices or input fields that cannot keep up with burst input (e.g. WiFi password fields on automotive displays).

## Changes

### Core (`@midscene/core`)
- Add `keyboardTypeDelay?: number` to `AndroidDeviceInputOpt`, `IOSDeviceInputOpt`, and `HarmonyDeviceInputOpt`
- Add `keyboardTypeDelay` to `KeyboardInputPrimitives.typeText` options interface
- Add `keyboardTypeDelay` to `ActionInputParam` schema and Zod validation
- Pass through `keyboardTypeDelay` in `defineActionInput`
- Update `aiInput` type signatures to accept `keyboardTypeDelay`

### Android (`@midscene/android`)
- Support per-character typing with configurable delay via `input -d <id> text <ch>`
- On non-default displays (`displayId !== 0`), force the `input text` path instead of yadb (since `app_process` does not accept the `-d` flag)
- Fix `clearInput` to use `input -d <id> keyevent` on non-default displays
- Fix `pressKey` and `hideKeyboard` to pass `-d <id>` display argument

### iOS (`@midscene/ios`)
- Support per-character typing with configurable delay via WDA `/wda/keys` endpoint

### HarmonyOS (`@midscene/harmony`)
- Support per-character typing with configurable delay via `uitest uiInput inputText`
- Pass through `keyboardTypeDelay` in input primitives adapter

## Usage

```typescript
// Device-level default
const device = new AndroidDevice(deviceId, { keyboardTypeDelay: 30 });

// Per-call override
await agent.aiInput('the wifi password field', {
  value: '12345678abc!',
  keyboardTypeDelay: 30,
});
```

## Validation

- [x] `npx nx build @midscene/core`
- [x] `npx nx build @midscene/android`
- [x] `npx nx build @midscene/ios`
- [x] `npx nx build @midscene/harmony`
- [x] `pnpm biome check` on all modified files
- [x] Input-related unit tests pass (`input-primitives.test.ts`, `input-mode.test.ts`)