### PR TITLE
fix(workflow): allow release note generation in notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,7 +391,7 @@ jobs:
     if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
     - name: Publish release notification to Discord
       id: notify
@@ -617,7 +617,7 @@ jobs:
     if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
     - name: Publish release notification to Feishu
       id: notify


### PR DESCRIPTION
## Summary

- grant `contents: write` to the Discord release notification job
- grant `contents: write` to the Feishu release notification job

## Root cause

Both jobs call GitHub's `POST /releases/generate-notes` endpoint with the workflow `GITHUB_TOKEN`. The jobs previously granted only `contents: read`, so GitHub rejected the request with `Resource not accessible by integration (HTTP 403)` before either webhook was called.

## Impact

Stable release notifications can generate temporary notes from the current release range and then deliver the filtered feature and fix entries to Discord and Feishu. The manually maintained GitHub Release body remains unchanged.

## Validation

- parsed `.github/workflows/release.yml` as YAML
- asserted that both notification jobs have `permissions.contents: write`
- ran `git diff --check`
- validated the PR title with commitlint
