### PR TITLE
refactor(core): colocate locate prompt spec

### DIFF
--- a/packages/core/src/ai-model/shared/model-locate-result/factory.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/factory.ts
@@ -1,7 +1,7 @@
-import { createLocateResultPromptSpec } from '../../prompts/locate-result-coordinates';
 import { finalizePixelBbox, finalizeSectionLocatePixelBboxGroup } from './bbox';
 import { parseNumericLocateResult } from './parse';
 import { mapLocateResultToPixelBboxByCoordinates } from './pixel-bbox-mapper';
+import { createLocateResultPromptSpec } from './prompt-spec';
 import type {
   LocateResultAdapter,
   LocateResultAdapterDefinition,

--- a/packages/core/src/ai-model/shared/model-locate-result/prompt-spec.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/prompt-spec.ts
@@ -2,8 +2,8 @@ import type {
   LocateResultBbox,
   LocateResultPromptSpec,
   NonEmptyArray,
-} from '../shared/model-locate-result';
-import type { ResolvedLocateResultCoordinates } from '../shared/model-locate-result/types';
+  ResolvedLocateResultCoordinates,
+} from './types';
 
 function describeLocateResultCoordinates({
   shape,

--- a/packages/core/tests/unit-test/locate-result-adapter.test.ts
+++ b/packages/core/tests/unit-test/locate-result-adapter.test.ts
@@ -1,5 +1,5 @@
-import { locateResultExampleRegions } from '@/ai-model/prompts/locate-result-coordinates';
 import { createLocateResultAdapter } from '@/ai-model/shared/model-locate-result';
+import { locateResultExampleRegions } from '@/ai-model/shared/model-locate-result/prompt-spec';
 import { pixelBboxToRect } from '@/ai-model/workflows/inspect/locate-result-rect';
 import { describe, expect, it, vi } from 'vitest';
 


### PR DESCRIPTION
## Summary

- move the locate result prompt spec into the `shared/model-locate-result` module
- update the factory and unit test imports to use the colocated module
- remove the otherwise standalone `ai-model/prompts` directory

## Why

The prompt spec is part of the locate-result adapter domain and is only consumed by that module. Colocating it makes the ownership boundary clearer without changing runtime behavior.

## Impact

Internal code organization only; there is no user-facing behavior change.

## Validation

- `pnpm --filter @midscene/core test -- locate-result-adapter.test.ts` (32 tests passed)
- pre-commit `npx biome check --diagnostic-level=info --fix`