### PR TITLE
fix(shared): support Command hotkey aliases

### DIFF
--- a/packages/shared/src/us-keyboard-layout.ts
+++ b/packages/shared/src/us-keyboard-layout.ts
@@ -699,6 +699,8 @@ export const isMac =
 const keyMap: Record<string, KeyInput> = {
   return: _keyDefinitions.Enter.key as KeyInput,
   enter: _keyDefinitions.Enter.key as KeyInput,
+  command: _keyDefinitions.Meta.key as KeyInput,
+  cmd: _keyDefinitions.Meta.key as KeyInput,
   ctrl: isMac
     ? (_keyDefinitions.Meta.key as KeyInput)
     : (_keyDefinitions.Control.key as KeyInput),

--- a/packages/shared/tests/unit-test/keyboard.test.ts
+++ b/packages/shared/tests/unit-test/keyboard.test.ts
@@ -18,6 +18,11 @@ describe('transformHotkeyInput', () => {
     expect(transformHotkeyInput('Alt 1')).toEqual(['Alt', '1']);
   });
 
+  it('should transform Command aliases to Meta', () => {
+    expect(transformHotkeyInput('Command r')).toEqual(['Meta', 'R']);
+    expect(transformHotkeyInput('CMD R')).toEqual(['Meta', 'R']);
+  });
+
   it('should transform key combinations with multiple modifiers', () => {
     if (isMac) {
       expect(transformHotkeyInput('Ctrl Shift a')).toEqual([


### PR DESCRIPTION
## Summary

- Map `Command` and `Cmd` hotkey aliases to the CDP `Meta` key.
- Add unit coverage for `Command R` and `CMD R`.

## Root cause and impact

`KeyboardPress` normalizes `Command+R` to separate key names, but the hotkey alias map did not recognize `Command`. The unknown key reached Chrome Extension CDP input and failed with `Unknown key: "Command"`. The new aliases make macOS Command shortcuts executable through the web action path.

## Validation

- `pnpm exec nx test @midscene/shared`
- `pnpm exec nx build @midscene/shared`