### PR TITLE
fix(core): repair malformed locate bbox tags

### DIFF
--- a/packages/core/src/ai-model/service-caller/json.ts
+++ b/packages/core/src/ai-model/service-caller/json.ts
@@ -111,9 +111,27 @@ function trimParsedJsonStrings(
 
 function repairKnownJsonIssues(
   jsonBlock: string,
-  _rawResponse: string,
+  context?: JsonParserContext,
 ): string {
-  // TODO: Add project-specific repairs that jsonrepair cannot handle.
+  if (context?.source !== 'locate') {
+    return jsonBlock;
+  }
+
+  // For example, {"bbox": [725, 505, 900, 526]</bbox>} becomes valid JSON.
+  const bboxTagFragments = [
+    '</bbox>',
+    '/bbox>',
+    '<bbox>',
+    '</bbox',
+    '/bbox',
+    '<bbox',
+    'bbox>',
+  ];
+
+  for (const fragment of bboxTagFragments) {
+    jsonBlock = jsonBlock.replaceAll(fragment, '');
+  }
+
   return jsonBlock;
 }
 
@@ -152,7 +170,7 @@ export function parseModelResponseJson(
       assertJsonObject(parsedObj);
     }
   } catch (e1) {
-    const code = repairKnownJsonIssues(cleanJsonString, raw);
+    const code = repairKnownJsonIssues(cleanJsonString, context);
     if (code === cleanJsonString) {
       throw new Error(
         `failed to parse LLM response into JSON. Error - ${String(

--- a/packages/core/tests/unit-test/json.test.ts
+++ b/packages/core/tests/unit-test/json.test.ts
@@ -82,6 +82,39 @@ describe('parseModelResponseJson', () => {
     expect(result).toEqual({ key: 'value' });
   });
 
+  it('should remove stray bbox tag fragments from locate responses after jsonrepair fails', () => {
+    const tagFragments = [
+      '<bbox>',
+      '<bbox',
+      'bbox>',
+      '</bbox>',
+      '/bbox>',
+      '</bbox',
+      '/bbox',
+    ];
+
+    for (const tagFragment of tagFragments) {
+      expect(
+        parseModelResponseJson(
+          `{
+          "bbox": [725, 505, 900, 526]${tagFragment}
+        }`,
+          { source: 'locate' },
+        ),
+      ).toEqual({
+        bbox: [725, 505, 900, 526],
+      });
+    }
+  });
+
+  it('should not remove stray bbox tag fragments from non-locate responses', () => {
+    expect(() =>
+      parseModelResponseJson('{"bbox": [725, 505, 900, 526]</bbox>}', {
+        source: 'generic-object',
+      }),
+    ).toThrow(/failed to parse LLM response into JSON/);
+  });
+
   it('should throw error for unparseable content', () => {
     const input = '{foo: true false}';
     expect(() => parseModelResponseJson(input)).toThrow(


### PR DESCRIPTION
## Summary

- repair malformed `bbox` tag fragments only for `locate` model responses after standard JSON repair fails
- replace the known fragments through an explicit ordered array instead of a regular expression
- cover all supported fragments and ensure non-locate responses are not repaired

## Root cause

Some model locate responses append incomplete XML-style `bbox` tags to a JSON array, which neither `JSON.parse` nor `jsonrepair` can parse.

## Validation

- `pnpm --dir packages/core test -- tests/unit-test/json.test.ts`