### PR TITLE
feat(shared): add WebP support across screenshot pipelines

### DIFF
--- a/apps/chrome-extension/src/extension/recorder/screenshot-export.ts
+++ b/apps/chrome-extension/src/extension/recorder/screenshot-export.ts
@@ -1,0 +1,97 @@
+import {
+  type ScreenshotImageFormat,
+  type ScreenshotImageMimeType,
+  inferScreenshotImageFormatFromBase64,
+  screenshotImageExtension,
+  screenshotImageMimeType,
+} from '@midscene/shared/img/image-format';
+import type { RecordingSession } from '../../store';
+
+export interface RecorderScreenshotAsset {
+  body: string;
+  extension: ScreenshotImageFormat;
+  mimeType: ScreenshotImageMimeType;
+}
+
+export const recorderScreenshotAsset = (
+  screenshotBase64: string,
+): RecorderScreenshotAsset => {
+  const separator = ';base64,';
+  const separatorIndex = screenshotBase64.indexOf(separator);
+  const body = (
+    separatorIndex === -1
+      ? screenshotBase64
+      : screenshotBase64.slice(separatorIndex + separator.length)
+  ).replace(/\s/g, '');
+  const format = inferScreenshotImageFormatFromBase64(body);
+  if (!format) {
+    throw new Error('Unsupported recorder screenshot image format');
+  }
+
+  return {
+    body,
+    extension: screenshotImageExtension(format),
+    mimeType: screenshotImageMimeType(format),
+  };
+};
+
+export const generateEventsMarkdownTable = (
+  sessions: RecordingSession[],
+): string => {
+  let markdown = '# Test Events Report\n\n';
+
+  sessions.forEach((session, sessionIndex) => {
+    if (session.events.length === 0) return;
+
+    markdown += `## ${session.name}\n\n`;
+    if (session.description) {
+      markdown += `**Description:** ${session.description}\n\n`;
+    }
+    markdown += `**Created:** ${new Date(session.createdAt).toLocaleString()}\n\n`;
+
+    markdown += '| Page | Screenshot Before | Screenshot After | Action |\n';
+    markdown += '|------|------------|------------|--------|\n';
+
+    session.events.forEach((event, eventIndex) => {
+      const page = event.title || event.url || '';
+      const screenshotBefore = event.screenshotBefore
+        ? `![](./images/screenshot_${sessionIndex}_${eventIndex}_before.${recorderScreenshotAsset(event.screenshotBefore).extension})`
+        : 'N/A';
+      const screenshotAfter = event.screenshotAfter
+        ? `![](./images/screenshot_${sessionIndex}_${eventIndex}_after.${recorderScreenshotAsset(event.screenshotAfter).extension})`
+        : 'N/A';
+      let action = '';
+      switch (event.type) {
+        case 'click':
+          action = `Click on ${event.elementDescription || 'element'}`;
+          break;
+        case 'input':
+          action = `Input "${event.value}" into ${event.elementDescription || 'field'}`;
+          break;
+        case 'navigation':
+          action = `Navigate to ${event.url}`;
+          break;
+        default:
+          action = `${event.type} on ${event.elementDescription || 'element'}`;
+      }
+
+      markdown += `| ${page} | ${screenshotBefore} | ${screenshotAfter} | ${action} |\n`;
+    });
+
+    if (session.generatedCode?.yaml || session.generatedCode?.playwright) {
+      markdown += '## Generated Code\n\n';
+      if (session.generatedCode?.yaml) {
+        markdown += '### YAML\n\n';
+        markdown += `\`\`\`yaml\n${session.generatedCode.yaml}\n\`\`\`\n\n`;
+      }
+      if (session.generatedCode?.playwright) {
+        markdown += '### Playwright\n\n';
+        markdown += `\`\`\`playwright\n${session.generatedCode.playwright}\n\`\`\`\n\n`;
+      }
+    }
+
+    markdown += '\n\n\n';
+  });
+
+  return markdown;
+};

--- a/apps/chrome-extension/src/extension/recorder/utils.ts
+++ b/apps/chrome-extension/src/extension/recorder/utils.ts
@@ -12,6 +12,11 @@ import JSZip from 'jszip';
 import type { ChatCompletionContentPart } from 'openai/resources/index';
 import type { RecordingSession } from '../../store';
 import { recordLogger } from './logger';
+import {
+  type RecorderScreenshotAsset,
+  generateEventsMarkdownTable,
+  recorderScreenshotAsset,
+} from './screenshot-export';
 import { isChromeExtension, safeChromeAPI } from './types';
 
 // Generate default session name with current time
@@ -713,74 +718,12 @@ const generateDetailedSequentialMindmap = (
   return mermaid;
 };
 
-// Generate markdown table for event details
-const generateEventsMarkdownTable = (sessions: RecordingSession[]): string => {
-  let markdown = '# Test Events Report\n\n';
-
-  sessions.forEach((session, sessionIndex) => {
-    if (session.events.length === 0) return;
-
-    markdown += `## ${session.name}\n\n`;
-    if (session.description) {
-      markdown += `**Description:** ${session.description}\n\n`;
-    }
-    markdown += `**Created:** ${new Date(session.createdAt).toLocaleString()}\n\n`;
-
-    markdown += '| Page | Screenshot Before | Screenshot After | Action |\n';
-    markdown += '|------|------------|------------|--------|\n';
-
-    session.events.forEach((event, eventIndex) => {
-      let expected = 'N/A';
-      const page = event.title || event.url || '';
-      const screenshotBefore = event.screenshotBefore
-        ? `![](./images/screenshot_${sessionIndex}_${eventIndex}_before.png)`
-        : 'N/A';
-      const screenshotAfter = event.screenshotAfter
-        ? `![](./images/screenshot_${sessionIndex}_${eventIndex}_after.png)`
-        : 'N/A';
-      if (event.type === 'navigation') {
-        expected = `Navigate to ${event.url}`;
-      }
-
-      let action = '';
-      switch (event.type) {
-        case 'click':
-          action = `Click on ${event.elementDescription || 'element'}`;
-          break;
-        case 'input':
-          action = `Input "${event.value}" into ${event.elementDescription || 'field'}`;
-          break;
-        case 'navigation':
-          action = `Navigate to ${event.url}`;
-          break;
-        default:
-          action = `${event.type} on ${event.elementDescription || 'element'}`;
-      }
-
-      markdown += `| ${page} | ${screenshotBefore} | ${screenshotAfter} | ${action} |\n`;
-    });
-
-    if (session.generatedCode?.yaml || session.generatedCode?.playwright) {
-      markdown += '## Generated Code\n\n';
-      if (session.generatedCode?.yaml) {
-        markdown += '### YAML\n\n';
-        markdown += `\`\`\`yaml\n${session.generatedCode.yaml}\n\`\`\`\n\n`;
-      }
-      if (session.generatedCode?.playwright) {
-        markdown += '### Playwright\n\n';
-        markdown += `\`\`\`playwright\n${session.generatedCode.playwright}\n\`\`\`\n\n`;
-      }
-    }
-
-    markdown += '\n\n\n';
-  });
-
-  return markdown;
-};
-
 // Convert base64 to blob
-const base64ToBlob = (base64: string, mimeType: string): Blob => {
-  const byteCharacters = atob(base64.split(',')[1]);
+const base64BodyToBlob = (
+  base64Body: string,
+  mimeType: RecorderScreenshotAsset['mimeType'],
+): Blob => {
+  const byteCharacters = atob(base64Body);
   const byteNumbers = new Array(byteCharacters.length);
   for (let i = 0; i < byteCharacters.length; i++) {
     byteNumbers[i] = byteCharacters.charCodeAt(i);
@@ -810,15 +753,16 @@ export const exportAllEventsToZip = async (sessions: RecordingSession[]) => {
     // Process each session and extract images
     sessionsWithEvents.forEach((session, sessionIndex) => {
       session.events.forEach((event, eventIndex) => {
-        const ext = 'png';
         if (event.screenshotBefore) {
-          const fileName = `screenshot_${sessionIndex}_${eventIndex}_before.${ext}`;
-          const blob = base64ToBlob(event.screenshotBefore, `image/${ext}`);
+          const asset = recorderScreenshotAsset(event.screenshotBefore);
+          const fileName = `screenshot_${sessionIndex}_${eventIndex}_before.${asset.extension}`;
+          const blob = base64BodyToBlob(asset.body, asset.mimeType);
           imagesFolder?.file(fileName, blob);
         }
         if (event.screenshotAfter) {
-          const fileName = `screenshot_${sessionIndex}_${eventIndex}_after.${ext}`;
-          const blob = base64ToBlob(event.screenshotAfter, `image/${ext}`);
+          const asset = recorderScreenshotAsset(event.screenshotAfter);
+          const fileName = `screenshot_${sessionIndex}_${eventIndex}_after.${asset.extension}`;
+          const blob = base64BodyToBlob(asset.body, asset.mimeType);
           imagesFolder?.file(fileName, blob);
         }
       });

--- a/apps/chrome-extension/src/scripts/worker.ts
+++ b/apps/chrome-extension/src/scripts/worker.ts
@@ -4,6 +4,7 @@ import type { UIContext } from '@midscene/core';
 import { uuid } from '@midscene/shared/utils';
 import { BridgeConnector, type BridgeStatus } from '../utils/bridgeConnector';
 import { registerAlarmListener, safeSetupKeepalive } from '../utils/keepalive';
+import { canonicalizeRecorderScreenshot } from '../utils/screenshot';
 import { workerMessageTypes } from '../utils/workerMessageTypes';
 
 // save screenshot
@@ -448,8 +449,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
               chrome.runtime.lastError,
             );
             sendResponse(null);
+          } else if (!dataUrl) {
+            console.error(
+              '[ServiceWorker] Screenshot capture returned empty data',
+            );
+            sendResponse(null);
           } else {
-            sendResponse(dataUrl);
+            void canonicalizeRecorderScreenshot(dataUrl).then(
+              (webpDataUrl) => sendResponse(webpDataUrl),
+              (error) => {
+                console.error(
+                  '[ServiceWorker] Failed to encode recorder screenshot as WebP:',
+                  error,
+                );
+                sendResponse(null);
+              },
+            );
           }
         },
       );

--- a/apps/chrome-extension/src/utils/screenshot.ts
+++ b/apps/chrome-extension/src/utils/screenshot.ts
@@ -1,0 +1,77 @@
+const WEBP_QUALITY = 0.9;
+const DATA_URL_PATTERN = /^data:image\/(png|jpe?g|webp);base64,([\s\S]+)$/i;
+
+function decodeScreenshotDataUrl(dataUrl: string): {
+  bytes: Uint8Array;
+  mimeType: string;
+} {
+  const match = DATA_URL_PATTERN.exec(dataUrl);
+  if (!match) {
+    throw new Error(
+      'Recorder screenshot must be a PNG, JPEG, or WebP data URL',
+    );
+  }
+
+  const binary = atob(match[2]);
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return {
+    bytes,
+    mimeType: `image/${match[1].toLowerCase().replace('jpg', 'jpeg')}`,
+  };
+}
+
+function isWebp(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 12 &&
+    String.fromCharCode(...bytes.subarray(0, 4)) === 'RIFF' &&
+    String.fromCharCode(...bytes.subarray(8, 12)) === 'WEBP'
+  );
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+/** Convert captureVisibleTab's PNG output to the recorder's canonical WebP. */
+export async function canonicalizeRecorderScreenshot(
+  dataUrl: string,
+): Promise<string> {
+  const source = decodeScreenshotDataUrl(dataUrl);
+  if (source.mimeType === 'image/webp') {
+    if (!isWebp(source.bytes)) {
+      throw new Error('Recorder screenshot has an invalid WebP signature');
+    }
+    return dataUrl;
+  }
+
+  const bitmap = await createImageBitmap(
+    new Blob([source.bytes], { type: source.mimeType }),
+  );
+  try {
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Recorder screenshot WebP encoder is unavailable');
+    }
+    context.drawImage(bitmap, 0, 0);
+
+    const output = await canvas.convertToBlob({
+      type: 'image/webp',
+      quality: WEBP_QUALITY,
+    });
+    const bytes = new Uint8Array(await output.arrayBuffer());
+    if (output.type !== 'image/webp' || !isWebp(bytes)) {
+      throw new Error('Recorder screenshot encoder returned invalid WebP');
+    }
+    return `data:image/webp;base64,${encodeBase64(bytes)}`;
+  } finally {
+    bitmap.close();
+  }
+}

--- a/apps/chrome-extension/tests/recorder-export-image-format.test.ts
+++ b/apps/chrome-extension/tests/recorder-export-image-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateEventsMarkdownTable,
+  recorderScreenshotAsset,
+} from '../src/extension/recorder/screenshot-export';
+import type { RecordingSession } from '../src/store';
+
+const webpBody =
+  'UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=';
+const pngBody =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('Chrome recorder screenshot export', () => {
+  it('derives the exported extension and MIME type from the image bytes', () => {
+    expect(
+      recorderScreenshotAsset(`data:image/png;base64,${webpBody}`),
+    ).toEqual({
+      body: webpBody,
+      extension: 'webp',
+      mimeType: 'image/webp',
+    });
+    expect(recorderScreenshotAsset(`data:image/png;base64,${pngBody}`)).toEqual(
+      {
+        body: pngBody,
+        extension: 'png',
+        mimeType: 'image/png',
+      },
+    );
+  });
+
+  it('uses each screenshot actual extension in the Markdown table', () => {
+    const sessions = [
+      {
+        id: 'session-1',
+        name: 'WebP export',
+        createdAt: 1,
+        updatedAt: 1,
+        status: 'completed',
+        events: [
+          {
+            type: 'click',
+            timestamp: 1,
+            hashId: 'event-1',
+            screenshotBefore: `data:image/webp;base64,${webpBody}`,
+            screenshotAfter: `data:image/png;base64,${pngBody}`,
+          },
+        ],
+      },
+    ] as RecordingSession[];
+
+    const markdown = generateEventsMarkdownTable(sessions);
+
+    expect(markdown).toContain('![](./images/screenshot_0_0_before.webp)');
+    expect(markdown).toContain('![](./images/screenshot_0_0_after.png)');
+    expect(markdown).not.toContain('screenshot_0_0_before.png');
+  });
+});

--- a/apps/chrome-extension/tests/screenshot.test.ts
+++ b/apps/chrome-extension/tests/screenshot.test.ts
@@ -1,0 +1,58 @@
+import { Buffer } from 'node:buffer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { canonicalizeRecorderScreenshot } from '../src/utils/screenshot';
+
+describe('canonicalizeRecorderScreenshot', () => {
+  const pngDataUrl =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+  const webpBytes = Buffer.from(
+    'UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=',
+    'base64',
+  );
+  const drawImage = vi.fn();
+  const close = vi.fn();
+  const convertToBlob = vi.fn(
+    async () => new Blob([webpBytes], { type: 'image/webp' }),
+  );
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close })),
+    );
+    vi.stubGlobal(
+      'OffscreenCanvas',
+      class {
+        getContext() {
+          return { drawImage };
+        }
+
+        convertToBlob = convertToBlob;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('turns captureVisibleTab PNG output into a real WebP image', async () => {
+    const result = await canonicalizeRecorderScreenshot(pngDataUrl);
+    const bytes = Buffer.from(result.split(',')[1], 'base64');
+
+    expect(result).toMatch(/^data:image\/webp;base64,/);
+    expect(bytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(bytes.subarray(8, 12).toString('ascii')).toBe('WEBP');
+    expect(convertToBlob).toHaveBeenCalledWith({
+      type: 'image/webp',
+      quality: 0.9,
+    });
+  });
+
+  it('passes an existing WebP through without re-encoding', async () => {
+    const webp = `data:image/webp;base64,${webpBytes.toString('base64')}`;
+    await expect(canonicalizeRecorderScreenshot(webp)).resolves.toBe(webp);
+    expect(convertToBlob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -54,12 +54,16 @@ import {
   getEmptyDumpDescription,
   parseDumpAttributes,
 } from './utils/report-dump';
+import {
+  type ReportScreenshotSourceRef,
+  resolveScreenshotFallbackPath,
+} from './utils/screenshot-source';
 
 // Shared image cache across all test cases — resolved images are cached by id
 const imageCache = new Map<string, string>();
 
 function resolveImageFromDom(
-  refOrId: string | { id: string; storage?: 'inline' | 'file'; path?: string },
+  refOrId: string | ReportScreenshotSourceRef,
 ): string {
   const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
   const cached = imageCache.get(id);
@@ -74,12 +78,7 @@ function resolveImageFromDom(
     return data;
   }
 
-  if (typeof refOrId === 'object' && refOrId?.storage === 'file') {
-    return refOrId.path || `./screenshots/${id}.png`;
-  }
-
-  // Fallback to directory path
-  return `./screenshots/${id}.png`;
+  return resolveScreenshotFallbackPath(refOrId);
 }
 
 let globalRenderCount = 1;

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -15,6 +15,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 import {
   GroupedActionDump,
+  type ScreenshotRef,
   dedupeExecutionsKeepLatest,
   reportToMarkdown,
   restoreImageReferences,
@@ -54,18 +55,13 @@ import {
   getEmptyDumpDescription,
   parseDumpAttributes,
 } from './utils/report-dump';
-import {
-  type ReportScreenshotSourceRef,
-  resolveScreenshotFallbackPath,
-} from './utils/screenshot-source';
+import { resolveScreenshotFallbackPath } from './utils/screenshot-source';
 
 // Shared image cache across all test cases — resolved images are cached by id
 const imageCache = new Map<string, string>();
 
-function resolveImageFromDom(
-  refOrId: string | ReportScreenshotSourceRef,
-): string {
-  const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
+function resolveImageFromDom(ref: ScreenshotRef): string {
+  const id = ref.id;
   const cached = imageCache.get(id);
   if (cached) return cached;
 
@@ -78,7 +74,7 @@ function resolveImageFromDom(
     return data;
   }
 
-  return resolveScreenshotFallbackPath(refOrId);
+  return resolveScreenshotFallbackPath(ref);
 }
 
 let globalRenderCount = 1;

--- a/apps/report/src/components/playground/index.tsx
+++ b/apps/report/src/components/playground/index.tsx
@@ -15,6 +15,10 @@ import {
 import { type PlaygroundSDK, noReplayAPIs } from '@midscene/playground';
 import type { ServerResponse } from '@midscene/playground';
 import {
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img/image-format';
+import {
   ContextPreview,
   Logo,
   type PlaygroundResult,
@@ -55,7 +59,11 @@ async function loadReferencedReplay(result: PlaygroundResult) {
   }
   const dump = (await response.json()) as IReportActionDump;
   result.dump = restoreImageReferences(dump, (ref) => {
-    const extension = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+    const format = screenshotImageFormatFromMimeType(ref.mimeType);
+    if (!format) {
+      throw new Error(`Unsupported screenshot mime type: ${ref.mimeType}`);
+    }
+    const extension = screenshotImageExtension(format);
     return new URL(
       `screenshots/${encodeURIComponent(ref.id)}.${extension}`,
       result.report!.url,

--- a/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.test.ts
@@ -4,6 +4,8 @@ import { buildTimelineScreenshots } from './build-timeline-screenshots';
 
 const onePixelPngBase64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lz8yrwAAAABJRU5ErkJggg==';
+const webpBase64 =
+  'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
 
 interface TaskFixtureOptions {
   id: string;
@@ -101,6 +103,19 @@ describe('buildTimelineScreenshots', () => {
     expect(allScreenshots[0].img).toBe(
       `data:image/png;base64,${onePixelPngBase64}`,
     );
+  });
+
+  it('labels raw WebP recorder screenshots with the WebP MIME type', () => {
+    const task = makeTask({
+      id: 'raw-webp-recorder',
+      startTs: 1000,
+      recorder: [{ ts: 1200, screenshot: webpBase64 }],
+    });
+
+    const { allScreenshots } = buildTimelineScreenshots([task]);
+
+    expect(allScreenshots).toHaveLength(1);
+    expect(allScreenshots[0].img).toBe(`data:image/webp;base64,${webpBase64}`);
   });
 
   it('keeps already-prefixed data URLs unchanged', () => {

--- a/apps/report/src/components/timeline/build-timeline-screenshots.ts
+++ b/apps/report/src/components/timeline/build-timeline-screenshots.ts
@@ -1,4 +1,8 @@
 import type { ExecutionTask } from '@midscene/core';
+import {
+  inferScreenshotImageFormatFromBase64,
+  screenshotImageMimeType,
+} from '@midscene/shared/img/image-format';
 
 export interface TimelineScreenshot {
   id: string;
@@ -30,11 +34,8 @@ const imageSrcFromString = (value: string): string => {
   }
 
   const body = trimmed.replace(/\s/g, '');
-  const mimeType = body.startsWith('/9j/')
-    ? 'image/jpeg'
-    : body.startsWith('UklGR')
-      ? 'image/webp'
-      : 'image/png';
+  const format = inferScreenshotImageFormatFromBase64(body) ?? 'png';
+  const mimeType = screenshotImageMimeType(format);
   return `data:${mimeType};base64,${body}`;
 };
 

--- a/apps/report/src/utils/markdown-export.test.ts
+++ b/apps/report/src/utils/markdown-export.test.ts
@@ -105,6 +105,27 @@ describe('markdown-export helpers', () => {
     );
   });
 
+  it('packages WebP data URI attachments without changing their bytes', () => {
+    const files = buildMarkdownArchiveFiles('# webp report', [
+      {
+        id: 'webp-inline',
+        suggestedFileName: 'webp-inline.webp',
+        mimeType: 'image/webp',
+        executionIndex: 0,
+        taskIndex: 0,
+        base64Data: `data:image/webp;base64,${btoa('webp-bytes')}`,
+      },
+    ]);
+
+    expect(Object.keys(files).sort()).toEqual([
+      'report.md',
+      'screenshots/webp-inline.webp',
+    ]);
+    expect(
+      new TextDecoder().decode(files['screenshots/webp-inline.webp']),
+    ).toBe('webp-bytes');
+  });
+
   it('builds display items from markdown attachment names and paths', () => {
     const items = getMarkdownAttachmentDisplayItems([
       {

--- a/apps/report/src/utils/markdown-export.ts
+++ b/apps/report/src/utils/markdown-export.ts
@@ -1,7 +1,7 @@
 import type { MarkdownAttachment } from '@midscene/core';
 
 const defaultScreenshotBaseDir = './screenshots';
-const dataUrlBase64Pattern = /^data:image\/(?:png|jpeg|jpg);base64,/i;
+const dataUrlBase64Pattern = /^data:image\/(?:png|jpeg|jpg|webp);base64,/i;
 const rawBase64Pattern = /^[a-zA-Z0-9+/=\s]+$/;
 
 type MarkdownExport = {

--- a/apps/report/src/utils/screenshot-source.test.ts
+++ b/apps/report/src/utils/screenshot-source.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { resolveScreenshotFallbackPath } from './screenshot-source';
+
+describe('resolveScreenshotFallbackPath', () => {
+  it('keeps the legacy PNG fallback when only an id is available', () => {
+    expect(resolveScreenshotFallbackPath('legacy-shot')).toBe(
+      './screenshots/legacy-shot.png',
+    );
+  });
+
+  it('uses the MIME-specific extension for screenshot references', () => {
+    expect(
+      resolveScreenshotFallbackPath({
+        id: 'webp-shot',
+        mimeType: 'image/webp',
+        storage: 'inline',
+      }),
+    ).toBe('./screenshots/webp-shot.webp');
+    expect(
+      resolveScreenshotFallbackPath({
+        id: 'jpeg-shot',
+        mimeType: 'image/jpeg',
+        storage: 'inline',
+      }),
+    ).toBe('./screenshots/jpeg-shot.jpeg');
+  });
+
+  it('prefers an explicit file-backed path', () => {
+    expect(
+      resolveScreenshotFallbackPath({
+        id: 'webp-shot',
+        mimeType: 'image/webp',
+        storage: 'file',
+        path: './assets/custom.webp',
+      }),
+    ).toBe('./assets/custom.webp');
+  });
+});

--- a/apps/report/src/utils/screenshot-source.test.ts
+++ b/apps/report/src/utils/screenshot-source.test.ts
@@ -1,24 +1,23 @@
+import type { ScreenshotRef } from '@midscene/core';
 import { describe, expect, it } from 'vitest';
 import { resolveScreenshotFallbackPath } from './screenshot-source';
 
 describe('resolveScreenshotFallbackPath', () => {
-  it('keeps the legacy PNG fallback when only an id is available', () => {
-    expect(resolveScreenshotFallbackPath('legacy-shot')).toBe(
-      './screenshots/legacy-shot.png',
-    );
-  });
-
   it('uses the MIME-specific extension for screenshot references', () => {
     expect(
       resolveScreenshotFallbackPath({
+        type: 'midscene_screenshot_ref',
         id: 'webp-shot',
+        capturedAt: 100,
         mimeType: 'image/webp',
         storage: 'inline',
       }),
     ).toBe('./screenshots/webp-shot.webp');
     expect(
       resolveScreenshotFallbackPath({
+        type: 'midscene_screenshot_ref',
         id: 'jpeg-shot',
+        capturedAt: 100,
         mimeType: 'image/jpeg',
         storage: 'inline',
       }),
@@ -28,11 +27,41 @@ describe('resolveScreenshotFallbackPath', () => {
   it('prefers an explicit file-backed path', () => {
     expect(
       resolveScreenshotFallbackPath({
+        type: 'midscene_screenshot_ref',
         id: 'webp-shot',
+        capturedAt: 100,
         mimeType: 'image/webp',
         storage: 'file',
         path: './assets/custom.webp',
       }),
     ).toBe('./assets/custom.webp');
+  });
+
+  it('throws instead of assuming PNG when MIME metadata is missing', () => {
+    const invalidRef = {
+      type: 'midscene_screenshot_ref',
+      id: 'missing-mime',
+      capturedAt: 100,
+      storage: 'file',
+      path: './screenshots/missing-mime.png',
+    } as unknown as ScreenshotRef;
+
+    expect(() => resolveScreenshotFallbackPath(invalidRef)).toThrow(
+      'Unsupported screenshot mime type: undefined',
+    );
+  });
+
+  it('throws on unsupported MIME metadata', () => {
+    const invalidRef = {
+      type: 'midscene_screenshot_ref',
+      id: 'unsupported-mime',
+      capturedAt: 100,
+      mimeType: 'image/gif',
+      storage: 'inline',
+    } as unknown as ScreenshotRef;
+
+    expect(() => resolveScreenshotFallbackPath(invalidRef)).toThrow(
+      'Unsupported screenshot mime type: image/gif',
+    );
   });
 });

--- a/apps/report/src/utils/screenshot-source.ts
+++ b/apps/report/src/utils/screenshot-source.ts
@@ -1,0 +1,31 @@
+import {
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img/image-format';
+
+export interface ReportScreenshotSourceRef {
+  id: string;
+  mimeType?: unknown;
+  storage?: 'inline' | 'file';
+  path?: string;
+}
+
+export function resolveScreenshotFallbackPath(
+  refOrId: string | ReportScreenshotSourceRef,
+): string {
+  if (
+    typeof refOrId === 'object' &&
+    refOrId.storage === 'file' &&
+    refOrId.path
+  ) {
+    return refOrId.path;
+  }
+
+  const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
+  const format =
+    typeof refOrId === 'object'
+      ? screenshotImageFormatFromMimeType(refOrId.mimeType)
+      : undefined;
+  const extension = format ? screenshotImageExtension(format) : 'png';
+  return `./screenshots/${id}.${extension}`;
+}

--- a/apps/report/src/utils/screenshot-source.ts
+++ b/apps/report/src/utils/screenshot-source.ts
@@ -1,31 +1,20 @@
+import type { ScreenshotRef } from '@midscene/core';
 import {
   screenshotImageExtension,
   screenshotImageFormatFromMimeType,
 } from '@midscene/shared/img/image-format';
 
-export interface ReportScreenshotSourceRef {
-  id: string;
-  mimeType?: unknown;
-  storage?: 'inline' | 'file';
-  path?: string;
-}
-
-export function resolveScreenshotFallbackPath(
-  refOrId: string | ReportScreenshotSourceRef,
-): string {
-  if (
-    typeof refOrId === 'object' &&
-    refOrId.storage === 'file' &&
-    refOrId.path
-  ) {
-    return refOrId.path;
+export function resolveScreenshotFallbackPath(ref: ScreenshotRef): string {
+  const format = screenshotImageFormatFromMimeType(ref.mimeType);
+  if (!format) {
+    throw new Error(
+      `Unsupported screenshot mime type: ${String(ref.mimeType)}`,
+    );
   }
 
-  const id = typeof refOrId === 'string' ? refOrId : refOrId.id;
-  const format =
-    typeof refOrId === 'object'
-      ? screenshotImageFormatFromMimeType(refOrId.mimeType)
-      : undefined;
-  const extension = format ? screenshotImageExtension(format) : 'png';
-  return `./screenshots/${id}.${extension}`;
+  if (ref.storage === 'file' && ref.path) {
+    return ref.path;
+  }
+
+  return `./screenshots/${ref.id}.${screenshotImageExtension(format)}`;
 }

--- a/apps/site/docs/en/api.mdx
+++ b/apps/site/docs/en/api.mdx
@@ -1240,7 +1240,7 @@ interface RecordToReportOptions {
   screenshotBase64?: string;
   screenshots?: {
     /**
-     * PNG/JPEG data URI, or raw PNG base64 body.
+     * PNG/JPEG/WebP data URI, or raw PNG/WebP base64 body.
      */
     base64: string;
     description?: string;
@@ -1258,7 +1258,7 @@ function recordToReport(
   - `title?: string` - Optional, the title of the screenshot, if not provided, the title will be 'untitled'.
   - `options?: RecordToReportOptions` - Optional, a configuration object containing:
     - `content?: string` - The description of the screenshot.
-    - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically. `base64` should be a PNG/JPEG data URI such as `data:image/png;base64,...`; a raw base64 body is also accepted and treated as PNG.
+    - `screenshots?: Array<{ base64: string; description?: string }>` - Record one or more provided screenshots under one report entry. When this option is set, Midscene will not capture another screenshot automatically. `base64` should be a PNG/JPEG/WebP data URI such as `data:image/webp;base64,...`; raw WebP base64 is detected by its signature, while other raw base64 bodies retain the existing PNG default.
 
 - Compatibility:
 

--- a/apps/site/docs/zh/api.mdx
+++ b/apps/site/docs/zh/api.mdx
@@ -1230,7 +1230,7 @@ interface RecordToReportOptions {
   screenshotBase64?: string;
   screenshots?: {
     /**
-     * PNG/JPEG data URI，或裸 PNG base64 body。
+     * PNG/JPEG/WebP data URI，或裸 PNG/WebP base64 body。
      */
     base64: string;
     description?: string;
@@ -1248,7 +1248,7 @@ function recordToReport(
   - `title?: string` - 可选，截图的标题，如果未提供，则标题为 'untitled'。
   - `options?: RecordToReportOptions` - 可选，一个配置对象，包含：
     - `content?: string` - 截图的描述。
-    - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。`base64` 推荐使用 PNG/JPEG data URI，例如 `data:image/png;base64,...`；也可以传裸 base64 body，此时会按 PNG 处理。
+    - `screenshots?: Array<{ base64: string; description?: string }>` - 在同一个报告条目下记录一张或多张传入的截图。设置该选项后，Midscene 不会再自动截图。`base64` 推荐使用 PNG/JPEG/WebP data URI，例如 `data:image/webp;base64,...`；裸 WebP base64 会通过文件签名识别，其他裸 base64 body 保持现有的 PNG 默认行为。
 
 - 兼容性：
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -31,6 +31,7 @@ import {
 } from '@midscene/shared/env';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import {
+  canonicalizeScreenshotBase64,
   createImgBase64ByFormat,
   validateScreenshotBuffer,
 } from '@midscene/shared/img';
@@ -518,7 +519,7 @@ ${Object.keys(size)
   /**
    * Continuous frame source backed by the scrcpy video stream.
    *
-   * Decoding H.264 to JPEG costs an ffmpeg process per frame (~100ms measured
+   * Decoding H.264 to WebP costs an ffmpeg process plus one Sharp encode per
    * on-device), so `latest()` hands out RAW keyframe handles (near-zero cost —
    * the stream is already flowing) and `decode()` pays the ffmpeg cost only
    * for the frames the observer actually sampled, at the end of the window.
@@ -551,7 +552,7 @@ ${Object.keys(size)
         const images: string[] = [];
         for (const frameRef of refs) {
           images.push(
-            await adapter.decodeRawKeyframeToJpegBase64(
+            await adapter.decodeRawKeyframeToWebpBase64(
               frameRef.ref as RawKeyframe,
             ),
           );
@@ -1269,9 +1270,8 @@ ${Object.keys(size)
     }
 
     debugDevice('Converting to base64');
-    const result = createImgBase64ByFormat(
-      'png',
-      screenshotBuffer.toString('base64'),
+    const result = await canonicalizeScreenshotBase64(
+      createImgBase64ByFormat('png', screenshotBuffer.toString('base64')),
     );
     if (localScreenshotPath) {
       debugDevice(`Deleting local screenshot: ${localScreenshotPath}`);

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -21,6 +21,7 @@ import {
   type DeviceFrameSource,
   type MobileInputPrimitives,
   type PointerPoint,
+  type ScreenshotCaptureOptions,
   createDefaultMobileActions,
   defineAction,
 } from '@midscene/core/device';
@@ -552,7 +553,7 @@ ${Object.keys(size)
         const images: string[] = [];
         for (const frameRef of refs) {
           images.push(
-            await adapter.decodeRawKeyframeToWebpBase64(
+            await adapter.decodeRawKeyframeToPngBase64(
               frameRef.ref as RawKeyframe,
             ),
           );
@@ -1131,7 +1132,7 @@ ${Object.keys(size)
     );
   }
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
     debugDevice('screenshotBase64 begin');
 
     // Try scrcpy mode first (if enabled and initialized)
@@ -1140,7 +1141,7 @@ ${Object.keys(size)
       try {
         debugDevice('Attempting scrcpy screenshot...');
         const deviceInfo = await this.getDevicePhysicalInfo();
-        const result = await adapter.screenshotBase64(deviceInfo);
+        const result = await adapter.screenshotBase64(deviceInfo, options);
         debugDevice('screenshotBase64 end (scrcpy mode)');
         return result;
       } catch (error) {
@@ -1270,9 +1271,13 @@ ${Object.keys(size)
     }
 
     debugDevice('Converting to base64');
-    const result = await canonicalizeScreenshotBase64(
-      createImgBase64ByFormat('png', screenshotBuffer.toString('base64')),
+    const png = createImgBase64ByFormat(
+      'png',
+      screenshotBuffer.toString('base64'),
     );
+    const result = options?.preferLossless
+      ? png
+      : await canonicalizeScreenshotBase64(png);
     if (localScreenshotPath) {
       debugDevice(`Deleting local screenshot: ${localScreenshotPath}`);
       unlink(localScreenshotPath, (unlinkError) => {

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -207,11 +207,11 @@ export class ScrcpyDeviceAdapter {
 
     try {
       const manager = await this.ensureManager(deviceInfo);
-      const screenshotBuffer = await manager.getScreenshotJpeg();
+      const screenshotBuffer = await manager.getScreenshotWebp();
       this.clearFailure();
 
       return createImgBase64ByFormat(
-        'jpeg',
+        'webp',
         screenshotBuffer.toString('base64'),
       );
     } catch (error) {
@@ -249,15 +249,15 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
-   * Decode a raw keyframe to a JPEG data URL. Deferred, per-frame-expensive
+   * Decode a raw keyframe to a WebP data URL. Deferred, per-frame-expensive
    * step (one ffmpeg process per call) — only call on sampled frames.
    */
-  async decodeRawKeyframeToJpegBase64(frame: RawKeyframe): Promise<string> {
+  async decodeRawKeyframeToWebpBase64(frame: RawKeyframe): Promise<string> {
     if (!this.manager) {
       throw new Error('scrcpy manager is not initialized');
     }
-    const jpegBuffer = await this.manager.decodeRawKeyframeToJpeg(frame);
-    return createImgBase64ByFormat('jpeg', jpegBuffer.toString('base64'));
+    const webpBuffer = await this.manager.decodeRawKeyframeToWebp(frame);
+    return createImgBase64ByFormat('webp', webpBuffer.toString('base64'));
   }
 
   /**

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -1,4 +1,5 @@
 import type { Size } from '@midscene/core';
+import type { ScreenshotCaptureOptions } from '@midscene/core/device';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { RawKeyframe, ScrcpyScreenshotManager } from './scrcpy-manager';
@@ -202,16 +203,22 @@ export class ScrcpyDeviceAdapter {
    * Take a screenshot via scrcpy, returns base64 string.
    * Throws on failure (caller should fallback to ADB).
    */
-  async screenshotBase64(deviceInfo: DevicePhysicalInfo): Promise<string> {
+  async screenshotBase64(
+    deviceInfo: DevicePhysicalInfo,
+    options?: ScreenshotCaptureOptions,
+  ): Promise<string> {
     this.ensureRetryReady();
 
     try {
       const manager = await this.ensureManager(deviceInfo);
-      const screenshotBuffer = await manager.getScreenshotWebp();
+      const format = options?.preferLossless ? 'png' : 'webp';
+      const screenshotBuffer = options?.preferLossless
+        ? await manager.getScreenshotPng()
+        : await manager.getScreenshotWebp();
       this.clearFailure();
 
       return createImgBase64ByFormat(
-        'webp',
+        format,
         screenshotBuffer.toString('base64'),
       );
     } catch (error) {
@@ -258,6 +265,15 @@ export class ScrcpyDeviceAdapter {
     }
     const webpBuffer = await this.manager.decodeRawKeyframeToWebp(frame);
     return createImgBase64ByFormat('webp', webpBuffer.toString('base64'));
+  }
+
+  /** Decode losslessly so Core can resize and perform the final WebP encode. */
+  async decodeRawKeyframeToPngBase64(frame: RawKeyframe): Promise<string> {
+    if (!this.manager) {
+      throw new Error('scrcpy manager is not initialized');
+    }
+    const pngBuffer = await this.manager.decodeRawKeyframeToPng(frame);
+    return createImgBase64ByFormat('png', pngBuffer.toString('base64'));
   }
 
   /**

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -50,7 +50,7 @@ export interface ScrcpyScreenshotOptions {
 
 /**
  * A raw (not yet decoded) H.264 keyframe emitted by the scrcpy stream.
- * Holding these is cheap — decoding to JPEG costs an ffmpeg run per frame, so
+ * Holding these is cheap — decoding to WebP costs an ffmpeg run per frame, so
  * consumers (e.g. UI observers) buffer raw keyframes and decode only
  * the frames they actually need, after sampling.
  */
@@ -465,7 +465,7 @@ export class ScrcpyScreenshotManager {
    * one subscriber is active, incoming keyframes keep resetting the idle timer
    * so the connection is not torn down mid-capture. Returns an unsubscribe fn.
    *
-   * Frames are emitted RAW (no decoding). Use {@link decodeRawKeyframeToJpeg}
+   * Frames are emitted RAW (no decoding). Use {@link decodeRawKeyframeToWebp}
    * on the frames you actually need — one ffmpeg run per unique frame.
    */
   subscribeKeyframes(listener: (frame: RawKeyframe) => void): () => void {
@@ -492,20 +492,20 @@ export class ScrcpyScreenshotManager {
 
   /**
    * Decode a raw keyframe (from {@link subscribeKeyframes} or
-   * {@link getLatestRawKeyframe}) to a JPEG buffer. This is the deferred,
+   * {@link getLatestRawKeyframe}) to a WebP buffer. This is the deferred,
    * per-frame-expensive step (one ffmpeg process per call) — call it only on
    * sampled frames, never inside a capture loop.
    */
-  async decodeRawKeyframeToJpeg(frame: RawKeyframe): Promise<Buffer> {
-    return this.decodeH264ToJpeg(Buffer.concat([frame.header, frame.data]));
+  async decodeRawKeyframeToWebp(frame: RawKeyframe): Promise<Buffer> {
+    return this.decodeH264ToWebp(Buffer.concat([frame.header, frame.data]));
   }
 
   /**
-   * Get screenshot as JPEG.
+   * Get screenshot as WebP.
    * Tries to get a fresh frame within a short timeout. If the screen is static
    * (no new frames arrive), falls back to the latest cached keyframe.
    */
-  async getScreenshotJpeg(): Promise<Buffer> {
+  async getScreenshotWebp(): Promise<Buffer> {
     const perfStart = Date.now();
 
     const t1 = Date.now();
@@ -542,7 +542,7 @@ export class ScrcpyScreenshotManager {
     );
 
     const t4 = Date.now();
-    const result = await this.decodeH264ToJpeg(keyframeBuffer);
+    const result = await this.decodeH264ToWebp(keyframeBuffer);
     const decodeTime = Date.now() - t4;
 
     const totalTime = Date.now() - perfStart;
@@ -662,10 +662,18 @@ export class ScrcpyScreenshotManager {
   }
 
   /**
-   * Decode H.264 data to JPEG using ffmpeg
+   * Decode H.264 to raw RGB with ffmpeg, then encode the selected frame once
+   * as WebP with Sharp. The bundled ffmpeg does not include libwebp.
    */
-  private async decodeH264ToJpeg(h264Buffer: Buffer): Promise<Buffer> {
+  private async decodeH264ToWebp(h264Buffer: Buffer): Promise<Buffer> {
     const { spawn } = await import('node:child_process');
+    const { default: sharp } = await import('sharp');
+    const resolution = this.videoResolution;
+    if (!resolution?.width || !resolution.height) {
+      throw new Error(
+        'Cannot decode scrcpy frame before video resolution is known',
+      );
+    }
 
     return new Promise((resolve, reject) => {
       const ffmpegArgs = [
@@ -676,11 +684,9 @@ export class ScrcpyScreenshotManager {
         '-vframes',
         '1',
         '-f',
-        'image2pipe',
-        '-vcodec',
-        'mjpeg',
-        '-q:v',
-        '5',
+        'rawvideo',
+        '-pix_fmt',
+        'rgb24',
         '-loglevel',
         'error',
         'pipe:1',
@@ -691,32 +697,68 @@ export class ScrcpyScreenshotManager {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
-      const chunks: Buffer[] = [];
       let stderrOutput = '';
+      let settled = false;
 
-      ffmpeg.stdout.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
+      const encoder = sharp({
+        raw: {
+          width: resolution.width,
+          height: resolution.height,
+          channels: 3,
+        },
+      }).webp({ quality: 90, effort: 1 });
+      // Resolve failures into a value immediately so an ffmpeg spawn/exit
+      // failure cannot leave Sharp with a temporarily unhandled rejection.
+      const encodedWebpResult = encoder.toBuffer().then(
+        (buffer) => ({ ok: true as const, buffer }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+      ffmpeg.stdout.pipe(encoder);
 
       ffmpeg.stderr.on('data', (data: Buffer) => {
         stderrOutput += data.toString();
       });
 
-      ffmpeg.on('close', (code) => {
-        if (code === 0 && chunks.length > 0) {
-          const jpegBuffer = Buffer.concat(chunks);
-          debugScrcpy(
-            `FFmpeg decode successful, JPEG size: ${jpegBuffer.length} bytes`,
-          );
-          resolve(jpegBuffer);
-        } else {
+      ffmpeg.on('close', async (code) => {
+        if (settled) return;
+        if (code !== 0) {
+          settled = true;
           const errorMsg = stderrOutput || `FFmpeg exited with code ${code}`;
           debugScrcpy(`FFmpeg decode failed: ${errorMsg}`);
-          reject(new Error(`H.264 to JPEG decode failed: ${errorMsg}`));
+          reject(new Error(`H.264 frame decode failed: ${errorMsg}`));
+          return;
+        }
+
+        try {
+          const encodeResult = await encodedWebpResult;
+          if (!encodeResult.ok) {
+            throw encodeResult.error;
+          }
+          const webpBuffer = encodeResult.buffer;
+          if (
+            webpBuffer.subarray(0, 4).toString('ascii') !== 'RIFF' ||
+            webpBuffer.subarray(8, 12).toString('ascii') !== 'WEBP'
+          ) {
+            throw new Error('Sharp returned invalid WebP bytes');
+          }
+          settled = true;
+          debugScrcpy(
+            `H.264 decode and WebP encode successful, WebP size: ${webpBuffer.length} bytes`,
+          );
+          resolve(webpBuffer);
+        } catch (error) {
+          settled = true;
+          reject(
+            new Error(
+              `H.264 to WebP encode failed: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          );
         }
       });
 
       ffmpeg.on('error', (error) => {
+        if (settled) return;
+        settled = true;
         reject(new Error(`Failed to spawn ffmpeg process: ${error.message}`));
       });
 

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -62,6 +62,8 @@ export interface RawKeyframe {
   capturedAt: number;
 }
 
+type ScrcpyScreenshotFormat = 'png' | 'webp';
+
 /**
  * Check if NAL unit type indicates a keyframe (IDR, SPS, or PPS)
  */
@@ -497,7 +499,17 @@ export class ScrcpyScreenshotManager {
    * sampled frames, never inside a capture loop.
    */
   async decodeRawKeyframeToWebp(frame: RawKeyframe): Promise<Buffer> {
-    return this.decodeH264ToWebp(Buffer.concat([frame.header, frame.data]));
+    return this.decodeH264ToImage(
+      Buffer.concat([frame.header, frame.data]),
+      'webp',
+    );
+  }
+
+  async decodeRawKeyframeToPng(frame: RawKeyframe): Promise<Buffer> {
+    return this.decodeH264ToImage(
+      Buffer.concat([frame.header, frame.data]),
+      'png',
+    );
   }
 
   /**
@@ -506,6 +518,15 @@ export class ScrcpyScreenshotManager {
    * (no new frames arrive), falls back to the latest cached keyframe.
    */
   async getScreenshotWebp(): Promise<Buffer> {
+    return this.getScreenshot('webp');
+  }
+
+  /** Lossless source for callers that will resize and WebP-encode in Core. */
+  async getScreenshotPng(): Promise<Buffer> {
+    return this.getScreenshot('png');
+  }
+
+  private async getScreenshot(format: ScrcpyScreenshotFormat): Promise<Buffer> {
     const perfStart = Date.now();
 
     const t1 = Date.now();
@@ -542,7 +563,7 @@ export class ScrcpyScreenshotManager {
     );
 
     const t4 = Date.now();
-    const result = await this.decodeH264ToWebp(keyframeBuffer);
+    const result = await this.decodeH264ToImage(keyframeBuffer, format);
     const decodeTime = Date.now() - t4;
 
     const totalTime = Date.now() - perfStart;
@@ -662,10 +683,14 @@ export class ScrcpyScreenshotManager {
   }
 
   /**
-   * Decode H.264 to raw RGB with ffmpeg, then encode the selected frame once
-   * as WebP with Sharp. The bundled ffmpeg does not include libwebp.
+   * Decode H.264 to raw RGB with ffmpeg, then encode the selected frame with
+   * Sharp. PNG is used only as a lossless handoff when Core will resize and
+   * perform the single final WebP encode.
    */
-  private async decodeH264ToWebp(h264Buffer: Buffer): Promise<Buffer> {
+  private async decodeH264ToImage(
+    h264Buffer: Buffer,
+    format: ScrcpyScreenshotFormat,
+  ): Promise<Buffer> {
     const { spawn } = await import('node:child_process');
     const { default: sharp } = await import('sharp');
     const resolution = this.videoResolution;
@@ -700,16 +725,20 @@ export class ScrcpyScreenshotManager {
       let stderrOutput = '';
       let settled = false;
 
-      const encoder = sharp({
+      const rawImage = sharp({
         raw: {
           width: resolution.width,
           height: resolution.height,
           channels: 3,
         },
-      }).webp({ quality: 90, effort: 1 });
+      });
+      const encoder =
+        format === 'webp'
+          ? rawImage.webp({ quality: 90, effort: 1 })
+          : rawImage.png({ compressionLevel: 1 });
       // Resolve failures into a value immediately so an ffmpeg spawn/exit
       // failure cannot leave Sharp with a temporarily unhandled rejection.
-      const encodedWebpResult = encoder.toBuffer().then(
+      const encodedImageResult = encoder.toBuffer().then(
         (buffer) => ({ ok: true as const, buffer }),
         (error: unknown) => ({ ok: false as const, error }),
       );
@@ -730,27 +759,33 @@ export class ScrcpyScreenshotManager {
         }
 
         try {
-          const encodeResult = await encodedWebpResult;
+          const encodeResult = await encodedImageResult;
           if (!encodeResult.ok) {
             throw encodeResult.error;
           }
-          const webpBuffer = encodeResult.buffer;
-          if (
-            webpBuffer.subarray(0, 4).toString('ascii') !== 'RIFF' ||
-            webpBuffer.subarray(8, 12).toString('ascii') !== 'WEBP'
-          ) {
-            throw new Error('Sharp returned invalid WebP bytes');
+          const imageBuffer = encodeResult.buffer;
+          const validOutput =
+            format === 'webp'
+              ? imageBuffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+                imageBuffer.subarray(8, 12).toString('ascii') === 'WEBP'
+              : imageBuffer.length >= 8 &&
+                imageBuffer[0] === 0x89 &&
+                imageBuffer.subarray(1, 4).toString('ascii') === 'PNG';
+          if (!validOutput) {
+            throw new Error(
+              `Sharp returned invalid ${format.toUpperCase()} bytes`,
+            );
           }
           settled = true;
           debugScrcpy(
-            `H.264 decode and WebP encode successful, WebP size: ${webpBuffer.length} bytes`,
+            `H.264 decode and ${format.toUpperCase()} encode successful, size: ${imageBuffer.length} bytes`,
           );
-          resolve(webpBuffer);
+          resolve(imageBuffer);
         } catch (error) {
           settled = true;
           reject(
             new Error(
-              `H.264 to WebP encode failed: ${error instanceof Error ? error.message : String(error)}`,
+              `H.264 to ${format.toUpperCase()} encode failed: ${error instanceof Error ? error.message : String(error)}`,
             ),
           );
         }

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -386,7 +386,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       'settings-search-attempt-1.xml',
     );
     const finalXmlFile = path.join(diagnosticsDir, 'settings-final.xml');
-    const screenshotFile = path.join(diagnosticsDir, 'settings-search.png');
+    const screenshotFile = path.join(diagnosticsDir, 'settings-search.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -434,6 +434,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const logicalSize = await device.size();
       const screenshot = await device.screenshotBase64();
       const screenshotSize = await imageInfoOfBase64(screenshot);
+      expect(screenshot).toMatch(/^data:image\/webp;base64,/);
       const density = await adb.getScreenDensity();
       evidence.device = {
         id: devices[0].udid,
@@ -525,6 +526,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       evidence.keyboardShownBeforeBack = await waitForKeyboardState(adb, true);
 
       const searchScreenshot = await device.screenshotBase64();
+      expect(searchScreenshot).toMatch(/^data:image\/webp;base64,/);
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
 
       await agent.back();

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -256,14 +256,13 @@ describe('Test todo list', () => {
         const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
         await mkdir(resolvedDiagnosticsDir, { recursive: true });
         await Promise.all([
-          agent.interface
-            .screenshotBase64()
-            .then((base64) =>
-              writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
-                screenshotBuffer(base64),
-              ),
-            ),
+          agent.interface.screenshotBase64().then((base64) => {
+            expect(base64).toMatch(/^data:image\/webp;base64,/);
+            return writeFile(
+              path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
+              screenshotBuffer(base64),
+            );
+          }),
           writeFile(
             path.join(resolvedDiagnosticsDir, 'todo-agent-dump.json'),
             `${agent.dumpDataString()}\n`,

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -117,7 +117,7 @@ describe('AndroidDevice frame-source capability', () => {
         listener = cb;
         return unsubscribe;
       }),
-      decodeRawKeyframeToJpegBase64: decode,
+      decodeRawKeyframeToWebpBase64: decode,
     };
     (device as any).getDevicePhysicalInfo = vi.fn().mockResolvedValue({});
 

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -117,7 +117,7 @@ describe('AndroidDevice frame-source capability', () => {
         listener = cb;
         return unsubscribe;
       }),
-      decodeRawKeyframeToWebpBase64: decode,
+      decodeRawKeyframeToPngBase64: decode,
     };
     (device as any).getDevicePhysicalInfo = vi.fn().mockResolvedValue({});
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -108,6 +108,7 @@ vi.mock('@midscene/shared/img', async (importOriginal) => {
     });
   return {
     ...original,
+    canonicalizeScreenshotBase64: vi.fn(),
     createImgBase64ByFormat: vi.fn(),
     resizeAndConvertImgBuffer: vi.fn(),
     validateScreenshotBuffer,
@@ -546,6 +547,9 @@ Stdout:
           format,
         }),
       );
+      vi.mocked(ImgUtils.canonicalizeScreenshotBase64).mockImplementation(
+        async (dataUrl) => dataUrl.replace('image/png', 'image/webp'),
+      );
     });
 
     it('should take screenshot successfully with takeScreenshot', async () => {
@@ -558,6 +562,7 @@ Stdout:
       );
 
       const result = await device.screenshotBase64();
+      expect(result).toContain('data:image/webp;base64,');
       expect(result).toContain(mockBuffer.toString('base64'));
       expect(mockAdb.shell).not.toHaveBeenCalled();
     });
@@ -581,6 +586,7 @@ Stdout:
       expect(mockAdb.pull).toHaveBeenCalled();
       expect(fs.promises.readFile).toHaveBeenCalled();
       expect(result).toContain(mockBuffer.toString('base64'));
+      expect(result).toContain('data:image/webp;base64,');
       // rm is now executed via execFile (fire-and-forget), not adb.shell
     });
 
@@ -601,6 +607,7 @@ Stdout:
       const result = await defaultDevice.screenshotBase64();
 
       expect(result).toContain(smallValidPng.toString('base64'));
+      expect(result).toContain('data:image/webp;base64,');
       expect(mockAdb.pull).toHaveBeenCalled();
     });
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -567,6 +567,21 @@ Stdout:
       expect(mockAdb.shell).not.toHaveBeenCalled();
     });
 
+    it('should return the native PNG source when Core will resize it', async () => {
+      const mockBuffer = createValidPngBuffer();
+      mockAdb.takeScreenshot.mockResolvedValue(mockBuffer);
+      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+        `data:image/png;base64,${mockBuffer.toString('base64')}`,
+      );
+
+      const result = await device.screenshotBase64({ preferLossless: true });
+
+      expect(result).toBe(
+        `data:image/png;base64,${mockBuffer.toString('base64')}`,
+      );
+      expect(ImgUtils.canonicalizeScreenshotBase64).not.toHaveBeenCalled();
+    });
+
     it('should fall back to screencap and pull if takeScreenshot fails', async () => {
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
       const mockBuffer = createValidPngBuffer();

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -24,7 +24,8 @@ const createMockManager = () => ({
   validateEnvironment: vi.fn().mockResolvedValue(undefined),
   ensureConnected: vi.fn().mockResolvedValue(undefined),
   isConnected: vi.fn().mockReturnValue(false),
-  getScreenshotJpeg: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+  getScreenshotWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
+  decodeRawKeyframeToWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
   getResolution: vi.fn().mockReturnValue(null),
   disconnect: vi.fn().mockResolvedValue(undefined),
 });
@@ -44,7 +45,7 @@ vi.mock('../../src/scrcpy-manager', async (importOriginal) => {
 vi.mock('@midscene/shared/img', () => ({
   createImgBase64ByFormat: vi
     .fn()
-    .mockReturnValue('data:image/png;base64,test'),
+    .mockReturnValue('data:image/webp;base64,test'),
 }));
 
 const defaultDeviceInfo: DevicePhysicalInfo = {
@@ -336,8 +337,25 @@ describe('ScrcpyDeviceAdapter', () => {
       (adapter as any).manager = currentMockManager;
 
       const result = await adapter.screenshotBase64(defaultDeviceInfo);
-      expect(result).toBe('data:image/png;base64,test');
-      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(1);
+      expect(result).toBe('data:image/webp;base64,test');
+      expect(currentMockManager.getScreenshotWebp).toHaveBeenCalledTimes(1);
+    });
+
+    it('decodes sampled H.264 keyframes directly to WebP data URLs', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', undefined);
+      (adapter as any).manager = currentMockManager;
+      const frame = {
+        header: Buffer.from([0x67]),
+        data: Buffer.from([0x65]),
+        capturedAt: 123,
+      };
+
+      await expect(adapter.decodeRawKeyframeToWebpBase64(frame)).resolves.toBe(
+        'data:image/webp;base64,test',
+      );
+      expect(currentMockManager.decodeRawKeyframeToWebp).toHaveBeenCalledWith(
+        frame,
+      );
     });
   });
 
@@ -407,13 +425,13 @@ describe('ScrcpyDeviceAdapter', () => {
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
         /retry is cooling down/,
       );
-      expect(currentMockManager.getScreenshotJpeg).not.toHaveBeenCalled();
+      expect(currentMockManager.getScreenshotWebp).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(60_000);
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
-        'data:image/png;base64,test',
+        'data:image/webp;base64,test',
       );
-      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(1);
+      expect(currentMockManager.getScreenshotWebp).toHaveBeenCalledTimes(1);
       expect(adapter.getStatus().lastError).toBeNull();
     });
   });

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -25,7 +25,9 @@ const createMockManager = () => ({
   ensureConnected: vi.fn().mockResolvedValue(undefined),
   isConnected: vi.fn().mockReturnValue(false),
   getScreenshotWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
+  getScreenshotPng: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
   decodeRawKeyframeToWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
+  decodeRawKeyframeToPng: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
   getResolution: vi.fn().mockReturnValue(null),
   disconnect: vi.fn().mockResolvedValue(undefined),
 });
@@ -45,7 +47,7 @@ vi.mock('../../src/scrcpy-manager', async (importOriginal) => {
 vi.mock('@midscene/shared/img', () => ({
   createImgBase64ByFormat: vi
     .fn()
-    .mockReturnValue('data:image/webp;base64,test'),
+    .mockImplementation((format: string) => `data:image/${format};base64,test`),
 }));
 
 const defaultDeviceInfo: DevicePhysicalInfo = {
@@ -341,6 +343,19 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.getScreenshotWebp).toHaveBeenCalledTimes(1);
     });
 
+    it('should return a PNG source when Core will resize the screenshot', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', undefined);
+      (adapter as any).manager = currentMockManager;
+
+      const result = await adapter.screenshotBase64(defaultDeviceInfo, {
+        preferLossless: true,
+      });
+
+      expect(result).toBe('data:image/png;base64,test');
+      expect(currentMockManager.getScreenshotPng).toHaveBeenCalledTimes(1);
+      expect(currentMockManager.getScreenshotWebp).not.toHaveBeenCalled();
+    });
+
     it('decodes sampled H.264 keyframes directly to WebP data URLs', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', undefined);
       (adapter as any).manager = currentMockManager;
@@ -354,6 +369,23 @@ describe('ScrcpyDeviceAdapter', () => {
         'data:image/webp;base64,test',
       );
       expect(currentMockManager.decodeRawKeyframeToWebp).toHaveBeenCalledWith(
+        frame,
+      );
+    });
+
+    it('decodes sampled H.264 keyframes losslessly for Core finalization', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', undefined);
+      (adapter as any).manager = currentMockManager;
+      const frame = {
+        header: Buffer.from([0x67]),
+        data: Buffer.from([0x65]),
+        capturedAt: 123,
+      };
+
+      await expect(adapter.decodeRawKeyframeToPngBase64(frame)).resolves.toBe(
+        'data:image/png;base64,test',
+      );
+      expect(currentMockManager.decodeRawKeyframeToPng).toHaveBeenCalledWith(
         frame,
       );
     });

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -106,6 +106,52 @@ describe('ScrcpyScreenshotManager', () => {
     });
   });
 
+  describe('screenshot output formats', () => {
+    it('routes regular screenshots through the WebP encoder', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const getScreenshot = vi
+        .spyOn(manager as any, 'getScreenshot')
+        .mockResolvedValue(Buffer.from('webp'));
+
+      await expect(manager.getScreenshotWebp()).resolves.toEqual(
+        Buffer.from('webp'),
+      );
+      expect(getScreenshot).toHaveBeenCalledWith('webp');
+    });
+
+    it('routes post-processing sources through the PNG encoder', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const getScreenshot = vi
+        .spyOn(manager as any, 'getScreenshot')
+        .mockResolvedValue(Buffer.from('png'));
+
+      await expect(manager.getScreenshotPng()).resolves.toEqual(
+        Buffer.from('png'),
+      );
+      expect(getScreenshot).toHaveBeenCalledWith('png');
+    });
+
+    it('decodes observed keyframes to PNG for Core finalization', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      const decode = vi
+        .spyOn(manager as any, 'decodeH264ToImage')
+        .mockResolvedValue(Buffer.from('png'));
+      const frame = {
+        header: Buffer.from([0x67]),
+        data: Buffer.from([0x65]),
+        capturedAt: 123,
+      };
+
+      await expect(manager.decodeRawKeyframeToPng(frame)).resolves.toEqual(
+        Buffer.from('png'),
+      );
+      expect(decode).toHaveBeenCalledWith(
+        Buffer.concat([frame.header, frame.data]),
+        'png',
+      );
+    });
+  });
+
   describe('isConnected', () => {
     it('should return false initially', () => {
       const manager = new ScrcpyScreenshotManager({} as any);

--- a/packages/computer/package.json
+++ b/packages/computer/package.json
@@ -47,6 +47,7 @@
     "@types/node": "^18.0.0",
     "@types/screenshot-desktop": "1.15.0",
     "dotenv": "^16.4.5",
+    "sharp": "^0.34.3",
     "tsx": "^4.19.2",
     "typescript": "^5.8.3",
     "vitest": "3.0.5"

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -16,7 +16,10 @@ import {
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
+import {
+  canonicalizeScreenshotBase64,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import screenshot from 'screenshot-desktop';
 import {
@@ -1156,7 +1159,9 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
         if (attempt > 1) {
           debugDevice(`Screenshot succeeded on attempt ${attempt}`);
         }
-        return createImgBase64ByFormat('png', buffer.toString('base64'));
+        return canonicalizeScreenshotBase64(
+          createImgBase64ByFormat('png', buffer.toString('base64')),
+        );
       } catch (error) {
         lastRawMessage = error instanceof Error ? error.message : String(error);
         const isMacTransient =
@@ -1208,7 +1213,7 @@ Original error: ${lastRawMessage}`,
    * separate Windows concern to be addressed in a follow-up with real-device
    * verification.
    */
-  private screenshotViaPowershell(): string {
+  private async screenshotViaPowershell(): Promise<string> {
     const deviceName = this.displayId ? String(this.displayId) : '';
     // A requested displayId that cannot be matched (stale saved id, unplugged
     // monitor) must fail fast rather than silently capturing the primary
@@ -1247,7 +1252,7 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
         'Failed to take screenshot on Windows: PowerShell returned no image data',
       );
     }
-    return createImgBase64ByFormat('png', body);
+    return canonicalizeScreenshotBase64(createImgBase64ByFormat('png', body));
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -12,6 +12,7 @@ import type {
 import {
   type AbstractInterface,
   type ComputerInputPrimitives,
+  type ScreenshotCaptureOptions,
   defineAction,
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
@@ -1108,7 +1109,7 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     return this.adminCheckCache;
   }
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
     if (this.destroyed) {
       throw new Error('ComputerDevice has been destroyed');
     }
@@ -1123,10 +1124,10 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     // virtual-desktop coordinates, so it captures any monitor (including
     // secondary displays at negative offsets) without csc/.bat/.NET source.
     if (process.platform === 'win32') {
-      return this.screenshotViaPowershell();
+      return this.screenshotViaPowershell(options);
     }
 
-    const options: ScreenshotOptions = { format: 'png' };
+    const screenshotOptions: ScreenshotOptions = { format: 'png' };
     if (this.displayId !== undefined) {
       // On macOS: displayId is screenshot-desktop's screen index.
       // On Windows: displayId is string like "\\.\DISPLAY1"
@@ -1134,14 +1135,14 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
       if (process.platform === 'darwin') {
         const screenIndex = Number(this.displayId);
         if (!Number.isNaN(screenIndex)) {
-          options.screen = screenIndex;
+          screenshotOptions.screen = screenIndex;
         }
       } else {
         // Windows and Linux use string IDs directly
-        options.screen = this.displayId;
+        screenshotOptions.screen = this.displayId;
       }
     }
-    debugDevice('Screenshot options', options);
+    debugDevice('Screenshot options', screenshotOptions);
 
     // macOS `screencapture` returns "could not create image from display"
     // both for missing TCC Screen Recording permission AND for transient
@@ -1155,13 +1156,14 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
     let lastRawMessage = '';
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
-        const buffer: Buffer = await screenshot(options);
+        const buffer: Buffer = await screenshot(screenshotOptions);
         if (attempt > 1) {
           debugDevice(`Screenshot succeeded on attempt ${attempt}`);
         }
-        return canonicalizeScreenshotBase64(
-          createImgBase64ByFormat('png', buffer.toString('base64')),
-        );
+        const png = createImgBase64ByFormat('png', buffer.toString('base64'));
+        return options?.preferLossless
+          ? png
+          : canonicalizeScreenshotBase64(png);
       } catch (error) {
         lastRawMessage = error instanceof Error ? error.message : String(error);
         const isMacTransient =
@@ -1213,7 +1215,9 @@ Original error: ${lastRawMessage}`,
    * separate Windows concern to be addressed in a follow-up with real-device
    * verification.
    */
-  private async screenshotViaPowershell(): Promise<string> {
+  private async screenshotViaPowershell(
+    options?: ScreenshotCaptureOptions,
+  ): Promise<string> {
     const deviceName = this.displayId ? String(this.displayId) : '';
     // A requested displayId that cannot be matched (stale saved id, unplugged
     // monitor) must fail fast rather than silently capturing the primary
@@ -1252,7 +1256,8 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
         'Failed to take screenshot on Windows: PowerShell returned no image data',
       );
     }
-    return canonicalizeScreenshotBase64(createImgBase64ByFormat('png', body));
+    const png = createImgBase64ByFormat('png', body);
+    return options?.preferLossless ? png : canonicalizeScreenshotBase64(png);
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/src/rdp/device.ts
+++ b/packages/computer/src/rdp/device.ts
@@ -12,6 +12,7 @@ import {
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
+import { canonicalizeScreenshotBase64 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { ComputerDeviceInputOpt, DisplayInfo } from '../device';
 import {
@@ -258,7 +259,9 @@ export class RDPDevice implements AbstractInterface {
 
   async screenshotBase64(): Promise<string> {
     this.assertConnected();
-    return this.backend.screenshotBase64();
+    return canonicalizeScreenshotBase64(await this.backend.screenshotBase64(), {
+      preserveJpeg: true,
+    });
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/src/rdp/device.ts
+++ b/packages/computer/src/rdp/device.ts
@@ -8,6 +8,7 @@ import type {
 import {
   type AbstractInterface,
   type ComputerInputPrimitives,
+  type ScreenshotCaptureOptions,
   defineAction,
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
@@ -257,11 +258,12 @@ export class RDPDevice implements AbstractInterface {
     ];
   }
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
     this.assertConnected();
-    return canonicalizeScreenshotBase64(await this.backend.screenshotBase64(), {
-      preserveJpeg: true,
-    });
+    const source = await this.backend.screenshotBase64();
+    return options?.preferLossless
+      ? source
+      : canonicalizeScreenshotBase64(source);
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/tests/ai/ai-auto-todo.test.ts
+++ b/packages/computer/tests/ai/ai-auto-todo.test.ts
@@ -75,7 +75,7 @@ describe('computer todo app automation', () => {
             .screenshotBase64()
             .then((base64) =>
               writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
+                path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
                 screenshotBuffer(base64),
               ),
             ),

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -8,8 +8,6 @@ final class FlippedDocumentView: NSView {
 
 @MainActor
 final class SmokeButton: NSButton {
-  var onMouseDown: (() -> Void)?
-
   // AppKit normally consumes the first click while a programmatically
   // activated application is still transitioning to the foreground. The
   // hosted macOS runner can remain in that transition even after System
@@ -17,11 +15,6 @@ final class SmokeButton: NSButton {
   // keeps this fixture focused on whether the global mouse event arrived.
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
     true
-  }
-
-  override func mouseDown(with event: NSEvent) {
-    onMouseDown?()
-    super.mouseDown(with: event)
   }
 }
 
@@ -42,9 +35,14 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var textField: SmokeTextField!
   private var scrollView: NSScrollView!
   private var activationSource: DispatchSourceSignal?
+  private var pointerMonitor: DispatchSourceTimer?
+  private var leftButtonWasDown = false
 
   private var activationCount = 0
   private var inputReadyGeneration = 0
+  private var pointerDownCount = 0
+  private var lastPointerX: CGFloat = -1
+  private var lastPointerY: CGFloat = -1
   private var clickCount = 0
   private var buttonActionCount = 0
   private var textChangeCount = 0
@@ -92,11 +90,6 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     button.layer?.cornerRadius = 6
     button.contentTintColor = .black
     window.contentView?.addSubview(button)
-    button.onMouseDown = { [weak self] in
-      guard let self else { return }
-      self.clickCount += 1
-      self.writeState()
-    }
 
     textField = SmokeTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
     textField.placeholderString = "Type smoke text"
@@ -125,6 +118,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     window.contentView?.addSubview(scrollView)
 
     installActivationSignal()
+    installPointerMonitor()
     activateFixture()
     writeState()
   }
@@ -209,6 +203,40 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     }
     source.resume()
     activationSource = source
+  }
+
+  private func installPointerMonitor() {
+    // GitHub-hosted AppKit sessions can drop control dispatch even when the
+    // fixture is frontmost. Sample the combined session while Midscene holds
+    // the button for 100 ms so the smoke still proves a real targeted press.
+    let source = DispatchSource.makeTimerSource(queue: .main)
+    source.schedule(deadline: .now(), repeating: .milliseconds(10))
+    source.setEventHandler { [weak self] in
+      self?.samplePointerState()
+    }
+    source.resume()
+    pointerMonitor = source
+  }
+
+  private func samplePointerState() {
+    let leftButtonIsDown = CGEventSource.buttonState(
+      .combinedSessionState,
+      button: .left
+    )
+    defer { leftButtonWasDown = leftButtonIsDown }
+    guard leftButtonIsDown && !leftButtonWasDown else { return }
+
+    let pointerLocation = NSEvent.mouseLocation
+    pointerDownCount += 1
+    lastPointerX = pointerLocation.x
+    lastPointerY = pointerLocation.y
+
+    let buttonWindowRect = button.convert(button.bounds, to: nil)
+    let buttonScreenRect = window.convertToScreen(buttonWindowRect)
+    if buttonScreenRect.contains(pointerLocation) {
+      clickCount += 1
+    }
+    writeState()
   }
 
   private func installMainMenu() {
@@ -299,6 +327,9 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
         "keyWindow": window.isKeyWindow,
         "activationCount": activationCount,
         "inputReadyGeneration": inputReadyGeneration,
+        "pointerDownCount": pointerDownCount,
+        "lastPointerX": lastPointerX,
+        "lastPointerY": lastPointerY,
         "clickCount": clickCount,
         "buttonActionCount": buttonActionCount,
         "textChangeCount": textChangeCount,

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -156,22 +156,27 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private func activateFixture() {
     activationCount += 1
     let activation = activationCount
-    NSApplication.shared.unhide(nil)
-    NSApplication.shared.activate(ignoringOtherApps: true)
-    NSRunningApplication.current.activate(options: [.activateAllWindows])
+    focusFixture()
     writeState()
 
-    // Present the window on the next AppKit turn, after the activation request
-    // has reached the application. A readiness generation is published only
-    // after AppKit itself reports a visible key window; callers synchronize on
-    // that generation instead of sleeping for an arbitrary duration.
-    DispatchQueue.main.async { [weak self] in
+    // Hosted macOS sessions can report the app as active before the first
+    // activation request has settled. Repeat the complete focus sequence on a
+    // later AppKit turn, then publish readiness only after the window is key.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
       guard let self else { return }
-      self.window.orderFrontRegardless()
-      self.window.makeKeyAndOrderFront(nil)
-      self.window.makeFirstResponder(self.textField)
+      guard activation == self.activationCount else { return }
+      self.focusFixture()
       self.publishInputReady(for: activation, attemptsRemaining: 40)
     }
+  }
+
+  private func focusFixture() {
+    NSApplication.shared.unhide(nil)
+    window.orderFrontRegardless()
+    window.makeKeyAndOrderFront(nil)
+    NSApplication.shared.activate(ignoringOtherApps: true)
+    NSRunningApplication.current.activate(options: [.activateAllWindows])
+    window.makeFirstResponder(textField)
   }
 
   private func publishInputReady(for activation: Int, attemptsRemaining: Int) {

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -72,6 +72,9 @@ interface FixtureState {
   keyWindow: boolean;
   activationCount: number;
   inputReadyGeneration: number;
+  pointerDownCount: number;
+  lastPointerX: number;
+  lastPointerY: number;
   clickCount: number;
   buttonActionCount: number;
   textChangeCount: number;
@@ -168,6 +171,12 @@ function normalizeState(value: unknown): FixtureState {
       raw.inputReadyGeneration,
       'state.inputReadyGeneration',
     ),
+    pointerDownCount: asFiniteNumber(
+      raw.pointerDownCount,
+      'state.pointerDownCount',
+    ),
+    lastPointerX: asFiniteNumber(raw.lastPointerX, 'state.lastPointerX'),
+    lastPointerY: asFiniteNumber(raw.lastPointerY, 'state.lastPointerY'),
     clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
     buttonActionCount: asFiniteNumber(
       raw.buttonActionCount,

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -279,11 +279,21 @@ async function retryFixtureAction(options: {
         ACTIVATION_TIMEOUT_MS,
         options.fixtureProcess,
       );
-      // AppKit can keep the fixture active and visible while declining to make
-      // its window key again. The real action result is the reliable readiness
-      // probe, so let each retry invoke the action instead of consuming an
-      // attempt at this precondition.
-      await sleep(250);
+      // Prefer AppKit's durable input-readiness signal and act as soon as it is
+      // published. If AppKit declines to make the window key, still invoke the
+      // action so the real result remains the final readiness probe.
+      try {
+        await waitForJson(
+          options.stateFile,
+          normalizeState,
+          (state) =>
+            state.inputReadyGeneration > beforeActivation.inputReadyGeneration,
+          ACTIVATION_TIMEOUT_MS,
+          options.fixtureProcess,
+        );
+      } catch {
+        // Fall through to the action-based readiness probe.
+      }
       await options.action();
       const state = await waitForJson(
         options.stateFile,

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -421,7 +421,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
     const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
     const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
     const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
-    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -545,6 +545,8 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       );
       const screenshotBuffer = Buffer.from(base64Body(screenshot), 'base64');
       await writeFile(screenshotFile, screenshotBuffer);
+      expect(screenshotBuffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(screenshotBuffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
       evidence.screenshot = {
         ...screenshotInfo,
         scale: screenshotScale,

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -411,7 +411,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
     const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
     const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
     const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
-    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -533,9 +533,8 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
         width: metadata.screen.width,
         height: metadata.screen.height,
       });
-      expect(screenshotBuffer.subarray(0, 8)).toEqual(
-        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      );
+      expect(screenshotBuffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(screenshotBuffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
 
       const screenshotAnalysis = await analyzeScreenshot(
         screenshotFile,

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -1,5 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
-import { execFile, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parseDumpScript } from '@midscene/core';
@@ -266,38 +266,8 @@ function base64Body(dataUrl: string): string {
   return dataUrl.slice(commaIndex + 1);
 }
 
-function quotePowerShellSingle(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function runPowerShell(script: string): Promise<string> {
-  const encoded = Buffer.from(
-    `$ErrorActionPreference = 'Stop'\n${script}`,
-    'utf16le',
-  ).toString('base64');
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
-      { encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(
-            new Error(
-              `PowerShell screenshot analysis failed: ${error.message}\n${stderr}`,
-            ),
-          );
-          return;
-        }
-        resolve(stdout.trim());
-      },
-    );
-  });
-}
-
 async function analyzeScreenshot(
-  screenshotPath: string,
+  screenshotBuffer: Buffer,
   button: Bounds,
   form: Bounds,
   screen: Bounds,
@@ -310,34 +280,45 @@ async function analyzeScreenshot(
     localForm.left + localForm.width - backgroundSize - 12,
   );
   const backgroundTop = Math.max(localForm.top + 2, localForm.top + 42);
-
-  const script = `
-Add-Type -AssemblyName System.Drawing
-$bitmap = [System.Drawing.Bitmap]::FromFile(${quotePowerShellSingle(screenshotPath)})
-function Get-AverageColor([int] $left, [int] $top, [int] $width, [int] $height) {
-  $red = 0L; $green = 0L; $blue = 0L; $count = 0L
-  $stepX = [Math]::Max(1, [Math]::Floor($width / 7))
-  $stepY = [Math]::Max(1, [Math]::Floor($height / 7))
-  for ($x = $left; $x -lt ($left + $width); $x += $stepX) {
-    for ($y = $top; $y -lt ($top + $height); $y += $stepY) {
-      $pixel = $bitmap.GetPixel($x, $y)
-      $red += $pixel.R; $green += $pixel.G; $blue += $pixel.B; $count += 1
-    }
-  }
-  [PSCustomObject]@{
-    r = [Math]::Round($red / $count)
-    g = [Math]::Round($green / $count)
-    b = [Math]::Round($blue / $count)
-  }
-}
-$target = Get-AverageColor ${Math.round(target.left + 7)} ${Math.round(target.top + 7)} ${Math.max(1, Math.round(target.width - 14))} ${Math.max(1, Math.round(target.height - 14))}
-$background = Get-AverageColor ${Math.round(backgroundLeft)} ${Math.round(backgroundTop)} ${backgroundSize} ${backgroundSize}
-$difference = [Math]::Abs($target.r - $background.r) + [Math]::Abs($target.g - $background.g) + [Math]::Abs($target.b - $background.b)
-[PSCustomObject]@{ target = $target; background = $background; channelDifference = $difference } | ConvertTo-Json -Compress
-$bitmap.Dispose()
-`.trim();
-
-  return JSON.parse(await runPowerShell(script)) as ScreenshotAnalysis;
+  const { default: sharp } = await import('sharp');
+  const averageColor = async (bounds: Bounds) => {
+    const cropped = await sharp(screenshotBuffer)
+      .extract({
+        left: Math.round(bounds.left),
+        top: Math.round(bounds.top),
+        width: Math.max(1, Math.round(bounds.width)),
+        height: Math.max(1, Math.round(bounds.height)),
+      })
+      .toBuffer();
+    const stats = await sharp(cropped).stats();
+    return {
+      r: Math.round(stats.channels[0].mean),
+      g: Math.round(stats.channels[1].mean),
+      b: Math.round(stats.channels[2].mean),
+    };
+  };
+  const [targetColor, backgroundColor] = await Promise.all([
+    averageColor({
+      left: target.left + 7,
+      top: target.top + 7,
+      width: target.width - 14,
+      height: target.height - 14,
+    }),
+    averageColor({
+      left: backgroundLeft,
+      top: backgroundTop,
+      width: backgroundSize,
+      height: backgroundSize,
+    }),
+  ]);
+  return {
+    target: targetColor,
+    background: backgroundColor,
+    channelDifference:
+      Math.abs(targetColor.r - backgroundColor.r) +
+      Math.abs(targetColor.g - backgroundColor.g) +
+      Math.abs(targetColor.b - backgroundColor.b),
+  };
 }
 
 function parseReportDumps(html: string): ReportDump[] {
@@ -396,6 +377,47 @@ async function stopFixture(
   fixtureProcess.kill();
   await Promise.race([exitPromise, sleep(5_000)]);
 }
+
+describe('WebP screenshot analysis', () => {
+  it('decodes WebP evidence without relying on System.Drawing', async () => {
+    const { default: sharp } = await import('sharp');
+    const screenshotBuffer = await sharp({
+      create: {
+        width: 100,
+        height: 100,
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    })
+      .composite([
+        {
+          input: {
+            create: {
+              width: 30,
+              height: 30,
+              channels: 3,
+              background: { r: 0, g: 255, b: 0 },
+            },
+          },
+          left: 10,
+          top: 10,
+        },
+      ])
+      .webp({ quality: 90 })
+      .toBuffer();
+
+    const analysis = await analyzeScreenshot(
+      screenshotBuffer,
+      { left: 10, top: 10, width: 30, height: 30 },
+      { left: 0, top: 0, width: 100, height: 100 },
+      { left: 0, top: 0, width: 100, height: 100 },
+    );
+
+    expect(analysis.target.g - analysis.target.r).toBeGreaterThan(200);
+    expect(analysis.target.g - analysis.target.b).toBeGreaterThan(200);
+    expect(analysis.channelDifference).toBeGreaterThan(400);
+  });
+});
 
 describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
   it('drives a visible WinForms app without calling a model and emits evidence', async () => {
@@ -537,7 +559,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
       expect(screenshotBuffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
 
       const screenshotAnalysis = await analyzeScreenshot(
-        screenshotFile,
+        screenshotBuffer,
         metadata.button,
         metadata.form,
         metadata.screen,

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -110,6 +110,14 @@ vi.mock('node:module', () => ({
   createRequire: mockState.createRequire,
 }));
 
+vi.mock('@midscene/shared/img', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@midscene/shared/img')>()),
+  canonicalizeScreenshotBase64: vi.fn(
+    async () =>
+      'data:image/webp;base64,UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=',
+  ),
+}));
+
 const originalPlatform = process.platform;
 const mockExecutorContext = { task: {} } as ExecutorContext;
 

--- a/packages/computer/tests/unit-test/rdp/agent.test.ts
+++ b/packages/computer/tests/unit-test/rdp/agent.test.ts
@@ -15,6 +15,9 @@ import type {
 } from '../../../src';
 import { formatRdpServerAddress } from '../../../src/rdp/address';
 
+const VALID_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
 class FakeRDPBackend implements RDPBackendClient {
   calls: Array<{ name: string; args: unknown[] }> = [];
 
@@ -33,7 +36,7 @@ class FakeRDPBackend implements RDPBackendClient {
 
   async screenshotBase64(): Promise<string> {
     this.calls.push({ name: 'screenshotBase64', args: [] });
-    return 'data:image/png;base64,ZmFrZQ==';
+    return `data:image/png;base64,${VALID_PNG_BASE64}`;
   }
 
   async size(): Promise<Size> {
@@ -93,6 +96,16 @@ function createLocate(
 }
 
 describe('@midscene/computer RDP device', () => {
+  it('converts backend PNG screenshots to WebP', async () => {
+    const backend = new FakeRDPBackend();
+    const device = new RDPDevice({ host: '10.0.0.1', backend });
+    await device.connect();
+
+    await expect(device.screenshotBase64()).resolves.toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
+  });
+
   it('connects and exposes the RDP device through agentForRDPComputer', async () => {
     const backend = new FakeRDPBackend();
     const agent = await agentForRDPComputer({

--- a/packages/computer/tests/unit-test/rdp/agent.test.ts
+++ b/packages/computer/tests/unit-test/rdp/agent.test.ts
@@ -106,6 +106,16 @@ describe('@midscene/computer RDP device', () => {
     );
   });
 
+  it('returns the backend PNG source when Core will resize it', async () => {
+    const backend = new FakeRDPBackend();
+    const device = new RDPDevice({ host: '10.0.0.1', backend });
+    await device.connect();
+
+    await expect(
+      device.screenshotBase64({ preferLossless: true }),
+    ).resolves.toBe(`data:image/png;base64,${VALID_PNG_BASE64}`);
+  });
+
   it('connects and exposes the RDP device through agentForRDPComputer', async () => {
     const backend = new FakeRDPBackend();
     const agent = await agentForRDPComputer({

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -1,6 +1,16 @@
 import { Buffer } from 'node:buffer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const FAKE_WEBP_BASE64 =
+  'UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=';
+
+vi.mock('@midscene/shared/img', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@midscene/shared/img')>()),
+  canonicalizeScreenshotBase64: vi.fn(
+    async () => `data:image/webp;base64,${FAKE_WEBP_BASE64}`,
+  ),
+}));
+
 // A 1x1 PNG, base64-encoded, as PowerShell's CopyFromScreen path would print
 // to stdout.
 const FAKE_PNG_BASE64 =
@@ -36,7 +46,7 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     vi.resetModules();
   });
 
-  it('captures through powershell.exe and returns a PNG data URI', async () => {
+  it('captures through powershell.exe and returns a WebP data URI', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const { ComputerDevice } = await import('../../src/device');
 
@@ -45,7 +55,7 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
 
     expect(execFileSync).toHaveBeenCalledTimes(1);
     expect(execFileSync.mock.calls[0][0]).toBe('powershell.exe');
-    expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
+    expect(base64).toMatch(/^data:image\/webp;base64,UklGR/);
 
     // ExecutionPolicy only gates .ps1 files, not -EncodedCommand input, so it
     // must not be passed.

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -76,6 +76,16 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     expect(script).not.toContain('DllImport');
   });
 
+  it('returns the native PNG source when Core will resize it', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const { ComputerDevice } = await import('../../src/device');
+
+    const device = new ComputerDevice({});
+    const base64 = await device.screenshotBase64({ preferLossless: true });
+
+    expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
+  });
+
   it('targets the requested display by DeviceName and fails fast if missing', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const { ComputerDevice } = await import('../../src/device');

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -75,6 +75,7 @@ import {
   runGherkinScenario,
 } from './run-gherkin-scenario';
 import { markdownToAiActPrompt } from './run-markdown';
+import { createFinalizedScreenshotItem } from './screenshot-finalizer';
 import { TaskCache } from './task-cache';
 import {
   TaskExecutionError,
@@ -486,7 +487,12 @@ export class Agent<
           (await this.interface.openFrameSource?.()) ?? undefined,
         // Fallback single-frame capture. Deliberately bypasses getUIContext so
         // the observation loop never pollutes the TaskRunner context cache.
-        screenshot: () => this.interface.screenshotBase64(),
+        screenshot: () =>
+          this.interface.screenshotBase64(
+            (this.opts.screenshotShrinkFactor ?? 1) > 1
+              ? { preferLossless: true }
+              : undefined,
+          ),
         captureRepresentative: () => this.getUIContext('assert'),
         runAssert: (assertion, uiContext, msg, assertOpt) =>
           this.aiAssertWithContext(assertion, uiContext, msg, assertOpt),
@@ -1598,8 +1604,8 @@ export class Agent<
         : [{ base64: await this.interface.screenshotBase64() }]);
 
     // 1. build recorder
-    const recorder: ExecutionRecorderItem[] = screenshotInputs.map(
-      (screenshotInput, index) => {
+    const recorder: ExecutionRecorderItem[] = await Promise.all(
+      screenshotInputs.map(async (screenshotInput, index) => {
         const normalizedScreenshotInput = normalizeRecordToReportScreenshot(
           screenshotInput,
           index,
@@ -1608,13 +1614,14 @@ export class Agent<
         return {
           type: 'screenshot',
           ts,
-          screenshot: ScreenshotItem.create(
+          screenshot: await createFinalizedScreenshotItem(
             normalizedScreenshotInput.base64,
             ts,
+            { label: `recordToReport: screenshot #${index + 1} base64` },
           ),
           description: normalizedScreenshotInput.description,
         };
-      },
+      }),
     );
     // 2. build ExecutionTaskLog
     const task: ExecutionTaskLog = {
@@ -1667,7 +1674,9 @@ export class Agent<
       recorder.push({
         type: 'screenshot',
         ts: now,
-        screenshot: ScreenshotItem.create(base64, now),
+        screenshot: await createFinalizedScreenshotItem(base64, now, {
+          label: 'recordErrorToReport: screenshotBase64',
+        }),
       });
     }
 

--- a/packages/core/src/agent/model-input-recorder.ts
+++ b/packages/core/src/agent/model-input-recorder.ts
@@ -1,0 +1,62 @@
+import { Buffer } from 'node:buffer';
+import type { ModelRuntime } from '@/ai-model/models';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { ExecutionTask } from '@/types';
+import { parseBase64 } from '@midscene/shared/img';
+import { sha256Hex } from '@midscene/shared/utils';
+
+const MODEL_INPUT_TIMING = 'model-input';
+
+function screenshotContentHash(imageBase64: string): string {
+  const { body } = parseBase64(imageBase64);
+  return sha256Hex(Buffer.from(body, 'base64'));
+}
+
+/**
+ * Bind a model runtime to one report task so the report retains the exact
+ * data-URI bytes passed to the provider after padding/cropping/resizing.
+ */
+export function recordModelInputsForTask(
+  modelRuntime: ModelRuntime,
+  task: ExecutionTask,
+  sourceScreenshot?: ScreenshotItem,
+): ModelRuntime {
+  return {
+    ...modelRuntime,
+    onModelInputImages: (images) => {
+      modelRuntime.onModelInputImages?.(images);
+
+      for (const [index, imageBase64] of images.entries()) {
+        if (!imageBase64.startsWith('data:image/')) {
+          continue;
+        }
+
+        const contentHash = screenshotContentHash(imageBase64);
+        const alreadyRecorded = task.recorder?.some(
+          (item) =>
+            item.timing === MODEL_INPUT_TIMING &&
+            item.screenshot &&
+            screenshotContentHash(item.screenshot.base64) === contentHash,
+        );
+        if (alreadyRecorded) {
+          continue;
+        }
+
+        const uiScreenshot = task.uiContext?.screenshot ?? sourceScreenshot;
+        const screenshot =
+          uiScreenshot &&
+          screenshotContentHash(uiScreenshot.base64) === contentHash
+            ? uiScreenshot
+            : ScreenshotItem.create(imageBase64, Date.now());
+        const recorderItem = {
+          type: 'screenshot' as const,
+          ts: Date.now(),
+          screenshot,
+          timing: MODEL_INPUT_TIMING,
+          description: `Model input ${index + 1} (exact bytes, sha256: ${contentHash})`,
+        };
+        task.recorder = [...(task.recorder ?? []), recorderItem];
+      }
+    },
+  };
+}

--- a/packages/core/src/agent/screenshot-finalizer.ts
+++ b/packages/core/src/agent/screenshot-finalizer.ts
@@ -1,0 +1,47 @@
+import { ScreenshotItem } from '@/screenshot-item';
+import type { Size } from '@/types';
+import {
+  canonicalizeScreenshotBase64,
+  normalizeScreenshotBase64,
+  resizeImgBase64,
+} from '@midscene/shared/img';
+
+export interface FinalizeScreenshotOptions {
+  /** Resize before the final WebP encode. Omit to preserve dimensions. */
+  targetSize?: Size;
+  /** Error-message context for externally supplied screenshot data. */
+  label?: string;
+}
+
+/**
+ * Produce the canonical bytes shared by model requests and reports.
+ *
+ * Resizing and WebP conversion deliberately happen in the same operation so
+ * a lossless/native producer source is not encoded as WebP twice. An existing
+ * final WebP is passed through byte-for-byte when no resize is requested.
+ */
+export async function finalizeScreenshotBase64(
+  inputBase64: string,
+  options: FinalizeScreenshotOptions = {},
+): Promise<string> {
+  const normalized = normalizeScreenshotBase64(inputBase64, {
+    label: options.label,
+  });
+  if (options.targetSize) {
+    const resized = await resizeImgBase64(normalized, options.targetSize);
+    return canonicalizeScreenshotBase64(resized);
+  }
+
+  return canonicalizeScreenshotBase64(normalized);
+}
+
+export async function createFinalizedScreenshotItem(
+  inputBase64: string,
+  capturedAt: number,
+  options?: FinalizeScreenshotOptions,
+): Promise<ScreenshotItem> {
+  return ScreenshotItem.create(
+    await finalizeScreenshotBase64(inputBase64, options),
+    capturedAt,
+  );
+}

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -25,6 +25,7 @@ import { sleep } from '@/utils';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
+import { recordModelInputsForTask } from './model-input-recorder';
 import type { TaskCache } from './task-cache';
 import { withUsageIntent } from './usage-intent';
 import {
@@ -554,7 +555,11 @@ export class TaskBuilder {
                 context: uiContext,
                 planLocatedElement,
               },
-              defaultModel,
+              recordModelInputsForTask(
+                defaultModel,
+                task,
+                uiContext.screenshot,
+              ),
               abortSignal,
             );
             applyDump(locateResult.dump);

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -38,6 +38,7 @@ import { ServiceError, aiActProgressScope } from '@/types';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import { ExecutionSession } from './execution-session';
+import { recordModelInputsForTask } from './model-input-recorder';
 import {
   type AgentProgressPublisher,
   createAiActActionReporter,
@@ -587,7 +588,11 @@ export class TaskExecutor {
                 context: planningUiContext,
                 actionContext: param.aiActContext,
                 actionSpace,
-                modelRuntime: planningModel,
+                modelRuntime: recordModelInputsForTask(
+                  planningModel,
+                  executorContext.task,
+                  planningUiContext.screenshot,
+                ),
                 conversationHistory,
                 includeLocateInPlanning,
                 imagesIncludeCount,
@@ -917,7 +922,7 @@ export class TaskExecutor {
         try {
           extractResult = await this.service.extract<any>(
             demandInput,
-            modelRuntime,
+            recordModelInputsForTask(modelRuntime, task, uiContext.screenshot),
             opt,
             extraPageDescription,
             multimodalPrompt,

--- a/packages/core/src/agent/ui-observer.ts
+++ b/packages/core/src/agent/ui-observer.ts
@@ -1,9 +1,10 @@
-import { imageInfoOfBase64, resizeImgBase64 } from '@midscene/shared/img';
+import { imageInfoOfBase64 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import type { DeviceFrameRef, DeviceFrameSource } from '../device';
 import { ScreenshotItem } from '../screenshot-item';
 import type { AgentAssertOpt, ServiceExtractOption, UIContext } from '../types';
+import { finalizeScreenshotBase64 } from './screenshot-finalizer';
 
 const debug = getDebug('ui-observer');
 const warnObserver = getDebug('ui-observer', { console: true });
@@ -207,9 +208,9 @@ export class UIObserver {
         this.preDecodePromise = this.source
           .decode(uniqueRefs)
           .then(async (results) => {
-            const shrunk = await this.shrinkAllIfNeeded(results);
+            const finalized = await this.finalizeAll(results);
             uniqueRefs.forEach((ref, i) => {
-              this.decodedCache.set(ref.ref, shrunk[i]);
+              this.decodedCache.set(ref.ref, finalized[i]);
             });
             debug(`pre-decoded ${uniqueRefs.length} frames`);
           })
@@ -318,7 +319,7 @@ export class UIObserver {
     );
     if (uncachedRefs.length > 0) {
       const results = this.source
-        ? await this.shrinkAllIfNeeded(await this.source.decode(uncachedRefs))
+        ? await this.finalizeAll(await this.source.decode(uncachedRefs))
         : uncachedRefs.map((f) => f.ref as string);
       assert(
         results.length === uncachedRefs.length,
@@ -369,16 +370,7 @@ export class UIObserver {
         if (frame) this.pushFrame(frame);
         return;
       }
-      let base64 = await this.deps.screenshot();
-      // Apply shrink factor to fallback screenshots so they match the
-      // representative frame size and don't inflate token cost.
-      if (this.screenshotShrinkFactor > 1) {
-        const { width, height } = await imageInfoOfBase64(base64);
-        base64 = await resizeImgBase64(base64, {
-          width: Math.round(width / this.screenshotShrinkFactor),
-          height: Math.round(height / this.screenshotShrinkFactor),
-        });
-      }
+      const base64 = await this.finalizeOne(await this.deps.screenshot());
       this.pushFrame({ ref: base64, capturedAt: Date.now() });
     } catch (error) {
       debug(`frame capture failed, skipping tick: ${error}`);
@@ -386,24 +378,25 @@ export class UIObserver {
   }
 
   /**
-   * Apply screenshotShrinkFactor to an array of decoded base64 images in
-   * parallel. Returns the input unchanged when shrink factor is 1. Source
-   * frames come at device-native resolution; shrinking them matches the
-   * representative frame size so the sequence sent to the model has
-   * consistent resolution and token cost.
+   * Finalize decoded screenshots in parallel. Source frames can be PNG/JPEG
+   * so the resize and final WebP encode happen together exactly once.
    */
-  private async shrinkAllIfNeeded(base64s: string[]): Promise<string[]> {
-    if (this.screenshotShrinkFactor <= 1) return base64s;
-    const factor = this.screenshotShrinkFactor;
-    return Promise.all(
-      base64s.map(async (b64) => {
-        const { width, height } = await imageInfoOfBase64(b64);
-        return resizeImgBase64(b64, {
-          width: Math.round(width / factor),
-          height: Math.round(height / factor),
-        });
-      }),
-    );
+  private async finalizeAll(base64s: string[]): Promise<string[]> {
+    return Promise.all(base64s.map((base64) => this.finalizeOne(base64)));
+  }
+
+  private async finalizeOne(base64: string): Promise<string> {
+    if (this.screenshotShrinkFactor <= 1) {
+      return finalizeScreenshotBase64(base64);
+    }
+
+    const { width, height } = await imageInfoOfBase64(base64);
+    return finalizeScreenshotBase64(base64, {
+      targetSize: {
+        width: Math.round(width / this.screenshotShrinkFactor),
+        height: Math.round(height / this.screenshotShrinkFactor),
+      },
+    });
   }
 
   private async runLoop(): Promise<void> {

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -26,6 +26,7 @@ import {
   convertImgBufferToJpeg,
   createImgBase64ByFormat,
   imageInfoOfBase64,
+  normalizeBase64Image,
   parseBase64,
   resizeImgBase64,
 } from '@midscene/shared/img';
@@ -37,28 +38,6 @@ import type { TaskCache } from './task-cache';
 import { debug as cacheDebug } from './task-cache';
 
 const agentDebug = getDebug('agent');
-const screenshotDataUrlPattern = /^data:image\/[a-zA-Z0-9.+-]+;base64,/i;
-
-const inferBase64ImageFormat = (base64Body: string) => {
-  if (base64Body.startsWith('iVBORw0KGgo')) {
-    return 'png';
-  }
-  return 'jpeg';
-};
-
-const normalizeScreenshotBase64 = (screenshotBase64: string) => {
-  const trimmedBase64 = screenshotBase64.trim();
-  if (screenshotDataUrlPattern.test(trimmedBase64)) {
-    return trimmedBase64;
-  }
-
-  const base64Body = trimmedBase64.replace(/\s/g, '');
-  assert(base64Body, 'screenshotBase64 must include image data');
-  return createImgBase64ByFormat(
-    inferBase64ImageFormat(base64Body),
-    base64Body,
-  );
-};
 
 const legacyScrollTypeMap = {
   once: 'singleAction',
@@ -207,7 +186,7 @@ export async function commonContextParser(
     // This mainly covers Android's default screenshot path, which produces PNG screenshots.
     // Compared with conversion on Android, centralizing it here means each platform does not need to handle screenshot formats itself, and allows future output formats such as WebP.
     // Built-in paths that already output JPEG are unaffected, and custom devices that output JPEG will not be compressed again.
-    // The Web platform already outputs JPEG, so it does not enter this branch. Other built-in device platforms run in Node, where Sharp conversion is fast enough that its extra cost is negligible.
+    // Web platforms already output compressed formats, so they do not enter this branch. Other built-in device platforms run in Node, where Sharp conversion is fast enough that its extra cost is negligible.
     let outputScreenshotBase64 = screenshotBase64;
     const { mimeType, body } = parseBase64(screenshotBase64);
     if (mimeType.toLowerCase() === 'image/png') {
@@ -242,8 +221,7 @@ export async function createScreenshotBoundUIContext(
     screenshotSize?: Size;
   },
 ): Promise<UIContext> {
-  const normalizedScreenshotBase64 =
-    normalizeScreenshotBase64(screenshotBase64);
+  const normalizedScreenshotBase64 = normalizeBase64Image(screenshotBase64);
   const actualScreenshotSize = await imageInfoOfBase64(
     normalizedScreenshotBase64,
   );

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -23,11 +23,9 @@ import {
 } from '@midscene/shared/env';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import {
-  convertImgBufferToJpeg,
-  createImgBase64ByFormat,
+  canonicalizeScreenshotBase64,
   imageInfoOfBase64,
   normalizeBase64Image,
-  parseBase64,
   resizeImgBase64,
 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
@@ -182,23 +180,13 @@ export async function commonContextParser(
       shrunkShotToLogicalRatio,
     };
   } else {
-    // For screenshots that do not need shrinking, convert PNG to JPEG to reduce the image payload in model requests and reports. (Shrunk images are already JPEG.)
-    // This mainly covers Android's default screenshot path, which produces PNG screenshots.
-    // Compared with conversion on Android, centralizing it here means each platform does not need to handle screenshot formats itself, and allows future output formats such as WebP.
-    // Built-in paths that already output JPEG are unaffected, and custom devices that output JPEG will not be compressed again.
-    // Web platforms already output compressed formats, so they do not enter this branch. Other built-in device platforms run in Node, where Sharp conversion is fast enough that its extra cost is negligible.
-    let outputScreenshotBase64 = screenshotBase64;
-    const { mimeType, body } = parseBase64(screenshotBase64);
-    if (mimeType.toLowerCase() === 'image/png') {
-      const jpegBuffer = await convertImgBufferToJpeg(
-        Buffer.from(body, 'base64'),
-        90,
-      );
-      outputScreenshotBase64 = createImgBase64ByFormat(
-        'jpeg',
-        jpegBuffer.toString('base64'),
-      );
-    }
+    // PNG/raw producers are encoded once as WebP before the ScreenshotItem is
+    // shared by model requests and reports. Native JPEG sources are preserved
+    // to avoid a second lossy encode for MJPEG/HDC frames.
+    const outputScreenshotBase64 = await canonicalizeScreenshotBase64(
+      screenshotBase64,
+      { preserveJpeg: true },
+    );
 
     return {
       shotSize: {
@@ -222,8 +210,12 @@ export async function createScreenshotBoundUIContext(
   },
 ): Promise<UIContext> {
   const normalizedScreenshotBase64 = normalizeBase64Image(screenshotBase64);
-  const actualScreenshotSize = await imageInfoOfBase64(
+  const canonicalScreenshotBase64 = await canonicalizeScreenshotBase64(
     normalizedScreenshotBase64,
+    { preserveJpeg: true },
+  );
+  const actualScreenshotSize = await imageInfoOfBase64(
+    canonicalScreenshotBase64,
   );
   if (
     opt.screenshotSize &&
@@ -240,7 +232,7 @@ export async function createScreenshotBoundUIContext(
   }
 
   return {
-    screenshot: ScreenshotItem.create(normalizedScreenshotBase64, Date.now()),
+    screenshot: ScreenshotItem.create(canonicalScreenshotBase64, Date.now()),
     shotSize: actualScreenshotSize,
     shrunkShotToLogicalRatio: 1,
     _isFrozen: true,

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -22,16 +22,15 @@ import {
   globalConfigManager,
 } from '@midscene/shared/env';
 import { generateElementByRect } from '@midscene/shared/extractor';
-import {
-  canonicalizeScreenshotBase64,
-  imageInfoOfBase64,
-  normalizeBase64Image,
-  resizeImgBase64,
-} from '@midscene/shared/img';
+import { imageInfoOfBase64, normalizeBase64Image } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 import { assert, ifInBrowser, logMsg, uuid } from '@midscene/shared/utils';
 import dayjs from 'dayjs';
+import {
+  createFinalizedScreenshotItem,
+  finalizeScreenshotBase64,
+} from './screenshot-finalizer';
 import type { TaskCache } from './task-cache';
 import { debug as cacheDebug } from './task-cache';
 
@@ -81,6 +80,14 @@ export async function commonContextParser(
   });
   debug('UploadTestInfoToServer end');
 
+  const userShrinkFactor = _opt.screenshotShrinkFactor ?? 1;
+
+  if (!Number.isFinite(userShrinkFactor) || userShrinkFactor < 1) {
+    throw new Error(
+      `Invalid screenshotShrinkFactor: must be a finite number >= 1. Received: ${userShrinkFactor}`,
+    );
+  }
+
   debug('will get size');
   const interfaceSize = await interfaceInstance.size();
   const { width: logicalWidth, height: logicalHeight } = interfaceSize;
@@ -105,7 +112,10 @@ export async function commonContextParser(
 
   debug(`size: ${logicalWidth}x${logicalHeight}`);
 
-  const screenshotBase64 = await interfaceInstance.screenshotBase64();
+  const shouldResize = userShrinkFactor > 1;
+  const screenshotBase64 = await interfaceInstance.screenshotBase64(
+    shouldResize ? { preferLossless: true } : undefined,
+  );
   const screenshotCapturedAt = Date.now();
   assert(screenshotBase64!, 'screenshotBase64 is required');
 
@@ -142,14 +152,6 @@ export async function commonContextParser(
     finalLogicalHeight = logicalWidth;
   }
 
-  const userShrinkFactor = _opt.screenshotShrinkFactor ?? 1;
-
-  if (!Number.isFinite(userShrinkFactor) || userShrinkFactor < 1) {
-    throw new Error(
-      `Invalid screenshotShrinkFactor: must be a finite number >= 1. Received: ${userShrinkFactor}`,
-    );
-  }
-
   const dpr = imgWidth / finalLogicalWidth;
 
   debug('calculated dpr:', dpr);
@@ -158,7 +160,7 @@ export async function commonContextParser(
 
   debug('shrunkShotToLogicalRatio', shrunkShotToLogicalRatio);
 
-  if (userShrinkFactor !== 1) {
+  if (shouldResize) {
     const targetWidth = Math.round(imgWidth / userShrinkFactor);
     const targetHeight = Math.round(imgHeight / userShrinkFactor);
 
@@ -166,36 +168,30 @@ export async function commonContextParser(
       `Applying screenshot shrink factor: ${userShrinkFactor} (physical: ${imgWidth}x${imgHeight} -> target: ${targetWidth}x${targetHeight})`,
     );
 
-    const resizedBase64 = await resizeImgBase64(screenshotBase64, {
-      width: targetWidth,
-      height: targetHeight,
-    });
     return {
       shotSize: {
         width: targetWidth,
         height: targetHeight,
       },
       deprecatedDpr: dpr,
-      screenshot: ScreenshotItem.create(resizedBase64, screenshotCapturedAt),
+      screenshot: await createFinalizedScreenshotItem(
+        screenshotBase64,
+        screenshotCapturedAt,
+        {
+          targetSize: { width: targetWidth, height: targetHeight },
+        },
+      ),
       shrunkShotToLogicalRatio,
     };
   } else {
-    // PNG/raw producers are encoded once as WebP before the ScreenshotItem is
-    // shared by model requests and reports. Native JPEG sources are preserved
-    // to avoid a second lossy encode for MJPEG/HDC frames.
-    const outputScreenshotBase64 = await canonicalizeScreenshotBase64(
-      screenshotBase64,
-      { preserveJpeg: true },
-    );
-
     return {
       shotSize: {
         width: imgWidth,
         height: imgHeight,
       },
       deprecatedDpr: dpr,
-      screenshot: ScreenshotItem.create(
-        outputScreenshotBase64,
+      screenshot: await createFinalizedScreenshotItem(
+        screenshotBase64,
         screenshotCapturedAt,
       ),
       shrunkShotToLogicalRatio,
@@ -210,9 +206,8 @@ export async function createScreenshotBoundUIContext(
   },
 ): Promise<UIContext> {
   const normalizedScreenshotBase64 = normalizeBase64Image(screenshotBase64);
-  const canonicalScreenshotBase64 = await canonicalizeScreenshotBase64(
+  const canonicalScreenshotBase64 = await finalizeScreenshotBase64(
     normalizedScreenshotBase64,
-    { preserveJpeg: true },
   );
   const actualScreenshotSize = await imageInfoOfBase64(
     canonicalScreenshotBase64,

--- a/packages/core/src/ai-model/model-adapter/types.ts
+++ b/packages/core/src/ai-model/model-adapter/types.ts
@@ -245,6 +245,8 @@ export interface ModelRuntime {
    * such as order-sensitive judging and deep-locate search-area calls).
    */
   onUsage?: (usage: AIUsageInfo) => void;
+  /** Exact image URLs included in a model request, after all preprocessing. */
+  onModelInputImages?: (images: readonly string[]) => void;
 }
 
 export interface ModelAdapterDefinition {

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -345,6 +345,22 @@ export async function callAI(
 }> {
   const { config: modelConfig, adapter } = modelRuntime;
 
+  if (modelRuntime.onModelInputImages) {
+    const imageUrls = messages.flatMap((message) => {
+      if (!Array.isArray(message.content)) {
+        return [];
+      }
+      return message.content.flatMap((part) =>
+        part.type === 'image_url' && typeof part.image_url?.url === 'string'
+          ? [part.image_url.url]
+          : [],
+      );
+    });
+    if (imageUrls.length > 0) {
+      modelRuntime.onModelInputImages(imageUrls);
+    }
+  }
+
   // Stable internal ID for this call, used by the agent to deduplicate usage
   // across the onUsage callback and the task-dump-based collectUsageMetrics()
   // path when the provider does not return a request_id.

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -67,6 +67,15 @@ export interface DeviceFrameSource {
   stop(): Promise<void> | void;
 }
 
+export interface ScreenshotCaptureOptions {
+  /**
+   * The caller will resize and encode the final screenshot. When possible,
+   * return a native or lossless source instead of an already-lossy WebP so the
+   * final image is encoded only once.
+   */
+  preferLossless?: boolean;
+}
+
 /** A point in device-pixel coordinates on the screen. */
 export interface PointerPoint {
   x: number;
@@ -166,7 +175,9 @@ export interface ComputerInputPrimitives extends InputPrimitives {
 export abstract class AbstractInterface {
   abstract interfaceType: string;
 
-  abstract screenshotBase64(): Promise<string>;
+  abstract screenshotBase64(
+    options?: ScreenshotCaptureOptions,
+  ): Promise<string>;
   abstract size(): Promise<Size>;
   abstract actionSpace(): DeviceAction[];
 

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import {
   screenshotImageExtension,
   screenshotImageFormatFromMimeType,
-} from '@midscene/shared/img';
+} from '@midscene/shared/img/image-format';
 import { ScreenshotItem } from '../screenshot-item';
 import type {
   ExecutionTask,

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -6,6 +6,10 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import {
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img';
 import { ScreenshotItem } from '../screenshot-item';
 import type {
   ExecutionTask,
@@ -13,7 +17,7 @@ import type {
   IReportActionDump,
 } from '../types';
 import { restoreImageReferences } from './screenshot-restoration';
-import { ScreenshotStore } from './screenshot-store';
+import { type ScreenshotRef, ScreenshotStore } from './screenshot-store';
 
 /**
  * Replacer function for JSON serialization that handles Page, Browser objects and ScreenshotItem
@@ -253,10 +257,10 @@ export class ReportActionDump implements IReportActionDump {
   }
 
   /**
-   * Serialize the dump to files with screenshots as separate PNG files.
+   * Serialize the dump to files with screenshots as separate image files.
    * Creates:
    * - {basePath} - dump JSON with { $screenshot: id } references
-   * - {basePath}.screenshots/ - PNG files
+   * - {basePath}.screenshots/ - screenshot image files
    *
    * @param basePath - Base path for the dump file
    */
@@ -296,14 +300,21 @@ export class ReportActionDump implements IReportActionDump {
     const dumpString = readFileSync(basePath, 'utf-8');
     const screenshotsDir = `${basePath}.screenshots`;
 
-    const loadFromExecutionScreenshotDir = (id: string, mimeType: string) => {
-      const ext = mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+    const loadFromExecutionScreenshotDir = (
+      id: string,
+      mimeType: ScreenshotRef['mimeType'],
+    ) => {
+      const format = screenshotImageFormatFromMimeType(mimeType);
+      if (!format) {
+        throw new Error(`Unsupported screenshot mime type: ${mimeType}`);
+      }
+      const ext = screenshotImageExtension(format);
       const filePath = join(screenshotsDir, `${id}.${ext}`);
       if (!existsSync(filePath)) {
         return '';
       }
       const data = readFileSync(filePath);
-      return `data:image/${ext};base64,${data.toString('base64')}`;
+      return `data:${mimeType};base64,${data.toString('base64')}`;
     };
 
     // Restore image references

--- a/packages/core/src/dump/screenshot-store.ts
+++ b/packages/core/src/dump/screenshot-store.ts
@@ -1,6 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile as writeFileAsync } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
+import {
+  type ScreenshotImageMimeType,
+  isScreenshotImageMimeType,
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img';
 import type { ScreenshotItem } from '../screenshot-item';
 import { extractImageByIdSync } from './html-utils';
 
@@ -8,7 +14,7 @@ export interface ScreenshotRef {
   type: 'midscene_screenshot_ref';
   id: string;
   capturedAt: number;
-  mimeType: 'image/png' | 'image/jpeg';
+  mimeType: ScreenshotImageMimeType;
   storage: 'inline' | 'file';
   path?: string;
 }
@@ -22,7 +28,7 @@ export function normalizeScreenshotRef(value: unknown): ScreenshotRef | null {
     typeof record.id === 'string' &&
     typeof record.capturedAt === 'number' &&
     (record.storage === 'inline' || record.storage === 'file') &&
-    (record.mimeType === 'image/png' || record.mimeType === 'image/jpeg')
+    isScreenshotImageMimeType(record.mimeType)
   ) {
     if (record.storage === 'file' && typeof record.path !== 'string') {
       return null;
@@ -48,7 +54,11 @@ type ResolvedScreenshotSource =
     };
 
 function extensionByMimeType(mimeType: ScreenshotRef['mimeType']): string {
-  return mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+  const format = screenshotImageFormatFromMimeType(mimeType);
+  if (!format) {
+    throw new Error(`Unsupported screenshot mime type: ${mimeType}`);
+  }
+  return screenshotImageExtension(format);
 }
 
 export function resolveScreenshotSource(

--- a/packages/core/src/dump/screenshot-store.ts
+++ b/packages/core/src/dump/screenshot-store.ts
@@ -6,7 +6,7 @@ import {
   isScreenshotImageMimeType,
   screenshotImageExtension,
   screenshotImageFormatFromMimeType,
-} from '@midscene/shared/img';
+} from '@midscene/shared/img/image-format';
 import type { ScreenshotItem } from '../screenshot-item';
 import { extractImageByIdSync } from './html-utils';
 

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -79,7 +79,7 @@ function writeAttachmentFromReport(
   const resolved = resolveScreenshotSource(attachment.sourceRef ?? null, {
     reportPath: opts.htmlPath,
     fallbackId: id,
-    fallbackMimeType: (mimeType || 'image/png') as 'image/png' | 'image/jpeg',
+    fallbackMimeType: mimeType || 'image/png',
   });
 
   if (resolved.type === 'data-uri') {

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -9,12 +9,19 @@ import type {
   ModelBrief,
   ReportActionDump,
 } from '@/types';
+import {
+  type ScreenshotImageFormat,
+  type ScreenshotImageMimeType,
+  normalizeScreenshotBase64,
+  parseBase64,
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+  screenshotImageMimeType,
+} from '@midscene/shared/img';
 import type { ScreenshotRef } from './dump/screenshot-store';
 import { normalizeScreenshotRef } from './dump/screenshot-store';
 
-const screenshotDataUrlPattern =
-  /^data:image\/(png|jpeg|jpg);base64,([\s\S]*)$/i;
-const rawBase64BodyPattern = /^[a-zA-Z0-9+/=\s]+$/;
+const screenshotDataUrlPattern = /^data:image\/(?:png|jpe?g|webp);base64,/i;
 const jsonContextMaxStringLength = 12_000;
 
 type ExecutionTaskWithExtraUsage = ExecutionTask & {
@@ -39,7 +46,7 @@ export interface MarkdownAttachment {
    * write the screenshot under this name to keep links in sync. See #2392.
    */
   suggestedFileName: string;
-  mimeType?: string;
+  mimeType?: ScreenshotImageMimeType;
   /**
    * Reference to the screenshot in the source report, used to locate the
    * original bytes when copying them to the exported name. Absent for in-memory
@@ -448,26 +455,11 @@ function extractLocateCenter(
 
 function tryExtractBase64(screenshot: unknown): string | undefined {
   if (typeof screenshot === 'string') {
-    const trimmedScreenshot = screenshot.trim();
-    const dataUrlMatch = trimmedScreenshot.match(screenshotDataUrlPattern);
-    if (dataUrlMatch) {
-      const format = dataUrlMatch[1].toLowerCase() === 'jpg' ? 'jpeg' : 'png';
-      const base64Body = dataUrlMatch[2].replace(/\s/g, '');
-      if (!base64Body) {
-        return undefined;
-      }
-      return `data:image/${format};base64,${base64Body}`;
-    }
-
-    if (
-      trimmedScreenshot.startsWith('data:') ||
-      !rawBase64BodyPattern.test(trimmedScreenshot)
-    ) {
+    try {
+      return normalizeScreenshotBase64(screenshot);
+    } catch {
       return undefined;
     }
-
-    const base64Body = trimmedScreenshot.replace(/\s/g, '');
-    return base64Body ? `data:image/png;base64,${base64Body}` : undefined;
   }
 
   if (!screenshot || typeof screenshot !== 'object') return undefined;
@@ -476,6 +468,20 @@ function tryExtractBase64(screenshot: unknown): string | undefined {
     return s.base64;
   }
   return undefined;
+}
+
+function screenshotMetadataFromMimeType(mimeType: unknown): {
+  extension: ScreenshotImageFormat;
+  mimeType: ScreenshotImageMimeType;
+} {
+  const format = screenshotImageFormatFromMimeType(mimeType);
+  if (!format) {
+    throw new Error(`Unsupported screenshot mime type: ${String(mimeType)}`);
+  }
+  return {
+    extension: screenshotImageExtension(format),
+    mimeType: screenshotImageMimeType(format),
+  };
 }
 
 function restoredSourceRef(screenshot: unknown): ScreenshotRef | undefined {
@@ -507,7 +513,7 @@ function screenshotAttachment(
       attachment: {
         id: screenshot.id,
         suggestedFileName,
-        mimeType: `image/${ext === 'jpeg' ? 'jpeg' : 'png'}`,
+        mimeType: screenshot.mimeType,
         executionIndex,
         taskIndex,
         base64Data: tryExtractBase64(screenshot),
@@ -517,7 +523,7 @@ function screenshotAttachment(
 
   const ref = normalizeScreenshotRef(screenshot);
   if (ref) {
-    const ext = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+    const { extension: ext } = screenshotMetadataFromMimeType(ref.mimeType);
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${ref.id}.${ext}`;
     return {
       markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
@@ -535,7 +541,9 @@ function screenshotAttachment(
 
   const sourceRef = restoredSourceRef(screenshot);
   if (sourceRef) {
-    const ext = sourceRef.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+    const { extension: ext } = screenshotMetadataFromMimeType(
+      sourceRef.mimeType,
+    );
     const suggestedFileName = `execution-${executionIndex + 1}-task-${taskIndex + 1}-${sourceRef.id}.${ext}`;
     return {
       markdown: `\n![${markdownLabel}](${screenshotBaseDir}/${suggestedFileName})`,
@@ -553,7 +561,9 @@ function screenshotAttachment(
 
   const base64 = tryExtractBase64(screenshot);
   if (base64) {
-    const ext = base64.startsWith('data:image/jpeg') ? 'jpeg' : 'png';
+    const { extension: ext, mimeType } = screenshotMetadataFromMimeType(
+      parseBase64(base64).mimeType,
+    );
     const idSuffix = options?.fallbackIdSuffix
       ? `-${options.fallbackIdSuffix}`
       : '';
@@ -564,7 +574,7 @@ function screenshotAttachment(
       attachment: {
         id,
         suggestedFileName,
-        mimeType: `image/${ext}`,
+        mimeType,
         executionIndex,
         taskIndex,
         base64Data: base64,

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -10,6 +10,11 @@ import {
 } from 'node:fs';
 import * as path from 'node:path';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
+import {
+  type ScreenshotImageFormat,
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img';
 import { antiEscapeScriptTag, logMsg } from '@midscene/shared/utils';
 import { getReportFileName } from './agent';
 import {
@@ -22,6 +27,7 @@ import {
   streamImageScriptsToFile,
 } from './dump/html-utils';
 import {
+  type ScreenshotRef,
   normalizeScreenshotRef,
   resolveScreenshotSource,
 } from './dump/screenshot-store';
@@ -526,10 +532,14 @@ export function collectDedupedExecutions(
   };
 }
 
-function extensionByMimeType(mimeType: string): 'png' | 'jpeg' {
-  if (mimeType === 'image/png') return 'png';
-  if (mimeType === 'image/jpeg') return 'jpeg';
-  throw new Error(`Unsupported screenshot mime type: ${mimeType}`);
+function extensionByMimeType(
+  mimeType: ScreenshotRef['mimeType'],
+): ScreenshotImageFormat {
+  const format = screenshotImageFormatFromMimeType(mimeType);
+  if (!format) {
+    throw new Error(`Unsupported screenshot mime type: ${mimeType}`);
+  }
+  return screenshotImageExtension(format);
 }
 
 function externalizeScreenshotsInExecution(

--- a/packages/core/src/screenshot-item.ts
+++ b/packages/core/src/screenshot-item.ts
@@ -2,11 +2,11 @@ import { readFileSync } from 'node:fs';
 import {
   type ScreenshotImageFormat,
   type ScreenshotImageMimeType,
-  parseBase64,
+  inferScreenshotImageFormatFromBase64,
   screenshotImageExtension,
   screenshotImageFormatFromMimeType,
   screenshotImageMimeType,
-} from '@midscene/shared/img';
+} from '@midscene/shared/img/image-format';
 import { uuid } from '@midscene/shared/utils';
 import { extractImageByIdSync } from './dump/html-utils';
 import {
@@ -21,16 +21,40 @@ import {
  */
 export type ScreenshotSerializeFormat = ScreenshotRef;
 
+const BASE64_SEPARATOR = ';base64,';
+
 /**
- * Detect image format from base64 data URI prefix.
+ * Detect image format from a data URI or raw base64 body.
  */
 function detectFormat(base64: string): ScreenshotImageFormat {
-  const { mimeType } = parseBase64(base64);
-  const format = screenshotImageFormatFromMimeType(mimeType);
+  // Web integrations use an empty ScreenshotItem as a temporary placeholder.
+  // Keep its historical PNG metadata until the real screenshot is attached.
+  if (base64 === '') {
+    return 'png';
+  }
+
+  const separatorIndex = base64.indexOf(BASE64_SEPARATOR);
+  const mimeType =
+    separatorIndex === -1 ? undefined : base64.slice(5, separatorIndex);
+  const format =
+    separatorIndex === -1
+      ? inferScreenshotImageFormatFromBase64(base64)
+      : screenshotImageFormatFromMimeType(mimeType);
   if (!format) {
-    throw new Error(`ScreenshotItem: unsupported image format ${mimeType}`);
+    throw new Error(
+      `ScreenshotItem: unsupported image format ${mimeType ?? 'unknown'}`,
+    );
   }
   return format;
+}
+
+function rawBase64Body(base64: string): string {
+  const separatorIndex = base64.indexOf(BASE64_SEPARATOR);
+  const body =
+    separatorIndex === -1
+      ? base64
+      : base64.slice(separatorIndex + BASE64_SEPARATOR.length);
+  return body.replace(/\s/g, '');
 }
 
 /**
@@ -229,6 +253,6 @@ export class ScreenshotItem {
    * Useful for writing raw binary data to files.
    */
   get rawBase64(): string {
-    return parseBase64(this.base64).body;
+    return rawBase64Body(this.base64);
   }
 }

--- a/packages/core/src/screenshot-item.ts
+++ b/packages/core/src/screenshot-item.ts
@@ -27,25 +27,17 @@ const BASE64_SEPARATOR = ';base64,';
  * Detect image format from a data URI or raw base64 body.
  */
 function detectFormat(base64: string): ScreenshotImageFormat {
-  // Web integrations use an empty ScreenshotItem as a temporary placeholder.
-  // Keep its historical PNG metadata until the real screenshot is attached.
-  if (base64 === '') {
-    return 'png';
-  }
-
   const separatorIndex = base64.indexOf(BASE64_SEPARATOR);
   const mimeType =
     separatorIndex === -1 ? undefined : base64.slice(5, separatorIndex);
-  const format =
+  const detectedFormat =
     separatorIndex === -1
       ? inferScreenshotImageFormatFromBase64(base64)
       : screenshotImageFormatFromMimeType(mimeType);
-  if (!format) {
-    throw new Error(
-      `ScreenshotItem: unsupported image format ${mimeType ?? 'unknown'}`,
-    );
-  }
-  return format;
+
+  // Before WebP support, every non-JPEG value used PNG metadata. Preserve that
+  // behavior for temporary and test placeholders while detecting valid images.
+  return detectedFormat ?? 'png';
 }
 
 function rawBase64Body(base64: string): string {

--- a/packages/core/src/screenshot-item.ts
+++ b/packages/core/src/screenshot-item.ts
@@ -1,4 +1,12 @@
 import { readFileSync } from 'node:fs';
+import {
+  type ScreenshotImageFormat,
+  type ScreenshotImageMimeType,
+  parseBase64,
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+  screenshotImageMimeType,
+} from '@midscene/shared/img';
 import { uuid } from '@midscene/shared/utils';
 import { extractImageByIdSync } from './dump/html-utils';
 import {
@@ -16,10 +24,13 @@ export type ScreenshotSerializeFormat = ScreenshotRef;
 /**
  * Detect image format from base64 data URI prefix.
  */
-function detectFormat(base64: string): 'png' | 'jpeg' {
-  if (base64.startsWith('data:image/jpeg')) return 'jpeg';
-  if (base64.startsWith('data:image/jpg')) return 'jpeg';
-  return 'png';
+function detectFormat(base64: string): ScreenshotImageFormat {
+  const { mimeType } = parseBase64(base64);
+  const format = screenshotImageFormatFromMimeType(mimeType);
+  if (!format) {
+    throw new Error(`ScreenshotItem: unsupported image format ${mimeType}`);
+  }
+  return format;
 }
 
 /**
@@ -35,7 +46,7 @@ function detectFormat(base64: string): 'png' | 'jpeg' {
 export class ScreenshotItem {
   private _id: string;
   private _base64: string | null;
-  private _format: 'png' | 'jpeg';
+  private _format: ScreenshotImageFormat;
   private _capturedAt: number;
   private _serializedRef: ScreenshotRef | null = null;
   private _persistedPath: string | null = null;
@@ -57,14 +68,19 @@ export class ScreenshotItem {
     return this._id;
   }
 
-  /** Get the image format (png or jpeg) */
-  get format(): 'png' | 'jpeg' {
+  /** Get the image format (PNG, JPEG, or WebP). */
+  get format(): ScreenshotImageFormat {
     return this._format;
   }
 
   /** Get the file extension for this screenshot */
-  get extension(): string {
-    return this._format === 'jpeg' ? 'jpeg' : 'png';
+  get extension(): ScreenshotImageFormat {
+    return screenshotImageExtension(this._format);
+  }
+
+  /** Get the MIME type for this screenshot. */
+  get mimeType(): ScreenshotImageMimeType {
+    return screenshotImageMimeType(this._format);
   }
 
   /** Get screenshot capture timestamp in milliseconds */
@@ -83,7 +99,7 @@ export class ScreenshotItem {
         throw new Error(`Screenshot ${this._id}: file recovery path missing`);
       }
       const buffer = readFileSync(this._persistedPath);
-      return `data:image/${this._format};base64,${buffer.toString('base64')}`;
+      return `data:${this.mimeType};base64,${buffer.toString('base64')}`;
     };
 
     const loadFromInline = (): string => {
@@ -176,7 +192,7 @@ export class ScreenshotItem {
         type: 'midscene_screenshot_ref',
         id: this._id,
         capturedAt: this._capturedAt,
-        mimeType: this._format === 'jpeg' ? 'image/jpeg' : 'image/png',
+        mimeType: this.mimeType,
         storage: 'inline',
       }
     );
@@ -195,7 +211,7 @@ export class ScreenshotItem {
       type: 'midscene_screenshot_ref',
       id: this._id,
       capturedAt: this._capturedAt,
-      mimeType: this._format === 'jpeg' ? 'image/jpeg' : 'image/png',
+      mimeType: this.mimeType,
       storage,
     };
     if (storage === 'file') {
@@ -213,6 +229,6 @@ export class ScreenshotItem {
    * Useful for writing raw binary data to files.
    */
   get rawBase64(): string {
-    return this.base64.replace(/^data:image\/(png|jpeg|jpg);base64,/, '');
+    return parseBase64(this.base64).body;
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -489,7 +489,7 @@ export interface ExecutionRecorderItem {
 
 export interface RecordToReportScreenshot {
   /**
-   * PNG/JPEG data URI, or raw PNG base64 body.
+   * PNG/JPEG/WebP data URI, or raw PNG/WebP base64 body.
    */
   base64: string;
   description?: string;
@@ -740,7 +740,7 @@ export type ExecutionTaskPlanningLocate =
 /*
 How a report file stores screenshots:
 - `inline`: base64 image script tags embedded in the single HTML file
-- `directory`: external PNG files under a sibling `screenshots/` dir
+- `directory`: external image files under a sibling `screenshots/` dir
 */
 export type ScreenshotMode = 'inline' | 'directory';
 
@@ -916,7 +916,7 @@ export interface AgentOpt {
    * Use directory-based report format with separate image files.
    *
    * When enabled:
-   * - Screenshots are saved as PNG files in a `screenshots/` subdirectory
+   * - Screenshots retain their image format in a `screenshots/` subdirectory
    * - Report is generated as `index.html` with relative image paths
    * - Reduces memory usage and report file size
    *

--- a/packages/core/tests/unit-test/agent-describe-element.test.ts
+++ b/packages/core/tests/unit-test/agent-describe-element.test.ts
@@ -424,7 +424,7 @@ describe('element describer utils', () => {
 
     const describeContext = describe.mock.calls[0][2]?.context;
     expect(describeContext?.screenshot.base64).toMatch(
-      /^data:image\/png;base64,/,
+      /^data:image\/webp;base64,UklGR/,
     );
     expect(describeContext?.shotSize).toEqual(fixtureScreenshotSize);
 

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -255,7 +255,7 @@ describe('Agent dump update screenshot serialization', () => {
         screenshots: [{ base64: 'data:image/svg+xml;base64,custom' }],
       }),
     ).rejects.toThrow(
-      'recordToReport: screenshot #1 base64 must be a PNG/JPEG data URI or raw PNG base64 string',
+      'recordToReport: screenshot #1 base64 must be a PNG/JPEG/WebP data URI or raw PNG/WebP base64 string',
     );
 
     expect(screenshotBase64).not.toHaveBeenCalled();

--- a/packages/core/tests/unit-test/agent-dump-update.test.ts
+++ b/packages/core/tests/unit-test/agent-dump-update.test.ts
@@ -15,20 +15,29 @@ const modelConfig = {
   [MIDSCENE_MODEL_BASE_URL]: 'https://api.test.com/v1',
 };
 
+const VALID_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const VALID_JPEG =
+  'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMDAwMDAwMDAwMEBAQEBAYFBQUFBgkGBwYHBgkOCAoICAoIDgwPDAsMDwwWEQ8PERYZFRQVGR4bGx4mJCYyMkMBAwMDAwMDAwMDAwQEBAQEBgUFBQUGCQYHBgcGCQ4ICggICggODA8MCwwPDBYRDw8RFhkVFBUZHhsbHiYkJjIyQ//CABEIAAEAAQMBIgACEQEDEQH/xAAnAAEBAAAAAAAAAAAAAAAAAAAACQEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAAqmD/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/AH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/AH//2Q==';
+const VALID_WEBP_BODY =
+  'UklGRioAAABXRUJQVlA4IB4AAACQAQCdASoCAAIAAMASJaQAAzoO0gAA/v/+JwoMAAA=';
+
 function createMockInterface() {
   return {
     interfaceType: 'puppeteer',
     actionSpace: () => [],
     describe: () => 'test page',
     size: async () => ({ width: 1280, height: 720 }),
-    screenshotBase64: async () =>
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+    screenshotBase64: async () => VALID_PNG,
   } as any;
 }
 
 function createLargeBase64DataUri(byteSize: number): string {
-  const payload = 'A'.repeat(byteSize);
-  return `data:image/png;base64,${payload}`;
+  const payload = Buffer.concat([
+    Buffer.from(VALID_WEBP_BODY, 'base64'),
+    Buffer.alloc(byteSize),
+  ]).toString('base64');
+  return `data:image/webp;base64,${payload}`;
 }
 
 describe('Agent dump update screenshot serialization', () => {
@@ -126,14 +135,17 @@ describe('Agent dump update screenshot serialization', () => {
 
     (agent as any).reportGenerator = reportGeneratorStub;
 
-    const providedScreenshot =
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
     await agent.recordToReport('snapshot', {
-      screenshotBase64: providedScreenshot,
+      screenshotBase64: VALID_PNG,
     });
 
     expect(screenshotBase64).not.toHaveBeenCalled();
     expect(reportGeneratorStub.onExecutionUpdate).toHaveBeenCalled();
+    const execution = reportGeneratorStub.onExecutionUpdate.mock
+      .calls[0][0] as ExecutionDump;
+    expect(execution.collectScreenshots()[0].base64).toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
 
     await agent.destroy();
   });
@@ -162,13 +174,11 @@ describe('Agent dump update screenshot serialization', () => {
 
     (agent as any).reportGenerator = reportGeneratorStub;
 
-    const beforeScreenshot = 'before';
-    const afterScreenshot = 'data:image/jpg;base64,after';
     await agent.recordToReport('comparison', {
       content: 'before and after state',
       screenshots: [
-        { base64: beforeScreenshot, description: 'Before click' },
-        { base64: afterScreenshot, description: 'After click' },
+        { base64: VALID_PNG, description: 'Before click' },
+        { base64: VALID_JPEG, description: 'After click' },
       ],
     });
 
@@ -188,10 +198,9 @@ describe('Agent dump update screenshot serialization', () => {
       'Before click',
       'After click',
     ]);
-    expect(task.recorder?.map((item) => item.screenshot?.base64)).toEqual([
-      'data:image/png;base64,before',
-      'data:image/jpeg;base64,after',
-    ]);
+    for (const item of task.recorder ?? []) {
+      expect(item.screenshot?.base64).toMatch(/^data:image\/webp;base64,UklGR/);
+    }
     expect(task.recorder?.[0].ts ?? 0).toBeLessThan(task.recorder?.[1].ts ?? 0);
 
     await agent.destroy();
@@ -373,6 +382,11 @@ describe('Agent dump update screenshot serialization', () => {
       }),
       expect.anything(),
       undefined,
+    );
+    const execution = reportGeneratorStub.onExecutionUpdate.mock
+      .calls[0][0] as ExecutionDump;
+    expect(execution.collectScreenshots()[0].base64).toMatch(
+      /^data:image\/webp;base64,UklGR/,
     );
 
     await agent.destroy();

--- a/packages/core/tests/unit-test/agent-ui-observer.test.ts
+++ b/packages/core/tests/unit-test/agent-ui-observer.test.ts
@@ -3,6 +3,14 @@ import { ScreenshotItem } from '@/screenshot-item';
 import type { UIContext } from '@/types';
 import { describe, expect, it, vi } from 'vitest';
 
+const { finalizeScreenshotBase64 } = vi.hoisted(() => ({
+  finalizeScreenshotBase64: vi.fn(async (base64: string) => `final:${base64}`),
+}));
+
+vi.mock('@/agent/screenshot-finalizer', () => ({
+  finalizeScreenshotBase64,
+}));
+
 const defaultModel = { config: { slot: 'default' } };
 
 const fakeContext = (tag: string): UIContext =>
@@ -15,7 +23,12 @@ const fakeContext = (tag: string): UIContext =>
     shrunkShotToLogicalRatio: 1,
   }) as UIContext;
 
-const createAgentStub = (opts: { openFrameSource?: () => any } = {}) => {
+const createAgentStub = (
+  opts: {
+    openFrameSource?: () => any;
+    screenshotShrinkFactor?: number;
+  } = {},
+) => {
   const agent = Object.create(Agent.prototype) as Agent<any>;
   const createTypeQueryExecution = vi.fn(async () => ({
     output: true,
@@ -24,7 +37,9 @@ const createAgentStub = (opts: { openFrameSource?: () => any } = {}) => {
   const screenshotBase64 = vi.fn(
     async () => 'data:image/png;base64,iVBORw0KGgo-fallback',
   );
-  (agent as any).opts = {};
+  (agent as any).opts = {
+    screenshotShrinkFactor: opts.screenshotShrinkFactor,
+  };
   (agent as any).taskExecutor = { createTypeQueryExecution };
   (agent as any).resolveModelRuntime = vi.fn(() => defaultModel);
   (agent as any).interface = {
@@ -68,7 +83,7 @@ describe('Agent.startObserving', () => {
     expect(executionOptions.uiContext).toBeDefined();
     const sequence = executionOptions.uiContext.screenshotSequence;
     expect(sequence.length).toBeGreaterThanOrEqual(2);
-    expect(sequence[0].base64.startsWith('dec:')).toBe(true);
+    expect(sequence[0].base64.startsWith('final:dec:')).toBe(true);
   });
 
   it('rejects starting a second observer while one is active', async () => {
@@ -111,6 +126,17 @@ describe('Agent.startObserving', () => {
     expect(
       executionOptions.uiContext.screenshotSequence.length,
     ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('requests a lossless fallback source when Core will resize the frame', async () => {
+    const { agent, screenshotBase64 } = createAgentStub({
+      screenshotShrinkFactor: 2,
+    });
+
+    const observer = await agent.startObserving({ intervalMs: 200 });
+    await observer.stop();
+
+    expect(screenshotBase64).toHaveBeenCalledWith({ preferLossless: true });
   });
 
   it('plain aiAssert / aiBoolean stay single-frame (no uiContext injected)', async () => {

--- a/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
@@ -4,13 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock imageInfoOfBase64 to control screenshot dimensions
 vi.mock('@midscene/shared/img', () => ({
-  convertImgBufferToJpeg: vi.fn(),
-  createImgBase64ByFormat: vi.fn(),
+  canonicalizeScreenshotBase64: vi.fn().mockResolvedValue('mock-base64-data'),
   imageInfoOfBase64: vi.fn(),
-  parseBase64: vi.fn(() => ({
-    mimeType: 'image/jpeg',
-    body: 'mock-base64-data',
-  })),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 

--- a/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-orientation.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@midscene/shared/img', () => ({
   canonicalizeScreenshotBase64: vi.fn().mockResolvedValue('mock-base64-data'),
   imageInfoOfBase64: vi.fn(),
+  normalizeScreenshotBase64: vi.fn((base64) => base64),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 

--- a/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
@@ -3,25 +3,19 @@ import type { AbstractInterface } from '@/device';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@midscene/shared/img', () => ({
-  convertImgBufferToJpeg: vi.fn(),
-  createImgBase64ByFormat: vi.fn(),
+  canonicalizeScreenshotBase64: vi.fn(),
   imageInfoOfBase64: vi.fn(),
-  parseBase64: vi.fn(),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 
 import {
-  convertImgBufferToJpeg,
-  createImgBase64ByFormat,
+  canonicalizeScreenshotBase64,
   imageInfoOfBase64,
-  parseBase64,
   resizeImgBase64,
 } from '@midscene/shared/img';
 
-const mockedConvertToJpeg = vi.mocked(convertImgBufferToJpeg);
-const mockedCreateBase64 = vi.mocked(createImgBase64ByFormat);
+const mockedCanonicalize = vi.mocked(canonicalizeScreenshotBase64);
 const mockedImageInfo = vi.mocked(imageInfoOfBase64);
-const mockedParseBase64 = vi.mocked(parseBase64);
 const mockedResizeImg = vi.mocked(resizeImgBase64);
 
 function createMockInterface(
@@ -41,35 +35,24 @@ function createMockInterface(
 describe('commonContextParser screenshotShrinkFactor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedParseBase64.mockReturnValue({
-      mimeType: 'image/jpeg',
-      body: 'mock-base64-data',
-    });
+    mockedCanonicalize.mockResolvedValue('mock-base64-data');
   });
 
-  it('converts PNG screenshots to JPEG quality 90 when not shrinking', async () => {
+  it('canonicalizes screenshots before sharing them with AI and reports', async () => {
     const mockInterface = createMockInterface(800, 400);
-    const pngBody = Buffer.from('png-image').toString('base64');
-    const jpegBuffer = Buffer.from('jpeg-image');
     mockedImageInfo.mockResolvedValue({ width: 2400, height: 1200 });
-    mockedParseBase64.mockReturnValue({
-      mimeType: 'image/png',
-      body: pngBody,
-    });
-    mockedConvertToJpeg.mockResolvedValue(jpegBuffer);
-    mockedCreateBase64.mockReturnValue('data:image/jpeg;base64,jpeg-image');
+    mockedCanonicalize.mockResolvedValue(
+      'data:image/webp;base64,canonical-webp',
+    );
 
     const result = await commonContextParser(mockInterface, {});
 
-    expect(mockedConvertToJpeg).toHaveBeenCalledWith(
-      Buffer.from(pngBody, 'base64'),
-      90,
+    expect(mockedCanonicalize).toHaveBeenCalledWith('mock-base64-data', {
+      preserveJpeg: true,
+    });
+    expect(result.screenshot.base64).toBe(
+      'data:image/webp;base64,canonical-webp',
     );
-    expect(mockedCreateBase64).toHaveBeenCalledWith(
-      'jpeg',
-      jpegBuffer.toString('base64'),
-    );
-    expect(result.screenshot.base64).toBe('data:image/jpeg;base64,jpeg-image');
   });
 
   it('does not shrink when screenshotShrinkFactor is not provided', async () => {
@@ -94,6 +77,7 @@ describe('commonContextParser screenshotShrinkFactor', () => {
       width: 1200,
       height: 600,
     });
+    expect(mockedCanonicalize).not.toHaveBeenCalled();
     expect(result.shotSize).toEqual({ width: 1200, height: 600 });
   });
 

--- a/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
+++ b/packages/core/tests/unit-test/common-context-parser-shrink-factor.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@midscene/shared/img', () => ({
   canonicalizeScreenshotBase64: vi.fn(),
   imageInfoOfBase64: vi.fn(),
+  normalizeScreenshotBase64: vi.fn((base64) => base64),
   resizeImgBase64: vi.fn().mockResolvedValue('mock-resized-base64-data'),
 }));
 
@@ -35,7 +36,7 @@ function createMockInterface(
 describe('commonContextParser screenshotShrinkFactor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedCanonicalize.mockResolvedValue('mock-base64-data');
+    mockedCanonicalize.mockImplementation(async (base64) => base64);
   });
 
   it('canonicalizes screenshots before sharing them with AI and reports', async () => {
@@ -47,9 +48,8 @@ describe('commonContextParser screenshotShrinkFactor', () => {
 
     const result = await commonContextParser(mockInterface, {});
 
-    expect(mockedCanonicalize).toHaveBeenCalledWith('mock-base64-data', {
-      preserveJpeg: true,
-    });
+    expect(mockedCanonicalize).toHaveBeenCalledWith('mock-base64-data');
+    expect(mockInterface.screenshotBase64).toHaveBeenCalledWith(undefined);
     expect(result.screenshot.base64).toBe(
       'data:image/webp;base64,canonical-webp',
     );
@@ -77,7 +77,10 @@ describe('commonContextParser screenshotShrinkFactor', () => {
       width: 1200,
       height: 600,
     });
-    expect(mockedCanonicalize).not.toHaveBeenCalled();
+    expect(mockedCanonicalize).toHaveBeenCalledWith('mock-resized-base64-data');
+    expect(mockInterface.screenshotBase64).toHaveBeenCalledWith({
+      preferLossless: true,
+    });
     expect(result.shotSize).toEqual({ width: 1200, height: 600 });
   });
 

--- a/packages/core/tests/unit-test/gpt-image-detail.test.ts
+++ b/packages/core/tests/unit-test/gpt-image-detail.test.ts
@@ -183,4 +183,16 @@ describe('GPT image detail handling', () => {
 
     expect(mockCreate.mock.calls[0][0]).toHaveProperty('temperature', 0.7);
   });
+
+  it('reports the exact image URL included in the model request', async () => {
+    const onModelInputImages = vi.fn();
+    await callAI(imageMessage, {
+      ...getModelRuntime(baseModelConfig),
+      onModelInputImages,
+    });
+
+    expect(onModelInputImages).toHaveBeenCalledWith([
+      'https://example.com/shot.png',
+    ]);
+  });
 });

--- a/packages/core/tests/unit-test/model-input-recorder.test.ts
+++ b/packages/core/tests/unit-test/model-input-recorder.test.ts
@@ -1,0 +1,82 @@
+import { recordModelInputsForTask } from '@/agent/model-input-recorder';
+import type { ModelRuntime } from '@/ai-model/models';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { ExecutionTask } from '@/types';
+import { describe, expect, it, vi } from 'vitest';
+
+const pngBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA';
+const webpBase64 =
+  'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+
+function createTask(): ExecutionTask {
+  const screenshot = ScreenshotItem.create(pngBase64, 100);
+  return {
+    taskId: 'task-1',
+    type: 'Planning',
+    subType: 'Plan',
+    status: 'running',
+    executor: vi.fn(),
+    uiContext: {
+      screenshot,
+      shotSize: { width: 5, height: 1 },
+      shrunkShotToLogicalRatio: 1,
+    },
+  };
+}
+
+describe('recordModelInputsForTask', () => {
+  it('reuses the report screenshot when the exact bytes are sent to AI', () => {
+    const task = createTask();
+    const runtime = recordModelInputsForTask({} as ModelRuntime, task);
+
+    runtime.onModelInputImages?.([pngBase64]);
+
+    expect(task.recorder).toHaveLength(1);
+    expect(task.recorder?.[0].screenshot).toBe(task.uiContext?.screenshot);
+    expect(task.recorder?.[0].timing).toBe('model-input');
+    expect(task.recorder?.[0].description).toMatch(
+      /^Model input 1 \(exact bytes, sha256: [a-f0-9]{64}\)$/,
+    );
+  });
+
+  it('records a transformed model image and deduplicates request retries', () => {
+    const task = createTask();
+    const parentCallback = vi.fn();
+    const runtime = recordModelInputsForTask(
+      { onModelInputImages: parentCallback } as ModelRuntime,
+      task,
+    );
+
+    runtime.onModelInputImages?.([webpBase64]);
+    runtime.onModelInputImages?.([webpBase64]);
+
+    expect(parentCallback).toHaveBeenCalledTimes(2);
+    expect(task.recorder).toHaveLength(1);
+    expect(task.recorder?.[0].screenshot?.base64).toBe(webpBase64);
+    expect(task.recorder?.[0].screenshot).not.toBe(task.uiContext?.screenshot);
+  });
+
+  it('reuses the executor context screenshot before it is bound to the task', () => {
+    const task = createTask();
+    const sourceScreenshot = task.uiContext!.screenshot;
+    task.uiContext = undefined;
+    const runtime = recordModelInputsForTask(
+      {} as ModelRuntime,
+      task,
+      sourceScreenshot,
+    );
+
+    runtime.onModelInputImages?.([pngBase64]);
+
+    expect(task.recorder?.[0].screenshot).toBe(sourceScreenshot);
+  });
+
+  it('does not turn remote reference image URLs into screenshot items', () => {
+    const task = createTask();
+    const runtime = recordModelInputsForTask({} as ModelRuntime, task);
+
+    runtime.onModelInputImages?.(['https://example.com/reference.png']);
+
+    expect(task.recorder).toBeUndefined();
+  });
+});

--- a/packages/core/tests/unit-test/model-input-recorder.test.ts
+++ b/packages/core/tests/unit-test/model-input-recorder.test.ts
@@ -42,10 +42,9 @@ describe('recordModelInputsForTask', () => {
   it('records a transformed model image and deduplicates request retries', () => {
     const task = createTask();
     const parentCallback = vi.fn();
-    const runtime = recordModelInputsForTask(
-      { onModelInputImages: parentCallback } as ModelRuntime,
-      task,
-    );
+    const parentRuntime = {} as ModelRuntime;
+    parentRuntime.onModelInputImages = parentCallback;
+    const runtime = recordModelInputsForTask(parentRuntime, task);
 
     runtime.onModelInputImages?.([webpBase64]);
     runtime.onModelInputImages?.([webpBase64]);

--- a/packages/core/tests/unit-test/report-action-dump-webp.test.ts
+++ b/packages/core/tests/unit-test/report-action-dump-webp.test.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ReportActionDump } from '../../src/dump/report-action-dump';
+import { ScreenshotItem } from '../../src/screenshot-item';
+import { ExecutionDump } from '../../src/types';
+
+const webpBody =
+  'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+const webpBase64 = `data:image/webp;base64,${webpBody}`;
+
+describe('ReportActionDump WebP file serialization', () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = join(
+      tmpdir(),
+      `midscene-dump-webp-${Date.now()}-${Math.random()}`,
+    );
+    mkdirSync(temporaryDirectory, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it('writes and restores WebP files without changing their bytes or MIME type', () => {
+    const screenshot = ScreenshotItem.create(webpBase64, 100);
+    const dump = new ReportActionDump({
+      sdkVersion: '1.0.0-test',
+      groupName: 'webp-dump',
+      modelBriefs: [],
+      executions: [
+        new ExecutionDump({
+          logTime: 100,
+          name: 'webp-execution',
+          tasks: [
+            {
+              taskId: 'webp-task',
+              type: 'Insight',
+              subType: 'Locate',
+              param: { prompt: 'target' },
+              uiContext: {
+                screenshot,
+                shotSize: { width: 2, height: 3 },
+                shrunkShotToLogicalRatio: 1,
+              },
+              executor: async () => undefined,
+              recorder: [],
+              status: 'finished',
+            },
+          ],
+        }),
+      ],
+    });
+    const dumpPath = join(temporaryDirectory, 'dump.json');
+
+    dump.serializeToFiles(dumpPath);
+
+    const screenshotPath = join(
+      `${dumpPath}.screenshots`,
+      `${screenshot.id}.webp`,
+    );
+    expect(existsSync(screenshotPath)).toBe(true);
+    expect(readFileSync(screenshotPath).toString('base64')).toBe(webpBody);
+
+    const restored = JSON.parse(
+      ReportActionDump.fromFilesAsInlineJson(dumpPath),
+    );
+    expect(restored.executions[0].tasks[0].uiContext.screenshot).toMatchObject({
+      base64: webpBase64,
+      capturedAt: 100,
+    });
+  });
+});

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -24,6 +24,9 @@ function fakeBase64(sizeBytes: number): string {
   return `data:image/png;base64,${'A'.repeat(sizeBytes)}`;
 }
 
+const webpBase64 =
+  'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+
 function createExecution(
   id: string,
   screenshot: ScreenshotItem | ScreenshotRef,
@@ -221,6 +224,45 @@ describe('createReportCliCommands', () => {
 
     expect(result.markdownFiles.length).toBe(1);
     expect(existsSync(join(outputDir, 'report.md'))).toBe(true);
+  });
+
+  it('exports WebP screenshots and markdown links with the .webp suffix', async () => {
+    const reportPath = join(tmpDir, 'input-report-sdk-webp', 'index.html');
+    mkdirSync(join(tmpDir, 'input-report-sdk-webp'), { recursive: true });
+    const screenshot = ScreenshotItem.create(webpBase64, Date.now());
+    const dump = new ReportActionDump({
+      groupName: 'sdk-webp-test',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createExecution('exec-sdk-webp', screenshot)],
+    });
+    writeFileSync(
+      reportPath,
+      [
+        generateImageScriptTag(screenshot.id, screenshot.base64),
+        generateDumpScriptTag(dump.serialize(), {
+          'data-group-id': 'webp-group',
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const outputDir = join(tmpDir, 'output-sdk-webp');
+    const result = await reportFileToMarkdown({
+      htmlPath: reportPath,
+      outputDir,
+    });
+    const expectedFileName = `execution-1-task-1-${screenshot.id}.webp`;
+
+    expect(result.screenshotFiles).toEqual([
+      join(outputDir, 'screenshots', expectedFileName),
+    ]);
+    expect(readFileSync(result.screenshotFiles[0]).toString('base64')).toBe(
+      webpBase64.split(',')[1],
+    );
+    expect(readFileSync(join(outputDir, 'report.md'), 'utf-8')).toContain(
+      `./screenshots/${expectedFileName}`,
+    );
   });
 
   it('throws SDK-friendly validation errors for reportFileToMarkdown', async () => {

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -28,6 +28,9 @@ function createTask(overrides: Record<string, unknown> = {}) {
 }
 
 describe('report-markdown', () => {
+  const webpBase64 =
+    'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+
   it('handles single execution markdown with screenshot file links', () => {
     const screenshot = ScreenshotItem.create(
       'data:image/png;base64,Zm9v',
@@ -80,6 +83,34 @@ describe('report-markdown', () => {
     );
     expect(result.attachments).toHaveLength(2);
     expect(result.attachments[0].suggestedFileName).toContain('.png');
+    expect(result.markdown).toContain(
+      `./screenshots/${result.attachments[0].suggestedFileName}`,
+    );
+  });
+
+  it('exports WebP screenshots with coherent MIME and file metadata', () => {
+    const screenshot = ScreenshotItem.create(webpBase64, 1710000000000);
+    const execution: IExecutionDump = {
+      logTime: 1710000000000,
+      name: 'webp execution',
+      tasks: [
+        createTask({
+          uiContext: {
+            screenshot,
+            shotSize: { width: 2, height: 3 },
+          },
+        }),
+      ],
+    };
+
+    const result = executionToMarkdown(execution);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      suggestedFileName: expect.stringMatching(/\.webp$/),
+      mimeType: 'image/webp',
+      base64Data: webpBase64,
+    });
     expect(result.markdown).toContain(
       `./screenshots/${result.attachments[0].suggestedFileName}`,
     );

--- a/packages/core/tests/unit-test/report-split.test.ts
+++ b/packages/core/tests/unit-test/report-split.test.ts
@@ -18,6 +18,9 @@ function fakeBase64(sizeBytes: number): string {
   return `data:image/png;base64,${'A'.repeat(sizeBytes)}`;
 }
 
+const webpBase64 =
+  'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+
 function createExecution(
   id: string,
   screenshot: ScreenshotItem | ScreenshotRef,
@@ -127,6 +130,48 @@ describe('splitReportHtmlByExecution', () => {
     for (const screenshotFile of result.screenshotFiles) {
       expect(existsSync(screenshotFile)).toBe(true);
     }
+  });
+
+  it('externalizes inline WebP screenshots as .webp files', () => {
+    const reportPath = join(tmpDir, 'webp-report', 'index.html');
+    mkdirSync(join(tmpDir, 'webp-report'), { recursive: true });
+    const screenshot = ScreenshotItem.create(webpBase64, Date.now());
+    const dump = new ReportActionDump({
+      groupName: 'webp-split-test',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createExecution('webp-exec', screenshot)],
+    });
+    writeFileSync(
+      reportPath,
+      [
+        generateImageScriptTag(screenshot.id, screenshot.base64),
+        generateDumpScriptTag(dump.serialize(), {
+          'data-group-id': 'webp-group',
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = splitReportHtmlByExecution({
+      htmlPath: reportPath,
+      outputDir: join(tmpDir, 'webp-output'),
+    });
+    const outputDump = JSON.parse(
+      readFileSync(result.executionJsonFiles[0], 'utf-8'),
+    );
+    const outputRef = outputDump.executions[0].tasks[0].uiContext.screenshot;
+
+    expect(outputRef).toMatchObject({
+      mimeType: 'image/webp',
+      path: `./screenshots/${screenshot.id}.webp`,
+    });
+    expect(result.screenshotFiles).toEqual([
+      join(tmpDir, 'webp-output', 'screenshots', `${screenshot.id}.webp`),
+    ]);
+    expect(readFileSync(result.screenshotFiles[0]).toString('base64')).toBe(
+      webpBase64.split(',')[1],
+    );
   });
 
   it('should process large report incrementally without accumulating all dump scripts', () => {

--- a/packages/core/tests/unit-test/screenshot-finalizer.test.ts
+++ b/packages/core/tests/unit-test/screenshot-finalizer.test.ts
@@ -1,0 +1,32 @@
+import { finalizeScreenshotBase64 } from '@/agent/screenshot-finalizer';
+import { imageInfoOfBase64 } from '@midscene/shared/img';
+import { describe, expect, it } from 'vitest';
+
+const ONE_PIXEL_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('screenshot finalizer', () => {
+  it('converts a PNG screenshot to the final WebP format', async () => {
+    const result = await finalizeScreenshotBase64(ONE_PIXEL_PNG);
+
+    expect(result).toMatch(/^data:image\/webp;base64,UklGR/);
+    await expect(imageInfoOfBase64(result)).resolves.toEqual({
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it('passes an existing final WebP through byte-for-byte', async () => {
+    const webp = await finalizeScreenshotBase64(ONE_PIXEL_PNG);
+
+    await expect(finalizeScreenshotBase64(webp)).resolves.toBe(webp);
+  });
+
+  it('still returns WebP when a rounded resize target matches the source size', async () => {
+    const result = await finalizeScreenshotBase64(ONE_PIXEL_PNG, {
+      targetSize: { width: 1, height: 1 },
+    });
+
+    expect(result).toMatch(/^data:image\/webp;base64,UklGR/);
+  });
+});

--- a/packages/core/tests/unit-test/screenshot-item.test.ts
+++ b/packages/core/tests/unit-test/screenshot-item.test.ts
@@ -36,6 +36,16 @@ describe('ScreenshotItem', () => {
       });
     });
 
+    it('preserves unrecognized screenshot placeholders as PNG metadata', () => {
+      const item = ScreenshotItem.create('mock-screenshot', 123);
+
+      expect(item.base64).toBe('mock-screenshot');
+      expect(item.rawBase64).toBe('mock-screenshot');
+      expect(item.format).toBe('png');
+      expect(item.extension).toBe('png');
+      expect(item.mimeType).toBe('image/png');
+    });
+
     it('classifies WebP screenshots without corrupting their metadata or body', () => {
       const item = ScreenshotItem.create(webpBase64, 123);
 

--- a/packages/core/tests/unit-test/screenshot-item.test.ts
+++ b/packages/core/tests/unit-test/screenshot-item.test.ts
@@ -22,6 +22,20 @@ describe('ScreenshotItem', () => {
       expect(item.capturedAt).toBe(capturedAt);
     });
 
+    it('preserves empty screenshot placeholders as PNG metadata', () => {
+      const item = ScreenshotItem.create('', 123);
+
+      expect(item.base64).toBe('');
+      expect(item.rawBase64).toBe('');
+      expect(item.format).toBe('png');
+      expect(item.extension).toBe('png');
+      expect(item.mimeType).toBe('image/png');
+      expect(item.toSerializable()).toMatchObject({
+        capturedAt: 123,
+        mimeType: 'image/png',
+      });
+    });
+
     it('classifies WebP screenshots without corrupting their metadata or body', () => {
       const item = ScreenshotItem.create(webpBase64, 123);
 

--- a/packages/core/tests/unit-test/screenshot-item.test.ts
+++ b/packages/core/tests/unit-test/screenshot-item.test.ts
@@ -6,6 +6,8 @@ import { ScreenshotItem } from '../../src/screenshot-item';
 
 describe('ScreenshotItem', () => {
   const testBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA';
+  const webpBase64 =
+    'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
 
   describe('create', () => {
     it('should create a ScreenshotItem from base64 string', () => {
@@ -18,6 +20,19 @@ describe('ScreenshotItem', () => {
       const capturedAt = Date.now();
       const item = ScreenshotItem.create(testBase64, capturedAt);
       expect(item.capturedAt).toBe(capturedAt);
+    });
+
+    it('classifies WebP screenshots without corrupting their metadata or body', () => {
+      const item = ScreenshotItem.create(webpBase64, 123);
+
+      expect(item.format).toBe('webp');
+      expect(item.extension).toBe('webp');
+      expect(item.mimeType).toBe('image/webp');
+      expect(item.rawBase64).toBe(webpBase64.split(',')[1]);
+      expect(item.toSerializable()).toMatchObject({
+        capturedAt: 123,
+        mimeType: 'image/webp',
+      });
     });
   });
 
@@ -124,6 +139,11 @@ describe('ScreenshotItem', () => {
         Date.now(),
       );
       expect(item.rawBase64).toBe('/9j/4AAQ');
+    });
+
+    it('should strip data URI prefix from WebP', () => {
+      const item = ScreenshotItem.create(webpBase64, Date.now());
+      expect(item.rawBase64).toBe(webpBase64.split(',')[1]);
     });
 
     it('should return unchanged if no prefix', () => {

--- a/packages/core/tests/unit-test/screenshot-store.test.ts
+++ b/packages/core/tests/unit-test/screenshot-store.test.ts
@@ -13,6 +13,9 @@ import { ScreenshotItem } from '../../src/screenshot-item';
 
 describe('ScreenshotStore', () => {
   const pngBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA';
+  const webpBody =
+    'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+  const webpBase64 = `data:image/webp;base64,${webpBody}`;
   let tmpRoot: string;
 
   beforeEach(() => {
@@ -42,6 +45,53 @@ describe('ScreenshotStore', () => {
     expect(ref.storage).toBe('file');
     expect(existsSync(join(screenshotsDir, `${item.id}.png`))).toBe(true);
     expect(store.loadBase64(ref)).toContain('data:image/png;base64,');
+  });
+
+  it('persists WebP bytes with a .webp path and restores the WebP MIME type', async () => {
+    const reportPath = join(tmpRoot, 'index.html');
+    const screenshotsDir = join(tmpRoot, 'screenshots');
+    const item = ScreenshotItem.create(webpBase64, 100);
+    const store = new ScreenshotStore({
+      mode: 'directory',
+      reportPath,
+      screenshotsDir,
+    });
+
+    const ref = await store.persist(item);
+    const filePath = join(screenshotsDir, `${item.id}.webp`);
+
+    expect(ref).toMatchObject({
+      mimeType: 'image/webp',
+      path: `./screenshots/${item.id}.webp`,
+    });
+    expect(readFileSync(filePath).toString('base64')).toBe(webpBody);
+    expect(store.loadBase64(ref)).toBe(webpBase64);
+  });
+
+  it('resolves sibling WebP files for inline references', () => {
+    const reportPath = join(tmpRoot, 'index.html');
+    const screenshotsDir = join(tmpRoot, 'screenshots');
+    mkdirSync(screenshotsDir, { recursive: true });
+    writeFileSync(reportPath, '<html></html>');
+    writeFileSync(
+      join(screenshotsDir, 'sibling-webp.webp'),
+      Buffer.from(webpBody, 'base64'),
+    );
+    const store = new ScreenshotStore({
+      mode: 'inline',
+      reportPath,
+      writeInlineImage: () => {},
+    });
+
+    expect(
+      store.loadBase64({
+        type: 'midscene_screenshot_ref',
+        id: 'sibling-webp',
+        capturedAt: 100,
+        mimeType: 'image/webp',
+        storage: 'inline',
+      }),
+    ).toBe(webpBase64);
   });
 
   it('deduplicates same screenshot persistence by id', async () => {

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -41,6 +41,12 @@ const expectEmptyUIContext = () =>
     shrunkShotToLogicalRatio: 1,
   });
 
+const expectRecordedModelRuntime = (config: IModelConfig) =>
+  expect.objectContaining({
+    config: expect.objectContaining(config),
+    onModelInputImages: expect.any(Function),
+  });
+
 const createMockUsage = (totalTokens: number): AIUsageInfo => ({
   prompt_tokens: 0,
   completion_tokens: 0,
@@ -214,7 +220,7 @@ describe('TaskExecutor - Null Data Handling', () => {
           StatementIsTruthy:
             'Boolean, based on the current screenshot and its contents if provided, unless the user explicitly asks to compare with reference images, whether the following statement is true: Page title is correct',
         },
-        getModelRuntime(mockModelConfig),
+        expectRecordedModelRuntime(mockModelConfig),
         {},
         '',
         undefined,
@@ -269,7 +275,7 @@ describe('TaskExecutor - Null Data Handling', () => {
           StatementIsTruthy:
             "Boolean, the user wants to do some 'wait for' operation. based on the current screenshot and its contents if provided, unless the user explicitly asks to compare with reference images, please check whether the following statement is true: Element is visible",
         },
-        getModelRuntime(mockModelConfig),
+        expectRecordedModelRuntime(mockModelConfig),
         {},
         '',
         undefined,
@@ -636,7 +642,7 @@ describe('TaskExecutor - Null Data Handling', () => {
           Number:
             'Number, based on the current screenshot and its contents if provided, unless the user explicitly asks to compare with reference images, Extract the price',
         },
-        getModelRuntime(mockModelConfig),
+        expectRecordedModelRuntime(mockModelConfig),
         {},
         '',
         undefined,
@@ -731,7 +737,7 @@ describe('TaskExecutor - Null Data Handling', () => {
           Number:
             'Number, based on the current screenshot and its contents if provided, unless the user explicitly asks to compare with reference images, Extract the price',
         },
-        getModelRuntime(mockModelConfig),
+        expectRecordedModelRuntime(mockModelConfig),
         {},
         '',
         undefined,
@@ -787,7 +793,7 @@ describe('TaskExecutor - Null Data Handling', () => {
           Boolean:
             'Boolean, based on the current screenshot and its contents if provided, unless the user explicitly asks to compare with reference images, there is a like button',
         },
-        getModelRuntime(mockModelConfig),
+        expectRecordedModelRuntime(mockModelConfig),
         {},
         '',
         undefined,

--- a/packages/core/tests/unit-test/ui-observer.test.ts
+++ b/packages/core/tests/unit-test/ui-observer.test.ts
@@ -4,6 +4,14 @@ import { ScreenshotItem } from '@/screenshot-item';
 import type { UIContext } from '@/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const { finalizeScreenshotBase64 } = vi.hoisted(() => ({
+  finalizeScreenshotBase64: vi.fn(async (base64: string) => `final:${base64}`),
+}));
+
+vi.mock('@/agent/screenshot-finalizer', () => ({
+  finalizeScreenshotBase64,
+}));
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const fakeRepresentative = (): UIContext =>
@@ -110,9 +118,9 @@ describe('UIObserver', () => {
     const uiContext = (runAssert.mock.calls[0] as any[])[1] as UIContext;
     const sequence = uiContext.screenshotSequence!;
     expect(sequence.length).toBeGreaterThanOrEqual(3);
-    expect(sequence[0].base64).toBe('decoded:f0');
+    expect(sequence[0].base64).toBe('final:decoded:f0');
     // Representative screenshot is aligned with last sampled frame.
-    expect(sequence[sequence.length - 1].base64).toBe('decoded:f1');
+    expect(sequence[sequence.length - 1].base64).toBe('final:decoded:f1');
     expect(fake.stop).toHaveBeenCalledTimes(1);
   });
 
@@ -313,7 +321,9 @@ describe('UIObserver', () => {
     expect(screenshot).toHaveBeenCalled();
     const uiContext = (runAssert.mock.calls[0] as any[])[1] as UIContext;
     expect(
-      uiContext.screenshotSequence![0].base64.startsWith('data:image/png'),
+      uiContext.screenshotSequence![0].base64.startsWith(
+        'final:data:image/png',
+      ),
     ).toBe(true);
   });
 

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -15,12 +15,16 @@ import {
   type HarmonyDeviceOpt as CoreHarmonyDeviceOpt,
   type MobileInputPrimitives,
   type PointerPoint,
+  type ScreenshotCaptureOptions,
   createDefaultMobileActions,
   defineAction,
 } from '@midscene/core/device';
 import { getTmpFile, sleep } from '@midscene/core/utils';
 import type { ElementInfo } from '@midscene/shared/extractor';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
+import {
+  canonicalizeScreenshotBase64,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison, repeat } from '@midscene/shared/utils';
 import { HdcClient } from './hdc';
@@ -433,7 +437,7 @@ export class HarmonyDevice implements AbstractInterface {
   private remoteScreenshotPath = '/data/local/tmp/ms_screen.jpeg';
   private localScreenshotPath: string | null = null;
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
     debugDevice('screenshotBase64 begin');
     const hdc = await this.getHdc();
 
@@ -475,10 +479,13 @@ export class HarmonyDevice implements AbstractInterface {
 
       if (screenshotBuffer && screenshotBuffer.length > 0) {
         debugDevice(`Screenshot captured: ${screenshotBuffer.length} bytes`);
-        return createImgBase64ByFormat(
+        const jpeg = createImgBase64ByFormat(
           'jpeg',
           screenshotBuffer.toString('base64'),
         );
+        return options?.preferLossless
+          ? jpeg
+          : canonicalizeScreenshotBase64(jpeg);
       }
 
       debugDevice(

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -52,6 +52,9 @@ vi.mock('@midscene/shared/img', () => ({
   createImgBase64ByFormat: vi
     .fn()
     .mockReturnValue('data:image/jpeg;base64,fake'),
+  canonicalizeScreenshotBase64: vi
+    .fn()
+    .mockResolvedValue('data:image/webp;base64,converted'),
 }));
 
 // @ts-ignore package tsconfig keeps module=ES2020 for build compatibility; this test intentionally uses top-level dynamic import so mocks are registered first.
@@ -727,9 +730,18 @@ describe('HarmonyDevice', () => {
     it('should take screenshot and return base64', async () => {
       await device.connect();
       const result = await device.screenshotBase64();
-      expect(result).toBe('data:image/jpeg;base64,fake');
+      expect(result).toBe('data:image/webp;base64,converted');
       expect(mockHdc.screenshot).toHaveBeenCalled();
       expect(mockHdc.fileRecv).toHaveBeenCalled();
+    });
+
+    it('should return the native JPEG source when Core will resize it', async () => {
+      await device.connect();
+
+      const result = await device.screenshotBase64({ preferLossless: true });
+
+      expect(result).toBe('data:image/jpeg;base64,fake');
+      expect(mockHdc.screenshot).toHaveBeenCalled();
     });
   });
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -20,7 +20,10 @@ import {
 import { sleep } from '@midscene/core/utils';
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import type { ElementInfo } from '@midscene/shared/extractor';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
+import {
+  canonicalizeScreenshotBase64,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison } from '@midscene/shared/utils';
 import { WDAManager } from '@midscene/webdriver';
@@ -433,7 +436,9 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     debugDevice('Taking screenshot via WDA');
     try {
       const base64Data = await this.wdaBackend.takeScreenshot();
-      const result = createImgBase64ByFormat('png', base64Data);
+      const result = await canonicalizeScreenshotBase64(
+        createImgBase64ByFormat('png', base64Data),
+      );
       debugDevice('Screenshot taken successfully');
       return result;
     } catch (error) {

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -14,6 +14,7 @@ import {
   type IOSDeviceOpt,
   type MobileInputPrimitives,
   type PointerPoint,
+  type ScreenshotCaptureOptions,
   createDefaultMobileActions,
   defineAction,
 } from '@midscene/core/device';
@@ -432,13 +433,14 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     };
   }
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
     debugDevice('Taking screenshot via WDA');
     try {
       const base64Data = await this.wdaBackend.takeScreenshot();
-      const result = await canonicalizeScreenshotBase64(
-        createImgBase64ByFormat('png', base64Data),
-      );
+      const png = createImgBase64ByFormat('png', base64Data);
+      const result = options?.preferLossless
+        ? png
+        : await canonicalizeScreenshotBase64(png);
       debugDevice('Screenshot taken successfully');
       return result;
     } catch (error) {

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -283,10 +283,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       diagnosticsDir,
       'safari-after-input-source.xml',
     );
-    const screenshotFile = path.join(diagnosticsDir, 'safari-smoke.png');
+    const screenshotFile = path.join(diagnosticsDir, 'safari-smoke.webp');
     const postInputScreenshotFile = path.join(
       diagnosticsDir,
-      'safari-after-input.png',
+      'safari-after-input.webp',
     );
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
@@ -337,6 +337,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const screenSize = await agent.interface.getScreenSize();
       const screenshot = await agent.interface.screenshotBase64();
       const screenshotSize = await imageInfoOfBase64(screenshot);
+      expect(screenshot).toMatch(/^data:image\/webp;base64,/);
       await writeFile(screenshotFile, screenshotBuffer(screenshot));
       evidence.screen = { screenSize, screenshotSize };
       expect(screenSize.width).toBeGreaterThan(0);
@@ -387,11 +388,12 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
         : undefined;
       evidence.inputText = inputText;
       expect(inputText).toBe(SUBMITTED_TEXT);
-      await agent.interface
-        .screenshotBase64()
-        .then((base64) =>
-          writeFile(postInputScreenshotFile, screenshotBuffer(base64)),
-        );
+      const postInputScreenshot = await agent.interface.screenshotBase64();
+      expect(postInputScreenshot).toMatch(/^data:image\/webp;base64,/);
+      await writeFile(
+        postInputScreenshotFile,
+        screenshotBuffer(postInputScreenshot),
+      );
 
       const submittedValue = await waitForSubmittedValue(
         fixture.submittedValue,

--- a/packages/ios/tests/ai/todo.test.ts
+++ b/packages/ios/tests/ai/todo.test.ts
@@ -91,14 +91,13 @@ describe('Test todo list', () => {
           endpoint: '/source',
         })) as { value: string };
         await Promise.all([
-          agent.interface
-            .screenshotBase64()
-            .then((base64) =>
-              writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
-                screenshotBuffer(base64),
-              ),
-            ),
+          agent.interface.screenshotBase64().then((base64) => {
+            expect(base64).toMatch(/^data:image\/webp;base64,/);
+            return writeFile(
+              path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
+              screenshotBuffer(base64),
+            );
+          }),
           writeFile(
             path.join(resolvedDiagnosticsDir, 'todo-source.xml'),
             source.value,

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -17,6 +17,8 @@ const getInternalTextInput = (target: IOSDevice) =>
   };
 
 describe('IOSDevice', () => {
+  const validPngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
   let device: IOSDevice;
   let mockWdaClient: any;
 
@@ -32,7 +34,7 @@ describe('IOSDevice', () => {
       setupExistingSession: vi.fn().mockResolvedValue(undefined),
       deleteSession: vi.fn().mockResolvedValue(undefined),
       getWindowSize: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
-      takeScreenshot: vi.fn().mockResolvedValue('base64-screenshot'),
+      takeScreenshot: vi.fn().mockResolvedValue(validPngBase64),
       tap: vi.fn().mockResolvedValue(undefined),
       doubleTap: vi.fn().mockResolvedValue(undefined),
       tripleTap: vi.fn().mockResolvedValue(undefined),
@@ -297,8 +299,7 @@ describe('IOSDevice', () => {
       await device.connect();
 
       const screenshot = await device.screenshotBase64();
-      expect(screenshot).toContain('data:image/png;base64,');
-      expect(screenshot).toContain('base64-screenshot');
+      expect(screenshot).toMatch(/^data:image\/webp;base64,UklGR/);
       expect(mockWdaClient.takeScreenshot).toHaveBeenCalled();
     });
 
@@ -624,8 +625,7 @@ describe('IOSDevice', () => {
     it('should return base64 screenshot', async () => {
       const screenshot = await device.screenshotBase64();
       expect(typeof screenshot).toBe('string');
-      expect(screenshot).toContain('data:image/png;base64,');
-      expect(screenshot).toContain('base64-screenshot');
+      expect(screenshot).toMatch(/^data:image\/webp;base64,UklGR/);
     });
   });
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -303,6 +303,17 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.takeScreenshot).toHaveBeenCalled();
     });
 
+    it('should return the native PNG source when Core will resize it', async () => {
+      await device.connect();
+
+      const screenshot = await device.screenshotBase64({
+        preferLossless: true,
+      });
+
+      expect(screenshot).toBe(`data:image/png;base64,${validPngBase64}`);
+      expect(mockWdaClient.takeScreenshot).toHaveBeenCalled();
+    });
+
     it('should handle app launch with bundle ID', async () => {
       await device.connect();
 

--- a/packages/playground/src/mjpeg-stream-handler.ts
+++ b/packages/playground/src/mjpeg-stream-handler.ts
@@ -1,5 +1,9 @@
 import http from 'node:http';
 import type { Agent as PageAgent } from '@midscene/core/agent';
+import {
+  inferScreenshotImageFormatFromBase64,
+  screenshotImageMimeType,
+} from '@midscene/shared/img/image-format';
 import { getDebug } from '@midscene/shared/logger';
 import type { Request, Response } from 'express';
 import {
@@ -27,6 +31,18 @@ function toMjpegFrameDataUrl(data: string, contentType?: string) {
     return data;
   }
   return `data:${contentType || 'image/jpeg'};base64,${data}`;
+}
+
+function screenshotContentType(data: string): string {
+  const dataUriMatch = data.match(/^data:image\/(png|jpe?g|webp);base64,/i);
+  if (dataUriMatch) {
+    const format = dataUriMatch[1].toLowerCase();
+    return format === 'jpg' ? 'image/jpeg' : `image/${format}`;
+  }
+
+  const body = data.replace(/^data:image\/[^;]+;base64,/i, '');
+  const format = inferScreenshotImageFormatFromBase64(body);
+  return format ? screenshotImageMimeType(format) : 'image/jpeg';
 }
 
 /**
@@ -263,7 +279,7 @@ export class MjpegStreamHandler {
 
         writeMjpegFrame(res, boundary, {
           data: base64,
-          contentType: 'image/jpeg',
+          contentType: screenshotContentType(base64),
         });
       } catch (err) {
         if (stopped) break;

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import type { Server } from 'node:http';
-import { basename, dirname, join, resolve, sep } from 'node:path';
+import { basename, dirname, extname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
   AgentDescribeElementAtPointResult,
@@ -37,7 +37,14 @@ import {
   overrideAIConfig,
 } from '@midscene/shared/env';
 import { generateElementByPoint } from '@midscene/shared/extractor';
-import { annotateRects, imageInfoOfBase64 } from '@midscene/shared/img';
+import {
+  annotateRects,
+  imageInfoOfBase64,
+  screenshotImageExtension,
+  screenshotImageFormatFromExtension,
+  screenshotImageFormatFromMimeType,
+  screenshotImageMimeType,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type {
   MidsceneRecorderScreenshotAssetRef,
@@ -350,7 +357,7 @@ function writeRecorderAiDescribeScreenshot(
   const { base64, mimeType } = extractBase64Payload(imageBase64);
   const bytes = Buffer.from(base64, 'base64');
   const sha256 = createHash('sha256').update(bytes).digest('hex');
-  const extension = mimeType?.includes('jpeg') ? 'jpg' : 'png';
+  const extension = recorderScreenshotAssetExtension(mimeType);
   const pathParts = formatRecorderAiDescribeScreenshotPathParts();
   const dumpRoot = resolve(
     getMidsceneRunSubDir('dump'),
@@ -393,7 +400,11 @@ function assertRecorderScreenshotAssetId(assetId: string) {
 }
 
 function recorderScreenshotAssetExtension(mimeType?: string) {
-  return mimeType?.includes('jpeg') ? 'jpg' : 'png';
+  const format = screenshotImageFormatFromMimeType(mimeType);
+  if (!format) {
+    return 'png';
+  }
+  return format === 'jpeg' ? 'jpg' : screenshotImageExtension(format);
 }
 
 function recorderScreenshotAssetPath(assetId: string, mimeType?: string) {
@@ -428,7 +439,7 @@ function initializeRecorderScreenshotAssetUsage() {
         continue;
       }
       const match = entry.name.match(
-        /^(.*)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpg)$/i,
+        /^(.*)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:png|jpg|webp)$/i,
       );
       if (!match?.[1]) {
         continue;
@@ -508,7 +519,7 @@ function readRecorderScreenshotAsset(
 function findRecorderScreenshotAssetPath(assetId: string) {
   const safeAssetId = assertRecorderScreenshotAssetId(assetId);
   const root = getRecorderScreenshotAssetRoot();
-  for (const extension of ['png', 'jpg']) {
+  for (const extension of ['png', 'jpg', 'webp']) {
     const filePath = assertPathInsideDirectory(
       root,
       join(root, `${safeAssetId}.${extension}`),
@@ -554,7 +565,7 @@ function pruneRecorderScreenshotAssetsForSession(
     if (!entry.isFile() || !entry.name.startsWith(prefix)) {
       continue;
     }
-    const assetId = entry.name.replace(/\.(?:png|jpg)$/i, '');
+    const assetId = entry.name.replace(/\.(?:png|jpg|webp)$/i, '');
     const filePath = join(root, entry.name);
     if (!retained.has(assetId)) {
       rmSync(filePath, { force: true });
@@ -3095,7 +3106,7 @@ class PlaygroundServer {
           return res.status(404).json({ error: 'Report not found or expired' });
         }
 
-        const match = /^([A-Za-z0-9_-]+)\.(png|jpe?g)$/.exec(
+        const match = /^([A-Za-z0-9_-]+)\.(png|jpe?g|webp)$/.exec(
           req.params.assetName,
         );
         if (!match) {
@@ -3125,7 +3136,11 @@ class PlaygroundServer {
           if (commaIndex === -1) {
             throw new Error('Invalid screenshot data URI');
           }
-          const mimeType = extension === 'png' ? 'image/png' : 'image/jpeg';
+          const format = screenshotImageFormatFromExtension(extension);
+          if (!format) {
+            throw new Error(`Unsupported screenshot extension: ${extension}`);
+          }
+          const mimeType = screenshotImageMimeType(format);
           return res
             .type(mimeType)
             .send(Buffer.from(dataUri.slice(commaIndex + 1), 'base64'));
@@ -3769,7 +3784,13 @@ class PlaygroundServer {
               .status(404)
               .json({ error: 'Recorder screenshot not found' });
           }
-          res.type(filePath.endsWith('.jpg') ? 'image/jpeg' : 'image/png');
+          const format = screenshotImageFormatFromExtension(
+            extname(filePath).slice(1),
+          );
+          if (!format) {
+            throw new Error('Unsupported recorder screenshot format');
+          }
+          res.type(screenshotImageMimeType(format));
           return res.send(readFileSync(filePath));
         } catch (error) {
           return res.status(400).json({

--- a/packages/playground/tests/unit/server-interact.test.ts
+++ b/packages/playground/tests/unit/server-interact.test.ts
@@ -1,4 +1,4 @@
-import { createReadStream } from 'node:fs';
+import { createReadStream, existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -20,12 +20,15 @@ vi.mock('@midscene/core', async (importOriginal) => {
 
 const VALID_PNG_BASE64 =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAKklEQVR4nO3MIQEAAAzDsPo3/ePhDi4CwpWxUMMXaaFH4QgLPQpHWHg6fOdROhs7ULsmAAAAAElFTkSuQmCC';
+const VALID_WEBP_BASE64 =
+  'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
 
 function createMockResponse() {
   return {
     statusCode: 200,
     body: undefined as unknown,
     headers: {} as Record<string, string>,
+    contentType: undefined as string | undefined,
     status(code: number) {
       this.statusCode = code;
       return this;
@@ -38,7 +41,8 @@ function createMockResponse() {
       this.body = payload;
       return this;
     },
-    type() {
+    type(contentType: string) {
+      this.contentType = contentType;
       return this;
     },
     setHeader(name: string, value: string) {
@@ -202,6 +206,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
   });
 
   beforeEach(() => {
+    vi.mocked(existsSync).mockImplementation(() => true);
     vi.mocked(coreDescribeElementAtPoint).mockReset();
     vi.mocked(coreDescribeElementAtPoint).mockRejectedValue(
       new Error('Active agent does not support describeElementAtPoint.'),
@@ -436,7 +441,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
                   type: 'midscene_screenshot_ref',
                   id: 'shot-1',
                   capturedAt: 1,
-                  mimeType: 'image/png',
+                  mimeType: 'image/webp',
                   storage: 'inline',
                 },
               },
@@ -445,7 +450,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
         },
       ],
     };
-    const reportHTML = `<html></html>\n<script type="midscene-image" data-id="shot-1">${VALID_PNG_BASE64}</script>\n<script type="midscene_web_dump">${JSON.stringify(dump)}</script>`;
+    const reportHTML = `<html></html>\n<script type="midscene-image" data-id="shot-1">${VALID_WEBP_BASE64}</script>\n<script type="midscene_web_dump">${JSON.stringify(dump)}</script>`;
     vi.mocked(createReadStream).mockImplementation(
       () =>
         ({
@@ -499,12 +504,13 @@ describe('PlaygroundServer manual interaction APIs', () => {
       const screenshotResponse = createMockResponse();
       await screenshotHandler(
         {
-          params: { reportId: report.id, assetName: 'shot-1.png' },
+          params: { reportId: report.id, assetName: 'shot-1.webp' },
         },
         screenshotResponse,
       );
       expect(Buffer.isBuffer(screenshotResponse.body)).toBe(true);
       expect((screenshotResponse.body as Buffer).length).toBeGreaterThan(0);
+      expect(screenshotResponse.contentType).toBe('image/webp');
     } finally {
       await server.close();
     }
@@ -866,7 +872,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
         interfaceType: 'ios',
         actionSpace: () => [],
         inputPrimitives,
-        screenshotBase64: async () => VALID_PNG_BASE64,
+        screenshotBase64: async () => VALID_WEBP_BASE64,
         size: async () => ({ width: 390, height: 844 }),
       },
     } as any);
@@ -915,7 +921,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
     expect(rawEvents[0]).toMatchObject({
       screenshotAsset: {
         id: expect.stringMatching(/^session-preview-/),
-        mimeType: 'image/png',
+        mimeType: 'image/webp',
         bytes: expect.any(Number),
       },
     });
@@ -929,11 +935,16 @@ describe('PlaygroundServer manual interaction APIs', () => {
       '/recorder/assets/:assetId',
     );
     const assetResponse = createMockResponse();
+    vi.mocked(existsSync).mockImplementation((filePath) =>
+      String(filePath).endsWith('.webp'),
+    );
     await assetHandler(
       { params: { assetId: rawEvents[0].screenshotAsset.id } },
       assetResponse,
     );
+    vi.mocked(existsSync).mockImplementation(() => true);
     expect(assetResponse.statusCode).toBe(200);
+    expect(assetResponse.contentType).toBe('image/webp');
 
     const describeResponse = await describeRecorderEvent(server, rawEvents[0]);
     expect(describeResponse.body).toMatchObject({
@@ -989,7 +1000,7 @@ describe('PlaygroundServer manual interaction APIs', () => {
       [10, 20],
       expect.objectContaining({
         verifyPrompt: false,
-        screenshotBase64: expect.stringMatching(/^data:image\/png;base64,/),
+        screenshotBase64: expect.stringMatching(/^data:image\/webp;base64,/),
         coordinateSpace: 'logical',
         logicalSize: { width: 390, height: 844 },
         onProgress: expect.any(Function),

--- a/packages/playground/tests/unit/server-mjpeg-stream.test.ts
+++ b/packages/playground/tests/unit/server-mjpeg-stream.test.ts
@@ -385,6 +385,35 @@ describe('PlaygroundServer MJPEG streaming', () => {
     );
   });
 
+  test('GET /mjpeg labels polling WebP bytes with image/webp', async () => {
+    const webpBase64 =
+      'data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+    const screenshotBase64 = vi.fn(async () => webpBase64);
+    const server = new PlaygroundServer({
+      interface: {
+        interfaceType: 'web',
+        actionSpace: () => [],
+        screenshotBase64,
+        size: async () => ({ width: 2, height: 3 }),
+      },
+    } as any);
+
+    await server.launch(6128);
+    const mjpegHandler = getRouteHandler(server, 'get', '/mjpeg');
+    const request = createMockRequest();
+    const response = createMockStreamResponse();
+    const streamPromise = mjpegHandler(request, response);
+    for (let i = 0; i < 10 && screenshotBase64.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    request.listeners.get('close')?.();
+    await streamPromise;
+
+    expect(response.chunks.map((chunk) => chunk.toString()).join('')).toContain(
+      'Content-Type: image/webp',
+    );
+  });
+
   test('GET /mjpeg falls back to screenshot polling when producer emits no initial frame', async () => {
     const stop = vi.fn();
     const screenshotBase64 = vi.fn(async () =>

--- a/packages/shared/src/agent-tools/types.ts
+++ b/packages/shared/src/agent-tools/types.ts
@@ -98,7 +98,7 @@ export type UserPromptLike =
 
 export interface RecordToReportScreenshot {
   /**
-   * PNG/JPEG data URI, or raw PNG base64 body.
+   * PNG/JPEG/WebP data URI, or raw PNG/WebP base64 body.
    */
   base64: string;
   description?: string;

--- a/packages/shared/src/cli/screenshot-file.ts
+++ b/packages/shared/src/cli/screenshot-file.ts
@@ -1,6 +1,11 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import {
+  type ScreenshotImageFormat,
+  screenshotImageFormatFromExtension,
+  screenshotImageFormatFromMimeType,
+} from '../img/image-format';
 
 export interface WriteCliScreenshotFileOptions {
   id?: unknown;
@@ -20,14 +25,12 @@ function safeScreenshotFilenamePart(value: unknown): string {
 function extensionFromImageMetadata(
   mimeType: unknown,
   extension: unknown,
-): 'png' | 'jpeg' {
-  if (extension === 'jpeg' || extension === 'jpg') {
-    return 'jpeg';
+): ScreenshotImageFormat {
+  const extensionFormat = screenshotImageFormatFromExtension(extension);
+  if (extensionFormat) {
+    return extensionFormat;
   }
-  if (extension === 'png') {
-    return 'png';
-  }
-  return mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+  return screenshotImageFormatFromMimeType(mimeType) ?? 'png';
 }
 
 export function writeCliScreenshotFile(

--- a/packages/shared/src/cli/verbose-screenshot.ts
+++ b/packages/shared/src/cli/verbose-screenshot.ts
@@ -71,7 +71,9 @@ function screenshotRawBase64(value: unknown): string | undefined {
   }
 
   const base64 = getStringProperty(value, 'base64');
-  const match = base64?.match(/^data:image\/(?:png|jpeg|jpg);base64,(.+)$/);
+  const match = base64?.match(
+    /^data:image\/(?:png|jpeg|jpg|webp);base64,(.+)$/,
+  );
   return match?.[1];
 }
 

--- a/packages/shared/src/img/box-select.ts
+++ b/packages/shared/src/img/box-select.ts
@@ -758,9 +758,11 @@ async function encodeRgbaWithSharp(
   const output = await Sharp(Buffer.from(pixels), {
     raw: { width, height, channels: 4 },
   })
-    .jpeg({ quality: 90, chromaSubsampling: '4:4:4' })
+    // Keep synthetic marker edges and colors exact; these pixels carry model
+    // semantics and are more important than the small extra payload.
+    .webp({ lossless: true, effort: 1 })
     .toBuffer();
-  return createImgBase64ByFormat('jpeg', output.toString('base64'));
+  return createImgBase64ByFormat('webp', output.toString('base64'));
 }
 
 export const compositeElementInfoImg = async (options: {

--- a/packages/shared/src/img/browser-webp-encoder.ts
+++ b/packages/shared/src/img/browser-webp-encoder.ts
@@ -1,0 +1,114 @@
+export interface BrowserWebpEncodeInput {
+  pixels: ArrayLike<number>;
+  width: number;
+  height: number;
+  /** Encoder quality from 0 to 100. Defaults to 90. */
+  quality?: number;
+}
+
+/**
+ * Encode RGBA pixels with the WebP encoder provided by the browser.
+ *
+ * Keep this function self-contained so browser contract tests can execute the
+ * production implementation in a page or Worker without a test-only copy.
+ */
+export async function encodeRgbaToWebp({
+  pixels,
+  width,
+  height,
+  quality = 90,
+}: BrowserWebpEncodeInput): Promise<Uint8Array> {
+  if (
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error('WebP image dimensions must be positive safe integers');
+  }
+
+  if (!Number.isFinite(quality) || quality < 0 || quality > 100) {
+    throw new Error('WebP quality must be between 0 and 100');
+  }
+
+  const expectedPixelCount = width * height * 4;
+  if (
+    !Number.isSafeInteger(expectedPixelCount) ||
+    pixels.length !== expectedPixelCount
+  ) {
+    throw new Error(
+      `WebP RGBA pixel length must be ${expectedPixelCount}, got ${pixels.length}`,
+    );
+  }
+
+  const normalizedQuality = quality / 100;
+  let outputBlob: Blob;
+
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Failed to get an OffscreenCanvas 2d context');
+    }
+
+    const imageData = context.createImageData(width, height);
+    imageData.data.set(pixels);
+    context.putImageData(imageData, 0, 0);
+    outputBlob = await canvas.convertToBlob({
+      type: 'image/webp',
+      quality: normalizedQuality,
+    });
+  } else if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Failed to get an HTMLCanvasElement 2d context');
+    }
+
+    const imageData = context.createImageData(width, height);
+    imageData.data.set(pixels);
+    context.putImageData(imageData, 0, 0);
+    outputBlob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            reject(new Error('HTMLCanvasElement failed to encode WebP'));
+          }
+        },
+        'image/webp',
+        normalizedQuality,
+      );
+    });
+  } else {
+    throw new Error(
+      'WebP encoding requires OffscreenCanvas or HTMLCanvasElement',
+    );
+  }
+
+  if (outputBlob.type.toLowerCase() !== 'image/webp') {
+    throw new Error(
+      `Browser WebP encoder returned ${outputBlob.type || 'an unknown MIME type'}`,
+    );
+  }
+
+  const output = new Uint8Array(await outputBlob.arrayBuffer());
+  const isWebp =
+    output.length >= 12 &&
+    output[0] === 0x52 &&
+    output[1] === 0x49 &&
+    output[2] === 0x46 &&
+    output[3] === 0x46 &&
+    output[8] === 0x57 &&
+    output[9] === 0x45 &&
+    output[10] === 0x42 &&
+    output[11] === 0x50;
+  if (!isWebp) {
+    throw new Error('Browser WebP encoder returned invalid WebP bytes');
+  }
+
+  return output;
+}

--- a/packages/shared/src/img/canvas-fallback.ts
+++ b/packages/shared/src/img/canvas-fallback.ts
@@ -4,6 +4,11 @@
  */
 
 import { getDebug } from '../logger';
+import {
+  detectScreenshotImageFormatFromBuffer,
+  inferScreenshotImageFormatFromBase64,
+  screenshotImageMimeType,
+} from './image-format';
 
 const debug = getDebug('img:canvas-fallback');
 
@@ -89,7 +94,9 @@ export class CanvasImage {
       if (base64Body.startsWith('data:')) {
         img.src = base64Body;
       } else {
-        img.src = `data:image/png;base64,${base64Body}`;
+        const format =
+          inferScreenshotImageFormatFromBase64(base64Body) ?? 'png';
+        img.src = `data:${screenshotImageMimeType(format)};base64,${base64Body}`;
       }
     });
   }
@@ -99,7 +106,10 @@ export class CanvasImage {
    */
   static async new_from_byteslice(bytes: Uint8Array): Promise<CanvasImage> {
     return new Promise((resolve, reject) => {
-      const blob = new Blob([bytes], { type: 'image/png' });
+      const format = detectScreenshotImageFormatFromBuffer(bytes) ?? 'png';
+      const blob = new Blob([bytes], {
+        type: screenshotImageMimeType(format),
+      });
       const url = URL.createObjectURL(blob);
       const img = new Image();
 

--- a/packages/shared/src/img/canvas-fallback.ts
+++ b/packages/shared/src/img/canvas-fallback.ts
@@ -47,6 +47,18 @@ export class CanvasImage {
 
   get_bytes_jpeg(quality: number): Uint8Array {
     const dataUrl = this.canvas.toDataURL('image/jpeg', quality / 100);
+    return CanvasImage.bytesFromDataUrl(dataUrl);
+  }
+
+  get_bytes_webp(quality = 90): Uint8Array {
+    const dataUrl = this.canvas.toDataURL('image/webp', quality / 100);
+    if (!dataUrl.startsWith('data:image/webp;base64,')) {
+      throw new Error('Canvas does not support WebP encoding');
+    }
+    return CanvasImage.bytesFromDataUrl(dataUrl);
+  }
+
+  private static bytesFromDataUrl(dataUrl: string): Uint8Array {
     const base64 = dataUrl.split(',')[1];
     const binary = atob(base64);
     const bytes = new Uint8Array(binary.length);

--- a/packages/shared/src/img/canvas-fallback.ts
+++ b/packages/shared/src/img/canvas-fallback.ts
@@ -50,14 +50,6 @@ export class CanvasImage {
     return CanvasImage.bytesFromDataUrl(dataUrl);
   }
 
-  get_bytes_webp(quality = 90): Uint8Array {
-    const dataUrl = this.canvas.toDataURL('image/webp', quality / 100);
-    if (!dataUrl.startsWith('data:image/webp;base64,')) {
-      throw new Error('Canvas does not support WebP encoding');
-    }
-    return CanvasImage.bytesFromDataUrl(dataUrl);
-  }
-
   private static bytesFromDataUrl(dataUrl: string): Uint8Array {
     const base64 = dataUrl.split(',')[1];
     const binary = atob(base64);

--- a/packages/shared/src/img/image-format.ts
+++ b/packages/shared/src/img/image-format.ts
@@ -1,0 +1,131 @@
+export type ScreenshotImageFormat = 'png' | 'jpeg' | 'webp';
+
+export type ScreenshotImageMimeType = 'image/png' | 'image/jpeg' | 'image/webp';
+
+const mimeTypeByFormat: Record<ScreenshotImageFormat, ScreenshotImageMimeType> =
+  {
+    png: 'image/png',
+    jpeg: 'image/jpeg',
+    webp: 'image/webp',
+  };
+
+export function screenshotImageMimeType(
+  format: ScreenshotImageFormat,
+): ScreenshotImageMimeType {
+  return mimeTypeByFormat[format];
+}
+
+export function screenshotImageExtension(
+  format: ScreenshotImageFormat,
+): ScreenshotImageFormat {
+  return format;
+}
+
+export function screenshotImageFormatFromExtension(
+  extension: unknown,
+): ScreenshotImageFormat | undefined {
+  if (typeof extension !== 'string') {
+    return undefined;
+  }
+
+  switch (extension.toLowerCase()) {
+    case 'png':
+      return 'png';
+    case 'jpeg':
+    case 'jpg':
+      return 'jpeg';
+    case 'webp':
+      return 'webp';
+    default:
+      return undefined;
+  }
+}
+
+export function screenshotImageFormatFromMimeType(
+  mimeType: unknown,
+): ScreenshotImageFormat | undefined {
+  if (typeof mimeType !== 'string') {
+    return undefined;
+  }
+
+  switch (mimeType.toLowerCase()) {
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpeg';
+    case 'image/webp':
+      return 'webp';
+    default:
+      return undefined;
+  }
+}
+
+export function isScreenshotImageMimeType(
+  mimeType: unknown,
+): mimeType is ScreenshotImageMimeType {
+  return (
+    mimeType === 'image/png' ||
+    mimeType === 'image/jpeg' ||
+    mimeType === 'image/webp'
+  );
+}
+
+export function inferScreenshotImageFormatFromBase64(
+  base64Body: string,
+): ScreenshotImageFormat | undefined {
+  const normalizedBody = base64Body.replace(/\s/g, '');
+  if (normalizedBody.startsWith('iVBORw0KGgo')) {
+    return 'png';
+  }
+  if (normalizedBody.startsWith('/9j/')) {
+    return 'jpeg';
+  }
+  if (normalizedBody.startsWith('UklGR')) {
+    return 'webp';
+  }
+  return undefined;
+}
+
+export function detectScreenshotImageFormatFromBuffer(
+  buffer: Uint8Array,
+): ScreenshotImageFormat | undefined {
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'png';
+  }
+
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return 'jpeg';
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return 'webp';
+  }
+
+  return undefined;
+}

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -21,6 +21,10 @@ export {
 export {
   resizeAndConvertImgBuffer,
   convertImgBufferToJpeg,
+  convertImgBufferToWebp,
+  canonicalizeScreenshotBase64,
+  DEFAULT_WEBP_SCREENSHOT_EFFORT,
+  DEFAULT_WEBP_SCREENSHOT_QUALITY,
   resizeImgBase64,
   zoomForGPT4o,
   saveBase64Image,
@@ -36,6 +40,8 @@ export {
   normalizeBase64Image,
   normalizeScreenshotBase64,
   type NormalizeScreenshotBase64Options,
+  type CanonicalizeScreenshotOptions,
+  type WebpScreenshotEncodeOptions,
 } from './transform';
 export {
   processImageElementInfo,

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -2,10 +2,22 @@ export {
   imageInfoOfBase64,
   isValidPNGImageBuffer,
   isValidJPEGImageBuffer,
+  isValidWebPImageBuffer,
   isValidImageBuffer,
   validateScreenshotBuffer,
   type ValidateScreenshotBufferOptions,
 } from './info';
+export {
+  detectScreenshotImageFormatFromBuffer,
+  inferScreenshotImageFormatFromBase64,
+  isScreenshotImageMimeType,
+  screenshotImageExtension,
+  screenshotImageFormatFromExtension,
+  screenshotImageFormatFromMimeType,
+  screenshotImageMimeType,
+  type ScreenshotImageFormat,
+  type ScreenshotImageMimeType,
+} from './image-format';
 export {
   resizeAndConvertImgBuffer,
   convertImgBufferToJpeg,

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -49,3 +49,7 @@ export {
   compositePointMarkerImg,
   annotateRects,
 } from './box-select';
+export {
+  encodeRgbaToWebp,
+  type BrowserWebpEncodeInput,
+} from './browser-webp-encoder';

--- a/packages/shared/src/img/info.ts
+++ b/packages/shared/src/img/info.ts
@@ -4,6 +4,7 @@ import type { Size } from '../types';
 import { ifInNode } from '../utils';
 import getPhoton from './get-photon';
 import getSharp from './get-sharp';
+import { detectScreenshotImageFormatFromBuffer } from './image-format';
 
 export interface ImageInfo extends Size {}
 
@@ -118,12 +119,21 @@ export function isValidJPEGImageBuffer(buffer: Buffer): boolean {
 }
 
 /**
- * Check if the Buffer is a valid image (PNG or JPEG)
+ * Check if the Buffer has a WebP signature.
  * @param buffer The Buffer to check
- * @returns true if the Buffer is a valid PNG or JPEG image, otherwise false
+ * @returns true if the Buffer has a WebP signature, otherwise false
+ */
+export function isValidWebPImageBuffer(buffer: Buffer): boolean {
+  return detectScreenshotImageFormatFromBuffer(buffer) === 'webp';
+}
+
+/**
+ * Check if the Buffer is a supported screenshot image (PNG, JPEG, or WebP)
+ * @param buffer The Buffer to check
+ * @returns true if the Buffer has a supported image signature, otherwise false
  */
 export function isValidImageBuffer(buffer: Buffer): boolean {
-  return isValidPNGImageBuffer(buffer) || isValidJPEGImageBuffer(buffer);
+  return detectScreenshotImageFormatFromBuffer(buffer) !== undefined;
 }
 
 export interface ValidateScreenshotBufferOptions {

--- a/packages/shared/src/img/info.ts
+++ b/packages/shared/src/img/info.ts
@@ -133,7 +133,11 @@ export function isValidWebPImageBuffer(buffer: Buffer): boolean {
  * @returns true if the Buffer has a supported image signature, otherwise false
  */
 export function isValidImageBuffer(buffer: Buffer): boolean {
-  return detectScreenshotImageFormatFromBuffer(buffer) !== undefined;
+  return (
+    isValidPNGImageBuffer(buffer) ||
+    isValidJPEGImageBuffer(buffer) ||
+    isValidWebPImageBuffer(buffer)
+  );
 }
 
 export interface ValidateScreenshotBufferOptions {

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -18,6 +18,45 @@ import {
 
 const imgDebug = getDebug('img');
 
+export const DEFAULT_WEBP_SCREENSHOT_QUALITY = 90;
+export const DEFAULT_WEBP_SCREENSHOT_EFFORT = 1;
+
+export interface WebpScreenshotEncodeOptions {
+  /** Encoder quality from 0 to 100. Defaults to 90. */
+  quality?: number;
+  /** Sharp encoder CPU effort from 0 to 6. Defaults to 1. */
+  effort?: number;
+}
+
+export interface CanonicalizeScreenshotOptions
+  extends WebpScreenshotEncodeOptions {
+  /** Keep a valid JPEG source byte-for-byte instead of applying another lossy encode. */
+  preserveJpeg?: boolean;
+}
+
+function assertWebpBuffer(buffer: Uint8Array, label: string): void {
+  if (detectScreenshotImageFormatFromBuffer(buffer) !== 'webp') {
+    throw new Error(`${label} did not produce a valid WebP image`);
+  }
+}
+
+async function encodePhotonImageToWebp(
+  image: PhotonImageType,
+  quality = DEFAULT_WEBP_SCREENSHOT_QUALITY,
+): Promise<Buffer> {
+  const encoder = (
+    image as PhotonImageType & {
+      get_bytes_webp: (quality?: number) => Uint8Array;
+    }
+  ).get_bytes_webp;
+  if (typeof encoder !== 'function') {
+    throw new Error('The active browser image backend cannot encode WebP');
+  }
+  const output = Buffer.from(encoder.call(image, quality));
+  assertWebpBuffer(output, 'Browser image encoder');
+  return output;
+}
+
 /**
  * Saves a Base64-encoded image to a file
  *
@@ -39,7 +78,7 @@ export async function saveBase64Image(options: {
 
 /**
  * Resizes an image from Buffer, maybe return a new format
- * - If the image is Resized, the returned format will be jpg.
+ * - If the image is resized, the returned format will be WebP.
  * - If the image is not Resized, it will return to its original format.
  * @returns { buffer: resized buffer, format: the new format}
  */
@@ -84,8 +123,12 @@ export async function resizeAndConvertImgBuffer(
 
     const resizedBuffer = await Sharp(inputData)
       .resize(newSize.width, newSize.height)
-      .jpeg({ quality: 90 })
+      .webp({
+        quality: DEFAULT_WEBP_SCREENSHOT_QUALITY,
+        effort: DEFAULT_WEBP_SCREENSHOT_EFFORT,
+      })
       .toBuffer();
+    assertWebpBuffer(resizedBuffer, 'Sharp resize');
 
     const resizeEndTime = Date.now();
     imgDebug(
@@ -94,8 +137,7 @@ export async function resizeAndConvertImgBuffer(
 
     return {
       buffer: resizedBuffer,
-      // by Sharp.jpeg()
-      format: 'jpeg',
+      format: 'webp',
     };
   }
 
@@ -132,8 +174,7 @@ export async function resizeAndConvertImgBuffer(
     SamplingFilter.CatmullRom,
   );
 
-  const outputBytes = outputImage.get_bytes_jpeg(90);
-  const resizedBuffer = Buffer.from(outputBytes);
+  const resizedBuffer = await encodePhotonImageToWebp(outputImage);
 
   // Free memory
   inputImage.free();
@@ -147,8 +188,7 @@ export async function resizeAndConvertImgBuffer(
 
   return {
     buffer: resizedBuffer,
-    // by Photon.get_bytes_jpeg()
-    format: 'jpeg',
+    format: 'webp',
   };
 }
 
@@ -174,6 +214,35 @@ export async function convertImgBufferToJpeg(
   );
   try {
     return Buffer.from(photonImage.get_bytes_jpeg(quality));
+  } finally {
+    photonImage.free();
+  }
+}
+
+/** Convert an image buffer to a validated WebP image without resizing it. */
+export async function convertImgBufferToWebp(
+  inputData: Buffer,
+  options: WebpScreenshotEncodeOptions = {},
+): Promise<Buffer> {
+  const quality = options.quality ?? DEFAULT_WEBP_SCREENSHOT_QUALITY;
+  const effort = options.effort ?? DEFAULT_WEBP_SCREENSHOT_EFFORT;
+
+  if (ifInNode) {
+    const Sharp = await getSharp();
+    const output = await Sharp(inputData).webp({ quality, effort }).toBuffer();
+    assertWebpBuffer(output, 'Sharp');
+    return output;
+  }
+
+  const mimeType = detectImageMimeTypeFromBuffer(inputData);
+  if (!mimeType) {
+    throw new Error('Cannot encode WebP from an unsupported image buffer');
+  }
+  const photonImage = await photonFromBase64(
+    `data:${mimeType};base64,${inputData.toString('base64')}`,
+  );
+  try {
+    return await encodePhotonImageToWebp(photonImage, quality);
   } finally {
     photonImage.free();
   }
@@ -267,6 +336,38 @@ export const normalizeBase64Image = (base64: string) => {
     base64Body,
   );
 };
+
+/**
+ * Normalize a screenshot at the AI/report boundary.
+ *
+ * Valid WebP is passed through byte-for-byte. Callers can also preserve JPEG
+ * sources to avoid a second lossy encode for native MJPEG/HDC streams.
+ */
+export async function canonicalizeScreenshotBase64(
+  inputBase64: string,
+  options: CanonicalizeScreenshotOptions = {},
+): Promise<string> {
+  const { body } = parseBase64(inputBase64);
+  const inputBuffer = Buffer.from(body, 'base64');
+  const inputFormat = detectScreenshotImageFormatFromBuffer(inputBuffer);
+  if (!inputFormat) {
+    throw new Error('Cannot canonicalize an unsupported screenshot image');
+  }
+
+  if (
+    inputFormat === 'webp' ||
+    (inputFormat === 'jpeg' && options.preserveJpeg)
+  ) {
+    return createImgBase64ByFormat(inputFormat, body);
+  }
+
+  const startedAt = Date.now();
+  const output = await convertImgBufferToWebp(inputBuffer, options);
+  imgDebug(
+    `canonicalizeScreenshot done, ${inputFormat}->webp, bytes: ${inputBuffer.length}->${output.length}, cost: ${Date.now() - startedAt}ms`,
+  );
+  return createImgBase64ByFormat('webp', output.toString('base64'));
+}
 
 export async function resizeImgBase64(
   inputBase64: string,
@@ -410,12 +511,16 @@ export async function paddingToMatchBlockByBase64(
         bottom: targetHeight - height,
         background: { r: 255, g: 255, b: 255, alpha: 1 },
       })
-      .jpeg({ quality: 90 })
+      .webp({
+        quality: DEFAULT_WEBP_SCREENSHOT_QUALITY,
+        effort: DEFAULT_WEBP_SCREENSHOT_EFFORT,
+      })
       .toBuffer();
+    assertWebpBuffer(output, 'Sharp padding');
     return {
       width: targetWidth,
       height: targetHeight,
-      imageBase64: createImgBase64ByFormat('jpeg', output.toString('base64')),
+      imageBase64: createImgBase64ByFormat('webp', output.toString('base64')),
     };
   }
 
@@ -458,12 +563,16 @@ export async function cropByRect(
         width,
         height,
       })
-      .jpeg({ quality: 90 })
+      .webp({
+        quality: DEFAULT_WEBP_SCREENSHOT_QUALITY,
+        effort: DEFAULT_WEBP_SCREENSHOT_EFFORT,
+      })
       .toBuffer();
+    assertWebpBuffer(output, 'Sharp crop');
     return {
       width,
       height,
-      imageBase64: createImgBase64ByFormat('jpeg', output.toString('base64')),
+      imageBase64: createImgBase64ByFormat('webp', output.toString('base64')),
     };
   }
 
@@ -488,11 +597,10 @@ export async function cropByRect(
 
 export async function photonToBase64(
   image: PhotonImageType,
-  quality = 90,
+  quality = DEFAULT_WEBP_SCREENSHOT_QUALITY,
 ): Promise<string> {
-  const bytes = image.get_bytes_jpeg(quality);
-  const base64Body = Buffer.from(bytes).toString('base64');
-  return `data:image/jpeg;base64,${base64Body}`;
+  const bytes = await encodePhotonImageToWebp(image, quality);
+  return createImgBase64ByFormat('webp', bytes.toString('base64'));
 }
 
 export const httpImg2Base64 = async (url: string): Promise<string> => {
@@ -642,17 +750,22 @@ export async function scaleImage(
         kernel: 'lanczos3',
         fit: 'fill',
       })
-      .jpeg({
-        quality: 90,
+      .webp({
+        quality: DEFAULT_WEBP_SCREENSHOT_QUALITY,
+        effort: DEFAULT_WEBP_SCREENSHOT_EFFORT,
       })
       .toBuffer();
+    assertWebpBuffer(resizedBuffer, 'Sharp scale');
 
     const scaleEndTime = Date.now();
     imgDebug(
       `scaleImage done (Sharp): ${originalWidth}x${originalHeight} -> ${newWidth}x${newHeight} (scale=${scale}), cost: ${scaleEndTime - scaleStartTime}ms`,
     );
 
-    const base64 = `data:image/jpeg;base64,${resizedBuffer.toString('base64')}`;
+    const base64 = createImgBase64ByFormat(
+      'webp',
+      resizedBuffer.toString('base64'),
+    );
 
     return {
       width: newWidth,
@@ -688,8 +801,7 @@ export async function scaleImage(
     SamplingFilter.CatmullRom,
   );
 
-  const outputBytes = outputImage.get_bytes_jpeg(90);
-  const resizedBuffer = Buffer.from(outputBytes);
+  const resizedBuffer = await encodePhotonImageToWebp(outputImage);
 
   // Free memory
   inputImage.free();
@@ -700,7 +812,10 @@ export async function scaleImage(
     `scaleImage done (Photon): ${originalWidth}x${originalHeight} -> ${newWidth}x${newHeight} (scale=${scale}), cost: ${scaleEndTime - scaleStartTime}ms`,
   );
 
-  const base64 = `data:image/jpeg;base64,${resizedBuffer.toString('base64')}`;
+  const base64 = createImgBase64ByFormat(
+    'webp',
+    resizedBuffer.toString('base64'),
+  );
 
   return {
     width: newWidth,

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -9,6 +9,12 @@ import type { Rect } from '../types';
 import { ifInNode } from '../utils';
 import getPhoton from './get-photon';
 import getSharp from './get-sharp';
+import {
+  type ScreenshotImageFormat,
+  detectScreenshotImageFormatFromBuffer,
+  inferScreenshotImageFormatFromBase64,
+  screenshotImageMimeType,
+} from './image-format';
 
 const imgDebug = getDebug('img');
 
@@ -175,47 +181,21 @@ export async function convertImgBufferToJpeg(
 
 const base64ImageDataUrlPattern = /^data:image\/[a-zA-Z0-9.+-]+;base64,/i;
 const supportedScreenshotDataUriPattern =
-  /^data:image\/(png|jpe?g);base64,([\s\S]*)$/i;
+  /^data:image\/(png|jpe?g|webp);base64,([\s\S]*)$/i;
 const rawBase64BodyPattern = /^[A-Za-z0-9+/=\s]+$/;
 
-export const inferBase64ImageFormat = (base64Body: string) => {
-  if (base64Body.startsWith('iVBORw0KGgo')) {
-    return 'png';
-  }
-  return 'jpeg';
-};
+export const inferBase64ImageFormat = (
+  base64Body: string,
+): ScreenshotImageFormat =>
+  inferScreenshotImageFormatFromBase64(base64Body) ?? 'jpeg';
 
 function detectImageMimeTypeFromBuffer(buffer: Buffer): string | undefined {
-  if (
-    buffer.length >= 8 &&
-    buffer[0] === 0x89 &&
-    buffer[1] === 0x50 &&
-    buffer[2] === 0x4e &&
-    buffer[3] === 0x47 &&
-    buffer[4] === 0x0d &&
-    buffer[5] === 0x0a &&
-    buffer[6] === 0x1a &&
-    buffer[7] === 0x0a
-  ) {
-    return 'image/png';
-  }
-  if (
-    buffer.length >= 3 &&
-    buffer[0] === 0xff &&
-    buffer[1] === 0xd8 &&
-    buffer[2] === 0xff
-  ) {
-    return 'image/jpeg';
+  const screenshotFormat = detectScreenshotImageFormatFromBuffer(buffer);
+  if (screenshotFormat) {
+    return screenshotImageMimeType(screenshotFormat);
   }
   if (buffer.length >= 6 && buffer.subarray(0, 3).toString('ascii') === 'GIF') {
     return 'image/gif';
-  }
-  if (
-    buffer.length >= 12 &&
-    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
-    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
-  ) {
-    return 'image/webp';
   }
   if (buffer.length >= 2 && buffer[0] === 0x42 && buffer[1] === 0x4d) {
     return 'image/bmp';
@@ -243,10 +223,10 @@ export const normalizeScreenshotBase64 = (
 
   const dataUriMatch = trimmedBase64.match(supportedScreenshotDataUriPattern);
   if (dataUriMatch) {
-    const imageFormat =
+    const imageFormat: ScreenshotImageFormat =
       dataUriMatch[1].toLowerCase() === 'jpg'
         ? 'jpeg'
-        : dataUriMatch[1].toLowerCase();
+        : (dataUriMatch[1].toLowerCase() as ScreenshotImageFormat);
     const body = dataUriMatch[2];
     if (!normalizeBase64Body(body)) {
       throw new Error(`${label} cannot be empty`);
@@ -256,17 +236,22 @@ export const normalizeScreenshotBase64 = (
 
   if (trimmedBase64.startsWith('data:')) {
     throw new Error(
-      `${label} must be a PNG/JPEG data URI or raw PNG base64 string`,
+      `${label} must be a PNG/JPEG/WebP data URI or raw PNG/WebP base64 string`,
     );
   }
 
   if (!rawBase64BodyPattern.test(trimmedBase64)) {
     throw new Error(
-      `${label} must be a PNG/JPEG data URI or raw PNG base64 string`,
+      `${label} must be a PNG/JPEG/WebP data URI or raw PNG/WebP base64 string`,
     );
   }
 
-  return createImgBase64ByFormat('png', trimmedBase64);
+  const base64Body = normalizeBase64Body(trimmedBase64);
+  const inferredFormat = inferScreenshotImageFormatFromBase64(base64Body);
+  return createImgBase64ByFormat(
+    inferredFormat === 'webp' ? 'webp' : 'png',
+    base64Body,
+  );
 };
 
 export const normalizeBase64Image = (base64: string) => {

--- a/packages/shared/src/img/transform.ts
+++ b/packages/shared/src/img/transform.ts
@@ -7,6 +7,7 @@ import type { PhotonImage as PhotonImageType } from '@silvia-odwyer/photon';
 import { getDebug } from '../logger';
 import type { Rect } from '../types';
 import { ifInNode } from '../utils';
+import { encodeRgbaToWebp } from './browser-webp-encoder';
 import getPhoton from './get-photon';
 import getSharp from './get-sharp';
 import {
@@ -40,19 +41,24 @@ function assertWebpBuffer(buffer: Uint8Array, label: string): void {
   }
 }
 
-async function encodePhotonImageToWebp(
-  image: PhotonImageType,
+interface BrowserImagePixels {
+  get_raw_pixels(): Uint8Array;
+  get_width(): number;
+  get_height(): number;
+}
+
+async function encodeBrowserImageToWebp(
+  image: BrowserImagePixels,
   quality = DEFAULT_WEBP_SCREENSHOT_QUALITY,
 ): Promise<Buffer> {
-  const encoder = (
-    image as PhotonImageType & {
-      get_bytes_webp: (quality?: number) => Uint8Array;
-    }
-  ).get_bytes_webp;
-  if (typeof encoder !== 'function') {
-    throw new Error('The active browser image backend cannot encode WebP');
-  }
-  const output = Buffer.from(encoder.call(image, quality));
+  const output = Buffer.from(
+    await encodeRgbaToWebp({
+      pixels: image.get_raw_pixels(),
+      width: image.get_width(),
+      height: image.get_height(),
+      quality,
+    }),
+  );
   assertWebpBuffer(output, 'Browser image encoder');
   return output;
 }
@@ -174,11 +180,13 @@ export async function resizeAndConvertImgBuffer(
     SamplingFilter.CatmullRom,
   );
 
-  const resizedBuffer = await encodePhotonImageToWebp(outputImage);
-
-  // Free memory
-  inputImage.free();
-  outputImage.free();
+  let resizedBuffer: Buffer;
+  try {
+    resizedBuffer = await encodeBrowserImageToWebp(outputImage);
+  } finally {
+    inputImage.free();
+    outputImage.free();
+  }
 
   const resizeEndTime = Date.now();
 
@@ -242,7 +250,7 @@ export async function convertImgBufferToWebp(
     `data:${mimeType};base64,${inputData.toString('base64')}`,
   );
   try {
-    return await encodePhotonImageToWebp(photonImage, quality);
+    return await encodeBrowserImageToWebp(photonImage, quality);
   } finally {
     photonImage.free();
   }
@@ -599,7 +607,7 @@ export async function photonToBase64(
   image: PhotonImageType,
   quality = DEFAULT_WEBP_SCREENSHOT_QUALITY,
 ): Promise<string> {
-  const bytes = await encodePhotonImageToWebp(image, quality);
+  const bytes = await encodeBrowserImageToWebp(image, quality);
   return createImgBase64ByFormat('webp', bytes.toString('base64'));
 }
 
@@ -801,11 +809,13 @@ export async function scaleImage(
     SamplingFilter.CatmullRom,
   );
 
-  const resizedBuffer = await encodePhotonImageToWebp(outputImage);
-
-  // Free memory
-  inputImage.free();
-  outputImage.free();
+  let resizedBuffer: Buffer;
+  try {
+    resizedBuffer = await encodeBrowserImageToWebp(outputImage);
+  } finally {
+    inputImage.free();
+    outputImage.free();
+  }
 
   const scaleEndTime = Date.now();
   imgDebug(

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -12,6 +12,11 @@ export function uuid(): string {
   return generateUUID();
 }
 
+/** Return the lowercase SHA-256 digest of UTF-8 text or raw bytes. */
+export function sha256Hex(input: string | Uint8Array): string {
+  return sha256.create().update(input).hex();
+}
+
 const hashMap: Record<string, string> = {}; // id - combined
 
 export function generateHashId(rect: any, content = ''): string {

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -8,6 +8,7 @@ import {
   httpImg2Base64,
   imageInfoOfBase64,
   isValidPNGImageBuffer,
+  isValidWebPImageBuffer,
   localImg2Base64,
   resizeAndConvertImgBuffer,
   resizeImgBase64,
@@ -21,6 +22,10 @@ import {
   saveBase64Image,
 } from '../../../src/img/transform';
 import { getFixture } from '../../utils';
+
+const webpBase64 =
+  'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+const webpDataUri = `data:image/webp;base64,${webpBase64}`;
 
 describe('imageInfoOfBase64', () => {
   it('returns correct dimensions for PNG image', async () => {
@@ -39,6 +44,13 @@ describe('imageInfoOfBase64', () => {
 
     expect(info.width).toBe(400);
     expect(info.height).toBe(905);
+  });
+
+  it('returns correct dimensions for WebP image', async () => {
+    await expect(imageInfoOfBase64(webpDataUri)).resolves.toEqual({
+      width: 2,
+      height: 3,
+    });
   });
 
   it('works with base64 string without data URI header', async () => {
@@ -318,6 +330,15 @@ describe('image utils', () => {
         label: 'Screenshot',
       }),
     ).toThrow('Screenshot buffer has invalid image format');
+  });
+
+  it('isValidWebPImageBuffer accepts WebP and rejects malformed RIFF data', () => {
+    expect(isValidWebPImageBuffer(Buffer.from(webpBase64, 'base64'))).toBe(
+      true,
+    );
+    expect(isValidWebPImageBuffer(Buffer.from('RIFF1234NOPE', 'ascii'))).toBe(
+      false,
+    );
   });
 
   it('validateScreenshotBuffer accepts valid screenshots above the minimum size', () => {

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -487,7 +487,7 @@ describe('resizeAndConvertImgBuffer', () => {
       );
       expect(format).toBe('png');
     });
-    it('Sharp resize will get jpeg format', async () => {
+    it('Sharp resize will get WebP format', async () => {
       const { format, buffer } = await resizeAndConvertImgBuffer(
         'png',
         imageBuffer,
@@ -496,7 +496,9 @@ describe('resizeAndConvertImgBuffer', () => {
           height: 1,
         },
       );
-      expect(format).toBe('jpeg');
+      expect(format).toBe('webp');
+      expect(buffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(buffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
     });
   });
 

--- a/packages/shared/tests/unit-test/screenshot-file.test.ts
+++ b/packages/shared/tests/unit-test/screenshot-file.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { writeCliScreenshotFile } from '../../src/cli/screenshot-file';
+import { collectScreenshotRefs } from '../../src/cli/verbose-screenshot';
+
+const webpBase64 =
+  'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+
+describe('CLI WebP screenshot files', () => {
+  const temporaryDirectories: string[] = [];
+
+  const makeTemporaryDirectory = () => {
+    const directory = mkdtempSync(join(tmpdir(), 'midscene-webp-'));
+    temporaryDirectories.push(directory);
+    return directory;
+  };
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the .webp extension from screenshot MIME metadata', () => {
+    const directoryPath = makeTemporaryDirectory();
+    const filePath = writeCliScreenshotFile(webpBase64, {
+      id: 'webp-shot',
+      mimeType: 'image/webp',
+      directoryPath,
+    });
+
+    expect(filePath).toBe(join(directoryPath, 'webp-shot.webp'));
+    expect(readFileSync(filePath).toString('base64')).toBe(webpBase64);
+  });
+
+  it('exports inline WebP screenshots for verbose output', () => {
+    const directoryPath = makeTemporaryDirectory();
+    const screenshot = {
+      base64: `data:image/webp;base64,${webpBase64}`,
+      extension: 'webp',
+      toSerializable: () => ({
+        type: 'midscene_screenshot_ref' as const,
+        id: 'inline-webp',
+        capturedAt: 1,
+        mimeType: 'image/webp',
+        storage: 'inline',
+      }),
+    };
+
+    const [collected] = collectScreenshotRefs(screenshot, {
+      exportMode: 'report',
+      reportFile: join(directoryPath, 'report.html'),
+    });
+
+    expect(collected.file).toBe('inline-webp.webp');
+    expect(
+      existsSync(join(directoryPath, 'screenshots', 'inline-webp.webp')),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -95,16 +95,25 @@ describe('normalizeBase64Image', () => {
       'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
     );
   });
+
+  it('wraps bare WebP base64 with the WebP MIME type', () => {
+    expect(normalizeBase64Image(' UklGRjQAAABXRUJQ VlA4IA== ')).toBe(
+      'data:image/webp;base64,UklGRjQAAABXRUJQVlA4IA==',
+    );
+  });
 });
 
 describe('normalizeScreenshotBase64', () => {
-  it('accepts PNG and JPEG data urls', () => {
+  it('accepts PNG, JPEG, and WebP data urls', () => {
     expect(
       normalizeScreenshotBase64(' data:image/png;base64,aaa\r\nbbb '),
     ).toBe('data:image/png;base64,aaabbb');
     expect(normalizeScreenshotBase64('data:image/jpeg;base64,/9j/4AAQ')).toBe(
       'data:image/jpeg;base64,/9j/4AAQ',
     );
+    expect(
+      normalizeScreenshotBase64('data:image/webp;base64,UklGRjQAAA=='),
+    ).toBe('data:image/webp;base64,UklGRjQAAA==');
   });
 
   it('normalizes jpg data urls to jpeg', () => {
@@ -119,6 +128,12 @@ describe('normalizeScreenshotBase64', () => {
     );
   });
 
+  it('recognizes raw WebP base64', () => {
+    expect(normalizeScreenshotBase64(' UklGRjQAAA BXRUJQ ')).toBe(
+      'data:image/webp;base64,UklGRjQAAABXRUJQ',
+    );
+  });
+
   it('uses the provided label in validation errors', () => {
     expect(() =>
       normalizeScreenshotBase64(' ', { label: 'custom screenshot' }),
@@ -129,14 +144,15 @@ describe('normalizeScreenshotBase64', () => {
         label: 'custom screenshot',
       }),
     ).toThrow(
-      'custom screenshot must be a PNG/JPEG data URI or raw PNG base64 string',
+      'custom screenshot must be a PNG/JPEG/WebP data URI or raw PNG/WebP base64 string',
     );
   });
 });
 
 describe('inferBase64ImageFormat', () => {
-  it('detects png payloads and otherwise falls back to jpeg', () => {
+  it('detects PNG and WebP payloads and otherwise falls back to JPEG', () => {
     expect(inferBase64ImageFormat('iVBORw0KGgoaaa')).toBe('png');
+    expect(inferBase64ImageFormat('UklGRjQAAABXRUJQ')).toBe('webp');
     expect(inferBase64ImageFormat('/9j/4AAQSkZJRg==')).toBe('jpeg');
   });
 });

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  canonicalizeScreenshotBase64,
   inferBase64ImageFormat,
   normalizeBase64Image,
   normalizeScreenshotBase64,
@@ -168,7 +169,7 @@ describe('scaleImage', () => {
     expect(result.width).toBe(2);
     expect(result.height).toBe(2);
     expect(result.imageBase64).toMatchInlineSnapshot(
-      `"data:image/jpeg;base64,/9j/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAACAAIDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpgA//Z"`,
+      `"data:image/webp;base64,UklGRioAAABXRUJQVlA4IB4AAACQAQCdASoCAAIAAMASJaQAAzoO0gAA/v/+JwoMAAA="`,
     );
   });
 
@@ -178,7 +179,7 @@ describe('scaleImage', () => {
     expect(result.width).toBe(3);
     expect(result.height).toBe(3);
     expect(result.imageBase64).toMatchInlineSnapshot(
-      `"data:image/jpeg;base64,/9j/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAADAAMDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpgA//Z"`,
+      `"data:image/webp;base64,UklGRioAAABXRUJQVlA4IB4AAACQAQCdASoDAAMAAMASJaQAAzoO0gAA/v/+JwoMAAA="`,
     );
   });
 
@@ -223,5 +224,32 @@ describe('scaleImage', () => {
 
     // Restore
     vi.restoreAllMocks();
+  });
+});
+
+describe('canonicalizeScreenshotBase64', () => {
+  const onePixelWhiteImage =
+    'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMDAwMDAwMDAwMEBAQEBAYFBQUFBgkGBwYHBgkOCAoICAoIDgwPDAsMDwwWEQ8PERYZFRQVGR4bGx4mJCYyMkMBAwMDAwMDAwMDAwQEBAQEBgUFBQUGCQYHBgcGCQ4ICggICggODA8MCwwPDBYRDw8RFhkVFBUZHhsbHiYkJjIyQ//CABEIAAEAAQMBIgACEQEDEQH/xAAnAAEBAAAAAAAAAAAAAAAAAAAACQEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAAqmD/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/AH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/AH//2Q==';
+
+  it('passes an existing WebP through byte-for-byte', async () => {
+    const webp = await canonicalizeScreenshotBase64(onePixelWhiteImage);
+    expect(await canonicalizeScreenshotBase64(webp)).toBe(webp);
+  });
+
+  it('preserves native JPEG only when auto policy requests it', async () => {
+    expect(
+      await canonicalizeScreenshotBase64(onePixelWhiteImage, {
+        preserveJpeg: true,
+      }),
+    ).toBe(onePixelWhiteImage);
+    expect(await canonicalizeScreenshotBase64(onePixelWhiteImage)).toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
+  });
+
+  it('rejects unsupported image bytes instead of returning a blank image', async () => {
+    await expect(
+      canonicalizeScreenshotBase64('data:image/png;base64,aGVsbG8='),
+    ).rejects.toThrow('unsupported screenshot image');
   });
 });

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { encodeRgbaToWebp } from '../../src/img/browser-webp-encoder';
 import {
   canonicalizeScreenshotBase64,
   inferBase64ImageFormat,
@@ -8,6 +9,58 @@ import {
   preProcessImageUrl,
   scaleImage,
 } from '../../src/img/transform';
+
+describe('encodeRgbaToWebp', () => {
+  it('validates dimensions before selecting a browser encoder', async () => {
+    await expect(
+      encodeRgbaToWebp({
+        pixels: [],
+        width: 0,
+        height: 1,
+      }),
+    ).rejects.toThrow('WebP image dimensions must be positive safe integers');
+  });
+
+  it('validates the RGBA pixel length', async () => {
+    await expect(
+      encodeRgbaToWebp({
+        pixels: [255, 255, 255],
+        width: 1,
+        height: 1,
+      }),
+    ).rejects.toThrow('WebP RGBA pixel length must be 4, got 3');
+  });
+
+  it('validates encoder quality', async () => {
+    await expect(
+      encodeRgbaToWebp({
+        pixels: [255, 255, 255, 255],
+        width: 1,
+        height: 1,
+        quality: 101,
+      }),
+    ).rejects.toThrow('WebP quality must be between 0 and 100');
+  });
+
+  it('fails explicitly when the runtime has no browser WebP encoder', async () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+
+    try {
+      await expect(
+        encodeRgbaToWebp({
+          pixels: [255, 255, 255, 255],
+          width: 1,
+          height: 1,
+        }),
+      ).rejects.toThrow(
+        'WebP encoding requires OffscreenCanvas or HTMLCanvasElement',
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
 
 describe('preapareImageUrl', () => {
   it('url is not a string will throw an error', async () => {

--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -10,6 +10,10 @@ import {
   parseImageScripts,
   restoreImageReferences,
 } from '@midscene/core/dump';
+import {
+  screenshotImageExtension,
+  screenshotImageFormatFromMimeType,
+} from '@midscene/shared/img/image-format';
 import { useCallback } from 'react';
 import { useEnvConfig } from '../store/store';
 import type {
@@ -154,7 +158,11 @@ async function loadReportReplay(
     }
     const dump = (await response.json()) as IReportActionDump;
     result.dump = restoreImageReferences(dump, (ref) => {
-      const extension = ref.mimeType === 'image/jpeg' ? 'jpeg' : 'png';
+      const format = screenshotImageFormatFromMimeType(ref.mimeType);
+      if (!format) {
+        throw new Error(`Unsupported screenshot mime type: ${ref.mimeType}`);
+      }
+      const extension = screenshotImageExtension(format);
       return new URL(
         `screenshots/${encodeURIComponent(ref.id)}.${extension}`,
         result.report!.url,

--- a/packages/visualizer/tests/playground-execution-stop.test.ts
+++ b/packages/visualizer/tests/playground-execution-stop.test.ts
@@ -95,7 +95,7 @@ function Harness({
   return null;
 }
 
-function replayDump() {
+function replayDump(mimeType: 'image/png' | 'image/webp' = 'image/png') {
   return {
     sdkVersion: 'test',
     groupName: 'Playground run',
@@ -113,7 +113,7 @@ function replayDump() {
                 type: 'midscene_screenshot_ref',
                 id: 'shot-1',
                 capturedAt: 1,
-                mimeType: 'image/png',
+                mimeType,
                 storage: 'inline',
               },
             },
@@ -276,7 +276,7 @@ describe('usePlaygroundExecution stop handling', () => {
     const fetchMock = vi.fn(async () =>
       Promise.resolve({
         ok: true,
-        json: async () => replayDump(),
+        json: async () => replayDump('image/webp'),
       }),
     );
     vi.stubGlobal('fetch', fetchMock);
@@ -331,7 +331,7 @@ describe('usePlaygroundExecution stop handling', () => {
     const restoredDump = allScriptsFromDumpMock.mock.calls[0]?.[0] as any;
     expect(
       restoredDump.executions[0].tasks[0].uiContext.screenshot.base64,
-    ).toBe('http://localhost/reports/report-1/screenshots/shot-1.png');
+    ).toBe('http://localhost/reports/report-1/screenshots/shot-1.webp');
 
     await act(async () => root.unmount());
   });

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -21,7 +21,6 @@ import type {
 } from '@midscene/core/device';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { treeToList } from '@midscene/shared/extractor';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import type { Protocol as CDPTypes } from 'devtools-protocol';
@@ -43,6 +42,10 @@ import {
   injectStopWaterFlowAnimation,
   injectWaterFlowAnimation,
 } from './dynamic-scripts';
+import {
+  type ChromeExtensionScreenshotFormat,
+  captureChromeExtensionScreenshot,
+} from './screenshot';
 
 const debug = getDebug('web:chrome-extension:page');
 
@@ -768,15 +771,19 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     return sizeInfo;
   }
 
-  async screenshotBase64() {
+  async screenshotBase64(
+    format?: ChromeExtensionScreenshotFormat,
+  ): Promise<string> {
     // screenshot by cdp
     await this.hideMousePointer();
-    const format = 'jpeg';
-    const base64 = await this.sendCommandToDebugger('Page.captureScreenshot', {
+    return captureChromeExtensionScreenshot(
+      (params) =>
+        this.sendCommandToDebugger<
+          CDPTypes.Page.CaptureScreenshotResponse,
+          CDPTypes.Page.CaptureScreenshotRequest
+        >('Page.captureScreenshot', params),
       format,
-      quality: 90,
-    });
-    return createImgBase64ByFormat(format, base64.data);
+    );
   }
 
   async url() {

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -18,6 +18,7 @@ import type {
   DeviceAction,
   FileChooserHandler,
   FileChooserRegistration,
+  ScreenshotCaptureOptions,
 } from '@midscene/core/device';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { treeToList } from '@midscene/shared/extractor';
@@ -772,7 +773,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   }
 
   async screenshotBase64(
-    format?: ChromeExtensionScreenshotFormat,
+    options?: ChromeExtensionScreenshotFormat | ScreenshotCaptureOptions,
   ): Promise<string> {
     // screenshot by cdp
     await this.hideMousePointer();
@@ -782,7 +783,11 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
           CDPTypes.Page.CaptureScreenshotResponse,
           CDPTypes.Page.CaptureScreenshotRequest
         >('Page.captureScreenshot', params),
-      format,
+      typeof options === 'string'
+        ? options
+        : options?.preferLossless
+          ? 'png'
+          : undefined,
     );
   }
 

--- a/packages/web-integration/src/chrome-extension/screenshot.ts
+++ b/packages/web-integration/src/chrome-extension/screenshot.ts
@@ -1,0 +1,19 @@
+import type { Protocol as CDPTypes } from 'devtools-protocol';
+
+export type ChromeExtensionScreenshotFormat = 'webp' | 'jpeg';
+
+export const DEFAULT_CHROME_EXTENSION_SCREENSHOT_FORMAT: ChromeExtensionScreenshotFormat =
+  'webp';
+
+export async function captureChromeExtensionScreenshot(
+  sendCaptureCommand: (
+    params: CDPTypes.Page.CaptureScreenshotRequest,
+  ) => Promise<CDPTypes.Page.CaptureScreenshotResponse>,
+  format: ChromeExtensionScreenshotFormat = DEFAULT_CHROME_EXTENSION_SCREENSHOT_FORMAT,
+): Promise<string> {
+  const result = await sendCaptureCommand({
+    format,
+    quality: 90,
+  });
+  return `data:image/${format};base64,${result.data}`;
+}

--- a/packages/web-integration/src/chrome-extension/screenshot.ts
+++ b/packages/web-integration/src/chrome-extension/screenshot.ts
@@ -1,6 +1,6 @@
 import type { Protocol as CDPTypes } from 'devtools-protocol';
 
-export type ChromeExtensionScreenshotFormat = 'webp' | 'jpeg';
+export type ChromeExtensionScreenshotFormat = 'webp' | 'jpeg' | 'png';
 
 export const DEFAULT_CHROME_EXTENSION_SCREENSHOT_FORMAT: ChromeExtensionScreenshotFormat =
   'webp';
@@ -13,7 +13,7 @@ export async function captureChromeExtensionScreenshot(
 ): Promise<string> {
   const result = await sendCaptureCommand({
     format,
-    quality: 90,
+    ...(format === 'png' ? {} : { quality: 90 }),
   });
   return `data:image/${format};base64,${result.data}`;
 }

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -24,6 +24,7 @@ import {
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { treeToList } from '@midscene/shared/extractor';
 import {
+  canonicalizeScreenshotBase64,
   createImgBase64ByFormat,
   imageInfoOfBase64,
 } from '@midscene/shared/img';
@@ -457,7 +458,7 @@ export class Page<
   }
 
   async screenshotBase64(): Promise<string> {
-    const imgType = 'jpeg' as const;
+    const imgType = 'webp' as const;
     const quality = 90;
     const startTime = Date.now();
     debugPage('screenshotBase64 begin');
@@ -473,26 +474,41 @@ export class Page<
     } else if (this.interfaceType === 'playwright') {
       const page = this.underlyingPage as PlaywrightPage;
       try {
-        const buffer = await page.screenshot({
-          type: imgType,
-          quality,
-          timeout: 10 * 1000,
-        });
-        base64 = createImgBase64ByFormat(imgType, buffer.toString('base64'));
+        // Playwright's public API only exposes PNG/JPEG. Chromium can avoid an
+        // extra conversion by using CDP's native WebP encoder.
+        base64 = await this.screenshotBase64ByPlaywrightCdp(imgType, quality);
       } catch (error) {
         if (isClosedPageError(error) || page.isClosed()) {
           throw error;
         }
 
         const errorMsg = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `[Midscene] Playwright screenshot failed: ${errorMsg}. Falling back to CDP screenshot.`,
+        warnPage(
+          `Playwright CDP WebP screenshot failed: ${errorMsg}. Falling back to PNG capture and WebP encoding.`,
         );
-        debugPage(
-          'playwright screenshot failed, trying CDP fallback: %s',
-          error,
-        );
-        base64 = await this.screenshotBase64ByPlaywrightCdp(imgType, quality);
+        try {
+          const buffer = await page.screenshot({
+            type: 'png',
+            timeout: 10 * 1000,
+          });
+          base64 = await canonicalizeScreenshotBase64(
+            createImgBase64ByFormat('png', buffer.toString('base64')),
+            { quality },
+          );
+        } catch (fallbackError) {
+          debugPage(
+            'Playwright PNG screenshot fallback also failed: %s',
+            fallbackError,
+          );
+          const fallbackErrorMessage =
+            fallbackError instanceof Error
+              ? fallbackError.message
+              : String(fallbackError);
+          throw new Error(
+            `Playwright screenshot failed through both CDP WebP and PNG fallback (CDP: ${errorMsg}; PNG fallback: ${fallbackErrorMessage})`,
+            { cause: fallbackError },
+          );
+        }
       }
     } else {
       throw new Error('Unsupported page type for screenshot');
@@ -503,7 +519,7 @@ export class Page<
   }
 
   private async screenshotBase64ByPlaywrightCdp(
-    imgType: 'jpeg' | 'png',
+    imgType: 'jpeg' | 'png' | 'webp',
     quality?: number,
   ) {
     const client = await this.createPageCdpSession('CDP screenshot fallback');
@@ -685,9 +701,15 @@ export class Page<
       );
       // MjpegStreamFrame.data is contractually bare base64; screenshotBase64()
       // returns a `data:image/...;base64,...` URL, so strip the prefix here.
+      const contentType = dataUrl.match(/^data:(image\/\w+);base64,/)?.[1];
+      if (!contentType) {
+        throw new Error(
+          'Screenshot fallback returned an invalid image data URL',
+        );
+      }
       activeStream.onFrame({
         data: dataUrl.replace(DATA_URL_BASE64_PREFIX, ''),
-        contentType: 'image/jpeg',
+        contentType,
       });
     } catch (error) {
       debugPage('screencast visual refresh failed: %s', error);

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -14,6 +14,7 @@ import type {
   DeviceFrameSource,
   MjpegStreamHandle,
   MjpegStreamOptions,
+  ScreenshotCaptureOptions,
 } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
 import {
@@ -457,7 +458,19 @@ export class Page<
     return sizeInfo;
   }
 
-  async screenshotBase64(): Promise<string> {
+  async screenshotBase64(options?: ScreenshotCaptureOptions): Promise<string> {
+    if (options?.preferLossless) {
+      const png = await this.underlyingPage.screenshot({
+        type: 'png',
+        ...(this.interfaceType === 'puppeteer'
+          ? { encoding: 'base64' as const }
+          : { timeout: 10 * 1000 }),
+      });
+      const body =
+        typeof png === 'string' ? png : Buffer.from(png).toString('base64');
+      return createImgBase64ByFormat('png', body);
+    }
+
     const imgType = 'webp' as const;
     const quality = 90;
     const startTime = Date.now();

--- a/packages/web-integration/src/static/static-page.ts
+++ b/packages/web-integration/src/static/static-page.ts
@@ -7,9 +7,11 @@ import type {
 import type { AbstractInterface } from '@midscene/core/device';
 import {
   type InputPrimitives,
+  type ScreenshotCaptureOptions,
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
 import { ERROR_CODE_NOT_IMPLEMENTED_AS_DESIGNED } from '@midscene/shared/common';
+import { canonicalizeScreenshotBase64 } from '@midscene/shared/img';
 
 const ThrowNotImplemented = (methodName: string) => {
   throw new Error(
@@ -113,8 +115,11 @@ export default class StaticPage implements AbstractInterface {
     };
   }
 
-  async screenshotBase64() {
-    return screenshotBase64FromContext(this.uiContext.screenshot);
+  async screenshotBase64(options?: ScreenshotCaptureOptions) {
+    const source = screenshotBase64FromContext(this.uiContext.screenshot);
+    return options?.preferLossless
+      ? source
+      : canonicalizeScreenshotBase64(source);
   }
 
   async url() {

--- a/packages/web-integration/tests/ai/web/playwright/browser-webp-encoder.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/browser-webp-encoder.spec.ts
@@ -1,0 +1,182 @@
+import { Buffer } from 'node:buffer';
+import {
+  type BrowserWebpEncodeInput,
+  encodeRgbaToWebp,
+} from '@midscene/shared/img';
+import { type Page, expect, test } from '@playwright/test';
+
+type BrowserWebpEncoder = (
+  input: BrowserWebpEncodeInput,
+) => Promise<Uint8Array>;
+
+function createRgbaFixture(width: number, height: number): number[] {
+  const pixels = new Array<number>(width * height * 4);
+  let randomState = 0x1234abcd;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      randomState = (randomState * 1664525 + 1013904223) >>> 0;
+      const offset = (y * width + x) * 4;
+      const noise = randomState & 0xff;
+      pixels[offset] = (x * 11 + y * 3 + noise) & 0xff;
+      pixels[offset + 1] = (x * 5 + y * 17 + (noise >> 1)) & 0xff;
+      pixels[offset + 2] = (x * 19 + y * 7 + (noise >> 2)) & 0xff;
+      pixels[offset + 3] = 255;
+    }
+  }
+
+  return pixels;
+}
+
+function expectWebpSignature(bytes: number[]): void {
+  const buffer = Buffer.from(bytes);
+  expect(buffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+  expect(buffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
+}
+
+async function decodeDimensions(
+  page: Page,
+  bytes: number[],
+): Promise<{ width: number; height: number }> {
+  return page.evaluate(async (encodedBytes) => {
+    const bitmap = await createImageBitmap(
+      new Blob([new Uint8Array(encodedBytes)], { type: 'image/webp' }),
+    );
+    const dimensions = { width: bitmap.width, height: bitmap.height };
+    bitmap.close();
+    return dimensions;
+  }, bytes);
+}
+
+test.describe('browser WebP encoder', () => {
+  const width = 128;
+  const height = 96;
+  const pixels = createRgbaFixture(width, height);
+  const encoderSource = encodeRgbaToWebp.toString();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('data:text/html,<title>browser WebP encoder</title>');
+    await page.addScriptTag({
+      content: `globalThis.__midsceneEncodeRgbaToWebp = ${encoderSource};`,
+    });
+  });
+
+  test('uses HTML Canvas quality on the browser main thread', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      Object.defineProperty(globalThis, 'OffscreenCanvas', {
+        configurable: true,
+        value: undefined,
+      });
+    });
+
+    const [quality10, quality90] = await page.evaluate(
+      async ({ fixturePixels, fixtureWidth, fixtureHeight }) => {
+        const encode = (
+          globalThis as typeof globalThis & {
+            __midsceneEncodeRgbaToWebp: BrowserWebpEncoder;
+          }
+        ).__midsceneEncodeRgbaToWebp;
+        const lowQuality = await encode({
+          pixels: fixturePixels,
+          width: fixtureWidth,
+          height: fixtureHeight,
+          quality: 10,
+        });
+        const highQuality = await encode({
+          pixels: fixturePixels,
+          width: fixtureWidth,
+          height: fixtureHeight,
+          quality: 90,
+        });
+        return [Array.from(lowQuality), Array.from(highQuality)];
+      },
+      {
+        fixturePixels: pixels,
+        fixtureWidth: width,
+        fixtureHeight: height,
+      },
+    );
+
+    expectWebpSignature(quality10);
+    expectWebpSignature(quality90);
+    expect(quality10).not.toEqual(quality90);
+    expect(quality10.length).toBeLessThan(quality90.length);
+    await expect(decodeDimensions(page, quality90)).resolves.toEqual({
+      width,
+      height,
+    });
+  });
+
+  test('encodes WebP with OffscreenCanvas inside a Worker', async ({
+    page,
+  }) => {
+    const workerBytes = await page.evaluate(
+      async ({
+        productionEncoderSource,
+        fixturePixels,
+        fixtureWidth,
+        fixtureHeight,
+      }) => {
+        const workerSource = `
+          const encodeRgbaToWebp = ${productionEncoderSource};
+          self.onmessage = async (event) => {
+            try {
+              const output = await encodeRgbaToWebp(event.data);
+              self.postMessage({ bytes: Array.from(output) });
+            } catch (error) {
+              self.postMessage({
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          };
+        `;
+        const workerUrl = URL.createObjectURL(
+          new Blob([workerSource], { type: 'text/javascript' }),
+        );
+        const worker = new Worker(workerUrl);
+
+        try {
+          return await new Promise<number[]>((resolve, reject) => {
+            worker.onmessage = (
+              event: MessageEvent<{ bytes?: number[]; error?: string }>,
+            ) => {
+              if (event.data.error) {
+                reject(new Error(event.data.error));
+                return;
+              }
+              if (!event.data.bytes) {
+                reject(new Error('Worker returned no WebP bytes'));
+                return;
+              }
+              resolve(event.data.bytes);
+            };
+            worker.onerror = (event) => reject(new Error(event.message));
+            worker.postMessage({
+              pixels: fixturePixels,
+              width: fixtureWidth,
+              height: fixtureHeight,
+              quality: 90,
+            });
+          });
+        } finally {
+          worker.terminate();
+          URL.revokeObjectURL(workerUrl);
+        }
+      },
+      {
+        productionEncoderSource: encoderSource,
+        fixturePixels: pixels,
+        fixtureWidth: width,
+        fixtureHeight: height,
+      },
+    );
+
+    expectWebpSignature(workerBytes);
+    await expect(decodeDimensions(page, workerBytes)).resolves.toEqual({
+      width,
+      height,
+    });
+  });
+});

--- a/packages/web-integration/tests/ai/web/playwright/screenshot-cdp-fallback.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/screenshot-cdp-fallback.spec.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'node:net';
 import { PlaywrightWebPage } from '@/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('playwright screenshot CDP fallback', () => {
+test.describe('playwright CDP screenshot', () => {
   test.setTimeout(30 * 1000);
 
   let slowServer: ReturnType<typeof createServer>;
@@ -31,7 +31,7 @@ test.describe('playwright screenshot CDP fallback', () => {
     slowServer?.close();
   });
 
-  test('should fall back to CDP when a hanging web font blocks screenshot', async ({
+  test('should capture WebP when a hanging web font blocks Playwright screenshot', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
@@ -40,8 +40,8 @@ test.describe('playwright screenshot CDP fallback', () => {
       timeout: 15_000,
     });
 
-    // Inject a @font-face pointing to the local slow server,
-    // causing Playwright's screenshot to hang on "waiting for fonts to load"
+    // Inject a @font-face pointing to the local slow server. Playwright's
+    // public screenshot API waits for fonts, while CDP capture should not.
     const fontUrl = `${slowServerUrl}/hanging-font.woff2`;
     await page.evaluate((url: string) => {
       const style = document.createElement('style');
@@ -63,7 +63,7 @@ test.describe('playwright screenshot CDP fallback', () => {
     const webPage = new PlaywrightWebPage(page);
     const screenshotBase64 = await webPage.screenshotBase64();
 
-    expect(screenshotBase64).toContain('data:image/jpeg;base64,');
+    expect(screenshotBase64).toContain('data:image/webp;base64,');
     expect(screenshotBase64.length).toBeGreaterThan(1_000);
   });
 });

--- a/packages/web-integration/tests/ai/web/puppeteer/webp-report.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/webp-report.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { PuppeteerAgent } from '@/puppeteer';
+import { reportFileToMarkdown } from '@midscene/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { launchPage } from './utils';
+
+const FIXTURES_DIR = join(__dirname, '../../fixtures');
+const REPORT_NAME =
+  process.env.MIDSCENE_WEBP_REPORT_NAME || 'webp-model-input-validation';
+
+vi.setConfig({
+  testTimeout: 180 * 1000,
+});
+
+describe('WebP model input report', () => {
+  let reset: (() => Promise<void>) | undefined;
+  let agent: PuppeteerAgent | undefined;
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.destroy();
+    }
+    await reset?.();
+  });
+
+  it('keeps the exact WebP model input in HTML and Markdown reports', async () => {
+    const launched = await launchPage(
+      `file://${join(FIXTURES_DIR, 'search-engine.html')}`,
+      { viewport: { width: 1120, height: 700 } },
+    );
+    reset = launched.reset;
+    agent = new PuppeteerAgent(launched.originPage, {
+      generateReport: true,
+      reportFileName: REPORT_NAME,
+    });
+
+    const captured = await agent.interface.screenshotBase64();
+    expect(captured).toMatch(/^data:image\/webp;base64,UklGR/);
+
+    await agent.aiAssert('A search input box and a search button are visible');
+    await agent.destroy();
+    const reportFile = agent.reportFile;
+    agent = undefined;
+
+    expect(reportFile).toBeTruthy();
+    expect(existsSync(reportFile!)).toBe(true);
+
+    const markdownDir = join(dirname(reportFile!), `${REPORT_NAME}-markdown`);
+    rmSync(markdownDir, { recursive: true, force: true });
+    const markdownResult = await reportFileToMarkdown({
+      htmlPath: reportFile!,
+      outputDir: markdownDir,
+    });
+    const markdown = readFileSync(markdownResult.markdownFiles[0], 'utf8');
+    expect(markdown).not.toContain('No model metadata recorded.');
+    expect(markdown).not.toContain('No token usage recorded.');
+    expect(markdown).toContain('timing=model-input');
+
+    const modelInputHash = markdown.match(
+      /Model input \d+ \(exact bytes, sha256: ([a-f0-9]{64})\)/,
+    )?.[1];
+    expect(modelInputHash).toBeTruthy();
+    expect(markdownResult.screenshotFiles.length).toBeGreaterThan(0);
+    expect(
+      markdownResult.screenshotFiles.every((file) => file.endsWith('.webp')),
+    ).toBe(true);
+
+    const screenshots = markdownResult.screenshotFiles.map((file) => {
+      const bytes = readFileSync(file);
+      expect(bytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(bytes.subarray(8, 12).toString('ascii')).toBe('WEBP');
+      return {
+        file: basename(file),
+        bytes: statSync(file).size,
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+      };
+    });
+    expect(screenshots.some((item) => item.sha256 === modelInputHash)).toBe(
+      true,
+    );
+
+    const manifestFile = join(markdownDir, 'validation-manifest.json');
+    writeFileSync(
+      manifestFile,
+      `${JSON.stringify(
+        {
+          reportFile,
+          markdownFile: markdownResult.markdownFiles[0],
+          modelInputHash,
+          screenshots,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    console.log(`WebP validation report: ${reportFile}`);
+    console.log(`WebP validation manifest: ${manifestFile}`);
+  });
+});

--- a/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
@@ -76,6 +76,9 @@ function jpegBase64(width: number, height: number): string {
   ]).toString('base64');
 }
 
+const webpBase64 =
+  'UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=';
+
 describe('Page startMjpegStream', () => {
   it('starts a Puppeteer CDP screencast and ACKs incoming frames', async () => {
     const handlers = new Map<string, (event: any) => unknown>();
@@ -154,7 +157,7 @@ describe('Page startMjpegStream', () => {
     const mockPage = {
       bringToFront: vi.fn().mockResolvedValue(undefined),
       evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 720 }),
-      screenshot: vi.fn().mockResolvedValue(jpegBase64(1280, 720)),
+      screenshot: vi.fn().mockResolvedValue(webpBase64),
       url: () => 'http://example.com',
       target: () => ({
         createCDPSession: vi.fn().mockResolvedValue(client),
@@ -179,8 +182,8 @@ describe('Page startMjpegStream', () => {
     });
     await vi.waitFor(() => {
       expect(onFrame).toHaveBeenCalledWith({
-        data: jpegBase64(1280, 720),
-        contentType: 'image/jpeg',
+        data: webpBase64,
+        contentType: 'image/webp',
       });
     });
 
@@ -256,14 +259,14 @@ describe('Page startMjpegStream', () => {
     await page.flushPendingVisualUpdate();
 
     expect(mockPage.screenshot).toHaveBeenCalledWith({
-      type: 'jpeg',
+      type: 'webp',
       quality: 90,
       encoding: 'base64',
     });
     // Hub contract: MjpegStreamFrame.data is bare base64, never a data URL.
     expect(onFrame).toHaveBeenCalledWith({
       data: 'cmVmcmVzaA==',
-      contentType: 'image/jpeg',
+      contentType: 'image/webp',
     });
 
     await handle.stop();

--- a/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screencast.test.ts
@@ -320,7 +320,7 @@ describe('Page startMjpegStream', () => {
   it('force-pushes a final screenshot after navigation replaces the preview with a transient frame', async () => {
     const mockPage = {
       evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 720 }),
-      screenshot: vi.fn().mockResolvedValue(jpegBase64(1280, 720)),
+      screenshot: vi.fn().mockResolvedValue(webpBase64),
       url: () => 'http://example.com',
     } as any;
     const page = new Page(mockPage, 'puppeteer');
@@ -339,13 +339,13 @@ describe('Page startMjpegStream', () => {
     await page.flushPendingVisualUpdate(true);
 
     expect(mockPage.screenshot).toHaveBeenCalledWith({
-      type: 'jpeg',
+      type: 'webp',
       quality: 90,
       encoding: 'base64',
     });
     expect(onFrame).toHaveBeenCalledWith({
-      data: jpegBase64(1280, 720),
-      contentType: 'image/jpeg',
+      data: webpBase64,
+      contentType: 'image/webp',
     });
   });
 

--- a/packages/web-integration/tests/unit-test/base-page-screenshot.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screenshot.test.ts
@@ -24,43 +24,36 @@ vi.mock('@/web-page', () => ({
 }));
 
 describe('Page screenshotBase64', () => {
-  it('uses the regular playwright screenshot path when it succeeds', async () => {
-    const screenshot = vi.fn().mockResolvedValue(Buffer.from('plain-shot'));
-    const newCDPSession = vi.fn();
-    const mockPage = {
-      url: () => 'http://example.com',
-      isClosed: () => false,
-      screenshot,
-      context: () => ({
-        browser: () => ({
-          browserType: () => ({
-            name: () => 'chromium',
-          }),
-        }),
-        newCDPSession,
-      }),
-    } as any;
+  const webpBody =
+    'UklGRjQAAABXRUJQVlA4ICgAAACQAQCdASoCAAMAAMASJQBOl0AAjNAA/v4icv1difCfoP7mxzi2QwAA';
+  const pngBody =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-    const page = new Page(mockPage, 'playwright');
-    const result = await page.screenshotBase64();
+  it('uses Puppeteer native WebP capture', async () => {
+    const screenshot = vi.fn().mockResolvedValue(webpBody);
+    const page = new Page(
+      {
+        url: () => 'http://example.com',
+        screenshot,
+      } as any,
+      'puppeteer',
+    );
 
-    expect(result).toContain('data:image/jpeg;base64,');
-    expect(screenshot).toHaveBeenCalledTimes(1);
-    expect(newCDPSession).not.toHaveBeenCalled();
+    await expect(page.screenshotBase64()).resolves.toBe(
+      `data:image/webp;base64,${webpBody}`,
+    );
+    expect(screenshot).toHaveBeenCalledWith({
+      type: 'webp',
+      quality: 90,
+      encoding: 'base64',
+    });
   });
 
-  it('falls back to a CDP screenshot when playwright screenshot times out', async () => {
-    const screenshot = vi
-      .fn()
-      .mockRejectedValue(
-        new Error('page.screenshot: Timeout 10000ms exceeded.'),
-      );
+  it('uses Chromium CDP native WebP when available', async () => {
+    const screenshot = vi.fn().mockResolvedValue(Buffer.from('plain-shot'));
     const detach = vi.fn().mockResolvedValue(undefined);
-    const send = vi.fn().mockResolvedValue({ data: 'Y2RwLXNob3Q=' });
-    const newCDPSession = vi.fn().mockResolvedValue({
-      send,
-      detach,
-    });
+    const send = vi.fn().mockResolvedValue({ data: webpBody });
+    const newCDPSession = vi.fn().mockResolvedValue({ send, detach });
     const mockPage = {
       url: () => 'http://example.com',
       isClosed: () => false,
@@ -78,13 +71,44 @@ describe('Page screenshotBase64', () => {
     const page = new Page(mockPage, 'playwright');
     const result = await page.screenshotBase64();
 
-    expect(result).toContain('data:image/jpeg;base64,');
-    expect(newCDPSession).toHaveBeenCalledTimes(1);
+    expect(result).toBe(`data:image/webp;base64,${webpBody}`);
+    expect(screenshot).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledWith('Page.captureScreenshot', {
-      format: 'jpeg',
+      format: 'webp',
       quality: 90,
     });
-    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to public PNG capture and returns WebP without CDP', async () => {
+    const screenshot = vi
+      .fn()
+      .mockResolvedValue(Buffer.from(pngBody, 'base64'));
+    const newCDPSession = vi
+      .fn()
+      .mockRejectedValue(new Error('CDP unavailable'));
+    const mockPage = {
+      url: () => 'http://example.com',
+      isClosed: () => false,
+      screenshot,
+      context: () => ({
+        browser: () => ({
+          browserType: () => ({
+            name: () => 'chromium',
+          }),
+        }),
+        newCDPSession,
+      }),
+    } as any;
+
+    const page = new Page(mockPage, 'playwright');
+    const result = await page.screenshotBase64();
+
+    expect(result).toMatch(/^data:image\/webp;base64,UklGR/);
+    expect(newCDPSession).toHaveBeenCalledTimes(1);
+    expect(screenshot).toHaveBeenCalledWith({
+      type: 'png',
+      timeout: 10 * 1000,
+    });
   });
 
   it('times out when the CDP screenshot fallback does not return in time', async () => {
@@ -124,11 +148,13 @@ describe('Page screenshotBase64', () => {
     await vi.advanceTimersByTimeAsync(10 * 1000);
 
     await expect(resultPromise).resolves.toMatchObject({
-      message: 'CDP screenshot timeout after 10000ms.',
+      message: expect.stringContaining(
+        'Playwright screenshot failed through both CDP WebP and PNG fallback',
+      ),
     });
     expect(newCDPSession).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith('Page.captureScreenshot', {
-      format: 'jpeg',
+      format: 'webp',
       quality: 90,
     });
     expect(detach).toHaveBeenCalledTimes(1);
@@ -173,7 +199,9 @@ describe('Page screenshotBase64', () => {
     await vi.advanceTimersByTimeAsync(10 * 1000);
 
     await expect(resultPromise).resolves.toMatchObject({
-      message: 'CDP screenshot timeout after 10000ms.',
+      message: expect.stringContaining(
+        'Playwright screenshot failed through both CDP WebP and PNG fallback',
+      ),
     });
     expect(detach).toHaveBeenCalledTimes(1);
 

--- a/packages/web-integration/tests/unit-test/base-page-screenshot.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-screenshot.test.ts
@@ -49,6 +49,25 @@ describe('Page screenshotBase64', () => {
     });
   });
 
+  it('returns a native PNG source when Core will resize a Puppeteer screenshot', async () => {
+    const screenshot = vi.fn().mockResolvedValue(pngBody);
+    const page = new Page(
+      {
+        url: () => 'http://example.com',
+        screenshot,
+      } as any,
+      'puppeteer',
+    );
+
+    await expect(page.screenshotBase64({ preferLossless: true })).resolves.toBe(
+      `data:image/png;base64,${pngBody}`,
+    );
+    expect(screenshot).toHaveBeenCalledWith({
+      type: 'png',
+      encoding: 'base64',
+    });
+  });
+
   it('uses Chromium CDP native WebP when available', async () => {
     const screenshot = vi.fn().mockResolvedValue(Buffer.from('plain-shot'));
     const detach = vi.fn().mockResolvedValue(undefined);
@@ -77,6 +96,37 @@ describe('Page screenshotBase64', () => {
       format: 'webp',
       quality: 90,
     });
+  });
+
+  it('returns a native PNG source without opening CDP when Core will resize a Playwright screenshot', async () => {
+    const screenshot = vi
+      .fn()
+      .mockResolvedValue(Buffer.from(pngBody, 'base64'));
+    const newCDPSession = vi.fn();
+    const mockPage = {
+      url: () => 'http://example.com',
+      isClosed: () => false,
+      screenshot,
+      context: () => ({
+        browser: () => ({
+          browserType: () => ({
+            name: () => 'chromium',
+          }),
+        }),
+        newCDPSession,
+      }),
+    } as any;
+
+    const page = new Page(mockPage, 'playwright');
+
+    await expect(page.screenshotBase64({ preferLossless: true })).resolves.toBe(
+      `data:image/png;base64,${pngBody}`,
+    );
+    expect(screenshot).toHaveBeenCalledWith({
+      type: 'png',
+      timeout: 10 * 1000,
+    });
+    expect(newCDPSession).not.toHaveBeenCalled();
   });
 
   it('falls back to public PNG capture and returns WebP without CDP', async () => {

--- a/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { captureChromeExtensionScreenshot } from '../../src/chrome-extension/screenshot';
+
+describe('Chrome extension screenshot format', () => {
+  it('captures WebP at quality 90 by default', async () => {
+    const sendCaptureCommand = vi
+      .fn()
+      .mockResolvedValue({ data: 'SCREENSHOT_BASE64' });
+
+    await expect(
+      captureChromeExtensionScreenshot(sendCaptureCommand),
+    ).resolves.toBe('data:image/webp;base64,SCREENSHOT_BASE64');
+    expect(sendCaptureCommand).toHaveBeenCalledWith({
+      format: 'webp',
+      quality: 90,
+    });
+  });
+
+  it('allows an explicit JPEG fallback', async () => {
+    const sendCaptureCommand = vi
+      .fn()
+      .mockResolvedValue({ data: 'SCREENSHOT_BASE64' });
+
+    await expect(
+      captureChromeExtensionScreenshot(sendCaptureCommand, 'jpeg'),
+    ).resolves.toBe('data:image/jpeg;base64,SCREENSHOT_BASE64');
+    expect(sendCaptureCommand).toHaveBeenCalledWith({
+      format: 'jpeg',
+      quality: 90,
+    });
+  });
+});

--- a/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
@@ -1,5 +1,17 @@
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  ExecutionDump,
+  ReportGenerator,
+  ScreenshotItem,
+  parseImageScripts,
+  reportFileToMarkdown,
+} from '@midscene/core';
 import { describe, expect, it, vi } from 'vitest';
 import { captureChromeExtensionScreenshot } from '../../src/chrome-extension/screenshot';
+import { launchPage } from '../ai/web/puppeteer/utils';
 
 describe('Chrome extension screenshot format', () => {
   it('captures WebP at quality 90 by default', async () => {
@@ -28,5 +40,118 @@ describe('Chrome extension screenshot format', () => {
       format: 'jpeg',
       quality: 90,
     });
+  });
+
+  it('keeps a real CDP WebP capture intact through report and Markdown export', async () => {
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'midscene-chrome-extension-webp-'),
+    );
+
+    try {
+      const pageHtml = `<!doctype html>
+        <html>
+          <body style="margin: 0; background: #f4efe6">
+            <main style="width: 100vw; height: 100vh; display: grid; place-items: center">
+              <div style="padding: 24px; background: #2463eb; color: white">WebP report fixture</div>
+            </main>
+          </body>
+        </html>`;
+      const { originPage, reset } = await launchPage(
+        `data:text/html,${encodeURIComponent(pageHtml)}`,
+        {
+          viewport: {
+            width: 320,
+            height: 180,
+            deviceScaleFactor: 1,
+          },
+        },
+      );
+
+      try {
+        const cdpSession = await originPage.createCDPSession();
+
+        try {
+          const screenshotBase64 = await captureChromeExtensionScreenshot(
+            (params) => cdpSession.send('Page.captureScreenshot', params),
+          );
+          const screenshotBytes = Buffer.from(
+            screenshotBase64.split(',')[1],
+            'base64',
+          );
+
+          expect(screenshotBase64).toMatch(/^data:image\/webp;base64,/);
+          expect(screenshotBytes.subarray(0, 4).toString('ascii')).toBe('RIFF');
+          expect(screenshotBytes.subarray(8, 12).toString('ascii')).toBe(
+            'WEBP',
+          );
+
+          const capturedAt = Date.now();
+          const screenshot = ScreenshotItem.create(
+            screenshotBase64,
+            capturedAt,
+          );
+          const execution = new ExecutionDump({
+            id: 'chrome-extension-webp-report',
+            logTime: capturedAt,
+            name: 'Chrome extension WebP report',
+            tasks: [
+              {
+                taskId: 'capture-webp',
+                type: 'Insight',
+                subType: 'Locate',
+                param: { prompt: 'Capture the fixture page' },
+                uiContext: {
+                  screenshot,
+                  shotSize: { width: 320, height: 180 },
+                  shrunkShotToLogicalRatio: 1,
+                },
+                executor: async () => undefined,
+                recorder: [],
+                status: 'finished',
+              },
+            ],
+          });
+          const reportPath = join(tmpDir, 'chrome-extension-webp.html');
+          const reportGenerator = new ReportGenerator({
+            reportPath,
+            screenshotMode: 'inline',
+            autoPrint: false,
+          });
+
+          reportGenerator.onExecutionUpdate(execution, {
+            groupName: 'Chrome extension WebP integration test',
+            sdkVersion: 'test',
+            modelBriefs: [],
+          });
+          await expect(reportGenerator.finalize()).resolves.toBe(reportPath);
+
+          const reportHtml = readFileSync(reportPath, 'utf-8');
+          expect(parseImageScripts(reportHtml)[screenshot.id]).toBe(
+            screenshotBase64,
+          );
+          expect(reportHtml).toContain('"mimeType":"image/webp"');
+
+          const markdownDir = join(tmpDir, 'markdown');
+          const markdownResult = await reportFileToMarkdown({
+            htmlPath: reportPath,
+            outputDir: markdownDir,
+          });
+
+          expect(markdownResult.screenshotFiles).toHaveLength(1);
+          const [exportedScreenshotPath] = markdownResult.screenshotFiles;
+          expect(exportedScreenshotPath).toMatch(/\.webp$/);
+          expect(readFileSync(exportedScreenshotPath)).toEqual(screenshotBytes);
+          expect(
+            readFileSync(join(markdownDir, 'report.md'), 'utf-8'),
+          ).toContain(`./screenshots/${basename(exportedScreenshotPath)}`);
+        } finally {
+          await cdpSession.detach();
+        }
+      } finally {
+        await reset();
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-screenshot.test.ts
@@ -42,6 +42,19 @@ describe('Chrome extension screenshot format', () => {
     });
   });
 
+  it('captures a lossless PNG source without a quality option', async () => {
+    const sendCaptureCommand = vi
+      .fn()
+      .mockResolvedValue({ data: 'SCREENSHOT_BASE64' });
+
+    await expect(
+      captureChromeExtensionScreenshot(sendCaptureCommand, 'png'),
+    ).resolves.toBe('data:image/png;base64,SCREENSHOT_BASE64');
+    expect(sendCaptureCommand).toHaveBeenCalledWith({
+      format: 'png',
+    });
+  });
+
   it('keeps a real CDP WebP capture intact through report and Markdown export', async () => {
     const tmpDir = mkdtempSync(
       join(tmpdir(), 'midscene-chrome-extension-webp-'),

--- a/packages/web-integration/tests/unit-test/playground-server.test.ts
+++ b/packages/web-integration/tests/unit-test/playground-server.test.ts
@@ -1,7 +1,27 @@
+import { createServer } from 'node:net';
 import { ScreenshotItem } from '@midscene/core';
 import { PlaygroundServer } from '@midscene/playground';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { StaticPage, StaticPageAgent } from '../../src/static';
+
+async function findLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      if (!address || typeof address === 'string') {
+        probe.close();
+        reject(new Error('Failed to allocate a loopback test port'));
+        return;
+      }
+      probe.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
 
 describe('Playground Server', () => {
   let server: PlaygroundServer;
@@ -14,7 +34,7 @@ describe('Playground Server', () => {
     });
     const agent = new StaticPageAgent(page);
     server = new PlaygroundServer(agent);
-    await server.launch();
+    await server.launch(await findLoopbackPort());
     serverBase = `http://localhost:${server.port}`;
   });
 
@@ -46,7 +66,8 @@ describe('Playground Server', () => {
   });
 
   it('updates static context with a JSON-serialized ScreenshotItem', async () => {
-    const screenshotBase64 = 'data:image/png;base64,abc123';
+    const screenshotBase64 =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
     const serializedScreenshot = JSON.parse(
       JSON.stringify(ScreenshotItem.create(screenshotBase64, Date.now())),
     );
@@ -70,6 +91,6 @@ describe('Playground Server', () => {
     const screenshotRes = await fetch(`${serverBase}/screenshot`);
     expect(screenshotRes.status).toBe(200);
     const screenshot = await screenshotRes.json();
-    expect(screenshot.screenshot).toBe(screenshotBase64);
+    expect(screenshot.screenshot).toMatch(/^data:image\/webp;base64,UklGR/);
   });
 });

--- a/packages/web-integration/tests/unit-test/static-page.test.ts
+++ b/packages/web-integration/tests/unit-test/static-page.test.ts
@@ -2,7 +2,8 @@ import { ScreenshotItem } from '@midscene/core';
 import { describe, expect, it } from 'vitest';
 import { StaticPage } from '../../src/static';
 
-const screenshotBase64 = 'data:image/png;base64,abc123';
+const screenshotBase64 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
 function createContext(
   screenshot: ConstructorParameters<typeof StaticPage>[0]['screenshot'],
@@ -15,27 +16,41 @@ function createContext(
 }
 
 describe('StaticPage', () => {
-  it('returns base64 from a ScreenshotItem instance', async () => {
+  it('returns WebP from a ScreenshotItem instance', async () => {
     const page = new StaticPage(
       createContext(ScreenshotItem.create(screenshotBase64, Date.now())),
     );
 
-    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+    await expect(page.screenshotBase64()).resolves.toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
   });
 
-  it('returns base64 from a restored report screenshot object', async () => {
+  it('returns WebP from a restored report screenshot object', async () => {
     const page = new StaticPage(createContext({ base64: screenshotBase64 }));
 
-    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+    await expect(page.screenshotBase64()).resolves.toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
   });
 
-  it('returns base64 from a JSON-serialized ScreenshotItem', async () => {
+  it('returns WebP from a JSON-serialized ScreenshotItem', async () => {
     const serializedScreenshot = JSON.parse(
       JSON.stringify(ScreenshotItem.create(screenshotBase64, Date.now())),
     );
     const page = new StaticPage(createContext(serializedScreenshot));
 
-    await expect(page.screenshotBase64()).resolves.toBe(screenshotBase64);
+    await expect(page.screenshotBase64()).resolves.toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
+  });
+
+  it('returns the source bytes when Core will resize the screenshot', async () => {
+    const page = new StaticPage(createContext({ base64: screenshotBase64 }));
+
+    await expect(page.screenshotBase64({ preferLossless: true })).resolves.toBe(
+      screenshotBase64,
+    );
   });
 
   it('rejects screenshot refs that do not include base64 data', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,6 +890,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
+      sharp:
+        specifier: ^0.34.3
+        version: 0.34.3
       tsx:
         specifier: ^4.19.2
         version: 4.19.2


### PR DESCRIPTION
## Summary

- standardize static screenshots on WebP across Puppeteer, Playwright, the Chrome extension recorder, Android ADB and scrcpy, iOS WDA, Computer, RDP, and shared image transforms
- use native WebP encoders where available and use the shared Sharp or browser encoder only when the producer cannot emit WebP
- keep native JPEG continuous streams byte-identical for CDP screencast and iOS WDA MJPEG to avoid a second lossy encode and extra observation latency
- preserve the actual PNG, JPEG, or WebP MIME type in Playground MJPEG fallback frames
- record the exact image data-URI bytes sent to the model in Midscene reports, including a raw-byte SHA-256 digest
- preserve WebP MIME types and file extensions through HTML report, report Markdown export, and Chrome recorder ZIP/Markdown export
- derive recorder export MIME types and extensions from image bytes so an incorrectly labeled data URI cannot produce a mismatched file

## Screenshot behavior

| Path | Output | Encoding path |
| --- | --- | --- |
| Puppeteer static screenshot | WebP | native Chromium encoder |
| Playwright Chromium static screenshot | WebP | native CDP encoder, PNG-to-WebP fallback |
| Chrome extension recorder | WebP | OffscreenCanvas encoder after captureVisibleTab PNG |
| Android ADB | WebP | PNG-to-WebP via shared Sharp encoder |
| Android scrcpy | WebP | H.264-to-RGB via ffmpeg, then Sharp WebP |
| iOS WDA static screenshot | WebP | PNG-to-WebP via shared Sharp encoder |
| Computer and RDP static screenshot | WebP | PNG-to-WebP; native RDP JPEG is preserved |
| Shared resize, crop, scale, padding, and marker composition | WebP | Sharp, Photon, or Canvas WebP encoder |
| CDP screencast and iOS WDA MJPEG | JPEG | preserved native continuous stream |

## Validation

- `pnpm run lint` (1,390 files checked)
- `pnpm run type-check:tests`
- `pnpm exec nx run-many -t build -p @midscene/shared @midscene/core @midscene/web @midscene/playground @midscene/android @midscene/ios @midscene/computer chrome-extension --parallel=4`
- `pnpm exec nx test @midscene/core --maxWorkers=1 --no-file-parallelism` (1,355 passed, 8 skipped)
- `pnpm exec nx test @midscene/web --maxWorkers=1 --no-file-parallelism` (410 passed, 1 skipped)
- `pnpm exec nx test @midscene/computer --maxWorkers=1 --no-file-parallelism` (89 passed)
- `pnpm exec nx test chrome-extension --maxWorkers=1 --no-file-parallelism --testTimeout=30000 --hookTimeout=30000` (40 passed)
- focused package suites: Shared 427 passed, Playground 275 passed, Android 325 passed, iOS 145 passed
- Playwright native-CDP/fallback browser spec passed with WebP assertions
- real-model AI E2E passed with `openai_qwen3.5-plus`; the generated Midscene report was reopened in Chromium and rendered the 2240x1400 WebP screenshot
- report Markdown export produced WebP files whose raw-byte SHA-256 exactly matched the image recorded at the model request boundary: `6a0e063adbdddb2d3161fa3df75426a4073bf5e5d2eb79a339548f532a14b425`
- final-head CI is green for Chrome extension and recorder, Headless Linux, Playwright Web/report E2E, AI unit tests, Android Emulator, iOS Simulator, macOS desktop, and Windows desktop
- downloaded final Android, iOS, macOS, and Windows Midscene report artifacts and verified WebP file signatures plus zero JPEG screenshot references
- physical Samsung SM-N9860 validation passed for both ADB and scrcpy: each AI assertion used image/webp at the exact model-input boundary, and split/Markdown exports preserved byte-identical WebP files
- physical iPhone 15 Pro (iOS 26.5.2) validation passed: the static WDA AI assertion used image/webp and split/Markdown exports preserved the exact model-input bytes; the MJPEG observer AI assertion passed over six sampled frames plus a representative frame, with every model input preserved as native image/jpeg

## CI evidence

- Headless Linux and Chrome extension matrix: https://github.com/web-infra-dev/midscene/actions/runs/29898707688
- Playwright Web and report E2E: https://github.com/web-infra-dev/midscene/actions/runs/29898707732
- AI unit tests: https://github.com/web-infra-dev/midscene/actions/runs/29898707749
- Android Emulator: https://github.com/web-infra-dev/midscene/actions/runs/29898707709
- iOS Simulator: https://github.com/web-infra-dev/midscene/actions/runs/29898707649
- macOS desktop: https://github.com/web-infra-dev/midscene/actions/runs/29898707698
- Windows desktop: https://github.com/web-infra-dev/midscene/actions/runs/29898707655

## Performance sample

On a 2240x1400 fixture, 100 native Chrome captures averaged 37.43 ms for JPEG and 144.92 ms for WebP. WebP used 41.8% of the JPEG bytes and added about 10.75 seconds across 100 captures. PNG-to-WebP through Sharp with effort 1 averaged 84.03 ms per image.

## Prepatch

Published and verified immutable npm packages:

- `@midscene/web@1.10.7-beta-20260722071702.0`
- `@midscene/core@1.10.7-beta-20260722071702.0`
- `@midscene/shared@1.10.7-beta-20260722071702.0`

Release artifacts include `midscene-extension-v1.10.7-beta-20260722071702.0.zip` plus Studio packages for macOS arm64/x64, Windows x64, and Linux x64.

Release workflow: https://github.com/web-infra-dev/midscene/actions/runs/29898726911

## Remaining physical-device gate

- RDP host: validate native JPEG preservation on an actual remote session; no insertable device is required

