### PR TITLE
fix(report): add missing dependency array to Tab key useEffect

### DIFF
--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -325,7 +325,7 @@ const DetailPanel = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  });
+  }, [viewType, availableViewTypes]);
 
   const options = availableViewTypes.map((type) => {
     if (type === VIEW_TYPE_REPLAY) {

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -147,17 +147,19 @@ const DetailPanel = ({
   );
 
   const hasReplay =
-    activeTask?.type === 'Planning' &&
-    animationScripts &&
-    animationScripts.length > 0;
+    activeTask?.type === 'Planning' && (animationScripts?.length ?? 0) > 0;
 
-  const availableViewTypes = [VIEW_TYPE_SCREENSHOT, VIEW_TYPE_JSON];
+  const availableViewTypes = useMemo(() => {
+    const viewTypes = [VIEW_TYPE_SCREENSHOT, VIEW_TYPE_JSON];
 
-  if (hasReplay) {
-    availableViewTypes.unshift(VIEW_TYPE_REPLAY);
-    // Temporary: hide the Markdown segment without removing the implementation.
-    // availableViewTypes.push(VIEW_TYPE_MARKDOWN);
-  }
+    if (hasReplay) {
+      viewTypes.unshift(VIEW_TYPE_REPLAY);
+      // Temporary: hide the Markdown segment without removing the implementation.
+      // viewTypes.push(VIEW_TYPE_MARKDOWN);
+    }
+
+    return viewTypes;
+  }, [hasReplay]);
 
   const viewType =
     availableViewTypes.indexOf(preferredViewType) >= 0


### PR DESCRIPTION
## Problem

The Tab-to-switch-view effect had no dependency array, so React cleaned up and registered the document listener after every render. The derived `availableViewTypes` array was also created during every render, so adding it directly as a dependency would still re-run the effect every time.

## Fix

- Memoize `availableViewTypes` based on whether replay is available
- Add `[viewType, availableViewTypes]` to the effect dependencies
- Keep the listener closure current while avoiding unrelated cleanup/register cycles

## Validation

- `pnpm run lint`
- `npx nx build @midscene/report`
- `npx nx test @midscene/report` (15 files, 82 tests)