### PR TITLE
fix(core): handle malformed Doubao bbox responses

### DIFF
--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -73,6 +73,28 @@ function parseNumbersFromBboxArray(input: unknown[]): number[] {
   return numbers.filter(Number.isFinite);
 }
 
+/**
+ * Some models return a tagged bbox tuple, e.g.
+ * - ["bbox", [782, 541, 815, 559]]
+ * - ["bbox", "782, 541, 815, 559"]
+ */
+function parseNumbersFromTaggedBboxArray(input: unknown[]): number[] | null {
+  if (input.length < 2) {
+    return null;
+  }
+
+  const taggedBbox = input[1];
+  if (typeof taggedBbox === 'string') {
+    return parseNumbersFromBboxString(taggedBbox);
+  }
+
+  if (Array.isArray(taggedBbox)) {
+    return parseNumbersFromBboxArray(taggedBbox);
+  }
+
+  return null;
+}
+
 export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
   const bbox = unwrapCoordinateListLikeInput(input as any);
   let bboxList: number[] = [];
@@ -91,7 +113,11 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
       );
     }
   } else if (Array.isArray(bbox)) {
-    bboxList = parseNumbersFromBboxArray(bbox);
+    if (typeof bbox[0] === 'string' && bbox[0].trim() === 'bbox') {
+      bboxList = parseNumbersFromTaggedBboxArray(bbox) ?? [];
+    } else {
+      bboxList = parseNumbersFromBboxArray(bbox);
+    }
   } else {
     bboxList = bbox as number[];
   }

--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -1,5 +1,4 @@
 import type { TModelFamily } from '@midscene/shared/env';
-import { assert } from '@midscene/shared/utils';
 import type {
   ChatCompletionCallContext,
   ChatCompletionParamsResult,
@@ -23,27 +22,28 @@ const doubaoPointCoordinatesMeta = {
   normalizedBy: 1000,
 } as const;
 
+function parseNumbersFromBboxString(input: string): number[] {
+  return (input.match(/\d+/g) ?? []).map(Number).filter(Number.isFinite);
+}
+
 export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
   const bbox = unwrapCoordinateListLikeInput(input as any);
-  if (typeof bbox === 'string') {
-    assert(
-      /^(\d+)\s(\d+)\s(\d+)\s(\d+)$/.test(bbox.trim()),
-      `invalid bbox data string for doubao-vision mode: ${bbox}`,
-    );
-    const splitted = bbox.split(' ');
-    if (splitted.length === 4) {
-      return createLocateResultValue(doubaoBboxCoordinatesMeta, [
-        Number(splitted[0]),
-        Number(splitted[1]),
-        Number(splitted[2]),
-        Number(splitted[3]),
-      ]);
-    }
-    throw new Error(`invalid bbox data string for doubao-vision mode: ${bbox}`);
-  }
-
   let bboxList: number[] = [];
-  if (Array.isArray(bbox) && typeof bbox[0] === 'string') {
+
+  if (typeof bbox === 'string') {
+    /**
+     * Some models return bbox as a string, e.g.
+     * - { "bbox": "[336, 163, 717, 200]" }.
+     * - { "bbox": "336, 163, 717, 200" }.
+     * - { "bbox": "336 163 717 200" }.
+     */
+    bboxList = parseNumbersFromBboxString(bbox);
+    if (bboxList.length !== 4) {
+      throw new Error(
+        `invalid bbox data string for doubao-vision mode: ${bbox}`,
+      );
+    }
+  } else if (Array.isArray(bbox) && typeof bbox[0] === 'string') {
     bbox.forEach((item) => {
       if (typeof item === 'string' && item.includes(',')) {
         const [x, y] = item.split(',');
@@ -80,7 +80,7 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
     ]);
   }
 
-  if (bbox.length === 8) {
+  if (bboxList.length === 8) {
     return createLocateResultValue(doubaoBboxCoordinatesMeta, [
       bboxList[0],
       bboxList[1],

--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -26,6 +26,53 @@ function parseNumbersFromBboxString(input: string): number[] {
   return (input.match(/\d+/g) ?? []).map(Number).filter(Number.isFinite);
 }
 
+function parseLeadingNumberFromString(input: string): number | undefined {
+  const match = input.match(/^\s*(\d+)/);
+  return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * Clean coordinate strings can contain multiple positive integers, e.g.
+ * - "123 100"
+ * - "123,100"
+ * - "277; 664 291;"
+ * Dirty strings like "345<" are handled by taking the leading number and
+ * dropping the remaining array items.
+ */
+function isCleanCoordinateString(input: string): boolean {
+  return /^\s*\d+(?:[\s,;]+\d+)*\s*[,;]?\s*$/.test(input);
+}
+
+function parseNumbersFromBboxArray(input: unknown[]): number[] {
+  const numbers: number[] = [];
+
+  for (const item of input) {
+    if (typeof item === 'number') {
+      numbers.push(item);
+      continue;
+    }
+
+    if (typeof item === 'string') {
+      if (isCleanCoordinateString(item)) {
+        numbers.push(...parseNumbersFromBboxString(item));
+        continue;
+      } else {
+        const leadingNumber = parseLeadingNumberFromString(item);
+        if (leadingNumber !== undefined) {
+          numbers.push(leadingNumber);
+        }
+        // Once a dirty string appears, the remaining array items usually belong
+        // to broken JSON repair output, e.g. [410, 295, 885, "345<", "/bbox>..."].
+        break;
+      }
+    }
+
+    break;
+  }
+
+  return numbers.filter(Number.isFinite);
+}
+
 export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
   const bbox = unwrapCoordinateListLikeInput(input as any);
   let bboxList: number[] = [];
@@ -43,18 +90,8 @@ export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
         `invalid bbox data string for doubao-vision mode: ${bbox}`,
       );
     }
-  } else if (Array.isArray(bbox) && typeof bbox[0] === 'string') {
-    bbox.forEach((item) => {
-      if (typeof item === 'string' && item.includes(',')) {
-        const [x, y] = item.split(',');
-        bboxList.push(Number(x.trim()), Number(y.trim()));
-      } else if (typeof item === 'string' && item.includes(' ')) {
-        const [x, y] = item.split(' ');
-        bboxList.push(Number(x.trim()), Number(y.trim()));
-      } else {
-        bboxList.push(Number(item));
-      }
-    });
+  } else if (Array.isArray(bbox)) {
+    bboxList = parseNumbersFromBboxArray(bbox);
   } else {
     bboxList = bbox as number[];
   }

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -290,6 +290,31 @@ describe('doubao model adapter', () => {
       coordinates: [336, 163, 717, 200],
       coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
     });
+    expect(parseDoubaoRawLocateValue([653, '277; 664 291;'])).toEqual({
+      coordinates: [653, 277, 664, 291],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+    expect(parseDoubaoRawLocateValue([653, '277, 664, 291,'])).toEqual({
+      coordinates: [653, 277, 664, 291],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+    /**
+     * Some models mix an XML-style bbox closing tag into JSON arrays, e.g.
+     * { "bbox": [410, 295, 885, 345</bbox>, "errors": [] }
+     * jsonrepair may parse it into the array shape below.
+     */
+    expect(
+      parseDoubaoRawLocateValue([
+        410,
+        295,
+        885,
+        '345<',
+        '/bbox>,\n  "errors": []\n}',
+      ]),
+    ).toEqual({
+      coordinates: [410, 295, 885, 345],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
   });
 
   it('throws on invalid raw Doubao locate string values', () => {

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -254,9 +254,22 @@ describe('doubao model adapter', () => {
         { preparedSize: { width: 1000, height: 2000 } },
       ),
     ).toEqual([100, 400, 300, 800]);
+    expect(
+      locateAdapter.resultAdapter.adaptElementLocateResultToPixelBbox(
+        '[336, 163, 717, 200]',
+        { preparedSize: { width: 1000, height: 2000 } },
+      ),
+    ).toEqual([336, 326, 716, 400]);
   });
 
-  it('parses raw Doubao locate values directly', () => {
+  it('parses valid raw Doubao locate values directly', () => {
+    expect(parseDoubaoRawLocateValue([100, 200, 300, 400])).toEqual({
+      coordinates: [100, 200, 300, 400],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+  });
+
+  it('parses tolerated malformed raw Doubao locate values', () => {
     expect(parseDoubaoRawLocateValue('100 200 300 400')).toEqual({
       coordinates: [100, 200, 300, 400],
       coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
@@ -265,10 +278,28 @@ describe('doubao model adapter', () => {
       coordinates: [100, 200, 300, 400],
       coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
     });
-    expect(() => parseDoubaoRawLocateValue('100 200 300 400 ')).toThrow(
+    expect(parseDoubaoRawLocateValue('100 200 300 400 ')).toEqual({
+      coordinates: [100, 200, 300, 400],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+    expect(parseDoubaoRawLocateValue('[336, 163, 717, 200]')).toEqual({
+      coordinates: [336, 163, 717, 200],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+    expect(parseDoubaoRawLocateValue('336,163,717,200')).toEqual({
+      coordinates: [336, 163, 717, 200],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+  });
+
+  it('throws on invalid raw Doubao locate string values', () => {
+    expect(() => parseDoubaoRawLocateValue('100')).toThrow(
       /invalid bbox data string/,
     );
     expect(() => parseDoubaoRawLocateValue('100 200 300')).toThrow(
+      /invalid bbox data string/,
+    );
+    expect(() => parseDoubaoRawLocateValue('1 2 3 4 5 6 7 8')).toThrow(
       /invalid bbox data string/,
     );
   });

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -298,6 +298,14 @@ describe('doubao model adapter', () => {
       coordinates: [653, 277, 664, 291],
       coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
     });
+    expect(parseDoubaoRawLocateValue(['bbox', [782, 541, 815, 559]])).toEqual({
+      coordinates: [782, 541, 815, 559],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+    expect(parseDoubaoRawLocateValue(['bbox', '782, 541, 815, 559'])).toEqual({
+      coordinates: [782, 541, 815, 559],
+      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
     /**
      * Some models mix an XML-style bbox closing tag into JSON arrays, e.g.
      * { "bbox": [410, 295, 885, 345</bbox>, "errors": [] }


### PR DESCRIPTION
## Summary

- Accept Doubao locate bbox values returned as four-number strings such as `[336, 163, 717, 200]`, comma-separated strings, or space-separated strings.
- Repair model JSON responses that mix `</bbox>` into bbox arrays before running `jsonrepair`.
- Add focused unit coverage for tolerated malformed bbox formats and JSON repair behavior.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/doubao.test.ts`
- `pnpm --filter @midscene/core test -- tests/unit-test/json.test.ts`