### PR TITLE
feat(core): support configurable retries for model response parse failures

### DIFF
--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -43,7 +43,7 @@ If you configure a dedicated Insight or Planning model, model-related `MIDSCENE_
 |------|-------------|
 | `MIDSCENE_MODEL_TIMEOUT` | Hard timeout for AI API calls in milliseconds (default intent). Defaults to `180000` (180s). Set to `0` to disable the hard timeout and let the request run indefinitely (only a caller-provided `AbortSignal` will cancel it). Note: Midscene controls the full request lifetime, not just the time until the first response header arrives, so stalled body reads can still be terminated cleanly |
 | `MIDSCENE_MODEL_TEMPERATURE` | Sampling temperature for model responses |
-| `MIDSCENE_MODEL_RETRY_COUNT` | Number of retries when AI call fails, default 1 (i.e., retry once after failure) |
+| `MIDSCENE_MODEL_RETRY_COUNT` | Number of retries when AI call fails, default 1 (i.e., retry once after failure). Retries occur when the model request encounters an HTTP error or when the model response cannot be structurally parsed |
 | `MIDSCENE_MODEL_RETRY_INTERVAL` | Interval between retries in milliseconds, default 2000 |
 | `MIDSCENE_MODEL_REASONING_ENABLED` | Controls whether model-native thinking is enabled. Midscene disables it by default. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode) |
 | `MIDSCENE_MODEL_REASONING_EFFORT` | Controls model-native thinking effort, supported by some models. Common values: `low`, `medium`, `high`. See [Model-Native Thinking Mode](./model-strategy#model-native-thinking-mode) |

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -41,7 +41,7 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 |------|-------------|
 | `MIDSCENE_MODEL_TIMEOUT` | AI 接口调用硬超时（毫秒，默认意图），默认 `180000`（180 秒）。设为 `0` 可禁用硬超时，只有调用方传入的 `AbortSignal` 能取消请求。说明：Midscene 控制的是完整请求生命周期，而不只是首个响应 header 返回的时间，因此即使响应体读取阶段卡住，也能被及时终止 |
 | `MIDSCENE_MODEL_TEMPERATURE` | 模型采样温度 |
-| `MIDSCENE_MODEL_RETRY_COUNT` | AI 调用失败时的重试次数，默认 1（即失败后重试 1 次）|
+| `MIDSCENE_MODEL_RETRY_COUNT` | AI 调用失败时的重试次数，默认 1（即失败后重试 1 次）。模型请求遇到 HTTP 错误，或模型返回值无法被结构化解析时，都会发起重试 |
 | `MIDSCENE_MODEL_RETRY_INTERVAL` | AI 调用重试间隔毫秒数，默认 2000 |
 | `MIDSCENE_MODEL_REASONING_ENABLED` | 控制是否启用模型的原生思考能力，Midscene 默认关闭。详见[模型原生的思考模式](./model-strategy#模型原生的思考模式) |
 | `MIDSCENE_MODEL_REASONING_EFFORT` | 控制模型的原生思考力度，部分模型支持。常用值：`low`、`medium`、`high`。详见[模型原生的思考模式](./model-strategy#模型原生的思考模式) |

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -275,7 +275,8 @@ export async function genericLocate(
         callAIWithObjectResponse<AIElementLocateResponse>(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
           jsonParserSource: 'locate',
-          retryTimes: 1,
+          retryTimes: modelRuntime.config.retryCount,
+          retryInterval: modelRuntime.config.retryInterval,
         }),
       parseResponse: (response): LocateModelResponse => {
         const rawResponse = response.contentString;
@@ -326,7 +327,8 @@ export async function genericLocate(
           response.reasoning_content,
         );
       },
-      parseRetryTimes: 1,
+      parseRetryTimes: modelRuntime.config.retryCount,
+      parseRetryInterval: modelRuntime.config.retryInterval,
       abortSignal: options.abortSignal,
       onParseRetry: (error) => {
         debugInspect(
@@ -434,7 +436,8 @@ export async function AiLocateSection(options: {
         callAIWithObjectResponse<AISectionLocatorResponse>(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
           jsonParserSource: 'section-locator',
-          retryTimes: 1,
+          retryTimes: modelRuntime.config.retryCount,
+          retryInterval: modelRuntime.config.retryInterval,
         }),
       parseResponse: (result) => {
         const sectionError = result.content.error;
@@ -475,7 +478,8 @@ export async function AiLocateSection(options: {
           result.reasoning_content,
         );
       },
-      parseRetryTimes: 1,
+      parseRetryTimes: modelRuntime.config.retryCount,
+      parseRetryInterval: modelRuntime.config.retryInterval,
       abortSignal: options.abortSignal,
       onParseRetry: (error) => {
         debugSection(
@@ -669,7 +673,8 @@ export async function AiExtractElementInfo<T>(options: {
         response.rawChoiceMessage,
       );
     },
-    parseRetryTimes: 1,
+    parseRetryTimes: modelRuntime.config.retryCount,
+    parseRetryInterval: modelRuntime.config.retryInterval,
     abortSignal: options.abortSignal,
     onParseRetry: (error) => {
       debugInspect(

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -183,7 +183,8 @@ async function callAndParsePlanningResponse(
         response.reasoning_content,
       );
     },
-    parseRetryTimes: 1,
+    parseRetryTimes: modelRuntime.config.retryCount,
+    parseRetryInterval: modelRuntime.config.retryInterval,
     abortSignal,
     onParseRetry: (parseError) => {
       debug(

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -773,6 +773,7 @@ export async function callAIWithObjectResponse<T>(
     abortSignal?: AbortSignal;
     jsonParserSource?: JsonParserSource;
     retryTimes?: number;
+    retryInterval?: number;
   },
 ): Promise<{
   // TODO: `content` is a misleading name here because this is already the parsed object response. Consider renaming it to `object` or `data`.
@@ -819,7 +820,8 @@ export async function callAIWithObjectResponse<T>(
         response.reasoning_content,
       );
     },
-    parseRetryTimes: options?.retryTimes,
+    parseRetryTimes: options?.retryTimes ?? modelConfig.retryCount,
+    parseRetryInterval: options?.retryInterval ?? modelConfig.retryInterval,
     abortSignal: options?.abortSignal,
   });
 }

--- a/packages/core/src/ai-model/service-caller/semantic-retry.ts
+++ b/packages/core/src/ai-model/service-caller/semantic-retry.ts
@@ -7,6 +7,8 @@ export type CallAiAndParseWithRetryOptions<Response, Parsed> = {
   toParseError: (error: unknown, response: Response) => Error;
   /** Number of additional model requests after a parsing failure. Defaults to 0. */
   parseRetryTimes?: number;
+  /** Delay in milliseconds before retrying a parsing failure. Defaults to 0. */
+  parseRetryInterval?: number;
   abortSignal?: AbortSignal;
   /** Runs immediately before a parsing failure triggers another model request. */
   onParseRetry?: (error: unknown, response: Response) => void;
@@ -25,11 +27,15 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
   parseResponse,
   toParseError,
   parseRetryTimes = 0,
+  parseRetryInterval = 0,
   abortSignal,
   onParseRetry,
 }: CallAiAndParseWithRetryOptions<Response, Parsed>): Promise<Parsed> {
   const normalizedRetryTimes = Number.isFinite(parseRetryTimes)
     ? Math.max(0, Math.floor(parseRetryTimes))
+    : 0;
+  const normalizedRetryInterval = Number.isFinite(parseRetryInterval)
+    ? Math.max(0, parseRetryInterval)
     : 0;
 
   const callAndParseOnce = async (
@@ -42,6 +48,14 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
     } catch (error) {
       if (remainingRetries > 0 && !abortSignal?.aborted) {
         onParseRetry?.(error, response);
+        if (normalizedRetryInterval > 0) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, normalizedRetryInterval),
+          );
+        }
+        if (abortSignal?.aborted) {
+          throw toParseError(error, response);
+        }
         return callAndParseOnce(remainingRetries - 1);
       }
       throw toParseError(error, response);

--- a/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
@@ -39,6 +39,8 @@ describe('AiExtractElementInfo prompt assembly', () => {
     modelDescription: 'test-model-desc',
     intent: 'insight',
     slot: 'insight',
+    retryCount: 1,
+    retryInterval: 2000,
   };
 
   beforeEach(() => {

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -24,6 +24,8 @@ describe('locate not-found parsing', () => {
     modelDescription: 'test-model-desc',
     intent: 'default',
     slot: 'default',
+    retryCount: 1,
+    retryInterval: 2000,
   };
 
   beforeEach(() => {

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -35,6 +35,8 @@ const mockModelConfig = (): IModelConfig => ({
   modelDescription: 'mock model',
   intent: 'planning',
   slot: 'planning',
+  retryCount: 1,
+  retryInterval: 2000,
 });
 
 const mockContext = (): UIContext =>
@@ -73,10 +75,15 @@ describe('plan XML parse retry', () => {
     vi.mocked(buildYamlFlowFromPlans).mockClear();
   });
 
-  it('should retry once when XML response parsing fails', async () => {
+  it('uses model retry settings when XML response parsing fails', async () => {
     vi.mocked(callAI)
       .mockResolvedValueOnce(
         mockAIResponse(`<log>Tap button</log>
+<action-type>Tap</action-type>
+<action-param-json>{invalid json}</action-param-json>`),
+      )
+      .mockResolvedValueOnce(
+        mockAIResponse(`<log>Still invalid</log>
 <action-type>Tap</action-type>
 <action-param-json>{invalid json}</action-param-json>`),
       )
@@ -88,13 +95,17 @@ describe('plan XML parse retry', () => {
     const result = await plan('tap the button', {
       context: mockContext(),
       actionSpace: mockActionSpace(),
-      modelRuntime: getModelRuntime(mockModelConfig()),
+      modelRuntime: getModelRuntime({
+        ...mockModelConfig(),
+        retryCount: 2,
+        retryInterval: 0,
+      }),
       conversationHistory: new ConversationHistory(),
       includeLocateInPlanning: false,
       deepThink: false,
     });
 
-    expect(callAI).toHaveBeenCalledTimes(2);
+    expect(callAI).toHaveBeenCalledTimes(3);
     expect(result.rawResponse).toContain('Tap button after retry');
     expect(result.actions).toEqual([{ type: 'Tap' }]);
   });

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -277,6 +277,40 @@ describe('service-caller reasoning fallback', () => {
     expect(response.content).toEqual({ bbox: [100, 200, 300, 400] });
   });
 
+  it('uses model retry settings for JSON parsing failures', async () => {
+    vi.useFakeTimers();
+    mockCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'not JSON' } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: '{"bbox":[100,200,300,400]}' } }],
+      });
+
+    try {
+      const responsePromise = callAIWithObjectResponse(
+        [{ role: 'user', content: 'locate element' }],
+        getModelRuntime({
+          ...baseModelConfig,
+          retryCount: 1,
+          retryInterval: 123,
+        }),
+        { jsonParserSource: 'locate' },
+      );
+
+      await vi.advanceTimersByTimeAsync(122);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(responsePromise).resolves.toMatchObject({
+        content: { bbox: [100, 200, 300, 400] },
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('disables reasoning by default for supported model families', async () => {
     mockCreate.mockResolvedValue({
       choices: [

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -490,6 +490,8 @@ export interface IModelConfig {
   /**
    * Number of retries when AI call fails.
    * Default is 1 (retry once after failure).
+   * Retries occur on HTTP errors or when the model response cannot be
+   * structurally parsed.
    */
   retryCount?: number;
   /**


### PR DESCRIPTION
## Summary

- apply model retry count and interval to structured response parsing failures
- retry JSON, planning XML, locate/section coordinate, and insight XML parsing with the configured delay
- document that retries cover HTTP request errors and structurally unparseable model responses

## Root cause

Structured response parsing used a fixed immediate retry, so `MIDSCENE_MODEL_RETRY_COUNT` and `MIDSCENE_MODEL_RETRY_INTERVAL` only controlled request failures.

## Validation

- `pnpm exec vitest --run tests/unit-test/service-caller-reasoning-fallback.test.ts tests/unit-test/llm-planning-retry.test.ts tests/unit-test/inspect-locate-not-found.test.ts tests/unit-test/inspect-extract-prompt.test.ts`
- `pnpm exec nx build @midscene/core`

The full `pnpm exec nx test @midscene/core` run still has two pre-existing `agent-custom-model` snapshot mismatches caused by `responseFormat: "auto"`; retry-related tests pass.