### PR TITLE
feat(studio): add advanced agent settings #2832

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -32,6 +32,13 @@ import {
   shell,
 } from 'electron';
 import type { TitleBarOverlay } from 'electron';
+import {
+  EMPTY_STUDIO_RUNTIME_SETTINGS,
+  type StudioRuntimeSettingsV1,
+  normalizeStudioRuntimeSettings,
+  resolveStudioAgentOptions,
+  serializeStudioRuntimeSettings,
+} from '../shared/advanced-settings';
 import { MACOS_TRAFFIC_LIGHT_POSITION } from '../shared/titlebar-layout';
 import { startStudioEventLoopWatchdog } from './performance-watchdog';
 import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
@@ -70,6 +77,7 @@ configureStudioShellEnvHydration({
 let mainWindow: BrowserWindow | null = null;
 let cachedAppIcon: NativeImage | null = null;
 let playgroundRuntimePromise: Promise<PlaygroundRuntimeService> | null = null;
+let playgroundRuntimeDesiredSettingsSignature: string | null = null;
 let deviceDiscoveryServicePromise: Promise<DeviceDiscoveryService> | null =
   null;
 const isStudioSmokeTest = process.env.MIDSCENE_STUDIO_SMOKE_TEST === '1';
@@ -311,18 +319,36 @@ async function prepareRecorderMarkdownReplayBundle(
   return { markdownPath };
 }
 
-const getPlaygroundRuntime = async (): Promise<PlaygroundRuntimeService> => {
+const getPlaygroundRuntime = async (
+  initialSettings?: StudioRuntimeSettingsV1,
+): Promise<PlaygroundRuntimeService> => {
+  const resolvedInitialSettings =
+    initialSettings ?? EMPTY_STUDIO_RUNTIME_SETTINGS;
+  const settingsSignature = serializeStudioRuntimeSettings(
+    resolvedInitialSettings,
+  );
   if (!playgroundRuntimePromise) {
+    playgroundRuntimeDesiredSettingsSignature = settingsSignature;
     playgroundRuntimePromise = Promise.resolve()
       .then(() =>
         createMultiPlatformRuntimeService({
+          agentOptions: resolveStudioAgentOptions(resolvedInitialSettings),
           deviceDiscoveryService: getDeviceDiscoveryService(),
         }),
       )
       .catch((error) => {
         playgroundRuntimePromise = null;
+        playgroundRuntimeDesiredSettingsSignature = null;
         throw error;
       });
+  } else if (
+    initialSettings !== undefined &&
+    playgroundRuntimeDesiredSettingsSignature !== null &&
+    playgroundRuntimeDesiredSettingsSignature !== settingsSignature
+  ) {
+    console.warn(
+      '[studio] Ignoring bootstrap settings that differ from the active runtime. Apply settings through restartPlayground.',
+    );
   }
 
   return playgroundRuntimePromise;
@@ -675,8 +701,9 @@ const registerIpcHandlers = () => {
   // HarmonyOS, and Computer. Legacy channel names (getAndroidPlayground*)
   // are aliased to the same strings in IPC_CHANNELS, so the old
   // renderer code keeps working transparently.
-  ipcMain.handle(IPC_CHANNELS.getPlaygroundBootstrap, async () => {
-    const runtime = await getPlaygroundRuntime();
+  ipcMain.handle(IPC_CHANNELS.getPlaygroundBootstrap, async (_event, input) => {
+    const settings = normalizeStudioRuntimeSettings(input);
+    const runtime = await getPlaygroundRuntime(settings);
     return requestPlaygroundBootstrap(runtime, (error) => {
       console.error(
         'Failed to start Midscene Studio playground runtime:',
@@ -684,8 +711,22 @@ const registerIpcHandlers = () => {
       );
     });
   });
-  ipcMain.handle(IPC_CHANNELS.restartPlayground, async () =>
-    (await getPlaygroundRuntime()).restart(),
+  ipcMain.handle(
+    IPC_CHANNELS.restartPlayground,
+    async (_event, input: unknown) => {
+      const runtime = await getPlaygroundRuntime();
+      if (input === undefined) {
+        return runtime.restart();
+      }
+
+      const settings = normalizeStudioRuntimeSettings(input);
+      const result = await runtime.restart(resolveStudioAgentOptions(settings));
+      if (result.status === 'ready' && !result.settingsApplyError) {
+        playgroundRuntimeDesiredSettingsSignature =
+          serializeStudioRuntimeSettings(settings);
+      }
+      return result;
+    },
   );
   ipcMain.handle(
     IPC_CHANNELS.discoverDevices,

--- a/apps/studio/src/main/playground/multi-platform-runtime.ts
+++ b/apps/studio/src/main/playground/multi-platform-runtime.ts
@@ -8,6 +8,12 @@ import type {
   RegisteredPlaygroundPlatform,
 } from '@midscene/playground';
 import { getDebug } from '@midscene/shared/logger';
+import {
+  type StudioResolvedAgentOptionsV1,
+  normalizeStudioRuntimeSettings,
+  resolveStudioAgentOptions,
+  serializeStudioRuntimeSettings,
+} from '@shared/advanced-settings';
 import type { DiscoveredDevice } from '@shared/electron-contract';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
 import { DEFAULT_STUDIO_WEB_VIEWPORT } from '@shared/web-viewport';
@@ -40,7 +46,7 @@ type PlaygroundModule = typeof import('@midscene/playground');
 
 type StudioPuppeteerAgentConstructor = new (
   page: unknown,
-  opts?: { cacheId?: string },
+  opts?: StudioResolvedAgentOptionsV1 & { cacheId?: string },
 ) => Agent;
 
 type StudioLaunchPuppeteerPage = (
@@ -78,6 +84,21 @@ type StudioWebCleanup = {
 type StudioDeviceDiscoveryService =
   | DeviceDiscoveryService
   | Promise<DeviceDiscoveryService>;
+
+const withAgentOptions = (
+  agentOptions: Readonly<StudioResolvedAgentOptionsV1>,
+): { agentOptions?: StudioResolvedAgentOptionsV1 } =>
+  Object.keys(agentOptions).length > 0
+    ? { agentOptions: { ...agentOptions } }
+    : {};
+
+const settingsFromResolvedAgentOptions = (
+  agentOptions: Readonly<StudioResolvedAgentOptionsV1>,
+) =>
+  normalizeStudioRuntimeSettings({
+    schemaVersion: 1,
+    agentOptions,
+  });
 
 const resolvePackageRootDir = (packageName: string): string =>
   path.resolve(path.dirname(require.resolve(packageName)), '..', '..');
@@ -317,8 +338,10 @@ function createStudioWebPreviewDescriptor(): PlaygroundPreviewDescriptor {
 }
 
 async function prepareStudioWebPlatform({
+  agentOptions,
   loadWebModule,
 }: {
+  agentOptions: Readonly<StudioResolvedAgentOptionsV1>;
   loadWebModule: typeof loadWebPlaygroundModule;
 }): Promise<PreparedPlaygroundPlatform> {
   const webModule = await loadWebModule();
@@ -440,6 +463,7 @@ async function prepareStudioWebPlatform({
           }
 
           const agent = new webModule.PuppeteerAgent(currentPage, {
+            ...agentOptions,
             cacheId: 'studio-web',
           });
           agentCleanup = [
@@ -477,6 +501,7 @@ async function prepareStudioWebPlatform({
 }
 
 const createStudioPlatformSpecs = ({
+  agentOptions = {},
   loadAndroidModule = loadAndroidPlaygroundModule,
   loadComputerModule = loadComputerPlaygroundModule,
   deviceDiscoveryService,
@@ -484,6 +509,7 @@ const createStudioPlatformSpecs = ({
   loadIosModule = loadIosPlaygroundModule,
   loadWebModule = loadWebPlaygroundModule,
 }: {
+  agentOptions?: Readonly<StudioResolvedAgentOptionsV1>;
   loadAndroidModule?: typeof loadAndroidPlaygroundModule;
   loadComputerModule?: typeof loadComputerPlaygroundModule;
   deviceDiscoveryService?: StudioDeviceDiscoveryService;
@@ -498,6 +524,7 @@ const createStudioPlatformSpecs = ({
     staticDirPackage: '@midscene/web',
     prepare: async () =>
       prepareStudioWebPlatform({
+        agentOptions,
         loadWebModule,
       }),
   },
@@ -509,6 +536,7 @@ const createStudioPlatformSpecs = ({
     prepare: async (staticDir) => {
       const androidModule = await loadAndroidModule();
       return androidModule.androidPlaygroundPlatform.prepare({
+        ...withAgentOptions(agentOptions),
         staticDir,
         scrcpyServer: await createStudioScrcpyController(
           androidModule.ScrcpyServer,
@@ -524,7 +552,10 @@ const createStudioPlatformSpecs = ({
     staticDirPackage: '@midscene/ios',
     prepare: async (staticDir) => {
       const iosModule = await loadIosModule();
-      return iosModule.iosPlaygroundPlatform.prepare({ staticDir });
+      return iosModule.iosPlaygroundPlatform.prepare({
+        ...withAgentOptions(agentOptions),
+        staticDir,
+      });
     },
   },
   {
@@ -535,6 +566,7 @@ const createStudioPlatformSpecs = ({
     prepare: async (staticDir) => {
       const harmonyModule = await loadHarmonyModule();
       return harmonyModule.harmonyPlaygroundPlatform.prepare({
+        ...withAgentOptions(agentOptions),
         staticDir,
         deferConnection: true,
       });
@@ -552,6 +584,7 @@ const createStudioPlatformSpecs = ({
     prepare: async (staticDir) => {
       const computerModule = await loadComputerModule();
       return computerModule.computerPlaygroundPlatform.prepare({
+        ...withAgentOptions(agentOptions),
         staticDir,
         getWindowController: () => null,
       });
@@ -583,6 +616,7 @@ function buildRegisteredPlatforms(
  * on the setup form routes to the correct backend.
  */
 export function createMultiPlatformRuntimeService({
+  agentOptions: initialAgentOptions,
   deviceDiscoveryService,
   loadModules,
   loadPlaygroundCore = loadPlaygroundCoreModules,
@@ -593,6 +627,7 @@ export function createMultiPlatformRuntimeService({
   loadWebModule = loadWebPlaygroundModule,
   resolvePackageStaticDir = resolveStaticDir,
 }: {
+  agentOptions?: StudioResolvedAgentOptionsV1;
   deviceDiscoveryService?: StudioDeviceDiscoveryService;
   loadModules?: () => Promise<MultiPlatformRuntimeModules>;
   loadPlaygroundCore?: () => Promise<PlaygroundCoreModules>;
@@ -603,6 +638,29 @@ export function createMultiPlatformRuntimeService({
   loadWebModule?: typeof loadWebPlaygroundModule;
   resolvePackageStaticDir?: (packageName: string) => string;
 } = {}): PlaygroundRuntimeService {
+  const createAgentOptionsSnapshot = (
+    agentOptions: StudioResolvedAgentOptionsV1 = {},
+  ): Readonly<StudioResolvedAgentOptionsV1> =>
+    Object.freeze(
+      resolveStudioAgentOptions(settingsFromResolvedAgentOptions(agentOptions)),
+    );
+  const getAgentOptionsSignature = (
+    agentOptions: Readonly<StudioResolvedAgentOptionsV1>,
+  ): string =>
+    serializeStudioRuntimeSettings(
+      settingsFromResolvedAgentOptions(agentOptions),
+    );
+
+  const initialSnapshot = createAgentOptionsSnapshot(initialAgentOptions);
+  const initialSignature = getAgentOptionsSignature(initialSnapshot);
+  const settingsState = {
+    desired: initialSnapshot,
+    desiredSignature: initialSignature,
+    active: null as Readonly<StudioResolvedAgentOptionsV1> | null,
+    activeSignature: null as string | null,
+    lastSuccessful: null as Readonly<StudioResolvedAgentOptionsV1> | null,
+    lastSuccessfulSignature: null as string | null,
+  };
   let bootstrap: PlaygroundBootstrap = {
     status: 'starting',
     serverUrl: null,
@@ -610,23 +668,39 @@ export function createMultiPlatformRuntimeService({
     error: null,
   };
   let launchResult: LaunchPlaygroundResult | null = null;
-  let startPromise: Promise<PlaygroundBootstrap> | null = null;
+  let lifecycleQueue: Promise<void> = Promise.resolve();
+  let startTransition: Promise<PlaygroundBootstrap> | null = null;
 
-  const close = async () => {
+  const enqueueLifecycle = <Result>(
+    operation: () => Promise<Result>,
+  ): Promise<Result> => {
+    const result = lifecycleQueue.then(operation, operation);
+    lifecycleQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const closeInternal = async () => {
     if (!launchResult) {
+      settingsState.active = null;
+      settingsState.activeSignature = null;
       return;
     }
     const activeLaunch = launchResult;
     launchResult = null;
-    await activeLaunch.close();
+    try {
+      await activeLaunch.close();
+    } finally {
+      settingsState.active = null;
+      settingsState.activeSignature = null;
+    }
   };
 
-  const start = async (): Promise<PlaygroundBootstrap> => {
+  const startInternal = async (): Promise<PlaygroundBootstrap> => {
     if (launchResult) {
       return bootstrap;
-    }
-    if (startPromise) {
-      return startPromise;
     }
 
     bootstrap = {
@@ -636,144 +710,192 @@ export function createMultiPlatformRuntimeService({
       error: null,
     };
 
-    startPromise = (async () => {
-      try {
-        const runtimeModules = loadModules ? await loadModules() : null;
-        const playgroundCoreModules =
-          runtimeModules ??
-          ({
-            ...(await loadPlaygroundCore()),
-          } as PlaygroundCoreModules);
-        const platforms = buildRegisteredPlatforms(
-          runtimeModules
-            ? [
-                {
-                  id: 'web',
-                  label: 'Web',
-                  description: 'Open and control a Chromium page',
-                  staticDirPackage: '@midscene/web',
-                  prepare: async () =>
-                    prepareStudioWebPlatform({
-                      loadWebModule: async () => ({
-                        PuppeteerAgent: runtimeModules.PuppeteerAgent,
-                        launchPuppeteerPage: runtimeModules.launchPuppeteerPage,
-                      }),
+    try {
+      const agentOptions = settingsState.desired;
+      const runtimeModules = loadModules ? await loadModules() : null;
+      const playgroundCoreModules =
+        runtimeModules ??
+        ({
+          ...(await loadPlaygroundCore()),
+        } as PlaygroundCoreModules);
+      const platforms = buildRegisteredPlatforms(
+        runtimeModules
+          ? [
+              {
+                id: 'web',
+                label: 'Web',
+                description: 'Open and control a Chromium page',
+                staticDirPackage: '@midscene/web',
+                prepare: async () =>
+                  prepareStudioWebPlatform({
+                    agentOptions,
+                    loadWebModule: async () => ({
+                      PuppeteerAgent: runtimeModules.PuppeteerAgent,
+                      launchPuppeteerPage: runtimeModules.launchPuppeteerPage,
                     }),
+                  }),
+              },
+              {
+                id: 'android',
+                label: 'Android',
+                description: 'Connect to an Android device via ADB',
+                staticDirPackage: '@midscene/android-playground',
+                prepare: async (staticDir) => {
+                  const scrcpyServer = await createStudioScrcpyController(
+                    runtimeModules.ScrcpyServer,
+                    deviceDiscoveryService,
+                  );
+                  return runtimeModules.androidPlaygroundPlatform.prepare({
+                    ...withAgentOptions(agentOptions),
+                    staticDir,
+                    scrcpyServer,
+                  });
                 },
-                {
-                  id: 'android',
-                  label: 'Android',
-                  description: 'Connect to an Android device via ADB',
-                  staticDirPackage: '@midscene/android-playground',
-                  prepare: async (staticDir) => {
-                    const scrcpyServer = await createStudioScrcpyController(
-                      runtimeModules.ScrcpyServer,
-                      deviceDiscoveryService,
-                    );
-                    return runtimeModules.androidPlaygroundPlatform.prepare({
-                      staticDir,
-                      scrcpyServer,
-                    });
-                  },
-                },
-                {
-                  id: 'ios',
-                  label: 'iOS',
-                  description: 'Connect to an iOS device via WebDriverAgent',
-                  staticDirPackage: '@midscene/ios',
-                  prepare: (staticDir) =>
-                    runtimeModules.iosPlaygroundPlatform.prepare({ staticDir }),
-                },
-                {
-                  id: 'harmony',
-                  label: 'HarmonyOS',
-                  description: 'Connect to a HarmonyOS device via HDC',
-                  staticDirPackage: '@midscene/harmony',
-                  prepare: (staticDir) =>
-                    runtimeModules.harmonyPlaygroundPlatform.prepare({
-                      staticDir,
-                      deferConnection: true,
-                    }),
-                },
-                {
-                  id: 'computer',
-                  label: 'Computer',
-                  description: 'Control the local desktop',
-                  staticDirPackage: '@midscene/computer-playground',
-                  prepare: (staticDir) =>
-                    runtimeModules.computerPlaygroundPlatform.prepare({
-                      staticDir,
-                      getWindowController: () => null,
-                    }),
-                },
-              ]
-            : createStudioPlatformSpecs({
-                deviceDiscoveryService,
-                loadAndroidModule,
-                loadComputerModule,
-                loadHarmonyModule,
-                loadIosModule,
-                loadWebModule,
-              }),
-          resolvePackageStaticDir,
-        );
-        const prepared =
-          await playgroundCoreModules.prepareMultiPlatformPlayground(
-            platforms,
-            {
-              title: 'Midscene Studio Beta',
-              description: 'Multi-platform playground',
-              selectorFieldKey: 'platformId',
-              selectorVariant: 'cards',
-            },
-          );
+              },
+              {
+                id: 'ios',
+                label: 'iOS',
+                description: 'Connect to an iOS device via WebDriverAgent',
+                staticDirPackage: '@midscene/ios',
+                prepare: (staticDir) =>
+                  runtimeModules.iosPlaygroundPlatform.prepare({
+                    ...withAgentOptions(agentOptions),
+                    staticDir,
+                  }),
+              },
+              {
+                id: 'harmony',
+                label: 'HarmonyOS',
+                description: 'Connect to a HarmonyOS device via HDC',
+                staticDirPackage: '@midscene/harmony',
+                prepare: (staticDir) =>
+                  runtimeModules.harmonyPlaygroundPlatform.prepare({
+                    ...withAgentOptions(agentOptions),
+                    staticDir,
+                    deferConnection: true,
+                  }),
+              },
+              {
+                id: 'computer',
+                label: 'Computer',
+                description: 'Control the local desktop',
+                staticDirPackage: '@midscene/computer-playground',
+                prepare: (staticDir) =>
+                  runtimeModules.computerPlaygroundPlatform.prepare({
+                    ...withAgentOptions(agentOptions),
+                    staticDir,
+                    getWindowController: () => null,
+                  }),
+              },
+            ]
+          : createStudioPlatformSpecs({
+              agentOptions,
+              deviceDiscoveryService,
+              loadAndroidModule,
+              loadComputerModule,
+              loadHarmonyModule,
+              loadIosModule,
+              loadWebModule,
+            }),
+        resolvePackageStaticDir,
+      );
+      const prepared =
+        await playgroundCoreModules.prepareMultiPlatformPlayground(platforms, {
+          title: 'Midscene Studio Beta',
+          description: 'Multi-platform playground',
+          selectorFieldKey: 'platformId',
+          selectorVariant: 'cards',
+        });
 
-        const nextLaunchResult =
-          await playgroundCoreModules.launchPreparedPlaygroundPlatform(
-            prepared,
-            {
-              corsOptions: createStudioCorsOptions(),
-              enableCors: true,
-              openBrowser: false,
-              verbose: false,
-            },
-          );
+      const nextLaunchResult =
+        await playgroundCoreModules.launchPreparedPlaygroundPlatform(prepared, {
+          corsOptions: createStudioCorsOptions(),
+          enableCors: true,
+          openBrowser: false,
+          verbose: false,
+        });
 
-        launchResult = nextLaunchResult;
-        bootstrap = {
-          status: 'ready',
-          serverUrl: playgroundCoreModules.buildPlaygroundBrowserUrl(
-            nextLaunchResult.host,
-            nextLaunchResult.port,
-          ),
-          port: nextLaunchResult.port,
-          error: null,
-        };
+      launchResult = nextLaunchResult;
+      settingsState.active = agentOptions;
+      settingsState.activeSignature = settingsState.desiredSignature;
+      settingsState.lastSuccessful = agentOptions;
+      settingsState.lastSuccessfulSignature = settingsState.desiredSignature;
+      bootstrap = {
+        status: 'ready',
+        serverUrl: playgroundCoreModules.buildPlaygroundBrowserUrl(
+          nextLaunchResult.host,
+          nextLaunchResult.port,
+        ),
+        port: nextLaunchResult.port,
+        error: null,
+      };
 
-        return bootstrap;
-      } catch (error) {
-        bootstrap = {
-          status: 'error',
-          serverUrl: null,
-          port: null,
-          error: getErrorMessage(error),
-        };
-        return bootstrap;
-      } finally {
-        startPromise = null;
-      }
-    })();
+      return bootstrap;
+    } catch (error) {
+      settingsState.active = null;
+      settingsState.activeSignature = null;
+      bootstrap = {
+        status: 'error',
+        serverUrl: null,
+        port: null,
+        error: getErrorMessage(error),
+      };
+      return bootstrap;
+    }
+  };
 
-    return startPromise;
+  const start = (): Promise<PlaygroundBootstrap> => {
+    if (startTransition) return startTransition;
+    const transition = enqueueLifecycle(startInternal);
+    startTransition = transition;
+    void transition.finally(() => {
+      if (startTransition === transition) startTransition = null;
+    });
+    return transition;
   };
 
   return {
-    close,
+    close: () => enqueueLifecycle(closeInternal),
     getBootstrap: () => bootstrap,
-    restart: async () => {
-      await close();
-      return start();
-    },
+    restart: (nextAgentOptions) =>
+      enqueueLifecycle(async () => {
+        const previousDesired = settingsState.desired;
+        const previousDesiredSignature = settingsState.desiredSignature;
+        if (nextAgentOptions !== undefined) {
+          const nextSnapshot = createAgentOptionsSnapshot(nextAgentOptions);
+          settingsState.desired = nextSnapshot;
+          settingsState.desiredSignature =
+            getAgentOptionsSignature(nextSnapshot);
+        }
+
+        await closeInternal();
+        const result = await startInternal();
+        if (result.status === 'error' && nextAgentOptions !== undefined) {
+          const settingsApplyError =
+            result.error || 'Failed to apply Studio runtime settings.';
+          settingsState.desired =
+            settingsState.lastSuccessful ?? previousDesired;
+          settingsState.desiredSignature =
+            settingsState.lastSuccessfulSignature ?? previousDesiredSignature;
+
+          const recoveryResult = await startInternal();
+          if (recoveryResult.status === 'ready') {
+            return {
+              ...recoveryResult,
+              settingsApplyError,
+            };
+          }
+
+          bootstrap = {
+            ...recoveryResult,
+            error: `${settingsApplyError} Failed to restore the previous runtime: ${
+              recoveryResult.error || 'unknown error'
+            }`,
+          };
+          return bootstrap;
+        }
+        return result;
+      }),
     start,
   };
 }

--- a/apps/studio/src/main/playground/types.ts
+++ b/apps/studio/src/main/playground/types.ts
@@ -1,9 +1,12 @@
+import type { StudioResolvedAgentOptionsV1 } from '@shared/advanced-settings';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
 
 /** Lifecycle contract for a playground runtime (single- or multi-platform). */
 export interface PlaygroundRuntimeService {
   close: () => Promise<void>;
   getBootstrap: () => PlaygroundBootstrap;
-  restart: () => Promise<PlaygroundBootstrap>;
+  restart: (
+    agentOptions?: StudioResolvedAgentOptionsV1,
+  ) => Promise<PlaygroundBootstrap>;
   start: () => Promise<PlaygroundBootstrap>;
 }

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -43,9 +43,10 @@ const electronShellApi: ElectronShellApi = {
 };
 
 const studioRuntimeApi: StudioRuntimeApi = {
-  getPlaygroundBootstrap: () =>
-    ipcRenderer.invoke(IPC_CHANNELS.getPlaygroundBootstrap),
-  restartPlayground: () => ipcRenderer.invoke(IPC_CHANNELS.restartPlayground),
+  getPlaygroundBootstrap: (settings) =>
+    ipcRenderer.invoke(IPC_CHANNELS.getPlaygroundBootstrap, settings),
+  restartPlayground: (settings) =>
+    ipcRenderer.invoke(IPC_CHANNELS.restartPlayground, settings),
   discoverDevices: (request) =>
     ipcRenderer.invoke(IPC_CHANNELS.discoverDevices, request),
   onDiscoveredDevicesChanged: (listener) => {

--- a/apps/studio/src/renderer/components/SettingsPanel/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsPanel/index.tsx
@@ -144,6 +144,7 @@ function readStoredLanguage(): string {
 
 export interface SettingsPanelProps {
   className?: string;
+  onAdvancedClick?: () => void;
   onGithubClick?: () => void;
   /** Fires after the user picks a theme so the parent can dismiss the
    * popover — the new theme is hidden behind the popover otherwise. */
@@ -160,6 +161,7 @@ export interface SettingsPanelProps {
 
 export default function SettingsPanel({
   className,
+  onAdvancedClick,
   onGithubClick,
   onThemeChange,
   onWebsiteClick,
@@ -235,6 +237,11 @@ export default function SettingsPanel({
             onMouseLeave={scheduleClose}
             trailingIcon={<ChevronIcon />}
             value={THEME_LABELS[mode]}
+          />
+          <SettingItem
+            label="Advanced"
+            onClick={onAdvancedClick}
+            trailingIcon={<ChevronIcon />}
           />
         </div>
 

--- a/apps/studio/src/renderer/components/ShellLayout/AdvancedSettingsModal.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/AdvancedSettingsModal.tsx
@@ -1,0 +1,218 @@
+import {
+  type StudioAgentOptionsV1,
+  type StudioRuntimeSettingsV1,
+  normalizeStudioRuntimeSettings,
+} from '@shared/advanced-settings';
+import { useEffect, useState } from 'react';
+
+export interface AdvancedSettingsModalProps {
+  open: boolean;
+  runtimeReady: boolean;
+  settings: StudioRuntimeSettingsV1;
+  onApply: (settings: StudioRuntimeSettingsV1) => Promise<void>;
+  onClose: () => void;
+}
+
+type NumericAgentOption =
+  | 'replanningCycleLimit'
+  | 'screenshotShrinkFactor'
+  | 'waitAfterAction';
+
+function optionalNumber(value: string): number | undefined {
+  return value.trim() ? Number(value) : undefined;
+}
+
+export function AdvancedSettingsModal({
+  onApply,
+  onClose,
+  open,
+  runtimeReady,
+  settings,
+}: AdvancedSettingsModalProps) {
+  const [draft, setDraft] = useState<StudioAgentOptionsV1>({});
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft({ ...settings.agentOptions });
+    setApplying(false);
+    setError(null);
+  }, [open, settings]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !applying) onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [applying, onClose, open]);
+
+  if (!open) return null;
+
+  const setNumericOption = (key: NumericAgentOption, value: string) => {
+    setDraft((current) => ({
+      ...current,
+      [key]: optionalNumber(value),
+    }));
+    setError(null);
+  };
+
+  const handleApply = async () => {
+    setError(null);
+    setApplying(true);
+    try {
+      const normalized = normalizeStudioRuntimeSettings({
+        schemaVersion: 1,
+        agentOptions: draft,
+      });
+      await onApply(normalized);
+    } catch (applyError) {
+      setError(
+        applyError instanceof Error ? applyError.message : String(applyError),
+      );
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const numberInputClass =
+    'box-border h-[34px] w-full rounded-[6px] border border-border-control bg-surface-elevated px-[10px] text-[13px] text-text-primary outline-none focus:border-brand';
+
+  return (
+    <dialog
+      aria-modal="true"
+      className="fixed inset-0 z-[1000] m-0 h-screen w-screen max-h-none max-w-none items-center justify-center border-0 bg-black/35 p-0 font-sans open:flex"
+      onClick={() => {
+        if (!applying) onClose();
+      }}
+      open
+    >
+      <div
+        className="box-border flex max-h-[calc(100vh-32px)] w-[560px] max-w-[calc(100vw-32px)] flex-col rounded-[8px] border border-border-subtle bg-surface-elevated shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-divider px-[20px] py-[16px]">
+          <h2 className="m-0 text-[16px] font-semibold text-text-primary">
+            Advanced Settings
+          </h2>
+          <button
+            aria-label="Close"
+            className="h-[24px] w-[24px] cursor-pointer border-0 bg-transparent p-0 text-[20px] leading-[24px] text-text-secondary hover:text-text-primary"
+            disabled={applying}
+            onClick={onClose}
+            type="button"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="grid min-h-0 grid-cols-2 gap-x-[16px] gap-y-[14px] overflow-y-auto px-[20px] py-[18px]">
+          <label className="flex min-w-0 flex-col gap-[6px] text-[12px] text-text-secondary">
+            Replanning cycle limit
+            <input
+              className={numberInputClass}
+              min={0}
+              onChange={(event) =>
+                setNumericOption('replanningCycleLimit', event.target.value)
+              }
+              placeholder="Use default"
+              step={1}
+              type="number"
+              value={draft.replanningCycleLimit ?? ''}
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-[6px] text-[12px] text-text-secondary">
+            Wait after action (ms)
+            <input
+              className={numberInputClass}
+              min={0}
+              onChange={(event) =>
+                setNumericOption('waitAfterAction', event.target.value)
+              }
+              placeholder="Use default"
+              step="any"
+              type="number"
+              value={draft.waitAfterAction ?? ''}
+            />
+          </label>
+          <label className="col-span-2 flex min-w-0 flex-col gap-[6px] text-[12px] text-text-secondary">
+            Screenshot shrink factor
+            <input
+              className={numberInputClass}
+              min={1}
+              onChange={(event) =>
+                setNumericOption('screenshotShrinkFactor', event.target.value)
+              }
+              placeholder="Use default"
+              step="any"
+              type="number"
+              value={draft.screenshotShrinkFactor ?? ''}
+            />
+          </label>
+          <label className="col-span-2 flex min-w-0 flex-col gap-[6px] text-[12px] text-text-secondary">
+            AI action context
+            <textarea
+              className="box-border h-[92px] w-full resize-y rounded-[6px] border border-border-control bg-surface-elevated p-[10px] text-[13px] leading-[18px] text-text-primary outline-none focus:border-brand"
+              onChange={(event) => {
+                const value = event.target.value;
+                setDraft((current) => ({
+                  ...current,
+                  aiActContext: value,
+                }));
+                setError(null);
+              }}
+              placeholder="Use default"
+              value={draft.aiActContext ?? ''}
+            />
+          </label>
+
+          {runtimeReady ? (
+            <p className="col-span-2 m-0 rounded-[6px] bg-surface-muted px-[10px] py-[8px] text-[12px] leading-[18px] text-text-secondary">
+              Applying settings disconnects the current target and restarts the
+              runtime.
+            </p>
+          ) : null}
+          {error ? (
+            <p className="col-span-2 m-0 text-[12px] leading-[18px] text-[#e13e37]">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex justify-between border-t border-divider px-[20px] py-[14px]">
+          <button
+            className="h-[32px] cursor-pointer rounded-[6px] border border-border-control bg-transparent px-[12px] text-[13px] text-text-secondary hover:bg-surface-hover"
+            disabled={applying}
+            onClick={() => {
+              setDraft({});
+              setError(null);
+            }}
+            type="button"
+          >
+            Reset to defaults
+          </button>
+          <div className="flex gap-[8px]">
+            <button
+              className="h-[32px] cursor-pointer rounded-[6px] border border-border-control bg-transparent px-[14px] text-[13px] text-text-primary hover:bg-surface-hover"
+              disabled={applying}
+              onClick={onClose}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="h-[32px] cursor-pointer rounded-[6px] border border-brand bg-brand px-[14px] text-[13px] text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={applying}
+              onClick={() => void handleApply()}
+              type="button"
+            >
+              {applying ? 'Applying...' : 'Apply'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import type { StudioRuntimeSettingsV1 } from '../../../shared/advanced-settings';
 import type { StudioPlatformId } from '../../../shared/electron-contract';
 import { STUDIO_EXTERNAL_LINKS } from '../../../shared/external-links';
 import {
@@ -18,6 +19,7 @@ import { assetUrls } from '../../assets';
 import { useStudioUpdater } from '../../hooks/useStudioUpdater';
 import { useStudioPlayground } from '../../playground/useStudioPlayground';
 import { type StudioMode, StudioModeTab } from '../../recorder/types';
+import { loadAdvancedSettings } from '../../settings/advanced-settings-storage';
 import MainContent from '../MainContent';
 import SettingsPanel from '../SettingsPanel';
 import Sidebar, { SidebarFooter } from '../Sidebar';
@@ -27,6 +29,7 @@ import {
   StudioRightPanelViewType,
   getStudioRightPanelWidth,
 } from '../StudioRightPanel';
+import { AdvancedSettingsModal } from './AdvancedSettingsModal';
 import { ModelEnvConfigModal } from './ModelEnvConfigModal';
 import { hasCompleteModelEnvConfig } from './connectivity-env';
 import { loadModelEnvText, saveModelEnvText } from './model-env-storage';
@@ -173,6 +176,9 @@ export default function ShellLayout() {
   const [studioRightPanelClosing, setStudioRightPanelClosing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [modelModalOpen, setModelModalOpen] = useState(false);
+  const [advancedModalOpen, setAdvancedModalOpen] = useState(false);
+  const [advancedSettings, setAdvancedSettings] =
+    useState<StudioRuntimeSettingsV1>(() => loadAdvancedSettings());
   // Bridges the gap between any device-click path (Sidebar row, Overview
   // card, Overview-form Submit) and antd Form.useWatch propagating the
   // chosen platform to MainContent. Without this hint the connecting
@@ -285,6 +291,11 @@ export default function ShellLayout() {
     setModelModalOpen(true);
   }, []);
   const closeModelModal = useCallback(() => setModelModalOpen(false), []);
+  const openAdvancedModal = useCallback(() => {
+    setSettingsOpen(false);
+    setAdvancedModalOpen(true);
+  }, []);
+  const closeAdvancedModal = useCallback(() => setAdvancedModalOpen(false), []);
   // Going back to Overview tears down the live session and clears every
   // selection-shaped form field so the sidebar / device cards stop
   // showing a "still selected" row that no longer corresponds to
@@ -440,6 +451,7 @@ export default function ShellLayout() {
           {settingsOpen && (
             <div className="absolute bottom-[78px] left-0 z-50">
               <SettingsPanel
+                onAdvancedClick={openAdvancedModal}
                 onGithubClick={() =>
                   openExternalUrl(STUDIO_EXTERNAL_LINKS.github)
                 }
@@ -567,6 +579,17 @@ export default function ShellLayout() {
         }}
         open={modelModalOpen}
         textValue={modelEnvText}
+      />
+      <AdvancedSettingsModal
+        onApply={async (nextSettings) => {
+          await studioPlayground.applyRuntimeSettings(nextSettings);
+          setAdvancedSettings(nextSettings);
+          closeAdvancedModal();
+        }}
+        onClose={closeAdvancedModal}
+        open={advancedModalOpen}
+        runtimeReady={studioPlayground.phase === 'ready'}
+        settings={advancedSettings}
       />
     </div>
   );

--- a/apps/studio/src/renderer/playground/StudioPlaygroundProvider.tsx
+++ b/apps/studio/src/renderer/playground/StudioPlaygroundProvider.tsx
@@ -1,9 +1,14 @@
+import type { StudioRuntimeSettingsV1 } from '@shared/advanced-settings';
 import type {
   DiscoverDevicesResult,
   PlaygroundBootstrap,
 } from '@shared/electron-contract';
 import type { PropsWithChildren } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  loadAdvancedSettings,
+  saveAdvancedSettings,
+} from '../settings/advanced-settings-storage';
 import StudioPlaygroundReadyProvider from './StudioPlaygroundReadyProvider';
 import { bucketDiscoveredDevices, bucketDiscoveryErrors } from './selectors';
 import type {
@@ -20,6 +25,8 @@ function normalizeBootstrapError(bootstrap: PlaygroundBootstrap): string {
   return bootstrap.error || 'Failed to start playground runtime.';
 }
 
+class RuntimeSettingsApplyError extends Error {}
+
 export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
   const [bootstrap, setBootstrap] = useState<
     | { phase: 'booting' }
@@ -27,6 +34,10 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
     | { phase: 'ready'; serverUrl: string }
   >({ phase: 'booting' });
   const [bootstrapTick, setBootstrapTick] = useState(0);
+  const runtimeSettingsRef = useRef(loadAdvancedSettings());
+  const requestGenerationRef = useRef(0);
+  const bootstrapSequenceRef = useRef(0);
+  const transitionInProgressRef = useRef(false);
 
   // Cross-platform device discovery — polls ALL platforms (ADB, HDC,
   // displays) once the playground runtime is ready, so the sidebar shows
@@ -103,16 +114,7 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
     };
   }, [applyDiscoveredDevices, bootstrap.phase]);
 
-  const readBootstrap = useCallback(async () => {
-    if (!window.studioRuntime) {
-      setBootstrap({
-        phase: 'error',
-        error: getMissingBridgeError(),
-      });
-      return;
-    }
-
-    const nextBootstrap = await window.studioRuntime.getPlaygroundBootstrap();
+  const applyBootstrap = useCallback((nextBootstrap: PlaygroundBootstrap) => {
     if (nextBootstrap.status === 'ready' && nextBootstrap.serverUrl) {
       setBootstrap({
         phase: 'ready',
@@ -131,6 +133,45 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
 
     setBootstrap({ phase: 'booting' });
   }, []);
+
+  const readBootstrap = useCallback(async () => {
+    if (transitionInProgressRef.current) return;
+    if (!window.studioRuntime) {
+      setBootstrap({
+        phase: 'error',
+        error: getMissingBridgeError(),
+      });
+      return;
+    }
+
+    const generation = requestGenerationRef.current;
+    const sequence = bootstrapSequenceRef.current + 1;
+    bootstrapSequenceRef.current = sequence;
+    try {
+      const nextBootstrap = await window.studioRuntime.getPlaygroundBootstrap(
+        runtimeSettingsRef.current,
+      );
+      if (
+        generation !== requestGenerationRef.current ||
+        sequence !== bootstrapSequenceRef.current ||
+        transitionInProgressRef.current
+      ) {
+        return;
+      }
+      applyBootstrap(nextBootstrap);
+    } catch (error) {
+      if (
+        generation !== requestGenerationRef.current ||
+        sequence !== bootstrapSequenceRef.current
+      ) {
+        return;
+      }
+      setBootstrap({
+        phase: 'error',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [applyBootstrap]);
 
   useEffect(() => {
     let cancelled = false;
@@ -160,38 +201,77 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
     };
   }, [bootstrap.phase, bootstrapTick, readBootstrap]);
 
-  const restartPlayground = useCallback(async () => {
-    setBootstrap({ phase: 'booting' });
-
-    if (!window.studioRuntime) {
-      setBootstrap({
-        phase: 'error',
-        error: getMissingBridgeError(),
-      });
-      return;
-    }
-
-    const nextBootstrap = await window.studioRuntime.restartPlayground();
-    if (nextBootstrap.status === 'ready' && nextBootstrap.serverUrl) {
-      setBootstrap({
-        phase: 'ready',
-        serverUrl: nextBootstrap.serverUrl,
-      });
-    } else if (nextBootstrap.status === 'error') {
-      setBootstrap({
-        phase: 'error',
-        error: normalizeBootstrapError(nextBootstrap),
-      });
-    } else {
+  const restartRuntime = useCallback(
+    async (settings?: StudioRuntimeSettingsV1) => {
+      const generation = requestGenerationRef.current + 1;
+      requestGenerationRef.current = generation;
+      bootstrapSequenceRef.current += 1;
+      transitionInProgressRef.current = true;
       setBootstrap({ phase: 'booting' });
-      setBootstrapTick((current) => current + 1);
+
+      try {
+        if (!window.studioRuntime) {
+          throw new Error(getMissingBridgeError());
+        }
+
+        const nextBootstrap =
+          await window.studioRuntime.restartPlayground(settings);
+        if (generation !== requestGenerationRef.current) return;
+
+        applyBootstrap(nextBootstrap);
+        if (nextBootstrap.settingsApplyError) {
+          throw new RuntimeSettingsApplyError(nextBootstrap.settingsApplyError);
+        }
+        if (nextBootstrap.status === 'error') {
+          throw new Error(normalizeBootstrapError(nextBootstrap));
+        }
+        if (nextBootstrap.status !== 'ready' || !nextBootstrap.serverUrl) {
+          setBootstrapTick((current) => current + 1);
+          return;
+        }
+        if (settings !== undefined) {
+          runtimeSettingsRef.current = saveAdvancedSettings(settings);
+        }
+      } catch (error) {
+        if (
+          generation === requestGenerationRef.current &&
+          !(error instanceof RuntimeSettingsApplyError)
+        ) {
+          setBootstrap({
+            phase: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        throw error;
+      } finally {
+        if (generation === requestGenerationRef.current) {
+          transitionInProgressRef.current = false;
+        }
+      }
+    },
+    [applyBootstrap],
+  );
+
+  const restartPlayground = useCallback(async () => {
+    try {
+      await restartRuntime();
+    } catch {
+      // restartRuntime has already moved the provider into its error state.
     }
-  }, []);
+  }, [restartRuntime]);
+
+  const applyRuntimeSettings = useCallback(
+    async (settings: StudioRuntimeSettingsV1) => {
+      await restartRuntime(settings);
+    },
+    [restartRuntime],
+  );
 
   const contextValue = useMemo(() => {
     if (bootstrap.phase === 'error') {
       return {
         phase: 'error' as const,
+        applyRuntimeSettings,
         error: bootstrap.error,
         restartPlayground,
         refreshDiscoveredDevices,
@@ -203,6 +283,7 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
 
     return {
       phase: 'booting' as const,
+      applyRuntimeSettings,
       restartPlayground,
       refreshDiscoveredDevices,
       setDiscoveryPollingPaused: setDiscoveryPollingPausedValue,
@@ -211,6 +292,7 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
     };
   }, [
     bootstrap,
+    applyRuntimeSettings,
     discoveredDevices,
     discoveryErrors,
     refreshDiscoveredDevices,
@@ -220,6 +302,8 @@ export function StudioPlaygroundProvider({ children }: PropsWithChildren) {
 
   return bootstrap.phase === 'ready' ? (
     <StudioPlaygroundReadyProvider
+      key={bootstrap.serverUrl}
+      applyRuntimeSettings={applyRuntimeSettings}
       discoveredDevices={discoveredDevices}
       discoveryErrors={discoveryErrors}
       refreshDiscoveredDevices={refreshDiscoveredDevices}

--- a/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
+++ b/apps/studio/src/renderer/playground/StudioPlaygroundReadyProvider.tsx
@@ -2,6 +2,7 @@ import {
   PlaygroundThemeProvider,
   usePlaygroundController,
 } from '@midscene/playground-app';
+import type { StudioRuntimeSettingsV1 } from '@shared/advanced-settings';
 import type { StudioPlatformId } from '@shared/electron-contract';
 import { Form } from 'antd';
 import type { PropsWithChildren } from 'react';
@@ -16,6 +17,7 @@ import { StudioPlaygroundContext } from './useStudioPlayground';
 const DEFAULT_PLATFORM_ID: StudioPlatformId = 'android';
 
 interface StudioPlaygroundReadyProviderProps {
+  applyRuntimeSettings: (settings: StudioRuntimeSettingsV1) => Promise<void>;
   discoveredDevices?: DiscoveredDevicesByPlatform;
   discoveryErrors?: DiscoveryErrorsByPlatform;
   refreshDiscoveredDevices: () => Promise<void>;
@@ -25,6 +27,7 @@ interface StudioPlaygroundReadyProviderProps {
 }
 
 export default function StudioPlaygroundReadyProvider({
+  applyRuntimeSettings,
   children,
   discoveredDevices,
   discoveryErrors,
@@ -61,6 +64,7 @@ export default function StudioPlaygroundReadyProvider({
   const contextValue = useMemo(
     () => ({
       phase: 'ready' as const,
+      applyRuntimeSettings,
       serverUrl,
       controller,
       restartPlayground,
@@ -70,6 +74,7 @@ export default function StudioPlaygroundReadyProvider({
       discoveryErrors,
     }),
     [
+      applyRuntimeSettings,
       controller,
       discoveredDevices,
       discoveryErrors,

--- a/apps/studio/src/renderer/playground/types.ts
+++ b/apps/studio/src/renderer/playground/types.ts
@@ -1,4 +1,5 @@
 import type { PlaygroundControllerResult } from '@midscene/playground-app';
+import type { StudioRuntimeSettingsV1 } from '@shared/advanced-settings';
 import type {
   DiscoveredDevice,
   PlatformDiscoveryError,
@@ -40,6 +41,9 @@ export type DiscoveryErrorsByPlatform = Partial<
 export type StudioPlaygroundContextValue =
   | {
       phase: 'booting';
+      applyRuntimeSettings: (
+        settings: StudioRuntimeSettingsV1,
+      ) => Promise<void>;
       restartPlayground: () => Promise<void>;
       refreshDiscoveredDevices: () => Promise<void>;
       setDiscoveryPollingPaused: (paused: boolean) => void;
@@ -49,6 +53,9 @@ export type StudioPlaygroundContextValue =
   | {
       phase: 'error';
       error: string;
+      applyRuntimeSettings: (
+        settings: StudioRuntimeSettingsV1,
+      ) => Promise<void>;
       restartPlayground: () => Promise<void>;
       refreshDiscoveredDevices: () => Promise<void>;
       setDiscoveryPollingPaused: (paused: boolean) => void;
@@ -59,6 +66,9 @@ export type StudioPlaygroundContextValue =
       phase: 'ready';
       serverUrl: string;
       controller: PlaygroundControllerResult;
+      applyRuntimeSettings: (
+        settings: StudioRuntimeSettingsV1,
+      ) => Promise<void>;
       restartPlayground: () => Promise<void>;
       refreshDiscoveredDevices: () => Promise<void>;
       setDiscoveryPollingPaused: (paused: boolean) => void;

--- a/apps/studio/src/renderer/settings/advanced-settings-storage.ts
+++ b/apps/studio/src/renderer/settings/advanced-settings-storage.ts
@@ -1,0 +1,60 @@
+import {
+  EMPTY_STUDIO_RUNTIME_SETTINGS,
+  type StudioRuntimeSettingsV1,
+  normalizeStudioRuntimeSettings,
+} from '@shared/advanced-settings';
+
+export const ADVANCED_SETTINGS_STORAGE_KEY =
+  'midscene-studio.advanced-settings';
+
+let warnedAboutInvalidSettings = false;
+let warnedAboutStorageFailure = false;
+
+function emptySettings(): StudioRuntimeSettingsV1 {
+  return normalizeStudioRuntimeSettings(EMPTY_STUDIO_RUNTIME_SETTINGS);
+}
+
+function warnAboutInvalidSettings(error: unknown): void {
+  if (warnedAboutInvalidSettings) return;
+  warnedAboutInvalidSettings = true;
+  console.warn('[studio] Ignoring invalid advanced settings:', error);
+}
+
+function warnAboutStorageFailure(error: unknown): void {
+  if (warnedAboutStorageFailure) return;
+  warnedAboutStorageFailure = true;
+  console.warn(
+    '[studio] Advanced settings are available for this session but could not be persisted:',
+    error,
+  );
+}
+
+export function loadAdvancedSettings(): StudioRuntimeSettingsV1 {
+  if (typeof window === 'undefined') {
+    return emptySettings();
+  }
+
+  try {
+    const stored = window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY);
+    if (!stored) return emptySettings();
+    return normalizeStudioRuntimeSettings(JSON.parse(stored));
+  } catch (error) {
+    warnAboutInvalidSettings(error);
+    return emptySettings();
+  }
+}
+
+export function saveAdvancedSettings(
+  settings: StudioRuntimeSettingsV1,
+): StudioRuntimeSettingsV1 {
+  const normalized = normalizeStudioRuntimeSettings(settings);
+  try {
+    window.localStorage.setItem(
+      ADVANCED_SETTINGS_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+  } catch (error) {
+    warnAboutStorageFailure(error);
+  }
+  return normalized;
+}

--- a/apps/studio/src/shared/advanced-settings.ts
+++ b/apps/studio/src/shared/advanced-settings.ts
@@ -1,0 +1,118 @@
+import {
+  type AgentBehaviorInitArgs,
+  agentBehaviorInitArgShape,
+} from '@midscene/shared/agent-tools';
+
+const STUDIO_AGENT_OPTION_KEYS = [
+  'aiActContext',
+  'replanningCycleLimit',
+  'screenshotShrinkFactor',
+  'waitAfterAction',
+] as const;
+
+type StudioAgentOptionKey = (typeof STUDIO_AGENT_OPTION_KEYS)[number];
+
+export type StudioAgentOptionsV1 = Pick<
+  AgentBehaviorInitArgs,
+  StudioAgentOptionKey
+>;
+
+export type StudioResolvedAgentOptionsV1 = StudioAgentOptionsV1;
+
+export interface StudioRuntimeSettingsV1 {
+  schemaVersion: 1;
+  agentOptions: StudioAgentOptionsV1;
+}
+
+const SETTINGS_KEYS = new Set(['schemaVersion', 'agentOptions']);
+const AGENT_OPTION_KEYS = new Set<string>(STUDIO_AGENT_OPTION_KEYS);
+const STUDIO_AGENT_OPTION_SHAPE = {
+  aiActContext: agentBehaviorInitArgShape.aiActContext,
+  replanningCycleLimit: agentBehaviorInitArgShape.replanningCycleLimit,
+  screenshotShrinkFactor: agentBehaviorInitArgShape.screenshotShrinkFactor,
+  waitAfterAction: agentBehaviorInitArgShape.waitAfterAction,
+};
+
+export const EMPTY_STUDIO_RUNTIME_SETTINGS: Readonly<StudioRuntimeSettingsV1> =
+  Object.freeze({
+    schemaVersion: 1,
+    agentOptions: Object.freeze({}),
+  });
+
+function assertPlainObject(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`);
+  }
+}
+
+function assertKnownKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  label: string,
+): void {
+  const unknownKey = Object.keys(value).find((key) => !allowed.has(key));
+  if (unknownKey) {
+    throw new Error(`${label} contains unknown key: ${unknownKey}`);
+  }
+}
+
+function normalizeAgentOptions(input: unknown): StudioAgentOptionsV1 {
+  if (input === undefined) return {};
+  assertPlainObject(input, 'agentOptions');
+  assertKnownKeys(input, AGENT_OPTION_KEYS, 'agentOptions');
+
+  const normalized: Record<string, unknown> = {};
+  for (const key of STUDIO_AGENT_OPTION_KEYS) {
+    const value = input[key];
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new Error(`agentOptions.${key} must be JSON-serializable`);
+    }
+    const parsed = STUDIO_AGENT_OPTION_SHAPE[key].safeParse(value);
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'is invalid';
+      throw new Error(`agentOptions.${key}: ${message}`);
+    }
+    if (parsed.data !== undefined) {
+      normalized[key] = parsed.data;
+    }
+  }
+  return normalized as StudioAgentOptionsV1;
+}
+
+export function normalizeStudioRuntimeSettings(
+  input: unknown,
+): StudioRuntimeSettingsV1 {
+  if (input === undefined) {
+    return { schemaVersion: 1, agentOptions: {} };
+  }
+
+  assertPlainObject(input, 'settings');
+  assertKnownKeys(input, SETTINGS_KEYS, 'settings');
+  if (input.schemaVersion !== undefined && input.schemaVersion !== 1) {
+    throw new Error('settings.schemaVersion must be 1');
+  }
+
+  return {
+    schemaVersion: 1,
+    agentOptions: normalizeAgentOptions(input.agentOptions),
+  };
+}
+
+export function resolveStudioAgentOptions(
+  settings: Readonly<StudioRuntimeSettingsV1>,
+): StudioResolvedAgentOptionsV1 {
+  return { ...settings.agentOptions };
+}
+
+export function serializeStudioRuntimeSettings(
+  settings: Readonly<StudioRuntimeSettingsV1>,
+): string {
+  return JSON.stringify(normalizeStudioRuntimeSettings(settings));
+}

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -7,6 +7,7 @@ import type {
   MidsceneRecorderEvent,
   MidsceneRecorderTarget,
 } from '@midscene/shared/recorder';
+import type { StudioRuntimeSettingsV1 } from './advanced-settings';
 
 /**
  * IPC channel names bridging the Midscene Studio main process and renderer.
@@ -158,6 +159,8 @@ export interface PlaygroundBootstrap {
   serverUrl: string | null;
   port: number | null;
   error: string | null;
+  /** The requested settings failed, but the previous runtime was restored. */
+  settingsApplyError?: string;
 }
 
 /**
@@ -269,8 +272,12 @@ export interface ElectronShellApi {
 export type NativeThemeMode = 'light' | 'dark' | 'system';
 
 export interface StudioRuntimeApi {
-  getPlaygroundBootstrap: () => Promise<PlaygroundBootstrap>;
-  restartPlayground: () => Promise<PlaygroundBootstrap>;
+  getPlaygroundBootstrap: (
+    settings?: StudioRuntimeSettingsV1,
+  ) => Promise<PlaygroundBootstrap>;
+  restartPlayground: (
+    settings?: StudioRuntimeSettingsV1,
+  ) => Promise<PlaygroundBootstrap>;
   /** Scan ALL platforms for connected devices (ADB, HDC, displays). */
   discoverDevices: (
     request?: DiscoverDevicesRequest,

--- a/apps/studio/tests/advanced-settings-modal.test.tsx
+++ b/apps/studio/tests/advanced-settings-modal.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdvancedSettingsModal } from '../src/renderer/components/ShellLayout/AdvancedSettingsModal';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('AdvancedSettingsModal', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('does not narrow the Core option ranges in the UI', async () => {
+    await act(async () => {
+      root.render(
+        <AdvancedSettingsModal
+          onApply={vi.fn()}
+          onClose={vi.fn()}
+          open
+          runtimeReady
+          settings={{ schemaVersion: 1, agentOptions: {} }}
+        />,
+      );
+    });
+
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="number"]'),
+    );
+    expect(inputs).toHaveLength(3);
+    expect(inputs[0]).toMatchObject({ min: '0', max: '', step: '1' });
+    expect(inputs[1]).toMatchObject({ min: '0', max: '', step: 'any' });
+    expect(inputs[2]).toMatchObject({ min: '1', max: '', step: 'any' });
+    expect(container.querySelector('textarea')?.maxLength).toBe(-1);
+  });
+
+  it('applies values beyond the former Studio-only limits', async () => {
+    const onApply = vi.fn(async () => undefined);
+    await act(async () => {
+      root.render(
+        <AdvancedSettingsModal
+          onApply={onApply}
+          onClose={vi.fn()}
+          open
+          runtimeReady={false}
+          settings={{ schemaVersion: 1, agentOptions: {} }}
+        />,
+      );
+    });
+
+    const inputs = container.querySelectorAll<HTMLInputElement>(
+      'input[type="number"]',
+    );
+    await act(async () => {
+      const setValue = (input: HTMLInputElement, value: string) => {
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(input, value);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      };
+      setValue(inputs[0], '1000');
+      setValue(inputs[1], '60000.5');
+      setValue(inputs[2], '24');
+    });
+
+    const applyButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Apply',
+    );
+    await act(async () => applyButton?.click());
+
+    expect(onApply).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      agentOptions: {
+        replanningCycleLimit: 1000,
+        waitAfterAction: 60000.5,
+        screenshotShrinkFactor: 24,
+      },
+    });
+  });
+});

--- a/apps/studio/tests/advanced-settings-storage.test.ts
+++ b/apps/studio/tests/advanced-settings-storage.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ADVANCED_SETTINGS_STORAGE_KEY,
+  loadAdvancedSettings,
+  saveAdvancedSettings,
+} from '../src/renderer/settings/advanced-settings-storage';
+
+describe('advanced settings storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('round-trips normalized settings', () => {
+    saveAdvancedSettings({
+      schemaVersion: 1,
+      agentOptions: {
+        aiActContext: 'Prefer visible controls',
+        screenshotShrinkFactor: 24,
+      },
+    });
+
+    expect(loadAdvancedSettings()).toEqual({
+      schemaVersion: 1,
+      agentOptions: {
+        aiActContext: 'Prefer visible controls',
+        screenshotShrinkFactor: 24,
+      },
+    });
+  });
+
+  it('falls back safely when stored data is invalid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    window.localStorage.setItem(
+      ADVANCED_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ agentOptions: { waitAfterAction: -1 } }),
+    );
+
+    expect(loadAdvancedSettings()).toEqual({
+      schemaVersion: 1,
+      agentOptions: {},
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('falls back safely when localStorage cannot be read', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage disabled', 'SecurityError');
+    });
+
+    expect(loadAdvancedSettings()).toEqual({
+      schemaVersion: 1,
+      agentOptions: {},
+    });
+  });
+
+  it('keeps settings available to the current session when persistence fails', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage quota exceeded', 'QuotaExceededError');
+    });
+
+    expect(
+      saveAdvancedSettings({
+        schemaVersion: 1,
+        agentOptions: { waitAfterAction: 250 },
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      agentOptions: { waitAfterAction: 250 },
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/studio/tests/advanced-settings.test.ts
+++ b/apps/studio/tests/advanced-settings.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeStudioRuntimeSettings,
+  resolveStudioAgentOptions,
+  serializeStudioRuntimeSettings,
+} from '../src/shared/advanced-settings';
+
+describe('Studio advanced settings contract', () => {
+  it('normalizes empty input to the versioned settings shape', () => {
+    expect(normalizeStudioRuntimeSettings(undefined)).toEqual({
+      schemaVersion: 1,
+      agentOptions: {},
+    });
+  });
+
+  it('accepts the same boundaries as the shared agent option schemas', () => {
+    const settings = normalizeStudioRuntimeSettings({
+      schemaVersion: 1,
+      agentOptions: {
+        aiActContext: '',
+        replanningCycleLimit: 0,
+        screenshotShrinkFactor: 21.5,
+        waitAfterAction: 0.5,
+      },
+    });
+
+    expect(settings.agentOptions).toEqual({
+      aiActContext: '',
+      replanningCycleLimit: 0,
+      screenshotShrinkFactor: 21.5,
+      waitAfterAction: 0.5,
+    });
+  });
+
+  it.each([
+    [{ agentOptions: { unknownOption: true } }, 'unknown key'],
+    [{ agentOptions: { replanningCycleLimit: -1 } }, 'greater than or equal'],
+    [{ agentOptions: { replanningCycleLimit: 1.5 } }, 'integer'],
+    [
+      { agentOptions: { screenshotShrinkFactor: 0.5 } },
+      'greater than or equal',
+    ],
+    [{ agentOptions: { waitAfterAction: -0.1 } }, 'greater than or equal'],
+    [
+      { agentOptions: { waitAfterAction: Number.POSITIVE_INFINITY } },
+      'JSON-serializable',
+    ],
+  ])('rejects invalid settings %#', (input, expectedMessage) => {
+    expect(() => normalizeStudioRuntimeSettings(input)).toThrow(
+      expectedMessage,
+    );
+  });
+
+  it('returns immutable-by-copy runtime values and stable serialization', () => {
+    const settings = normalizeStudioRuntimeSettings({
+      agentOptions: { waitAfterAction: 250 },
+    });
+    const resolved = resolveStudioAgentOptions(settings);
+
+    resolved.waitAfterAction = 500;
+
+    expect(settings.agentOptions.waitAfterAction).toBe(250);
+    expect(serializeStudioRuntimeSettings(settings)).toBe(
+      '{"schemaVersion":1,"agentOptions":{"waitAfterAction":250}}',
+    );
+  });
+});

--- a/apps/studio/tests/android-runtime.test.ts
+++ b/apps/studio/tests/android-runtime.test.ts
@@ -206,6 +206,10 @@ describe('playground runtime bootstrap', () => {
       | undefined;
 
     const runtime = createMultiPlatformRuntimeService({
+      agentOptions: {
+        aiActContext: 'Prefer visible controls',
+        screenshotShrinkFactor: 24,
+      },
       loadPlaygroundCore: (async () =>
         ({
           launchPreparedPlaygroundPlatform: async () => ({
@@ -308,10 +312,137 @@ describe('playground runtime bootstrap', () => {
     expect(session?.metadata?.sessionDisplayName).toBe('http://localhost:4173');
     expect(session?.preview?.kind).toBe('mjpeg');
     expect(agent).toBeInstanceOf(FakePuppeteerAgent);
+    expect((agent as FakePuppeteerAgent).opts).toEqual({
+      aiActContext: 'Prefer visible controls',
+      screenshotShrinkFactor: 24,
+      cacheId: 'studio-web',
+    });
 
     await prepared?.sessionManager?.destroySession?.();
     expect(destroyAgent).toHaveBeenCalledTimes(1);
     expect(cleanupBrowser).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes restarts with immutable option snapshots for platform preparation', async () => {
+    const close = vi.fn(async () => undefined);
+    const iosPrepare = vi.fn(async () => ({
+      platformId: 'ios',
+      title: 'iOS',
+    }));
+    const platformGenerations: RegisteredPlaygroundPlatform[][] = [];
+    let port = 5800;
+    const runtime = createMultiPlatformRuntimeService({
+      agentOptions: { waitAfterAction: 100 },
+      loadPlaygroundCore: (async () =>
+        ({
+          launchPreparedPlaygroundPlatform: async () => ({
+            close,
+            host: '127.0.0.1',
+            port: port++,
+            server: { setPreparedPlatform: () => undefined },
+          }),
+          buildPlaygroundBrowserUrl,
+          prepareMultiPlatformPlayground: async (
+            platforms: RegisteredPlaygroundPlatform[],
+          ) => {
+            platformGenerations.push(platforms);
+            return {
+              platformId: 'multi-platform',
+              title: 'Studio',
+              metadata: {},
+            };
+          },
+        }) as unknown as Awaited<
+          ReturnType<PlaygroundCoreLoader>
+        >) as PlaygroundCoreLoader,
+      loadIosModule: (async () =>
+        ({
+          iosPlaygroundPlatform: { prepare: iosPrepare },
+        }) as never) as RuntimeServiceOptions['loadIosModule'],
+    });
+
+    await runtime.start();
+    await platformGenerations[0][2].prepare();
+    const firstRestart = runtime.restart({ waitAfterAction: 200 });
+    const secondRestart = runtime.restart({ waitAfterAction: 300 });
+    await Promise.all([firstRestart, secondRestart]);
+    await platformGenerations[1][2].prepare();
+    await platformGenerations[2][2].prepare();
+
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(iosPrepare).toHaveBeenNthCalledWith(1, {
+      agentOptions: { waitAfterAction: 100 },
+      staticDir: expect.any(String),
+    });
+    expect(iosPrepare).toHaveBeenNthCalledWith(2, {
+      agentOptions: { waitAfterAction: 200 },
+      staticDir: expect.any(String),
+    });
+    expect(iosPrepare).toHaveBeenNthCalledWith(3, {
+      agentOptions: { waitAfterAction: 300 },
+      staticDir: expect.any(String),
+    });
+  });
+
+  it('restores the previous runtime after a settings restart fails', async () => {
+    const iosPrepare = vi.fn(async () => ({
+      platformId: 'ios',
+      title: 'iOS',
+    }));
+    const platformGenerations: RegisteredPlaygroundPlatform[][] = [];
+    let launchCount = 0;
+    const runtime = createMultiPlatformRuntimeService({
+      agentOptions: { waitAfterAction: 100 },
+      loadPlaygroundCore: (async () =>
+        ({
+          launchPreparedPlaygroundPlatform: async () => {
+            launchCount += 1;
+            if (launchCount === 2) {
+              throw new Error('Synthetic restart failure');
+            }
+            return {
+              close: async () => undefined,
+              host: '127.0.0.1',
+              port: 5800 + launchCount,
+              server: { setPreparedPlatform: () => undefined },
+            };
+          },
+          buildPlaygroundBrowserUrl,
+          prepareMultiPlatformPlayground: async (
+            platforms: RegisteredPlaygroundPlatform[],
+          ) => {
+            platformGenerations.push(platforms);
+            return {
+              platformId: 'multi-platform',
+              title: 'Studio',
+              metadata: {},
+            };
+          },
+        }) as unknown as Awaited<
+          ReturnType<PlaygroundCoreLoader>
+        >) as PlaygroundCoreLoader,
+      loadIosModule: (async () =>
+        ({
+          iosPlaygroundPlatform: { prepare: iosPrepare },
+        }) as never) as RuntimeServiceOptions['loadIosModule'],
+    });
+
+    await runtime.start();
+    const restartResult = await runtime.restart({ waitAfterAction: 999 });
+    expect(restartResult).toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        error: null,
+        settingsApplyError: 'Synthetic restart failure',
+      }),
+    );
+    expect(runtime.getBootstrap()).not.toHaveProperty('settingsApplyError');
+    await platformGenerations[2][2].prepare();
+
+    expect(iosPrepare).toHaveBeenCalledWith({
+      agentOptions: { waitAfterAction: 100 },
+      staticDir: expect.any(String),
+    });
   });
 
   it('prepares Harmony in deferred mode so Studio never exits on device selection', async () => {

--- a/apps/studio/tests/main-content-overview.test.tsx
+++ b/apps/studio/tests/main-content-overview.test.tsx
@@ -113,6 +113,7 @@ function createReadyContextValue(): ReadyStudioPlaygroundContextValue {
       web: [],
     },
     refreshDiscoveredDevices: vi.fn(async () => undefined),
+    applyRuntimeSettings: vi.fn(async () => undefined),
     restartPlayground: vi.fn(async () => undefined),
     setDiscoveryPollingPaused: vi.fn(),
   };

--- a/apps/studio/tests/main-content-web-navigation.test.tsx
+++ b/apps/studio/tests/main-content-web-navigation.test.tsx
@@ -166,6 +166,7 @@ function createConnectedWebContextValue(): ReadyStudioPlaygroundContextValue {
       web: [],
     },
     refreshDiscoveredDevices: vi.fn(async () => undefined),
+    applyRuntimeSettings: vi.fn(async () => undefined),
     restartPlayground: vi.fn(async () => undefined),
     setDiscoveryPollingPaused: vi.fn(),
   };

--- a/apps/studio/tests/playground-import-replay.test.tsx
+++ b/apps/studio/tests/playground-import-replay.test.tsx
@@ -130,6 +130,7 @@ function createReadyPlayground() {
     },
     phase: 'ready',
     refreshDiscoveredDevices: vi.fn(async () => undefined),
+    applyRuntimeSettings: vi.fn(async () => undefined),
     restartPlayground: vi.fn(async () => undefined),
     serverUrl: 'http://localhost:5800',
     setDiscoveryPollingPaused: vi.fn(),

--- a/apps/studio/tests/preload-bridge.test.ts
+++ b/apps/studio/tests/preload-bridge.test.ts
@@ -68,8 +68,12 @@ describe('preload bridge', () => {
       content: '{}',
     });
 
-    await studioRuntimeApi.getPlaygroundBootstrap();
-    await studioRuntimeApi.restartPlayground();
+    const runtimeSettings = {
+      schemaVersion: 1 as const,
+      agentOptions: { waitAfterAction: 250 },
+    };
+    await studioRuntimeApi.getPlaygroundBootstrap(runtimeSettings);
+    await studioRuntimeApi.restartPlayground(runtimeSettings);
     await studioRuntimeApi.discoverDevices();
     const stopListening = studioRuntimeApi.onDiscoveredDevicesChanged(
       () => undefined,
@@ -168,8 +172,8 @@ describe('preload bridge', () => {
           content: '{}',
         },
       ],
-      [IPC_CHANNELS.getPlaygroundBootstrap],
-      [IPC_CHANNELS.restartPlayground],
+      [IPC_CHANNELS.getPlaygroundBootstrap, runtimeSettings],
+      [IPC_CHANNELS.restartPlayground, runtimeSettings],
       [IPC_CHANNELS.discoverDevices, undefined],
       [IPC_CHANNELS.setDiscoveryPollingPaused, true],
       [

--- a/apps/studio/tests/sidebar-device-list.test.ts
+++ b/apps/studio/tests/sidebar-device-list.test.ts
@@ -56,6 +56,7 @@ function createReadyContextValue(): ReadyStudioPlaygroundContextValue {
       web: [],
     },
     refreshDiscoveredDevices: vi.fn(async () => undefined),
+    applyRuntimeSettings: vi.fn(async () => undefined),
     restartPlayground: vi.fn(async () => undefined),
     setDiscoveryPollingPaused: vi.fn(),
   };

--- a/apps/studio/tests/studio-playground-ready-provider.test.ts
+++ b/apps/studio/tests/studio-playground-ready-provider.test.ts
@@ -56,6 +56,7 @@ describe('StudioPlaygroundReadyProvider', () => {
         StudioPlaygroundReadyProvider,
         {
           refreshDiscoveredDevices: async () => undefined,
+          applyRuntimeSettings: async () => undefined,
           restartPlayground: async () => undefined,
           setDiscoveryPollingPaused: () => undefined,
           serverUrl: 'http://127.0.0.1:5800',
@@ -84,6 +85,7 @@ describe('StudioPlaygroundReadyProvider', () => {
         StudioPlaygroundReadyProvider,
         {
           refreshDiscoveredDevices: async () => undefined,
+          applyRuntimeSettings: async () => undefined,
           restartPlayground: async () => undefined,
           setDiscoveryPollingPaused: () => undefined,
           serverUrl: 'http://127.0.0.1:5800',
@@ -140,6 +142,7 @@ describe('StudioPlaygroundReadyProvider', () => {
               web: [],
             },
             refreshDiscoveredDevices: async () => undefined,
+            applyRuntimeSettings: async () => undefined,
             restartPlayground: async () => undefined,
             setDiscoveryPollingPaused: () => undefined,
             serverUrl: 'http://127.0.0.1:5800',

--- a/apps/studio/tests/studio-playground-settings-provider.test.tsx
+++ b/apps/studio/tests/studio-playground-settings-provider.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { type PropsWithChildren, act } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ADVANCED_SETTINGS_STORAGE_KEY } from '../src/renderer/settings/advanced-settings-storage';
+import type { StudioRuntimeSettingsV1 } from '../src/shared/advanced-settings';
+
+const mocks = vi.hoisted(() => ({
+  readyProps: null as null | {
+    applyRuntimeSettings: (settings: StudioRuntimeSettingsV1) => Promise<void>;
+    serverUrl: string;
+  },
+}));
+
+vi.mock('../src/renderer/playground/StudioPlaygroundReadyProvider', () => ({
+  default: (
+    props: PropsWithChildren<{
+      applyRuntimeSettings: (
+        settings: StudioRuntimeSettingsV1,
+      ) => Promise<void>;
+      serverUrl: string;
+    }>,
+  ) => {
+    mocks.readyProps = props;
+    return null;
+  },
+}));
+
+import { StudioPlaygroundProvider } from '../src/renderer/playground/StudioPlaygroundProvider';
+import { useStudioPlayground } from '../src/renderer/playground/useStudioPlayground';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('StudioPlaygroundProvider advanced settings', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.readyProps = null;
+    window.localStorage.clear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('boots with stored settings and persists only a successful restart', async () => {
+    const storedSettings: StudioRuntimeSettingsV1 = {
+      schemaVersion: 1,
+      agentOptions: { waitAfterAction: 250 },
+    };
+    const nextSettings: StudioRuntimeSettingsV1 = {
+      schemaVersion: 1,
+      agentOptions: {
+        replanningCycleLimit: 0,
+        screenshotShrinkFactor: 24,
+      },
+    };
+    window.localStorage.setItem(
+      ADVANCED_SETTINGS_STORAGE_KEY,
+      JSON.stringify(storedSettings),
+    );
+    const getPlaygroundBootstrap = vi.fn(async () => ({
+      status: 'ready' as const,
+      serverUrl: 'http://127.0.0.1:5800',
+      port: 5800,
+      error: null,
+    }));
+    const restartPlayground = vi.fn(async () => ({
+      status: 'ready' as const,
+      serverUrl: 'http://127.0.0.1:5801',
+      port: 5801,
+      error: null,
+    }));
+    vi.stubGlobal('studioRuntime', {
+      getPlaygroundBootstrap,
+      restartPlayground,
+      discoverDevices: vi.fn(async () => ({ devices: [], errors: [] })),
+      onDiscoveredDevicesChanged: vi.fn(() => () => undefined),
+      setDiscoveryPollingPaused: vi.fn(async () => undefined),
+    });
+    Object.defineProperty(window, 'studioRuntime', {
+      configurable: true,
+      value: globalThis.studioRuntime,
+    });
+
+    await act(async () => {
+      root.render(
+        <StudioPlaygroundProvider>
+          <div>Studio</div>
+        </StudioPlaygroundProvider>,
+      );
+    });
+
+    expect(getPlaygroundBootstrap).toHaveBeenCalledWith(storedSettings);
+    expect(mocks.readyProps).not.toBeNull();
+
+    await act(async () => {
+      await mocks.readyProps?.applyRuntimeSettings(nextSettings);
+    });
+
+    expect(restartPlayground).toHaveBeenCalledWith(nextSettings);
+    expect(
+      JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!),
+    ).toEqual(nextSettings);
+
+    restartPlayground.mockResolvedValueOnce({
+      status: 'ready',
+      serverUrl: 'http://127.0.0.1:5802',
+      port: 5802,
+      error: null,
+      settingsApplyError: 'Synthetic restart failure',
+    });
+    const failedSettings: StudioRuntimeSettingsV1 = {
+      schemaVersion: 1,
+      agentOptions: { waitAfterAction: 999 },
+    };
+
+    await act(async () => {
+      await expect(
+        mocks.readyProps?.applyRuntimeSettings(failedSettings),
+      ).rejects.toThrow('Synthetic restart failure');
+    });
+    expect(
+      JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!),
+    ).toEqual(nextSettings);
+    expect(mocks.readyProps?.serverUrl).toBe('http://127.0.0.1:5802');
+  });
+
+  it('ignores an old bootstrap response after applying new settings', async () => {
+    type ReadyBootstrap = {
+      status: 'ready';
+      serverUrl: string;
+      port: number;
+      error: null;
+    };
+    let resolveInitialBootstrap: ((value: ReadyBootstrap) => void) | undefined;
+    const initialBootstrap = new Promise<ReadyBootstrap>((resolve) => {
+      resolveInitialBootstrap = resolve;
+    });
+    const getPlaygroundBootstrap = vi
+      .fn()
+      .mockReturnValueOnce(initialBootstrap)
+      .mockResolvedValue({
+        status: 'ready' as const,
+        serverUrl: 'http://127.0.0.1:5801',
+        port: 5801,
+        error: null,
+      });
+    const restartPlayground = vi.fn(async () => ({
+      status: 'ready' as const,
+      serverUrl: 'http://127.0.0.1:5801',
+      port: 5801,
+      error: null,
+    }));
+    const runtimeBridge = {
+      getPlaygroundBootstrap,
+      restartPlayground,
+      discoverDevices: vi.fn(async () => ({ devices: [], errors: [] })),
+      onDiscoveredDevicesChanged: vi.fn(() => () => undefined),
+      setDiscoveryPollingPaused: vi.fn(async () => undefined),
+    };
+    vi.stubGlobal('studioRuntime', runtimeBridge);
+    Object.defineProperty(window, 'studioRuntime', {
+      configurable: true,
+      value: runtimeBridge,
+    });
+
+    let applyWhileBooting:
+      | ((settings: StudioRuntimeSettingsV1) => Promise<void>)
+      | undefined;
+    function CaptureBootingContext() {
+      applyWhileBooting = useStudioPlayground().applyRuntimeSettings;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <StudioPlaygroundProvider>
+          <CaptureBootingContext />
+        </StudioPlaygroundProvider>,
+      );
+    });
+
+    const settings: StudioRuntimeSettingsV1 = {
+      schemaVersion: 1,
+      agentOptions: { waitAfterAction: 300 },
+    };
+    await act(async () => {
+      await applyWhileBooting?.(settings);
+    });
+    expect(mocks.readyProps?.serverUrl).toBe('http://127.0.0.1:5801');
+
+    await act(async () => {
+      resolveInitialBootstrap?.({
+        status: 'ready',
+        serverUrl: 'http://127.0.0.1:5800',
+        port: 5800,
+        error: null,
+      });
+      await initialBootstrap;
+    });
+
+    expect(mocks.readyProps?.serverUrl).toBe('http://127.0.0.1:5801');
+    expect(restartPlayground).toHaveBeenCalledWith(settings);
+  });
+});

--- a/apps/studio/tests/studio-recorder-provider.test.tsx
+++ b/apps/studio/tests/studio-recorder-provider.test.tsx
@@ -189,6 +189,7 @@ function createConnectedStudioContext({
       web: [],
     },
     refreshDiscoveredDevices: vi.fn(async () => undefined),
+    applyRuntimeSettings: vi.fn(async () => undefined),
     restartPlayground: vi.fn(async () => undefined),
     setDiscoveryPollingPaused: vi.fn(),
   };

--- a/packages/android-playground/src/platform.ts
+++ b/packages/android-playground/src/platform.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {
   AndroidAgent,
+  type AndroidAgentOpt,
   AndroidDevice,
   getConnectedDevicesWithDetails,
 } from '@midscene/android';
@@ -22,6 +23,7 @@ export interface ScrcpyServerController {
 }
 
 export interface AndroidPlatformOptions {
+  agentOptions?: AndroidAgentOpt;
   staticDir?: string;
   scrcpyServer?: ScrcpyServerController;
   scrcpyPort?: number;
@@ -137,7 +139,10 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         const connectAgent = async () => {
           const device = new AndroidDevice(deviceId);
           await device.connect();
-          return new AndroidAgent(device);
+          return new AndroidAgent(
+            device,
+            options?.agentOptions ? { ...options.agentOptions } : undefined,
+          );
         };
 
         if (options?.scrcpyServer) {

--- a/packages/android-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/android-playground/tests/unit/platform-session-manager.test.ts
@@ -4,17 +4,18 @@ const connectMock = vi.fn();
 const currentDevice = { connect: connectMock };
 const getConnectedDevicesWithDetailsMock = vi.fn();
 const findAvailablePortMock = vi.fn(async (port: number) => port);
+const androidAgentMock = vi.fn().mockImplementation((device) => ({
+  interface: {
+    interfaceType: 'android',
+    describe: () => 'Mock Android device',
+    actionSpace: () => [],
+  },
+  destroy: vi.fn(),
+  device,
+}));
 
 vi.mock('@midscene/android', () => ({
-  AndroidAgent: vi.fn().mockImplementation((device) => ({
-    interface: {
-      interfaceType: 'android',
-      describe: () => 'Mock Android device',
-      actionSpace: () => [],
-    },
-    destroy: vi.fn(),
-    device,
-  })),
+  AndroidAgent: androidAgentMock,
   AndroidDevice: vi.fn().mockImplementation(() => currentDevice),
   getConnectedDevicesWithDetails: getConnectedDevicesWithDetailsMock,
 }));
@@ -74,6 +75,31 @@ describe('androidPlaygroundPlatform session manager', () => {
       deviceId: 'SERIAL123',
     });
     expect(connectMock).toHaveBeenCalled();
+  });
+
+  test('passes agent options to the initial and follow-up agents', async () => {
+    const { androidPlaygroundPlatform } = await import('../../src/platform');
+    const agentOptions = {
+      aiActContext: 'Prefer visible controls',
+      waitAfterAction: 250,
+    };
+    const prepared = await androidPlaygroundPlatform.prepare({ agentOptions });
+    const created = await prepared.sessionManager?.createSession({
+      deviceId: 'SERIAL123',
+    });
+
+    await created?.agentFactory?.();
+
+    expect(androidAgentMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      agentOptions,
+    );
+    expect(androidAgentMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      agentOptions,
+    );
   });
 
   test('keeps the setup schema usable when adb discovery fails', async () => {

--- a/packages/computer-playground/src/platform.ts
+++ b/packages/computer-playground/src/platform.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {
+  type ComputerAgentOpt,
   agentFromComputer,
   checkAccessibilityPermission,
   checkScreenRecordingPermission,
@@ -15,6 +16,7 @@ import { findAvailablePort } from '@midscene/shared/node';
 import type { BrowserWindowController } from './browser-window-controller';
 
 export interface ComputerPlatformOptions {
+  agentOptions?: Omit<ComputerAgentOpt, 'displayId'>;
   staticDir?: string;
   getWindowController?: () => BrowserWindowController | null;
 }
@@ -119,20 +121,27 @@ export const computerPlaygroundPlatform = definePlaygroundPlatform<
           input?.displayId === undefined || input.displayId === null
             ? undefined
             : String(input.displayId);
-        const agent = await agentFromComputer(
-          displayId ? { displayId } : undefined,
-        );
+        const createAgent = (targetDisplayId?: string) => {
+          if (!options?.agentOptions && !targetDisplayId) {
+            return agentFromComputer();
+          }
+          return agentFromComputer({
+            ...options?.agentOptions,
+            ...(targetDisplayId ? { displayId: targetDisplayId } : {}),
+          });
+        };
+        const agent = await createAgent(displayId);
         const displays = await getConnectedDisplays();
         const selectedDisplay =
-          displays.find((display) => display.id === displayId) ||
+          displays.find((display) => String(display.id) === displayId) ||
           displays.find((display) => display.primary) ||
           displays[0];
 
         return {
           agent,
           agentFactory: () =>
-            agentFromComputer(
-              selectedDisplay ? { displayId: selectedDisplay.id } : undefined,
+            createAgent(
+              selectedDisplay ? String(selectedDisplay.id) : undefined,
             ),
           preview: createScreenshotPreviewDescriptor({
             title: 'Desktop preview',

--- a/packages/computer-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/computer-playground/tests/unit/platform-session-manager.test.ts
@@ -114,4 +114,39 @@ describe('computerPlaygroundPlatform session manager', () => {
       executionUx: 'countdown-before-run',
     });
   });
+
+  test('combines agent options with the selected display for every agent', async () => {
+    checkAccessibilityPermissionMock.mockReturnValue({ hasPermission: true });
+    agentFromComputerMock.mockResolvedValue({
+      interface: {
+        interfaceType: 'computer',
+        describe: () => 'Desktop',
+        actionSpace: () => [],
+      },
+      destroy: vi.fn(),
+    });
+    const { computerPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await computerPlaygroundPlatform.prepare({
+      agentOptions: {
+        screenshotShrinkFactor: 24,
+        waitAfterAction: 250,
+      },
+    });
+    const created = await prepared.sessionManager?.createSession({
+      displayId: '1',
+    });
+
+    await created?.agentFactory?.();
+
+    expect(agentFromComputerMock).toHaveBeenNthCalledWith(1, {
+      displayId: '1',
+      screenshotShrinkFactor: 24,
+      waitAfterAction: 250,
+    });
+    expect(agentFromComputerMock).toHaveBeenNthCalledWith(2, {
+      displayId: '1',
+      screenshotShrinkFactor: 24,
+      waitAfterAction: 250,
+    });
+  });
 });

--- a/packages/harmony/src/platform.ts
+++ b/packages/harmony/src/platform.ts
@@ -8,11 +8,12 @@ import {
 } from '@midscene/playground';
 import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
-import { HarmonyAgent } from './agent';
+import { HarmonyAgent, type HarmonyAgentOpt } from './agent';
 import { HarmonyDevice } from './device';
 import { getConnectedDevices } from './utils';
 
 export interface HarmonyPlatformOptions {
+  agentOptions?: HarmonyAgentOpt;
   deferConnection?: boolean;
   deviceId?: string;
   staticDir?: string;
@@ -177,7 +178,10 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
         const connectAgent = async () => {
           const device = new HarmonyDevice(deviceId);
           await device.connect();
-          return new HarmonyAgent(device);
+          return new HarmonyAgent(
+            device,
+            options?.agentOptions ? { ...options.agentOptions } : undefined,
+          );
         };
 
         const agent = await connectAgent();
@@ -226,7 +230,10 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
       agentFactory: async () => {
         const device = new HarmonyDevice(selectedDeviceId);
         await device.connect();
-        return new HarmonyAgent(device);
+        return new HarmonyAgent(
+          device,
+          options?.agentOptions ? { ...options.agentOptions } : undefined,
+        );
       },
       launchOptions: {
         port: availablePort,

--- a/packages/harmony/tests/unit-test/platform.test.ts
+++ b/packages/harmony/tests/unit-test/platform.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const connectMock = vi.fn();
 const getConnectedDevicesMock = vi.fn();
 const findAvailablePortMock = vi.fn(async () => 5810);
+const harmonyAgentMock = vi.fn().mockImplementation((device) => ({
+  device,
+  interface: {
+    interfaceType: 'harmony',
+    actionSpace: () => [],
+    describe: () => 'Mock Harmony device',
+  },
+}));
 
 vi.mock('@midscene/playground', () => ({
   createScreenshotPreviewDescriptor: (overrides = {}) => ({
@@ -18,14 +26,7 @@ vi.mock('@midscene/shared/node', () => ({
 }));
 
 vi.mock('../../src/agent', () => ({
-  HarmonyAgent: vi.fn().mockImplementation((device) => ({
-    device,
-    interface: {
-      interfaceType: 'harmony',
-      actionSpace: () => [],
-      describe: () => 'Mock Harmony device',
-    },
-  })),
+  HarmonyAgent: harmonyAgentMock,
 }));
 
 vi.mock('../../src/device', () => ({
@@ -97,6 +98,33 @@ describe('harmonyPlaygroundPlatform', () => {
       deviceId: 'SERIAL123',
     });
     expect(connectMock).toHaveBeenCalled();
+  });
+
+  test('passes agent options through deferred and direct agent factories', async () => {
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
+    const agentOptions = {
+      replanningCycleLimit: 0,
+      waitAfterAction: 250,
+    };
+    const deferred = await harmonyPlaygroundPlatform.prepare({
+      agentOptions,
+      deferConnection: true,
+    });
+    const created = await deferred.sessionManager?.createSession({
+      deviceId: 'SERIAL123',
+    });
+    await created?.agentFactory?.();
+
+    const direct = await harmonyPlaygroundPlatform.prepare({
+      agentOptions,
+      deviceId: 'SERIAL123',
+    });
+    await direct.agentFactory?.();
+
+    expect(harmonyAgentMock).toHaveBeenCalledTimes(3);
+    for (const call of harmonyAgentMock.mock.calls) {
+      expect(call[1]).toEqual(agentOptions);
+    }
   });
 
   test('keeps deferred setup usable when no HarmonyOS devices are connected', async () => {

--- a/packages/ios/src/platform.ts
+++ b/packages/ios/src/platform.ts
@@ -9,9 +9,14 @@ import {
   PLAYGROUND_SERVER_PORT,
 } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
-import { type IOSAgent, agentFromWebDriverAgent } from './agent';
+import {
+  type IOSAgent,
+  type IOSAgentOpt,
+  agentFromWebDriverAgent,
+} from './agent';
 
 export interface IOSPlatformOptions {
+  agentOptions?: IOSAgentOpt;
   staticDir?: string;
 }
 
@@ -119,6 +124,7 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
 
         const connectAgent = async (): Promise<IOSAgent> => {
           return agentFromWebDriverAgent({
+            ...options?.agentOptions,
             wdaHost: host,
             wdaPort: port,
             ...(sessionId ? { sessionId } : {}),

--- a/packages/ios/tests/unit-test/platform-session-manager.test.ts
+++ b/packages/ios/tests/unit-test/platform-session-manager.test.ts
@@ -84,4 +84,29 @@ describe('iosPlaygroundPlatform session manager', () => {
       wdaPort: 8300,
     });
   });
+
+  test('passes agent options to the initial and follow-up agents', async () => {
+    const { iosPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await iosPlaygroundPlatform.prepare({
+      agentOptions: {
+        aiActContext: 'Prefer visible controls',
+        screenshotShrinkFactor: 24,
+      },
+    });
+    const created = await prepared.sessionManager?.createSession({
+      host: 'localhost',
+      port: 8100,
+    });
+
+    await created?.agentFactory?.();
+
+    const expected = {
+      aiActContext: 'Prefer visible controls',
+      screenshotShrinkFactor: 24,
+      wdaHost: 'localhost',
+      wdaPort: 8100,
+    };
+    expect(agentFromWebDriverAgentMock).toHaveBeenNthCalledWith(1, expected);
+    expect(agentFromWebDriverAgentMock).toHaveBeenNthCalledWith(2, expected);
+  });
 });


### PR DESCRIPTION
Add a versioned advanced-settings model to Midscene Studio and pass existing Agent behavior options through the Studio runtime to all supported platforms.

This PR supports:

- `aiActContext`
- `replanningCycleLimit`
- `screenshotShrinkFactor`
- `waitAfterAction`