### PR TITLE
Add Discord and Feishu release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,7 @@ jobs:
                   {key: "other", label: "Other"}
                 ];
               def safe_title:
-                gsub("(?<char>[\\\\`*_~\\[\\]()<>#])"; "\\\\\(.char)");
+                gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
               def item_line:
                 if .pr != "" then
                   "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,20 +608,34 @@ jobs:
       id: notify
       continue-on-error: true
       env:
-        FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
-        FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
-        FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
+        FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
+        FEISHU_WEBHOOK_SECRET_2: ${{ secrets.FEISHU_WEBHOOK_SECRET_2 }}
+        FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+        FEISHU_WEBHOOK_URL_2: ${{ secrets.FEISHU_WEBHOOK_URL_2 }}
         GH_TOKEN: ${{ github.token }}
         RELEASE_VERSION: ${{ needs.release.outputs.version }}
       run: |
         set -euo pipefail
 
-        if [[ -z "$FEISHU_APP_ID" || -z "$FEISHU_APP_SECRET" || -z "$FEISHU_CHAT_ID" ]]; then
-          echo "::warning::The Feishu application credentials or chat ID are not configured; skipping the Feishu release notification."
+        WEBHOOK_URLS=("$FEISHU_WEBHOOK_URL" "$FEISHU_WEBHOOK_URL_2")
+        WEBHOOK_SECRETS=("$FEISHU_WEBHOOK_SECRET" "$FEISHU_WEBHOOK_SECRET_2")
+        CONFIGURED_TARGETS=0
+        for TARGET_INDEX in "${!WEBHOOK_URLS[@]}"; do
+          if [[ -z "${WEBHOOK_URLS[$TARGET_INDEX]}" && -z "${WEBHOOK_SECRETS[$TARGET_INDEX]}" ]]; then
+            continue
+          fi
+          if [[ -z "${WEBHOOK_URLS[$TARGET_INDEX]}" || -z "${WEBHOOK_SECRETS[$TARGET_INDEX]}" ]]; then
+            echo "::warning::Feishu webhook target $((TARGET_INDEX + 1)) is only partially configured."
+            exit 1
+          fi
+          ((CONFIGURED_TARGETS += 1))
+        done
+
+        if [[ "$CONFIGURED_TARGETS" -eq 0 ]]; then
+          echo "::warning::No Feishu webhook targets are configured; skipping the Feishu release notification."
           echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Skipped because one or more required repository secrets are not configured: \
-          \`FEISHU_APP_ID\`, \`FEISHU_APP_SECRET\`, \`FEISHU_CHAT_ID\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Skipped because no complete Feishu webhook URL and signing secret pair is configured." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
 
@@ -635,25 +649,6 @@ jobs:
         RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
         NPM_URL="https://www.npmjs.com/package/@midscene/core/v/${PACKAGE_VERSION}"
-
-        TOKEN_RESPONSE="$(
-          jq -cn \
-            '{app_id: env.FEISHU_APP_ID, app_secret: env.FEISHU_APP_SECRET}' \
-            | curl \
-                --fail-with-body \
-                --silent \
-                --show-error \
-                --request POST \
-                --header 'Content-Type: application/json; charset=utf-8' \
-                --data-binary @- \
-                'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal'
-        )"
-
-        if [[ "$(jq -r '.code // -1' <<< "$TOKEN_RESPONSE")" != "0" ]]; then
-          echo "Feishu tenant access token request failed: $(jq -c '{code, msg}' <<< "$TOKEN_RESPONSE")" >&2
-          exit 1
-        fi
-        TENANT_ACCESS_TOKEN="$(jq -er '.tenant_access_token' <<< "$TOKEN_RESPONSE")"
 
         CARD_CONTENT="$(
           jq -cn \
@@ -855,37 +850,65 @@ jobs:
                 }
             '
         )"
-        IDEMPOTENCY_KEY="$(printf '%s-%s-feishu' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" | cut -c1-50)"
-        PAYLOAD="$(
-          jq -cn \
-            --arg content "$CARD_CONTENT" \
-            --arg receive_id "$FEISHU_CHAT_ID" \
-            --arg uuid "$IDEMPOTENCY_KEY" \
-            '{receive_id: $receive_id, msg_type: "interactive", content: $content, uuid: $uuid}'
-        )"
-
-        FEISHU_RESPONSE="$(
-          printf 'header = "Authorization: Bearer %s"\n' "$TENANT_ACCESS_TOKEN" \
-            | curl \
-                --config - \
-                --fail-with-body \
-                --silent \
-                --show-error \
-                --request POST \
-                --header 'Content-Type: application/json; charset=utf-8' \
-                --data "$PAYLOAD" \
-                'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id'
-        )"
-
-        if [[ "$(jq -r '.code // -1' <<< "$FEISHU_RESPONSE")" != "0" ]]; then
-          echo "Feishu message request failed: $(jq -c '{code, msg}' <<< "$FEISHU_RESPONSE")" >&2
-          exit 1
-        fi
-        MESSAGE_ID="$(jq -er '.data.message_id' <<< "$FEISHU_RESPONSE")"
-
         echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "Published the ${RELEASE_VERSION} notification as message \`${MESSAGE_ID}\`." >> "$GITHUB_STEP_SUMMARY"
+        DELIVERY_FAILURES=0
+        DELIVERED_TARGETS=0
+        for TARGET_INDEX in "${!WEBHOOK_URLS[@]}"; do
+          WEBHOOK_URL="${WEBHOOK_URLS[$TARGET_INDEX]}"
+          WEBHOOK_SECRET="${WEBHOOK_SECRETS[$TARGET_INDEX]}"
+          if [[ -z "$WEBHOOK_URL" && -z "$WEBHOOK_SECRET" ]]; then
+            continue
+          fi
+
+          TIMESTAMP="$(date +%s)"
+          SIGNING_KEY="$(printf '%s\n%s' "$TIMESTAMP" "$WEBHOOK_SECRET")"
+          SIGNATURE="$(
+            printf '' \
+              | openssl dgst -sha256 -hmac "$SIGNING_KEY" -binary \
+              | openssl base64 -A
+          )"
+          unset SIGNING_KEY
+
+          PAYLOAD="$(
+            jq -cn \
+              --argjson card "$CARD_CONTENT" \
+              --arg sign "$SIGNATURE" \
+              --arg timestamp "$TIMESTAMP" \
+              '{timestamp: $timestamp, sign: $sign, msg_type: "interactive", card: $card}'
+          )"
+
+          if ! FEISHU_RESPONSE="$(
+            printf 'url = "%s"\n' "$WEBHOOK_URL" \
+              | curl \
+                  --config - \
+                  --fail-with-body \
+                  --silent \
+                  --show-error \
+                  --request POST \
+                  --header 'Content-Type: application/json; charset=utf-8' \
+                  --data "$PAYLOAD"
+          )"; then
+            echo "Feishu webhook target $((TARGET_INDEX + 1)) request failed." >&2
+            ((DELIVERY_FAILURES += 1))
+            continue
+          fi
+
+          if [[ "$(jq -r '.code // .StatusCode // -1' <<< "$FEISHU_RESPONSE")" != "0" ]]; then
+            echo "Feishu webhook target $((TARGET_INDEX + 1)) rejected the request: $(
+              jq -c '{code: (.code // .StatusCode), msg: (.msg // .StatusMessage)}' <<< "$FEISHU_RESPONSE"
+            )" >&2
+            ((DELIVERY_FAILURES += 1))
+            continue
+          fi
+
+          ((DELIVERED_TARGETS += 1))
+        done
+
+        echo "Published the ${RELEASE_VERSION} notification to ${DELIVERED_TARGETS} Feishu group(s) through signed webhooks." >> "$GITHUB_STEP_SUMMARY"
+        if [[ "$DELIVERY_FAILURES" -ne 0 ]]; then
+          exit 1
+        fi
 
     - name: Summarize Feishu notification failure
       if: ${{ steps.notify.outcome == 'failure' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,7 +399,6 @@ jobs:
       env:
         DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         GH_TOKEN: ${{ github.token }}
-        RELEASE_IMAGE_URL: https://midscenejs.com/og-image.png
         RELEASE_VERSION: ${{ needs.release.outputs.version }}
       run: |
         set -euo pipefail
@@ -424,28 +423,108 @@ jobs:
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
 
         PAYLOAD="$(
-          jq -n \
+          jq -cn \
             --arg body "$RELEASE_BODY" \
-            --arg image_url "$RELEASE_IMAGE_URL" \
             --arg package_version "$PACKAGE_VERSION" \
             --arg published_at "$RELEASE_PUBLISHED_AT" \
             --arg release_name "$RELEASE_NAME" \
             --arg release_url "$RELEASE_URL" \
             --arg version "$RELEASE_VERSION" \
             '
-              ($release_name
-                | if length > 0 then . else "Midscene.js \($version)" end
-                | .[0:256]
-              ) as $title
-              | ($body
-                  | if length == 0 then
-                      "Midscene.js \($version) is now available."
-                    elif length > 3500 then
-                      .[0:3500] + "\n\n…"
-                    else
-                      .
-                    end
+              def release_title:
+                ($release_name | gsub("^\\s+|\\s+$"; "")) as $name
+                | if $name == "" or $name == $version or $name == ($version | ltrimstr("v")) then
+                    "Midscene.js \($version)"
+                  else
+                    $name
+                  end;
+              def normalized_type:
+                (try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other")
+                | ascii_downcase
+                | if . == "feat" then "feat"
+                  elif . == "fix" then "fix"
+                  elif . == "perf" then "perf"
+                  elif . == "refactor" then "refactor"
+                  elif . == "docs" then "docs"
+                  elif . == "test" or . == "tests" then "test"
+                  elif . == "build" then "build"
+                  elif . == "ci" then "ci"
+                  elif . == "chore" then "chore"
+                  else "other"
+                  end;
+              def parse_change:
+                . as $line
+                | if $line | test("^[*-] ") then
+                    (try
+                      ($line
+                        | capture("^[*-] (?<title>.+?) by @[^ ]+ in (?<url>https://github\\.com/[^ ]+/pull/(?<pr>[0-9]+))$")
+                      )
+                    catch
+                      {title: ($line | sub("^[*-] "; "")), url: "", pr: ""}
+                    )
+                    | .title |= gsub("^\\s+|\\s+$"; "")
+                    | .type = (.title | normalized_type)
+                  else
+                    empty
+                  end;
+              def category_definitions:
+                [
+                  {key: "feat", label: "Features"},
+                  {key: "fix", label: "Fixes"},
+                  {key: "perf", label: "Performance"},
+                  {key: "refactor", label: "Refactors"},
+                  {key: "docs", label: "Documentation"},
+                  {key: "test", label: "Tests"},
+                  {key: "build", label: "Build"},
+                  {key: "ci", label: "CI"},
+                  {key: "chore", label: "Chores"},
+                  {key: "other", label: "Other"}
+                ];
+              def safe_title:
+                gsub("(?<char>[\\\\`*_~\\[\\]()<>#])"; "\\\\\(.char)");
+              def item_line:
+                if .pr != "" then
+                  "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"
+                else
+                  "- \(.title | safe_title)"
+                end;
+
+              ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
+              | [$clean_body | split("\n")[] | parse_change] as $changes
+              | [
+                  category_definitions[] as $category
+                  | [$changes[] | select(.type == $category.key)] as $items
+                  | select($items | length > 0)
+                  | $category + {items: $items}
+                ] as $groups
+              | ($changes | length) as $change_count
+              | ($groups | length) as $category_count
+              | ($groups
+                  | map("**\(.label)**\n" + (.items | map(item_line) | join("\n")))
+                  | join("\n\n")
+                ) as $grouped_notes
+              | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
+              | (if $change_count > 0 then
+                    $grouped_notes
+                  elif $raw_notes != "" then
+                    $raw_notes
+                  else
+                    "Midscene.js \($version) is now available."
+                  end
+                ) as $notes
+              | (if $change_count > 0 then
+                    "\($change_count) \(if $change_count == 1 then "change" else "changes" end)"
+                    + " · \($category_count) \(if $category_count == 1 then "category" else "categories" end)"
+                  else
+                    "Latest stable release"
+                  end
+                ) as $summary
+              | ("Latest stable release\n\n"
+                  + (if $change_count > 0 then "**\($summary)**\n\n" else "" end)
+                  + $notes
+                  | if length > 3500 then .[0:3500] + "\n\n…" else . end
                 ) as $description
+              | (release_title | .[0:256]) as $title
               | {
                   username: "Midscene Release",
                   avatar_url: "https://midscenejs.com/midscene-icon.png",
@@ -469,11 +548,8 @@ jobs:
                         inline: true
                       }
                     ],
-                    image: {
-                      url: $image_url
-                    },
                     footer: {
-                      text: "Midscene.js Release"
+                      text: $summary
                     },
                     timestamp: $published_at
                   }]
@@ -579,7 +655,7 @@ jobs:
         fi
         TENANT_ACCESS_TOKEN="$(jq -er '.tenant_access_token' <<< "$TOKEN_RESPONSE")"
 
-        POST_CONTENT="$(
+        CARD_CONTENT="$(
           jq -cn \
             --arg body "$RELEASE_BODY" \
             --arg release_name "$RELEASE_NAME" \
@@ -587,29 +663,193 @@ jobs:
             --arg npm_url "$NPM_URL" \
             --arg version "$RELEASE_VERSION" \
             '
-              ($release_name
-                | if length > 0 then . else "Midscene.js \($version)" end
-                | .[0:100]
-              ) as $title
-              | ($body
-                  | if length == 0 then
-                      "Midscene.js \($version) is now available."
-                    elif length > 8000 then
-                      .[0:8000] + "\n\n…"
+              def release_title:
+                ($release_name | gsub("^\\s+|\\s+$"; "")) as $name
+                | if $name == "" or $name == $version or $name == ($version | ltrimstr("v")) then
+                    "Midscene.js \($version)"
+                  else
+                    $name
+                  end;
+              def normalized_type:
+                (try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other")
+                | ascii_downcase
+                | if . == "feat" then "feat"
+                  elif . == "fix" then "fix"
+                  elif . == "perf" then "perf"
+                  elif . == "refactor" then "refactor"
+                  elif . == "docs" then "docs"
+                  elif . == "test" or . == "tests" then "test"
+                  elif . == "build" then "build"
+                  elif . == "ci" then "ci"
+                  elif . == "chore" then "chore"
+                  else "other"
+                  end;
+              def parse_change:
+                . as $line
+                | if $line | test("^[*-] ") then
+                    (try
+                      ($line
+                        | capture("^[*-] (?<title>.+?) by @[^ ]+ in (?<url>https://github\\.com/[^ ]+/pull/(?<pr>[0-9]+))$")
+                      )
+                    catch
+                      {title: ($line | sub("^[*-] "; "")), url: "", pr: ""}
+                    )
+                    | .title |= gsub("^\\s+|\\s+$"; "")
+                    | .type = (.title | normalized_type)
+                  else
+                    empty
+                  end;
+              def category_definitions:
+                [
+                  {key: "feat", label: "Features"},
+                  {key: "fix", label: "Fixes"},
+                  {key: "perf", label: "Performance"},
+                  {key: "refactor", label: "Refactors"},
+                  {key: "docs", label: "Documentation"},
+                  {key: "test", label: "Tests"},
+                  {key: "build", label: "Build"},
+                  {key: "ci", label: "CI"},
+                  {key: "chore", label: "Chores"},
+                  {key: "other", label: "Other"}
+                ];
+              def safe_title:
+                gsub("&"; "&#38;")
+                | gsub("<"; "&#60;")
+                | gsub(">"; "&#62;")
+                | gsub("\\*"; "&#42;")
+                | gsub("~"; "&#126;")
+                | gsub("\\["; "&#91;")
+                | gsub("\\]"; "&#93;")
+                | gsub("\\("; "&#40;")
+                | gsub("\\)"; "&#41;")
+                | gsub("#"; "&#35;")
+                | gsub("_"; "&#95;")
+                | gsub(":"; "&#58;");
+              def item_line:
+                if .pr != "" then
+                  "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"
+                else
+                  "- \(.title | safe_title)"
+                end;
+
+              ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
+              | [$clean_body | split("\n")[] | parse_change] as $changes
+              | [
+                  category_definitions[] as $category
+                  | [$changes[] | select(.type == $category.key)] as $items
+                  | select($items | length > 0)
+                  | $category + {items: $items}
+                ] as $groups
+              | ($changes | length) as $change_count
+              | ($groups | length) as $category_count
+              | ($groups
+                  | map("**\(.label)**\n" + (.items | map(item_line) | join("\n")))
+                  | join("\n\n")
+                ) as $grouped_notes
+              | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
+              | (if $change_count > 0 then
+                    $grouped_notes
+                  elif $raw_notes != "" then
+                    $raw_notes
+                  else
+                    "Midscene.js \($version) is now available."
+                  end
+                ) as $notes
+              | ($notes
+                  | if length > 7500 then
+                      .[0:7400] + "\n\n… [View the full release notes](\($release_url))"
                     else
                       .
                     end
                 ) as $description
+              | (if $change_count > 0 then
+                    "\($change_count) \(if $change_count == 1 then "change" else "changes" end)"
+                    + " · \($category_count) \(if $category_count == 1 then "category" else "categories" end)"
+                  else
+                    "Latest stable release"
+                  end
+                ) as $summary
+              | (release_title | .[0:100]) as $title
               | {
-                  zh_cn: {
-                    title: $title,
-                    content: [
-                      [{tag: "text", text: $description}],
-                      [
-                        {tag: "a", text: "View GitHub Release", href: $release_url},
-                        {tag: "text", text: " · "},
-                        {tag: "a", text: "View @midscene/core on npm", href: $npm_url}
-                      ]
+                  schema: "2.0",
+                  config: {
+                    update_multi: true,
+                    width_mode: "default",
+                    summary: {
+                      content: "\($title) · \($summary)"
+                    }
+                  },
+                  header: {
+                    title: {tag: "plain_text", content: $title},
+                    subtitle: {tag: "plain_text", content: $summary},
+                    template: "blue",
+                    icon: {tag: "standard_icon", token: "bell_outlined"},
+                    text_tag_list: [{
+                      tag: "text_tag",
+                      text: {tag: "plain_text", content: "Release"},
+                      color: "blue"
+                    }]
+                  },
+                  body: {
+                    direction: "vertical",
+                    padding: "12px 12px 20px 12px",
+                    vertical_spacing: "12px",
+                    elements: [
+                      {
+                        tag: "column_set",
+                        flex_mode: "none",
+                        columns: [{
+                          tag: "column",
+                          width: "weighted",
+                          weight: 1,
+                          background_style: "blue-50",
+                          padding: "12px",
+                          vertical_spacing: "4px",
+                          elements: [{
+                            tag: "markdown",
+                            content: (if $change_count > 0 then
+                                "**Latest stable release**\n\($summary)"
+                              else
+                                "**Latest stable release**"
+                              end)
+                          }]
+                        }]
+                      },
+                      {
+                        tag: "markdown",
+                        content: $description
+                      },
+                      {
+                        tag: "column_set",
+                        flex_mode: "bisect",
+                        horizontal_spacing: "8px",
+                        columns: [
+                          {
+                            tag: "column",
+                            width: "weighted",
+                            weight: 1,
+                            elements: [{
+                              tag: "button",
+                              text: {tag: "plain_text", content: "GitHub Release"},
+                              type: "primary_filled",
+                              width: "fill",
+                              behaviors: [{type: "open_url", default_url: $release_url}]
+                            }]
+                          },
+                          {
+                            tag: "column",
+                            width: "weighted",
+                            weight: 1,
+                            elements: [{
+                              tag: "button",
+                              text: {tag: "plain_text", content: "@midscene/core on npm"},
+                              type: "default",
+                              width: "fill",
+                              behaviors: [{type: "open_url", default_url: $npm_url}]
+                            }]
+                          }
+                        ]
+                      }
                     ]
                   }
                 }
@@ -618,10 +858,10 @@ jobs:
         IDEMPOTENCY_KEY="$(printf '%s-%s-feishu' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" | cut -c1-50)"
         PAYLOAD="$(
           jq -cn \
-            --arg content "$POST_CONTENT" \
+            --arg content "$CARD_CONTENT" \
             --arg receive_id "$FEISHU_CHAT_ID" \
             --arg uuid "$IDEMPOTENCY_KEY" \
-            '{receive_id: $receive_id, msg_type: "post", content: $content, uuid: $uuid}'
+            '{receive_id: $receive_id, msg_type: "interactive", content: $content, uuid: $uuid}'
         )"
 
         FEISHU_RESPONSE="$(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -708,18 +708,7 @@ jobs:
                   {key: "other", label: "Other"}
                 ];
               def safe_title:
-                gsub("&"; "&#38;")
-                | gsub("<"; "&#60;")
-                | gsub(">"; "&#62;")
-                | gsub("\\*"; "&#42;")
-                | gsub("~"; "&#126;")
-                | gsub("\\["; "&#91;")
-                | gsub("\\]"; "&#93;")
-                | gsub("\\("; "&#40;")
-                | gsub("\\)"; "&#41;")
-                | gsub("#"; "&#35;")
-                | gsub("_"; "&#95;")
-                | gsub(":"; "&#58;");
+                gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
               def item_line:
                 if .pr != "" then
                   "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,3 +383,274 @@ jobs:
           ${{ github.workspace }}/.release/studio/artifacts/*.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify_discord:
+    needs:
+    - release
+    - package_studio
+    if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Publish release notification to Discord
+      id: notify
+      continue-on-error: true
+      env:
+        DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_IMAGE_URL: https://midscenejs.com/og-image.png
+        RELEASE_VERSION: ${{ needs.release.outputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
+          echo "::warning::DISCORD_WEBHOOK_URL is not configured; skipping the Discord release notification."
+          echo "## Discord notification" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Skipped because the repository secret \`DISCORD_WEBHOOK_URL\` is not configured." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        RELEASE_JSON="$(
+          gh release view "$RELEASE_VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body,name,publishedAt,url
+        )"
+        RELEASE_NAME="$(jq -r '.name // empty' <<< "$RELEASE_JSON")"
+        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
+        RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
+        RELEASE_PUBLISHED_AT="$(jq -r '.publishedAt' <<< "$RELEASE_JSON")"
+        PACKAGE_VERSION="${RELEASE_VERSION#v}"
+
+        PAYLOAD="$(
+          jq -n \
+            --arg body "$RELEASE_BODY" \
+            --arg image_url "$RELEASE_IMAGE_URL" \
+            --arg package_version "$PACKAGE_VERSION" \
+            --arg published_at "$RELEASE_PUBLISHED_AT" \
+            --arg release_name "$RELEASE_NAME" \
+            --arg release_url "$RELEASE_URL" \
+            --arg version "$RELEASE_VERSION" \
+            '
+              ($release_name
+                | if length > 0 then . else "Midscene.js \($version)" end
+                | .[0:256]
+              ) as $title
+              | ($body
+                  | if length == 0 then
+                      "Midscene.js \($version) is now available."
+                    elif length > 3500 then
+                      .[0:3500] + "\n\n…"
+                    else
+                      .
+                    end
+                ) as $description
+              | {
+                  username: "Midscene Release",
+                  avatar_url: "https://midscenejs.com/midscene-icon.png",
+                  allowed_mentions: {
+                    parse: []
+                  },
+                  embeds: [{
+                    title: $title,
+                    url: $release_url,
+                    description: $description,
+                    color: 43248,
+                    fields: [
+                      {
+                        name: "GitHub Release",
+                        value: "[View release](\($release_url))",
+                        inline: true
+                      },
+                      {
+                        name: "npm",
+                        value: "[@midscene/core](https://www.npmjs.com/package/@midscene/core/v/\($package_version))",
+                        inline: true
+                      }
+                    ],
+                    image: {
+                      url: $image_url
+                    },
+                    footer: {
+                      text: "Midscene.js Release"
+                    },
+                    timestamp: $published_at
+                  }]
+                }
+            '
+        )"
+
+        WEBHOOK_METADATA="$(
+          printf 'url = "%s"\n' "$DISCORD_WEBHOOK_URL" \
+            | curl \
+                --config - \
+                --fail-with-body \
+                --silent \
+                --show-error
+        )"
+        GUILD_ID="$(jq -er '.guild_id' <<< "$WEBHOOK_METADATA")"
+
+        DISCORD_RESPONSE="$(
+          printf 'url = "%s?wait=true"\n' "$DISCORD_WEBHOOK_URL" \
+            | curl \
+                --config - \
+                --fail-with-body \
+                --silent \
+                --show-error \
+                --request POST \
+                --header 'Content-Type: application/json' \
+                --data "$PAYLOAD"
+        )"
+
+        MESSAGE_ID="$(jq -er '.id' <<< "$DISCORD_RESPONSE")"
+        CHANNEL_ID="$(jq -er '.channel_id' <<< "$DISCORD_RESPONSE")"
+        MESSAGE_URL="https://discord.com/channels/${GUILD_ID}/${CHANNEL_ID}/${MESSAGE_ID}"
+
+        echo "## Discord notification" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "Published [the ${RELEASE_VERSION} notification](${MESSAGE_URL})." >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Summarize Discord notification failure
+      if: ${{ steps.notify.outcome == 'failure' }}
+      run: |
+        echo "::warning::The GitHub Release succeeded, but its Discord notification failed."
+        echo "## Discord notification fallback" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "The GitHub Release succeeded, but its Discord notification failed. Review the previous step and resend the announcement manually." >> "$GITHUB_STEP_SUMMARY"
+
+  notify_feishu:
+    needs:
+    - release
+    - package_studio
+    if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Publish release notification to Feishu
+      id: notify
+      continue-on-error: true
+      env:
+        FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+        FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+        FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_VERSION: ${{ needs.release.outputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$FEISHU_APP_ID" || -z "$FEISHU_APP_SECRET" || -z "$FEISHU_CHAT_ID" ]]; then
+          echo "::warning::The Feishu application credentials or chat ID are not configured; skipping the Feishu release notification."
+          echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Skipped because one or more required repository secrets are not configured: \
+          \`FEISHU_APP_ID\`, \`FEISHU_APP_SECRET\`, \`FEISHU_CHAT_ID\`." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        RELEASE_JSON="$(
+          gh release view "$RELEASE_VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body,name,url
+        )"
+        RELEASE_NAME="$(jq -r '.name // empty' <<< "$RELEASE_JSON")"
+        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
+        RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
+        PACKAGE_VERSION="${RELEASE_VERSION#v}"
+        NPM_URL="https://www.npmjs.com/package/@midscene/core/v/${PACKAGE_VERSION}"
+
+        TOKEN_RESPONSE="$(
+          jq -cn \
+            '{app_id: env.FEISHU_APP_ID, app_secret: env.FEISHU_APP_SECRET}' \
+            | curl \
+                --fail-with-body \
+                --silent \
+                --show-error \
+                --request POST \
+                --header 'Content-Type: application/json; charset=utf-8' \
+                --data-binary @- \
+                'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal'
+        )"
+
+        if [[ "$(jq -r '.code // -1' <<< "$TOKEN_RESPONSE")" != "0" ]]; then
+          echo "Feishu tenant access token request failed: $(jq -c '{code, msg}' <<< "$TOKEN_RESPONSE")" >&2
+          exit 1
+        fi
+        TENANT_ACCESS_TOKEN="$(jq -er '.tenant_access_token' <<< "$TOKEN_RESPONSE")"
+
+        POST_CONTENT="$(
+          jq -cn \
+            --arg body "$RELEASE_BODY" \
+            --arg release_name "$RELEASE_NAME" \
+            --arg release_url "$RELEASE_URL" \
+            --arg npm_url "$NPM_URL" \
+            --arg version "$RELEASE_VERSION" \
+            '
+              ($release_name
+                | if length > 0 then . else "Midscene.js \($version)" end
+                | .[0:100]
+              ) as $title
+              | ($body
+                  | if length == 0 then
+                      "Midscene.js \($version) is now available."
+                    elif length > 8000 then
+                      .[0:8000] + "\n\n…"
+                    else
+                      .
+                    end
+                ) as $description
+              | {
+                  zh_cn: {
+                    title: $title,
+                    content: [
+                      [{tag: "text", text: $description}],
+                      [
+                        {tag: "a", text: "View GitHub Release", href: $release_url},
+                        {tag: "text", text: " · "},
+                        {tag: "a", text: "View @midscene/core on npm", href: $npm_url}
+                      ]
+                    ]
+                  }
+                }
+            '
+        )"
+        IDEMPOTENCY_KEY="$(printf '%s-%s-feishu' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" | cut -c1-50)"
+        PAYLOAD="$(
+          jq -cn \
+            --arg content "$POST_CONTENT" \
+            --arg receive_id "$FEISHU_CHAT_ID" \
+            --arg uuid "$IDEMPOTENCY_KEY" \
+            '{receive_id: $receive_id, msg_type: "post", content: $content, uuid: $uuid}'
+        )"
+
+        FEISHU_RESPONSE="$(
+          printf 'header = "Authorization: Bearer %s"\n' "$TENANT_ACCESS_TOKEN" \
+            | curl \
+                --config - \
+                --fail-with-body \
+                --silent \
+                --show-error \
+                --request POST \
+                --header 'Content-Type: application/json; charset=utf-8' \
+                --data "$PAYLOAD" \
+                'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id'
+        )"
+
+        if [[ "$(jq -r '.code // -1' <<< "$FEISHU_RESPONSE")" != "0" ]]; then
+          echo "Feishu message request failed: $(jq -c '{code, msg}' <<< "$FEISHU_RESPONSE")" >&2
+          exit 1
+        fi
+        MESSAGE_ID="$(jq -er '.data.message_id' <<< "$FEISHU_RESPONSE")"
+
+        echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "Published the ${RELEASE_VERSION} notification as message \`${MESSAGE_ID}\`." >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Summarize Feishu notification failure
+      if: ${{ steps.notify.outcome == 'failure' }}
+      run: |
+        echo "::warning::The GitHub Release succeeded, but its Feishu notification failed."
+        echo "## Feishu notification fallback" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "The GitHub Release succeeded, but its Feishu notification failed. Review the previous step and resend the announcement manually." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- publish successful stable release announcements to Discord and two Feishu groups after the packages and Studio artifacts are ready
- normalize generated release notes into Features, Fixes, Performance, Refactors, Documentation, Tests, Build, CI, Chores, and Other groups
- show the same release title, change/category totals, compact PR links, GitHub Release link, and npm link on both platforms
- render Feishu notifications as Card 2.0 messages and deliver them through independently signed group webhooks
- keep notification failures isolated from the release result and surface actionable fallbacks in the GitHub Actions summary

## Why

Release announcements were a manual follow-up after publishing. Automating both community notifications keeps release communication timely and consistent while preserving the release workflow as the source of truth. Grouped release notes are easier to scan than the raw GitHub-generated body on both desktop and mobile.

## Impact

Only successful, non-prerelease runs send notifications. Missing credentials cause the corresponding notification to be skipped with a warning, and delivery failures do not fail an otherwise successful release. Each configured Feishu target is attempted independently, so one rejected webhook does not prevent the other group from receiving the announcement.

The workflow reads credentials from these repository secrets:

- `DISCORD_WEBHOOK_URL`
- `FEISHU_WEBHOOK_URL`
- `FEISHU_WEBHOOK_SECRET`
- `FEISHU_WEBHOOK_URL_2`
- `FEISHU_WEBHOOK_SECRET_2`

No new runtime or development dependencies are introduced.

## Validation

- `pnpm run lint`
- parsed `.github/workflows/release.yml` with the repository-installed `js-yaml`
- validated both notification shell blocks with `bash -n`
- executed both payload builders with mocked GitHub, Discord, and Feishu API responses
- verified both Feishu targets generate signatures from their own signing secret
- delivered the real v1.10.3 Card 2.0 payload successfully to both Feishu groups
- sent the corrected v1.10.3 card to a personal Feishu conversation and verified release titles contain no literal HTML entities
- sent the corrected Discord embed and verified conventional-commit scopes and issue references contain no visible escape characters
- verified the real v1.10.3 fixture produces 7 changes in 4 ordered categories on both platforms
- verified empty-body and unknown-type fallbacks
- verified contributor-controlled Markdown, mention, and link injection is escaped
- checked Discord embed limits, Feishu Card 2.0 structure, and URL button behavior
- `git diff --check`

## Security

Feishu delivery now uses group-scoped custom webhooks protected by independent signing secrets. The workflow no longer requests a tenant access token and no longer needs an application ID, application secret, chat ID, or Feishu API permission. The previous application-bot repository secrets were removed after both signed webhooks passed a live delivery test.

Contributor-controlled PR titles are classified before rendering and escaped per platform before being inserted into Markdown. Discord also disables all allowed mention parsing.