### PR TITLE
feat(device): use WebP for device screenshot producers

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -31,6 +31,7 @@ import {
 } from '@midscene/shared/env';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import {
+  canonicalizeScreenshotBase64,
   createImgBase64ByFormat,
   validateScreenshotBuffer,
 } from '@midscene/shared/img';
@@ -518,7 +519,7 @@ ${Object.keys(size)
   /**
    * Continuous frame source backed by the scrcpy video stream.
    *
-   * Decoding H.264 to JPEG costs an ffmpeg process per frame (~100ms measured
+   * Decoding H.264 to WebP costs an ffmpeg process plus one Sharp encode per
    * on-device), so `latest()` hands out RAW keyframe handles (near-zero cost —
    * the stream is already flowing) and `decode()` pays the ffmpeg cost only
    * for the frames the observer actually sampled, at the end of the window.
@@ -551,7 +552,7 @@ ${Object.keys(size)
         const images: string[] = [];
         for (const frameRef of refs) {
           images.push(
-            await adapter.decodeRawKeyframeToJpegBase64(
+            await adapter.decodeRawKeyframeToWebpBase64(
               frameRef.ref as RawKeyframe,
             ),
           );
@@ -1269,9 +1270,8 @@ ${Object.keys(size)
     }
 
     debugDevice('Converting to base64');
-    const result = createImgBase64ByFormat(
-      'png',
-      screenshotBuffer.toString('base64'),
+    const result = await canonicalizeScreenshotBase64(
+      createImgBase64ByFormat('png', screenshotBuffer.toString('base64')),
     );
     if (localScreenshotPath) {
       debugDevice(`Deleting local screenshot: ${localScreenshotPath}`);

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -207,11 +207,11 @@ export class ScrcpyDeviceAdapter {
 
     try {
       const manager = await this.ensureManager(deviceInfo);
-      const screenshotBuffer = await manager.getScreenshotJpeg();
+      const screenshotBuffer = await manager.getScreenshotWebp();
       this.clearFailure();
 
       return createImgBase64ByFormat(
-        'jpeg',
+        'webp',
         screenshotBuffer.toString('base64'),
       );
     } catch (error) {
@@ -249,15 +249,15 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
-   * Decode a raw keyframe to a JPEG data URL. Deferred, per-frame-expensive
+   * Decode a raw keyframe to a WebP data URL. Deferred, per-frame-expensive
    * step (one ffmpeg process per call) — only call on sampled frames.
    */
-  async decodeRawKeyframeToJpegBase64(frame: RawKeyframe): Promise<string> {
+  async decodeRawKeyframeToWebpBase64(frame: RawKeyframe): Promise<string> {
     if (!this.manager) {
       throw new Error('scrcpy manager is not initialized');
     }
-    const jpegBuffer = await this.manager.decodeRawKeyframeToJpeg(frame);
-    return createImgBase64ByFormat('jpeg', jpegBuffer.toString('base64'));
+    const webpBuffer = await this.manager.decodeRawKeyframeToWebp(frame);
+    return createImgBase64ByFormat('webp', webpBuffer.toString('base64'));
   }
 
   /**

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -50,7 +50,7 @@ export interface ScrcpyScreenshotOptions {
 
 /**
  * A raw (not yet decoded) H.264 keyframe emitted by the scrcpy stream.
- * Holding these is cheap — decoding to JPEG costs an ffmpeg run per frame, so
+ * Holding these is cheap — decoding to WebP costs an ffmpeg run per frame, so
  * consumers (e.g. UI observers) buffer raw keyframes and decode only
  * the frames they actually need, after sampling.
  */
@@ -465,7 +465,7 @@ export class ScrcpyScreenshotManager {
    * one subscriber is active, incoming keyframes keep resetting the idle timer
    * so the connection is not torn down mid-capture. Returns an unsubscribe fn.
    *
-   * Frames are emitted RAW (no decoding). Use {@link decodeRawKeyframeToJpeg}
+   * Frames are emitted RAW (no decoding). Use {@link decodeRawKeyframeToWebp}
    * on the frames you actually need — one ffmpeg run per unique frame.
    */
   subscribeKeyframes(listener: (frame: RawKeyframe) => void): () => void {
@@ -492,20 +492,20 @@ export class ScrcpyScreenshotManager {
 
   /**
    * Decode a raw keyframe (from {@link subscribeKeyframes} or
-   * {@link getLatestRawKeyframe}) to a JPEG buffer. This is the deferred,
+   * {@link getLatestRawKeyframe}) to a WebP buffer. This is the deferred,
    * per-frame-expensive step (one ffmpeg process per call) — call it only on
    * sampled frames, never inside a capture loop.
    */
-  async decodeRawKeyframeToJpeg(frame: RawKeyframe): Promise<Buffer> {
-    return this.decodeH264ToJpeg(Buffer.concat([frame.header, frame.data]));
+  async decodeRawKeyframeToWebp(frame: RawKeyframe): Promise<Buffer> {
+    return this.decodeH264ToWebp(Buffer.concat([frame.header, frame.data]));
   }
 
   /**
-   * Get screenshot as JPEG.
+   * Get screenshot as WebP.
    * Tries to get a fresh frame within a short timeout. If the screen is static
    * (no new frames arrive), falls back to the latest cached keyframe.
    */
-  async getScreenshotJpeg(): Promise<Buffer> {
+  async getScreenshotWebp(): Promise<Buffer> {
     const perfStart = Date.now();
 
     const t1 = Date.now();
@@ -542,7 +542,7 @@ export class ScrcpyScreenshotManager {
     );
 
     const t4 = Date.now();
-    const result = await this.decodeH264ToJpeg(keyframeBuffer);
+    const result = await this.decodeH264ToWebp(keyframeBuffer);
     const decodeTime = Date.now() - t4;
 
     const totalTime = Date.now() - perfStart;
@@ -662,10 +662,18 @@ export class ScrcpyScreenshotManager {
   }
 
   /**
-   * Decode H.264 data to JPEG using ffmpeg
+   * Decode H.264 to raw RGB with ffmpeg, then encode the selected frame once
+   * as WebP with Sharp. The bundled ffmpeg does not include libwebp.
    */
-  private async decodeH264ToJpeg(h264Buffer: Buffer): Promise<Buffer> {
+  private async decodeH264ToWebp(h264Buffer: Buffer): Promise<Buffer> {
     const { spawn } = await import('node:child_process');
+    const { default: sharp } = await import('sharp');
+    const resolution = this.videoResolution;
+    if (!resolution?.width || !resolution.height) {
+      throw new Error(
+        'Cannot decode scrcpy frame before video resolution is known',
+      );
+    }
 
     return new Promise((resolve, reject) => {
       const ffmpegArgs = [
@@ -676,11 +684,9 @@ export class ScrcpyScreenshotManager {
         '-vframes',
         '1',
         '-f',
-        'image2pipe',
-        '-vcodec',
-        'mjpeg',
-        '-q:v',
-        '5',
+        'rawvideo',
+        '-pix_fmt',
+        'rgb24',
         '-loglevel',
         'error',
         'pipe:1',
@@ -691,32 +697,68 @@ export class ScrcpyScreenshotManager {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
-      const chunks: Buffer[] = [];
       let stderrOutput = '';
+      let settled = false;
 
-      ffmpeg.stdout.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
+      const encoder = sharp({
+        raw: {
+          width: resolution.width,
+          height: resolution.height,
+          channels: 3,
+        },
+      }).webp({ quality: 90, effort: 1 });
+      // Resolve failures into a value immediately so an ffmpeg spawn/exit
+      // failure cannot leave Sharp with a temporarily unhandled rejection.
+      const encodedWebpResult = encoder.toBuffer().then(
+        (buffer) => ({ ok: true as const, buffer }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+      ffmpeg.stdout.pipe(encoder);
 
       ffmpeg.stderr.on('data', (data: Buffer) => {
         stderrOutput += data.toString();
       });
 
-      ffmpeg.on('close', (code) => {
-        if (code === 0 && chunks.length > 0) {
-          const jpegBuffer = Buffer.concat(chunks);
-          debugScrcpy(
-            `FFmpeg decode successful, JPEG size: ${jpegBuffer.length} bytes`,
-          );
-          resolve(jpegBuffer);
-        } else {
+      ffmpeg.on('close', async (code) => {
+        if (settled) return;
+        if (code !== 0) {
+          settled = true;
           const errorMsg = stderrOutput || `FFmpeg exited with code ${code}`;
           debugScrcpy(`FFmpeg decode failed: ${errorMsg}`);
-          reject(new Error(`H.264 to JPEG decode failed: ${errorMsg}`));
+          reject(new Error(`H.264 frame decode failed: ${errorMsg}`));
+          return;
+        }
+
+        try {
+          const encodeResult = await encodedWebpResult;
+          if (!encodeResult.ok) {
+            throw encodeResult.error;
+          }
+          const webpBuffer = encodeResult.buffer;
+          if (
+            webpBuffer.subarray(0, 4).toString('ascii') !== 'RIFF' ||
+            webpBuffer.subarray(8, 12).toString('ascii') !== 'WEBP'
+          ) {
+            throw new Error('Sharp returned invalid WebP bytes');
+          }
+          settled = true;
+          debugScrcpy(
+            `H.264 decode and WebP encode successful, WebP size: ${webpBuffer.length} bytes`,
+          );
+          resolve(webpBuffer);
+        } catch (error) {
+          settled = true;
+          reject(
+            new Error(
+              `H.264 to WebP encode failed: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          );
         }
       });
 
       ffmpeg.on('error', (error) => {
+        if (settled) return;
+        settled = true;
         reject(new Error(`Failed to spawn ffmpeg process: ${error.message}`));
       });
 

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -347,7 +347,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
     );
     const searchXmlFile = path.join(diagnosticsDir, 'settings-search.xml');
     const finalXmlFile = path.join(diagnosticsDir, 'settings-final.xml');
-    const screenshotFile = path.join(diagnosticsDir, 'settings-search.png');
+    const screenshotFile = path.join(diagnosticsDir, 'settings-search.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -395,6 +395,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       const logicalSize = await device.size();
       const screenshot = await device.screenshotBase64();
       const screenshotSize = await imageInfoOfBase64(screenshot);
+      expect(screenshot).toMatch(/^data:image\/webp;base64,/);
       const density = await adb.getScreenDensity();
       evidence.device = {
         id: devices[0].udid,
@@ -528,6 +529,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       evidence.keyboardShownBeforeBack = await waitForKeyboardState(adb, true);
 
       const searchScreenshot = await device.screenshotBase64();
+      expect(searchScreenshot).toMatch(/^data:image\/webp;base64,/);
       await writeFile(screenshotFile, screenshotBuffer(searchScreenshot));
 
       await agent.back();

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -224,14 +224,13 @@ describe('Test todo list', () => {
         const resolvedDiagnosticsDir = path.resolve(diagnosticsDir);
         await mkdir(resolvedDiagnosticsDir, { recursive: true });
         await Promise.all([
-          agent.interface
-            .screenshotBase64()
-            .then((base64) =>
-              writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
-                screenshotBuffer(base64),
-              ),
-            ),
+          agent.interface.screenshotBase64().then((base64) => {
+            expect(base64).toMatch(/^data:image\/webp;base64,/);
+            return writeFile(
+              path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
+              screenshotBuffer(base64),
+            );
+          }),
           writeFile(
             path.join(resolvedDiagnosticsDir, 'todo-agent-dump.json'),
             `${agent.dumpDataString()}\n`,

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -117,7 +117,7 @@ describe('AndroidDevice frame-source capability', () => {
         listener = cb;
         return unsubscribe;
       }),
-      decodeRawKeyframeToJpegBase64: decode,
+      decodeRawKeyframeToWebpBase64: decode,
     };
     (device as any).getDevicePhysicalInfo = vi.fn().mockResolvedValue({});
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -108,6 +108,7 @@ vi.mock('@midscene/shared/img', async (importOriginal) => {
     });
   return {
     ...original,
+    canonicalizeScreenshotBase64: vi.fn(),
     createImgBase64ByFormat: vi.fn(),
     resizeAndConvertImgBuffer: vi.fn(),
     validateScreenshotBuffer,
@@ -546,6 +547,9 @@ Stdout:
           format,
         }),
       );
+      vi.mocked(ImgUtils.canonicalizeScreenshotBase64).mockImplementation(
+        async (dataUrl) => dataUrl.replace('image/png', 'image/webp'),
+      );
     });
 
     it('should take screenshot successfully with takeScreenshot', async () => {
@@ -558,6 +562,7 @@ Stdout:
       );
 
       const result = await device.screenshotBase64();
+      expect(result).toContain('data:image/webp;base64,');
       expect(result).toContain(mockBuffer.toString('base64'));
       expect(mockAdb.shell).not.toHaveBeenCalled();
     });
@@ -581,6 +586,7 @@ Stdout:
       expect(mockAdb.pull).toHaveBeenCalled();
       expect(fs.promises.readFile).toHaveBeenCalled();
       expect(result).toContain(mockBuffer.toString('base64'));
+      expect(result).toContain('data:image/webp;base64,');
       // rm is now executed via execFile (fire-and-forget), not adb.shell
     });
 
@@ -601,6 +607,7 @@ Stdout:
       const result = await defaultDevice.screenshotBase64();
 
       expect(result).toContain(smallValidPng.toString('base64'));
+      expect(result).toContain('data:image/webp;base64,');
       expect(mockAdb.pull).toHaveBeenCalled();
     });
 

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -24,7 +24,8 @@ const createMockManager = () => ({
   validateEnvironment: vi.fn().mockResolvedValue(undefined),
   ensureConnected: vi.fn().mockResolvedValue(undefined),
   isConnected: vi.fn().mockReturnValue(false),
-  getScreenshotJpeg: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+  getScreenshotWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
+  decodeRawKeyframeToWebp: vi.fn().mockResolvedValue(Buffer.from('fake-webp')),
   getResolution: vi.fn().mockReturnValue(null),
   disconnect: vi.fn().mockResolvedValue(undefined),
 });
@@ -44,7 +45,7 @@ vi.mock('../../src/scrcpy-manager', async (importOriginal) => {
 vi.mock('@midscene/shared/img', () => ({
   createImgBase64ByFormat: vi
     .fn()
-    .mockReturnValue('data:image/png;base64,test'),
+    .mockReturnValue('data:image/webp;base64,test'),
 }));
 
 const defaultDeviceInfo: DevicePhysicalInfo = {
@@ -336,8 +337,25 @@ describe('ScrcpyDeviceAdapter', () => {
       (adapter as any).manager = currentMockManager;
 
       const result = await adapter.screenshotBase64(defaultDeviceInfo);
-      expect(result).toBe('data:image/png;base64,test');
-      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(1);
+      expect(result).toBe('data:image/webp;base64,test');
+      expect(currentMockManager.getScreenshotWebp).toHaveBeenCalledTimes(1);
+    });
+
+    it('decodes sampled H.264 keyframes directly to WebP data URLs', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', undefined);
+      (adapter as any).manager = currentMockManager;
+      const frame = {
+        header: Buffer.from([0x67]),
+        data: Buffer.from([0x65]),
+        capturedAt: 123,
+      };
+
+      await expect(adapter.decodeRawKeyframeToWebpBase64(frame)).resolves.toBe(
+        'data:image/webp;base64,test',
+      );
+      expect(currentMockManager.decodeRawKeyframeToWebp).toHaveBeenCalledWith(
+        frame,
+      );
     });
   });
 
@@ -407,13 +425,13 @@ describe('ScrcpyDeviceAdapter', () => {
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
         /retry is cooling down/,
       );
-      expect(currentMockManager.getScreenshotJpeg).not.toHaveBeenCalled();
+      expect(currentMockManager.getScreenshotWebp).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(60_000);
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
-        'data:image/png;base64,test',
+        'data:image/webp;base64,test',
       );
-      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(1);
+      expect(currentMockManager.getScreenshotWebp).toHaveBeenCalledTimes(1);
       expect(adapter.getStatus().lastError).toBeNull();
     });
   });

--- a/packages/computer/package.json
+++ b/packages/computer/package.json
@@ -47,6 +47,7 @@
     "@types/node": "^18.0.0",
     "@types/screenshot-desktop": "1.15.0",
     "dotenv": "^16.4.5",
+    "sharp": "^0.34.3",
     "tsx": "^4.19.2",
     "typescript": "^5.8.3",
     "vitest": "3.0.5"

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -16,7 +16,10 @@ import {
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
+import {
+  canonicalizeScreenshotBase64,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import screenshot from 'screenshot-desktop';
 import {
@@ -1156,7 +1159,9 @@ Available Displays: ${displays.length > 0 ? displays.map((d) => d.name).join(', 
         if (attempt > 1) {
           debugDevice(`Screenshot succeeded on attempt ${attempt}`);
         }
-        return createImgBase64ByFormat('png', buffer.toString('base64'));
+        return canonicalizeScreenshotBase64(
+          createImgBase64ByFormat('png', buffer.toString('base64')),
+        );
       } catch (error) {
         lastRawMessage = error instanceof Error ? error.message : String(error);
         const isMacTransient =
@@ -1208,7 +1213,7 @@ Original error: ${lastRawMessage}`,
    * separate Windows concern to be addressed in a follow-up with real-device
    * verification.
    */
-  private screenshotViaPowershell(): string {
+  private async screenshotViaPowershell(): Promise<string> {
     const deviceName = this.displayId ? String(this.displayId) : '';
     // A requested displayId that cannot be matched (stale saved id, unplugged
     // monitor) must fail fast rather than silently capturing the primary
@@ -1247,7 +1252,7 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
         'Failed to take screenshot on Windows: PowerShell returned no image data',
       );
     }
-    return createImgBase64ByFormat('png', body);
+    return canonicalizeScreenshotBase64(createImgBase64ByFormat('png', body));
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/src/rdp/device.ts
+++ b/packages/computer/src/rdp/device.ts
@@ -12,6 +12,7 @@ import {
   defineActionsFromInputPrimitives,
 } from '@midscene/core/device';
 import { sleep } from '@midscene/core/utils';
+import { canonicalizeScreenshotBase64 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { ComputerDeviceInputOpt, DisplayInfo } from '../device';
 import {
@@ -258,7 +259,9 @@ export class RDPDevice implements AbstractInterface {
 
   async screenshotBase64(): Promise<string> {
     this.assertConnected();
-    return this.backend.screenshotBase64();
+    return canonicalizeScreenshotBase64(await this.backend.screenshotBase64(), {
+      preserveJpeg: true,
+    });
   }
 
   async size(): Promise<Size> {

--- a/packages/computer/tests/ai/ai-auto-todo.test.ts
+++ b/packages/computer/tests/ai/ai-auto-todo.test.ts
@@ -75,7 +75,7 @@ describe('computer todo app automation', () => {
             .screenshotBase64()
             .then((base64) =>
               writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
+                path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
                 screenshotBuffer(base64),
               ),
             ),

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -440,7 +440,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
     const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
     const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
     const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
-    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -564,6 +564,8 @@ describe.skipIf(!RUN_LIVE_SMOKE)('macOS desktop live smoke', () => {
       );
       const screenshotBuffer = Buffer.from(base64Body(screenshot), 'base64');
       await writeFile(screenshotFile, screenshotBuffer);
+      expect(screenshotBuffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(screenshotBuffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
       evidence.screenshot = {
         ...screenshotInfo,
         scale: screenshotScale,

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -1,5 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
-import { execFile, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parseDumpScript } from '@midscene/core';
@@ -266,38 +266,8 @@ function base64Body(dataUrl: string): string {
   return dataUrl.slice(commaIndex + 1);
 }
 
-function quotePowerShellSingle(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function runPowerShell(script: string): Promise<string> {
-  const encoded = Buffer.from(
-    `$ErrorActionPreference = 'Stop'\n${script}`,
-    'utf16le',
-  ).toString('base64');
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
-      { encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(
-            new Error(
-              `PowerShell screenshot analysis failed: ${error.message}\n${stderr}`,
-            ),
-          );
-          return;
-        }
-        resolve(stdout.trim());
-      },
-    );
-  });
-}
-
 async function analyzeScreenshot(
-  screenshotPath: string,
+  screenshotBuffer: Buffer,
   button: Bounds,
   form: Bounds,
   screen: Bounds,
@@ -310,34 +280,45 @@ async function analyzeScreenshot(
     localForm.left + localForm.width - backgroundSize - 12,
   );
   const backgroundTop = Math.max(localForm.top + 2, localForm.top + 42);
-
-  const script = `
-Add-Type -AssemblyName System.Drawing
-$bitmap = [System.Drawing.Bitmap]::FromFile(${quotePowerShellSingle(screenshotPath)})
-function Get-AverageColor([int] $left, [int] $top, [int] $width, [int] $height) {
-  $red = 0L; $green = 0L; $blue = 0L; $count = 0L
-  $stepX = [Math]::Max(1, [Math]::Floor($width / 7))
-  $stepY = [Math]::Max(1, [Math]::Floor($height / 7))
-  for ($x = $left; $x -lt ($left + $width); $x += $stepX) {
-    for ($y = $top; $y -lt ($top + $height); $y += $stepY) {
-      $pixel = $bitmap.GetPixel($x, $y)
-      $red += $pixel.R; $green += $pixel.G; $blue += $pixel.B; $count += 1
-    }
-  }
-  [PSCustomObject]@{
-    r = [Math]::Round($red / $count)
-    g = [Math]::Round($green / $count)
-    b = [Math]::Round($blue / $count)
-  }
-}
-$target = Get-AverageColor ${Math.round(target.left + 7)} ${Math.round(target.top + 7)} ${Math.max(1, Math.round(target.width - 14))} ${Math.max(1, Math.round(target.height - 14))}
-$background = Get-AverageColor ${Math.round(backgroundLeft)} ${Math.round(backgroundTop)} ${backgroundSize} ${backgroundSize}
-$difference = [Math]::Abs($target.r - $background.r) + [Math]::Abs($target.g - $background.g) + [Math]::Abs($target.b - $background.b)
-[PSCustomObject]@{ target = $target; background = $background; channelDifference = $difference } | ConvertTo-Json -Compress
-$bitmap.Dispose()
-`.trim();
-
-  return JSON.parse(await runPowerShell(script)) as ScreenshotAnalysis;
+  const { default: sharp } = await import('sharp');
+  const averageColor = async (bounds: Bounds) => {
+    const cropped = await sharp(screenshotBuffer)
+      .extract({
+        left: Math.round(bounds.left),
+        top: Math.round(bounds.top),
+        width: Math.max(1, Math.round(bounds.width)),
+        height: Math.max(1, Math.round(bounds.height)),
+      })
+      .toBuffer();
+    const stats = await sharp(cropped).stats();
+    return {
+      r: Math.round(stats.channels[0].mean),
+      g: Math.round(stats.channels[1].mean),
+      b: Math.round(stats.channels[2].mean),
+    };
+  };
+  const [targetColor, backgroundColor] = await Promise.all([
+    averageColor({
+      left: target.left + 7,
+      top: target.top + 7,
+      width: target.width - 14,
+      height: target.height - 14,
+    }),
+    averageColor({
+      left: backgroundLeft,
+      top: backgroundTop,
+      width: backgroundSize,
+      height: backgroundSize,
+    }),
+  ]);
+  return {
+    target: targetColor,
+    background: backgroundColor,
+    channelDifference:
+      Math.abs(targetColor.r - backgroundColor.r) +
+      Math.abs(targetColor.g - backgroundColor.g) +
+      Math.abs(targetColor.b - backgroundColor.b),
+  };
 }
 
 function parseReportDumps(html: string): ReportDump[] {
@@ -397,6 +378,47 @@ async function stopFixture(
   await Promise.race([exitPromise, sleep(5_000)]);
 }
 
+describe('WebP screenshot analysis', () => {
+  it('decodes WebP evidence without relying on System.Drawing', async () => {
+    const { default: sharp } = await import('sharp');
+    const screenshotBuffer = await sharp({
+      create: {
+        width: 100,
+        height: 100,
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    })
+      .composite([
+        {
+          input: {
+            create: {
+              width: 30,
+              height: 30,
+              channels: 3,
+              background: { r: 0, g: 255, b: 0 },
+            },
+          },
+          left: 10,
+          top: 10,
+        },
+      ])
+      .webp({ quality: 90 })
+      .toBuffer();
+
+    const analysis = await analyzeScreenshot(
+      screenshotBuffer,
+      { left: 10, top: 10, width: 30, height: 30 },
+      { left: 0, top: 0, width: 100, height: 100 },
+      { left: 0, top: 0, width: 100, height: 100 },
+    );
+
+    expect(analysis.target.g - analysis.target.r).toBeGreaterThan(200);
+    expect(analysis.target.g - analysis.target.b).toBeGreaterThan(200);
+    expect(analysis.channelDifference).toBeGreaterThan(400);
+  });
+});
+
 describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
   it('drives a visible WinForms app without calling a model and emits evidence', async () => {
     const diagnosticsEnv = process.env.MIDSCENE_WINDOWS_DIAGNOSTICS_DIR;
@@ -411,7 +433,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
     const stateFile = path.join(diagnosticsDir, 'fixture-state.json');
     const fixtureStdoutFile = path.join(diagnosticsDir, 'fixture.stdout.log');
     const fixtureStderrFile = path.join(diagnosticsDir, 'fixture.stderr.log');
-    const screenshotFile = path.join(diagnosticsDir, 'desktop.png');
+    const screenshotFile = path.join(diagnosticsDir, 'desktop.webp');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
     const runDir = path.resolve(process.env.MIDSCENE_RUN_DIR || 'midscene_run');
@@ -533,12 +555,11 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Windows desktop live smoke', () => {
         width: metadata.screen.width,
         height: metadata.screen.height,
       });
-      expect(screenshotBuffer.subarray(0, 8)).toEqual(
-        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      );
+      expect(screenshotBuffer.subarray(0, 4).toString('ascii')).toBe('RIFF');
+      expect(screenshotBuffer.subarray(8, 12).toString('ascii')).toBe('WEBP');
 
       const screenshotAnalysis = await analyzeScreenshot(
-        screenshotFile,
+        screenshotBuffer,
         metadata.button,
         metadata.form,
         metadata.screen,

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -110,6 +110,14 @@ vi.mock('node:module', () => ({
   createRequire: mockState.createRequire,
 }));
 
+vi.mock('@midscene/shared/img', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@midscene/shared/img')>()),
+  canonicalizeScreenshotBase64: vi.fn(
+    async () =>
+      'data:image/webp;base64,UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=',
+  ),
+}));
+
 const originalPlatform = process.platform;
 const mockExecutorContext = { task: {} } as ExecutorContext;
 

--- a/packages/computer/tests/unit-test/rdp/agent.test.ts
+++ b/packages/computer/tests/unit-test/rdp/agent.test.ts
@@ -15,6 +15,9 @@ import type {
 } from '../../../src';
 import { formatRdpServerAddress } from '../../../src/rdp/address';
 
+const VALID_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
 class FakeRDPBackend implements RDPBackendClient {
   calls: Array<{ name: string; args: unknown[] }> = [];
 
@@ -33,7 +36,7 @@ class FakeRDPBackend implements RDPBackendClient {
 
   async screenshotBase64(): Promise<string> {
     this.calls.push({ name: 'screenshotBase64', args: [] });
-    return 'data:image/png;base64,ZmFrZQ==';
+    return `data:image/png;base64,${VALID_PNG_BASE64}`;
   }
 
   async size(): Promise<Size> {
@@ -93,6 +96,16 @@ function createLocate(
 }
 
 describe('@midscene/computer RDP device', () => {
+  it('converts backend PNG screenshots to WebP', async () => {
+    const backend = new FakeRDPBackend();
+    const device = new RDPDevice({ host: '10.0.0.1', backend });
+    await device.connect();
+
+    await expect(device.screenshotBase64()).resolves.toMatch(
+      /^data:image\/webp;base64,UklGR/,
+    );
+  });
+
   it('connects and exposes the RDP device through agentForRDPComputer', async () => {
     const backend = new FakeRDPBackend();
     const agent = await agentForRDPComputer({

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -1,6 +1,16 @@
 import { Buffer } from 'node:buffer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const FAKE_WEBP_BASE64 =
+  'UklGRioAAABXRUJQVlA4IB4AAAAwAQCdASoBAAEAAUAmJQBOgCHwAP7+hNQAAAA=';
+
+vi.mock('@midscene/shared/img', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@midscene/shared/img')>()),
+  canonicalizeScreenshotBase64: vi.fn(
+    async () => `data:image/webp;base64,${FAKE_WEBP_BASE64}`,
+  ),
+}));
+
 // A 1x1 PNG, base64-encoded, as PowerShell's CopyFromScreen path would print
 // to stdout.
 const FAKE_PNG_BASE64 =
@@ -36,7 +46,7 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
     vi.resetModules();
   });
 
-  it('captures through powershell.exe and returns a PNG data URI', async () => {
+  it('captures through powershell.exe and returns a WebP data URI', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const { ComputerDevice } = await import('../../src/device');
 
@@ -45,7 +55,7 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
 
     expect(execFileSync).toHaveBeenCalledTimes(1);
     expect(execFileSync.mock.calls[0][0]).toBe('powershell.exe');
-    expect(base64).toBe(`data:image/png;base64,${FAKE_PNG_BASE64}`);
+    expect(base64).toMatch(/^data:image\/webp;base64,UklGR/);
 
     // ExecutionPolicy only gates .ps1 files, not -EncodedCommand input, so it
     // must not be passed.

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -20,7 +20,10 @@ import {
 import { sleep } from '@midscene/core/utils';
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import type { ElementInfo } from '@midscene/shared/extractor';
-import { createImgBase64ByFormat } from '@midscene/shared/img';
+import {
+  canonicalizeScreenshotBase64,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison } from '@midscene/shared/utils';
 import { WDAManager } from '@midscene/webdriver';
@@ -433,7 +436,9 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     debugDevice('Taking screenshot via WDA');
     try {
       const base64Data = await this.wdaBackend.takeScreenshot();
-      const result = createImgBase64ByFormat('png', base64Data);
+      const result = await canonicalizeScreenshotBase64(
+        createImgBase64ByFormat('png', base64Data),
+      );
       debugDevice('Screenshot taken successfully');
       return result;
     } catch (error) {

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -283,10 +283,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       diagnosticsDir,
       'safari-after-input-source.xml',
     );
-    const screenshotFile = path.join(diagnosticsDir, 'safari-smoke.png');
+    const screenshotFile = path.join(diagnosticsDir, 'safari-smoke.webp');
     const postInputScreenshotFile = path.join(
       diagnosticsDir,
-      'safari-after-input.png',
+      'safari-after-input.webp',
     );
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
     const evidenceFile = path.join(diagnosticsDir, 'evidence.json');
@@ -337,6 +337,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const screenSize = await agent.interface.getScreenSize();
       const screenshot = await agent.interface.screenshotBase64();
       const screenshotSize = await imageInfoOfBase64(screenshot);
+      expect(screenshot).toMatch(/^data:image\/webp;base64,/);
       await writeFile(screenshotFile, screenshotBuffer(screenshot));
       evidence.screen = { screenSize, screenshotSize };
       expect(screenSize.width).toBeGreaterThan(0);
@@ -387,11 +388,12 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
         : undefined;
       evidence.inputText = inputText;
       expect(inputText).toBe(SUBMITTED_TEXT);
-      await agent.interface
-        .screenshotBase64()
-        .then((base64) =>
-          writeFile(postInputScreenshotFile, screenshotBuffer(base64)),
-        );
+      const postInputScreenshot = await agent.interface.screenshotBase64();
+      expect(postInputScreenshot).toMatch(/^data:image\/webp;base64,/);
+      await writeFile(
+        postInputScreenshotFile,
+        screenshotBuffer(postInputScreenshot),
+      );
 
       const submittedValue = await waitForSubmittedValue(
         fixture.submittedValue,

--- a/packages/ios/tests/ai/todo.test.ts
+++ b/packages/ios/tests/ai/todo.test.ts
@@ -91,14 +91,13 @@ describe('Test todo list', () => {
           endpoint: '/source',
         })) as { value: string };
         await Promise.all([
-          agent.interface
-            .screenshotBase64()
-            .then((base64) =>
-              writeFile(
-                path.join(resolvedDiagnosticsDir, 'todo-final.png'),
-                screenshotBuffer(base64),
-              ),
-            ),
+          agent.interface.screenshotBase64().then((base64) => {
+            expect(base64).toMatch(/^data:image\/webp;base64,/);
+            return writeFile(
+              path.join(resolvedDiagnosticsDir, 'todo-final.webp'),
+              screenshotBuffer(base64),
+            );
+          }),
           writeFile(
             path.join(resolvedDiagnosticsDir, 'todo-source.xml'),
             source.value,

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -17,6 +17,8 @@ const getInternalTextInput = (target: IOSDevice) =>
   };
 
 describe('IOSDevice', () => {
+  const validPngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
   let device: IOSDevice;
   let mockWdaClient: any;
 
@@ -32,7 +34,7 @@ describe('IOSDevice', () => {
       setupExistingSession: vi.fn().mockResolvedValue(undefined),
       deleteSession: vi.fn().mockResolvedValue(undefined),
       getWindowSize: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
-      takeScreenshot: vi.fn().mockResolvedValue('base64-screenshot'),
+      takeScreenshot: vi.fn().mockResolvedValue(validPngBase64),
       tap: vi.fn().mockResolvedValue(undefined),
       doubleTap: vi.fn().mockResolvedValue(undefined),
       tripleTap: vi.fn().mockResolvedValue(undefined),
@@ -297,8 +299,7 @@ describe('IOSDevice', () => {
       await device.connect();
 
       const screenshot = await device.screenshotBase64();
-      expect(screenshot).toContain('data:image/png;base64,');
-      expect(screenshot).toContain('base64-screenshot');
+      expect(screenshot).toMatch(/^data:image\/webp;base64,UklGR/);
       expect(mockWdaClient.takeScreenshot).toHaveBeenCalled();
     });
 
@@ -624,8 +625,7 @@ describe('IOSDevice', () => {
     it('should return base64 screenshot', async () => {
       const screenshot = await device.screenshotBase64();
       expect(typeof screenshot).toBe('string');
-      expect(screenshot).toContain('data:image/png;base64,');
-      expect(screenshot).toContain('base64-screenshot');
+      expect(screenshot).toMatch(/^data:image\/webp;base64,UklGR/);
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,6 +890,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
+      sharp:
+        specifier: ^0.34.3
+        version: 0.34.3
       tsx:
         specifier: ^4.19.2
         version: 4.19.2


### PR DESCRIPTION
## Summary

- route Android ADB, iOS WDA, macOS, and Windows PNG captures through the shared canonical WebP encoder
- encode Android scrcpy H.264 frames as WebP through its dedicated FFmpeg-to-Sharp pipeline
- preserve native JPEG streams where another lossy conversion would add cost and reduce fidelity
- retain the desktop smoke-test stability changes in this final downstream PR
- update Android, iOS, Computer, Windows, and RDP regression coverage

The reusable PNG/JPEG-to-WebP implementation lives in `packages/shared/src/img/transform.ts`: `canonicalizeScreenshotBase64()` validates the actual image bytes and calls `convertImgBufferToWebp()`, which uses `Sharp.webp({ quality: 90, effort: 1 })` in Node. Device adapters call this shared boundary unless the source already provides a JPEG stream that should be preserved.

### WebP generation paths

| Scenario | Source format | Where WebP is generated |
| --- | --- | --- |
| Android ADB | PNG | `packages/android/src/device.ts` calls shared `canonicalizeScreenshotBase64()`, which encodes with Sharp |
| Android scrcpy | H.264 keyframe | `packages/android/src/scrcpy-manager.ts` decodes H.264 to raw RGB with FFmpeg, then encodes once with `Sharp.webp({ quality: 90, effort: 1 })` |
| iOS WDA screenshot | PNG | `packages/ios/src/device.ts` calls shared `canonicalizeScreenshotBase64()`, which encodes with Sharp |
| macOS desktop | PNG | `packages/computer/src/device.ts` calls shared `canonicalizeScreenshotBase64()`, which encodes with Sharp |
| Windows desktop | PNG | `packages/computer/src/device.ts` calls shared `canonicalizeScreenshotBase64()`, which encodes with Sharp |
| RDP | JPEG or PNG, depending on backend | `packages/computer/src/rdp/device.ts` uses `preserveJpeg: true`: JPEG remains byte-for-byte JPEG, while PNG is encoded as WebP |
| iOS MJPEG frame source | JPEG | No WebP encoding; native JPEG frames pass through to avoid a second lossy encode |

## Stack

- Depends on #2857
- Replaces the clean-stack role of #2853
- #2853 remains unchanged as a rollback option
- Stability-only changes are intentionally isolated in this downstream device PR

## Validation

- `pnpm exec nx run-many -t build -p @midscene/android @midscene/ios @midscene/computer`
- `pnpm --filter @midscene/android test` (16 files, 325 tests passed)
- `pnpm --filter @midscene/ios test` (12 files, 146 tests passed)
- `pnpm --filter @midscene/computer test` (13 files, 89 tests passed)
- `pnpm run type-check:tests`
- `pnpm run lint`
