### PR TITLE
feat(studio): support common agent options

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -34,6 +34,7 @@ import {
   shell,
 } from 'electron';
 import type { TitleBarOverlay } from 'electron';
+import { normalizeStudioAgentOptions } from '../shared/agent-options';
 import { MACOS_TRAFFIC_LIGHT_POSITION } from '../shared/titlebar-layout';
 import { startStudioEventLoopWatchdog } from './performance-watchdog';
 import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
@@ -744,6 +745,11 @@ const registerIpcHandlers = () => {
   ipcMain.handle(IPC_CHANNELS.runConnectivityTest, async (_event, request) =>
     runConnectivityTest(request),
   );
+  ipcMain.handle(IPC_CHANNELS.updateAgentOptions, async (_event, options) => {
+    await (await getPlaygroundRuntime()).updateAgentOptions(
+      normalizeStudioAgentOptions(options),
+    );
+  });
   ipcMain.handle(IPC_CHANNELS.generateRecorderCode, async (_event, request) => {
     return generateRecorderCodeInMain(request);
   });

--- a/apps/studio/src/main/playground/multi-platform-runtime.ts
+++ b/apps/studio/src/main/playground/multi-platform-runtime.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import type { Agent } from '@midscene/core/agent';
+import type { Agent, AgentOpt } from '@midscene/core/agent';
 import type {
   LaunchPlaygroundResult,
   PlaygroundPreviewDescriptor,
@@ -8,6 +8,7 @@ import type {
   RegisteredPlaygroundPlatform,
 } from '@midscene/playground';
 import { getDebug } from '@midscene/shared/logger';
+import type { StudioAgentOptions } from '@shared/agent-options';
 import type { DiscoveredDevice } from '@shared/electron-contract';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
 import { DEFAULT_STUDIO_WEB_VIEWPORT } from '@shared/web-viewport';
@@ -40,7 +41,7 @@ type PlaygroundModule = typeof import('@midscene/playground');
 
 type StudioPuppeteerAgentConstructor = new (
   page: unknown,
-  opts?: { cacheId?: string },
+  opts?: AgentOpt & { cacheId?: string },
 ) => Agent;
 
 type StudioLaunchPuppeteerPage = (
@@ -334,8 +335,10 @@ function createStudioWebPreviewDescriptor(): PlaygroundPreviewDescriptor {
 
 async function prepareStudioWebPlatform({
   loadWebModule,
+  getAgentOptions,
 }: {
   loadWebModule: typeof loadWebPlaygroundModule;
+  getAgentOptions: () => StudioAgentOptions;
 }): Promise<PreparedPlaygroundPlatform> {
   const webModule = await loadWebModule();
   // The two cleanup baskets are kept separate so the playground server's
@@ -456,6 +459,7 @@ async function prepareStudioWebPlatform({
           }
 
           const agent = new webModule.PuppeteerAgent(currentPage, {
+            ...getAgentOptions(),
             cacheId: 'studio-web',
           });
           agentCleanup = [
@@ -518,6 +522,7 @@ const createStudioPlatformSpecs = ({
   loadHarmonyModule = loadHarmonyPlaygroundModule,
   loadIosModule = loadIosPlaygroundModule,
   loadWebModule = loadWebPlaygroundModule,
+  getAgentOptions = () => ({}),
 }: {
   loadAndroidModule?: typeof loadAndroidPlaygroundModule;
   loadComputerModule?: typeof loadComputerPlaygroundModule;
@@ -525,6 +530,7 @@ const createStudioPlatformSpecs = ({
   loadHarmonyModule?: typeof loadHarmonyPlaygroundModule;
   loadIosModule?: typeof loadIosPlaygroundModule;
   loadWebModule?: typeof loadWebPlaygroundModule;
+  getAgentOptions?: () => StudioAgentOptions;
 } = {}): StudioPlatformSpec[] => [
   {
     id: 'web',
@@ -534,6 +540,7 @@ const createStudioPlatformSpecs = ({
     prepare: async () =>
       prepareStudioWebPlatform({
         loadWebModule,
+        getAgentOptions,
       }),
   },
   {
@@ -545,6 +552,7 @@ const createStudioPlatformSpecs = ({
       const androidModule = await loadAndroidModule();
       return androidModule.androidPlaygroundPlatform.prepare({
         staticDir,
+        getAgentOptions,
         scrcpyServer: await createStudioScrcpyController(
           androidModule.ScrcpyServer,
           deviceDiscoveryService,
@@ -559,7 +567,10 @@ const createStudioPlatformSpecs = ({
     staticDirPackage: '@midscene/ios',
     prepare: async (staticDir) => {
       const iosModule = await loadIosModule();
-      return iosModule.iosPlaygroundPlatform.prepare({ staticDir });
+      return iosModule.iosPlaygroundPlatform.prepare({
+        staticDir,
+        getAgentOptions,
+      });
     },
   },
   {
@@ -572,6 +583,7 @@ const createStudioPlatformSpecs = ({
       return harmonyModule.harmonyPlaygroundPlatform.prepare({
         staticDir,
         deferConnection: true,
+        getAgentOptions,
       });
     },
   },
@@ -589,6 +601,7 @@ const createStudioPlatformSpecs = ({
       return computerModule.computerPlaygroundPlatform.prepare({
         staticDir,
         getWindowController: () => null,
+        getAgentOptions,
       });
     },
   },
@@ -638,6 +651,7 @@ export function createMultiPlatformRuntimeService({
   loadWebModule?: typeof loadWebPlaygroundModule;
   resolvePackageStaticDir?: (packageName: string) => string;
 } = {}): PlaygroundRuntimeService {
+  let agentOptions: StudioAgentOptions = {};
   let bootstrap: PlaygroundBootstrap = {
     status: 'starting',
     serverUrl: null,
@@ -693,6 +707,7 @@ export function createMultiPlatformRuntimeService({
                         PuppeteerAgent: runtimeModules.PuppeteerAgent,
                         launchPuppeteerPage: runtimeModules.launchPuppeteerPage,
                       }),
+                      getAgentOptions: () => agentOptions,
                     }),
                 },
                 {
@@ -708,6 +723,7 @@ export function createMultiPlatformRuntimeService({
                     return runtimeModules.androidPlaygroundPlatform.prepare({
                       staticDir,
                       scrcpyServer,
+                      getAgentOptions: () => agentOptions,
                     });
                   },
                 },
@@ -717,7 +733,10 @@ export function createMultiPlatformRuntimeService({
                   description: 'Connect to an iOS device via WebDriverAgent',
                   staticDirPackage: '@midscene/ios',
                   prepare: (staticDir) =>
-                    runtimeModules.iosPlaygroundPlatform.prepare({ staticDir }),
+                    runtimeModules.iosPlaygroundPlatform.prepare({
+                      staticDir,
+                      getAgentOptions: () => agentOptions,
+                    }),
                 },
                 {
                   id: 'harmony',
@@ -728,6 +747,7 @@ export function createMultiPlatformRuntimeService({
                     runtimeModules.harmonyPlaygroundPlatform.prepare({
                       staticDir,
                       deferConnection: true,
+                      getAgentOptions: () => agentOptions,
                     }),
                 },
                 {
@@ -739,6 +759,7 @@ export function createMultiPlatformRuntimeService({
                     runtimeModules.computerPlaygroundPlatform.prepare({
                       staticDir,
                       getWindowController: () => null,
+                      getAgentOptions: () => agentOptions,
                     }),
                 },
               ]
@@ -749,6 +770,7 @@ export function createMultiPlatformRuntimeService({
                 loadHarmonyModule,
                 loadIosModule,
                 loadWebModule,
+                getAgentOptions: () => agentOptions,
               }),
           resolvePackageStaticDir,
         );
@@ -810,5 +832,8 @@ export function createMultiPlatformRuntimeService({
       return start();
     },
     start,
+    async updateAgentOptions(nextOptions) {
+      agentOptions = nextOptions;
+    },
   };
 }

--- a/apps/studio/src/main/playground/types.ts
+++ b/apps/studio/src/main/playground/types.ts
@@ -1,3 +1,4 @@
+import type { StudioAgentOptions } from '@shared/agent-options';
 import type { PlaygroundBootstrap } from '@shared/electron-contract';
 
 /** Lifecycle contract for a playground runtime (single- or multi-platform). */
@@ -6,4 +7,5 @@ export interface PlaygroundRuntimeService {
   getBootstrap: () => PlaygroundBootstrap;
   restart: () => Promise<PlaygroundBootstrap>;
   start: () => Promise<PlaygroundBootstrap>;
+  updateAgentOptions: (options: StudioAgentOptions) => Promise<void>;
 }

--- a/apps/studio/src/preload/index.ts
+++ b/apps/studio/src/preload/index.ts
@@ -65,6 +65,8 @@ const studioRuntimeApi: StudioRuntimeApi = {
     ipcRenderer.invoke(IPC_CHANNELS.setDiscoveryPollingPaused, paused),
   runConnectivityTest: (request) =>
     ipcRenderer.invoke(IPC_CHANNELS.runConnectivityTest, request),
+  updateAgentOptions: (options) =>
+    ipcRenderer.invoke(IPC_CHANNELS.updateAgentOptions, options),
   generateRecorderCode: (request) =>
     ipcRenderer.invoke(IPC_CHANNELS.generateRecorderCode, request),
   generateRecorderMetadata: (request) =>

--- a/apps/studio/src/renderer/components/SettingsDock/index.tsx
+++ b/apps/studio/src/renderer/components/SettingsDock/index.tsx
@@ -77,7 +77,7 @@ export default function SettingsDock({
     <div className="flex flex-col gap-[2px]">
       <DockRow
         icon={<EnvIcon alert={envAlert} />}
-        label="Model Config"
+        label="Config"
         onClick={onEnvClick}
       />
       <DockRow

--- a/apps/studio/src/renderer/components/ShellLayout/AgentOptionConfigForm.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/AgentOptionConfigForm.tsx
@@ -1,0 +1,143 @@
+import type {
+  StudioAgentOptionKey,
+  StudioAgentOptions,
+} from '../../../shared/agent-options';
+
+export type AgentOptionFormValues = Record<StudioAgentOptionKey, string>;
+
+export function agentOptionsToFormValues(
+  options: StudioAgentOptions,
+): AgentOptionFormValues {
+  return {
+    replanningCycleLimit: options.replanningCycleLimit?.toString() ?? '',
+    waitAfterAction: options.waitAfterAction?.toString() ?? '',
+    screenshotShrinkFactor: options.screenshotShrinkFactor?.toString() ?? '',
+  };
+}
+
+export function parseAgentOptionFormValues(
+  values: AgentOptionFormValues,
+):
+  | { options: StudioAgentOptions; error: null }
+  | { options: null; error: string } {
+  const options: StudioAgentOptions = {};
+  const replanningCycleLimit = values.replanningCycleLimit.trim();
+  const waitAfterAction = values.waitAfterAction.trim();
+  const screenshotShrinkFactor = values.screenshotShrinkFactor.trim();
+
+  if (replanningCycleLimit) {
+    const value = Number(replanningCycleLimit);
+    if (!Number.isInteger(value) || value < 0) {
+      return {
+        options: null,
+        error:
+          'Replanning cycle limit must be an integer greater than or equal to 0.',
+      };
+    }
+    options.replanningCycleLimit = value;
+  }
+
+  if (waitAfterAction) {
+    const value = Number(waitAfterAction);
+    if (!Number.isFinite(value) || value < 0) {
+      return {
+        options: null,
+        error: 'Wait after action must be a number greater than or equal to 0.',
+      };
+    }
+    options.waitAfterAction = value;
+  }
+
+  if (screenshotShrinkFactor) {
+    const value = Number(screenshotShrinkFactor);
+    if (!Number.isFinite(value) || value < 1) {
+      return {
+        options: null,
+        error:
+          'Screenshot shrink factor must be a number greater than or equal to 1.',
+      };
+    }
+    options.screenshotShrinkFactor = value;
+  }
+
+  return { options, error: null };
+}
+
+const fields: Array<{
+  key: StudioAgentOptionKey;
+  label: string;
+  placeholder: string;
+  min: number;
+  step: number;
+}> = [
+  {
+    key: 'replanningCycleLimit',
+    label: 'Replanning Cycle Limit',
+    placeholder: 'Model default',
+    min: 0,
+    step: 1,
+  },
+  {
+    key: 'waitAfterAction',
+    label: 'Wait After Action (ms)',
+    placeholder: 'Default: 300',
+    min: 0,
+    step: 1,
+  },
+  {
+    key: 'screenshotShrinkFactor',
+    label: 'Screenshot Shrink Factor',
+    placeholder: 'Default: 1',
+    min: 1,
+    step: 0.1,
+  },
+];
+
+export function AgentOptionConfigForm({
+  values,
+  onChange,
+  error,
+}: {
+  values: AgentOptionFormValues;
+  onChange: (key: StudioAgentOptionKey, value: string) => void;
+  error?: string | null;
+}) {
+  return (
+    <div className="px-[21px] pb-[16px]">
+      <h3 className="m-0 mb-[12px] font-sans text-[14px] font-semibold leading-[20px] text-text-primary">
+        Agent Option Config
+      </h3>
+      <div className="flex flex-col gap-[10px]">
+        {fields.map((field) => (
+          <label
+            className="grid grid-cols-[1fr_180px] items-center gap-[16px]"
+            key={field.key}
+          >
+            <span className="font-sans text-[12px] leading-[16px] text-text-secondary">
+              {field.label}
+            </span>
+            <input
+              aria-label={field.label}
+              className="box-border h-[36px] w-full rounded-[8px] border border-border-control bg-surface-elevated px-[10px] font-sans text-[13px] text-text-primary outline-none placeholder:text-text-placeholder focus:border-brand"
+              min={field.min}
+              onChange={(event) => onChange(field.key, event.target.value)}
+              placeholder={field.placeholder}
+              step={field.step}
+              type="number"
+              value={values[field.key]}
+            />
+          </label>
+        ))}
+      </div>
+      <p className="m-0 mt-[8px] font-sans text-[11px] leading-[14px] text-text-secondary">
+        Leave a field empty to use the default value. Changes apply on the next
+        Agent connection.
+      </p>
+      {error ? (
+        <p className="m-0 mt-[6px] font-sans text-[11px] leading-[14px] text-[#E13E37]">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigModal.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { StudioAgentOptions } from '../../../shared/agent-options';
 import { MaskedIcon } from '../MaskedIcon';
+import {
+  AgentOptionConfigForm,
+  type AgentOptionFormValues,
+  agentOptionsToFormValues,
+  parseAgentOptionFormValues,
+} from './AgentOptionConfigForm';
 import { ModelEnvConfigFormFields } from './ModelEnvConfigFormFields';
 import { ModelEnvConfigStatus } from './ModelEnvConfigStatus';
 import {
@@ -20,8 +27,12 @@ export interface ModelEnvConfigModalProps {
   open: boolean;
   initialTab?: TabKey;
   textValue?: string;
+  agentOptionsValue?: StudioAgentOptions;
   onClose: () => void;
-  onSave?: (payload: { text: string }) => void;
+  onSave?: (payload: {
+    text: string;
+    agentOptions: StudioAgentOptions;
+  }) => void | Promise<void>;
 }
 
 const TEXT_PLACEHOLDER =
@@ -51,11 +62,11 @@ function ConnectivityPlayIcon() {
   );
 }
 
-function EnvModalHeader({ onClose }: { onClose: () => void }) {
+function ConfigModalHeader({ onClose }: { onClose: () => void }) {
   return (
     <div className="relative z-10 box-border flex w-full items-center justify-between px-[20px] pt-[20.8px]">
       <h2 className="m-0 font-sans text-[16px] font-semibold leading-[24px] tracking-normal text-text-primary">
-        Model Env Config
+        Config
       </h2>
       <button
         aria-label="Close"
@@ -69,7 +80,7 @@ function EnvModalHeader({ onClose }: { onClose: () => void }) {
   );
 }
 
-function EnvModalTabs({
+function EnvStyleSelect({
   tab,
   onTabChange,
 }: {
@@ -77,83 +88,94 @@ function EnvModalTabs({
   onTabChange: (tab: TabKey) => void;
 }) {
   return (
-    <div className="relative z-10 box-border flex h-[36px] w-[210px] items-center rounded-[32px] border border-border-control bg-surface-muted p-[2px]">
-      {/*
-        Active tab fills with `bg-surface-elevated` for the white pill on
-        light mode. In dark mode `surface-elevated` and `surface-muted`
-        collapse to the same `#2b2b2b`, so the pill disappears — fall
-        back to the translucent `bg-surface-active` overlay only in dark.
-      */}
-      <button
-        className={`flex h-[32px] w-[103px] cursor-pointer items-center justify-center border-0 p-0 font-sans text-[14px] leading-[16.9px] transition-colors duration-200 ${
-          tab === 'text'
-            ? 'rounded-[30px] bg-surface-elevated font-medium text-text-primary dark:bg-surface-active'
-            : 'rounded-[10px] bg-transparent font-normal text-text-secondary'
-        }`}
-        onClick={() => onTabChange('text')}
-        type="button"
+    <div className="relative z-10 h-[32px] w-[132px]">
+      <select
+        aria-label="Model env config style"
+        className="h-full w-full cursor-pointer appearance-none rounded-[8px] border border-border-control bg-surface-elevated px-[12px] pr-[32px] font-sans text-[14px] font-medium leading-[16.9px] text-text-primary outline-none hover:bg-surface-hover focus:border-brand"
+        onChange={(event) => onTabChange(event.target.value as TabKey)}
+        value={tab}
       >
-        .env Style
-      </button>
-      <button
-        className={`flex h-[32px] w-[103px] cursor-pointer items-center justify-center border-0 p-0 font-sans text-[14px] leading-[16.9px] transition-colors duration-200 ${
-          tab === 'form'
-            ? 'rounded-[30px] bg-surface-elevated font-medium text-text-primary dark:bg-surface-active'
-            : 'rounded-[10px] bg-transparent font-normal text-text-secondary'
-        }`}
-        onClick={() => onTabChange('form')}
-        type="button"
+        <option value="text">.env Style</option>
+        <option value="form">Form Style</option>
+      </select>
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute right-[10px] top-1/2 h-[12px] w-[12px] -translate-y-1/2 text-text-secondary"
+        fill="none"
+        viewBox="0 0 12 12"
       >
-        Form Style
-      </button>
+        <path
+          d="M3 4.5L6 7.5L9 4.5"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.2"
+        />
+      </svg>
     </div>
   );
 }
 
-function EnvModalFooter({
+function ConnectivityButton({
   onConnectivityTest,
-  onSave,
   canRunConnectivityTest,
+  isSaving,
   testStatus,
 }: {
   onConnectivityTest: () => void;
-  onSave: () => void;
   canRunConnectivityTest: boolean;
+  isSaving: boolean;
   testStatus: TestStatus;
 }) {
   const isTesting = testStatus.kind === 'running';
   const connectivityLabel = isTesting ? 'Testing...' : 'Verify and Save Model';
 
   return (
-    <div className="relative z-10 mt-auto box-border flex w-full items-center justify-end gap-[16px] px-[20px] pb-[24px]">
-      <button
-        className={`flex h-[32px] w-auto min-w-[190px] items-center justify-center gap-[6px] rounded-[8px] border border-border-control bg-surface-elevated px-[16px] py-0 ${
-          isTesting
-            ? 'cursor-not-allowed opacity-60'
-            : canRunConnectivityTest
-              ? 'cursor-pointer hover:bg-surface-hover'
-              : 'cursor-not-allowed'
-        }`}
-        disabled={!canRunConnectivityTest || isTesting}
-        onClick={onConnectivityTest}
-        type="button"
-      >
-        {isTesting ? (
-          <img
-            alt=""
-            className="h-4 w-4 animate-spin"
-            src={connectivityIconSrc}
-          />
-        ) : (
-          <ConnectivityPlayIcon />
-        )}
-        <span className="whitespace-nowrap font-sans text-[14px] font-medium text-text-primary leading-[16px]">
-          {connectivityLabel}
-        </span>
-      </button>
+    <button
+      className={`flex h-[32px] w-auto min-w-[190px] items-center justify-center gap-[6px] rounded-[8px] border border-border-control bg-surface-elevated px-[16px] py-0 ${
+        isTesting
+          ? 'cursor-not-allowed opacity-60'
+          : canRunConnectivityTest
+            ? 'cursor-pointer hover:bg-surface-hover'
+            : 'cursor-not-allowed'
+      }`}
+      disabled={!canRunConnectivityTest || isTesting || isSaving}
+      onClick={onConnectivityTest}
+      type="button"
+    >
+      {isTesting ? (
+        <img
+          alt=""
+          className="h-4 w-4 animate-spin"
+          src={connectivityIconSrc}
+        />
+      ) : (
+        <ConnectivityPlayIcon />
+      )}
+      <span className="whitespace-nowrap font-sans text-[14px] font-medium text-text-primary leading-[16px]">
+        {connectivityLabel}
+      </span>
+    </button>
+  );
+}
 
+function EnvModalFooter({
+  onSave,
+  canSave,
+  isSaving,
+}: {
+  onSave: () => void;
+  canSave: boolean;
+  isSaving: boolean;
+}) {
+  return (
+    <div className="relative z-10 mt-auto box-border flex w-full items-center justify-end px-[20px] pb-[24px]">
       <button
-        className="flex h-[32px] w-[76px] cursor-pointer items-center justify-center rounded-[8px] border border-brand bg-brand p-0 hover:opacity-90"
+        className={`flex h-[32px] w-[76px] items-center justify-center rounded-[8px] border border-brand bg-brand p-0 hover:opacity-90 ${
+          canSave ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
+        }`}
+        disabled={!canSave}
+        aria-busy={isSaving}
         onClick={onSave}
         type="button"
       >
@@ -169,12 +191,19 @@ export function ModelEnvConfigModal({
   open,
   initialTab = 'text',
   textValue: initialTextValue,
+  agentOptionsValue: initialAgentOptionsValue,
   onClose,
   onSave,
 }: ModelEnvConfigModalProps) {
   const [tab, setTab] = useState<TabKey>(initialTab);
   const [text, setText] = useState(initialTextValue ?? '');
+  const [agentOptionValues, setAgentOptionValues] =
+    useState<AgentOptionFormValues>(() =>
+      agentOptionsToFormValues(initialAgentOptionsValue ?? {}),
+    );
   const [testStatus, setTestStatus] = useState<TestStatus>({ kind: 'idle' });
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const testRunIdRef = useRef(0);
   const pendingSaveTimerRef = useRef<number | null>(null);
 
@@ -196,8 +225,13 @@ export function ModelEnvConfigModal({
     testRunIdRef.current += 1;
     setTab(initialTab);
     setText(initialTextValue ?? '');
+    setAgentOptionValues(
+      agentOptionsToFormValues(initialAgentOptionsValue ?? {}),
+    );
     setTestStatus({ kind: 'idle' });
-  }, [initialTab, initialTextValue, open]);
+    setIsSaving(false);
+    setSaveError(null);
+  }, [initialAgentOptionsValue, initialTab, initialTextValue, open]);
 
   useEffect(() => () => clearPendingSaveTimer(), []);
 
@@ -218,6 +252,10 @@ export function ModelEnvConfigModal({
   }, [open, onClose]);
 
   const envValues = useMemo(() => parseEnvText(text), [text]);
+  const parsedAgentOptions = useMemo(
+    () => parseAgentOptionFormValues(agentOptionValues),
+    [agentOptionValues],
+  );
   const resolvedConnection = useMemo(
     () => resolveModelConnection(envValues),
     [envValues],
@@ -228,7 +266,6 @@ export function ModelEnvConfigModal({
       ? resolvedConnection.error
       : null;
   const canRunConnectivityTest = !('error' in resolvedConnection);
-  const isExpandedForm = tab === 'form';
   const hasTestStatus =
     testStatus.kind === 'success' || testStatus.kind === 'error';
   const statusKind = validationError
@@ -239,26 +276,6 @@ export function ModelEnvConfigModal({
   const statusMessage =
     validationError ??
     (testStatus.kind === 'error' ? testStatus.message : undefined);
-  const hasStatusRow = statusKind !== null;
-  const hasValidationStatus = validationError !== null;
-  const modalHeightClass = (() => {
-    if (isExpandedForm && hasValidationStatus) return 'h-[683px]';
-    if (isExpandedForm && hasStatusRow) return 'h-[603px]';
-    if (isExpandedForm) return 'h-[563px]';
-    if (hasValidationStatus) return 'h-[524px]';
-    if (hasStatusRow) return 'h-[444px]';
-    return 'h-[404px]';
-  })();
-  const modalVerticalOffsetClass = (() => {
-    if (isExpandedForm && hasValidationStatus) return 'translate-y-[139.5px]';
-    if (isExpandedForm && hasStatusRow) return 'translate-y-[99.5px]';
-    if (isExpandedForm) return 'translate-y-[79.5px]';
-    if (hasValidationStatus) return 'translate-y-[60px]';
-    if (hasStatusRow) return 'translate-y-[20px]';
-    return '';
-  })();
-  const descriptionMarginClass = hasStatusRow ? 'mt-[12px]' : 'mt-[16px]';
-
   if (!open) {
     return null;
   }
@@ -267,6 +284,7 @@ export function ModelEnvConfigModal({
     clearPendingSaveTimer();
     testRunIdRef.current += 1;
     setText(nextText);
+    setSaveError(null);
     setTestStatus((currentStatus) =>
       currentStatus.kind === 'idle' ? currentStatus : { kind: 'idle' },
     );
@@ -276,8 +294,37 @@ export function ModelEnvConfigModal({
     handleTextChange(setEnvFieldValue(text, key, value));
   };
 
+  const handleAgentOptionChange = (
+    key: keyof AgentOptionFormValues,
+    value: string,
+  ) => {
+    clearPendingSaveTimer();
+    testRunIdRef.current += 1;
+    setAgentOptionValues((current) => ({ ...current, [key]: value }));
+    setSaveError(null);
+    setTestStatus((currentStatus) =>
+      currentStatus.kind === 'idle' ? currentStatus : { kind: 'idle' },
+    );
+  };
+
+  const saveConfig = async (agentOptions: StudioAgentOptions) => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await onSave?.({ text, agentOptions });
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const handleConnectivityTest = async () => {
-    if (testStatus.kind === 'running' || 'error' in resolvedConnection) {
+    if (
+      testStatus.kind === 'running' ||
+      'error' in resolvedConnection ||
+      !parsedAgentOptions.options
+    ) {
       return;
     }
 
@@ -302,7 +349,7 @@ export function ModelEnvConfigModal({
         clearPendingSaveTimer();
         pendingSaveTimerRef.current = window.setTimeout(() => {
           if (testRunIdRef.current === testRunId) {
-            onSave?.({ text });
+            void saveConfig(parsedAgentOptions.options);
           }
           pendingSaveTimerRef.current = null;
         }, SAVE_AFTER_SUCCESS_DELAY_MS);
@@ -324,9 +371,12 @@ export function ModelEnvConfigModal({
   };
 
   const handleSave = () => {
+    if (!parsedAgentOptions.options || isSaving) {
+      return;
+    }
     clearPendingSaveTimer();
     testRunIdRef.current += 1;
-    onSave?.({ text });
+    void saveConfig(parsedAgentOptions.options);
   };
 
   return (
@@ -338,18 +388,21 @@ export function ModelEnvConfigModal({
       role="dialog"
     >
       <div
-        className={`relative box-border flex ${modalHeightClass} w-[400px] ${modalVerticalOffsetClass} flex-col overflow-hidden rounded-[16px] bg-surface-elevated shadow-[0px_4px_20px_rgba(0,0,0,0.05)]`}
+        className="relative box-border flex max-h-[90vh] min-h-[600px] w-[500px] flex-col overflow-y-auto rounded-[16px] bg-surface-elevated shadow-[0px_4px_20px_rgba(0,0,0,0.05)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <EnvModalHeader onClose={onClose} />
-        <div className="mt-[19.2px] px-[21px]">
-          <EnvModalTabs onTabChange={setTab} tab={tab} />
+        <ConfigModalHeader onClose={onClose} />
+        <h3 className="m-0 mt-[20px] px-[21px] font-sans text-[14px] font-semibold leading-[20px] text-text-primary">
+          Model Env Config
+        </h3>
+        <div className="mt-[12px] px-[21px]">
+          <EnvStyleSelect onTabChange={setTab} tab={tab} />
         </div>
 
         {tab === 'text' ? (
-          <div className="relative z-10 mt-[16px] flex w-full justify-center">
+          <div className="relative z-10 mx-[21px] mt-[16px]">
             <textarea
-              className="box-border h-[162px] w-[360px] resize-none overflow-hidden rounded-[12px] border border-border-control bg-surface-elevated p-[12px] font-sans text-[14px] font-normal leading-[16.9px] text-text-primary outline-none placeholder:text-text-placeholder"
+              className="box-border h-[162px] w-full resize-none overflow-hidden rounded-[12px] border border-border-control bg-surface-elevated p-[12px] font-sans text-[14px] font-normal leading-[16.9px] text-text-primary outline-none placeholder:text-text-placeholder"
               onChange={(event) => handleTextChange(event.target.value)}
               placeholder={TEXT_PLACEHOLDER}
               value={text}
@@ -364,7 +417,7 @@ export function ModelEnvConfigModal({
         )}
 
         {tab === 'text' ? (
-          <div className={`relative z-10 ${descriptionMarginClass} px-[21px]`}>
+          <div className="relative z-10 mt-[16px] px-[21px]">
             <p className="m-0 font-sans text-[12px] font-normal leading-[14.5px] text-text-secondary">
               The format is KEY=VALUE and separated by new lines. These data
               will be saved{' '}
@@ -376,15 +429,33 @@ export function ModelEnvConfigModal({
           </div>
         ) : null}
 
-        {statusKind ? (
-          <ModelEnvConfigStatus kind={statusKind} message={statusMessage} />
-        ) : null}
+        <div className="relative z-10 mt-[12px] flex items-start justify-end gap-[12px] px-[21px]">
+          {statusKind ? (
+            <ModelEnvConfigStatus kind={statusKind} message={statusMessage} />
+          ) : null}
+          <ConnectivityButton
+            canRunConnectivityTest={
+              canRunConnectivityTest &&
+              Boolean(parsedAgentOptions.options) &&
+              !isSaving
+            }
+            isSaving={isSaving}
+            onConnectivityTest={handleConnectivityTest}
+            testStatus={testStatus}
+          />
+        </div>
+
+        <div className="mx-[21px] my-[16px] h-px shrink-0 bg-border-control" />
+        <AgentOptionConfigForm
+          error={parsedAgentOptions.error ?? saveError}
+          onChange={handleAgentOptionChange}
+          values={agentOptionValues}
+        />
 
         <EnvModalFooter
-          canRunConnectivityTest={canRunConnectivityTest}
-          onConnectivityTest={handleConnectivityTest}
+          canSave={Boolean(parsedAgentOptions.options) && !isSaving}
+          isSaving={isSaving}
           onSave={handleSave}
-          testStatus={testStatus}
         />
       </div>
     </div>

--- a/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/ModelEnvConfigStatus.tsx
@@ -76,9 +76,9 @@ export function ModelEnvConfigStatus({
     (isSuccess ? 'Test passed.' : 'Test failed. Please try again.');
 
   return (
-    <div className="relative z-10 mt-[12px] px-[21px]">
+    <div className="relative z-10 min-w-0 flex-1">
       <div
-        className={`box-border flex min-h-[32px] w-[360px] items-start justify-between rounded-[8px] px-[12px] py-[8px] ${statusClasses}`}
+        className={`box-border flex min-h-[32px] w-full items-start rounded-[8px] px-[12px] py-[8px] ${statusClasses}`}
       >
         <div className="flex min-w-0 flex-1 items-start gap-[10px]">
           {isSuccess ? <SuccessStatusIcon /> : <ErrorStatusIcon />}
@@ -89,7 +89,6 @@ export function ModelEnvConfigStatus({
             {message}
           </span>
         </div>
-        <div aria-hidden="true" className="h-4 w-4 opacity-[0.01]" />
       </div>
     </div>
   );

--- a/apps/studio/src/renderer/components/ShellLayout/agent-options-storage.ts
+++ b/apps/studio/src/renderer/components/ShellLayout/agent-options-storage.ts
@@ -1,0 +1,33 @@
+import {
+  type StudioAgentOptions,
+  normalizeStudioAgentOptions,
+} from '../../../shared/agent-options';
+
+const STORAGE_KEY = 'studio:agent-options';
+
+export function loadAgentOptions(): StudioAgentOptions {
+  if (typeof localStorage === 'undefined') {
+    return {};
+  }
+
+  const value = localStorage.getItem(STORAGE_KEY);
+  if (!value) {
+    return {};
+  }
+
+  try {
+    return normalizeStudioAgentOptions(JSON.parse(value));
+  } catch {
+    return {};
+  }
+}
+
+export function saveAgentOptions(options: StudioAgentOptions): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify(normalizeStudioAgentOptions(options)),
+  );
+}

--- a/apps/studio/src/renderer/components/ShellLayout/index.tsx
+++ b/apps/studio/src/renderer/components/ShellLayout/index.tsx
@@ -1,3 +1,4 @@
+import { getDebug } from '@midscene/shared/logger';
 import {
   type CSSProperties,
   useCallback,
@@ -28,6 +29,7 @@ import {
   getStudioRightPanelWidth,
 } from '../StudioRightPanel';
 import { ModelEnvConfigModal } from './ModelEnvConfigModal';
+import { loadAgentOptions, saveAgentOptions } from './agent-options-storage';
 import { hasCompleteModelEnvConfig } from './connectivity-env';
 import { loadModelEnvText, saveModelEnvText } from './model-env-storage';
 import type { ShellActiveView } from './types';
@@ -45,6 +47,7 @@ const COLLAPSED_TITLEBAR_INSET = 280;
 const SIDEBAR_TOGGLE_LEFT = 98;
 const SIDEBAR_TRANSITION_CLASS = 'duration-200 ease-[cubic-bezier(0.2,0,0,1)]';
 const STUDIO_RIGHT_PANEL_ANIMATION_MS = 160;
+const debugAgentOptions = getDebug('studio:agent-options', { console: true });
 
 const requireElectronShell = () => {
   if (!window.electronShell) {
@@ -187,6 +190,8 @@ export default function ShellLayout() {
   const [modelEnvText, setModelEnvText] = useState<string>(() =>
     loadModelEnvText(),
   );
+  const [agentOptions, setAgentOptions] = useState(() => loadAgentOptions());
+  const initialAgentOptionsRef = useRef(agentOptions);
   const [sidebarWidth, setSidebarWidth] = useState<number>(() =>
     readPersistedWidth(
       SIDEBAR_WIDTH_STORAGE_KEY,
@@ -204,6 +209,17 @@ export default function ShellLayout() {
     () => hasCompleteModelEnvConfig(modelEnvText),
     [modelEnvText],
   );
+  useEffect(() => {
+    const runtime = window.studioRuntime;
+    if (!runtime) {
+      return;
+    }
+    void runtime
+      .updateAgentOptions(initialAgentOptionsRef.current)
+      .catch((error) =>
+        debugAgentOptions('Failed to restore Agent options:', error),
+      );
+  }, []);
   const clearStudioRightPanelCloseTimer = useCallback(() => {
     if (studioRightPanelCloseTimerRef.current !== null) {
       window.clearTimeout(studioRightPanelCloseTimerRef.current);
@@ -563,9 +579,17 @@ export default function ShellLayout() {
 
       <ModelEnvConfigModal
         onClose={closeModelModal}
-        onSave={({ text }) => {
+        agentOptionsValue={agentOptions}
+        onSave={async ({ text, agentOptions: nextAgentOptions }) => {
+          const runtime = window.studioRuntime;
+          if (!runtime) {
+            throw new Error('Studio runtime is not available.');
+          }
+          await runtime.updateAgentOptions(nextAgentOptions);
           saveModelEnvText(text);
           setModelEnvText(text);
+          saveAgentOptions(nextAgentOptions);
+          setAgentOptions(nextAgentOptions);
           closeModelModal();
         }}
         open={modelModalOpen}

--- a/apps/studio/src/shared/agent-options.ts
+++ b/apps/studio/src/shared/agent-options.ts
@@ -1,0 +1,43 @@
+import type { AgentOpt } from '@midscene/core/agent';
+
+export const STUDIO_AGENT_OPTION_KEYS = [
+  'replanningCycleLimit',
+  'waitAfterAction',
+  'screenshotShrinkFactor',
+] as const;
+
+export type StudioAgentOptionKey = (typeof STUDIO_AGENT_OPTION_KEYS)[number];
+export type StudioAgentOptions = Pick<AgentOpt, StudioAgentOptionKey>;
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+export function normalizeStudioAgentOptions(
+  value: unknown,
+): StudioAgentOptions {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const source = value as Record<string, unknown>;
+  const result: StudioAgentOptions = {};
+
+  if (
+    isFiniteNumber(source.replanningCycleLimit) &&
+    Number.isInteger(source.replanningCycleLimit) &&
+    source.replanningCycleLimit >= 0
+  ) {
+    result.replanningCycleLimit = source.replanningCycleLimit;
+  }
+  if (isFiniteNumber(source.waitAfterAction) && source.waitAfterAction >= 0) {
+    result.waitAfterAction = source.waitAfterAction;
+  }
+  if (
+    isFiniteNumber(source.screenshotShrinkFactor) &&
+    source.screenshotShrinkFactor >= 1
+  ) {
+    result.screenshotShrinkFactor = source.screenshotShrinkFactor;
+  }
+
+  return result;
+}

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -7,6 +7,7 @@ import type {
   MidsceneRecorderEvent,
   MidsceneRecorderTarget,
 } from '@midscene/shared/recorder';
+import type { StudioAgentOptions } from './agent-options';
 
 /**
  * IPC channel names bridging the Midscene Studio main process and renderer.
@@ -36,6 +37,7 @@ export const IPC_CHANNELS = {
   discoveredDevicesUpdated: 'studio:discovered-devices-updated',
   setDiscoveryPollingPaused: 'studio:set-discovery-polling-paused',
   runConnectivityTest: 'studio:run-connectivity-test',
+  updateAgentOptions: 'studio:update-agent-options',
   generateRecorderCode: 'studio:generate-recorder-code',
   generateRecorderMetadata: 'studio:generate-recorder-metadata',
   describeRecorderUIEvents: 'studio:describe-recorder-ui-events',
@@ -285,6 +287,7 @@ export interface StudioRuntimeApi {
   runConnectivityTest: (
     request: ConnectivityTestRequest,
   ) => Promise<ConnectivityTestResult>;
+  updateAgentOptions: (options: StudioAgentOptions) => Promise<void>;
   generateRecorderCode: (
     request: GenerateRecorderCodeRequest,
   ) => Promise<GenerateRecorderCodeResult>;

--- a/apps/studio/tests/agent-option-config-form.test.tsx
+++ b/apps/studio/tests/agent-option-config-form.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AgentOptionConfigForm,
+  agentOptionsToFormValues,
+  parseAgentOptionFormValues,
+} from '../src/renderer/components/ShellLayout/AgentOptionConfigForm';
+
+describe('AgentOptionConfigForm', () => {
+  it('renders only the three supported Agent options', () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentOptionConfigForm, {
+        values: agentOptionsToFormValues({}),
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain('Agent Option Config');
+    expect(html).toContain('Replanning Cycle Limit');
+    expect(html).toContain('Wait After Action (ms)');
+    expect(html).toContain('Screenshot Shrink Factor');
+    expect(html).toContain('Changes apply on the next Agent connection.');
+    expect(html).not.toContain('aiActContext');
+    expect(html).not.toContain('reportFileName');
+  });
+
+  it('parses valid values and omits empty fields', () => {
+    expect(
+      parseAgentOptionFormValues({
+        replanningCycleLimit: '0',
+        waitAfterAction: '',
+        screenshotShrinkFactor: '2.5',
+      }),
+    ).toEqual({
+      options: {
+        replanningCycleLimit: 0,
+        screenshotShrinkFactor: 2.5,
+      },
+      error: null,
+    });
+  });
+
+  it('rejects values outside the supported ranges', () => {
+    expect(
+      parseAgentOptionFormValues({
+        replanningCycleLimit: '-1',
+        waitAfterAction: '300',
+        screenshotShrinkFactor: '1',
+      }),
+    ).toMatchObject({ options: null });
+    expect(
+      parseAgentOptionFormValues({
+        replanningCycleLimit: '12',
+        waitAfterAction: '-1',
+        screenshotShrinkFactor: '1',
+      }),
+    ).toMatchObject({ options: null });
+    expect(
+      parseAgentOptionFormValues({
+        replanningCycleLimit: '12',
+        waitAfterAction: '300',
+        screenshotShrinkFactor: '0.5',
+      }),
+    ).toMatchObject({ options: null });
+  });
+});

--- a/apps/studio/tests/agent-options-storage.test.ts
+++ b/apps/studio/tests/agent-options-storage.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadAgentOptions,
+  saveAgentOptions,
+} from '../src/renderer/components/ShellLayout/agent-options-storage';
+
+describe('agent options storage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists and restores supported options', () => {
+    saveAgentOptions({
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    });
+
+    expect(loadAgentOptions()).toEqual({
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    });
+  });
+
+  it('filters unsupported and invalid stored fields', () => {
+    localStorage.setItem(
+      'studio:agent-options',
+      JSON.stringify({
+        replanningCycleLimit: -1,
+        waitAfterAction: 500,
+        screenshotShrinkFactor: 0.5,
+        reportFileName: 'ignored.html',
+      }),
+    );
+
+    expect(loadAgentOptions()).toEqual({ waitAfterAction: 500 });
+  });
+
+  it('preserves a zero replanning cycle limit', () => {
+    saveAgentOptions({ replanningCycleLimit: 0 });
+    expect(loadAgentOptions()).toEqual({ replanningCycleLimit: 0 });
+  });
+
+  it('recovers from malformed storage', () => {
+    localStorage.setItem('studio:agent-options', '{invalid');
+    expect(loadAgentOptions()).toEqual({});
+  });
+});

--- a/apps/studio/tests/android-runtime.test.ts
+++ b/apps/studio/tests/android-runtime.test.ts
@@ -251,6 +251,11 @@ describe('playground runtime bootstrap', () => {
       port: 5800,
       error: null,
     });
+    await runtime.updateAgentOptions({
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    });
 
     const webPlatform = capturedPlatforms?.find(
       (platform) => platform.id === 'web',
@@ -308,6 +313,12 @@ describe('playground runtime bootstrap', () => {
     expect(session?.metadata?.sessionDisplayName).toBe('http://localhost:4173');
     expect(session?.preview?.kind).toBe('mjpeg');
     expect(agent).toBeInstanceOf(FakePuppeteerAgent);
+    expect((agent as unknown as FakePuppeteerAgent).opts).toEqual({
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+      cacheId: 'studio-web',
+    });
 
     await prepared?.sessionManager?.destroySession?.();
     expect(destroyAgent).toHaveBeenCalledTimes(1);
@@ -315,19 +326,29 @@ describe('playground runtime bootstrap', () => {
   });
 
   it('prepares Harmony in deferred mode so Studio never exits on device selection', async () => {
-    const harmonyPrepare = vi.fn(async () => ({
-      platformId: 'harmony',
-      title: 'Midscene HarmonyOS Playground',
-      metadata: {
-        sessionConnected: false,
-        setupState: 'required',
-      },
-      sessionManager: {
-        createSession: async () => ({
-          displayName: 'unused',
-        }),
-      },
-    }));
+    const harmonyPrepare = vi.fn(
+      async (_options: {
+        staticDir?: string;
+        deferConnection?: boolean;
+        getAgentOptions?: () => {
+          replanningCycleLimit?: number;
+          waitAfterAction?: number;
+          screenshotShrinkFactor?: number;
+        };
+      }) => ({
+        platformId: 'harmony',
+        title: 'Midscene HarmonyOS Playground',
+        metadata: {
+          sessionConnected: false,
+          setupState: 'required',
+        },
+        sessionManager: {
+          createSession: async () => ({
+            displayName: 'unused',
+          }),
+        },
+      }),
+    );
     let capturedPlatforms:
       | import('@midscene/playground').RegisteredPlaygroundPlatform[]
       | undefined;
@@ -380,12 +401,21 @@ describe('playground runtime bootstrap', () => {
       port: 5800,
       error: null,
     });
+    const agentOptions = {
+      replanningCycleLimit: 0,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+    await runtime.updateAgentOptions(agentOptions);
 
     await capturedPlatforms?.[3]?.prepare();
 
     expect(harmonyPrepare).toHaveBeenCalledWith({
       staticDir: '/virtual/@midscene/harmony',
       deferConnection: true,
+      getAgentOptions: expect.any(Function),
     });
+    const prepareOptions = harmonyPrepare.mock.calls[0]?.[0];
+    expect(prepareOptions?.getAgentOptions?.()).toEqual(agentOptions);
   });
 });

--- a/apps/studio/tests/model-env-config-modal.test.tsx
+++ b/apps/studio/tests/model-env-config-modal.test.tsx
@@ -85,6 +85,36 @@ function setTextareaValue(container: HTMLElement, value: string) {
   );
 }
 
+function setNumberInputValue(
+  container: HTMLElement,
+  label: string,
+  value: string,
+) {
+  const input = container.querySelector<HTMLInputElement>(
+    `input[aria-label="${label}"]`,
+  );
+  expect(input).toBeTruthy();
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  valueSetter?.call(input, value);
+  input?.dispatchEvent(new InputEvent('input', { bubbles: true }));
+}
+
+function setEnvStyle(container: HTMLElement, value: 'text' | 'form') {
+  const select = container.querySelector<HTMLSelectElement>(
+    'select[aria-label="Model env config style"]',
+  );
+  expect(select).toBeTruthy();
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLSelectElement.prototype,
+    'value',
+  )?.set;
+  valueSetter?.call(select, value);
+  select?.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
 async function unmountModal(root: ReturnType<typeof createRoot>) {
   await act(async () => {
     root.unmount();
@@ -119,12 +149,11 @@ describe('ModelEnvConfigModal', () => {
       }),
     );
 
-    expect(html).toContain('box-border flex h-[404px] w-[400px]');
+    expect(html).toContain('max-h-[90vh] min-h-[600px] w-[500px]');
     expect(html).toContain('text-[16px] font-semibold leading-[24px]');
-    expect(html).toContain('w-[210px]');
-    expect(html).toContain('items-center');
-    expect(html).toContain('rounded-[32px]');
-    expect(html).toContain('bg-surface-muted');
+    expect(html).toContain('w-[132px]');
+    expect(html).toContain('appearance-none');
+    expect(html).toContain('aria-label="Model env config style"');
     expect(html).toContain('border-border-control');
     expect(html).toContain('bg-surface-elevated');
     expect(html).toContain('text-[12px] font-normal leading-[14.5px]');
@@ -132,6 +161,11 @@ describe('ModelEnvConfigModal', () => {
     expect(html).toContain('shadow-[0px_4px_20px_rgba(0,0,0,0.05)]');
     expect(html).toContain('.env Style');
     expect(html).toContain('Form Style');
+    expect(html).toContain('Model Env Config');
+    expect(html).toContain('Agent Option Config');
+    expect(html).toContain('Replanning Cycle Limit');
+    expect(html).toContain('Wait After Action (ms)');
+    expect(html).toContain('Screenshot Shrink Factor');
     expect(html).toContain('The format is KEY=VALUE');
     expect(html).toContain('Verify and Save Model');
     expect(html).toContain('bg-black/35 font-sans');
@@ -151,7 +185,6 @@ describe('ModelEnvConfigModal', () => {
     );
     expect(html).toContain('h-[32px]');
     expect(html).toContain('justify-end');
-    expect(html).toContain('gap-[16px]');
     expect(html).toContain('w-auto min-w-[190px]');
     expect(html).not.toContain('Cancel');
     expect(html).toContain('gap-[6px]');
@@ -160,6 +193,12 @@ describe('ModelEnvConfigModal', () => {
     expect(html).toContain('bg-surface-elevated');
     expect(html).toContain('text-text-primary leading-[16px]');
     expect(html).not.toMatch(/[\u4e00-\u9fff]/);
+
+    const verifyIndex = html.indexOf('Verify and Save Model');
+    const agentOptionIndex = html.indexOf('Agent Option Config');
+    const saveIndex = html.lastIndexOf('>Save<');
+    expect(verifyIndex).toBeLessThan(agentOptionIndex);
+    expect(saveIndex).toBeGreaterThan(agentOptionIndex);
   });
 
   it('enables connectivity test only when required model config is present', async () => {
@@ -170,6 +209,51 @@ describe('ModelEnvConfigModal', () => {
     const validRender = await renderModal(VALID_ENV_TEXT);
     expect(getConnectivityButton(validRender.container).disabled).toBe(false);
     await unmountModal(validRender.root);
+  });
+
+  it('saves the three supported Agent options with the model config', async () => {
+    const onSave = vi.fn();
+    const { container, root } = await renderModal(VALID_ENV_TEXT, { onSave });
+
+    await act(async () => {
+      setNumberInputValue(container, 'Replanning Cycle Limit', '12');
+      setNumberInputValue(container, 'Wait After Action (ms)', '500');
+      setNumberInputValue(container, 'Screenshot Shrink Factor', '2');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      getButtonByText(container, 'Save').click();
+    });
+
+    expect(onSave).toHaveBeenCalledWith({
+      text: VALID_ENV_TEXT,
+      agentOptions: {
+        replanningCycleLimit: 12,
+        waitAfterAction: 500,
+        screenshotShrinkFactor: 2,
+      },
+    });
+
+    await unmountModal(root);
+  });
+
+  it('keeps the modal open and reports runtime synchronization failures', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('Runtime sync failed'));
+    const { container, root } = await renderModal(VALID_ENV_TEXT, { onSave });
+
+    await act(async () => {
+      getButtonByText(container, 'Save').click();
+      await Promise.resolve();
+    });
+
+    expect(onSave).toHaveBeenCalledWith({
+      text: VALID_ENV_TEXT,
+      agentOptions: {},
+    });
+    expect(container.textContent).toContain('Runtime sync failed');
+    expect(getButtonByText(container, 'Save').disabled).toBe(false);
+
+    await unmountModal(root);
   });
 
   it('shows invalid model family without crashing the modal', async () => {
@@ -192,7 +276,7 @@ describe('ModelEnvConfigModal', () => {
     );
     expect(errorMessage?.className).toContain('whitespace-pre-wrap');
     expect(errorMessage?.className).not.toContain('text-ellipsis');
-    expect(container.querySelector('.h-\\[524px\\]')).toBeTruthy();
+    expect(container.querySelector('.max-h-\\[90vh\\]')).toBeTruthy();
 
     await unmountModal(root);
   });
@@ -370,6 +454,9 @@ describe('ModelEnvConfigModal', () => {
     expect(container.innerHTML).toContain('text-status-success-fg');
     expect(button.textContent).toContain('Verify and Save Model');
     expect(button.textContent).not.toContain('Test passed');
+    expect(container.textContent?.indexOf('Test passed.')).toBeLessThan(
+      container.textContent?.indexOf('Verify and Save Model') ?? -1,
+    );
     expect(button.innerHTML).toContain('text-text-primary leading-[16px]');
     expect(button.innerHTML).not.toContain('model-env-connectivity.svg');
     expect(button.innerHTML).toContain(
@@ -384,7 +471,10 @@ describe('ModelEnvConfigModal', () => {
       await Promise.resolve();
     });
 
-    expect(onSave).toHaveBeenCalledWith({ text: VALID_ENV_TEXT });
+    expect(onSave).toHaveBeenCalledWith({
+      text: VALID_ENV_TEXT,
+      agentOptions: {},
+    });
 
     await unmountModal(root);
   });
@@ -399,11 +489,11 @@ describe('ModelEnvConfigModal', () => {
     const { container, root } = await renderModal(VALID_ENV_TEXT);
 
     await act(async () => {
-      getButtonByText(container, 'Form Style').click();
+      setEnvStyle(container, 'form');
       await Promise.resolve();
     });
     await act(async () => {
-      getButtonByText(container, '.env Style').click();
+      setEnvStyle(container, 'text');
       await Promise.resolve();
     });
     await act(async () => {
@@ -433,7 +523,7 @@ describe('ModelEnvConfigModal', () => {
       await Promise.resolve();
     });
 
-    expect(container.innerHTML).toContain('h-[444px] w-[400px]');
+    expect(container.innerHTML).toContain('max-h-[90vh]');
     expect(container.innerHTML).toContain('bg-[#E13E37]/11');
     expect(container.innerHTML).toContain('text-[#E13E37]');
     expect(container.textContent).toContain(
@@ -542,8 +632,7 @@ describe('ModelEnvConfigModal', () => {
       }),
     );
 
-    expect(html).toContain('h-[563px] w-[400px]');
-    expect(html).toContain('translate-y-[79.5px]');
+    expect(html).toContain('max-h-[90vh] min-h-[600px] w-[500px]');
     expect(html).toContain('flex flex-col gap-[24px]');
     expect(html).toContain('h-[61px]');
     expect(html).toContain('h-[36px]');
@@ -559,10 +648,10 @@ describe('ModelEnvConfigModal', () => {
     expect(baseUrlLabel?.className).toContain('text-[14px]');
     expect(baseUrlLabel?.className).toContain('text-text-primary');
 
-    const formTab = Array.from(wrapper.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Form Style',
+    const styleSelect = wrapper.querySelector<HTMLSelectElement>(
+      'select[aria-label="Model env config style"]',
     );
-    expect(formTab?.className).toContain('rounded-[30px]');
-    expect(formTab?.className).not.toContain('rounded-[10px]');
+    expect(styleSelect?.value).toBe('form');
+    expect(styleSelect?.className).toContain('rounded-[8px]');
   });
 });

--- a/apps/studio/tests/playground-bootstrap-request.test.ts
+++ b/apps/studio/tests/playground-bootstrap-request.test.ts
@@ -14,6 +14,7 @@ function createRuntimeMock(
       error: null,
     }),
     restart: vi.fn(),
+    updateAgentOptions: vi.fn().mockResolvedValue(undefined),
     start: vi.fn().mockResolvedValue({
       status: 'ready',
       serverUrl: 'http://127.0.0.1:3000',

--- a/apps/studio/tests/preload-bridge.test.ts
+++ b/apps/studio/tests/preload-bridge.test.ts
@@ -81,6 +81,11 @@ describe('preload bridge', () => {
       MIDSCENE_MODEL_BASE_URL: 'https://api.example.com/v1',
       MIDSCENE_MODEL_NAME: 'gpt-4o',
     });
+    await studioRuntimeApi.updateAgentOptions({
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    });
     await studioRuntimeApi.generateRecorderCode({
       type: 'playwright',
       input: {
@@ -180,6 +185,14 @@ describe('preload bridge', () => {
           MIDSCENE_MODEL_API_KEY: 'sk-test',
           MIDSCENE_MODEL_BASE_URL: 'https://api.example.com/v1',
           MIDSCENE_MODEL_NAME: 'gpt-4o',
+        },
+      ],
+      [
+        IPC_CHANNELS.updateAgentOptions,
+        {
+          replanningCycleLimit: 12,
+          waitAfterAction: 500,
+          screenshotShrinkFactor: 2,
         },
       ],
       [

--- a/apps/studio/tests/shell-layout-recorder-overlay.test.tsx
+++ b/apps/studio/tests/shell-layout-recorder-overlay.test.tsx
@@ -4,6 +4,17 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  modelEnvModalProps: null as null | {
+    onSave?: (payload: {
+      text: string;
+      agentOptions: {
+        replanningCycleLimit?: number;
+        waitAfterAction?: number;
+        screenshotShrinkFactor?: number;
+      };
+    }) => void | Promise<void>;
+  },
+  saveAgentOptions: vi.fn(),
   playground: {
     phase: 'ready',
     controller: {
@@ -171,7 +182,15 @@ vi.mock('../src/renderer/components/SettingsPanel', () => ({
 }));
 
 vi.mock('../src/renderer/components/ShellLayout/ModelEnvConfigModal', () => ({
-  ModelEnvConfigModal: () => null,
+  ModelEnvConfigModal: (props: unknown) => {
+    mocks.modelEnvModalProps = props as typeof mocks.modelEnvModalProps;
+    return null;
+  },
+}));
+
+vi.mock('../src/renderer/components/ShellLayout/agent-options-storage', () => ({
+  loadAgentOptions: () => ({}),
+  saveAgentOptions: mocks.saveAgentOptions,
 }));
 
 vi.mock('../src/renderer/components/ShellLayout/connectivity-env', () => ({
@@ -207,6 +226,48 @@ describe('ShellLayout right panel tabs', () => {
   afterEach(() => {
     document.body.replaceChildren();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    mocks.modelEnvModalProps = null;
+  });
+
+  it('waits for runtime Agent options synchronization before persisting', async () => {
+    let resolveRuntimeUpdate: (() => void) | undefined;
+    const updateAgentOptions = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRuntimeUpdate = resolve;
+          }),
+      );
+    vi.stubGlobal('studioRuntime', { updateAgentOptions });
+    const { root } = await renderShellLayout();
+    const agentOptions = {
+      replanningCycleLimit: 0,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+
+    let savePromise: void | Promise<void>;
+    await act(async () => {
+      savePromise = mocks.modelEnvModalProps?.onSave?.({
+        text: 'MIDSCENE_MODEL_NAME=test-model',
+        agentOptions,
+      });
+      await Promise.resolve();
+    });
+
+    expect(updateAgentOptions).toHaveBeenLastCalledWith(agentOptions);
+    expect(mocks.saveAgentOptions).not.toHaveBeenCalled();
+
+    resolveRuntimeUpdate?.();
+    await act(async () => {
+      await savePromise;
+    });
+
+    expect(mocks.saveAgentOptions).toHaveBeenCalledWith(agentOptions);
+    await act(async () => root.unmount());
   });
 
   it('aligns the update pill with the sidebar toggle in one titlebar flex row', async () => {

--- a/apps/studio/tests/sidebar-settings.test.ts
+++ b/apps/studio/tests/sidebar-settings.test.ts
@@ -8,7 +8,7 @@ import { ThemeProvider } from '../src/renderer/theme/ThemeProvider';
 (globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = 'test-version';
 
 describe('studio sidebar settings entrypoints', () => {
-  it('renders Settings and Model Config as stacked rows in the bottom dock', () => {
+  it('renders Settings and Config as stacked rows in the bottom dock', () => {
     const html = renderToStaticMarkup(
       createElement(SettingsDock, {
         onEnvClick: () => undefined,
@@ -18,7 +18,7 @@ describe('studio sidebar settings entrypoints', () => {
     );
 
     expect(html).toContain('Settings');
-    expect(html).toContain('Model Config');
+    expect(html).toContain('Config');
     expect(html).not.toContain('>Env<');
   });
 
@@ -34,6 +34,6 @@ describe('studio sidebar settings entrypoints', () => {
     expect(html).toContain('GitHub');
     expect(html).toContain('Website');
     expect(html).not.toContain('Environment');
-    expect(html).not.toContain('Model Config');
+    expect(html).not.toContain('Config');
   });
 });

--- a/packages/android-playground/src/platform.ts
+++ b/packages/android-playground/src/platform.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {
   AndroidAgent,
+  type AndroidAgentOpt,
   AndroidDevice,
   getConnectedDevicesWithDetails,
 } from '@midscene/android';
@@ -25,6 +26,7 @@ export interface AndroidPlatformOptions {
   staticDir?: string;
   scrcpyServer?: ScrcpyServerController;
   scrcpyPort?: number;
+  getAgentOptions?: () => AndroidAgentOpt;
 }
 
 async function getAdbTargets(): Promise<PlaygroundSessionTarget[]> {
@@ -137,7 +139,7 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         const connectAgent = async () => {
           const device = new AndroidDevice(deviceId);
           await device.connect();
-          return new AndroidAgent(device);
+          return new AndroidAgent(device, options?.getAgentOptions?.());
         };
 
         if (options?.scrcpyServer) {

--- a/packages/android-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/android-playground/tests/unit/platform-session-manager.test.ts
@@ -4,17 +4,18 @@ const connectMock = vi.fn();
 const currentDevice = { connect: connectMock };
 const getConnectedDevicesWithDetailsMock = vi.fn();
 const findAvailablePortMock = vi.fn(async (port: number) => port);
+const androidAgentMock = vi.fn().mockImplementation((device) => ({
+  interface: {
+    interfaceType: 'android',
+    describe: () => 'Mock Android device',
+    actionSpace: () => [],
+  },
+  destroy: vi.fn(),
+  device,
+}));
 
 vi.mock('@midscene/android', () => ({
-  AndroidAgent: vi.fn().mockImplementation((device) => ({
-    interface: {
-      interfaceType: 'android',
-      describe: () => 'Mock Android device',
-      actionSpace: () => [],
-    },
-    destroy: vi.fn(),
-    device,
-  })),
+  AndroidAgent: androidAgentMock,
   AndroidDevice: vi.fn().mockImplementation(() => currentDevice),
   getConnectedDevicesWithDetails: getConnectedDevicesWithDetailsMock,
 }));
@@ -93,6 +94,34 @@ describe('androidPlaygroundPlatform session manager', () => {
     });
 
     await expect(prepared.sessionManager?.listTargets?.()).resolves.toEqual([]);
+  });
+
+  test('passes host Agent options to each new Android Agent', async () => {
+    const agentOptions = {
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+    const { androidPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await androidPlaygroundPlatform.prepare({
+      getAgentOptions: () => agentOptions,
+    });
+
+    const created = await prepared.sessionManager?.createSession({
+      deviceId: 'SERIAL123',
+    });
+    await created?.agentFactory?.();
+
+    expect(androidAgentMock).toHaveBeenNthCalledWith(
+      1,
+      currentDevice,
+      agentOptions,
+    );
+    expect(androidAgentMock).toHaveBeenNthCalledWith(
+      2,
+      currentDevice,
+      agentOptions,
+    );
   });
 
   test('bubbles adb discovery failures out of createSession so the user sees the root cause', async () => {

--- a/packages/computer-playground/src/platform.ts
+++ b/packages/computer-playground/src/platform.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {
+  type ComputerAgentOpt,
   agentFromComputer,
   checkAccessibilityPermission,
   checkScreenRecordingPermission,
@@ -17,6 +18,7 @@ import type { BrowserWindowController } from './browser-window-controller';
 export interface ComputerPlatformOptions {
   staticDir?: string;
   getWindowController?: () => BrowserWindowController | null;
+  getAgentOptions?: () => ComputerAgentOpt;
 }
 
 export const computerPlaygroundPlatform = definePlaygroundPlatform<
@@ -119,9 +121,10 @@ export const computerPlaygroundPlatform = definePlaygroundPlatform<
           input?.displayId === undefined || input.displayId === null
             ? undefined
             : String(input.displayId);
-        const agent = await agentFromComputer(
-          displayId ? { displayId } : undefined,
-        );
+        const agent = await agentFromComputer({
+          ...options?.getAgentOptions?.(),
+          ...(displayId ? { displayId } : {}),
+        });
         const displays = await getConnectedDisplays();
         const selectedDisplay =
           displays.find((display) => display.id === displayId) ||
@@ -131,9 +134,10 @@ export const computerPlaygroundPlatform = definePlaygroundPlatform<
         return {
           agent,
           agentFactory: () =>
-            agentFromComputer(
-              selectedDisplay ? { displayId: selectedDisplay.id } : undefined,
-            ),
+            agentFromComputer({
+              ...options?.getAgentOptions?.(),
+              ...(selectedDisplay ? { displayId: selectedDisplay.id } : {}),
+            }),
           preview: createScreenshotPreviewDescriptor({
             title: 'Desktop preview',
           }),

--- a/packages/computer-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/computer-playground/tests/unit/platform-session-manager.test.ts
@@ -114,4 +114,40 @@ describe('computerPlaygroundPlatform session manager', () => {
       executionUx: 'countdown-before-run',
     });
   });
+
+  test('passes host Agent options to the Computer Agent and its factory', async () => {
+    checkAccessibilityPermissionMock.mockReturnValue({ hasPermission: true });
+    agentFromComputerMock.mockResolvedValue({
+      interface: {
+        interfaceType: 'computer',
+        describe: () => 'Desktop',
+        actionSpace: () => [],
+        screenshotBase64: vi.fn(async () => 'screenshot'),
+      },
+      destroy: vi.fn(),
+    });
+    const agentOptions = {
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+
+    const { computerPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await computerPlaygroundPlatform.prepare({
+      getAgentOptions: () => agentOptions,
+    });
+    const created = await prepared.sessionManager?.createSession({
+      displayId: '1',
+    });
+    await created?.agentFactory?.();
+
+    expect(agentFromComputerMock).toHaveBeenNthCalledWith(1, {
+      ...agentOptions,
+      displayId: '1',
+    });
+    expect(agentFromComputerMock).toHaveBeenNthCalledWith(2, {
+      ...agentOptions,
+      displayId: 1,
+    });
+  });
 });

--- a/packages/harmony/src/platform.ts
+++ b/packages/harmony/src/platform.ts
@@ -8,7 +8,7 @@ import {
 } from '@midscene/playground';
 import { PLAYGROUND_SERVER_PORT } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
-import { HarmonyAgent } from './agent';
+import { HarmonyAgent, type HarmonyAgentOpt } from './agent';
 import { HarmonyDevice } from './device';
 import { getConnectedDevices } from './utils';
 
@@ -16,6 +16,7 @@ export interface HarmonyPlatformOptions {
   deferConnection?: boolean;
   deviceId?: string;
   staticDir?: string;
+  getAgentOptions?: () => HarmonyAgentOpt;
 }
 
 const HARMONY_NO_DEVICE_MESSAGE =
@@ -177,7 +178,7 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
         const connectAgent = async () => {
           const device = new HarmonyDevice(deviceId);
           await device.connect();
-          return new HarmonyAgent(device);
+          return new HarmonyAgent(device, options?.getAgentOptions?.());
         };
 
         const agent = await connectAgent();
@@ -226,7 +227,7 @@ export const harmonyPlaygroundPlatform = definePlaygroundPlatform<
       agentFactory: async () => {
         const device = new HarmonyDevice(selectedDeviceId);
         await device.connect();
-        return new HarmonyAgent(device);
+        return new HarmonyAgent(device, options?.getAgentOptions?.());
       },
       launchOptions: {
         port: availablePort,

--- a/packages/harmony/tests/unit-test/platform.test.ts
+++ b/packages/harmony/tests/unit-test/platform.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const connectMock = vi.fn();
 const getConnectedDevicesMock = vi.fn();
 const findAvailablePortMock = vi.fn(async () => 5810);
+const harmonyAgentMock = vi.fn().mockImplementation((device) => ({
+  device,
+  interface: {
+    interfaceType: 'harmony',
+    actionSpace: () => [],
+    describe: () => 'Mock Harmony device',
+  },
+}));
 
 vi.mock('@midscene/playground', () => ({
   createScreenshotPreviewDescriptor: (overrides = {}) => ({
@@ -18,14 +26,7 @@ vi.mock('@midscene/shared/node', () => ({
 }));
 
 vi.mock('../../src/agent', () => ({
-  HarmonyAgent: vi.fn().mockImplementation((device) => ({
-    device,
-    interface: {
-      interfaceType: 'harmony',
-      actionSpace: () => [],
-      describe: () => 'Mock Harmony device',
-    },
-  })),
+  HarmonyAgent: harmonyAgentMock,
 }));
 
 vi.mock('../../src/device', () => ({
@@ -115,6 +116,34 @@ describe('harmonyPlaygroundPlatform', () => {
     await expect(prepared.sessionManager?.listTargets?.()).resolves.toEqual([]);
     await expect(prepared.sessionManager?.createSession({})).rejects.toThrow(
       'No HarmonyOS devices found',
+    );
+  });
+
+  test('passes host Agent options to each new HarmonyOS Agent', async () => {
+    const agentOptions = {
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+    const { harmonyPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await harmonyPlaygroundPlatform.prepare({
+      deferConnection: true,
+      getAgentOptions: () => agentOptions,
+    });
+    const created = await prepared.sessionManager?.createSession({
+      deviceId: 'SERIAL123',
+    });
+    await created?.agentFactory?.();
+
+    expect(harmonyAgentMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      agentOptions,
+    );
+    expect(harmonyAgentMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      agentOptions,
     );
   });
 

--- a/packages/ios/src/platform.ts
+++ b/packages/ios/src/platform.ts
@@ -9,10 +9,15 @@ import {
   PLAYGROUND_SERVER_PORT,
 } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
-import { type IOSAgent, agentFromWebDriverAgent } from './agent';
+import {
+  type IOSAgent,
+  type IOSAgentOpt,
+  agentFromWebDriverAgent,
+} from './agent';
 
 export interface IOSPlatformOptions {
   staticDir?: string;
+  getAgentOptions?: () => IOSAgentOpt;
 }
 
 // Quick liveness probe so getSetupSchema can flip on autoSubmitWhenReady
@@ -119,6 +124,7 @@ export const iosPlaygroundPlatform = definePlaygroundPlatform<
 
         const connectAgent = async (): Promise<IOSAgent> => {
           return agentFromWebDriverAgent({
+            ...options?.getAgentOptions?.(),
             wdaHost: host,
             wdaPort: port,
             ...(sessionId ? { sessionId } : {}),

--- a/packages/ios/tests/unit-test/platform-session-manager.test.ts
+++ b/packages/ios/tests/unit-test/platform-session-manager.test.ts
@@ -84,4 +84,32 @@ describe('iosPlaygroundPlatform session manager', () => {
       wdaPort: 8300,
     });
   });
+
+  test('passes host Agent options to each new iOS Agent', async () => {
+    const agentOptions = {
+      replanningCycleLimit: 12,
+      waitAfterAction: 500,
+      screenshotShrinkFactor: 2,
+    };
+    const { iosPlaygroundPlatform } = await import('../../src/platform');
+    const prepared = await iosPlaygroundPlatform.prepare({
+      getAgentOptions: () => agentOptions,
+    });
+    const created = await prepared.sessionManager?.createSession({
+      host: 'localhost',
+      port: 8100,
+    });
+    await created?.agentFactory?.();
+
+    expect(agentFromWebDriverAgentMock).toHaveBeenNthCalledWith(1, {
+      ...agentOptions,
+      wdaHost: 'localhost',
+      wdaPort: 8100,
+    });
+    expect(agentFromWebDriverAgentMock).toHaveBeenNthCalledWith(2, {
+      ...agentOptions,
+      wdaHost: 'localhost',
+      wdaPort: 8100,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- rename the Studio model configuration entry to a general Config modal and add an Agent Option Config section
- support replanning cycle limit, wait-after-action delay, and screenshot shrink factor with validation and local persistence
- synchronize saved options to the Studio main-process runtime and apply them when the next Web, Android, iOS, HarmonyOS, or Computer Agent is created
- add unit coverage for the form, persistence, IPC bridge, runtime synchronization, and platform Agent constructor arguments

## Behavior

- saving updates the runtime option cache but does not recreate an active Agent
- updated options take effect on the next Agent connection
- empty fields preserve the corresponding core/model default

## Validation

- pnpm run lint
- pnpm test (apps/studio)
- pnpm test -- tests/unit/platform-session-manager.test.ts (packages/android-playground)
- pnpm test -- tests/unit/platform-session-manager.test.ts (packages/computer-playground)
- pnpm test -- tests/unit-test/platform-session-manager.test.ts (packages/ios)
- pnpm test -- tests/unit-test/platform.test.ts (packages/harmony)
- pnpm build (apps/studio)
- pnpm build (packages/android-playground)
- pnpm build (packages/computer-playground)
- pnpm build (packages/ios)
- pnpm build (packages/harmony)