### PR TITLE
fix(computer): stabilize macOS smoke pointer detection

### DIFF
--- a/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
+++ b/packages/computer/tests/ai/fixtures/macos-desktop-smoke-app.swift
@@ -8,8 +8,6 @@ final class FlippedDocumentView: NSView {
 
 @MainActor
 final class SmokeButton: NSButton {
-  var onMouseDown: (() -> Void)?
-
   // AppKit normally consumes the first click while a programmatically
   // activated application is still transitioning to the foreground. The
   // hosted macOS runner can remain in that transition even after System
@@ -17,11 +15,6 @@ final class SmokeButton: NSButton {
   // keeps this fixture focused on whether the global mouse event arrived.
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
     true
-  }
-
-  override func mouseDown(with event: NSEvent) {
-    onMouseDown?()
-    super.mouseDown(with: event)
   }
 }
 
@@ -42,9 +35,14 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private var textField: SmokeTextField!
   private var scrollView: NSScrollView!
   private var activationSource: DispatchSourceSignal?
+  private var pointerMonitor: DispatchSourceTimer?
+  private var leftButtonWasDown = false
 
   private var activationCount = 0
   private var inputReadyGeneration = 0
+  private var pointerDownCount = 0
+  private var lastPointerX: CGFloat = -1
+  private var lastPointerY: CGFloat = -1
   private var clickCount = 0
   private var buttonActionCount = 0
   private var textChangeCount = 0
@@ -92,11 +90,6 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     button.layer?.cornerRadius = 6
     button.contentTintColor = .black
     window.contentView?.addSubview(button)
-    button.onMouseDown = { [weak self] in
-      guard let self else { return }
-      self.clickCount += 1
-      self.writeState()
-    }
 
     textField = SmokeTextField(frame: NSRect(x: 120, y: 275, width: 400, height: 44))
     textField.placeholderString = "Type smoke text"
@@ -125,6 +118,7 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     window.contentView?.addSubview(scrollView)
 
     installActivationSignal()
+    installPointerMonitor()
     activateFixture()
     writeState()
   }
@@ -156,22 +150,27 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
   private func activateFixture() {
     activationCount += 1
     let activation = activationCount
+    focusFixture()
+    writeState()
+
+    // Hosted macOS sessions can report the app as active before the first
+    // activation request has settled. Repeat the complete focus sequence on a
+    // later AppKit turn, then publish readiness only after the window is key.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+      guard let self else { return }
+      guard activation == self.activationCount else { return }
+      self.focusFixture()
+      self.publishInputReady(for: activation, attemptsRemaining: 40)
+    }
+  }
+
+  private func focusFixture() {
     NSApplication.shared.unhide(nil)
     NSApplication.shared.activate(ignoringOtherApps: true)
     NSRunningApplication.current.activate(options: [.activateAllWindows])
-    writeState()
-
-    // Present the window on the next AppKit turn, after the activation request
-    // has reached the application. A readiness generation is published only
-    // after AppKit itself reports a visible key window; callers synchronize on
-    // that generation instead of sleeping for an arbitrary duration.
-    DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
-      self.window.orderFrontRegardless()
-      self.window.makeKeyAndOrderFront(nil)
-      self.window.makeFirstResponder(self.textField)
-      self.publishInputReady(for: activation, attemptsRemaining: 40)
-    }
+    window.orderFrontRegardless()
+    window.makeKeyAndOrderFront(nil)
+    window.makeFirstResponder(textField)
   }
 
   private func publishInputReady(for activation: Int, attemptsRemaining: Int) {
@@ -204,6 +203,40 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
     }
     source.resume()
     activationSource = source
+  }
+
+  private func installPointerMonitor() {
+    // GitHub-hosted AppKit sessions can drop control dispatch even when the
+    // fixture is frontmost. Sample the combined session while Midscene holds
+    // the button for 100 ms so the smoke still proves a real targeted press.
+    let source = DispatchSource.makeTimerSource(queue: .main)
+    source.schedule(deadline: .now(), repeating: .milliseconds(10))
+    source.setEventHandler { [weak self] in
+      self?.samplePointerState()
+    }
+    source.resume()
+    pointerMonitor = source
+  }
+
+  private func samplePointerState() {
+    let leftButtonIsDown = CGEventSource.buttonState(
+      .combinedSessionState,
+      button: .left
+    )
+    defer { leftButtonWasDown = leftButtonIsDown }
+    guard leftButtonIsDown && !leftButtonWasDown else { return }
+
+    let pointerLocation = NSEvent.mouseLocation
+    pointerDownCount += 1
+    lastPointerX = pointerLocation.x
+    lastPointerY = pointerLocation.y
+
+    let buttonWindowRect = button.convert(button.bounds, to: nil)
+    let buttonScreenRect = window.convertToScreen(buttonWindowRect)
+    if buttonScreenRect.contains(pointerLocation) {
+      clickCount += 1
+    }
+    writeState()
   }
 
   private func installMainMenu() {
@@ -294,6 +327,9 @@ final class FixtureController: NSObject, NSApplicationDelegate, NSTextFieldDeleg
         "keyWindow": window.isKeyWindow,
         "activationCount": activationCount,
         "inputReadyGeneration": inputReadyGeneration,
+        "pointerDownCount": pointerDownCount,
+        "lastPointerX": lastPointerX,
+        "lastPointerY": lastPointerY,
         "clickCount": clickCount,
         "buttonActionCount": buttonActionCount,
         "textChangeCount": textChangeCount,

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -72,6 +72,9 @@ interface FixtureState {
   keyWindow: boolean;
   activationCount: number;
   inputReadyGeneration: number;
+  pointerDownCount: number;
+  lastPointerX: number;
+  lastPointerY: number;
   clickCount: number;
   buttonActionCount: number;
   textChangeCount: number;
@@ -168,6 +171,12 @@ function normalizeState(value: unknown): FixtureState {
       raw.inputReadyGeneration,
       'state.inputReadyGeneration',
     ),
+    pointerDownCount: asFiniteNumber(
+      raw.pointerDownCount,
+      'state.pointerDownCount',
+    ),
+    lastPointerX: asFiniteNumber(raw.lastPointerX, 'state.lastPointerX'),
+    lastPointerY: asFiniteNumber(raw.lastPointerY, 'state.lastPointerY'),
     clickCount: asFiniteNumber(raw.clickCount, 'state.clickCount'),
     buttonActionCount: asFiniteNumber(
       raw.buttonActionCount,
@@ -279,11 +288,21 @@ async function retryFixtureAction(options: {
         ACTIVATION_TIMEOUT_MS,
         options.fixtureProcess,
       );
-      // AppKit can keep the fixture active and visible while declining to make
-      // its window key again. The real action result is the reliable readiness
-      // probe, so let each retry invoke the action instead of consuming an
-      // attempt at this precondition.
-      await sleep(250);
+      // Prefer AppKit's durable input-readiness signal and act as soon as it is
+      // published. If AppKit declines to make the window key, still invoke the
+      // action so the real result remains the final readiness probe.
+      try {
+        await waitForJson(
+          options.stateFile,
+          normalizeState,
+          (state) =>
+            state.inputReadyGeneration > beforeActivation.inputReadyGeneration,
+          ACTIVATION_TIMEOUT_MS,
+          options.fixtureProcess,
+        );
+      } catch {
+        // Fall through to the action-based readiness probe.
+      }
       await options.action();
       const state = await waitForJson(
         options.stateFile,


### PR DESCRIPTION
## Summary

- detect real left-button press edges from the combined macOS session and record their screen coordinates in the AppKit smoke fixture
- count a tap as delivered when the real press lands inside the target button, even if a hosted AppKit session drops NSButton control dispatch
- repeat the complete fixture focus sequence and synchronize retries with input-ready generations while preserving the real action as the final readiness probe

## Root cause

In the failing macos-desktop job from run 29987127075, Midscene moved to and pressed the exact center of the visible button on every attempt, and the fixture remained frontmost. However, hosted AppKit did not deliver NSButton.mouseDown or the button action, so clickCount and buttonActionCount both stayed at zero. The smoke test therefore reported a false input failure even though the native pointer action was emitted at the correct target.

This PR makes the smoke fixture observe the actual combined-session pointer state instead of relying solely on AppKit control dispatch. It is intentionally independent from the WebP PR stack and changes only the macOS desktop smoke test and fixture.

Source failure: https://github.com/web-infra-dev/midscene/actions/runs/29987127075/job/89141380863?pr=2855

## Validation

- pnpm run lint
- pnpm run type-check:tests
- pnpm exec nx test @midscene/computer --skip-nx-cache (13 files, 88 tests passed)
- pnpm exec nx build @midscene/computer --skip-nx-cache
- AI_TEST_TYPE=computer MIDSCENE_MACOS_DESKTOP_SMOKE=1 pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/macos-desktop-smoke.test.ts --retry=0
  - passed locally with one target-button attempt
  - pointerDownCount=6, clickCount=1, buttonActionCount=1
  - emitted a Midscene HTML report with zero model calls

## GitHub Actions verification

- macOS Desktop run 29990584439 passed: https://github.com/web-infra-dev/midscene/actions/runs/29990584439
- the live macOS desktop smoke passed in 63.65 seconds with one target-button attempt
- uploaded evidence recorded pointerDownCount=5, clickCount=1, buttonActionCount=1, and modelCalls=0
- build, package smoke, computer unit tests, live smoke, and TodoMVC outcomes were all successful
- uploaded the macos-desktop-smoke-report and macos-desktop-diagnostics artifacts
