### PR TITLE
fix(web-integration): preserve drag mouse button state

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -921,6 +921,9 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
         x: from.x,
         y: from.y,
         button: 'left',
+        // CDP uses `buttons` to represent the currently pressed mouse buttons.
+        // HTML5 drag/drop needs this state to treat following moves as dragging.
+        buttons: 1,
         clickCount: 1,
       });
 
@@ -930,6 +933,8 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
         type: 'mouseMoved',
         x: to.x,
         y: to.y,
+        button: 'left',
+        buttons: 1,
       });
 
       await sleep(500);
@@ -939,6 +944,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
         x: to.x,
         y: to.y,
         button: 'left',
+        buttons: 0,
         clickCount: 1,
       });
 

--- a/packages/web-integration/tests/unit-test/chrome-extension-drag.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-drag.test.ts
@@ -1,0 +1,317 @@
+import { pathToFileURL } from 'node:url';
+import puppeteer, { type Browser, type CDPSession, type Page } from 'puppeteer';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const TEST_TIMEOUT_MS = 120_000;
+const DRAG_FIXTURE_URL = pathToFileURL(
+  `${__dirname}/fixtures/base-page-drag.html`,
+).toString();
+
+const mockSendCommand = vi.fn();
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    getURL: vi.fn((path: string) => path),
+  },
+  tabs: {
+    get: vi.fn(),
+    query: vi.fn(),
+    update: vi.fn(),
+  },
+  debugger: {
+    attach: vi.fn(),
+    detach: vi.fn(),
+    sendCommand: mockSendCommand,
+    onEvent: {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    },
+  },
+});
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../src/chrome-extension/dynamic-scripts', () => ({
+  getHtmlElementScript: vi.fn(async () => 'void 0'),
+  injectStopWaterFlowAnimation: vi.fn(async () => 'void 0'),
+  injectWaterFlowAnimation: vi.fn(async () => 'void 0'),
+}));
+
+import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
+
+async function elementCenter(
+  page: Page,
+  selector: string,
+): Promise<{ x: number; y: number }> {
+  return page.$eval(selector, (element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  });
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function legacyDragWithoutButtons(
+  cdpSession: CDPSession,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+) {
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: from.x,
+    y: from.y,
+  });
+
+  await sleep(200);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x: from.x,
+    y: from.y,
+    button: 'left',
+    clickCount: 1,
+  });
+
+  await sleep(300);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: to.x,
+    y: to.y,
+  });
+
+  await sleep(500);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x: to.x,
+    y: to.y,
+    button: 'left',
+    clickCount: 1,
+  });
+
+  await sleep(200);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: to.x,
+    y: to.y,
+  });
+}
+
+async function dragWithButtonState(
+  cdpSession: CDPSession,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  steps: number,
+) {
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: from.x,
+    y: from.y,
+  });
+
+  await sleep(200);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x: from.x,
+    y: from.y,
+    button: 'left',
+    buttons: 1,
+    clickCount: 1,
+  });
+
+  await sleep(300);
+  for (let i = 1; i <= steps; i++) {
+    await cdpSession.send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x: from.x + ((to.x - from.x) * i) / steps,
+      y: from.y + ((to.y - from.y) * i) / steps,
+      button: 'left',
+      buttons: 1,
+    });
+  }
+
+  await sleep(500);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x: to.x,
+    y: to.y,
+    button: 'left',
+    buttons: 0,
+    clickCount: 1,
+  });
+
+  await sleep(200);
+  await cdpSession.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: to.x,
+    y: to.y,
+  });
+}
+
+describe('ChromeExtensionProxyPage drag', () => {
+  let page: ChromeExtensionProxyPage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page = new ChromeExtensionProxyPage(false);
+    (page as any).activeTabId = 7;
+
+    vi.mocked(chrome.tabs.get).mockResolvedValue({
+      id: 7,
+      url: 'https://example.com',
+      status: 'complete',
+    } as chrome.tabs.Tab);
+
+    mockSendCommand.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches drag mouse events with left button state', async () => {
+    await page.mouse.drag({ x: 10, y: 20 }, { x: 110, y: 220 });
+
+    const inputEvents = mockSendCommand.mock.calls
+      .filter(([, method]) => method === 'Input.dispatchMouseEvent')
+      .map(([, , params]) => params as Record<string, unknown>);
+
+    expect(
+      inputEvents.find(({ type }) => type === 'mousePressed'),
+    ).toMatchObject({
+      type: 'mousePressed',
+      x: 10,
+      y: 20,
+      button: 'left',
+      buttons: 1,
+      clickCount: 1,
+    });
+
+    const dragMoves = inputEvents.filter(
+      ({ type, button, buttons }) =>
+        type === 'mouseMoved' && button === 'left' && buttons === 1,
+    );
+
+    expect(dragMoves).toHaveLength(1);
+    expect(dragMoves[0]).toMatchObject({
+      type: 'mouseMoved',
+      x: 110,
+      y: 220,
+      button: 'left',
+      buttons: 1,
+    });
+
+    expect(
+      inputEvents.find(({ type }) => type === 'mouseReleased'),
+    ).toMatchObject({
+      type: 'mouseReleased',
+      x: 110,
+      y: 220,
+      button: 'left',
+      buttons: 0,
+      clickCount: 1,
+    });
+  });
+
+  describe('with a real CDP page', () => {
+    let browser: Browser;
+    let realPage: Page;
+    let cdpSession: CDPSession;
+
+    beforeAll(async () => {
+      browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      });
+    }, TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      await browser?.close();
+    }, TEST_TIMEOUT_MS);
+
+    beforeEach(async () => {
+      realPage = await browser.newPage();
+      await realPage.goto(DRAG_FIXTURE_URL);
+      cdpSession = await realPage.target().createCDPSession();
+
+      mockSendCommand.mockImplementation(async (_target, method, params) =>
+        cdpSession.send(method, params),
+      );
+    }, TEST_TIMEOUT_MS);
+
+    afterEach(async () => {
+      await cdpSession?.detach().catch(() => undefined);
+      await realPage?.close().catch(() => undefined);
+    });
+
+    it(
+      'performs HTML5 drag and drop on the fixture page',
+      async () => {
+        const source = await elementCenter(realPage, '[data-fruit="banana"]');
+        const target = await elementCenter(realPage, '#dropzone');
+
+        await page.mouse.drag(source, target);
+
+        await realPage.waitForFunction(
+          () =>
+            document.querySelector('#result')?.textContent ===
+            'Dropped: banana',
+        );
+
+        await expect(
+          realPage.$eval('#result', (element) => element.textContent),
+        ).resolves.toBe('Dropped: banana');
+      },
+      TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'does not perform HTML5 drag and drop when mouse move omits button state',
+      async () => {
+        const source = await elementCenter(realPage, '[data-fruit="orange"]');
+        const target = await elementCenter(realPage, '#dropzone');
+
+        await legacyDragWithoutButtons(cdpSession, source, target);
+
+        await expect(
+          realPage.$eval('#result', (element) => element.textContent),
+        ).resolves.toBe('Dropped: none');
+      },
+      TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'performs HTML5 drag and drop with a single button-state mouse move',
+      async () => {
+        const source = await elementCenter(realPage, '[data-fruit="apple"]');
+        const target = await elementCenter(realPage, '#dropzone');
+
+        await dragWithButtonState(cdpSession, source, target, 1);
+
+        await realPage.waitForFunction(
+          () =>
+            document.querySelector('#result')?.textContent === 'Dropped: apple',
+        );
+
+        await expect(
+          realPage.$eval('#result', (element) => element.textContent),
+        ).resolves.toBe('Dropped: apple');
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
+});

--- a/packages/web-integration/tests/unit-test/fixtures/base-page-drag.html
+++ b/packages/web-integration/tests/unit-test/fixtures/base-page-drag.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Midscene Drag Fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 32px;
+        font-family: Arial, sans-serif;
+      }
+
+      .items {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+
+      .item {
+        width: 96px;
+        height: 56px;
+        display: grid;
+        place-items: center;
+        border: 1px solid #2f5f8f;
+        border-radius: 6px;
+        background: #e8f3ff;
+        color: #17324d;
+        cursor: grab;
+        user-select: none;
+      }
+
+      .dropzone {
+        width: 360px;
+        height: 220px;
+        display: grid;
+        place-items: center;
+        border: 2px dashed #64748b;
+        border-radius: 8px;
+        background: #f8fafc;
+        color: #334155;
+      }
+
+      .dropzone.over {
+        border-color: #2563eb;
+        background: #eff6ff;
+      }
+
+      #result {
+        margin-top: 20px;
+        font-size: 18px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="items">
+      <div class="item" draggable="true" data-fruit="apple">apple</div>
+      <div class="item" draggable="true" data-fruit="banana">banana</div>
+      <div class="item" draggable="true" data-fruit="orange">orange</div>
+    </div>
+
+    <div class="dropzone" id="dropzone">Drop here</div>
+    <div id="result">Dropped: none</div>
+
+    <script>
+      const dropzone = document.querySelector('#dropzone');
+      const result = document.querySelector('#result');
+
+      for (const item of document.querySelectorAll('.item')) {
+        item.addEventListener('dragstart', (event) => {
+          event.dataTransfer.effectAllowed = 'move';
+          event.dataTransfer.setData('text/plain', item.dataset.fruit);
+        });
+      }
+
+      dropzone.addEventListener('dragenter', (event) => {
+        event.preventDefault();
+        dropzone.classList.add('over');
+      });
+
+      dropzone.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      });
+
+      dropzone.addEventListener('dragleave', () => {
+        dropzone.classList.remove('over');
+      });
+
+      dropzone.addEventListener('drop', (event) => {
+        event.preventDefault();
+        dropzone.classList.remove('over');
+        const fruit = event.dataTransfer.getData('text/plain');
+        result.textContent = `Dropped: ${fruit}`;
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Preserve CDP mouse `buttons` state during Chrome extension drag actions.
- Add a standalone HTML5 drag/drop fixture for regression coverage.
- Add unit coverage for the CDP command shape, real drag/drop success, and the legacy no-buttons failure path.

## Root Cause

Chrome CDP `Input.dispatchMouseEvent` needs `buttons` to describe the currently pressed mouse buttons. Without that state, the following move is not treated as an active left-button drag by HTML5 drag/drop handlers.

## Validation

- `../../node_modules/.pnpm/node_modules/.bin/vitest run --config vitest.config.ts tests/unit-test/chrome-extension-drag.test.ts`

Note: the browser-backed test requires permission to launch headless Chromium locally.