### PR TITLE
fix(android): recover scrcpy after transient initialization failures

### DIFF
--- a/apps/site/docs/en/android-api-reference.mdx
+++ b/apps/site/docs/en/android-api-reference.mdx
@@ -82,8 +82,21 @@ const device = new AndroidDevice(deviceId, {
 | `idleTimeoutMs` | `number` | `30000` | Auto-disconnect after idle (ms). Set to `0` to disable |
 
 :::tip
-Scrcpy mode automatically falls back to ADB screenshots if the connection fails. No extra error handling is needed.
+Scrcpy mode automatically falls back to ADB screenshots if the connection fails. Transient failures enter a five-second cooldown and the next screenshot retries Scrcpy after the cooldown, without recreating the `AndroidDevice`.
 :::
+
+Use `getScrcpyStatus()` when the caller needs to observe degraded capture, and `retryScrcpy()` to retry immediately instead of waiting for the cooldown:
+
+```ts
+const status = device.getScrcpyStatus();
+
+if (status.enabled && !status.connected && status.lastError) {
+  console.warn(status.lastError);
+  await device.retryScrcpy();
+}
+```
+
+`getScrcpyStatus()` returns `enabled`, `connected`, `lastError`, and `retryAfter`. Initialization errors include available output from the device-side Scrcpy server to make codec and media-stack failures diagnosable.
 
 ### Usage notes
 

--- a/apps/site/docs/zh/android-api-reference.mdx
+++ b/apps/site/docs/zh/android-api-reference.mdx
@@ -82,8 +82,21 @@ const device = new AndroidDevice(deviceId, {
 | `idleTimeoutMs` | `number` | `30000` | 空闲超时后自动断开连接（ms），设为 `0` 禁用 |
 
 :::tip
-Scrcpy 模式在连接失败时会自动降级到 ADB 截图，无需额外处理。
+Scrcpy 模式在连接失败时会自动降级到 ADB 截图。瞬态失败会进入五秒冷却期，冷却结束后的下一次截图会自动重试 Scrcpy，无需重新创建 `AndroidDevice`。
 :::
+
+如果调用方需要感知截图已降级，可以使用 `getScrcpyStatus()`；如需跳过冷却期立即重试，可以使用 `retryScrcpy()`：
+
+```ts
+const status = device.getScrcpyStatus();
+
+if (status.enabled && !status.connected && status.lastError) {
+  console.warn(status.lastError);
+  await device.retryScrcpy();
+}
+```
+
+`getScrcpyStatus()` 返回 `enabled`、`connected`、`lastError` 和 `retryAfter`。初始化异常会包含可获取到的设备端 Scrcpy server 输出，便于诊断编码器和媒体栈尚未就绪等问题。
 
 ### 使用说明
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -48,6 +48,7 @@ import {
 import {
   type DevicePhysicalInfo,
   ScrcpyDeviceAdapter,
+  type ScrcpyStatus,
 } from './scrcpy-device-adapter';
 import type { RawKeyframe } from './scrcpy-manager';
 
@@ -358,8 +359,8 @@ export class AndroidDevice implements AbstractInterface {
   public async connect(): Promise<ADB> {
     const adb = await this.getAdb();
 
-    // Initialize scrcpy connection (if enabled)
-    // If it fails, scrcpy is permanently disabled and ADB fallback is used
+    // Initialize scrcpy connection (if enabled). A transient failure falls back
+    // to ADB while preserving the ability to retry on the same device instance.
     const adapter = this.getScrcpyAdapter();
     if (adapter.isEnabled()) {
       try {
@@ -371,7 +372,7 @@ export class AndroidDevice implements AbstractInterface {
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         warnDevice(
-          `[midscene] Scrcpy unavailable, using ADB fallback (device: ${this.deviceId}): ${msg}`,
+          `[midscene] Scrcpy unavailable, using ADB fallback (device: ${this.deviceId}): ${msg}. Call retryScrcpy() to retry immediately.`,
         );
       }
     }
@@ -490,6 +491,23 @@ ${Object.keys(size)
         };
       },
     });
+  }
+
+  /** Current scrcpy configuration, connection, and recovery state. */
+  public getScrcpyStatus(): ScrcpyStatus {
+    return this.getScrcpyAdapter().getStatus();
+  }
+
+  /** Retry scrcpy initialization without recreating the AndroidDevice. */
+  public async retryScrcpy(): Promise<ScrcpyStatus> {
+    const adapter = this.getScrcpyAdapter();
+    if (!adapter.getStatus().enabled) {
+      throw new Error('scrcpy is disabled in AndroidDevice options');
+    }
+
+    const deviceInfo = await this.getDevicePhysicalInfo();
+    await adapter.initialize(deviceInfo);
+    return adapter.getStatus();
   }
 
   /**

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -8,4 +8,7 @@ export {
   getConnectedDevicesWithDetails,
 } from './utils';
 export type { AndroidConnectedDevice } from './utils';
-export { ScrcpyDeviceAdapter } from './scrcpy-device-adapter';
+export {
+  ScrcpyDeviceAdapter,
+  type ScrcpyStatus,
+} from './scrcpy-device-adapter';

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -5,6 +5,7 @@ import type { RawKeyframe, ScrcpyScreenshotManager } from './scrcpy-manager';
 import { DEFAULT_SCRCPY_CONFIG } from './scrcpy-manager';
 
 const debugAdapter = getDebug('android:scrcpy-adapter');
+const SCRCPY_RETRY_COOLDOWN_MS = 5_000;
 
 interface ScrcpyConfig {
   enabled?: boolean;
@@ -28,6 +29,13 @@ export interface DevicePhysicalInfo {
   isCurrentOrientation?: boolean;
 }
 
+export interface ScrcpyStatus {
+  enabled: boolean;
+  connected: boolean;
+  lastError: string | null;
+  retryAfter: number | null;
+}
+
 /**
  * Adapter that encapsulates all scrcpy-related logic for AndroidDevice.
  * Handles config normalization, manager lifecycle, screenshot, and resolution.
@@ -35,7 +43,8 @@ export interface DevicePhysicalInfo {
 export class ScrcpyDeviceAdapter {
   private manager: ScrcpyScreenshotManager | null = null;
   private resolvedConfig: ResolvedScrcpyConfig | null = null;
-  private initFailed = false;
+  private lastError: string | null = null;
+  private retryAfter: number | null = null;
 
   constructor(
     private deviceId: string,
@@ -43,22 +52,55 @@ export class ScrcpyDeviceAdapter {
   ) {}
 
   isEnabled(): boolean {
-    if (this.initFailed) return false;
+    if (!this.isConfigured()) return false;
+    return this.retryAfter === null || Date.now() >= this.retryAfter;
+  }
+
+  getStatus(): ScrcpyStatus {
+    return {
+      enabled: this.isConfigured(),
+      connected: this.manager?.isConnected() ?? false,
+      lastError: this.lastError,
+      retryAfter: this.retryAfter,
+    };
+  }
+
+  private isConfigured(): boolean {
     return this.scrcpyConfig?.enabled ?? DEFAULT_SCRCPY_CONFIG.enabled;
   }
 
   /**
-   * Initialize scrcpy connection. Called once during device.connect().
-   * If initialization fails, marks scrcpy as permanently disabled (no further retries).
+   * Initialize scrcpy connection. Called during device.connect() and explicit retries.
    */
   async initialize(deviceInfo: DevicePhysicalInfo): Promise<void> {
     try {
       const manager = await this.ensureManager(deviceInfo);
       await manager.ensureConnected();
+      this.clearFailure();
     } catch (error) {
-      this.initFailed = true;
+      this.recordFailure(error);
       throw error;
     }
+  }
+
+  private recordFailure(error: unknown): void {
+    this.lastError = error instanceof Error ? error.message : String(error);
+    this.retryAfter = Date.now() + SCRCPY_RETRY_COOLDOWN_MS;
+  }
+
+  private clearFailure(): void {
+    this.lastError = null;
+    this.retryAfter = null;
+  }
+
+  private ensureRetryReady(): void {
+    if (this.retryAfter === null || Date.now() >= this.retryAfter) {
+      return;
+    }
+
+    throw new Error(
+      `scrcpy retry is cooling down until ${new Date(this.retryAfter).toISOString()}. Last error: ${this.lastError}`,
+    );
   }
 
   /**
@@ -78,7 +120,7 @@ export class ScrcpyDeviceAdapter {
       config?.videoBitRate ?? DEFAULT_SCRCPY_CONFIG.videoBitRate;
 
     this.resolvedConfig = {
-      enabled: this.isEnabled(),
+      enabled: this.isConfigured(),
       maxSize,
       idleTimeoutMs:
         config?.idleTimeoutMs ?? DEFAULT_SCRCPY_CONFIG.idleTimeoutMs,
@@ -144,10 +186,21 @@ export class ScrcpyDeviceAdapter {
    * Throws on failure (caller should fallback to ADB).
    */
   async screenshotBase64(deviceInfo: DevicePhysicalInfo): Promise<string> {
-    const manager = await this.ensureManager(deviceInfo);
-    const screenshotBuffer = await manager.getScreenshotJpeg();
+    this.ensureRetryReady();
 
-    return createImgBase64ByFormat('jpeg', screenshotBuffer.toString('base64'));
+    try {
+      const manager = await this.ensureManager(deviceInfo);
+      const screenshotBuffer = await manager.getScreenshotJpeg();
+      this.clearFailure();
+
+      return createImgBase64ByFormat(
+        'jpeg',
+        screenshotBuffer.toString('base64'),
+      );
+    } catch (error) {
+      this.recordFailure(error);
+      throw error;
+    }
   }
 
   /**
@@ -160,9 +213,17 @@ export class ScrcpyDeviceAdapter {
     deviceInfo: DevicePhysicalInfo,
     listener: (frame: RawKeyframe) => void,
   ): Promise<() => void> {
-    const manager = await this.ensureManager(deviceInfo);
-    await manager.ensureConnected();
-    return manager.subscribeKeyframes(listener);
+    this.ensureRetryReady();
+
+    try {
+      const manager = await this.ensureManager(deviceInfo);
+      await manager.ensureConnected();
+      this.clearFailure();
+      return manager.subscribeKeyframes(listener);
+    } catch (error) {
+      this.recordFailure(error);
+      throw error;
+    }
   }
 
   /** Latest raw keyframe seen on the stream, or null if none yet. */
@@ -227,5 +288,6 @@ export class ScrcpyDeviceAdapter {
       this.manager = null;
     }
     this.resolvedConfig = null;
+    this.clearFailure();
   }
 }

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -25,6 +25,8 @@ const FRESH_FRAME_TIMEOUT_MS = 300; // Short timeout to wait for a fresh frame; 
 const KEYFRAME_POLL_INTERVAL_MS = 200;
 const MAX_SCAN_BYTES = 1_000;
 const CONNECTION_WAIT_MS = 1_000;
+const MAX_SERVER_OUTPUT_LINES = 100;
+const SERVER_OUTPUT_DRAIN_TIMEOUT_MS = 500;
 
 // Busy-loop detection thresholds
 const BUSY_LOOP_WINDOW_MS = 1_000; // Sliding window for measuring frame rate
@@ -181,6 +183,9 @@ export class ScrcpyScreenshotManager {
       );
     }
 
+    const serverOutput: string[] = [];
+    let serverOutputTask: Promise<void> | null = null;
+
     try {
       this.isConnecting = true;
       debugScrcpy('Starting scrcpy connection...');
@@ -213,6 +218,10 @@ export class ScrcpyScreenshotManager {
         DefaultServerPath,
         scrcpyOptions,
       );
+      serverOutputTask = this.collectServerOutput(
+        this.scrcpyClient.output,
+        serverOutput,
+      );
 
       const videoStreamPromise = this.scrcpyClient.videoStream;
       if (!videoStreamPromise) {
@@ -233,10 +242,67 @@ export class ScrcpyScreenshotManager {
     } catch (error) {
       debugScrcpy(`Failed to connect scrcpy: ${error}`);
       await this.disconnect();
-      throw error;
+      if (serverOutputTask) {
+        await Promise.race([
+          serverOutputTask,
+          new Promise<void>((resolve) =>
+            setTimeout(resolve, SERVER_OUTPUT_DRAIN_TIMEOUT_MS),
+          ),
+        ]);
+      }
+      throw this.createConnectionError(error, serverOutput);
     } finally {
       this.isConnecting = false;
     }
+  }
+
+  private async collectServerOutput(
+    output: ReadableStream<string>,
+    lines: string[],
+  ): Promise<void> {
+    const reader = output.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        lines.push(value);
+        if (lines.length > MAX_SERVER_OUTPUT_LINES) {
+          lines.splice(0, lines.length - MAX_SERVER_OUTPUT_LINES);
+        }
+      }
+    } catch (error) {
+      debugScrcpy(`Failed to read scrcpy server output: ${error}`);
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private createConnectionError(error: unknown, serverOutput: string[]): Error {
+    const errorOutput = this.getErrorOutput(error);
+    const output = [...new Set([...errorOutput, ...serverOutput])].filter(
+      (line) => line.trim().length > 0,
+    );
+    const message = error instanceof Error ? error.message : String(error);
+    const outputDetails =
+      output.length > 0 ? `\nScrcpy server output:\n${output.join('\n')}` : '';
+
+    return new Error(`Failed to connect scrcpy: ${message}${outputDetails}`, {
+      cause: error,
+    });
+  }
+
+  private getErrorOutput(error: unknown): string[] {
+    if (typeof error !== 'object' || error === null || !('output' in error)) {
+      return [];
+    }
+
+    const output = (error as { output?: unknown }).output;
+    if (!Array.isArray(output)) {
+      return [];
+    }
+
+    return output.filter((line): line is string => typeof line === 'string');
   }
 
   /**

--- a/packages/android/tests/unit-test/device-scrcpy-status.test.ts
+++ b/packages/android/tests/unit-test/device-scrcpy-status.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AndroidDevice } from '../../src/device';
+
+const deviceInfo = {
+  physicalWidth: 1080,
+  physicalHeight: 1920,
+  dpr: 3,
+  orientation: 0,
+};
+
+describe('AndroidDevice scrcpy recovery API', () => {
+  it('should expose scrcpy status from the device adapter', () => {
+    const device = new AndroidDevice('device', {
+      scrcpyConfig: { enabled: true },
+    });
+    const status = {
+      enabled: true,
+      connected: false,
+      lastError: 'codec not ready',
+      retryAfter: Date.now() + 5_000,
+    };
+    (device as any).scrcpyAdapter = {
+      getStatus: vi.fn().mockReturnValue(status),
+    };
+
+    expect(device.getScrcpyStatus()).toBe(status);
+  });
+
+  it('should retry scrcpy on the same AndroidDevice instance', async () => {
+    const device = new AndroidDevice('device', {
+      scrcpyConfig: { enabled: true },
+    });
+    const status = {
+      enabled: true,
+      connected: true,
+      lastError: null,
+      retryAfter: null,
+    };
+    const adapter = {
+      isEnabled: vi.fn().mockReturnValue(true),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue(status),
+    };
+    (device as any).scrcpyAdapter = adapter;
+    (device as any).getDevicePhysicalInfo = vi
+      .fn()
+      .mockResolvedValue(deviceInfo);
+
+    await expect(device.retryScrcpy()).resolves.toBe(status);
+    expect(adapter.initialize).toHaveBeenCalledWith(deviceInfo);
+  });
+
+  it('should reject explicit retries when scrcpy is disabled', async () => {
+    const device = new AndroidDevice('device', {
+      scrcpyConfig: { enabled: false },
+    });
+
+    await expect(device.retryScrcpy()).rejects.toThrow('scrcpy is disabled');
+  });
+});

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -19,6 +19,7 @@ vi.mock('@yume-chan/adb-server-node-tcp', () => ({
 const createMockManager = () => ({
   validateEnvironment: vi.fn().mockResolvedValue(undefined),
   ensureConnected: vi.fn().mockResolvedValue(undefined),
+  isConnected: vi.fn().mockReturnValue(false),
   getScreenshotJpeg: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
   getResolution: vi.fn().mockReturnValue(null),
   disconnect: vi.fn().mockResolvedValue(undefined),
@@ -55,6 +56,7 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -74,12 +76,27 @@ describe('ScrcpyDeviceAdapter', () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       expect(adapter.isEnabled()).toBe(true);
     });
+  });
 
-    it('should return false when initFailed is true', () => {
-      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
-      expect(adapter.isEnabled()).toBe(true);
-      (adapter as any).initFailed = true;
-      expect(adapter.isEnabled()).toBe(false);
+  describe('getStatus', () => {
+    it('should distinguish disabled configuration from runtime connection state', () => {
+      const disabled = new ScrcpyDeviceAdapter('device', { enabled: false });
+      expect(disabled.getStatus()).toEqual({
+        enabled: false,
+        connected: false,
+        lastError: null,
+        retryAfter: null,
+      });
+
+      const enabled = new ScrcpyDeviceAdapter('device', { enabled: true });
+      (enabled as any).manager = currentMockManager;
+      currentMockManager.isConnected.mockReturnValue(true);
+      expect(enabled.getStatus()).toEqual({
+        enabled: true,
+        connected: true,
+        lastError: null,
+        retryAfter: null,
+      });
     });
   });
 
@@ -300,37 +317,69 @@ describe('ScrcpyDeviceAdapter', () => {
       expect((adapter as any).manager).toBe(currentMockManager);
     });
 
-    it('should set initFailed=true when ensureManager fails', async () => {
+    it('should record ensureManager failures without permanently disabling scrcpy', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       currentMockManager.validateEnvironment.mockRejectedValue(
         new Error('ffmpeg not found'),
       );
 
       await expect(adapter.initialize(defaultDeviceInfo)).rejects.toThrow();
-      expect((adapter as any).initFailed).toBe(true);
-      expect(adapter.isEnabled()).toBe(false);
+      expect(adapter.getStatus()).toMatchObject({
+        enabled: true,
+        connected: false,
+        lastError: expect.stringContaining('ffmpeg not found'),
+        retryAfter: expect.any(Number),
+      });
     });
 
-    it('should set initFailed=true when ensureConnected fails', async () => {
+    it('should recover after a transient ensureConnected failure', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
-      currentMockManager.ensureConnected.mockRejectedValue(
-        new Error('scrcpy connection failed'),
-      );
+      currentMockManager.ensureConnected
+        .mockRejectedValueOnce(new Error('scrcpy connection failed'))
+        .mockResolvedValueOnce(undefined);
 
       await expect(adapter.initialize(defaultDeviceInfo)).rejects.toThrow(
         'scrcpy connection failed',
       );
-      expect((adapter as any).initFailed).toBe(true);
       expect(adapter.isEnabled()).toBe(false);
-    });
-
-    it('should not set initFailed on success', async () => {
-      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+      expect(adapter.getStatus().enabled).toBe(true);
 
       await adapter.initialize(defaultDeviceInfo);
+      currentMockManager.isConnected.mockReturnValue(true);
 
-      expect((adapter as any).initFailed).toBe(false);
-      expect(adapter.isEnabled()).toBe(true);
+      expect(currentMockManager.ensureConnected).toHaveBeenCalledTimes(2);
+      expect(adapter.getStatus()).toEqual({
+        enabled: true,
+        connected: true,
+        lastError: null,
+        retryAfter: null,
+      });
+    });
+  });
+
+  describe('retry cooldown', () => {
+    it('should fall back during cooldown and retry on a later screenshot', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+      currentMockManager.ensureConnected.mockRejectedValueOnce(
+        new Error('codec not ready'),
+      );
+
+      await expect(adapter.initialize(defaultDeviceInfo)).rejects.toThrow(
+        'codec not ready',
+      );
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
+        /retry is cooling down/,
+      );
+      expect(currentMockManager.getScreenshotJpeg).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(60_000);
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
+      );
+      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(1);
+      expect(adapter.getStatus().lastError).toBeNull();
     });
   });
 
@@ -345,6 +394,8 @@ describe('ScrcpyDeviceAdapter', () => {
       expect((adapter as any).manager).toBeNull();
       expect((adapter as any).resolvedConfig).toBeNull();
       expect(currentMockManager.disconnect).toHaveBeenCalledTimes(1);
+      expect(adapter.getStatus().lastError).toBeNull();
+      expect(adapter.getStatus().retryAfter).toBeNull();
     });
 
     it('should handle disconnect errors gracefully (no throw)', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -144,6 +144,42 @@ describe('ScrcpyScreenshotManager', () => {
 
       await expect(manager.ensureConnected()).resolves.toBeUndefined();
     });
+
+    it('should include client and server output in connection errors', () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const error = Object.assign(new Error('ExactReadable ended'), {
+        output: ['server exited before metadata'],
+      });
+
+      const result = (manager as any).createConnectionError(error, [
+        'java.lang.IllegalStateException: codec not ready',
+      ]);
+
+      expect(result.message).toContain('ExactReadable ended');
+      expect(result.message).toContain('server exited before metadata');
+      expect(result.message).toContain(
+        'java.lang.IllegalStateException: codec not ready',
+      );
+    });
+
+    it('should bound collected server output to the latest lines', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const lines: string[] = [];
+      const output = new ReadableStream<string>({
+        start(controller) {
+          for (let index = 0; index < 110; index++) {
+            controller.enqueue(`line-${index}`);
+          }
+          controller.close();
+        },
+      });
+
+      await (manager as any).collectServerOutput(output, lines);
+
+      expect(lines).toHaveLength(100);
+      expect(lines[0]).toBe('line-10');
+      expect(lines.at(-1)).toBe('line-109');
+    });
   });
 
   describe('disconnect', () => {


### PR DESCRIPTION
## Summary

- keep Scrcpy eligible after transient initialization failures and retry automatically after a five-second cooldown
- expose `getScrcpyStatus()` and `retryScrcpy()` so callers can observe degraded capture and retry on the same `AndroidDevice`
- include bounded device-side Scrcpy server output in connection errors
- document the recovery API in English and Chinese

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/android` (308 tests passed)
- `pnpm exec nx build @midscene/android`

Closes #2805