### PR TITLE
fix(computer): suppress PowerShell CLIXML progress noise on Windows

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -252,7 +252,11 @@ function escapePowershellSingleQuoted(value: string): string {
  * no-op here while making the invocation look more privileged to auditing.
  */
 function runPowershell(script: string): string {
-  const encoded = Buffer.from(script, 'utf16le').toString('base64');
+  // Suppress PowerShell progress output (CLIXML) that non-interactive
+  // child processes emit to stdout — it shows up as `#< CLIXML` XML noise
+  // in Midscene logs and wastes tokens in agent flows (#2751).
+  const prefixed = `$ProgressPreference = 'SilentlyContinue'\n${script}`;
+  const encoded = Buffer.from(prefixed, 'utf16le').toString('base64');
   return execFileSync(
     'powershell.exe',
     ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],


### PR DESCRIPTION
## Summary

On Windows, running `@midscene/computer` produces PowerShell CLIXML progress records (starting with `#< CLIXML`) mixed into stdout during health check operations like taking screenshots and listing monitors. This noise is meaningless in logs and wastes tokens in agent flows.

**Root cause:** The `runPowershell()` helper in `packages/computer/src/device.ts` invokes `powershell.exe` for display enumeration and screenshot capture without suppressing progress output. Non-interactive PowerShell child processes emit progress records as CLIXML to stdout.

**Fix:** Prepend `$ProgressPreference = 'SilentlyContinue'` to every script passed through `runPowershell()`. This suppresses progress output at the source for all callers (`listWindowsDisplays`, `screenshotViaPowershell`) without requiring per-script changes.

Fixes #2751

## Validation

- [x] `npx vitest run tests/unit-test/windows-screenshot.test.ts` — 3 tests passed
- [x] `npx vitest run tests/unit-test/device-security.test.ts` — 11 tests passed
- [x] `npx vitest run tests/unit-test/display-coordinate.test.ts` — 6 tests passed
- [x] `npx vitest run tests/unit-test/device.test.ts` — 5 tests passed