### PR TITLE
fix(web-integration): fix clearInput in Chrome extension bridge mode

### DIFF
--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -906,13 +906,12 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     await this.mouse.click(element.center[0], element.center[1]);
 
     await this.sendCommandToDebugger('Input.dispatchKeyEvent', {
-      type: 'keyDown',
+      type: 'rawKeyDown',
       commands: ['selectAll'],
     });
 
     await this.sendCommandToDebugger('Input.dispatchKeyEvent', {
       type: 'keyUp',
-      commands: ['selectAll'],
     });
 
     await sleep(100);

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -898,10 +898,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   }
 
   async clearInput(element: ElementInfo) {
-    if (!element) {
-      console.warn('No element to clear input');
-      return;
-    }
+    assert(element, 'Chrome extension clearInput requires an element');
 
     await this.mouse.click(element.center[0], element.center[1]);
 

--- a/packages/web-integration/tests/unit-test/chrome-extension-clear-input.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-clear-input.test.ts
@@ -1,0 +1,50 @@
+import type { ElementInfo } from '@midscene/shared/extractor';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+}));
+
+import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
+
+type DebuggerCommandSender = {
+  sendCommandToDebugger: (
+    command: string,
+    params: Record<string, unknown>,
+  ) => Promise<unknown>;
+};
+
+describe('ChromeExtensionProxyPage clearInput', () => {
+  let page: ChromeExtensionProxyPage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page = new ChromeExtensionProxyPage(false);
+  });
+
+  it('selects all text with a raw CDP key event before pressing Backspace', async () => {
+    const click = vi.spyOn(page.mouse, 'click').mockResolvedValue();
+    const press = vi.spyOn(page.keyboard, 'press').mockResolvedValue();
+    const sendCommand = vi
+      .spyOn(page as unknown as DebuggerCommandSender, 'sendCommandToDebugger')
+      .mockResolvedValue(undefined);
+
+    await page.clearInput({ center: [12, 34] } as ElementInfo);
+
+    expect(click).toHaveBeenCalledWith(12, 34);
+    expect(sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'rawKeyDown',
+      commands: ['selectAll'],
+    });
+    expect(sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyUp',
+    });
+    expect(press).toHaveBeenCalledWith({ key: 'Backspace' });
+  });
+
+  it('rejects a missing element instead of silently skipping the clear', async () => {
+    await expect(
+      page.clearInput(undefined as unknown as ElementInfo),
+    ).rejects.toThrow('Chrome extension clearInput requires an element');
+  });
+});


### PR DESCRIPTION
## Status

> [!WARNING]
> Runtime A/B validation did not reproduce the reported failure. Both the legacy and proposed CDP event sequences cleared the input successfully. This PR should not be merged until the failing environment or reproduction steps are identified.

## Original hypothesis

Chrome Extension Bridge mode uses `clearInput` before typing a replacement value. The proposed fix assumes that Chromium ignores the `selectAll` editing command when it is sent with `type: 'keyDown'`, causing Backspace to remove only one character.

## Proposed changes

- Dispatch `selectAll` with `type: 'rawKeyDown'`
- Remove `commands` from the matching `keyUp` event
- Throw a contextual error when the required element is missing instead of warning and silently returning
- Add unit coverage for the CDP event sequence and missing-element contract

## Validation

### Automated checks

- `pnpm run lint`
- `npx nx build @midscene/web`
- `npx nx test @midscene/web`
  - 50 test files passed
  - 410 tests passed
  - 1 test skipped

### Real Chromium A/B

The same focused input was reset before each case, followed by the legacy or proposed CDP sequence and a Backspace key press.

| Browser | Legacy: `keyDown` + `commands` on `keyUp` | Proposed: `rawKeyDown` |
| --- | --- | --- |
| Chrome 135.0.7049.42 | Cleared successfully | Cleared successfully |
| Google Chrome 150.0.7871.130 | Cleared successfully | Cleared successfully |

Observed value in all cases: `""`.

## Conclusion

The current runtime evidence does not confirm that the original implementation causes the reported one-character deletion. A reproducible browser, OS, extension-mode setup, or failing artifact is still required before treating this change as a verified bug fix.