### PR TITLE
fix(core): compact duplicate report dumps on finalize

### DIFF
--- a/packages/core/src/dump/report-dump-compactor.ts
+++ b/packages/core/src/dump/report-dump-compactor.ts
@@ -1,8 +1,11 @@
-import { randomUUID } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { type FileHandle, open, rename, stat, unlink } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
-import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
+import {
+  antiEscapeScriptTag,
+  escapeScriptTag,
+  uuid,
+} from '@midscene/shared/utils';
 import { type ExecutionDump, ReportActionDump } from '../types';
 
 const SCRIPT_OPEN = Buffer.from('<script');
@@ -257,7 +260,7 @@ async function replaceReportFile(
 
   const backupPath = join(
     dirname(reportPath),
-    `.${basename(reportPath)}.${randomUUID()}.backup`,
+    `.${basename(reportPath)}.${uuid()}.backup`,
   );
   await rename(reportPath, backupPath);
   try {
@@ -293,7 +296,7 @@ export async function compactReportDumps(
 
   const temporaryPath = join(
     dirname(reportPath),
-    `.${basename(reportPath)}.${randomUUID()}.tmp`,
+    `.${basename(reportPath)}.${uuid()}.tmp`,
   );
 
   try {

--- a/packages/core/src/dump/report-dump-compactor.ts
+++ b/packages/core/src/dump/report-dump-compactor.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { type FileHandle, open, rename, stat, unlink } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
+import { type ExecutionDump, ReportActionDump } from '../types';
+
+const SCRIPT_OPEN = Buffer.from('<script');
+const SCRIPT_CLOSE = Buffer.from('</script>');
+const READ_CHUNK_SIZE = 32 * 1024 * 1024;
+const DUMP_TYPE_ATTRIBUTE = 'type="midscene_web_dump"';
+const GROUP_ID_REGEXP = /data-group-id="([^"]+)"/;
+
+interface ScriptTag {
+  openTag: string;
+  content: Buffer;
+}
+
+interface DumpGroup {
+  baseDump: ReportActionDump;
+  executionsByKey: Map<string, ExecutionDump>;
+  firstOpenTag: string;
+  noIdExecutionIndex: number;
+  tagCount: number;
+}
+
+interface DumpAnalysis {
+  groups: Map<string, DumpGroup>;
+  tagCount: number;
+}
+
+export interface ReportDumpCompactionResult {
+  beforeBytes: number;
+  afterBytes: number;
+  beforeDumpCount: number;
+  afterDumpCount: number;
+}
+
+function decodeGroupId(openTag: string): string | undefined {
+  if (!openTag.includes(DUMP_TYPE_ATTRIBUTE)) return undefined;
+  const encodedGroupId = openTag.match(GROUP_ID_REGEXP)?.[1];
+  return encodedGroupId ? decodeURIComponent(encodedGroupId) : undefined;
+}
+
+async function scanScriptTags(
+  reportPath: string,
+  onScript: (script: ScriptTag) => void | Promise<void>,
+): Promise<void> {
+  let pending: Buffer = Buffer.alloc(0);
+
+  for await (const chunk of createReadStream(reportPath, {
+    highWaterMark: READ_CHUNK_SIZE,
+  })) {
+    pending =
+      pending.length === 0
+        ? (chunk as Buffer)
+        : Buffer.concat([pending, chunk as Buffer]);
+
+    while (pending.length > 0) {
+      const scriptStart = pending.indexOf(SCRIPT_OPEN);
+      if (scriptStart === -1) {
+        pending = pending.subarray(
+          Math.max(0, pending.length - SCRIPT_OPEN.length + 1),
+        );
+        break;
+      }
+
+      if (scriptStart > 0) {
+        pending = pending.subarray(scriptStart);
+      }
+
+      const openTagEnd = pending.indexOf(0x3e, SCRIPT_OPEN.length);
+      if (openTagEnd === -1) break;
+
+      const closeTagStart = pending.indexOf(SCRIPT_CLOSE, openTagEnd + 1);
+      if (closeTagStart === -1) break;
+
+      const scriptEnd = closeTagStart + SCRIPT_CLOSE.length;
+      await onScript({
+        openTag: pending.subarray(0, openTagEnd + 1).toString('utf-8'),
+        content: pending.subarray(openTagEnd + 1, closeTagStart),
+      });
+      pending = pending.subarray(scriptEnd);
+    }
+  }
+
+  if (pending.indexOf(SCRIPT_OPEN) !== -1) {
+    throw new Error(
+      `Report contains an unterminated script tag: ${reportPath}`,
+    );
+  }
+}
+
+async function analyzeDumpGroups(reportPath: string): Promise<DumpAnalysis> {
+  const groups = new Map<string, DumpGroup>();
+  let tagCount = 0;
+
+  await scanScriptTags(reportPath, ({ openTag, content }) => {
+    const groupId = decodeGroupId(openTag);
+    if (!groupId) return;
+
+    const dump = ReportActionDump.fromSerializedString(
+      antiEscapeScriptTag(content.toString('utf-8').trim()),
+    );
+    let group = groups.get(groupId);
+    if (!group) {
+      group = {
+        baseDump: dump,
+        executionsByKey: new Map(),
+        firstOpenTag: openTag,
+        noIdExecutionIndex: 0,
+        tagCount: 0,
+      };
+      groups.set(groupId, group);
+    }
+
+    group.tagCount += 1;
+    tagCount += 1;
+    for (const execution of dump.executions) {
+      const executionKey = execution.id
+        ? `id:${execution.id}`
+        : `no-id:${group.noIdExecutionIndex++}`;
+      group.executionsByKey.set(executionKey, execution);
+    }
+  });
+
+  return { groups, tagCount };
+}
+
+function compactedDumpTag(group: DumpGroup): Buffer {
+  group.baseDump.executions = Array.from(group.executionsByKey.values());
+  const serialized = escapeScriptTag(group.baseDump.serialize());
+  return Buffer.from(
+    `${group.firstOpenTag}${serialized}${SCRIPT_CLOSE.toString('utf-8')}`,
+  );
+}
+
+async function writeAll(handle: FileHandle, data: Buffer): Promise<void> {
+  let offset = 0;
+  while (offset < data.length) {
+    const { bytesWritten } = await handle.write(
+      data,
+      offset,
+      data.length - offset,
+      null,
+    );
+    if (bytesWritten === 0) {
+      throw new Error('Failed to make progress while writing compacted report');
+    }
+    offset += bytesWritten;
+  }
+}
+
+async function rewriteReport(
+  sourcePath: string,
+  targetPath: string,
+  analysis: DumpAnalysis,
+): Promise<void> {
+  const compactedTags = new Map(
+    Array.from(analysis.groups, ([groupId, group]) => [
+      groupId,
+      compactedDumpTag(group),
+    ]),
+  );
+  const seenTagsByGroup = new Map<string, number>();
+  const emittedGroups = new Set<string>();
+  const output = await open(targetPath, 'wx');
+  let pending: Buffer = Buffer.alloc(0);
+
+  try {
+    for await (const chunk of createReadStream(sourcePath, {
+      highWaterMark: READ_CHUNK_SIZE,
+    })) {
+      pending =
+        pending.length === 0
+          ? (chunk as Buffer)
+          : Buffer.concat([pending, chunk as Buffer]);
+
+      while (pending.length > 0) {
+        const scriptStart = pending.indexOf(SCRIPT_OPEN);
+        if (scriptStart === -1) {
+          const writableLength = Math.max(
+            0,
+            pending.length - SCRIPT_OPEN.length + 1,
+          );
+          await writeAll(output, pending.subarray(0, writableLength));
+          pending = pending.subarray(writableLength);
+          break;
+        }
+
+        await writeAll(output, pending.subarray(0, scriptStart));
+        pending = pending.subarray(scriptStart);
+
+        const openTagEnd = pending.indexOf(0x3e, SCRIPT_OPEN.length);
+        if (openTagEnd === -1) break;
+
+        const closeTagStart = pending.indexOf(SCRIPT_CLOSE, openTagEnd + 1);
+        if (closeTagStart === -1) break;
+
+        const scriptEnd = closeTagStart + SCRIPT_CLOSE.length;
+        const openTag = pending.subarray(0, openTagEnd + 1).toString('utf-8');
+        const groupId = decodeGroupId(openTag);
+
+        if (!groupId || !analysis.groups.has(groupId)) {
+          await writeAll(output, pending.subarray(0, scriptEnd));
+        } else {
+          const seenCount = (seenTagsByGroup.get(groupId) ?? 0) + 1;
+          seenTagsByGroup.set(groupId, seenCount);
+          if (seenCount === analysis.groups.get(groupId)!.tagCount) {
+            await writeAll(output, compactedTags.get(groupId)!);
+            emittedGroups.add(groupId);
+          }
+        }
+        pending = pending.subarray(scriptEnd);
+      }
+    }
+
+    if (pending.indexOf(SCRIPT_OPEN) !== -1) {
+      throw new Error(
+        `Report contains an unterminated script tag: ${sourcePath}`,
+      );
+    }
+    await writeAll(output, pending);
+
+    for (const [groupId, group] of analysis.groups) {
+      if (
+        seenTagsByGroup.get(groupId) !== group.tagCount ||
+        !emittedGroups.has(groupId)
+      ) {
+        throw new Error(
+          `Report compaction did not rewrite every dump in group: ${groupId}`,
+        );
+      }
+    }
+    await output.sync();
+  } finally {
+    await output.close();
+  }
+}
+
+function canRetryRenameOnWindows(error: unknown): boolean {
+  if (process.platform !== 'win32') return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EACCES' || code === 'EEXIST' || code === 'EPERM';
+}
+
+async function replaceReportFile(
+  temporaryPath: string,
+  reportPath: string,
+): Promise<void> {
+  try {
+    await rename(temporaryPath, reportPath);
+    return;
+  } catch (error) {
+    if (!canRetryRenameOnWindows(error)) throw error;
+  }
+
+  const backupPath = join(
+    dirname(reportPath),
+    `.${basename(reportPath)}.${randomUUID()}.backup`,
+  );
+  await rename(reportPath, backupPath);
+  try {
+    await rename(temporaryPath, reportPath);
+  } catch (replaceError) {
+    try {
+      await rename(backupPath, reportPath);
+    } catch (restoreError) {
+      throw new Error(
+        `Failed to replace compacted report and restore the original report: ${String(replaceError)}; restore error: ${String(restoreError)}`,
+      );
+    }
+    throw replaceError;
+  }
+  await unlink(backupPath);
+}
+
+export async function compactReportDumps(
+  reportPath: string,
+): Promise<ReportDumpCompactionResult> {
+  const before = await stat(reportPath);
+  const analysis = await analyzeDumpGroups(reportPath);
+  const afterDumpCount = analysis.groups.size;
+
+  if (analysis.tagCount <= afterDumpCount) {
+    return {
+      beforeBytes: before.size,
+      afterBytes: before.size,
+      beforeDumpCount: analysis.tagCount,
+      afterDumpCount,
+    };
+  }
+
+  const temporaryPath = join(
+    dirname(reportPath),
+    `.${basename(reportPath)}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    await rewriteReport(reportPath, temporaryPath, analysis);
+    const after = await stat(temporaryPath);
+    await replaceReportFile(temporaryPath, reportPath);
+    return {
+      beforeBytes: before.size,
+      afterBytes: after.size,
+      beforeDumpCount: analysis.tagCount,
+      afterDumpCount,
+    };
+  } catch (error) {
+    try {
+      await unlink(temporaryPath);
+    } catch (cleanupError) {
+      if ((cleanupError as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw new Error(
+          `Report compaction failed and the temporary file could not be removed: ${String(error)}; cleanup error: ${String(cleanupError)}`,
+        );
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -26,6 +26,7 @@ import {
   generateImageScriptTag,
   getBaseUrlFixScript,
 } from './dump/html-utils';
+import { compactReportDumps } from './dump/report-dump-compactor';
 import { ScreenshotStore } from './dump/screenshot-store';
 import {
   type ExecutionDump,
@@ -213,6 +214,7 @@ export class ReportGenerator implements IReportGenerator {
     }
 
     await this.appendAgentReportComment();
+    await compactReportDumps(this.reportPath);
     return this.reportPath;
   }
 

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -18,6 +18,7 @@ import {
   MIDSCENE_REPORT_QUIET,
   globalConfigManager,
 } from '@midscene/shared/env';
+import { getDebug } from '@midscene/shared/logger';
 import { ifInBrowser, logMsg, uuid } from '@midscene/shared/utils';
 import {
   DATA_SCREENSHOT_MODE_ATTR,
@@ -36,6 +37,8 @@ import {
   type ScreenshotMode,
 } from './types';
 import { getReportTpl } from './utils';
+
+const warnReport = getDebug('report-generator', { console: true });
 
 export interface IReportGenerator {
   /**
@@ -214,7 +217,13 @@ export class ReportGenerator implements IReportGenerator {
     }
 
     await this.appendAgentReportComment();
-    await compactReportDumps(this.reportPath);
+    try {
+      await compactReportDumps(this.reportPath);
+    } catch (error) {
+      warnReport(
+        `Failed to compact report ${this.reportPath}; keeping the uncompressed report: ${String(error)}`,
+      );
+    }
     return this.reportPath;
   }
 

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -227,6 +227,54 @@ describe('ReportGenerator — append-only model', () => {
       expect(countGroupedDumpScripts(html)).toBe(3);
     });
 
+    it('should remove superseded dump tags when the report is finalized', async () => {
+      const reportPath = join(tmpDir, 'finalize-compacts-dumps.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'inline',
+        autoPrint: false,
+      });
+
+      const firstScreenshot = ScreenshotItem.create(
+        fakeBase64(100),
+        Date.now(),
+      );
+      const secondScreenshot = ScreenshotItem.create(
+        fakeBase64(120),
+        Date.now(),
+      );
+      const executionId = 'execution-updated-before-finalize';
+
+      generator.onExecutionUpdate(
+        createExecution([firstScreenshot], 'finalize-compact', executionId),
+        defaultReportMeta,
+      );
+      await generator.flush();
+      generator.onExecutionUpdate(
+        createExecution(
+          [firstScreenshot, secondScreenshot],
+          'finalize-compact',
+          executionId,
+        ),
+        defaultReportMeta,
+      );
+      await generator.flush();
+
+      const runningHtml = readFileSync(reportPath, 'utf-8');
+      expect(countGroupedDumpScripts(runningHtml)).toBe(2);
+
+      await generator.finalize();
+
+      const finalizedHtml = readFileSync(reportPath, 'utf-8');
+      const dumpScripts = extractGroupedDumpScripts(finalizedHtml);
+      expect(dumpScripts).toHaveLength(1);
+
+      const finalDump = JSON.parse(unescapeContent(dumpScripts[0].content));
+      expect(finalDump.executions).toHaveLength(1);
+      expect(finalDump.executions[0].id).toBe(executionId);
+      expect(finalDump.executions[0].tasks).toHaveLength(2);
+    });
+
     it('should overwrite existing report file by default when a new generator uses the same path', async () => {
       const reportPath = join(tmpDir, 'append-existing-report.html');
       const firstGenerator = new ReportGenerator({
@@ -263,8 +311,8 @@ describe('ReportGenerator — append-only model', () => {
       await secondGenerator.finalize();
 
       const html = readFileSync(reportPath, 'utf-8');
-      // second finalize() re-writes last execution once, so total dump tags = 2
-      expect(countGroupedDumpScripts(html)).toBe(2);
+      // Finalized reports contain one compacted dump for the active group.
+      expect(countGroupedDumpScripts(html)).toBe(1);
       expect(html).not.toContain(firstScreenshot.id);
       expect(html).toContain(secondScreenshot.id);
     });
@@ -848,6 +896,13 @@ describe('ReportGenerator — append-only model', () => {
       expect(
         existsSync(join(reportDir, 'screenshots', `${screenshot.id}.png`)),
       ).toBe(true);
+
+      await generator.finalize();
+      const finalizedHtml = readFileSync(reportPath, 'utf-8');
+      expect(countGroupedDumpScripts(finalizedHtml)).toBe(1);
+      expect(
+        existsSync(join(reportDir, 'screenshots', `${screenshot.id}.png`)),
+      ).toBe(true);
     });
 
     it('should write merged attributes in directory mode', async () => {
@@ -1249,6 +1304,13 @@ describe('ReportGenerator — append-only model', () => {
         .length;
       expect(agentCommentCount).toBe(1);
       expect(html).toContain('Executions: 2; Tasks: 2');
+
+      const dumpScripts = extractGroupedDumpScripts(html);
+      expect(dumpScripts).toHaveLength(1);
+      const compactedDump = JSON.parse(unescapeContent(dumpScripts[0].content));
+      expect(
+        compactedDump.executions.map(({ id }: { id: string }) => id),
+      ).toEqual([exec1.id, exec2.id]);
     });
 
     it('keeps same-name executions without id in the agent comment', async () => {
@@ -1288,6 +1350,15 @@ describe('ReportGenerator — append-only model', () => {
 
       const html = readFileSync(reportPath, 'utf-8');
       expect(html).toContain('Executions: 2; Tasks: 2');
+
+      const dumpScripts = extractGroupedDumpScripts(html);
+      expect(dumpScripts).toHaveLength(1);
+      const compactedDump = JSON.parse(unescapeContent(dumpScripts[0].content));
+      expect(
+        compactedDump.executions.map(
+          ({ tasks }: { tasks: { taskId: string }[] }) => tasks[0].taskId,
+        ),
+      ).toEqual(['task-a', 'task-b', 'task-b']);
     });
 
     it('should work correctly in directory mode with lazy loading', async () => {

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -13,6 +13,7 @@ import {
   parseImageScripts,
   unescapeContent,
 } from '@/dump/html-utils';
+import * as reportDumpCompactor from '@/dump/report-dump-compactor';
 import { ReportGenerator, nullReportGenerator } from '@/report-generator';
 import { ScreenshotItem } from '@/screenshot-item';
 import {
@@ -273,6 +274,35 @@ describe('ReportGenerator — append-only model', () => {
       expect(finalDump.executions).toHaveLength(1);
       expect(finalDump.executions[0].id).toBe(executionId);
       expect(finalDump.executions[0].tasks).toHaveLength(2);
+    });
+
+    it('should preserve a successful report when final compaction fails', async () => {
+      const reportPath = join(tmpDir, 'finalize-compaction-failure.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'inline',
+        autoPrint: false,
+      });
+
+      generator.onExecutionUpdate(
+        createExecution([], 'compaction-failure'),
+        defaultReportMeta,
+      );
+
+      const compactionError = new Error('ENOSPC: no space left on device');
+      const compactSpy = vi
+        .spyOn(reportDumpCompactor, 'compactReportDumps')
+        .mockRejectedValueOnce(compactionError);
+
+      try {
+        await expect(generator.finalize()).resolves.toBe(reportPath);
+      } finally {
+        compactSpy.mockRestore();
+      }
+
+      const finalizedHtml = readFileSync(reportPath, 'utf-8');
+      expect(finalizedHtml).toContain('compaction-failure');
+      expect(countGroupedDumpScripts(finalizedHtml)).toBeGreaterThan(0);
     });
 
     it('should overwrite existing report file by default when a new generator uses the same path', async () => {


### PR DESCRIPTION
## Summary

- Compact superseded grouped dump scripts when `ReportGenerator` finalizes a report.
- Preserve the latest execution for each stable execution ID while retaining all legacy executions without IDs.
- Keep live report generation append-only and preserve inline and directory-mode screenshot data.
- Rewrite through a sibling temporary file and replace the finalized report atomically.

## Root cause

Report generation appends a complete dump snapshot on every execution update, and `finalize()` appends the latest execution once more to capture its final state. The report UI deduplicates these snapshots when loading the page, but the HTML file retained every historical dump.

In the supplied report, this produced 487 grouped dump tags and inflated the file from the compacted 94.94 MiB to 150.32 MiB, an increase of approximately 58.33%.

## Impact

Completed reports now contain one compacted dump per report group without changing append-only behavior while a run is active.

The supplied report was reduced from 157,617,354 bytes to 99,547,590 bytes (36.84% smaller). Browser-level verification confirmed that the merged dump content and image index remained unchanged: 1 execution, 119 tasks, and 83 image nodes.

## Regression coverage

The regression test was added before the implementation and failed with three dump tags instead of one. It now passes and also covers:

- multiple execution IDs
- legacy executions without IDs
- inline screenshot mode
- directory screenshot mode
- report merging performance

## Validation

- `pnpm run lint`
- `pnpm --dir packages/core exec vitest --run tests/unit-test/report-generator.test.ts tests/unit-test/report-merge-count.test.ts` — 58 tests passed
- `pnpm exec nx build @midscene/core`
- Real-report compaction — 487 dump tags reduced to 1 in 1.15 seconds with equivalent browser-visible content
- `pnpm exec nx test @midscene/core` — 1,340 passed, 8 skipped, and 1 unrelated size-threshold failure in `merge-browser-parse.test.ts` (expected less than 15 MiB; current generated report is 16.92 MiB)

## Previous review history

Supersedes #2837, which was recreated so the pull request and commits are both attributed to @quanruzhuoxiu. The previous automated inline review remains available on #2837.

## CI follow-up

- Replaced the Node-only `randomUUID` import with the browser-compatible shared `uuid()` helper so browser bundles can link the report compactor.
- `pnpm --dir packages/core exec vitest --run tests/unit-test/report-generator.test.ts tests/unit-test/report-merge-count.test.ts` — 58 tests passed
- `pnpm run lint`
- `pnpm exec nx build computer-playground --skip-nx-cache`
- `pnpm exec nx run-many --target=build --exclude=doc --verbose --skip-nx-cache` — 27 projects built successfully

## Review follow-up

- Treat final report compaction as best-effort so an `ENOSPC` or other compaction error cannot turn a completed Agent run into a failure.
- Preserve and return the uncompressed report while logging a Midscene warning.
- Added a regression test that forces compaction to reject and verifies `finalize()` still resolves with the report path.