### PR TITLE
fix(web-integration): avoid default Playwright network idle warning

### DIFF
--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -8,10 +8,7 @@ import type { WebPageAgentOpt } from '@/web-element';
 import type { Cache } from '@midscene/core';
 import type { Agent as PageAgent } from '@midscene/core/agent';
 import { processCacheConfig } from '@midscene/core/utils';
-import {
-  DEFAULT_WAIT_FOR_NAVIGATION_TIMEOUT,
-  DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT,
-} from '@midscene/shared/constants';
+import { DEFAULT_WAIT_FOR_NAVIGATION_TIMEOUT } from '@midscene/shared/constants';
 import { getDebug } from '@midscene/shared/logger';
 import { uuid } from '@midscene/shared/utils';
 import { replaceIllegalPathCharsAndSpace } from '@midscene/shared/utils';
@@ -78,7 +75,7 @@ export const PlaywrightAiFixture = (options?: PlaywrightAiFixtureOptions) => {
   const {
     forceSameTabNavigation = true,
     autoFollowNewPage = false,
-    waitForNetworkIdleTimeout = DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT,
+    waitForNetworkIdleTimeout,
     waitForNavigationTimeout = DEFAULT_WAIT_FOR_NAVIGATION_TIMEOUT,
     cache,
     ...sharedAgentOptions

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -263,8 +263,13 @@ export class Page<
     this.interfaceType = interfaceType;
     this.waitForNavigationTimeout =
       opts?.waitForNavigationTimeout ?? DEFAULT_WAIT_FOR_NAVIGATION_TIMEOUT;
+    // Playwright cannot perform this post-action wait. Default to 0 so the
+    // internal action hook stays silent; an explicit non-zero value warns below.
     this.waitForNetworkIdleTimeout =
-      opts?.waitForNetworkIdleTimeout ?? DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT;
+      opts?.waitForNetworkIdleTimeout ??
+      (interfaceType === 'puppeteer'
+        ? DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT
+        : 0);
     this.onBeforeInvokeAction = opts?.beforeInvokeAction;
     this.onAfterInvokeAction = opts?.afterInvokeAction;
     this.customActions = opts?.customActions;
@@ -316,12 +321,12 @@ export class Page<
     moment: 'afterInvokeAction',
     actionName?: string,
   ): Promise<void> {
-    if (this.interfaceType === 'puppeteer') {
-      if (this.waitForNetworkIdleTimeout === 0) {
-        debugPage('waitForNetworkIdle timeout is 0, skip waiting');
-        return;
-      }
+    if (this.waitForNetworkIdleTimeout === 0) {
+      debugPage('waitForNetworkIdle timeout is 0, skip waiting');
+      return;
+    }
 
+    if (this.interfaceType === 'puppeteer') {
       debugPage(
         `waitForNetworkIdle begin at moment ${moment} with timeout: ${this.waitForNetworkIdleTimeout} and concurrency: ${DEFAULT_WAIT_FOR_NETWORK_IDLE_CONCURRENCY} and actionName: ${actionName}`,
       );

--- a/packages/web-integration/tests/unit-test/base-page-invoke-action.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-invoke-action.test.ts
@@ -1,9 +1,16 @@
 import { Page } from '@/puppeteer/base-page';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  warning: vi.fn(),
+}));
 
 // Mock necessary dependencies to avoid loading AI service dependencies
 vi.mock('@midscene/shared/logger', () => ({
-  getDebug: vi.fn(() => vi.fn()),
+  getDebug: vi.fn((_topic: string, options?: { console?: boolean }) =>
+    options?.console ? loggerMocks.warning : loggerMocks.debug,
+  ),
   logMsg: vi.fn(),
 }));
 
@@ -34,6 +41,11 @@ vi.mock('@/web-page', () => ({
 }));
 
 describe('Page - beforeInvokeAction and afterInvokeAction', () => {
+  beforeEach(() => {
+    loggerMocks.debug.mockClear();
+    loggerMocks.warning.mockClear();
+  });
+
   describe('beforeInvokeAction', () => {
     it('should call the beforeInvokeAction hook', async () => {
       const mockPage = {
@@ -376,7 +388,7 @@ describe('Page - beforeInvokeAction and afterInvokeAction', () => {
       expect(mockPage.waitForSelector).not.toHaveBeenCalled();
     });
 
-    it('should work with playwright interface in afterInvokeAction', async () => {
+    it('should not warn about network idle with default Playwright options', async () => {
       const mockPage = {
         url: () => 'http://example.com',
         mouse: { move: vi.fn() },
@@ -392,6 +404,45 @@ describe('Page - beforeInvokeAction and afterInvokeAction', () => {
       expect(mockPage.waitForSelector).toHaveBeenCalledWith('html', {
         timeout: 5000,
       });
+      expect(loggerMocks.warning).not.toHaveBeenCalled();
+    });
+
+    it('should warn once when network idle is explicitly enabled for Playwright', async () => {
+      const mockPage = {
+        url: () => 'http://example.com',
+        mouse: { move: vi.fn() },
+        keyboard: { down: vi.fn(), up: vi.fn(), press: vi.fn(), type: vi.fn() },
+        waitForSelector: vi.fn().mockResolvedValue(true),
+        evaluate: vi.fn(),
+      } as any;
+
+      const page = new Page(mockPage, 'playwright', {
+        waitForNetworkIdleTimeout: 2000,
+      });
+      await page.afterInvokeAction('firstAction', {});
+      await page.afterInvokeAction('secondAction', {});
+
+      expect(loggerMocks.warning).toHaveBeenCalledTimes(1);
+      expect(loggerMocks.warning).toHaveBeenCalledWith(
+        expect.stringContaining('waitForNetworkIdle is skipped for Playwright'),
+      );
+    });
+
+    it('should not warn when network idle is explicitly disabled for Playwright', async () => {
+      const mockPage = {
+        url: () => 'http://example.com',
+        mouse: { move: vi.fn() },
+        keyboard: { down: vi.fn(), up: vi.fn(), press: vi.fn(), type: vi.fn() },
+        waitForSelector: vi.fn().mockResolvedValue(true),
+        evaluate: vi.fn(),
+      } as any;
+
+      const page = new Page(mockPage, 'playwright', {
+        waitForNetworkIdleTimeout: 0,
+      });
+      await page.afterInvokeAction('testAction', {});
+
+      expect(loggerMocks.warning).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-options.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-options.test.ts
@@ -70,6 +70,20 @@ describe('PlaywrightAiFixture option forwarding', () => {
       forceChromeSelectRendering: true,
       generateReport: true,
     });
+    expect(mockState.ctorOpts[0].waitForNetworkIdleTimeout).toBeUndefined();
+  });
+
+  it('should forward an explicitly configured network idle timeout', async () => {
+    const fixture = PlaywrightAiFixture({
+      waitForNetworkIdleTimeout: 4321,
+    });
+
+    await fixture.ai({ page: createPage() }, async () => {}, createTestInfo());
+
+    expect(mockState.ctorOpts).toHaveLength(1);
+    expect(mockState.ctorOpts[0]).toMatchObject({
+      waitForNetworkIdleTimeout: 4321,
+    });
   });
 
   it('should allow the first agentForPage call to override fixture defaults', async () => {


### PR DESCRIPTION
## Summary

- stop `PlaywrightAiFixture` from injecting the shared network-idle timeout when callers omit the option
- default Playwright post-action network-idle handling to disabled while preserving Puppeteer's 2000 ms default
- keep the one-time warning when a caller explicitly configures a non-zero Playwright network-idle timeout
- add regression coverage for default, explicitly enabled, and explicitly disabled behavior

## Root cause

`Page.afterInvokeAction` always invokes `waitForNetworkIdle`. The shared 2000 ms default was propagated into Playwright even though Playwright does not provide the intended post-action network-idle capability, so the first action emitted a warning without any user opt-in.

## User impact

Playwright users no longer see a misleading `waitForNetworkIdle` warning under default configuration. Explicit unsupported configuration remains visible through a single warning, and Puppeteer behavior is unchanged.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/web` (409 passed, 1 skipped)
- `pnpm exec nx build @midscene/web`
- built-package Playwright smoke check: 0 warnings by default and 1 warning across two actions with an explicit non-zero timeout
