### PR TITLE
fix(studio): bound recorder screenshot memory

### DIFF
--- a/apps/studio/src/renderer/components/MainContent/index.tsx
+++ b/apps/studio/src/renderer/components/MainContent/index.tsx
@@ -390,11 +390,14 @@ export default function MainContent({
     !isReady || !studioPlayground.controller.state.sessionViewState.connected;
   const previewConnectionFailed =
     previewStatus === 'error' || previewStatus === 'disconnected';
-  const connectionStatus: ConnectionStatus = previewConnectionFailed
-    ? 'failed'
-    : isConnected
-      ? 'connected'
-      : 'disconnected';
+  const connectionStatus: ConnectionStatus =
+    previewStatus === 'recovering'
+      ? 'recovering'
+      : previewConnectionFailed
+        ? 'failed'
+        : isConnected
+          ? 'connected'
+          : 'disconnected';
 
   const previewHeaderSubInfo: { key: string; text: string }[] = [];
   if (isConnected && previewDeviceId) {
@@ -417,6 +420,7 @@ export default function MainContent({
   const pillStatusLabel: Record<ConnectionStatus, string> = {
     connected: 'Live',
     disconnected: 'Idle',
+    recovering: 'Recovering',
     failed: 'Failed',
   };
   // Pill chrome — adopts the imported "Live" tag visual (rounded background,
@@ -428,6 +432,7 @@ export default function MainContent({
   > = {
     connected: { bg: '#DEEBEC', fg: '#42B56C', dot: '#42B56C' },
     disconnected: { bg: '#ECECEC', fg: '#818283', dot: '#B6B6B6' },
+    recovering: { bg: '#FFF4D6', fg: '#B7791F', dot: '#F59E0B' },
     failed: { bg: '#FDE7E7', fg: '#C0392B', dot: '#E53935' },
   };
   const pillColors = pillPalette[connectionStatus];

--- a/apps/studio/src/renderer/components/Playground/index.tsx
+++ b/apps/studio/src/renderer/components/Playground/index.tsx
@@ -6,7 +6,7 @@ import type {
 } from '@midscene/visualizer';
 import { App as AntdApp, Tooltip } from 'antd';
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { downloadStudioReport } from '../../playground/report-download';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
 import { isStudioRecorderEntryEnabled } from '../../recorder/feature-flag';
@@ -140,6 +140,10 @@ export default function Playground({
   const recorder = useStudioRecorder();
   const recorderEntryEnabled = isStudioRecorderEntryEnabled();
   const stopRecording = recorder.stopRecording;
+  const stopRecordingRef = useRef(stopRecording);
+  useEffect(() => {
+    stopRecordingRef.current = stopRecording;
+  }, [stopRecording]);
   const [externalRunRequest, setExternalRunRequest] =
     useState<StudioExternalRunRequest | null>(null);
   const currentTargetSignature = useMemo(
@@ -311,26 +315,21 @@ export default function Playground({
   useEffect(() => {
     if (!recorderEntryEnabled && rightPanelMode === 'recorder') {
       onRightPanelModeChange('playground');
-      void stopRecording();
+      void stopRecordingRef.current();
     }
-  }, [
-    onRightPanelModeChange,
-    recorderEntryEnabled,
-    rightPanelMode,
-    stopRecording,
-  ]);
+  }, [onRightPanelModeChange, recorderEntryEnabled, rightPanelMode]);
 
   useEffect(() => {
     if (rightPanelMode !== 'recorder') {
-      void stopRecording();
+      void stopRecordingRef.current();
     }
-  }, [rightPanelMode, stopRecording]);
+  }, [rightPanelMode]);
 
   useEffect(() => {
     return () => {
-      void stopRecording();
+      void stopRecordingRef.current();
     };
-  }, [stopRecording]);
+  }, []);
 
   if (recorderEntryEnabled && rightPanelMode === 'recorder') {
     return (

--- a/apps/studio/src/renderer/components/PlaygroundShell/ConnectionStatusDot.tsx
+++ b/apps/studio/src/renderer/components/PlaygroundShell/ConnectionStatusDot.tsx
@@ -1,4 +1,8 @@
-export type ConnectionStatus = 'connected' | 'disconnected' | 'failed';
+export type ConnectionStatus =
+  | 'connected'
+  | 'disconnected'
+  | 'recovering'
+  | 'failed';
 
 // Outer translucent halo + solid inner disc of the same hue. Default
 // sizing is 12px outer / 8px inner; callers can pass a smaller `size`
@@ -12,6 +16,10 @@ const PALETTE: Record<ConnectionStatus, { inner: string; border: string }> = {
     inner: 'rgba(182, 182, 182, 1)',
     border: 'rgba(182, 182, 182, 0.25)',
   },
+  recovering: {
+    inner: 'rgba(245, 158, 11, 1)',
+    border: 'rgba(245, 158, 11, 0.25)',
+  },
   failed: {
     inner: 'rgba(229, 57, 53, 1)',
     border: 'rgba(229, 57, 53, 0.25)',
@@ -21,6 +29,7 @@ const PALETTE: Record<ConnectionStatus, { inner: string; border: string }> = {
 const LABEL: Record<ConnectionStatus, string> = {
   connected: 'Device connected',
   disconnected: 'Device not connected',
+  recovering: 'Device connection recovering',
   failed: 'Device connection failed',
 };
 

--- a/apps/studio/src/renderer/playground/preview-discovery.ts
+++ b/apps/studio/src/renderer/playground/preview-discovery.ts
@@ -3,6 +3,7 @@ import type { PlaygroundRuntimeInfo } from '@midscene/playground';
 export type StudioPreviewConnectionState =
   | 'connecting'
   | 'waiting-for-stream'
+  | 'recovering'
   | 'connected'
   | 'disconnected'
   | 'error'

--- a/apps/studio/src/renderer/recorder/StudioRecorderProvider.tsx
+++ b/apps/studio/src/renderer/recorder/StudioRecorderProvider.tsx
@@ -5,6 +5,7 @@ import type {
 import { getDebug } from '@midscene/shared/logger';
 import type { MidsceneRecorderSemanticAction } from '@midscene/shared/recorder';
 import {
+  DEFAULT_MIDSCENE_RECORDER_MARKDOWN_MAX_SCREENSHOTS,
   buildMidsceneRecorderActionSummary,
   buildMidsceneRecorderReplayInstruction,
   getMidsceneRecorderEventDescription,
@@ -23,6 +24,7 @@ import {
   generateStudioRecorderPlaywright,
   generateStudioRecorderYaml,
   getStudioRecorderExportVariantFileName,
+  materializeStudioRecorderSessionScreenshots,
   saveStudioRecorderFile,
 } from './export';
 import { createSecureRecorderId } from './secure-id';
@@ -414,7 +416,9 @@ function shouldDescribeRecorderEvent(event: StudioRecordedEvent) {
   if (semantic?.status === 'ready') {
     return false;
   }
-  return Boolean(event.screenshotBefore || event.screenshotAfter);
+  return Boolean(
+    event.screenshotAsset || event.screenshotBefore || event.screenshotAfter,
+  );
 }
 
 function createPendingRecorderEvent(
@@ -733,6 +737,7 @@ function mergeRecorderInputEvents(
       value,
     },
     pageInfo: next.pageInfo || current.pageInfo,
+    screenshotAsset: next.screenshotAsset || current.screenshotAsset,
     screenshotAfter: next.screenshotAfter || current.screenshotAfter,
     screenshotWithBox: next.screenshotWithBox || current.screenshotWithBox,
     timestamp: next.timestamp,
@@ -903,16 +908,51 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
+  const clearRecorderScreenshotAssets = useCallback(
+    async (sessionId: string) => {
+      if (studioPlayground.phase !== 'ready') {
+        return;
+      }
+      try {
+        await studioPlayground.controller.state.playgroundSDK.clearRecorderScreenshotAssets(
+          sessionId,
+        );
+      } catch (error) {
+        debugRecorder('failed to remove recorder screenshot assets:', error);
+      }
+    },
+    [studioPlayground],
+  );
+
+  const persistStudioRecorderSession = useCallback(
+    async (session: StudioRecordingSession) => {
+      const trimmedSessionIds = await upsertStudioRecorderSession(session);
+      await Promise.all(
+        trimmedSessionIds.map((sessionId) =>
+          clearRecorderScreenshotAssets(sessionId),
+        ),
+      );
+      for (const sessionId of trimmedSessionIds) {
+        stateRef.current = reducer(stateRef.current, {
+          type: 'delete-session',
+          sessionId,
+        });
+        dispatch({ type: 'delete-session', sessionId });
+      }
+    },
+    [clearRecorderScreenshotAssets],
+  );
+
   const upsertSessionSnapshot = useCallback(
     async (session: StudioRecordingSession) => {
       const snapshot = stateRef.current;
       const sessionWithSummary = applyLocalSessionSummary(session);
       stateRef.current = upsertSessionInState(snapshot, sessionWithSummary);
       dispatch({ type: 'upsert-session', session: sessionWithSummary });
-      await upsertStudioRecorderSession(sessionWithSummary);
+      await persistStudioRecorderSession(sessionWithSummary);
       return sessionWithSummary;
     },
-    [],
+    [persistStudioRecorderSession],
   );
 
   const updateRecordedEvent = useCallback(
@@ -1201,13 +1241,13 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
 
       stateRef.current = upsertSessionInState(snapshot, updatedSession);
       dispatch({ type: 'upsert-session', session: updatedSession });
-      await upsertStudioRecorderSession(updatedSession);
+      await persistStudioRecorderSession(updatedSession);
       const canonicalEvent =
         findSessionEventByHashLineage(updatedSession, event) || event;
       enqueueRecorderEventDescription(updatedSession.id, canonicalEvent);
       return updatedSession;
     },
-    [enqueueRecorderEventDescription],
+    [enqueueRecorderEventDescription, persistStudioRecorderSession],
   );
 
   const flushPendingRecorderInput = useCallback(
@@ -1521,7 +1561,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     stateRef.current = upsertSessionInState(latestSnapshot, updatedSession);
     dispatch({ type: 'upsert-session', session: updatedSession });
     dispatch({ type: 'set-recording', isRecording: false });
-    await upsertStudioRecorderSession(updatedSession);
+    await persistStudioRecorderSession(updatedSession);
     await generateSessionMetadata(updatedSession);
   }, [
     generateSessionMetadata,
@@ -1529,6 +1569,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     clearRecorderRuntime,
     stopRecorderRuntime,
     waitForRecorderEventDescriptions,
+    persistStudioRecorderSession,
   ]);
 
   useEffect(() => {
@@ -1588,12 +1629,12 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       updatedAt: now,
       startedAt: now,
     };
-    await upsertStudioRecorderSession(session);
+    await persistStudioRecorderSession(session);
     await setCurrentStudioRecorderSessionId(session.id);
     stateRef.current = upsertSessionInState(stateRef.current, session);
     dispatch({ type: 'upsert-session', session });
     return session;
-  }, [canStartRecording, currentTarget]);
+  }, [canStartRecording, currentTarget, persistStudioRecorderSession]);
 
   const deleteSession = useCallback(
     async (sessionId: string) => {
@@ -1601,6 +1642,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
         await stopRecording();
       }
       await deleteStudioRecorderSession(sessionId);
+      await clearRecorderScreenshotAssets(sessionId);
       const nextSessions = stateRef.current.sessions.filter(
         (session) => session.id !== sessionId,
       );
@@ -1611,7 +1653,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       await setCurrentStudioRecorderSessionId(nextCurrentSessionId);
       dispatch({ type: 'delete-session', sessionId });
     },
-    [stopRecording],
+    [clearRecorderScreenshotAssets, stopRecording],
   );
 
   const renameSession = useCallback(
@@ -1633,9 +1675,9 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       };
       stateRef.current = upsertSessionInState(snapshot, updatedSession);
       dispatch({ type: 'upsert-session', session: updatedSession });
-      await upsertStudioRecorderSession(updatedSession);
+      await persistStudioRecorderSession(updatedSession);
     },
-    [flushPendingRecorderInput],
+    [flushPendingRecorderInput, persistStudioRecorderSession],
   );
 
   const selectSession = useCallback((sessionId: string) => {
@@ -1723,7 +1765,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
               sessionForCodegen,
             );
             dispatch({ type: 'upsert-session', session: sessionForCodegen });
-            await upsertStudioRecorderSession(sessionForCodegen);
+            await persistStudioRecorderSession(sessionForCodegen);
             options.onProgress?.({
               step: 'metadata',
               status: 'completed',
@@ -1799,13 +1841,14 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       };
       stateRef.current = upsertSessionInState(stateRef.current, updatedSession);
       dispatch({ type: 'upsert-session', session: updatedSession });
-      await upsertStudioRecorderSession(updatedSession);
+      await persistStudioRecorderSession(updatedSession);
       return code;
     },
     [
       describeUndescribedSessionEvents,
       flushPendingRecorderInput,
       markPendingDescriptionsAsFallback,
+      persistStudioRecorderSession,
       waitForRecorderEventDescriptions,
     ],
   );
@@ -2033,6 +2076,23 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     stopRecorderRuntime,
   ]);
 
+  const materializeSessionForScreenshotExport = useCallback(
+    async (session: StudioRecordingSession, maxScreenshots?: number) => {
+      if (studioPlayground.phase !== 'ready') {
+        throw new Error(
+          'Studio Playground is unavailable for screenshot export.',
+        );
+      }
+      const { playgroundSDK } = studioPlayground.controller.state;
+      return materializeStudioRecorderSessionScreenshots(
+        session,
+        (assetId) => playgroundSDK.getRecorderScreenshotAsset(assetId),
+        maxScreenshots,
+      );
+    },
+    [studioPlayground],
+  );
+
   const exportSessionJson = useCallback(
     async (sessionId: string) => {
       await flushPendingRecorderInput(sessionId);
@@ -2113,7 +2173,9 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
             'zip',
           ),
           filters: [{ name: 'ZIP Archive', extensions: ['zip'] }],
-          content: await createStudioRecorderMarkdownZipBase64(session),
+          content: await createStudioRecorderMarkdownZipBase64(
+            await materializeSessionForScreenshotExport(session),
+          ),
           encoding: 'base64',
         });
         return;
@@ -2138,7 +2200,11 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
         content: playwright,
       });
     },
-    [exportSessionYaml, flushPendingRecorderInput],
+    [
+      exportSessionYaml,
+      flushPendingRecorderInput,
+      materializeSessionForScreenshotExport,
+    ],
   );
 
   const exportAllZip = useCallback(async () => {
@@ -2147,14 +2213,29 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     if (!sessions.length) {
       return;
     }
+    let remainingScreenshots =
+      DEFAULT_MIDSCENE_RECORDER_MARKDOWN_MAX_SCREENSHOTS;
+    const exportSessions: StudioRecordingSession[] = [];
+    for (const session of sessions) {
+      const exportSession = await materializeSessionForScreenshotExport(
+        session,
+        remainingScreenshots,
+      );
+      remainingScreenshots -= exportSession.events.filter(
+        (event, index) =>
+          Boolean(event.screenshotWithBox) &&
+          !session.events[index]?.screenshotWithBox,
+      ).length;
+      exportSessions.push(exportSession);
+    }
     await saveStudioRecorderFile({
       title: 'Export Recorder Archive',
       defaultFileName: 'midscene-studio-recordings.zip',
       filters: [{ name: 'ZIP Archive', extensions: ['zip'] }],
-      content: await createStudioRecorderZipBase64(sessions),
+      content: await createStudioRecorderZipBase64(exportSessions),
       encoding: 'base64',
     });
-  }, [flushPendingRecorderInput]);
+  }, [flushPendingRecorderInput, materializeSessionForScreenshotExport]);
 
   useEffect(() => {
     if (state.isRecording && !canStartRecording) {

--- a/apps/studio/src/renderer/recorder/StudioRecorderProvider.tsx
+++ b/apps/studio/src/renderer/recorder/StudioRecorderProvider.tsx
@@ -543,6 +543,8 @@ type StudioRecorderRuntime = {
   sessionId: string;
   cursor: number;
   stopping: boolean;
+  stopPromise?: Promise<void>;
+  preserveUntilExplicitClear?: boolean;
   drainAgain?: boolean;
   drainPromise?: Promise<void>;
   getRecorderEvents: (since?: number) => Promise<{
@@ -564,60 +566,6 @@ type PendingRecorderInput = {
   sessionId: string;
   event: StudioRecordedEvent;
 };
-
-const AUTHORITATIVE_RECORDER_DISCOVERY_PLATFORMS = new Set([
-  'android',
-  'harmony',
-  'computer',
-]);
-
-function isDiscoveredDeviceAvailable(
-  device: {
-    id: string;
-    status?: string;
-    sessionValues?: Record<string, unknown>;
-  },
-  target: StudioRecorderTarget,
-) {
-  const targetDeviceId = target.deviceId;
-  if (!targetDeviceId) {
-    return false;
-  }
-  const deviceStatus = device.status?.toLowerCase();
-  if (deviceStatus && deviceStatus !== 'device') {
-    return false;
-  }
-  return (
-    device.id === targetDeviceId ||
-    device.sessionValues?.deviceId === targetDeviceId ||
-    device.sessionValues?.displayId === targetDeviceId
-  );
-}
-
-function isRecorderTargetMissingFromDiscovery(
-  studioPlayground: ReturnType<typeof useStudioPlayground>,
-  target: StudioRecorderTarget | null,
-) {
-  if (
-    !target ||
-    !AUTHORITATIVE_RECORDER_DISCOVERY_PLATFORMS.has(target.platformId)
-  ) {
-    return false;
-  }
-  if (studioPlayground.phase !== 'ready') {
-    return false;
-  }
-  if (studioPlayground.discoveryErrors?.[target.platformId]) {
-    return false;
-  }
-  const discoveredDevices = studioPlayground.discoveredDevices;
-  if (!discoveredDevices) {
-    return false;
-  }
-  return !discoveredDevices[target.platformId].some((device) =>
-    isDiscoveredDeviceAvailable(device, target),
-  );
-}
 
 function isStudioPreviewInputEvent(event: StudioRecordedEvent) {
   return (
@@ -866,17 +814,10 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     () => selectStudioRecorderTarget(studioPlayground),
     [studioPlayground],
   );
-  const currentTargetSignature = useMemo(
-    () => createStudioRecorderTargetSignature(currentTarget),
-    [currentTarget],
-  );
   const canStartRecording = canStartStudioRecording(
     studioPlayground,
     currentTarget,
   );
-  const playgroundSessionConnected =
-    studioPlayground.phase === 'ready' &&
-    studioPlayground.controller.state.sessionViewState.connected;
 
   const currentSession = useMemo(
     () =>
@@ -1374,23 +1315,37 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       { preserveRuntime = false }: { preserveRuntime?: boolean } = {},
     ) => {
       const runtime = recorderRuntimeRef.current;
-      if (!runtime || runtime.sessionId !== sessionId || runtime.stopping) {
+      if (!runtime || runtime.sessionId !== sessionId) {
         return;
       }
+      if (preserveRuntime) {
+        runtime.preserveUntilExplicitClear = true;
+      }
 
-      runtime.stopping = true;
-      try {
-        await runtime.stopRecorderSession?.();
-      } catch (error) {
-        debugRecorder('failed to stop server recorder session:', error);
+      if (!runtime.stopPromise) {
+        runtime.stopping = true;
+        runtime.stopPromise = (async () => {
+          try {
+            await runtime.stopRecorderSession?.();
+          } catch (error) {
+            debugRecorder('failed to stop server recorder session:', error);
+          }
+
+          try {
+            await drainRecorderRuntime(sessionId);
+          } catch (error) {
+            debugRecorder('failed to drain recorder events:', error);
+          }
+        })();
       }
 
       try {
-        await drainRecorderRuntime(sessionId);
-      } catch (error) {
-        debugRecorder('failed to drain recorder events:', error);
+        await runtime.stopPromise;
       } finally {
-        if (!preserveRuntime && recorderRuntimeRef.current === runtime) {
+        if (
+          !runtime.preserveUntilExplicitClear &&
+          recorderRuntimeRef.current === runtime
+        ) {
           recorderRuntimeRef.current = null;
         }
       }
@@ -1404,6 +1359,23 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       recorderRuntimeRef.current = null;
     }
   }, []);
+
+  const materializeSessionForScreenshotExport = useCallback(
+    async (session: StudioRecordingSession, maxScreenshots?: number) => {
+      if (studioPlayground.phase !== 'ready') {
+        throw new Error(
+          'Studio Playground is unavailable for recorder screenshots.',
+        );
+      }
+      const { playgroundSDK } = studioPlayground.controller.state;
+      return materializeStudioRecorderSessionScreenshots(
+        session,
+        (assetId) => playgroundSDK.getRecorderScreenshotAsset(assetId),
+        maxScreenshots,
+      );
+    },
+    [studioPlayground],
+  );
 
   const generateSessionMetadata = useCallback(
     async (session: StudioRecordingSession) => {
@@ -1420,8 +1392,9 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
         const { generateStudioRecorderMetadataWithAI } = await import(
           './codegen'
         );
-        const metadata =
-          await generateStudioRecorderMetadataWithAI(localSummarySession);
+        const metadata = await generateStudioRecorderMetadataWithAI(
+          await materializeSessionForScreenshotExport(localSummarySession, 1),
+        );
         if (!metadata.title && !metadata.description) {
           return localSummarySession;
         }
@@ -1438,7 +1411,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
         return localSummarySession;
       }
     },
-    [upsertSessionSnapshot],
+    [materializeSessionForScreenshotExport, upsertSessionSnapshot],
   );
 
   const describeUndescribedSessionEvents = useCallback(
@@ -1572,6 +1545,11 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
     persistStudioRecorderSession,
   ]);
 
+  const stopRecordingRef = useRef(stopRecording);
+  useEffect(() => {
+    stopRecordingRef.current = stopRecording;
+  }, [stopRecording]);
+
   useEffect(() => {
     let cancelled = false;
     void Promise.all([
@@ -1607,9 +1585,9 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     return () => {
-      void stopRecording();
+      void stopRecordingRef.current();
     };
-  }, [stopRecording]);
+  }, []);
 
   const startRecording = useCallback(async () => {
     if (!canStartRecording || !currentTarget) {
@@ -1639,7 +1617,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
   const deleteSession = useCallback(
     async (sessionId: string) => {
       if (stateRef.current.currentSessionId === sessionId) {
-        await stopRecording();
+        await stopRecordingRef.current();
       }
       await deleteStudioRecorderSession(sessionId);
       await clearRecorderScreenshotAssets(sessionId);
@@ -1749,8 +1727,9 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
             status: 'loading',
             details: 'Analyzing session content...',
           });
-          const metadata =
-            await generateStudioRecorderMetadataWithAI(sessionForCodegen);
+          const metadata = await generateStudioRecorderMetadataWithAI(
+            await materializeSessionForScreenshotExport(sessionForCodegen, 1),
+          );
           if (metadata.title || metadata.description) {
             sessionForCodegen = {
               ...sessionForCodegen,
@@ -1810,11 +1789,14 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       });
       let code: string;
       try {
-        code = await generateStudioRecorderCodeWithAI(sessionForCodegen, {
-          type,
-          language: options.language,
-          onChunk: options.onChunk,
-        });
+        code = await generateStudioRecorderCodeWithAI(
+          await materializeSessionForScreenshotExport(sessionForCodegen),
+          {
+            type,
+            language: options.language,
+            onChunk: options.onChunk,
+          },
+        );
       } catch (error) {
         options.onProgress?.({
           step: 'code',
@@ -1848,6 +1830,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       describeUndescribedSessionEvents,
       flushPendingRecorderInput,
       markPendingDescriptionsAsFallback,
+      materializeSessionForScreenshotExport,
       persistStudioRecorderSession,
       waitForRecorderEventDescriptions,
     ],
@@ -2029,7 +2012,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
         const error =
           result.error || 'Recorder is unavailable for the current target.';
         debugRecorder('server recorder is unavailable: %s', error);
-        await stopRecording();
+        await stopRecordingRef.current();
         dispatch({ type: 'set-error', error });
         return;
       }
@@ -2039,7 +2022,7 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
           result.error ||
           'Current target does not expose preview interaction controls.';
         debugRecorder('preview recorder unavailable: %s', error);
-        await stopRecording();
+        await stopRecordingRef.current();
         dispatch({ type: 'set-error', error });
         return;
       }
@@ -2072,26 +2055,8 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       ? studioPlayground.controller.state.playgroundSDK
       : null,
     drainRecorderRuntime,
-    stopRecording,
     stopRecorderRuntime,
   ]);
-
-  const materializeSessionForScreenshotExport = useCallback(
-    async (session: StudioRecordingSession, maxScreenshots?: number) => {
-      if (studioPlayground.phase !== 'ready') {
-        throw new Error(
-          'Studio Playground is unavailable for screenshot export.',
-        );
-      }
-      const { playgroundSDK } = studioPlayground.controller.state;
-      return materializeStudioRecorderSessionScreenshots(
-        session,
-        (assetId) => playgroundSDK.getRecorderScreenshotAsset(assetId),
-        maxScreenshots,
-      );
-    },
-    [studioPlayground],
-  );
 
   const exportSessionJson = useCallback(
     async (sessionId: string) => {
@@ -2236,50 +2201,6 @@ export function StudioRecorderProvider({ children }: PropsWithChildren) {
       encoding: 'base64',
     });
   }, [flushPendingRecorderInput, materializeSessionForScreenshotExport]);
-
-  useEffect(() => {
-    if (state.isRecording && !canStartRecording) {
-      void stopRecording();
-    }
-  }, [canStartRecording, state.isRecording, stopRecording]);
-
-  useEffect(() => {
-    if (!state.isRecording) {
-      return;
-    }
-    const recordingTarget = currentSession?.target ?? currentTarget;
-    if (
-      !playgroundSessionConnected ||
-      isRecorderTargetMissingFromDiscovery(studioPlayground, recordingTarget)
-    ) {
-      void stopRecording();
-    }
-  }, [
-    currentSession?.target,
-    currentTarget,
-    playgroundSessionConnected,
-    state.isRecording,
-    stopRecording,
-    studioPlayground,
-  ]);
-
-  const recordingTargetSignatureRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!state.isRecording) {
-      recordingTargetSignatureRef.current = currentTargetSignature;
-      return;
-    }
-    if (!recordingTargetSignatureRef.current) {
-      recordingTargetSignatureRef.current = currentTargetSignature;
-      return;
-    }
-    if (
-      currentTargetSignature &&
-      recordingTargetSignatureRef.current !== currentTargetSignature
-    ) {
-      void stopRecording();
-    }
-  }, [currentTargetSignature, state.isRecording, stopRecording]);
 
   const contextValue = useMemo<StudioRecorderContextValue>(
     () => ({

--- a/apps/studio/src/renderer/recorder/export.ts
+++ b/apps/studio/src/renderer/recorder/export.ts
@@ -25,18 +25,17 @@ export async function materializeStudioRecorderSessionScreenshots(
       continue;
     }
     const screenshot = await loadScreenshot(event.screenshotAsset.id);
-    if (screenshot) {
-      remainingScreenshots -= 1;
+    if (!screenshot) {
+      throw new Error(
+        `Recorder screenshot asset is unavailable: ${event.screenshotAsset.id}`,
+      );
     }
-    events.push(
-      screenshot
-        ? {
-            ...event,
-            screenshotAsset: undefined,
-            screenshotWithBox: screenshot,
-          }
-        : event,
-    );
+    remainingScreenshots -= 1;
+    events.push({
+      ...event,
+      screenshotAsset: undefined,
+      screenshotWithBox: screenshot,
+    });
   }
   return { ...session, events };
 }

--- a/apps/studio/src/renderer/recorder/export.ts
+++ b/apps/studio/src/renderer/recorder/export.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_MIDSCENE_RECORDER_MARKDOWN_MAX_SCREENSHOTS,
   createMidsceneRecorderMarkdownScreenshotAssets,
   getMidsceneRecorderEventDescription,
   getMidsceneRecorderSemantic,
@@ -10,6 +11,35 @@ import type {
 } from '@shared/electron-contract';
 import JSZip from 'jszip';
 import type { StudioRecordedEvent, StudioRecordingSession } from './types';
+
+export async function materializeStudioRecorderSessionScreenshots(
+  session: StudioRecordingSession,
+  loadScreenshot: (assetId: string) => Promise<string | null>,
+  maxScreenshots = DEFAULT_MIDSCENE_RECORDER_MARKDOWN_MAX_SCREENSHOTS,
+): Promise<StudioRecordingSession> {
+  const events: StudioRecordedEvent[] = [];
+  let remainingScreenshots = Math.max(0, maxScreenshots);
+  for (const event of session.events) {
+    if (!event.screenshotAsset || remainingScreenshots === 0) {
+      events.push(event);
+      continue;
+    }
+    const screenshot = await loadScreenshot(event.screenshotAsset.id);
+    if (screenshot) {
+      remainingScreenshots -= 1;
+    }
+    events.push(
+      screenshot
+        ? {
+            ...event,
+            screenshotAsset: undefined,
+            screenshotWithBox: screenshot,
+          }
+        : event,
+    );
+  }
+  return { ...session, events };
+}
 
 function getElectronShell(): Pick<
   ElectronShellApi,

--- a/apps/studio/src/renderer/recorder/replay.ts
+++ b/apps/studio/src/renderer/recorder/replay.ts
@@ -23,6 +23,8 @@ Execution rules:
 - If the current UI is already ahead of an earlier required recorded action, use visible safe affordances and the recorded context to return to the earliest unsatisfied prerequisite state and perform the missing recorded action sequence.
 - Before failing because the recorded target is absent, compare the current UI with the recorded goal, previous steps, and following steps. If the intended outcome of the missing step is already satisfied, mark that step as done and continue with the next unsatisfied recorded intent.
 - Do not undo visible progress or change durable application state only to recreate an earlier intermediate UI. Doing so is allowed only when it is visibly safe and necessary to execute an explicit recorded workflow action that has not run in this replay.
+- If a recorded target or prerequisite remains missing after visible, explainable attempts to reach it, do not keep repeating the same navigation or action pattern for that same missing target. A bounded retry is acceptable when the UI visibly changes or new evidence appears.
+- After each prerequisite-recovery action, verify that the current UI is closer to the recorded intent. If repeated attempts do not make the next recorded intent more reachable, stop and report that the current UI likely does not match the recording state.
 - Stop only when the recorded intent cannot be inferred or no safe visible path exists.
 
 Recorded Markdown:

--- a/apps/studio/src/renderer/recorder/storage.ts
+++ b/apps/studio/src/renderer/recorder/storage.ts
@@ -1,7 +1,7 @@
 import type { StudioRecordingSession } from './types';
 
 const DB_NAME = 'midscene-studio-recorder';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const SESSION_STORE = 'sessions';
 const CONFIG_STORE = 'config';
 const CURRENT_SESSION_KEY = 'currentSessionId';
@@ -32,7 +32,11 @@ function openDatabase(): Promise<IDBDatabase | null> {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = (event) => {
       const db = request.result;
-      if (event.oldVersion > 0 && event.oldVersion < 2) {
+      // Recorder sessions before v3 embed every full-size screenshot as a
+      // data URL. They are intentionally disposable while Studio is in beta:
+      // loading them all at startup can exhaust the renderer heap before the
+      // new asset-backed format has a chance to run.
+      if (event.oldVersion > 0 && event.oldVersion < 3) {
         if (db.objectStoreNames.contains(SESSION_STORE)) {
           db.deleteObjectStore(SESSION_STORE);
         }
@@ -95,15 +99,16 @@ function withStore<T>(
   });
 }
 
-async function trimSessions(): Promise<void> {
+async function trimSessions(): Promise<string[]> {
   const sessions = await getStudioRecorderSessions();
   if (sessions.length <= MAX_SESSIONS) {
-    return;
+    return [];
   }
   const expired = sessions.slice(MAX_SESSIONS);
   await Promise.all(
     expired.map((session) => deleteStudioRecorderSession(session.id)),
   );
+  return expired.map((session) => session.id);
 }
 
 export async function getStudioRecorderSessions(): Promise<
@@ -123,20 +128,22 @@ export async function getStudioRecorderSessions(): Promise<
 
 export async function upsertStudioRecorderSession(
   session: StudioRecordingSession,
-): Promise<void> {
+): Promise<string[]> {
   const safeSession = sanitizeSession(session);
   if (typeof indexedDB === 'undefined') {
-    memoryStore.sessions = [
+    const sessions = [
       safeSession,
       ...memoryStore.sessions.filter((item) => item.id !== safeSession.id),
-    ].slice(0, MAX_SESSIONS);
-    return;
+    ].sort((a, b) => b.updatedAt - a.updatedAt);
+    const expired = sessions.slice(MAX_SESSIONS);
+    memoryStore.sessions = sessions.slice(0, MAX_SESSIONS);
+    return expired.map((item) => item.id);
   }
 
   await withStore(SESSION_STORE, 'readwrite', (store) =>
     store.put(safeSession),
   );
-  await trimSessions();
+  return trimSessions();
 }
 
 export async function deleteStudioRecorderSession(

--- a/apps/studio/src/renderer/recorder/storage.ts
+++ b/apps/studio/src/renderer/recorder/storage.ts
@@ -1,10 +1,12 @@
 import type { StudioRecordingSession } from './types';
 
 const DB_NAME = 'midscene-studio-recorder';
-const DB_VERSION = 3;
+const DB_VERSION = 2;
 const SESSION_STORE = 'sessions';
 const CONFIG_STORE = 'config';
 const CURRENT_SESSION_KEY = 'currentSessionId';
+const RECORDER_STORAGE_FORMAT_KEY = 'recorderStorageFormat';
+const RECORDER_STORAGE_FORMAT_VERSION = 'asset-backed-v1';
 const MAX_SESSIONS = 20;
 
 interface StudioRecorderConfigRecord {
@@ -23,6 +25,39 @@ function sanitizeSession(
   return JSON.parse(JSON.stringify(session)) as StudioRecordingSession;
 }
 
+function migrateLegacyRecorderSessions(db: IDBDatabase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(
+      [SESSION_STORE, CONFIG_STORE],
+      'readwrite',
+    );
+    const sessions = transaction.objectStore(SESSION_STORE);
+    const config = transaction.objectStore(CONFIG_STORE);
+    const migration = config.get(
+      RECORDER_STORAGE_FORMAT_KEY,
+    ) as IDBRequest<StudioRecorderConfigRecord>;
+    let shouldClearSessions = false;
+
+    migration.onsuccess = () => {
+      shouldClearSessions =
+        migration.result?.value !== RECORDER_STORAGE_FORMAT_VERSION;
+      if (shouldClearSessions) {
+        sessions.clear();
+        config.put({
+          key: RECORDER_STORAGE_FORMAT_KEY,
+          value: RECORDER_STORAGE_FORMAT_VERSION,
+        } satisfies StudioRecorderConfigRecord);
+      }
+    };
+    migration.onerror = () => {
+      reject(migration.error || new Error('Failed to read recorder migration'));
+    };
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error || new Error('Failed to migrate recorder data'));
+  });
+}
+
 function openDatabase(): Promise<IDBDatabase | null> {
   if (typeof indexedDB === 'undefined') {
     return Promise.resolve(null);
@@ -32,11 +67,7 @@ function openDatabase(): Promise<IDBDatabase | null> {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = (event) => {
       const db = request.result;
-      // Recorder sessions before v3 embed every full-size screenshot as a
-      // data URL. They are intentionally disposable while Studio is in beta:
-      // loading them all at startup can exhaust the renderer heap before the
-      // new asset-backed format has a chance to run.
-      if (event.oldVersion > 0 && event.oldVersion < 3) {
+      if (event.oldVersion > 0 && event.oldVersion < 2) {
         if (db.objectStoreNames.contains(SESSION_STORE)) {
           db.deleteObjectStore(SESSION_STORE);
         }
@@ -52,7 +83,13 @@ function openDatabase(): Promise<IDBDatabase | null> {
       }
     };
     request.onsuccess = () => {
-      resolve(request.result);
+      const db = request.result;
+      void migrateLegacyRecorderSessions(db)
+        .then(() => resolve(db))
+        .catch((error) => {
+          db.close();
+          reject(error);
+        });
     };
     request.onerror = () => {
       reject(request.error || new Error('Failed to open recorder database'));

--- a/apps/studio/tests/playground-import-replay.test.tsx
+++ b/apps/studio/tests/playground-import-replay.test.tsx
@@ -173,4 +173,47 @@ describe('Studio Playground imported replay', () => {
       root.unmount();
     });
   });
+
+  it('does not stop an active recorder when its callback changes', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const firstStopRecording = vi.fn(async () => undefined);
+    mocks.recorder = {
+      ...createRecorder(),
+      state: { isRecording: true },
+      stopRecording: firstStopRecording,
+    };
+
+    await act(async () => {
+      root.render(
+        <Playground
+          onRightPanelModeChange={() => undefined}
+          rightPanelMode="recorder"
+        />,
+      );
+    });
+
+    const secondStopRecording = vi.fn(async () => undefined);
+    mocks.recorder = {
+      ...mocks.recorder,
+      stopRecording: secondStopRecording,
+    };
+    await act(async () => {
+      root.render(
+        <Playground
+          onRightPanelModeChange={() => undefined}
+          rightPanelMode="recorder"
+        />,
+      );
+    });
+
+    expect(firstStopRecording).not.toHaveBeenCalled();
+    expect(secondStopRecording).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+    expect(secondStopRecording).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/studio/tests/playground-import-replay.test.tsx
+++ b/apps/studio/tests/playground-import-replay.test.tsx
@@ -162,6 +162,12 @@ describe('Studio Playground imported replay', () => {
     expect(request.value.prompt).toContain(
       '# Replay\n\n## Steps\n1. Tap login',
     );
+    expect(request.value.prompt).toContain(
+      'do not keep repeating the same navigation or action pattern',
+    );
+    expect(request.value.prompt).toContain(
+      'current UI likely does not match the recording state',
+    );
 
     await act(async () => {
       root.unmount();

--- a/apps/studio/tests/preview-discovery.test.ts
+++ b/apps/studio/tests/preview-discovery.test.ts
@@ -41,6 +41,7 @@ describe('shouldPauseDiscoveryPollingDuringPreview', () => {
     expectPauseDecision(null, true);
     expectPauseDecision('connecting', true);
     expectPauseDecision('waiting-for-stream', true);
+    expectPauseDecision('recovering', true);
   });
 
   it('resumes discovery once the scrcpy preview has settled', () => {

--- a/apps/studio/tests/studio-recorder-export.test.ts
+++ b/apps/studio/tests/studio-recorder-export.test.ts
@@ -5,6 +5,7 @@ import {
   createStudioRecorderMarkdownZipBase64,
   createStudioRecorderZipBase64,
   generateStudioRecorderMarkdown,
+  materializeStudioRecorderSessionScreenshots,
   saveStudioRecorderFile,
 } from '../src/renderer/recorder/export';
 import type { StudioRecordingSession } from '../src/renderer/recorder/types';
@@ -15,6 +16,55 @@ describe('studio recorder export', () => {
     vi.restoreAllMocks();
     document.body.innerHTML = '';
     (window as Window & { electronShell?: unknown }).electronShell = undefined;
+  });
+
+  it('materializes screenshot assets only in the export copy', async () => {
+    const session = {
+      id: 'session-assets',
+      name: 'Asset-backed recording',
+      status: 'completed',
+      target: {
+        platformId: 'web',
+        label: 'Web',
+        values: { url: 'https://example.com' },
+      },
+      events: [
+        {
+          type: 'click',
+          platformId: 'web',
+          actionType: 'Click',
+          rawPayload: {},
+          target: {
+            platformId: 'web',
+            label: 'Web',
+            values: { url: 'https://example.com' },
+          },
+          pageInfo: { width: 1280, height: 720 },
+          screenshotAsset: {
+            id: 'screenshot-1',
+            mimeType: 'image/png',
+            bytes: 42,
+          },
+          timestamp: 1,
+          hashId: 'click-asset-1',
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    } satisfies StudioRecordingSession;
+    const loadScreenshot = vi.fn(async () => 'data:image/png;base64,asset');
+
+    const exportSession = await materializeStudioRecorderSessionScreenshots(
+      session,
+      loadScreenshot,
+    );
+
+    expect(loadScreenshot).toHaveBeenCalledWith('screenshot-1');
+    expect(session.events[0].screenshotWithBox).toBeUndefined();
+    expect(exportSession.events[0]).toMatchObject({
+      screenshotWithBox: 'data:image/png;base64,asset',
+    });
+    expect(exportSession.events[0].screenshotAsset).toBeUndefined();
   });
 
   it('falls back to browser download when generic file IPC is unavailable', async () => {

--- a/apps/studio/tests/studio-recorder-export.test.ts
+++ b/apps/studio/tests/studio-recorder-export.test.ts
@@ -19,7 +19,7 @@ describe('studio recorder export', () => {
   });
 
   it('materializes screenshot assets only in the export copy', async () => {
-    const session = {
+    const session: StudioRecordingSession = {
       id: 'session-assets',
       name: 'Asset-backed recording',
       status: 'completed',
@@ -51,7 +51,7 @@ describe('studio recorder export', () => {
       ],
       createdAt: 1,
       updatedAt: 2,
-    } satisfies StudioRecordingSession;
+    };
     const loadScreenshot = vi.fn(async () => 'data:image/png;base64,asset');
 
     const exportSession = await materializeStudioRecorderSessionScreenshots(

--- a/apps/studio/tests/studio-recorder-provider.test.tsx
+++ b/apps/studio/tests/studio-recorder-provider.test.tsx
@@ -188,6 +188,7 @@ function createConnectedStudioContext({
     interact,
     startRecorderSession,
     stopRecorderSession,
+    getRecorderScreenshotAsset,
     getRecorderEvents,
     describeRecorderEventAtPoint,
   };
@@ -283,7 +284,27 @@ describe('StudioRecorderProvider preview recording', () => {
     await mounted.cleanup();
   });
 
-  it('stops recording when the current target disappears from discovery', async () => {
+  it('keeps recording when the live Playground context rerenders', async () => {
+    const { context, stopRecorderSession, startRecorderSession } =
+      createConnectedStudioContext();
+    const mounted = await mountRecorder(context);
+
+    await act(async () => {
+      await mounted.recorder?.startRecording();
+    });
+    await flushPromises();
+
+    await mounted.rerender({ ...context });
+    await flushPromises();
+
+    expect(mounted.recorder?.state.isRecording).toBe(true);
+    expect(stopRecorderSession).not.toHaveBeenCalled();
+    expect(startRecorderSession).toHaveBeenCalledTimes(1);
+
+    await mounted.cleanup();
+  });
+
+  it('keeps recording through transient discovery and server-status refreshes', async () => {
     const { context, stopRecorderSession } = createConnectedStudioContext();
     const mounted = await mountRecorder(context);
 
@@ -296,6 +317,13 @@ describe('StudioRecorderProvider preview recording', () => {
 
     await mounted.rerender({
       ...context,
+      controller: {
+        ...context.controller,
+        state: {
+          ...context.controller.state,
+          serverOnline: false,
+        },
+      },
       discoveredDevices: {
         ...context.discoveredDevices!,
         computer: [],
@@ -304,9 +332,9 @@ describe('StudioRecorderProvider preview recording', () => {
     await flushPromises();
     await flushPromises();
 
-    expect(stopRecorderSession).toHaveBeenCalled();
-    expect(mounted.recorder?.state.isRecording).toBe(false);
-    expect(mounted.recorder?.currentSession?.status).toBe('completed');
+    expect(stopRecorderSession).not.toHaveBeenCalled();
+    expect(mounted.recorder?.state.isRecording).toBe(true);
+    expect(mounted.recorder?.currentSession?.status).toBe('recording');
 
     await mounted.cleanup();
   });
@@ -1631,6 +1659,70 @@ describe('StudioRecorderProvider preview recording', () => {
     await mounted.cleanup();
   });
 
+  it('shares an in-flight stop and drains final events before completing', async () => {
+    const finalEvent = {
+      type: 'click',
+      source: 'studio-preview',
+      actionType: 'Click',
+      semantic: {
+        source: 'heuristic',
+        status: 'ready',
+        elementDescription: 'Final click',
+      },
+      elementRect: { x: 30, y: 40 },
+      pageInfo: { width: 1200, height: 800 },
+      timestamp: 456,
+      hashId: 'click-final-shared-stop',
+    };
+    const stopDeferred = createDeferred<{ ok: boolean }>();
+    let serverStopped = false;
+    const { context, stopRecorderSession, getRecorderEvents } =
+      createConnectedStudioContext();
+    stopRecorderSession.mockImplementation(async () => {
+      const result = await stopDeferred.promise;
+      serverStopped = true;
+      return result;
+    });
+    getRecorderEvents.mockImplementation(async (since = 0) => ({
+      events: serverStopped && since === 0 ? [finalEvent] : [],
+      nextIndex: serverStopped ? 1 : since,
+    }));
+    const mounted = await mountRecorder(context);
+
+    await act(async () => {
+      await mounted.recorder?.startRecording();
+    });
+    await flushPromises();
+
+    let firstStop!: Promise<void>;
+    let secondStop!: Promise<void>;
+    let secondSettled = false;
+    await act(async () => {
+      firstStop = mounted.recorder!.stopRecording();
+      secondStop = mounted.recorder!.stopRecording();
+      secondStop.then(() => {
+        secondSettled = true;
+      });
+      await Promise.resolve();
+    });
+
+    expect(stopRecorderSession).toHaveBeenCalledTimes(1);
+    expect(secondSettled).toBe(false);
+
+    await act(async () => {
+      stopDeferred.resolve({ ok: true });
+      await Promise.all([firstStop, secondStop]);
+    });
+    await flushPromises();
+
+    expect(mounted.recorder?.state.isRecording).toBe(false);
+    expect(mounted.recorder?.currentSession?.events).toEqual([
+      expect.objectContaining({ hashId: 'click-final-shared-stop' }),
+    ]);
+
+    await mounted.cleanup();
+  });
+
   it('keeps the recorder runtime available while queued descriptions drain after stop', async () => {
     const events = [1, 2, 3].map((index) => ({
       type: 'click',
@@ -1921,6 +2013,67 @@ describe('StudioRecorderProvider preview recording', () => {
     expect(markdown).toBe('ai markdown\n');
     expect(mounted.recorder?.currentSession?.generatedCode?.markdown).toBe(
       'ai markdown\n',
+    );
+
+    await mounted.cleanup();
+  });
+
+  it('materializes asset-backed screenshots for generation without persisting inline data', async () => {
+    const event = {
+      type: 'click',
+      source: 'studio-preview',
+      actionType: 'Click',
+      semantic: {
+        source: 'heuristic',
+        status: 'ready',
+        elementDescription: 'Asset-backed click',
+      },
+      elementRect: { x: 10, y: 20 },
+      pageInfo: { width: 1200, height: 800 },
+      screenshotAsset: {
+        id: 'asset-backed-click.jpg',
+        mimeType: 'image/jpeg',
+        bytes: 4,
+      },
+      timestamp: 123,
+      hashId: 'click-asset-backed',
+    };
+    const { context, getRecorderScreenshotAsset } =
+      createConnectedStudioContext({ events: [event] });
+    getRecorderScreenshotAsset.mockResolvedValue(
+      'data:image/jpeg;base64,c2hvdA==',
+    );
+    const mounted = await mountRecorder(context);
+
+    await act(async () => {
+      await mounted.recorder?.startRecording();
+    });
+    await flushPromises();
+
+    const sessionId = mounted.recorder?.currentSession?.id;
+    await act(async () => {
+      await mounted.recorder!.generateSessionCode(sessionId!);
+    });
+    await flushPromises();
+
+    expect(generateStudioRecorderCodeWithAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            hashId: 'click-asset-backed',
+            screenshotAsset: undefined,
+            screenshotWithBox: 'data:image/jpeg;base64,c2hvdA==',
+          }),
+        ],
+      }),
+      expect.objectContaining({ type: 'markdown' }),
+    );
+    expect(mounted.recorder?.currentSession?.events[0]).toMatchObject({
+      hashId: 'click-asset-backed',
+      screenshotAsset: { id: 'asset-backed-click.jpg' },
+    });
+    expect(mounted.recorder?.currentSession?.events[0].screenshotWithBox).toBe(
+      undefined,
     );
 
     await mounted.cleanup();

--- a/apps/studio/tests/studio-recorder-provider.test.tsx
+++ b/apps/studio/tests/studio-recorder-provider.test.tsx
@@ -103,6 +103,8 @@ function createConnectedStudioContext({
   const interact = vi.fn(async (_payload?: unknown) => ({ ok: true }));
   const startRecorderSession = vi.fn(async () => startResult);
   const stopRecorderSession = vi.fn(async () => ({ ok: true }));
+  const clearRecorderScreenshotAssets = vi.fn(async () => undefined);
+  const getRecorderScreenshotAsset = vi.fn(async () => null);
   const getRecorderEvents = vi.fn(async (since = 0) => ({
     events: since === 0 ? events : [],
     nextIndex: since === 0 ? events.length : since,
@@ -111,6 +113,8 @@ function createConnectedStudioContext({
     interact,
     startRecorderSession,
     stopRecorderSession,
+    clearRecorderScreenshotAssets,
+    getRecorderScreenshotAsset,
     getRecorderEvents,
     ...(describeRecorderEventAtPoint ? { describeRecorderEventAtPoint } : {}),
   };
@@ -394,7 +398,11 @@ describe('StudioRecorderProvider preview recording', () => {
       },
       elementRect: { x: 10, y: 20 },
       pageInfo: { width: 1200, height: 800 },
-      screenshotAfter: 'data:image/png;base64,shot',
+      screenshotAsset: {
+        id: 'click-described-screenshot',
+        mimeType: 'image/png',
+        bytes: 4,
+      },
       timestamp: 123,
       hashId: 'click-ai-describe-failed',
     };

--- a/apps/studio/tests/studio-recorder-storage.test.ts
+++ b/apps/studio/tests/studio-recorder-storage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getStudioRecorderSessions,
+  upsertStudioRecorderSession,
+} from '../src/renderer/recorder/storage';
+import type { StudioRecordingSession } from '../src/renderer/recorder/types';
+
+function createSession(index: number): StudioRecordingSession {
+  return {
+    id: `session-${index}`,
+    name: `Session ${index}`,
+    status: 'completed',
+    target: {
+      platformId: 'web',
+      label: 'Web',
+      values: { url: 'https://example.com' },
+    },
+    events: [],
+    createdAt: index,
+    updatedAt: index,
+  };
+}
+
+describe('studio recorder storage', () => {
+  it('returns sessions evicted by the retention limit', async () => {
+    let evictedSessionIds: string[] = [];
+    for (let index = 0; index <= 20; index += 1) {
+      evictedSessionIds = await upsertStudioRecorderSession(
+        createSession(index),
+      );
+    }
+
+    expect(evictedSessionIds).toEqual(['session-0']);
+    expect(await getStudioRecorderSessions()).toHaveLength(20);
+  });
+});

--- a/apps/studio/tests/studio-recorder.test.ts
+++ b/apps/studio/tests/studio-recorder.test.ts
@@ -483,6 +483,12 @@ describe('studio recorder replay adapters', () => {
     expect(prompt).toContain(
       'Do not undo visible progress or change durable application state',
     );
+    expect(prompt).toContain(
+      'do not keep repeating the same navigation or action pattern',
+    );
+    expect(prompt).toContain(
+      'current UI likely does not match the recording state',
+    );
     expect(prompt).not.toMatch(
       /\blogin\b|authorization|SMS|phone|one-tap|product|recommendations|hot search/i,
     );

--- a/packages/android-playground/src/scrcpy-preview-status.ts
+++ b/packages/android-playground/src/scrcpy-preview-status.ts
@@ -9,6 +9,38 @@ export interface ScrcpyPreviewStatusEvent {
   message: string;
 }
 
+export type ScrcpyPreviewErrorReason =
+  | 'adb-unavailable'
+  | 'process-exited'
+  | 'startup-timeout'
+  | 'stream-ended'
+  | 'stream-read-failed'
+  | 'unknown';
+
+export interface ScrcpyPreviewErrorEvent {
+  message: string;
+  reason: ScrcpyPreviewErrorReason;
+  recoverable: boolean;
+  sessionId: string;
+}
+
+export function buildScrcpyPreviewErrorEvent(
+  reason: ScrcpyPreviewErrorReason,
+  sessionId: string,
+  message: string,
+): ScrcpyPreviewErrorEvent {
+  return {
+    reason,
+    sessionId,
+    message,
+    recoverable:
+      reason === 'process-exited' ||
+      reason === 'startup-timeout' ||
+      reason === 'stream-ended' ||
+      reason === 'stream-read-failed',
+  };
+}
+
 export function getScrcpyPreviewStatusMessage(
   phase: ScrcpyPreviewPhase,
 ): string {

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -19,7 +19,9 @@ import cors from 'cors';
 import express from 'express';
 import { Server } from 'socket.io';
 import {
+  type ScrcpyPreviewErrorReason,
   type ScrcpyPreviewPhase,
+  buildScrcpyPreviewErrorEvent,
   buildScrcpyPreviewStatusEvent,
 } from './scrcpy-preview-status';
 import { withTimeout } from './timeout';
@@ -28,6 +30,26 @@ export const debugPage = getDebug('android:playground');
 const promiseExec = promisify(exec);
 
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+const MAX_SCRCPY_OUTPUT_LINES = 100;
+
+interface ActiveScrcpySession {
+  client: any;
+  closeReason?: string;
+  failureReported: boolean;
+  id: string;
+  outputLines: string[];
+}
+
+export function appendBoundedScrcpyOutput(
+  outputLines: string[],
+  line: string,
+  maxLines = MAX_SCRCPY_OUTPUT_LINES,
+) {
+  outputLines.push(line);
+  if (outputLines.length > maxLines) {
+    outputLines.splice(0, outputLines.length - maxLines);
+  }
+}
 
 function isPrivateIP(hostname: string): boolean {
   // 10.x.x.x, 172.16-31.x.x, 192.168.x.x
@@ -384,27 +406,97 @@ export default class ScrcpyServer {
         socket.handshake.address,
       );
 
-      let scrcpyClient: any = null;
+      let activeSession: ActiveScrcpySession | null = null;
+      let sessionGeneration = 0;
       let adb = null;
 
-      const closeScrcpyClient = async (
+      const closeScrcpySession = async (
         reason: string,
-        clientToClose = scrcpyClient,
+        sessionToClose = activeSession,
       ) => {
-        if (!clientToClose) {
+        if (!sessionToClose) {
           return;
         }
 
-        if (scrcpyClient === clientToClose) {
-          scrcpyClient = null;
+        sessionToClose.closeReason ??= reason;
+        if (activeSession === sessionToClose) {
+          activeSession = null;
         }
 
         try {
-          debugPage('closing scrcpy client, reason: %s', reason);
-          await clientToClose.close();
+          debugPage(
+            'closing scrcpy session %s, reason: %s',
+            sessionToClose.id,
+            reason,
+          );
+          await sessionToClose.client.close();
         } catch (error) {
           console.error(`failed to close scrcpy client (${reason}):`, error);
         }
+      };
+
+      const emitPreviewError = (
+        session: ActiveScrcpySession,
+        reason: ScrcpyPreviewErrorReason,
+        message: string,
+      ) => {
+        if (session.failureReported || session.closeReason) {
+          return;
+        }
+        session.failureReported = true;
+        debugPage(
+          'scrcpy session %s failed (%s), recent output:\n%s',
+          session.id,
+          reason,
+          session.outputLines.join('\n'),
+        );
+        if (socket.connected) {
+          socket.emit(
+            'preview-error',
+            buildScrcpyPreviewErrorEvent(reason, session.id, message),
+          );
+        }
+      };
+
+      const monitorScrcpySession = (session: ActiveScrcpySession) => {
+        void (async () => {
+          try {
+            const reader = session.client.output.getReader();
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              for (const line of String(value).split(/\r?\n/)) {
+                if (!line) continue;
+                appendBoundedScrcpyOutput(session.outputLines, line);
+                debugPage('scrcpy[%s]: %s', session.id, line);
+              }
+            }
+          } catch (error) {
+            if (!session.closeReason) {
+              debugPage(
+                'failed reading scrcpy output for %s: %s',
+                session.id,
+                error,
+              );
+            }
+          }
+        })();
+
+        void Promise.resolve(session.client.exited)
+          .then(() => {
+            emitPreviewError(
+              session,
+              'process-exited',
+              'Scrcpy service exited. Recovering preview.',
+            );
+          })
+          .catch((error) => {
+            emitPreviewError(
+              session,
+              'process-exited',
+              `Scrcpy service exited unexpectedly: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
       };
 
       const emitPreviewStatus = (phase: ScrcpyPreviewPhase) => {
@@ -437,7 +529,8 @@ export default class ScrcpyServer {
       socket.on('switch-device', async (deviceId) => {
         debugPage('received client request to switch device:', deviceId);
         try {
-          await closeScrcpyClient('switch device');
+          sessionGeneration += 1;
+          await closeScrcpySession('switch device');
 
           this.currentDeviceId = deviceId;
           debugPage('device switched to:', deviceId);
@@ -461,6 +554,11 @@ export default class ScrcpyServer {
         'connect-device',
         async (options: ScrcpyConnectDeviceRequest = {}) => {
           const { ScrcpyVideoCodecId } = await import('@yume-chan/scrcpy');
+          const generation = sessionGeneration + 1;
+          sessionGeneration = generation;
+          const sessionId = `${socket.id}:${generation}`;
+          const isCurrentGeneration = () =>
+            socket.connected && sessionGeneration === generation;
           try {
             debugPage(
               'received device connection request, options: %s, client id: %s',
@@ -468,7 +566,7 @@ export default class ScrcpyServer {
               socket.id,
             );
 
-            await closeScrcpyClient('new connect-device request');
+            await closeScrcpySession('new connect-device request');
 
             emitPreviewStatus('connecting-device');
 
@@ -484,7 +582,18 @@ export default class ScrcpyServer {
             adb = await this.getAdb(requestedDeviceId);
             if (!adb) {
               console.error('no available device found');
-              socket.emit('error', { message: 'No device found' });
+              socket.emit(
+                'preview-error',
+                buildScrcpyPreviewErrorEvent(
+                  'adb-unavailable',
+                  sessionId,
+                  'No Android device is available.',
+                ),
+              );
+              return;
+            }
+
+            if (!isCurrentGeneration()) {
               return;
             }
 
@@ -492,11 +601,23 @@ export default class ScrcpyServer {
               'starting scrcpy service, device id: %s',
               this.currentDeviceId,
             );
-            scrcpyClient = await this.startScrcpy(
+            const scrcpyClient: any = await this.startScrcpy(
               adb,
               options,
               emitPreviewStatus,
             );
+            if (!isCurrentGeneration()) {
+              await scrcpyClient.close();
+              return;
+            }
+            const session: ActiveScrcpySession = {
+              client: scrcpyClient,
+              failureReported: false,
+              id: sessionId,
+              outputLines: [],
+            };
+            activeSession = session;
+            monitorScrcpySession(session);
             debugPage('scrcpy service started successfully');
 
             // check scrcpyClient object structure
@@ -541,6 +662,11 @@ export default class ScrcpyServer {
                   videoStream = scrcpyClient.videoStream;
                 }
 
+                if (!isCurrentGeneration() || activeSession !== session) {
+                  await closeScrcpySession('stale video stream', session);
+                  return;
+                }
+
                 debugPage(
                   'video stream fetched successfully, metadata: %s',
                   videoStream.metadata,
@@ -579,7 +705,7 @@ export default class ScrcpyServer {
                 );
 
                 const { stream } = videoStream;
-                const streamScrcpyClient = scrcpyClient;
+                const streamSession = session;
 
                 // convert video stream
                 const reader = stream.getReader();
@@ -588,6 +714,12 @@ export default class ScrcpyServer {
                     while (true) {
                       const { done, value } = await reader.read();
                       if (done) break;
+                      if (
+                        !isCurrentGeneration() ||
+                        activeSession !== streamSession
+                      ) {
+                        return;
+                      }
 
                       // ensure type field is correctly set to 'configuration' or 'data'
                       const frameType = value.type || 'data'; // default to 'data'
@@ -610,15 +742,14 @@ export default class ScrcpyServer {
                     }
                   } catch (error) {
                     console.error('error processing video stream:', error);
-                    if (socket.connected) {
-                      socket.emit('error', {
-                        message:
-                          'Scrcpy video stream failed. Reconnecting preview.',
-                      });
-                    }
-                    void closeScrcpyClient(
+                    emitPreviewError(
+                      streamSession,
+                      'stream-read-failed',
+                      `Scrcpy video stream failed: ${error instanceof Error ? error.message : String(error)}`,
+                    );
+                    void closeScrcpySession(
                       'video stream error',
-                      streamScrcpyClient,
+                      streamSession,
                     );
                     return;
                   }
@@ -629,16 +760,12 @@ export default class ScrcpyServer {
                   // "connected" but no frames flow, so the renderer's decoder
                   // never tears down and the preview freezes on the last
                   // frame until the user manually disconnects.
-                  if (socket.connected) {
-                    socket.emit('error', {
-                      message:
-                        'Scrcpy video stream ended. Reconnecting preview.',
-                    });
-                  }
-                  void closeScrcpyClient(
-                    'video stream ended',
-                    streamScrcpyClient,
+                  emitPreviewError(
+                    streamSession,
+                    'stream-ended',
+                    'Scrcpy video stream ended. Recovering preview.',
                   );
+                  void closeScrcpySession('video stream ended', streamSession);
                 };
 
                 processStream();
@@ -646,16 +773,24 @@ export default class ScrcpyServer {
                 console.error(
                   'scrcpyClient object does not have videoStream property',
                 );
-                socket.emit('error', {
-                  message: 'Video stream not available in scrcpy client',
-                });
+                emitPreviewError(
+                  session,
+                  'unknown',
+                  'Video stream is not available in the scrcpy client.',
+                );
+                await closeScrcpySession('video stream unavailable', session);
+                return;
               }
             } catch (error: any) {
               console.error('error processing video stream:', error);
-              await closeScrcpyClient('video stream setup error');
-              socket.emit('error', {
-                message: `Video stream processing error: ${error.message}`,
-              });
+              emitPreviewError(
+                session,
+                error?.message?.includes('Timed out')
+                  ? 'startup-timeout'
+                  : 'unknown',
+                `Video stream processing error: ${error.message}`,
+              );
+              await closeScrcpySession('video stream setup error', session);
             }
 
             // set control ready
@@ -665,10 +800,28 @@ export default class ScrcpyServer {
             }
           } catch (error: any) {
             console.error('failed to connect device:', error);
-            await closeScrcpyClient('connect-device error');
-            socket.emit('error', {
-              message: `Failed to connect device: ${error?.message || 'Unknown error'}`,
-            });
+            const session = activeSession;
+            if (session?.id === sessionId) {
+              emitPreviewError(
+                session,
+                error?.message?.includes('Timed out')
+                  ? 'startup-timeout'
+                  : 'unknown',
+                `Failed to connect device: ${error?.message || 'Unknown error'}`,
+              );
+              await closeScrcpySession('connect-device error', session);
+            } else if (isCurrentGeneration()) {
+              socket.emit(
+                'preview-error',
+                buildScrcpyPreviewErrorEvent(
+                  error?.message?.includes('Timed out')
+                    ? 'startup-timeout'
+                    : 'unknown',
+                  sessionId,
+                  `Failed to connect device: ${error?.message || 'Unknown error'}`,
+                ),
+              );
+            }
           }
         },
       );
@@ -676,7 +829,8 @@ export default class ScrcpyServer {
       // handle disconnection
       socket.on('disconnect', async (reason) => {
         debugPage('client disconnected, id: %s, reason: %s', socket.id, reason);
-        await closeScrcpyClient(`socket disconnect: ${reason}`);
+        sessionGeneration += 1;
+        await closeScrcpySession(`socket disconnect: ${reason}`);
       });
 
       // Don't block listener registration on the initial device scan. On a

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -387,6 +387,26 @@ export default class ScrcpyServer {
       let scrcpyClient: any = null;
       let adb = null;
 
+      const closeScrcpyClient = async (
+        reason: string,
+        clientToClose = scrcpyClient,
+      ) => {
+        if (!clientToClose) {
+          return;
+        }
+
+        if (scrcpyClient === clientToClose) {
+          scrcpyClient = null;
+        }
+
+        try {
+          debugPage('closing scrcpy client, reason: %s', reason);
+          await clientToClose.close();
+        } catch (error) {
+          console.error(`failed to close scrcpy client (${reason}):`, error);
+        }
+      };
+
       const emitPreviewStatus = (phase: ScrcpyPreviewPhase) => {
         socket.emit('preview-status', buildScrcpyPreviewStatusEvent(phase));
       };
@@ -417,11 +437,7 @@ export default class ScrcpyServer {
       socket.on('switch-device', async (deviceId) => {
         debugPage('received client request to switch device:', deviceId);
         try {
-          // if there is a connection, close it first
-          if (scrcpyClient) {
-            await scrcpyClient.close();
-            scrcpyClient = null;
-          }
+          await closeScrcpyClient('switch device');
 
           this.currentDeviceId = deviceId;
           debugPage('device switched to:', deviceId);
@@ -451,6 +467,8 @@ export default class ScrcpyServer {
               options,
               socket.id,
             );
+
+            await closeScrcpyClient('new connect-device request');
 
             emitPreviewStatus('connecting-device');
 
@@ -561,6 +579,7 @@ export default class ScrcpyServer {
                 );
 
                 const { stream } = videoStream;
+                const streamScrcpyClient = scrcpyClient;
 
                 // convert video stream
                 const reader = stream.getReader();
@@ -593,9 +612,14 @@ export default class ScrcpyServer {
                     console.error('error processing video stream:', error);
                     if (socket.connected) {
                       socket.emit('error', {
-                        message: 'video stream processing error',
+                        message:
+                          'Scrcpy video stream failed. Reconnecting preview.',
                       });
                     }
+                    void closeScrcpyClient(
+                      'video stream error',
+                      streamScrcpyClient,
+                    );
                     return;
                   }
 
@@ -607,20 +631,14 @@ export default class ScrcpyServer {
                   // frame until the user manually disconnects.
                   if (socket.connected) {
                     socket.emit('error', {
-                      message: 'video stream ended',
+                      message:
+                        'Scrcpy video stream ended. Reconnecting preview.',
                     });
                   }
-                  if (scrcpyClient) {
-                    try {
-                      await scrcpyClient.close();
-                    } catch (closeError) {
-                      console.error(
-                        'failed to close scrcpy client after stream ended:',
-                        closeError,
-                      );
-                    }
-                    scrcpyClient = null;
-                  }
+                  void closeScrcpyClient(
+                    'video stream ended',
+                    streamScrcpyClient,
+                  );
                 };
 
                 processStream();
@@ -634,6 +652,7 @@ export default class ScrcpyServer {
               }
             } catch (error: any) {
               console.error('error processing video stream:', error);
+              await closeScrcpyClient('video stream setup error');
               socket.emit('error', {
                 message: `Video stream processing error: ${error.message}`,
               });
@@ -646,17 +665,7 @@ export default class ScrcpyServer {
             }
           } catch (error: any) {
             console.error('failed to connect device:', error);
-            if (scrcpyClient) {
-              try {
-                await scrcpyClient.close();
-              } catch (closeError) {
-                console.error(
-                  'failed to close scrcpy client after error:',
-                  closeError,
-                );
-              }
-              scrcpyClient = null;
-            }
+            await closeScrcpyClient('connect-device error');
             socket.emit('error', {
               message: `Failed to connect device: ${error?.message || 'Unknown error'}`,
             });
@@ -667,17 +676,7 @@ export default class ScrcpyServer {
       // handle disconnection
       socket.on('disconnect', async (reason) => {
         debugPage('client disconnected, id: %s, reason: %s', socket.id, reason);
-
-        if (scrcpyClient) {
-          try {
-            // close scrcpy
-            debugPage('closing scrcpy client');
-            await scrcpyClient.close();
-          } catch (error) {
-            console.error('failed to close scrcpy client:', error);
-          }
-          scrcpyClient = null;
-        }
+        await closeScrcpyClient(`socket disconnect: ${reason}`);
       });
 
       // Don't block listener registration on the initial device scan. On a

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -578,7 +578,10 @@ export default class ScrcpyServer {
                       // byte to a boxed JS Number, blowing the V8 old space on
                       // low-memory hosts (e.g. 8GB Windows) after a few seconds
                       // of a 2 Mbps stream.
-                      socket.emit('video-data', {
+                      // Frames are disposable. `volatile` prevents Socket.IO
+                      // from retaining an unbounded write buffer when the
+                      // renderer is busy decoding or has stopped responding.
+                      socket.volatile.emit('video-data', {
                         data: value.data,
                         type: frameType,
                         timestamp: Date.now(),

--- a/packages/android-playground/tests/unit/scrcpy-preview-status.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-preview-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildScrcpyPreviewErrorEvent,
   buildScrcpyPreviewStatusEvent,
   getScrcpyPreviewStatusMessage,
 } from '../../src/scrcpy-preview-status';
@@ -25,5 +26,20 @@ describe('scrcpy preview status helpers', () => {
       phase: 'starting-service',
       message: 'Starting scrcpy service…',
     });
+  });
+
+  it('marks transient stream failures as recoverable', () => {
+    expect(
+      buildScrcpyPreviewErrorEvent('stream-ended', 'socket:1', 'stream ended'),
+    ).toEqual({
+      reason: 'stream-ended',
+      sessionId: 'socket:1',
+      message: 'stream ended',
+      recoverable: true,
+    });
+    expect(
+      buildScrcpyPreviewErrorEvent('adb-unavailable', 'socket:2', 'no device')
+        .recoverable,
+    ).toBe(false);
   });
 });

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import ScrcpyServer, {
+  appendBoundedScrcpyOutput,
   resolveRequestedDeviceId,
 } from '../../src/scrcpy-server';
 
@@ -44,6 +45,14 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 describe('ScrcpyServer', () => {
+  it('keeps only the most recent scrcpy output lines', () => {
+    const lines: string[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      appendBoundedScrcpyOutput(lines, `line-${index}`, 3);
+    }
+    expect(lines).toEqual(['line-2', 'line-3', 'line-4']);
+  });
+
   it('prefers the explicit device from the preview handshake', () => {
     expect(
       resolveRequestedDeviceId(

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -24,11 +24,15 @@ import type { Socket } from 'socket.io-client';
 import { io } from 'socket.io-client';
 import {
   SCRCPY_METADATA_TIMEOUT_MS,
+  SCRCPY_STABLE_CONNECTION_MS,
   type ScrcpyPreviewStatus,
+  canRecoverScrcpyPreview,
   getDefaultScrcpyWaitingStatusText,
   getScrcpyDecoderStatusText,
   getScrcpyMetadataTimeoutMessage,
   getScrcpyPreviewStatusText,
+  getScrcpyRecoveryDelayMs,
+  isScrcpyPreviewErrorEvent,
   isScrcpyPreviewStatusEvent,
 } from './scrcpy-preview';
 import { createScrcpyVideoStream } from './scrcpy-stream';
@@ -62,6 +66,7 @@ interface ScrcpyPanelProps {
   renderErrorOverlay?: ScrcpyErrorOverlayRenderer;
   serverUrl?: string;
   metadataTimeoutMs?: number;
+  /** @deprecated Recovery now uses a bounded progressive backoff. */
   reconnectInterval?: number;
   viewportStyle?: CSSProperties;
   // Receives the canvas-area wrapper so the device-interaction layer can
@@ -84,7 +89,6 @@ export function ScrcpyPanel({
   renderErrorOverlay,
   serverUrl,
   metadataTimeoutMs = SCRCPY_METADATA_TIMEOUT_MS,
-  reconnectInterval = 3000,
   viewportStyle,
   contentRef,
 }: ScrcpyPanelProps) {
@@ -93,6 +97,9 @@ export function ScrcpyPanel({
   const decoderRef = useRef<WebCodecsVideoDecoder | null>(null);
   const metadataTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stableConnectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const ignoreDisconnectRef = useRef(false);
   const connectionAttemptRef = useRef(0);
   const [status, setStatus] = useState<ScrcpyPreviewStatus>('connecting');
@@ -166,6 +173,8 @@ export function ScrcpyPanel({
 
     let disposed = false;
     let connectTimer: ReturnType<typeof setTimeout> | null = null;
+    let recoveryEpisodeStartedAt = Date.now();
+    let attempt = 1;
 
     const cleanup = () => {
       if (connectTimer) {
@@ -173,6 +182,10 @@ export function ScrcpyPanel({
         connectTimer = null;
       }
       clearMetadataTimeout();
+      if (stableConnectionTimerRef.current) {
+        clearTimeout(stableConnectionTimerRef.current);
+        stableConnectionTimerRef.current = null;
+      }
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
@@ -188,16 +201,53 @@ export function ScrcpyPanel({
       onIntrinsicSize?.(null);
     };
 
-    const scheduleReconnect = () => {
+    const scheduleReconnect = (message: string, recoverable = true) => {
+      const nextAttempt = attempt + 1;
+      const elapsedMs = Date.now() - recoveryEpisodeStartedAt;
       if (disposed || reconnectTimerRef.current) {
         return;
       }
+      if (!canRecoverScrcpyPreview(recoverable, nextAttempt, elapsedMs)) {
+        setStatus('error');
+        setErrorMessage(message);
+        setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
+        clearMetadataTimeout();
+        if (stableConnectionTimerRef.current) {
+          clearTimeout(stableConnectionTimerRef.current);
+          stableConnectionTimerRef.current = null;
+        }
+        ignoreDisconnectRef.current = true;
+        socketRef.current?.disconnect();
+        socketRef.current = null;
+        disposeDecoder();
+        clearCanvas();
+        onIntrinsicSize?.(null);
+        return;
+      }
 
+      const delayMs = getScrcpyRecoveryDelayMs(attempt);
+      setStatus('recovering');
+      setErrorMessage(null);
+      setWaitingStatusMessage(
+        `Preview interrupted. Recovering (${nextAttempt}/5)…`,
+      );
+      clearMetadataTimeout();
+      if (stableConnectionTimerRef.current) {
+        clearTimeout(stableConnectionTimerRef.current);
+        stableConnectionTimerRef.current = null;
+      }
+      ignoreDisconnectRef.current = true;
+      socketRef.current?.disconnect();
+      socketRef.current = null;
+      disposeDecoder();
+      clearCanvas();
+      onIntrinsicSize?.(null);
       reconnectTimerRef.current = setTimeout(() => {
         reconnectTimerRef.current = null;
         cleanup();
+        attempt = nextAttempt;
         connect();
-      }, reconnectInterval);
+      }, delayMs);
     };
 
     const createDecoder = async (codecId: ScrcpyVideoCodecId) => {
@@ -241,7 +291,26 @@ export function ScrcpyPanel({
         transports: ['websocket'],
       });
       socketRef.current = socket;
-      const videoStream = createScrcpyVideoStream(socket);
+      const videoStream = createScrcpyVideoStream(socket, {
+        onFirstDataPacket: () => {
+          if (!isCurrentAttempt() || stableConnectionTimerRef.current) {
+            return;
+          }
+          clearMetadataTimeout();
+          setWaitingStatusMessage('Verifying video stream stability…');
+          stableConnectionTimerRef.current = setTimeout(() => {
+            stableConnectionTimerRef.current = null;
+            if (!isCurrentAttempt()) {
+              return;
+            }
+            recoveryEpisodeStartedAt = Date.now();
+            attempt = 1;
+            setErrorMessage(null);
+            setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
+            setStatus('connected');
+          }, SCRCPY_STABLE_CONNECTION_MS);
+        },
+      });
 
       socket.on('connect', () => {
         if (!isCurrentAttempt()) {
@@ -256,12 +325,7 @@ export function ScrcpyPanel({
           }
 
           ignoreDisconnectRef.current = true;
-          setStatus('error');
-          setErrorMessage(getScrcpyMetadataTimeoutMessage(metadataTimeoutMs));
-          setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-          socket.disconnect();
-          socketRef.current = null;
-          scheduleReconnect();
+          scheduleReconnect(getScrcpyMetadataTimeoutMessage(metadataTimeoutMs));
         }, metadataTimeoutMs);
 
         socket.emit('connect-device', {
@@ -286,7 +350,6 @@ export function ScrcpyPanel({
           if (!isCurrentAttempt()) {
             return;
           }
-          clearMetadataTimeout();
           disposeDecoder();
           setWaitingStatusMessage(getScrcpyDecoderStatusText());
           if (
@@ -310,23 +373,17 @@ export function ScrcpyPanel({
             if (!isCurrentAttempt()) {
               return;
             }
-            setStatus('error');
-            setErrorMessage(error.message);
-            scheduleReconnect();
+            scheduleReconnect(error.message);
           });
 
-          setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-          setStatus('connected');
+          setStatus('waiting-for-stream');
         } catch (error) {
           if (!isCurrentAttempt()) {
             return;
           }
-          setStatus('error');
-          setErrorMessage(
+          scheduleReconnect(
             error instanceof Error ? error.message : 'Failed to start decoder.',
           );
-          setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-          scheduleReconnect();
         }
       });
 
@@ -339,10 +396,7 @@ export function ScrcpyPanel({
           ignoreDisconnectRef.current = false;
           return;
         }
-        setStatus('disconnected');
-        setErrorMessage(null);
-        setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-        scheduleReconnect();
+        scheduleReconnect('scrcpy preview disconnected.');
       });
 
       socket.on('connect_error', (error: Error) => {
@@ -350,10 +404,14 @@ export function ScrcpyPanel({
           return;
         }
         clearMetadataTimeout();
-        setStatus('error');
-        setErrorMessage(error.message);
-        setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-        scheduleReconnect();
+        scheduleReconnect(error.message);
+      });
+
+      socket.on('preview-error', (event: unknown) => {
+        if (!isCurrentAttempt() || !isScrcpyPreviewErrorEvent(event)) {
+          return;
+        }
+        scheduleReconnect(event.message, event.recoverable);
       });
 
       socket.on('error', (error: Error) => {
@@ -361,10 +419,7 @@ export function ScrcpyPanel({
           return;
         }
         clearMetadataTimeout();
-        setStatus('error');
-        setErrorMessage(error.message);
-        setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
-        scheduleReconnect();
+        scheduleReconnect(error.message);
       });
     };
 
@@ -380,7 +435,7 @@ export function ScrcpyPanel({
       disposed = true;
       cleanup();
     };
-  }, [deviceId, metadataTimeoutMs, reconnectInterval, retryNonce, serverUrl]);
+  }, [deviceId, metadataTimeoutMs, retryNonce, serverUrl]);
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -467,7 +522,7 @@ export function ScrcpyPanel({
               <Text style={{ color: '#fff' }}>{statusText}</Text>
               {status === 'error' ? (
                 <Text style={{ color: '#d1d5db' }}>
-                  Scrcpy preview will retry automatically.
+                  Reconnect the preview to try again.
                 </Text>
               ) : null}
               {!webCodecsSupported && (

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -94,6 +94,7 @@ export function ScrcpyPanel({
   const metadataTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ignoreDisconnectRef = useRef(false);
+  const connectionAttemptRef = useRef(0);
   const [status, setStatus] = useState<ScrcpyPreviewStatus>('connecting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [waitingStatusMessage, setWaitingStatusMessage] = useState<string>(() =>
@@ -223,6 +224,11 @@ export function ScrcpyPanel({
         return;
       }
 
+      const attemptId = connectionAttemptRef.current + 1;
+      connectionAttemptRef.current = attemptId;
+      const isCurrentAttempt = () =>
+        !disposed && connectionAttemptRef.current === attemptId;
+
       ignoreDisconnectRef.current = false;
       setStatus('connecting');
       setErrorMessage(null);
@@ -238,11 +244,14 @@ export function ScrcpyPanel({
       const videoStream = createScrcpyVideoStream(socket);
 
       socket.on('connect', () => {
+        if (!isCurrentAttempt()) {
+          return;
+        }
         setStatus('waiting-for-stream');
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
         clearMetadataTimeout();
         metadataTimeoutRef.current = setTimeout(() => {
-          if (disposed) {
+          if (!isCurrentAttempt()) {
             return;
           }
 
@@ -264,7 +273,7 @@ export function ScrcpyPanel({
       });
 
       socket.on('preview-status', (event: unknown) => {
-        if (disposed || !isScrcpyPreviewStatusEvent(event)) {
+        if (!isCurrentAttempt() || !isScrcpyPreviewStatusEvent(event)) {
           return;
         }
 
@@ -274,6 +283,9 @@ export function ScrcpyPanel({
 
       socket.on('video-metadata', async (metadata: VideoMetadata) => {
         try {
+          if (!isCurrentAttempt()) {
+            return;
+          }
           clearMetadataTimeout();
           disposeDecoder();
           setWaitingStatusMessage(getScrcpyDecoderStatusText());
@@ -295,7 +307,7 @@ export function ScrcpyPanel({
           decoderRef.current = decoder;
 
           videoStream.pipeTo(decoder.writable).catch((error: Error) => {
-            if (disposed) {
+            if (!isCurrentAttempt()) {
               return;
             }
             setStatus('error');
@@ -306,7 +318,7 @@ export function ScrcpyPanel({
           setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
           setStatus('connected');
         } catch (error) {
-          if (disposed) {
+          if (!isCurrentAttempt()) {
             return;
           }
           setStatus('error');
@@ -319,10 +331,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('disconnect', () => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         if (ignoreDisconnectRef.current) {
           ignoreDisconnectRef.current = false;
           return;
@@ -334,10 +346,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('connect_error', (error: Error) => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         setStatus('error');
         setErrorMessage(error.message);
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());
@@ -345,10 +357,10 @@ export function ScrcpyPanel({
       });
 
       socket.on('error', (error: Error) => {
-        clearMetadataTimeout();
-        if (disposed) {
+        if (!isCurrentAttempt()) {
           return;
         }
+        clearMetadataTimeout();
         setStatus('error');
         setErrorMessage(error.message);
         setWaitingStatusMessage(getDefaultScrcpyWaitingStatusText());

--- a/packages/playground-app/src/scrcpy-preview.ts
+++ b/packages/playground-app/src/scrcpy-preview.ts
@@ -5,6 +5,7 @@ export const SCRCPY_METADATA_TIMEOUT_MS = SCRCPY_PREVIEW_METADATA_TIMEOUT_MS;
 export type ScrcpyPreviewStatus =
   | 'connecting'
   | 'waiting-for-stream'
+  | 'recovering'
   | 'connected'
   | 'disconnected'
   | 'error';
@@ -14,6 +15,18 @@ export interface ScrcpyPreviewStatusEvent {
   phase?: string;
 }
 
+export interface ScrcpyPreviewErrorEvent {
+  message: string;
+  reason: string;
+  recoverable: boolean;
+  sessionId: string;
+}
+
+export const SCRCPY_RECOVERY_MAX_ATTEMPTS = 5;
+export const SCRCPY_RECOVERY_MAX_ELAPSED_MS = 15_000;
+export const SCRCPY_STABLE_CONNECTION_MS = 2_000;
+const SCRCPY_RECOVERY_DELAYS_MS = [1_000, 2_000, 3_000, 3_000] as const;
+
 export function isScrcpyPreviewStatusEvent(
   value: unknown,
 ): value is ScrcpyPreviewStatusEvent {
@@ -22,6 +35,41 @@ export function isScrcpyPreviewStatusEvent(
     value !== null &&
     'message' in value &&
     typeof (value as { message?: unknown }).message === 'string'
+  );
+}
+
+export function isScrcpyPreviewErrorEvent(
+  value: unknown,
+): value is ScrcpyPreviewErrorEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const event = value as Partial<ScrcpyPreviewErrorEvent>;
+  return (
+    typeof event.message === 'string' &&
+    typeof event.reason === 'string' &&
+    typeof event.recoverable === 'boolean' &&
+    typeof event.sessionId === 'string'
+  );
+}
+
+export function getScrcpyRecoveryDelayMs(attempt: number): number {
+  const delayIndex = Math.max(
+    0,
+    Math.min(attempt - 1, SCRCPY_RECOVERY_DELAYS_MS.length - 1),
+  );
+  return SCRCPY_RECOVERY_DELAYS_MS[delayIndex];
+}
+
+export function canRecoverScrcpyPreview(
+  recoverable: boolean,
+  nextAttempt: number,
+  elapsedMs: number,
+): boolean {
+  return (
+    recoverable &&
+    nextAttempt <= SCRCPY_RECOVERY_MAX_ATTEMPTS &&
+    elapsedMs < SCRCPY_RECOVERY_MAX_ELAPSED_MS
   );
 }
 
@@ -42,6 +90,8 @@ export function getScrcpyPreviewStatusText(
       return 'Live scrcpy preview connected';
     case 'waiting-for-stream':
       return waitingMessage;
+    case 'recovering':
+      return waitingMessage;
     case 'error':
       return 'Unable to start scrcpy preview';
     case 'disconnected':
@@ -55,5 +105,5 @@ export function getScrcpyMetadataTimeoutMessage(
   timeoutMs: number = SCRCPY_METADATA_TIMEOUT_MS,
 ): string {
   const seconds = Math.max(1, Math.round(timeoutMs / 1000));
-  return `Timed out waiting ${seconds}s for scrcpy video stream metadata.`;
+  return `Timed out waiting ${seconds}s for scrcpy video stream data.`;
 }

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -27,10 +27,16 @@ interface ScrcpyVideoSocketLike {
   off(event: 'error', handler: (error: Error) => void): void;
 }
 
+interface ScrcpyVideoStreamOptions {
+  onFirstDataPacket?: () => void;
+}
+
 export function createScrcpyVideoStream(
   socket: ScrcpyVideoSocketLike,
+  options: ScrcpyVideoStreamOptions = {},
 ): ReadableStream<ScrcpyMediaStreamPacket> {
   let configurationPacketSent = false;
+  let firstDataPacketReported = false;
   let pendingDataPackets: ScrcpyMediaStreamPacket[] = [];
   let cleanupListeners: (() => void) | undefined;
   let pendingKeyframe: ScrcpyMediaStreamPacket | undefined;
@@ -39,6 +45,12 @@ export function createScrcpyVideoStream(
       start(controller) {
         const canEnqueue = () =>
           controller.desiredSize === null || controller.desiredSize > 0;
+        const reportFirstDataPacket = () => {
+          if (!firstDataPacketReported) {
+            firstDataPacketReported = true;
+            options.onFirstDataPacket?.();
+          }
+        };
         const handleVideoData = (data: RawScrcpyVideoPacket) => {
           try {
             const payload = toUint8Array(data.data);
@@ -58,6 +70,9 @@ export function createScrcpyVideoStream(
               // This small, bounded initial burst is required by WebCodecs:
               // it must receive configuration before any retained frame.
               controller.enqueue(packet);
+              if (pendingDataPackets.length > 0) {
+                reportFirstDataPacket();
+              }
               pendingDataPackets.forEach((queuedPacket) =>
                 controller.enqueue(queuedPacket),
               );
@@ -78,6 +93,7 @@ export function createScrcpyVideoStream(
             }
 
             if (canEnqueue()) {
+              reportFirstDataPacket();
               controller.enqueue(packet);
             } else if (packet.keyframe) {
               // Discard delta frames while the decoder is behind. The newest

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -32,72 +32,95 @@ export function createScrcpyVideoStream(
 ): ReadableStream<ScrcpyMediaStreamPacket> {
   let configurationPacketSent = false;
   let pendingDataPackets: ScrcpyMediaStreamPacket[] = [];
-
-  const transformStream = new TransformStream<
-    ScrcpyMediaStreamPacket,
-    ScrcpyMediaStreamPacket
-  >({
-    transform(chunk, controller) {
-      if (chunk.type === 'configuration') {
-        configurationPacketSent = true;
-        controller.enqueue(chunk);
-        pendingDataPackets.forEach((queuedPacket) =>
-          controller.enqueue(queuedPacket),
-        );
-        pendingDataPackets = [];
-        return;
-      }
-
-      if (chunk.type === 'data' && !configurationPacketSent) {
-        pendingDataPackets.push(chunk);
-        return;
-      }
-
-      controller.enqueue(chunk);
-    },
-  });
-
   let cleanupListeners: (() => void) | undefined;
-  const readable = new ReadableStream<ScrcpyMediaStreamPacket>({
-    start(controller) {
-      const handleVideoData = (data: RawScrcpyVideoPacket) => {
-        try {
-          const payload = toUint8Array(data.data);
-          if (data.type === 'configuration') {
-            controller.enqueue({
-              type: 'configuration',
-              data: payload,
-            });
-            return;
+  let pendingKeyframe: ScrcpyMediaStreamPacket | undefined;
+  const readable = new ReadableStream<ScrcpyMediaStreamPacket>(
+    {
+      start(controller) {
+        const canEnqueue = () =>
+          controller.desiredSize === null || controller.desiredSize > 0;
+        const handleVideoData = (data: RawScrcpyVideoPacket) => {
+          try {
+            const payload = toUint8Array(data.data);
+            const packet: ScrcpyMediaStreamPacket =
+              data.type === 'configuration'
+                ? {
+                    type: 'configuration',
+                    data: payload,
+                  }
+                : {
+                    type: 'data',
+                    data: payload,
+                    keyframe: data.keyFrame,
+                  };
+            if (packet.type === 'configuration') {
+              configurationPacketSent = true;
+              // This small, bounded initial burst is required by WebCodecs:
+              // it must receive configuration before any retained frame.
+              controller.enqueue(packet);
+              pendingDataPackets.forEach((queuedPacket) =>
+                controller.enqueue(queuedPacket),
+              );
+              pendingDataPackets = [];
+              return;
+            }
+
+            if (!configurationPacketSent) {
+              // Socket.IO cannot apply Web Streams backpressure to scrcpy.
+              // Keep a tiny pre-configuration buffer instead of retaining
+              // every frame while the renderer initializes its decoder.
+              if (packet.keyframe) {
+                pendingDataPackets = [packet];
+              } else if (pendingDataPackets.length < 2) {
+                pendingDataPackets.push(packet);
+              }
+              return;
+            }
+
+            if (canEnqueue()) {
+              controller.enqueue(packet);
+            } else if (packet.keyframe) {
+              // Discard delta frames while the decoder is behind. The newest
+              // keyframe lets it resume without accumulating stale frames.
+              pendingKeyframe = packet;
+            }
+          } catch (error) {
+            controller.error(error);
           }
+        };
 
-          controller.enqueue({
-            type: 'data',
-            data: payload,
-            keyframe: data.keyFrame,
-          });
-        } catch (error) {
-          controller.error(error);
+        const handleDisconnect = () => controller.close();
+        const handleError = (error: Error) => controller.error(error);
+
+        cleanupListeners = () => {
+          socket.off('video-data', handleVideoData);
+          socket.off('disconnect', handleDisconnect);
+          socket.off('error', handleError);
+        };
+
+        socket.on('video-data', handleVideoData);
+        socket.on('disconnect', handleDisconnect);
+        socket.on('error', handleError);
+      },
+      pull(controller) {
+        if (controller.desiredSize === null || controller.desiredSize > 0) {
+          if (
+            pendingKeyframe &&
+            (controller.desiredSize === null || controller.desiredSize > 0)
+          ) {
+            controller.enqueue(pendingKeyframe);
+            pendingKeyframe = undefined;
+          }
         }
-      };
-
-      const handleDisconnect = () => controller.close();
-      const handleError = (error: Error) => controller.error(error);
-
-      cleanupListeners = () => {
-        socket.off('video-data', handleVideoData);
-        socket.off('disconnect', handleDisconnect);
-        socket.off('error', handleError);
-      };
-
-      socket.on('video-data', handleVideoData);
-      socket.on('disconnect', handleDisconnect);
-      socket.on('error', handleError);
+      },
+      cancel() {
+        cleanupListeners?.();
+        pendingKeyframe = undefined;
+        pendingDataPackets = [];
+      },
     },
-    cancel() {
-      cleanupListeners?.();
-    },
-  });
+    { highWaterMark: 4 },
+  );
 
-  return readable.pipeThrough(transformStream);
+  return readable;
 }

--- a/packages/playground-app/tests/scrcpy-preview.test.ts
+++ b/packages/playground-app/tests/scrcpy-preview.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canRecoverScrcpyPreview,
   getDefaultScrcpyWaitingStatusText,
   getScrcpyDecoderStatusText,
   getScrcpyMetadataTimeoutMessage,
   getScrcpyPreviewStatusText,
+  getScrcpyRecoveryDelayMs,
+  isScrcpyPreviewErrorEvent,
   isScrcpyPreviewStatusEvent,
 } from '../src/scrcpy-preview';
 
@@ -48,7 +51,29 @@ describe('scrcpy preview helpers', () => {
 
   it('formats the metadata timeout message in seconds', () => {
     expect(getScrcpyMetadataTimeoutMessage(12_000)).toBe(
-      'Timed out waiting 12s for scrcpy video stream metadata.',
+      'Timed out waiting 12s for scrcpy video stream data.',
     );
+  });
+
+  it('validates structured backend errors', () => {
+    expect(
+      isScrcpyPreviewErrorEvent({
+        message: 'ended',
+        reason: 'stream-ended',
+        recoverable: true,
+        sessionId: 'socket:1',
+      }),
+    ).toBe(true);
+    expect(isScrcpyPreviewErrorEvent({ message: 'ended' })).toBe(false);
+  });
+
+  it('bounds recovery by attempt count and elapsed time', () => {
+    expect(canRecoverScrcpyPreview(true, 5, 14_999)).toBe(true);
+    expect(canRecoverScrcpyPreview(true, 6, 1_000)).toBe(false);
+    expect(canRecoverScrcpyPreview(true, 2, 15_000)).toBe(false);
+    expect(canRecoverScrcpyPreview(false, 2, 1_000)).toBe(false);
+    expect([1, 2, 3, 4, 5].map(getScrcpyRecoveryDelayMs)).toEqual([
+      1_000, 2_000, 3_000, 3_000, 3_000,
+    ]);
   });
 });

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -122,6 +122,33 @@ describe('createScrcpyVideoStream', () => {
     ]);
   });
 
+  test('bounds the pre-configuration buffer while the decoder initializes', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket);
+    const collected = collectStream(stream);
+
+    for (let index = 0; index < 10; index += 1) {
+      socket.dispatchVideoData({
+        type: 'data',
+        data: new Uint8Array([index]),
+      });
+    }
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([9]),
+    });
+    socket.dispatchDisconnect();
+
+    const packets = await collected;
+    expect(packets).toHaveLength(3);
+    expect(packets[0].type).toBe('configuration');
+    expect(
+      packets
+        .filter((packet) => packet.type === 'data')
+        .map((packet) => packet.data[0]),
+    ).toEqual([0, 1]);
+  });
+
   test('propagates keyFrame flag from raw packet as keyframe', async () => {
     const socket = new MockScrcpySocket();
     const stream = createScrcpyVideoStream(socket);

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -1,5 +1,5 @@
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createScrcpyVideoStream } from '../src/scrcpy-stream';
 
 interface RawVideoPayload {
@@ -120,6 +120,25 @@ describe('createScrcpyVideoStream', () => {
       { type: 'data', data: [1, 2, 3] },
       { type: 'data', data: [4, 5, 6] },
     ]);
+  });
+
+  test('reports first usable data only after configuration is available', async () => {
+    const socket = new MockScrcpySocket();
+    const onFirstDataPacket = vi.fn();
+    const stream = createScrcpyVideoStream(socket, { onFirstDataPacket });
+    const collected = collectStream(stream);
+
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([1]) });
+    expect(onFirstDataPacket).not.toHaveBeenCalled();
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([9]),
+    });
+    socket.dispatchVideoData({ type: 'data', data: new Uint8Array([2]) });
+    socket.dispatchDisconnect();
+    await collected;
+
+    expect(onFirstDataPacket).toHaveBeenCalledTimes(1);
   });
 
   test('bounds the pre-configuration buffer while the decoder initializes', async () => {

--- a/packages/playground/src/adapters/remote-execution.ts
+++ b/packages/playground/src/adapters/remote-execution.ts
@@ -690,6 +690,46 @@ export class RemoteExecutionAdapter extends BasePlaygroundAdapter {
     }
   }
 
+  async getRecorderScreenshotAsset(assetId: string): Promise<string | null> {
+    if (!this.serverUrl || !assetId) {
+      return null;
+    }
+    try {
+      const response = await fetch(
+        `${this.serverUrl}/recorder/assets/${encodeURIComponent(assetId)}`,
+      );
+      if (!response.ok) {
+        return null;
+      }
+      const blob = await response.blob();
+      return await new Promise<string | null>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () =>
+          resolve(typeof reader.result === 'string' ? reader.result : null);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(blob);
+      });
+    } catch (error) {
+      console.error('Failed to fetch recorder screenshot asset:', error);
+      return null;
+    }
+  }
+
+  async clearRecorderScreenshotAssets(sessionId: string): Promise<void> {
+    if (!this.serverUrl || !sessionId) {
+      return;
+    }
+    const response = await fetch(
+      `${this.serverUrl}/recorder/assets/session/${encodeURIComponent(sessionId)}`,
+      { method: 'DELETE' },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Recorder screenshot cleanup request failed (${response.status})`,
+      );
+    }
+  }
+
   // Get interface information from server
   async getInterfaceInfo(): Promise<{
     type: string;

--- a/packages/playground/src/sdk/index.ts
+++ b/packages/playground/src/sdk/index.ts
@@ -318,6 +318,19 @@ export class PlaygroundSDK {
     };
   }
 
+  async getRecorderScreenshotAsset(assetId: string): Promise<string | null> {
+    if (this.adapter instanceof RemoteExecutionAdapter) {
+      return this.adapter.getRecorderScreenshotAsset(assetId);
+    }
+    return null;
+  }
+
+  async clearRecorderScreenshotAssets(sessionId: string): Promise<void> {
+    if (this.adapter instanceof RemoteExecutionAdapter) {
+      await this.adapter.clearRecorderScreenshotAssets(sessionId);
+    }
+  }
+
   // Get interface information (type and description)
   async getInterfaceInfo(): Promise<{
     type: string;

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -1,5 +1,13 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import type { Server } from 'node:http';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,6 +42,7 @@ import {
 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type {
+  MidsceneRecorderScreenshotAssetRef,
   MidsceneRecorderSemantic,
   MidsceneRecorderSemanticAction,
 } from '@midscene/shared/recorder';
@@ -73,6 +82,12 @@ const RECORDER_CAPTURE_AFTER_INTERACT_DELAY_MS = 250;
 const RECORDER_AI_DESCRIBE_AFTER_INTERACT_TIMEOUT_MS = 30_000;
 const RECORDER_AI_DESCRIBE_SCREENSHOT_DUMP_DIR =
   'recorder-ai-describe-screenshots';
+const RECORDER_SCREENSHOT_ASSET_DIR = 'recorder-screenshots';
+const RECORDER_SCREENSHOT_ASSET_MAX_SESSION_BYTES = 128 * 1024 * 1024;
+const RECORDER_SCREENSHOT_ASSET_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+const recorderScreenshotAssetQuotaExceededSessions = new Set<string>();
+const recorderScreenshotAssetBytesBySession = new Map<string, number>();
+let recorderScreenshotAssetUsageInitialized = false;
 
 function createElementDescriberRuntime(
   agent: PageAgent,
@@ -259,6 +274,163 @@ function writeRecorderAiDescribeScreenshot(
     bytes: bytes.byteLength,
     mimeType,
   };
+}
+
+function getRecorderScreenshotAssetRoot() {
+  const root = resolve(
+    getMidsceneRunSubDir('output'),
+    RECORDER_SCREENSHOT_ASSET_DIR,
+  );
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function assertRecorderScreenshotAssetId(assetId: string) {
+  if (!/^[a-zA-Z0-9_-]+$/.test(assetId)) {
+    throw new Error('Invalid recorder screenshot asset id');
+  }
+  return assetId;
+}
+
+function recorderScreenshotAssetExtension(mimeType?: string) {
+  return mimeType?.includes('jpeg') ? 'jpg' : 'png';
+}
+
+function recorderScreenshotAssetPath(assetId: string, mimeType?: string) {
+  const root = getRecorderScreenshotAssetRoot();
+  const safeAssetId = assertRecorderScreenshotAssetId(assetId);
+  return assertPathInsideDirectory(
+    root,
+    join(root, `${safeAssetId}.${recorderScreenshotAssetExtension(mimeType)}`),
+  );
+}
+
+function getRecorderScreenshotAssetUsage(sessionId: string) {
+  initializeRecorderScreenshotAssetUsage();
+  const safeSessionId = sanitizeRecorderPathSegment(sessionId, 'session');
+  const sessionBytes =
+    recorderScreenshotAssetBytesBySession.get(safeSessionId) || 0;
+  const totalBytes = Array.from(
+    recorderScreenshotAssetBytesBySession.values(),
+  ).reduce((total, bytes) => total + bytes, 0);
+  return { totalBytes, sessionBytes };
+}
+
+function initializeRecorderScreenshotAssetUsage() {
+  if (recorderScreenshotAssetUsageInitialized) {
+    return;
+  }
+  recorderScreenshotAssetUsageInitialized = true;
+  const root = getRecorderScreenshotAssetRoot();
+  try {
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      const match = entry.name.match(
+        /^(.*)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpg)$/i,
+      );
+      if (!match?.[1]) {
+        continue;
+      }
+      const sessionId = match[1];
+      const bytes = statSync(join(root, entry.name)).size;
+      recorderScreenshotAssetBytesBySession.set(
+        sessionId,
+        (recorderScreenshotAssetBytesBySession.get(sessionId) || 0) + bytes,
+      );
+    }
+  } catch (error) {
+    debugRecorderAssets(
+      'failed to initialize recorder screenshot asset usage:',
+      error,
+    );
+  }
+}
+
+function persistRecorderScreenshotAsset(
+  sessionId: string,
+  imageBase64?: string,
+): MidsceneRecorderScreenshotAssetRef | undefined {
+  if (!imageBase64?.startsWith('data:')) {
+    return undefined;
+  }
+  const { base64, mimeType } = extractBase64Payload(imageBase64);
+  const bytes = Buffer.from(base64, 'base64');
+  const safeSessionId = sanitizeRecorderPathSegment(sessionId, 'session');
+  const usage = getRecorderScreenshotAssetUsage(sessionId);
+  if (
+    usage.sessionBytes + bytes.byteLength >
+      RECORDER_SCREENSHOT_ASSET_MAX_SESSION_BYTES ||
+    usage.totalBytes + bytes.byteLength >
+      RECORDER_SCREENSHOT_ASSET_MAX_TOTAL_BYTES
+  ) {
+    if (!recorderScreenshotAssetQuotaExceededSessions.has(safeSessionId)) {
+      recorderScreenshotAssetQuotaExceededSessions.add(safeSessionId);
+      debugRecorderAssets('recorder screenshot asset quota reached %o', {
+        sessionId: safeSessionId,
+        sessionBytes: usage.sessionBytes,
+        totalBytes: usage.totalBytes,
+      });
+    }
+    return undefined;
+  }
+  const assetId = `${safeSessionId}-${randomUUID()}`;
+  const normalizedMimeType = mimeType || 'image/png';
+  const filePath = recorderScreenshotAssetPath(assetId, normalizedMimeType);
+  try {
+    writeFileSync(filePath, bytes);
+  } catch (error) {
+    debugRecorderAssets('failed to persist recorder screenshot asset:', error);
+    return undefined;
+  }
+  recorderScreenshotAssetBytesBySession.set(
+    safeSessionId,
+    usage.sessionBytes + bytes.byteLength,
+  );
+  return {
+    id: assetId,
+    mimeType: normalizedMimeType,
+    bytes: bytes.byteLength,
+  };
+}
+
+function readRecorderScreenshotAsset(
+  asset: MidsceneRecorderScreenshotAssetRef,
+): string | undefined {
+  const filePath = recorderScreenshotAssetPath(asset.id, asset.mimeType);
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  return `data:${asset.mimeType};base64,${readFileSync(filePath).toString('base64')}`;
+}
+
+function findRecorderScreenshotAssetPath(assetId: string) {
+  const safeAssetId = assertRecorderScreenshotAssetId(assetId);
+  const root = getRecorderScreenshotAssetRoot();
+  for (const extension of ['png', 'jpg']) {
+    const filePath = assertPathInsideDirectory(
+      root,
+      join(root, `${safeAssetId}.${extension}`),
+    );
+    if (existsSync(filePath)) {
+      return filePath;
+    }
+  }
+  return undefined;
+}
+
+function removeRecorderScreenshotAssetsForSession(sessionId: string) {
+  const safeSessionId = sanitizeRecorderPathSegment(sessionId, 'session');
+  const prefix = `${safeSessionId}-`;
+  const root = getRecorderScreenshotAssetRoot();
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith(prefix)) {
+      rmSync(join(root, entry.name), { force: true });
+    }
+  }
+  recorderScreenshotAssetQuotaExceededSessions.delete(safeSessionId);
+  recorderScreenshotAssetBytesBySession.delete(safeSessionId);
 }
 
 function calculateRecorderScreenshotAnnotation(
@@ -551,6 +723,9 @@ const STATIC_PATH = join(__dirname, '..', '..', 'static');
 const debugScreenshot = getDebug('playground:screenshot', { console: true });
 const debugMjpeg = getDebug('playground:mjpeg', { console: true });
 const debugInteract = getDebug('playground:interact', { console: true });
+const debugRecorderAssets = getDebug('playground:recorder-assets', {
+  console: true,
+});
 
 /**
  * Thrown when a caller supplies an /interact body that fails validation
@@ -1467,6 +1642,15 @@ class PlaygroundServer {
     }
   }
 
+  private persistStudioPreviewRecorderScreenshot(
+    screenshot?: string,
+  ): MidsceneRecorderScreenshotAssetRef | undefined {
+    if (!this._recorderSessionId) {
+      return undefined;
+    }
+    return persistRecorderScreenshotAsset(this._recorderSessionId, screenshot);
+  }
+
   private async storeStudioPreviewRecorderEvent(
     payload: Record<string, unknown>,
     snapshotBefore?: PlaygroundRecorderSnapshot,
@@ -1564,6 +1748,19 @@ class PlaygroundServer {
             { x, y },
           )
         : undefined;
+    const screenshotAsset = this.persistStudioPreviewRecorderScreenshot(
+      screenshotWithMarker || screenshotBefore || screenshotAfter,
+    );
+    const shouldDiscardDataUrlScreenshot = Boolean(
+      (screenshotWithMarker || screenshotBefore || screenshotAfter)?.startsWith(
+        'data:',
+      ),
+    );
+    const hasRetainedScreenshot = Boolean(
+      screenshotAsset ||
+        (!shouldDiscardDataUrlScreenshot &&
+          (screenshotWithMarker || screenshotBefore || screenshotAfter)),
+    );
 
     const base = {
       source: 'studio-preview' as const,
@@ -1572,13 +1769,23 @@ class PlaygroundServer {
       pageInfo,
       url,
       title,
-      screenshotBefore,
-      screenshotAfter,
-      screenshotWithBox: screenshotWithMarker,
-      semantic: {
-        source: 'aiDescribe' as const,
-        status: 'pending' as const,
-      },
+      ...(screenshotAsset
+        ? { screenshotAsset }
+        : shouldDiscardDataUrlScreenshot
+          ? {}
+          : {
+              screenshotBefore,
+              screenshotAfter,
+              screenshotWithBox: screenshotWithMarker,
+            }),
+      semantic: hasRetainedScreenshot
+        ? {
+            source: 'aiDescribe' as const,
+            status: 'pending' as const,
+          }
+        : buildFailedAiDescribeRecorderSemantic(
+            'Recorder screenshot was not retained because asset storage is unavailable or its quota was reached.',
+          ),
       timestamp,
       hashId: `studio-preview-${actionType}-${timestamp}-${Math.random()
         .toString(36)
@@ -1696,7 +1903,7 @@ class PlaygroundServer {
   }> {
     const startedAt = new Date();
     const startedAtMs = Date.now();
-    const eventScreenshot = this.getRecorderAiDescribeScreenshot(event);
+    const eventScreenshot = await this.getRecorderAiDescribeScreenshot(event);
     const traceBase = createRecorderAiDescribeTraceBase(event, eventScreenshot);
     const finishTrace = async (
       status: PlaygroundRecorderDescribeTrace['status'],
@@ -1948,9 +2155,15 @@ class PlaygroundServer {
     }
   }
 
-  private getRecorderAiDescribeScreenshot(
+  private async getRecorderAiDescribeScreenshot(
     event: PlaygroundRecorderEvent,
-  ): string | undefined {
+  ): Promise<string | undefined> {
+    if (event.screenshotAsset) {
+      const screenshot = readRecorderScreenshotAsset(event.screenshotAsset);
+      if (screenshot) {
+        return screenshot;
+      }
+    }
     if (
       event.type === 'click' ||
       event.type === 'input' ||
@@ -1959,7 +2172,9 @@ class PlaygroundServer {
     ) {
       return event.screenshotBefore || event.screenshotAfter;
     }
-    return event.screenshotAfter || event.screenshotBefore;
+    return (
+      event.screenshotAfter || event.screenshotBefore || event.screenshotWithBox
+    );
   }
 
   private queueStudioPreviewRecorderEventAppend(
@@ -2039,6 +2254,11 @@ class PlaygroundServer {
       { value: afterUrl },
       afterUrl,
     );
+    const screenshotAsset =
+      this.persistStudioPreviewRecorderScreenshot(screenshotAfter);
+    const shouldDiscardDataUrlScreenshot = Boolean(
+      screenshotAfter?.startsWith('data:'),
+    );
     return {
       source: 'studio-preview',
       type: 'navigation',
@@ -2052,8 +2272,11 @@ class PlaygroundServer {
       url: afterUrl,
       title: pageStateAfter.title,
       value: afterUrl,
-      screenshotBefore: screenshotAfter,
-      screenshotAfter,
+      ...(screenshotAsset
+        ? { screenshotAsset }
+        : shouldDiscardDataUrlScreenshot
+          ? {}
+          : { screenshotBefore: screenshotAfter, screenshotAfter }),
       semantic: buildReadyRecorderSemantic(
         'heuristic',
         semanticEvent,
@@ -2081,6 +2304,11 @@ class PlaygroundServer {
       { value: pageState.url },
       pageState.url,
     );
+    const screenshotAsset =
+      this.persistStudioPreviewRecorderScreenshot(screenshot);
+    const shouldDiscardDataUrlScreenshot = Boolean(
+      screenshot?.startsWith('data:'),
+    );
     return {
       source: 'studio-preview',
       type: 'navigation',
@@ -2093,8 +2321,11 @@ class PlaygroundServer {
       url: pageState.url,
       title: pageState.title,
       value: pageState.url,
-      screenshotBefore: screenshot,
-      screenshotAfter: screenshot,
+      ...(screenshotAsset
+        ? { screenshotAsset }
+        : shouldDiscardDataUrlScreenshot
+          ? {}
+          : { screenshotBefore: screenshot, screenshotAfter: screenshot }),
       semantic: buildReadyRecorderSemantic(
         'heuristic',
         semanticEvent,
@@ -3014,6 +3245,50 @@ class PlaygroundServer {
         nextIndex: this._recorderEvents.length,
       });
     });
+
+    this._app.get(
+      '/recorder/assets/:assetId',
+      async (req: Request, res: Response) => {
+        try {
+          const assetId = String(req.params.assetId || '');
+          const filePath = findRecorderScreenshotAssetPath(assetId);
+          if (!filePath) {
+            return res
+              .status(404)
+              .json({ error: 'Recorder screenshot not found' });
+          }
+          res.type(filePath.endsWith('.jpg') ? 'image/jpeg' : 'image/png');
+          return res.send(readFileSync(filePath));
+        } catch (error) {
+          return res.status(400).json({
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Invalid recorder screenshot request',
+          });
+        }
+      },
+    );
+
+    this._app.delete(
+      '/recorder/assets/session/:sessionId',
+      async (req: Request, res: Response) => {
+        try {
+          removeRecorderScreenshotAssetsForSession(
+            String(req.params.sessionId || ''),
+          );
+          return res.json({ ok: true });
+        } catch (error) {
+          return res.status(400).json({
+            ok: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Invalid recorder session id',
+          });
+        }
+      },
+    );
 
     this._app.post(
       '/recorder/describe-event',

--- a/packages/playground/tests/unit/server-interact.test.ts
+++ b/packages/playground/tests/unit/server-interact.test.ts
@@ -33,6 +33,9 @@ function createMockResponse() {
       this.body = payload;
       return this;
     },
+    type() {
+      return this;
+    },
   };
 }
 
@@ -411,7 +414,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
         interfaceType: 'android',
         describe: () => 'Android device',
         actionSpace: () => [{ name: 'Tap', description: 'tap', call: tapCall }],
-        screenshotBase64: async () => 'base64-image',
+        screenshotBase64: async () => VALID_PNG_BASE64,
         size: async () => ({ width: 1080, height: 1920 }),
       },
     } as any);
@@ -506,7 +509,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
         interfaceType: 'ios',
         actionSpace: () => [],
         inputPrimitives,
-        screenshotBase64: async () => 'base64-image',
+        screenshotBase64: async () => VALID_PNG_BASE64,
         size: async () => ({ width: 390, height: 844 }),
       },
     } as any);
@@ -552,6 +555,28 @@ describe('PlaygroundServer manual interaction APIs', () => {
     });
     const rawEvents = (eventsResponse.body as any).events;
     expect(rawEvents).toHaveLength(1);
+    expect(rawEvents[0]).toMatchObject({
+      screenshotAsset: {
+        id: expect.stringMatching(/^session-preview-/),
+        mimeType: 'image/png',
+        bytes: expect.any(Number),
+      },
+    });
+    expect(rawEvents[0].screenshotBefore).toBeUndefined();
+    expect(rawEvents[0].screenshotAfter).toBeUndefined();
+    expect(rawEvents[0].screenshotWithBox).toBeUndefined();
+
+    const assetHandler = getRouteHandler(
+      server,
+      'get',
+      '/recorder/assets/:assetId',
+    );
+    const assetResponse = createMockResponse();
+    await assetHandler(
+      { params: { assetId: rawEvents[0].screenshotAsset.id } },
+      assetResponse,
+    );
+    expect(assetResponse.statusCode).toBe(200);
 
     const describeResponse = await describeRecorderEvent(server, rawEvents[0]);
     expect(describeResponse.body).toMatchObject({
@@ -617,12 +642,56 @@ describe('PlaygroundServer manual interaction APIs', () => {
       [10, 20],
       expect.objectContaining({
         verifyPrompt: true,
-        screenshotBase64: 'base64-image',
+        screenshotBase64: expect.stringMatching(/^data:image\/png;base64,/),
         coordinateSpace: 'logical',
         logicalSize: { width: 390, height: 844 },
         onProgress: expect.any(Function),
       }),
     );
+  });
+
+  test('recorder marks events failed when a screenshot cannot be retained', async () => {
+    const inputPrimitives = makeInputPrimitiveStub();
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'ios',
+        actionSpace: () => [],
+        inputPrimitives,
+        screenshotBase64: async () => undefined,
+        size: async () => ({ width: 390, height: 844 }),
+      },
+    } as any);
+
+    await server.launch(6119);
+    const startRecorderHandler = getRouteHandler(
+      server,
+      'post',
+      '/recorder/start',
+    );
+    await startRecorderHandler(
+      { body: { sessionId: 'session-without-screenshot' } },
+      createMockResponse(),
+    );
+    const interactHandler = getRouteHandler(server, 'post', '/interact');
+    await interactHandler(
+      { body: { actionType: 'Tap', x: 10, y: 20 } },
+      createMockResponse(),
+    );
+    await server.waitForRecorderIdle();
+
+    const eventsHandler = getRouteHandler(server, 'get', '/recorder/events');
+    const eventsResponse = createMockResponse();
+    await eventsHandler({ query: { since: '0' } }, eventsResponse);
+    expect((eventsResponse.body as any).events).toMatchObject([
+      {
+        type: 'click',
+        semantic: {
+          source: 'aiDescribe',
+          status: 'failed',
+          error: expect.stringContaining('screenshot was not retained'),
+        },
+      },
+    ]);
   });
 
   test('recorder dispatches preview interactions before taking the after screenshot', async () => {

--- a/packages/shared/src/recorder.ts
+++ b/packages/shared/src/recorder.ts
@@ -34,6 +34,19 @@ export interface MidsceneRecorderPageInfo {
   height: number;
 }
 
+/**
+ * A screenshot stored outside the recording event payload.
+ *
+ * Recorder events are persisted in the Studio renderer. Keeping full data
+ * URLs there makes long recordings retain every screenshot in the renderer
+ * heap, so screenshot bytes live in the Playground run directory instead.
+ */
+export interface MidsceneRecorderScreenshotAssetRef {
+  id: string;
+  mimeType: string;
+  bytes: number;
+}
+
 export interface MidsceneRecorderEvent {
   type: MidsceneRecorderEventType;
   source?: MidsceneRecorderSourceKind;
@@ -46,6 +59,8 @@ export interface MidsceneRecorderEvent {
   pageInfo: MidsceneRecorderPageInfo;
   screenshotBefore?: string;
   screenshotAfter?: string;
+  /** The single screenshot retained for AI description and Markdown export. */
+  screenshotAsset?: MidsceneRecorderScreenshotAssetRef;
   semantic?: MidsceneRecorderSemantic;
   elementDescription?: string;
   descriptionLoading?: boolean;


### PR DESCRIPTION
## Summary
- Store recorder screenshots as file-backed assets instead of renderer-held data URLs.
- Bound scrcpy frame buffering and recorder asset retention, including cleanup for evicted sessions.
- Bound screenshot materialization during exports and mark unavailable screenshots as failed instead of pending.

## Tests / verification
- pnpm --dir packages/playground test -- server-interact.test.ts
- pnpm --dir apps/studio test -- studio-recorder-export.test.ts studio-recorder-provider.test.tsx studio-recorder-storage.test.ts
- pnpm --dir packages/playground-app test -- scrcpy-stream.test.ts
- pnpm --dir apps/studio build
- pnpm --dir packages/playground build
- pnpm run lint

## Notes
- Existing pre-v3 recorder history is intentionally discarded during the IndexedDB migration.