### PR TITLE
fix(android): recover from scrcpy stream disconnections

### DIFF
--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -289,6 +289,7 @@ export class ScrcpyScreenshotManager {
     let windowStart = Date.now();
     let lastBusyWarn = 0;
     let totalReads = 0;
+    let endReason = 'stream closed';
 
     try {
       while (true) {
@@ -329,13 +330,20 @@ export class ScrcpyScreenshotManager {
         this.processFrame(value);
       }
     } catch (error) {
+      endReason = 'stream error';
       debugScrcpy(
         `Frame consumer error (total reads: ${totalReads}): ${error}`,
       );
+    }
+
+    // Only tear down the session that owns this reader. An obsolete reader can
+    // finish after disconnect() has already cleared it or a reconnect has
+    // installed a replacement reader.
+    if (this.streamReader === reader) {
       await this.disconnect();
     }
     debugScrcpy(
-      `Frame consumer loop ended normally (total reads: ${totalReads})`,
+      `Frame consumer loop ended (${endReason}, total reads: ${totalReads})`,
     );
   }
 
@@ -704,8 +712,10 @@ export class ScrcpyScreenshotManager {
     // Cancel reader first to stop consumeFramesLoop
     if (reader) {
       try {
-        reader.cancel();
-      } catch {}
+        await reader.cancel();
+      } catch (error) {
+        debugScrcpy(`Error cancelling scrcpy stream reader: ${error}`);
+      }
     }
 
     // Then close the client

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -146,6 +146,73 @@ describe('ScrcpyScreenshotManager', () => {
     });
   });
 
+  describe('consumeFramesLoop', () => {
+    it('should absorb a rejected cancellation after a stream read error', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const streamError = new Error(
+        'The underlying readable ended before the struct was deserialized',
+      );
+      const reader = {
+        read: vi.fn().mockRejectedValue(streamError),
+        cancel: vi.fn().mockRejectedValue(streamError),
+      };
+      const close = vi.fn().mockResolvedValue(undefined);
+      (manager as any).streamReader = reader;
+      (manager as any).scrcpyClient = { close };
+      (manager as any).videoStream = {};
+      (manager as any).isInitialized = true;
+
+      await expect(
+        (manager as any).consumeFramesLoop(reader),
+      ).resolves.toBeUndefined();
+
+      expect(reader.cancel).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledOnce();
+      expect(manager.isConnected()).toBe(false);
+    });
+
+    it('should disconnect the current session after a clean stream end', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const reader = {
+        read: vi.fn().mockResolvedValue({ done: true }),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      };
+      const close = vi.fn().mockResolvedValue(undefined);
+      (manager as any).streamReader = reader;
+      (manager as any).scrcpyClient = { close };
+      (manager as any).videoStream = {};
+      (manager as any).isInitialized = true;
+
+      await (manager as any).consumeFramesLoop(reader);
+
+      expect(reader.cancel).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledOnce();
+      expect(manager.isConnected()).toBe(false);
+    });
+
+    it('should not disconnect a replacement session when an obsolete reader ends', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const obsoleteReader = {
+        read: vi.fn().mockResolvedValue({ done: true }),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      };
+      const replacementReader = {
+        cancel: vi.fn().mockResolvedValue(undefined),
+      };
+      const close = vi.fn().mockResolvedValue(undefined);
+      (manager as any).streamReader = replacementReader;
+      (manager as any).scrcpyClient = { close };
+      (manager as any).videoStream = {};
+      (manager as any).isInitialized = true;
+
+      await (manager as any).consumeFramesLoop(obsoleteReader);
+
+      expect(obsoleteReader.cancel).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      expect(manager.isConnected()).toBe(true);
+    });
+  });
+
   describe('disconnect', () => {
     it('should reset all state', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
@@ -191,12 +258,45 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('should cancel streamReader to stop consumeFramesLoop', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const cancelFn = vi.fn();
+      const cancelFn = vi.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = { cancel: cancelFn };
 
       await manager.disconnect();
 
       expect(cancelFn).toHaveBeenCalled();
+      expect((manager as any).streamReader).toBeNull();
+    });
+
+    it('should wait for asynchronous streamReader cancellation', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      let resolveCancel: (() => void) | undefined;
+      const cancelPromise = new Promise<void>((resolve) => {
+        resolveCancel = resolve;
+      });
+      (manager as any).streamReader = {
+        cancel: vi.fn().mockReturnValue(cancelPromise),
+      };
+
+      let disconnected = false;
+      const disconnectPromise = manager.disconnect().then(() => {
+        disconnected = true;
+      });
+      await Promise.resolve();
+
+      expect(disconnected).toBe(false);
+
+      resolveCancel?.();
+      await disconnectPromise;
+      expect(disconnected).toBe(true);
+    });
+
+    it('should handle streamReader.cancel() error gracefully', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).streamReader = {
+        cancel: vi.fn().mockRejectedValue(new Error('stream already errored')),
+      };
+
+      await expect(manager.disconnect()).resolves.toBeUndefined();
       expect((manager as any).streamReader).toBeNull();
     });
 


### PR DESCRIPTION
## Summary

- await and contain rejected scrcpy stream cancellation promises during disconnect
- clear the current scrcpy session after stream errors and clean EOF so the next request can reconnect lazily
- ignore termination from obsolete readers so they cannot tear down a replacement connection
- add regression coverage for the host-crash path and stream lifecycle races

## Root cause

`consumeFramesLoop` already caught the rejection from `reader.read()`. During cleanup, however, `disconnect()` called `reader.cancel()` inside a synchronous `try/catch` without awaiting its Promise. When the stream was already errored, `cancel()` rejected again with the stored `StructNotEnoughDataError`. That detached rejection became an `unhandledRejection`, which terminated the host Node.js process under the default policy.

## User impact

A transient ADB or cloud-device disconnect no longer turns scrcpy cleanup into a process-level crash. The failed session is cleared, allowing the existing `ensureConnected()` path to reconnect on the next screenshot request.

## Validation

- `pnpm --filter @midscene/android test -- tests/unit-test/scrcpy-manager.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 npx nx test @midscene/android` (14 files, 308 tests)
- `npx nx build @midscene/android`
- `pnpm run lint`

The first full Android test run exhausted Node's default heap before completing; the same target passed after increasing the heap limit as shown above.

## Prepatch release

- Published version: `1.10.5-beta-20260715113309.0`
- Published with dist-tag: `beta`
- Workflow: https://github.com/web-infra-dev/midscene/actions/runs/29411926446

The shared `beta` dist-tag was subsequently advanced to `1.10.5-beta-20260715114156.0` by a concurrent release from `main`; the version above remains available by its exact version and contains this fix.

Fixes #2804
