### PR TITLE
fix(site): keep navigation usable before hydration

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "rspress dev",
-    "build": "rspress build && ./config_deploy.sh",
+    "build": "rspress build && node scripts/rspress-route-preload.mjs doc_build && ./config_deploy.sh",
     "preview": "rspress preview",
     "test": "vitest --run"
   },

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "rspress dev",
     "build": "rspress build && ./config_deploy.sh",
-    "preview": "rspress preview"
+    "preview": "rspress preview",
+    "test": "vitest --run"
   },
   "engines": {
     "pnpm": ">=9.3.0",
@@ -24,10 +25,12 @@
     "@rspress/plugin-client-redirects": "2.0.8",
     "@rspress/plugin-llms": "2.0.8",
     "@rspress/plugin-sitemap": "2.0.8",
+    "@rspress/shared": "2.0.8",
     "@tailwindcss/postcss": "4.1.11",
     "@types/node": "^18.0.0",
     "autoprefixer": "10.4.22",
     "postcss": "8.5.6",
-    "tailwindcss": "4.1.11"
+    "tailwindcss": "4.1.11",
+    "vitest": "3.0.5"
   }
 }

--- a/apps/site/scripts/rspress-route-preload.mjs
+++ b/apps/site/scripts/rspress-route-preload.mjs
@@ -1,0 +1,185 @@
+import { realpathSync } from 'node:fs';
+import { access, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROUTE_PATTERN =
+  /\{path:"([^"]+)",element:.*?,filePath:"([^"]+)",preload:async\(\)=>\((.*?)\),lang:"([^"]+)"/gs;
+const PRELOAD_MARKER = 'data-rspress-route-preload';
+
+export function extractRoutePreloads(source) {
+  return [...source.matchAll(ROUTE_PATTERN)].map((match) => ({
+    routePath: JSON.parse(`"${match[1]}"`),
+    pageId: JSON.parse(`"${match[2]}"`),
+    chunkIds: [
+      ...match[3].matchAll(/\.e\((?:"([^"]+)"|'([^']+)'|(\d+))\)/g),
+    ].map((chunkMatch) => chunkMatch[1] || chunkMatch[2] || chunkMatch[3]),
+    lang: JSON.parse(`"${match[4]}"`),
+  }));
+}
+
+export function routePathToHtmlPath(routePath) {
+  const normalized = routePath.split(/[?#]/, 1)[0].replace(/^\/+/, '');
+  if (!normalized) return 'index.html';
+  if (normalized.includes('*')) {
+    throw new Error(`Cannot map wildcard route to HTML: ${routePath}`);
+  }
+  if (normalized.endsWith('/')) return `${normalized}index.html`;
+  return `${normalized}.html`;
+}
+
+function parseArgs(argv) {
+  const outputDir = argv[0];
+  if (!outputDir) {
+    throw new Error(
+      'Usage: node scripts/rspress-route-preload.mjs <output-dir>',
+    );
+  }
+  return { outputDir: path.resolve(outputDir) };
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function injectRoutePreloads({ outputDir }) {
+  const asyncDir = path.join(outputDir, 'static/js/async');
+  const chunkFiles = (await readdir(asyncDir))
+    .filter((file) => file.endsWith('.js'))
+    .sort();
+  const chunkById = new Map(
+    chunkFiles.map((file) => [file.split('.', 1)[0], file]),
+  );
+  const runtimeFiles = (
+    await readdir(path.join(outputDir, 'static/js'))
+  ).filter((file) => /^index\..+\.js$/.test(file));
+
+  if (runtimeFiles.length !== 1) {
+    throw new Error(
+      `Expected one Rspress index runtime, found ${runtimeFiles.length}`,
+    );
+  }
+
+  const runtimeSource = await readFile(
+    path.join(outputDir, 'static/js', runtimeFiles[0]),
+    'utf8',
+  );
+  const routes = extractRoutePreloads(runtimeSource);
+  const htmlToChunks = new Map();
+
+  if (routes.length === 0) {
+    throw new Error(
+      `No Rspress route preload entries found in ${runtimeFiles[0]}`,
+    );
+  }
+
+  for (const route of routes) {
+    const htmlRelativePath = routePathToHtmlPath(route.routePath);
+    const htmlPath = path.join(outputDir, htmlRelativePath);
+    const routeChunks = [
+      ...new Set(route.chunkIds.map((id) => chunkById.get(id)).filter(Boolean)),
+    ];
+
+    if (!(await fileExists(htmlPath))) {
+      throw new Error(
+        `Rspress route ${route.routePath} maps to missing HTML: ${htmlRelativePath} (${route.pageId})`,
+      );
+    }
+    if (routeChunks.length === 0) {
+      throw new Error(
+        `Rspress route ${route.routePath} has no preloadable async chunks (${route.pageId})`,
+      );
+    }
+
+    const previousChunks = htmlToChunks.get(htmlRelativePath);
+    if (previousChunks && previousChunks.join(',') !== routeChunks.join(',')) {
+      throw new Error(
+        `Rspress HTML ${htmlRelativePath} maps to conflicting chunk sets: ${previousChunks.join(', ')}, ${routeChunks.join(', ')}`,
+      );
+    }
+    htmlToChunks.set(htmlRelativePath, routeChunks);
+  }
+
+  let injected = 0;
+  let preloadedChunks = 0;
+  let unchanged = 0;
+
+  for (const [htmlRelativePath, routeChunks] of htmlToChunks) {
+    const htmlPath = path.join(outputDir, htmlRelativePath);
+    const html = await readFile(htmlPath, 'utf8');
+    if (!html.includes('id="__rspress_root"')) {
+      throw new Error(
+        `Refusing to modify non-Rspress HTML mapped from a page chunk: ${htmlRelativePath}`,
+      );
+    }
+
+    const existingMarker = new RegExp(
+      `<link\\s+[^>]*${PRELOAD_MARKER}[^>]*>`,
+      'g',
+    );
+    const markers = html.match(existingMarker) || [];
+    const chunkUrls = routeChunks.map(
+      (chunkFile) => `/static/js/async/${chunkFile}`,
+    );
+    preloadedChunks += chunkUrls.length;
+
+    if (markers.length > 0) {
+      const existingUrls = markers
+        .map((marker) => marker.match(/href="([^"]+)"/)?.[1])
+        .filter(Boolean)
+        .sort();
+      if (existingUrls.join(',') !== [...chunkUrls].sort().join(',')) {
+        throw new Error(
+          `Rspress HTML ${htmlRelativePath} contains a stale route preload marker`,
+        );
+      }
+      unchanged += 1;
+      continue;
+    }
+
+    if (!html.includes('</head>')) {
+      throw new Error(
+        `Rspress HTML ${htmlRelativePath} has no closing </head>`,
+      );
+    }
+    const preloads = chunkUrls
+      .map(
+        (chunkUrl) =>
+          `<link rel="preload" as="script" href="${chunkUrl}" ${PRELOAD_MARKER}>`,
+      )
+      .join('\n');
+    await writeFile(htmlPath, html.replace('</head>', `${preloads}\n</head>`));
+    injected += 1;
+  }
+
+  return {
+    injected,
+    mappedPages: htmlToChunks.size,
+    preloadedChunks,
+    unchanged,
+  };
+}
+
+const isMain =
+  process.argv[1] &&
+  realpathSync(process.argv[1]) ===
+    realpathSync(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  try {
+    const result = await injectRoutePreloads(parseArgs(process.argv.slice(2)));
+    console.log(
+      `[rspress-route-preload] mapped=${result.mappedPages} injected=${result.injected} chunks=${result.preloadedChunks} unchanged=${result.unchanged}`,
+    );
+  } catch (error) {
+    console.error(
+      `[rspress-route-preload] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/apps/site/scripts/rspress-route-preload.test.mjs
+++ b/apps/site/scripts/rspress-route-preload.test.mjs
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractRoutePreloads,
+  injectRoutePreloads,
+  routePathToHtmlPath,
+} from './rspress-route-preload.mjs';
+
+describe('Rspress route preload injection', () => {
+  it('extracts numeric and quoted async chunk ids', () => {
+    const source = [
+      '{path:"/",element:a.createElement(r),filePath:"en/index.md",preload:async()=>(await r.preload(),Promise.all([i.e(4194),i.e("100")]).then(i.bind(i,1))),lang:"en",version:""}',
+    ].join(',');
+
+    expect(extractRoutePreloads(source)).toEqual([
+      {
+        chunkIds: ['4194', '100'],
+        lang: 'en',
+        pageId: 'en/index.md',
+        routePath: '/',
+      },
+    ]);
+  });
+
+  it('maps generated route paths to HTML files', () => {
+    expect(routePathToHtmlPath('/')).toBe('index.html');
+    expect(routePathToHtmlPath('/guide/start')).toBe('guide/start.html');
+    expect(routePathToHtmlPath('/guide/')).toBe('guide/index.html');
+    expect(routePathToHtmlPath('/zh/')).toBe('zh/index.html');
+  });
+
+  it('injects exact route chunks and remains idempotent', async () => {
+    const outputDir = await mkdtemp(
+      path.join(os.tmpdir(), 'rspress-route-preload-'),
+    );
+    const asyncDir = path.join(outputDir, 'static/js/async');
+    const jsDir = path.join(outputDir, 'static/js');
+    await mkdir(path.join(outputDir, 'guide'), { recursive: true });
+    await mkdir(asyncDir, { recursive: true });
+    await writeFile(path.join(asyncDir, '100.home.js'), 'home');
+    await writeFile(path.join(asyncDir, '200.guide.js'), 'guide');
+    await writeFile(
+      path.join(jsDir, 'index.runtime.js'),
+      [
+        '{path:"/",element:a.createElement(r),filePath:"en/index.md",preload:async()=>(i.e("100").then(i.bind(i,1))),lang:"en",version:""}',
+        '{path:"/guide/start",element:a.createElement(r),filePath:"en/guide/start.mdx",preload:async()=>(i.e("200").then(i.bind(i,2))),lang:"en",version:""}',
+      ].join(','),
+    );
+    const html =
+      '<html><head></head><body><div id="__rspress_root"></div></body></html>';
+    await writeFile(path.join(outputDir, 'index.html'), html);
+    await writeFile(path.join(outputDir, 'guide/start.html'), html);
+
+    try {
+      await expect(injectRoutePreloads({ outputDir })).resolves.toEqual({
+        injected: 2,
+        mappedPages: 2,
+        preloadedChunks: 2,
+        unchanged: 0,
+      });
+      await expect(injectRoutePreloads({ outputDir })).resolves.toEqual({
+        injected: 0,
+        mappedPages: 2,
+        preloadedChunks: 2,
+        unchanged: 2,
+      });
+      expect(
+        await readFile(path.join(outputDir, 'index.html'), 'utf8'),
+      ).toMatch(
+        /href="\/static\/js\/async\/100\.home\.js" data-rspress-route-preload/,
+      );
+    } finally {
+      await rm(outputDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageMenu.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageMenu.tsx
@@ -1,0 +1,74 @@
+export interface NativeLanguageMenuItem {
+  href?: string;
+  label: string;
+  lang: string;
+}
+
+interface NativeLanguageMenuProps {
+  activeLabel: string;
+  items: NativeLanguageMenuItem[];
+}
+
+export function NativeLanguageMenu({
+  activeLabel,
+  items,
+}: NativeLanguageMenuProps) {
+  return (
+    <details
+      className="site-language-menu rp-nav-menu__item"
+      suppressHydrationWarning
+    >
+      <summary
+        className="site-language-menu__summary rp-nav-menu__item__container"
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ')
+            event.stopPropagation();
+        }}
+      >
+        <span>{activeLabel}</span>
+        <svg
+          aria-hidden="true"
+          className="rp-nav-menu__item__icon"
+          width="1em"
+          height="1em"
+          viewBox="0 0 32 32"
+        >
+          <path
+            fill="currentColor"
+            d="M16 22 6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z"
+          />
+        </svg>
+      </summary>
+      <ul className="site-language-menu__list rp-hover-group rp-hover-group--right">
+        {items.map((item) => (
+          <li
+            key={item.lang}
+            className={`rp-hover-group__item${item.href ? '' : ' rp-hover-group__item--active'}`}
+            data-depth="0"
+          >
+            {item.href ? (
+              <a
+                href={item.href}
+                className="rp-hover-group__item__link"
+                aria-label={item.label}
+                hrefLang={item.lang}
+                lang={item.lang}
+                rel="alternate"
+              >
+                {item.label}
+              </a>
+            ) : (
+              <span
+                className="rp-hover-group__item__link"
+                aria-current="page"
+                lang={item.lang}
+              >
+                {item.label}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageMenu.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageMenu.tsx
@@ -14,31 +14,30 @@ export function NativeLanguageMenu({
   items,
 }: NativeLanguageMenuProps) {
   return (
-    <details
-      className="site-language-menu rp-nav-menu__item"
-      suppressHydrationWarning
-    >
-      <summary
-        className="site-language-menu__summary rp-nav-menu__item__container"
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ')
-            event.stopPropagation();
-        }}
-      >
-        <span>{activeLabel}</span>
-        <svg
-          aria-hidden="true"
-          className="rp-nav-menu__item__icon"
-          width="1em"
-          height="1em"
-          viewBox="0 0 32 32"
+    <div className="site-language-menu rp-nav-menu__item">
+      <details className="site-language-menu__details" suppressHydrationWarning>
+        <summary
+          className="site-language-menu__summary rp-nav-menu__item__container"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ')
+              event.stopPropagation();
+          }}
         >
-          <path
-            fill="currentColor"
-            d="M16 22 6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z"
-          />
-        </svg>
-      </summary>
+          <span>{activeLabel}</span>
+          <svg
+            aria-hidden="true"
+            className="rp-nav-menu__item__icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 32 32"
+          >
+            <path
+              fill="currentColor"
+              d="M16 22 6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z"
+            />
+          </svg>
+        </summary>
+      </details>
       <ul className="site-language-menu__list rp-hover-group rp-hover-group--right">
         {items.map((item) => (
           <li
@@ -69,6 +68,6 @@ export function NativeLanguageMenu({
           </li>
         ))}
       </ul>
-    </details>
+    </div>
   );
 }

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
@@ -34,6 +34,23 @@ describe('native language switcher', () => {
     );
   });
 
+  it('opens native and Rspress navigation menus on hover or keyboard focus before hydration', () => {
+    const css = readFileSync(
+      new URL('./native-language-switcher.css', import.meta.url),
+      'utf8',
+    );
+
+    expect(css).toMatch(
+      /\.site-language-menu:is\(\[open\], :hover, :focus-within\)/,
+    );
+    expect(css).toMatch(/\.rp-nav-menu__item:is\(:hover, :focus-within\)/);
+    expect(css).toMatch(/\.rp-nav-hamburger__md:is\(:hover, :focus-within\)/);
+    expect(css).toMatch(
+      /\.rp-nav-hamburger__sm\s*\{[\s\S]*?display:\s*none\s*!important/,
+    );
+    expect(css).toMatch(/\.site-mobile-nav\s*\{[\s\S]*?display:\s*block/);
+  });
+
   it('builds equivalent language paths for home, docs, query strings, and 404 pages', () => {
     const version = { current: '', default: '' };
 

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
@@ -16,8 +16,9 @@ describe('native language switcher', () => {
       />,
     );
 
-    expect(html).toMatch(/^<details/);
+    expect(html).toMatch(/^<div[^>]+site-language-menu/);
     expect(html).toMatch(/<summary[^>]+>.*English/s);
+    expect(html).toMatch(/<\/details><ul class="site-language-menu__list/);
     expect(html).toContain('<a href="/zh/index.html"');
     expect(html).not.toContain('aria-label="Language"');
     expect(html).not.toContain('rp-link');
@@ -40,8 +41,9 @@ describe('native language switcher', () => {
       'utf8',
     );
 
+    expect(css).toMatch(/\.site-language-menu:is\(:hover, :focus-within\)/);
     expect(css).toMatch(
-      /\.site-language-menu:is\(\[open\], :hover, :focus-within\)/,
+      /\.site-language-menu__details\[open\] \+ \.site-language-menu__list/,
     );
     expect(css).toMatch(/\.rp-nav-menu__item:is\(:hover, :focus-within\)/);
     expect(css).toMatch(/\.rp-nav-hamburger__md:is\(:hover, :focus-within\)/);

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.test.tsx
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { NativeLanguageMenu } from './NativeLanguageMenu';
+import { replaceLanguageInPath } from './languagePath';
+
+describe('native language switcher', () => {
+  it('renders links that work without React hydration', () => {
+    const html = renderToStaticMarkup(
+      <NativeLanguageMenu
+        activeLabel="English"
+        items={[
+          { label: 'English', lang: 'en' },
+          { href: '/zh/index.html', label: '简体中文', lang: 'zh' },
+        ]}
+      />,
+    );
+
+    expect(html).toMatch(/^<details/);
+    expect(html).toMatch(/<summary[^>]+>.*English/s);
+    expect(html).toContain('<a href="/zh/index.html"');
+    expect(html).not.toContain('aria-label="Language"');
+    expect(html).not.toContain('rp-link');
+  });
+
+  it('fully removes Rspress mobile locale controls from layout and keyboard navigation', () => {
+    const css = readFileSync(
+      new URL('./native-language-switcher.css', import.meta.url),
+      'utf8',
+    );
+
+    expect(css).toMatch(
+      /\.rp-nav-screen-langs-group\s*\{[\s\S]*?display:\s*none\s*!important/,
+    );
+  });
+
+  it('builds equivalent language paths for home, docs, query strings, and 404 pages', () => {
+    const version = { current: '', default: '' };
+
+    expect(
+      replaceLanguageInPath(
+        '/',
+        { current: 'en', target: 'zh', default: 'en' },
+        version,
+        false,
+        false,
+      ),
+    ).toBe('/zh/index.html');
+    expect(
+      replaceLanguageInPath(
+        '/guide/start.html?from=nav',
+        { current: 'en', target: 'zh', default: 'en' },
+        version,
+        false,
+        false,
+      ),
+    ).toBe('/zh/guide/start.html?from=nav');
+    expect(
+      replaceLanguageInPath(
+        '/zh/guide/start.html',
+        { current: 'zh', target: 'en', default: 'en' },
+        version,
+        false,
+        false,
+      ),
+    ).toBe('/guide/start.html');
+    expect(
+      replaceLanguageInPath(
+        '/missing',
+        { current: 'en', target: 'zh', default: 'en' },
+        version,
+        true,
+        true,
+      ),
+    ).toBe('/zh/index');
+  });
+
+  it('preserves a non-default version and base prefix while switching language', () => {
+    expect(
+      replaceLanguageInPath(
+        '/docs/v2/guide/start.html',
+        { current: 'en', target: 'zh', default: 'en' },
+        { current: 'v2', default: 'v1' },
+        false,
+        false,
+        '/docs/',
+      ),
+    ).toBe('/v2/zh/guide/start.html');
+  });
+});

--- a/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeLanguageSwitcher.tsx
@@ -1,0 +1,58 @@
+import {
+  useLocation,
+  usePage,
+  useSite,
+  useVersion,
+  withBase,
+} from '@rspress/core/runtime';
+import { NativeLanguageMenu } from './NativeLanguageMenu';
+import { replaceLanguageInPath } from './languagePath';
+import './native-language-switcher.css';
+
+export function NativeLanguageSwitcher() {
+  const { page } = usePage();
+  const { site } = useSite();
+  const version = useVersion();
+  const { pathname, search } = useLocation();
+  const languages = Object.values(
+    site.locales || site.themeConfig.locales || {},
+  );
+
+  if (languages.length < 2) return null;
+
+  const currentLanguage = page.lang;
+  const defaultLanguage = site.lang || '';
+  const defaultVersion = site.multiVersion.default || '';
+  const cleanUrls = site.route?.cleanUrls || false;
+  const activeLabel =
+    languages.find((language) => language.lang === currentLanguage)?.label ||
+    currentLanguage;
+  const items = languages.map((language) => {
+    const isCurrent = language.lang === currentLanguage;
+    const path = isCurrent
+      ? undefined
+      : replaceLanguageInPath(
+          pathname + search,
+          {
+            current: currentLanguage,
+            target: language.lang,
+            default: defaultLanguage,
+          },
+          {
+            current: version,
+            default: defaultVersion,
+          },
+          cleanUrls,
+          page.pageType === '404',
+          site.base,
+        );
+
+    return {
+      href: path ? withBase(path) : undefined,
+      label: language.label,
+      lang: language.lang,
+    };
+  });
+
+  return <NativeLanguageMenu activeLabel={activeLabel} items={items} />;
+}

--- a/apps/site/theme/components/native-language-switcher/NativeMobileMenu.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeMobileMenu.tsx
@@ -1,0 +1,134 @@
+import type { NavItem } from '@rspress/core';
+
+interface NativeMobileMenuProps {
+  items: NavItem[];
+  resolveHref?: (href: string) => string;
+}
+
+function NavItemLabel({ item }: { item: NavItem }) {
+  return (
+    <>
+      {item.text}
+      {item.tag ? (
+        <span className="site-mobile-nav__tag">{item.tag}</span>
+      ) : null}
+    </>
+  );
+}
+
+function NativeMobileNavItem({
+  item,
+  resolveHref,
+}: {
+  item: NavItem;
+  resolveHref: (href: string) => string;
+}) {
+  const hasChildren =
+    'items' in item && Array.isArray(item.items) && item.items.length > 0;
+  const hasLink =
+    'link' in item && typeof item.link === 'string' && item.link.length > 0;
+
+  if (hasChildren) {
+    return (
+      <details className="site-mobile-nav__group" suppressHydrationWarning>
+        <summary className="site-mobile-nav__item site-mobile-nav__group-summary">
+          <NavItemLabel item={item} />
+          <svg
+            aria-hidden="true"
+            className="site-mobile-nav__arrow"
+            width="1em"
+            height="1em"
+            viewBox="0 0 32 32"
+          >
+            <path
+              fill="currentColor"
+              d="M16 22 6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z"
+            />
+          </svg>
+        </summary>
+        <div className="site-mobile-nav__group-items">
+          {hasLink ? (
+            <a
+              className="site-mobile-nav__item site-mobile-nav__group-link"
+              href={resolveHref(item.link)}
+              hrefLang={item.lang}
+              lang={item.lang}
+              rel={item.rel}
+            >
+              <NavItemLabel item={item} />
+            </a>
+          ) : null}
+          {item.items.map((child, index) => (
+            <NativeMobileNavItem
+              key={`${child.text || 'item'}-${index}`}
+              item={child}
+              resolveHref={resolveHref}
+            />
+          ))}
+        </div>
+      </details>
+    );
+  }
+
+  if (hasLink) {
+    return (
+      <a
+        className="site-mobile-nav__item"
+        href={resolveHref(item.link)}
+        download={'download' in item ? item.download : undefined}
+        hrefLang={item.lang}
+        lang={item.lang}
+        rel={item.rel}
+      >
+        <NavItemLabel item={item} />
+      </a>
+    );
+  }
+
+  return (
+    <span className="site-mobile-nav__item site-mobile-nav__item--label">
+      {item.text}
+    </span>
+  );
+}
+
+export function NativeMobileMenu({
+  items,
+  resolveHref = (href) => href,
+}: NativeMobileMenuProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <details className="site-mobile-nav" suppressHydrationWarning>
+      <summary
+        className="site-mobile-nav__toggle"
+        aria-label="Mobile navigation"
+      >
+        <svg
+          aria-hidden="true"
+          width="21"
+          height="21"
+          fill="none"
+          viewBox="0 0 21 21"
+        >
+          <path
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.667"
+            d="M3.645 5.225h13.333M3.645 10.225h13.333M3.645 15.225h13.333"
+          />
+        </svg>
+      </summary>
+      <nav className="site-mobile-nav__panel" aria-label="Mobile navigation">
+        {items.map((item, index) => (
+          <NativeMobileNavItem
+            key={`${item.text || 'item'}-${index}`}
+            item={item}
+            resolveHref={resolveHref}
+          />
+        ))}
+      </nav>
+    </details>
+  );
+}

--- a/apps/site/theme/components/native-language-switcher/NativeMobileNav.test.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeMobileNav.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { NativeMobileMenu } from './NativeMobileMenu';
+
+describe('native mobile navigation', () => {
+  it('renders native links and nested groups that work without hydration', () => {
+    const html = renderToStaticMarkup(
+      <NativeMobileMenu
+        resolveHref={(href) =>
+          href.startsWith('http') ? href : `/docs${href}`
+        }
+        items={[
+          { text: 'Guide', link: '/guide', lang: 'en', rel: 'help' },
+          {
+            text: 'Versions',
+            link: '/versions',
+            items: [
+              { text: 'Current', link: '/current', download: true },
+              { text: 'Legacy', link: 'https://legacy.example.com' },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toMatch(/^<details class="site-mobile-nav">/);
+    expect(html).toMatch(/<nav[^>]+aria-label="Mobile navigation"/);
+    expect(html).toMatch(
+      /<a class="site-mobile-nav__item" href="\/docs\/guide" hrefLang="en" lang="en" rel="help">Guide<\/a>/,
+    );
+    expect(html).toMatch(/<summary[^>]*>Versions/);
+    expect(html).toContain('href="/docs/versions"');
+    expect(html).toContain('href="/docs/current" download=""');
+    expect(html).toContain('href="https://legacy.example.com"');
+    expect(html).not.toMatch(/onClick|rp-link/);
+  });
+
+  it('does not render an empty mobile navigation control', () => {
+    expect(renderToStaticMarkup(<NativeMobileMenu items={[]} />)).toBe('');
+  });
+});

--- a/apps/site/theme/components/native-language-switcher/NativeMobileNav.test.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeMobileNav.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import { NativeMobileMenu } from './NativeMobileMenu';
@@ -37,5 +38,23 @@ describe('native mobile navigation', () => {
 
   it('does not render an empty mobile navigation control', () => {
     expect(renderToStaticMarkup(<NativeMobileMenu items={[]} />)).toBe('');
+  });
+
+  it('sizes the panel from below the filtered nav to the dynamic viewport', () => {
+    const css = readFileSync(
+      new URL('./native-language-switcher.css', import.meta.url),
+      'utf8',
+    );
+
+    expect(css).toMatch(
+      /\.site-mobile-nav__panel\s*\{[\s\S]*?position:\s*absolute/,
+    );
+    expect(css).toMatch(/\.site-mobile-nav__panel\s*\{[\s\S]*?top:\s*100%/);
+    expect(css).toMatch(
+      /height:\s*calc\(100dvh - var\(--rp-nav-height\) - var\(--rp-banner-height, 0px\)\)/,
+    );
+    expect(css).not.toMatch(
+      /\.site-mobile-nav__panel\s*\{[\s\S]*?position:\s*fixed/,
+    );
   });
 });

--- a/apps/site/theme/components/native-language-switcher/NativeMobileNav.tsx
+++ b/apps/site/theme/components/native-language-switcher/NativeMobileNav.tsx
@@ -1,0 +1,7 @@
+import { useNav, withBase } from '@rspress/core/runtime';
+import { NativeMobileMenu } from './NativeMobileMenu';
+
+export function NativeMobileNav() {
+  const items = useNav();
+  return <NativeMobileMenu items={items} resolveHref={withBase} />;
+}

--- a/apps/site/theme/components/native-language-switcher/Nav.tsx
+++ b/apps/site/theme/components/native-language-switcher/Nav.tsx
@@ -3,6 +3,7 @@ import {
   Nav as OriginalNav,
 } from '@rspress/core/theme-original';
 import { NativeLanguageSwitcher } from './NativeLanguageSwitcher';
+import { NativeMobileNav } from './NativeMobileNav';
 
 export function Nav({ afterNavMenu, ...props }: NavProps) {
   return (
@@ -12,6 +13,7 @@ export function Nav({ afterNavMenu, ...props }: NavProps) {
         <>
           {afterNavMenu}
           <NativeLanguageSwitcher />
+          <NativeMobileNav />
         </>
       }
     />

--- a/apps/site/theme/components/native-language-switcher/Nav.tsx
+++ b/apps/site/theme/components/native-language-switcher/Nav.tsx
@@ -1,0 +1,19 @@
+import {
+  type NavProps,
+  Nav as OriginalNav,
+} from '@rspress/core/theme-original';
+import { NativeLanguageSwitcher } from './NativeLanguageSwitcher';
+
+export function Nav({ afterNavMenu, ...props }: NavProps) {
+  return (
+    <OriginalNav
+      {...props}
+      afterNavMenu={
+        <>
+          {afterNavMenu}
+          <NativeLanguageSwitcher />
+        </>
+      }
+    />
+  );
+}

--- a/apps/site/theme/components/native-language-switcher/languagePath.ts
+++ b/apps/site/theme/components/native-language-switcher/languagePath.ts
@@ -1,0 +1,49 @@
+import { addLeadingSlash, normalizeHref, removeBase } from '@rspress/shared';
+
+export interface LanguageRouteState {
+  current: string;
+  target: string;
+  default: string;
+}
+
+export interface VersionRouteState {
+  current: string;
+  default: string;
+}
+
+export function replaceLanguageInPath(
+  rawUrl: string,
+  language: LanguageRouteState,
+  version: VersionRouteState,
+  cleanUrls: boolean,
+  isPageNotFound: boolean,
+  base = '/',
+): string {
+  let url = removeBase(rawUrl, base);
+  if (!url || isPageNotFound) url = '/';
+  url = normalizeHref(url, cleanUrls);
+
+  const parts = url.split('/').filter(Boolean);
+  let versionPart = '';
+  let languagePart = '';
+
+  if (version.current && version.current !== version.default) {
+    versionPart = parts.shift() || '';
+  }
+
+  if (language.target !== language.default) {
+    languagePart = language.target;
+    if (language.current !== language.default) parts.shift();
+  } else {
+    parts.shift();
+  }
+
+  let pagePath = parts.join('/') || '';
+  if ((versionPart || languagePart) && !pagePath) {
+    pagePath = cleanUrls ? 'index' : 'index.html';
+  }
+
+  return addLeadingSlash(
+    [versionPart, languagePart, pagePath].filter(Boolean).join('/'),
+  );
+}

--- a/apps/site/theme/components/native-language-switcher/native-language-switcher.css
+++ b/apps/site/theme/components/native-language-switcher/native-language-switcher.css
@@ -1,0 +1,50 @@
+/* The native menu replaces Rspress' hydration-dependent desktop and mobile language controls. */
+.rp-nav__others > .rp-nav-menu__divider + .rp-nav-menu__item,
+.rp-nav-screen-langs,
+.rp-nav-screen-langs-group {
+  display: none !important;
+}
+
+.site-language-menu {
+  flex: none;
+  min-width: 0;
+}
+
+.site-language-menu__summary {
+  list-style: none;
+  user-select: none;
+}
+
+.site-language-menu__summary::-webkit-details-marker {
+  display: none;
+}
+
+.site-language-menu__list {
+  top: 80%;
+  right: 0;
+  left: auto;
+  max-height: min(70vh, 30rem);
+  overflow-y: auto;
+  transform: none;
+}
+
+.site-language-menu:not([open]) > .site-language-menu__list {
+  display: none;
+}
+
+.site-language-menu[open] > .site-language-menu__list {
+  display: flex;
+}
+
+.site-language-menu[open]
+  > .site-language-menu__summary
+  .rp-nav-menu__item__icon {
+  transform: rotate(180deg);
+}
+
+@media (width <= 767px) {
+  .site-language-menu__summary {
+    gap: 2px;
+    font-size: 13px;
+  }
+}

--- a/apps/site/theme/components/native-language-switcher/native-language-switcher.css
+++ b/apps/site/theme/components/native-language-switcher/native-language-switcher.css
@@ -10,6 +10,10 @@
   min-width: 0;
 }
 
+.site-language-menu__details {
+  display: contents;
+}
+
 .site-language-menu__summary {
   list-style: none;
   user-select: none;
@@ -20,6 +24,7 @@
 }
 
 .site-language-menu__list {
+  display: none;
   top: 80%;
   right: 0;
   left: auto;
@@ -28,19 +33,13 @@
   transform: none;
 }
 
-.site-language-menu:not([open]):not(:hover):not(:focus-within)
-  > .site-language-menu__list {
-  display: none;
-}
-
-.site-language-menu:is([open], :hover, :focus-within)
-  > .site-language-menu__list {
+.site-language-menu:is(:hover, :focus-within) > .site-language-menu__list,
+.site-language-menu__details[open] + .site-language-menu__list {
   display: flex;
 }
 
-.site-language-menu:is([open], :hover, :focus-within)
-  > .site-language-menu__summary
-  .rp-nav-menu__item__icon {
+.site-language-menu:is(:hover, :focus-within) .rp-nav-menu__item__icon,
+.site-language-menu__details[open] .rp-nav-menu__item__icon {
   transform: rotate(180deg);
 }
 

--- a/apps/site/theme/components/native-language-switcher/native-language-switcher.css
+++ b/apps/site/theme/components/native-language-switcher/native-language-switcher.css
@@ -28,23 +28,144 @@
   transform: none;
 }
 
-.site-language-menu:not([open]) > .site-language-menu__list {
+.site-language-menu:not([open]):not(:hover):not(:focus-within)
+  > .site-language-menu__list {
   display: none;
 }
 
-.site-language-menu[open] > .site-language-menu__list {
+.site-language-menu:is([open], :hover, :focus-within)
+  > .site-language-menu__list {
   display: flex;
 }
 
-.site-language-menu[open]
+.site-language-menu:is([open], :hover, :focus-within)
   > .site-language-menu__summary
   .rp-nav-menu__item__icon {
   transform: rotate(180deg);
 }
 
-@media (width <= 767px) {
+/* Keep SSR-rendered Rspress submenus keyboard reachable before React hydration. */
+.rp-nav-menu__item > .rp-hover-group.rp-hover-group--hidden,
+.rp-nav-hamburger__md > .rp-hover-group.rp-hover-group--hidden {
+  visibility: visible;
+}
+
+.rp-nav-menu__item:is(:hover, :focus-within)
+  > .rp-hover-group.rp-hover-group--hidden,
+.rp-nav-hamburger__md:is(:hover, :focus-within)
+  > .rp-hover-group.rp-hover-group--hidden {
+  opacity: 1;
+  pointer-events: auto;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.site-mobile-nav {
+  display: none;
+}
+
+.site-mobile-nav__toggle {
+  cursor: pointer;
+  list-style: none;
+  border-radius: 4px;
+  padding: 8px;
+}
+
+.site-mobile-nav__toggle::-webkit-details-marker,
+.site-mobile-nav__group-summary::-webkit-details-marker {
+  display: none;
+}
+
+.site-mobile-nav[open] > .site-mobile-nav__toggle {
+  background-color: var(--rp-c-bg-mute);
+}
+
+.site-mobile-nav__panel {
+  position: fixed;
+  top: calc(var(--rp-nav-height) + var(--rp-banner-height, 0px));
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: var(--rp-z-index-nav-screen);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  padding: 24px 48px;
+  background: var(--rp-c-bg);
+}
+
+.site-mobile-nav:not([open]) > .site-mobile-nav__panel {
+  display: none;
+}
+
+.site-mobile-nav__item {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  color: var(--rp-c-text-1);
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.site-mobile-nav__item:hover,
+.site-mobile-nav__item:focus-visible {
+  color: var(--rp-c-brand);
+  background: var(--rp-c-bg-mute);
+  outline: none;
+}
+
+.site-mobile-nav__item--label {
+  color: var(--rp-c-text-2);
+}
+
+.site-mobile-nav__group-summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.site-mobile-nav__group-items {
+  display: flex;
+  flex-direction: column;
+  padding-left: 16px;
+}
+
+.site-mobile-nav__group-link {
+  font-weight: 600;
+}
+
+.site-mobile-nav__arrow {
+  flex: none;
+  transition: transform 0.2s ease-out;
+}
+
+.site-mobile-nav__group[open]
+  > .site-mobile-nav__group-summary
+  .site-mobile-nav__arrow {
+  transform: rotate(180deg);
+}
+
+.site-mobile-nav__tag {
+  margin-left: 4px;
+  color: var(--rp-c-brand);
+  font-size: 12px;
+}
+
+@media (width <= 768px) {
   .site-language-menu__summary {
     gap: 2px;
     font-size: 13px;
+  }
+
+  .rp-nav-hamburger__sm {
+    display: none !important;
+  }
+
+  .site-mobile-nav {
+    display: block;
   }
 }

--- a/apps/site/theme/components/native-language-switcher/native-language-switcher.css
+++ b/apps/site/theme/components/native-language-switcher/native-language-switcher.css
@@ -79,17 +79,21 @@
 }
 
 .site-mobile-nav__panel {
-  position: fixed;
-  top: calc(var(--rp-nav-height) + var(--rp-banner-height, 0px));
+  position: absolute;
+  top: 100%;
   right: 0;
-  bottom: 0;
+  bottom: auto;
   left: 0;
   z-index: var(--rp-z-index-nav-screen);
+  box-sizing: border-box;
   display: flex;
+  height: calc(100vh - var(--rp-nav-height) - var(--rp-banner-height, 0px));
+  height: calc(100dvh - var(--rp-nav-height) - var(--rp-banner-height, 0px));
   flex-direction: column;
   gap: 2px;
   overflow-y: auto;
-  padding: 24px 48px;
+  overscroll-behavior: contain;
+  padding: 24px 48px calc(24px + env(safe-area-inset-bottom));
   background: var(--rp-c-bg);
 }
 

--- a/apps/site/theme/index.tsx
+++ b/apps/site/theme/index.tsx
@@ -5,6 +5,7 @@ import {
   LlmsViewOptions,
 } from '@rspress/plugin-llms/runtime';
 import { BenchmarkReportPreview } from './components/BenchmarkReportPreview';
+import { Nav } from './components/native-language-switcher/Nav';
 import { HomeLayout } from './pages';
 
 function getCustomMDXComponent() {
@@ -27,5 +28,5 @@ function getCustomMDXComponent() {
   };
 }
 
-export { BenchmarkReportPreview, getCustomMDXComponent, HomeLayout };
+export { BenchmarkReportPreview, getCustomMDXComponent, HomeLayout, Nav };
 export * from '@rspress/core/theme-original';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       '@rspress/plugin-sitemap':
         specifier: 2.0.8
         version: 2.0.8(@rspress/core@2.0.8(@types/mdast@4.0.4)(@types/react@19.1.5)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
+      '@rspress/shared':
+        specifier: 2.0.8
+        version: 2.0.8(core-js@3.47.0)
       '@tailwindcss/postcss':
         specifier: 4.1.11
         version: 4.1.11
@@ -510,6 +513,9 @@ importers:
       tailwindcss:
         specifier: 4.1.11
         version: 4.1.11
+      vitest:
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
 
   apps/studio:
     dependencies:


### PR DESCRIPTION
## Summary

- render the locale picker as native `details`/`summary` markup and keep its popup as a sibling so closed-details browser layout rules cannot collapse the hover menu to `0 × 0`
- support click, hover, and keyboard focus before React hydration
- render a native mobile navigation tree from the Rspress nav config so all top-level links remain usable without JavaScript
- keep SSR-rendered Rspress desktop and tablet submenus available on hover/focus before hydration
- preload each page’s exact async route chunk from generated HTML to shorten the hydration gap for React-only controls

## Verification

- targeted Vitest suites: 10/10 passed
- targeted TypeScript check for the custom theme components
- Rspress production build: 105/105 pages mapped, 111 route chunks preloaded
- JavaScript-disabled Chromium strict check: hover, focus, and click each produced an `82 × 82` popup with a menu item at the browser hit-test point

No smoke test was run, per request.