### PR TITLE
fix(core): preserve raw assistant messages

### DIFF
--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -395,15 +395,21 @@ export async function plan(
     conversationHistory.appendMemory(planFromAI.memory);
   }
 
-  conversationHistory.append({
-    role: 'assistant',
-    content: [
-      {
-        type: 'text',
-        text: rawResponse,
-      },
-    ],
-  });
+  // Some model providers require reasoning_content to be replayed verbatim in
+  // later turns, so retain their original assistant choice when available.
+  if (rawChoiceMessage) {
+    conversationHistory.append(rawChoiceMessage as ChatCompletionMessageParam);
+  } else {
+    conversationHistory.append({
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: rawResponse,
+        },
+      ],
+    });
+  }
 
   return returnValue;
 }

--- a/packages/core/src/ai-model/workflows/planning/custom-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/custom-planning.ts
@@ -160,6 +160,7 @@ export async function runCustomPlanning<TParsed>(
     content,
     input,
   );
+  // UI-TARS and Auto-GLM define their own assistant history format.
   if (assistantContent) {
     options.conversationHistory.append({
       role: 'assistant',

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -99,6 +99,48 @@ describe('plan XML parse retry', () => {
     expect(result.actions).toEqual([{ type: 'Tap' }]);
   });
 
+  it('replays the complete assistant message in the next planning turn', async () => {
+    const firstResponse = `<log>Tap button</log>
+<action-type>Tap</action-type>`;
+    const rawAssistantMessage = {
+      role: 'assistant' as const,
+      content: firstResponse,
+      reasoning_content: 'The button is visible in the center of the screen.',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'Tap', arguments: '{"x":50,"y":50}' },
+        },
+      ],
+    };
+    const conversationHistory = new ConversationHistory();
+    vi.mocked(callAI)
+      .mockResolvedValueOnce({
+        ...mockAIResponse(firstResponse),
+        rawChoiceMessage: rawAssistantMessage,
+      })
+      .mockResolvedValueOnce(
+        mockAIResponse(`<log>Task completed</log>
+<complete>true</complete>`),
+      );
+
+    const options = {
+      context: mockContext(),
+      actionSpace: mockActionSpace(),
+      modelRuntime: getModelRuntime(mockModelConfig()),
+      conversationHistory,
+      includeLocateInPlanning: false,
+      deepThink: false,
+    } as const;
+
+    await plan('tap the button', options);
+    await plan('tap the button', options);
+
+    const secondRequestMessages = vi.mocked(callAI).mock.calls[1]?.[0];
+    expect(secondRequestMessages).toContainEqual(rawAssistantMessage);
+  });
+
   it('preserves retry request errors instead of reporting them as XML parse errors', async () => {
     const requestError = new Error('failed to call AI model service');
     vi.mocked(callAI)


### PR DESCRIPTION
## Summary

- replay the original assistant choice in standard Planning when available
- preserve `reasoning_content` and `tool_calls` across planning turns
- keep custom-planning history formatting owned by UI-TARS and Auto-GLM

## Why

Planning previously reconstructed assistant history from text content only, dropping provider-specific fields required by some multi-turn APIs.

## Validation

- `npx nx test @midscene/core -- tests/unit-test/llm-planning-retry.test.ts`