### PR TITLE
fix(studio): stabilize android replay runs

### DIFF
--- a/apps/studio/src/renderer/recorder/replay.ts
+++ b/apps/studio/src/renderer/recorder/replay.ts
@@ -23,6 +23,8 @@ Execution rules:
 - If the current UI is already ahead of an earlier required recorded action, use visible safe affordances and the recorded context to return to the earliest unsatisfied prerequisite state and perform the missing recorded action sequence.
 - Before failing because the recorded target is absent, compare the current UI with the recorded goal, previous steps, and following steps. If the intended outcome of the missing step is already satisfied, mark that step as done and continue with the next unsatisfied recorded intent.
 - Do not undo visible progress or change durable application state only to recreate an earlier intermediate UI. Doing so is allowed only when it is visibly safe and necessary to execute an explicit recorded workflow action that has not run in this replay.
+- If a recorded target or prerequisite remains missing after visible, explainable attempts to reach it, do not keep repeating the same navigation or action pattern for that same missing target. A bounded retry is acceptable when the UI visibly changes or new evidence appears.
+- After each prerequisite-recovery action, verify that the current UI is closer to the recorded intent. If repeated attempts do not make the next recorded intent more reachable, stop and report that the current UI likely does not match the recording state.
 - Stop only when the recorded intent cannot be inferred or no safe visible path exists.
 
 Recorded Markdown:

--- a/apps/studio/tests/studio-recorder.test.ts
+++ b/apps/studio/tests/studio-recorder.test.ts
@@ -483,6 +483,12 @@ describe('studio recorder replay adapters', () => {
     expect(prompt).toContain(
       'Do not undo visible progress or change durable application state',
     );
+    expect(prompt).toContain(
+      'do not keep repeating the same navigation or action pattern',
+    );
+    expect(prompt).toContain(
+      'current UI likely does not match the recording state',
+    );
     expect(prompt).not.toMatch(
       /\blogin\b|authorization|SMS|phone|one-tap|product|recommendations|hot search/i,
     );

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -387,6 +387,26 @@ export default class ScrcpyServer {
       let scrcpyClient: any = null;
       let adb = null;
 
+      const closeScrcpyClient = async (
+        reason: string,
+        clientToClose = scrcpyClient,
+      ) => {
+        if (!clientToClose) {
+          return;
+        }
+
+        if (scrcpyClient === clientToClose) {
+          scrcpyClient = null;
+        }
+
+        try {
+          debugPage('closing scrcpy client, reason: %s', reason);
+          await clientToClose.close();
+        } catch (error) {
+          console.error(`failed to close scrcpy client (${reason}):`, error);
+        }
+      };
+
       const emitPreviewStatus = (phase: ScrcpyPreviewPhase) => {
         socket.emit('preview-status', buildScrcpyPreviewStatusEvent(phase));
       };
@@ -417,11 +437,7 @@ export default class ScrcpyServer {
       socket.on('switch-device', async (deviceId) => {
         debugPage('received client request to switch device:', deviceId);
         try {
-          // if there is a connection, close it first
-          if (scrcpyClient) {
-            await scrcpyClient.close();
-            scrcpyClient = null;
-          }
+          await closeScrcpyClient('switch device');
 
           this.currentDeviceId = deviceId;
           debugPage('device switched to:', deviceId);
@@ -451,6 +467,8 @@ export default class ScrcpyServer {
               options,
               socket.id,
             );
+
+            await closeScrcpyClient('new connect-device request');
 
             emitPreviewStatus('connecting-device');
 
@@ -561,6 +579,7 @@ export default class ScrcpyServer {
                 );
 
                 const { stream } = videoStream;
+                const streamScrcpyClient = scrcpyClient;
 
                 // convert video stream
                 const reader = stream.getReader();
@@ -590,9 +609,14 @@ export default class ScrcpyServer {
                     console.error('error processing video stream:', error);
                     if (socket.connected) {
                       socket.emit('error', {
-                        message: 'video stream processing error',
+                        message:
+                          'Scrcpy video stream failed. Reconnecting preview.',
                       });
                     }
+                    void closeScrcpyClient(
+                      'video stream error',
+                      streamScrcpyClient,
+                    );
                     return;
                   }
 
@@ -604,20 +628,14 @@ export default class ScrcpyServer {
                   // frame until the user manually disconnects.
                   if (socket.connected) {
                     socket.emit('error', {
-                      message: 'video stream ended',
+                      message:
+                        'Scrcpy video stream ended. Reconnecting preview.',
                     });
                   }
-                  if (scrcpyClient) {
-                    try {
-                      await scrcpyClient.close();
-                    } catch (closeError) {
-                      console.error(
-                        'failed to close scrcpy client after stream ended:',
-                        closeError,
-                      );
-                    }
-                    scrcpyClient = null;
-                  }
+                  void closeScrcpyClient(
+                    'video stream ended',
+                    streamScrcpyClient,
+                  );
                 };
 
                 processStream();
@@ -631,6 +649,7 @@ export default class ScrcpyServer {
               }
             } catch (error: any) {
               console.error('error processing video stream:', error);
+              await closeScrcpyClient('video stream setup error');
               socket.emit('error', {
                 message: `Video stream processing error: ${error.message}`,
               });
@@ -643,17 +662,7 @@ export default class ScrcpyServer {
             }
           } catch (error: any) {
             console.error('failed to connect device:', error);
-            if (scrcpyClient) {
-              try {
-                await scrcpyClient.close();
-              } catch (closeError) {
-                console.error(
-                  'failed to close scrcpy client after error:',
-                  closeError,
-                );
-              }
-              scrcpyClient = null;
-            }
+            await closeScrcpyClient('connect-device error');
             socket.emit('error', {
               message: `Failed to connect device: ${error?.message || 'Unknown error'}`,
             });
@@ -664,17 +673,7 @@ export default class ScrcpyServer {
       // handle disconnection
       socket.on('disconnect', async (reason) => {
         debugPage('client disconnected, id: %s, reason: %s', socket.id, reason);
-
-        if (scrcpyClient) {
-          try {
-            // close scrcpy
-            debugPage('closing scrcpy client');
-            await scrcpyClient.close();
-          } catch (error) {
-            console.error('failed to close scrcpy client:', error);
-          }
-          scrcpyClient = null;
-        }
+        await closeScrcpyClient(`socket disconnect: ${reason}`);
       });
 
       // Don't block listener registration on the initial device scan. On a

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -81,6 +81,14 @@ const maxErrorCountAllowedInOnePlanningLoop = 5;
 // single place that truncates feedback before it is sent to the model; action
 // implementations should hand over the untruncated value.
 const maxPlanningFeedbackLength = 500;
+const minRepeatedActionHistoryLength = 6;
+const maxActionSignatureLength = 160;
+const repeatedActionSignatureTypes = new Set([
+  'tap',
+  'click',
+  'doubleclick',
+  'longpress',
+]);
 
 function truncatePlanningFeedback(feedback: string): string {
   if (feedback.length <= maxPlanningFeedbackLength) {
@@ -89,6 +97,100 @@ function truncatePlanningFeedback(feedback: string): string {
 
   return `${feedback.slice(0, maxPlanningFeedbackLength)}
 ...[truncated, ${feedback.length - maxPlanningFeedbackLength} more characters]`;
+}
+
+function normalizeActionSignaturePart(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.replace(/\s+/g, ' ').trim();
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeActionSignaturePart).filter(Boolean).join(',');
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.prompt === 'string') {
+      return normalizeActionSignaturePart(record.prompt);
+    }
+    if (typeof record.description === 'string') {
+      return normalizeActionSignaturePart(record.description);
+    }
+    if (record.locate) {
+      return normalizeActionSignaturePart(record.locate);
+    }
+
+    return Object.keys(record).sort().join(',');
+  }
+
+  return String(value);
+}
+
+function actionSignature(action: PlanningAction): string | undefined {
+  const type = action.type || 'unknown';
+  const normalizedType = type.toLowerCase();
+  if (!repeatedActionSignatureTypes.has(normalizedType)) {
+    return undefined;
+  }
+
+  const param = (action.param || {}) as Record<string, unknown>;
+  const locateText = normalizeActionSignaturePart(param.locate);
+  if (!locateText) {
+    return undefined;
+  }
+
+  const signature = `${type}:${locateText}`;
+  return signature.slice(0, maxActionSignatureLength);
+}
+
+function findRepeatedActionPattern(history: string[]): string[] | undefined {
+  if (history.length < minRepeatedActionHistoryLength) {
+    return undefined;
+  }
+
+  const maxWindowSize = Math.floor(history.length / 2);
+  for (let windowSize = 1; windowSize <= maxWindowSize; windowSize++) {
+    const repeatCount = Math.max(
+      2,
+      Math.ceil(minRepeatedActionHistoryLength / windowSize),
+    );
+    const repeatedLength = windowSize * repeatCount;
+    if (history.length < repeatedLength) {
+      continue;
+    }
+
+    const pattern = history.slice(history.length - windowSize);
+    let matched = true;
+    for (let repeatIndex = 2; repeatIndex <= repeatCount; repeatIndex++) {
+      const start = history.length - windowSize * repeatIndex;
+      const previous = history.slice(start, start + windowSize);
+      if (previous.some((item, index) => item !== pattern[index])) {
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) {
+      return pattern;
+    }
+  }
+
+  return undefined;
+}
+
+function repeatedActionPatternKey(pattern: string[]): string {
+  const rotations = pattern.map((_, index) =>
+    [...pattern.slice(index), ...pattern.slice(0, index)].join('\n'),
+  );
+  return rotations.sort()[0];
 }
 
 export { TaskExecutionError };
@@ -506,6 +608,9 @@ export class TaskExecutor {
     let outputString: string | undefined;
     let latestPlanResult: PlanningAIResponse | undefined;
     let latestPlanIndex = 0;
+    const successfulActionHistory: string[] = [];
+    let warnedRepeatedActionPatternKey: string | undefined;
+    let warnedRepeatedActionPatternFailAfterLength = Number.POSITIVE_INFINITY;
 
     if (abortSignal?.aborted) {
       return appendFailedPlan(
@@ -747,8 +852,10 @@ export class TaskExecutor {
         replanningCycleLimit,
         (phase, data) => this.emitAiActProgress(phase, data),
       );
+      let actionBatchCompleted = false;
       try {
         await session.appendAndRun(executables.tasks);
+        actionBatchCompleted = true;
         this.setPendingFeedbackMessage(
           conversationHistory,
           initialTimeString,
@@ -791,6 +898,49 @@ export class TaskExecutor {
       // // Check if task is complete
       if (!planResult?.shouldContinuePlanning) {
         break;
+      }
+
+      if (actionBatchCompleted) {
+        successfulActionHistory.push(
+          ...plans
+            .map(actionSignature)
+            .filter((item): item is string => !!item),
+        );
+        const repeatedPattern = findRepeatedActionPattern(
+          successfulActionHistory,
+        );
+        if (repeatedPattern) {
+          const repeatedPatternKey = repeatedActionPatternKey(repeatedPattern);
+          const repeatedActionMessage = `The same action pattern has repeated without completing the task. Repeated actions: ${repeatedPattern.join(
+            ' -> ',
+          )}. Verify whether the UI has progressed, choose a different visible path, or fail with a clear reason if the target is not reachable.`;
+
+          if (
+            warnedRepeatedActionPatternKey === repeatedPatternKey &&
+            successfulActionHistory.length >=
+              warnedRepeatedActionPatternFailAfterLength
+          ) {
+            return appendFailedPlan(
+              `Task appears stuck because the same action pattern repeated without completing. Repeated actions: ${repeatedPattern.join(
+                ' -> ',
+              )}`,
+              planIndex,
+            );
+          }
+
+          if (warnedRepeatedActionPatternKey !== repeatedPatternKey) {
+            warnedRepeatedActionPatternKey = repeatedPatternKey;
+            warnedRepeatedActionPatternFailAfterLength =
+              successfulActionHistory.length + repeatedPattern.length;
+          }
+
+          const timeString = await this.getTimeString();
+          this.setPendingFeedbackMessage(
+            conversationHistory,
+            timeString,
+            repeatedActionMessage,
+          );
+        }
       }
 
       // We are about to replan, which means the batch we just ran did not finish

--- a/packages/core/tests/unit-test/task-executor-concurrency.test.ts
+++ b/packages/core/tests/unit-test/task-executor-concurrency.test.ts
@@ -818,4 +818,213 @@ ${thirdPlanningFeedback}`);
       'Current time: 2023-10-15 08:30:00 (YYYY-MM-DD HH:mm:ss)',
     ]);
   });
+
+  it('warns once before failing when the same action pattern repeats without completion', async () => {
+    const repeatedActions = [
+      'target A',
+      'intermediate B',
+      'navigation C',
+      'target A',
+      'intermediate B',
+      'navigation C',
+      'target A',
+      'intermediate B',
+      'navigation C',
+    ];
+    let planCallCount = 0;
+    const seenPendingFeedback: string[] = [];
+
+    vi.mocked(genericXmlPlan).mockImplementation(
+      async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        const locatePrompt = repeatedActions[planCallCount++] || 'target A';
+        return {
+          actions: [
+            { type: 'Tap', param: { locate: { prompt: locatePrompt } } },
+          ],
+          yamlFlow: [],
+          shouldContinuePlanning: true,
+          log: '',
+          rawResponse: '',
+        } as any;
+      },
+    );
+
+    await expect(
+      taskExecutor.action(
+        'repeat without completion',
+        planningModel(),
+        defaultModel(),
+        true,
+        undefined,
+        undefined,
+        10,
+      ),
+    ).rejects.toThrow('same action pattern repeated without completing');
+    expect(planCallCount).toBe(9);
+    expect(
+      seenPendingFeedback.some((feedback) =>
+        feedback.includes(
+          'The same action pattern has repeated without completing the task',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('continues when the planner changes path after repeated-pattern feedback', async () => {
+    const plannedActions = [
+      'target A',
+      'intermediate B',
+      'navigation C',
+      'target A',
+      'intermediate B',
+      'navigation C',
+      'different path D',
+    ];
+    let planCallCount = 0;
+    const seenPendingFeedback: string[] = [];
+
+    vi.mocked(genericXmlPlan).mockImplementation(
+      async (_instruction, opts: any) => {
+        seenPendingFeedback.push(
+          opts.conversationHistory.pendingFeedbackMessage,
+        );
+        const locatePrompt = plannedActions[planCallCount++];
+        if (!locatePrompt) {
+          return {
+            actions: [],
+            yamlFlow: [],
+            shouldContinuePlanning: false,
+            log: '',
+            rawResponse: '',
+            finalizeSuccess: true,
+            finalizeMessage: 'done',
+          } as any;
+        }
+
+        return {
+          actions: [
+            { type: 'Tap', param: { locate: { prompt: locatePrompt } } },
+          ],
+          yamlFlow: [],
+          shouldContinuePlanning: true,
+          log: '',
+          rawResponse: '',
+        } as any;
+      },
+    );
+
+    const result = await taskExecutor.action(
+      'change path after repeat warning',
+      planningModel(),
+      defaultModel(),
+      true,
+      undefined,
+      undefined,
+      10,
+    );
+
+    expect(result.output?.output).toBe('done');
+    expect(result.runner.latestErrorTask()).toBeNull();
+    expect(planCallCount).toBe(8);
+    expect(
+      seenPendingFeedback.some((feedback) =>
+        feedback.includes(
+          'The same action pattern has repeated without completing the task',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not fail non-repeating replanning actions', async () => {
+    const plannedActions = [
+      'target A',
+      'target B',
+      'target C',
+      'target D',
+      'target E',
+      'target F',
+    ];
+    let planCallCount = 0;
+
+    vi.mocked(genericXmlPlan).mockImplementation(async () => {
+      const locatePrompt = plannedActions[planCallCount++];
+      if (!locatePrompt) {
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: false,
+          log: '',
+          rawResponse: '',
+          finalizeSuccess: true,
+          finalizeMessage: 'done',
+        } as any;
+      }
+
+      return {
+        actions: [{ type: 'Tap', param: { locate: { prompt: locatePrompt } } }],
+        yamlFlow: [],
+        shouldContinuePlanning: true,
+        log: '',
+        rawResponse: '',
+      } as any;
+    });
+
+    const result = await taskExecutor.action(
+      'non-repeat replanning',
+      planningModel(),
+      defaultModel(),
+      true,
+      undefined,
+      undefined,
+      10,
+    );
+
+    expect(result.output?.output).toBe('done');
+    expect(result.runner.latestErrorTask()).toBeNull();
+    expect(planCallCount).toBe(7);
+  });
+
+  it('does not treat repeated scrolling as a stuck action pattern', async () => {
+    let planCallCount = 0;
+
+    vi.mocked(genericXmlPlan).mockImplementation(async () => {
+      planCallCount++;
+      if (planCallCount > 6) {
+        return {
+          actions: [],
+          yamlFlow: [],
+          shouldContinuePlanning: false,
+          log: '',
+          rawResponse: '',
+          finalizeSuccess: true,
+          finalizeMessage: 'done',
+        } as any;
+      }
+
+      return {
+        actions: [{ type: 'Scroll', param: { direction: 'down' } }],
+        yamlFlow: [],
+        shouldContinuePlanning: true,
+        log: '',
+        rawResponse: '',
+      } as any;
+    });
+
+    const result = await taskExecutor.action(
+      'scroll through a long page',
+      planningModel(),
+      defaultModel(),
+      true,
+      undefined,
+      undefined,
+      10,
+    );
+
+    expect(result.output?.output).toBe('done');
+    expect(result.runner.latestErrorTask()).toBeNull();
+    expect(planCallCount).toBe(7);
+  });
 });

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -94,6 +94,7 @@ export function ScrcpyPanel({
   const metadataTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ignoreDisconnectRef = useRef(false);
+  const connectionAttemptRef = useRef(0);
   const [status, setStatus] = useState<ScrcpyPreviewStatus>('connecting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [waitingStatusMessage, setWaitingStatusMessage] = useState<string>(() =>
@@ -223,6 +224,11 @@ export function ScrcpyPanel({
         return;
       }
 
+      const attemptId = connectionAttemptRef.current + 1;
+      connectionAttemptRef.current = attemptId;
+      const isCurrentAttempt = () =>
+        !disposed && connectionAttemptRef.current === attemptId;
+
       ignoreDisconnectRef.current = false;
       setStatus('connecting');
       setErrorMessage(null);
@@ -238,11 +244,14 @@ export function ScrcpyPanel({
       const videoStream = createScrcpyVideoStream(socket);
 
       socket.on('connect', () => {
+        if (!isCurrentAttempt()) {
+          return;
+        }
         setStatus('waiting-for-stream');
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
         clearMetadataTimeout();
         metadataTimeoutRef.current = setTimeout(() => {
-          if (disposed) {
+          if (!isCurrentAttempt()) {
             return;
           }
 
@@ -264,7 +273,7 @@ export function ScrcpyPanel({
       });
 
       socket.on('preview-status', (event: unknown) => {
-        if (disposed || !isScrcpyPreviewStatusEvent(event)) {
+        if (!isCurrentAttempt() || !isScrcpyPreviewStatusEvent(event)) {
           return;
         }
 
@@ -274,6 +283,9 @@ export function ScrcpyPanel({
 
       socket.on('video-metadata', async (metadata: VideoMetadata) => {
         try {
+          if (!isCurrentAttempt()) {
+            return;
+          }
           clearMetadataTimeout();
           disposeDecoder();
           setWaitingStatusMessage(getScrcpyDecoderStatusText());
@@ -295,7 +307,7 @@ export function ScrcpyPanel({
           decoderRef.current = decoder;
 
           videoStream.pipeTo(decoder.writable).catch((error: Error) => {
-            if (disposed) {
+            if (!isCurrentAttempt()) {
               return;
             }
             setStatus('error');
@@ -306,7 +318,7 @@ export function ScrcpyPanel({
           setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
           setStatus('connected');
         } catch (error) {
-          if (disposed) {
+          if (!isCurrentAttempt()) {
             return;
           }
           setStatus('error');
@@ -319,10 +331,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('disconnect', () => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         if (ignoreDisconnectRef.current) {
           ignoreDisconnectRef.current = false;
           return;
@@ -334,10 +346,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('connect_error', (error: Error) => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         setStatus('error');
         setErrorMessage(error.message);
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
@@ -345,10 +357,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('error', (error: Error) => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         setStatus('error');
         setErrorMessage(error.message);
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());


### PR DESCRIPTION
## Summary
- Recover Android preview more reliably when the scrcpy video stream fails or ends by notifying the renderer before asynchronously closing the stale client.
- Isolate stale ScrcpyPanel socket callbacks across reconnect attempts.
- Add generic repeated locate-action loop detection for aiAct/replay: warn the planner first, then fail only if the same loop continues.
- Tighten recorder replay prompt guidance to stop when recorded UI prerequisites are not reachable.

## Tests / verification
- pnpm run lint
- pnpm exec biome check packages/android-playground/src/scrcpy-server.ts packages/playground-app/src/ScrcpyPanel.tsx apps/studio/src/renderer/recorder/replay.ts packages/core/src/agent/tasks.ts packages/core/tests/unit-test/task-executor-concurrency.test.ts apps/studio/tests/studio-recorder.test.ts --diagnostic-level=info
- pnpm --filter @midscene/core test -- tests/unit-test/task-executor-concurrency.test.ts
- pnpm --filter @midscene/playground-app test -- tests/scrcpy-preview.test.ts tests/scrcpy-stream.test.ts
- pnpm --filter studio test -- tests/studio-recorder.test.ts -t "studio recorder replay adapters"

## Notes / risks
- This addresses the software-side scrcpy preview reconnect and repeated replay navigation loop observed in the logs. Physical USB/ADB transport instability can still require environment-side debugging.