### PR TITLE
fix(core): preserve report response dump shape

### DIFF
--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -297,7 +297,7 @@ export async function genericLocate(
     };
   }
 
-  const rawResponse = JSON.stringify(res.content);
+  const rawResponse = res.contentString;
 
   let errors: string[] | undefined =
     'errors' in res.content ? res.content.errors : [];
@@ -446,7 +446,7 @@ export async function AiLocateSection(options: {
     return {
       searchAreaConfig: undefined,
       error: sectionError,
-      rawResponse: JSON.stringify(result.content),
+      rawResponse: result.contentString,
       rawChoiceMessage: result.rawChoiceMessage,
       usage: result.usage,
     };
@@ -495,7 +495,7 @@ export async function AiLocateSection(options: {
   return {
     searchAreaConfig,
     error: sectionError,
-    rawResponse: JSON.stringify(result.content),
+    rawResponse: result.contentString,
     rawChoiceMessage: result.rawChoiceMessage,
     usage: result.usage,
   };

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -656,7 +656,7 @@ export async function callAI(
             }
             throw new AIResponseParseError(
               'empty content from AI model',
-              JSON.stringify(result),
+              content || '',
               errorUsage,
               rawChoiceMessage,
             );

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -142,9 +142,9 @@ export default class Service {
     const taskInfo: ServiceTaskInfo = {
       ...(this.taskInfo ? this.taskInfo : {}),
       durationMs: timeCost,
-      rawResponse: JSON.stringify(rawResponse),
+      rawResponse,
       rawChoiceMessage,
-      formatResponse: JSON.stringify(parseResult),
+      formatResponse: parseResult,
       usage,
       searchArea: searchArea.trace.sourceRect,
       searchAreaRawResponse: searchArea.trace.rawResponse,
@@ -367,7 +367,7 @@ export default class Service {
       durationMs: timeCost,
       rawResponse,
       rawChoiceMessage,
-      formatResponse: JSON.stringify(parseResult),
+      formatResponse: parseResult,
       usage,
       reasoning_content,
     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -179,12 +179,12 @@ export type DeepThinkOption = 'unset' | true | false;
 
 export interface ServiceTaskInfo {
   durationMs: number;
-  formatResponse?: string;
+  formatResponse?: unknown;
   /**
    * Adapter-extracted content used by Midscene for parsing. This is not the
    * full provider response or choices[0].message.
    */
-  rawResponse?: string;
+  rawResponse?: unknown;
   rawChoiceMessage?: unknown;
   usage?: AIUsageInfo;
   searchArea?: Rect;

--- a/packages/core/tests/unit-test/service-caller-empty-content.test.ts
+++ b/packages/core/tests/unit-test/service-caller-empty-content.test.ts
@@ -73,7 +73,8 @@ describe('service-caller empty content handling', () => {
         request_id: 'req_test_123',
       });
       expect(typedError.usage?.intent).toBeUndefined();
-      expect(typedError.rawResponse).toContain('"choices"');
+      expect(typedError.rawResponse).toBe('');
+      expect(typedError.rawChoiceMessage).toEqual({ content: '' });
     }
   });
 });


### PR DESCRIPTION
## Summary

- Preserve structured `rawResponse` / `formatResponse` values in report task dumps instead of pre-stringifying them.
- Keep empty model content parse errors focused on the extracted content string while retaining `rawChoiceMessage` for the full choice message context.
- Update the focused empty-content unit test to assert the new debug payload split.

## Why

The report JSON view was showing escaped string payloads because response dump fields were serialized before being stored. Empty-content errors also stored the full provider result in `rawResponse`, which made the field carry provider-level data while `rawChoiceMessage` already records the choice message details.

## Validation

- `pnpm --filter @midscene/core test`
- `pnpm --filter @midscene/core test service-caller-empty-content.test.ts`

Note: lint was not run manually.