### PR TITLE
fix(computer): retry RDP-only auto connections

### DIFF
--- a/packages/computer/native/rdp/CMakeLists.txt
+++ b/packages/computer/native/rdp/CMakeLists.txt
@@ -58,6 +58,26 @@ target_link_libraries(
   Threads::Threads
 )
 
+include(CTest)
+
+if(BUILD_TESTING)
+  add_executable(
+    rdp-connection-policy-test
+    tests/connection_policy_test.cpp
+  )
+
+  target_include_directories(
+    rdp-connection-policy-test
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  add_test(
+    NAME rdp-connection-policy-test
+    COMMAND rdp-connection-policy-test
+  )
+endif()
+
 if(APPLE)
   target_compile_definitions(rdp-helper PRIVATE _DARWIN_C_SOURCE)
 endif()

--- a/packages/computer/native/rdp/include/rdp_helper_connection_policy.hpp
+++ b/packages/computer/native/rdp/include/rdp_helper_connection_policy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string_view>
+
+namespace midscene::rdp {
+
+constexpr bool ShouldRetryAutoWithRdp(std::string_view security_protocol,
+                                      bool transport_failed,
+                                      bool using_rdp_security_layer) noexcept {
+  return security_protocol == "auto" && transport_failed &&
+         using_rdp_security_layer;
+}
+
+}  // namespace midscene::rdp

--- a/packages/computer/native/rdp/src/session.cpp
+++ b/packages/computer/native/rdp/src/session.cpp
@@ -36,6 +36,8 @@
 #include <freerdp/transport_io.h>
 #include <winpr/synch.h>
 
+#include "rdp_helper_connection_policy.hpp"
+
 namespace midscene::rdp {
 
 namespace {
@@ -992,8 +994,26 @@ ConnectionInfo FreeRdpSessionTransport::Connect(const ConnectionConfig& config) 
   }
 
   if (!connected) {
+    const UINT32 last_error_code =
+        freerdp_get_last_error(instance_->context);
+    const bool using_rdp_security_layer =
+        freerdp_settings_get_bool(settings, FreeRDP_UseRdpSecurityLayer) ==
+        TRUE;
+    const bool retry_with_rdp = ShouldRetryAutoWithRdp(
+        config.security_protocol,
+        last_error_code == FREERDP_ERROR_CONNECT_TRANSPORT_FAILED,
+        using_rdp_security_layer);
     const std::string error = LastFreeRdpErrorLocked();
     StopInstance(false);
+    if (retry_with_rdp) {
+      // Some RDP-only servers reject the initial TLS/NLA negotiation. FreeRDP
+      // can then carry stale transport state into its RDP fallback and fail
+      // while parsing the encrypted Demand Active PDU. A fresh instance forced
+      // to the protocol FreeRDP already selected avoids that corrupted state.
+      ConnectionConfig retry_config = config;
+      retry_config.security_protocol = "rdp";
+      return Connect(retry_config);
+    }
     throw std::runtime_error("Failed to connect to RDP server: " + error);
   }
 

--- a/packages/computer/native/rdp/tests/connection_policy_test.cpp
+++ b/packages/computer/native/rdp/tests/connection_policy_test.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <string_view>
+
+#include "rdp_helper_connection_policy.hpp"
+
+namespace {
+
+bool ExpectRetry(std::string_view name,
+                 std::string_view protocol,
+                 bool transport_failed,
+                 bool using_rdp_security_layer,
+                 bool expected) {
+  const bool actual = midscene::rdp::ShouldRetryAutoWithRdp(
+      protocol, transport_failed, using_rdp_security_layer);
+  if (actual == expected) {
+    return true;
+  }
+
+  std::cerr << name << ": expected retry=" << expected
+            << ", actual=" << actual << '\n';
+  return false;
+}
+
+}  // namespace
+
+int main() {
+  bool passed = true;
+  passed &= ExpectRetry("auto RDP transport fallback", "auto", true, true,
+                        true);
+  passed &= ExpectRetry("explicit RDP", "rdp", true, true, false);
+  passed &= ExpectRetry("auto authentication failure", "auto", false, true,
+                        false);
+  passed &= ExpectRetry("auto unreachable host", "auto", true, false, false);
+  return passed ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Retry `securityProtocol: "auto"` with a fresh FreeRDP instance when negotiation has selected standard RDP Security but activation fails with `ERRCONNECT_CONNECT_TRANSPORT_FAILED`.
- Avoid retrying explicit protocols, authentication failures, and unreachable hosts.
- Add a native connection-policy regression test and wire it into CTest.

## Root cause

Some RDP-only servers reject TLS/NLA negotiation. FreeRDP can select standard RDP Security afterward while retaining stale transport state, then fail while activating the desktop session. Reconnecting with a fresh instance forced to the security protocol FreeRDP already selected avoids that invalid state.

## Impact

Callers can continue using `securityProtocol: "auto"` for RDP-only Windows desktops instead of forcing `"rdp"`. NLA/TLS connections and unrelated network or authentication failures keep their existing behavior.

## Validation

- `pnpm run lint`
- `npx nx test @midscene/computer` (82 tests passed)
- `npx nx build @midscene/computer`
- Native Debug and Release CMake builds
- `ctest --test-dir /tmp/midscene-rdp-release-build --output-on-failure` (1/1 test passed)
- Real RDP verification against an RDP-only Windows desktop: the patched Release helper connected with `securityProtocol: "auto"` and received a 1280x720 desktop frame
