### PR TITLE
feat(core): add httpRequest as a YAML flow item type

### DIFF
--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -301,6 +301,17 @@ export interface MidsceneYamlFlowItemLogScreenshot {
   content?: string;
 }
 
+export interface MidsceneYamlFlowItemHttpRequest {
+  httpRequest: {
+    url: string;
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    headers?: Record<string, string>;
+    body?: unknown;
+    timeout?: number;
+  };
+  name?: string;
+}
+
 export type MidsceneYamlFlowItem =
   | MidsceneYamlFlowItemAIAction
   | MidsceneYamlFlowItemAIAssert
@@ -308,7 +319,8 @@ export type MidsceneYamlFlowItem =
   | MidsceneYamlFlowItemRunGherkinScenario
   | MidsceneYamlFlowItemEvaluateJavaScript
   | MidsceneYamlFlowItemSleep
-  | MidsceneYamlFlowItemLogScreenshot;
+  | MidsceneYamlFlowItemLogScreenshot
+  | MidsceneYamlFlowItemHttpRequest;
 
 export interface FreeFn {
   name: string;

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -44,6 +44,7 @@ import type {
   MidsceneYamlFlowItemAIAssert,
   MidsceneYamlFlowItemAIWaitFor,
   MidsceneYamlFlowItemEvaluateJavaScript,
+  MidsceneYamlFlowItemHttpRequest,
   MidsceneYamlFlowItemLogScreenshot,
   MidsceneYamlFlowItemRunGherkinScenario,
   MidsceneYamlFlowItemSleep,
@@ -460,6 +461,49 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
         `ms for sleep must be greater than 0, but got ${ms}`,
       );
       await new Promise((resolve) => setTimeout(resolve, msNumber));
+    } else if ('httpRequest' in flowItem) {
+      const httpRequestTask = flowItem as unknown as MidsceneYamlFlowItemHttpRequest;
+      const { url, method = 'GET', headers, body, timeout } = httpRequestTask.httpRequest;
+      assert(url, 'missing url for httpRequest');
+
+      const init: RequestInit = { method, headers: headers as HeadersInit };
+      if (body !== undefined) {
+        init.body = JSON.stringify(body);
+        init.headers = {
+          'Content-Type': 'application/json',
+          ...(headers || {}),
+        };
+      }
+
+      let controller: AbortController | undefined;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      if (timeout !== undefined && timeout > 0) {
+        controller = new AbortController();
+        init.signal = controller.signal;
+        timeoutId = setTimeout(() => controller!.abort(), timeout);
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `httpRequest to ${url} failed with status ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      const data = contentType.includes('application/json')
+        ? await response.json()
+        : await response.text();
+
+      this.setResult(httpRequestTask.name, { status: response.status, data });
     } else if ('javascript' in flowItem) {
       const evaluateJavaScriptTask =
         flowItem as unknown as MidsceneYamlFlowItemEvaluateJavaScript;


### PR DESCRIPTION
Closes #2755

## What

Add `httpRequest` as a first-class flow item so YAML scripts can call HTTP endpoints (seed data, trigger webhooks, clean up state) directly, without wrapping everything in a `javascript` block.

```yaml
tasks:
  - name: seed test user
    flow:
      - httpRequest:
          url: https://api.example.com/users
          method: POST
          headers:
            Authorization: Bearer ${{ env.API_TOKEN }}
          body:
            name: Test User
            email: test@example.com
        name: createUserResponse

      - aiAction: fill in the login form with email test@example.com

      - httpRequest:
          url: https://api.example.com/users/{{createUserResponse.data.id}}
          method: DELETE
        name: cleanup
```

## Design decisions

1. **Non-2xx throws** — any non-OK response raises an error and fails the task immediately. This is the right default for test setup/teardown where a failed seed should abort the whole run.

2. **JSON-only body serialisation** — when `body` is present it is serialised with `JSON.stringify` and `Content-Type: application/json` is set automatically. Caller-supplied headers are merged on top so they can override it. Raw string/FormData bodies are out of scope for now.

3. **Timeout via `AbortController`** — optional `timeout` (milliseconds) aborts the fetch after the deadline instead of hanging the player indefinitely. Uses the `AbortController` / `fetch` built-ins available in Node 18+.

Result shape stored under `name`: `{ status: number, data: object | string }`.

## Validation

```
pnpm run lint   # passes clean
```