### PR TITLE
refactor(core): remove legacy location field flag

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -276,8 +276,6 @@ export const multimodalPromptToChatMessages = async (
   return msgs;
 };
 
-const locateFieldFlagName = 'midscene_location_field_flag';
-
 // Schema for locator field input (when users provide locate parameters)
 const MidsceneLocationInput = z
   .object({
@@ -311,12 +309,6 @@ export const ifMidsceneLocatorField = (field: any): boolean => {
   if (actualField._def?.typeName === 'ZodObject') {
     const shape = actualField._def.shape();
 
-    // Method 1: Check for the location field flag (for result schema)
-    if (locateFieldFlagName in shape) {
-      return true;
-    }
-
-    // Method 2: Check if it's the input schema by checking for 'prompt' field
     // Input schema has 'prompt' as a required field
     if ('prompt' in shape && shape.prompt) {
       return true;

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -503,13 +503,11 @@ describe('dumpActionParam', () => {
     const input1 = {
       foo: 'test',
       locator1: {
-        midscene_location_field_flag: true,
         prompt: 'first locator',
         center: [100, 200],
         rect: { left: 50, top: 100, width: 100, height: 50 },
       },
       locator2: {
-        midscene_location_field_flag: true,
         prompt: 'second locator',
         center: [200, 300],
         rect: { left: 150, top: 200, width: 100, height: 50 },
@@ -533,7 +531,6 @@ describe('dumpActionParam', () => {
     const input2 = {
       foo: 'test2',
       locator1: {
-        midscene_location_field_flag: true,
         prompt: 'only locator',
         center: [50, 100],
         rect: { left: 25, top: 50, width: 50, height: 25 },
@@ -558,7 +555,6 @@ describe('dumpActionParam', () => {
 
     const inputWithImages = {
       locator: {
-        midscene_location_field_flag: true,
         prompt: {
           prompt: 'find the button',
           images: [
@@ -580,7 +576,6 @@ describe('dumpActionParam', () => {
 
     const inputWithOneImage = {
       locator: {
-        midscene_location_field_flag: true,
         prompt: {
           prompt: 'find the text',
           images: [{ name: 'text.png', url: 'data:image/png;base64,abc' }],
@@ -599,7 +594,6 @@ describe('dumpActionParam', () => {
 
     const inputWithEmptyImages = {
       locator: {
-        midscene_location_field_flag: true,
         prompt: {
           prompt: 'find the link',
           images: [],
@@ -645,13 +639,11 @@ describe('dumpActionParam', () => {
     const input2 = {
       foo: 'test2',
       locator1: {
-        midscene_location_field_flag: true,
         // missing prompt
         center: [100, 200],
         rect: { left: 50, top: 100, width: 100, height: 50 },
       },
       locator2: {
-        midscene_location_field_flag: true,
         prompt: 'valid locator',
         center: [200, 300],
         rect: { left: 150, top: 200, width: 100, height: 50 },
@@ -667,7 +659,6 @@ describe('dumpActionParam', () => {
             100,
             200,
           ],
-          "midscene_location_field_flag": true,
           "rect": {
             "height": 50,
             "left": 50,

--- a/packages/playground/src/adapters/base.ts
+++ b/packages/playground/src/adapters/base.ts
@@ -140,7 +140,6 @@ export abstract class BasePlaygroundAdapter {
       locatorFieldKeys.forEach((key: string) => {
         if (typeof paramsForValidation[key] === 'string') {
           paramsForValidation[key] = {
-            midscene_location_field_flag: true,
             prompt: paramsForValidation[key],
             center: [0, 0], // dummy values for validation
             rect: { left: 0, top: 0, width: 0, height: 0 },
@@ -162,11 +161,7 @@ export abstract class BasePlaygroundAdapter {
       const errorMessages = zodError.errors
         .filter((err) => {
           const path = err.path.join('.');
-          return (
-            !path.includes('center') &&
-            !path.includes('rect') &&
-            !path.includes('midscene_location_field_flag')
-          );
+          return !path.includes('center') && !path.includes('rect');
         })
         .map((err) => {
           const field = err.path.join('.');

--- a/packages/playground/src/common.ts
+++ b/packages/playground/src/common.ts
@@ -151,7 +151,6 @@ export function validateStructuredParams(
       locatorFieldKeys.forEach((key: string) => {
         if (typeof paramsForValidation[key] === 'string') {
           paramsForValidation[key] = {
-            midscene_location_field_flag: true,
             prompt: paramsForValidation[key],
             center: [0, 0],
             rect: { left: 0, top: 0, width: 0, height: 0 },
@@ -170,11 +169,7 @@ export function validateStructuredParams(
       const errorMessages = zodError.errors
         .filter((err) => {
           const path = err.path.join('.');
-          return (
-            !path.includes('center') &&
-            !path.includes('rect') &&
-            !path.includes('midscene_location_field_flag')
-          );
+          return !path.includes('center') && !path.includes('rect');
         })
         .map((err) => {
           const field = err.path.join('.');

--- a/packages/shared/src/zod-schema-utils.ts
+++ b/packages/shared/src/zod-schema-utils.ts
@@ -33,9 +33,7 @@ export function unwrapZodField(field: unknown): unknown {
 
 /**
  * Check if a field is a Midscene locator field
- * Checks for either:
- * 1. midscene_location_field_flag in shape (result schema)
- * 2. prompt field in shape (input schema)
+ * Locator input schemas are identified by their prompt field.
  */
 export function isMidsceneLocatorField(field: unknown): boolean {
   const actualField = unwrapZodField(field) as {
@@ -45,11 +43,6 @@ export function isMidsceneLocatorField(field: unknown): boolean {
   if (actualField._def?.typeName === 'ZodObject') {
     const shape = actualField._def.shape?.();
     if (shape) {
-      // Method 1: Check for the location field flag (for result schema)
-      if ('midscene_location_field_flag' in shape) {
-        return true;
-      }
-      // Method 2: Check if it's the input schema by checking for 'prompt' field
       if ('prompt' in shape && shape.prompt) {
         return true;
       }

--- a/packages/visualizer/src/types.ts
+++ b/packages/visualizer/src/types.ts
@@ -84,9 +84,6 @@ export const VALIDATION_CONSTANTS = {
     STRING: 'ZodString',
     BOOLEAN: 'ZodBoolean',
   },
-  FIELD_FLAGS: {
-    LOCATION: 'midscene_location_field_flag',
-  },
   DEFAULT_VALUES: {
     ACTION_TYPE: 'aiAct',
     TIMEOUT_MS: 15000,
@@ -126,8 +123,7 @@ export const isLocateField = (field: ZodType): boolean => {
       shape = fieldWithRuntime.shape;
     }
 
-    // Check for the location flag in shape
-    if (shape && VALIDATION_CONSTANTS.FIELD_FLAGS.LOCATION in shape) {
+    if (shape && 'prompt' in shape && shape.prompt) {
       return true;
     }
 

--- a/packages/visualizer/tests/inline-structured-field-config.test.ts
+++ b/packages/visualizer/tests/inline-structured-field-config.test.ts
@@ -26,7 +26,7 @@ function makeLocateField() {
   return {
     _def: {
       typeName: 'ZodObject',
-      shape: { midscene_location_field_flag: {} },
+      shape: { prompt: makeStringField() },
     },
   };
 }


### PR DESCRIPTION
## Summary

- remove the legacy `midscene_location_field_flag` marker and compatibility checks
- identify locator schemas consistently through their required `prompt` field
- update Playground validation shims and Visualizer test fixtures

## Why

The current locator input schema no longer defines or relies on `midscene_location_field_flag`. Keeping the marker created dead compatibility branches and synthetic validation data without affecting runtime behavior.

## Impact

Locator schema detection continues to use `prompt`; no public API behavior is expected to change.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/utils.test.ts` (40 tests)
- `pnpm --filter @midscene/shared test -- tests/unit-test/zod-schema-utils.test.ts` (32 tests)
- `pnpm --filter @midscene/visualizer test -- tests/inline-structured-field-config.test.ts` (13 tests)
- `pnpm --filter @midscene/playground test` (262 tests)
- commit hook: `npx biome check --diagnostic-level=info --fix`