### PR TITLE
fix(site): disable Bing image previews

### DIFF
--- a/apps/site/rspress.config.ts
+++ b/apps/site/rspress.config.ts
@@ -125,6 +125,8 @@ export default defineConfig(async () => {
         },
       ],
       ['meta', { name: 'twitter:image:alt', content: 'Midscene.js logo' }],
+      // Prevent Bing from selecting arbitrary homepage images as search previews.
+      ['meta', { name: 'bingbot', content: 'max-image-preview:none' }],
       `<script type="application/ld+json">${SEARCH_IDENTITY_JSON_LD}</script>`,
     ],
     markdown: {

--- a/apps/site/scripts/check-search-metadata.mjs
+++ b/apps/site/scripts/check-search-metadata.mjs
@@ -10,6 +10,8 @@ const siteRoot = path.resolve(
 const outputRoot = path.join(siteRoot, 'doc_build');
 const faviconUrl = 'https://midscenejs.com/favicon.png';
 const ogImageUrl = 'https://midscenejs.com/og-image.png';
+const bingImagePreviewMeta =
+  '<meta name="bingbot" content="max-image-preview:none">';
 
 const readOutput = (relativePath, encoding = 'utf8') =>
   readFile(path.join(outputRoot, relativePath), encoding);
@@ -24,6 +26,10 @@ for (const relativePath of ['index.html', 'zh/index.html']) {
   assert.ok(
     html.includes(ogImageUrl),
     `${relativePath} must reference the production OG image`,
+  );
+  assert.ok(
+    html.includes(bingImagePreviewMeta),
+    `${relativePath} must disable Bing image previews`,
   );
   const jsonLdMatch = html.match(
     /<script type="application\/ld\+json">([^<]+)<\/script>/,


### PR DESCRIPTION
## Summary

- add a Bing-specific `max-image-preview:none` directive to the generated site metadata
- keep the directive scoped to `bingbot` so other search engines retain their existing preview behavior
- extend the search metadata regression check across both English and Chinese homepages

## Root cause

Bing does not guarantee that `og:image` will be used for ordinary web search thumbnails. The rendered homepage exposes multiple crawlable images, including CSS-hidden light and dark variants, so Bing can select an arbitrary content image even when the preferred Open Graph logo is present.

Blocking individual image URLs only moves the selection to another candidate. The page-level Bing directive prevents that fallback behavior deterministically.

## Impact

After deployment and recrawling, Bing should stop showing the large right-side image preview for Midscene.js search results. The square favicon, Open Graph image, JSON-LD identity metadata, visible homepage, and preview behavior for other search engines remain unchanged.

## Validation

- `npx nx build doc`
- `node apps/site/scripts/check-search-metadata.mjs`
- `pnpm run lint`
- `git diff --check`
