### PR TITLE
test(workflow): stabilize Android and macOS smoke checks

### DIFF
--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -437,18 +437,23 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       });
 
       let searchAttempts = 0;
+      let locateActionCalls = 0;
       const searchAttemptErrors: string[] = [];
       const performSearchAttempt = async (target: {
         bounds: Bounds;
       }): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> => {
         searchAttempts += 1;
         evidence.searchAttempts = searchAttempts;
+        locateActionCalls += 1;
+        evidence.locateActionCalls = locateActionCalls;
         await agent!.callActionInActionSpace('Tap', {
           locate: locate(target.bounds, 'Settings search bar'),
         });
         const searchInput = await waitForEditableNode(adb, searchXmlFile);
         evidence.searchInputResourceId = searchInput.resourceId;
 
+        locateActionCalls += 1;
+        evidence.locateActionCalls = locateActionCalls;
         await agent!.callActionInActionSpace('Input', {
           value: 'wifi',
           mode: 'typeOnly',
@@ -510,7 +515,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(searchAttempts * 2);
+      expect(locateTasks).toHaveLength(locateActionCalls);
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -535,7 +540,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(searchAttempts * 2);
+      expect(reportLocateTasks).toHaveLength(locateActionCalls);
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -27,6 +27,7 @@ const SYSTEM_ERROR_DIALOG_ACTION_IDS = [
 ] as const;
 const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 30_000;
+const UI_DUMP_MAX_ATTEMPTS = 3;
 
 interface Bounds {
   left: number;
@@ -60,13 +61,48 @@ function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isTransientAdbTransportError(error: unknown): boolean {
+  return /device offline|device unauthorized|no devices\/emulators found/i.test(
+    errorMessage(error),
+  );
+}
+
+function isRetryableUiDumpError(error: unknown): boolean {
+  return (
+    isTransientAdbTransportError(error) ||
+    /No such file or directory|empty uiautomator dump/i.test(
+      errorMessage(error),
+    )
+  );
+}
+
 async function dumpUiautomatorXml(adb: ADB): Promise<string> {
-  await adb.shell(`uiautomator dump --compressed ${UI_DUMP_PATH}`);
-  const xml = await adb.shell(`cat ${UI_DUMP_PATH}`);
-  if (typeof xml !== 'string' || xml.trim().length === 0) {
-    throw new Error('Android emulator returned an empty uiautomator dump');
+  for (let attempt = 1; attempt <= UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await adb.shell(`rm -f ${UI_DUMP_PATH}`);
+      await adb.shell(`uiautomator dump --compressed ${UI_DUMP_PATH}`);
+      const xml = await adb.shell(`cat ${UI_DUMP_PATH}`);
+      if (typeof xml !== 'string' || xml.trim().length === 0) {
+        throw new Error('Android emulator returned an empty uiautomator dump');
+      }
+      return xml;
+    } catch (error) {
+      if (attempt === UI_DUMP_MAX_ATTEMPTS || !isRetryableUiDumpError(error)) {
+        throw error;
+      }
+      if (isTransientAdbTransportError(error)) {
+        await adb.waitForDevice(15);
+      } else {
+        await sleep(POLL_INTERVAL_MS);
+      }
+    }
   }
-  return xml;
+
+  throw new Error('UI dump retry loop completed without a result');
 }
 
 function boundsForResourceId(xml: string, resourceId: string): Bounds[] {

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -14,6 +14,7 @@ const pageUrl = 'https://todomvc.com/examples/react/dist/';
 const diagnosticsDir = process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR;
 const CHROME_FIRST_RUN_DUMP_PATH =
   '/sdcard/midscene_chrome_first_run_window_dump.xml';
+const CHROME_UI_DUMP_MAX_ATTEMPTS = 3;
 const expectedActiveTasks = [
   'Learn JS today',
   'Learn Rust tomorrow',
@@ -53,15 +54,39 @@ function screenshotBuffer(base64: string): Buffer {
   return Buffer.from(match[1], 'base64');
 }
 
-async function dumpUiautomatorXml(adb: ADB): Promise<string> {
-  await adb.shell(
-    `uiautomator dump --compressed ${CHROME_FIRST_RUN_DUMP_PATH}`,
+function isTransientAdbTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /device offline|device unauthorized|no devices\/emulators found/i.test(
+    message,
   );
-  const xml = await adb.shell(`cat ${CHROME_FIRST_RUN_DUMP_PATH}`);
-  if (typeof xml !== 'string' || xml.trim().length === 0) {
-    throw new Error('Android emulator returned an empty Chrome UI dump');
+}
+
+async function dumpUiautomatorXml(adb: ADB): Promise<string> {
+  for (let attempt = 1; attempt <= CHROME_UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await adb.shell(
+        `uiautomator dump --compressed ${CHROME_FIRST_RUN_DUMP_PATH}`,
+      );
+      const xml = await adb.shell(`cat ${CHROME_FIRST_RUN_DUMP_PATH}`);
+      if (typeof xml !== 'string' || xml.trim().length === 0) {
+        throw new Error('Android emulator returned an empty Chrome UI dump');
+      }
+      return xml;
+    } catch (error) {
+      if (
+        attempt === CHROME_UI_DUMP_MAX_ATTEMPTS ||
+        !isTransientAdbTransportError(error)
+      ) {
+        throw error;
+      }
+      console.log(
+        `Chrome UI dump hit a transient ADB transport error; recovering device before attempt ${attempt + 1}`,
+      );
+      await adb.waitForDevice(15);
+    }
   }
-  return xml;
+
+  throw new Error('Chrome UI dump retry loop completed without a result');
 }
 
 function centerForExactText(

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -15,6 +15,8 @@ const diagnosticsDir = process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR;
 const CHROME_FIRST_RUN_DUMP_PATH =
   '/sdcard/midscene_chrome_first_run_window_dump.xml';
 const CHROME_UI_DUMP_MAX_ATTEMPTS = 3;
+const CHROME_FIRST_RUN_DISMISS_TIMEOUT_MS = 10_000;
+const CHROME_FIRST_RUN_POLL_INTERVAL_MS = 500;
 const expectedActiveTasks = [
   'Learn JS today',
   'Learn Rust tomorrow',
@@ -61,9 +63,18 @@ function isTransientAdbTransportError(error: unknown): boolean {
   );
 }
 
+function isRetryableChromeUiDumpError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    isTransientAdbTransportError(error) ||
+    /No such file or directory|empty Chrome UI dump/i.test(message)
+  );
+}
+
 async function dumpUiautomatorXml(adb: ADB): Promise<string> {
   for (let attempt = 1; attempt <= CHROME_UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
     try {
+      await adb.shell(`rm -f ${CHROME_FIRST_RUN_DUMP_PATH}`);
       await adb.shell(
         `uiautomator dump --compressed ${CHROME_FIRST_RUN_DUMP_PATH}`,
       );
@@ -75,14 +86,18 @@ async function dumpUiautomatorXml(adb: ADB): Promise<string> {
     } catch (error) {
       if (
         attempt === CHROME_UI_DUMP_MAX_ATTEMPTS ||
-        !isTransientAdbTransportError(error)
+        !isRetryableChromeUiDumpError(error)
       ) {
         throw error;
       }
       console.log(
-        `Chrome UI dump hit a transient ADB transport error; recovering device before attempt ${attempt + 1}`,
+        `Chrome UI dump was not ready; retrying attempt ${attempt + 1}`,
       );
-      await adb.waitForDevice(15);
+      if (isTransientAdbTransportError(error)) {
+        await adb.waitForDevice(15);
+      } else {
+        await sleep(CHROME_FIRST_RUN_POLL_INTERVAL_MS);
+      }
     }
   }
 
@@ -120,7 +135,7 @@ async function dismissChromeFirstRunIfPresent(adb: ADB): Promise<{
   tapAttempts: number;
 }> {
   const beforeXml = await dumpUiautomatorXml(adb);
-  const useWithoutAccount = centerForExactText(
+  let useWithoutAccount = centerForExactText(
     beforeXml,
     'Use without an account',
   );
@@ -138,16 +153,23 @@ async function dismissChromeFirstRunIfPresent(adb: ADB): Promise<{
     await adb.shell(
       `input swipe ${useWithoutAccount.x} ${useWithoutAccount.y} ${useWithoutAccount.x} ${useWithoutAccount.y} 150`,
     );
-    await sleep(1000);
-    afterXml = await dumpUiautomatorXml(adb);
-    if (!centerForExactText(afterXml, 'Use without an account')) {
-      return {
-        beforeXml,
+    const deadline = Date.now() + CHROME_FIRST_RUN_DISMISS_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await sleep(CHROME_FIRST_RUN_POLL_INTERVAL_MS);
+      afterXml = await dumpUiautomatorXml(adb);
+      useWithoutAccount = centerForExactText(
         afterXml,
-        detected: true,
-        dismissed: true,
-        tapAttempts,
-      };
+        'Use without an account',
+      );
+      if (!useWithoutAccount) {
+        return {
+          beforeXml,
+          afterXml,
+          detected: true,
+          dismissed: true,
+          tapAttempts,
+        };
+      }
     }
   }
 

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -176,6 +176,27 @@ function normalizeState(value: unknown): FixtureState {
   };
 }
 
+function foregroundFixtureProcess(processId: number): void {
+  if (!Number.isSafeInteger(processId) || processId <= 0) {
+    throw new Error(
+      `fixture process id must be a positive integer, got ${processId}`,
+    );
+  }
+
+  const script = [
+    'on run argv',
+    'set targetPid to item 1 of argv as integer',
+    'tell application "System Events"',
+    'set targetProcess to first application process whose unix id is targetPid',
+    'set frontmost of targetProcess to true',
+    'end tell',
+    'end run',
+  ].join('\n');
+  execFileSync('/usr/bin/osascript', ['-e', script, String(processId)], {
+    stdio: 'pipe',
+  });
+}
+
 async function waitForJson<T>(
   filePath: string,
   normalize: (value: unknown) => T,
@@ -235,6 +256,7 @@ async function retryFixtureAction(options: {
         ACTIVATION_TIMEOUT_MS,
         options.fixtureProcess,
       );
+      foregroundFixtureProcess(options.fixturePid);
       process.kill(options.fixturePid, 'SIGUSR1');
       await waitForJson(
         options.stateFile,


### PR DESCRIPTION
## Summary

- count actual Android Locate action calls when a tap attempt does not reach the input action
- recover transient ADB transport disconnects and retry UI dumps whose XML file is not ready yet
- wait for Chrome's first-run control to disappear after tapping it instead of assuming a fixed transition time
- bring the macOS fixture process to the foreground by PID through System Events before requesting key-window activation

## Root causes

- Android smoke retries could execute only a Tap on an incomplete attempt, while the assertion assumed every attempt always produced both Tap and Input Locate tasks
- Android `uiautomator dump` can return before its XML file is available, and Chrome startup can briefly cycle ADB through `device offline`
- Chrome's first-run dismissal can complete after the next UI dump, so the previous fixed-delay check could report failure even though the tap succeeded
- AppKit self-activation was unreliable after the fixture lost foreground focus on hosted macOS runners

## Validation

- `pnpm run lint`
- Android Emulator workflow: 3 consecutive successes on final SHA `403dcb1c9`
  - pull request: https://github.com/web-infra-dev/midscene/actions/runs/29390748987
  - workflow dispatch: https://github.com/web-infra-dev/midscene/actions/runs/29390757180
  - workflow dispatch: https://github.com/web-infra-dev/midscene/actions/runs/29391999211
- macOS Desktop workflow: 3 consecutive dispatch successes plus a successful pull-request check on the final SHA
  - https://github.com/web-infra-dev/midscene/actions/runs/29387242619
  - https://github.com/web-infra-dev/midscene/actions/runs/29387841247
  - https://github.com/web-infra-dev/midscene/actions/runs/29388508295
  - final pull-request check: https://github.com/web-infra-dev/midscene/actions/runs/29390748994
- iOS Simulator baseline on `main`: 3 consecutive successes; this PR does not touch iOS or shared runtime code
  - https://github.com/web-infra-dev/midscene/actions/runs/29384143003
  - https://github.com/web-infra-dev/midscene/actions/runs/29384147440
  - https://github.com/web-infra-dev/midscene/actions/runs/29384882959

## Notes

The focused Android AI test could not be collected locally because Vite exhausted the Node.js heap even with an 8 GB limit. The hosted Android workflow runs the same live test files and completed all three final verification runs successfully.
