### PR TITLE
fix(core): tolerate malformed Doubao bbox values

### DIFF
--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -22,105 +22,47 @@ const doubaoPointCoordinatesMeta = {
   normalizedBy: 1000,
 } as const;
 
-function parseNumbersFromBboxString(input: string): number[] {
-  return (input.match(/\d+/g) ?? []).map(Number).filter(Number.isFinite);
+const coordinateSequencePattern =
+  /(?:^|[^a-zA-Z0-9])(\d+(?:[^a-zA-Z0-9]+\d+)+)(?=$|[^a-zA-Z0-9])/g;
+
+function isFourFiniteNumberArray(input: unknown): input is number[] {
+  return (
+    Array.isArray(input) &&
+    input.length === 4 &&
+    input.every((value) => typeof value === 'number' && Number.isFinite(value))
+  );
 }
 
-function parseLeadingNumberFromString(input: string): number | undefined {
-  const match = input.match(/^\s*(\d+)/);
-  return match ? Number(match[1]) : undefined;
-}
-
-/**
- * Clean coordinate strings can contain multiple positive integers, e.g.
- * - "123 100"
- * - "123,100"
- * - "277; 664 291;"
- * Dirty strings like "345<" are handled by taking the leading number and
- * dropping the remaining array items.
- */
-function isCleanCoordinateString(input: string): boolean {
-  return /^\s*\d+(?:[\s,;]+\d+)*\s*[,;]?\s*$/.test(input);
-}
-
-function parseNumbersFromBboxArray(input: unknown[]): number[] {
-  const numbers: number[] = [];
-
-  for (const item of input) {
-    if (typeof item === 'number') {
-      numbers.push(item);
-      continue;
-    }
-
-    if (typeof item === 'string') {
-      if (isCleanCoordinateString(item)) {
-        numbers.push(...parseNumbersFromBboxString(item));
-        continue;
-      } else {
-        const leadingNumber = parseLeadingNumberFromString(item);
-        if (leadingNumber !== undefined) {
-          numbers.push(leadingNumber);
-        }
-        // Once a dirty string appears, the remaining array items usually belong
-        // to broken JSON repair output, e.g. [410, 295, 885, "345<", "/bbox>..."].
-        break;
-      }
-    }
-
-    break;
+function parseNumbersFromUnexpectedBboxStructure(input: unknown): number[] {
+  const serialized = JSON.stringify(input);
+  if (!serialized) {
+    return [];
   }
 
-  return numbers.filter(Number.isFinite);
-}
+  const sequences = Array.from(
+    serialized.matchAll(coordinateSequencePattern),
+    (match) => match[1].match(/\d+/g)?.map(Number) ?? [],
+  );
+  const longestLength = Math.max(
+    0,
+    ...sequences.map((sequence) => sequence.length),
+  );
+  const longestSequences = sequences.filter(
+    (sequence) => sequence.length === longestLength,
+  );
 
-/**
- * Some models return a tagged bbox tuple, e.g.
- * - ["bbox", [782, 541, 815, 559]]
- * - ["bbox", "782, 541, 815, 559"]
- */
-function parseNumbersFromTaggedBboxArray(input: unknown[]): number[] | null {
-  if (input.length < 2) {
-    return null;
+  if (longestSequences.length !== 1) {
+    return [];
   }
 
-  const taggedBbox = input[1];
-  if (typeof taggedBbox === 'string') {
-    return parseNumbersFromBboxString(taggedBbox);
-  }
-
-  if (Array.isArray(taggedBbox)) {
-    return parseNumbersFromBboxArray(taggedBbox);
-  }
-
-  return null;
+  return longestSequences[0];
 }
 
 export function parseDoubaoRawLocateValue(input: unknown): LocateResultValue {
   const bbox = unwrapCoordinateListLikeInput(input as any);
-  let bboxList: number[] = [];
-
-  if (typeof bbox === 'string') {
-    /**
-     * Some models return bbox as a string, e.g.
-     * - { "bbox": "[336, 163, 717, 200]" }.
-     * - { "bbox": "336, 163, 717, 200" }.
-     * - { "bbox": "336 163 717 200" }.
-     */
-    bboxList = parseNumbersFromBboxString(bbox);
-    if (bboxList.length !== 4) {
-      throw new Error(
-        `invalid bbox data string for doubao-vision mode: ${bbox}`,
-      );
-    }
-  } else if (Array.isArray(bbox)) {
-    if (typeof bbox[0] === 'string' && bbox[0].trim() === 'bbox') {
-      bboxList = parseNumbersFromTaggedBboxArray(bbox) ?? [];
-    } else {
-      bboxList = parseNumbersFromBboxArray(bbox);
-    }
-  } else {
-    bboxList = bbox as number[];
-  }
+  const bboxList = isFourFiniteNumberArray(bbox)
+    ? bbox
+    : parseNumbersFromUnexpectedBboxStructure(bbox);
 
   if (bboxList.length === 4 || bboxList.length === 5) {
     return createLocateResultValue(doubaoBboxCoordinatesMeta, [

--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -22,6 +22,11 @@ const doubaoPointCoordinatesMeta = {
   normalizedBy: 1000,
 } as const;
 
+/**
+ * Finds a sequence of numbers separated by punctuation or whitespace in a
+ * string. Separators cannot be letters, which prevents extracting the `2` in
+ * a mixed alphanumeric token such as `bbox_2d` as a coordinate.
+ */
 const coordinateSequencePattern =
   /(?:^|[^a-zA-Z0-9])(\d+(?:[^a-zA-Z0-9]+\d+)+)(?=$|[^a-zA-Z0-9])/g;
 

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -269,71 +269,175 @@ describe('doubao model adapter', () => {
     });
   });
 
-  it('parses tolerated malformed raw Doubao locate values', () => {
-    expect(parseDoubaoRawLocateValue('100 200 300 400')).toEqual({
-      coordinates: [100, 200, 300, 400],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue(['100', '200', '300', '400'])).toEqual({
-      coordinates: [100, 200, 300, 400],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue('100 200 300 400 ')).toEqual({
-      coordinates: [100, 200, 300, 400],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue('[336, 163, 717, 200]')).toEqual({
-      coordinates: [336, 163, 717, 200],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue('336,163,717,200')).toEqual({
-      coordinates: [336, 163, 717, 200],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue([653, '277; 664 291;'])).toEqual({
-      coordinates: [653, 277, 664, 291],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue([653, '277, 664, 291,'])).toEqual({
-      coordinates: [653, 277, 664, 291],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue(['bbox', [782, 541, 815, 559]])).toEqual({
-      coordinates: [782, 541, 815, 559],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    expect(parseDoubaoRawLocateValue(['bbox', '782, 541, 815, 559'])).toEqual({
-      coordinates: [782, 541, 815, 559],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
-    /**
-     * Some models mix an XML-style bbox closing tag into JSON arrays, e.g.
-     * { "bbox": [410, 295, 885, 345</bbox>, "errors": [] }
-     * jsonrepair may parse it into the array shape below.
-     */
-    expect(
-      parseDoubaoRawLocateValue([
-        410,
-        295,
-        885,
-        '345<',
-        '/bbox>,\n  "errors": []\n}',
-      ]),
-    ).toEqual({
-      coordinates: [410, 295, 885, 345],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
-    });
+  it.each([
+    {
+      name: 'space-separated string',
+      input: '100 200 300 400',
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'separate numeric strings',
+      input: ['100', '200', '300', '400'],
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'trailing whitespace',
+      input: '100 200 300 400 ',
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'bracketed coordinate string',
+      input: '[336, 163, 717, 200]',
+      result: {
+        coordinates: [336, 163, 717, 200],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'comma-separated string',
+      input: '336,163,717,200',
+      result: {
+        coordinates: [336, 163, 717, 200],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'mixed numbers and semicolon-delimited string',
+      input: [653, '277; 664 291;'],
+      result: {
+        coordinates: [653, 277, 664, 291],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'mixed numbers and trailing comma-delimited string',
+      input: [653, '277, 664, 291,'],
+      result: {
+        coordinates: [653, 277, 664, 291],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'bbox tag wrapping coordinates',
+      input: ['bbox', [782, 541, 815, 559]],
+      result: {
+        coordinates: [782, 541, 815, 559],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'bbox tag wrapping a coordinate string',
+      input: ['bbox', '782, 541, 815, 559'],
+      result: {
+        coordinates: [782, 541, 815, 559],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'JSON repair output with an XML-style closing tag',
+      input: [410, 295, 885, '345<', '/bbox>,\n  "errors": []\n}'],
+      result: {
+        coordinates: [410, 295, 885, 345],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'underscore-delimited bbox token from JSON repair',
+      input: ['bbox_859_773_923_808'],
+      result: {
+        coordinates: [859, 773, 923, 808],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'underscore-delimited bbox string',
+      input: 'bbox_859_773_923_808',
+      result: {
+        coordinates: [859, 773, 923, 808],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'coordinates following bbox_2d metadata',
+      input: ['bbox_2d', [650, 700, 710, 730]],
+      result: {
+        coordinates: [650, 700, 710, 730],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'negative sign ignored in malformed coordinate structure',
+      input: ['-100', 200, 300, 400],
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'decimal coordinate split into integer tokens',
+      input: ['100.5', 200, 300, 400],
+      result: {
+        coordinates: [100, 5, 200, 300],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'longer coordinate sequence over shorter error-code sequence',
+      input: 'error: 500, 503; bbox_100_200_300_400',
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'first bbox from a nested bbox list',
+      input: [
+        [100, 200, 300, 400],
+        [500, 600, 700, 800],
+      ],
+      result: {
+        coordinates: [100, 200, 300, 400],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'three-number string point fallback',
+      input: '100 200 300',
+      result: {
+        coordinates: [100, 200],
+        coordinatesMeta: { shape: 'point', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+    {
+      name: 'eight-number polygon string',
+      input: '1 2 3 4 5 6 7 8',
+      result: {
+        coordinates: [1, 2, 5, 6],
+        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      },
+    },
+  ])('parses malformed raw Doubao locate value: $name', ({ input, result }) => {
+    expect(parseDoubaoRawLocateValue(input)).toEqual(result);
   });
 
-  it('throws on invalid raw Doubao locate string values', () => {
-    expect(() => parseDoubaoRawLocateValue('100')).toThrow(
-      /invalid bbox data string/,
-    );
-    expect(() => parseDoubaoRawLocateValue('100 200 300')).toThrow(
-      /invalid bbox data string/,
-    );
-    expect(() => parseDoubaoRawLocateValue('1 2 3 4 5 6 7 8')).toThrow(
-      /invalid bbox data string/,
+  it.each([
+    ['without a coordinate sequence', '100'],
+    [
+      'with two equal-length coordinate sequences',
+      'first: 100 200 300 400; second: 500 600 700 800',
+    ],
+  ])('throws on raw Doubao locate values %s', (_, input) => {
+    expect(() => parseDoubaoRawLocateValue(input)).toThrow(
+      /invalid bbox data/,
     );
   });
 

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -436,9 +436,7 @@ describe('doubao model adapter', () => {
       'first: 100 200 300 400; second: 500 600 700 800',
     ],
   ])('throws on raw Doubao locate values %s', (_, input) => {
-    expect(() => parseDoubaoRawLocateValue(input)).toThrow(
-      /invalid bbox data/,
-    );
+    expect(() => parseDoubaoRawLocateValue(input)).toThrow(/invalid bbox data/);
   });
 
   it('normalizes doubao five-number bbox by using the first four values', () => {


### PR DESCRIPTION
## Summary

Improves Doubao locate-value parsing for malformed or repaired bbox structures by extracting the unique longest contiguous coordinate sequence from serialized fallback input.

- Supports underscore-delimited bbox tokens and malformed tagged/nested/string structures.
- Keeps direct four-number arrays on the fast path and preserves existing point/polygon length semantics.
- Rejects ambiguous equal-length coordinate sequences instead of guessing.
- Consolidates malformed-input coverage into table-driven unit tests, including JSON repair remnants and metadata/error-code noise.

## Root cause

Doubao responses repaired from malformed JSON can wrap or encode coordinates in forms the prior array/string-specific parsers did not recognize, including `bbox_...` tokens.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/doubao.test.ts`