### PR TITLE
fix(android): use consistent adb configuration

### DIFF
--- a/apps/site/docs/en/android-api-reference.mdx
+++ b/apps/site/docs/en/android-api-reference.mdx
@@ -30,7 +30,11 @@ Create a connection to an adb-managed device that an AndroidAgent can drive.
 ### Import
 
 ```ts
-import { AndroidDevice, getConnectedDevices } from '@midscene/android';
+import {
+  AndroidDevice,
+  getConnectedDevices,
+  getConnectedDevicesWithDetails,
+} from '@midscene/android';
 ```
 
 ### Constructor
@@ -220,19 +224,53 @@ function agentFromAdbDevice(
 ```
 
 - `deviceId?: string` &mdash; Connect to a specific device; omitted means “first available”.
-- `opts?: PageAgentOpt & AndroidDeviceOpt` &mdash; Combine agent options with [AndroidDevice](#androiddevice) settings.
+- `opts?: PageAgentOpt & AndroidDeviceOpt` &mdash; Combine agent options with [AndroidDevice](#androiddevice) settings. When `deviceId` is omitted, Midscene uses the ADB settings from `opts` for discovery.
 
 #### `getConnectedDevices()`
 
 Enumerate adb devices Midscene can drive.
 
 ```ts
-function getConnectedDevices(): Promise<Array<{
+function getConnectedDevices(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<Array<{
   udid: string;
   state: string;
   port?: number;
 }>>;
 ```
+
+Pass `deviceOptions` to use the same ADB executable and server settings as `AndroidDevice`. Midscene reads `androidAdbPath`, `remoteAdbHost`, and `remoteAdbPort`; other device options do not affect discovery.
+
+This example discovers devices through a remote ADB server with a specific local ADB executable:
+
+```ts
+const devices = await getConnectedDevices({
+  androidAdbPath: '/absolute/path/to/adb',
+  remoteAdbHost: '192.168.1.10',
+  remoteAdbPort: 5038,
+});
+```
+
+#### `getConnectedDevicesWithDetails()`
+
+Enumerate connected devices and add metadata when ADB reports it. Midscene leaves unavailable fields as `undefined`.
+
+```ts
+function getConnectedDevicesWithDetails(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<Array<{
+  udid: string;
+  state: string;
+  port?: number;
+  model?: string;
+  brand?: string;
+  resolution?: string;
+  density?: number;
+}>>;
+```
+
+`deviceOptions` selects the ADB executable and server settings for both device discovery and metadata lookup.
 
 ### See also
 

--- a/apps/site/docs/en/android-api-reference.mdx
+++ b/apps/site/docs/en/android-api-reference.mdx
@@ -224,7 +224,7 @@ function agentFromAdbDevice(
 ```
 
 - `deviceId?: string` &mdash; Connect to a specific device; omitted means “first available”.
-- `opts?: PageAgentOpt & AndroidDeviceOpt` &mdash; Combine agent options with [AndroidDevice](#androiddevice) settings. When `deviceId` is omitted, Midscene uses the ADB settings from `opts` for discovery.
+- `opts?: PageAgentOpt & AndroidDeviceOpt` &mdash; Agent options and [AndroidDevice](#androiddevice) settings. When you omit `deviceId`, Midscene discovers a device through adb. Set `androidAdbPath`, `remoteAdbHost`, and `remoteAdbPort` in `opts` to choose the adb configuration for device discovery and connection.
 
 #### `getConnectedDevices()`
 
@@ -240,9 +240,7 @@ function getConnectedDevices(
 }>>;
 ```
 
-Pass `deviceOptions` to use the same ADB executable and server settings as `AndroidDevice`. Midscene reads `androidAdbPath`, `remoteAdbHost`, and `remoteAdbPort`; other device options do not affect discovery.
-
-This example discovers devices through a remote ADB server with a specific local ADB executable:
+`deviceOptions` is optional. Omit it to use Midscene's default adb configuration. Set `androidAdbPath` to choose an adb executable, or set `remoteAdbHost` and `remoteAdbPort` to connect to a remote adb server:
 
 ```ts
 const devices = await getConnectedDevices({
@@ -254,7 +252,7 @@ const devices = await getConnectedDevices({
 
 #### `getConnectedDevicesWithDetails()`
 
-Enumerate connected devices and add metadata when ADB reports it. Midscene leaves unavailable fields as `undefined`.
+This function works like `getConnectedDevices()` and also returns the device brand, model, resolution, and screen density. Unavailable fields are `undefined`.
 
 ```ts
 function getConnectedDevicesWithDetails(
@@ -269,8 +267,6 @@ function getConnectedDevicesWithDetails(
   density?: number;
 }>>;
 ```
-
-`deviceOptions` selects the ADB executable and server settings for both device discovery and metadata lookup.
 
 ### See also
 

--- a/apps/site/docs/zh/android-api-reference.mdx
+++ b/apps/site/docs/zh/android-api-reference.mdx
@@ -223,7 +223,7 @@ function agentFromAdbDevice(
 ```
 
 - `deviceId?: string` —— 连接特定设备；留空表示使用“第一个可用设备”。
-- `opts?: PageAgentOpt & AndroidDeviceOpt` —— 在一个对象中合并 Agent 选项与 [`AndroidDevice`](#androiddevice) 的设置。省略 `deviceId` 时，Midscene 会使用 `opts` 中的 ADB 设置发现设备。
+- `opts?: PageAgentOpt & AndroidDeviceOpt` —— Agent 选项与 [`AndroidDevice`](#androiddevice) 设置。未传 `deviceId` 时，Midscene 会通过 adb 自动发现设备。可在 `opts` 中设置 `androidAdbPath`、`remoteAdbHost` 和 `remoteAdbPort`，指定用于发现和连接设备的 adb。
 
 #### `getConnectedDevices()`
 
@@ -239,9 +239,7 @@ function getConnectedDevices(
 }>>;
 ```
 
-传入 `deviceOptions` 可让设备发现与 `AndroidDevice` 使用同一个 adb 可执行文件和 server 配置。Midscene 会读取 `androidAdbPath`、`remoteAdbHost` 和 `remoteAdbPort`；其他设备选项不会影响设备发现。
-
-以下示例通过远程 adb server 发现设备，并指定本地 adb 可执行文件：
+`deviceOptions` 是可选参数。省略时，Midscene 使用默认 adb 配置。通过 `androidAdbPath` 指定 adb 可执行文件，或通过 `remoteAdbHost` 和 `remoteAdbPort` 连接远程 adb server：
 
 ```ts
 const devices = await getConnectedDevices({
@@ -253,7 +251,7 @@ const devices = await getConnectedDevices({
 
 #### `getConnectedDevicesWithDetails()`
 
-列举已连接设备，并在 adb 可读取时补充设备元数据。无法读取的字段保持 `undefined`。
+与 `getConnectedDevices()` 功能类似，并额外返回设备品牌、型号、分辨率和屏幕密度。无法获取的字段为 `undefined`。
 
 ```ts
 function getConnectedDevicesWithDetails(
@@ -268,8 +266,6 @@ function getConnectedDevicesWithDetails(
   density?: number;
 }>>;
 ```
-
-`deviceOptions` 会为设备发现和元数据读取选择同一个 adb 可执行文件和 server 配置。
 
 ### 相关阅读
 

--- a/apps/site/docs/zh/android-api-reference.mdx
+++ b/apps/site/docs/zh/android-api-reference.mdx
@@ -30,7 +30,11 @@
 ### 导入
 
 ```ts
-import { AndroidDevice, getConnectedDevices } from '@midscene/android';
+import {
+  AndroidDevice,
+  getConnectedDevices,
+  getConnectedDevicesWithDetails,
+} from '@midscene/android';
 ```
 
 ### 构造函数
@@ -219,19 +223,53 @@ function agentFromAdbDevice(
 ```
 
 - `deviceId?: string` —— 连接特定设备；留空表示使用“第一个可用设备”。
-- `opts?: PageAgentOpt & AndroidDeviceOpt` —— 在一个对象中合并 Agent 选项与 [`AndroidDevice`](#androiddevice) 的设置。
+- `opts?: PageAgentOpt & AndroidDeviceOpt` —— 在一个对象中合并 Agent 选项与 [`AndroidDevice`](#androiddevice) 的设置。省略 `deviceId` 时，Midscene 会使用 `opts` 中的 ADB 设置发现设备。
 
 #### `getConnectedDevices()`
 
 列举 Midscene 可驱动的 adb 设备。
 
 ```ts
-function getConnectedDevices(): Promise<Array<{
+function getConnectedDevices(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<Array<{
   udid: string;
   state: string;
   port?: number;
 }>>;
 ```
+
+传入 `deviceOptions` 可让设备发现与 `AndroidDevice` 使用同一个 adb 可执行文件和 server 配置。Midscene 会读取 `androidAdbPath`、`remoteAdbHost` 和 `remoteAdbPort`；其他设备选项不会影响设备发现。
+
+以下示例通过远程 adb server 发现设备，并指定本地 adb 可执行文件：
+
+```ts
+const devices = await getConnectedDevices({
+  androidAdbPath: '/absolute/path/to/adb',
+  remoteAdbHost: '192.168.1.10',
+  remoteAdbPort: 5038,
+});
+```
+
+#### `getConnectedDevicesWithDetails()`
+
+列举已连接设备，并在 adb 可读取时补充设备元数据。无法读取的字段保持 `undefined`。
+
+```ts
+function getConnectedDevicesWithDetails(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<Array<{
+  udid: string;
+  state: string;
+  port?: number;
+  model?: string;
+  brand?: string;
+  resolution?: string;
+  density?: number;
+}>>;
+```
+
+`deviceOptions` 会为设备发现和元数据读取选择同一个 adb 可执行文件和 server 配置。
 
 ### 相关阅读
 

--- a/packages/android/src/adb.ts
+++ b/packages/android/src/adb.ts
@@ -1,0 +1,61 @@
+import type { AndroidDeviceOpt } from '@midscene/core/device';
+import {
+  MIDSCENE_ADB_PATH,
+  MIDSCENE_ADB_REMOTE_HOST,
+  MIDSCENE_ADB_REMOTE_PORT,
+  globalConfigManager,
+} from '@midscene/shared/env';
+import { getDebug } from '@midscene/shared/logger';
+import { ADB, type ADBOptions, getSdkRootFromEnv } from 'appium-adb';
+
+const warnAdb = getDebug('android:adb', { console: true });
+
+export interface CreateAndroidAdbOptions {
+  adbExecTimeout: number;
+  deviceId?: string;
+  deviceOptions?: AndroidDeviceOpt;
+}
+
+export async function createAndroidAdb({
+  adbExecTimeout,
+  deviceId,
+  deviceOptions,
+}: CreateAndroidAdbOptions): Promise<ADB> {
+  const androidAdbPath =
+    deviceOptions?.androidAdbPath ||
+    globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_PATH);
+  const remoteAdbHost =
+    deviceOptions?.remoteAdbHost ||
+    globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_REMOTE_HOST);
+  const remoteAdbPort =
+    deviceOptions?.remoteAdbPort ||
+    globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_REMOTE_PORT);
+
+  const adbOptions: ADBOptions = {
+    udid: deviceId,
+    adbExecTimeout,
+    remoteAdbHost: remoteAdbHost || undefined,
+    remoteAdbPort: remoteAdbPort ? Number(remoteAdbPort) : undefined,
+  };
+
+  if (androidAdbPath) {
+    return new ADB({
+      ...adbOptions,
+      executable: { path: androidAdbPath, defaultArgs: [] },
+    });
+  }
+
+  const sdkRoot = getSdkRootFromEnv();
+  if (sdkRoot) {
+    try {
+      return await ADB.createADB(adbOptions);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnAdb(
+        `Unable to initialize adb from Android SDK at "${sdkRoot}", falling back to adb from PATH: ${message}`,
+      );
+    }
+  }
+
+  return new ADB(adbOptions);
+}

--- a/packages/android/src/agent.ts
+++ b/packages/android/src/agent.ts
@@ -143,7 +143,7 @@ export async function agentFromAdbDevice(
   opts?: AndroidAgentOpt & AndroidDeviceOpt,
 ) {
   if (!deviceId) {
-    const devices = await getConnectedDevices();
+    const devices = await getConnectedDevices(opts);
 
     if (devices.length === 0) {
       throw new Error(

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -26,9 +26,6 @@ import {
 } from '@midscene/core/device';
 import { getTmpFile, sleep } from '@midscene/core/utils';
 import {
-  MIDSCENE_ADB_PATH,
-  MIDSCENE_ADB_REMOTE_HOST,
-  MIDSCENE_ADB_REMOTE_PORT,
   MIDSCENE_ANDROID_IME_STRATEGY,
   globalConfigManager,
 } from '@midscene/shared/env';
@@ -40,7 +37,8 @@ import {
 import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison, repeat } from '@midscene/shared/utils';
 
-import { ADB } from 'appium-adb';
+import type { ADB } from 'appium-adb';
+import { createAndroidAdb } from './adb';
 import {
   buildRunAdbShellPlanningFeedback,
   runAdbShellStdoutOrThrow,
@@ -401,24 +399,10 @@ export class AndroidDevice implements AbstractInterface {
       let error: Error | null = null;
       debugDevice(`Initializing ADB with device ID: ${this.deviceId}`);
       try {
-        const androidAdbPath =
-          this.options?.androidAdbPath ||
-          globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_PATH);
-        const remoteAdbHost =
-          this.options?.remoteAdbHost ||
-          globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_REMOTE_HOST);
-        const remoteAdbPort =
-          this.options?.remoteAdbPort ||
-          globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_REMOTE_PORT);
-
-        this.adb = new ADB({
-          udid: this.deviceId,
+        this.adb = await createAndroidAdb({
           adbExecTimeout: 60000,
-          executable: androidAdbPath
-            ? { path: androidAdbPath, defaultArgs: [] }
-            : undefined,
-          remoteAdbHost: remoteAdbHost || undefined,
-          remoteAdbPort: remoteAdbPort ? Number(remoteAdbPort) : undefined,
+          deviceId: this.deviceId,
+          deviceOptions: this.options,
         });
 
         const size = await this.getScreenSize();
@@ -475,13 +459,14 @@ ${Object.keys(size)
           } catch (error: any) {
             const methodName = String(prop);
             const deviceId = this.deviceId;
+            const adbExecutable = target.executable.path;
             debugDevice(
-              `ADB error with device ${deviceId} when calling ${methodName}: ${error}`,
+              `ADB error with device ${deviceId} when calling ${methodName} (ADB executable: ${adbExecutable}): ${error}`,
             );
 
             // throw the error again
             throw new Error(
-              `ADB error with device ${deviceId} when calling ${methodName}, please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
+              `ADB error with device ${deviceId} when calling ${methodName} (ADB executable: ${adbExecutable}), please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
               {
                 cause: error,
               },
@@ -500,6 +485,13 @@ ${Object.keys(size)
       this.scrcpyAdapter = new ScrcpyDeviceAdapter(
         this.deviceId,
         this.options?.scrcpyConfig,
+        async () => {
+          const adb = await this.getAdb();
+          return {
+            host: adb.adbHost ?? '127.0.0.1',
+            port: adb.adbPort ?? 5037,
+          };
+        },
       );
     }
     return this.scrcpyAdapter;

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -20,6 +20,20 @@ interface ResolvedScrcpyConfig {
   idleTimeoutMs: number;
 }
 
+interface AdbServerEndpoint {
+  host: string;
+  port: number;
+}
+
+type ResolveAdbServerEndpoint = () =>
+  | AdbServerEndpoint
+  | Promise<AdbServerEndpoint>;
+
+const DEFAULT_ADB_SERVER_ENDPOINT: AdbServerEndpoint = {
+  host: '127.0.0.1',
+  port: 5037,
+};
+
 export interface DevicePhysicalInfo {
   physicalWidth: number;
   physicalHeight: number;
@@ -40,6 +54,8 @@ export class ScrcpyDeviceAdapter {
   constructor(
     private deviceId: string,
     private scrcpyConfig: ScrcpyConfig | undefined,
+    private resolveAdbServerEndpoint: ResolveAdbServerEndpoint = () =>
+      DEFAULT_ADB_SERVER_ENDPOINT,
   ) {}
 
   isEnabled(): boolean {
@@ -108,8 +124,9 @@ export class ScrcpyDeviceAdapter {
         './scrcpy-manager'
       );
 
+      const adbServerEndpoint = await this.resolveAdbServerEndpoint();
       const adbClient = new AdbServerClient(
-        new AdbServerNodeTcpConnector({ host: '127.0.0.1', port: 5037 }),
+        new AdbServerNodeTcpConnector(adbServerEndpoint),
       );
       const adb = new Adb(
         await adbClient.createTransport({ serial: this.deviceId }),

--- a/packages/android/src/utils.ts
+++ b/packages/android/src/utils.ts
@@ -1,5 +1,7 @@
+import type { AndroidDeviceOpt } from '@midscene/core/device';
 import { getDebug } from '@midscene/shared/logger';
-import { ADB, type Device } from 'appium-adb';
+import type { ADB, Device } from 'appium-adb';
+import { createAndroidAdb } from './adb';
 
 const debugUtils = getDebug('android:utils');
 const DETAIL_LOOKUP_ADB_TIMEOUT_MS = 8000;
@@ -54,17 +56,26 @@ async function withTimeout<T>(
   }
 }
 
-async function createAdbForDetailLookup(): Promise<ADB> {
-  return await ADB.createADB({
+async function createAdbForDetailLookup(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<ADB> {
+  return await createAndroidAdb({
     adbExecTimeout: DETAIL_LOOKUP_ADB_TIMEOUT_MS,
+    deviceOptions,
   });
 }
 
-export async function getConnectedDevices(): Promise<Device[]> {
+export async function getConnectedDevices(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<Device[]> {
+  let adbExecutable: string | undefined;
+
   try {
-    const adb = await ADB.createADB({
+    const adb = await createAndroidAdb({
       adbExecTimeout: 60000,
+      deviceOptions,
     });
+    adbExecutable = adb.executable.path;
     const devices = await adb.getConnectedDevices();
 
     debugUtils(`Found ${devices.length} connected devices: `, devices);
@@ -72,8 +83,11 @@ export async function getConnectedDevices(): Promise<Device[]> {
     return devices;
   } catch (error: any) {
     console.error('Failed to get device list:', error);
+    const adbExecutableContext = adbExecutable
+      ? ` (ADB executable: ${adbExecutable})`
+      : '';
     throw new Error(
-      `Unable to get connected Android device list, please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
+      `Unable to get connected Android device list${adbExecutableContext}, please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
       {
         cause: error,
       },
@@ -81,10 +95,10 @@ export async function getConnectedDevices(): Promise<Device[]> {
   }
 }
 
-export async function getConnectedDevicesWithDetails(): Promise<
-  AndroidConnectedDevice[]
-> {
-  const devices = await getConnectedDevices();
+export async function getConnectedDevicesWithDetails(
+  deviceOptions?: AndroidDeviceOpt,
+): Promise<AndroidConnectedDevice[]> {
+  const devices = await getConnectedDevices(deviceOptions);
 
   if (devices.length === 0) {
     return [];
@@ -95,7 +109,7 @@ export async function getConnectedDevicesWithDetails(): Promise<
       const detailedDevice: AndroidConnectedDevice = { ...device };
 
       try {
-        const adb = await createAdbForDetailLookup();
+        const adb = await createAdbForDetailLookup(deviceOptions);
         adb.setDeviceId(device.udid);
 
         const [modelResult, brandResult, sizeResult, densityResult] =

--- a/packages/android/tests/unit-test/adb.test.ts
+++ b/packages/android/tests/unit-test/adb.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  adbConstructor: vi.fn(),
+  createADB: vi.fn(),
+  getEnvConfigValue: vi.fn(),
+  getSdkRootFromEnv: vi.fn(),
+  warnAdb: vi.fn(),
+}));
+
+vi.mock('@midscene/shared/env', () => ({
+  MIDSCENE_ADB_PATH: 'MIDSCENE_ADB_PATH',
+  MIDSCENE_ADB_REMOTE_HOST: 'MIDSCENE_ADB_REMOTE_HOST',
+  MIDSCENE_ADB_REMOTE_PORT: 'MIDSCENE_ADB_REMOTE_PORT',
+  globalConfigManager: {
+    getEnvConfigValue: mocks.getEnvConfigValue,
+  },
+}));
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => mocks.warnAdb),
+}));
+
+vi.mock('appium-adb', () => {
+  class MockADB {
+    static createADB = mocks.createADB;
+
+    constructor(options: unknown) {
+      mocks.adbConstructor(options);
+    }
+  }
+
+  return {
+    ADB: MockADB,
+    getSdkRootFromEnv: mocks.getSdkRootFromEnv,
+  };
+});
+
+import { createAndroidAdb } from '../../src/adb';
+
+describe('createAndroidAdb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getEnvConfigValue.mockReturnValue(undefined);
+    mocks.getSdkRootFromEnv.mockReturnValue('/android/sdk');
+  });
+
+  it('uses the explicit executable and remote server for the ADB client', async () => {
+    await createAndroidAdb({
+      adbExecTimeout: 8000,
+      deviceId: 'device-1',
+      deviceOptions: {
+        androidAdbPath: '/custom/platform-tools/adb',
+        remoteAdbHost: '192.168.1.10',
+        remoteAdbPort: 5038,
+      },
+    });
+
+    expect(mocks.adbConstructor).toHaveBeenCalledWith({
+      udid: 'device-1',
+      adbExecTimeout: 8000,
+      executable: {
+        path: '/custom/platform-tools/adb',
+        defaultArgs: [],
+      },
+      remoteAdbHost: '192.168.1.10',
+      remoteAdbPort: 5038,
+    });
+    expect(mocks.createADB).not.toHaveBeenCalled();
+  });
+
+  it('uses MIDSCENE_ADB settings when device options are absent', async () => {
+    mocks.getEnvConfigValue.mockImplementation((key: string) => {
+      const values: Record<string, string> = {
+        MIDSCENE_ADB_PATH: '/env/platform-tools/adb',
+        MIDSCENE_ADB_REMOTE_HOST: 'adb.example.com',
+        MIDSCENE_ADB_REMOTE_PORT: '5040',
+      };
+      return values[key];
+    });
+
+    await createAndroidAdb({ adbExecTimeout: 60000 });
+
+    expect(mocks.adbConstructor).toHaveBeenCalledWith({
+      udid: undefined,
+      adbExecTimeout: 60000,
+      executable: {
+        path: '/env/platform-tools/adb',
+        defaultArgs: [],
+      },
+      remoteAdbHost: 'adb.example.com',
+      remoteAdbPort: 5040,
+    });
+    expect(mocks.createADB).not.toHaveBeenCalled();
+  });
+
+  it('uses Appium SDK resolution when no custom executable is configured', async () => {
+    const sdkAdb = { source: 'android-sdk' };
+    mocks.createADB.mockResolvedValue(sdkAdb);
+
+    await expect(
+      createAndroidAdb({
+        adbExecTimeout: 60000,
+        deviceId: 'device-2',
+      }),
+    ).resolves.toBe(sdkAdb);
+
+    expect(mocks.createADB).toHaveBeenCalledWith({
+      udid: 'device-2',
+      adbExecTimeout: 60000,
+      remoteAdbHost: undefined,
+      remoteAdbPort: undefined,
+    });
+    expect(mocks.adbConstructor).not.toHaveBeenCalled();
+  });
+
+  it('falls back to PATH when the configured Android SDK cannot resolve adb', async () => {
+    mocks.getSdkRootFromEnv.mockReturnValue('/stale/android/sdk');
+    mocks.createADB.mockRejectedValue(
+      new Error('The Android SDK root folder does not exist'),
+    );
+
+    await createAndroidAdb({
+      adbExecTimeout: 60000,
+      deviceId: 'device-3',
+    });
+
+    expect(mocks.createADB).toHaveBeenCalledWith({
+      udid: 'device-3',
+      adbExecTimeout: 60000,
+      remoteAdbHost: undefined,
+      remoteAdbPort: undefined,
+    });
+    expect(mocks.adbConstructor).toHaveBeenCalledWith({
+      udid: 'device-3',
+      adbExecTimeout: 60000,
+      remoteAdbHost: undefined,
+      remoteAdbPort: undefined,
+    });
+    expect(mocks.warnAdb).toHaveBeenCalledWith(
+      'Unable to initialize adb from Android SDK at "/stale/android/sdk", falling back to adb from PATH: The Android SDK root folder does not exist',
+    );
+  });
+
+  it('preserves the PATH fallback when no Android SDK root is configured', async () => {
+    mocks.getSdkRootFromEnv.mockReturnValue(undefined);
+
+    await createAndroidAdb({
+      adbExecTimeout: 60000,
+      deviceId: 'device-3',
+    });
+
+    expect(mocks.adbConstructor).toHaveBeenCalledWith({
+      udid: 'device-3',
+      adbExecTimeout: 60000,
+      remoteAdbHost: undefined,
+      remoteAdbPort: undefined,
+    });
+    expect(mocks.createADB).not.toHaveBeenCalled();
+  });
+});

--- a/packages/android/tests/unit-test/agent.test.ts
+++ b/packages/android/tests/unit-test/agent.test.ts
@@ -306,7 +306,7 @@ ${'o'.repeat(200)}
       vi.unstubAllEnvs();
     });
 
-    it('should use the first device if no deviceId is provided', async () => {
+    it('should use the first device and forward ADB options if no deviceId is provided', async () => {
       const mockDevices = [{ udid: 'device-1' }, { udid: 'device-2' }];
       vi.spyOn(Utils, 'getConnectedDevices').mockResolvedValue(
         mockDevices as any,
@@ -327,13 +327,15 @@ ${'o'.repeat(200)}
         };
       });
 
-      const agent = await agentFromAdbDevice();
+      const options = {
+        androidAdbPath: '/custom/platform-tools/adb',
+        remoteAdbHost: 'localhost',
+        remoteAdbPort: 5038,
+      };
+      const agent = await agentFromAdbDevice(undefined, options);
 
-      expect(Utils.getConnectedDevices).toHaveBeenCalled();
-      expect(AndroidDevice).toHaveBeenCalledWith(
-        'device-1',
-        expect.any(Object),
-      );
+      expect(Utils.getConnectedDevices).toHaveBeenCalledWith(options);
+      expect(AndroidDevice).toHaveBeenCalledWith('device-1', options);
       expect(mockConnect).toHaveBeenCalled();
       expect(agent).toBeInstanceOf(AndroidAgent);
     });

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -17,6 +17,10 @@ import { AndroidDevice, escapeForShell } from '../../src/device';
 
 // Mock the entire appium-adb module
 const createMockAdb = () => ({
+  executable: {
+    path: '/mock/platform-tools/adb',
+    defaultArgs: [],
+  },
   EXEC_OUTPUT_FORMAT: {
     FULL: 'full',
     STDOUT: 'stdout',
@@ -45,13 +49,24 @@ const createValidPngBuffer = (size = 64) =>
   ]);
 
 vi.mock('appium-adb', () => {
-  return {
-    ADB: vi.fn(() => {
+  const MockADB = vi.fn(() => {
+    if (!mockAdbInstance) {
+      mockAdbInstance = createMockAdb();
+    }
+    return mockAdbInstance;
+  });
+  Object.assign(MockADB, {
+    createADB: vi.fn(async () => {
       if (!mockAdbInstance) {
         mockAdbInstance = createMockAdb();
       }
       return mockAdbInstance;
     }),
+  });
+
+  return {
+    ADB: MockADB,
+    getSdkRootFromEnv: vi.fn(() => undefined),
   };
 });
 
@@ -138,6 +153,28 @@ describe('AndroidDevice', () => {
     expect(() => new AndroidDevice(undefined as any)).toThrow(
       'deviceId is required for AndroidDevice',
     );
+  });
+
+  it('should include the ADB executable in proxied command errors', async () => {
+    mockAdb.shell.mockRejectedValue(new Error('protocol fault'));
+    const adbProxy = (device as any).createAdbProxy(mockAdb);
+
+    await expect(adbProxy.shell(['wm', 'size'])).rejects.toThrow(
+      'ADB error with device test-device when calling shell (ADB executable: /mock/platform-tools/adb)',
+    );
+  });
+
+  it('should share the resolved ADB server endpoint with scrcpy', async () => {
+    Object.assign(mockAdb, {
+      adbHost: '192.168.1.10',
+      adbPort: 5038,
+    });
+    const adapter = (device as any).getScrcpyAdapter();
+
+    await expect((adapter as any).resolveAdbServerEndpoint()).resolves.toEqual({
+      host: '192.168.1.10',
+      port: 5038,
+    });
   });
 
   describe('launch', () => {

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -3,6 +3,10 @@ import type { DevicePhysicalInfo } from '../../src/scrcpy-device-adapter';
 import { ScrcpyDeviceAdapter } from '../../src/scrcpy-device-adapter';
 import { DEFAULT_SCRCPY_CONFIG } from '../../src/scrcpy-manager';
 
+const mocks = vi.hoisted(() => ({
+  AdbServerNodeTcpConnector: vi.fn(),
+}));
+
 // Mock @yume-chan packages (ESM-only, used via dynamic import in ensureManager)
 vi.mock('@yume-chan/adb', () => ({
   Adb: vi.fn().mockImplementation(() => ({})),
@@ -12,7 +16,7 @@ vi.mock('@yume-chan/adb', () => ({
 }));
 
 vi.mock('@yume-chan/adb-server-node-tcp', () => ({
-  AdbServerNodeTcpConnector: vi.fn(),
+  AdbServerNodeTcpConnector: mocks.AdbServerNodeTcpConnector,
 }));
 
 // Mock ScrcpyScreenshotManager returned by dynamic import in ensureManager
@@ -236,6 +240,37 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   describe('ensureManager', () => {
+    it('should use the local ADB server endpoint by default', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+
+      await adapter.ensureManager(defaultDeviceInfo);
+
+      expect(mocks.AdbServerNodeTcpConnector).toHaveBeenCalledWith({
+        host: '127.0.0.1',
+        port: 5037,
+      });
+    });
+
+    it('should connect to the resolved ADB server endpoint', async () => {
+      const resolveAdbServerEndpoint = vi.fn().mockResolvedValue({
+        host: '192.168.1.10',
+        port: 5038,
+      });
+      const adapter = new ScrcpyDeviceAdapter(
+        'device',
+        { enabled: true },
+        resolveAdbServerEndpoint,
+      );
+
+      await adapter.ensureManager(defaultDeviceInfo);
+
+      expect(resolveAdbServerEndpoint).toHaveBeenCalledTimes(1);
+      expect(mocks.AdbServerNodeTcpConnector).toHaveBeenCalledWith({
+        host: '192.168.1.10',
+        port: 5038,
+      });
+    });
+
     it('should return cached manager without re-validation', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', undefined);
       (adapter as any).manager = currentMockManager;

--- a/packages/android/tests/unit-test/utils.test.ts
+++ b/packages/android/tests/unit-test/utils.test.ts
@@ -1,28 +1,32 @@
-import { ADB } from 'appium-adb';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getConnectedDevices,
   getConnectedDevicesWithDetails,
 } from '../../src/utils';
 
-vi.mock('appium-adb', () => {
-  const mockAdb = {
+const mocks = vi.hoisted(() => ({
+  adb: {
+    executable: {
+      path: '/mock/platform-tools/adb',
+      defaultArgs: [],
+    },
     getConnectedDevices: vi.fn(),
     setDeviceId: vi.fn(),
     shell: vi.fn(),
     getScreenDensity: vi.fn(),
-  };
-  return {
-    ADB: {
-      createADB: vi.fn(() => Promise.resolve(mockAdb)),
-    },
-  };
-});
+  },
+  createAndroidAdb: vi.fn(),
+}));
+
+vi.mock('../../src/adb', () => ({
+  createAndroidAdb: mocks.createAndroidAdb,
+}));
 
 describe('Android Utils', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    const mockAdbInstance = await ADB.createADB();
+    const mockAdbInstance = mocks.adb;
+    mocks.createAndroidAdb.mockResolvedValue(mockAdbInstance);
     (mockAdbInstance.setDeviceId as Mock).mockImplementation(() => undefined);
     (mockAdbInstance.shell as Mock).mockReset();
     (mockAdbInstance.getScreenDensity as Mock).mockReset();
@@ -32,25 +36,44 @@ describe('Android Utils', () => {
   describe('getConnectedDevices', () => {
     it('should return a list of connected devices', async () => {
       const mockDevices = [{ udid: 'device-1' }, { udid: 'device-2' }];
-      const mockAdbInstance = await ADB.createADB();
+      const mockAdbInstance = mocks.adb;
       (mockAdbInstance.getConnectedDevices as Mock).mockResolvedValue(
         mockDevices,
       );
 
       const devices = await getConnectedDevices();
 
-      expect(ADB.createADB).toHaveBeenCalled();
+      expect(mocks.createAndroidAdb).toHaveBeenCalledWith({
+        adbExecTimeout: 60000,
+        deviceOptions: undefined,
+      });
       expect(mockAdbInstance.getConnectedDevices).toHaveBeenCalled();
       expect(devices).toEqual(mockDevices);
     });
 
+    it('should use the provided ADB options for device discovery', async () => {
+      const deviceOptions = {
+        androidAdbPath: '/custom/platform-tools/adb',
+        remoteAdbHost: 'localhost',
+        remoteAdbPort: 5038,
+      };
+      mocks.adb.getConnectedDevices.mockResolvedValue([]);
+
+      await getConnectedDevices(deviceOptions);
+
+      expect(mocks.createAndroidAdb).toHaveBeenCalledWith({
+        adbExecTimeout: 60000,
+        deviceOptions,
+      });
+    });
+
     it('should throw a formatted error if getting devices fails', async () => {
       const error = new Error('Failed to connect to ADB');
-      const mockAdbInstance = await ADB.createADB();
+      const mockAdbInstance = mocks.adb;
       (mockAdbInstance.getConnectedDevices as Mock).mockRejectedValue(error);
 
       await expect(getConnectedDevices()).rejects.toThrow(
-        `Unable to get connected Android device list, please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
+        `Unable to get connected Android device list (ADB executable: /mock/platform-tools/adb), please check https://midscenejs.com/integrate-with-android.html#faq : ${error.message}`,
       );
     });
   });
@@ -58,7 +81,7 @@ describe('Android Utils', () => {
   describe('getConnectedDevicesWithDetails', () => {
     it('should enrich devices with model, resolution, and density when available', async () => {
       const mockDevices = [{ udid: 'device-1', state: 'device' }];
-      const mockAdbInstance = await ADB.createADB();
+      const mockAdbInstance = mocks.adb;
       (mockAdbInstance.getConnectedDevices as Mock).mockResolvedValue(
         mockDevices,
       );
@@ -81,14 +104,39 @@ describe('Android Utils', () => {
           density: 420,
         },
       ]);
-      expect(ADB.createADB).toHaveBeenLastCalledWith({
+      expect(mocks.createAndroidAdb).toHaveBeenLastCalledWith({
         adbExecTimeout: 8000,
+        deviceOptions: undefined,
+      });
+    });
+
+    it('should use the same ADB options for discovery and detail lookup', async () => {
+      const deviceOptions = {
+        androidAdbPath: '/custom/platform-tools/adb',
+        remoteAdbHost: 'localhost',
+        remoteAdbPort: 5038,
+      };
+      mocks.adb.getConnectedDevices.mockResolvedValue([
+        { udid: 'device-1', state: 'device' },
+      ]);
+      mocks.adb.shell.mockResolvedValue('');
+      mocks.adb.getScreenDensity.mockResolvedValue(undefined);
+
+      await getConnectedDevicesWithDetails(deviceOptions);
+
+      expect(mocks.createAndroidAdb).toHaveBeenNthCalledWith(1, {
+        adbExecTimeout: 60000,
+        deviceOptions,
+      });
+      expect(mocks.createAndroidAdb).toHaveBeenNthCalledWith(2, {
+        adbExecTimeout: 8000,
+        deviceOptions,
       });
     });
 
     it('should silently fall back to the basic device list when detail lookup fails', async () => {
       const mockDevices = [{ udid: 'device-1', state: 'device' }];
-      const mockAdbInstance = await ADB.createADB();
+      const mockAdbInstance = mocks.adb;
       (mockAdbInstance.getConnectedDevices as Mock).mockResolvedValue(
         mockDevices,
       );
@@ -106,7 +154,7 @@ describe('Android Utils', () => {
 
       try {
         const mockDevices = [{ udid: 'device-1', state: 'device' }];
-        const mockAdbInstance = await ADB.createADB();
+        const mockAdbInstance = mocks.adb;
         (mockAdbInstance.getConnectedDevices as Mock).mockResolvedValue(
           mockDevices,
         );


### PR DESCRIPTION
## Summary

- centralize ADB client creation so device discovery, metadata lookup, and `AndroidDevice` operations use the same executable and remote server settings
- forward Android device options during automatic discovery while preserving Android SDK and `PATH` fallbacks
- make Scrcpy connect to the ADB server endpoint resolved by the existing appium-adb instance, including remote hosts and non-default ports
- include the selected ADB executable in command errors for diagnostics
- document the public discovery options and detailed device metadata in the English and Chinese Android API references

## Root cause

Midscene created independent ADB clients for discovery, metadata lookup, and device operations, which could resolve different executables against the shared ADB server. Scrcpy also used a separate hard-coded `127.0.0.1:5037` connector, so it ignored `remoteAdbHost` and `remoteAdbPort`.

## Validation

- `pnpm --filter @midscene/android test -- tests/unit-test/scrcpy-adapter.test.ts tests/unit-test/page.test.ts` (204 tests passed)
- `pnpm --filter @midscene/android test` (313 tests passed)
- `pnpm --filter @midscene/android build`
- `pnpm run lint`