### PR TITLE
fix(shared): reject truncated PNG screenshots

### DIFF
--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -38,11 +38,19 @@ const createMockAdb = () => ({
 
 let mockAdbInstance: ReturnType<typeof createMockAdb>;
 
-const createValidPngBuffer = (size = 64) =>
-  Buffer.concat([
-    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    Buffer.alloc(Math.max(size - 8, 0)),
+const createValidPngBuffer = (size = 64) => {
+  const signature = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
   ]);
+  const iend = Buffer.from([
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ]);
+  return Buffer.concat([
+    signature,
+    Buffer.alloc(Math.max(size - signature.length - iend.length, 0)),
+    iend,
+  ]);
+};
 
 vi.mock('appium-adb', () => {
   return {

--- a/packages/shared/src/img/info.ts
+++ b/packages/shared/src/img/info.ts
@@ -50,7 +50,10 @@ export async function imageInfoOfBase64(
  * @returns true if the Buffer is a valid PNG image, otherwise false
  */
 export function isValidPNGImageBuffer(buffer: Buffer): boolean {
-  if (!buffer || buffer.length < 8) {
+  // A PNG consists of the 8-byte signature followed by chunks and must end
+  // with the 12-byte IEND chunk. Checking only the signature lets truncated
+  // screenshots through, which then fail when sent to an image model.
+  if (!buffer || buffer.length < 20) {
     return false;
   }
 
@@ -66,7 +69,18 @@ export function isValidPNGImageBuffer(buffer: Buffer): boolean {
     buffer[6] === 0x1a &&
     buffer[7] === 0x0a;
 
-  return isPNG;
+  if (!isPNG) {
+    return false;
+  }
+
+  // IEND has a zero-length payload and a fixed CRC (AE 42 60 82). It must be
+  // the final chunk in a conforming PNG.
+  const pngIendChunk = Buffer.from([
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ]);
+  return buffer
+    .subarray(buffer.length - pngIendChunk.length)
+    .equals(pngIendChunk);
 }
 
 /**

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -291,6 +291,18 @@ describe('image utils', () => {
     expect(isValid).toBe(false);
   });
 
+  it('rejects a truncated PNG that has a valid signature but no IEND chunk', () => {
+    const validPng = readFileSync(getFixture('icon.png'));
+    const truncatedPng = validPng.subarray(0, validPng.length - 12);
+
+    expect(isValidPNGImageBuffer(truncatedPng)).toBe(false);
+    expect(() =>
+      validateScreenshotBuffer(truncatedPng, {
+        label: 'Screenshot',
+      }),
+    ).toThrow('Screenshot buffer has invalid image format');
+  });
+
   it('validateScreenshotBuffer accepts valid screenshots above the minimum size', () => {
     const buffer = readFileSync(getFixture('icon.png'));
 


### PR DESCRIPTION
## Summary

- require PNG screenshot buffers to end with a valid IEND chunk
- add a regression test for a real PNG truncated immediately before IEND
- update Android screenshot test fixtures to satisfy the stricter PNG contract

## Root cause

Screenshot validation only checked the PNG signature, buffer size, and non-empty content. A partially copied screenshot could therefore retain a valid signature and IHDR while missing its IEND chunk. The invalid image would pass local validation and later be rejected by the model provider.

## Impact

Truncated PNG screenshots are now rejected before they can be sent to a vision model. Both the primary Android ADB screenshot path and the `screencap`/`adb pull` fallback use this shared validator.

## Validation

- `packages/shared/node_modules/.bin/vitest --run tests/unit-test/image/index.test.ts` (34 tests passed)
- `packages/android/node_modules/.bin/vitest --run tests/unit-test/page.test.ts` (165 tests passed)
- `pnpm run lint` (1,288 files checked)
- `git diff --check`