### PR TITLE
fix(core): preserve AI timeout reasons

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -56,6 +56,7 @@ import {
   buildRequestAbortSignal,
   isHardTimeoutError,
   resolveEffectiveTimeoutMs,
+  restoreHardTimeoutError,
 } from './request-timeout';
 import { callAiAndParseWithRetry } from './semantic-retry';
 export {
@@ -606,6 +607,8 @@ export async function callAI(
             break;
           }
         }
+      } catch (error) {
+        throw restoreHardTimeoutError(toError(error), streamSignal);
       } finally {
         cleanupStreamSignal();
       }
@@ -685,8 +688,8 @@ export async function callAI(
 
           break; // Success, exit retry loop
         } catch (error) {
-          lastError = toError(error);
-          attemptErrors.push({ attempt, error });
+          lastError = restoreHardTimeoutError(toError(error), attemptSignal);
+          attemptErrors.push({ attempt, error: lastError });
           const wasHardTimeout = isHardTimeoutError(lastError);
           if (wasHardTimeout) {
             warnCall(

--- a/packages/core/src/ai-model/service-caller/request-timeout.ts
+++ b/packages/core/src/ai-model/service-caller/request-timeout.ts
@@ -51,6 +51,29 @@ export function isHardTimeoutError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * The OpenAI SDK converts an abort from a caller-provided signal into an
+ * APIUserAbortError and discards the signal's reason. Restore our timeout
+ * reason before surfacing the error to callers (and consequently reports).
+ */
+export function restoreHardTimeoutError(
+  error: Error,
+  signal: AbortSignal,
+): Error {
+  if (!signal.aborted || !isHardTimeoutError(signal.reason)) {
+    return error;
+  }
+
+  const timeoutReason = signal.reason as Error & { code?: string };
+  const restored = new Error(timeoutReason.message, {
+    cause: error,
+  }) as Error & {
+    code?: string;
+  };
+  restored.code = AI_CALL_HARD_TIMEOUT_CODE;
+  return restored;
+}
+
 // Wires a hard timeout into the abort signal passed to fetch so the request
 // is actually cancelled even if the provider/client timeout only covers part
 // of the request. Honours any abortSignal supplied by the caller. Passing

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -135,6 +135,64 @@ describe('service-caller request timeout', () => {
     }
   });
 
+  it('restores the hard-timeout reason when the OpenAI SDK discards it', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+    const { isHardTimeoutError } = await import(
+      '@/ai-model/service-caller/request-timeout'
+    );
+
+    mockCreate.mockImplementation((_body, opts) => {
+      const signal = opts?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          // openai@6.3.0 turns an external abort into APIUserAbortError and
+          // loses signal.reason; mirror that behaviour here.
+          reject(new Error('Request was aborted.'));
+        });
+      });
+    });
+
+    try {
+      await callAI(
+        [{ role: 'user', content: 'hello' }],
+        getModelRuntime(baseConfig({ timeout: 30 })),
+      );
+      throw new Error('should have timed out');
+    } catch (err) {
+      expect(err).toMatchObject({
+        message: expect.stringMatching(/AI call hard timeout after 30ms/),
+      });
+      expect(isHardTimeoutError(err)).toBe(true);
+      expect((err as Error).cause).toMatchObject({
+        code: 'AI_CALL_HARD_TIMEOUT',
+        cause: { message: 'Request was aborted.' },
+      });
+    }
+  });
+
+  it('restores the hard-timeout reason for streaming requests too', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+
+    mockCreate.mockImplementation((_body, opts) => {
+      const signal = opts?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(new Error('Request was aborted.'));
+        });
+      });
+    });
+
+    await expect(
+      callAI(
+        [{ role: 'user', content: 'hello' }],
+        getModelRuntime(baseConfig({ timeout: 30 })),
+        { stream: true, onChunk: vi.fn() },
+      ),
+    ).rejects.toThrow(/AI call hard timeout after 30ms/);
+  });
+
   it('uses the 180s default timeout when none is configured', async () => {
     const { callAI } = await import('@/ai-model/service-caller');
     const { getModelRuntime } = await import('@/ai-model/models');


### PR DESCRIPTION
## Summary

Preserve Midscene hard-timeout reasons when the OpenAI SDK converts an external abort into `APIUserAbortError` and discards the original signal reason.

This makes report errors identify the configured full-request timeout while retaining the SDK abort as the causal error.

## Validation

- `pnpm --filter @midscene/core test service-caller-timeout.test.ts`