### PR TITLE
feat(core): support per-call AI context

### DIFF
--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -507,6 +507,10 @@ const DetailSide = (): JSX.Element => {
     // Get subGoalStatus and memoriesStatus from param
     const subGoalStatus = (planningTask.param as any)?.subGoalStatus;
     const memoriesStatus = (planningTask.param as any)?.memoriesStatus;
+    const locateContext =
+      planningTask.subType === 'Locate'
+        ? (planningTask.param as any)?.context
+        : undefined;
 
     if (planningTask.param?.userInstruction) {
       const instructionContent =
@@ -540,7 +544,7 @@ const DetailSide = (): JSX.Element => {
           ...(isPageContextFrozen
             ? [
                 {
-                  key: 'context',
+                  key: 'UI Context',
                   content: <Tag color="blue">Frozen Context 🧊</Tag>,
                 },
               ]
@@ -562,6 +566,14 @@ const DetailSide = (): JSX.Element => {
             content: promptContent,
             images: images,
           },
+          ...(locateContext
+            ? [
+                {
+                  key: 'context',
+                  content: locateContext,
+                },
+              ]
+            : []),
           ...(memoriesStatus
             ? [
                 {
@@ -581,7 +593,7 @@ const DetailSide = (): JSX.Element => {
           ...(isPageContextFrozen
             ? [
                 {
-                  key: 'context',
+                  key: 'UI Context',
                   content: <Tag color="blue">Frozen Context 🧊</Tag>,
                 },
               ]
@@ -618,10 +630,18 @@ const DetailSide = (): JSX.Element => {
               },
             ]
           : []),
-        ...(isPageContextFrozen
+        ...(taskParam?.context
           ? [
               {
                 key: 'context',
+                content: taskParam.context,
+              },
+            ]
+          : []),
+        ...(isPageContextFrozen
+          ? [
+              {
+                key: 'UI Context',
                 content: <Tag color="blue">Frozen Context 🧊</Tag>,
               },
             ]

--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -509,6 +509,10 @@ const DetailSide = (): JSX.Element => {
     // Get subGoalStatus and memoriesStatus from param
     const subGoalStatus = (planningTask.param as any)?.subGoalStatus;
     const memoriesStatus = (planningTask.param as any)?.memoriesStatus;
+    const locateContext =
+      planningTask.subType === 'Locate'
+        ? (planningTask.param as any)?.context
+        : undefined;
 
     if (planningTask.param?.userInstruction) {
       const instructionContent =
@@ -542,7 +546,7 @@ const DetailSide = (): JSX.Element => {
           ...(isPageContextFrozen
             ? [
                 {
-                  key: 'context',
+                  key: 'UI Context',
                   content: <Tag color="blue">Frozen Context 🧊</Tag>,
                 },
               ]
@@ -564,6 +568,16 @@ const DetailSide = (): JSX.Element => {
             content: promptContent,
             images: images,
           },
+          ...(locateContext
+            ? [
+                {
+                  key: 'context',
+                  content: (
+                    <pre className="act-context-source">{locateContext}</pre>
+                  ),
+                },
+              ]
+            : []),
           ...(memoriesStatus
             ? [
                 {
@@ -583,7 +597,7 @@ const DetailSide = (): JSX.Element => {
           ...(isPageContextFrozen
             ? [
                 {
-                  key: 'context',
+                  key: 'UI Context',
                   content: <Tag color="blue">Frozen Context 🧊</Tag>,
                 },
               ]
@@ -620,10 +634,20 @@ const DetailSide = (): JSX.Element => {
               },
             ]
           : []),
-        ...(isPageContextFrozen
+        ...(taskParam?.context
           ? [
               {
                 key: 'context',
+                content: (
+                  <pre className="act-context-source">{taskParam.context}</pre>
+                ),
+              },
+            ]
+          : []),
+        ...(isPageContextFrozen
+          ? [
+              {
+                key: 'UI Context',
                 content: <Tag color="blue">Frozen Context 🧊</Tag>,
               },
             ]

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -170,9 +170,10 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     abortSignal?: AbortSignal;
+    context?: string;
   },
 ): Promise<string | undefined>;
-function ai(prompt: string): Promise<string | undefined>; // shorthand form
+function ai(prompt: string, options?: Object): Promise<string | undefined>; // shorthand form
 ```
 
 - Parameters:
@@ -187,6 +188,7 @@ function ai(prompt: string): Promise<string | undefined>; // shorthand form
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `abortSignal?: AbortSignal` - An optional [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that allows you to abort the `aiAct` execution. When the signal is triggered, Midscene will stop the current planning loop and throw an error. This is useful for implementing timeouts or user-initiated cancellations.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return Value:
 
@@ -244,6 +246,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
   - `locate: string | Object` - A natural language description of the element to tap, or [prompting with images](#prompting-with-images).
   - `options?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `fileChooserAccept?: string | string[]` - When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
@@ -287,6 +290,7 @@ function aiHover(locate: string | Object, options?: Object): Promise<void>;
   - `locate: string | Object` - A natural language description of the element to hover over, or [prompting with images](#prompting-with-images).
   - `options?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -313,6 +317,7 @@ function aiInput(
   opt: {
     value: string | number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
     autoDismissKeyboard?: boolean;
@@ -339,6 +344,7 @@ function aiInput(
       - When `mode` is `'typeOnly'`: The text will be typed directly without clearing the field first.
       - When `mode` is `'clear'`: The text is ignored and the input field will be cleared.
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
     - `autoDismissKeyboard?: boolean` - If true, the keyboard will be dismissed after input text, only available in Android/iOS/HarmonyOS. (Default: true)
@@ -384,6 +390,7 @@ function aiClearInput(
   locate: string | Object,
   opt?: {
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -395,6 +402,7 @@ function aiClearInput(
   - `locate: string | Object` - A natural language description of the input field to clear, or [prompting with images](#prompting-with-images).
   - `opt?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -432,6 +440,7 @@ function aiKeyboardPress(
   opt: {
     keyName: string;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -452,6 +461,7 @@ function aiKeyboardPress(
   - `opt: Object` - Configuration object containing:
     - `keyName: string` - **Required**. The web key to press, e.g. 'Enter', 'Tab', 'Escape', etc. Key Combination is not supported. Refer to the [complete list of supported key names in our source code](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts) for available values.
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -495,6 +505,7 @@ function aiScroll(
     direction?: 'down' | 'up' | 'left' | 'right';
     distance?: number | null;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -517,6 +528,7 @@ function aiScroll(
     - `direction?: 'down' | 'up' | 'right' | 'left'` - The direction to scroll. Defaults to `down`. Only effective when `scrollType` is `singleAction`. Whether it is Android or Web, the scrolling direction here all refers to which direction of the page's content will appear on the screen. For example, when the scrolling direction is `down`, the hidden content at the bottom of the page will gradually reveal itself from the bottom of the screen upwards.
     - `distance?: number | null` - Optional, the distance to scroll in px. Use `null` to allow Midscene to decide automatically.
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -566,6 +578,7 @@ function aiPinch(
     distance?: number;
     duration?: number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -580,6 +593,7 @@ function aiPinch(
     - `distance?: number` - How far each finger moves in pixels. Defaults to a quarter of the shorter screen dimension.
     - `duration?: number` - Duration of the pinch gesture in milliseconds. Defaults to `500`.
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -621,6 +635,7 @@ function aiLongPress(
   opt?: {
     duration?: number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -633,6 +648,7 @@ function aiLongPress(
   - `opt?: Object` - Optional, a configuration object containing:
     - `duration?: number` - How long the press is held, in milliseconds. When omitted, each platform applies its own default (Android `2000`, iOS `1000`, Web `500`).
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -671,6 +687,7 @@ function aiDoubleClick(locate: string | Object, options?: Object): Promise<void>
   - `locate: string | Object` - A natural language description of the element to double-click on, or [prompting with images](#prompting-with-images).
   - `options?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -706,6 +723,7 @@ function aiRightClick(locate: string, options?: Object): Promise<void>;
   - `locate: string | Object` - A natural language description of the element to right-click on, or [prompting with images](#prompting-with-images).
   - `options?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -744,6 +762,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return Value:
 
@@ -774,6 +793,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return Value:
 
@@ -823,6 +843,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 - Return Value:
 
   - Returns a `Promise<boolean>` when AI returns a boolean value.
@@ -853,6 +874,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 - Return Value:
 
   - Returns a `Promise<number>` when AI returns a number value.
@@ -886,6 +908,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 - Return Value:
 
   - Returns a `Promise<string>` when AI returns a string value.
@@ -924,6 +947,7 @@ function aiAssert(
   - `options?: Object` - Optional, a configuration object containing:
     - `domIncluded?: boolean | 'visible-only'` - Whether to send simplified DOM information to the model, usually used for extracting invisible attributes like image links. If set to `'visible-only'`, only the visible elements will be sent. False by default.
     - `screenshotIncluded?: boolean` - Whether to send screenshot to the model. True by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return Value:
 
@@ -1012,6 +1036,7 @@ function aiLocate(
   - `locate: string | Object` - A natural language description of the element to locate, or [prompting with images](#prompting-with-images).
   - `options?: Object` - Optional, a configuration object containing:
     - `deepLocate?: boolean` - Whether to enable [Deep Locate](#deep-locate-deeplocate). Previously named `deepThink`, now renamed to `deepLocate`. False by default.
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` - The xpath of the element to operate. If provided, Midscene will first use this xpath to locate the element before using the cache and the AI model. Empty by default.
     - `cacheable?: boolean` - Whether cacheable when enabling [caching feature](./caching.mdx). True by default.
 
@@ -1044,6 +1069,7 @@ function aiWaitFor(
   options?: {
     timeoutMs?: number;
     checkIntervalMs?: number;
+    context?: string;
   },
 ): Promise<void>;
 ```
@@ -1054,6 +1080,7 @@ function aiWaitFor(
   - `options?: object` - An optional configuration object containing:
     - `timeoutMs?: number` - Maximum window in milliseconds for starting a new check (default: 15000). If the previous evaluation began before this window closes, Midscene keeps checking; otherwise it stops with a timeout.
     - `checkIntervalMs?: number` - Interval for checking in milliseconds (default: 3000).
+    - `context?: string` - Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return Value:
 
@@ -1428,6 +1455,41 @@ const agent = new PuppeteerAgent(page, {
   },
 });
 ```
+
+## Per-call context
+
+Every `agent.ai*` method accepts an optional `context` string in its options. Use it to provide business knowledge, user state, terminology, or other background that is relevant to one request without changing the main prompt.
+
+```typescript
+await agent.aiAssert('The currently logged-in user is a VIP member', undefined, {
+  context:
+    'A VIP member is identified by a VIP badge displayed on the user avatar in the top-right corner of the page.',
+});
+
+await agent.aiTap('Favorite button', {
+  context:
+    'The favorite button is the five-pointed star icon in the bottom-right corner of the page.',
+});
+```
+
+You can also place a large set of custom business rules in `context`, then use it to build reusable business-specific assertion or interaction methods. Each call only needs a short prompt for the current task, so the complete business rules do not have to be repeated every time.
+
+```typescript
+const myAssert = (prompt: string, errMsg?: string) =>
+  agent.aiAssert(prompt, errMsg, {
+    context: `Custom business assertion rules, for example:
+- A VIP member's avatar displays a VIP badge
+- When a product is marked "Out of stock", it must not have a clickable purchase button
+- When an order status is "Completed", the amount paid must be visible`,
+  });
+
+await myAssert('The currently logged-in user is a VIP member');
+await myAssert('An out-of-stock product cannot be purchased');
+```
+
+The context only applies to that method call. For `aiAct`, a per-call `context` takes precedence over the Agent-level `aiActContext` (including an explicitly empty string). Other AI methods do not automatically inherit `aiActContext`.
+
+`context` supplements the request; it does not replace the method's main prompt or change the return schema of an object-form `aiQuery`.
 
 ## Deep Locate (deepLocate)
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -1443,14 +1443,9 @@ The path to the report file.
 Every `agent.ai*` method accepts an optional `context` string in its options. Use it to provide business knowledge, user state, terminology, or other background that is relevant to one request without changing the main prompt.
 
 ```typescript
-await agent.aiAssert('The currently logged-in user is a VIP member', undefined, {
+await agent.aiAssert('The current page uses the new version styling', undefined, {
   context:
-    'A VIP member is identified by a VIP badge displayed on the user avatar in the top-right corner of the page.',
-});
-
-await agent.aiTap('Favorite button', {
-  context:
-    'The favorite button is the five-pointed star icon in the bottom-right corner of the page.',
+    'In the new version, the Tab bar is at the top and the page theme color is red. In the old version, the Tab bar is at the bottom and the page theme color is green. Treat the page as the new version only when both new-version conditions are met.',
 });
 ```
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -1454,20 +1454,6 @@ await agent.aiTap('Favorite button', {
 });
 ```
 
-You can also place a large set of custom business rules in `context`, then use it to build reusable business-specific assertion or interaction methods. Each call only needs a short prompt for the current task, so the complete business rules do not have to be repeated every time.
-
-```typescript
-const myAssert = (prompt: string, errMsg?: string) =>
-  agent.aiAssert(prompt, errMsg, {
-    context: `Custom business assertion rules, for example:
-- A VIP member's avatar displays a VIP badge
-- When a product is marked "Out of stock", it must not have a clickable purchase button
-- When an order status is "Completed", the amount paid must be visible`,
-  });
-
-await myAssert('The currently logged-in user is a VIP member');
-await myAssert('An out-of-stock product cannot be purchased');
-```
 
 The context only applies to that method call. For `aiAct`, a per-call `context` takes precedence over the Agent-level `aiActContext` (including an explicitly empty string). Other AI methods do not automatically inherit `aiActContext`.
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -1438,6 +1438,39 @@ const agent = new PuppeteerAgent(page, {
 
 The path to the report file.
 
+## Per-call context
+
+Every `agent.ai*` method accepts an optional `context` string in its options. Use it to provide business knowledge, user state, terminology, or other background that is relevant to one request without changing the main prompt.
+
+```typescript
+await agent.aiAssert('The currently logged-in user is a VIP member', undefined, {
+  context:
+    'A VIP member is identified by a VIP badge displayed on the user avatar in the top-right corner of the page.',
+});
+
+await agent.aiTap('Favorite button', {
+  context:
+    'The favorite button is the five-pointed star icon in the bottom-right corner of the page.',
+});
+```
+
+You can also place a large set of custom business rules in `context`, then use it to build reusable business-specific assertion or interaction methods. Each call only needs a short prompt for the current task, so the complete business rules do not have to be repeated every time.
+
+```typescript
+const myAssert = (prompt: string, errMsg?: string) =>
+  agent.aiAssert(prompt, errMsg, {
+    context: `Custom business assertion rules, for example:
+- A VIP member's avatar displays a VIP badge
+- When a product is marked "Out of stock", it must not have a clickable purchase button
+- When an order status is "Completed", the amount paid must be visible`,
+  });
+
+await myAssert('The currently logged-in user is a VIP member');
+await myAssert('An out-of-stock product cannot be purchased');
+```
+
+The context only applies to that method call. For `aiAct`, a per-call `context` takes precedence over the Agent-level `aiActContext` (including an explicitly empty string). Other AI methods do not automatically inherit `aiActContext`.
+
 
 ### Shared types {#shared-types}
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -137,9 +137,10 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     abortSignal?: AbortSignal;
+    context?: string;
   },
 ): Promise<string | undefined>;
-function ai(prompt: string): Promise<string | undefined>; // shorthand form
+function ai(prompt: string, options?: Object): Promise<string | undefined>; // shorthand form
 ```
 
 - Parameters:
@@ -149,6 +150,7 @@ function ai(prompt: string): Promise<string | undefined>; // shorthand form
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
     - `deepThink?: 'unset' | true | false` — Controls the planning implementation used by Midscene when `aiAct` performs planning. When enabled, `aiAct` focuses more on task decomposition and separates task planning from UI element locating into different model calls. For compatibility, `'unset'` is accepted and treated the same as `false`. [Learn more about deepThink](../model-strategy#about-the-deepthink-option-in-aiact).
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `fileChooserAccept?: string | string[]` — When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
@@ -211,6 +213,7 @@ function aiTap(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` — A natural language description of the element to tap, or [prompting with images](#prompting-with-images).
   - `options?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
     - `fileChooserAccept?: string | string[]` — When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
@@ -254,6 +257,7 @@ function aiHover(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` — A natural language description of the element to hover over, or [prompting with images](#prompting-with-images).
   - `options?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -306,6 +310,7 @@ function aiInput(
       - When `mode` is `'typeOnly'`: The text will be typed directly without clearing the field first.
       - When `mode` is `'clear'`: The text is ignored and the input field will be cleared.
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
     - `autoDismissKeyboard?: boolean` — Whether to dismiss the on-screen keyboard after entering text. Available only on Android, iOS, and HarmonyOS. Default: `true`.
@@ -362,6 +367,7 @@ function aiClearInput(
   - `locate: string | object` — A natural language description of the input field to clear, or [prompting with images](#prompting-with-images).
   - `opt?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -419,6 +425,7 @@ function aiKeyboardPress(
   - `opt: object` — Configuration:
     - `keyName: string` — **Required.** Keyboard key to press, such as `'Enter'`, `'Tab'`, or `'Escape'`. Key combinations are not supported. See the [complete list of supported key names](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts).
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -484,6 +491,7 @@ function aiScroll(
     - `direction?: 'down' | 'up' | 'right' | 'left'` — Direction of content movement. Used only when `scrollType` is `'singleAction'`. For example, `'down'` reveals content below the current viewport. Default: `'down'`.
     - `distance?: number | null` — Scroll distance in pixels. Use `null` to let Midscene choose the distance.
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -547,6 +555,7 @@ function aiPinch(
     - `distance?: number` — Distance each finger moves in pixels. Default: one quarter of the shorter screen dimension.
     - `duration?: number` — Gesture duration in milliseconds. Default: `500`.
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -600,6 +609,7 @@ function aiLongPress(
   - `opt?: object` — Optional configuration:
     - `duration?: number` — How long to hold the press, in milliseconds. Defaults: Android `2000`, iOS `1000`, and web `500`. HarmonyOS uses the system long-click duration and ignores this option.
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -638,6 +648,7 @@ function aiDoubleClick(locate: string | object, options?: object): Promise<void>
   - `locate: string | object` — A natural language description of the element to double-click on, or [prompting with images](#prompting-with-images).
   - `options?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -673,6 +684,7 @@ function aiRightClick(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` — A natural language description of the element to right-click on, or [prompting with images](#prompting-with-images).
   - `options?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -713,6 +725,7 @@ function aiAsk(prompt: string | object, options?: object): Promise<string>;
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return value:
 
@@ -743,6 +756,7 @@ function aiQuery<T>(dataDemand: string | object, options?: object): Promise<T>;
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return value:
 
@@ -791,6 +805,7 @@ function aiBoolean(prompt: string | object, options?: object): Promise<boolean>;
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 - Return value:
 
   - Returns a Promise that resolves to the boolean returned by the AI model.
@@ -821,6 +836,7 @@ function aiNumber(prompt: string | object, options?: object): Promise<number>;
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 - Return value:
 
   - Returns a Promise that resolves to the number returned by the AI model.
@@ -854,6 +870,7 @@ function aiString(prompt: string | object, options?: object): Promise<string>;
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 - Return value:
 
   - Returns a Promise that resolves to the string returned by the AI model.
@@ -898,6 +915,7 @@ function aiLocate(
   - `locate: string | object` — A natural language description of the element to locate, or [prompting with images](#prompting-with-images).
   - `options?: object` — Optional configuration:
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
     - `xpath?: string` — XPath for the target element. Midscene tries the XPath before consulting the cache or AI model. Default: `undefined`.
     - `cacheable?: boolean` — Whether this call can use the [cache](../caching.mdx). Default: `true`.
 
@@ -940,6 +958,7 @@ function aiAssert(
   - `options?: object` — Optional configuration:
     - `domIncluded?: boolean | 'visible-only'` — Whether to include simplified DOM data, which can expose attributes such as image URLs. Use `'visible-only'` to include only visible elements. Default: `false`.
     - `screenshotIncluded?: boolean` — Whether to include a screenshot. Default: `true`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return value:
 
@@ -1015,6 +1034,7 @@ function aiWaitFor(
   options?: {
     timeoutMs?: number;
     checkIntervalMs?: number;
+    context?: string;
   },
 ): Promise<void>;
 ```
@@ -1025,6 +1045,7 @@ function aiWaitFor(
   - `options?: object` — Optional configuration:
     - `timeoutMs?: number` — Maximum window in milliseconds for starting a new check. If the previous check began within this window, Midscene may complete it; otherwise the method times out. Default: `15000`.
     - `checkIntervalMs?: number` — Minimum interval in milliseconds between the start of consecutive checks. Default: `3000`.
+    - `context?: string` — Additional context for this call. See [Per-call context](#per-call-context).
 
 - Return value:
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -172,9 +172,10 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     abortSignal?: AbortSignal;
+    context?: string;
   },
 ): Promise<string | undefined>;
-function ai(prompt: string): Promise<string | undefined>; // 简写形式
+function ai(prompt: string, options?: Object): Promise<string | undefined>; // 简写形式
 ```
 
 - 参数：
@@ -189,6 +190,7 @@ function ai(prompt: string): Promise<string | undefined>; // 简写形式
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -242,6 +244,7 @@ function aiTap(locate: string | Object, options?: Object): Promise<void>;
   - `locate: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: Object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
@@ -281,6 +284,7 @@ function aiHover(locate: string | Object, options?: Object): Promise<void>;
   - `locate: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: Object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 - 返回值：
@@ -306,6 +310,7 @@ function aiInput(
   opt: {
     value: string | number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
     autoDismissKeyboard?: boolean;
@@ -332,6 +337,7 @@ function aiInput(
       - 当 `mode` 为 `'typeOnly'` 时：直接输入文本，不会先清空输入框。
       - 当 `mode` 为 `'clear'` 时：会忽略文本内容，仅清空输入框。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `autoDismissKeyboard?: boolean` - 如果为 true，则键盘会在输入文本后自动关闭，仅在 Android/iOS/HarmonyOS 中有效。默认值为 true。
@@ -377,6 +383,7 @@ function aiClearInput(
   locate: string | Object,
   opt?: {
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -388,6 +395,7 @@ function aiClearInput(
   - `locate: string | Object` - 要清空的输入框的自然语言描述，或[通过图像提示](#通过图像提示)。
   - `opt?: Object` - 可选配置对象：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认 `false`。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 要操作元素的 xpath，默认空。
     - `cacheable?: boolean` - 启用[缓存功能](./caching.mdx)时是否缓存，默认 `true`。
 
@@ -425,6 +433,7 @@ function aiKeyboardPress(
   opt: {
     keyName: string;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -445,6 +454,7 @@ function aiKeyboardPress(
   - `opt: Object` - 配置对象，包含：
     - `keyName: string` - **必填**，要按下的键，如 `Enter`、`Tab`、`Escape` 等。不支持组合键。可在[我们的源码中查看完整的按键名称列表](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts)。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -488,6 +498,7 @@ function aiScroll(
     direction?: 'down' | 'up' | 'left' | 'right';
     distance?: number | null;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -510,6 +521,7 @@ function aiScroll(
     - `direction?: 'down' | 'up' | 'left' | 'right'` - 滚动方向，默认值为 `down`。仅在 `scrollType` 为 `singleAction` 时生效。不论是 Android 还是 Web，这里的滚动方向都是指页面哪个方向的内容会进入屏幕。比如当滚动方向是 `down` 时，页面下方被隐藏的内容会从屏幕底部开始逐渐向上露出。
     - `distance?: number | null` - 滚动距离，单位为像素。设置为 `null` 表示由 Midscene 自动决定。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -559,6 +571,7 @@ function aiPinch(
     distance?: number;
     duration?: number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -573,6 +586,7 @@ function aiPinch(
     - `distance?: number` - 每根手指移动的距离（像素）。默认值为屏幕较短边的四分之一。
     - `duration?: number` - 缩放手势持续时间（毫秒），默认值为 `500`。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径。默认值为空。
     - `cacheable?: boolean` - 当启用[缓存功能](./caching.mdx)时，是否允许缓存。默认值为 true。
 
@@ -614,6 +628,7 @@ function aiLongPress(
   opt?: {
     duration?: number;
     deepLocate?: boolean;
+    context?: string;
     xpath?: string;
     cacheable?: boolean;
   },
@@ -626,6 +641,7 @@ function aiLongPress(
   - `opt?: Object` - 可选配置对象：
     - `duration?: number` - 按住时长（毫秒）。未传时各平台使用各自默认值：Android `2000`，iOS `1000`，Web `500`。
     - `deepLocate?: boolean` - 是否启用[深度定位](#深度定位deeplocate)，默认 `false`。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 要操作元素的 xpath，默认空。
     - `cacheable?: boolean` - 启用[缓存功能](./caching.mdx)时是否缓存，默认 `true`。
 
@@ -664,6 +680,7 @@ function aiDoubleClick(locate: string | Object, options?: Object): Promise<void>
   - `locate: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: Object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -697,6 +714,7 @@ function aiRightClick(locate: string | Object, options?: Object): Promise<void>;
   - `locate: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: Object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -733,6 +751,7 @@ function aiAsk(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -763,6 +782,7 @@ function aiQuery<T>(dataDemand: string | Object, options?: Object): Promise<T>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -814,6 +834,7 @@ function aiBoolean(prompt: string | Object, options?: Object): Promise<boolean>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -846,6 +867,7 @@ function aiNumber(prompt: string | Object, options?: Object): Promise<number>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -880,6 +902,7 @@ function aiString(prompt: string | Object, options?: Object): Promise<string>;
   - `options?: Object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -919,6 +942,7 @@ function aiAssert(
   - options?: Object - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -1007,6 +1031,7 @@ function aiLocate(
   - `locate: string | Object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: Object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -1037,6 +1062,7 @@ function aiWaitFor(
   options?: {
     timeoutMs?: number;
     checkIntervalMs?: number;
+    context?: string;
   },
 ): Promise<void>;
 ```
@@ -1047,6 +1073,7 @@ function aiWaitFor(
   - `options?: object` - 可选的配置对象
     - `timeoutMs?: number` - 超时时间（毫秒，默认为 15000）。每轮检查开始时都会记录时间，只要该时间点仍在超时窗口内，就会进入下一轮检查；否则视为超时
     - `checkIntervalMs?: number` - 检查间隔（毫秒），默认为 3000
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -1438,6 +1465,39 @@ overrideAIConfig({
   // OPENAI_API_KEY: '...',
 });
 ```
+
+## 单次调用上下文
+
+每个 `agent.ai*` 方法的 options 都支持可选的 `context` 字符串。它可以为单次请求补充业务知识、用户状态、术语或其他背景，而不必把这些信息写入主 prompt。
+
+```typescript
+await agent.aiAssert('当前登录用户是 VIP 会员', undefined, {
+  context: 'VIP 会员的标准是页面右上角的用户头像会展示一个 VIP 的徽章。',
+});
+
+await agent.aiTap('收藏按钮', {
+  context: '收藏按钮是页面右下角的五角星 icon。',
+});
+```
+
+你也可以把大量业务自定义规则集中写入 `context`，再基于它封装通用的业务断言方法或点击方法。不同调用只需传入本次任务的简短 prompt，无需每次重复编写完整的业务规则。
+
+```typescript
+const myAssert = (prompt: string, errMsg?: string) =>
+  agent.aiAssert(prompt, errMsg, {
+    context: `业务自定义的大量断言规则，例如：
+- VIP 会员的头像会展示 VIP 徽章
+- 商品显示“暂时缺货”时，不应存在可点击的购买按钮
+- 订单状态为“已完成”时，实付金额必须可见`,
+  });
+
+await myAssert('当前登录用户是 VIP 会员');
+await myAssert('缺货商品不能购买');
+```
+
+context 仅对本次方法调用生效。对于 `aiAct`，单次调用的 `context` 优先于 Agent 级别的 `aiActContext`（显式传入空字符串也会覆盖）。其他 AI 方法不会自动继承 `aiActContext`。
+
+`context` 只补充请求信息，不会替代方法的主 prompt，也不会改变对象形式 `aiQuery` 的返回 schema。
 
 ## 深度定位（deepLocate）
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -1427,21 +1427,6 @@ await agent.aiTap('收藏按钮', {
 });
 ```
 
-你也可以把大量业务自定义规则集中写入 `context`，再基于它封装通用的业务断言方法或点击方法。不同调用只需传入本次任务的简短 prompt，无需每次重复编写完整的业务规则。
-
-```typescript
-const myAssert = (prompt: string, errMsg?: string) =>
-  agent.aiAssert(prompt, errMsg, {
-    context: `业务自定义的大量断言规则，例如：
-- VIP 会员的头像会展示 VIP 徽章
-- 商品显示“暂时缺货”时，不应存在可点击的购买按钮
-- 订单状态为“已完成”时，实付金额必须可见`,
-  });
-
-await myAssert('当前登录用户是 VIP 会员');
-await myAssert('缺货商品不能购买');
-```
-
 context 仅对本次方法调用生效。对于 `aiAct`，单次调用的 `context` 优先于 Agent 级别的 `aiActContext`（显式传入空字符串也会覆盖）。其他 AI 方法不会自动继承 `aiActContext`。
 
 <a id="深度定位deeplocate"></a>

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -1418,12 +1418,9 @@ const agent = new PuppeteerAgent(page, {
 每个 `agent.ai*` 方法的 options 都支持可选的 `context` 字符串。它可以为单次请求补充业务知识、用户状态、术语或其他背景，而不必把这些信息写入主 prompt。
 
 ```typescript
-await agent.aiAssert('当前登录用户是 VIP 会员', undefined, {
-  context: 'VIP 会员的标准是页面右上角的用户头像会展示一个 VIP 的徽章。',
-});
-
-await agent.aiTap('收藏按钮', {
-  context: '收藏按钮是页面右下角的五角星 icon。',
+await agent.aiAssert('当前页面是新版本样式', undefined, {
+  context:
+    '新版本的 Tab 栏位于页面顶部，且页面主色调为红色；旧版本的 Tab 栏位于页面底部，且页面主色调为绿色。只有同时满足新版本的两项条件时，才视为新版本。',
 });
 ```
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -1413,6 +1413,37 @@ const agent = new PuppeteerAgent(page, {
 
 报告文件的路径。
 
+## 单次调用上下文
+
+每个 `agent.ai*` 方法的 options 都支持可选的 `context` 字符串。它可以为单次请求补充业务知识、用户状态、术语或其他背景，而不必把这些信息写入主 prompt。
+
+```typescript
+await agent.aiAssert('当前登录用户是 VIP 会员', undefined, {
+  context: 'VIP 会员的标准是页面右上角的用户头像会展示一个 VIP 的徽章。',
+});
+
+await agent.aiTap('收藏按钮', {
+  context: '收藏按钮是页面右下角的五角星 icon。',
+});
+```
+
+你也可以把大量业务自定义规则集中写入 `context`，再基于它封装通用的业务断言方法或点击方法。不同调用只需传入本次任务的简短 prompt，无需每次重复编写完整的业务规则。
+
+```typescript
+const myAssert = (prompt: string, errMsg?: string) =>
+  agent.aiAssert(prompt, errMsg, {
+    context: `业务自定义的大量断言规则，例如：
+- VIP 会员的头像会展示 VIP 徽章
+- 商品显示“暂时缺货”时，不应存在可点击的购买按钮
+- 订单状态为“已完成”时，实付金额必须可见`,
+  });
+
+await myAssert('当前登录用户是 VIP 会员');
+await myAssert('缺货商品不能购买');
+```
+
+context 仅对本次方法调用生效。对于 `aiAct`，单次调用的 `context` 优先于 Agent 级别的 `aiActContext`（显式传入空字符串也会覆盖）。其他 AI 方法不会自动继承 `aiActContext`。
+
 <a id="深度定位deeplocate"></a>
 
 ### 共享类型 {#shared-types}

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -135,9 +135,10 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     abortSignal?: AbortSignal;
+    context?: string;
   },
 ): Promise<string | undefined>;
-function ai(prompt: string): Promise<string | undefined>; // 简写形式
+function ai(prompt: string, options?: Object): Promise<string | undefined>; // 简写形式
 ```
 
 - 参数：
@@ -147,6 +148,7 @@ function ai(prompt: string): Promise<string | undefined>; // 简写形式
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `deepThink?: 'unset' | true | false` - 控制 Midscene 在 `aiAct` 执行规划时的具体实现。开启后，`aiAct` 会更注重任务拆解，并将任务 Planning 和 UI 元素定位拆解为不同的模型调用。为了兼容旧写法，`'unset'` 仍然可以传入，并会被按 `false` 处理。[详情参阅 deepThink 说明](../model-strategy#关于-aiact-方法的-deepthink-参数)。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
@@ -205,6 +207,7 @@ function aiTap(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
@@ -244,6 +247,7 @@ function aiHover(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 - 返回值：
@@ -295,6 +299,7 @@ function aiInput(
       - 当 `mode` 为 `'typeOnly'` 时：直接输入文本，不会先清空输入框。
       - 当 `mode` 为 `'clear'` 时：会忽略文本内容，仅清空输入框。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
     - `autoDismissKeyboard?: boolean` - 如果为 true，则键盘会在输入文本后自动关闭，仅在 Android/iOS/HarmonyOS 中有效。默认值为 true。
@@ -351,6 +356,7 @@ function aiClearInput(
   - `locate: string | object` - 要清空的输入框的自然语言描述，或[通过图像提示](#通过图像提示)。
   - `opt?: object` - 可选配置对象：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认 `false`。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 要操作元素的 xpath，默认空。
     - `cacheable?: boolean` - 启用[缓存功能](../caching.mdx)时是否缓存，默认 `true`。
 
@@ -408,6 +414,7 @@ function aiKeyboardPress(
   - `opt: object` - 配置对象，包含：
     - `keyName: string` - **必填**，要按下的键，如 `Enter`、`Tab`、`Escape` 等。不支持组合键。可在[我们的源码中查看完整的按键名称列表](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts)。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -473,6 +480,7 @@ function aiScroll(
     - `direction?: 'down' | 'up' | 'left' | 'right'` - 滚动方向，默认值为 `down`。仅在 `scrollType` 为 `singleAction` 时生效。不论是 Android 还是 Web，这里的滚动方向都是指页面哪个方向的内容会进入屏幕。比如当滚动方向是 `down` 时，页面下方被隐藏的内容会从屏幕底部开始逐渐向上露出。
     - `distance?: number | null` - 滚动距离，单位为像素。设置为 `null` 表示由 Midscene 自动决定。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -536,6 +544,7 @@ function aiPinch(
     - `distance?: number` - 每根手指移动的距离（像素）。默认值为屏幕较短边的四分之一。
     - `duration?: number` - 缩放手势持续时间（毫秒），默认值为 `500`。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径。默认值为空。
     - `cacheable?: boolean` - 当启用[缓存功能](../caching.mdx)时，是否允许缓存。默认值为 true。
 
@@ -589,6 +598,7 @@ function aiLongPress(
   - `opt?: object` - 可选配置对象：
     - `duration?: number` - 按住时长（毫秒）。Android 默认 `2000`，iOS 默认 `1000`，Web 默认 `500`。HarmonyOS 使用系统长按时长并忽略此选项。
     - `deepLocate?: boolean` - 是否启用[深度定位](#深度定位deeplocate)，默认 `false`。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 要操作元素的 xpath，默认空。
     - `cacheable?: boolean` - 启用[缓存功能](../caching.mdx)时是否缓存，默认 `true`。
 
@@ -627,6 +637,7 @@ function aiDoubleClick(locate: string | object, options?: object): Promise<void>
   - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -660,6 +671,7 @@ function aiRightClick(locate: string | object, options?: object): Promise<void>;
   - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -696,6 +708,7 @@ function aiAsk(prompt: string | object, options?: object): Promise<string>;
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -726,6 +739,7 @@ function aiQuery<T>(dataDemand: string | object, options?: object): Promise<T>;
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -777,6 +791,7 @@ function aiBoolean(prompt: string | object, options?: object): Promise<boolean>;
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -809,6 +824,7 @@ function aiNumber(prompt: string | object, options?: object): Promise<number>;
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -843,6 +859,7 @@ function aiString(prompt: string | object, options?: object): Promise<string>;
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -886,6 +903,7 @@ function aiLocate(
   - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
   - `options?: object` - 可选，一个配置对象，包含：
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
     - `xpath?: string` - 目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
     - `cacheable?: boolean` - 当启用 [缓存功能](../caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 true
 
@@ -926,6 +944,7 @@ function aiAssert(
   - `options?: object` - 可选，一个配置对象，包含：
     - `domIncluded?: boolean | 'visible-only'` - 是否向模型发送精简后的 DOM 信息，一般用于提取 UI 中不可见的属性，比如图片的链接。如果设置为 `'visible-only'`，则只发送可见的元素。默认值为 false。
     - `screenshotIncluded?: boolean` - 是否向模型发送截图。默认值为 true。
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 
@@ -1001,6 +1020,7 @@ function aiWaitFor(
   options?: {
     timeoutMs?: number;
     checkIntervalMs?: number;
+    context?: string;
   },
 ): Promise<void>;
 ```
@@ -1011,6 +1031,7 @@ function aiWaitFor(
   - `options?: object` - 可选的配置对象
     - `timeoutMs?: number` - 超时时间（毫秒，默认为 15000）。每轮检查开始时都会记录时间，只要该时间点仍在超时窗口内，就会进入下一轮检查；否则视为超时
     - `checkIntervalMs?: number` - 相邻两次检查开始时间的最小间隔（毫秒），默认值为 3000
+    - `context?: string` - 本次调用的额外上下文。详见[单次调用上下文](#单次调用上下文)。
 
 - 返回值：
 

--- a/backlogs.md
+++ b/backlogs.md
@@ -1,5 +1,0 @@
-# Backlog
-
-- 排查并增强 `aiAct` plan 回放：相邻的状态切换型 `aiTap` 若经 locate cache 解析为同一元素，当前会原样连续执行，可能把刚展开的下拉框再次收起。需要确定应在规划阶段约束、执行阶段检测/重规划，还是两者结合，并补覆盖下拉选择场景的回归测试。
-- 改善报告的 cache 可观测性：`aiAct` plan cache 命中目前只显示为 `LoadYaml Cache`，其后回放的 Tap/Locate 不继承来源标记，容易被误读为未走缓存；评估为回放子步骤增加“来自已缓存工作流”的只读标识。
-- 压缩已完成的 inline report dump：当前写入策略会在每次进度更新时 append 完整 dump，前端仅在读取时按 execution id/name 保留最后一份。长任务会留下大量冗余 JSON；例如 Android report 有 487 份同一 execution 的 dump（约 55 MiB 可回收）。保留运行期 append 的非阻塞特性，但在结束、导出或上传前增加安全的 compact 步骤，并补长任务回归测试。

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -47,6 +47,7 @@ import { getVersion, processCacheConfig, reportHTMLContent } from '@/utils';
 import {
   ScriptPlayer,
   buildDetailedLocateParam,
+  buildDetailedLocateParamAndRestParams,
   parseYamlScript,
 } from '../yaml/index';
 
@@ -489,7 +490,7 @@ export class Agent<
         screenshot: () => this.interface.screenshotBase64(),
         captureRepresentative: () => this.getUIContext('assert'),
         runAssert: (assertion, uiContext, msg, assertOpt) =>
-          this.aiAssertWithContext(assertion, uiContext, msg, assertOpt),
+          this.aiAssertWithUIContext(assertion, uiContext, msg, assertOpt),
         runBoolean: (prompt, uiContext, boolOpt) =>
           this.aiBooleanWithContext(prompt, uiContext, boolOpt),
         onStopped: () => {
@@ -816,7 +817,10 @@ export class Agent<
     );
     assert(locatePrompt, 'missing locate prompt for input');
 
-    const detailedLocateParam = buildDetailedLocateParam(locatePrompt, opt);
+    const { locateParam, restParams } = buildDetailedLocateParamAndRestParams(
+      locatePrompt,
+      opt,
+    );
 
     // Convert value to string to ensure consistency
     const stringValue = typeof value === 'number' ? String(value) : value;
@@ -825,9 +829,9 @@ export class Agent<
     const mode = opt?.mode === 'append' ? 'typeOnly' : opt?.mode;
 
     await this.callActionInActionSpace('Input', {
-      ...(opt || {}),
+      ...restParams,
       value: stringValue,
-      locate: detailedLocateParam,
+      locate: locateParam,
       mode,
     });
   }
@@ -884,13 +888,14 @@ export class Agent<
 
     assert(opt?.keyName, 'missing keyName for keyboard press');
 
-    const detailedLocateParam = locatePrompt
-      ? buildDetailedLocateParam(locatePrompt, opt)
-      : undefined;
+    const { locateParam, restParams } = buildDetailedLocateParamAndRestParams(
+      locatePrompt || '',
+      opt,
+    );
 
     await this.callActionInActionSpace('KeyboardPress', {
-      ...(opt || {}),
-      locate: detailedLocateParam,
+      ...restParams,
+      locate: locateParam,
     });
   }
 
@@ -964,14 +969,14 @@ export class Agent<
       }
     }
 
-    const detailedLocateParam = buildDetailedLocateParam(
+    const { locateParam, restParams } = buildDetailedLocateParamAndRestParams(
       locatePrompt || '',
       opt,
     );
 
     await this.callActionInActionSpace('Scroll', {
-      ...(opt || {}),
-      locate: detailedLocateParam,
+      ...restParams,
+      locate: locateParam,
     });
   }
 
@@ -983,14 +988,14 @@ export class Agent<
       duration?: number;
     },
   ): Promise<void> {
-    const detailedLocateParam = buildDetailedLocateParam(
+    const { locateParam, restParams } = buildDetailedLocateParamAndRestParams(
       locatePrompt || '',
       opt,
     );
 
     await this.callActionInActionSpace('Pinch', {
-      ...opt,
-      locate: detailedLocateParam,
+      ...restParams,
+      locate: locateParam,
     });
   }
 
@@ -1000,11 +1005,14 @@ export class Agent<
   ): Promise<void> {
     assert(locatePrompt, 'missing locate prompt for long press');
 
-    const detailedLocateParam = buildDetailedLocateParam(locatePrompt, opt);
+    const { locateParam, restParams } = buildDetailedLocateParamAndRestParams(
+      locatePrompt,
+      opt,
+    );
 
     await this.callActionInActionSpace('LongPress', {
-      ...(opt || {}),
-      locate: detailedLocateParam,
+      ...restParams,
+      locate: locateParam,
     });
   }
 
@@ -1316,10 +1324,10 @@ export class Agent<
     msg?: string,
     opt?: AgentAssertOpt & ServiceExtractOption,
   ) {
-    return this.aiAssertWithContext(assertion, undefined, msg, opt);
+    return this.aiAssertWithUIContext(assertion, undefined, msg, opt);
   }
 
-  private async aiAssertWithContext(
+  private async aiAssertWithUIContext(
     assertion: TUserPrompt,
     uiContext?: UIContext,
     msg?: string,
@@ -1332,13 +1340,10 @@ export class Agent<
       screenshotIncluded:
         opt?.screenshotIncluded ??
         defaultServiceExtractOption.screenshotIncluded,
+      ...(opt?.context !== undefined ? { context: opt.context } : {}),
     };
 
-    const assertionWithContext = buildPromptWithContext(
-      assertion,
-      opt?.context,
-    );
-    const { textPrompt, multimodalPrompt } = parsePrompt(assertionWithContext);
+    const { textPrompt, multimodalPrompt } = parsePrompt(assertion);
     const assertionText =
       typeof assertion === 'string' ? assertion : assertion.prompt;
 

--- a/packages/core/src/agent/prompt-context.ts
+++ b/packages/core/src/agent/prompt-context.ts
@@ -21,3 +21,25 @@ export const buildPromptWithContext = (
     prompt: promptWithContext,
   };
 };
+
+export const buildLocatePromptWithContext = (
+  prompt: TUserPrompt,
+  context: string | undefined,
+): TUserPrompt => {
+  const trimmedContext = context?.trim();
+  if (!trimmedContext) {
+    return prompt;
+  }
+
+  const promptText = typeof prompt === 'string' ? prompt : prompt.prompt;
+  const promptWithContext = `<CONTEXT>\n${trimmedContext}\n</CONTEXT>\n\n<LOCATE_TARGET>\n${promptText}\n</LOCATE_TARGET>`;
+
+  if (typeof prompt === 'string') {
+    return promptWithContext;
+  }
+
+  return {
+    ...prompt,
+    prompt: promptWithContext,
+  };
+};

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -696,12 +696,29 @@ export class TaskBuilder {
           };
         }
 
-        onResult?.(element);
+        const promptDisplay = param.promptDisplay;
+        const elementForAction = promptDisplay
+          ? {
+              ...element,
+              description: promptDisplay,
+            }
+          : element;
+
+        if (promptDisplay && locateDump?.matchedElement) {
+          locateDump.matchedElement = locateDump.matchedElement.map(
+            (matchedElement) => ({
+              ...matchedElement,
+              description: promptDisplay,
+            }),
+          );
+        }
+
+        onResult?.(elementForAction);
 
         return {
           output: {
             element: {
-              ...element,
+              ...elementForAction,
               // backward compatibility for aiLocate, which return value needs a dpr field
               dpr: uiContext.deprecatedDpr,
             },

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -856,6 +856,7 @@ export class TaskExecutor {
       subType: type,
       param: {
         domIncluded: opt?.domIncluded,
+        ...(opt?.context !== undefined ? { context: opt.context } : {}),
         dataDemand: multimodalPrompt
           ? ({
               demand,

--- a/packages/core/src/agent/ui-utils.ts
+++ b/packages/core/src/agent/ui-utils.ts
@@ -37,6 +37,10 @@ export function locateParamStr(locate?: DetailedLocateParam | string): string {
   }
 
   if (typeof locate === 'object') {
+    if (typeof locate.promptDisplay === 'string') {
+      return locate.promptDisplay;
+    }
+
     // Check for nested prompt.prompt (Planning Locate tasks)
     if (
       typeof locate.prompt === 'object' &&

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -521,6 +521,7 @@ export async function AiExtractElementInfo<T>(options: {
   const extractDataPromptText = extractDataQueryPrompt(
     options.pageDescription || '',
     dataQuery,
+    extractOption?.context,
   );
 
   const userContent: ChatCompletionUserMessageParam['content'] = [];

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -583,6 +583,7 @@ export async function AiExtractElementInfo<T>(options: {
   const extractDataPromptText = extractDataQueryPrompt(
     options.pageDescription || '',
     dataQuery,
+    extractOption?.context,
   );
 
   const userContent: ChatCompletionUserMessageParam['content'] = [];

--- a/packages/core/src/ai-model/prompt/extraction.ts
+++ b/packages/core/src/ai-model/prompt/extraction.ts
@@ -191,6 +191,7 @@ By viewing the screenshot and page contents, you can extract the following data:
 export const extractDataQueryPrompt = (
   pageDescription: string,
   dataQuery: string | Record<string, string>,
+  context?: string,
 ) => {
   let dataQueryText = '';
   if (typeof dataQuery === 'string') {
@@ -199,11 +200,16 @@ export const extractDataQueryPrompt = (
     dataQueryText = JSON.stringify(dataQuery, null, 2);
   }
 
+  const trimmedContext = context?.trim();
+  const contextSection = trimmedContext
+    ? `\n<CONTEXT>\n${trimmedContext}\n</CONTEXT>\n`
+    : '';
+
   return `
 <PageDescription>
 ${pageDescription}
 </PageDescription>
-
+${contextSection}
 <DATA_DEMAND>
 ${dataQueryText}
 </DATA_DEMAND>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -636,6 +636,7 @@ task - service-query
 export interface ExecutionTaskInsightQueryParam {
   dataDemand: ServiceExtractParam;
   domIncluded?: boolean | 'visible-only';
+  context?: string;
 }
 
 export interface ExecutionTaskInsightQueryOutput {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -9,6 +9,8 @@ import type { UIContext } from './types';
 
 export interface LocateOption extends Partial<TMultimodalPrompt> {
   prompt?: TUserPrompt;
+  /** Additional context for this AI request. */
+  context?: string;
   deepLocate?: boolean; // only available in vl model
   /** @deprecated Use `deepLocate` instead. Kept for backward compatibility. */
   deepThink?: boolean; // alias for deepLocate
@@ -19,14 +21,23 @@ export interface LocateOption extends Partial<TMultimodalPrompt> {
 }
 
 export interface ServiceExtractOption {
+  /** Additional context for this AI request. */
+  context?: string;
   domIncluded?: boolean | 'visible-only';
   screenshotIncluded?: boolean;
   [key: string]: unknown;
 }
 
 export interface DetailedLocateParam
-  extends Omit<LocateOption, 'deepThink' | keyof TMultimodalPrompt> {
+  extends Omit<
+    LocateOption,
+    'context' | 'deepThink' | keyof TMultimodalPrompt
+  > {
   prompt: TUserPrompt;
+  /** Original prompt text used for user-facing reports. */
+  promptDisplay?: string;
+  /** Per-call business context used for user-facing reports. */
+  context?: string;
 }
 
 export type ScrollType =

--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -8,6 +8,7 @@ import type {
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import yaml from 'js-yaml';
+import { buildLocatePromptWithContext } from '../agent/prompt-context';
 
 const debugUtils = getDebug('yaml:utils');
 
@@ -315,6 +316,10 @@ export function buildDetailedLocateParam(
     return undefined;
   }
 
+  const promptDisplay = typeof prompt === 'string' ? prompt : prompt.prompt;
+  const context = opt?.context?.trim() || undefined;
+  prompt = buildLocatePromptWithContext(prompt, opt?.context);
+
   const multimodalPrompt = extractMultimodalPrompt(opt);
   if (multimodalPrompt) {
     prompt =
@@ -331,6 +336,7 @@ export function buildDetailedLocateParam(
 
   return {
     prompt,
+    ...(context ? { promptDisplay, context } : {}),
     deepLocate,
     cacheable,
     xpath,
@@ -355,7 +361,7 @@ export function buildDetailedLocateParamAndRestParams(
     // Get all keys from opt
     const allKeys = Object.keys(opt);
 
-    // Keys already included in locateParam: prompt, deepLocate, cacheable, xpath
+    // `context` has already been merged into the locate prompt.
     const locateParamKeys = Object.keys(locateParam || {});
     const multimodalPromptKeys =
       typeof locateParam?.prompt === 'object' && locateParam?.prompt !== null
@@ -366,6 +372,8 @@ export function buildDetailedLocateParamAndRestParams(
     for (const key of allKeys) {
       if (
         !locateParamKeys.includes(key) &&
+        key !== 'context' &&
+        key !== 'deepThink' &&
         !multimodalPromptKeys.includes(key) &&
         !excludeKeys.includes(key) &&
         key !== 'locate'

--- a/packages/core/tests/unit-test/action-long-press.test.ts
+++ b/packages/core/tests/unit-test/action-long-press.test.ts
@@ -83,6 +83,31 @@ describe('LongPress Action', () => {
       );
     });
 
+    it('separates locate options from action params', async () => {
+      const agent = createAgentStub();
+      const callActionSpy = (agent as any)
+        .callActionInActionSpace as ReturnType<typeof vi.fn>;
+
+      await agent.aiLongPress('首页任意一篇文章', {
+        context: '文章位于首页的信息流中',
+        deepLocate: true,
+        duration: 2000,
+      });
+
+      expect(callActionSpy).toHaveBeenCalledWith('LongPress', {
+        duration: 2000,
+        locate: {
+          cacheable: true,
+          context: '文章位于首页的信息流中',
+          deepLocate: true,
+          prompt:
+            '<CONTEXT>\n文章位于首页的信息流中\n</CONTEXT>\n\n<LOCATE_TARGET>\n首页任意一篇文章\n</LOCATE_TARGET>',
+          promptDisplay: '首页任意一篇文章',
+          xpath: undefined,
+        },
+      });
+    });
+
     it('throws when locate prompt is missing', async () => {
       const agent = createAgentStub();
       await expect(agent.aiLongPress('' as any)).rejects.toThrow(

--- a/packages/core/tests/unit-test/agent-context-option.test.ts
+++ b/packages/core/tests/unit-test/agent-context-option.test.ts
@@ -89,7 +89,7 @@ describe('Agent per-call context option', () => {
     expect(taskExecutor.action.mock.calls[0][4]).toBe('');
   });
 
-  it('adds per-call context to aiAssert prompts internally', async () => {
+  it('passes aiAssert context separately from the assertion prompt', async () => {
     const { agent, taskExecutor } = createAgentStub();
 
     const result = await agent.aiAssert(
@@ -103,9 +103,10 @@ describe('Agent per-call context option', () => {
 
     expect(taskExecutor.createTypeQueryExecution).toHaveBeenCalledWith(
       'Assert',
-      'Context for this request:\nThe current user is a logged-in buyer.\n\nThe success toast is visible',
+      'The success toast is visible',
       defaultModel,
       {
+        context: 'The current user is a logged-in buyer.',
         domIncluded: false,
         screenshotIncluded: true,
       },

--- a/packages/core/tests/unit-test/agent-scroll-compat.test.ts
+++ b/packages/core/tests/unit-test/agent-scroll-compat.test.ts
@@ -99,7 +99,6 @@ describe('Agent aiScroll legacy scrollType compatibility', () => {
 
     expect(callActionSpy).toHaveBeenCalledTimes(1);
     expect(callActionSpy).toHaveBeenCalledWith('Scroll', {
-      deepThink: true,
       locate: undefined,
       scrollType: 'scrollToBottom',
     });

--- a/packages/core/tests/unit-test/prompt-context.test.ts
+++ b/packages/core/tests/unit-test/prompt-context.test.ts
@@ -1,4 +1,7 @@
-import { buildPromptWithContext } from '@/agent/prompt-context';
+import {
+  buildLocatePromptWithContext,
+  buildPromptWithContext,
+} from '@/agent/prompt-context';
 import { describe, expect, it } from 'vitest';
 
 describe('buildPromptWithContext', () => {
@@ -32,6 +35,35 @@ describe('buildPromptWithContext', () => {
         'Context for this request:\nUse mobile layout.\n\nClick the target shown in the reference image.',
       images: [{ name: 'target', url: './target.png' }],
       convertHttpImage2Base64: true,
+    });
+  });
+});
+
+describe('buildLocatePromptWithContext', () => {
+  it('wraps context and locate target in explicit tags', () => {
+    expect(
+      buildLocatePromptWithContext(
+        'Favorite button',
+        'The favorite button is the star icon in the bottom-right corner.',
+      ),
+    ).toBe(
+      '<CONTEXT>\nThe favorite button is the star icon in the bottom-right corner.\n</CONTEXT>\n\n<LOCATE_TARGET>\nFavorite button\n</LOCATE_TARGET>',
+    );
+  });
+
+  it('preserves multimodal fields while wrapping the prompt text', () => {
+    expect(
+      buildLocatePromptWithContext(
+        {
+          prompt: 'Favorite button',
+          images: [{ name: 'target', url: './target.png' }],
+        },
+        'Use the mobile layout.',
+      ),
+    ).toEqual({
+      prompt:
+        '<CONTEXT>\nUse the mobile layout.\n</CONTEXT>\n\n<LOCATE_TARGET>\nFavorite button\n</LOCATE_TARGET>',
+      images: [{ name: 'target', url: './target.png' }],
     });
   });
 });

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -585,4 +585,19 @@ describe('extract element', () => {
     });
     expect(prompt).toMatchSnapshot();
   });
+
+  it('adds context without changing an object data demand', () => {
+    const prompt = extractDataQueryPrompt(
+      'todo page',
+      { foo: 'an array indicates the foo' },
+      'Only include active items.',
+    );
+
+    expect(prompt).toContain(
+      '<CONTEXT>\nOnly include active items.\n</CONTEXT>',
+    );
+    expect(prompt).toContain(
+      '<DATA_DEMAND>\n{\n  "foo": "an array indicates the foo"\n}\n</DATA_DEMAND>',
+    );
+  });
 });

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -130,6 +130,77 @@ describe('TaskBuilder', () => {
     ]);
   });
 
+  it('uses promptDisplay for the located element passed to an action', async () => {
+    const actionSchema = z.object({
+      locate: getMidsceneLocationSchema().describe('element to locate'),
+    });
+    const mockAction: DeviceAction = {
+      name: 'Tap',
+      description: 'mock tap action',
+      paramSchema: actionSchema,
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([mockAction]);
+    const locateDump = {
+      taskInfo: { durationMs: 1 },
+      matchedElement: [
+        {
+          center: [50, 50],
+          rect: { left: 40, top: 40, width: 20, height: 20 },
+          description:
+            '<CONTEXT>favorite fruit rule</CONTEXT><LOCATE_TARGET>orange</LOCATE_TARGET>',
+        },
+      ],
+    };
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate: vi.fn(async () => ({
+        element: {
+          center: [50, 50],
+          rect: { left: 40, top: 40, width: 20, height: 20 },
+          description:
+            '<CONTEXT>favorite fruit rule</CONTEXT><LOCATE_TARGET>orange</LOCATE_TARGET>',
+        },
+        dump: locateDump,
+      })),
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const plans: PlanningAction[] = [
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt:
+              '<CONTEXT>favorite fruit rule</CONTEXT><LOCATE_TARGET>orange</LOCATE_TARGET>',
+            promptDisplay: 'orange',
+            context: 'favorite fruit rule',
+          },
+        },
+      },
+    ];
+
+    const { tasks } = await taskBuilder.build(
+      plans,
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+    const locateTask = tasks[0];
+    await locateTask.executor(locateTask.param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+
+    expect((plans[0].param as any).locate.description).toBe('orange');
+    expect(locateDump.matchedElement[0].description).toBe('orange');
+  });
+
   it('throws when building an executable task for an action outside actionSpace', async () => {
     const mockInterface = new MockInterface([defineActionSleep()]);
     const insightService = {

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -647,7 +647,7 @@ describe('TaskExecutor - Null Data Handling', () => {
       expect(result.thought).toBe('Extracted the numeric value successfully');
     });
 
-    it('should preserve domIncluded on Insight task params for report rendering', async () => {
+    it('should preserve report fields on Insight task params', async () => {
       const mockInsight = {
         contextRetrieverFn: vi.fn(async () => await createMockUIContext()),
         extract: vi.fn(async () => ({
@@ -680,10 +680,14 @@ describe('TaskExecutor - Null Data Handling', () => {
         'Number',
         'Extract the price',
         getModelRuntime(mockModelConfig),
-        { domIncluded: true },
+        {
+          context: 'Use wholesale pricing rules.',
+          domIncluded: true,
+        },
       );
 
       expect(queryTask.param).toEqual({
+        context: 'Use wholesale pricing rules.',
         domIncluded: true,
         dataDemand: 'Extract the price',
       });

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import * as fs from 'node:fs';
+import { locateParamStr } from '@/agent/ui-utils';
 import { dumpActionParam, findAllMidsceneLocatorField } from '@/common';
 import { getMidsceneLocationSchema } from '@/index';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
@@ -267,6 +268,19 @@ describe('utils', () => {
 });
 
 describe('buildDetailedLocateParam', () => {
+  it('adds per-call context to the locate prompt', () => {
+    const result = buildDetailedLocateParam('Click the checkout button', {
+      context: 'The current user is a wholesale customer.',
+    });
+
+    expect(result?.prompt).toBe(
+      '<CONTEXT>\nThe current user is a wholesale customer.\n</CONTEXT>\n\n<LOCATE_TARGET>\nClick the checkout button\n</LOCATE_TARGET>',
+    );
+    expect(result?.promptDisplay).toBe('Click the checkout button');
+    expect(result?.context).toBe('The current user is a wholesale customer.');
+    expect(locateParamStr(result)).toBe('Click the checkout button');
+  });
+
   it('merges multimodal locate options into the prompt object', () => {
     const result = buildDetailedLocateParam('Click the icon', {
       images: [
@@ -298,6 +312,20 @@ describe('buildDetailedLocateParam', () => {
 });
 
 describe('buildDetailedLocateParamAndRestParams', () => {
+  it('consumes context without leaking it into action params', () => {
+    const result = buildDetailedLocateParamAndRestParams(
+      'Click the checkout button',
+      {
+        context: 'The current user is a wholesale customer.',
+      },
+    );
+
+    expect(result.locateParam?.prompt).toContain(
+      'The current user is a wholesale customer.',
+    );
+    expect(result.restParams).not.toHaveProperty('context');
+  });
+
   it('does not leak multimodal locate options into rest params', () => {
     const uiContext = {
       screenshot: {

--- a/packages/web-integration/tests/ai/web/playwright/__fixtures__/context-ai-tap/index.html
+++ b/packages/web-integration/tests/ai/web/playwright/__fixtures__/context-ai-tap/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Context AI Tap Fixture</title>
+    <style>
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+        background: #f6f7fb;
+        color: #20232a;
+        font-family: system-ui, sans-serif;
+      }
+
+      main {
+        padding: 32px;
+        border-radius: 16px;
+        background: white;
+        box-shadow: 0 12px 36px rgb(28 39 49 / 12%);
+        text-align: center;
+      }
+
+      .choices {
+        display: flex;
+        gap: 16px;
+        margin: 24px 0;
+      }
+
+      button {
+        min-width: 120px;
+        padding: 14px 20px;
+        border: 1px solid #c9ced8;
+        border-radius: 10px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 18px;
+      }
+
+      button:hover {
+        background: #f0f3f8;
+      }
+
+      #result {
+        min-height: 24px;
+        margin: 0;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Choose a fruit</h1>
+      <div class="choices">
+        <button type="button" data-fruit="apple">apple</button>
+        <button type="button" data-fruit="banana">banana</button>
+        <button type="button" data-fruit="orange">orange</button>
+      </div>
+      <p id="result" aria-live="polite">No fruit selected</p>
+    </main>
+    <script>
+      document.querySelectorAll('[data-fruit]').forEach((button) => {
+        button.addEventListener('click', () => {
+          const fruit = button.dataset.fruit;
+          document.body.dataset.selectedFruit = fruit;
+          document.querySelector('#result').textContent = `Selected: ${fruit}`;
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-integration/tests/ai/web/playwright/context-ai-tap.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/context-ai-tap.spec.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { expect } from '@playwright/test';
+import { test } from './fixture';
+
+test('AI methods use per-call context', async ({ agentForPage, page }) => {
+  const fixtureDir = path.resolve(__dirname, '__fixtures__/context-ai-tap');
+  await page.goto(pathToFileURL(path.join(fixtureDir, 'index.html')).href);
+
+  const agent = await agentForPage(page);
+  await agent.aiTap("Click Tom's favorite fruit", {
+    context: "Tom's favorite fruit is orange.",
+  });
+  await agent.aiAssert(
+    "The selected fruit is Tom's favorite fruit",
+    undefined,
+    {
+      context: "Tom's favorite fruit is orange.",
+    },
+  );
+
+  await expect(page.locator('body')).toHaveAttribute(
+    'data-selected-fruit',
+    'orange',
+  );
+  await expect(page.locator('#result')).toHaveText('Selected: orange');
+});


### PR DESCRIPTION
## What changed

- add a per-call `context` option to Agent AI methods
- keep model prompts and report-facing fields separate for locate and insight tasks
- show context as dedicated information in reports without leaking tagged model prompts into titles or element descriptions
- document the option in both English and Chinese API docs, including business-specific wrapper examples
- add unit coverage and a Playwright AI fixture covering contextual tap and assertion

## Why

Callers need to provide reusable business knowledge to individual AI operations without repeating full rules in every prompt. The report should present that context separately while preserving the structured prompt sent to the model.

## Impact

Users can pass additional context per AI call and build domain-specific assertion or interaction helpers. Existing behavior remains unchanged when context is omitted.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/task-builder.test.ts`
- `pnpm exec nx build @midscene/core`
- `git diff --check`

The model-backed Playwright E2E fixture was added but requires the Midscene model environment variables to run.