### PR TITLE
ci(computer): add Windows desktop validation

### DIFF
--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -1,0 +1,329 @@
+name: Windows Desktop
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/windows-desktop.yml'
+      - 'apps/report/**'
+      - 'packages/computer/**'
+      - 'packages/core/package.json'
+      - 'packages/core/rslib.config.ts'
+      - 'packages/core/src/agent/**'
+      - 'packages/core/src/device/**'
+      - 'packages/core/src/dump/**'
+      - 'packages/core/src/index.ts'
+      - 'packages/core/src/report-generator.ts'
+      - 'packages/core/src/report.ts'
+      - 'packages/core/src/screenshot-item.ts'
+      - 'packages/core/src/types.ts'
+      - 'packages/core/src/utils.ts'
+      - 'packages/shared/package.json'
+      - 'packages/shared/src/**'
+      - 'scripts/report-template-utils.mjs'
+      - 'nx.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  windows-desktop:
+    runs-on: windows-2022
+    timeout-minutes: 35
+    env:
+      CI: '1'
+      FORCE_COLOR: '0'
+      MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run
+      MIDSCENE_WINDOWS_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/windows-desktop-diagnostics
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Verify interactive Windows desktop
+        shell: pwsh
+        run: |
+          $diagnosticsDir = $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR
+          New-Item -ItemType Directory -Force -Path $diagnosticsDir | Out-Null
+          $manifestPath = Join-Path $diagnosticsDir 'runner-environment.json'
+          $probe = [ordered]@{
+            capturedAt = [DateTimeOffset]::UtcNow.ToString('o')
+            runnerName = $env:RUNNER_NAME
+            runnerOS = $env:RUNNER_OS
+            runnerArch = $env:RUNNER_ARCH
+            imageOS = $env:ImageOS
+            imageVersion = $env:ImageVersion
+            valid = $false
+          }
+
+          function Write-ProbeManifest {
+            $probe | ConvertTo-Json -Depth 8 |
+              Set-Content -LiteralPath $manifestPath -Encoding utf8
+          }
+
+          # Leave an artifact even if loading desktop assemblies fails.
+          Write-ProbeManifest
+
+          try {
+            Add-Type -TypeDefinition @'
+          using System.Runtime.InteropServices;
+          public static class MidsceneNativeDpi {
+            [DllImport("user32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool SetProcessDPIAware();
+
+            [DllImport("user32.dll")]
+            public static extern uint GetDpiForSystem();
+          }
+          '@
+
+            $dpiAware = [MidsceneNativeDpi]::SetProcessDPIAware()
+            if (-not $dpiAware) {
+              $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+              if ($lastError -ne 5) {
+                throw "SetProcessDPIAware failed with Win32 error $lastError."
+              }
+            }
+
+            Add-Type -AssemblyName System.Windows.Forms
+            $process = [System.Diagnostics.Process]::GetCurrentProcess()
+            $primaryScreen = [System.Windows.Forms.Screen]::PrimaryScreen
+            if ($null -eq $primaryScreen) {
+              throw 'Windows did not expose a primary screen.'
+            }
+
+            $bounds = $primaryScreen.Bounds
+            $workingArea = $primaryScreen.WorkingArea
+            $dpi = [int][MidsceneNativeDpi]::GetDpiForSystem()
+            $windowsPowerShellVersion = (
+              & powershell.exe -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion.ToString()' |
+                Out-String
+            ).Trim()
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Unable to query Windows PowerShell version.'
+            }
+
+            $probe.userInteractive = [Environment]::UserInteractive
+            $probe.sessionId = $process.SessionId
+            $probe.sessionName = $env:SESSIONNAME
+            $probe.powerShellVersion = $PSVersionTable.PSVersion.ToString()
+            $probe.windowsPowerShellVersion = $windowsPowerShellVersion
+            $probe.dpi = $dpi
+            $probe.primaryScreen = [ordered]@{
+              deviceName = $primaryScreen.DeviceName
+              primary = $primaryScreen.Primary
+              width = $bounds.Width
+              height = $bounds.Height
+              workingAreaWidth = $workingArea.Width
+              workingAreaHeight = $workingArea.Height
+              bitsPerPixel = $primaryScreen.BitsPerPixel
+            }
+
+            $violations = @()
+            if (-not $probe.userInteractive) {
+              $violations += 'Environment.UserInteractive is false'
+            }
+            if ($probe.sessionId -le 0) {
+              $violations += "PowerShell is running in non-interactive session $($probe.sessionId)"
+            }
+            if ($bounds.Width -le 0 -or $bounds.Height -le 0) {
+              $violations += "Primary screen has invalid bounds $($bounds.Width)x$($bounds.Height)"
+            }
+            if ($dpi -ne 96) {
+              $violations += "Expected 96 DPI (100% scaling), received $dpi DPI"
+            }
+
+            $probe.violations = $violations
+            $probe.valid = $violations.Count -eq 0
+            Write-ProbeManifest
+            $probe | ConvertTo-Json -Depth 8
+
+            if (-not $probe.valid) {
+              throw "Windows desktop preflight failed: $($violations -join '; ')"
+            }
+          } catch {
+            $probe.error = $_.Exception.ToString()
+            Write-ProbeManifest
+            throw
+          }
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.13.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        shell: pwsh
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build report and computer packages
+        id: build
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
+          if ($LASTEXITCODE -ne 0) {
+            throw '@midscene/report or @midscene/computer failed to build.'
+          }
+
+          node apps/report/scripts/inject-report-template.mjs
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to inject the report template into @midscene/core.'
+          }
+
+      - name: Validate computer package outputs
+        id: package-smoke
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          node -e "const mod=require('./packages/computer/dist/lib/index.js'); if(typeof mod.ComputerDevice!=='function'||typeof mod.ComputerAgent!=='function') throw new Error('invalid CJS exports')"
+          if ($LASTEXITCODE -ne 0) { throw 'CJS entrypoint validation failed.' }
+
+          node --input-type=module -e "const mod=await import('./packages/computer/dist/es/index.mjs'); if(typeof mod.ComputerDevice!=='function'||typeof mod.ComputerAgent!=='function') throw new Error('invalid ESM exports')"
+          if ($LASTEXITCODE -ne 0) { throw 'ESM entrypoint validation failed.' }
+
+          $typesPath = 'packages/computer/dist/types/index.d.ts'
+          if (-not (Test-Path -LiteralPath $typesPath -PathType Leaf)) {
+            throw "Missing declaration entrypoint: $typesPath"
+          }
+
+          $packageJson = Get-Content -Raw packages/computer/package.json |
+            ConvertFrom-Json
+          $cliVersion = (& node packages/computer/bin/midscene-computer --version |
+            Out-String).Trim()
+          if ($LASTEXITCODE -ne 0) { throw 'Computer CLI failed to start.' }
+          $expectedCliVersion = "midscene-computer v$($packageJson.version)"
+          if ($cliVersion -ne $expectedCliVersion) {
+            throw "Unexpected CLI version '$cliVersion'; expected '$expectedCliVersion'."
+          }
+
+          $packDir = Join-Path $env:RUNNER_TEMP 'midscene-computer-pack'
+          New-Item -ItemType Directory -Force -Path $packDir | Out-Null
+          pnpm --dir packages/computer pack --pack-destination $packDir
+          if ($LASTEXITCODE -ne 0) { throw 'pnpm pack failed.' }
+
+          $archive = Get-ChildItem -LiteralPath $packDir -Filter '*.tgz' |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if ($null -eq $archive) { throw 'pnpm pack did not create a tarball.' }
+
+          $packageEntries = @(& tar -tf $archive.FullName)
+          if ($LASTEXITCODE -ne 0) { throw 'Unable to inspect the package tarball.' }
+          $packageEntries | Set-Content -LiteralPath (
+            Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'package-files.txt'
+          ) -Encoding utf8
+
+          $requiredEntries = @(
+            'package/package.json',
+            'package/bin/midscene-computer',
+            'package/dist/lib/cli.js',
+            'package/dist/lib/index.js',
+            'package/dist/es/index.mjs',
+            'package/dist/types/index.d.ts'
+          )
+          $missingEntries = @(
+            $requiredEntries | Where-Object { $_ -notin $packageEntries }
+          )
+          if ($missingEntries.Count -gt 0) {
+            throw "Package tarball is missing: $($missingEntries -join ', ')"
+          }
+
+      - name: Run computer unit tests
+        id: unit-tests
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $logPath = Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'unit-tests.log'
+          pnpm exec nx test @midscene/computer --skip-nx-cache 2>&1 |
+            Tee-Object -FilePath $logPath
+          $testExitCode = $LASTEXITCODE
+          if ($testExitCode -ne 0) {
+            throw "Computer unit tests failed with exit code $testExitCode."
+          }
+
+      - name: Run live Windows desktop smoke test
+        id: live-smoke
+        continue-on-error: true
+        timeout-minutes: 10
+        shell: pwsh
+        env:
+          AI_TEST_TYPE: computer
+          MIDSCENE_WINDOWS_DESKTOP_SMOKE: '1'
+          MIDSCENE_WINDOWS_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/windows-desktop-diagnostics
+          MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run
+        run: |
+          $logPath = Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'live-smoke.log'
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/windows-desktop-smoke.test.ts --retry=0 2>&1 |
+            Tee-Object -FilePath $logPath
+          $testExitCode = $LASTEXITCODE
+          if ($testExitCode -ne 0) {
+            throw "Windows desktop smoke failed with exit code $testExitCode."
+          }
+
+      - name: Collect step outcomes
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR | Out-Null
+          $outcomes = [ordered]@{
+            build = '${{ steps.build.outcome }}'
+            packageSmoke = '${{ steps.package-smoke.outcome }}'
+            unitTests = '${{ steps.unit-tests.outcome }}'
+            liveSmoke = '${{ steps.live-smoke.outcome }}'
+          }
+          $outcomes | ConvertTo-Json |
+            Set-Content -LiteralPath (
+              Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'step-outcomes.json'
+            ) -Encoding utf8
+
+      - name: Upload Windows desktop report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-desktop-smoke-report
+          path: midscene_run/report/windows-desktop-smoke.html
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Windows desktop diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-desktop-diagnostics
+          path: midscene_run/windows-desktop-diagnostics
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Check Windows validation results
+        if: always()
+        shell: pwsh
+        run: |
+          $failed = @()
+          if ('${{ steps.build.outcome }}' -ne 'success') { $failed += 'build' }
+          if ('${{ steps.package-smoke.outcome }}' -ne 'success') { $failed += 'package smoke' }
+          if ('${{ steps.unit-tests.outcome }}' -ne 'success') { $failed += 'unit tests' }
+          if ('${{ steps.live-smoke.outcome }}' -ne 'success') { $failed += 'live desktop smoke' }
+          if ($failed.Count -gt 0) {
+            throw "Windows validation failed: $($failed -join ', ')"
+          }

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -15,6 +15,8 @@ on:
       - 'packages/core/src/report-generator.ts'
       - 'packages/core/src/report.ts'
       - 'packages/core/src/screenshot-item.ts'
+      - 'packages/core/src/task-runner.ts'
+      - 'packages/core/src/task-timing.ts'
       - 'packages/core/src/types.ts'
       - 'packages/core/src/utils.ts'
       - 'packages/shared/package.json'

--- a/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
+++ b/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
@@ -42,10 +42,9 @@ function Write-JsonAtomically {
     [System.IO.Directory]::CreateDirectory($directory) | Out-Null
   }
 
-  $temporaryPath = [System.IO.Path]::Combine(
-    $directory,
-    ".{0}.{1}.tmp" -f [System.IO.Path]::GetFileName($Path), [System.Guid]::NewGuid().ToString('N')
-  )
+  $fileName = [System.IO.Path]::GetFileName($Path)
+  $suffix = [System.Guid]::NewGuid().ToString('N')
+  $temporaryPath = [System.IO.Path]::Combine($directory, ".$fileName.$suffix.tmp")
   $encoding = New-Object System.Text.UTF8Encoding($false)
   $json = $Value | ConvertTo-Json -Depth 8 -Compress
 

--- a/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
+++ b/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
@@ -50,12 +50,7 @@ function Write-JsonAtomically {
 
   try {
     [System.IO.File]::WriteAllText($temporaryPath, $json, $encoding)
-    if ([System.IO.File]::Exists($Path)) {
-      [System.IO.File]::Replace($temporaryPath, $Path, $null)
-    }
-    else {
-      [System.IO.File]::Move($temporaryPath, $Path)
-    }
+    Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
   }
   finally {
     if ([System.IO.File]::Exists($temporaryPath)) {

--- a/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
+++ b/packages/computer/tests/ai/fixtures/windows-desktop-smoke-app.ps1
@@ -1,0 +1,418 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReadyFile,
+
+  [Parameter(Mandatory = $true)]
+  [string]$StateFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([System.Threading.Thread]::CurrentThread.ApartmentState -ne [System.Threading.ApartmentState]::STA) {
+  throw 'The Windows desktop smoke fixture must run in a PowerShell STA process.'
+}
+
+$ReadyFile = [System.IO.Path]::GetFullPath($ReadyFile)
+$StateFile = [System.IO.Path]::GetFullPath($StateFile)
+
+if ($ReadyFile -eq $StateFile) {
+  throw 'ReadyFile and StateFile must be different paths.'
+}
+
+if (-not [Environment]::UserInteractive) {
+  throw 'The Windows desktop smoke fixture requires an interactive user session.'
+}
+if ([System.Diagnostics.Process]::GetCurrentProcess().SessionId -eq 0) {
+  throw 'The Windows desktop smoke fixture cannot run in Windows session 0.'
+}
+
+function Write-JsonAtomically {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Value
+  )
+
+  $directory = [System.IO.Path]::GetDirectoryName($Path)
+  if (-not [System.IO.Directory]::Exists($directory)) {
+    [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+  }
+
+  $temporaryPath = [System.IO.Path]::Combine(
+    $directory,
+    ".{0}.{1}.tmp" -f [System.IO.Path]::GetFileName($Path), [System.Guid]::NewGuid().ToString('N')
+  )
+  $encoding = New-Object System.Text.UTF8Encoding($false)
+  $json = $Value | ConvertTo-Json -Depth 8 -Compress
+
+  try {
+    [System.IO.File]::WriteAllText($temporaryPath, $json, $encoding)
+    if ([System.IO.File]::Exists($Path)) {
+      [System.IO.File]::Replace($temporaryPath, $Path, $null)
+    }
+    else {
+      [System.IO.File]::Move($temporaryPath, $Path)
+    }
+  }
+  finally {
+    if ([System.IO.File]::Exists($temporaryPath)) {
+      [System.IO.File]::Delete($temporaryPath)
+    }
+  }
+}
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class MidsceneWindowsFixtureNativeMethods
+{
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetProcessDPIAware();
+
+    [DllImport("user32.dll")]
+    public static extern uint GetDpiForWindow(IntPtr windowHandle);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool IsWindowVisible(IntPtr windowHandle);
+}
+'@
+
+$dpiAware = [MidsceneWindowsFixtureNativeMethods]::SetProcessDPIAware()
+if (-not $dpiAware) {
+  $lastError = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+  if ($lastError -ne 5) {
+    throw "SetProcessDPIAware failed with Win32 error $lastError."
+  }
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+[System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+[System.Windows.Forms.Application]::SetUnhandledExceptionMode(
+  [System.Windows.Forms.UnhandledExceptionMode]::ThrowException
+)
+
+function New-BoundsValue {
+  param(
+    [Parameter(Mandatory = $true)]
+    [int]$X,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Y,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Width,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Height
+  )
+
+  return [ordered]@{
+    x = $X
+    y = $Y
+    width = $Width
+    height = $Height
+    left = $X
+    top = $Y
+    right = $X + $Width
+    bottom = $Y + $Height
+    centerX = $X + [int][Math]::Floor($Width / 2)
+    centerY = $Y + [int][Math]::Floor($Height / 2)
+  }
+}
+
+function Get-ControlScreenBounds {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Windows.Forms.Control]$Control
+  )
+
+  $screenLocation = $Control.PointToScreen([System.Drawing.Point]::Empty)
+  return New-BoundsValue `
+    -X $screenLocation.X `
+    -Y $screenLocation.Y `
+    -Width $Control.Width `
+    -Height $Control.Height
+}
+
+$form = New-Object System.Windows.Forms.Form
+$form.Text = 'Midscene Windows Desktop Smoke'
+$form.Name = 'MidsceneWindowsDesktopSmoke'
+$form.AccessibleName = 'Midscene Windows Desktop Smoke'
+$form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+$form.ClientSize = New-Object System.Drawing.Size(680, 470)
+$form.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::FixedSingle
+$form.MaximizeBox = $false
+$form.MinimizeBox = $false
+$form.ShowInTaskbar = $true
+$form.TopMost = $true
+$form.BackColor = [System.Drawing.Color]::FromArgb(242, 246, 250)
+
+$primaryScreen = [System.Windows.Forms.Screen]::PrimaryScreen
+if ($null -eq $primaryScreen) {
+  throw 'Windows Forms did not report a primary screen.'
+}
+
+$workingArea = $primaryScreen.WorkingArea
+$form.Left = $workingArea.Left + [Math]::Max(20, [int][Math]::Floor(($workingArea.Width - $form.Width) / 2))
+$form.Top = $workingArea.Top + [Math]::Max(20, [int][Math]::Floor(($workingArea.Height - $form.Height) / 2))
+
+$heading = New-Object System.Windows.Forms.Label
+$heading.AutoSize = $true
+$heading.Location = New-Object System.Drawing.Point(48, 28)
+$heading.Font = New-Object System.Drawing.Font('Segoe UI', 15, [System.Drawing.FontStyle]::Bold)
+$heading.ForeColor = [System.Drawing.Color]::FromArgb(31, 41, 55)
+$heading.Text = 'Midscene Windows CI desktop fixture'
+
+$button = New-Object System.Windows.Forms.Button
+$button.Name = 'MidsceneSmokeButton'
+$button.AccessibleName = 'Midscene Smoke Button'
+$button.Location = New-Object System.Drawing.Point(50, 88)
+$button.Size = New-Object System.Drawing.Size(270, 76)
+$button.FlatStyle = [System.Windows.Forms.FlatStyle]::Flat
+$button.FlatAppearance.BorderSize = 2
+$button.FlatAppearance.BorderColor = [System.Drawing.Color]::FromArgb(0, 92, 52)
+$button.BackColor = [System.Drawing.Color]::FromArgb(0, 210, 80)
+$button.ForeColor = [System.Drawing.Color]::FromArgb(10, 35, 20)
+$button.UseVisualStyleBackColor = $false
+$button.Font = New-Object System.Drawing.Font('Segoe UI', 12, [System.Drawing.FontStyle]::Bold)
+$button.Text = 'MIDSCENE GREEN TARGET'
+
+$textLabel = New-Object System.Windows.Forms.Label
+$textLabel.AutoSize = $true
+$textLabel.Location = New-Object System.Drawing.Point(366, 82)
+$textLabel.Font = New-Object System.Drawing.Font('Segoe UI', 9)
+$textLabel.ForeColor = [System.Drawing.Color]::FromArgb(55, 65, 81)
+$textLabel.Text = 'Type into the real WinForms TextBox:'
+
+$textBox = New-Object System.Windows.Forms.TextBox
+$textBox.Name = 'MidsceneSmokeTextBox'
+$textBox.AccessibleName = 'Midscene Smoke Text Box'
+$textBox.Location = New-Object System.Drawing.Point(368, 108)
+$textBox.Size = New-Object System.Drawing.Size(258, 34)
+$textBox.Font = New-Object System.Drawing.Font('Segoe UI', 12)
+
+$scrollLabel = New-Object System.Windows.Forms.Label
+$scrollLabel.AutoSize = $true
+$scrollLabel.Location = New-Object System.Drawing.Point(50, 202)
+$scrollLabel.Font = New-Object System.Drawing.Font('Segoe UI', 10, [System.Drawing.FontStyle]::Bold)
+$scrollLabel.ForeColor = [System.Drawing.Color]::FromArgb(31, 41, 55)
+$scrollLabel.Text = 'Hover here and send a real mouse-wheel event'
+
+$scrollArea = New-Object System.Windows.Forms.ListBox
+$scrollArea.Name = 'MidsceneSmokeScrollArea'
+$scrollArea.AccessibleName = 'Midscene Smoke Scroll Area'
+$scrollArea.Location = New-Object System.Drawing.Point(50, 232)
+$scrollArea.Size = New-Object System.Drawing.Size(576, 174)
+$scrollArea.IntegralHeight = $false
+$scrollArea.TabStop = $true
+$scrollArea.BackColor = [System.Drawing.Color]::FromArgb(231, 245, 255)
+$scrollArea.BorderStyle = [System.Windows.Forms.BorderStyle]::FixedSingle
+$scrollArea.Font = New-Object System.Drawing.Font('Segoe UI', 11)
+
+for ($index = 0; $index -lt 30; $index += 1) {
+  $scrollArea.Items.Add("Scrollable evidence row $($index + 1)") | Out-Null
+}
+
+$form.Controls.AddRange(@(
+  $heading,
+  $button,
+  $textLabel,
+  $textBox,
+  $scrollLabel,
+  $scrollArea
+))
+
+$state = [ordered]@{
+  schemaVersion = 1
+  processId = [System.Diagnostics.Process]::GetCurrentProcess().Id
+  updatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  visible = $false
+  clickCount = 0
+  text = ''
+  lastKey = ''
+  keyEventCount = 0
+  wheelEventCount = 0
+  lastWheelDelta = 0
+  wheelDelta = 0
+  totalWheelDelta = 0
+  scrollX = 0
+  scrollY = 0
+  scrollValue = 0
+}
+
+function Write-State {
+  $state.updatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  $state.visible = $form.Visible -and
+    [MidsceneWindowsFixtureNativeMethods]::IsWindowVisible($form.Handle) -and
+    ($form.WindowState -ne [System.Windows.Forms.FormWindowState]::Minimized)
+  $state.text = $textBox.Text
+  $state.scrollX = 0
+  $state.scrollY = [int]$scrollArea.TopIndex
+  $state.scrollValue = $state.scrollY
+  Write-JsonAtomically -Path $StateFile -Value $state
+}
+
+$button.Add_Click({
+  $state.clickCount += 1
+  Write-State
+})
+
+$textBox.Add_TextChanged({
+  $state.text = $textBox.Text
+  Write-State
+})
+
+$textBox.Add_KeyDown({
+  param($sender, $eventArgs)
+  $state.lastKey = $eventArgs.KeyCode.ToString()
+  $state.keyEventCount += 1
+  Write-State
+})
+
+$scrollArea.Add_MouseWheel({
+  param($sender, $eventArgs)
+  $state.lastWheelDelta = $eventArgs.Delta
+  $state.wheelDelta = $eventArgs.Delta
+  $state.totalWheelDelta += $eventArgs.Delta
+  $state.wheelEventCount += 1
+  $currentScrollValue = [int]$scrollArea.TopIndex
+  $rowsPerDetent = 3
+  $detents = [Math]::Max(1, [Math]::Abs([int]($eventArgs.Delta / 120)))
+  $rowDelta = if ($eventArgs.Delta -lt 0) {
+    $rowsPerDetent * $detents
+  }
+  else {
+    -$rowsPerDetent * $detents
+  }
+  $targetScrollValue = [Math]::Min(
+    $scrollArea.Items.Count - 1,
+    [Math]::Max(0, $currentScrollValue + $rowDelta)
+  )
+  $scrollArea.TopIndex = $targetScrollValue
+  Write-State
+})
+
+$focusScrollArea = {
+  if ($scrollArea.CanFocus) {
+    $scrollArea.Focus() | Out-Null
+  }
+}
+$scrollArea.Add_MouseEnter($focusScrollArea)
+
+$timer = New-Object System.Windows.Forms.Timer
+$timer.Interval = 750
+$timer.Add_Tick({
+  $focusedControl = $form.ActiveControl
+  $form.BringToFront()
+  if (
+    $null -ne $focusedControl -and
+    -not $focusedControl.IsDisposed -and
+    $focusedControl.CanFocus -and
+    $form.Contains($focusedControl)
+  ) {
+    $focusedControl.Focus() | Out-Null
+  }
+  Write-State
+})
+
+$form.Add_Shown({
+  $currentProcess = [System.Diagnostics.Process]::GetCurrentProcess()
+  $form.Activate()
+  $form.BringToFront()
+  $form.Refresh()
+
+  $dpi = [MidsceneWindowsFixtureNativeMethods]::GetDpiForWindow($form.Handle)
+  if ($dpi -eq 0) {
+    throw 'GetDpiForWindow returned zero for the visible fixture window.'
+  }
+
+  $screenBounds = $primaryScreen.Bounds
+  $screenWorkingArea = $primaryScreen.WorkingArea
+  $formBounds = $form.Bounds
+  $visible = $form.Visible -and
+    [MidsceneWindowsFixtureNativeMethods]::IsWindowVisible($form.Handle) -and
+    ($form.WindowState -ne [System.Windows.Forms.FormWindowState]::Minimized)
+
+  if (-not $visible) {
+    throw 'The Windows desktop smoke fixture window is not visible.'
+  }
+
+  Write-State
+
+  $screenMetadata = New-BoundsValue `
+    -X $screenBounds.X `
+    -Y $screenBounds.Y `
+    -Width $screenBounds.Width `
+    -Height $screenBounds.Height
+  $screenMetadata['deviceName'] = $primaryScreen.DeviceName
+  $screenMetadata['primary'] = $primaryScreen.Primary
+  $screenMetadata['workingArea'] = New-BoundsValue `
+    -X $screenWorkingArea.X `
+    -Y $screenWorkingArea.Y `
+    -Width $screenWorkingArea.Width `
+    -Height $screenWorkingArea.Height
+
+  $formMetadata = New-BoundsValue `
+    -X $formBounds.X `
+    -Y $formBounds.Y `
+    -Width $formBounds.Width `
+    -Height $formBounds.Height
+  $formMetadata['handle'] = $form.Handle.ToInt64().ToString()
+  $formMetadata['title'] = $form.Text
+  $formMetadata['visible'] = $visible
+
+  $buttonMetadata = Get-ControlScreenBounds -Control $button
+  $buttonMetadata['handle'] = $button.Handle.ToInt64().ToString()
+  $buttonMetadata['name'] = $button.Name
+  $buttonMetadata['text'] = $button.Text
+
+  $textBoxMetadata = Get-ControlScreenBounds -Control $textBox
+  $textBoxMetadata['handle'] = $textBox.Handle.ToInt64().ToString()
+  $textBoxMetadata['name'] = $textBox.Name
+
+  $scrollMetadata = Get-ControlScreenBounds -Control $scrollArea
+  $scrollMetadata['handle'] = $scrollArea.Handle.ToInt64().ToString()
+  $scrollMetadata['name'] = $scrollArea.Name
+
+  $ready = [ordered]@{
+    schemaVersion = 1
+    userInteractive = [Environment]::UserInteractive
+    sessionId = $currentProcess.SessionId
+    processId = $currentProcess.Id
+    visible = $visible
+    dpi = [int]$dpi
+    screen = $screenMetadata
+    form = $formMetadata
+    button = $buttonMetadata
+    textBox = $textBoxMetadata
+    scroll = $scrollMetadata
+  }
+
+  Write-JsonAtomically -Path $ReadyFile -Value $ready
+  $timer.Start()
+  [Console]::Out.WriteLine(
+    "MIDSCENE_WINDOWS_FIXTURE_READY pid=$($ready.processId) session=$($ready.sessionId) dpi=$($ready.dpi)"
+  )
+  [Console]::Out.Flush()
+})
+
+$form.Add_FormClosed({
+  $timer.Stop()
+  $state.updatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  $state.visible = $false
+  Write-JsonAtomically -Path $StateFile -Value $state
+})
+
+[Console]::Out.WriteLine('MIDSCENE_WINDOWS_FIXTURE_STARTING')
+[Console]::Out.Flush()
+[System.Windows.Forms.Application]::Run($form)

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -1,0 +1,744 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parseDumpScript } from '@midscene/core';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_FAMILY,
+  MIDSCENE_MODEL_NAME,
+  MIDSCENE_MODEL_RETRY_COUNT,
+  MIDSCENE_MODEL_TIMEOUT,
+} from '@midscene/shared/env';
+import { imageInfoOfBase64 } from '@midscene/shared/img';
+import { describe, expect, it } from 'vitest';
+import {
+  ComputerAgent,
+  ComputerDevice,
+  checkComputerEnvironment,
+} from '../../src';
+
+const RUN_LIVE_SMOKE =
+  process.platform === 'win32' &&
+  process.env.MIDSCENE_WINDOWS_DESKTOP_SMOKE === '1';
+
+const FIXTURE_PATH = path.join(
+  __dirname,
+  'fixtures',
+  'windows-desktop-smoke-app.ps1',
+);
+const REPORT_FILE_NAME = 'windows-desktop-smoke';
+const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
+const FIXTURE_READY_TIMEOUT_MS = 30_000;
+const STATE_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+
+interface Bounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface FixtureMetadata {
+  userInteractive: boolean;
+  sessionId: number;
+  processId?: number;
+  visible: boolean;
+  dpi: number;
+  screenDeviceName: string;
+  screen: Bounds;
+  form: Bounds;
+  button: Bounds;
+  textBox: Bounds;
+  scroll: Bounds;
+}
+
+interface FixtureState {
+  visible: boolean;
+  clickCount: number;
+  text: string;
+  lastKey: string;
+  wheelEventCount: number;
+  wheelDelta: number;
+  scrollValue: number;
+}
+
+interface PixelChannels {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface ScreenshotAnalysis {
+  target: PixelChannels;
+  background: PixelChannels;
+  channelDifference: number;
+}
+
+interface ReportTask {
+  type?: string;
+  subType?: string;
+  hitBy?: { from?: string };
+  timing?: { callAiStart?: number; callAiEnd?: number };
+  usage?: unknown;
+  searchAreaUsage?: unknown;
+}
+
+interface ReportExecution {
+  id?: string;
+  name?: string;
+  tasks?: ReportTask[];
+}
+
+interface ReportDump {
+  executions?: ReportExecution[];
+}
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+function asFiniteNumber(value: unknown, label: string): number {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${label} must be a finite number, got ${String(value)}`);
+  }
+  return numberValue;
+}
+
+function normalizeBounds(value: unknown, label: string): Bounds {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${label} bounds are missing`);
+  }
+
+  const raw = value as Record<string, unknown>;
+  const left = asFiniteNumber(raw.left ?? raw.x, `${label}.left`);
+  const top = asFiniteNumber(raw.top ?? raw.y, `${label}.top`);
+  const width = asFiniteNumber(raw.width, `${label}.width`);
+  const height = asFiniteNumber(raw.height, `${label}.height`);
+
+  if (width <= 0 || height <= 0) {
+    throw new Error(`${label} bounds must be positive, got ${width}x${height}`);
+  }
+
+  return { left, top, width, height };
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeMetadata(value: unknown): FixtureMetadata {
+  const raw = asRecord(value, 'fixture metadata');
+  const rawScreen = asRecord(raw.screen, 'fixture.screen');
+  const rawForm = asRecord(raw.form, 'fixture.form');
+  const rawButton = asRecord(raw.button, 'fixture.button');
+  const rawTextBox = asRecord(raw.textBox, 'fixture.textBox');
+  const rawScroll = asRecord(raw.scroll, 'fixture.scroll');
+  return {
+    userInteractive: raw.userInteractive === true,
+    sessionId: asFiniteNumber(raw.sessionId, 'fixture.sessionId'),
+    processId:
+      raw.processId === undefined
+        ? undefined
+        : asFiniteNumber(raw.processId, 'fixture.processId'),
+    visible: raw.visible === true || rawForm.visible === true,
+    dpi: asFiniteNumber(raw.dpi, 'fixture.dpi'),
+    screenDeviceName: String(rawScreen.deviceName ?? ''),
+    screen: normalizeBounds(rawScreen, 'fixture.screen'),
+    form: normalizeBounds(rawForm, 'fixture.form'),
+    button: normalizeBounds(rawButton, 'fixture.button'),
+    textBox: normalizeBounds(rawTextBox, 'fixture.textBox'),
+    scroll: normalizeBounds(rawScroll, 'fixture.scroll'),
+  };
+}
+
+function normalizeState(value: unknown): FixtureState {
+  if (!value || typeof value !== 'object') {
+    throw new Error('fixture state must be an object');
+  }
+
+  const raw = value as Record<string, unknown>;
+  return {
+    visible: raw.visible === true,
+    clickCount: asFiniteNumber(raw.clickCount ?? 0, 'state.clickCount'),
+    text: String(raw.text ?? ''),
+    lastKey: String(raw.lastKey ?? ''),
+    wheelEventCount: asFiniteNumber(
+      raw.wheelEventCount ?? 0,
+      'state.wheelEventCount',
+    ),
+    wheelDelta: asFiniteNumber(
+      raw.lastWheelDelta ?? raw.wheelDelta ?? 0,
+      'state.wheelDelta',
+    ),
+    scrollValue: asFiniteNumber(
+      raw.scrollY ?? raw.scrollValue ?? 0,
+      'state.scrollValue',
+    ),
+  };
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function waitForJson<T>(
+  filePath: string,
+  normalize: (value: unknown) => T,
+  predicate: (value: T) => boolean,
+  timeoutMs: number,
+  childProcess?: ChildProcessWithoutNullStreams,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    if (childProcess && childProcess.exitCode !== null) {
+      throw new Error(
+        `fixture exited before ${path.basename(filePath)} was ready (exit code ${childProcess.exitCode})`,
+      );
+    }
+
+    try {
+      const value = normalize(await readJsonFile(filePath));
+      if (predicate(value)) {
+        return value;
+      }
+    } catch (error) {
+      // The fixture updates JSON asynchronously. Missing or partially-written
+      // files are expected while polling; retain the latest error for timeout
+      // diagnostics instead of weakening the final assertion.
+      lastError = error;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `timed out after ${timeoutMs}ms waiting for ${filePath}${
+      lastError instanceof Error ? `: ${lastError.message}` : ''
+    }`,
+  );
+}
+
+function toDisplayLocalBounds(bounds: Bounds, screen: Bounds): Bounds {
+  return {
+    left: bounds.left - screen.left,
+    top: bounds.top - screen.top,
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+function locatedPixelBbox(bounds: Bounds, screen: Bounds) {
+  const local = toDisplayLocalBounds(bounds, screen);
+  const inset = Math.min(
+    4,
+    Math.floor(local.width / 4),
+    Math.floor(local.height / 4),
+  );
+  return [
+    Math.round(local.left + inset),
+    Math.round(local.top + inset),
+    Math.round(local.left + local.width - inset),
+    Math.round(local.top + local.height - inset),
+  ] as [number, number, number, number];
+}
+
+function locate(bounds: Bounds, screen: Bounds, prompt: string) {
+  return {
+    prompt,
+    locatedPixelBbox: locatedPixelBbox(bounds, screen),
+  };
+}
+
+function base64Body(dataUrl: string): string {
+  const commaIndex = dataUrl.indexOf(',');
+  if (commaIndex === -1) {
+    throw new Error('screenshot is not a base64 data URL');
+  }
+  return dataUrl.slice(commaIndex + 1);
+}
+
+function quotePowerShellSingle(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function runPowerShell(script: string): Promise<string> {
+  const encoded = Buffer.from(
+    `$ErrorActionPreference = 'Stop'\n${script}`,
+    'utf16le',
+  ).toString('base64');
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+      { encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            new Error(
+              `PowerShell screenshot analysis failed: ${error.message}\n${stderr}`,
+            ),
+          );
+          return;
+        }
+        resolve(stdout.trim());
+      },
+    );
+  });
+}
+
+async function analyzeScreenshot(
+  screenshotPath: string,
+  button: Bounds,
+  form: Bounds,
+  screen: Bounds,
+): Promise<ScreenshotAnalysis> {
+  const target = toDisplayLocalBounds(button, screen);
+  const localForm = toDisplayLocalBounds(form, screen);
+  const backgroundSize = 10;
+  const backgroundLeft = Math.max(
+    localForm.left + 2,
+    localForm.left + localForm.width - backgroundSize - 12,
+  );
+  const backgroundTop = Math.max(localForm.top + 2, localForm.top + 42);
+
+  const script = `
+Add-Type -AssemblyName System.Drawing
+$bitmap = [System.Drawing.Bitmap]::FromFile(${quotePowerShellSingle(screenshotPath)})
+function Get-AverageColor([int] $left, [int] $top, [int] $width, [int] $height) {
+  $red = 0L; $green = 0L; $blue = 0L; $count = 0L
+  $stepX = [Math]::Max(1, [Math]::Floor($width / 7))
+  $stepY = [Math]::Max(1, [Math]::Floor($height / 7))
+  for ($x = $left; $x -lt ($left + $width); $x += $stepX) {
+    for ($y = $top; $y -lt ($top + $height); $y += $stepY) {
+      $pixel = $bitmap.GetPixel($x, $y)
+      $red += $pixel.R; $green += $pixel.G; $blue += $pixel.B; $count += 1
+    }
+  }
+  [PSCustomObject]@{
+    r = [Math]::Round($red / $count)
+    g = [Math]::Round($green / $count)
+    b = [Math]::Round($blue / $count)
+  }
+}
+$target = Get-AverageColor ${Math.round(target.left + 7)} ${Math.round(target.top + 7)} ${Math.max(1, Math.round(target.width - 14))} ${Math.max(1, Math.round(target.height - 14))}
+$background = Get-AverageColor ${Math.round(backgroundLeft)} ${Math.round(backgroundTop)} $backgroundSize $backgroundSize
+$difference = [Math]::Abs($target.r - $background.r) + [Math]::Abs($target.g - $background.g) + [Math]::Abs($target.b - $background.b)
+[PSCustomObject]@{ target = $target; background = $background; channelDifference = $difference } | ConvertTo-Json -Compress
+$bitmap.Dispose()
+`.trim();
+
+  return JSON.parse(await runPowerShell(script)) as ScreenshotAnalysis;
+}
+
+function parseReportDumps(html: string): ReportDump[] {
+  const marker = '<script type="midscene_web_dump"';
+  const closeTag = '</script>';
+  const dumps: ReportDump[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const openIndex = html.indexOf(marker, cursor);
+    if (openIndex === -1) break;
+    const closeIndex = html.indexOf(closeTag, openIndex);
+    if (closeIndex === -1) break;
+    const prefix = html.slice(0, closeIndex + closeTag.length);
+    try {
+      const parsed = JSON.parse(parseDumpScript(prefix)) as ReportDump;
+      if (Array.isArray(parsed.executions)) {
+        dumps.push(parsed);
+      }
+    } catch {
+      // The bundled report application can contain the marker as source text.
+      // Only structurally valid JSON dump tags are evidence for this smoke.
+    }
+    cursor = closeIndex + closeTag.length;
+  }
+
+  return dumps;
+}
+
+function latestExecutions(dumps: ReportDump[]): ReportExecution[] {
+  const byKey = new Map<string, ReportExecution>();
+  let anonymousIndex = 0;
+  for (const dump of dumps) {
+    for (const execution of dump.executions ?? []) {
+      const key =
+        execution.id || execution.name || `anonymous-${anonymousIndex++}`;
+      byKey.set(key, execution);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+async function stopFixture(
+  fixtureProcess: ChildProcessWithoutNullStreams | undefined,
+): Promise<void> {
+  if (
+    !fixtureProcess ||
+    fixtureProcess.exitCode !== null ||
+    fixtureProcess.signalCode !== null
+  ) {
+    return;
+  }
+  const exitPromise = new Promise<void>((resolve) =>
+    fixtureProcess.once('exit', () => resolve()),
+  );
+  fixtureProcess.kill();
+  await Promise.race([exitPromise, sleep(5_000)]);
+}
+
+describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
+  it('drives a visible WinForms app without calling a model and emits evidence', async () => {
+    const diagnosticsEnv = process.env.MIDSCENE_WINDOWS_DIAGNOSTICS_DIR;
+    if (!diagnosticsEnv) {
+      throw new Error(
+        'MIDSCENE_WINDOWS_DIAGNOSTICS_DIR is required for the Windows desktop smoke',
+      );
+    }
+
+    const diagnosticsDir = path.resolve(diagnosticsEnv);
+    const readyFile = path.join(diagnosticsDir, 'fixture-ready.json');
+    const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
+    const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
+    const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
+    const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
+    const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
+    const reportFile = path.join(runDir, 'report', REPORT_HTML_FILE_NAME);
+
+    let fixtureProcess: ChildProcessWithoutNullStreams | undefined;
+    let device: ComputerDevice | undefined;
+    let selectedDisplayDevice: ComputerDevice | undefined;
+    let missingDisplayDevice: ComputerDevice | undefined;
+    let agent: ComputerAgent<ComputerDevice> | undefined;
+    let fixtureStdout = '';
+    let fixtureStderr = '';
+    const evidence: Record<string, unknown> = {
+      platform: process.platform,
+      diagnosticsDir,
+      reportFile,
+    };
+
+    await mkdir(diagnosticsDir, { recursive: true });
+    await rm(readyFile, { force: true });
+    await rm(stateFile, { force: true });
+    await rm(reportFile, { force: true });
+
+    try {
+      const startedFixture = spawn(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-STA',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          FIXTURE_PATH,
+          '-ReadyFile',
+          readyFile,
+          '-StateFile',
+          stateFile,
+        ],
+        {
+          windowsHide: false,
+          stdio: 'pipe',
+        },
+      );
+      fixtureProcess = startedFixture;
+      startedFixture.stdin.end();
+      startedFixture.stdout.setEncoding('utf8');
+      startedFixture.stderr.setEncoding('utf8');
+      startedFixture.stdout.on('data', (chunk: string) => {
+        fixtureStdout += chunk;
+      });
+      startedFixture.stderr.on('data', (chunk: string) => {
+        fixtureStderr += chunk;
+      });
+
+      const metadata = await waitForJson(
+        readyFile,
+        normalizeMetadata,
+        (value) => value.visible,
+        FIXTURE_READY_TIMEOUT_MS,
+        startedFixture,
+      );
+      evidence.fixture = metadata;
+
+      expect(metadata.userInteractive).toBe(true);
+      expect(metadata.sessionId).toBeGreaterThan(0);
+      expect(metadata.visible).toBe(true);
+      expect(metadata.dpi).toBe(96);
+      expect(metadata.screen.width).toBeGreaterThan(0);
+      expect(metadata.screen.height).toBeGreaterThan(0);
+      expect(metadata.screenDeviceName).toMatch(/^\\\\\.\\DISPLAY\d+$/i);
+      expect(metadata.form.left).toBeGreaterThanOrEqual(metadata.screen.left);
+      expect(metadata.form.top).toBeGreaterThanOrEqual(metadata.screen.top);
+      expect(metadata.form.left + metadata.form.width).toBeLessThanOrEqual(
+        metadata.screen.left + metadata.screen.width,
+      );
+      expect(metadata.form.top + metadata.form.height).toBeLessThanOrEqual(
+        metadata.screen.top + metadata.screen.height,
+      );
+      if (metadata.processId !== undefined) {
+        expect(metadata.processId).toBe(startedFixture.pid);
+      }
+
+      const displays = await ComputerDevice.listDisplays();
+      evidence.displays = displays;
+      expect(displays.length).toBeGreaterThan(0);
+      const primaryDisplay = displays.find((display) => display.primary);
+      expect(primaryDisplay).toBeDefined();
+      expect(primaryDisplay!.id).toBe(metadata.screenDeviceName);
+
+      const environment = await checkComputerEnvironment();
+      evidence.environment = environment;
+      expect(environment).toMatchObject({
+        available: true,
+        platform: 'win32',
+      });
+      expect(environment.displays).toBeGreaterThan(0);
+
+      device = new ComputerDevice({});
+      await device.connect();
+      const deviceSize = await device.size();
+      evidence.deviceSize = deviceSize;
+      expect(deviceSize).toEqual({
+        width: metadata.screen.width,
+        height: metadata.screen.height,
+      });
+      const screenshotBase64 = await device.screenshotBase64();
+      const screenshotBuffer = Buffer.from(
+        base64Body(screenshotBase64),
+        'base64',
+      );
+      await writeFile(screenshotFile, screenshotBuffer);
+
+      const screenshotInfo = await imageInfoOfBase64(screenshotBase64);
+      evidence.screenshot = {
+        ...screenshotInfo,
+        bytes: screenshotBuffer.length,
+      };
+      expect(screenshotInfo).toEqual({
+        width: metadata.screen.width,
+        height: metadata.screen.height,
+      });
+      expect(screenshotBuffer.subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
+
+      const screenshotAnalysis = await analyzeScreenshot(
+        screenshotFile,
+        metadata.button,
+        metadata.form,
+        metadata.screen,
+      );
+      evidence.screenshotAnalysis = screenshotAnalysis;
+      expect(
+        screenshotAnalysis.target.g - screenshotAnalysis.target.r,
+      ).toBeGreaterThan(20);
+      expect(
+        screenshotAnalysis.target.g - screenshotAnalysis.target.b,
+      ).toBeGreaterThan(20);
+      expect(screenshotAnalysis.channelDifference).toBeGreaterThan(60);
+
+      selectedDisplayDevice = new ComputerDevice({
+        displayId: primaryDisplay!.id,
+      });
+      const selectedDisplayScreenshot =
+        await selectedDisplayDevice.screenshotBase64();
+      expect(await imageInfoOfBase64(selectedDisplayScreenshot)).toEqual(
+        screenshotInfo,
+      );
+
+      missingDisplayDevice = new ComputerDevice({
+        displayId: String.raw`\\.\MIDSCENE_MISSING_DISPLAY`,
+      });
+      await expect(missingDisplayDevice.screenshotBase64()).rejects.toThrow(
+        /Requested display not found|Failed to take screenshot on Windows/,
+      );
+
+      agent = new ComputerAgent(device, {
+        modelConfig: {
+          [MIDSCENE_MODEL_NAME]: 'windows-ci-model-must-not-run',
+          [MIDSCENE_MODEL_API_KEY]: 'windows-ci-unused-key',
+          [MIDSCENE_MODEL_BASE_URL]: 'http://127.0.0.1:1/v1',
+          [MIDSCENE_MODEL_FAMILY]: 'qwen3-vl',
+          [MIDSCENE_MODEL_TIMEOUT]: '1000',
+          [MIDSCENE_MODEL_RETRY_COUNT]: '0',
+        },
+        groupName: 'Windows desktop live smoke',
+        groupDescription:
+          'Deterministic WinForms input and screenshot validation on GitHub Actions',
+        reportFileName: REPORT_FILE_NAME,
+        autoPrintReportMsg: false,
+        generateReport: true,
+        waitAfterAction: 200,
+      });
+
+      await agent.callActionInActionSpace('Tap', {
+        locate: locate(metadata.button, metadata.screen, 'green smoke button'),
+      });
+      const clickedState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => state.clickCount >= 1,
+        STATE_TIMEOUT_MS,
+        startedFixture,
+      );
+      expect(clickedState.clickCount).toBe(1);
+
+      const inputText = 'Midscene Windows 输入 😀';
+      await agent.callActionInActionSpace('Input', {
+        value: inputText,
+        mode: 'replace',
+        locate: locate(metadata.textBox, metadata.screen, 'smoke text box'),
+      });
+      const inputState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => state.text === inputText,
+        STATE_TIMEOUT_MS,
+        startedFixture,
+      );
+      expect(inputState.text).toBe(inputText);
+
+      await agent.callActionInActionSpace('KeyboardPress', {
+        keyName: 'Enter',
+        locate: locate(metadata.textBox, metadata.screen, 'smoke text box'),
+      });
+      const keyState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => /enter|return/i.test(state.lastKey),
+        STATE_TIMEOUT_MS,
+        startedFixture,
+      );
+      expect(keyState.lastKey).toMatch(/enter|return/i);
+
+      await agent.callActionInActionSpace('Scroll', {
+        scrollType: 'singleAction',
+        direction: 'down',
+        distance: 200,
+        locate: locate(metadata.scroll, metadata.screen, 'scroll smoke panel'),
+      });
+      const scrolledState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) =>
+          state.wheelEventCount > 0 &&
+          state.wheelDelta !== 0 &&
+          state.scrollValue > 0,
+        STATE_TIMEOUT_MS,
+        startedFixture,
+      );
+      evidence.finalState = scrolledState;
+      expect(scrolledState.visible).toBe(true);
+      expect(scrolledState.wheelEventCount).toBeGreaterThan(0);
+      expect(scrolledState.wheelDelta).not.toBe(0);
+      expect(scrolledState.scrollValue).toBeGreaterThan(0);
+
+      const dump = JSON.parse(agent.dumpDataString()) as ReportDump;
+      await writeFile(dumpFile, `${JSON.stringify(dump, null, 2)}\n`, 'utf8');
+      const dumpTasks = (dump.executions ?? []).flatMap(
+        (execution) => execution.tasks ?? [],
+      );
+      const locateTasks = dumpTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(locateTasks).toHaveLength(4);
+      expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
+        true,
+      );
+      expect(agent.metrics.calls).toBe(0);
+      expect(
+        dumpTasks.some(
+          (task) =>
+            task.timing?.callAiStart !== undefined ||
+            task.timing?.callAiEnd !== undefined ||
+            task.usage !== undefined ||
+            task.searchAreaUsage !== undefined,
+        ),
+      ).toBe(false);
+
+      await agent.destroy();
+      expect(agent.reportFile).toBe(reportFile);
+      const reportHtml = await readFile(reportFile, 'utf8');
+      expect(reportHtml).not.toContain('REPLACE_ME_WITH_REPORT_HTML');
+      const reportExecutions = latestExecutions(parseReportDumps(reportHtml));
+      const reportTasks = reportExecutions.flatMap(
+        (execution) => execution.tasks ?? [],
+      );
+      const reportLocateTasks = reportTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(reportLocateTasks).toHaveLength(4);
+      expect(
+        reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
+      ).toBe(true);
+      for (const action of ['Tap', 'Input', 'KeyboardPress', 'Scroll']) {
+        expect(
+          reportTasks.some(
+            (task) => task.type === 'Action Space' && task.subType === action,
+          ),
+        ).toBe(true);
+      }
+
+      evidence.report = {
+        path: reportFile,
+        executionCount: reportExecutions.length,
+        locateHitSources: reportLocateTasks.map((task) => task.hitBy?.from),
+        modelCalls: agent.metrics.calls,
+      };
+    } catch (error) {
+      evidence.error =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : String(error);
+      throw error;
+    } finally {
+      if (agent) {
+        try {
+          await agent.destroy();
+        } catch (error) {
+          evidence.agentDestroyError = String(error);
+        }
+      } else if (device) {
+        try {
+          await device.destroy();
+        } catch (error) {
+          evidence.deviceDestroyError = String(error);
+        }
+      }
+      await selectedDisplayDevice?.destroy().catch((error) => {
+        evidence.selectedDisplayDestroyError = String(error);
+      });
+      await missingDisplayDevice?.destroy().catch((error) => {
+        evidence.missingDisplayDestroyError = String(error);
+      });
+      await stopFixture(fixtureProcess).catch((error) => {
+        evidence.fixtureStopError = String(error);
+      });
+
+      await Promise.all([
+        writeFile(fixtureStdoutFile, fixtureStdout, 'utf8'),
+        writeFile(fixtureStderrFile, fixtureStderr, 'utf8'),
+        writeFile(
+          evidenceFile,
+          `${JSON.stringify(evidence, null, 2)}\n`,
+          'utf8',
+        ),
+      ]);
+    }
+  });
+});

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -331,7 +331,7 @@ function Get-AverageColor([int] $left, [int] $top, [int] $width, [int] $height) 
   }
 }
 $target = Get-AverageColor ${Math.round(target.left + 7)} ${Math.round(target.top + 7)} ${Math.max(1, Math.round(target.width - 14))} ${Math.max(1, Math.round(target.height - 14))}
-$background = Get-AverageColor ${Math.round(backgroundLeft)} ${Math.round(backgroundTop)} $backgroundSize $backgroundSize
+$background = Get-AverageColor ${Math.round(backgroundLeft)} ${Math.round(backgroundTop)} ${backgroundSize} ${backgroundSize}
 $difference = [Math]::Abs($target.r - $background.r) + [Math]::Abs($target.g - $background.g) + [Math]::Abs($target.b - $background.b)
 [PSCustomObject]@{ target = $target; background = $background; channelDifference = $difference } | ConvertTo-Json -Compress
 $bitmap.Dispose()


### PR DESCRIPTION
## Summary

- add a dedicated `windows-2022` workflow with interactive-session, Session ID, screen, DPI, PowerShell, build, unit, package, and CLI validation
- launch a visible topmost WinForms fixture and verify real PowerShell screenshots plus libnut mouse, Unicode keyboard, key press, and wheel input
- run deterministic `ComputerAgent` actions through `locatedPixelBbox`, assert every locate is `hitBy.from === 'Plan'`, prove zero model calls, and validate the generated Midscene HTML report structurally
- always upload the HTML report and bounded diagnostics, then restore the original build/test failure outcome

## Why

The regular CI only exercises `@midscene/computer` on Linux. Existing Windows screenshot and input unit tests rely on mocks or allow empty environment results, so they cannot prove that the Windows PowerShell and native libnut paths work on a real desktop session.

This PR is based directly on `main` and only validates capabilities already present there. It does not depend on UI Automation, XPath cache replay, model credentials, or another feature branch.

## Validation

- `pnpm exec biome check packages/computer/tests/ai/windows-desktop-smoke.test.ts`
- `pnpm exec tsc --noEmit -p packages/computer/tsconfig.json`
- `AI_TEST_TYPE=computer MIDSCENE_WINDOWS_DESKTOP_SMOKE=1 pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/windows-desktop-smoke.test.ts --retry=0` (correctly skipped on macOS)
- `pnpm exec nx test @midscene/computer --skip-nx-cache` (13 files, 82 tests)
- `pnpm exec nx run-many --target=build --projects=@midscene/report,@midscene/computer --skip-nx-cache`
- `node apps/report/scripts/inject-report-template.mjs`
- `pnpm --dir packages/computer pack --pack-destination <temp-dir>` plus required tarball-entry checks
- `pnpm run lint`
- hosted Windows run [29143291585](https://github.com/web-infra-dev/midscene/actions/runs/29143291585) passed in 3m17s

The hosted evidence confirms an interactive Session 2 at 96 DPI and 1024x768, a visible WinForms fixture, a nonblank green target screenshot, successful click/Unicode input/Enter/wheel state changes, four `Plan` locate hits, and zero model calls. All 12 PR checks pass.

## Scope

The required smoke intentionally targets GitHub hosted `windows-2022`, an interactive 96-DPI session, and an ordinary-permission WinForms app. Native RDP, mixed DPI, elevated windows, multi-display hardware, Windows UI Automation, and cache replay remain separate follow-up coverage.
