### PR TITLE
ci(workflow): limit release notes and validate PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    name: Validate title
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+      with:
+        version: 9.3.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: '24.13.0'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Validate PR title
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: printf '%s\n' "$PR_TITLE" | pnpm exec commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,7 +439,7 @@ jobs:
                     $name
                   end;
               def normalized_type:
-                (try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other")
+                ((try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other") // "other")
                 | ascii_downcase
                 | if . == "feat" then "feat"
                   elif . == "fix" then "fix"
@@ -452,6 +452,9 @@ jobs:
                   elif . == "chore" then "chore"
                   else "other"
                   end;
+              def normalized_scope:
+                ((try capture("^[A-Za-z]+\\((?<scope>[^)]*)\\)!?:").scope catch "") // "")
+                | ascii_downcase;
               def parse_change:
                 . as $line
                 | if $line | test("^[*-] ") then
@@ -464,6 +467,7 @@ jobs:
                     )
                     | .title |= gsub("^\\s+|\\s+$"; "")
                     | .type = (.title | normalized_type)
+                    | .scope = (.title | normalized_scope)
                   else
                     empty
                   end;
@@ -473,7 +477,6 @@ jobs:
                   {key: "fix", label: "Fixes"},
                   {key: "perf", label: "Performance"},
                   {key: "refactor", label: "Refactors"},
-                  {key: "docs", label: "Documentation"},
                   {key: "test", label: "Tests"},
                   {key: "build", label: "Build"},
                   {key: "ci", label: "CI"},
@@ -490,7 +493,11 @@ jobs:
                 end;
 
               ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
-              | [$clean_body | split("\n")[] | parse_change] as $changes
+              | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
+              | [
+                  $parsed_changes[]
+                  | select(.type != "docs" and .scope != "site")
+                ] as $changes
               | [
                   category_definitions[] as $category
                   | [$changes[] | select(.type == $category.key)] as $items
@@ -506,6 +513,8 @@ jobs:
               | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
               | (if $change_count > 0 then
                     $grouped_notes
+                  elif ($parsed_changes | length) > 0 then
+                    "Midscene.js \($version) is now available."
                   elif $raw_notes != "" then
                     $raw_notes
                   else
@@ -666,7 +675,7 @@ jobs:
                     $name
                   end;
               def normalized_type:
-                (try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other")
+                ((try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other") // "other")
                 | ascii_downcase
                 | if . == "feat" then "feat"
                   elif . == "fix" then "fix"
@@ -679,6 +688,9 @@ jobs:
                   elif . == "chore" then "chore"
                   else "other"
                   end;
+              def normalized_scope:
+                ((try capture("^[A-Za-z]+\\((?<scope>[^)]*)\\)!?:").scope catch "") // "")
+                | ascii_downcase;
               def parse_change:
                 . as $line
                 | if $line | test("^[*-] ") then
@@ -691,6 +703,7 @@ jobs:
                     )
                     | .title |= gsub("^\\s+|\\s+$"; "")
                     | .type = (.title | normalized_type)
+                    | .scope = (.title | normalized_scope)
                   else
                     empty
                   end;
@@ -700,7 +713,6 @@ jobs:
                   {key: "fix", label: "Fixes"},
                   {key: "perf", label: "Performance"},
                   {key: "refactor", label: "Refactors"},
-                  {key: "docs", label: "Documentation"},
                   {key: "test", label: "Tests"},
                   {key: "build", label: "Build"},
                   {key: "ci", label: "CI"},
@@ -717,7 +729,11 @@ jobs:
                 end;
 
               ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
-              | [$clean_body | split("\n")[] | parse_change] as $changes
+              | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
+              | [
+                  $parsed_changes[]
+                  | select(.type != "docs" and .scope != "site")
+                ] as $changes
               | [
                   category_definitions[] as $category
                   | [$changes[] | select(.type == $category.key)] as $items
@@ -733,6 +749,8 @@ jobs:
               | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
               | (if $change_count > 0 then
                     $grouped_notes
+                  elif ($parsed_changes | length) > 0 then
+                    "Midscene.js \($version) is now available."
                   elif $raw_notes != "" then
                     $raw_notes
                   else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,14 +474,7 @@ jobs:
               def category_definitions:
                 [
                   {key: "feat", label: "Features"},
-                  {key: "fix", label: "Fixes"},
-                  {key: "perf", label: "Performance"},
-                  {key: "refactor", label: "Refactors"},
-                  {key: "test", label: "Tests"},
-                  {key: "build", label: "Build"},
-                  {key: "ci", label: "CI"},
-                  {key: "chore", label: "Chores"},
-                  {key: "other", label: "Other"}
+                  {key: "fix", label: "Fixes"}
                 ];
               def safe_title:
                 gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
@@ -496,7 +489,7 @@ jobs:
               | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
               | [
                   $parsed_changes[]
-                  | select(.type != "docs" and .scope != "site")
+                  | select((.type == "feat" or .type == "fix") and .scope != "site")
                 ] as $changes
               | [
                   category_definitions[] as $category
@@ -710,14 +703,7 @@ jobs:
               def category_definitions:
                 [
                   {key: "feat", label: "Features"},
-                  {key: "fix", label: "Fixes"},
-                  {key: "perf", label: "Performance"},
-                  {key: "refactor", label: "Refactors"},
-                  {key: "test", label: "Tests"},
-                  {key: "build", label: "Build"},
-                  {key: "ci", label: "CI"},
-                  {key: "chore", label: "Chores"},
-                  {key: "other", label: "Other"}
+                  {key: "fix", label: "Fixes"}
                 ];
               def safe_title:
                 gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
@@ -732,7 +718,7 @@ jobs:
               | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
               | [
                   $parsed_changes[]
-                  | select(.type != "docs" and .scope != "site")
+                  | select((.type == "feat" or .type == "fix") and .scope != "site")
                 ] as $changes
               | [
                   category_definitions[] as $category


### PR DESCRIPTION
## Summary

- limit Discord and Feishu release notifications to `Features` and `Fixes`
- continue excluding feature and fix entries whose Conventional Commit scope is `site`
- preserve unscoped Conventional titles while parsing GitHub-generated release notes
- use a generic availability message when every parsed change is filtered out
- add a dedicated commitlint-based CI check for pull request titles

## Why

Stable release announcements should focus on product features and bug fixes. Documentation, website, refactor, CI, chore, and non-Conventional entries add noise to the public Discord and Feishu notifications.

Pull request titles also need automatic enforcement so future generated release notes consistently contain parseable Conventional Commit titles such as `feat(core): ...` or `fix(workflow): ...`.

## Root cause

The notification formatter categorized every parsed GitHub-generated release entry. It had no allowlist for feature and fix types, and the repository had no CI check for pull request titles. Unmatched jq `capture` expressions could also produce an empty stream, unintentionally dropping valid unscoped titles. Finally, the raw-body fallback could expose filtered entries when no changes remained.

## Impact

Discord and Feishu now render the same feature-and-fix-only change set with matching counts. For the latest `v1.10.4` release, both payloads contain 8 changes across 2 categories instead of 18 unfiltered entries.

The new `PR Title / Validate title` check runs when a pull request is opened, edited, synchronized, or reopened. It reuses the repository's existing commitlint configuration.

## Validation

- confirmed the current PR title passes commitlint
- confirmed these invalid title fixtures fail commitlint:
  - `Refactor/web agent core page manager`
  - `Fix Puppeteer CLI connection lifecycle and tab reuse`
  - `Support Windows auto updates for Studio`
  - `Add Discord and Feishu release notifications`
- exercised the actual Discord and Feishu workflow scripts with mixed included/excluded fixtures
- verified the all-filtered fallback for both channels
- generated both latest `v1.10.4` payloads: `8 changes · 2 categories`
- parsed the changed workflow YAML and checked their shell syntax
- `git diff --check`
- `pnpm run lint`
