### PR TITLE
fix(studio): reclaim keyboard focus after Computer Target tap on second monitor

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -435,6 +435,9 @@ const createMainWindow = () => {
 };
 
 const registerIpcHandlers = () => {
+  ipcMain.handle(IPC_CHANNELS.focusWindow, () => {
+    mainWindow?.focus();
+  });
   ipcMain.handle(IPC_CHANNELS.minimizeWindow, () => {
     mainWindow?.minimize();
   });

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -12,6 +12,7 @@ import { contextBridge, ipcRenderer } from 'electron';
  */
 
 const electronShellApi: ElectronShellApi = {
+  focusWindow: () => ipcRenderer.invoke(IPC_CHANNELS.focusWindow),
   closeWindow: () => ipcRenderer.invoke(IPC_CHANNELS.closeWindow),
   minimizeWindow: () => ipcRenderer.invoke(IPC_CHANNELS.minimizeWindow),
   openExternalUrl: (url) =>

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -39,6 +39,9 @@ export const IPC_CHANNELS = {
   describeRecorderUIEvents: 'studio:describe-recorder-ui-events',
   prepareRecorderMarkdownReplay: 'studio:prepare-recorder-markdown-replay',
   chooseReplayFile: 'studio:choose-replay-file',
+  // Reclaim OS keyboard focus after a Computer Target native tap that moved
+  // focus to a foreground window on a second monitor (Windows multi-monitor).
+  focusWindow: 'shell:focus-window',
   // Auto-updater bridge — main owns the electron-updater state machine,
   // the renderer just renders it.
   updaterCheck: 'updater:check',
@@ -221,6 +224,12 @@ export interface DiscoverDevicesRequest {
  * pass through this interface so the renderer stays trivially sandboxable.
  */
 export interface ElectronShellApi {
+  /**
+   * Ask the main process to call `BrowserWindow.focus()` so the Electron
+   * window reclaims OS keyboard focus after a Computer Target native tap on a
+   * second monitor shifts focus away from the Studio window (Windows).
+   */
+  focusWindow: () => Promise<void>;
   /** Request the main process to close the current shell window. */
   closeWindow: () => Promise<void>;
   /** Request the main process to minimize the current shell window. */

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -293,6 +293,15 @@ export function PreviewRenderer({
       if (!res.ok) {
         showManualControlError('Tap failed', res.error);
       }
+      // On Windows, a native Computer Target tap can shift OS keyboard focus to
+      // the foreground window on the second monitor, silencing keydown events in
+      // the Studio renderer. Ask the main process to reclaim focus so the
+      // Recorder's keyboard listener stays active. No-op outside Electron.
+      (
+        window as {
+          electronShell?: { focusWindow?: () => Promise<void> };
+        }
+      ).electronShell?.focusWindow?.();
     },
     [
       enqueueManualControl,


### PR DESCRIPTION
## Problem

Fixes #2748.

When Studio is open on Monitor A and a Computer Target tap is dispatched to Monitor B, the Windows OS shifts keyboard focus to the foreground window on Monitor B. After that point, `window.addEventListener('keydown', ...)` in the Studio Electron renderer stops receiving events, so the Recorder silently drops every keystroke until the user manually clicks back into the Studio window.

Root cause: the native tap synthesized by the Computer driver is treated by Windows as user interaction on Monitor B, triggering a foreground-window change that pulls OS keyboard focus away from the Electron `BrowserWindow` on Monitor A.

## Fix

Add a `focusWindow` IPC channel (`shell:focus-window`) that lets the renderer ask the main process to call `BrowserWindow.focus()`, reclaiming OS keyboard focus after each tap.

**`apps/studio/src/shared/electron-contract.ts`**
- Add `focusWindow: 'shell:focus-window'` to `IPC_CHANNELS`.
- Add `focusWindow(): Promise<void>` to the `ElectronShellApi` interface.

**`apps/studio/src/preload/index.ts`**
- Wire the channel: `focusWindow: () => ipcRenderer.invoke(IPC_CHANNELS.focusWindow)`.

**`apps/studio/src/main/index.ts`**
- Handle in the main process: `ipcMain.handle(IPC_CHANNELS.focusWindow, () => { mainWindow?.focus(); })`.

**`packages/playground-app/src/PreviewRenderer.tsx`**
- Call `window.electronShell?.focusWindow?.()` at the end of `handleTap`, after the tap response is received. Optional chaining makes this a no-op in browser and Chrome-extension contexts where `window.electronShell` is absent.

## Validation

- `pnpm run lint` — clean.