### PR TITLE
fix(computer): stabilize macOS desktop input focus

### DIFF
--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -828,14 +828,7 @@ export class ComputerDevice implements AbstractInterface {
         const element = opts?.target as LocateResultElement | undefined;
 
         if (element) {
-          const [x, y] = element.center;
-          const target = this.toGlobalPoint({ x, y });
-          this.inputDriver.moveMouse(
-            Math.round(target.x),
-            Math.round(target.y),
-          );
-          this.inputDriver.mouseClick('left');
-          await this.inputDriver.delay(INPUT_FOCUS_DELAY);
+          await this.focusKeyboardTarget(element, INPUT_FOCUS_DELAY);
 
           if (opts?.replace !== false) {
             await this.selectAllAndDelete();
@@ -848,23 +841,14 @@ export class ComputerDevice implements AbstractInterface {
       keyboardPress: async (keyName, opts) => {
         const target = opts?.target as LocateResultElement | undefined;
         if (target) {
-          const [x, y] = target.center;
-          const point = this.toGlobalPoint({ x, y });
-          this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
-          this.inputDriver.mouseClick('left');
-          await this.inputDriver.delay(50);
+          await this.focusKeyboardTarget(target, 50);
         }
 
         await this.pressKeyboardShortcut(keyName);
       },
       clearInput: async (target) => {
         if (target) {
-          const element = target as LocateResultElement;
-          const [x, y] = element.center;
-          const point = this.toGlobalPoint({ x, y });
-          this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
-          this.inputDriver.mouseClick('left');
-          await this.inputDriver.delay(100);
+          await this.focusKeyboardTarget(target as LocateResultElement, 100);
         }
 
         await this.selectAllAndDelete();
@@ -883,6 +867,25 @@ export class ComputerDevice implements AbstractInterface {
     this.displayId = options?.displayId;
     this.useAppleScript =
       process.platform === 'darwin' && options?.keyboardDriver !== 'libnut';
+  }
+
+  private async focusKeyboardTarget(
+    element: LocateResultElement,
+    delayMs: number,
+  ): Promise<void> {
+    const [x, y] = element.center;
+    if (process.platform === 'darwin') {
+      // Reuse the macOS tap path, which holds mouse-down long enough for
+      // AppKit and follows up when the click changes the foreground process.
+      // A bare libnut mouseClick can be consumed solely as an activation click
+      // on hosted desktops, leaving subsequent AppleScript typing unfocused.
+      await this.inputPrimitives.pointer.tap({ x, y });
+    } else {
+      const point = this.toGlobalPoint({ x, y });
+      this.inputDriver.moveMouse(Math.round(point.x), Math.round(point.y));
+      this.inputDriver.mouseClick('left');
+    }
+    await this.inputDriver.delay(delayMs);
   }
 
   describe(): string {

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -10,6 +10,15 @@ final class FlippedDocumentView: NSView {
 final class SmokeButton: NSButton {
   var onMouseDown: (() -> Void)?
 
+  // AppKit normally consumes the first click while a programmatically
+  // activated application is still transitioning to the foreground. The
+  // hosted macOS runner can remain in that transition even after System
+  // Events says the process is frontmost. Accepting the activation click
+  // keeps this fixture focused on whether the global mouse event arrived.
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    true
+  }
+
   override func mouseDown(with event: NSEvent) {
     onMouseDown?()
     super.mouseDown(with: event)
@@ -28,6 +37,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var activationSource: DispatchSourceSignal?
 
   private var activationCount = 0
+  private var inputReadyGeneration = 0
   private var clickCount = 0
   private var buttonActionCount = 0
   private var lastKey = ""
@@ -108,12 +118,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
 
     installActivationSignal()
     activateFixture()
-    window.makeFirstResponder(textField)
     writeState()
-
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-      self?.writeReadyMetadata()
-    }
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -140,22 +145,46 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   }
 
   private func activateFixture() {
-    focusFixture()
     activationCount += 1
+    let activation = activationCount
+    NSApplication.shared.unhide(nil)
+    NSApplication.shared.activate(ignoringOtherApps: true)
+    NSRunningApplication.current.activate(options: [.activateAllWindows])
     writeState()
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-      self?.focusFixture()
-      self?.writeState()
+
+    // Present the window on the next AppKit turn, after the activation request
+    // has reached the application. A readiness generation is published only
+    // after AppKit itself reports a visible key window; callers synchronize on
+    // that generation instead of sleeping for an arbitrary duration.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      self.window.orderFrontRegardless()
+      self.window.makeKeyAndOrderFront(nil)
+      self.window.makeFirstResponder(self.textField)
+      self.publishInputReady(for: activation, attemptsRemaining: 40)
     }
   }
 
-  private func focusFixture() {
-    NSApplication.shared.unhide(nil)
-    window.orderFrontRegardless()
-    window.makeKeyAndOrderFront(nil)
-    NSApplication.shared.activate(ignoringOtherApps: true)
-    NSRunningApplication.current.activate(options: [.activateAllWindows])
-    window.makeFirstResponder(textField)
+  private func publishInputReady(for activation: Int, attemptsRemaining: Int) {
+    guard activation == activationCount else { return }
+    if window.isVisible && window.isKeyWindow && NSApplication.shared.isActive {
+      inputReadyGeneration += 1
+      writeState()
+      if inputReadyGeneration == 1 {
+        writeReadyMetadata()
+      }
+      return
+    }
+    guard attemptsRemaining > 0 else {
+      writeState()
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+      self?.publishInputReady(
+        for: activation,
+        attemptsRemaining: attemptsRemaining - 1
+      )
+    }
   }
 
   private func installActivationSignal() {
@@ -255,6 +284,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
         "active": NSApplication.shared.isActive,
         "keyWindow": window.isKeyWindow,
         "activationCount": activationCount,
+        "inputReadyGeneration": inputReadyGeneration,
         "clickCount": clickCount,
         "buttonActionCount": buttonActionCount,
         "text": textField.stringValue,

--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -26,13 +26,20 @@ final class SmokeButton: NSButton {
 }
 
 @MainActor
+final class SmokeTextField: NSTextField {
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    true
+  }
+}
+
+@MainActor
 final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDelegate {
   private let readyURL: URL
   private let stateURL: URL
 
   private var window: NSWindow!
   private var button: SmokeButton!
-  private var textField: NSTextField!
+  private var textField: SmokeTextField!
   private var scrollView: NSScrollView!
   private var activationSource: DispatchSourceSignal?
 
@@ -90,7 +97,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
       self.writeState()
     }
 
-    textField = NSTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
+    textField = SmokeTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
     textField.placeholderString = "Type smoke text"
     textField.delegate = self
     textField.target = self

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -70,6 +70,7 @@ interface FixtureState {
   active: boolean;
   keyWindow: boolean;
   activationCount: number;
+  inputReadyGeneration: number;
   clickCount: number;
   buttonActionCount: number;
   text: string;
@@ -160,6 +161,10 @@ function normalizeState(value: unknown): FixtureState {
     activationCount: asFiniteNumber(
       raw.activationCount,
       'state.activationCount',
+    ),
+    inputReadyGeneration: asFiniteNumber(
+      raw.inputReadyGeneration,
+      'state.inputReadyGeneration',
     ),
     clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
     buttonActionCount: asFiniteNumber(
@@ -261,15 +266,15 @@ async function retryFixtureAction(options: {
       await waitForJson(
         options.stateFile,
         normalizeState,
-        // GitHub's hosted macOS session reports the fixture as frontmost to
-        // System Events while AppKit still reports inactive/non-key. The
-        // fixture's activation signal is the reliable synchronization point;
-        // each caller subsequently verifies that the real input was received.
-        (state) => state.activationCount > beforeActivation.activationCount,
+        (state) =>
+          state.activationCount > beforeActivation.activationCount &&
+          state.inputReadyGeneration > beforeActivation.inputReadyGeneration &&
+          state.visible &&
+          state.active &&
+          state.keyWindow,
         ACTIVATION_TIMEOUT_MS,
         options.fixtureProcess,
       );
-      await sleep(250);
       await options.action();
       const state = await waitForJson(
         options.stateFile,

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -403,4 +403,25 @@ describe('ComputerDevice pointer input', () => {
       'left',
     );
   });
+
+  it('uses the held tap path when focusing a macOS keyboard target', async () => {
+    const device = await createConnectedDevice();
+
+    await device.inputPrimitives.keyboard.keyboardPress('Enter', {
+      target: { center: [100, 120] },
+    });
+
+    expect(mockState.libnut.mouseClick).not.toHaveBeenCalled();
+    expect(mockState.libnut.mouseToggle).toHaveBeenCalledTimes(2);
+    expect(mockState.libnut.mouseToggle).toHaveBeenNthCalledWith(
+      1,
+      'down',
+      'left',
+    );
+    expect(mockState.libnut.mouseToggle).toHaveBeenNthCalledWith(
+      2,
+      'up',
+      'left',
+    );
+  });
 });


### PR DESCRIPTION
## What changed

- route targeted macOS keyboard focus through the held pointer-tap path instead of a bare native click
- cover targeted keyboard focus with a unit regression test
- publish an AppKit `inputReadyGeneration` only after the fixture is visible, active, and key
- synchronize actions on that generation instead of a fixed 250 ms delay
- allow the fixture button to accept the activation click while hosted macOS transitions the app to the foreground

## Root cause

GitHub-hosted macOS can report a process as frontmost before AppKit has completed its activation transition. The previous fixture treated an activation signal plus a fixed delay as input readiness, so the first global click could be consumed by AppKit solely to activate the app and never reach the button. Targeted keyboard actions also used a short bare click rather than the held/focus-aware macOS pointer path, allowing the same activation race to leave text input unfocused.

This change keeps the real global input path under test while replacing the timing guess with an AppKit-owned readiness handshake. It does not add Vitest retries.

## Validation

- `git diff --check`
- Biome checks for all changed TypeScript files
- macOS Desktop workflow: three consecutive live-smoke passes and three complete workflow passes before the targeted-keyboard follow-up
- latest macOS Desktop workflow (pending)
