### PR TITLE
ci(workflow): add cross-platform TodoMVC smokes

### DIFF
--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -1,0 +1,219 @@
+name: Android Emulator
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/android-emulator.yml'
+      - 'apps/report/**'
+      - 'packages/android/**'
+      - 'packages/core/package.json'
+      - 'packages/core/rslib.config.ts'
+      - 'packages/core/src/**'
+      - 'packages/shared/package.json'
+      - 'packages/shared/src/**'
+      - 'scripts/report-template-utils.mjs'
+      - 'nx.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-emulator-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  android-emulator:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 55
+    env:
+      CI: '1'
+      FORCE_COLOR: '0'
+      MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
+      MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
+      MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
+      MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run
+      MIDSCENE_ANDROID_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/android-emulator-diagnostics
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Prepare Android diagnostics and KVM
+        shell: bash
+        run: |
+          mkdir -p "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR"
+          {
+            uname -a
+            ls -l /dev/kvm || true
+          } 2>&1 | tee "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR/runner-environment.log"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' |
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.13.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build report and Android packages
+        id: build
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/android" --skip-nx-cache 2>&1 |
+            tee "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR/build.log"
+          node apps/report/scripts/inject-report-template.mjs
+
+      - name: Validate Android package outputs
+        id: package-smoke
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const mod=require('./packages/android/dist/lib/index.js'); if(typeof mod.AndroidDevice!=='function'||typeof mod.AndroidAgent!=='function') throw new Error('invalid CJS exports')"
+          node --input-type=module -e "const mod=await import('./packages/android/dist/es/index.mjs'); if(typeof mod.AndroidDevice!=='function'||typeof mod.AndroidAgent!=='function') throw new Error('invalid ESM exports')"
+          test -f packages/android/dist/types/index.d.ts
+
+          actual_cli_version=$(node packages/android/bin/midscene-android --version)
+          package_version=$(node -p "require('./packages/android/package.json').version")
+          expected_cli_version="midscene-android v${package_version}"
+          if [[ "$actual_cli_version" != "$expected_cli_version" ]]; then
+            echo "Unexpected CLI version '$actual_cli_version'; expected '$expected_cli_version'." >&2
+            exit 1
+          fi
+
+          pack_dir="$RUNNER_TEMP/midscene-android-pack"
+          mkdir -p "$pack_dir"
+          pnpm --dir packages/android pack --pack-destination "$pack_dir"
+          archive=$(find "$pack_dir" -name '*.tgz' -type f | head -n 1)
+          test -n "$archive"
+          tar -tf "$archive" > "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR/package-files.txt"
+          for required in \
+            package/package.json \
+            package/bin/midscene-android \
+            package/dist/lib/cli.js \
+            package/dist/lib/index.js \
+            package/dist/es/index.mjs \
+            package/dist/types/index.d.ts; do
+            grep -Fxq "$required" "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR/package-files.txt"
+          done
+
+      - name: Run Android unit tests
+        id: unit-tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm exec nx test @midscene/android --skip-nx-cache 2>&1 |
+            tee "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR/unit-tests.log"
+
+      - name: Run Android Emulator smoke and TodoMVC tests
+        id: emulator-tests
+        continue-on-error: true
+        timeout-minutes: 35
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          cores: 2
+          ram-size: 4096M
+          heap-size: 512M
+          emulator-boot-timeout: 600
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-save -noaudio -no-boot-anim -camera-back none
+          script: bash packages/android/scripts/run-emulator-ci-smokes.sh
+
+      - name: Collect host step outcomes
+        if: always()
+        shell: bash
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          PACKAGE_OUTCOME: ${{ steps.package-smoke.outcome }}
+          UNIT_OUTCOME: ${{ steps.unit-tests.outcome }}
+          EMULATOR_OUTCOME: ${{ steps.emulator-tests.outcome }}
+        run: |
+          mkdir -p "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR"
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const outcomes = {
+              build: process.env.BUILD_OUTCOME,
+              packageSmoke: process.env.PACKAGE_OUTCOME,
+              unitTests: process.env.UNIT_OUTCOME,
+              emulatorTests: process.env.EMULATOR_OUTCOME,
+            };
+            fs.writeFileSync(
+              path.join(process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR, "host-step-outcomes.json"),
+              `${JSON.stringify(outcomes, null, 2)}\n`,
+            );
+          '
+
+      - name: Upload Android Emulator smoke report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: android-emulator-smoke-report
+          path: midscene_run/report/android-emulator-smoke.html
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Android TodoMVC report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: android-todo-mvc-report
+          path: midscene_run/report/todo-mvc-android.html
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Android Emulator diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: android-emulator-diagnostics
+          path: midscene_run/android-emulator-diagnostics
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Check Android validation results
+        if: always()
+        shell: bash
+        run: |
+          failed=()
+          [[ '${{ steps.build.outcome }}' == success ]] || failed+=(build)
+          [[ '${{ steps.package-smoke.outcome }}' == success ]] || failed+=("package smoke")
+          [[ '${{ steps.unit-tests.outcome }}' == success ]] || failed+=("unit tests")
+          [[ '${{ steps.emulator-tests.outcome }}' == success ]] || failed+=("emulator tests")
+          if ((${#failed[@]} > 0)); then
+            printf 'Android validation failed: %s\n' "${failed[*]}" >&2
+            exit 1
+          fi

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -165,7 +165,7 @@ jobs:
           AI_TEST_TYPE: computer
         run: |
           set -o pipefail
-          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=1 2>&1 |
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=0 2>&1 |
             tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/todo-mvc.log"
 
       - name: Collect step outcomes

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -1,0 +1,238 @@
+name: macOS Desktop
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/macos-desktop.yml'
+      - 'apps/report/**'
+      - 'packages/computer/**'
+      - 'packages/core/package.json'
+      - 'packages/core/rslib.config.ts'
+      - 'packages/core/src/**'
+      - 'packages/shared/package.json'
+      - 'packages/shared/src/**'
+      - 'scripts/report-template-utils.mjs'
+      - 'nx.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  macos-desktop:
+    runs-on: macos-15-intel
+    timeout-minutes: 50
+    env:
+      CI: '1'
+      FORCE_COLOR: '0'
+      MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
+      MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
+      MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
+      MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run
+      MIDSCENE_MACOS_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/macos-desktop-diagnostics
+      MIDSCENE_TODO_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/macos-desktop-diagnostics
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Inspect macOS desktop session
+        shell: bash
+        run: |
+          mkdir -p "$MIDSCENE_MACOS_DIAGNOSTICS_DIR"
+          {
+            sw_vers
+            uname -a
+            xcrun swiftc --version
+            if [[ -x "/Library/Application Support/VMware Tools/vmware-resolutionSet" ]]; then
+              sudo "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
+              sleep 2
+            fi
+            system_profiler SPDisplaysDataType
+            ui_enabled=$(osascript -e 'tell application "System Events" to return UI elements enabled')
+            echo "UI elements enabled: $ui_enabled"
+            if [[ "$ui_enabled" != "true" ]]; then
+              echo "macOS Accessibility UI elements are not enabled" >&2
+              exit 1
+            fi
+          } 2>&1 | tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/runner-environment.log"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.13.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build report and computer packages
+        id: build
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache 2>&1 |
+            tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/build.log"
+          node apps/report/scripts/inject-report-template.mjs
+
+      - name: Validate computer package outputs
+        id: package-smoke
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const mod=require('./packages/computer/dist/lib/index.js'); if(typeof mod.ComputerDevice!=='function'||typeof mod.ComputerAgent!=='function') throw new Error('invalid CJS exports')"
+          node --input-type=module -e "const mod=await import('./packages/computer/dist/es/index.mjs'); if(typeof mod.ComputerDevice!=='function'||typeof mod.ComputerAgent!=='function') throw new Error('invalid ESM exports')"
+          test -f packages/computer/dist/types/index.d.ts
+
+          actual_cli_version=$(node packages/computer/bin/midscene-computer --version)
+          package_version=$(node -p "require('./packages/computer/package.json').version")
+          expected_cli_version="midscene-computer v${package_version}"
+          if [[ "$actual_cli_version" != "$expected_cli_version" ]]; then
+            echo "Unexpected CLI version '$actual_cli_version'; expected '$expected_cli_version'." >&2
+            exit 1
+          fi
+
+          pack_dir="$RUNNER_TEMP/midscene-computer-pack"
+          mkdir -p "$pack_dir"
+          pnpm --dir packages/computer pack --pack-destination "$pack_dir"
+          archive=$(find "$pack_dir" -name '*.tgz' -type f | head -n 1)
+          test -n "$archive"
+          tar -tf "$archive" > "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/package-files.txt"
+          for required in \
+            package/package.json \
+            package/bin/midscene-computer \
+            package/dist/lib/cli.js \
+            package/dist/lib/index.js \
+            package/dist/es/index.mjs \
+            package/dist/types/index.d.ts; do
+            grep -Fxq "$required" "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/package-files.txt"
+          done
+
+      - name: Run computer unit tests
+        id: unit-tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm exec nx test @midscene/computer --skip-nx-cache 2>&1 |
+            tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/unit-tests.log"
+
+      - name: Run live macOS desktop smoke test
+        id: live-smoke
+        continue-on-error: true
+        timeout-minutes: 10
+        shell: bash
+        env:
+          AI_TEST_TYPE: computer
+          MIDSCENE_MACOS_DESKTOP_SMOKE: '1'
+        run: |
+          set -o pipefail
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/macos-desktop-smoke.test.ts --retry=0 2>&1 |
+            tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/live-smoke.log"
+
+      - name: Run macOS TodoMVC AI test
+        id: todo-mvc
+        continue-on-error: true
+        timeout-minutes: 25
+        shell: bash
+        env:
+          AI_TEST_TYPE: computer
+        run: |
+          set -o pipefail
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=1 2>&1 |
+            tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/todo-mvc.log"
+
+      - name: Collect step outcomes
+        if: always()
+        shell: bash
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          PACKAGE_OUTCOME: ${{ steps.package-smoke.outcome }}
+          UNIT_OUTCOME: ${{ steps.unit-tests.outcome }}
+          LIVE_OUTCOME: ${{ steps.live-smoke.outcome }}
+          TODO_OUTCOME: ${{ steps.todo-mvc.outcome }}
+        run: |
+          mkdir -p "$MIDSCENE_MACOS_DIAGNOSTICS_DIR"
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const outcomes = {
+              build: process.env.BUILD_OUTCOME,
+              packageSmoke: process.env.PACKAGE_OUTCOME,
+              unitTests: process.env.UNIT_OUTCOME,
+              liveSmoke: process.env.LIVE_OUTCOME,
+              todoMvc: process.env.TODO_OUTCOME,
+            };
+            fs.writeFileSync(
+              path.join(process.env.MIDSCENE_MACOS_DIAGNOSTICS_DIR, "step-outcomes.json"),
+              `${JSON.stringify(outcomes, null, 2)}\n`,
+            );
+          '
+
+      - name: Upload macOS desktop smoke report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-desktop-smoke-report
+          path: midscene_run/report/macos-desktop-smoke.html
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload macOS TodoMVC report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-todo-mvc-report
+          path: midscene_run/report/todo-mvc-darwin.html
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload macOS desktop diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-desktop-diagnostics
+          path: midscene_run/macos-desktop-diagnostics
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Check macOS validation results
+        if: always()
+        shell: bash
+        run: |
+          failed=()
+          [[ '${{ steps.build.outcome }}' == success ]] || failed+=(build)
+          [[ '${{ steps.package-smoke.outcome }}' == success ]] || failed+=("package smoke")
+          [[ '${{ steps.unit-tests.outcome }}' == success ]] || failed+=("unit tests")
+          [[ '${{ steps.live-smoke.outcome }}' == success ]] || failed+=("live desktop smoke")
+          [[ '${{ steps.todo-mvc.outcome }}' == success ]] || failed+=("TodoMVC")
+          if ((${#failed[@]} > 0)); then
+            printf 'macOS validation failed: %s\n' "${failed[*]}" >&2
+            exit 1
+          fi

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -290,7 +290,7 @@ jobs:
           AI_TEST_TYPE: computer
         run: |
           $logPath = Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'todo-mvc.log'
-          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=1 2>&1 |
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=0 2>&1 |
             Tee-Object -FilePath $logPath
           $testExitCode = $LASTEXITCODE
           if ($testExitCode -ne 0) {

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -8,17 +8,7 @@ on:
       - 'packages/computer/**'
       - 'packages/core/package.json'
       - 'packages/core/rslib.config.ts'
-      - 'packages/core/src/agent/**'
-      - 'packages/core/src/device/**'
-      - 'packages/core/src/dump/**'
-      - 'packages/core/src/index.ts'
-      - 'packages/core/src/report-generator.ts'
-      - 'packages/core/src/report.ts'
-      - 'packages/core/src/screenshot-item.ts'
-      - 'packages/core/src/task-runner.ts'
-      - 'packages/core/src/task-timing.ts'
-      - 'packages/core/src/types.ts'
-      - 'packages/core/src/utils.ts'
+      - 'packages/core/src/**'
       - 'packages/shared/package.json'
       - 'packages/shared/src/**'
       - 'scripts/report-template-utils.mjs'
@@ -44,12 +34,20 @@ concurrency:
 jobs:
   windows-desktop:
     runs-on: windows-2022
-    timeout-minutes: 35
+    timeout-minutes: 50
     env:
       CI: '1'
       FORCE_COLOR: '0'
+      MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
+      MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
+      MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
+      MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
       MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run
       MIDSCENE_WINDOWS_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/windows-desktop-diagnostics
+      MIDSCENE_TODO_DIAGNOSTICS_DIR: ${{ github.workspace }}/midscene_run/windows-desktop-diagnostics
 
     steps:
       - name: Checkout source
@@ -283,6 +281,22 @@ jobs:
             throw "Windows desktop smoke failed with exit code $testExitCode."
           }
 
+      - name: Run Windows TodoMVC AI test
+        id: todo-mvc
+        continue-on-error: true
+        timeout-minutes: 25
+        shell: pwsh
+        env:
+          AI_TEST_TYPE: computer
+        run: |
+          $logPath = Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'todo-mvc.log'
+          pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=1 2>&1 |
+            Tee-Object -FilePath $logPath
+          $testExitCode = $LASTEXITCODE
+          if ($testExitCode -ne 0) {
+            throw "Windows TodoMVC test failed with exit code $testExitCode."
+          }
+
       - name: Collect step outcomes
         if: always()
         shell: pwsh
@@ -293,6 +307,7 @@ jobs:
             packageSmoke = '${{ steps.package-smoke.outcome }}'
             unitTests = '${{ steps.unit-tests.outcome }}'
             liveSmoke = '${{ steps.live-smoke.outcome }}'
+            todoMvc = '${{ steps.todo-mvc.outcome }}'
           }
           $outcomes | ConvertTo-Json |
             Set-Content -LiteralPath (
@@ -317,6 +332,15 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Upload Windows TodoMVC report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-todo-mvc-report
+          path: midscene_run/report/todo-mvc-win32.html
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Check Windows validation results
         if: always()
         shell: pwsh
@@ -326,6 +350,7 @@ jobs:
           if ('${{ steps.package-smoke.outcome }}' -ne 'success') { $failed += 'package smoke' }
           if ('${{ steps.unit-tests.outcome }}' -ne 'success') { $failed += 'unit tests' }
           if ('${{ steps.live-smoke.outcome }}' -ne 'success') { $failed += 'live desktop smoke' }
+          if ('${{ steps.todo-mvc.outcome }}' -ne 'success') { $failed += 'TodoMVC' }
           if ($failed.Count -gt 0) {
             throw "Windows validation failed: $($failed -join ', ')"
           }

--- a/packages/android/scripts/run-emulator-ci-smokes.sh
+++ b/packages/android/scripts/run-emulator-ci-smokes.sh
@@ -43,7 +43,7 @@ smoke_exit=${PIPESTATUS[0]}
 
 AI_TEST_TYPE=android \
 pnpm exec nx test @midscene/android --skip-nx-cache -- \
-  tests/ai/todo.test.ts --retry=1 2>&1 |
+  tests/ai/todo.test.ts --retry=0 2>&1 |
   tee "$diagnostics_dir/todo-mvc.log"
 todo_exit=${PIPESTATUS[0]}
 set -e

--- a/packages/android/scripts/run-emulator-ci-smokes.sh
+++ b/packages/android/scripts/run-emulator-ci-smokes.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${MIDSCENE_ANDROID_DIAGNOSTICS_DIR:?MIDSCENE_ANDROID_DIAGNOSTICS_DIR is required}"
+
+diagnostics_dir="$MIDSCENE_ANDROID_DIAGNOSTICS_DIR"
+todo_url="https://todomvc.com/examples/react/dist/"
+mkdir -p "$diagnostics_dir"
+
+adb devices -l > "$diagnostics_dir/adb-devices.txt"
+{
+  adb shell getprop ro.product.model
+  adb shell getprop ro.build.version.sdk
+  adb shell wm size
+  adb shell wm density
+} > "$diagnostics_dir/device-environment.txt" 2>&1
+
+adb shell settings put system system_locales en-US
+adb shell settings put system font_scale 1.0
+adb shell settings put secure show_ime_with_hard_keyboard 0
+adb shell settings put system screen_off_timeout 1800000
+
+set +e
+resolve_output=$(adb shell cmd package resolve-activity --brief \
+  -a android.intent.action.VIEW -d "$todo_url" 2>&1)
+resolve_exit=$?
+set -e
+printf '%s\n' "$resolve_output" > "$diagnostics_dir/browser-resolve-activity.txt"
+
+browser_preflight_exit=$resolve_exit
+if [[ -z "$resolve_output" || "$resolve_output" == *"No activity found"* ]]; then
+  browser_preflight_exit=1
+fi
+
+set +e
+AI_TEST_TYPE=android \
+MIDSCENE_ANDROID_EMULATOR_SMOKE=1 \
+pnpm exec nx test @midscene/android --skip-nx-cache -- \
+  tests/ai/android-emulator-smoke.test.ts --retry=0 2>&1 |
+  tee "$diagnostics_dir/emulator-smoke.log"
+smoke_exit=${PIPESTATUS[0]}
+
+AI_TEST_TYPE=android \
+pnpm exec nx test @midscene/android --skip-nx-cache -- \
+  tests/ai/todo.test.ts --retry=1 2>&1 |
+  tee "$diagnostics_dir/todo-mvc.log"
+todo_exit=${PIPESTATUS[0]}
+set -e
+
+adb logcat -d -t 2000 > "$diagnostics_dir/emulator-logcat.txt" 2>&1 || true
+adb exec-out screencap -p > "$diagnostics_dir/emulator-final.png" 2>/dev/null || true
+
+BROWSER_PREFLIGHT_EXIT="$browser_preflight_exit" \
+SMOKE_EXIT="$smoke_exit" \
+TODO_EXIT="$todo_exit" \
+node -e '
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const outcomes = {
+    browserPreflight: Number(process.env.BROWSER_PREFLIGHT_EXIT),
+    deterministicSmoke: Number(process.env.SMOKE_EXIT),
+    todoMvc: Number(process.env.TODO_EXIT),
+  };
+  fs.writeFileSync(
+    path.join(process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR, "emulator-step-outcomes.json"),
+    `${JSON.stringify(outcomes, null, 2)}\n`,
+  );
+'
+
+if ((browser_preflight_exit != 0 || smoke_exit != 0 || todo_exit != 0)); then
+  echo "Android emulator validation failed: browser=$browser_preflight_exit smoke=$smoke_exit todo=$todo_exit" >&2
+  exit 1
+fi

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -348,7 +348,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
 
       await agent.callActionInActionSpace('Input', {
         value: 'wifi',
-        mode: 'replace',
+        mode: 'typeOnly',
         autoDismissKeyboard: false,
         locate: locate(searchInput.bounds, 'Settings search input'),
       });

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -204,6 +204,38 @@ async function waitForResource(
   );
 }
 
+async function keyboardIsShown(adb: ADB): Promise<boolean> {
+  const status = await adb.isSoftKeyboardPresent();
+  return typeof status === 'boolean'
+    ? status
+    : status?.isKeyboardShown === true;
+}
+
+async function waitForKeyboardState(
+  adb: ADB,
+  expected: boolean,
+): Promise<boolean> {
+  const deadline = Date.now() + TARGET_TIMEOUT_MS;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const shown = await keyboardIsShown(adb);
+      if (shown === expected) {
+        return shown;
+      }
+      lastError = new Error(
+        `Expected keyboard shown=${expected}, received ${shown}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for Android keyboard shown=${expected}. Last error: ${String(lastError)}`,
+  );
+}
+
 function locate(bounds: Bounds, prompt: string) {
   return {
     prompt,
@@ -360,23 +392,26 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const searchState = await waitForEditableNode(adb, searchXmlFile, 'wifi');
       expect(searchState.xml).toMatch(/text="wifi"/i);
 
+      evidence.keyboardShownBeforeBack = await waitForKeyboardState(adb, true);
+
       const searchScreenshot = await device.screenshotBase64();
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
 
       await agent.back();
       evidence.backNavigationCount = 1;
-      await sleep(POLL_INTERVAL_MS);
+      evidence.keyboardShownAfterBack = await waitForKeyboardState(adb, false);
       const postBackXml = await dumpUiautomatorXml(adb);
       await writeFile(finalXmlFile, postBackXml, 'utf8');
-      const returnedHomeAfterBack =
-        boundsForResourceId(postBackXml, SETTINGS_SEARCH_BAR_ID).length === 1;
-      evidence.returnedHomeAfterBack = returnedHomeAfterBack;
-      if (!returnedHomeAfterBack) {
-        await adb.shell('am force-stop com.android.settings');
-        await adb.shell('am start -W -n com.android.settings/.Settings');
-        evidence.settingsRelaunchedAfterBack = true;
-        await waitForResource(adb, [SETTINGS_SEARCH_BAR_ID], finalXmlFile);
-      }
+      evidence.postBackSurface = boundsForResourceId(
+        postBackXml,
+        SETTINGS_SEARCH_BAR_ID,
+      ).length
+        ? 'settings-home'
+        : postBackXml.includes('com.google.android.apps.nexuslauncher')
+          ? 'launcher'
+          : postBackXml.includes('open_search_view_edit_text')
+            ? 'settings-search'
+            : 'other';
 
       const dump = JSON.parse(agent.dumpDataString()) as ReportDump;
       await writeFile(dumpFile, `${JSON.stringify(dump, null, 2)}\n`, 'utf8');

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -1,0 +1,365 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parseDumpScript } from '@midscene/core';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_FAMILY,
+  MIDSCENE_MODEL_NAME,
+  MIDSCENE_MODEL_RETRY_COUNT,
+  MIDSCENE_MODEL_TIMEOUT,
+} from '@midscene/shared/env';
+import { imageInfoOfBase64 } from '@midscene/shared/img';
+import type ADB from 'appium-adb';
+import { describe, expect, it, vi } from 'vitest';
+import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
+
+const RUN_LIVE_SMOKE =
+  process.env.AI_TEST_TYPE === 'android' &&
+  process.env.MIDSCENE_ANDROID_EMULATOR_SMOKE === '1';
+const REPORT_FILE_NAME = 'android-emulator-smoke';
+const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
+const UI_DUMP_PATH = '/sdcard/midscene_emulator_smoke_window_dump.xml';
+const SETTINGS_SEARCH_BAR_ID = 'com.android.settings:id/search_action_bar';
+const SETTINGS_SEARCH_INPUT_IDS = [
+  'android:id/search_src_text',
+  'com.android.settings:id/search_src_text',
+] as const;
+const POLL_INTERVAL_MS = 500;
+const TARGET_TIMEOUT_MS = 30_000;
+
+interface Bounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface ReportTask {
+  type?: string;
+  subType?: string;
+  hitBy?: { from?: string };
+  timing?: { callAiStart?: number; callAiEnd?: number };
+  usage?: unknown;
+  searchAreaUsage?: unknown;
+}
+
+interface ReportExecution {
+  id?: string;
+  name?: string;
+  tasks?: ReportTask[];
+}
+
+interface ReportDump {
+  executions?: ReportExecution[];
+}
+
+vi.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+async function dumpUiautomatorXml(adb: ADB): Promise<string> {
+  await adb.shell(`uiautomator dump --compressed ${UI_DUMP_PATH}`);
+  const xml = await adb.shell(`cat ${UI_DUMP_PATH}`);
+  if (typeof xml !== 'string' || xml.trim().length === 0) {
+    throw new Error('Android emulator returned an empty uiautomator dump');
+  }
+  return xml;
+}
+
+function boundsForResourceId(xml: string, resourceId: string): Bounds[] {
+  const nodeTags = xml.match(/<node\b[^>]*>/g) ?? [];
+  const resourceAttribute = `resource-id="${resourceId}"`;
+  return nodeTags
+    .filter((tag) => tag.includes(resourceAttribute))
+    .map((tag) => {
+      const boundsMatch = /bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/.exec(tag);
+      if (!boundsMatch) {
+        throw new Error(`Missing bounds for Android resource ${resourceId}`);
+      }
+      const left = Number(boundsMatch[1]);
+      const top = Number(boundsMatch[2]);
+      const right = Number(boundsMatch[3]);
+      const bottom = Number(boundsMatch[4]);
+      if (right <= left || bottom <= top) {
+        throw new Error(
+          `Invalid bounds for Android resource ${resourceId}: ${boundsMatch[0]}`,
+        );
+      }
+      return {
+        left,
+        top,
+        width: right - left,
+        height: bottom - top,
+      };
+    });
+}
+
+async function waitForResource(
+  adb: ADB,
+  resourceIds: readonly string[],
+): Promise<{ resourceId: string; bounds: Bounds; xml: string }> {
+  const deadline = Date.now() + TARGET_TIMEOUT_MS;
+  let lastXml = '';
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      lastXml = await dumpUiautomatorXml(adb);
+      for (const resourceId of resourceIds) {
+        const matches = boundsForResourceId(lastXml, resourceId);
+        if (matches.length === 1) {
+          return { resourceId, bounds: matches[0], xml: lastXml };
+        }
+        if (matches.length > 1) {
+          lastError = new Error(
+            `Expected one ${resourceId}, found ${matches.length}`,
+          );
+        }
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for Android resources ${resourceIds.join(', ')}. Last error: ${String(lastError)}. Last XML length: ${lastXml.length}`,
+  );
+}
+
+function locate(bounds: Bounds, prompt: string) {
+  return {
+    prompt,
+    locatedPixelBbox: [
+      bounds.left,
+      bounds.top,
+      bounds.left + bounds.width,
+      bounds.top + bounds.height,
+    ] as [number, number, number, number],
+  };
+}
+
+function screenshotBuffer(base64: string): Buffer {
+  const match = /^data:image\/\w+;base64,(.+)$/s.exec(base64);
+  if (!match) {
+    throw new Error('Android emulator screenshot is not a base64 data URL');
+  }
+  return Buffer.from(match[1], 'base64');
+}
+
+function parseReportDumps(html: string): ReportDump[] {
+  const marker = '<script type="midscene_web_dump"';
+  const closeTag = '</script>';
+  const dumps: ReportDump[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const openIndex = html.indexOf(marker, cursor);
+    if (openIndex === -1) break;
+    const closeIndex = html.indexOf(closeTag, openIndex);
+    if (closeIndex === -1) break;
+    const prefix = html.slice(0, closeIndex + closeTag.length);
+    try {
+      const parsed = JSON.parse(parseDumpScript(prefix)) as ReportDump;
+      if (Array.isArray(parsed.executions)) {
+        dumps.push(parsed);
+      }
+    } catch {
+      // The report bundle contains the marker as source text; ignore it.
+    }
+    cursor = closeIndex + closeTag.length;
+  }
+
+  return dumps;
+}
+
+function latestExecutions(dumps: ReportDump[]): ReportExecution[] {
+  const byKey = new Map<string, ReportExecution>();
+  let anonymousIndex = 0;
+  for (const dump of dumps) {
+    for (const execution of dump.executions ?? []) {
+      const key =
+        execution.id || execution.name || `anonymous-${anonymousIndex++}`;
+      byKey.set(key, execution);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
+  it('drives AOSP Settings without calling a model and emits evidence', async () => {
+    const diagnosticsEnv = process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR;
+    if (!diagnosticsEnv) {
+      throw new Error(
+        'MIDSCENE_ANDROID_DIAGNOSTICS_DIR is required for the Android emulator smoke',
+      );
+    }
+
+    const diagnosticsDir = path.resolve(diagnosticsEnv);
+    const initialXmlFile = path.join(diagnosticsDir, 'settings-initial.xml');
+    const searchXmlFile = path.join(diagnosticsDir, 'settings-search.xml');
+    const finalXmlFile = path.join(diagnosticsDir, 'settings-final.xml');
+    const screenshotFile = path.join(diagnosticsDir, 'settings-search.png');
+    const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
+    const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
+    const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
+    const reportFile = path.join(runDir, 'report', REPORT_HTML_FILE_NAME);
+
+    let device: AndroidDevice | undefined;
+    let agent: AndroidAgent | undefined;
+    const evidence: Record<string, unknown> = {
+      platform: process.platform,
+      diagnosticsDir,
+      reportFile,
+    };
+
+    await mkdir(diagnosticsDir, { recursive: true });
+    await rm(reportFile, { force: true });
+
+    try {
+      const devices = await getConnectedDevices();
+      expect(devices).toHaveLength(1);
+      evidence.connectedDevice = devices[0];
+
+      device = new AndroidDevice(devices[0].udid);
+      const adb = await device.connect();
+      await adb.shell('settings put system font_scale 1.0');
+      await adb.shell('am force-stop com.android.settings');
+      await adb.shell('am start -W -n com.android.settings/.Settings');
+
+      const logicalSize = await device.size();
+      const screenshot = await device.screenshotBase64();
+      const screenshotSize = await imageInfoOfBase64(screenshot);
+      const density = await adb.getScreenDensity();
+      evidence.device = {
+        id: devices[0].udid,
+        model: (await adb.shell('getprop ro.product.model')).trim(),
+        apiLevel: (await adb.shell('getprop ro.build.version.sdk')).trim(),
+        density,
+        logicalSize,
+        screenshotSize,
+      };
+      expect(logicalSize.width).toBeGreaterThan(0);
+      expect(logicalSize.height).toBeGreaterThan(0);
+      expect(screenshotSize.width).toBeGreaterThan(logicalSize.width);
+      expect(screenshotSize.height).toBeGreaterThan(logicalSize.height);
+
+      const initialTarget = await waitForResource(adb, [
+        SETTINGS_SEARCH_BAR_ID,
+      ]);
+      await writeFile(initialXmlFile, initialTarget.xml, 'utf8');
+
+      agent = new AndroidAgent(device, {
+        modelConfig: {
+          [MIDSCENE_MODEL_NAME]: 'android-ci-model-must-not-run',
+          [MIDSCENE_MODEL_API_KEY]: 'android-ci-unused-key',
+          [MIDSCENE_MODEL_BASE_URL]: 'http://127.0.0.1:1/v1',
+          [MIDSCENE_MODEL_FAMILY]: 'qwen3-vl',
+          [MIDSCENE_MODEL_TIMEOUT]: '1000',
+          [MIDSCENE_MODEL_RETRY_COUNT]: '0',
+        },
+        groupName: 'Android Emulator live smoke',
+        groupDescription:
+          'Deterministic AOSP Settings input and screenshot validation on GitHub Actions',
+        reportFileName: REPORT_FILE_NAME,
+        autoPrintReportMsg: false,
+        generateReport: true,
+        waitAfterAction: 200,
+      });
+
+      await agent.callActionInActionSpace('Tap', {
+        locate: locate(initialTarget.bounds, 'Settings search bar'),
+      });
+      const searchInput = await waitForResource(adb, SETTINGS_SEARCH_INPUT_IDS);
+
+      await agent.callActionInActionSpace('Input', {
+        value: 'wifi',
+        mode: 'replace',
+        autoDismissKeyboard: true,
+        locate: locate(searchInput.bounds, 'Settings search input'),
+      });
+      const searchState = await waitForResource(adb, SETTINGS_SEARCH_INPUT_IDS);
+      expect(searchState.xml).toMatch(/text="wifi"/i);
+      await writeFile(searchXmlFile, searchState.xml, 'utf8');
+
+      const searchScreenshot = await device.screenshotBase64();
+      await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
+
+      await agent.back();
+      const finalTarget = await waitForResource(adb, [SETTINGS_SEARCH_BAR_ID]);
+      await writeFile(finalXmlFile, finalTarget.xml, 'utf8');
+
+      const dump = JSON.parse(agent.dumpDataString()) as ReportDump;
+      await writeFile(dumpFile, `${JSON.stringify(dump, null, 2)}\n`, 'utf8');
+      const dumpTasks = (dump.executions ?? []).flatMap(
+        (execution) => execution.tasks ?? [],
+      );
+      const locateTasks = dumpTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(locateTasks).toHaveLength(2);
+      expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
+        true,
+      );
+      expect(agent.metrics.calls).toBe(0);
+      expect(
+        dumpTasks.some(
+          (task) =>
+            task.timing?.callAiStart !== undefined ||
+            task.timing?.callAiEnd !== undefined ||
+            task.usage !== undefined ||
+            task.searchAreaUsage !== undefined,
+        ),
+      ).toBe(false);
+
+      await agent.destroy();
+      expect(agent.reportFile).toBe(reportFile);
+      const reportHtml = await readFile(reportFile, 'utf8');
+      expect(reportHtml).not.toContain('REPLACE_ME_WITH_REPORT_HTML');
+      const reportTasks = latestExecutions(
+        parseReportDumps(reportHtml),
+      ).flatMap((execution) => execution.tasks ?? []);
+      const reportLocateTasks = reportTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(reportLocateTasks).toHaveLength(2);
+      expect(
+        reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
+      ).toBe(true);
+      for (const action of ['Tap', 'Input', 'AndroidBackButton']) {
+        expect(
+          reportTasks.some(
+            (task) => task.type === 'Action Space' && task.subType === action,
+          ),
+        ).toBe(true);
+      }
+      evidence.report = {
+        path: reportFile,
+        modelCalls: agent.metrics.calls,
+        locateHitSources: reportLocateTasks.map((task) => task.hitBy?.from),
+      };
+    } catch (error) {
+      evidence.error =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : String(error);
+      throw error;
+    } finally {
+      if (agent) {
+        await agent.destroy().catch((error) => {
+          evidence.agentDestroyError = String(error);
+        });
+      } else if (device) {
+        await device.destroy().catch((error) => {
+          evidence.deviceDestroyError = String(error);
+        });
+      }
+      await writeFile(
+        evidenceFile,
+        `${JSON.stringify(evidence, null, 2)}\n`,
+        'utf8',
+      );
+    }
+  });
+});

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -172,6 +172,7 @@ async function waitForEditableNode(
 async function waitForResource(
   adb: ADB,
   resourceIds: readonly string[],
+  diagnosticsFile?: string,
 ): Promise<{ resourceId: string; bounds: Bounds; xml: string }> {
   const deadline = Date.now() + TARGET_TIMEOUT_MS;
   let lastXml = '';
@@ -179,6 +180,9 @@ async function waitForResource(
   while (Date.now() < deadline) {
     try {
       lastXml = await dumpUiautomatorXml(adb);
+      if (diagnosticsFile) {
+        await writeFile(diagnosticsFile, lastXml, 'utf8');
+      }
       for (const resourceId of resourceIds) {
         const matches = boundsForResourceId(lastXml, resourceId);
         if (matches.length === 1) {
@@ -317,10 +321,11 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       expect(screenshotSize.width).toBeGreaterThan(logicalSize.width);
       expect(screenshotSize.height).toBeGreaterThan(logicalSize.height);
 
-      const initialTarget = await waitForResource(adb, [
-        SETTINGS_SEARCH_BAR_ID,
-      ]);
-      await writeFile(initialXmlFile, initialTarget.xml, 'utf8');
+      const initialTarget = await waitForResource(
+        adb,
+        [SETTINGS_SEARCH_BAR_ID],
+        initialXmlFile,
+      );
 
       agent = new AndroidAgent(device, {
         modelConfig: {
@@ -359,21 +364,19 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
 
       await agent.back();
-      let returnedHomeAfterFirstBack = false;
-      for (let attempt = 0; attempt < 10; attempt += 1) {
-        const xml = await dumpUiautomatorXml(adb);
-        if (boundsForResourceId(xml, SETTINGS_SEARCH_BAR_ID).length === 1) {
-          returnedHomeAfterFirstBack = true;
-          break;
-        }
-        await sleep(POLL_INTERVAL_MS);
+      evidence.backNavigationCount = 1;
+      await sleep(POLL_INTERVAL_MS);
+      const postBackXml = await dumpUiautomatorXml(adb);
+      await writeFile(finalXmlFile, postBackXml, 'utf8');
+      const returnedHomeAfterBack =
+        boundsForResourceId(postBackXml, SETTINGS_SEARCH_BAR_ID).length === 1;
+      evidence.returnedHomeAfterBack = returnedHomeAfterBack;
+      if (!returnedHomeAfterBack) {
+        await adb.shell('am force-stop com.android.settings');
+        await adb.shell('am start -W -n com.android.settings/.Settings');
+        evidence.settingsRelaunchedAfterBack = true;
+        await waitForResource(adb, [SETTINGS_SEARCH_BAR_ID], finalXmlFile);
       }
-      if (!returnedHomeAfterFirstBack) {
-        await agent.back();
-      }
-      evidence.backNavigationCount = returnedHomeAfterFirstBack ? 1 : 2;
-      const finalTarget = await waitForResource(adb, [SETTINGS_SEARCH_BAR_ID]);
-      await writeFile(finalXmlFile, finalTarget.xml, 'utf8');
 
       const dump = JSON.parse(agent.dumpDataString()) as ReportDump;
       await writeFile(dumpFile, `${JSON.stringify(dump, null, 2)}\n`, 'utf8');

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -21,6 +21,10 @@ const REPORT_FILE_NAME = 'android-emulator-smoke';
 const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
 const UI_DUMP_PATH = '/sdcard/midscene_emulator_smoke_window_dump.xml';
 const SETTINGS_SEARCH_BAR_ID = 'com.android.settings:id/search_action_bar';
+const SYSTEM_ERROR_DIALOG_ACTION_IDS = [
+  'android:id/aerr_close',
+  'android:id/aerr_wait',
+] as const;
 const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 30_000;
 
@@ -204,6 +208,36 @@ async function waitForResource(
   );
 }
 
+async function dismissSystemErrorDialogIfPresent(
+  adb: ADB,
+  diagnosticsFile: string,
+): Promise<{
+  detected: boolean;
+  actionResourceId?: string;
+  checks: number;
+}> {
+  for (let checks = 1; checks <= 4; checks += 1) {
+    const xml = await dumpUiautomatorXml(adb);
+    await writeFile(diagnosticsFile, xml, 'utf8');
+    for (const resourceId of SYSTEM_ERROR_DIALOG_ACTION_IDS) {
+      const [bounds] = boundsForResourceId(xml, resourceId);
+      if (!bounds) {
+        continue;
+      }
+      const x = Math.round(bounds.left + bounds.width / 2);
+      const y = Math.round(bounds.top + bounds.height / 2);
+      await adb.shell(`input swipe ${x} ${y} ${x} ${y} 150`);
+      await sleep(1_000);
+      return { detected: true, actionResourceId: resourceId, checks };
+    }
+    if (xml.includes(`resource-id="${SETTINGS_SEARCH_BAR_ID}"`)) {
+      return { detected: false, checks };
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return { detected: false, checks: 4 };
+}
+
 async function keyboardIsShown(adb: ADB): Promise<boolean> {
   const status = await adb.isSoftKeyboardPresent();
   return typeof status === 'boolean'
@@ -306,6 +340,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
 
     const diagnosticsDir = path.resolve(diagnosticsEnv);
     const initialXmlFile = path.join(diagnosticsDir, 'settings-initial.xml');
+    const systemDialogXmlFile = path.join(
+      diagnosticsDir,
+      'settings-system-dialog.xml',
+    );
     const searchXmlFile = path.join(diagnosticsDir, 'settings-search.xml');
     const firstSearchAttemptXmlFile = path.join(
       diagnosticsDir,
@@ -337,8 +375,25 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       device = new AndroidDevice(devices[0].udid);
       const adb = await device.connect();
       await adb.shell('settings put system font_scale 1.0');
-      await adb.shell('am force-stop com.android.settings');
-      await adb.shell('am start -W -n com.android.settings/.Settings');
+      const settingsLaunches: Array<{
+        attempt: number;
+        systemDialog: Awaited<
+          ReturnType<typeof dismissSystemErrorDialogIfPresent>
+        >;
+      }> = [];
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        await adb.shell('am force-stop com.android.settings');
+        await adb.shell('am start -W -n com.android.settings/.Settings');
+        const systemDialog = await dismissSystemErrorDialogIfPresent(
+          adb,
+          systemDialogXmlFile,
+        );
+        settingsLaunches.push({ attempt, systemDialog });
+        if (!systemDialog.detected) {
+          break;
+        }
+      }
+      evidence.settingsLaunches = settingsLaunches;
 
       const logicalSize = await device.size();
       const screenshot = await device.screenshotBase64();

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -307,6 +307,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
     const diagnosticsDir = path.resolve(diagnosticsEnv);
     const initialXmlFile = path.join(diagnosticsDir, 'settings-initial.xml');
     const searchXmlFile = path.join(diagnosticsDir, 'settings-search.xml');
+    const firstSearchAttemptXmlFile = path.join(
+      diagnosticsDir,
+      'settings-search-attempt-1.xml',
+    );
     const finalXmlFile = path.join(diagnosticsDir, 'settings-final.xml');
     const screenshotFile = path.join(diagnosticsDir, 'settings-search.png');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
@@ -377,19 +381,49 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
         waitAfterAction: 200,
       });
 
-      await agent.callActionInActionSpace('Tap', {
-        locate: locate(initialTarget.bounds, 'Settings search bar'),
-      });
-      const searchInput = await waitForEditableNode(adb, searchXmlFile);
-      evidence.searchInputResourceId = searchInput.resourceId;
+      let searchAttempts = 0;
+      const searchAttemptErrors: string[] = [];
+      const performSearchAttempt = async (target: {
+        bounds: Bounds;
+      }): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> => {
+        searchAttempts += 1;
+        evidence.searchAttempts = searchAttempts;
+        await agent!.callActionInActionSpace('Tap', {
+          locate: locate(target.bounds, 'Settings search bar'),
+        });
+        const searchInput = await waitForEditableNode(adb, searchXmlFile);
+        evidence.searchInputResourceId = searchInput.resourceId;
 
-      await agent.callActionInActionSpace('Input', {
-        value: 'wifi',
-        mode: 'typeOnly',
-        autoDismissKeyboard: false,
-        locate: locate(searchInput.bounds, 'Settings search input'),
-      });
-      const searchState = await waitForEditableNode(adb, searchXmlFile, 'wifi');
+        await agent!.callActionInActionSpace('Input', {
+          value: 'wifi',
+          mode: 'typeOnly',
+          autoDismissKeyboard: false,
+          locate: locate(searchInput.bounds, 'Settings search input'),
+        });
+        return waitForEditableNode(adb, searchXmlFile, 'wifi');
+      };
+
+      let searchState: { resourceId?: string; bounds: Bounds; xml: string };
+      try {
+        searchState = await performSearchAttempt(initialTarget);
+      } catch (error) {
+        searchAttemptErrors.push(String(error));
+        evidence.searchAttemptErrors = searchAttemptErrors;
+        await writeFile(
+          firstSearchAttemptXmlFile,
+          await readFile(searchXmlFile, 'utf8'),
+          'utf8',
+        );
+        await adb.shell('am force-stop com.android.settings');
+        await adb.shell('am start -W -n com.android.settings/.Settings');
+        const retryTarget = await waitForResource(
+          adb,
+          [SETTINGS_SEARCH_BAR_ID],
+          initialXmlFile,
+        );
+        searchState = await performSearchAttempt(retryTarget);
+      }
+      evidence.searchAttemptErrors = searchAttemptErrors;
       expect(searchState.xml).toMatch(/text="wifi"/i);
 
       evidence.keyboardShownBeforeBack = await waitForKeyboardState(adb, true);
@@ -421,7 +455,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(2);
+      expect(locateTasks).toHaveLength(searchAttempts * 2);
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -446,7 +480,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(2);
+      expect(reportLocateTasks).toHaveLength(searchAttempts * 2);
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -21,10 +21,6 @@ const REPORT_FILE_NAME = 'android-emulator-smoke';
 const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
 const UI_DUMP_PATH = '/sdcard/midscene_emulator_smoke_window_dump.xml';
 const SETTINGS_SEARCH_BAR_ID = 'com.android.settings:id/search_action_bar';
-const SETTINGS_SEARCH_INPUT_IDS = [
-  'android:id/search_src_text',
-  'com.android.settings:id/search_src_text',
-] as const;
 const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 30_000;
 
@@ -95,6 +91,82 @@ function boundsForResourceId(xml: string, resourceId: string): Bounds[] {
         height: bottom - top,
       };
     });
+}
+
+function attributeValue(
+  nodeTag: string,
+  attribute: string,
+): string | undefined {
+  return new RegExp(`${attribute}="([^"]*)"`).exec(nodeTag)?.[1];
+}
+
+function boundsForNodeTag(nodeTag: string, description: string): Bounds {
+  const boundsMatch = /bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/.exec(nodeTag);
+  if (!boundsMatch) {
+    throw new Error(`Missing bounds for Android ${description}`);
+  }
+  const left = Number(boundsMatch[1]);
+  const top = Number(boundsMatch[2]);
+  const right = Number(boundsMatch[3]);
+  const bottom = Number(boundsMatch[4]);
+  if (right <= left || bottom <= top) {
+    throw new Error(
+      `Invalid bounds for Android ${description}: ${boundsMatch[0]}`,
+    );
+  }
+  return {
+    left,
+    top,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+async function waitForEditableNode(
+  adb: ADB,
+  diagnosticsFile: string,
+  expectedText?: string,
+): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> {
+  const deadline = Date.now() + TARGET_TIMEOUT_MS;
+  let lastXml = '';
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      lastXml = await dumpUiautomatorXml(adb);
+      await writeFile(diagnosticsFile, lastXml, 'utf8');
+      const candidates = (lastXml.match(/<node\b[^>]*>/g) ?? []).filter(
+        (tag) => {
+          const className = attributeValue(tag, 'class');
+          const text = attributeValue(tag, 'text');
+          return (
+            className?.endsWith('EditText') &&
+            (expectedText === undefined || text === expectedText)
+          );
+        },
+      );
+      const focusedCandidates = candidates.filter(
+        (tag) => attributeValue(tag, 'focused') === 'true',
+      );
+      const matches =
+        focusedCandidates.length === 1 ? focusedCandidates : candidates;
+      if (matches.length === 1) {
+        return {
+          resourceId: attributeValue(matches[0], 'resource-id'),
+          bounds: boundsForNodeTag(matches[0], 'editable node'),
+          xml: lastXml,
+        };
+      }
+      lastError = new Error(
+        `Expected one editable node, found ${candidates.length} (${focusedCandidates.length} focused)`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for Android editable node${expectedText ? ` with text ${expectedText}` : ''}. Last error: ${String(lastError)}. Last XML saved to ${diagnosticsFile} (${lastXml.length} bytes)`,
+  );
 }
 
 async function waitForResource(
@@ -271,7 +343,8 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       await agent.callActionInActionSpace('Tap', {
         locate: locate(initialTarget.bounds, 'Settings search bar'),
       });
-      const searchInput = await waitForResource(adb, SETTINGS_SEARCH_INPUT_IDS);
+      const searchInput = await waitForEditableNode(adb, searchXmlFile);
+      evidence.searchInputResourceId = searchInput.resourceId;
 
       await agent.callActionInActionSpace('Input', {
         value: 'wifi',
@@ -279,9 +352,8 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
         autoDismissKeyboard: true,
         locate: locate(searchInput.bounds, 'Settings search input'),
       });
-      const searchState = await waitForResource(adb, SETTINGS_SEARCH_INPUT_IDS);
+      const searchState = await waitForEditableNode(adb, searchXmlFile, 'wifi');
       expect(searchState.xml).toMatch(/text="wifi"/i);
-      await writeFile(searchXmlFile, searchState.xml, 'utf8');
 
       const searchScreenshot = await device.screenshotBase64();
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -349,7 +349,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       await agent.callActionInActionSpace('Input', {
         value: 'wifi',
         mode: 'replace',
-        autoDismissKeyboard: true,
+        autoDismissKeyboard: false,
         locate: locate(searchInput.bounds, 'Settings search input'),
       });
       const searchState = await waitForEditableNode(adb, searchXmlFile, 'wifi');
@@ -359,6 +359,19 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
 
       await agent.back();
+      let returnedHomeAfterFirstBack = false;
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        const xml = await dumpUiautomatorXml(adb);
+        if (boundsForResourceId(xml, SETTINGS_SEARCH_BAR_ID).length === 1) {
+          returnedHomeAfterFirstBack = true;
+          break;
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      if (!returnedHomeAfterFirstBack) {
+        await agent.back();
+      }
+      evidence.backNavigationCount = returnedHomeAfterFirstBack ? 1 : 2;
       const finalTarget = await waitForResource(adb, [SETTINGS_SEARCH_BAR_ID]);
       await writeFile(finalXmlFile, finalTarget.xml, 'utf8');
 

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -86,27 +86,52 @@ function centerForExactText(
   };
 }
 
-async function dismissChromeFirstRunIfPresent(
-  adb: ADB,
-): Promise<{ beforeXml: string; afterXml?: string; dismissed: boolean }> {
+async function dismissChromeFirstRunIfPresent(adb: ADB): Promise<{
+  beforeXml: string;
+  afterXml?: string;
+  detected: boolean;
+  dismissed: boolean;
+  tapAttempts: number;
+}> {
   const beforeXml = await dumpUiautomatorXml(adb);
   const useWithoutAccount = centerForExactText(
     beforeXml,
     'Use without an account',
   );
   if (!useWithoutAccount) {
-    return { beforeXml, dismissed: false };
+    return {
+      beforeXml,
+      detected: false,
+      dismissed: false,
+      tapAttempts: 0,
+    };
   }
 
-  await adb.shell(`input tap ${useWithoutAccount.x} ${useWithoutAccount.y}`);
-  await sleep(2000);
-  const afterXml = await dumpUiautomatorXml(adb);
-  if (centerForExactText(afterXml, 'Use without an account')) {
-    throw new Error(
-      'Chrome first-run screen remained after deterministic setup',
+  let afterXml = beforeXml;
+  for (let tapAttempts = 1; tapAttempts <= 2; tapAttempts += 1) {
+    await adb.shell(
+      `input swipe ${useWithoutAccount.x} ${useWithoutAccount.y} ${useWithoutAccount.x} ${useWithoutAccount.y} 150`,
     );
+    await sleep(1000);
+    afterXml = await dumpUiautomatorXml(adb);
+    if (!centerForExactText(afterXml, 'Use without an account')) {
+      return {
+        beforeXml,
+        afterXml,
+        detected: true,
+        dismissed: true,
+        tapAttempts,
+      };
+    }
   }
-  return { beforeXml, afterXml, dismissed: true };
+
+  return {
+    beforeXml,
+    afterXml,
+    detected: true,
+    dismissed: false,
+    tapAttempts: 2,
+  };
 }
 
 describe('Test todo list', () => {
@@ -145,6 +170,24 @@ describe('Test todo list', () => {
           'utf8',
         );
       }
+      await writeFile(
+        path.join(resolvedDiagnosticsDir, 'chrome-first-run-metadata.json'),
+        `${JSON.stringify(
+          {
+            detected: chromeFirstRun.detected,
+            dismissed: chromeFirstRun.dismissed,
+            tapAttempts: chromeFirstRun.tapAttempts,
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+    }
+    if (chromeFirstRun.detected && !chromeFirstRun.dismissed) {
+      throw new Error(
+        'Chrome first-run screen remained after deterministic setup',
+      );
     }
     if (chromeFirstRun.dismissed) {
       await page.launch(pageUrl);

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -194,6 +194,6 @@ describe('Test todo list', () => {
       );
       expect(placeholder).toBe('What needs to be done?');
     },
-    720 * 1000,
+    1200 * 1000,
   );
 });

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -1,5 +1,7 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 
 vi.setConfig({
@@ -7,54 +9,190 @@ vi.setConfig({
 });
 
 const pageUrl = 'https://todomvc.com/examples/react/dist/';
+const diagnosticsDir = process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR;
+const expectedActiveTasks = [
+  'Learn JS today',
+  'Learn Rust tomorrow',
+  'Learning AI the day after tomorrow',
+] as const;
+const completedTask = 'Learning AI the day after tomorrow';
+const visibleTodoListQuery =
+  'string[], extract the exact text of every visible todo item label from the todo list, one string per row from top to bottom. Ignore the input box, any draft text inside it, the item counter, and the filter buttons.';
+
+async function queryVisibleTodoListWithRetry(
+  agent: AndroidAgent,
+  expectedTasks: readonly string[],
+  logLabel: string,
+): Promise<string[]> {
+  let tasks: string[] = [];
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    tasks = await agent.aiQuery<string[]>(visibleTodoListQuery);
+    console.log(`${logLabel} attempt ${attempt}`, tasks);
+    if (
+      tasks.length === expectedTasks.length &&
+      expectedTasks.every((task) => tasks.includes(task))
+    ) {
+      return tasks;
+    }
+  }
+
+  return tasks;
+}
+
+function screenshotBuffer(base64: string): Buffer {
+  const match = /^data:image\/\w+;base64,(.+)$/s.exec(base64);
+  if (!match) {
+    throw new Error('Android TodoMVC screenshot is not a base64 data URL');
+  }
+  return Buffer.from(match[1], 'base64');
+}
 
 describe('Test todo list', () => {
-  let agent: AndroidAgent;
+  let agent: AndroidAgent | undefined;
 
   beforeAll(async () => {
     const devices = await getConnectedDevices();
+    expect(devices).toHaveLength(1);
     const page = new AndroidDevice(devices[0].udid, {
       scrcpyConfig: {
         enabled: true,
       },
     });
     agent = new AndroidAgent(page, {
+      reportFileName: 'todo-mvc-android',
+      autoPrintReportMsg: false,
       aiActionContext:
-        'If any location, permission, user agreement, etc. popup, click agree. If login page pops up, close it.',
+        'If any browser, permission, or user agreement popup appears, close or accept it. Operate only the visible TodoMVC page.',
     });
     await page.connect();
     await page.launch(pageUrl);
     await sleep(3000);
   });
 
+  afterAll(async () => {
+    if (!agent) {
+      return;
+    }
+
+    let diagnosticsError: unknown;
+    if (diagnosticsDir) {
+      try {
+        const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
+        await mkdir(resolvedDiagnosticsDir, { recursive: true });
+        await Promise.all([
+          agent.interface
+            .screenshotBase64()
+            .then((base64) =>
+              writeFile(
+                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
+                screenshotBuffer(base64),
+              ),
+            ),
+          writeFile(
+            path.join(resolvedDiagnosticsDir, 'todo-agent-dump.json'),
+            `${agent.dumpDataString()}\n`,
+            'utf8',
+          ),
+        ]);
+      } catch (error) {
+        diagnosticsError = error;
+      }
+    }
+
+    let destroyError: unknown;
+    try {
+      await agent.destroy();
+    } catch (error) {
+      destroyError = error;
+    }
+
+    if (diagnosticsDir) {
+      const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
+      await writeFile(
+        path.join(resolvedDiagnosticsDir, 'todo-report-metadata.json'),
+        `${JSON.stringify(
+          {
+            platform: process.platform,
+            reportFile: agent.reportFile,
+            diagnosticsError:
+              diagnosticsError instanceof Error
+                ? diagnosticsError.message
+                : diagnosticsError,
+            destroyError:
+              destroyError instanceof Error
+                ? destroyError.message
+                : destroyError,
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+    }
+
+    if (destroyError) {
+      throw destroyError;
+    }
+  });
+
   it(
     'ai todo',
     async () => {
-      await agent.aiAct(
-        "type 'Study JS today' in the task box input and press the Enter key",
-      );
-      await agent.aiAct(
-        "type 'Study Rust tomorrow' in the task box input and press the Enter key",
-      );
-      await agent.aiAct(
-        "type 'Study AI the day after tomorrow' in the task box input and press the Enter key",
-      );
-      await agent.aiAct(
-        'move the mouse to the second item in the task list and click the delete button on the right of the second task',
-      );
-      await agent.aiAct(
-        'click the check button on the left of the second task',
-      );
-      await agent.aiAct(
-        "click the 'completed' status button below the task list",
-      );
+      if (!agent) {
+        throw new Error('AndroidAgent was not initialized');
+      }
 
-      const list = await agent.aiQuery('string[], the complete task list');
-      expect(list.length).toEqual(1);
-
+      await agent.aiAct(
+        'Prepare the TodoMVC page for a clean test. Close any browser startup popup if present. If todo items already exist, delete every item with its × button. Stop when the task input is visible and the todo list is empty.',
+      );
       await agent.aiAssert(
-        'Near the bottom of the list, there is a tip shows "1 item left".',
+        'The TodoMVC task input is visible and there are no existing task items',
       );
+      await agent.aiAct(
+        'Type "Learn JS today" in the task input, then press Enter to create the task',
+      );
+      await agent.aiAct(
+        'Type "Learn Rust tomorrow" in the task input, then press Enter to create the task',
+      );
+      await agent.aiAct(
+        'Type "Learning AI the day after tomorrow" in the task input, then press Enter to create the task',
+      );
+
+      const allTasks = await queryVisibleTodoListWithRetry(
+        agent,
+        expectedActiveTasks,
+        'allTaskList',
+      );
+      expect(allTasks).toEqual(
+        expect.arrayContaining([...expectedActiveTasks]),
+      );
+      expect(allTasks).toHaveLength(expectedActiveTasks.length);
+
+      await agent.aiAct(
+        'Tap the "Learn Rust tomorrow" task row once to reveal its delete control. Do not tap its checkbox.',
+      );
+      await agent.aiAct(
+        'Tap the delete button (×) to the right of "Learn Rust tomorrow"',
+      );
+      await agent.aiAct(
+        'Tap the checkbox next to "Learning AI the day after tomorrow"',
+      );
+      await agent.aiAct(
+        'Tap the "Completed" status filter below the task list',
+      );
+
+      const completedTasks = await queryVisibleTodoListWithRetry(
+        agent,
+        [completedTask],
+        'completedTaskList',
+      );
+      expect(completedTasks).toEqual([completedTask]);
+
+      const placeholder = await agent.aiQuery<string>(
+        'string, return the placeholder text in the input box',
+      );
+      expect(placeholder).toBe('What needs to be done?');
     },
     720 * 1000,
   );

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -20,6 +20,7 @@ const expectedActiveTasks = [
   'Learning AI the day after tomorrow',
 ] as const;
 const completedTask = 'Learning AI the day after tomorrow';
+const tasksAfterDelete = ['Learn JS today', completedTask] as const;
 const visibleTodoListQuery =
   'string[], extract the exact text of every visible todo item label from the todo list, one string per row from top to bottom. Ignore the input box, any draft text inside it, the item counter, and the filter buttons.';
 
@@ -294,18 +295,26 @@ describe('Test todo list', () => {
       );
       expect(allTasks).toHaveLength(expectedActiveTasks.length);
 
-      await agent.aiAct(
-        'Tap the "Learn Rust tomorrow" task row once to reveal its delete control. Do not tap its checkbox.',
+      await agent.aiTap(
+        'the text label "Learn Rust tomorrow" in the task row, away from its checkbox',
       );
-      await agent.aiAct(
-        'Tap the delete button (×) to the right of "Learn Rust tomorrow"',
+      await agent.aiTap(
+        'the delete button (×) at the right edge of the "Learn Rust tomorrow" task row',
       );
-      await agent.aiAct(
-        'Tap the checkbox next to "Learning AI the day after tomorrow"',
+      const remainingTasks = await queryVisibleTodoListWithRetry(
+        agent,
+        tasksAfterDelete,
+        'remainingTaskList',
       );
-      await agent.aiAct(
-        'Tap the "Completed" status filter below the task list',
+      expect(remainingTasks).toEqual(
+        expect.arrayContaining([...tasksAfterDelete]),
       );
+      expect(remainingTasks).toHaveLength(tasksAfterDelete.length);
+
+      await agent.aiTap(
+        'the checkbox immediately to the left of "Learning AI the day after tomorrow"',
+      );
+      await agent.aiTap('the "Completed" status filter below the todo list');
 
       const completedTasks = await queryVisibleTodoListWithRetry(
         agent,

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -1,15 +1,19 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
+import type ADB from 'appium-adb';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 
 vi.setConfig({
   testTimeout: 240 * 1000,
+  hookTimeout: 60 * 1000,
 });
 
 const pageUrl = 'https://todomvc.com/examples/react/dist/';
 const diagnosticsDir = process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR;
+const CHROME_FIRST_RUN_DUMP_PATH =
+  '/sdcard/midscene_chrome_first_run_window_dump.xml';
 const expectedActiveTasks = [
   'Learn JS today',
   'Learn Rust tomorrow',
@@ -48,6 +52,63 @@ function screenshotBuffer(base64: string): Buffer {
   return Buffer.from(match[1], 'base64');
 }
 
+async function dumpUiautomatorXml(adb: ADB): Promise<string> {
+  await adb.shell(
+    `uiautomator dump --compressed ${CHROME_FIRST_RUN_DUMP_PATH}`,
+  );
+  const xml = await adb.shell(`cat ${CHROME_FIRST_RUN_DUMP_PATH}`);
+  if (typeof xml !== 'string' || xml.trim().length === 0) {
+    throw new Error('Android emulator returned an empty Chrome UI dump');
+  }
+  return xml;
+}
+
+function centerForExactText(
+  xml: string,
+  text: string,
+): { x: number; y: number } | undefined {
+  const textAttribute = `text="${text}"`;
+  const contentDescriptionAttribute = `content-desc="${text}"`;
+  const nodeTag = (xml.match(/<node\b[^>]*>/g) ?? []).find(
+    (tag) =>
+      tag.includes(textAttribute) || tag.includes(contentDescriptionAttribute),
+  );
+  if (!nodeTag) {
+    return undefined;
+  }
+  const bounds = /bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/.exec(nodeTag);
+  if (!bounds) {
+    throw new Error(`Chrome first-run control has no bounds: ${text}`);
+  }
+  return {
+    x: Math.round((Number(bounds[1]) + Number(bounds[3])) / 2),
+    y: Math.round((Number(bounds[2]) + Number(bounds[4])) / 2),
+  };
+}
+
+async function dismissChromeFirstRunIfPresent(
+  adb: ADB,
+): Promise<{ beforeXml: string; afterXml?: string; dismissed: boolean }> {
+  const beforeXml = await dumpUiautomatorXml(adb);
+  const useWithoutAccount = centerForExactText(
+    beforeXml,
+    'Use without an account',
+  );
+  if (!useWithoutAccount) {
+    return { beforeXml, dismissed: false };
+  }
+
+  await adb.shell(`input tap ${useWithoutAccount.x} ${useWithoutAccount.y}`);
+  await sleep(2000);
+  const afterXml = await dumpUiautomatorXml(adb);
+  if (centerForExactText(afterXml, 'Use without an account')) {
+    throw new Error(
+      'Chrome first-run screen remained after deterministic setup',
+    );
+  }
+  return { beforeXml, afterXml, dismissed: true };
+}
+
 describe('Test todo list', () => {
   let agent: AndroidAgent | undefined;
 
@@ -65,9 +126,30 @@ describe('Test todo list', () => {
       aiActionContext:
         'If any browser, permission, or user agreement popup appears, close or accept it. Operate only the visible TodoMVC page.',
     });
-    await page.connect();
+    const adb = await page.connect();
     await page.launch(pageUrl);
     await sleep(3000);
+    const chromeFirstRun = await dismissChromeFirstRunIfPresent(adb);
+    if (diagnosticsDir) {
+      const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
+      await mkdir(resolvedDiagnosticsDir, { recursive: true });
+      await writeFile(
+        path.join(resolvedDiagnosticsDir, 'chrome-first-run-before.xml'),
+        chromeFirstRun.beforeXml,
+        'utf8',
+      );
+      if (chromeFirstRun.afterXml) {
+        await writeFile(
+          path.join(resolvedDiagnosticsDir, 'chrome-first-run-after.xml'),
+          chromeFirstRun.afterXml,
+          'utf8',
+        );
+      }
+    }
+    if (chromeFirstRun.dismissed) {
+      await page.launch(pageUrl);
+      await sleep(3000);
+    }
   });
 
   afterAll(async () => {

--- a/packages/cli/tests/unit-test/execution-summary.test.ts
+++ b/packages/cli/tests/unit-test/execution-summary.test.ts
@@ -344,7 +344,11 @@ describe('execution summary', () => {
         expect.stringContaining('Failed to merge retry attempt report'),
       );
       expect(mergeReports).toHaveBeenCalled();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await vi.waitFor(() => {
+        expect(existsSync(join(runDir, 'log', 'execution-summary.log'))).toBe(
+          true,
+        );
+      });
     } finally {
       mergeReports.mockRestore();
       if (previousRunDir === undefined) {

--- a/packages/computer/tests/ai/ai-auto-todo.test.ts
+++ b/packages/computer/tests/ai/ai-auto-todo.test.ts
@@ -194,6 +194,6 @@ describe('computer todo app automation', () => {
       );
       expect(placeholder).toBe('What needs to be done?');
     },
-    600 * 1000,
+    1200 * 1000,
   );
 });

--- a/packages/computer/tests/ai/ai-auto-todo.test.ts
+++ b/packages/computer/tests/ai/ai-auto-todo.test.ts
@@ -1,4 +1,6 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import { openBrowserAndNavigate } from './test-utils';
 
@@ -7,15 +9,121 @@ vi.setConfig({
 });
 
 const isCacheEnabled = process.env.MIDSCENE_CACHE;
+const diagnosticsDir = process.env.MIDSCENE_TODO_DIAGNOSTICS_DIR;
+const expectedActiveTasks = [
+  'Learn JS today',
+  'Learn Rust tomorrow',
+  'Learning AI the day after tomorrow',
+] as const;
+const completedTask = 'Learning AI the day after tomorrow';
+const visibleTodoListQuery =
+  'string[], extract the exact text of every visible todo item label from the todo list, one string per row from top to bottom. Ignore the input box, any draft text inside it, the item counter, and the filter buttons.';
+
+async function queryVisibleTodoListWithRetry(
+  agent: ComputerAgent,
+  expectedTasks: readonly string[],
+  logLabel: string,
+): Promise<string[]> {
+  let tasks: string[] = [];
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    tasks = await agent.aiQuery<string[]>(visibleTodoListQuery);
+    console.log(`${logLabel} attempt ${attempt}`, tasks);
+    if (
+      tasks.length === expectedTasks.length &&
+      expectedTasks.every((task) => tasks.includes(task))
+    ) {
+      return tasks;
+    }
+  }
+
+  return tasks;
+}
+
+function screenshotBuffer(base64: string): Buffer {
+  const match = /^data:image\/\w+;base64,(.+)$/s.exec(base64);
+  if (!match) {
+    throw new Error('TodoMVC diagnostic screenshot is not a base64 data URL');
+  }
+  return Buffer.from(match[1], 'base64');
+}
 
 describe('computer todo app automation', () => {
-  let agent: ComputerAgent;
+  let agent: ComputerAgent | undefined;
 
   beforeAll(async () => {
     agent = await agentFromComputer({
+      reportFileName: `todo-mvc-${process.platform}`,
+      autoPrintReportMsg: false,
       aiActionContext:
-        'If any popup appears, click agree. If login page appears, skip it.',
+        'If any popup appears, close it. Operate only the visible TodoMVC page.',
     });
+  });
+
+  afterAll(async () => {
+    if (!agent) {
+      return;
+    }
+
+    let diagnosticsError: unknown;
+    if (diagnosticsDir) {
+      try {
+        const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
+        await mkdir(resolvedDiagnosticsDir, { recursive: true });
+        await Promise.all([
+          agent.interface
+            .screenshotBase64()
+            .then((base64) =>
+              writeFile(
+                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
+                screenshotBuffer(base64),
+              ),
+            ),
+          writeFile(
+            path.join(resolvedDiagnosticsDir, 'todo-agent-dump.json'),
+            `${agent.dumpDataString()}\n`,
+            'utf8',
+          ),
+        ]);
+      } catch (error) {
+        diagnosticsError = error;
+      }
+    }
+
+    let destroyError: unknown;
+    try {
+      await agent.destroy();
+    } catch (error) {
+      destroyError = error;
+    }
+
+    if (diagnosticsDir) {
+      const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
+      await writeFile(
+        path.join(resolvedDiagnosticsDir, 'todo-report-metadata.json'),
+        `${JSON.stringify(
+          {
+            platform: process.platform,
+            reportFile: agent.reportFile,
+            diagnosticsError:
+              diagnosticsError instanceof Error
+                ? diagnosticsError.message
+                : diagnosticsError,
+            destroyError:
+              destroyError instanceof Error
+                ? destroyError.message
+                : destroyError,
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+    }
+
+    if (destroyError) {
+      throw destroyError;
+    }
   });
 
   it(
@@ -25,15 +133,22 @@ describe('computer todo app automation', () => {
         vi.setConfig({ testTimeout: 1000 * 1000 });
       }
 
+      if (!agent) {
+        throw new Error('ComputerAgent was not initialized');
+      }
+
       await openBrowserAndNavigate(
         agent,
         'https://todomvc.com/examples/react/dist/',
       );
 
-      // Wait for page to load
-      await agent.aiAssert('The todo input box is visible');
+      await agent.aiAct(
+        'Prepare the TodoMVC page for a clean test. Close any browser startup popup if present. If todo items already exist, delete every item with its × button. Stop when the task input is visible and the todo list is empty.',
+      );
+      await agent.aiAssert(
+        'The TodoMVC task input is visible and there are no existing task items',
+      );
 
-      // Add tasks
       await agent.aiAct(
         'Click the task input box, type "Learn JS today", then press Enter to create the task',
       );
@@ -44,18 +159,21 @@ describe('computer todo app automation', () => {
         'Click the task input box, type "Learning AI the day after tomorrow", then press Enter to create the task',
       );
 
-      // Verify tasks were created
-      const allTaskList = await agent.aiQuery<string[]>(
-        'string[], tasks in the list',
+      const allTaskList = await queryVisibleTodoListWithRetry(
+        agent,
+        expectedActiveTasks,
+        'allTaskList',
       );
-      console.log('allTaskList', allTaskList);
-      expect(allTaskList).toContain('Learn JS today');
-      expect(allTaskList).toContain('Learn Rust tomorrow');
-      expect(allTaskList).toContain('Learning AI the day after tomorrow');
+      expect(allTaskList).toEqual(
+        expect.arrayContaining([...expectedActiveTasks]),
+      );
+      expect(allTaskList).toHaveLength(expectedActiveTasks.length);
 
-      // Interact with tasks - hover to show delete button, then click it
       await agent.aiAct(
-        'Hover over the "Learn Rust tomorrow" task and click the × delete button that appears on the right side of it',
+        'Move the mouse over "Learn Rust tomorrow" in the task list to reveal the delete button',
+      );
+      await agent.aiAct(
+        'Click the delete button (×) to the right of "Learn Rust tomorrow"',
       );
       await agent.aiAct(
         'Click the checkbox next to "Learning AI the day after tomorrow"',
@@ -64,15 +182,14 @@ describe('computer todo app automation', () => {
         'Click the "Completed" filter button below the task list',
       );
 
-      // Verify remaining tasks
-      const taskList = await agent.aiQuery<string[]>(
-        'string[], Extract all task names from the list',
+      const taskList = await queryVisibleTodoListWithRetry(
+        agent,
+        [completedTask],
+        'completedTaskList',
       );
-      expect(taskList.length).toBe(1);
-      expect(taskList[0]).toBe('Learning AI the day after tomorrow');
+      expect(taskList).toEqual([completedTask]);
 
-      // Verify placeholder text
-      const placeholder = await agent.aiQuery(
+      const placeholder = await agent.aiQuery<string>(
         'string, return the placeholder text in the input box',
       );
       expect(placeholder).toBe('What needs to be done?');

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app-Info.plist
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app-Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>MidsceneDesktopSmokeFixture</string>
+  <key>CFBundleIdentifier</key>
+  <string>ai.midscene.desktop-smoke-fixture</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Midscene Desktop Smoke Fixture</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -24,7 +24,6 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var button: SmokeButton!
   private var textField: NSTextField!
   private var scrollView: NSScrollView!
-  private var activationTimer: Timer?
 
   private var clickCount = 0
   private var buttonActionCount = 0
@@ -105,10 +104,6 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
       self?.writeReadyMetadata()
-    }
-    activationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
-      [weak self] _ in
-      Task { @MainActor in self?.activateFixture() }
     }
   }
 

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -1,0 +1,258 @@
+import AppKit
+import Foundation
+
+final class FlippedDocumentView: NSView {
+  override var isFlipped: Bool { true }
+}
+
+@MainActor
+final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDelegate {
+  private let readyURL: URL
+  private let stateURL: URL
+
+  private var window: NSWindow!
+  private var button: NSButton!
+  private var textField: NSTextField!
+  private var scrollView: NSScrollView!
+  private var activationTimer: Timer?
+
+  private var clickCount = 0
+  private var lastKey = ""
+  private var wheelEventCount = 0
+
+  init(readyFile: String, stateFile: String) {
+    readyURL = URL(fileURLWithPath: readyFile)
+    stateURL = URL(fileURLWithPath: stateFile)
+    super.init()
+  }
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    installMainMenu()
+
+    guard let screen = NSScreen.main else {
+      fail("macOS did not expose a primary screen")
+    }
+
+    let windowSize = NSSize(width: 640, height: 500)
+    let origin = NSPoint(
+      x: screen.visibleFrame.midX - windowSize.width / 2,
+      y: screen.visibleFrame.midY - windowSize.height / 2
+    )
+    window = NSWindow(
+      contentRect: NSRect(origin: origin, size: windowSize),
+      styleMask: [.titled, .closable, .miniaturizable],
+      backing: .buffered,
+      defer: false,
+      screen: screen
+    )
+    window.title = "Midscene macOS Desktop Smoke"
+    window.isReleasedWhenClosed = false
+
+    button = NSButton(title: "Midscene Smoke Button", target: self, action: #selector(buttonClicked))
+    button.frame = NSRect(x: 190, y: 370, width: 260, height: 72)
+    button.isBordered = false
+    button.wantsLayer = true
+    button.layer?.backgroundColor = NSColor.systemGreen.cgColor
+    button.layer?.cornerRadius = 6
+    button.contentTintColor = .black
+    window.contentView?.addSubview(button)
+
+    textField = NSTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
+    textField.placeholderString = "Type smoke text"
+    textField.delegate = self
+    textField.target = self
+    textField.action = #selector(textCommitted)
+    window.contentView?.addSubview(textField)
+
+    scrollView = NSScrollView(frame: NSRect(x: 120, y: 55, width: 400, height: 160))
+    scrollView.hasVerticalScroller = true
+    scrollView.borderType = .bezelBorder
+    let documentView = FlippedDocumentView(frame: NSRect(x: 0, y: 0, width: 380, height: 720))
+    for index in 0..<18 {
+      let label = NSTextField(labelWithString: "Scrollable smoke row \(index + 1)")
+      label.frame = NSRect(x: 20, y: 16 + index * 38, width: 320, height: 24)
+      documentView.addSubview(label)
+    }
+    scrollView.documentView = documentView
+    scrollView.contentView.postsBoundsChangedNotifications = true
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(scrollBoundsChanged),
+      name: NSView.boundsDidChangeNotification,
+      object: scrollView.contentView
+    )
+    window.contentView?.addSubview(scrollView)
+
+    activateFixture()
+    window.makeFirstResponder(textField)
+    writeState()
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      self?.writeReadyMetadata()
+    }
+    activationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor in self?.activateFixture() }
+    }
+  }
+
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    true
+  }
+
+  func controlTextDidChange(_ obj: Notification) {
+    writeState()
+  }
+
+  @objc private func buttonClicked() {
+    clickCount += 1
+    writeState()
+  }
+
+  @objc private func textCommitted() {
+    lastKey = "Enter"
+    writeState()
+  }
+
+  @objc private func scrollBoundsChanged() {
+    wheelEventCount += 1
+    writeState()
+  }
+
+  private func activateFixture() {
+    window.makeKeyAndOrderFront(nil)
+    NSApplication.shared.activate(ignoringOtherApps: true)
+    NSRunningApplication.current.activate(options: [.activateAllWindows])
+  }
+
+  private func installMainMenu() {
+    let mainMenu = NSMenu()
+
+    let applicationMenuItem = NSMenuItem()
+    mainMenu.addItem(applicationMenuItem)
+    let applicationMenu = NSMenu()
+    applicationMenuItem.submenu = applicationMenu
+    applicationMenu.addItem(
+      withTitle: "Quit Midscene Desktop Smoke Fixture",
+      action: #selector(NSApplication.terminate(_:)),
+      keyEquivalent: "q"
+    )
+
+    let editMenuItem = NSMenuItem()
+    mainMenu.addItem(editMenuItem)
+    let editMenu = NSMenu(title: "Edit")
+    editMenuItem.submenu = editMenu
+    editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+    editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+    editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+    editMenu.addItem(NSMenuItem.separator())
+    editMenu.addItem(
+      withTitle: "Select All",
+      action: #selector(NSText.selectAll(_:)),
+      keyEquivalent: "a"
+    )
+
+    NSApplication.shared.mainMenu = mainMenu
+  }
+
+  private func topLeftBounds(of view: NSView, on screen: NSScreen) -> [String: CGFloat] {
+    let windowRect = view.convert(view.bounds, to: nil)
+    let screenRect = window.convertToScreen(windowRect)
+    return [
+      "left": screenRect.minX - screen.frame.minX,
+      "top": screen.frame.maxY - screenRect.maxY,
+      "width": screenRect.width,
+      "height": screenRect.height,
+    ]
+  }
+
+  private func windowBounds(on screen: NSScreen) -> [String: CGFloat] {
+    let frame = window.frame
+    return [
+      "left": frame.minX - screen.frame.minX,
+      "top": screen.frame.maxY - frame.maxY,
+      "width": frame.width,
+      "height": frame.height,
+    ]
+  }
+
+  private func writeReadyMetadata() {
+    guard let screen = window.screen ?? NSScreen.main else {
+      fail("fixture window is not attached to a screen")
+    }
+    writeJSON(
+      [
+        "processId": ProcessInfo.processInfo.processIdentifier,
+        "visible": window.isVisible,
+        "backingScaleFactor": window.backingScaleFactor,
+        "screen": [
+          "left": 0,
+          "top": 0,
+          "width": screen.frame.width,
+          "height": screen.frame.height,
+        ],
+        "window": windowBounds(on: screen),
+        "button": topLeftBounds(of: button, on: screen),
+        "textField": topLeftBounds(of: textField, on: screen),
+        "scroll": topLeftBounds(of: scrollView, on: screen),
+      ],
+      to: readyURL
+    )
+    print("Midscene macOS desktop smoke fixture ready")
+    fflush(stdout)
+  }
+
+  private func writeState() {
+    guard window != nil, textField != nil, scrollView != nil else {
+      return
+    }
+    writeJSON(
+      [
+        "visible": window.isVisible,
+        "clickCount": clickCount,
+        "text": textField.stringValue,
+        "lastKey": lastKey,
+        "wheelEventCount": wheelEventCount,
+        "scrollValue": scrollView.contentView.bounds.origin.y,
+      ],
+      to: stateURL
+    )
+  }
+
+  private func writeJSON(_ value: [String: Any], to url: URL) {
+    do {
+      let data = try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted])
+      try data.write(to: url, options: [.atomic])
+    } catch {
+      fail("Failed to write fixture JSON: \(error)")
+    }
+  }
+
+  private func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("\(message)\n".utf8))
+    exit(3)
+  }
+}
+
+@main
+@MainActor
+struct MacOSDesktopSmokeFixture {
+  static func main() {
+    guard CommandLine.arguments.count == 3 else {
+      FileHandle.standardError.write(
+        Data("Usage: macos-desktop-smoke-app <ready-file> <state-file>\n".utf8)
+      )
+      exit(2)
+    }
+
+    let app = NSApplication.shared
+    app.setActivationPolicy(.regular)
+    let controller = FixtureController(
+      readyFile: CommandLine.arguments[1],
+      stateFile: CommandLine.arguments[2]
+    )
+    app.delegate = controller
+    app.run()
+    withExtendedLifetime(controller) {}
+  }
+}

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -6,16 +6,25 @@ final class FlippedDocumentView: NSView {
 }
 
 @MainActor
+final class SmokeButton: NSButton {
+  var onMouseDown: (() -> Void)?
+
+  override func mouseDown(with event: NSEvent) {
+    onMouseDown?()
+    super.mouseDown(with: event)
+  }
+}
+
+@MainActor
 final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDelegate {
   private let readyURL: URL
   private let stateURL: URL
 
   private var window: NSWindow!
-  private var button: NSButton!
+  private var button: SmokeButton!
   private var textField: NSTextField!
   private var scrollView: NSScrollView!
   private var activationTimer: Timer?
-  private var mouseMonitor: Any?
 
   private var clickCount = 0
   private var buttonActionCount = 0
@@ -50,7 +59,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     window.title = "Midscene macOS Desktop Smoke"
     window.isReleasedWhenClosed = false
 
-    button = NSButton(title: "Midscene Smoke Button", target: self, action: #selector(buttonClicked))
+    button = SmokeButton(title: "Midscene Smoke Button", target: self, action: #selector(buttonClicked))
     button.frame = NSRect(x: 190, y: 370, width: 260, height: 72)
     button.isBordered = false
     button.wantsLayer = true
@@ -58,19 +67,10 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     button.layer?.cornerRadius = 6
     button.contentTintColor = .black
     window.contentView?.addSubview(button)
-
-    mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) {
-      [weak self] event in
-      guard let self, event.window === self.window else {
-        return event
-      }
-      let point = self.button.convert(event.locationInWindow, from: nil)
-      guard self.button.bounds.contains(point) else {
-        return event
-      }
+    button.onMouseDown = { [weak self] in
+      guard let self else { return }
       self.clickCount += 1
       self.writeState()
-      return event
     }
 
     textField = NSTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
@@ -114,12 +114,6 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     true
-  }
-
-  func applicationWillTerminate(_ notification: Notification) {
-    if let mouseMonitor {
-      NSEvent.removeMonitor(mouseMonitor)
-    }
   }
 
   func controlTextDidChange(_ obj: Notification) {

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -15,8 +15,10 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var textField: NSTextField!
   private var scrollView: NSScrollView!
   private var activationTimer: Timer?
+  private var mouseMonitor: Any?
 
   private var clickCount = 0
+  private var buttonActionCount = 0
   private var lastKey = ""
   private var wheelEventCount = 0
 
@@ -56,6 +58,20 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     button.layer?.cornerRadius = 6
     button.contentTintColor = .black
     window.contentView?.addSubview(button)
+
+    mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) {
+      [weak self] event in
+      guard let self, event.window === self.window else {
+        return event
+      }
+      let point = self.button.convert(event.locationInWindow, from: nil)
+      guard self.button.bounds.contains(point) else {
+        return event
+      }
+      self.clickCount += 1
+      self.writeState()
+      return event
+    }
 
     textField = NSTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
     textField.placeholderString = "Type smoke text"
@@ -100,12 +116,18 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     true
   }
 
+  func applicationWillTerminate(_ notification: Notification) {
+    if let mouseMonitor {
+      NSEvent.removeMonitor(mouseMonitor)
+    }
+  }
+
   func controlTextDidChange(_ obj: Notification) {
     writeState()
   }
 
   @objc private func buttonClicked() {
-    clickCount += 1
+    buttonActionCount += 1
     writeState()
   }
 
@@ -210,6 +232,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
       [
         "visible": window.isVisible,
         "clickCount": clickCount,
+        "buttonActionCount": buttonActionCount,
         "text": textField.stringValue,
         "lastKey": lastKey,
         "wheelEventCount": wheelEventCount,

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import Foundation
 
 final class FlippedDocumentView: NSView {
@@ -24,7 +25,9 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var button: SmokeButton!
   private var textField: NSTextField!
   private var scrollView: NSScrollView!
+  private var activationSource: DispatchSourceSignal?
 
+  private var activationCount = 0
   private var clickCount = 0
   private var buttonActionCount = 0
   private var lastKey = ""
@@ -98,6 +101,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     )
     window.contentView?.addSubview(scrollView)
 
+    installActivationSignal()
     activateFixture()
     window.makeFirstResponder(textField)
     writeState()
@@ -131,9 +135,31 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   }
 
   private func activateFixture() {
+    focusFixture()
+    activationCount += 1
+    writeState()
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+      self?.focusFixture()
+      self?.writeState()
+    }
+  }
+
+  private func focusFixture() {
+    NSApplication.shared.unhide(nil)
+    window.orderFrontRegardless()
     window.makeKeyAndOrderFront(nil)
     NSApplication.shared.activate(ignoringOtherApps: true)
     NSRunningApplication.current.activate(options: [.activateAllWindows])
+  }
+
+  private func installActivationSignal() {
+    signal(SIGUSR1, SIG_IGN)
+    let source = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
+    source.setEventHandler { [weak self] in
+      self?.activateFixture()
+    }
+    source.resume()
+    activationSource = source
   }
 
   private func installMainMenu() {
@@ -220,6 +246,9 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     writeJSON(
       [
         "visible": window.isVisible,
+        "active": NSApplication.shared.isActive,
+        "keyWindow": window.isKeyWindow,
+        "activationCount": activationCount,
         "clickCount": clickCount,
         "buttonActionCount": buttonActionCount,
         "text": textField.stringValue,

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -67,6 +67,7 @@ interface FixtureMetadata {
 interface FixtureState {
   visible: boolean;
   clickCount: number;
+  buttonActionCount: number;
   text: string;
   lastKey: string;
   wheelEventCount: number;
@@ -151,6 +152,10 @@ function normalizeState(value: unknown): FixtureState {
   return {
     visible: raw.visible === true,
     clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
+    buttonActionCount: asFiniteNumber(
+      raw.buttonActionCount,
+      'state.buttonActionCount',
+    ),
     text: String(raw.text ?? ''),
     lastKey: String(raw.lastKey ?? ''),
     wheelEventCount: asFiniteNumber(

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -1,0 +1,609 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parseDumpScript } from '@midscene/core';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_FAMILY,
+  MIDSCENE_MODEL_NAME,
+  MIDSCENE_MODEL_RETRY_COUNT,
+  MIDSCENE_MODEL_TIMEOUT,
+} from '@midscene/shared/env';
+import { cropByRect, imageInfoOfBase64 } from '@midscene/shared/img';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ComputerAgent,
+  ComputerDevice,
+  checkComputerEnvironment,
+} from '../../src';
+
+const RUN_LIVE_SMOKE =
+  process.platform === 'darwin' &&
+  process.env.MIDSCENE_MACOS_DESKTOP_SMOKE === '1';
+const FIXTURE_SOURCE = path.join(
+  __dirname,
+  'fixtures',
+  'macos-desktop-smoke-app.swift',
+);
+const FIXTURE_INFO_PLIST = path.join(
+  __dirname,
+  'fixtures',
+  'macos-desktop-smoke-app-Info.plist',
+);
+const REPORT_FILE_NAME = 'macos-desktop-smoke';
+const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
+const FIXTURE_READY_TIMEOUT_MS = 30_000;
+const STATE_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+
+interface Bounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface FixtureMetadata {
+  processId: number;
+  visible: boolean;
+  backingScaleFactor: number;
+  screen: Bounds;
+  window: Bounds;
+  button: Bounds;
+  textField: Bounds;
+  scroll: Bounds;
+}
+
+interface FixtureState {
+  visible: boolean;
+  clickCount: number;
+  text: string;
+  lastKey: string;
+  wheelEventCount: number;
+  scrollValue: number;
+}
+
+interface ReportTask {
+  type?: string;
+  subType?: string;
+  hitBy?: { from?: string };
+  timing?: { callAiStart?: number; callAiEnd?: number };
+  usage?: unknown;
+  searchAreaUsage?: unknown;
+}
+
+interface ReportExecution {
+  id?: string;
+  name?: string;
+  tasks?: ReportTask[];
+}
+
+interface ReportDump {
+  executions?: ReportExecution[];
+}
+
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 30_000 });
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+function asFiniteNumber(value: unknown, label: string): number {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${label} must be a finite number, got ${String(value)}`);
+  }
+  return numberValue;
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeBounds(value: unknown, label: string): Bounds {
+  const raw = asRecord(value, label);
+  const bounds = {
+    left: asFiniteNumber(raw.left, `${label}.left`),
+    top: asFiniteNumber(raw.top, `${label}.top`),
+    width: asFiniteNumber(raw.width, `${label}.width`),
+    height: asFiniteNumber(raw.height, `${label}.height`),
+  };
+  if (bounds.width <= 0 || bounds.height <= 0) {
+    throw new Error(
+      `${label} must have positive dimensions, got ${bounds.width}x${bounds.height}`,
+    );
+  }
+  return bounds;
+}
+
+function normalizeMetadata(value: unknown): FixtureMetadata {
+  const raw = asRecord(value, 'fixture metadata');
+  return {
+    processId: asFiniteNumber(raw.processId, 'fixture.processId'),
+    visible: raw.visible === true,
+    backingScaleFactor: asFiniteNumber(
+      raw.backingScaleFactor,
+      'fixture.backingScaleFactor',
+    ),
+    screen: normalizeBounds(raw.screen, 'fixture.screen'),
+    window: normalizeBounds(raw.window, 'fixture.window'),
+    button: normalizeBounds(raw.button, 'fixture.button'),
+    textField: normalizeBounds(raw.textField, 'fixture.textField'),
+    scroll: normalizeBounds(raw.scroll, 'fixture.scroll'),
+  };
+}
+
+function normalizeState(value: unknown): FixtureState {
+  const raw = asRecord(value, 'fixture state');
+  return {
+    visible: raw.visible === true,
+    clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
+    text: String(raw.text ?? ''),
+    lastKey: String(raw.lastKey ?? ''),
+    wheelEventCount: asFiniteNumber(
+      raw.wheelEventCount,
+      'state.wheelEventCount',
+    ),
+    scrollValue: asFiniteNumber(raw.scrollValue, 'state.scrollValue'),
+  };
+}
+
+async function waitForJson<T>(
+  filePath: string,
+  normalize: (value: unknown) => T,
+  predicate: (value: T) => boolean,
+  timeoutMs: number,
+  fixtureProcess: ChildProcessWithoutNullStreams,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (fixtureProcess.exitCode !== null) {
+      throw new Error(
+        `macOS fixture exited early with code ${fixtureProcess.exitCode}`,
+      );
+    }
+    try {
+      const normalized = normalize(
+        JSON.parse(await readFile(filePath, 'utf8')),
+      );
+      if (predicate(normalized)) {
+        return normalized;
+      }
+      lastError = new Error(
+        `Fixture state did not satisfy predicate: ${JSON.stringify(normalized)}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for ${filePath}. Last error: ${String(lastError)}`,
+  );
+}
+
+function assertInside(inner: Bounds, outer: Bounds, label: string): void {
+  expect(inner.left, `${label}.left`).toBeGreaterThanOrEqual(outer.left);
+  expect(inner.top, `${label}.top`).toBeGreaterThanOrEqual(outer.top);
+  expect(inner.left + inner.width, `${label}.right`).toBeLessThanOrEqual(
+    outer.left + outer.width,
+  );
+  expect(inner.top + inner.height, `${label}.bottom`).toBeLessThanOrEqual(
+    outer.top + outer.height,
+  );
+}
+
+function screenshotBounds(bounds: Bounds, scale: number): Bounds {
+  return {
+    left: Math.round(bounds.left * scale),
+    top: Math.round(bounds.top * scale),
+    width: Math.max(1, Math.round(bounds.width * scale)),
+    height: Math.max(1, Math.round(bounds.height * scale)),
+  };
+}
+
+function locate(bounds: Bounds, scale: number, prompt: string) {
+  const scaled = screenshotBounds(bounds, scale);
+  return {
+    prompt,
+    locatedPixelBbox: [
+      scaled.left,
+      scaled.top,
+      scaled.left + scaled.width,
+      scaled.top + scaled.height,
+    ] as [number, number, number, number],
+  };
+}
+
+function base64Body(base64: string): string {
+  const match = /^data:image\/\w+;base64,(.+)$/s.exec(base64);
+  if (!match) {
+    throw new Error('macOS screenshot is not a base64 data URL');
+  }
+  return match[1];
+}
+
+function parseReportDumps(html: string): ReportDump[] {
+  const marker = '<script type="midscene_web_dump"';
+  const closeTag = '</script>';
+  const dumps: ReportDump[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const openIndex = html.indexOf(marker, cursor);
+    if (openIndex === -1) break;
+    const closeIndex = html.indexOf(closeTag, openIndex);
+    if (closeIndex === -1) break;
+    const prefix = html.slice(0, closeIndex + closeTag.length);
+    try {
+      const parsed = JSON.parse(parseDumpScript(prefix)) as ReportDump;
+      if (Array.isArray(parsed.executions)) {
+        dumps.push(parsed);
+      }
+    } catch {
+      // The report bundle contains the marker as source text; ignore it.
+    }
+    cursor = closeIndex + closeTag.length;
+  }
+
+  return dumps;
+}
+
+function latestExecutions(dumps: ReportDump[]): ReportExecution[] {
+  const byKey = new Map<string, ReportExecution>();
+  let anonymousIndex = 0;
+  for (const dump of dumps) {
+    for (const execution of dump.executions ?? []) {
+      const key =
+        execution.id || execution.name || `anonymous-${anonymousIndex++}`;
+      byKey.set(key, execution);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+async function stopFixture(
+  fixtureProcess: ChildProcessWithoutNullStreams | undefined,
+): Promise<void> {
+  if (!fixtureProcess || fixtureProcess.exitCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>((resolve) =>
+    fixtureProcess.once('exit', () => resolve()),
+  );
+  fixtureProcess.kill('SIGTERM');
+  await Promise.race([exited, sleep(5_000)]);
+}
+
+describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
+  it('drives a visible AppKit app without calling a model and emits evidence', async () => {
+    const diagnosticsEnv = process.env.MIDSCENE_MACOS_DIAGNOSTICS_DIR;
+    if (!diagnosticsEnv) {
+      throw new Error(
+        'MIDSCENE_MACOS_DIAGNOSTICS_DIR is required for the macOS desktop smoke',
+      );
+    }
+
+    const diagnosticsDir = path.resolve(diagnosticsEnv);
+    const readyFile = path.join(diagnosticsDir, 'fixture-ready.json');
+    const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
+    const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
+    const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
+    const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
+    const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
+    const reportFile = path.join(runDir, 'report', REPORT_HTML_FILE_NAME);
+
+    let fixtureProcess: ChildProcessWithoutNullStreams | undefined;
+    let fixtureTempDir: string | undefined;
+    let device: ComputerDevice | undefined;
+    let agent: ComputerAgent<ComputerDevice> | undefined;
+    let fixtureStdout = '';
+    let fixtureStderr = '';
+    const evidence: Record<string, unknown> = {
+      platform: process.platform,
+      diagnosticsDir,
+      reportFile,
+    };
+
+    await mkdir(diagnosticsDir, { recursive: true });
+    await Promise.all([
+      rm(readyFile, { force: true }),
+      rm(stateFile, { force: true }),
+      rm(reportFile, { force: true }),
+    ]);
+
+    try {
+      fixtureTempDir = await mkdtemp(
+        path.join(tmpdir(), 'midscene-macos-desktop-smoke-'),
+      );
+      const appDir = path.join(
+        fixtureTempDir,
+        'Midscene Desktop Smoke Fixture.app',
+      );
+      const contentsDir = path.join(appDir, 'Contents');
+      const executableDir = path.join(contentsDir, 'MacOS');
+      const executable = path.join(
+        executableDir,
+        'MidsceneDesktopSmokeFixture',
+      );
+      await mkdir(executableDir, { recursive: true });
+      await copyFile(FIXTURE_INFO_PLIST, path.join(contentsDir, 'Info.plist'));
+      execFileSync(
+        'xcrun',
+        ['swiftc', '-parse-as-library', FIXTURE_SOURCE, '-o', executable],
+        { stdio: 'pipe' },
+      );
+
+      fixtureProcess = spawn(executable, [readyFile, stateFile], {
+        stdio: 'pipe',
+      });
+      fixtureProcess.stdin.end();
+      fixtureProcess.stdout.setEncoding('utf8');
+      fixtureProcess.stderr.setEncoding('utf8');
+      fixtureProcess.stdout.on('data', (chunk: string) => {
+        fixtureStdout += chunk;
+      });
+      fixtureProcess.stderr.on('data', (chunk: string) => {
+        fixtureStderr += chunk;
+      });
+
+      const metadata = await waitForJson(
+        readyFile,
+        normalizeMetadata,
+        (value) => value.visible,
+        FIXTURE_READY_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      evidence.fixture = metadata;
+      expect(metadata.processId).toBe(fixtureProcess.pid);
+      expect(metadata.backingScaleFactor).toBeGreaterThanOrEqual(1);
+      for (const [label, bounds] of Object.entries({
+        window: metadata.window,
+        button: metadata.button,
+        textField: metadata.textField,
+        scroll: metadata.scroll,
+      })) {
+        assertInside(bounds, metadata.screen, label);
+      }
+
+      const displays = await ComputerDevice.listDisplays();
+      evidence.displays = displays;
+      expect(displays.length).toBeGreaterThan(0);
+      expect(displays.some((display) => display.primary)).toBe(true);
+
+      const environment = await checkComputerEnvironment();
+      evidence.environment = environment;
+      expect(environment).toMatchObject({
+        available: true,
+        platform: 'darwin',
+      });
+
+      device = new ComputerDevice({});
+      await device.connect();
+      const logicalSize = await device.size();
+      evidence.logicalSize = logicalSize;
+      expect(logicalSize).toEqual({
+        width: metadata.screen.width,
+        height: metadata.screen.height,
+      });
+
+      const screenshot = await device.screenshotBase64();
+      const screenshotInfo = await imageInfoOfBase64(screenshot);
+      const screenshotScale = screenshotInfo.width / logicalSize.width;
+      expect(screenshotInfo.height / logicalSize.height).toBeCloseTo(
+        screenshotScale,
+        2,
+      );
+      const screenshotBuffer = Buffer.from(base64Body(screenshot), 'base64');
+      await writeFile(screenshotFile, screenshotBuffer);
+      evidence.screenshot = {
+        ...screenshotInfo,
+        scale: screenshotScale,
+        bytes: screenshotBuffer.length,
+      };
+
+      const buttonBounds = screenshotBounds(metadata.button, screenshotScale);
+      const sampleWidth = Math.max(20, Math.min(100, buttonBounds.width - 10));
+      const sampleHeight = Math.max(20, Math.min(45, buttonBounds.height - 10));
+      const [targetCrop, backgroundCrop] = await Promise.all([
+        cropByRect(screenshot, {
+          left: Math.round(
+            buttonBounds.left + (buttonBounds.width - sampleWidth) / 2,
+          ),
+          top: Math.round(
+            buttonBounds.top + (buttonBounds.height - sampleHeight) / 2,
+          ),
+          width: sampleWidth,
+          height: sampleHeight,
+        }),
+        cropByRect(screenshot, {
+          left: Math.round((metadata.window.left + 20) * screenshotScale),
+          top: Math.round((metadata.window.top + 70) * screenshotScale),
+          width: sampleWidth,
+          height: sampleHeight,
+        }),
+      ]);
+      expect(targetCrop.imageBase64).not.toBe(backgroundCrop.imageBase64);
+
+      agent = new ComputerAgent(device, {
+        modelConfig: {
+          [MIDSCENE_MODEL_NAME]: 'macos-ci-model-must-not-run',
+          [MIDSCENE_MODEL_API_KEY]: 'macos-ci-unused-key',
+          [MIDSCENE_MODEL_BASE_URL]: 'http://127.0.0.1:1/v1',
+          [MIDSCENE_MODEL_FAMILY]: 'qwen3-vl',
+          [MIDSCENE_MODEL_TIMEOUT]: '1000',
+          [MIDSCENE_MODEL_RETRY_COUNT]: '0',
+        },
+        groupName: 'macOS desktop live smoke',
+        groupDescription:
+          'Deterministic AppKit input and screenshot validation on GitHub Actions',
+        reportFileName: REPORT_FILE_NAME,
+        autoPrintReportMsg: false,
+        generateReport: true,
+        waitAfterAction: 200,
+      });
+
+      await agent.callActionInActionSpace('Tap', {
+        locate: locate(metadata.button, screenshotScale, 'green smoke button'),
+      });
+      const clickedState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => state.clickCount >= 1,
+        STATE_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      expect(clickedState.clickCount).toBe(1);
+
+      const inputText = 'Midscene macOS 输入 😀';
+      await agent.callActionInActionSpace('Input', {
+        value: inputText,
+        mode: 'replace',
+        locate: locate(metadata.textField, screenshotScale, 'smoke text field'),
+      });
+      const inputState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => state.text === inputText,
+        STATE_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      expect(inputState.text).toBe(inputText);
+
+      await agent.callActionInActionSpace('KeyboardPress', {
+        keyName: 'Enter',
+        locate: locate(metadata.textField, screenshotScale, 'smoke text field'),
+      });
+      const keyState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) => state.lastKey === 'Enter',
+        STATE_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      expect(keyState.lastKey).toBe('Enter');
+
+      const beforeScroll = await waitForJson(
+        stateFile,
+        normalizeState,
+        () => true,
+        STATE_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      await agent.callActionInActionSpace('Scroll', {
+        scrollType: 'singleAction',
+        direction: 'down',
+        distance: 180,
+        locate: locate(metadata.scroll, screenshotScale, 'scroll smoke area'),
+      });
+      const scrolledState = await waitForJson(
+        stateFile,
+        normalizeState,
+        (state) =>
+          state.wheelEventCount > beforeScroll.wheelEventCount &&
+          state.scrollValue !== beforeScroll.scrollValue,
+        STATE_TIMEOUT_MS,
+        fixtureProcess,
+      );
+      evidence.finalState = scrolledState;
+      expect(scrolledState.visible).toBe(true);
+
+      const dump = JSON.parse(agent.dumpDataString()) as ReportDump;
+      await writeFile(dumpFile, `${JSON.stringify(dump, null, 2)}\n`, 'utf8');
+      const dumpTasks = (dump.executions ?? []).flatMap(
+        (execution) => execution.tasks ?? [],
+      );
+      const locateTasks = dumpTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(locateTasks).toHaveLength(4);
+      expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
+        true,
+      );
+      expect(agent.metrics.calls).toBe(0);
+      expect(
+        dumpTasks.some(
+          (task) =>
+            task.timing?.callAiStart !== undefined ||
+            task.timing?.callAiEnd !== undefined ||
+            task.usage !== undefined ||
+            task.searchAreaUsage !== undefined,
+        ),
+      ).toBe(false);
+
+      await agent.destroy();
+      expect(agent.reportFile).toBe(reportFile);
+      const reportHtml = await readFile(reportFile, 'utf8');
+      expect(reportHtml).not.toContain('REPLACE_ME_WITH_REPORT_HTML');
+      const reportTasks = latestExecutions(
+        parseReportDumps(reportHtml),
+      ).flatMap((execution) => execution.tasks ?? []);
+      const reportLocateTasks = reportTasks.filter(
+        (task) => task.type === 'Planning' && task.subType === 'Locate',
+      );
+      expect(reportLocateTasks).toHaveLength(4);
+      expect(
+        reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
+      ).toBe(true);
+      for (const action of ['Tap', 'Input', 'KeyboardPress', 'Scroll']) {
+        expect(
+          reportTasks.some(
+            (task) => task.type === 'Action Space' && task.subType === action,
+          ),
+        ).toBe(true);
+      }
+      evidence.report = {
+        path: reportFile,
+        modelCalls: agent.metrics.calls,
+        locateHitSources: reportLocateTasks.map((task) => task.hitBy?.from),
+      };
+    } catch (error) {
+      evidence.error =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : String(error);
+      throw error;
+    } finally {
+      if (agent) {
+        await agent.destroy().catch((error) => {
+          evidence.agentDestroyError = String(error);
+        });
+      } else if (device) {
+        await device.destroy().catch((error) => {
+          evidence.deviceDestroyError = String(error);
+        });
+      }
+      await stopFixture(fixtureProcess).catch((error) => {
+        evidence.fixtureStopError = String(error);
+      });
+      await Promise.all([
+        writeFile(fixtureStdoutFile, fixtureStdout, 'utf8'),
+        writeFile(fixtureStderrFile, fixtureStderr, 'utf8'),
+        writeFile(
+          evidenceFile,
+          `${JSON.stringify(evidence, null, 2)}\n`,
+          'utf8',
+        ),
+      ]);
+      if (fixtureTempDir) {
+        await rm(fixtureTempDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -43,6 +43,7 @@ const FIXTURE_INFO_PLIST = path.join(
 const REPORT_FILE_NAME = 'macos-desktop-smoke';
 const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
 const FIXTURE_READY_TIMEOUT_MS = 30_000;
+const ACTIVATION_TIMEOUT_MS = 3_000;
 const STATE_TIMEOUT_MS = 15_000;
 const POLL_INTERVAL_MS = 100;
 
@@ -66,6 +67,9 @@ interface FixtureMetadata {
 
 interface FixtureState {
   visible: boolean;
+  active: boolean;
+  keyWindow: boolean;
+  activationCount: number;
   clickCount: number;
   buttonActionCount: number;
   text: string;
@@ -151,6 +155,12 @@ function normalizeState(value: unknown): FixtureState {
   const raw = asRecord(value, 'fixture state');
   return {
     visible: raw.visible === true,
+    active: raw.active === true,
+    keyWindow: raw.keyWindow === true,
+    activationCount: asFiniteNumber(
+      raw.activationCount,
+      'state.activationCount',
+    ),
     clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
     buttonActionCount: asFiniteNumber(
       raw.buttonActionCount,
@@ -206,6 +216,7 @@ async function retryFixtureAction(options: {
   fixtureProcess: ChildProcessWithoutNullStreams;
   predicate: (state: FixtureState) => boolean;
   stateFile: string;
+  fixturePid: number;
   waitDurations: readonly number[];
 }): Promise<{
   state?: FixtureState;
@@ -217,6 +228,25 @@ async function retryFixtureAction(options: {
   for (const waitDuration of options.waitDurations) {
     attempts += 1;
     try {
+      const beforeActivation = await waitForJson(
+        options.stateFile,
+        normalizeState,
+        () => true,
+        ACTIVATION_TIMEOUT_MS,
+        options.fixtureProcess,
+      );
+      process.kill(options.fixturePid, 'SIGUSR1');
+      await waitForJson(
+        options.stateFile,
+        normalizeState,
+        (state) =>
+          state.activationCount > beforeActivation.activationCount &&
+          state.active &&
+          state.keyWindow,
+        ACTIVATION_TIMEOUT_MS,
+        options.fixtureProcess,
+      );
+      await sleep(250);
       await options.action();
       const state = await waitForJson(
         options.stateFile,
@@ -315,6 +345,7 @@ function latestExecutions(dumps: ReportDump[]): ReportExecution[] {
 
 async function stopFixture(
   fixtureProcess: ChildProcessWithoutNullStreams | undefined,
+  fixturePid: number | undefined,
 ): Promise<void> {
   if (!fixtureProcess || fixtureProcess.exitCode !== null) {
     return;
@@ -322,8 +353,21 @@ async function stopFixture(
   const exited = new Promise<void>((resolve) =>
     fixtureProcess.once('exit', () => resolve()),
   );
-  fixtureProcess.kill('SIGTERM');
+  if (fixturePid && fixturePid !== fixtureProcess.pid) {
+    try {
+      process.kill(fixturePid, 'SIGTERM');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+        throw error;
+      }
+    }
+  } else {
+    fixtureProcess.kill('SIGTERM');
+  }
   await Promise.race([exited, sleep(5_000)]);
+  if (fixtureProcess.exitCode === null) {
+    fixtureProcess.kill('SIGTERM');
+  }
 }
 
 describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
@@ -347,11 +391,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
     const reportFile = path.join(runDir, 'report', REPORT_HTML_FILE_NAME);
 
     let fixtureProcess: ChildProcessWithoutNullStreams | undefined;
+    let fixturePid: number | undefined;
     let fixtureTempDir: string | undefined;
     let device: ComputerDevice | undefined;
     let agent: ComputerAgent<ComputerDevice> | undefined;
-    let fixtureStdout = '';
-    let fixtureStderr = '';
     const evidence: Record<string, unknown> = {
       platform: process.platform,
       diagnosticsDir,
@@ -387,18 +430,28 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
         { stdio: 'pipe' },
       );
 
-      fixtureProcess = spawn(executable, [readyFile, stateFile], {
-        stdio: 'pipe',
-      });
+      await Promise.all([
+        writeFile(fixtureStdoutFile, '', 'utf8'),
+        writeFile(fixtureStderrFile, '', 'utf8'),
+      ]);
+      fixtureProcess = spawn(
+        '/usr/bin/open',
+        [
+          '-W',
+          '-n',
+          '-F',
+          '-o',
+          fixtureStdoutFile,
+          '--stderr',
+          fixtureStderrFile,
+          appDir,
+          '--args',
+          readyFile,
+          stateFile,
+        ],
+        { stdio: 'pipe' },
+      );
       fixtureProcess.stdin.end();
-      fixtureProcess.stdout.setEncoding('utf8');
-      fixtureProcess.stderr.setEncoding('utf8');
-      fixtureProcess.stdout.on('data', (chunk: string) => {
-        fixtureStdout += chunk;
-      });
-      fixtureProcess.stderr.on('data', (chunk: string) => {
-        fixtureStderr += chunk;
-      });
 
       const metadata = await waitForJson(
         readyFile,
@@ -407,8 +460,11 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
         FIXTURE_READY_TIMEOUT_MS,
         fixtureProcess,
       );
+      fixturePid = metadata.processId;
       evidence.fixture = metadata;
-      expect(metadata.processId).toBe(fixtureProcess.pid);
+      evidence.launcherProcessId = fixtureProcess.pid;
+      expect(metadata.processId).toBeGreaterThan(0);
+      expect(metadata.processId).not.toBe(fixtureProcess.pid);
       expect(metadata.backingScaleFactor).toBeGreaterThanOrEqual(1);
       for (const [label, bounds] of Object.entries({
         window: metadata.window,
@@ -508,6 +564,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       const tapResult = await retryFixtureAction({
         action: tapButton,
         fixtureProcess,
+        fixturePid,
         predicate: (state) => state.clickCount >= 1,
         stateFile,
         waitDurations: actionWaitDurations,
@@ -535,6 +592,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
             ),
           }),
         fixtureProcess,
+        fixturePid,
         predicate: (state) => state.text === inputText,
         stateFile,
         waitDurations: actionWaitDurations,
@@ -560,6 +618,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
             ),
           }),
         fixtureProcess,
+        fixturePid,
         predicate: (state) => state.lastKey === 'Enter',
         stateFile,
         waitDurations: actionWaitDurations,
@@ -594,6 +653,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
             ),
           }),
         fixtureProcess,
+        fixturePid,
         predicate: (state) =>
           state.wheelEventCount > beforeScroll.wheelEventCount &&
           state.scrollValue !== beforeScroll.scrollValue,
@@ -681,18 +741,14 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
           evidence.deviceDestroyError = String(error);
         });
       }
-      await stopFixture(fixtureProcess).catch((error) => {
+      await stopFixture(fixtureProcess, fixturePid).catch((error) => {
         evidence.fixtureStopError = String(error);
       });
-      await Promise.all([
-        writeFile(fixtureStdoutFile, fixtureStdout, 'utf8'),
-        writeFile(fixtureStderrFile, fixtureStderr, 'utf8'),
-        writeFile(
-          evidenceFile,
-          `${JSON.stringify(evidence, null, 2)}\n`,
-          'utf8',
-        ),
-      ]);
+      await writeFile(
+        evidenceFile,
+        `${JSON.stringify(evidence, null, 2)}\n`,
+        'utf8',
+      );
       if (fixtureTempDir) {
         await rm(fixtureTempDir, { recursive: true, force: true });
       }

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -201,6 +201,38 @@ async function waitForJson<T>(
   );
 }
 
+async function retryFixtureAction(options: {
+  action: () => Promise<unknown>;
+  fixtureProcess: ChildProcessWithoutNullStreams;
+  predicate: (state: FixtureState) => boolean;
+  stateFile: string;
+  waitDurations: readonly number[];
+}): Promise<{
+  state?: FixtureState;
+  attempts: number;
+  errors: string[];
+}> {
+  const errors: string[] = [];
+  let attempts = 0;
+  for (const waitDuration of options.waitDurations) {
+    attempts += 1;
+    try {
+      await options.action();
+      const state = await waitForJson(
+        options.stateFile,
+        normalizeState,
+        options.predicate,
+        waitDuration,
+        options.fixtureProcess,
+      );
+      return { state, attempts, errors };
+    } catch (error) {
+      errors.push(String(error));
+    }
+  }
+  return { attempts, errors };
+}
+
 function assertInside(inner: Bounds, outer: Bounds, label: string): void {
   expect(inner.left, `${label}.left`).toBeGreaterThanOrEqual(outer.left);
   expect(inner.top, `${label}.top`).toBeGreaterThanOrEqual(outer.top);
@@ -472,61 +504,74 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
             'green smoke button',
           ),
         });
-      const tapWaitDurations = [3_000, 5_000, 10_000, STATE_TIMEOUT_MS];
-      const tapAttemptErrors: string[] = [];
-      let tapAttempts = 0;
-      let clickedState: FixtureState | undefined;
-      for (const waitDuration of tapWaitDurations) {
-        tapAttempts += 1;
-        await tapButton();
-        try {
-          clickedState = await waitForJson(
-            stateFile,
-            normalizeState,
-            (state) => state.clickCount >= 1,
-            waitDuration,
-            fixtureProcess,
-          );
-          break;
-        } catch (error) {
-          tapAttemptErrors.push(String(error));
-        }
-      }
+      const actionWaitDurations = [2_000, 3_000, 5_000, 8_000];
+      const tapResult = await retryFixtureAction({
+        action: tapButton,
+        fixtureProcess,
+        predicate: (state) => state.clickCount >= 1,
+        stateFile,
+        waitDurations: actionWaitDurations,
+      });
+      evidence.tapAttempts = tapResult.attempts;
+      evidence.tapAttemptErrors = tapResult.errors;
+      const clickedState = tapResult.state;
       if (!clickedState) {
         throw new Error(
-          `macOS fixture did not receive ${tapAttempts} button taps: ${tapAttemptErrors.at(-1)}`,
+          `macOS fixture did not receive ${tapResult.attempts} button taps: ${tapResult.errors.at(-1)}`,
         );
       }
-      evidence.tapAttempts = tapAttempts;
-      evidence.tapAttemptErrors = tapAttemptErrors;
       expect(clickedState.clickCount).toBeGreaterThanOrEqual(1);
 
       const inputText = 'Midscene macOS 输入 😀';
-      await agent.callActionInActionSpace('Input', {
-        value: inputText,
-        mode: 'replace',
-        locate: locate(metadata.textField, screenshotScale, 'smoke text field'),
-      });
-      const inputState = await waitForJson(
-        stateFile,
-        normalizeState,
-        (state) => state.text === inputText,
-        STATE_TIMEOUT_MS,
+      const inputResult = await retryFixtureAction({
+        action: () =>
+          agent!.callActionInActionSpace('Input', {
+            value: inputText,
+            mode: 'replace',
+            locate: locate(
+              metadata.textField,
+              screenshotScale,
+              'smoke text field',
+            ),
+          }),
         fixtureProcess,
-      );
+        predicate: (state) => state.text === inputText,
+        stateFile,
+        waitDurations: actionWaitDurations,
+      });
+      evidence.inputAttempts = inputResult.attempts;
+      evidence.inputAttemptErrors = inputResult.errors;
+      const inputState = inputResult.state;
+      if (!inputState) {
+        throw new Error(
+          `macOS fixture did not receive text after ${inputResult.attempts} input attempts: ${inputResult.errors.at(-1)}`,
+        );
+      }
       expect(inputState.text).toBe(inputText);
 
-      await agent.callActionInActionSpace('KeyboardPress', {
-        keyName: 'Enter',
-        locate: locate(metadata.textField, screenshotScale, 'smoke text field'),
-      });
-      const keyState = await waitForJson(
-        stateFile,
-        normalizeState,
-        (state) => state.lastKey === 'Enter',
-        STATE_TIMEOUT_MS,
+      const keyResult = await retryFixtureAction({
+        action: () =>
+          agent!.callActionInActionSpace('KeyboardPress', {
+            keyName: 'Enter',
+            locate: locate(
+              metadata.textField,
+              screenshotScale,
+              'smoke text field',
+            ),
+          }),
         fixtureProcess,
-      );
+        predicate: (state) => state.lastKey === 'Enter',
+        stateFile,
+        waitDurations: actionWaitDurations,
+      });
+      evidence.keyAttempts = keyResult.attempts;
+      evidence.keyAttemptErrors = keyResult.errors;
+      const keyState = keyResult.state;
+      if (!keyState) {
+        throw new Error(
+          `macOS fixture did not receive Enter after ${keyResult.attempts} keyboard attempts: ${keyResult.errors.at(-1)}`,
+        );
+      }
       expect(keyState.lastKey).toBe('Enter');
 
       const beforeScroll = await waitForJson(
@@ -536,21 +581,33 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
         STATE_TIMEOUT_MS,
         fixtureProcess,
       );
-      await agent.callActionInActionSpace('Scroll', {
-        scrollType: 'singleAction',
-        direction: 'down',
-        distance: 180,
-        locate: locate(metadata.scroll, screenshotScale, 'scroll smoke area'),
-      });
-      const scrolledState = await waitForJson(
-        stateFile,
-        normalizeState,
-        (state) =>
+      const scrollResult = await retryFixtureAction({
+        action: () =>
+          agent!.callActionInActionSpace('Scroll', {
+            scrollType: 'singleAction',
+            direction: 'down',
+            distance: 180,
+            locate: locate(
+              metadata.scroll,
+              screenshotScale,
+              'scroll smoke area',
+            ),
+          }),
+        fixtureProcess,
+        predicate: (state) =>
           state.wheelEventCount > beforeScroll.wheelEventCount &&
           state.scrollValue !== beforeScroll.scrollValue,
-        STATE_TIMEOUT_MS,
-        fixtureProcess,
-      );
+        stateFile,
+        waitDurations: actionWaitDurations,
+      });
+      evidence.scrollAttempts = scrollResult.attempts;
+      evidence.scrollAttemptErrors = scrollResult.errors;
+      const scrolledState = scrollResult.state;
+      if (!scrolledState) {
+        throw new Error(
+          `macOS fixture did not scroll after ${scrollResult.attempts} attempts: ${scrollResult.errors.at(-1)}`,
+        );
+      }
       evidence.finalState = scrolledState;
       expect(scrolledState.visible).toBe(true);
 
@@ -562,7 +619,12 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(3 + tapAttempts);
+      const actionAttempts =
+        tapResult.attempts +
+        inputResult.attempts +
+        keyResult.attempts +
+        scrollResult.attempts;
+      expect(locateTasks).toHaveLength(actionAttempts);
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -587,7 +649,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(3 + tapAttempts);
+      expect(reportLocateTasks).toHaveLength(actionAttempts);
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -472,29 +472,33 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
             'green smoke button',
           ),
         });
-      let tapAttempts = 1;
-      await tapButton();
-      let clickedState: FixtureState;
-      try {
-        clickedState = await waitForJson(
-          stateFile,
-          normalizeState,
-          (state) => state.clickCount >= 1,
-          3_000,
-          fixtureProcess,
-        );
-      } catch {
-        tapAttempts = 2;
+      const tapWaitDurations = [3_000, 5_000, 10_000, STATE_TIMEOUT_MS];
+      const tapAttemptErrors: string[] = [];
+      let tapAttempts = 0;
+      let clickedState: FixtureState | undefined;
+      for (const waitDuration of tapWaitDurations) {
+        tapAttempts += 1;
         await tapButton();
-        clickedState = await waitForJson(
-          stateFile,
-          normalizeState,
-          (state) => state.clickCount >= 1,
-          STATE_TIMEOUT_MS,
-          fixtureProcess,
+        try {
+          clickedState = await waitForJson(
+            stateFile,
+            normalizeState,
+            (state) => state.clickCount >= 1,
+            waitDuration,
+            fixtureProcess,
+          );
+          break;
+        } catch (error) {
+          tapAttemptErrors.push(String(error));
+        }
+      }
+      if (!clickedState) {
+        throw new Error(
+          `macOS fixture did not receive ${tapAttempts} button taps: ${tapAttemptErrors.at(-1)}`,
         );
       }
       evidence.tapAttempts = tapAttempts;
+      evidence.tapAttemptErrors = tapAttemptErrors;
       expect(clickedState.clickCount).toBeGreaterThanOrEqual(1);
 
       const inputText = 'Midscene macOS 输入 😀';

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -459,17 +459,38 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
         waitAfterAction: 200,
       });
 
-      await agent.callActionInActionSpace('Tap', {
-        locate: locate(metadata.button, screenshotScale, 'green smoke button'),
-      });
-      const clickedState = await waitForJson(
-        stateFile,
-        normalizeState,
-        (state) => state.clickCount >= 1,
-        STATE_TIMEOUT_MS,
-        fixtureProcess,
-      );
-      expect(clickedState.clickCount).toBe(1);
+      const tapButton = () =>
+        agent!.callActionInActionSpace('Tap', {
+          locate: locate(
+            metadata.button,
+            screenshotScale,
+            'green smoke button',
+          ),
+        });
+      let tapAttempts = 1;
+      await tapButton();
+      let clickedState: FixtureState;
+      try {
+        clickedState = await waitForJson(
+          stateFile,
+          normalizeState,
+          (state) => state.clickCount >= 1,
+          3_000,
+          fixtureProcess,
+        );
+      } catch {
+        tapAttempts = 2;
+        await tapButton();
+        clickedState = await waitForJson(
+          stateFile,
+          normalizeState,
+          (state) => state.clickCount >= 1,
+          STATE_TIMEOUT_MS,
+          fixtureProcess,
+        );
+      }
+      evidence.tapAttempts = tapAttempts;
+      expect(clickedState.clickCount).toBeGreaterThanOrEqual(1);
 
       const inputText = 'Midscene macOS 输入 😀';
       await agent.callActionInActionSpace('Input', {
@@ -532,7 +553,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(4);
+      expect(locateTasks).toHaveLength(3 + tapAttempts);
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -557,7 +578,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(4);
+      expect(reportLocateTasks).toHaveLength(3 + tapAttempts);
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/computer/tests/ai/test-utils.ts
+++ b/packages/computer/tests/ai/test-utils.ts
@@ -1,9 +1,12 @@
-import { execSync, spawn } from 'node:child_process';
+import { execFileSync, execSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
 import type { ComputerAgent } from '../../src';
 
 const IS_MAC = process.platform === 'darwin';
 const IS_LINUX = process.platform === 'linux';
+const IS_WINDOWS = process.platform === 'win32';
 
 /**
  * Check if running in a headless Linux environment (Xvfb, no desktop)
@@ -34,6 +37,30 @@ export function findLinuxBrowser(): string {
 }
 
 /**
+ * Find the Chrome binary installed on a GitHub-hosted Windows runner.
+ */
+export function findWindowsBrowser(): string {
+  const candidates = [
+    process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'],
+    process.env.LOCALAPPDATA,
+  ]
+    .filter((root): root is string => Boolean(root))
+    .map((root) =>
+      path.join(root, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    );
+
+  const browser = candidates.find((candidate) => existsSync(candidate));
+  if (browser) {
+    return browser;
+  }
+
+  throw new Error(
+    `No Chrome binary found on Windows. Tried: ${candidates.join(', ')}`,
+  );
+}
+
+/**
  * Opens a browser and navigates to the specified URL
  */
 export async function openBrowserAndNavigate(
@@ -58,6 +85,40 @@ export async function openBrowserAndNavigate(
       ],
       { stdio: 'ignore', detached: true },
     );
+    child.unref();
+    await sleep(8000);
+    return;
+  }
+
+  if (process.env.CI && IS_MAC) {
+    execFileSync('open', ['-a', 'Safari', url], { stdio: 'ignore' });
+    await sleep(5000);
+    return;
+  }
+
+  if (process.env.CI && IS_WINDOWS) {
+    const chromeArguments = [
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-session-crashed-bubble',
+      '--start-maximized',
+      '--new-window',
+    ];
+    if (process.env.RUNNER_TEMP) {
+      chromeArguments.push(
+        `--user-data-dir=${path.join(
+          process.env.RUNNER_TEMP,
+          `midscene-chrome-${process.pid}`,
+        )}`,
+      );
+    }
+    chromeArguments.push(url);
+
+    const child = spawn(findWindowsBrowser(), chromeArguments, {
+      stdio: 'ignore',
+      detached: true,
+      windowsHide: false,
+    });
     child.unref();
     await sleep(8000);
     return;


### PR DESCRIPTION
## Summary

- add a macOS Intel hosted-runner workflow with a visible native AppKit fixture, deterministic no-model Tap/Input/KeyboardPress/Scroll validation, package checks, diagnostics, and an HTML report
- add an Android Emulator workflow with deterministic no-model Settings Tap/Input/Back validation, package checks, diagnostics, and an HTML report
- run an aligned TodoMVC AI smoke on macOS, Android, and Windows, with stable assertions, retry cleanup, platform-specific reports, and final screenshots/dumps
- broaden the Windows workflow core trigger to `packages/core/src/**` so TaskRunner and timing changes cannot bypass platform coverage

This is a standalone PR based on current `main`; it does not depend on `fix/cache-xpath-replay`.

## Validation

- `pnpm run lint`
- `pnpm exec tsc --noEmit -p packages/computer/tsconfig.json`
- `pnpm exec tsc --noEmit -p packages/android/tsconfig.json`
- `pnpm exec nx test @midscene/computer --skip-nx-cache`
- `pnpm exec nx test @midscene/android --skip-nx-cache`
- `pnpm exec nx build @midscene/computer --skip-nx-cache`
- `pnpm exec nx build @midscene/android --skip-nx-cache`
- `AI_TEST_TYPE=computer MIDSCENE_MACOS_DESKTOP_SMOKE=1 ... pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/macos-desktop-smoke.test.ts --retry=0`
- `bash -n packages/android/scripts/run-emulator-ci-smokes.sh`
- parsed all three workflow files with `js-yaml`
- actionlint 1.7.7 passes after ignoring only its stale unknown-label diagnostic for the current GitHub-supported `macos-15-intel` runner

The live Android Emulator and all model-backed TodoMVC paths are intentionally validated by the new GitHub Actions jobs.