### PR TITLE
feat(core): compress PNG screenshots for reports

### DIFF
--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -23,8 +23,10 @@ import {
 } from '@midscene/shared/env';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import {
+  convertImgBufferToJpeg,
   createImgBase64ByFormat,
   imageInfoOfBase64,
+  parseBase64,
   resizeImgBase64,
 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
@@ -200,17 +202,38 @@ export async function commonContextParser(
       screenshot: ScreenshotItem.create(resizedBase64, screenshotCapturedAt),
       shrunkShotToLogicalRatio,
     };
-  }
+  } else {
+    // For screenshots that do not need shrinking, convert PNG to JPEG to reduce the image payload in model requests and reports. (Shrunk images are already JPEG.)
+    // This mainly covers Android's default screenshot path, which produces PNG screenshots.
+    // Compared with conversion on Android, centralizing it here means each platform does not need to handle screenshot formats itself, and allows future output formats such as WebP.
+    // Built-in paths that already output JPEG are unaffected, and custom devices that output JPEG will not be compressed again.
+    // The Web platform already outputs JPEG, so it does not enter this branch. Other built-in device platforms run in Node, where Sharp conversion is fast enough that its extra cost is negligible.
+    let outputScreenshotBase64 = screenshotBase64;
+    const { mimeType, body } = parseBase64(screenshotBase64);
+    if (mimeType.toLowerCase() === 'image/png') {
+      const jpegBuffer = await convertImgBufferToJpeg(
+        Buffer.from(body, 'base64'),
+        90,
+      );
+      outputScreenshotBase64 = createImgBase64ByFormat(
+        'jpeg',
+        jpegBuffer.toString('base64'),
+      );
+    }
 
-  return {
-    shotSize: {
-      width: imgWidth,
-      height: imgHeight,
-    },
-    deprecatedDpr: dpr,
-    screenshot: ScreenshotItem.create(screenshotBase64, screenshotCapturedAt),
-    shrunkShotToLogicalRatio,
-  };
+    return {
+      shotSize: {
+        width: imgWidth,
+        height: imgHeight,
+      },
+      deprecatedDpr: dpr,
+      screenshot: ScreenshotItem.create(
+        outputScreenshotBase64,
+        screenshotCapturedAt,
+      ),
+      shrunkShotToLogicalRatio,
+    };
+  }
 }
 
 export async function createScreenshotBoundUIContext(

--- a/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
@@ -4,7 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock imageInfoOfBase64 to control screenshot dimensions
 vi.mock('@midscene/shared/img', () => ({
+  convertImgBufferToJpeg: vi.fn(),
+  createImgBase64ByFormat: vi.fn(),
   imageInfoOfBase64: vi.fn(),
+  parseBase64: vi.fn(() => ({
+    mimeType: 'image/jpeg',
+    body: 'mock-base64-data',
+  })),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 

--- a/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
@@ -3,13 +3,25 @@ import type { AbstractInterface } from '@/device';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@midscene/shared/img', () => ({
+  convertImgBufferToJpeg: vi.fn(),
+  createImgBase64ByFormat: vi.fn(),
   imageInfoOfBase64: vi.fn(),
+  parseBase64: vi.fn(),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 
-import { imageInfoOfBase64, resizeImgBase64 } from '@midscene/shared/img';
+import {
+  convertImgBufferToJpeg,
+  createImgBase64ByFormat,
+  imageInfoOfBase64,
+  parseBase64,
+  resizeImgBase64,
+} from '@midscene/shared/img';
 
+const mockedConvertToJpeg = vi.mocked(convertImgBufferToJpeg);
+const mockedCreateBase64 = vi.mocked(createImgBase64ByFormat);
 const mockedImageInfo = vi.mocked(imageInfoOfBase64);
+const mockedParseBase64 = vi.mocked(parseBase64);
 const mockedResizeImg = vi.mocked(resizeImgBase64);
 
 function createMockInterface(
@@ -29,6 +41,35 @@ function createMockInterface(
 describe('commonContextParser screenshotShrinkFactor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedParseBase64.mockReturnValue({
+      mimeType: 'image/jpeg',
+      body: 'mock-base64-data',
+    });
+  });
+
+  it('converts PNG screenshots to JPEG quality 90 when not shrinking', async () => {
+    const mockInterface = createMockInterface(800, 400);
+    const pngBody = Buffer.from('png-image').toString('base64');
+    const jpegBuffer = Buffer.from('jpeg-image');
+    mockedImageInfo.mockResolvedValue({ width: 2400, height: 1200 });
+    mockedParseBase64.mockReturnValue({
+      mimeType: 'image/png',
+      body: pngBody,
+    });
+    mockedConvertToJpeg.mockResolvedValue(jpegBuffer);
+    mockedCreateBase64.mockReturnValue('data:image/jpeg;base64,jpeg-image');
+
+    const result = await commonContextParser(mockInterface, {});
+
+    expect(mockedConvertToJpeg).toHaveBeenCalledWith(
+      Buffer.from(pngBody, 'base64'),
+      90,
+    );
+    expect(mockedCreateBase64).toHaveBeenCalledWith(
+      'jpeg',
+      jpegBuffer.toString('base64'),
+    );
+    expect(result.screenshot.base64).toBe('data:image/jpeg;base64,jpeg-image');
   });
 
   it('does not shrink when screenshotShrinkFactor is not provided', async () => {

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -8,6 +8,7 @@ export {
 } from './info';
 export {
   resizeAndConvertImgBuffer,
+  convertImgBufferToJpeg,
   resizeImgBase64,
   zoomForGPT4o,
   saveBase64Image,

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -156,6 +156,31 @@ export async function resizeAndConvertImgBuffer(
 
 export const normalizeBase64Body = (body: string) => body.replace(/\s/g, '');
 
+/** Convert an image buffer to JPEG without changing its dimensions. */
+export async function convertImgBufferToJpeg(
+  inputData: Buffer,
+  quality = 90,
+): Promise<Buffer> {
+  if (ifInNode) {
+    try {
+      const Sharp = await getSharp();
+      return await Sharp(inputData).jpeg({ quality }).toBuffer();
+    } catch (error) {
+      imgDebug('Sharp failed, falling back to Photon:', error);
+    }
+  }
+
+  const mimeType = detectImageMimeTypeFromBuffer(inputData) ?? 'image/png';
+  const photonImage = await photonFromBase64(
+    `data:${mimeType};base64,${inputData.toString('base64')}`,
+  );
+  try {
+    return Buffer.from(photonImage.get_bytes_jpeg(quality));
+  } finally {
+    photonImage.free();
+  }
+}
+
 const base64ImageDataUrlPattern = /^data:image\/[a-zA-Z0-9.+-]+;base64,/i;
 const supportedScreenshotDataUriPattern =
   /^data:image\/(png|jpe?g);base64,([\s\S]*)$/i;


### PR DESCRIPTION
## Summary

- Convert unshrunk PNG screenshots to JPEG quality 90 in `commonContextParser`.
- Keep the shrink path unchanged so resizing performs the only JPEG encoding.
- Centralize image-format conversion for future output-format support.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/common-context-parser-shrink-factor.test.ts tests/unit-test/common-context-parser-orientation.test.ts`
- `npx nx build @midscene/shared`
- `npx nx build @midscene/core`