### PR TITLE
feat(core): add mouse action: aiMiddleClick

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -735,6 +735,19 @@ export class Agent<
     });
   }
 
+  async aiMiddleClick(
+    locatePrompt: TUserPrompt,
+    opt?: LocateOption,
+  ): Promise<void> {
+    assert(locatePrompt, 'missing locate prompt for middle click');
+
+    const detailedLocateParam = buildDetailedLocateParam(locatePrompt, opt);
+
+    await this.callActionInActionSpace('MiddleClick', {
+      locate: detailedLocateParam,
+    });
+  }
+
   async aiDoubleClick(
     locatePrompt: TUserPrompt,
     opt?: LocateOption,

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -77,6 +77,7 @@ export interface PointerInputPrimitives {
   tap(p: PointerPoint, opts?: { duration?: number }): Promise<void>;
   doubleClick?(p: PointerPoint): Promise<void>;
   rightClick?(p: PointerPoint): Promise<void>;
+  middleClick?(p: PointerPoint): Promise<void>;
   hover?(p: PointerPoint): Promise<void>;
   longPress?(p: PointerPoint, opts?: { duration?: number }): Promise<void>;
   dragAndDrop?(from: PointerPoint, to: PointerPoint): Promise<void>;
@@ -380,6 +381,37 @@ export const defineActionRightClick = (
     missingLocateMessage: 'Element not found, cannot right click',
     call: async (point) => {
       await rightClick(point);
+    },
+  });
+};
+
+// MiddleClick
+export const actionMiddleClickParamSchema = z.object({
+  locate: getMidsceneLocationSchema().describe(
+    'The element to be middle clicked',
+  ),
+});
+export type ActionMiddleClickParam = {
+  locate: LocateResultElement;
+};
+
+export const defineActionMiddleClick = (
+  middleClick: NonNullable<PointerInputPrimitives['middleClick']>,
+): DeviceAction<ActionMiddleClickParam> => {
+  return defineLocatedPointAction<
+    typeof actionMiddleClickParamSchema,
+    ActionMiddleClickParam
+  >({
+    name: 'MiddleClick',
+    description: 'Middle click the element',
+    interfaceAlias: 'aiMiddleClick',
+    paramSchema: actionMiddleClickParamSchema,
+    sample: {
+      locate: { prompt: 'the link to open in a new tab' },
+    },
+    missingLocateMessage: 'Element not found, cannot middle click',
+    call: async (point) => {
+      await middleClick(point);
     },
   });
 };
@@ -1053,6 +1085,9 @@ export function defineActionsFromInputPrimitives(
     }
     if (pointer.rightClick) {
       actions.push(defineActionRightClick(pointer.rightClick));
+    }
+    if (pointer.middleClick) {
+      actions.push(defineActionMiddleClick(pointer.middleClick));
     }
     if (pointer.hover) {
       actions.push(defineActionHover(pointer.hover));

--- a/packages/core/tests/unit-test/device/input-primitives.test.ts
+++ b/packages/core/tests/unit-test/device/input-primitives.test.ts
@@ -5,6 +5,24 @@ import { describe, expect, it, vi } from 'vitest';
 const mockExecutorContext = { task: {} } as ExecutorContext;
 
 describe('defineActionsFromInputPrimitives', () => {
+  it('should expose middle click when the pointer primitive is configured', () => {
+    const middleClick = vi.fn();
+
+    const actions = defineActionsFromInputPrimitives({
+      pointer: {
+        tap: vi.fn(),
+        middleClick,
+      },
+    });
+
+    const middleClickAction = actions.find(
+      (action) => action.name === 'MiddleClick',
+    );
+
+    expect(middleClickAction).toBeDefined();
+    expect(middleClickAction?.interfaceAlias).toBe('aiMiddleClick');
+  });
+
   it('should expose configured system input primitives as actions', async () => {
     const backButton = vi.fn();
     const homeButton = vi.fn();

--- a/packages/core/tests/unit-test/yaml-doc-usage.test.ts
+++ b/packages/core/tests/unit-test/yaml-doc-usage.test.ts
@@ -37,6 +37,7 @@ const createDocAgent = (overrides: Record<string, any> = {}) => {
       { name: 'Hover', interfaceAlias: 'aiHover' },
       { name: 'DoubleClick', interfaceAlias: 'aiDoubleClick' },
       { name: 'RightClick', interfaceAlias: 'aiRightClick' },
+      { name: 'MiddleClick', interfaceAlias: 'aiMiddleClick' },
       { name: 'Launch', interfaceAlias: 'launch' },
       { name: 'Terminate', interfaceAlias: 'terminate' },
       { name: 'RunAdbShell', interfaceAlias: 'runAdbShell' },
@@ -188,6 +189,7 @@ tasks:
           convertHttpImage2Base64: true
       - aiDoubleClick: Double-clickable element
       - aiRightClick: Right-clickable element
+      - aiMiddleClick: Middle-clickable element
       - aiInput: Search box
         value: 12345
         xpath: //*[@id="search"]
@@ -321,6 +323,14 @@ tasks:
     expect(agent.callActionInActionSpace).toHaveBeenCalledWith('RightClick', {
       locate: {
         prompt: 'Right-clickable element',
+        deepLocate: false,
+        cacheable: true,
+        xpath: undefined,
+      },
+    });
+    expect(agent.callActionInActionSpace).toHaveBeenCalledWith('MiddleClick', {
+      locate: {
+        prompt: 'Middle-clickable element',
         deepLocate: false,
         cacheable: true,
         xpath: undefined,


### PR DESCRIPTION
Add mouse middle click action, similar to `aiRightClick`.

e.g.
```
await agent.aiMiddleClick("terminal area");
```