### PR TITLE
feat(web-integration): add bridge animation toggle

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -1836,6 +1836,7 @@ const agent = new AgentOverChromeBridge({
 - `allowRemoteAccess?: boolean` — Whether to allow remote machines to attach. Default: `false`, which binds to `127.0.0.1`.
 - `host?: string` — Override the interface for the bridge server. Takes precedence over `allowRemoteAccess`.
 - `port?: number` — TCP port for the bridge server. Default: `3766`.
+- `enableWaterFlowAnimation?: boolean` — Show the blue animated border and mouse pointer while Midscene controls the page. Defaults to `true`; set it to `false` when taking screenshots without the visual overlay.
 
 See [Bridge mode by Chrome extension](../bridge-mode#constructor) for full installation and capability details.
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -1813,6 +1813,7 @@ const agent = new AgentOverChromeBridge({
 - `allowRemoteAccess?: boolean` —— 是否允许远程机器连接，默认 `false`（监听 `127.0.0.1`）。
 - `host?: string` —— 自定义 Bridge Server 的监听地址，优先级高于 `allowRemoteAccess`。
 - `port?: number` —— Bridge Server 端口，默认 `3766`。
+- `enableWaterFlowAnimation?: boolean` —— Midscene 控制页面时是否显示蓝色动态边框和鼠标指示，默认 `true`；如需截取不含视觉覆盖层的截图，可设为 `false`。
 
 完整安装与能力说明，见 [Chrome 插件桥接模式](../bridge-mode#constructor)。
 

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -228,6 +228,8 @@ export const getBridgePageInCliSide = (options?: {
 export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
   private destroyAfterDisconnectFlag?: boolean;
 
+  private enableWaterFlowAnimation: boolean;
+
   constructor(
     opts?: AgentOpt & {
       /**
@@ -249,6 +251,12 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
       closeNewTabsAfterDisconnect?: boolean;
       serverListeningTimeout?: number | false;
       closeConflictServer?: boolean;
+      /**
+       * Show the blue water-flow border and mouse pointer while controlling
+       * the page.
+       * @default true
+       */
+      enableWaterFlowAnimation?: boolean;
     },
   ) {
     const host = getBridgeServerHost({
@@ -274,6 +282,13 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
       }),
     );
     this.destroyAfterDisconnectFlag = opts?.closeNewTabsAfterDisconnect;
+    this.enableWaterFlowAnimation = opts?.enableWaterFlowAnimation ?? true;
+  }
+
+  private async configureWaterFlowAnimation() {
+    if (!this.enableWaterFlowAnimation) {
+      await this.page.setWaterFlowAnimationEnabled(false);
+    }
   }
 
   async setDestroyOptionsAfterConnect() {
@@ -286,6 +301,7 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
 
   async connectNewTabWithUrl(url: string, options?: BridgeConnectTabOptions) {
     await this.page.connectNewTabWithUrl(url, options);
+    await this.configureWaterFlowAnimation();
     await sleep(500);
     await this.setDestroyOptionsAfterConnect();
   }
@@ -300,6 +316,7 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
 
   async connectCurrentTab(options?: BridgeConnectTabOptions) {
     await this.page.connectCurrentTab(options);
+    await this.configureWaterFlowAnimation();
     await sleep(500);
     await this.setDestroyOptionsAfterConnect();
   }

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -300,7 +300,10 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
   }
 
   async connectNewTabWithUrl(url: string, options?: BridgeConnectTabOptions) {
-    await this.page.connectNewTabWithUrl(url, options);
+    await this.page.connectNewTabWithUrl(url, {
+      ...options,
+      enableWaterFlowAnimation: this.enableWaterFlowAnimation,
+    });
     await this.configureWaterFlowAnimation();
     await sleep(500);
     await this.setDestroyOptionsAfterConnect();
@@ -315,7 +318,10 @@ export class AgentOverChromeBridge extends Agent<ChromeExtensionPageCliSide> {
   }
 
   async connectCurrentTab(options?: BridgeConnectTabOptions) {
-    await this.page.connectCurrentTab(options);
+    await this.page.connectCurrentTab({
+      ...options,
+      enableWaterFlowAnimation: this.enableWaterFlowAnimation,
+    });
     await this.configureWaterFlowAnimation();
     await sleep(500);
     await this.setDestroyOptionsAfterConnect();

--- a/packages/web-integration/src/bridge-mode/common.ts
+++ b/packages/web-integration/src/bridge-mode/common.ts
@@ -50,6 +50,12 @@ export interface BridgeConnectTabOptions {
    * @default 30000 (30 seconds)
    */
   timeout?: number;
+  /**
+   * Whether the blue water-flow animation border and mouse pointer
+   * overlay should be shown while controlling the page.
+   * @default true
+   */
+  enableWaterFlowAnimation?: boolean;
 }
 
 export enum MouseEvent {

--- a/packages/web-integration/src/bridge-mode/page-browser-side.ts
+++ b/packages/web-integration/src/bridge-mode/page-browser-side.ts
@@ -172,6 +172,9 @@ export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
           return this.keyboard[actionName].apply(this.keyboard, args as any);
         }
 
+        // Generic method lookup. Methods like `setWaterFlowAnimationEnabled`
+        // and `getWaterFlowAnimationEnabled` are inherited from
+        // ChromeExtensionProxyPage and found via `this[method]`.
         if (!this[method as keyof ChromeExtensionProxyPage]) {
           this.onLogMessage(`method not found: ${method}`, 'log');
           return undefined;
@@ -230,6 +233,14 @@ export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
       forceSameTabNavigation: true,
     },
   ) {
+    // Set the water-flow animation flag BEFORE any debugger commands are
+    // sent (which trigger enableWaterFlowAnimation via sendCommandToDebugger).
+    // Otherwise the animation gets injected during the connection flow
+    // before the CLI side's setWaterFlowAnimationEnabled(false) arrives.
+    if (options.enableWaterFlowAnimation !== undefined) {
+      this.waterFlowAnimationEnabled = options.enableWaterFlowAnimation;
+    }
+
     const tab = await chrome.tabs.create({ url });
     const tabId = tab.id;
     assert(tabId, 'failed to get tabId after creating a new tab');
@@ -258,6 +269,12 @@ export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
       forceSameTabNavigation: true,
     },
   ) {
+    // Set the water-flow animation flag BEFORE any debugger commands are
+    // sent (which trigger enableWaterFlowAnimation via sendCommandToDebugger).
+    if (options.enableWaterFlowAnimation !== undefined) {
+      this.waterFlowAnimationEnabled = options.enableWaterFlowAnimation;
+    }
+
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
     const tabId = tabs[0]?.id;
     assert(tabId, 'failed to get tabId');

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -177,7 +177,7 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   private isMobileEmulation: boolean | null = null;
 
-  private waterFlowAnimationEnabled = true;
+  protected waterFlowAnimationEnabled = true;
 
   public _continueWhenFailedToAttachDebugger = false;
 
@@ -358,7 +358,9 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
       });
     }
 
-    if (!this.waterFlowAnimationEnabled) return;
+    if (!this.waterFlowAnimationEnabled) {
+      return;
+    }
 
     const script = await injectWaterFlowAnimation();
     // we will call this function in sendCommandToDebugger, so we have to use the chrome.debugger.sendCommand
@@ -383,6 +385,13 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
         expression: script,
       });
     }
+  }
+
+  /**
+   * Returns the current water-flow animation enabled flag.
+   */
+  public getWaterFlowAnimationEnabled(): boolean {
+    return this.waterFlowAnimationEnabled;
   }
 
   /**

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -177,6 +177,8 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
 
   private isMobileEmulation: boolean | null = null;
 
+  private waterFlowAnimationEnabled = true;
+
   public _continueWhenFailedToAttachDebugger = false;
 
   constructor(forceSameTabNavigation: boolean) {
@@ -291,6 +293,8 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
   }
 
   private async showMousePointer(x: number, y: number) {
+    if (!this.waterFlowAnimationEnabled) return;
+
     // update mouse pointer while redirecting
     const pointerScript = `(() => {
       if(typeof window.midsceneWaterFlowAnimation !== 'undefined') {
@@ -354,6 +358,8 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
       });
     }
 
+    if (!this.waterFlowAnimationEnabled) return;
+
     const script = await injectWaterFlowAnimation();
     // we will call this function in sendCommandToDebugger, so we have to use the chrome.debugger.sendCommand
     await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
@@ -367,6 +373,16 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
       expression: script,
     });
+  }
+
+  public async setWaterFlowAnimationEnabled(enabled: boolean) {
+    this.waterFlowAnimationEnabled = enabled;
+    if (!enabled) {
+      const script = await injectStopWaterFlowAnimation();
+      await this.sendCommandToDebugger('Runtime.evaluate', {
+        expression: script,
+      });
+    }
   }
 
   /**

--- a/packages/web-integration/tests/unit-test/chrome-extension-debugger-race.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-debugger-race.test.ts
@@ -18,6 +18,12 @@ vi.mock('@midscene/shared/logger', () => ({
   getDebug: vi.fn(() => vi.fn()),
 }));
 
+vi.mock('../../src/chrome-extension/dynamic-scripts', () => ({
+  getHtmlElementScript: vi.fn(),
+  injectWaterFlowAnimation: vi.fn(async () => 'enable-water-flow'),
+  injectStopWaterFlowAnimation: vi.fn(async () => 'disable-water-flow'),
+}));
+
 import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
 
 describe('debugger detach race during lazy attach', () => {
@@ -97,5 +103,30 @@ describe('debugger detach race during lazy attach', () => {
     expect(result).toEqual({ width: 1024, height: 768 });
     // attach was triggered exactly once by the lazy retry path.
     expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not inject the water-flow animation when it is disabled', async () => {
+    (chrome.debugger.sendCommand as any).mockResolvedValue({
+      result: { value: { width: 1024, height: 768 } },
+    });
+
+    await page.setWaterFlowAnimationEnabled(false);
+    vi.clearAllMocks();
+
+    const result = await page.size();
+
+    expect(result).toEqual({ width: 1024, height: 768 });
+    expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+      { tabId: 1302238007 },
+      'Runtime.evaluate',
+      expect.objectContaining({
+        expression: expect.stringContaining('window.innerWidth'),
+      }),
+    );
+    expect(chrome.debugger.sendCommand).not.toHaveBeenCalledWith(
+      { tabId: 1302238007 },
+      'Runtime.evaluate',
+      { expression: 'enable-water-flow' },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add an `enableWaterFlowAnimation` option to `AgentOverChromeBridge`
- keep the existing blue border and pointer enabled by default for compatibility
- disable and prevent reinjection of the visual overlay when the option is `false`
- document the option in the English and Chinese API references

## Motivation

The Chrome extension bridge injects a blue animated border while Midscene controls a desktop Chrome tab. That overlay can appear in screenshots captured after an action. Callers now have an explicit way to turn it off without changing the default experience.

## Validation

- `pnpm --dir packages/web-integration test tests/unit-test/chrome-extension-debugger-race.test.ts`
- `pnpm run lint`
- `pnpm exec nx build @midscene/web`
