### PR TITLE
fix(playground): default server host to loopback

### DIFF
--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -54,7 +54,9 @@ If you configure a dedicated Insight or Planning model, model-related `MIDSCENE_
 | `MIDSCENE_MODEL_EXTRA_BODY_JSON` | JSON blob merged into each chat completion request body. Unlike `MIDSCENE_MODEL_INIT_CONFIG_JSON` (which configures the SDK client), this is spread into every `completion.create()` call sent to the model, e.g. enabling thinking mode in vLLM: `'{"chat_template_kwargs":{"enable_thinking":true}}'` |
 | `MIDSCENE_RUN_DIR` | Run artifact directory, like report and logs. Defaults to `midscene_run` in the current working directory; accepts absolute or relative paths |
 | `MIDSCENE_PREFERRED_LANGUAGE` | Optional. Preferred response language. Defaults to `Chinese` if timezone is GMT+8, otherwise `English` |
-| `MIDSCENE_PLAYGROUND_HOST` | Playground server listen host. Defaults to `0.0.0.0` so local device runtimes can reach it. Set to `127.0.0.1` for local-only access |
+| `MIDSCENE_PLAYGROUND_HOST` | Playground server listen host. Defaults to `127.0.0.1` for local-only access. Override it when remote device runtimes need to connect, for example with `0.0.0.0` to listen on all network interfaces |
+
+> **Playground network access:** The default loopback address is reachable only from the machine running Playground. If a physical device, virtual machine, container, or another computer connects through the host's network address, set `MIDSCENE_PLAYGROUND_HOST` to a reachable interface address (or `0.0.0.0` to listen on all interfaces). Only expose Playground on a trusted network.
 
 > Note: Control replanning behavior with the agent option `replanningCycleLimit` (defaults to 20, or 40 for `vlm-ui-tars`), not with environment variables.
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -52,9 +52,13 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 | `MIDSCENE_MODEL_EXTRA_BODY_JSON` | 合并到每次 chat completion 请求体中的 JSON。与 `MIDSCENE_MODEL_INIT_CONFIG_JSON`（配置 SDK 客户端）不同，此参数会展开到每次发送到模型的 `completion.create()` 调用体中，例如在 vLLM 中启用思考模式：`'{"chat_template_kwargs":{"enable_thinking":true}}'` |
 | `MIDSCENE_RUN_DIR` | 运行产物目录，默认值为当前工作目录下的 `midscene_run`，支持设置绝对路径或相对路径 |
 | `MIDSCENE_PREFERRED_LANGUAGE` | 可选，模型响应的语言；如果当前系统时区是 GMT+8 则默认是 `Chinese`，否则是 `English` |
-| `MIDSCENE_PLAYGROUND_HOST` | Playground 服务器监听地址，默认 `127.0.0.1`，仅允许本机访问。如需让远程设备运行时连接，可覆盖为其他地址，例如使用 `0.0.0.0` 监听所有网络接口 |
+| `MIDSCENE_PLAYGROUND_HOST` | Playground 服务器的监听地址。默认值为 `127.0.0.1`，仅供本机访问 |
 
-> **Playground 网络访问：** 默认回环地址只能从运行 Playground 的机器访问。如果物理设备、虚拟机、容器或其他机器需要通过宿主机网络地址连接，请将 `MIDSCENE_PLAYGROUND_HOST` 设为可访问的网卡地址（或使用 `0.0.0.0` 监听所有网络接口）。仅应在可信网络中开放 Playground。
+> **Playground 网络访问**
+>
+> - 本机访问：无需设置，默认监听 `127.0.0.1`。
+> - 远程访问：物理设备、虚拟机、容器和其他机器需要设置 `MIDSCENE_PLAYGROUND_HOST`。配置值应为远程设备可访问的服务器网卡地址。
+> - 监听所有网络接口：可设为 `0.0.0.0`。只在可信网络中使用这个地址。
 
 > 提示：通过 Agent 的 `replanningCycleLimit` 入参控制重规划次数（默认 20，`vlm-ui-tars` 为 40），不再使用环境变量。
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -52,7 +52,9 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 | `MIDSCENE_MODEL_EXTRA_BODY_JSON` | 合并到每次 chat completion 请求体中的 JSON。与 `MIDSCENE_MODEL_INIT_CONFIG_JSON`（配置 SDK 客户端）不同，此参数会展开到每次发送到模型的 `completion.create()` 调用体中，例如在 vLLM 中启用思考模式：`'{"chat_template_kwargs":{"enable_thinking":true}}'` |
 | `MIDSCENE_RUN_DIR` | 运行产物目录，默认值为当前工作目录下的 `midscene_run`，支持设置绝对路径或相对路径 |
 | `MIDSCENE_PREFERRED_LANGUAGE` | 可选，模型响应的语言；如果当前系统时区是 GMT+8 则默认是 `Chinese`，否则是 `English` |
-| `MIDSCENE_PLAYGROUND_HOST` | Playground 服务器监听地址，默认 `0.0.0.0`，方便本地设备运行时访问。如需仅允许本机访问，可设为 `127.0.0.1` |
+| `MIDSCENE_PLAYGROUND_HOST` | Playground 服务器监听地址，默认 `127.0.0.1`，仅允许本机访问。如需让远程设备运行时连接，可覆盖为其他地址，例如使用 `0.0.0.0` 监听所有网络接口 |
+
+> **Playground 网络访问：** 默认回环地址只能从运行 Playground 的机器访问。如果物理设备、虚拟机、容器或其他机器需要通过宿主机网络地址连接，请将 `MIDSCENE_PLAYGROUND_HOST` 设为可访问的网卡地址（或使用 `0.0.0.0` 监听所有网络接口）。仅应在可信网络中开放 Playground。
 
 > 提示：通过 Agent 的 `replanningCycleLimit` 入参控制重规划次数（默认 20，`vlm-ui-tars` 为 40），不再使用环境变量。
 

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -453,9 +453,9 @@ function createRecorderAiDescribeTraceBase(
   };
 }
 
-/** Default `0.0.0.0`. Override via `MIDSCENE_PLAYGROUND_HOST` (e.g. `127.0.0.1`). */
+/** Default `127.0.0.1`. Override via `MIDSCENE_PLAYGROUND_HOST` (e.g. `0.0.0.0`). */
 export function resolvePlaygroundListenHost(): string {
-  return process.env.MIDSCENE_PLAYGROUND_HOST?.trim() || '0.0.0.0';
+  return process.env.MIDSCENE_PLAYGROUND_HOST?.trim() || '127.0.0.1';
 }
 
 export function resolvePlaygroundBrowserHost(): string {

--- a/packages/playground/tests/unit/launcher.test.ts
+++ b/packages/playground/tests/unit/launcher.test.ts
@@ -5,7 +5,10 @@ import {
   playgroundForAgentFactory,
 } from '../../src/launcher';
 import { launchPreparedPlaygroundPlatform } from '../../src/platform-launcher';
-import { buildPlaygroundBrowserUrl } from '../../src/server';
+import {
+  buildPlaygroundBrowserUrl,
+  resolvePlaygroundListenHost,
+} from '../../src/server';
 
 function createMockAgent() {
   return {
@@ -25,6 +28,21 @@ describe('playground launcher', () => {
       'http://localhost:5921',
     );
     expect(buildPlaygroundBrowserUrl('::1', 5921)).toBe('http://[::1]:5921');
+  });
+
+  it('should default the listen host to 127.0.0.1', () => {
+    const originalHost = process.env.MIDSCENE_PLAYGROUND_HOST;
+    Reflect.deleteProperty(process.env, 'MIDSCENE_PLAYGROUND_HOST');
+
+    try {
+      expect(resolvePlaygroundListenHost()).toBe('127.0.0.1');
+    } finally {
+      if (originalHost === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_PLAYGROUND_HOST');
+      } else {
+        process.env.MIDSCENE_PLAYGROUND_HOST = originalHost;
+      }
+    }
   });
 
   it('should launch with a custom static path and fixed id', async () => {


### PR DESCRIPTION
## Summary

- change the default Playground server listen host from `0.0.0.0` to `127.0.0.1`
- preserve `MIDSCENE_PLAYGROUND_HOST` overrides for remote-access workflows
- add regression coverage for the loopback default
- update the English and Chinese model configuration documentation with network-access guidance

## Why

Listening on all network interfaces by default can expose the Playground server to other machines on the local network. Binding to the loopback interface provides a safer default for local development.

## User impact

Local browser workflows on the same machine continue to work without configuration changes. Physical devices, virtual machines, containers, or other computers that connect through the host network must explicitly set `MIDSCENE_PLAYGROUND_HOST` to a reachable interface address, such as `0.0.0.0`. The documentation also warns users to expose Playground only on trusted networks.

## Validation

- `pnpm exec nx test @midscene/playground -- tests/unit/launcher.test.ts` (6 tests passed)
- `pnpm run lint`
- `pnpm exec nx build @midscene/playground`
- `git diff --check`
