### PR TITLE
fix(core): record model response request IDs

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -80,6 +80,16 @@ function stringifyForDebug(value: unknown): string {
   }
 }
 
+function getLatestSuccessfulResponseRequestId(
+  context: OpenAIErrorResponseContext,
+): string | undefined {
+  return context.responseRequestIds?.reduce<string | undefined>(
+    (latestRequestId, response) =>
+      response.ok ? response.requestId : latestRequestId,
+    undefined,
+  );
+}
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -516,7 +526,9 @@ export async function callAI(
           _request_id?: string | null;
         };
 
-        requestId = stream._request_id;
+        requestId =
+          getLatestSuccessfulResponseRequestId(openAIErrorResponseContext) ??
+          stream._request_id;
 
         for await (const chunk of stream) {
           const parsedChunk = adapter.chatCompletion.extractContentAndReasoning(
@@ -618,9 +630,12 @@ export async function callAI(
           );
 
           timeCost = Date.now() - startTime;
+          requestId =
+            getLatestSuccessfulResponseRequestId(openAIErrorResponseContext) ??
+            result._request_id;
 
           debugProfileStats(
-            `model, ${modelName}, mode, ${modelFamily || 'default'}, prompt-tokens, ${result.usage?.prompt_tokens || ''}, completion-tokens, ${result.usage?.completion_tokens || ''}, total-tokens, ${result.usage?.total_tokens || ''}, cost-ms, ${timeCost}, requestId, ${result._request_id || ''}, temperature, ${temperature ?? ''}`,
+            `model, ${modelName}, mode, ${modelFamily || 'default'}, prompt-tokens, ${result.usage?.prompt_tokens || ''}, completion-tokens, ${result.usage?.completion_tokens || ''}, total-tokens, ${result.usage?.total_tokens || ''}, cost-ms, ${timeCost}, requestId, ${requestId || ''}, temperature, ${temperature ?? ''}`,
           );
 
           debugProfileDetail(
@@ -641,7 +656,6 @@ export async function callAI(
           content = parsedMessage.content;
           accumulatedReasoning = parsedMessage.reasoning_content;
           usage = result.usage;
-          requestId = result._request_id;
           responseModelName = result.model;
 
           content = resolveContentWithReasoningFallback(

--- a/packages/core/src/ai-model/service-caller/openai-error.ts
+++ b/packages/core/src/ai-model/service-caller/openai-error.ts
@@ -6,6 +6,12 @@ const MAX_FETCH_ERROR_LENGTH = 4000;
 const debugOpenAIFetch = getDebug('ai:call');
 
 export interface OpenAIErrorResponseContext {
+  responseRequestIds?: Array<{
+    attempt: number;
+    requestId: string;
+    status: number;
+    ok: boolean;
+  }>;
   rawResponseBodies?: Array<{
     attempt: number;
     body: string;
@@ -96,6 +102,20 @@ export function wrapOpenAICompatibleFetch(
       throw error;
     }
 
+    const requestId =
+      response.headers.get('x-request-id') ??
+      response.headers.get('x-model-request-id');
+
+    if (requestId) {
+      context.responseRequestIds ??= [];
+      context.responseRequestIds.push({
+        attempt,
+        requestId,
+        status: response.status,
+        ok: response.ok,
+      });
+    }
+
     if (!response.ok) {
       // OpenAI SDK only exposes the `error` field for JSON error responses.
       // Non-standard provider bodies like `{ err: 'xxx' }` would otherwise be
@@ -141,6 +161,24 @@ export function formatOpenAIAPIErrorDetails(
     details.push(
       `OpenAI raw error response bodies:\n${rawResponseBodyDetails}`,
     );
+  }
+
+  const errorResponseRequestIds = context.responseRequestIds?.filter(
+    ({ ok }) => !ok,
+  );
+  if (errorResponseRequestIds?.length === 1) {
+    const { attempt, requestId, status } = errorResponseRequestIds[0];
+    details.push(
+      `OpenAI error response request ID (attempt ${attempt}, status ${status}): ${requestId}`,
+    );
+  } else if (errorResponseRequestIds?.length) {
+    const requestIdDetails = errorResponseRequestIds
+      .map(
+        ({ attempt, requestId, status }) =>
+          `Attempt ${attempt} (status ${status}): ${requestId}`,
+      )
+      .join('\n');
+    details.push(`OpenAI error response request IDs:\n${requestIdDetails}`);
   }
 
   if (context.fetchErrors?.length === 1) {

--- a/packages/core/tests/unit-test/service-caller-openai-error.test.ts
+++ b/packages/core/tests/unit-test/service-caller-openai-error.test.ts
@@ -61,6 +61,9 @@ describe('service-caller OpenAI error handling', () => {
     expect(wrappedResponse).toBe(response);
     await expect(wrappedResponse.text()).resolves.toBe(responseBody);
     expect(context).toEqual({
+      responseRequestIds: [
+        { attempt: 1, requestId: 'req_123', status: 422, ok: false },
+      ],
       rawResponseBodies: [{ attempt: 1, body: responseBody }],
     });
   });
@@ -80,6 +83,71 @@ describe('service-caller OpenAI error handling', () => {
       wrapOpenAICompatibleFetch(context)('https://example.com'),
     ).resolves.toBe(response);
     expect(context).toEqual({});
+  });
+
+  it('uses x-model-request-id as usage request_id when x-request-id is absent', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        headers: { 'x-model-request-id': 'model_req_123' },
+      }),
+    );
+    mockCreate.mockImplementation(async () => {
+      await mockOpenAIConstructor.mock.calls
+        .at(-1)?.[0]
+        .fetch('https://example.com/v1/chat/completions');
+      return {
+        choices: [{ message: { content: 'hello' } }],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+        _request_id: null,
+      };
+    });
+
+    const response = await callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime(baseConfig()),
+    );
+
+    expect(response.usage?.request_id).toBe('model_req_123');
+  });
+
+  it('prefers x-request-id over x-model-request-id', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        headers: {
+          'x-request-id': 'req_123',
+          'x-model-request-id': 'model_req_123',
+        },
+      }),
+    );
+    mockCreate.mockImplementation(async () => {
+      await mockOpenAIConstructor.mock.calls
+        .at(-1)?.[0]
+        .fetch('https://example.com/v1/chat/completions');
+      return {
+        choices: [{ message: { content: 'hello' } }],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+        _request_id: null,
+      };
+    });
+
+    const response = await callAI(
+      [{ role: 'user', content: 'hello' }],
+      getModelRuntime(baseConfig()),
+    );
+
+    expect(response.usage?.request_id).toBe('req_123');
   });
 
   it('keeps raw response bodies from multiple failed requests', async () => {
@@ -173,7 +241,10 @@ describe('service-caller OpenAI error handling', () => {
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(rawResponseBody, {
         status: 422,
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          'x-model-request-id': 'model_req_123',
+        },
       }),
     );
     mockCreate.mockImplementation(async () => {
@@ -192,6 +263,9 @@ describe('service-caller OpenAI error handling', () => {
 
     await expect(promise).rejects.toThrow(
       /OpenAI raw error response body: \{"detail":"model does not exist","trace_id":"trace_123"\}/,
+    );
+    await expect(promise).rejects.toThrow(
+      /OpenAI error response request ID \(attempt 1, status 422\): model_req_123/,
     );
   });
 });


### PR DESCRIPTION
## Summary

- Capture model response request IDs from `x-request-id` with `x-model-request-id` as a fallback.
- Preserve request IDs from both successful and failed HTTP responses, including retry attempt and status metadata.
- Include failed-response request IDs in model-call error details while ensuring usage records use only the final successful response ID.

## Root cause

The OpenAI SDK only exposes the standard `x-request-id` as `_request_id`; provider-specific `x-model-request-id` headers were not retained by Midscene.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/service-caller-openai-error.test.ts`