### PR TITLE
fix(web-integration): secure bridge server with Origin-based access control

### DIFF
--- a/packages/web-integration/src/bridge-mode/io-server.ts
+++ b/packages/web-integration/src/bridge-mode/io-server.ts
@@ -1,5 +1,10 @@
-import { createServer } from 'node:http';
+import {
+  type IncomingMessage,
+  type ServerResponse,
+  createServer,
+} from 'node:http';
 import { sleep } from '@midscene/core/utils';
+import { getDebug } from '@midscene/shared/logger';
 import { logMsg } from '@midscene/shared/utils';
 import { Server, type Socket as ServerSocket } from 'socket.io';
 import { io as ClientIO } from 'socket.io-client';
@@ -15,7 +20,24 @@ import {
   DefaultBridgeServerPort,
 } from './common';
 
+const debug = getDebug('web:bridge:io-server');
+
 declare const __VERSION__: string;
+
+/**
+ * Returns true if the given Origin header value is allowed to connect
+ * to the bridge server. Trusted origins are:
+ * - No Origin header (local Node.js processes like killRunningServer)
+ * - chrome-extension:// origins (the Midscene Chrome extension)
+ *
+ * Browser pages (https://evil.com, etc.) are rejected to prevent
+ * Cross-Site WebSocket Hijacking (CSWSH) attacks.
+ */
+function isTrustedOrigin(origin: string | undefined): boolean {
+  if (!origin) return true;
+  if (origin.startsWith('chrome-extension://')) return true;
+  return false;
+}
 
 export const killRunningServer = async (port?: number, host = 'localhost') => {
   try {
@@ -27,7 +49,7 @@ export const killRunningServer = async (port?: number, host = 'localhost') => {
     await sleep(300);
     await client.close();
   } catch (e) {
-    // console.error('failed to kill port', e);
+    debug('failed to kill port: %O', e);
   }
 };
 
@@ -86,8 +108,14 @@ export class BridgeServer {
             }, 2000)
           : null;
 
-      // Create HTTP server and start listening on the specified host and port
-      const httpServer = createServer();
+      // Create HTTP server — no /bridge-auth endpoint needed since we use
+      // pure Origin checking in the Socket.IO middleware below.
+      const httpServer = createServer(
+        (_req: IncomingMessage, res: ServerResponse) => {
+          res.writeHead(404);
+          res.end();
+        },
+      );
 
       // Set up HTTP server event listeners FIRST
       httpServer.once('listening', () => {
@@ -117,14 +145,23 @@ export class BridgeServer {
       });
 
       this.io.use((socket, next) => {
-        // Always allow kill signal connections through
-        if (socket.handshake.url.includes(BridgeSignalKill)) {
-          return next();
+        // Reject connections from untrusted browser origins to prevent
+        // Cross-Site WebSocket Hijacking (CSWSH) and unauthorized kill signals.
+        // The browser automatically sets the Origin header on WebSocket
+        // handshakes, and JavaScript cannot override it.
+        const origin = socket.handshake.headers.origin;
+        if (!isTrustedOrigin(origin)) {
+          debug('connection rejected: untrusted origin=%s', origin);
+          return next(new Error('origin not allowed'));
         }
+
         // Allow new connections to replace old ones (reconnection after
         // extension Stop→Start). If the old socket is already disconnected
         // or unresponsive, accept the new connection immediately.
-        if (this.socket?.connected) {
+        if (
+          socket.handshake.url.includes(BridgeSignalKill) === false &&
+          this.socket?.connected
+        ) {
           return next(new Error('server already connected by another client'));
         }
         next();

--- a/packages/web-integration/tests/unit-test/bridge/security.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/security.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Security tests for Bridge Server (GHSA-mrhp-4xj5-p96f)
+ *
+ * These tests verify that:
+ * 1. Cross-origin WebSocket connections are rejected (CSWSH prevention)
+ * 2. Cross-origin kill signals are rejected (DoS prevention)
+ *
+ * Protection mechanism: Socket.IO middleware checks the Origin header on
+ * every connection. Only trusted origins (no Origin = local process, or
+ * chrome-extension://) are allowed. Browser pages cannot forge or omit
+ * the Origin header on WebSocket handshakes.
+ *
+ * Before the fix: these tests FAIL, confirming the vulnerabilities.
+ * After the fix:  these tests PASS, confirming the vulnerabilities are closed.
+ */
+
+import {
+  BridgeEvent,
+  BridgeSignalKill,
+  DefaultBridgeServerHost,
+} from '@/bridge-mode/common';
+import { BridgeServer, killRunningServer } from '@/bridge-mode/io-server';
+import { io as ClientIO } from 'socket.io-client';
+import { describe, expect, it } from 'vitest';
+
+const DEFAULT_HOST = DefaultBridgeServerHost;
+let portCounter = 3456;
+const nextPort = () => portCounter++;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Try to connect via WebSocket with given options, resolve connection result
+function tryConnect(
+  port: number,
+  opts: {
+    origin?: string;
+    query?: Record<string, string>;
+  } = {},
+): Promise<{ connected: boolean; gotConnectedEvent: boolean }> {
+  return new Promise((resolve) => {
+    const client = ClientIO(`ws://localhost:${port}`, {
+      extraHeaders: opts.origin ? { Origin: opts.origin } : undefined,
+      query: { version: 'test', ...(opts.query || {}) },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+
+    let gotConnectedEvent = false;
+    client.on(BridgeEvent.Connected, () => {
+      gotConnectedEvent = true;
+    });
+
+    client.on('connect', () => {
+      // Give a moment for bridge-connected event to fire
+      setTimeout(() => {
+        client.close();
+        resolve({ connected: true, gotConnectedEvent });
+      }, 200);
+    });
+    client.on('connect_error', () => {
+      resolve({ connected: false, gotConnectedEvent: false });
+    });
+    setTimeout(() => {
+      client.close();
+      resolve({ connected: false, gotConnectedEvent: false });
+    }, 2000);
+  });
+}
+
+describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
+  // ─── VULN-1: Cross-origin WebSocket hijacking ────────────────────────────
+
+  it('VULN-1a: rejects connection from browser origin', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    // Simulate a webpage at https://evil.com trying to hijack the bridge
+    const result = await tryConnect(port, {
+      origin: 'https://evil.com',
+    });
+
+    // The malicious client must NOT be able to connect
+    expect(result.connected).toBe(false);
+    expect(result.gotConnectedEvent).toBe(false);
+
+    await server.close();
+  }, 10000);
+
+  it('VULN-1b: rejects connections from multiple malicious origins', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    const maliciousOrigins = [
+      'https://attacker.example.com',
+      'http://malicious.net',
+      'https://phishing.google.com',
+    ];
+
+    for (const origin of maliciousOrigins) {
+      const result = await tryConnect(port, { origin });
+      expect(result.connected).toBe(false);
+      expect(result.gotConnectedEvent).toBe(false);
+    }
+
+    await server.close();
+  }, 15000);
+
+  it('VULN-1c: prevents session hijack — malicious client cannot intercept commands', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    // Malicious client tries to connect first to hijack the session
+    const maliciousClient = ClientIO(`ws://localhost:${port}`, {
+      extraHeaders: { Origin: 'https://attacker.com' },
+      query: { version: 'evil' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+
+    let hijackSuccess = false;
+    const interceptedMethods: string[] = [];
+
+    maliciousClient.on(BridgeEvent.Connected, () => {
+      hijackSuccess = true;
+    });
+    maliciousClient.on(BridgeEvent.Call, (call: any) => {
+      interceptedMethods.push(call.method);
+      maliciousClient.emit(BridgeEvent.CallResponse, {
+        id: call.id,
+        response: 'FAKE',
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      maliciousClient.on('connect', resolve);
+      maliciousClient.on('connect_error', () => resolve());
+      setTimeout(resolve, 2000);
+    });
+    await sleep(300);
+
+    // The hijack must not succeed
+    expect(hijackSuccess).toBe(false);
+    expect(interceptedMethods).toEqual([]);
+
+    maliciousClient.close();
+    await server.close();
+  }, 10000);
+
+  // ─── VULN-2: Kill signal DoS ─────────────────────────────────────────────
+
+  it('VULN-2a: rejects kill signal from browser origin', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    // Connect a legitimate client first (no Origin = local process)
+    const legitClient = ClientIO(`ws://localhost:${port}`, {
+      query: { version: 'legit' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+    await new Promise<void>((resolve) => {
+      legitClient.on(BridgeEvent.Connected, resolve);
+      legitClient.on('connect_error', () => resolve());
+      setTimeout(resolve, 2000);
+    });
+
+    // Set up legit client to respond to calls
+    legitClient.on(BridgeEvent.Call, (call: any) => {
+      legitClient.emit(BridgeEvent.CallResponse, {
+        id: call.id,
+        response: 'ok',
+      });
+    });
+
+    // Simulate malicious webpage sending kill signal
+    const maliciousClient = ClientIO(`ws://localhost:${port}`, {
+      extraHeaders: { Origin: 'https://evil.com' },
+      query: { [BridgeSignalKill]: '1' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+
+    await new Promise<void>((resolve) => {
+      maliciousClient.on('connect', () => {
+        maliciousClient.close();
+        resolve();
+      });
+      maliciousClient.on('connect_error', () => resolve());
+      setTimeout(resolve, 2000);
+    });
+    await sleep(500);
+
+    // Verify server still works — the kill signal must have been rejected
+    const result = await server.call('test', ['a']).catch(() => null);
+    expect(result).toBe('ok');
+
+    maliciousClient.close();
+    legitClient.close();
+    try {
+      await server.close();
+    } catch {}
+  }, 10000);
+
+  it('VULN-2b: killRunningServer still works (legitimate local use)', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    // Connect a legitimate client (no Origin = local process)
+    const client = ClientIO(`ws://localhost:${port}`, {
+      query: { version: 'test' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+    await new Promise<void>((resolve) => {
+      client.on(BridgeEvent.Connected, resolve);
+      setTimeout(resolve, 2000);
+    });
+
+    // killRunningServer (from local process, no Origin header) should still work
+    await killRunningServer(port);
+    await sleep(300);
+
+    // Server should be dead
+    await expect(server.call('test', ['a'])).rejects.toThrow();
+    client.close();
+  }, 10000);
+
+  // ─── Positive: legitimate flows still work ───────────────────────────────
+
+  it('positive: local process (no Origin) can connect and exchange calls', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    let receivedMethod = '';
+    const client = ClientIO(`ws://localhost:${port}`, {
+      query: { version: 'test' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+
+    let connected = false;
+    client.on(BridgeEvent.Connected, () => {
+      connected = true;
+    });
+    client.on(BridgeEvent.Call, (call: any) => {
+      receivedMethod = call.method;
+      client.emit(BridgeEvent.CallResponse, {
+        id: call.id,
+        response: 'ok',
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      client.on('connect', resolve);
+      setTimeout(resolve, 2000);
+    });
+    await sleep(200);
+
+    expect(connected).toBe(true);
+
+    // Server sends a call, client receives it
+    const result = await server.call('screenshotBase64', []);
+    expect(result).toBe('ok');
+    expect(receivedMethod).toBe('screenshotBase64');
+
+    client.close();
+    await server.close();
+  }, 10000);
+
+  it('positive: chrome-extension:// origin can connect', async () => {
+    const port = nextPort();
+    const server = new BridgeServer(DEFAULT_HOST, port);
+    await server.listen();
+
+    const extOrigin = 'chrome-extension://admccjkmockfdflocgggjfgdacdodkdf';
+    const result = await tryConnect(port, { origin: extOrigin });
+
+    expect(result.connected).toBe(true);
+    expect(result.gotConnectedEvent).toBe(true);
+
+    await server.close();
+  }, 10000);
+
+  it('positive: closeConflictServer kills old server (no Origin kill signal)', async () => {
+    const port = nextPort();
+    const server1 = new BridgeServer(DEFAULT_HOST, port);
+    await server1.listen({ timeout: false });
+
+    // Connect a client to server1 so we can verify it's alive
+    const client1 = ClientIO(`ws://localhost:${port}`, {
+      query: { version: 'test' },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+    await new Promise<void>((resolve) => {
+      client1.on(BridgeEvent.Connected, resolve);
+      setTimeout(resolve, 2000);
+    });
+    client1.on(BridgeEvent.Call, (call: any) => {
+      client1.emit(BridgeEvent.CallResponse, { id: call.id, response: 'ok' });
+    });
+    await sleep(100);
+
+    // Verify server1 is working
+    expect(await server1.call('test', ['a'])).toBe('ok');
+
+    // server2 with closeConflictServer=true should kill server1 via kill signal
+    const server2 = new BridgeServer(
+      DEFAULT_HOST,
+      port,
+      undefined,
+      undefined,
+      true,
+    );
+    // Don't await full listen — it waits for extension connection.
+    // Just give killRunningServer time to fire and kill server1.
+    server2.listen({ timeout: false }).catch(() => {});
+    await sleep(500);
+
+    // server1 should be dead — its io is closed by the kill signal
+    let dead = false;
+    try {
+      await server1.call('test', ['a']);
+    } catch {
+      dead = true;
+    }
+    expect(dead).toBe(true);
+
+    client1.close();
+    await server2.close();
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

This PR addresses the security vulnerabilities reported in GHSA-mrhp-4xj5-p96f. The Bridge Server (running on port 3766) was vulnerable to:

1. **Cross-Site WebSocket Hijacking (CSWSH)**: Any malicious webpage could connect to `ws://localhost:3766` and intercept CLI commands (e.g., `screenshotBase64`, `getBrowserTabList`) because WebSocket connections bypass browser CORS policies.

2. **Unauthenticated Kill Signal DoS**: Any webpage could send a `?MIDSCENE_BRIDGE_SIGNAL_KILL=1` query parameter to shut down the bridge server, denying service to legitimate users.

3. **No Origin Validation**: The server accepted connections from any origin with no authentication.

## Approach: Pure Origin-Based Access Control

The fix uses **Origin header checking** in the Socket.IO middleware — no tokens, no extra endpoints. The browser automatically sets the `Origin` header on WebSocket handshakes, and JavaScript **cannot** override it, making this a reliable defense against CSWSH attacks.

This is simpler and more secure than a token-based approach because:
- No token distribution endpoint (which would itself need authentication)
- No "key under the doormat" problem
- Fewer moving parts — only the middleware changes

## Changes

### `io-server.ts`
- Adds `isTrustedOrigin()` function that allows:
  - **No Origin header** → trusted (local Node.js processes like `killRunningServer`)
  - `chrome-extension://...` → trusted (Midscene Chrome extension)
  - **Any other origin** (e.g., `https://evil.com`) → **rejected**
- Adds Socket.IO middleware that checks `socket.handshake.headers.origin` against `isTrustedOrigin()` on every connection, including kill signal connections

### `security.test.ts` (new)
- 8 security tests covering:
  - VULN-1a/b/c: Cross-origin connection hijacking prevention
  - VULN-2a: Kill signal from browser origin rejected
  - VULN-2b: `killRunningServer` still works from local process
  - Positive: local process (no Origin) connects and exchanges calls
  - Positive: `chrome-extension://` origin can connect
  - Positive: `closeConflictServer` port cleanup still works

## Verification

- ✅ All 8 security tests pass
- ✅ Real CLI bridge scripts run successfully:
  - `current_tab/check_content.yaml` — `aiAssert` via bridge ✅
  - `new_tab/open-new-tab.yaml` — `ai` + `aiAssert` via bridge ✅
  - Custom `aiAct` test (click link on example.com) ✅
- ✅ Chrome extension connects correctly (`chrome-extension://` origin allowed)
- ✅ `killRunningServer()` from local process still works (no Origin header → allowed)
- ✅ `closeConflictServer` port cleanup still works
- ✅ `pnpm run lint` passes

## Security Model

| Caller | Origin Header | Allowed? |
|--------|--------------|----------|
| Local CLI process | (none) | ✅ Yes |
| Chrome extension | `chrome-extension://...` | ✅ Yes |
| Malicious webpage | `https://evil.com` | ❌ No |
| Kill signal from browser | `https://evil.com` | ❌ No |
| Kill signal from local CLI | (none) | ✅ Yes |

## Related

Fixes GHSA-mrhp-4xj5-p96f