### PR TITLE
test(web-integration): require search query replacement

### DIFF
--- a/packages/web-integration/tests/ai/web/puppeteer/search.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/search.test.ts
@@ -67,7 +67,7 @@ describe(
         ctx.agent = new PuppeteerAgent(originPage);
         await ctx.agent.aiAct('type "AI 101" in search box');
         await ctx.agent.aiAct(
-          'type "Hello world" in search box, hit Enter, wait 2s',
+          'replace all existing text in the search box with "Hello world", hit Enter, wait 2s',
         );
 
         await ctx.agent.aiWaitFor(


### PR DESCRIPTION
## Summary

- make the second Puppeteer search action explicitly replace the existing query
- preserve the sequential `aiAct` and `aiWaitFor` coverage instead of bypassing the AI path
- remove ambiguity that allowed the planner to use incremental `typeOnly` input

## Failure evidence

The same commit produced both outcomes in the AI unit workflow:

- [Attempt 1 failed](https://github.com/web-infra-dev/midscene/actions/runs/30029501183/attempts/1) because the second instruction appended `Hello world`, leaving the query as `AI 101Hello world` and returning only AI results.
- [Attempt 2 passed](https://github.com/web-infra-dev/midscene/actions/runs/30029501183/attempts/2) without a code change.

The original instruction said only `type`, which can legitimately select incremental `typeOnly` input. The updated instruction explicitly requests replacement, matching the Input action's default `replace` semantics.

## Validation

- `pnpm install --frozen-lockfile` (all 27 project builds passed)
- `pnpm run lint`
- [AI unit run 30031727797](https://github.com/web-infra-dev/midscene/actions/runs/30031727797) passed with the updated prompt
- [Midscene test-ai-output artifact](https://github.com/web-infra-dev/midscene/actions/runs/30031727797/artifacts/8573879769) was retained (76,408,885 compressed bytes)
- e2e-web and e2e-report both passed in [Playwright run 30031727931](https://github.com/web-infra-dev/midscene/actions/runs/30031727931)
- all current PR checks pass
