### PR TITLE
Fix Puppeteer CLI connection lifecycle and tab reuse

### DIFF
--- a/packages/web-integration/src/agent-tools-puppeteer.ts
+++ b/packages/web-integration/src/agent-tools-puppeteer.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ScreenshotItem } from '@midscene/core';
@@ -36,6 +36,7 @@ const ENDPOINT_FILE = join(tmpdir(), 'midscene-puppeteer-endpoint');
 const USER_DATA_DIR = join(tmpdir(), 'midscene-puppeteer-profile');
 const TARGET_ID_FILE = join(tmpdir(), 'midscene-puppeteer-target-id');
 const DETACHED_CHROME_LAUNCH_TIMEOUT_MS = 30_000;
+const DETACHED_CHROME_ENDPOINT_POLL_INTERVAL_MS = 25;
 const debug = getDebug('agent-tools:puppeteer');
 
 export const PUPPETEER_ENDPOINT_FILE = ENDPOINT_FILE;
@@ -96,21 +97,21 @@ function getTargetId(page: Page): string | undefined {
 
 export function waitForDetachedChromeEndpoint(
   proc: ChildProcess,
+  stderrFile: string,
   timeoutMs = DETACHED_CHROME_LAUNCH_TIMEOUT_MS,
 ): Promise<string> {
-  const stderr = proc.stderr;
-  if (!stderr) {
-    return Promise.reject(new Error('Chrome stderr pipe is unavailable.'));
-  }
-
   return new Promise<string>((resolve, reject) => {
     let output = '';
     let settled = false;
+    let exited = false;
+    let pollTimer: NodeJS.Timeout | undefined;
     const cleanup = () => {
       clearTimeout(timeout);
-      stderr.removeListener('data', onData);
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
       proc.removeListener('exit', onExit);
-      stderr.destroy();
+      proc.removeListener('error', onError);
     };
     const resolveOnce = (value: string) => {
       if (settled) return;
@@ -127,18 +128,50 @@ export function waitForDetachedChromeEndpoint(
       cleanup();
       reject(error);
     };
-    const onData = (data: Buffer) => {
-      output += data.toString();
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      exited = true;
+      void readFile(stderrFile, 'utf-8')
+        .catch(() => output)
+        .then((latestOutput) => {
+          output = latestOutput;
+          rejectOnce(
+            new Error(
+              `Chrome exited with code ${code ?? signal} before DevTools was ready.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
+            ),
+          );
+        });
+    };
+    const onError = (error: Error) => {
+      rejectOnce(
+        new Error(`Failed to launch Chrome. Stderr log: "${stderrFile}".`, {
+          cause: error,
+        }),
+        true,
+      );
+    };
+    const pollForEndpoint = async (): Promise<void> => {
+      if (settled || exited) return;
+      try {
+        output = await readFile(stderrFile, 'utf-8');
+      } catch (error) {
+        rejectOnce(
+          new Error(`Failed to read Chrome stderr log "${stderrFile}".`, {
+            cause: error,
+          }),
+          true,
+        );
+        return;
+      }
+
+      if (settled || exited) return;
       const match = output.match(/DevTools listening on (ws:\/\/[^\s]+)/);
       if (match) {
         resolveOnce(match[1]);
+        return;
       }
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      rejectOnce(
-        new Error(
-          `Chrome exited with code ${code ?? signal} before DevTools was ready.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
-        ),
+      pollTimer = setTimeout(
+        () => void pollForEndpoint(),
+        DETACHED_CHROME_ENDPOINT_POLL_INTERVAL_MS,
       );
     };
     const timeout = setTimeout(
@@ -152,8 +185,9 @@ export function waitForDetachedChromeEndpoint(
       timeoutMs,
     );
 
-    stderr.on('data', onData);
     proc.on('exit', onExit);
+    proc.on('error', onError);
+    void pollForEndpoint();
   });
 }
 
@@ -178,14 +212,29 @@ class PuppeteerBrowserManager {
     return this.persistence.targetIdFile || TARGET_ID_FILE;
   }
 
+  private get chromeStderrFile() {
+    return join(this.userDataDir, 'chrome-stderr.log');
+  }
+
   async readSavedTargetId(): Promise<string | null> {
-    if (!existsSync(this.targetIdFile)) return null;
+    let content: string;
     try {
-      return (await readFile(this.targetIdFile, 'utf-8')).trim() || null;
+      content = await readFile(this.targetIdFile, 'utf-8');
     } catch (error) {
-      debug('Failed to read saved Puppeteer targetId: %s', error);
-      return null;
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw new Error(
+        `Failed to read Puppeteer targetId from "${this.targetIdFile}".`,
+        { cause: error },
+      );
     }
+
+    const targetId = content.trim();
+    if (!targetId) {
+      throw new Error(
+        `Puppeteer targetId file "${this.targetIdFile}" is empty.`,
+      );
+    }
+    return targetId;
   }
 
   async saveTargetId(targetId: string): Promise<void> {
@@ -193,16 +242,32 @@ class PuppeteerBrowserManager {
       await writeFile(this.targetIdFile, targetId, 'utf-8');
       debug('Saved Puppeteer targetId: %s', targetId);
     } catch (error) {
-      debug('Failed to save Puppeteer targetId: %s', error);
+      throw new Error(
+        `Failed to save Puppeteer targetId to "${this.targetIdFile}".`,
+        { cause: error },
+      );
     }
   }
 
   async cleanupTargetIdFile(): Promise<void> {
-    if (!existsSync(this.targetIdFile)) return;
     try {
       await unlink(this.targetIdFile);
     } catch (error) {
-      debug('Failed to clean Puppeteer targetId file: %s', error);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw new Error(
+        `Failed to remove Puppeteer targetId file "${this.targetIdFile}".`,
+        { cause: error },
+      );
+    }
+  }
+
+  async cleanupChromeStderrFile(): Promise<void> {
+    try {
+      await unlink(this.chromeStderrFile);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        debug('Failed to clean Chrome stderr log: %s', error);
+      }
     }
   }
 
@@ -257,6 +322,7 @@ class PuppeteerBrowserManager {
       }
     } catch {}
     await this.cleanupTargetIdFile();
+    await this.cleanupChromeStderrFile();
   }
 
   disconnect(): void {
@@ -277,13 +343,31 @@ class PuppeteerBrowserManager {
       viewport,
     });
 
-    const proc = spawn(chromePath, args, {
-      detached: true,
-      stdio: ['ignore', 'ignore', 'pipe'],
-    });
+    const stderrFile = this.chromeStderrFile;
+    const stderrHandle = await open(stderrFile, 'w');
+    let proc: ChildProcess;
+    try {
+      proc = spawn(chromePath, args, {
+        detached: true,
+        stdio: ['ignore', 'ignore', stderrHandle.fd],
+      });
+    } catch (error) {
+      await stderrHandle.close();
+      throw error;
+    }
+    const endpointPromise = waitForDetachedChromeEndpoint(proc, stderrFile);
     proc.unref();
+    try {
+      await stderrHandle.close();
+    } catch (error) {
+      terminateDetachedChrome(proc);
+      await endpointPromise.catch(() => undefined);
+      throw new Error(`Failed to close Chrome stderr log "${stderrFile}".`, {
+        cause: error,
+      });
+    }
 
-    return waitForDetachedChromeEndpoint(proc);
+    return endpointPromise;
   }
 }
 
@@ -394,13 +478,12 @@ export class WebPuppeteerMidsceneTools extends BaseMidsceneTools<
     }
 
     const targetId = getTargetId(page);
-    if (targetId) {
-      await this.browserManager.saveTargetId(targetId);
-    } else {
-      debug(
-        'No targetId on Puppeteer page target; falling back to page ordering on the next CLI command.',
+    if (!targetId) {
+      throw new Error(
+        'Failed to persist Puppeteer page session because Puppeteer did not expose a Chrome targetId.',
       );
     }
+    await this.browserManager.saveTargetId(targetId);
 
     const reportOptions = this.readCliReportAgentOptions();
     this.agent = new PuppeteerAgent(page as unknown as PuppeteerPage, {

--- a/packages/web-integration/src/agent-tools-puppeteer.ts
+++ b/packages/web-integration/src/agent-tools-puppeteer.ts
@@ -15,6 +15,7 @@ import {
 } from '@midscene/shared/agent-tools/base-tools';
 import { resolveChromePath } from '@midscene/shared/agent-tools/chrome-path';
 import type { ToolDefinition } from '@midscene/shared/agent-tools/types';
+import { getDebug } from '@midscene/shared/logger';
 import type { Page as PuppeteerPage } from 'puppeteer';
 import puppeteer from 'puppeteer-core';
 import type { Browser, Page } from 'puppeteer-core';
@@ -33,13 +34,16 @@ import { StaticPage } from './static';
 
 const ENDPOINT_FILE = join(tmpdir(), 'midscene-puppeteer-endpoint');
 const USER_DATA_DIR = join(tmpdir(), 'midscene-puppeteer-profile');
+const TARGET_ID_FILE = join(tmpdir(), 'midscene-puppeteer-target-id');
 const DETACHED_CHROME_LAUNCH_TIMEOUT_MS = 30_000;
+const debug = getDebug('agent-tools:puppeteer');
 
 export const PUPPETEER_ENDPOINT_FILE = ENDPOINT_FILE;
 
 export interface PuppeteerPersistenceOptions {
   endpointFile?: string;
   userDataDir?: string;
+  targetIdFile?: string;
 }
 
 export interface WebPuppeteerMidsceneToolsOptions {
@@ -86,6 +90,73 @@ function terminateDetachedChrome(proc: ChildProcess): void {
   } catch {}
 }
 
+function getTargetId(page: Page): string | undefined {
+  return (page.target() as unknown as { _targetId?: string })._targetId;
+}
+
+export function waitForDetachedChromeEndpoint(
+  proc: ChildProcess,
+  timeoutMs = DETACHED_CHROME_LAUNCH_TIMEOUT_MS,
+): Promise<string> {
+  const stderr = proc.stderr;
+  if (!stderr) {
+    return Promise.reject(new Error('Chrome stderr pipe is unavailable.'));
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    let output = '';
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stderr.removeListener('data', onData);
+      proc.removeListener('exit', onExit);
+      stderr.destroy();
+    };
+    const resolveOnce = (value: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const rejectOnce = (error: Error, terminate = false) => {
+      if (settled) return;
+      settled = true;
+      if (terminate) {
+        terminateDetachedChrome(proc);
+      }
+      cleanup();
+      reject(error);
+    };
+    const onData = (data: Buffer) => {
+      output += data.toString();
+      const match = output.match(/DevTools listening on (ws:\/\/[^\s]+)/);
+      if (match) {
+        resolveOnce(match[1]);
+      }
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      rejectOnce(
+        new Error(
+          `Chrome exited with code ${code ?? signal} before DevTools was ready.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
+        ),
+      );
+    };
+    const timeout = setTimeout(
+      () =>
+        rejectOnce(
+          new Error(
+            `Chrome launch timeout.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
+          ),
+          true,
+        ),
+      timeoutMs,
+    );
+
+    stderr.on('data', onData);
+    proc.on('exit', onExit);
+  });
+}
+
 /**
  * Persistent Puppeteer browser manager.
  * Launches a detached Chrome and persists the WS endpoint across CLI calls.
@@ -103,6 +174,38 @@ class PuppeteerBrowserManager {
     return this.persistence.userDataDir || USER_DATA_DIR;
   }
 
+  private get targetIdFile() {
+    return this.persistence.targetIdFile || TARGET_ID_FILE;
+  }
+
+  async readSavedTargetId(): Promise<string | null> {
+    if (!existsSync(this.targetIdFile)) return null;
+    try {
+      return (await readFile(this.targetIdFile, 'utf-8')).trim() || null;
+    } catch (error) {
+      debug('Failed to read saved Puppeteer targetId: %s', error);
+      return null;
+    }
+  }
+
+  async saveTargetId(targetId: string): Promise<void> {
+    try {
+      await writeFile(this.targetIdFile, targetId, 'utf-8');
+      debug('Saved Puppeteer targetId: %s', targetId);
+    } catch (error) {
+      debug('Failed to save Puppeteer targetId: %s', error);
+    }
+  }
+
+  async cleanupTargetIdFile(): Promise<void> {
+    if (!existsSync(this.targetIdFile)) return;
+    try {
+      await unlink(this.targetIdFile);
+    } catch (error) {
+      debug('Failed to clean Puppeteer targetId file: %s', error);
+    }
+  }
+
   async getOrLaunch(
     viewport?: ViewportSize,
   ): Promise<{ browser: Browser; reused: boolean }> {
@@ -115,13 +218,16 @@ class PuppeteerBrowserManager {
           defaultViewport: null,
         });
         return { browser, reused: true };
-      } catch {
+      } catch (error) {
+        debug('Failed to reuse persisted Puppeteer endpoint: %s', error);
         try {
           await unlink(endpointFile);
         } catch {}
+        await this.cleanupTargetIdFile();
       }
     }
 
+    await this.cleanupTargetIdFile();
     const wsEndpoint = await this.launchDetachedChrome(viewport);
     await writeFile(endpointFile, wsEndpoint);
 
@@ -134,17 +240,23 @@ class PuppeteerBrowserManager {
 
   async closeBrowser(): Promise<void> {
     const endpointFile = this.endpointFile;
-    if (!existsSync(endpointFile)) return;
+    if (existsSync(endpointFile)) {
+      try {
+        const endpoint = (await readFile(endpointFile, 'utf-8')).trim();
+        const browser = await puppeteer.connect({
+          browserWSEndpoint: endpoint,
+        });
+        await browser.close();
+      } catch (error) {
+        debug('Failed to close persisted Puppeteer browser: %s', error);
+      }
+    }
     try {
-      const endpoint = (await readFile(endpointFile, 'utf-8')).trim();
-      const browser = await puppeteer.connect({
-        browserWSEndpoint: endpoint,
-      });
-      await browser.close();
+      if (existsSync(endpointFile)) {
+        await unlink(endpointFile);
+      }
     } catch {}
-    try {
-      await unlink(endpointFile);
-    } catch {}
+    await this.cleanupTargetIdFile();
   }
 
   disconnect(): void {
@@ -171,58 +283,7 @@ class PuppeteerBrowserManager {
     });
     proc.unref();
 
-    return new Promise<string>((resolve, reject) => {
-      let output = '';
-      let settled = false;
-      const cleanup = () => {
-        clearTimeout(timeout);
-        proc.stderr!.removeListener('data', onData);
-        proc.removeListener('exit', onExit);
-      };
-      const resolveOnce = (value: string) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        resolve(value);
-      };
-      const rejectOnce = (error: Error, terminate = false) => {
-        if (settled) return;
-        settled = true;
-        if (terminate) {
-          terminateDetachedChrome(proc);
-        }
-        cleanup();
-        reject(error);
-      };
-      const onData = (data: Buffer) => {
-        output += data.toString();
-        const match = output.match(/DevTools listening on (ws:\/\/[^\s]+)/);
-        if (match) {
-          resolveOnce(match[1]);
-        }
-      };
-      proc.stderr!.on('data', onData);
-
-      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-        rejectOnce(
-          new Error(
-            `Chrome exited with code ${code ?? signal} before DevTools was ready.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
-          ),
-        );
-      };
-      proc.on('exit', onExit);
-
-      const timeout = setTimeout(
-        () =>
-          rejectOnce(
-            new Error(
-              `Chrome launch timeout.\nChrome stderr: ${output}\nTip: if running in a container, launch Chrome with sandbox-compatible arguments.`,
-            ),
-            true,
-          ),
-        DETACHED_CHROME_LAUNCH_TIMEOUT_MS,
-      );
-    });
+    return waitForDetachedChromeEndpoint(proc);
   }
 }
 
@@ -313,12 +374,16 @@ export class WebPuppeteerMidsceneTools extends BaseMidsceneTools<
         waitUntil: 'domcontentloaded',
       });
     } else {
-      // Reuse the last web page
+      const savedTargetId = await this.browserManager.readSavedTargetId();
+      const matchedPage = savedTargetId
+        ? pages.find((candidate) => getTargetId(candidate) === savedTargetId)
+        : undefined;
       const webPages = pages.filter((p) => /^https?:\/\//.test(p.url()));
       page =
-        webPages.length > 0
+        matchedPage ??
+        (webPages.length > 0
           ? webPages[webPages.length - 1]
-          : pages[pages.length - 1] || (await browser.newPage());
+          : pages[pages.length - 1] || (await browser.newPage()));
 
       if (reused) {
         await page.bringToFront();
@@ -326,6 +391,15 @@ export class WebPuppeteerMidsceneTools extends BaseMidsceneTools<
       if (this.viewport) {
         await page.setViewport(this.viewport);
       }
+    }
+
+    const targetId = getTargetId(page);
+    if (targetId) {
+      await this.browserManager.saveTargetId(targetId);
+    } else {
+      debug(
+        'No targetId on Puppeteer page target; falling back to page ordering on the next CLI command.',
+      );
     }
 
     const reportOptions = this.readCliReportAgentOptions();
@@ -394,6 +468,7 @@ export class WebPuppeteerMidsceneTools extends BaseMidsceneTools<
             this.lastInitArgsSignature = undefined;
           }
           this.browserManager.disconnect();
+          await this.browserManager.cleanupTargetIdFile();
           return this.buildTextResult(
             'Disconnected from web page (browser still running)',
           );

--- a/packages/web-integration/tests/unit-test/agent-init-args.test.ts
+++ b/packages/web-integration/tests/unit-test/agent-init-args.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { WebMidsceneTools } from '@/agent-tools';
@@ -67,7 +73,7 @@ vi.mock('@/cdp-target-store', () => ({
 
 function createPersistenceRoot(): {
   root: string;
-  persistence: Required<PuppeteerPersistenceOptions>;
+  persistence: PuppeteerPersistenceOptions & { targetIdFile: string };
 } {
   const root = join(
     tmpdir(),
@@ -77,6 +83,7 @@ function createPersistenceRoot(): {
   const persistence = {
     endpointFile: join(root, 'endpoint'),
     userDataDir: join(root, 'profile'),
+    targetIdFile: join(root, 'target-id'),
   };
   writeFileSync(persistence.endpointFile, 'ws://127.0.0.1:9222/devtools/1');
   return { root, persistence };
@@ -213,6 +220,70 @@ describe('web agent tool init args', () => {
           screenshotShrinkFactor: 2,
         }),
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the saved Puppeteer target when browser.pages returns newer tabs first', async () => {
+    const { root, persistence } = createPersistenceRoot();
+    const newerPage = {
+      ...mockPage,
+      url: vi.fn(() => 'https://bbb.example.com/'),
+      target: vi.fn(() => ({ _targetId: 'target-bbb' })),
+    };
+    const olderPage = {
+      ...mockPage,
+      url: vi.fn(() => 'https://aaa.example.com/'),
+      target: vi.fn(() => ({ _targetId: 'target-aaa' })),
+    };
+
+    try {
+      writeFileSync(persistence.targetIdFile, 'target-bbb');
+      mockBrowser.pages.mockResolvedValueOnce([newerPage, olderPage]);
+
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+
+      const takeScreenshotTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'take_screenshot');
+      await takeScreenshotTool?.handler({});
+
+      expect(PuppeteerAgent).toHaveBeenLastCalledWith(
+        newerPage,
+        expect.any(Object),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('persists the connected Puppeteer target and clears it on disconnect and close', async () => {
+    const { root, persistence } = createPersistenceRoot();
+
+    try {
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const connectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_connect');
+      const disconnectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_disconnect');
+      const closeTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_close');
+
+      await connectTool?.handler({ web: { url: 'https://bbb.example.com' } });
+      expect(readFileSync(persistence.targetIdFile, 'utf-8')).toBe('target-1');
+
+      await disconnectTool?.handler({});
+      expect(existsSync(persistence.targetIdFile)).toBe(false);
+
+      writeFileSync(persistence.targetIdFile, 'target-1');
+      await closeTool?.handler({});
+      expect(existsSync(persistence.targetIdFile)).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/web-integration/tests/unit-test/agent-init-args.test.ts
+++ b/packages/web-integration/tests/unit-test/agent-init-args.test.ts
@@ -25,7 +25,7 @@ const mockPage = {
   bringToFront: vi.fn(),
   goto: vi.fn(),
   setViewport: vi.fn(),
-  target: vi.fn(() => ({ _targetId: 'target-1' })),
+  target: vi.fn((): { _targetId?: string } => ({ _targetId: 'target-1' })),
 };
 
 const mockBrowser = {
@@ -87,6 +87,15 @@ function createPersistenceRoot(): {
   };
   writeFileSync(persistence.endpointFile, 'ws://127.0.0.1:9222/devtools/1');
   return { root, persistence };
+}
+
+async function rejectedError(promise: Promise<unknown>): Promise<Error> {
+  const error = await promise.then(
+    () => null,
+    (reason: unknown) => reason,
+  );
+  expect(error).toBeInstanceOf(Error);
+  return error as Error;
 }
 
 type WebInitArgTestFactory = () => {
@@ -254,6 +263,117 @@ describe('web agent tool init args', () => {
         newerPage,
         expect.any(Object),
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails instead of guessing a Puppeteer tab when the saved target cannot be read', async () => {
+    const { root, persistence } = createPersistenceRoot();
+
+    try {
+      mkdirSync(persistence.targetIdFile);
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const connectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_connect');
+
+      const error = await rejectedError(connectTool!.handler({}));
+
+      expect(error.message).toContain(
+        `Failed to read Puppeteer targetId from "${persistence.targetIdFile}"`,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(PuppeteerAgent).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails the current command when the Puppeteer target cannot be saved', async () => {
+    const { root, persistence } = createPersistenceRoot();
+
+    try {
+      mkdirSync(persistence.targetIdFile);
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const connectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_connect');
+
+      const error = await rejectedError(
+        connectTool!.handler({ web: { url: 'https://bbb.example.com' } }),
+      );
+
+      expect(error.message).toContain(
+        `Failed to save Puppeteer targetId to "${persistence.targetIdFile}"`,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(PuppeteerAgent).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an empty Puppeteer target file as corrupt state', async () => {
+    const { root, persistence } = createPersistenceRoot();
+
+    try {
+      writeFileSync(persistence.targetIdFile, ' \n');
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const connectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_connect');
+
+      await expect(connectTool!.handler({})).rejects.toThrow(
+        `Puppeteer targetId file "${persistence.targetIdFile}" is empty`,
+      );
+      expect(PuppeteerAgent).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the existing page when no Puppeteer target has been saved yet', async () => {
+    const { root, persistence } = createPersistenceRoot();
+
+    try {
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const takeScreenshotTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'take_screenshot');
+
+      await takeScreenshotTool!.handler({});
+
+      expect(PuppeteerAgent).toHaveBeenCalledWith(mockPage, expect.any(Object));
+      expect(readFileSync(persistence.targetIdFile, 'utf-8')).toBe('target-1');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when Puppeteer does not expose a target ID for the selected page', async () => {
+    const { root, persistence } = createPersistenceRoot();
+    const pageWithoutTargetId = {
+      ...mockPage,
+      target: vi.fn(() => ({})),
+    };
+
+    try {
+      mockBrowser.pages.mockResolvedValueOnce([pageWithoutTargetId]);
+      const tools = new WebPuppeteerMidsceneTools(undefined, { persistence });
+      await tools.initTools();
+      const connectTool = tools
+        .getToolDefinitions()
+        .find((tool) => tool.name === 'web_connect');
+
+      await expect(connectTool!.handler({})).rejects.toThrow(
+        'Puppeteer did not expose a Chrome targetId',
+      );
+      expect(PuppeteerAgent).not.toHaveBeenCalled();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/web-integration/tests/unit-test/agent-tools-puppeteer.test.ts
+++ b/packages/web-integration/tests/unit-test/agent-tools-puppeteer.test.ts
@@ -1,6 +1,10 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import {
   WebPuppeteerMidsceneTools,
   buildDetachedChromeArgs,
+  waitForDetachedChromeEndpoint,
 } from '@/agent-tools-puppeteer';
 import {
   defaultPuppeteerWindowViewportSize,
@@ -9,6 +13,26 @@ import {
 import { describe, expect, it } from 'vitest';
 
 describe('WebPuppeteerMidsceneTools', () => {
+  it('releases the Chrome stderr pipe after reading the DevTools endpoint', async () => {
+    const stderr = new PassThrough();
+    const proc = Object.assign(new EventEmitter(), {
+      stderr,
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+    }) as unknown as ChildProcess;
+    const endpointPromise = waitForDetachedChromeEndpoint(proc, 1_000);
+
+    stderr.write(
+      'Chrome startup log\nDevTools listening on ws://127.0.0.1:9222/devtools/browser/test\n',
+    );
+
+    await expect(endpointPromise).resolves.toBe(
+      'ws://127.0.0.1:9222/devtools/browser/test',
+    );
+    expect(stderr.destroyed).toBe(true);
+  });
+
   it('builds detached Chrome args from the configured viewport', () => {
     const args = buildDetachedChromeArgs({
       userDataDir: '/tmp/midscene-profile',

--- a/packages/web-integration/tests/unit-test/agent-tools-puppeteer.test.ts
+++ b/packages/web-integration/tests/unit-test/agent-tools-puppeteer.test.ts
@@ -1,6 +1,14 @@
-import type { ChildProcess } from 'node:child_process';
-import { EventEmitter } from 'node:events';
-import { PassThrough } from 'node:stream';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   WebPuppeteerMidsceneTools,
   buildDetachedChromeArgs,
@@ -13,24 +21,62 @@ import {
 import { describe, expect, it } from 'vitest';
 
 describe('WebPuppeteerMidsceneTools', () => {
-  it('releases the Chrome stderr pipe after reading the DevTools endpoint', async () => {
-    const stderr = new PassThrough();
-    const proc = Object.assign(new EventEmitter(), {
-      stderr,
-      killed: false,
-      exitCode: null,
-      signalCode: null,
-    }) as unknown as ChildProcess;
-    const endpointPromise = waitForDetachedChromeEndpoint(proc, 1_000);
-
-    stderr.write(
-      'Chrome startup log\nDevTools listening on ws://127.0.0.1:9222/devtools/browser/test\n',
+  it('keeps a child process alive when it continues writing stderr after endpoint discovery', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-chrome-stderr-'));
+    const stderrFile = join(root, 'chrome-stderr.log');
+    const stderrFd = openSync(stderrFile, 'w');
+    const proc = spawn(
+      process.execPath,
+      [
+        '-e',
+        `
+          process.stderr.write('DevTools listening on ws://127.0.0.1:9222/devtools/browser/test\\n');
+          let count = 0;
+          const timer = setInterval(() => {
+            count += 1;
+            process.stderr.write('runtime log ' + count + '\\n');
+            if (count === 3) {
+              clearInterval(timer);
+              process.stdout.write('alive\\n');
+              setTimeout(() => process.exit(0), 20);
+            }
+          }, 20);
+        `,
+      ],
+      { stdio: ['ignore', 'pipe', stderrFd] },
     );
-
-    await expect(endpointPromise).resolves.toBe(
-      'ws://127.0.0.1:9222/devtools/browser/test',
+    const endpointPromise = waitForDetachedChromeEndpoint(
+      proc,
+      stderrFile,
+      1_000,
     );
-    expect(stderr.destroyed).toBe(true);
+    closeSync(stderrFd);
+
+    try {
+      const alivePromise = once(proc.stdout!, 'data', {
+        signal: AbortSignal.timeout(1_000),
+      });
+      const exitPromise = once(proc, 'exit', {
+        signal: AbortSignal.timeout(1_000),
+      });
+      await expect(endpointPromise).resolves.toBe(
+        'ws://127.0.0.1:9222/devtools/browser/test',
+      );
+      const [aliveOutput] = await alivePromise;
+      const [exitCode, signal] = await exitPromise;
+
+      expect(aliveOutput.toString()).toContain('alive');
+      expect(exitCode).toBe(0);
+      expect(signal).toBeNull();
+      expect(readFileSync(stderrFile, 'utf-8')).toContain('runtime log 3');
+    } finally {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        const exitPromise = once(proc, 'exit');
+        proc.kill('SIGTERM');
+        await exitPromise;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('builds detached Chrome args from the configured viewport', () => {

--- a/packages/web-integration/tests/unit-test/cli-viewport-e2e.test.ts
+++ b/packages/web-integration/tests/unit-test/cli-viewport-e2e.test.ts
@@ -54,6 +54,7 @@ describe('midscene-web CLI viewport e2e', () => {
     persistence = {
       endpointFile: join(persistentRoot, 'endpoint'),
       userDataDir: join(persistentRoot, 'profile'),
+      targetIdFile: join(persistentRoot, 'target-id'),
     };
 
     server = createServer((_req, res) => {


### PR DESCRIPTION
## Summary

- redirect detached Chrome stderr to a profile-scoped log file and poll it for the DevTools endpoint without closing Chrome's live stderr destination
- persist the exact Puppeteer target ID across stateless CLI commands so actions remain on the most recently connected tab
- fail explicitly when target ID state cannot be read or written, or is corrupt, instead of silently falling back to page ordering
- clear persisted tab and stderr state when the browser endpoint becomes stale, on explicit disconnect, and on browser close
- add regression coverage with a real child process that continues writing stderr after endpoint discovery, plus target state read/write failure cases

## Root cause

The first `connect --url` invocation kept the detached Chrome stderr pipe referenced after the browser was ready. Destroying that pipe would let the CLI exit, but would also remove Chrome's live stderr reader and risk `EPIPE` or a broken pipe on later writes. Later CLI commands also inferred the current page from `browser.pages()` ordering, which is not stable across Chrome reconnections and could select an older tab.

Chrome now inherits a regular log file as stderr, while the launcher closes only its own file descriptor. Target ID persistence is treated as required cross-command state: only a missing state file or a target that the user has closed uses the intended recovery path.

## Validation

- `npx nx test @midscene/web --skip-nx-cache` (375 passed, 1 skipped)
- `npx nx build @midscene/web --skip-nx-cache`
- `pnpm run lint`
- real headless Google Chrome verification: the first connection exited normally while Chrome remained alive with stderr attached to `chrome-stderr.log`; after connecting AAA then BBB, the persisted target ID matched BBB and a fresh CLI screenshot showed BBB
- `midscene-web close` closed Chrome and removed the stderr log

## Prepatch

- Release run: https://github.com/web-infra-dev/midscene/actions/runs/29097193666
- Published `1.10.4-beta-20260710135045.0`
- Verified the exact version and `beta` dist-tag for `@midscene/core`, `@midscene/web`, and `@midscene/cli`