### PR TITLE
test(android): retry transient emulator UI failures

### DIFF
--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -32,6 +32,7 @@ const SYSTEM_ERROR_DIALOG_ACTION_IDS = [
 const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 30_000;
 const UI_DUMP_MAX_ATTEMPTS = 3;
+const SEARCH_MAX_ATTEMPTS = 3;
 
 interface Bounds {
   left: number;
@@ -366,10 +367,6 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       'settings-system-dialog.xml',
     );
     const searchXmlFile = path.join(diagnosticsDir, 'settings-search.xml');
-    const firstSearchAttemptXmlFile = path.join(
-      diagnosticsDir,
-      'settings-search-attempt-1.xml',
-    );
     const finalXmlFile = path.join(diagnosticsDir, 'settings-final.xml');
     const screenshotFile = path.join(diagnosticsDir, 'settings-search.png');
     const dumpFile = path.join(diagnosticsDir, 'agent-dump.json');
@@ -484,25 +481,46 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
         return waitForEditableNode(adb, searchXmlFile, 'wifi');
       };
 
-      let searchState: { resourceId?: string; bounds: Bounds; xml: string };
-      try {
-        searchState = await performSearchAttempt(initialTarget);
-      } catch (error) {
-        searchAttemptErrors.push(String(error));
-        evidence.searchAttemptErrors = searchAttemptErrors;
-        await writeFile(
-          firstSearchAttemptXmlFile,
-          await readFile(searchXmlFile, 'utf8'),
-          'utf8',
+      let searchState:
+        | { resourceId?: string; bounds: Bounds; xml: string }
+        | undefined;
+      let searchTarget = initialTarget;
+      for (let attempt = 1; attempt <= SEARCH_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          searchState = await performSearchAttempt(searchTarget);
+          break;
+        } catch (error) {
+          searchAttemptErrors.push(String(error));
+          evidence.searchAttemptErrors = searchAttemptErrors;
+          const failedSearchXml = await readFile(searchXmlFile, 'utf8').catch(
+            () => '',
+          );
+          if (failedSearchXml) {
+            await writeFile(
+              path.join(
+                diagnosticsDir,
+                `settings-search-attempt-${attempt}.xml`,
+              ),
+              failedSearchXml,
+              'utf8',
+            );
+          }
+          if (attempt === SEARCH_MAX_ATTEMPTS) {
+            throw error;
+          }
+          await adb.shell('am force-stop com.android.settings');
+          await adb.shell('am start -W -n com.android.settings/.Settings');
+          searchTarget = await waitForResource(
+            adb,
+            [SETTINGS_SEARCH_BAR_ID],
+            initialXmlFile,
+          );
+        }
+      }
+      if (!searchState) {
+        throw new Error(
+          'Settings search retry loop completed without a result',
         );
-        await adb.shell('am force-stop com.android.settings');
-        await adb.shell('am start -W -n com.android.settings/.Settings');
-        const retryTarget = await waitForResource(
-          adb,
-          [SETTINGS_SEARCH_BAR_ID],
-          initialXmlFile,
-        );
-        searchState = await performSearchAttempt(retryTarget);
       }
       evidence.searchAttemptErrors = searchAttemptErrors;
       expect(searchState.xml).toMatch(/text="wifi"/i);

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -13,6 +13,10 @@ import { imageInfoOfBase64 } from '@midscene/shared/img';
 import type ADB from 'appium-adb';
 import { describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
+import {
+  isRetryableUiDumpError,
+  isTransientAdbTransportError,
+} from '../android-emulator-ui-dump';
 
 const RUN_LIVE_SMOKE =
   process.env.AI_TEST_TYPE === 'android' &&
@@ -59,25 +63,6 @@ vi.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
 
 function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function isTransientAdbTransportError(error: unknown): boolean {
-  return /device offline|device unauthorized|no devices\/emulators found/i.test(
-    errorMessage(error),
-  );
-}
-
-function isRetryableUiDumpError(error: unknown): boolean {
-  return (
-    isTransientAdbTransportError(error) ||
-    /No such file or directory|empty uiautomator dump/i.test(
-      errorMessage(error),
-    )
-  );
 }
 
 async function dumpUiautomatorXml(adb: ADB): Promise<string> {

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -13,10 +13,7 @@ import { imageInfoOfBase64 } from '@midscene/shared/img';
 import type ADB from 'appium-adb';
 import { describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
-import {
-  isRetryableUiDumpError,
-  isTransientAdbTransportError,
-} from '../android-emulator-ui-dump';
+import { dumpUiHierarchyWithRetry } from '../android-emulator-ui-dump';
 
 const RUN_LIVE_SMOKE =
   process.env.AI_TEST_TYPE === 'android' &&
@@ -33,6 +30,7 @@ const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 30_000;
 const UI_DUMP_MAX_ATTEMPTS = 3;
 const SEARCH_MAX_ATTEMPTS = 3;
+const SEARCH_TIMEOUT_MS = 90_000;
 
 interface Bounds {
   left: number;
@@ -66,29 +64,26 @@ function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));
 }
 
-async function dumpUiautomatorXml(adb: ADB): Promise<string> {
-  for (let attempt = 1; attempt <= UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      await adb.shell(`rm -f ${UI_DUMP_PATH}`);
-      await adb.shell(`uiautomator dump --compressed ${UI_DUMP_PATH}`);
-      const xml = await adb.shell(`cat ${UI_DUMP_PATH}`);
-      if (typeof xml !== 'string' || xml.trim().length === 0) {
-        throw new Error('Android emulator returned an empty uiautomator dump');
-      }
-      return xml;
-    } catch (error) {
-      if (attempt === UI_DUMP_MAX_ATTEMPTS || !isRetryableUiDumpError(error)) {
-        throw error;
-      }
-      if (isTransientAdbTransportError(error)) {
-        await adb.waitForDevice(15);
-      } else {
-        await sleep(POLL_INTERVAL_MS);
-      }
-    }
+class AndroidUiStateTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AndroidUiStateTimeoutError';
   }
+}
 
-  throw new Error('UI dump retry loop completed without a result');
+async function dumpUiautomatorXml(adb: ADB): Promise<string> {
+  const result = await dumpUiHierarchyWithRetry(adb, {
+    remotePath: UI_DUMP_PATH,
+    label: 'uiautomator',
+    maxAttempts: UI_DUMP_MAX_ATTEMPTS,
+    retryIntervalMs: POLL_INTERVAL_MS,
+    onRetry: ({ nextAttempt, phase, error }) => {
+      console.log(
+        `UI hierarchy dump failed during ${phase}; retrying attempt ${nextAttempt}: ${String(error)}`,
+      );
+    },
+  });
+  return result.xml;
 }
 
 function boundsForResourceId(xml: string, resourceId: string): Bounds[] {
@@ -152,46 +147,38 @@ async function waitForEditableNode(
   adb: ADB,
   diagnosticsFile: string,
   expectedText?: string,
+  deadline = Date.now() + TARGET_TIMEOUT_MS,
 ): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> {
-  const deadline = Date.now() + TARGET_TIMEOUT_MS;
   let lastXml = '';
-  let lastError: unknown;
+  let lastState = 'No hierarchy has been read';
   while (Date.now() < deadline) {
-    try {
-      lastXml = await dumpUiautomatorXml(adb);
-      await writeFile(diagnosticsFile, lastXml, 'utf8');
-      const candidates = (lastXml.match(/<node\b[^>]*>/g) ?? []).filter(
-        (tag) => {
-          const className = attributeValue(tag, 'class');
-          const text = attributeValue(tag, 'text');
-          return (
-            className?.endsWith('EditText') &&
-            (expectedText === undefined || text === expectedText)
-          );
-        },
+    lastXml = await dumpUiautomatorXml(adb);
+    await writeFile(diagnosticsFile, lastXml, 'utf8');
+    const candidates = (lastXml.match(/<node\b[^>]*>/g) ?? []).filter((tag) => {
+      const className = attributeValue(tag, 'class');
+      const text = attributeValue(tag, 'text');
+      return (
+        className?.endsWith('EditText') &&
+        (expectedText === undefined || text === expectedText)
       );
-      const focusedCandidates = candidates.filter(
-        (tag) => attributeValue(tag, 'focused') === 'true',
-      );
-      const matches =
-        focusedCandidates.length === 1 ? focusedCandidates : candidates;
-      if (matches.length === 1) {
-        return {
-          resourceId: attributeValue(matches[0], 'resource-id'),
-          bounds: boundsForNodeTag(matches[0], 'editable node'),
-          xml: lastXml,
-        };
-      }
-      lastError = new Error(
-        `Expected one editable node, found ${candidates.length} (${focusedCandidates.length} focused)`,
-      );
-    } catch (error) {
-      lastError = error;
+    });
+    const focusedCandidates = candidates.filter(
+      (tag) => attributeValue(tag, 'focused') === 'true',
+    );
+    const matches =
+      focusedCandidates.length === 1 ? focusedCandidates : candidates;
+    if (matches.length === 1) {
+      return {
+        resourceId: attributeValue(matches[0], 'resource-id'),
+        bounds: boundsForNodeTag(matches[0], 'editable node'),
+        xml: lastXml,
+      };
     }
+    lastState = `Expected one editable node, found ${candidates.length} (${focusedCandidates.length} focused)`;
     await sleep(POLL_INTERVAL_MS);
   }
-  throw new Error(
-    `Timed out waiting for Android editable node${expectedText ? ` with text ${expectedText}` : ''}. Last error: ${String(lastError)}. Last XML saved to ${diagnosticsFile} (${lastXml.length} bytes)`,
+  throw new AndroidUiStateTimeoutError(
+    `Timed out waiting for Android editable node${expectedText ? ` with text ${expectedText}` : ''}. Last state: ${lastState}. Last XML saved to ${diagnosticsFile} (${lastXml.length} bytes)`,
   );
 }
 
@@ -199,34 +186,26 @@ async function waitForResource(
   adb: ADB,
   resourceIds: readonly string[],
   diagnosticsFile?: string,
+  deadline = Date.now() + TARGET_TIMEOUT_MS,
 ): Promise<{ resourceId: string; bounds: Bounds; xml: string }> {
-  const deadline = Date.now() + TARGET_TIMEOUT_MS;
   let lastXml = '';
-  let lastError: unknown;
+  let lastState = 'No hierarchy has been read';
   while (Date.now() < deadline) {
-    try {
-      lastXml = await dumpUiautomatorXml(adb);
-      if (diagnosticsFile) {
-        await writeFile(diagnosticsFile, lastXml, 'utf8');
+    lastXml = await dumpUiautomatorXml(adb);
+    if (diagnosticsFile) {
+      await writeFile(diagnosticsFile, lastXml, 'utf8');
+    }
+    for (const resourceId of resourceIds) {
+      const matches = boundsForResourceId(lastXml, resourceId);
+      if (matches.length === 1) {
+        return { resourceId, bounds: matches[0], xml: lastXml };
       }
-      for (const resourceId of resourceIds) {
-        const matches = boundsForResourceId(lastXml, resourceId);
-        if (matches.length === 1) {
-          return { resourceId, bounds: matches[0], xml: lastXml };
-        }
-        if (matches.length > 1) {
-          lastError = new Error(
-            `Expected one ${resourceId}, found ${matches.length}`,
-          );
-        }
-      }
-    } catch (error) {
-      lastError = error;
+      lastState = `Expected one ${resourceId}, found ${matches.length}`;
     }
     await sleep(POLL_INTERVAL_MS);
   }
-  throw new Error(
-    `Timed out waiting for Android resources ${resourceIds.join(', ')}. Last error: ${String(lastError)}. Last XML length: ${lastXml.length}`,
+  throw new AndroidUiStateTimeoutError(
+    `Timed out waiting for Android resources ${resourceIds.join(', ')}. Last state: ${lastState}. Last XML length: ${lastXml.length}`,
   );
 }
 
@@ -457,9 +436,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
       let searchAttempts = 0;
       let locateActionCalls = 0;
       const searchAttemptErrors: string[] = [];
-      const performSearchAttempt = async (target: {
-        bounds: Bounds;
-      }): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> => {
+      const performSearchAttempt = async (
+        target: { bounds: Bounds },
+        deadline: number,
+      ): Promise<{ resourceId?: string; bounds: Bounds; xml: string }> => {
         searchAttempts += 1;
         evidence.searchAttempts = searchAttempts;
         locateActionCalls += 1;
@@ -467,27 +447,50 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
         await agent!.callActionInActionSpace('Tap', {
           locate: locate(target.bounds, 'Settings search bar'),
         });
-        const searchInput = await waitForEditableNode(adb, searchXmlFile);
+        const searchInput = await waitForEditableNode(
+          adb,
+          searchXmlFile,
+          undefined,
+          deadline,
+        );
         evidence.searchInputResourceId = searchInput.resourceId;
 
         locateActionCalls += 1;
         evidence.locateActionCalls = locateActionCalls;
         await agent!.callActionInActionSpace('Input', {
           value: 'wifi',
-          mode: 'typeOnly',
+          mode: 'replace',
           autoDismissKeyboard: false,
           locate: locate(searchInput.bounds, 'Settings search input'),
         });
-        return waitForEditableNode(adb, searchXmlFile, 'wifi');
+        return waitForEditableNode(adb, searchXmlFile, 'wifi', deadline);
       };
 
       let searchState:
         | { resourceId?: string; bounds: Bounds; xml: string }
         | undefined;
       let searchTarget = initialTarget;
+      const searchDeadline = Date.now() + SEARCH_TIMEOUT_MS;
       for (let attempt = 1; attempt <= SEARCH_MAX_ATTEMPTS; attempt += 1) {
+        const attemptDeadline = Math.min(
+          searchDeadline,
+          Date.now() + TARGET_TIMEOUT_MS,
+        );
         try {
-          searchState = await performSearchAttempt(searchTarget);
+          if (attempt > 1) {
+            await adb.shell('am force-stop com.android.settings');
+            await adb.shell('am start -W -n com.android.settings/.Settings');
+            searchTarget = await waitForResource(
+              adb,
+              [SETTINGS_SEARCH_BAR_ID],
+              initialXmlFile,
+              attemptDeadline,
+            );
+          }
+          searchState = await performSearchAttempt(
+            searchTarget,
+            attemptDeadline,
+          );
           break;
         } catch (error) {
           searchAttemptErrors.push(String(error));
@@ -505,16 +508,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('Android Emulator live smoke', () => {
               'utf8',
             );
           }
-          if (attempt === SEARCH_MAX_ATTEMPTS) {
+          if (
+            !(error instanceof AndroidUiStateTimeoutError) ||
+            attempt === SEARCH_MAX_ATTEMPTS ||
+            Date.now() >= searchDeadline
+          ) {
             throw error;
           }
-          await adb.shell('am force-stop com.android.settings');
-          await adb.shell('am start -W -n com.android.settings/.Settings');
-          searchTarget = await waitForResource(
-            adb,
-            [SETTINGS_SEARCH_BAR_ID],
-            initialXmlFile,
-          );
         }
       }
       if (!searchState) {

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -4,10 +4,7 @@ import { sleep } from '@midscene/core/utils';
 import type ADB from 'appium-adb';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
-import {
-  isRetryableUiDumpError,
-  isTransientAdbTransportError,
-} from '../android-emulator-ui-dump';
+import { dumpUiHierarchyWithRetry } from '../android-emulator-ui-dump';
 
 vi.setConfig({
   testTimeout: 240 * 1000,
@@ -63,36 +60,18 @@ function screenshotBuffer(base64: string): Buffer {
 }
 
 async function dumpUiautomatorXml(adb: ADB): Promise<string> {
-  for (let attempt = 1; attempt <= CHROME_UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      await adb.shell(`rm -f ${CHROME_FIRST_RUN_DUMP_PATH}`);
-      await adb.shell(
-        `uiautomator dump --compressed ${CHROME_FIRST_RUN_DUMP_PATH}`,
-      );
-      const xml = await adb.shell(`cat ${CHROME_FIRST_RUN_DUMP_PATH}`);
-      if (typeof xml !== 'string' || xml.trim().length === 0) {
-        throw new Error('Android emulator returned an empty Chrome UI dump');
-      }
-      return xml;
-    } catch (error) {
-      if (
-        attempt === CHROME_UI_DUMP_MAX_ATTEMPTS ||
-        !isRetryableUiDumpError(error)
-      ) {
-        throw error;
-      }
+  const result = await dumpUiHierarchyWithRetry(adb, {
+    remotePath: CHROME_FIRST_RUN_DUMP_PATH,
+    label: 'Chrome UI',
+    maxAttempts: CHROME_UI_DUMP_MAX_ATTEMPTS,
+    retryIntervalMs: CHROME_FIRST_RUN_POLL_INTERVAL_MS,
+    onRetry: ({ nextAttempt, phase, error }) => {
       console.log(
-        `Chrome UI dump was not ready; retrying attempt ${attempt + 1}`,
+        `Chrome UI dump failed during ${phase}; retrying attempt ${nextAttempt}: ${String(error)}`,
       );
-      if (isTransientAdbTransportError(error)) {
-        await adb.waitForDevice(15);
-      } else {
-        await sleep(CHROME_FIRST_RUN_POLL_INTERVAL_MS);
-      }
-    }
-  }
-
-  throw new Error('Chrome UI dump retry loop completed without a result');
+    },
+  });
+  return result.xml;
 }
 
 function centerForExactText(

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -4,6 +4,10 @@ import { sleep } from '@midscene/core/utils';
 import type ADB from 'appium-adb';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
+import {
+  isRetryableUiDumpError,
+  isTransientAdbTransportError,
+} from '../android-emulator-ui-dump';
 
 vi.setConfig({
   testTimeout: 240 * 1000,
@@ -58,21 +62,6 @@ function screenshotBuffer(base64: string): Buffer {
   return Buffer.from(match[1], 'base64');
 }
 
-function isTransientAdbTransportError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /device offline|device unauthorized|no devices\/emulators found/i.test(
-    message,
-  );
-}
-
-function isRetryableChromeUiDumpError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    isTransientAdbTransportError(error) ||
-    /No such file or directory|empty Chrome UI dump/i.test(message)
-  );
-}
-
 async function dumpUiautomatorXml(adb: ADB): Promise<string> {
   for (let attempt = 1; attempt <= CHROME_UI_DUMP_MAX_ATTEMPTS; attempt += 1) {
     try {
@@ -88,7 +77,7 @@ async function dumpUiautomatorXml(adb: ADB): Promise<string> {
     } catch (error) {
       if (
         attempt === CHROME_UI_DUMP_MAX_ATTEMPTS ||
-        !isRetryableChromeUiDumpError(error)
+        !isRetryableUiDumpError(error)
       ) {
         throw error;
       }

--- a/packages/android/tests/android-emulator-ui-dump.ts
+++ b/packages/android/tests/android-emulator-ui-dump.ts
@@ -1,0 +1,20 @@
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isTransientAdbTransportError(error: unknown): boolean {
+  return /device offline|device unauthorized|no devices\/emulators found/i.test(
+    errorMessage(error),
+  );
+}
+
+export function isRetryableUiDumpError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    isTransientAdbTransportError(error) ||
+    /No such file or directory|empty (?:Chrome UI|uiautomator) dump/i.test(
+      message,
+    ) ||
+    /uiautomator dump[\s\S]*exited with code 255/i.test(message)
+  );
+}

--- a/packages/android/tests/android-emulator-ui-dump.ts
+++ b/packages/android/tests/android-emulator-ui-dump.ts
@@ -1,20 +1,133 @@
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+type UiDumpPhase = 'cleanup' | 'dump' | 'read' | 'validate';
+
+export interface UiDumpAdb {
+  shell(command: string): Promise<string>;
+  waitForDevice(timeoutSeconds: number): Promise<unknown>;
+}
+
+interface ProcessError {
+  code?: unknown;
+  stdout?: unknown;
+  stderr?: unknown;
+}
+
+export interface UiDumpRetryContext {
+  attempt: number;
+  nextAttempt: number;
+  phase: UiDumpPhase;
+  error: unknown;
+}
+
+export interface DumpUiHierarchyOptions {
+  remotePath: string;
+  label: string;
+  maxAttempts?: number;
+  retryIntervalMs?: number;
+  waitForDeviceTimeoutSeconds?: number;
+  onRetry?: (context: UiDumpRetryContext) => Promise<void> | void;
+}
+
+export interface UiHierarchyDump {
+  xml: string;
+  attempts: number;
+}
+
+class EmptyUiHierarchyDumpError extends Error {
+  constructor(label: string) {
+    super(`Android emulator returned an empty ${label} dump`);
+    this.name = 'EmptyUiHierarchyDumpError';
+  }
+}
+
+function processError(error: unknown): ProcessError | undefined {
+  return typeof error === 'object' && error !== null
+    ? (error as ProcessError)
+    : undefined;
+}
+
+function errorText(error: unknown): string {
+  const detail = processError(error);
+  return [
+    error instanceof Error ? error.message : String(error),
+    detail?.stdout,
+    detail?.stderr,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+}
+
+function processExitCode(error: unknown): number | null | undefined {
+  const code = processError(error)?.code;
+  return typeof code === 'number' || code === null ? code : undefined;
 }
 
 export function isTransientAdbTransportError(error: unknown): boolean {
   return /device offline|device unauthorized|no devices\/emulators found/i.test(
-    errorMessage(error),
+    errorText(error),
   );
 }
 
-export function isRetryableUiDumpError(error: unknown): boolean {
-  const message = errorMessage(error);
+function isRetryableUiDumpError(error: unknown, phase: UiDumpPhase): boolean {
   return (
     isTransientAdbTransportError(error) ||
-    /No such file or directory|empty (?:Chrome UI|uiautomator) dump/i.test(
-      message,
-    ) ||
-    /uiautomator dump[\s\S]*exited with code 255/i.test(message)
+    (phase === 'dump' && processExitCode(error) === 255) ||
+    (phase === 'read' && /No such file or directory/i.test(errorText(error))) ||
+    (phase === 'validate' && error instanceof EmptyUiHierarchyDumpError)
   );
+}
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+export async function dumpUiHierarchyWithRetry(
+  adb: UiDumpAdb,
+  options: DumpUiHierarchyOptions,
+): Promise<UiHierarchyDump> {
+  const {
+    remotePath,
+    label,
+    maxAttempts = 3,
+    retryIntervalMs = 500,
+    waitForDeviceTimeoutSeconds = 15,
+    onRetry,
+  } = options;
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error('UI dump maxAttempts must be a positive integer');
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let phase: UiDumpPhase = 'cleanup';
+    try {
+      await adb.shell(`rm -f ${remotePath}`);
+      phase = 'dump';
+      await adb.shell(`uiautomator dump --compressed ${remotePath}`);
+      phase = 'read';
+      const xml = await adb.shell(`cat ${remotePath}`);
+      phase = 'validate';
+      if (typeof xml !== 'string' || xml.trim().length === 0) {
+        throw new EmptyUiHierarchyDumpError(label);
+      }
+      return { xml, attempts: attempt };
+    } catch (error) {
+      if (attempt === maxAttempts || !isRetryableUiDumpError(error, phase)) {
+        throw error;
+      }
+
+      await onRetry?.({
+        attempt,
+        nextAttempt: attempt + 1,
+        phase,
+        error,
+      });
+      if (isTransientAdbTransportError(error)) {
+        await adb.waitForDevice(waitForDeviceTimeoutSeconds);
+      } else {
+        await sleep(retryIntervalMs);
+      }
+    }
+  }
+
+  throw new Error('UI dump retry loop completed without a result');
 }

--- a/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
+++ b/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isRetryableUiDumpError,
+  isTransientAdbTransportError,
+} from '../android-emulator-ui-dump';
+
+describe('Android emulator UI dump error classification', () => {
+  it.each([
+    'device offline',
+    'device unauthorized',
+    'no devices/emulators found',
+  ])('recognizes transient adb transport errors: %s', (message) => {
+    const error = new Error(message);
+
+    expect(isTransientAdbTransportError(error)).toBe(true);
+    expect(isRetryableUiDumpError(error)).toBe(true);
+  });
+
+  it.each([
+    'No such file or directory',
+    'Android emulator returned an empty Chrome UI dump',
+    'Android emulator returned an empty uiautomator dump',
+    "Error executing adbExec. Original error: 'Command 'adb shell 'uiautomator dump --compressed /sdcard/window.xml'' exited with code 255'; Command output: <empty>",
+  ])('retries transient UI dump failures: %s', (message) => {
+    expect(isRetryableUiDumpError(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    'Assertion failed: expected the Settings page',
+    "Command 'adb shell input keyevent 4' exited with code 255",
+    "Command 'adb shell uiautomator dump' exited with code 1",
+  ])('does not retry unrelated failures: %s', (message) => {
+    expect(isRetryableUiDumpError(new Error(message))).toBe(false);
+  });
+});

--- a/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
+++ b/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
@@ -1,35 +1,189 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
-  isRetryableUiDumpError,
+  dumpUiHierarchyWithRetry,
   isTransientAdbTransportError,
 } from '../android-emulator-ui-dump';
+import type {
+  DumpUiHierarchyOptions,
+  UiDumpAdb,
+} from '../android-emulator-ui-dump';
 
-describe('Android emulator UI dump error classification', () => {
+type ShellResult = string | Error;
+
+function createAdbMock(results: ShellResult[]) {
+  const queue = [...results];
+  const shell = vi.fn(async () => {
+    const result = queue.shift();
+    if (result instanceof Error) {
+      throw result;
+    }
+    return result ?? '';
+  });
+  const waitForDevice = vi.fn(async () => undefined);
+  const adb: UiDumpAdb = { shell, waitForDevice };
+  return { adb, shell, waitForDevice };
+}
+
+function execError(
+  message: string,
+  code: number,
+  details: { stdout?: string; stderr?: string } = {},
+): Error & { code: number; stdout: string; stderr: string } {
+  return Object.assign(new Error(message), {
+    code,
+    stdout: details.stdout ?? '',
+    stderr: details.stderr ?? '',
+  });
+}
+
+const options: DumpUiHierarchyOptions = {
+  remotePath: '/sdcard/window.xml',
+  label: 'uiautomator',
+  retryIntervalMs: 0,
+};
+
+describe('Android emulator UI hierarchy dump', () => {
   it.each([
     'device offline',
     'device unauthorized',
     'no devices/emulators found',
   ])('recognizes transient adb transport errors: %s', (message) => {
-    const error = new Error(message);
+    expect(isTransientAdbTransportError(new Error(message))).toBe(true);
+  });
 
-    expect(isTransientAdbTransportError(error)).toBe(true);
-    expect(isRetryableUiDumpError(error)).toBe(true);
+  it('recognizes transport errors reported through process stderr', () => {
+    expect(
+      isTransientAdbTransportError(
+        execError('adb failed', 1, { stderr: 'error: device offline' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns the first valid hierarchy without retrying', async () => {
+    const { adb, shell } = createAdbMock(['', '', '<hierarchy />']);
+
+    await expect(dumpUiHierarchyWithRetry(adb, options)).resolves.toEqual({
+      xml: '<hierarchy />',
+      attempts: 1,
+    });
+    expect(shell).toHaveBeenNthCalledWith(1, 'rm -f /sdcard/window.xml');
+    expect(shell).toHaveBeenNthCalledWith(
+      2,
+      'uiautomator dump --compressed /sdcard/window.xml',
+    );
+    expect(shell).toHaveBeenNthCalledWith(3, 'cat /sdcard/window.xml');
+  });
+
+  it('retries a structured exit code 255 in the dump phase', async () => {
+    const failure = execError('uiautomator was not ready', 255);
+    const { adb, waitForDevice } = createAdbMock([
+      '',
+      failure,
+      '',
+      '',
+      '<hierarchy />',
+    ]);
+    const onRetry = vi.fn();
+
+    await expect(
+      dumpUiHierarchyWithRetry(adb, { ...options, onRetry }),
+    ).resolves.toMatchObject({ attempts: 2 });
+    expect(onRetry).toHaveBeenCalledWith({
+      attempt: 1,
+      nextAttempt: 2,
+      phase: 'dump',
+      error: failure,
+    });
+    expect(waitForDevice).not.toHaveBeenCalled();
   });
 
   it.each([
-    'No such file or directory',
-    'Android emulator returned an empty Chrome UI dump',
-    'Android emulator returned an empty uiautomator dump',
-    "Error executing adbExec. Original error: 'Command 'adb shell 'uiautomator dump --compressed /sdcard/window.xml'' exited with code 255'; Command output: <empty>",
-  ])('retries transient UI dump failures: %s', (message) => {
-    expect(isRetryableUiDumpError(new Error(message))).toBe(true);
+    {
+      name: 'a missing dump file',
+      results: [
+        '',
+        '',
+        new Error('cat: window.xml: No such file or directory'),
+        '',
+        '',
+        '<hierarchy />',
+      ],
+      phase: 'read',
+    },
+    {
+      name: 'an empty hierarchy',
+      results: ['', '', '', '', '', '<hierarchy />'],
+      phase: 'validate',
+    },
+  ] satisfies Array<{
+    name: string;
+    results: ShellResult[];
+    phase: 'read' | 'validate';
+  }>)('retries $name', async ({ results, phase }) => {
+    const { adb } = createAdbMock(results);
+    const onRetry = vi.fn();
+
+    await expect(
+      dumpUiHierarchyWithRetry(adb, { ...options, onRetry }),
+    ).resolves.toMatchObject({ attempts: 2 });
+    expect(onRetry).toHaveBeenCalledWith(expect.objectContaining({ phase }));
+  });
+
+  it('waits for the device before retrying a transport failure', async () => {
+    const { adb, waitForDevice } = createAdbMock([
+      new Error('device offline'),
+      '',
+      '',
+      '<hierarchy />',
+    ]);
+
+    await expect(dumpUiHierarchyWithRetry(adb, options)).resolves.toMatchObject(
+      { attempts: 2 },
+    );
+    expect(waitForDevice).toHaveBeenCalledWith(15);
   });
 
   it.each([
-    'Assertion failed: expected the Settings page',
-    "Command 'adb shell input keyevent 4' exited with code 255",
-    "Command 'adb shell uiautomator dump' exited with code 1",
-  ])('does not retry unrelated failures: %s', (message) => {
-    expect(isRetryableUiDumpError(new Error(message))).toBe(false);
+    {
+      name: 'an unrelated dump failure',
+      results: ['', execError('permission denied', 1)],
+      calls: 2,
+    },
+    {
+      name: 'exit code 255 during cleanup',
+      results: [execError('cleanup failed', 255)],
+      calls: 1,
+    },
+  ])('does not retry $name', async ({ results, calls }) => {
+    const failure = results.at(-1);
+    const { adb, shell } = createAdbMock(results);
+
+    await expect(dumpUiHierarchyWithRetry(adb, options)).rejects.toBe(failure);
+    expect(shell).toHaveBeenCalledTimes(calls);
+  });
+
+  it('stops after the configured number of attempts', async () => {
+    const failure = execError('uiautomator was not ready', 255);
+    const shell = vi.fn(async (command: string) => {
+      if (command.startsWith('uiautomator dump')) {
+        throw failure;
+      }
+      return '';
+    });
+    const adb: UiDumpAdb = {
+      shell,
+      waitForDevice: vi.fn(async () => undefined),
+    };
+    const onRetry = vi.fn();
+
+    await expect(
+      dumpUiHierarchyWithRetry(adb, {
+        ...options,
+        maxAttempts: 3,
+        onRetry,
+      }),
+    ).rejects.toBe(failure);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(shell).toHaveBeenCalledTimes(6);
   });
 });


### PR DESCRIPTION
## Summary

- consolidate the duplicated emulator UI hierarchy dump loops into one test-only helper that records the `cleanup`, `dump`, `read`, and `validate` phases
- retry only known transient failures: ADB transport loss, structured exit code 255 from the dump command, a temporarily missing dump file, or an empty hierarchy
- fail unknown command, parsing, filesystem, action, and assertion errors immediately while preserving the original error
- retry Settings search only for the explicit `AndroidUiStateTimeoutError`; cap each attempt at 30 seconds, all attempts at 90 seconds, and restart Settings before later attempts
- use replace-mode input so a replay is idempotent, and retain failed-attempt XML evidence

## Why retry at this boundary

The same Android emulator commit produced both a failed and a passing workflow without a code change. The failed attempt stopped before TodoMVC because `uiautomator dump --compressed ...` exited with code 255 and empty output; the next workflow attempt passed. This is a real failure of the test support command, but it is not by itself a failure of the Midscene behavior that the case is intended to validate.

The helper therefore retries only the known transient infrastructure states at the UI-dump boundary. It does not retry arbitrary test failures or the complete CI job.

## Failure evidence

- [UI dump attempt 2 failed](https://github.com/web-infra-dev/midscene/actions/runs/30005003922/attempts/2) with dump exit code 255.
- [The same run attempt 3 passed](https://github.com/web-infra-dev/midscene/actions/runs/30005003922/attempts/3) without a code change.
- [Settings run 30028291517](https://github.com/web-infra-dev/midscene/actions/runs/30028291517) exhausted the previous Settings search attempts while waiting for the `wifi` UI state.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/android --output-style=static` (17 files, 336 tests passed)
- `pnpm --filter @midscene/android exec tsc --noEmit -p tsconfig.json`
- `AI_TEST_TYPE=android pnpm --filter @midscene/android exec vitest list tests/ai/android-emulator-smoke.test.ts tests/ai/todo.test.ts`
- [Android Emulator run 30073952276](https://github.com/web-infra-dev/midscene/actions/runs/30073952276) passed the package checks, 336 unit tests, the deterministic Settings smoke, TodoMVC, report uploads, diagnostics upload, and final validation
- the live run completed on the first Settings attempt (`searchAttempts: 1`) with no retry errors; the 12 focused unit tests cover every permitted retry class, immediate fatal failure, and exhaustion
- downloaded report artifacts are renderable and contain Midscene dump data: Settings smoke 2,835,868 bytes and TodoMVC 6,779,468 bytes
- all current PR checks pass
