### PR TITLE
refactor(cli): delegate feature scenarios to core

### DIFF
--- a/packages/cli/src/framework/feature-file.ts
+++ b/packages/cli/src/framework/feature-file.ts
@@ -183,13 +183,14 @@ const collectScenarioInfo = (
   return [{ id: scenario.id, ruleName }];
 };
 
-const pickleStepToFlowItem = (step: PickleStep) => {
+const pickleStepToScenarioLine = (step: PickleStep): string => {
   switch (step.type) {
     case 'Outcome':
-      return { aiAssert: step.text };
+      return `  Then ${step.text}`;
     case 'Context':
+      return `  Given ${step.text}`;
     case 'Action':
-      return { aiAct: step.text };
+      return `  When ${step.text}`;
     default:
       throw new Error(`Unsupported Gherkin step type: ${String(step.type)}`);
   }
@@ -277,7 +278,24 @@ export function compileFeatureFile(
       scenarioInfo.ruleName,
       scenarioName,
     ].filter(Boolean);
-    const flow = pickle.steps.map(pickleStepToFlowItem);
+    if (pickle.steps.length === 0) {
+      throw new Error(
+        `${file}: Scenario "${scenarioName}" must contain at least one step`,
+      );
+    }
+    if (
+      [scenarioName, ...pickle.steps.map((step) => step.text)].some((value) =>
+        /[\r\n]/.test(value),
+      )
+    ) {
+      throw new Error(
+        `${file}: Expanded scenario names and steps must not contain newlines`,
+      );
+    }
+    const scenarioText = [
+      `Scenario: ${scenarioName}`,
+      ...pickle.steps.map(pickleStepToScenarioLine),
+    ].join('\n');
     return {
       scenarioName,
       testName: nameParts.join(' > '),
@@ -285,7 +303,7 @@ export function compileFeatureFile(
         tasks: [
           {
             name: scenarioName,
-            flow,
+            flow: [{ runGherkinScenario: scenarioText }],
           },
         ],
       },

--- a/packages/cli/tests/unit-test/framework/feature-file.test.ts
+++ b/packages/cli/tests/unit-test/framework/feature-file.test.ts
@@ -1,8 +1,39 @@
 import { compileFeatureFile } from '@/framework/feature-file';
 import { describe, expect, test } from 'vitest';
 
+const runScenarioFlow = (name: string, steps: string[]) => [
+  {
+    runGherkinScenario: [
+      `Scenario: ${name}`,
+      ...steps.map((step) => `  ${step}`),
+    ].join('\n'),
+  },
+];
+
 describe('feature-file parser', () => {
-  test('compiles scenarios into Midscene aiAct and aiAssert tasks', () => {
+  test('delegates concrete scenarios to core runGherkinScenario execution', () => {
+    const [compiled] = compileFeatureFile(
+      [
+        'Feature: Login',
+        'Scenario: Failed login',
+        '  Given I open the login page',
+        '  When I enter a bad password',
+        '  Then an error is shown',
+        '',
+      ].join('\n'),
+      '/repo/features/login.feature',
+    );
+
+    expect(compiled.executionConfig.tasks[0].flow).toEqual(
+      runScenarioFlow('Failed login', [
+        'Given I open the login page',
+        'When I enter a bad password',
+        'Then an error is shown',
+      ]),
+    );
+  });
+
+  test('canonicalizes inherited And and But keywords for core execution', () => {
     const compiled = compileFeatureFile(
       [
         'Feature: Login',
@@ -24,12 +55,12 @@ describe('feature-file parser', () => {
           tasks: [
             {
               name: 'Failed login',
-              flow: [
-                { aiAct: 'I open the login page' },
-                { aiAct: 'I type a bad password' },
-                { aiAssert: 'an error is shown' },
-                { aiAssert: 'the user stays signed out' },
-              ],
+              flow: runScenarioFlow('Failed login', [
+                'Given I open the login page',
+                'Given I type a bad password',
+                'Then an error is shown',
+                'Then the user stays signed out',
+              ]),
             },
           ],
         },
@@ -64,12 +95,12 @@ describe('feature-file parser', () => {
           tasks: [
             {
               name: 'Add item',
-              flow: [
-                { aiAct: 'I am signed in' },
-                { aiAct: 'the cart is empty' },
-                { aiAct: 'I add a hat' },
-                { aiAssert: 'the cart has 1 item' },
-              ],
+              flow: runScenarioFlow('Add item', [
+                'Given I am signed in',
+                'Given the cart is empty',
+                'When I add a hat',
+                'Then the cart has 1 item',
+              ]),
             },
           ],
         },
@@ -99,8 +130,14 @@ describe('feature-file parser', () => {
       'Checkout > Add quantities #2',
     ]);
     expect(compiled.map((item) => item.executionConfig.tasks[0].flow)).toEqual([
-      [{ aiAct: 'I add 2 hats' }, { aiAssert: 'the cart has 2 item' }],
-      [{ aiAct: 'I add 3 shoes' }, { aiAssert: 'the cart has 3 item' }],
+      runScenarioFlow('Add quantities #1', [
+        'When I add 2 hats',
+        'Then the cart has 2 item',
+      ]),
+      runScenarioFlow('Add quantities #2', [
+        'When I add 3 shoes',
+        'Then the cart has 3 item',
+      ]),
     ]);
   });
 
@@ -128,8 +165,8 @@ describe('feature-file parser', () => {
       'Checkout > Add 3 shoes',
     ]);
     expect(compiled.map((item) => item.executionConfig.tasks[0].flow)).toEqual([
-      [{ aiAssert: 'the cart has 2 hats' }],
-      [{ aiAssert: 'the cart has 3 shoes' }],
+      runScenarioFlow('Add 2 hats', ['Then the cart has 2 hats']),
+      runScenarioFlow('Add 3 shoes', ['Then the cart has 3 shoes']),
     ]);
   });
 
@@ -147,11 +184,13 @@ describe('feature-file parser', () => {
       '/repo/features/checkout.feature',
     );
 
-    expect(compiled[0].executionConfig.tasks[0].flow).toEqual([
-      { aiAct: 'I am signed in' },
-      { aiAct: 'I open the cart' },
-      { aiAssert: 'the cart is visible' },
-    ]);
+    expect(compiled[0].executionConfig.tasks[0].flow).toEqual(
+      runScenarioFlow('Continue from background', [
+        'Given I am signed in',
+        'Given I open the cart',
+        'Then the cart is visible',
+      ]),
+    );
 
     expect(() =>
       compileFeatureFile(
@@ -204,6 +243,36 @@ describe('feature-file parser', () => {
       ),
     ).toThrow(
       '/repo/features/checkout.feature:2: Scenario Outline requires at least one Examples row',
+    );
+  });
+
+  test('rejects expanded scenario content containing newlines', () => {
+    expect(() =>
+      compileFeatureFile(
+        [
+          'Feature: Checkout',
+          'Scenario Outline: Add <item>',
+          '  When I add <item>',
+          '  Examples:',
+          '    | item                  |',
+          '    | first\\nThen injected |',
+          '',
+        ].join('\n'),
+        '/repo/features/checkout.feature',
+      ),
+    ).toThrow(
+      '/repo/features/checkout.feature: Expanded scenario names and steps must not contain newlines',
+    );
+  });
+
+  test('rejects scenarios without executable steps', () => {
+    expect(() =>
+      compileFeatureFile(
+        ['Feature: Checkout', 'Scenario: Empty cart', ''].join('\n'),
+        '/repo/features/checkout.feature',
+      ),
+    ).toThrow(
+      '/repo/features/checkout.feature: Scenario "Empty cart" must contain at least one step',
     );
   });
 

--- a/packages/cli/tests/unit-test/framework/feature-loader.test.ts
+++ b/packages/cli/tests/unit-test/framework/feature-loader.test.ts
@@ -3,6 +3,15 @@ import featureLoader, {
 } from '@/framework/feature-loader';
 import { describe, expect, test } from 'vitest';
 
+const runScenarioFlow = (name: string, steps: string[]) => [
+  {
+    runGherkinScenario: [
+      `Scenario: ${name}`,
+      ...steps.map((step) => `  ${step}`),
+    ].join('\n'),
+  },
+];
+
 describe('feature file loader', () => {
   test('emits one Rstest case per scenario using precomputed result files', () => {
     const output = transformFeatureFileToRstestModule({
@@ -22,10 +31,10 @@ describe('feature file loader', () => {
               tasks: [
                 {
                   name: 'Add item',
-                  flow: [
-                    { aiAct: 'I open the product page' },
-                    { aiAssert: 'the cart shows one item' },
-                  ],
+                  flow: runScenarioFlow('Add item', [
+                    'Given I open the product page',
+                    'Then the cart shows one item',
+                  ]),
                 },
               ],
             },
@@ -47,10 +56,10 @@ describe('feature file loader', () => {
               tasks: [
                 {
                   name: 'Remove item',
-                  flow: [
-                    { aiAct: 'the cart has one item' },
-                    { aiAssert: 'the cart is empty' },
-                  ],
+                  flow: runScenarioFlow('Remove item', [
+                    'Given the cart has one item',
+                    'Then the cart is empty',
+                  ]),
                 },
               ],
             },
@@ -68,8 +77,9 @@ describe('feature file loader', () => {
       '"testName": "features/checkout.feature > Checkout > Add item"',
     );
     expect(output).toContain('"resultFile": "/tmp/results/001-add-item.json"');
-    expect(output).toContain('"aiAct": "I open the product page"');
-    expect(output).toContain('"aiAssert": "the cart shows one item"');
+    expect(output).toContain(
+      '"runGherkinScenario": "Scenario: Add item\\n  Given I open the product page\\n  Then the cart shows one item"',
+    );
     expect(output).toContain(
       '"testName": "features/checkout.feature > Checkout > Remove item"',
     );
@@ -91,7 +101,9 @@ describe('feature file loader', () => {
               tasks: [
                 {
                   name: 'Retry checkout #1',
-                  flow: [{ aiAct: 'I open checkout' }],
+                  flow: runScenarioFlow('Retry checkout #1', [
+                    'Given I open checkout',
+                  ]),
                 },
               ],
             },
@@ -105,7 +117,9 @@ describe('feature file loader', () => {
               tasks: [
                 {
                   name: 'Retry checkout #2',
-                  flow: [{ aiAct: 'I refresh checkout' }],
+                  flow: runScenarioFlow('Retry checkout #2', [
+                    'Given I refresh checkout',
+                  ]),
                 },
               ],
             },
@@ -117,11 +131,15 @@ describe('feature file loader', () => {
     expect(output).toContain(
       '"resultFile": "/tmp/results/001-retry-checkout.json"',
     );
-    expect(output).toContain('"aiAct": "I open checkout"');
+    expect(output).toContain(
+      '"runGherkinScenario": "Scenario: Retry checkout #1\\n  Given I open checkout"',
+    );
     expect(output).toContain(
       '"resultFile": "/tmp/results/002-retry-checkout.json"',
     );
-    expect(output).toContain('"aiAct": "I refresh checkout"');
+    expect(output).toContain(
+      '"runGherkinScenario": "Scenario: Retry checkout #2\\n  Given I refresh checkout"',
+    );
   });
 
   test('throws when Rspack loader metadata is missing for the feature file', () => {


### PR DESCRIPTION
## Summary
- delegates each expanded `.feature` case to the existing core `Agent.runGherkinScenario()` execution path
- canonicalizes Gherkin pickle step types to `Given` / `When` / `Then` after Background, Rule, and Examples expansion
- preserves #2706's Rstest scheduling and per-scenario reporting while reusing core prompt, cache, abort, and error semantics

## Stack
- stacked on #2706 (`feat/cli-feature-runner-poc`)
- does not modify or close #2706
- only three CLI files changed; no core API or package changes

## Safety
- rejects expanded scenario names/steps containing newlines before serializing line-based Gherkin
- rejects concrete scenarios with no executable steps before invoking the core runner

## Test plan
- `npx nx test @midscene/core -- tests/unit-test/run-gherkin-scenario.test.ts tests/unit-test/yaml-doc-usage.test.ts`
- `npx nx test @midscene/cli`
- `npx nx build @midscene/cli`
- `pnpm run lint`
- `pnpm run type-check:tests`
- `git diff --check`