### PR TITLE
fix(core): retry semantic response parsing

### DIFF
--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -1,5 +1,4 @@
 import type {
-  AIDataExtractionResponse,
   AIElementLocateResponse,
   AISectionLocatorResponse,
   AIUsageInfo,
@@ -45,6 +44,7 @@ import {
   callAI,
   callAIWithObjectResponse,
 } from './service-caller/index';
+import { callAiAndParseWithRetry } from './service-caller/semantic-retry';
 import { prepareModelImage } from './workflows/image-preprocess';
 import {
   mergePixelBboxesToRect,
@@ -83,6 +83,10 @@ function hasLocateResult(input: unknown, resultKey: string) {
     ? locateResult.length > 0
     : locateResult !== undefined;
 }
+
+type SectionLocateObjectResponse = Awaited<
+  ReturnType<typeof callAIWithObjectResponse<AISectionLocatorResponse>>
+>;
 
 export async function buildSearchAreaConfig(options: {
   context: UIContext;
@@ -265,99 +269,90 @@ export async function genericLocate(
     msgs.push(...locateRequest.referenceImageMessages);
   }
 
-  const locateOnce = async (
-    retryOnCoordinateParseFailure: boolean,
-  ): Promise<LocateModelResponse> => {
-    let res: Awaited<
-      ReturnType<typeof callAIWithObjectResponse<AIElementLocateResponse>>
-    >;
-    try {
-      res = await callAIWithObjectResponse<AIElementLocateResponse>(
-        msgs,
-        modelRuntime,
-        {
+  try {
+    return await callAiAndParseWithRetry({
+      callAi: () =>
+        callAIWithObjectResponse<AIElementLocateResponse>(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
           jsonParserSource: 'locate',
           retryTimes: 1,
-        },
-      );
-    } catch (callError) {
-      const errorMessage =
-        callError instanceof Error ? callError.message : String(callError);
-      const rawResponse =
-        callError instanceof AIResponseParseError
-          ? callError.rawResponse
-          : errorMessage;
-      const usage =
-        callError instanceof AIResponseParseError ? callError.usage : undefined;
-      const rawChoiceMessage =
-        callError instanceof AIResponseParseError
-          ? callError.rawChoiceMessage
-          : undefined;
-      return {
-        rawResponse,
-        rawChoiceMessage,
-        usage,
-        errors: [`AI call error: ${errorMessage}`],
-      };
-    }
+        }),
+      parseResponse: (response): LocateModelResponse => {
+        const rawResponse = response.contentString;
+        const errors: string[] | undefined =
+          'errors' in response.content ? response.content.errors : [];
+        if (
+          !hasLocateResult(response.content, resultAdapter.promptSpec.resultKey)
+        ) {
+          return {
+            rawResponse,
+            rawChoiceMessage: response.rawChoiceMessage,
+            usage: response.usage,
+            reasoningContent: response.reasoning_content,
+            errors: errors as string[],
+          };
+        }
 
-    const rawResponse = res.contentString;
-    let errors: string[] | undefined =
-      'errors' in res.content ? res.content.errors : [];
-    if (!hasLocateResult(res.content, resultAdapter.promptSpec.resultKey)) {
-      return {
-        rawResponse,
-        rawChoiceMessage: res.rawChoiceMessage,
-        usage: res.usage,
-        reasoningContent: res.reasoning_content,
-        errors: errors as string[],
-      };
-    }
-
-    try {
-      const locatedPixelBbox =
-        resultAdapter.adaptElementLocateResultToPixelBbox(res.content, {
-          preparedSize: preparedImage.preparedSize,
-          contentSize: preparedImage.contentSize,
-        });
-      return {
-        locatedPixelBbox,
-        rawResponse,
-        rawChoiceMessage: res.rawChoiceMessage,
-        usage: res.usage,
-        reasoningContent: res.reasoning_content,
-        errors: errors as string[],
-      };
-    } catch (e) {
-      if (retryOnCoordinateParseFailure && !options.abortSignal?.aborted) {
+        const locatedPixelBbox =
+          resultAdapter.adaptElementLocateResultToPixelBbox(response.content, {
+            preparedSize: preparedImage.preparedSize,
+            contentSize: preparedImage.contentSize,
+          });
+        return {
+          locatedPixelBbox,
+          rawResponse,
+          rawChoiceMessage: response.rawChoiceMessage,
+          usage: response.usage,
+          reasoningContent: response.reasoning_content,
+          errors: errors as string[],
+        };
+      },
+      toParseError: (error, response) => {
+        const parseErrorMessage =
+          error instanceof Error
+            ? `Failed to parse locate result: ${error.message}`
+            : 'unknown error in locate result';
+        const modelErrors =
+          'errors' in response.content ? response.content.errors : undefined;
+        const message =
+          modelErrors && modelErrors.length > 0
+            ? `${modelErrors.join('\n')} (${parseErrorMessage})`
+            : parseErrorMessage;
+        return new AIResponseParseError(
+          message,
+          response.contentString,
+          response.usage,
+          response.rawChoiceMessage,
+          response.reasoning_content,
+        );
+      },
+      parseRetryTimes: 1,
+      abortSignal: options.abortSignal,
+      onParseRetry: (error) => {
         debugInspect(
           'retrying locate after coordinate parsing failed: %s',
-          e instanceof Error ? e.message : String(e),
+          error instanceof Error ? error.message : String(error),
         );
-        return locateOnce(false);
-      }
-
-      const msg =
-        e instanceof Error
-          ? `Failed to parse locate result: ${e.message}`
-          : 'unknown error in locate';
-      if (!errors || errors.length === 0) {
-        errors = [msg];
-      } else {
-        errors.push(`(${msg})`);
-      }
+      },
+    });
+  } catch (callError) {
+    if (callError instanceof AIResponseParseError) {
       return {
-        rawResponse,
-        rawChoiceMessage: res.rawChoiceMessage,
-        usage: res.usage,
-        reasoningContent: res.reasoning_content,
-        errors,
+        rawResponse: callError.rawResponse,
+        rawChoiceMessage: callError.rawChoiceMessage,
+        usage: callError.usage,
+        reasoningContent: callError.reasoningContent,
+        errors: [callError.message],
       };
     }
-  };
 
-  return locateOnce(true);
+    const errorMessage =
+      callError instanceof Error ? callError.message : String(callError);
+    return {
+      rawResponse: errorMessage,
+      errors: [`AI call error: ${errorMessage}`],
+    };
+  }
 }
 
 export async function AiLocateSection(options: {
@@ -421,140 +416,147 @@ export async function AiLocateSection(options: {
     msgs.push(...addOns);
   }
 
-  const locateSectionOnce = async (
-    retryOnCoordinateParseFailure: boolean,
-  ): Promise<{
-    searchAreaConfig?: SearchAreaConfig;
-    error?: string;
-    rawResponse: string;
-    rawChoiceMessage?: unknown;
-    usage?: AIUsageInfo;
-  }> => {
-    let result: Awaited<
-      ReturnType<typeof callAIWithObjectResponse<AISectionLocatorResponse>>
-    >;
-    try {
-      result = await callAIWithObjectResponse<AISectionLocatorResponse>(
-        msgs,
-        modelRuntime,
-        {
+  let parsedResult:
+    | {
+        result: SectionLocateObjectResponse;
+        sectionError?: string;
+        mergedRect?: undefined;
+      }
+    | {
+        result: SectionLocateObjectResponse;
+        sectionError?: string;
+        mergedRect: Rect;
+      };
+
+  try {
+    parsedResult = await callAiAndParseWithRetry({
+      callAi: () =>
+        callAIWithObjectResponse<AISectionLocatorResponse>(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
           jsonParserSource: 'section-locator',
           retryTimes: 1,
-        },
-      );
-    } catch (callError) {
-      const errorMessage =
-        callError instanceof Error ? callError.message : String(callError);
-      const rawResponse =
-        callError instanceof AIResponseParseError
-          ? callError.rawResponse
-          : errorMessage;
-      const usage =
-        callError instanceof AIResponseParseError ? callError.usage : undefined;
-      const rawChoiceMessage =
-        callError instanceof AIResponseParseError
-          ? callError.rawChoiceMessage
-          : undefined;
+        }),
+      parseResponse: (result) => {
+        const sectionError = result.content.error;
+        if (
+          !hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)
+        ) {
+          return { result, sectionError };
+        }
+
+        const adaptedResult =
+          resultAdapter.adaptSectionLocateResultToPixelBboxGroup(
+            result.content,
+            {
+              preparedSize: preparedImage.preparedSize,
+              contentSize: preparedImage.contentSize,
+            },
+          );
+        const mergedRect = mergePixelBboxesToRect([
+          adaptedResult.target,
+          ...(adaptedResult.references ?? []),
+        ]);
+        debugSection('mergedRect %j', mergedRect);
+        return { result, sectionError, mergedRect };
+      },
+      toParseError: (error, result) => {
+        const parseErrorMessage =
+          error instanceof Error
+            ? `Failed to parse section locate result: ${error.message}`
+            : 'unknown error in section locate';
+        const message = result.content.error
+          ? `${result.content.error} (${parseErrorMessage})`
+          : parseErrorMessage;
+        return new AIResponseParseError(
+          message,
+          result.contentString,
+          result.usage,
+          result.rawChoiceMessage,
+          result.reasoning_content,
+        );
+      },
+      parseRetryTimes: 1,
+      abortSignal: options.abortSignal,
+      onParseRetry: (error) => {
+        debugSection(
+          'retrying section locate after coordinate parsing failed: %s',
+          error instanceof Error ? error.message : String(error),
+        );
+      },
+    });
+  } catch (callError) {
+    if (callError instanceof AIResponseParseError) {
       return {
         searchAreaConfig: undefined,
-        error: `AI call error: ${errorMessage}`,
-        rawResponse,
-        rawChoiceMessage,
-        usage,
+        error: callError.message,
+        rawResponse: callError.rawResponse,
+        rawChoiceMessage: callError.rawChoiceMessage,
+        usage: callError.usage,
       };
     }
 
-    let sectionError = result.content.error;
-    if (!hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)) {
-      return {
-        searchAreaConfig: undefined,
-        error: sectionError,
-        rawResponse: result.contentString,
-        rawChoiceMessage: result.rawChoiceMessage,
-        usage: result.usage,
-      };
-    }
+    const errorMessage =
+      callError instanceof Error ? callError.message : String(callError);
+    return {
+      searchAreaConfig: undefined,
+      error: `AI call error: ${errorMessage}`,
+      rawResponse: errorMessage,
+    };
+  }
 
-    let mergedRect: Rect;
-    try {
-      const adaptedResult =
-        resultAdapter.adaptSectionLocateResultToPixelBboxGroup(result.content, {
-          preparedSize: preparedImage.preparedSize,
-          contentSize: preparedImage.contentSize,
-        });
-      mergedRect = mergePixelBboxesToRect([
-        adaptedResult.target,
-        ...(adaptedResult.references ?? []),
-      ]);
-      debugSection('mergedRect %j', mergedRect);
-    } catch (error) {
-      if (retryOnCoordinateParseFailure && !options.abortSignal?.aborted) {
-        debugSection('retrying section locate after coordinate parsing failed');
-        return locateSectionOnce(false);
-      }
+  const { result, sectionError, mergedRect } = parsedResult;
+  if (!mergedRect) {
+    return {
+      searchAreaConfig: undefined,
+      error: sectionError,
+      rawResponse: result.contentString,
+      rawChoiceMessage: result.rawChoiceMessage,
+      usage: result.usage,
+    };
+  }
 
-      const parseErrorMessage =
-        error instanceof Error
-          ? `Failed to parse section locate result: ${error.message}`
-          : 'unknown error in section locate';
-      sectionError = sectionError
-        ? `${sectionError} (${parseErrorMessage})`
-        : parseErrorMessage;
-      return {
-        searchAreaConfig: undefined,
-        error: sectionError,
-        rawResponse: result.contentString,
-        rawChoiceMessage: result.rawChoiceMessage,
-        usage: result.usage,
-      };
-    }
+  try {
+    const expandedRect = expandSearchArea(mergedRect, context.shotSize);
+    const originalWidth = expandedRect.width;
+    const originalHeight = expandedRect.height;
+    debugSection('expanded sectionRect %j', expandedRect);
 
-    try {
-      const expandedRect = expandSearchArea(mergedRect, context.shotSize);
-      const originalWidth = expandedRect.width;
-      const originalHeight = expandedRect.height;
-      debugSection('expanded sectionRect %j', expandedRect);
+    const searchAreaConfig = await buildSearchAreaConfig({
+      context,
+      baseRect: mergedRect,
+    });
 
-      const searchAreaConfig = await buildSearchAreaConfig({
-        context,
-        baseRect: mergedRect,
-      });
-
-      debugSection(
-        'scaled section image from %dx%d to %dx%d (scale=%d)',
-        originalWidth,
-        originalHeight,
-        searchAreaConfig.image.width,
-        searchAreaConfig.image.height,
-        searchAreaConfig.mapping.scale,
-      );
-      return {
-        searchAreaConfig,
-        error: sectionError,
-        rawResponse: result.contentString,
-        rawChoiceMessage: result.rawChoiceMessage,
-        usage: result.usage,
-      };
-    } catch (error) {
-      const parseErrorMessage =
-        error instanceof Error
-          ? `Failed to parse section locate result: ${error.message}`
-          : 'unknown error in section locate';
-      sectionError = sectionError
-        ? `${sectionError} (${parseErrorMessage})`
-        : parseErrorMessage;
-      return {
-        searchAreaConfig: undefined,
-        error: sectionError,
-        rawResponse: result.contentString,
-        rawChoiceMessage: result.rawChoiceMessage,
-        usage: result.usage,
-      };
-    }
-  };
-
-  return locateSectionOnce(true);
+    debugSection(
+      'scaled section image from %dx%d to %dx%d (scale=%d)',
+      originalWidth,
+      originalHeight,
+      searchAreaConfig.image.width,
+      searchAreaConfig.image.height,
+      searchAreaConfig.mapping.scale,
+    );
+    return {
+      searchAreaConfig,
+      error: sectionError,
+      rawResponse: result.contentString,
+      rawChoiceMessage: result.rawChoiceMessage,
+      usage: result.usage,
+    };
+  } catch (error) {
+    const parseErrorMessage =
+      error instanceof Error
+        ? `Failed to parse section locate result: ${error.message}`
+        : 'unknown error in section locate';
+    const errorMessage = sectionError
+      ? `${sectionError} (${parseErrorMessage})`
+      : parseErrorMessage;
+    return {
+      searchAreaConfig: undefined,
+      error: errorMessage,
+      rawResponse: result.contentString,
+      rawChoiceMessage: result.rawChoiceMessage,
+      usage: result.usage,
+    };
+  }
 }
 
 export async function AiExtractElementInfo<T>(options: {
@@ -636,25 +638,18 @@ export async function AiExtractElementInfo<T>(options: {
     msgs.push(...addOns);
   }
 
-  const extractOnce = async (
-    allowSemanticRetry: boolean,
-  ): Promise<{
-    parseResult: AIDataExtractionResponse<T>;
-    rawResponse: string;
-    rawChoiceMessage?: unknown;
-    usage?: AIUsageInfo;
-    reasoning_content?: string;
-  }> => {
-    const {
-      content: rawResponse,
-      usage,
-      reasoning_content,
-      rawChoiceMessage,
-    } = await callAI(msgs, modelRuntime, {
-      abortSignal: options.abortSignal,
-    });
-
-    try {
+  return callAiAndParseWithRetry({
+    callAi: () =>
+      callAI(msgs, modelRuntime, {
+        abortSignal: options.abortSignal,
+      }),
+    parseResponse: (response) => {
+      const {
+        content: rawResponse,
+        usage,
+        reasoning_content,
+        rawChoiceMessage,
+      } = response;
       const parseResult = parseXMLExtractionResponse<T>(rawResponse);
       return {
         parseResult,
@@ -663,24 +658,26 @@ export async function AiExtractElementInfo<T>(options: {
         usage,
         reasoning_content,
       };
-    } catch (parseError) {
-      if (allowSemanticRetry && !options.abortSignal?.aborted) {
-        debugInspect('retrying insight after XML parsing failed');
-        return extractOnce(false);
-      }
-
+    },
+    toParseError: (parseError, response) => {
       const errorMessage =
         parseError instanceof Error ? parseError.message : String(parseError);
-      throw new AIResponseParseError(
+      return new AIResponseParseError(
         `XML parse error: ${errorMessage}`,
-        rawResponse,
-        usage,
-        rawChoiceMessage,
+        response.content,
+        response.usage,
+        response.rawChoiceMessage,
       );
-    }
-  };
-
-  return extractOnce(true);
+    },
+    parseRetryTimes: 1,
+    abortSignal: options.abortSignal,
+    onParseRetry: (error) => {
+      debugInspect(
+        'retrying insight after XML parsing failed: %s',
+        error instanceof Error ? error.message : String(error),
+      );
+    },
+  });
 }
 
 export async function AiJudgeOrderSensitive(

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -224,6 +224,7 @@ export async function genericLocate(
     adapter.locate.kind === 'standard',
     'generic locate requires a standard locate adapter',
   );
+  const resultAdapter = adapter.locate.resultAdapter;
   const userInstructionPrompt = findElementPrompt(
     locateRequest.elementDescriptionText,
   );
@@ -264,83 +265,99 @@ export async function genericLocate(
     msgs.push(...locateRequest.referenceImageMessages);
   }
 
-  let res: Awaited<
-    ReturnType<typeof callAIWithObjectResponse<AIElementLocateResponse>>
-  >;
-  try {
-    res = await callAIWithObjectResponse<AIElementLocateResponse>(
-      msgs,
-      modelRuntime,
-      {
-        abortSignal: options.abortSignal,
-        jsonParserSource: 'locate',
-      },
-    );
-  } catch (callError) {
-    const errorMessage =
-      callError instanceof Error ? callError.message : String(callError);
-    const rawResponse =
-      callError instanceof AIResponseParseError
-        ? callError.rawResponse
-        : errorMessage;
-    const usage =
-      callError instanceof AIResponseParseError ? callError.usage : undefined;
-    const rawChoiceMessage =
-      callError instanceof AIResponseParseError
-        ? callError.rawChoiceMessage
-        : undefined;
-    return {
-      rawResponse,
-      rawChoiceMessage,
-      usage,
-      errors: [`AI call error: ${errorMessage}`],
-    };
-  }
-
-  const rawResponse = res.contentString;
-
-  let errors: string[] | undefined =
-    'errors' in res.content ? res.content.errors : [];
-  const resultAdapter = adapter.locate.resultAdapter;
-  if (!hasLocateResult(res.content, resultAdapter.promptSpec.resultKey)) {
-    return {
-      rawResponse,
-      rawChoiceMessage: res.rawChoiceMessage,
-      usage: res.usage,
-      reasoningContent: res.reasoning_content,
-      errors: errors as string[],
-    };
-  }
-
-  let targetPixelBbox;
-  try {
-    targetPixelBbox = resultAdapter.adaptElementLocateResultToPixelBbox(
-      res.content,
-      {
-        preparedSize: preparedImage.preparedSize,
-        contentSize: preparedImage.contentSize,
-      },
-    );
-  } catch (e) {
-    const msg =
-      e instanceof Error
-        ? `Failed to parse locate result: ${e.message}`
-        : 'unknown error in locate';
-    if (!errors || errors?.length === 0) {
-      errors = [msg];
-    } else {
-      errors.push(`(${msg})`);
+  const locateOnce = async (
+    retryOnCoordinateParseFailure: boolean,
+  ): Promise<LocateModelResponse> => {
+    let res: Awaited<
+      ReturnType<typeof callAIWithObjectResponse<AIElementLocateResponse>>
+    >;
+    try {
+      res = await callAIWithObjectResponse<AIElementLocateResponse>(
+        msgs,
+        modelRuntime,
+        {
+          abortSignal: options.abortSignal,
+          jsonParserSource: 'locate',
+          retryTimes: 1,
+        },
+      );
+    } catch (callError) {
+      const errorMessage =
+        callError instanceof Error ? callError.message : String(callError);
+      const rawResponse =
+        callError instanceof AIResponseParseError
+          ? callError.rawResponse
+          : errorMessage;
+      const usage =
+        callError instanceof AIResponseParseError ? callError.usage : undefined;
+      const rawChoiceMessage =
+        callError instanceof AIResponseParseError
+          ? callError.rawChoiceMessage
+          : undefined;
+      return {
+        rawResponse,
+        rawChoiceMessage,
+        usage,
+        errors: [`AI call error: ${errorMessage}`],
+      };
     }
-  }
 
-  return {
-    locatedPixelBbox: targetPixelBbox,
-    rawResponse,
-    rawChoiceMessage: res.rawChoiceMessage,
-    usage: res.usage,
-    reasoningContent: res.reasoning_content,
-    errors: errors as string[],
+    const rawResponse = res.contentString;
+    let errors: string[] | undefined =
+      'errors' in res.content ? res.content.errors : [];
+    if (!hasLocateResult(res.content, resultAdapter.promptSpec.resultKey)) {
+      return {
+        rawResponse,
+        rawChoiceMessage: res.rawChoiceMessage,
+        usage: res.usage,
+        reasoningContent: res.reasoning_content,
+        errors: errors as string[],
+      };
+    }
+
+    try {
+      const locatedPixelBbox =
+        resultAdapter.adaptElementLocateResultToPixelBbox(res.content, {
+          preparedSize: preparedImage.preparedSize,
+          contentSize: preparedImage.contentSize,
+        });
+      return {
+        locatedPixelBbox,
+        rawResponse,
+        rawChoiceMessage: res.rawChoiceMessage,
+        usage: res.usage,
+        reasoningContent: res.reasoning_content,
+        errors: errors as string[],
+      };
+    } catch (e) {
+      if (retryOnCoordinateParseFailure && !options.abortSignal?.aborted) {
+        debugInspect(
+          'retrying locate after coordinate parsing failed: %s',
+          e instanceof Error ? e.message : String(e),
+        );
+        return locateOnce(false);
+      }
+
+      const msg =
+        e instanceof Error
+          ? `Failed to parse locate result: ${e.message}`
+          : 'unknown error in locate';
+      if (!errors || errors.length === 0) {
+        errors = [msg];
+      } else {
+        errors.push(`(${msg})`);
+      }
+      return {
+        rawResponse,
+        rawChoiceMessage: res.rawChoiceMessage,
+        usage: res.usage,
+        reasoningContent: res.reasoning_content,
+        errors,
+      };
+    }
   };
+
+  return locateOnce(true);
 }
 
 export async function AiLocateSection(options: {
@@ -362,6 +379,7 @@ export async function AiLocateSection(options: {
     adapter.locate.kind === 'standard',
     'section locate requires a standard locate adapter',
   );
+  const resultAdapter = adapter.locate.resultAdapter;
   const screenshotBase64 = context.screenshot.base64;
   const preparedImage = await prepareModelImage({
     imageBase64: screenshotBase64,
@@ -403,102 +421,140 @@ export async function AiLocateSection(options: {
     msgs.push(...addOns);
   }
 
-  let result: Awaited<
-    ReturnType<typeof callAIWithObjectResponse<AISectionLocatorResponse>>
-  >;
-  try {
-    result = await callAIWithObjectResponse<AISectionLocatorResponse>(
-      msgs,
-      modelRuntime,
-      {
-        abortSignal: options.abortSignal,
-        jsonParserSource: 'section-locator',
-      },
-    );
-  } catch (callError) {
-    const errorMessage =
-      callError instanceof Error ? callError.message : String(callError);
-    const rawResponse =
-      callError instanceof AIResponseParseError
-        ? callError.rawResponse
-        : errorMessage;
-    const usage =
-      callError instanceof AIResponseParseError ? callError.usage : undefined;
-    const rawChoiceMessage =
-      callError instanceof AIResponseParseError
-        ? callError.rawChoiceMessage
-        : undefined;
-    return {
-      searchAreaConfig: undefined,
-      error: `AI call error: ${errorMessage}`,
-      rawResponse,
-      rawChoiceMessage,
-      usage,
-    };
-  }
+  const locateSectionOnce = async (
+    retryOnCoordinateParseFailure: boolean,
+  ): Promise<{
+    searchAreaConfig?: SearchAreaConfig;
+    error?: string;
+    rawResponse: string;
+    rawChoiceMessage?: unknown;
+    usage?: AIUsageInfo;
+  }> => {
+    let result: Awaited<
+      ReturnType<typeof callAIWithObjectResponse<AISectionLocatorResponse>>
+    >;
+    try {
+      result = await callAIWithObjectResponse<AISectionLocatorResponse>(
+        msgs,
+        modelRuntime,
+        {
+          abortSignal: options.abortSignal,
+          jsonParserSource: 'section-locator',
+          retryTimes: 1,
+        },
+      );
+    } catch (callError) {
+      const errorMessage =
+        callError instanceof Error ? callError.message : String(callError);
+      const rawResponse =
+        callError instanceof AIResponseParseError
+          ? callError.rawResponse
+          : errorMessage;
+      const usage =
+        callError instanceof AIResponseParseError ? callError.usage : undefined;
+      const rawChoiceMessage =
+        callError instanceof AIResponseParseError
+          ? callError.rawChoiceMessage
+          : undefined;
+      return {
+        searchAreaConfig: undefined,
+        error: `AI call error: ${errorMessage}`,
+        rawResponse,
+        rawChoiceMessage,
+        usage,
+      };
+    }
 
-  let searchAreaConfig:
-    | Awaited<ReturnType<typeof buildSearchAreaConfig>>
-    | undefined;
-  let sectionError = result.content.error;
-  const resultAdapter = adapter.locate.resultAdapter;
-  if (!hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)) {
-    return {
-      searchAreaConfig: undefined,
-      error: sectionError,
-      rawResponse: result.contentString,
-      rawChoiceMessage: result.rawChoiceMessage,
-      usage: result.usage,
-    };
-  }
+    let sectionError = result.content.error;
+    if (!hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)) {
+      return {
+        searchAreaConfig: undefined,
+        error: sectionError,
+        rawResponse: result.contentString,
+        rawChoiceMessage: result.rawChoiceMessage,
+        usage: result.usage,
+      };
+    }
 
-  try {
-    const adaptedResult =
-      resultAdapter.adaptSectionLocateResultToPixelBboxGroup(result.content, {
-        preparedSize: preparedImage.preparedSize,
-        contentSize: preparedImage.contentSize,
+    let mergedRect: Rect;
+    try {
+      const adaptedResult =
+        resultAdapter.adaptSectionLocateResultToPixelBboxGroup(result.content, {
+          preparedSize: preparedImage.preparedSize,
+          contentSize: preparedImage.contentSize,
+        });
+      mergedRect = mergePixelBboxesToRect([
+        adaptedResult.target,
+        ...(adaptedResult.references ?? []),
+      ]);
+      debugSection('mergedRect %j', mergedRect);
+    } catch (error) {
+      if (retryOnCoordinateParseFailure && !options.abortSignal?.aborted) {
+        debugSection('retrying section locate after coordinate parsing failed');
+        return locateSectionOnce(false);
+      }
+
+      const parseErrorMessage =
+        error instanceof Error
+          ? `Failed to parse section locate result: ${error.message}`
+          : 'unknown error in section locate';
+      sectionError = sectionError
+        ? `${sectionError} (${parseErrorMessage})`
+        : parseErrorMessage;
+      return {
+        searchAreaConfig: undefined,
+        error: sectionError,
+        rawResponse: result.contentString,
+        rawChoiceMessage: result.rawChoiceMessage,
+        usage: result.usage,
+      };
+    }
+
+    try {
+      const expandedRect = expandSearchArea(mergedRect, context.shotSize);
+      const originalWidth = expandedRect.width;
+      const originalHeight = expandedRect.height;
+      debugSection('expanded sectionRect %j', expandedRect);
+
+      const searchAreaConfig = await buildSearchAreaConfig({
+        context,
+        baseRect: mergedRect,
       });
-    const mergedRect = mergePixelBboxesToRect([
-      adaptedResult.target,
-      ...(adaptedResult.references ?? []),
-    ]);
-    debugSection('mergedRect %j', mergedRect);
 
-    const expandedRect = expandSearchArea(mergedRect, context.shotSize);
-    const originalWidth = expandedRect.width;
-    const originalHeight = expandedRect.height;
-    debugSection('expanded sectionRect %j', expandedRect);
-
-    searchAreaConfig = await buildSearchAreaConfig({
-      context,
-      baseRect: mergedRect,
-    });
-
-    debugSection(
-      'scaled section image from %dx%d to %dx%d (scale=%d)',
-      originalWidth,
-      originalHeight,
-      searchAreaConfig.image.width,
-      searchAreaConfig.image.height,
-      searchAreaConfig.mapping.scale,
-    );
-  } catch (error) {
-    const parseErrorMessage =
-      error instanceof Error
-        ? `Failed to parse section locate result: ${error.message}`
-        : 'unknown error in section locate';
-    sectionError = sectionError
-      ? `${sectionError} (${parseErrorMessage})`
-      : parseErrorMessage;
-  }
-
-  return {
-    searchAreaConfig,
-    error: sectionError,
-    rawResponse: result.contentString,
-    rawChoiceMessage: result.rawChoiceMessage,
-    usage: result.usage,
+      debugSection(
+        'scaled section image from %dx%d to %dx%d (scale=%d)',
+        originalWidth,
+        originalHeight,
+        searchAreaConfig.image.width,
+        searchAreaConfig.image.height,
+        searchAreaConfig.mapping.scale,
+      );
+      return {
+        searchAreaConfig,
+        error: sectionError,
+        rawResponse: result.contentString,
+        rawChoiceMessage: result.rawChoiceMessage,
+        usage: result.usage,
+      };
+    } catch (error) {
+      const parseErrorMessage =
+        error instanceof Error
+          ? `Failed to parse section locate result: ${error.message}`
+          : 'unknown error in section locate';
+      sectionError = sectionError
+        ? `${sectionError} (${parseErrorMessage})`
+        : parseErrorMessage;
+      return {
+        searchAreaConfig: undefined,
+        error: sectionError,
+        rawResponse: result.contentString,
+        rawChoiceMessage: result.rawChoiceMessage,
+        usage: result.usage,
+      };
+    }
   };
+
+  return locateSectionOnce(true);
 }
 
 export async function AiExtractElementInfo<T>(options: {
@@ -580,36 +636,51 @@ export async function AiExtractElementInfo<T>(options: {
     msgs.push(...addOns);
   }
 
-  const {
-    content: rawResponse,
-    usage,
-    reasoning_content,
-    rawChoiceMessage,
-  } = await callAI(msgs, modelRuntime, {
-    abortSignal: options.abortSignal,
-  });
-
-  let parseResult: AIDataExtractionResponse<T>;
-  try {
-    parseResult = parseXMLExtractionResponse<T>(rawResponse);
-  } catch (parseError) {
-    const errorMessage =
-      parseError instanceof Error ? parseError.message : String(parseError);
-    throw new AIResponseParseError(
-      `XML parse error: ${errorMessage}`,
-      rawResponse,
+  const extractOnce = async (
+    allowSemanticRetry: boolean,
+  ): Promise<{
+    parseResult: AIDataExtractionResponse<T>;
+    rawResponse: string;
+    rawChoiceMessage?: unknown;
+    usage?: AIUsageInfo;
+    reasoning_content?: string;
+  }> => {
+    const {
+      content: rawResponse,
       usage,
+      reasoning_content,
       rawChoiceMessage,
-    );
-  }
+    } = await callAI(msgs, modelRuntime, {
+      abortSignal: options.abortSignal,
+    });
 
-  return {
-    parseResult,
-    rawResponse,
-    rawChoiceMessage,
-    usage,
-    reasoning_content,
+    try {
+      const parseResult = parseXMLExtractionResponse<T>(rawResponse);
+      return {
+        parseResult,
+        rawResponse,
+        rawChoiceMessage,
+        usage,
+        reasoning_content,
+      };
+    } catch (parseError) {
+      if (allowSemanticRetry && !options.abortSignal?.aborted) {
+        debugInspect('retrying insight after XML parsing failed');
+        return extractOnce(false);
+      }
+
+      const errorMessage =
+        parseError instanceof Error ? parseError.message : String(parseError);
+      throw new AIResponseParseError(
+        `XML parse error: ${errorMessage}`,
+        rawResponse,
+        usage,
+        rawChoiceMessage,
+      );
+    }
   };
+
+  return extractOnce(true);
 }
 
 export async function AiJudgeOrderSensitive(

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -1,6 +1,7 @@
 import { type TUserPrompt, userPromptToString } from '@/common';
 import type {
   PlanningAIResponse,
+  PlanningAction,
   RawResponsePlanningAIResponse,
 } from '@/types';
 import { getDebug } from '@midscene/shared/logger';
@@ -16,6 +17,10 @@ import {
 } from './prompt/util';
 import { AIResponseParseError, callAI } from './service-caller/index';
 import type { JsonParser, JsonParserSource } from './service-caller/json';
+import type {
+  LocateResultAdapter,
+  LocateResultContext,
+} from './shared/model-locate-result';
 import { prepareModelImage } from './workflows/image-preprocess';
 import { normalizePlanningActionLocateFields } from './workflows/planning/locate-normalization';
 import type { PlanOptions } from './workflows/planning/types';
@@ -104,6 +109,84 @@ export function parseXMLPlanningResponse(
     ...(updateSubGoals?.length ? { updateSubGoals } : {}),
     ...(markFinishedIndexes?.length ? { markFinishedIndexes } : {}),
   };
+}
+
+type PlanningCallResponse = Awaited<ReturnType<typeof callAI>>;
+
+type CallAndParsePlanningResponseOptions = {
+  messages: ChatCompletionMessageParam[];
+  modelRuntime: PlanOptions['modelRuntime'];
+  abortSignal?: AbortSignal;
+  includeLocateInPlanning: boolean;
+  actionSpace: PlanOptions['actionSpace'];
+  locateResultAdapter?: LocateResultAdapter;
+  locateResultContext: LocateResultContext;
+};
+
+async function callAndParsePlanningResponse(
+  options: CallAndParsePlanningResponseOptions,
+  retryOnParseFailure = true,
+): Promise<{
+  response: PlanningCallResponse;
+  planFromAI: RawResponsePlanningAIResponse;
+  actions: PlanningAction[];
+  yamlFlow: ReturnType<typeof buildYamlFlowFromPlans>;
+}> {
+  const {
+    messages,
+    modelRuntime,
+    abortSignal,
+    includeLocateInPlanning,
+    actionSpace,
+    locateResultAdapter,
+    locateResultContext,
+  } = options;
+  const response = await callAI(messages, modelRuntime, {
+    abortSignal,
+    requiresOriginalImageDetail: includeLocateInPlanning,
+  });
+  try {
+    const planFromAI = parseXMLPlanningResponse(
+      response.content,
+      modelRuntime.adapter.jsonParser,
+    );
+    if (planFromAI.action && planFromAI.finalizeSuccess !== undefined) {
+      warnLog(
+        'Planning response included both an action and <complete>; ignoring <complete> output.',
+      );
+      planFromAI.finalizeMessage = undefined;
+      planFromAI.finalizeSuccess = undefined;
+    }
+
+    const actions = planFromAI.action ? [planFromAI.action] : [];
+    // Keep yamlFlow based on the model's original action params. Coordinate
+    // normalization adds runtime-only locatedPixelBbox fields afterwards.
+    const yamlFlow = buildYamlFlowFromPlans(actions, actionSpace);
+    normalizePlanningActionLocateFields(actions, {
+      actionSpace,
+      includeLocateInPlanning,
+      locateResultAdapter,
+      locateResultContext,
+    });
+    return { response, planFromAI, actions, yamlFlow };
+  } catch (parseError) {
+    if (retryOnParseFailure && !abortSignal?.aborted) {
+      debug(
+        'retrying plan after response parsing failed: %s',
+        parseError instanceof Error ? parseError.message : String(parseError),
+      );
+      return callAndParsePlanningResponse(options, false);
+    }
+
+    const errorMessage =
+      parseError instanceof Error ? parseError.message : String(parseError);
+    throw new AIResponseParseError(
+      `XML parse error: ${errorMessage}`,
+      response.content,
+      response.usage,
+      response.rawChoiceMessage,
+    );
+  }
 }
 
 export async function plan(
@@ -233,126 +316,89 @@ export async function plan(
     ...historyLog,
   ];
 
-  let {
-    content: rawResponse,
-    usage,
-    reasoning_content,
-    rawChoiceMessage,
-  } = await callAI(msgs, modelRuntime, {
-    abortSignal: opts.abortSignal,
-    // Planning with locate results is localization-sensitive. Adapters decide
-    // whether this should request original image detail.
-    requiresOriginalImageDetail: opts.includeLocateInPlanning,
-  });
-
-  // Parse XML response to JSON object, retry once on parse failure
-  let planFromAI: RawResponsePlanningAIResponse;
-  try {
-    try {
-      planFromAI = parseXMLPlanningResponse(rawResponse, adapter.jsonParser);
-    } catch {
-      const retry = await callAI(msgs, modelRuntime, {
-        abortSignal: opts.abortSignal,
-        // Keep retry requests consistent with the initial planning call.
-        requiresOriginalImageDetail: opts.includeLocateInPlanning,
-      });
-      rawResponse = retry.content;
-      usage = retry.usage;
-      reasoning_content = retry.reasoning_content;
-      rawChoiceMessage = retry.rawChoiceMessage;
-      planFromAI = parseXMLPlanningResponse(rawResponse, adapter.jsonParser);
-    }
-
-    if (planFromAI.action && planFromAI.finalizeSuccess !== undefined) {
-      warnLog(
-        'Planning response included both an action and <complete>; ignoring <complete> output.',
-      );
-      planFromAI.finalizeMessage = undefined;
-      planFromAI.finalizeSuccess = undefined;
-    }
-
-    const actions = planFromAI.action ? [planFromAI.action] : [];
-    let shouldContinuePlanning = true;
-
-    // Check if task is completed via <complete> tag
-    if (planFromAI.finalizeSuccess !== undefined) {
-      debug('task completed via <complete> tag, stop planning');
-      shouldContinuePlanning = false;
-      // Mark all sub-goals as finished when goal is completed in planning deep-think mode.
-      if (includeSubGoals) {
-        conversationHistory.markAllSubGoalsFinished();
-      }
-    }
-
-    const returnValue: PlanningAIResponse = {
-      ...planFromAI,
-      actions,
-      rawResponse,
-      rawChoiceMessage,
+  const {
+    response: {
+      content: rawResponse,
       usage,
       reasoning_content,
-      yamlFlow: buildYamlFlowFromPlans(actions, opts.actionSpace),
-      shouldContinuePlanning,
-    };
-
-    assert(planFromAI, "can't get plans from AI");
-
-    normalizePlanningActionLocateFields(actions, {
-      actionSpace: opts.actionSpace,
-      includeLocateInPlanning: opts.includeLocateInPlanning,
-      locateResultAdapter,
-      locateResultContext: {
-        preparedSize: preparedImage.preparedSize,
-        contentSize: preparedImage.contentSize,
-      },
-    });
-
-    // Update sub-goals in conversation history only in planning deep-think mode.
-    if (includeSubGoals) {
-      if (planFromAI.updateSubGoals?.length) {
-        conversationHistory.mergeSubGoals(planFromAI.updateSubGoals);
-      }
-      if (planFromAI.markFinishedIndexes?.length) {
-        for (const index of planFromAI.markFinishedIndexes) {
-          conversationHistory.markSubGoalFinished(index);
-        }
-      }
-      // Append the planning log to the currently running sub-goal
-      if (planFromAI.log) {
-        conversationHistory.appendSubGoalLog(planFromAI.log);
-      }
-    } else {
-      // Without planning deep-think mode, accumulate logs as historical execution steps.
-      if (planFromAI.log) {
-        conversationHistory.appendHistoricalLog(planFromAI.log);
-      }
-    }
-
-    // Append memory to conversation history if present
-    if (planFromAI.memory) {
-      conversationHistory.appendMemory(planFromAI.memory);
-    }
-
-    conversationHistory.append({
-      role: 'assistant',
-      content: [
-        {
-          type: 'text',
-          text: rawResponse,
-        },
-      ],
-    });
-
-    return returnValue;
-  } catch (parseError) {
-    // Throw AIResponseParseError with usage and rawResponse preserved
-    const errorMessage =
-      parseError instanceof Error ? parseError.message : String(parseError);
-    throw new AIResponseParseError(
-      `XML parse error: ${errorMessage}`,
-      rawResponse,
-      usage,
       rawChoiceMessage,
-    );
+    },
+    planFromAI,
+    actions,
+    yamlFlow,
+  } = await callAndParsePlanningResponse({
+    messages: msgs,
+    modelRuntime,
+    abortSignal: opts.abortSignal,
+    includeLocateInPlanning: opts.includeLocateInPlanning,
+    actionSpace: opts.actionSpace,
+    locateResultAdapter,
+    locateResultContext: {
+      preparedSize: preparedImage.preparedSize,
+      contentSize: preparedImage.contentSize,
+    },
+  });
+
+  let shouldContinuePlanning = true;
+
+  // Check if task is completed via <complete> tag
+  if (planFromAI.finalizeSuccess !== undefined) {
+    debug('task completed via <complete> tag, stop planning');
+    shouldContinuePlanning = false;
+    // Mark all sub-goals as finished when goal is completed in planning deep-think mode.
+    if (includeSubGoals) {
+      conversationHistory.markAllSubGoalsFinished();
+    }
   }
+
+  const returnValue: PlanningAIResponse = {
+    ...planFromAI,
+    actions,
+    rawResponse,
+    rawChoiceMessage,
+    usage,
+    reasoning_content,
+    yamlFlow,
+    shouldContinuePlanning,
+  };
+
+  assert(planFromAI, "can't get plans from AI");
+
+  // Update sub-goals in conversation history only in planning deep-think mode.
+  if (includeSubGoals) {
+    if (planFromAI.updateSubGoals?.length) {
+      conversationHistory.mergeSubGoals(planFromAI.updateSubGoals);
+    }
+    if (planFromAI.markFinishedIndexes?.length) {
+      for (const index of planFromAI.markFinishedIndexes) {
+        conversationHistory.markSubGoalFinished(index);
+      }
+    }
+    // Append the planning log to the currently running sub-goal
+    if (planFromAI.log) {
+      conversationHistory.appendSubGoalLog(planFromAI.log);
+    }
+  } else {
+    // Without planning deep-think mode, accumulate logs as historical execution steps.
+    if (planFromAI.log) {
+      conversationHistory.appendHistoricalLog(planFromAI.log);
+    }
+  }
+
+  // Append memory to conversation history if present
+  if (planFromAI.memory) {
+    conversationHistory.appendMemory(planFromAI.memory);
+  }
+
+  conversationHistory.append({
+    role: 'assistant',
+    content: [
+      {
+        type: 'text',
+        text: rawResponse,
+      },
+    ],
+  });
+
+  return returnValue;
 }

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -17,6 +17,7 @@ import {
 } from './prompt/util';
 import { AIResponseParseError, callAI } from './service-caller/index';
 import type { JsonParser, JsonParserSource } from './service-caller/json';
+import { callAiAndParseWithRetry } from './service-caller/semantic-retry';
 import type {
   LocateResultAdapter,
   LocateResultContext,
@@ -125,7 +126,6 @@ type CallAndParsePlanningResponseOptions = {
 
 async function callAndParsePlanningResponse(
   options: CallAndParsePlanningResponseOptions,
-  retryOnParseFailure = true,
 ): Promise<{
   response: PlanningCallResponse;
   planFromAI: RawResponsePlanningAIResponse;
@@ -141,52 +141,57 @@ async function callAndParsePlanningResponse(
     locateResultAdapter,
     locateResultContext,
   } = options;
-  const response = await callAI(messages, modelRuntime, {
-    abortSignal,
-    requiresOriginalImageDetail: includeLocateInPlanning,
-  });
-  try {
-    const planFromAI = parseXMLPlanningResponse(
-      response.content,
-      modelRuntime.adapter.jsonParser,
-    );
-    if (planFromAI.action && planFromAI.finalizeSuccess !== undefined) {
-      warnLog(
-        'Planning response included both an action and <complete>; ignoring <complete> output.',
+  return callAiAndParseWithRetry({
+    callAi: () =>
+      callAI(messages, modelRuntime, {
+        abortSignal,
+        requiresOriginalImageDetail: includeLocateInPlanning,
+      }),
+    parseResponse: (response) => {
+      const planFromAI = parseXMLPlanningResponse(
+        response.content,
+        modelRuntime.adapter.jsonParser,
       );
-      planFromAI.finalizeMessage = undefined;
-      planFromAI.finalizeSuccess = undefined;
-    }
+      if (planFromAI.action && planFromAI.finalizeSuccess !== undefined) {
+        warnLog(
+          'Planning response included both an action and <complete>; ignoring <complete> output.',
+        );
+        planFromAI.finalizeMessage = undefined;
+        planFromAI.finalizeSuccess = undefined;
+      }
 
-    const actions = planFromAI.action ? [planFromAI.action] : [];
-    // Keep yamlFlow based on the model's original action params. Coordinate
-    // normalization adds runtime-only locatedPixelBbox fields afterwards.
-    const yamlFlow = buildYamlFlowFromPlans(actions, actionSpace);
-    normalizePlanningActionLocateFields(actions, {
-      actionSpace,
-      includeLocateInPlanning,
-      locateResultAdapter,
-      locateResultContext,
-    });
-    return { response, planFromAI, actions, yamlFlow };
-  } catch (parseError) {
-    if (retryOnParseFailure && !abortSignal?.aborted) {
+      const actions = planFromAI.action ? [planFromAI.action] : [];
+      // Keep yamlFlow based on the model's original action params. Coordinate
+      // normalization adds runtime-only locatedPixelBbox fields afterwards.
+      const yamlFlow = buildYamlFlowFromPlans(actions, actionSpace);
+      normalizePlanningActionLocateFields(actions, {
+        actionSpace,
+        includeLocateInPlanning,
+        locateResultAdapter,
+        locateResultContext,
+      });
+      return { response, planFromAI, actions, yamlFlow };
+    },
+    toParseError: (parseError, response) => {
+      const errorMessage =
+        parseError instanceof Error ? parseError.message : String(parseError);
+      return new AIResponseParseError(
+        `XML parse error: ${errorMessage}`,
+        response.content,
+        response.usage,
+        response.rawChoiceMessage,
+        response.reasoning_content,
+      );
+    },
+    parseRetryTimes: 1,
+    abortSignal,
+    onParseRetry: (parseError) => {
       debug(
         'retrying plan after response parsing failed: %s',
         parseError instanceof Error ? parseError.message : String(parseError),
       );
-      return callAndParsePlanningResponse(options, false);
-    }
-
-    const errorMessage =
-      parseError instanceof Error ? parseError.message : String(parseError);
-    throw new AIResponseParseError(
-      `XML parse error: ${errorMessage}`,
-      response.content,
-      response.usage,
-      response.rawChoiceMessage,
-    );
-  }
+    },
+  });
 }
 
 export async function plan(

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -10,18 +10,21 @@ export class AIResponseParseError extends Error {
    */
   rawResponse: string;
   rawChoiceMessage?: unknown;
+  reasoningContent?: string;
 
   constructor(
     message: string,
     rawResponse: string,
     usage?: AIUsageInfo,
     rawChoiceMessage?: unknown,
+    reasoningContent?: string,
   ) {
     super(message);
     this.name = 'AIResponseParseError';
     this.rawResponse = rawResponse;
     this.usage = usage;
     this.rawChoiceMessage = rawChoiceMessage;
+    this.reasoningContent = reasoningContent;
   }
 }
 import {
@@ -54,6 +57,7 @@ import {
   isHardTimeoutError,
   resolveEffectiveTimeoutMs,
 } from './request-timeout';
+import { callAiAndParseWithRetry } from './semantic-retry';
 export {
   extractJSONFromCodeBlock,
   parseModelResponseJson,
@@ -779,21 +783,13 @@ export async function callAIWithObjectResponse<T>(
   rawChoiceMessage?: unknown;
 }> {
   const { config: modelConfig, adapter } = modelRuntime;
-  const retryTimes = Math.max(0, Math.floor(options?.retryTimes ?? 0));
-  const callAndParseObjectResponse = async (
-    remainingRetries: number,
-  ): Promise<{
-    content: T;
-    contentString: string;
-    usage?: AIUsageInfo;
-    reasoning_content?: string;
-    rawChoiceMessage?: unknown;
-  }> => {
-    const response = await callAI(messages, modelRuntime, {
-      abortSignal: options?.abortSignal,
-    });
-    assert(response, 'empty response');
-    try {
+  return callAiAndParseWithRetry({
+    callAi: () =>
+      callAI(messages, modelRuntime, {
+        abortSignal: options?.abortSignal,
+      }),
+    parseResponse: (response) => {
+      assert(response, 'empty response');
       const jsonContent = adapter.jsonParser(response.content, {
         source: options?.jsonParserSource ?? 'generic-object',
       });
@@ -811,22 +807,21 @@ export async function callAIWithObjectResponse<T>(
         reasoning_content: response.reasoning_content,
         rawChoiceMessage: response.rawChoiceMessage,
       };
-    } catch (error) {
-      if (remainingRetries > 0 && !options?.abortSignal?.aborted) {
-        return callAndParseObjectResponse(remainingRetries - 1);
-      }
+    },
+    toParseError: (error, response) => {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      throw new AIResponseParseError(
+      return new AIResponseParseError(
         errorMessage,
         response.content,
         response.usage,
         response.rawChoiceMessage,
+        response.reasoning_content,
       );
-    }
-  };
-
-  return callAndParseObjectResponse(retryTimes);
+    },
+    parseRetryTimes: options?.retryTimes,
+    abortSignal: options?.abortSignal,
+  });
 }
 
 export async function callAIWithStringResponse(

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -768,6 +768,7 @@ export async function callAIWithObjectResponse<T>(
   options?: {
     abortSignal?: AbortSignal;
     jsonParserSource?: JsonParserSource;
+    retryTimes?: number;
   },
 ): Promise<{
   // TODO: `content` is a misleading name here because this is already the parsed object response. Consider renaming it to `object` or `data`.
@@ -778,38 +779,54 @@ export async function callAIWithObjectResponse<T>(
   rawChoiceMessage?: unknown;
 }> {
   const { config: modelConfig, adapter } = modelRuntime;
-  const response = await callAI(messages, modelRuntime, {
-    abortSignal: options?.abortSignal,
-  });
-  assert(response, 'empty response');
-  let jsonContent: unknown;
-  try {
-    jsonContent = adapter.jsonParser(response.content, {
-      source: options?.jsonParserSource ?? 'generic-object',
+  const retryTimes = Math.max(0, Math.floor(options?.retryTimes ?? 0));
+  const callAndParseObjectResponse = async (
+    remainingRetries: number,
+  ): Promise<{
+    content: T;
+    contentString: string;
+    usage?: AIUsageInfo;
+    reasoning_content?: string;
+    rawChoiceMessage?: unknown;
+  }> => {
+    const response = await callAI(messages, modelRuntime, {
+      abortSignal: options?.abortSignal,
     });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new AIResponseParseError(
-      errorMessage,
-      response.content,
-      response.usage,
-    );
-  }
-  if (typeof jsonContent !== 'object') {
-    throw new AIResponseParseError(
-      `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,
-      response.content,
-      response.usage,
-      response.rawChoiceMessage,
-    );
-  }
-  return {
-    content: jsonContent as T,
-    contentString: response.content,
-    usage: response.usage,
-    reasoning_content: response.reasoning_content,
-    rawChoiceMessage: response.rawChoiceMessage,
+    assert(response, 'empty response');
+    try {
+      const jsonContent = adapter.jsonParser(response.content, {
+        source: options?.jsonParserSource ?? 'generic-object',
+      });
+      // This API expects a JSON object. Bare JSON primitives are valid JSON,
+      // but do not satisfy object-response callers.
+      if (!jsonContent || typeof jsonContent !== 'object') {
+        throw new Error(
+          `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,
+        );
+      }
+      return {
+        content: jsonContent as T,
+        contentString: response.content,
+        usage: response.usage,
+        reasoning_content: response.reasoning_content,
+        rawChoiceMessage: response.rawChoiceMessage,
+      };
+    } catch (error) {
+      if (remainingRetries > 0 && !options?.abortSignal?.aborted) {
+        return callAndParseObjectResponse(remainingRetries - 1);
+      }
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new AIResponseParseError(
+        errorMessage,
+        response.content,
+        response.usage,
+        response.rawChoiceMessage,
+      );
+    }
   };
+
+  return callAndParseObjectResponse(retryTimes);
 }
 
 export async function callAIWithStringResponse(

--- a/packages/core/src/ai-model/service-caller/semantic-retry.ts
+++ b/packages/core/src/ai-model/service-caller/semantic-retry.ts
@@ -1,0 +1,52 @@
+export type CallAiAndParseWithRetryOptions<Response, Parsed> = {
+  /** Sends a single model request. Request errors are always propagated as-is. */
+  callAi: () => Promise<Response>;
+  /** Parses a successful model response. Only failures from this callback retry. */
+  parseResponse: (response: Response) => Parsed | Promise<Parsed>;
+  /** Converts the final parsing failure into the caller's domain error. */
+  toParseError: (error: unknown, response: Response) => Error;
+  /** Number of additional model requests after a parsing failure. Defaults to 0. */
+  parseRetryTimes?: number;
+  abortSignal?: AbortSignal;
+  /** Runs immediately before a parsing failure triggers another model request. */
+  onParseRetry?: (error: unknown, response: Response) => void;
+};
+
+/**
+ * Calls AI and parses its response, retrying only when the response cannot be
+ * structurally parsed.
+ *
+ * Errors thrown by callAi() intentionally bypass this retry mechanism and are
+ * propagated as-is. Only a successful callAi() response that fails the
+ * parseResponse() callback triggers another model request.
+ */
+export async function callAiAndParseWithRetry<Response, Parsed>({
+  callAi,
+  parseResponse,
+  toParseError,
+  parseRetryTimes = 0,
+  abortSignal,
+  onParseRetry,
+}: CallAiAndParseWithRetryOptions<Response, Parsed>): Promise<Parsed> {
+  const normalizedRetryTimes = Number.isFinite(parseRetryTimes)
+    ? Math.max(0, Math.floor(parseRetryTimes))
+    : 0;
+
+  const callAndParseOnce = async (
+    remainingRetries: number,
+  ): Promise<Parsed> => {
+    const response = await callAi();
+
+    try {
+      return await parseResponse(response);
+    } catch (error) {
+      if (remainingRetries > 0 && !abortSignal?.aborted) {
+        onParseRetry?.(error, response);
+        return callAndParseOnce(remainingRetries - 1);
+      }
+      throw toParseError(error, response);
+    }
+  };
+
+  return callAndParseOnce(normalizedRetryTimes);
+}

--- a/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
@@ -162,4 +162,30 @@ describe('AiExtractElementInfo prompt assembly', () => {
       abortSignal: abortController.signal,
     });
   });
+
+  it('retries once when the insight XML response cannot be parsed', async () => {
+    vi.mocked(callAI)
+      .mockResolvedValueOnce({
+        content: '<observation>Looks correct.</observation>',
+        usage: undefined,
+        reasoning_content: undefined,
+      } as any)
+      .mockResolvedValueOnce({
+        content:
+          '<observation>Looks correct.</observation><data-json>{"result":true}</data-json>',
+        usage: undefined,
+        reasoning_content: undefined,
+      } as any);
+
+    const result = await AiExtractElementInfo<{ result: boolean }>({
+      context: createFakeContext(),
+      dataQuery: {
+        StatementIsTruthy: 'Boolean, whether the success toast is visible',
+      },
+      modelRuntime: getModelRuntime(modelConfig),
+    });
+
+    expect(callAI).toHaveBeenCalledTimes(2);
+    expect(result.parseResult.data).toEqual({ result: true });
+  });
 });

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -121,6 +121,29 @@ describe('locate not-found parsing', () => {
     expect(result.parseResult.errors).toEqual([]);
   });
 
+  it('retries once when section result adapter cannot map coordinates', async () => {
+    vi.mocked(callAIWithObjectResponse)
+      .mockResolvedValueOnce({
+        content: { bbox: [100, Number.NaN, 300, 400] },
+        usage: undefined,
+        contentString: '{"bbox":[100,null,300,400]}',
+      })
+      .mockResolvedValueOnce({
+        content: { bbox: [100, 200, 300, 400] },
+        usage: undefined,
+        contentString: '{"bbox":[100,200,300,400]}',
+      });
+
+    const result = await AiLocateSection({
+      context: createFakeContext(),
+      sectionDescription: 'invalid coordinate section',
+      modelRuntime: getModelRuntime(modelConfig),
+    });
+
+    expect(callAIWithObjectResponse).toHaveBeenCalledTimes(2);
+    expect(result.searchAreaConfig).toBeDefined();
+  });
+
   it('passes locate request context to custom locate and maps its bbox result', async () => {
     const locateFn = vi.fn<LocateFn>().mockResolvedValue({
       locatedPixelBbox: [100, 50, 130, 70],

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -90,16 +90,22 @@ describe('locate not-found parsing', () => {
     });
   });
 
-  it('returns locate parsing errors when result adapter cannot map coordinates', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
-      content: {
-        bbox: [100, Number.NaN, 300, 400],
-        errors: ['model returned invalid coordinates'],
-      },
-      usage: undefined,
-      contentString:
-        '{"bbox":[100,null,300,400],"errors":["model returned invalid coordinates"]}',
-    });
+  it('retries once when result adapter cannot map coordinates', async () => {
+    vi.mocked(callAIWithObjectResponse)
+      .mockResolvedValueOnce({
+        content: {
+          bbox: [100, Number.NaN, 300, 400],
+          errors: ['model returned invalid coordinates'],
+        },
+        usage: undefined,
+        contentString:
+          '{"bbox":[100,null,300,400],"errors":["model returned invalid coordinates"]}',
+      })
+      .mockResolvedValueOnce({
+        content: { bbox: [100, 200, 300, 400] },
+        usage: undefined,
+        contentString: '{"bbox":[100,200,300,400]}',
+      });
 
     const result = await AiLocateElement({
       context: createFakeContext(),
@@ -107,14 +113,12 @@ describe('locate not-found parsing', () => {
       modelRuntime: getModelRuntime(modelConfig),
     });
 
-    expect(result.rect).toBeUndefined();
-    expect(result.parseResult.element).toBeUndefined();
-    expect(result.parseResult.errors).toEqual([
-      'model returned invalid coordinates',
-      expect.stringMatching(
-        /Failed to parse locate result: invalid parsed locate result/,
-      ),
-    ]);
+    expect(callAIWithObjectResponse).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(callAIWithObjectResponse).mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ retryTimes: 1 }),
+    );
+    expect(result.rect).toBeDefined();
+    expect(result.parseResult.errors).toEqual([]);
   });
 
   it('passes locate request context to custom locate and maps its bbox result', async () => {

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -2,9 +2,11 @@ import { ConversationHistory } from '@/ai-model/conversation-history';
 import { plan } from '@/ai-model/llm-planning';
 import { getModelRuntime } from '@/ai-model/models';
 import { callAI } from '@/ai-model/service-caller/index';
+import { buildYamlFlowFromPlans, getMidsceneLocationSchema } from '@/common';
 import type { DeviceAction, UIContext } from '@/types';
 import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 vi.mock('@/ai-model/service-caller/index', async (importOriginal) => {
   const actual =
@@ -12,6 +14,14 @@ vi.mock('@/ai-model/service-caller/index', async (importOriginal) => {
   return {
     ...actual,
     callAI: vi.fn(),
+  };
+});
+
+vi.mock('@/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common')>();
+  return {
+    ...actual,
+    buildYamlFlowFromPlans: vi.fn(actual.buildYamlFlowFromPlans),
   };
 });
 
@@ -60,6 +70,7 @@ const latestCallAIOptions = () => vi.mocked(callAI).mock.calls[0]?.[2];
 describe('plan XML parse retry', () => {
   beforeEach(() => {
     vi.mocked(callAI).mockReset();
+    vi.mocked(buildYamlFlowFromPlans).mockClear();
   });
 
   it('should retry once when XML response parsing fails', async () => {
@@ -86,6 +97,29 @@ describe('plan XML parse retry', () => {
     expect(callAI).toHaveBeenCalledTimes(2);
     expect(result.rawResponse).toContain('Tap button after retry');
     expect(result.actions).toEqual([{ type: 'Tap' }]);
+  });
+
+  it('preserves retry request errors instead of reporting them as XML parse errors', async () => {
+    const requestError = new Error('failed to call AI model service');
+    vi.mocked(callAI)
+      .mockResolvedValueOnce(
+        mockAIResponse(`<action-type>Tap</action-type>
+<action-param-json>{invalid json}</action-param-json>`),
+      )
+      .mockRejectedValueOnce(requestError);
+
+    await expect(
+      plan('tap the button', {
+        context: mockContext(),
+        actionSpace: mockActionSpace(),
+        modelRuntime: getModelRuntime(mockModelConfig()),
+        conversationHistory: new ConversationHistory(),
+        includeLocateInPlanning: false,
+        deepThink: false,
+      }),
+    ).rejects.toBe(requestError);
+
+    expect(callAI).toHaveBeenCalledTimes(2);
   });
 
   it('should tell the model when no previous aiAct actions have been executed', async () => {
@@ -138,5 +172,66 @@ describe('plan XML parse retry', () => {
 
     expect(latestImageDetail()).toBe('high');
     expect(latestCallAIOptions()?.requiresOriginalImageDetail).toBe(true);
+  });
+
+  it('retries once when planning locate coordinates cannot be normalized', async () => {
+    const actionSpace: DeviceAction[] = [
+      {
+        name: 'Tap',
+        description: 'Tap an element',
+        paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+        call: vi.fn(),
+      },
+    ];
+    vi.mocked(callAI)
+      .mockResolvedValueOnce(
+        mockAIResponse(`<action-type>Tap</action-type>
+<action-param-json>{"locate":{"prompt":"submit","bbox":["invalid"]}}</action-param-json>`),
+      )
+      .mockResolvedValueOnce(
+        mockAIResponse(`<action-type>Tap</action-type>
+<action-param-json>{"locate":{"prompt":"submit","bbox":[100,200,300,400]}}</action-param-json>`),
+      );
+    const yamlFlowInputs: unknown[] = [];
+    const buildYamlFlow = vi.mocked(buildYamlFlowFromPlans);
+    const originalBuildYamlFlow = buildYamlFlow.getMockImplementation();
+    const captureYamlFlowInput = (
+      plans: Parameters<typeof buildYamlFlowFromPlans>[0],
+      currentActionSpace: Parameters<typeof buildYamlFlowFromPlans>[1],
+    ) => {
+      yamlFlowInputs.push(structuredClone(plans));
+      return originalBuildYamlFlow!(plans, currentActionSpace);
+    };
+    buildYamlFlow
+      .mockImplementationOnce(captureYamlFlowInput)
+      .mockImplementationOnce(captureYamlFlowInput);
+
+    const result = await plan('tap submit', {
+      context: mockContext(),
+      actionSpace,
+      modelRuntime: getModelRuntime({
+        ...mockModelConfig(),
+        modelFamily: 'qwen3-vl',
+      }),
+      conversationHistory: new ConversationHistory(),
+      includeLocateInPlanning: true,
+      deepThink: false,
+    });
+
+    expect(callAI).toHaveBeenCalledTimes(2);
+    expect(result.actions[0]?.param?.locate?.locatedPixelBbox).toEqual([
+      10, 20, 30, 40,
+    ]);
+    expect(yamlFlowInputs[1]).toEqual([
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: 'submit',
+            bbox: [100, 200, 300, 400],
+          },
+        },
+      },
+    ]);
   });
 });

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -219,7 +219,7 @@ describe('plan XML parse retry', () => {
     });
 
     expect(callAI).toHaveBeenCalledTimes(2);
-    expect(result.actions[0]?.param?.locate?.locatedPixelBbox).toEqual([
+    expect(result.actions?.[0]?.param?.locate?.locatedPixelBbox).toEqual([
       10, 20, 30, 40,
     ]);
     expect(yamlFlowInputs[1]).toEqual([

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -256,6 +256,27 @@ describe('service-caller reasoning fallback', () => {
     );
   });
 
+  it('retries JSON parsing when retryTimes is configured', async () => {
+    mockCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'not JSON' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: '{"bbox":[100,200,300,400]}' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+
+    const response = await callAIWithObjectResponse(
+      [{ role: 'user', content: 'locate element' }],
+      getModelRuntime(baseModelConfig),
+      { jsonParserSource: 'locate', retryTimes: 1 },
+    );
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(response.content).toEqual({ bbox: [100, 200, 300, 400] });
+  });
+
   it('disables reasoning by default for supported model families', async () => {
     mockCreate.mockResolvedValue({
       choices: [


### PR DESCRIPTION
## Summary

- add a shared `callAiAndParseWithRetry` flow for retrying only structured model-response parsing failures
- apply the flow to object responses, locate, section locate, and insight extraction
- preserve raw model response metadata through `AIResponseParseError` for semantic parse failures

## Validation

- `pnpm exec nx build @midscene/core`

Unit tests were intentionally not run.