### PR TITLE
fix(report): truncate long case descriptions

### DIFF
--- a/apps/report/src/components/playwright-case-selector/case-description.ts
+++ b/apps/report/src/components/playwright-case-selector/case-description.ts
@@ -1,0 +1,20 @@
+import type { PlaywrightTaskAttributes } from '../../types';
+
+const MAX_FAILED_CASE_DESCRIPTION_LENGTH = 30;
+
+export function getCaseDescription(
+  attributes: Pick<
+    PlaywrightTaskAttributes,
+    'playwright_test_description' | 'playwright_test_status'
+  >,
+): string {
+  const description = attributes.playwright_test_description;
+  if (
+    attributes.playwright_test_status === 'failed' &&
+    description.length > MAX_FAILED_CASE_DESCRIPTION_LENGTH
+  ) {
+    return `${description.slice(0, MAX_FAILED_CASE_DESCRIPTION_LENGTH - 3)}...`;
+  }
+
+  return description;
+}

--- a/apps/report/src/components/playwright-case-selector/case-description.ts
+++ b/apps/report/src/components/playwright-case-selector/case-description.ts
@@ -1,6 +1,6 @@
 import type { PlaywrightTaskAttributes } from '../../types';
 
-const MAX_FAILED_CASE_DESCRIPTION_LENGTH = 30;
+const MAX_FAILED_CASE_DESCRIPTION_LENGTH = 300;
 
 export function getCaseDescription(
   attributes: Pick<

--- a/apps/report/src/components/playwright-case-selector/case-description.ts
+++ b/apps/report/src/components/playwright-case-selector/case-description.ts
@@ -1,19 +1,8 @@
-import type { PlaywrightTaskAttributes } from '../../types';
+const MAX_CASE_DESCRIPTION_LENGTH = 100;
 
-const MAX_FAILED_CASE_DESCRIPTION_LENGTH = 300;
-
-export function getCaseDescription(
-  attributes: Pick<
-    PlaywrightTaskAttributes,
-    'playwright_test_description' | 'playwright_test_status'
-  >,
-): string {
-  const description = attributes.playwright_test_description;
-  if (
-    attributes.playwright_test_status === 'failed' &&
-    description.length > MAX_FAILED_CASE_DESCRIPTION_LENGTH
-  ) {
-    return `${description.slice(0, MAX_FAILED_CASE_DESCRIPTION_LENGTH - 3)}...`;
+export function getCaseDescription(description: string): string {
+  if (description.length > MAX_CASE_DESCRIPTION_LENGTH) {
+    return `${description.slice(0, MAX_CASE_DESCRIPTION_LENGTH - 3)}...`;
   }
 
   return description;

--- a/apps/report/src/components/playwright-case-selector/index.tsx
+++ b/apps/report/src/components/playwright-case-selector/index.tsx
@@ -129,9 +129,9 @@ function PlaywrightCaseTitle(props: {
         <>
           {' - '}
           {isDescriptionTruncated ? (
-            <Tooltip title={fullDescription}>
-              <span className="case-description">{description}</span>
-            </Tooltip>
+            <span className="case-description" title={fullDescription}>
+              {description}
+            </span>
           ) : (
             description
           )}

--- a/apps/report/src/components/playwright-case-selector/index.tsx
+++ b/apps/report/src/components/playwright-case-selector/index.tsx
@@ -9,6 +9,7 @@ import { Input, Tooltip } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { PlaywrightTaskAttributes, PlaywrightTasks } from '../../types';
+import { getCaseDescription } from './case-description';
 import './index.less';
 import { type DumpStoreType, useExecutionDump } from '../store';
 
@@ -84,6 +85,7 @@ function PlaywrightCaseTitle(props: {
 }): JSX.Element {
   const { attributes, timingRange } = props;
   const status = iconForStatus(attributes.playwright_test_status);
+  const description = getCaseDescription(attributes);
   const duration = timingRange?.duration ?? attributes.playwright_test_duration;
   const extraStatusLabel =
     STATUS_DISPLAY_LABEL[attributes.playwright_test_status];
@@ -121,9 +123,7 @@ function PlaywrightCaseTitle(props: {
       {status}
       {'  '}
       {attributes.playwright_test_title || 'unnamed'}
-      {attributes.playwright_test_description
-        ? ` - ${attributes.playwright_test_description}`
-        : ''}
+      {description ? ` - ${description}` : ''}
       {cost}
     </span>
   );

--- a/apps/report/src/components/playwright-case-selector/index.tsx
+++ b/apps/report/src/components/playwright-case-selector/index.tsx
@@ -85,7 +85,9 @@ function PlaywrightCaseTitle(props: {
 }): JSX.Element {
   const { attributes, timingRange } = props;
   const status = iconForStatus(attributes.playwright_test_status);
-  const description = getCaseDescription(attributes);
+  const fullDescription = attributes.playwright_test_description;
+  const description = getCaseDescription(fullDescription);
+  const isDescriptionTruncated = description !== fullDescription;
   const duration = timingRange?.duration ?? attributes.playwright_test_duration;
   const extraStatusLabel =
     STATUS_DISPLAY_LABEL[attributes.playwright_test_status];
@@ -123,7 +125,18 @@ function PlaywrightCaseTitle(props: {
       {status}
       {'  '}
       {attributes.playwright_test_title || 'unnamed'}
-      {description ? ` - ${description}` : ''}
+      {description ? (
+        <>
+          {' - '}
+          {isDescriptionTruncated ? (
+            <Tooltip title={fullDescription}>
+              <span className="case-description">{description}</span>
+            </Tooltip>
+          ) : (
+            description
+          )}
+        </>
+      ) : null}
       {cost}
     </span>
   );

--- a/apps/report/tests/case-description.test.ts
+++ b/apps/report/tests/case-description.test.ts
@@ -2,35 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { getCaseDescription } from '../src/components/playwright-case-selector/case-description';
 
 describe('getCaseDescription', () => {
-  it('truncates a long description for failed cases', () => {
+  it('truncates a long description', () => {
     const description = `Error(s) occurred in running yaml script:\nServiceError: failed to locate the dashboard button. ${'at Service.locate (/project/service.ts:1:1) '.repeat(5)}`;
 
-    const result = getCaseDescription({
-      playwright_test_description: description,
-      playwright_test_status: 'failed',
-    });
+    const result = getCaseDescription(description);
 
-    expect(result).toHaveLength(300);
-    expect(result).toBe(`${description.slice(0, 297)}...`);
+    expect(result).toHaveLength(100);
+    expect(result).toBe(`${description.slice(0, 97)}...`);
   });
 
-  it('keeps a short description for failed cases', () => {
-    expect(
-      getCaseDescription({
-        playwright_test_description: 'ServiceError: failed to locate',
-        playwright_test_status: 'failed',
-      }),
-    ).toBe('ServiceError: failed to locate');
+  it('keeps a short description', () => {
+    expect(getCaseDescription('ServiceError: failed to locate')).toBe(
+      'ServiceError: failed to locate',
+    );
   });
 
-  it('keeps a long description for non-failed cases', () => {
-    const description = 'checkout flow '.repeat(20);
+  it('keeps a description at the length limit', () => {
+    const description = 'a'.repeat(100);
 
-    expect(
-      getCaseDescription({
-        playwright_test_description: description,
-        playwright_test_status: 'passed',
-      }),
-    ).toBe(description);
+    expect(getCaseDescription(description)).toBe(description);
   });
 });

--- a/apps/report/tests/case-description.test.ts
+++ b/apps/report/tests/case-description.test.ts
@@ -10,8 +10,8 @@ describe('getCaseDescription', () => {
       playwright_test_status: 'failed',
     });
 
-    expect(result).toHaveLength(30);
-    expect(result).toBe(`${description.slice(0, 27)}...`);
+    expect(result).toHaveLength(300);
+    expect(result).toBe(`${description.slice(0, 297)}...`);
   });
 
   it('keeps a short description for failed cases', () => {

--- a/apps/report/tests/case-description.test.ts
+++ b/apps/report/tests/case-description.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getCaseDescription } from '../src/components/playwright-case-selector/case-description';
+
+describe('getCaseDescription', () => {
+  it('truncates a long description for failed cases', () => {
+    const description = `Error(s) occurred in running yaml script:\nServiceError: failed to locate the dashboard button. ${'at Service.locate (/project/service.ts:1:1) '.repeat(5)}`;
+
+    const result = getCaseDescription({
+      playwright_test_description: description,
+      playwright_test_status: 'failed',
+    });
+
+    expect(result).toHaveLength(30);
+    expect(result).toBe(`${description.slice(0, 27)}...`);
+  });
+
+  it('keeps a short description for failed cases', () => {
+    expect(
+      getCaseDescription({
+        playwright_test_description: 'ServiceError: failed to locate',
+        playwright_test_status: 'failed',
+      }),
+    ).toBe('ServiceError: failed to locate');
+  });
+
+  it('keeps a long description for non-failed cases', () => {
+    const description = 'checkout flow '.repeat(20);
+
+    expect(
+      getCaseDescription({
+        playwright_test_description: description,
+        playwright_test_status: 'passed',
+      }),
+    ).toBe(description);
+  });
+});


### PR DESCRIPTION
## Summary

- truncate report case descriptions to 100 characters regardless of test status
- preserve short descriptions and append `...` only when the limit is exceeded
- set the complete original description as the browser-native `title` only on truncated text
- add focused unit coverage under `apps/report/tests`

## Root cause

The case selector rendered the complete `playwright_test_description`. Descriptions can contain long error stacks or other verbose metadata, causing a single option to occupy most of the dropdown and making other reports difficult to select.

## User impact

All long case descriptions now use the same compact presentation. Users can still inspect the complete description by hovering over truncated text, and the underlying report metadata remains unchanged. Short descriptions do not get a redundant hover title.

## Validation

- `pnpm --filter @midscene/report test` (78 tests passed)
- `pnpm --filter @midscene/report build`
- verified a real 1,927-character report description renders as exactly 100 characters and remains available through the native `title`
- staged-file Biome check run by the commit hook