### PR TITLE
feat(android): add UI tree reporting and XPath inspection

### DIFF
--- a/apps/report/src/components/detail-panel/index.less
+++ b/apps/report/src/components/detail-panel/index.less
@@ -101,6 +101,116 @@
     color: #24292f;
   }
 
+  .ui-tree-view {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
+  .ui-tree-view-embedded {
+    overflow-y: visible;
+  }
+
+  .ui-tree-summary {
+    color: @weak-text;
+    font-size: 12px;
+  }
+
+  .ui-tree-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .ui-tree-search {
+    width: min(420px, 60%);
+  }
+
+  .ui-tree-columns {
+    display: grid;
+    grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+    gap: 16px;
+    min-height: 0;
+  }
+
+  .ui-tree-browser,
+  .ui-tree-details {
+    min-width: 0;
+    padding: 12px;
+    border: 1px solid @heavy-border-color;
+    border-radius: 6px;
+  }
+
+  .ui-tree-browser {
+    overflow: hidden;
+  }
+
+  .ui-tree-details {
+    overflow: auto;
+  }
+
+  .ui-tree-horizontal-scroll {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable;
+  }
+
+  .ui-tree-scroll-content {
+    min-width: 100%;
+    max-width: none;
+    flex: none;
+  }
+
+  .ui-tree-scroll-content .ant-tree {
+    width: 100%;
+  }
+
+  .ui-tree-scroll-content .ant-tree-title {
+    white-space: nowrap;
+  }
+
+  .ui-tree-node-details-title {
+    margin-bottom: 14px;
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  .ui-tree-node-details-section {
+    margin: 12px 0 6px;
+    color: @weak-text;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .ui-tree-node-details table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family:
+      'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 12px;
+
+    th,
+    td {
+      padding: 5px 8px;
+      border-bottom: 1px solid @heavy-border-color;
+      text-align: left;
+      vertical-align: top;
+      word-break: break-all;
+    }
+
+    th {
+      width: 35%;
+      font-weight: 600;
+    }
+  }
+
   .report-json-view {
     white-space: pre-wrap;
     word-break: break-word;

--- a/apps/report/src/components/detail-panel/index.tsx
+++ b/apps/report/src/components/detail-panel/index.tsx
@@ -2,6 +2,7 @@
 import './index.less';
 import { isElementField, useExecutionDump } from '@/components/store';
 import {
+  ApartmentOutlined,
   CameraOutlined,
   CopyOutlined,
   DownloadOutlined,
@@ -32,6 +33,8 @@ import {
 import OpenInPlayground from '../open-in-playground';
 import { sanitizeJsonViewData } from './json-view-data';
 import { getExecutionMarkdownView } from './markdown-view';
+import { hasUITreeView } from './ui-tree-data';
+import UITreeView from './ui-tree-view';
 
 const ScreenshotDisplay = (props: {
   title: string;
@@ -54,6 +57,7 @@ const ScreenshotDisplay = (props: {
 const VIEW_TYPE_REPLAY = 'replay';
 const VIEW_TYPE_MARKDOWN = 'markdown';
 const VIEW_TYPE_SCREENSHOT = 'screenshot';
+const VIEW_TYPE_UI_TREE = 'ui-tree';
 const VIEW_TYPE_JSON = 'json';
 
 const jsonViewStyles = {
@@ -151,7 +155,12 @@ const DetailPanel = ({
     animationScripts &&
     animationScripts.length > 0;
 
-  const availableViewTypes = [VIEW_TYPE_SCREENSHOT, VIEW_TYPE_JSON];
+  const availableViewTypes = [VIEW_TYPE_SCREENSHOT];
+
+  if (hasUITreeView(activeTask?.uiContext)) {
+    availableViewTypes.push(VIEW_TYPE_UI_TREE);
+  }
+  availableViewTypes.push(VIEW_TYPE_JSON);
 
   if (hasReplay) {
     availableViewTypes.unshift(VIEW_TYPE_REPLAY);
@@ -211,6 +220,14 @@ const DetailPanel = ({
           clickToExpandNode
         />
       </div>
+    );
+  } else if (viewType === VIEW_TYPE_UI_TREE) {
+    content = (
+      <UITreeView
+        key={activeTask.taskId}
+        snapshot={activeTask.uiContext?.uiTree}
+        error={activeTask.uiContext?.uiTreeError}
+      />
     );
   } else if (viewType === VIEW_TYPE_SCREENSHOT) {
     const screenshotItems: {
@@ -354,6 +371,13 @@ const DetailPanel = ({
         label: 'JSON View',
         value: type,
         icon: <FileTextOutlined />,
+      };
+    }
+    if (type === VIEW_TYPE_UI_TREE) {
+      return {
+        label: 'UI Tree',
+        value: type,
+        icon: <ApartmentOutlined />,
       };
     }
 

--- a/apps/report/src/components/detail-panel/json-view-data.ts
+++ b/apps/report/src/components/detail-panel/json-view-data.ts
@@ -1,3 +1,6 @@
+import type { UITreeSnapshot } from '@midscene/core';
+import { summarizeUITreeSnapshot } from './ui-tree-data';
+
 export const OMITTED_SCREENSHOT_BASE64_TEXT = '[omitted screenshot base64]';
 
 function isScreenshotPath(path: string[]): boolean {
@@ -42,6 +45,16 @@ export function sanitizeJsonViewData(
       } else if (descriptor.get) {
         fieldValue = descriptor.get.call(value);
       } else {
+        continue;
+      }
+
+      if (
+        key === 'uiTree' &&
+        typeof fieldValue === 'object' &&
+        fieldValue !== null &&
+        'root' in fieldValue
+      ) {
+        result[key] = summarizeUITreeSnapshot(fieldValue as UITreeSnapshot);
         continue;
       }
 

--- a/apps/report/src/components/detail-panel/ui-tree-data.test.ts
+++ b/apps/report/src/components/detail-panel/ui-tree-data.test.ts
@@ -1,0 +1,178 @@
+import type { UIContext, UITreeSnapshot, UiNode } from '@midscene/core';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  buildUITreeViewModel,
+  estimateUITreeCanvasWidth,
+  hasUITreeView,
+  searchUITreeViewModel,
+} from './ui-tree-data';
+import UITreeView, { UITreeNodeDetails } from './ui-tree-view';
+
+const child: UiNode = {
+  type: 'android.widget.Button',
+  attrs: {
+    'resource-id': 'com.example:id/submit',
+    'content-desc': 'Submit form',
+    enabled: 'true',
+  },
+  bounds: { left: 10, top: 20, width: 100, height: 40 },
+  children: [],
+};
+
+const snapshot: UITreeSnapshot = {
+  platform: 'android',
+  capturedAt: 123,
+  root: {
+    type: 'android.widget.FrameLayout',
+    attrs: {},
+    bounds: { left: 0, top: 0, width: 200, height: 400 },
+    children: [child],
+  },
+  xpathPolicy: {
+    stableAttrs: ['resource-id'],
+    textAttrs: ['content-desc', 'text'],
+    excludedTargetTypes: ['android.webkit.WebView'],
+    max: 3,
+  },
+};
+
+describe('UI tree report data', () => {
+  it('shows the UI Tree entry for either a snapshot or a capture error', () => {
+    expect(hasUITreeView({ uiTree: snapshot } as UIContext)).toBe(true);
+    expect(
+      hasUITreeView({ uiTreeError: 'layout dump failed' } as UIContext),
+    ).toBe(true);
+    expect(hasUITreeView(undefined)).toBe(false);
+    expect(hasUITreeView({} as UIContext)).toBe(false);
+  });
+
+  it('uses index paths as keys and expands only the root by default', () => {
+    const model = buildUITreeViewModel(snapshot);
+
+    expect(model.treeData[0].key).toBe('0');
+    expect(model.treeData[0].children?.[0].key).toBe('0-0');
+    expect(model.treeData[0].children?.[0].title).toContain(
+      'com.example:id/submit',
+    );
+    expect(model.defaultExpandedKeys).toEqual(['0']);
+    expect(model.nodeByKey.get('0-0')).toBe(child);
+  });
+
+  it('renders all selected-node attributes and bounds', () => {
+    const html = renderToStaticMarkup(
+      createElement(UITreeNodeDetails, { node: child }),
+    );
+
+    expect(html).toContain('com.example:id/submit');
+    expect(html).toContain('Submit form');
+    expect(html).toContain('enabled');
+    expect(html).toContain('left');
+    expect(html).toContain('100');
+  });
+
+  it('searches type and all attribute names and values case-insensitively', () => {
+    const model = buildUITreeViewModel(snapshot);
+
+    expect(searchUITreeViewModel(model, 'BUTTON submit').matchCount).toBe(1);
+    expect(searchUITreeViewModel(model, 'enabled').matchCount).toBe(1);
+    expect(searchUITreeViewModel(model, 'SUBMIT FORM').matchCount).toBe(1);
+  });
+
+  it('keeps matching ancestors and expands the path to search results', () => {
+    const model = buildUITreeViewModel(snapshot);
+    const result = searchUITreeViewModel(model, 'com.example:id/submit');
+
+    expect(result.treeData).toHaveLength(1);
+    expect(result.treeData[0].key).toBe('0');
+    expect(result.treeData[0].children?.map((node) => node.key)).toEqual([
+      '0-0',
+    ]);
+    expect(result.expandedKeys).toEqual(['0']);
+    expect(result.matchCount).toBe(1);
+  });
+
+  it('restores the complete tree and default expansion for an empty query', () => {
+    const model = buildUITreeViewModel(snapshot);
+    const result = searchUITreeViewModel(model, '   ');
+
+    expect(result.treeData).toBe(model.treeData);
+    expect(result.expandedKeys).toEqual(['0']);
+    expect(result.matchCount).toBe(model.nodeCount);
+  });
+
+  it('returns an empty tree when no node matches', () => {
+    const model = buildUITreeViewModel(snapshot);
+    const result = searchUITreeViewModel(model, 'does-not-exist');
+
+    expect(result.treeData).toEqual([]);
+    expect(result.expandedKeys).toEqual([]);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('renders the uiTreeError state', () => {
+    const html = renderToStaticMarkup(
+      createElement(UITreeView, { error: 'layout dump failed' }),
+    );
+
+    expect(html).toContain('UI tree capture failed');
+    expect(html).toContain('layout dump failed');
+  });
+
+  it('renders the UI tree search input', () => {
+    const html = renderToStaticMarkup(createElement(UITreeView, { snapshot }));
+
+    expect(html).toContain('Search class, attribute, or value');
+    expect(html).toContain('aria-label="Search UI tree"');
+  });
+
+  it('renders a horizontal scroll viewport around the virtual tree', () => {
+    const html = renderToStaticMarkup(createElement(UITreeView, { snapshot }));
+
+    expect(html).toContain('ui-tree-horizontal-scroll');
+    expect(html).toContain('ui-tree-scroll-content');
+    expect(html).toContain('data-ui-tree-canvas-width');
+  });
+
+  it('keeps a stable horizontal canvas for deeply nested virtual rows', () => {
+    let nestedNode = child;
+    for (let depth = 0; depth < 24; depth++) {
+      nestedNode = {
+        type: 'android.view.ViewGroup',
+        attrs: { 'content-desc': `nested-level-${depth}` },
+        bounds: { left: 0, top: 0, width: 200, height: 400 },
+        children: [nestedNode],
+      };
+    }
+    const deepModel = buildUITreeViewModel({
+      ...snapshot,
+      root: nestedNode,
+    });
+
+    const shallowWidth = estimateUITreeCanvasWidth(
+      buildUITreeViewModel(snapshot).treeData,
+    );
+    expect(shallowWidth).toBeGreaterThanOrEqual(640);
+    expect(estimateUITreeCanvasWidth(deepModel.treeData)).toBeGreaterThan(
+      shallowWidth,
+    );
+  });
+
+  it('does not default-expand every node in a large tree', () => {
+    const manyChildren = Array.from({ length: 2_000 }, (_, index) => ({
+      type: 'android.widget.TextView',
+      attrs: { text: `row-${index}` },
+      bounds: { left: 0, top: index, width: 100, height: 1 },
+      children: [],
+    }));
+    const model = buildUITreeViewModel({
+      ...snapshot,
+      root: { ...snapshot.root, children: manyChildren },
+    });
+
+    expect(model.nodeCount).toBe(2_001);
+    expect(model.defaultExpandedKeys).toEqual(['0']);
+    expect(model.defaultExpandedKeys).not.toHaveLength(model.nodeCount);
+  });
+});

--- a/apps/report/src/components/detail-panel/ui-tree-data.ts
+++ b/apps/report/src/components/detail-panel/ui-tree-data.ts
@@ -1,0 +1,182 @@
+import type { UIContext, UITreeSnapshot, UiNode } from '@midscene/core';
+
+export interface UITreeDataNode {
+  key: string;
+  title: string;
+  children?: UITreeDataNode[];
+}
+
+export interface UITreeViewModel {
+  treeData: UITreeDataNode[];
+  nodeByKey: Map<string, UiNode>;
+  defaultExpandedKeys: string[];
+  nodeCount: number;
+}
+
+export interface UITreeSearchResult {
+  treeData: UITreeDataNode[];
+  expandedKeys: string[];
+  matchCount: number;
+  query: string;
+}
+
+const UI_TREE_MIN_CANVAS_WIDTH = 640;
+const UI_TREE_INDENT_WIDTH = 24;
+const UI_TREE_ROW_PADDING = 72;
+
+export function hasUITreeView(uiContext: UIContext | undefined): boolean {
+  return Boolean(uiContext?.uiTree || uiContext?.uiTreeError);
+}
+
+function estimatedTextWidth(text: string): number {
+  return Array.from(text).reduce(
+    (width, character) => width + (character.charCodeAt(0) > 255 ? 14 : 8),
+    0,
+  );
+}
+
+export function estimateUITreeCanvasWidth(treeData: UITreeDataNode[]): number {
+  let requiredWidth = 0;
+  const visit = (nodes: UITreeDataNode[], depth: number) => {
+    for (const node of nodes) {
+      requiredWidth = Math.max(
+        requiredWidth,
+        depth * UI_TREE_INDENT_WIDTH +
+          estimatedTextWidth(node.title) +
+          UI_TREE_ROW_PADDING,
+      );
+      if (node.children) visit(node.children, depth + 1);
+    }
+  };
+  visit(treeData, 0);
+  return Math.max(UI_TREE_MIN_CANVAS_WIDTH, Math.ceil(requiredWidth));
+}
+
+export function formatUITreeNodeTitle(node: UiNode): string {
+  const labels = [node.type];
+  const resourceId = node.attrs['resource-id'];
+  const semanticText = node.attrs['content-desc'] || node.attrs.text;
+  if (resourceId) labels.push(`resource-id=${resourceId}`);
+  if (semanticText) labels.push(semanticText);
+  return labels.join(' · ');
+}
+
+export function countUITreeNodes(root: UiNode): number {
+  let count = 0;
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) continue;
+    count++;
+    pending.push(...current.children);
+  }
+  return count;
+}
+
+export function buildUITreeViewModel(
+  snapshot: UITreeSnapshot,
+): UITreeViewModel {
+  const nodeByKey = new Map<string, UiNode>();
+  const buildNode = (node: UiNode, key: string): UITreeDataNode => {
+    nodeByKey.set(key, node);
+    return {
+      key,
+      title: formatUITreeNodeTitle(node),
+      ...(node.children.length > 0
+        ? {
+            children: node.children.map((child, index) =>
+              buildNode(child, `${key}-${index}`),
+            ),
+          }
+        : {}),
+    };
+  };
+
+  return {
+    treeData: [buildNode(snapshot.root, '0')],
+    nodeByKey,
+    defaultExpandedKeys: ['0'],
+    nodeCount: countUITreeNodes(snapshot.root),
+  };
+}
+
+function nodeMatchesSearch(node: UiNode, tokens: string[]): boolean {
+  const searchableText = [
+    node.type,
+    ...Object.entries(node.attrs).flatMap(([name, value]) => [
+      name,
+      value ?? '',
+    ]),
+  ]
+    .join('\n')
+    .toLowerCase();
+  return tokens.every((token) => searchableText.includes(token));
+}
+
+export function searchUITreeViewModel(
+  model: UITreeViewModel,
+  searchText: string,
+): UITreeSearchResult {
+  const query = searchText.trim().toLowerCase();
+  if (!query) {
+    return {
+      treeData: model.treeData,
+      expandedKeys: model.defaultExpandedKeys,
+      matchCount: model.nodeCount,
+      query,
+    };
+  }
+
+  const tokens = query.split(/\s+/);
+  const expandedKeys = new Set<string>();
+  let matchCount = 0;
+  const filterNode = (dataNode: UITreeDataNode): UITreeDataNode | undefined => {
+    const node = model.nodeByKey.get(dataNode.key);
+    if (!node) {
+      throw new Error(`UI tree node is missing for key ${dataNode.key}`);
+    }
+
+    const matches = nodeMatchesSearch(node, tokens);
+    if (matches) matchCount++;
+    const children = (dataNode.children ?? [])
+      .map(filterNode)
+      .filter((child): child is UITreeDataNode => Boolean(child));
+
+    if (!matches && children.length === 0) return undefined;
+    if (children.length > 0) expandedKeys.add(dataNode.key);
+    return {
+      key: dataNode.key,
+      title: dataNode.title,
+      ...(children.length > 0 ? { children } : {}),
+    };
+  };
+
+  const treeData = model.treeData
+    .map(filterNode)
+    .filter((node): node is UITreeDataNode => Boolean(node));
+  return {
+    treeData,
+    expandedKeys: [...expandedKeys].sort(
+      (left, right) =>
+        left.split('-').length - right.split('-').length ||
+        left.localeCompare(right),
+    ),
+    matchCount,
+    query,
+  };
+}
+
+export function summarizeUITreeSnapshot(snapshot: UITreeSnapshot) {
+  return {
+    platform: snapshot.platform,
+    capturedAt: snapshot.capturedAt,
+    xpathPolicy: snapshot.xpathPolicy,
+    root: {
+      type: snapshot.root.type,
+      bounds: snapshot.root.bounds,
+      childCount: snapshot.root.children.length,
+      nodeCount: countUITreeNodes(snapshot.root),
+      note: '[UI tree root omitted from JSON View; open UI Tree instead]',
+    },
+  };
+}

--- a/apps/report/src/components/detail-panel/ui-tree-view.test.ts
+++ b/apps/report/src/components/detail-panel/ui-tree-view.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import type { UITreeSnapshot } from '@midscene/core';
+import type { ChangeEventHandler, ReactNode } from 'react';
+import { act, createElement } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+vi.mock('@ant-design/icons', async () => {
+  const React = await import('react');
+  return { SearchOutlined: () => React.createElement('span') };
+});
+
+vi.mock('antd', async () => {
+  const React = await import('react');
+
+  interface MockTreeNode {
+    key: string;
+    title: string;
+    children?: MockTreeNode[];
+  }
+
+  const flatten = (nodes: MockTreeNode[]): MockTreeNode[] =>
+    nodes.flatMap((node) => [node, ...flatten(node.children ?? [])]);
+
+  const Empty = ({ description }: { description?: ReactNode }) =>
+    React.createElement('div', null, description);
+  Object.assign(Empty, { PRESENTED_IMAGE_SIMPLE: 'simple' });
+
+  return {
+    Alert: ({
+      message,
+      description,
+    }: {
+      message?: ReactNode;
+      description?: ReactNode;
+    }) => React.createElement('div', null, message, description),
+    Empty,
+    Input: ({
+      value,
+      onChange,
+      placeholder,
+      'aria-label': ariaLabel,
+    }: {
+      value?: string;
+      onChange?: ChangeEventHandler<HTMLInputElement>;
+      placeholder?: string;
+      'aria-label'?: string;
+    }) =>
+      React.createElement('input', {
+        value,
+        onChange,
+        placeholder,
+        'aria-label': ariaLabel,
+      }),
+    Tree: ({
+      treeData,
+      onSelect,
+    }: {
+      treeData: MockTreeNode[];
+      onSelect?: (keys: Array<string | number>) => void;
+    }) =>
+      React.createElement(
+        'div',
+        { className: 'mock-tree' },
+        flatten(treeData).map((node) =>
+          React.createElement(
+            'button',
+            {
+              key: node.key,
+              type: 'button',
+              'data-node-key': node.key,
+              onClick: () => onSelect?.([node.key]),
+            },
+            node.title,
+          ),
+        ),
+      ),
+  };
+});
+
+import UITreeView from './ui-tree-view';
+
+const snapshot: UITreeSnapshot = {
+  platform: 'android',
+  capturedAt: 123,
+  root: {
+    type: 'Window',
+    attrs: {},
+    bounds: { left: 0, top: 0, width: 200, height: 400 },
+    children: [
+      {
+        type: 'android.widget.Button',
+        attrs: {
+          'resource-id': 'com.example:id/submit',
+          text: 'Submit',
+        },
+        bounds: { left: 10, top: 20, width: 100, height: 40 },
+        children: [],
+      },
+    ],
+  },
+  xpathPolicy: {
+    stableAttrs: ['resource-id'],
+    textAttrs: ['content-desc', 'text'],
+    excludedTargetTypes: [],
+    max: 3,
+  },
+};
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+function renderTree() {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(UITreeView, { snapshot })));
+  return container;
+}
+
+describe('UI tree report interactions', () => {
+  it('shows attributes and bounds after selecting a tree node', () => {
+    const view = renderTree();
+    const child = view.querySelector<HTMLButtonElement>(
+      '[data-node-key="0-0"]',
+    );
+    expect(child).not.toBeNull();
+
+    act(() => child?.click());
+
+    expect(view.textContent).toContain('com.example:id/submit');
+    expect(view.textContent).toContain('Bounds');
+    expect(view.textContent).toContain('left');
+    expect(view.textContent).toContain('100');
+  });
+
+  it('turns horizontal wheel input into viewport scrolling', () => {
+    const view = renderTree();
+    const viewport = view.querySelector<HTMLDivElement>(
+      '.ui-tree-horizontal-scroll',
+    );
+    expect(viewport).not.toBeNull();
+    if (!viewport) return;
+
+    Object.defineProperties(viewport, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1_000 },
+    });
+    const wheel = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 120,
+    });
+
+    viewport.dispatchEvent(wheel);
+
+    expect(viewport.scrollLeft).toBe(120);
+    expect(wheel.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/report/src/components/detail-panel/ui-tree-view.tsx
+++ b/apps/report/src/components/detail-panel/ui-tree-view.tsx
@@ -1,0 +1,187 @@
+import { SearchOutlined } from '@ant-design/icons';
+import type { UITreeSnapshot, UiNode } from '@midscene/core';
+import { Alert, Empty, Input, Tree } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildUITreeViewModel,
+  estimateUITreeCanvasWidth,
+  searchUITreeViewModel,
+} from './ui-tree-data';
+
+export function UITreeNodeDetails({ node }: { node: UiNode }) {
+  return (
+    <div className="ui-tree-node-details">
+      <div className="ui-tree-node-details-title">{node.type}</div>
+      <div className="ui-tree-node-details-section">Bounds</div>
+      <table>
+        <tbody>
+          {Object.entries(node.bounds).map(([name, value]) => (
+            <tr key={name}>
+              <th>{name}</th>
+              <td>{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="ui-tree-node-details-section">Attributes</div>
+      <table>
+        <tbody>
+          {Object.entries(node.attrs).map(([name, value]) => (
+            <tr key={name}>
+              <th>{name}</th>
+              <td>{value ?? 'undefined'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function UITreeView({
+  snapshot,
+  error,
+  embedded = false,
+}: {
+  snapshot?: UITreeSnapshot;
+  error?: string;
+  embedded?: boolean;
+}) {
+  const model = useMemo(
+    () => (snapshot ? buildUITreeViewModel(snapshot) : null),
+    [snapshot],
+  );
+  const [selectedKey, setSelectedKey] = useState<string>();
+  const [searchText, setSearchText] = useState('');
+  const horizontalScrollRef = useRef<HTMLDivElement>(null);
+  const searchResult = useMemo(
+    () => (model ? searchUITreeViewModel(model, searchText) : null),
+    [model, searchText],
+  );
+  const canvasWidth = useMemo(
+    () => (model ? estimateUITreeCanvasWidth(model.treeData) : 640),
+    [model],
+  );
+  const selectedNode = selectedKey
+    ? model?.nodeByKey.get(selectedKey)
+    : undefined;
+  const hasTreeRows = Boolean(searchResult?.treeData.length);
+
+  useEffect(() => {
+    const viewport = horizontalScrollRef.current;
+    if (!viewport) return;
+
+    const handleHorizontalWheel = (event: WheelEvent) => {
+      const delta =
+        Math.abs(event.deltaX) > 0
+          ? event.deltaX
+          : event.shiftKey
+            ? event.deltaY
+            : 0;
+      if (delta === 0) return;
+
+      const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
+      const nextScrollLeft = Math.max(
+        0,
+        Math.min(maxScrollLeft, viewport.scrollLeft + delta),
+      );
+      if (nextScrollLeft !== viewport.scrollLeft) {
+        viewport.scrollLeft = nextScrollLeft;
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+    viewport.addEventListener('wheel', handleHorizontalWheel, {
+      passive: false,
+    });
+    return () => viewport.removeEventListener('wheel', handleHorizontalWheel);
+  }, [hasTreeRows]);
+
+  if (!snapshot || !model || !searchResult) {
+    return error ? (
+      <Alert
+        type="error"
+        showIcon
+        message="UI tree capture failed"
+        description={error}
+      />
+    ) : (
+      <Empty description="No UI tree" />
+    );
+  }
+
+  return (
+    <div
+      className={`ui-tree-view${embedded ? ' ui-tree-view-embedded' : ' scrollable'}`}
+    >
+      {error && (
+        <Alert
+          type="warning"
+          showIcon
+          message="UI tree capture warning"
+          description={error}
+        />
+      )}
+      <div className="ui-tree-toolbar">
+        <Input
+          className="ui-tree-search"
+          aria-label="Search UI tree"
+          allowClear
+          placeholder="Search class, attribute, or value"
+          prefix={<SearchOutlined />}
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+        />
+        <div className="ui-tree-summary">
+          {searchResult.query
+            ? `${searchResult.matchCount} of ${model.nodeCount} nodes`
+            : `${model.nodeCount} nodes`}{' '}
+          · captured at {snapshot.capturedAt}
+        </div>
+      </div>
+      <div className="ui-tree-columns">
+        <div className="ui-tree-browser">
+          {searchResult.treeData.length > 0 ? (
+            <div
+              className="ui-tree-horizontal-scroll"
+              ref={horizontalScrollRef}
+            >
+              <div
+                className="ui-tree-scroll-content"
+                data-ui-tree-canvas-width={canvasWidth}
+                style={{ width: canvasWidth }}
+              >
+                <Tree
+                  key={searchResult.query || 'all-nodes'}
+                  virtual
+                  height={560}
+                  treeData={searchResult.treeData}
+                  defaultExpandedKeys={searchResult.expandedKeys}
+                  selectedKeys={selectedKey ? [selectedKey] : []}
+                  onSelect={(keys) => {
+                    setSelectedKey(keys[0] ? String(keys[0]) : undefined);
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No matching UI tree nodes"
+            />
+          )}
+        </div>
+        <div className="ui-tree-details">
+          {selectedNode ? (
+            <UITreeNodeDetails node={selectedNode} />
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="Select a UI tree node"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/report/tests/json-view-data.test.ts
+++ b/apps/report/tests/json-view-data.test.ts
@@ -118,4 +118,44 @@ describe('sanitizeJsonViewData', () => {
       second: { value: 1 },
     });
   });
+
+  it('replaces a full UI tree root with a compact summary', () => {
+    const result = sanitizeJsonViewData({
+      uiContext: {
+        uiTree: {
+          platform: 'android',
+          capturedAt: 123,
+          xpathPolicy: {
+            stableAttrs: ['resource-id'],
+            textAttrs: ['content-desc', 'text'],
+            excludedTargetTypes: [],
+            max: 3,
+          },
+          root: {
+            type: 'Root',
+            attrs: { large: 'root attrs should be omitted' },
+            bounds: { left: 0, top: 0, width: 100, height: 100 },
+            children: [
+              {
+                type: 'Child',
+                attrs: { text: 'child attrs should be omitted' },
+                bounds: { left: 0, top: 0, width: 10, height: 10 },
+                children: [],
+              },
+            ],
+          },
+        },
+      },
+    }) as {
+      uiContext: { uiTree: { root: Record<string, unknown> } };
+    };
+
+    expect(result.uiContext.uiTree.root).toMatchObject({
+      type: 'Root',
+      childCount: 1,
+      nodeCount: 2,
+    });
+    expect(result.uiContext.uiTree.root).not.toHaveProperty('attrs');
+    expect(result.uiContext.uiTree.root).not.toHaveProperty('children');
+  });
 });

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -11,6 +11,8 @@ import {
   type LocateResultElement,
   type Point,
   type Size,
+  type UITreeSnapshot,
+  type UiNode,
   getMidsceneLocationSchema,
   z,
 } from '@midscene/core';
@@ -49,6 +51,10 @@ import {
   type ScrcpyStatus,
 } from './scrcpy-device-adapter';
 import type { RawKeyframe } from './scrcpy-manager';
+import {
+  ANDROID_UI_TREE_XPATH_POLICY,
+  uiautomatorXmlToUiNode,
+} from './ui-tree';
 
 // Re-export AndroidDeviceOpt and AndroidDeviceInputOpt for backward compatibility
 export type {
@@ -61,12 +67,144 @@ const defaultScrollUntilTimes = 10;
 const defaultFastScrollDuration = 100;
 const defaultNormalScrollDuration = 1000;
 
+const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
+const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
+const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
+const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
+const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
+
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
 
 const debugDevice = getDebug('android:device');
 const warnDevice = getDebug('android:device', { console: true });
+const debugUITree = getDebug('android:ui-tree');
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validateHierarchyXml(
+  xml: unknown,
+  source: AndroidAccessibilityTreeSource,
+): asserts xml is string {
+  if (
+    typeof xml !== 'string' ||
+    !/<hierarchy(?:\s|>)/.test(xml) ||
+    !xml.includes('</hierarchy>')
+  ) {
+    throw new Error(`${source} did not produce valid hierarchy XML`);
+  }
+}
+
+function physicalDisplayIdForLogicalDisplay(
+  displayDump: string,
+  logicalDisplayId: number,
+): string | null {
+  for (const viewportMatch of displayDump.matchAll(
+    /DisplayViewport\{([^}]*)\}/g,
+  )) {
+    const viewport = viewportMatch[1];
+    const displayId = viewport.match(/\bdisplayId=(\d+)\b/)?.[1];
+    const physicalId = viewport.match(/\buniqueId=['"]local:(\d+)['"]/)?.[1];
+    if (Number(displayId) === logicalDisplayId && physicalId) {
+      return physicalId;
+    }
+  }
+
+  const lines = displayDump.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const displayId = lines[index].match(/^\s*mDisplayId=(\d+)\b/)?.[1];
+    if (Number(displayId) !== logicalDisplayId) continue;
+
+    for (let cursor = index + 1; cursor < lines.length; cursor++) {
+      if (/^\s*mDisplayId=\d+\b/.test(lines[cursor])) break;
+      const physicalId = lines[cursor].match(
+        /mBaseDisplayInfo=.*\buniqueId "local:(\d+)"/,
+      )?.[1];
+      if (physicalId) return physicalId;
+    }
+  }
+
+  return null;
+}
+
+function focusedPackageForLogicalDisplay(
+  windowDump: string,
+  logicalDisplayId: number,
+): string | null {
+  const displayMatches = [
+    ...windowDump.matchAll(/^\s*Display: mDisplayId=(\d+)\b.*$/gm),
+  ];
+  const displayIndex = displayMatches.findIndex(
+    (match) => Number(match[1]) === logicalDisplayId,
+  );
+  if (displayIndex === -1) return null;
+
+  const start = displayMatches[displayIndex].index ?? 0;
+  const end = displayMatches[displayIndex + 1]?.index ?? windowDump.length;
+  const displayBlock = windowDump.slice(start, end);
+  for (const field of ['mCurrentFocus', 'mFocusedApp']) {
+    const value = displayBlock.match(
+      new RegExp(`^\\s*${field}=([^\\n]*)$`, 'm'),
+    )?.[1];
+    const packageName = value?.match(/\bu\d+\s+([A-Za-z0-9_$.-]+)\//)?.[1];
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function firstTreePackage(root: UiNode): string | null {
+  if (root.attrs.package) return root.attrs.package;
+  for (const child of root.children) {
+    const packageName = firstTreePackage(child);
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function windowDisplayIdsForPackage(
+  windowDump: string,
+  packageName: string,
+): number[] {
+  const windowMatches = [
+    ...windowDump.matchAll(/^\s*Window #\d+ Window\{.*$/gm),
+  ];
+  const displayIds = new Set<number>();
+
+  for (let index = 0; index < windowMatches.length; index++) {
+    const start = windowMatches[index].index ?? 0;
+    const end = windowMatches[index + 1]?.index ?? windowDump.length;
+    const windowBlock = windowDump.slice(start, end);
+    const ownerPackage = windowBlock.match(
+      /^\s*mOwnerUid=.*\bpackage=([A-Za-z0-9_$.-]+)\b/m,
+    )?.[1];
+    const headerPackage = windowMatches[index][0].match(
+      /\bu\d+\s+([A-Za-z0-9_$.-]+)\//,
+    )?.[1];
+    if (ownerPackage !== packageName && headerPackage !== packageName) {
+      continue;
+    }
+
+    const displayId = windowBlock.match(/^\s*mDisplayId=(\d+)\b/m)?.[1];
+    if (displayId !== undefined) displayIds.add(Number(displayId));
+  }
+
+  return [...displayIds];
+}
+
+function uiTreeExtent(root: UiNode): { right: number; bottom: number } {
+  let right = root.bounds.left + root.bounds.width;
+  let bottom = root.bounds.top + root.bounds.height;
+  for (const child of root.children) {
+    const childExtent = uiTreeExtent(child);
+    right = Math.max(right, childExtent.right);
+    bottom = Math.max(bottom, childExtent.bottom);
+  }
+  return { right, bottom };
+}
 
 /**
  * Escape text for safe use in shell single-quoted strings.
@@ -685,6 +823,180 @@ ${Object.keys(size)
       node: null,
       children: [],
     };
+  }
+
+  private async dumpAccessibilityXmlAttempt(
+    source: AndroidAccessibilityTreeSource,
+  ): Promise<string> {
+    const adb = await this.getAdb();
+    const destination =
+      source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
+
+    if (source === 'yadb') {
+      await this.ensureYadb();
+    }
+
+    await runAdbShellStdoutOrThrow(adb, `rm -f ${destination}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const command =
+      source === 'yadb'
+        ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${destination}`
+        : `uiautomator dump --compressed ${destination}`;
+    await runAdbShellStdoutOrThrow(adb, command, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const xml = await runAdbShellStdoutOrThrow(adb, `cat ${destination}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    validateHierarchyXml(xml, source);
+    return xml;
+  }
+
+  private async dumpAccessibilityXml(): Promise<string> {
+    const sources: AndroidAccessibilityTreeSource[] =
+      (this.options?.displayId ?? 0) === 0
+        ? ['yadb', 'uiautomator']
+        : ['uiautomator'];
+    const failures: string[] = [];
+
+    for (const source of sources) {
+      for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+        const startedAt = Date.now();
+        try {
+          const xml = await this.dumpAccessibilityXmlAttempt(source);
+          debugUITree(
+            'capture source=%s attempt=%d durationMs=%d bytes=%d',
+            source,
+            attempt,
+            Date.now() - startedAt,
+            xml.length,
+          );
+          return xml;
+        } catch (error) {
+          const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+          failures.push(failure);
+          debugUITree(
+            'capture failed source=%s attempt=%d durationMs=%d error=%s',
+            source,
+            attempt,
+            Date.now() - startedAt,
+            errorMessage(error),
+          );
+          if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
+            await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
+          }
+        }
+      }
+    }
+
+    throw new Error(
+      `Unable to read Android accessibility hierarchy after ${failures.length} attempt(s): ${failures.join('; ')}`,
+    );
+  }
+
+  private async validateUITreeDisplay(root: UiNode): Promise<void> {
+    if (typeof this.options?.displayId !== 'number') return;
+
+    const displayId = this.options.displayId;
+    const adb = await this.getAdb();
+    const displayWindowDump = await runAdbShellStdoutOrThrow(
+      adb,
+      'dumpsys window displays',
+      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+    );
+    const expectedPackage = focusedPackageForLogicalDisplay(
+      displayWindowDump,
+      displayId,
+    );
+    const treePackage = firstTreePackage(root);
+    if (!expectedPackage) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no focused package found on the target display`,
+      );
+    }
+    if (!treePackage) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: accessibility hierarchy has no package`,
+      );
+    }
+
+    const allWindowDump = await runAdbShellStdoutOrThrow(
+      adb,
+      'dumpsys window windows',
+      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+    );
+    const treePackageDisplayIds = windowDisplayIdsForPackage(
+      allWindowDump,
+      treePackage,
+    );
+    if (treePackageDisplayIds.length === 0) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no window display ownership found for accessibility package ${treePackage}`,
+      );
+    }
+    if (!treePackageDisplayIds.includes(displayId)) {
+      throw new Error(
+        `Android UI tree display mismatch for displayId=${displayId}: expected focused package ${expectedPackage}, but accessibility hierarchy belongs to ${treePackage} on displayId=${treePackageDisplayIds.join(',')}`,
+      );
+    }
+
+    const targetSize = await this.size();
+    const extent = uiTreeExtent(root);
+    const tolerance = 1;
+    if (
+      extent.right > targetSize.width + tolerance ||
+      extent.bottom > targetSize.height + tolerance
+    ) {
+      throw new Error(
+        `Android UI tree bounds exceed displayId=${displayId}: tree ${Math.round(extent.right)}x${Math.round(extent.bottom)} is outside target ${targetSize.width}x${targetSize.height}`,
+      );
+    }
+  }
+
+  async getUITree(): Promise<UITreeSnapshot> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+      try {
+        const xml =
+          attempt === 1
+            ? await this.dumpAccessibilityXml()
+            : await this.dumpAccessibilityXmlAttempt('uiautomator');
+        const capturedAt = Date.now();
+        const root = uiautomatorXmlToUiNode(xml, this.devicePixelRatio || 1);
+        await this.validateUITreeDisplay(root);
+        return {
+          platform: 'android',
+          capturedAt,
+          root,
+          xpathPolicy: {
+            ...ANDROID_UI_TREE_XPATH_POLICY,
+            stableAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.stableAttrs],
+            textAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.textAttrs],
+            excludedTargetTypes: [
+              ...ANDROID_UI_TREE_XPATH_POLICY.excludedTargetTypes,
+            ],
+          },
+        };
+      } catch (error) {
+        lastError = error;
+        debugUITree(
+          'alignment failed attempt=%d/%d error=%s',
+          attempt,
+          ACCESSIBILITY_DUMP_ATTEMPTS,
+          errorMessage(error),
+        );
+        if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
+          await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
+        }
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(
+          `Unable to capture Android UI tree: ${errorMessage(lastError)}`,
+        );
   }
 
   async getScreenSize(): Promise<{
@@ -2106,6 +2418,19 @@ ${Object.keys(size)
 
     const adb = await this.getAdb();
     try {
+      const displayDump = await adb.shell('dumpsys display');
+      const logicalDisplayPhysicalId = physicalDisplayIdForLogicalDisplay(
+        displayDump,
+        this.options.displayId,
+      );
+      if (logicalDisplayPhysicalId) {
+        this.cachedPhysicalDisplayId = logicalDisplayPhysicalId;
+        debugDevice(
+          `Found and cached physical display ID: ${logicalDisplayPhysicalId} for logical display ID: ${this.options.displayId}`,
+        );
+        return this.cachedPhysicalDisplayId;
+      }
+
       const stdout = await adb.shell(
         `dumpsys SurfaceFlinger --display-id ${this.options.displayId}`,
       );

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -825,7 +825,7 @@ ${Object.keys(size)
     };
   }
 
-  private async dumpAccessibilityXmlAttempt(
+  private async dumpAccessibilityXml(
     source: AndroidAccessibilityTreeSource,
   ): Promise<string> {
     const adb = await this.getAdb();
@@ -851,48 +851,6 @@ ${Object.keys(size)
     });
     validateHierarchyXml(xml, source);
     return xml;
-  }
-
-  private async dumpAccessibilityXml(): Promise<string> {
-    const sources: AndroidAccessibilityTreeSource[] =
-      (this.options?.displayId ?? 0) === 0
-        ? ['yadb', 'uiautomator']
-        : ['uiautomator'];
-    const failures: string[] = [];
-
-    for (const source of sources) {
-      for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
-        const startedAt = Date.now();
-        try {
-          const xml = await this.dumpAccessibilityXmlAttempt(source);
-          debugUITree(
-            'capture source=%s attempt=%d durationMs=%d bytes=%d',
-            source,
-            attempt,
-            Date.now() - startedAt,
-            xml.length,
-          );
-          return xml;
-        } catch (error) {
-          const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
-          failures.push(failure);
-          debugUITree(
-            'capture failed source=%s attempt=%d durationMs=%d error=%s',
-            source,
-            attempt,
-            Date.now() - startedAt,
-            errorMessage(error),
-          );
-          if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
-            await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
-          }
-        }
-      }
-    }
-
-    throw new Error(
-      `Unable to read Android accessibility hierarchy after ${failures.length} attempt(s): ${failures.join('; ')}`,
-    );
   }
 
   private async validateUITreeDisplay(root: UiNode): Promise<void> {
@@ -955,16 +913,28 @@ ${Object.keys(size)
   }
 
   async getUITree(): Promise<UITreeSnapshot> {
-    let lastError: unknown;
+    await this.initializeDevicePixelRatio();
+    const sources: AndroidAccessibilityTreeSource[] =
+      (this.options?.displayId ?? 0) === 0
+        ? ['yadb', 'uiautomator']
+        : ['uiautomator'];
+    const failures: string[] = [];
+
     for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+      const source = sources[Math.min(attempt - 1, sources.length - 1)];
+      const startedAt = Date.now();
       try {
-        const xml =
-          attempt === 1
-            ? await this.dumpAccessibilityXml()
-            : await this.dumpAccessibilityXmlAttempt('uiautomator');
+        const xml = await this.dumpAccessibilityXml(source);
         const capturedAt = Date.now();
-        const root = uiautomatorXmlToUiNode(xml, this.devicePixelRatio || 1);
+        const root = uiautomatorXmlToUiNode(xml, this.devicePixelRatio);
         await this.validateUITreeDisplay(root);
+        debugUITree(
+          'capture source=%s attempt=%d durationMs=%d bytes=%d',
+          source,
+          attempt,
+          Date.now() - startedAt,
+          xml.length,
+        );
         return {
           platform: 'android',
           capturedAt,
@@ -979,11 +949,14 @@ ${Object.keys(size)
           },
         };
       } catch (error) {
-        lastError = error;
+        const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+        failures.push(failure);
         debugUITree(
-          'alignment failed attempt=%d/%d error=%s',
+          'capture failed source=%s attempt=%d/%d durationMs=%d error=%s',
+          source,
           attempt,
           ACCESSIBILITY_DUMP_ATTEMPTS,
+          Date.now() - startedAt,
           errorMessage(error),
         );
         if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
@@ -992,11 +965,9 @@ ${Object.keys(size)
       }
     }
 
-    throw lastError instanceof Error
-      ? lastError
-      : new Error(
-          `Unable to capture Android UI tree: ${errorMessage(lastError)}`,
-        );
+    throw new Error(
+      `Unable to capture Android UI tree after ${failures.length} attempt(s): ${failures.join('; ')}`,
+    );
   }
 
   async getScreenSize(): Promise<{

--- a/packages/android/src/ui-tree.ts
+++ b/packages/android/src/ui-tree.ts
@@ -1,0 +1,160 @@
+import type { UITreeSnapshot, UiNode } from '@midscene/core';
+
+export const ANDROID_UI_TREE_XPATH_POLICY: UITreeSnapshot['xpathPolicy'] = {
+  stableAttrs: ['resource-id'],
+  textAttrs: ['content-desc', 'text'],
+  excludedTargetTypes: [
+    'android.widget.GridView',
+    'android.widget.ListView',
+    'android.widget.ScrollView',
+    'android.widget.HorizontalScrollView',
+    'android.widget.RecyclerView',
+    'android.support.v7.widget.RecyclerView',
+    'androidx.recyclerview.widget.RecyclerView',
+    'android.support.v4.view.ViewPager',
+    'androidx.viewpager.widget.ViewPager',
+    'androidx.viewpager2.widget.ViewPager2',
+    'android.webkit.WebView',
+  ],
+  max: 3,
+};
+
+interface XmlElement {
+  name: string;
+  attrs: Record<string, string>;
+  children: XmlElement[];
+}
+
+const TAG_RE = /<(\/?)([A-Za-z_][A-Za-z0-9_.\-:]*)([^>]*?)(\/?)>/g;
+const ATTR_RE = /([A-Za-z_][A-Za-z0-9_.\-:]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+const BOUNDS_RE = /^\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]$/;
+const ENTITY_TABLE: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+function decodeEntities(value: string): string {
+  if (!value.includes('&')) return value;
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (full, body) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) {
+      const code = Number.parseInt(body.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    if (body.startsWith('#')) {
+      const code = Number.parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    return ENTITY_TABLE[body] ?? full;
+  });
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  ATTR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((match = ATTR_RE.exec(raw))) {
+    attrs[match[1]] = decodeEntities(match[3] ?? match[4] ?? '');
+  }
+  return attrs;
+}
+
+function parseXml(input: string): XmlElement {
+  if (input.trim().length === 0) {
+    throw new Error('parseAndroidUITreeXml: input is empty');
+  }
+  const cleaned = input
+    .replace(/<\?xml[\s\S]*?\?>/g, '')
+    .replace(/<!DOCTYPE[\s\S]*?>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+  TAG_RE.lastIndex = 0;
+
+  const stack: XmlElement[] = [];
+  let root: XmlElement | undefined;
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((match = TAG_RE.exec(cleaned))) {
+    const isClose = match[1] === '/';
+    const name = match[2];
+    if (isClose) {
+      const current = stack.pop();
+      if (!current || current.name !== name) {
+        throw new Error(
+          `parseAndroidUITreeXml: unbalanced close tag </${name}>`,
+        );
+      }
+      continue;
+    }
+
+    const element: XmlElement = {
+      name,
+      attrs: parseAttrs(match[3] ?? ''),
+      children: [],
+    };
+    const parent = stack[stack.length - 1];
+    if (parent) {
+      parent.children.push(element);
+    } else if (root) {
+      throw new Error('parseAndroidUITreeXml: more than one top-level element');
+    } else {
+      root = element;
+    }
+    if (match[4] !== '/') stack.push(element);
+  }
+
+  if (stack.length > 0) {
+    throw new Error('parseAndroidUITreeXml: unclosed element');
+  }
+  if (!root) {
+    throw new Error('parseAndroidUITreeXml: no root element');
+  }
+  return root;
+}
+
+function parseBounds(
+  raw: string | undefined,
+  devicePixelRatio: number,
+): UiNode['bounds'] {
+  const match = raw ? BOUNDS_RE.exec(raw) : undefined;
+  if (!match) return { left: 0, top: 0, width: 0, height: 0 };
+  const left = Number.parseInt(match[1], 10);
+  const top = Number.parseInt(match[2], 10);
+  const right = Number.parseInt(match[3], 10);
+  const bottom = Number.parseInt(match[4], 10);
+  const ratio = devicePixelRatio > 0 ? devicePixelRatio : 1;
+  return {
+    left: left / ratio,
+    top: top / ratio,
+    width: Math.max(0, right - left) / ratio,
+    height: Math.max(0, bottom - top) / ratio,
+  };
+}
+
+function toUiNode(element: XmlElement, devicePixelRatio: number): UiNode {
+  const attrs: Record<string, string> = {};
+  for (const [name, value] of Object.entries(element.attrs)) {
+    if (name !== 'bounds') attrs[name] = value;
+  }
+  return {
+    type: element.attrs.class || element.name,
+    attrs,
+    bounds: parseBounds(element.attrs.bounds, devicePixelRatio),
+    children: element.children.map((child) =>
+      toUiNode(child, devicePixelRatio),
+    ),
+  };
+}
+
+export function uiautomatorXmlToUiNode(
+  xml: string,
+  devicePixelRatio: number,
+): UiNode {
+  const root = parseXml(xml);
+  if (root.name === 'hierarchy' && root.children.length === 1) {
+    return toUiNode(root.children[0], devicePixelRatio);
+  }
+  return toUiNode(root, devicePixelRatio);
+}

--- a/packages/android/tests/unit-test/agent.test.ts
+++ b/packages/android/tests/unit-test/agent.test.ts
@@ -39,6 +39,7 @@ describe('AndroidAgent', () => {
         actionSpace: vi.fn().mockReturnValue([]),
         screenshotBase64: vi.fn(),
         size: vi.fn(),
+        getUITree: vi.fn(),
         getElementsInfo: vi.fn(),
         url: vi.fn(),
         launch: vi.fn(),
@@ -61,6 +62,86 @@ describe('AndroidAgent', () => {
             modelConfig: mockedModelConfig,
           }),
       ).not.toThrow();
+    });
+
+    it('does not capture a UI tree when captureUITree is disabled', async () => {
+      const mockPage = new AndroidDevice('test-device');
+      vi.mocked(mockPage.screenshotBase64).mockResolvedValue(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      );
+      vi.mocked(mockPage.size).mockResolvedValue({ width: 1, height: 1 });
+      const agent = new AndroidAgent(mockPage, {
+        generateReport: false,
+        modelConfig: mockedModelConfig,
+      });
+
+      const uiContext = await agent.getUIContext();
+
+      expect(mockPage.getUITree).not.toHaveBeenCalled();
+      expect(uiContext.uiTree).toBeUndefined();
+      expect(agent.opts.captureUITree).toBe(false);
+    });
+
+    it('captures a UI tree only for Locate contexts', async () => {
+      const mockPage = new AndroidDevice('test-device');
+      vi.mocked(mockPage.screenshotBase64).mockResolvedValue(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      );
+      vi.mocked(mockPage.size).mockResolvedValue({ width: 1, height: 1 });
+      vi.mocked(mockPage.getUITree).mockResolvedValue({
+        platform: 'android',
+        capturedAt: 1,
+        root: {
+          type: 'Window',
+          attrs: {},
+          bounds: { left: 0, top: 0, width: 1, height: 1 },
+          children: [],
+        },
+        xpathPolicy: {
+          stableAttrs: ['resource-id'],
+          textAttrs: ['content-desc', 'text'],
+          excludedTargetTypes: [],
+          max: 5,
+        },
+      });
+      const agent = new AndroidAgent(mockPage, {
+        captureUITree: true,
+        generateReport: false,
+        modelConfig: mockedModelConfig,
+      });
+
+      const regularContext = await agent.getUIContext();
+      const locateContext = await agent.getUIContext('locate');
+
+      expect(regularContext.uiTree).toBeUndefined();
+      expect(mockPage.getUITree).toHaveBeenCalledOnce();
+      expect(locateContext.uiTree?.platform).toBe('android');
+    });
+
+    it('keeps the Locate UI context usable when the layout dump fails', async () => {
+      const mockPage = new AndroidDevice('test-device');
+      vi.mocked(mockPage.screenshotBase64).mockResolvedValue(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      );
+      vi.mocked(mockPage.size).mockResolvedValue({ width: 1, height: 1 });
+      vi.mocked(mockPage.getUITree).mockRejectedValue(
+        new Error('layout dump failed'),
+      );
+      const agent = new AndroidAgent(mockPage, {
+        captureUITree: true,
+        generateReport: false,
+        modelConfig: mockedModelConfig,
+      });
+
+      const uiContext = await agent.getUIContext('locate');
+
+      expect(mockPage.getUITree).toHaveBeenCalledOnce();
+      expect(
+        vi.mocked(mockPage.screenshotBase64).mock.invocationCallOrder[0],
+      ).toBeLessThan(vi.mocked(mockPage.getUITree).mock.invocationCallOrder[0]);
+      expect(uiContext.screenshot.base64).toContain('data:image/');
+      expect(uiContext.uiTree).toBeUndefined();
+      expect(uiContext.uiTreeError).toBe('layout dump failed');
     });
   });
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -185,6 +185,240 @@ describe('AndroidDevice', () => {
     });
   });
 
+  describe('UI tree', () => {
+    const hierarchy = (children: string) => `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" bounds="[0,0][400,800]">
+    ${children}
+  </node>
+</hierarchy>`;
+
+    const mockYadbHierarchy = (xml: string) => {
+      mockAdb.shell.mockImplementation(async (command) => {
+        if (
+          String(command) ===
+          'cat /data/local/tmp/midscene_yadb_layout_dump.xml'
+        ) {
+          return xml;
+        }
+        return '';
+      });
+    };
+
+    it('returns a snapshot from the accessibility hierarchy', async () => {
+      mockYadbHierarchy(
+        hierarchy(
+          '<node class="android.widget.Button" resource-id="submit" text="Submit" bounds="[20,40][180,100]"/>',
+        ),
+      );
+      (device as any).devicePixelRatio = 2;
+      const beforeCapture = Date.now();
+
+      const snapshot = await device.getUITree();
+
+      expect(snapshot).toMatchObject({
+        platform: 'android',
+        xpathPolicy: {
+          stableAttrs: ['resource-id'],
+          textAttrs: ['content-desc', 'text'],
+          max: 3,
+        },
+        root: {
+          type: 'android.widget.FrameLayout',
+          bounds: { left: 0, top: 0, width: 200, height: 400 },
+          children: [
+            {
+              type: 'android.widget.Button',
+              attrs: { 'resource-id': 'submit', text: 'Submit' },
+              bounds: { left: 10, top: 20, width: 80, height: 30 },
+            },
+          ],
+        },
+      });
+      expect(snapshot.capturedAt).toBeGreaterThanOrEqual(beforeCapture);
+      expect(snapshot.xpathPolicy.excludedTargetTypes).toContain(
+        'android.webkit.WebView',
+      );
+      expect(mockAdb.shell).toHaveBeenCalledWith(
+        'cat /data/local/tmp/midscene_yadb_layout_dump.xml',
+        expect.objectContaining({ timeout: 5_000 }),
+      );
+    });
+
+    it('rejects a tree captured from a different logical display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.wrong.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}
+  mFocusedApp=ActivityRecord{def u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.wrong.display/.MainActivity}:
+  mDisplayId=3 rootTaskId=10
+  mOwnerUid=10001 package=com.wrong.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /UI tree display mismatch.*displayId=2.*com\.expected\.display.*com\.wrong\.display/,
+      );
+    });
+
+    it('accepts a system overlay owned by the configured display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.android.systemui" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 StatusBar}:
+  mDisplayId=2 rootTaskId=1
+  mOwnerUid=10002 package=com.android.systemui`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).resolves.toMatchObject({
+        root: { attrs: { package: 'com.android.systemui' } },
+      });
+    });
+
+    it('rejects a tree whose display ownership cannot be verified', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.unknown.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') return '';
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /no window display ownership found.*com\.unknown\.display/,
+      );
+    });
+
+    it('records capturedAt immediately after reading the hierarchy', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      let currentTime = 10;
+      vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          currentTime = 100;
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.expected.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          currentTime = 200;
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.expected.display/.MainActivity}:
+  mDisplayId=2 rootTaskId=10
+  mOwnerUid=10001 package=com.expected.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).resolves.toMatchObject({
+        capturedAt: 100,
+      });
+    });
+
+    it('rejects a tree whose bounds exceed the configured display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.expected.display" bounds="[0,0][600,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.expected.display/.MainActivity}:
+  mDisplayId=2 rootTaskId=10
+  mOwnerUid=10001 package=com.expected.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /UI tree bounds exceed displayId=2.*600x800.*400x800/,
+      );
+    });
+  });
+
   describe('launch', () => {
     it('should start URI for http/https links', async () => {
       const uri = 'https://example.com';
@@ -2503,6 +2737,30 @@ Stdout:
         'dumpsys SurfaceFlinger --display-id 1',
       );
       expect(result).toBe('4630946423637606531');
+    });
+
+    it('maps a logical display ID to its physical unique ID', async () => {
+      deviceWithDisplay = new AndroidDevice('test-device', {
+        displayId: 0,
+      });
+      setupMockAdb(mockAdbInstance);
+      mockAdbInstance.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'dumpsys display') {
+          return `mDisplayId=0
+    mBaseDisplayInfo=DisplayInfo{"Outer", displayId 0, uniqueId "local:222"}
+mDisplayId=2
+    mBaseDisplayInfo=DisplayInfo{"Inner", displayId 2, uniqueId "local:111"}`;
+        }
+        return '';
+      });
+
+      await expect(deviceWithDisplay.getPhysicalDisplayId()).resolves.toBe(
+        '222',
+      );
+      expect(mockAdbInstance.shell).not.toHaveBeenCalledWith(
+        'dumpsys SurfaceFlinger --display-id 0',
+      );
     });
 
     it('should use display-specific size when displayId is set', async () => {

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -211,7 +211,7 @@ describe('AndroidDevice', () => {
           '<node class="android.widget.Button" resource-id="submit" text="Submit" bounds="[20,40][180,100]"/>',
         ),
       );
-      (device as any).devicePixelRatio = 2;
+      mockAdb.getScreenDensity.mockResolvedValue(320);
       const beforeCapture = Date.now();
 
       const snapshot = await device.getUITree();
@@ -239,10 +239,40 @@ describe('AndroidDevice', () => {
       expect(snapshot.xpathPolicy.excludedTargetTypes).toContain(
         'android.webkit.WebView',
       );
+      expect(mockAdb.getScreenDensity).toHaveBeenCalledOnce();
       expect(mockAdb.shell).toHaveBeenCalledWith(
         'cat /data/local/tmp/midscene_yadb_layout_dump.xml',
         expect.objectContaining({ timeout: 5_000 }),
       );
+    });
+
+    it('shares one total retry budget across accessibility dump sources', async () => {
+      mockAdb.getScreenDensity.mockResolvedValue(160);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (
+          value.includes(' -layout ') ||
+          value.startsWith('uiautomator dump')
+        ) {
+          throw new Error('layout dump failed');
+        }
+        return '';
+      });
+
+      await expect(device.getUITree()).rejects.toThrow('layout dump failed');
+
+      const dumpCommands = mockAdb.shell.mock.calls
+        .map(([command]) => String(command))
+        .filter(
+          (command) =>
+            command.includes(' -layout ') ||
+            command.startsWith('uiautomator dump'),
+        );
+      expect(dumpCommands).toEqual([
+        'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout /data/local/tmp/midscene_yadb_layout_dump.xml',
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
+      ]);
     });
 
     it('rejects a tree captured from a different logical display', async () => {

--- a/packages/android/tests/unit-test/ui-tree.test.ts
+++ b/packages/android/tests/unit-test/ui-tree.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { uiautomatorXmlToUiNode } from '../../src/ui-tree';
+
+describe('uiautomatorXmlToUiNode', () => {
+  it('unwraps a hierarchy and converts physical bounds to logical bounds', () => {
+    const root = uiautomatorXmlToUiNode(
+      `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.example" bounds="[0,0][400,800]">
+    <node class="android.widget.Button" resource-id="submit" text="Pay &amp; continue" bounds="[20,40][180,100]"/>
+  </node>
+</hierarchy>`,
+      2,
+    );
+
+    expect(root).toMatchObject({
+      type: 'android.widget.FrameLayout',
+      attrs: { package: 'com.example' },
+      bounds: { left: 0, top: 0, width: 200, height: 400 },
+      children: [
+        {
+          type: 'android.widget.Button',
+          attrs: {
+            'resource-id': 'submit',
+            text: 'Pay & continue',
+          },
+          bounds: { left: 10, top: 20, width: 80, height: 30 },
+        },
+      ],
+    });
+    expect(root.attrs.bounds).toBeUndefined();
+  });
+
+  it('retains a synthetic hierarchy root for multi-window dumps', () => {
+    const root = uiautomatorXmlToUiNode(
+      `<hierarchy>
+        <node class="WindowA" bounds="[0,0][100,100]"/>
+        <node class="WindowB" bounds="[100,0][200,100]"/>
+      </hierarchy>`,
+      1,
+    );
+
+    expect(root.type).toBe('hierarchy');
+    expect(root.children.map((child) => child.type)).toEqual([
+      'WindowA',
+      'WindowB',
+    ]);
+  });
+
+  it('throws for malformed XML', () => {
+    expect(() =>
+      uiautomatorXmlToUiNode('<hierarchy><node></hierarchy>', 1),
+    ).toThrow('unbalanced close tag');
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -66,6 +66,7 @@ import { getDebug } from '@midscene/shared/logger';
 import { assert, ifInBrowser, uuid } from '@midscene/shared/utils';
 import { defineActionSleep } from '../device';
 import { validateAgentCacheInput } from './cache-config';
+import { generateInspectionXpathCandidates } from './inspection-xpath';
 import { MetricsCollector, type MidsceneUsageMetrics } from './metrics';
 import { AgentProgressBus } from './progress';
 import { buildPromptWithContext } from './prompt-context';
@@ -285,6 +286,7 @@ export class Agent<
 
     this.opts = Object.assign(
       {
+        captureUITree: false,
         generateReport: true,
         persistExecutionDump: false,
         autoPrintReportMsg: true,
@@ -319,8 +321,8 @@ export class Agent<
 
     this.onTaskStartTip = this.opts.onTaskStartTip;
 
-    this.service = new Service(async () => {
-      return this.getUIContext();
+    this.service = new Service(async (action) => {
+      return this.getUIContext(action);
     });
 
     // Process cache configuration
@@ -405,6 +407,94 @@ export class Agent<
     return false;
   }
 
+  /**
+   * Generate ranked inspection XPath candidates for a point in a saved Android
+   * UI context. Screenshot coordinates are used by default and converted to
+   * logical coordinates with `shrunkShotToLogicalRatio`. This method reads only
+   * the supplied historical tree and never reconnects to the device.
+   *
+   * @throws When the tree is missing or non-Android, coordinates are invalid or
+   * out of bounds, no node is hit, or only a structural node is exposed.
+   */
+  async getXpathsByPoint(
+    uiContext: UIContext,
+    point: { x: number; y: number },
+    options?: {
+      coordinateSpace?: 'screenshot' | 'logical';
+    },
+  ): Promise<string[]> {
+    if (!uiContext?.uiTree) {
+      const captureError = uiContext?.uiTreeError
+        ? ` Capture error: ${uiContext.uiTreeError}`
+        : '';
+      throw new Error(
+        `getXpathsByPoint: UI tree is missing from UIContext.${captureError}`,
+      );
+    }
+    if (uiContext.uiTree.platform !== 'android') {
+      throw new Error(
+        `getXpathsByPoint: unsupported UI tree platform ${String(uiContext.uiTree.platform)}; only android is supported`,
+      );
+    }
+
+    const coordinateSpace = options?.coordinateSpace ?? 'screenshot';
+    if (coordinateSpace !== 'screenshot' && coordinateSpace !== 'logical') {
+      throw new Error(
+        `getXpathsByPoint: invalid coordinateSpace ${String(coordinateSpace)}`,
+      );
+    }
+    if (
+      !point ||
+      !Number.isFinite(point.x) ||
+      !Number.isFinite(point.y) ||
+      point.x < 0 ||
+      point.y < 0
+    ) {
+      throw new Error(
+        'getXpathsByPoint: point must contain finite, non-negative x and y coordinates',
+      );
+    }
+
+    const ratio = uiContext.shrunkShotToLogicalRatio;
+    if (!Number.isFinite(ratio) || ratio <= 0) {
+      throw new Error(
+        `getXpathsByPoint: invalid shrunkShotToLogicalRatio ${String(ratio)}`,
+      );
+    }
+    const bounds =
+      coordinateSpace === 'screenshot'
+        ? uiContext.shotSize
+        : {
+            width: uiContext.shotSize.width / ratio,
+            height: uiContext.shotSize.height / ratio,
+          };
+    if (
+      !Number.isFinite(bounds.width) ||
+      !Number.isFinite(bounds.height) ||
+      bounds.width <= 0 ||
+      bounds.height <= 0
+    ) {
+      throw new Error(
+        'getXpathsByPoint: UIContext has invalid coordinate bounds',
+      );
+    }
+    if (point.x >= bounds.width || point.y >= bounds.height) {
+      throw new Error(
+        `getXpathsByPoint: point (${point.x}, ${point.y}) is outside ${coordinateSpace} bounds ${bounds.width}x${bounds.height}`,
+      );
+    }
+
+    const logicalPoint =
+      coordinateSpace === 'screenshot'
+        ? { x: point.x / ratio, y: point.y / ratio }
+        : point;
+    return generateInspectionXpathCandidates(
+      uiContext.uiTree.root,
+      logicalPoint,
+      uiContext.uiTree.xpathPolicy,
+    );
+  }
+
   async getUIContext(action?: ServiceAction): Promise<UIContext> {
     // Some non-web flows, such as Android, need an Agent instance before they
     // can call device methods via ADB, so defer missing modelFamily errors
@@ -423,6 +513,8 @@ export class Agent<
         return await commonContextParser(this.interface, {
           uploadServerUrl: this.modelConfigManager.getUploadTestServerUrl(),
           screenshotShrinkFactor: this.opts.screenshotShrinkFactor,
+          captureUITree:
+            Boolean(this.opts.captureUITree) && action === 'locate',
         });
       } catch (error) {
         if (attempt < maxRetries && this.isRetryableContextError(error)) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -411,7 +411,9 @@ export class Agent<
    * Generate ranked inspection XPath candidates for a point in a saved Android
    * UI context. Screenshot coordinates are used by default and converted to
    * logical coordinates with `shrunkShotToLogicalRatio`. This method reads only
-   * the supplied historical tree and never reconnects to the device.
+   * the supplied historical tree and never reconnects to the device. A pruned
+   * target-lineage snapshot returns only semantic candidates proven unique on
+   * the original full page; it never fabricates a positional fallback.
    *
    * @throws When the tree is missing or non-Android, coordinates are invalid or
    * out of bounds, no node is hit, or only a structural node is exposed.
@@ -491,7 +493,11 @@ export class Agent<
     return generateInspectionXpathCandidates(
       uiContext.uiTree.root,
       logicalPoint,
-      uiContext.uiTree.xpathPolicy,
+      {
+        ...uiContext.uiTree.xpathPolicy,
+        treeScope: uiContext.uiTree.inspection?.scope ?? 'full',
+        pageIdentityCounts: uiContext.uiTree.inspection?.pageIdentityCounts,
+      },
     );
   }
 

--- a/packages/core/src/agent/execution-session.ts
+++ b/packages/core/src/agent/execution-session.ts
@@ -4,6 +4,7 @@ import {
   type TaskRunnerEventListener,
 } from '@/task-runner';
 import type {
+  ExecutionTask,
   ExecutionTaskApply,
   ExecutionTaskProgressOptions,
   UIContext,
@@ -26,7 +27,7 @@ export class ExecutionSession {
 
   constructor(
     name: string,
-    contextProvider: () => Promise<UIContext>,
+    contextProvider: (task?: ExecutionTask) => Promise<UIContext>,
     options?: ExecutionSessionOptions,
   ) {
     this.runner = new TaskRunner(name, contextProvider, options);

--- a/packages/core/src/agent/inspection-xpath.ts
+++ b/packages/core/src/agent/inspection-xpath.ts
@@ -1,0 +1,396 @@
+import type { Rect, UiNode } from '@/types';
+
+const DEFAULT_MAX_CANDIDATES = 5;
+const MAX_ATTR_VALUE_LENGTH = 256;
+const XPATH_TAG_RE = /^[A-Za-z_*][A-Za-z0-9_.\-:*]*$/;
+
+interface PointXY {
+  x: number;
+  y: number;
+}
+
+export interface InspectionXpathOptions {
+  expectedRect?: Rect;
+  excludedTargetTypes?: readonly string[];
+  stableAttrs?: readonly string[];
+  textAttrs?: readonly string[];
+  max?: number;
+}
+
+interface PointHit {
+  node: UiNode;
+  path: UiNode[];
+  order: number;
+}
+
+function pointInBounds(node: UiNode, point: PointXY): boolean {
+  const { left, top, width, height } = node.bounds;
+  return (
+    width > 0 &&
+    height > 0 &&
+    point.x >= left &&
+    point.x < left + width &&
+    point.y >= top &&
+    point.y < top + height
+  );
+}
+
+function nodeArea(node: UiNode): number {
+  return Math.max(0, node.bounds.width) * Math.max(0, node.bounds.height);
+}
+
+function collectNodesAtPoint(root: UiNode, point: PointXY): PointHit[] {
+  const hits: PointHit[] = [];
+  const visit = (node: UiNode, path: UiNode[]) => {
+    const containsPoint = pointInBounds(node, point);
+    const hasBounds = node.bounds.width > 0 && node.bounds.height > 0;
+    if (!containsPoint && hasBounds) return;
+
+    if (containsPoint) {
+      hits.push({ node, path, order: hits.length });
+    }
+    for (const child of node.children) {
+      visit(child, [...path, child]);
+    }
+  };
+  visit(root, [root]);
+  return hits;
+}
+
+function findNodeAtPoint(
+  root: UiNode,
+  point: PointXY,
+): { node: UiNode; path: UiNode[] } | undefined {
+  const best = collectNodesAtPoint(root, point).sort((left, right) => {
+    const areaDelta = nodeArea(left.node) - nodeArea(right.node);
+    if (areaDelta !== 0) return areaDelta;
+    const depthDelta = right.path.length - left.path.length;
+    if (depthDelta !== 0) return depthDelta;
+    return right.order - left.order;
+  })[0];
+  return best ? { node: best.node, path: best.path } : undefined;
+}
+
+function rectIntersectionOverUnion(node: UiNode, expectedRect: Rect): number {
+  const left = Math.max(node.bounds.left, expectedRect.left);
+  const top = Math.max(node.bounds.top, expectedRect.top);
+  const right = Math.min(
+    node.bounds.left + node.bounds.width,
+    expectedRect.left + expectedRect.width,
+  );
+  const bottom = Math.min(
+    node.bounds.top + node.bounds.height,
+    expectedRect.top + expectedRect.height,
+  );
+  const intersection = Math.max(0, right - left) * Math.max(0, bottom - top);
+  const nodeArea =
+    Math.max(0, node.bounds.width) * Math.max(0, node.bounds.height);
+  const expectedArea =
+    Math.max(0, expectedRect.width) * Math.max(0, expectedRect.height);
+  const union = nodeArea + expectedArea - intersection;
+  return union > 0 ? intersection / union : 0;
+}
+
+function findNodeAtPointByExpectedRect(
+  root: UiNode,
+  point: PointXY,
+  expectedRect: Rect,
+): { node: UiNode; path: UiNode[] } | undefined {
+  const hits: Array<{ node: UiNode; path: UiNode[]; overlap: number }> = [];
+  const visit = (node: UiNode, path: UiNode[]) => {
+    const containsPoint = pointInBounds(node, point);
+    const hasBounds = node.bounds.width > 0 && node.bounds.height > 0;
+    if (!containsPoint && hasBounds) return;
+    if (containsPoint) {
+      hits.push({
+        node,
+        path,
+        overlap: rectIntersectionOverUnion(node, expectedRect),
+      });
+    }
+    for (const child of node.children) visit(child, [...path, child]);
+  };
+  visit(root, [root]);
+
+  const best = hits
+    .filter(({ overlap }) => overlap > 0)
+    .sort(
+      (left, right) =>
+        right.overlap - left.overlap || right.path.length - left.path.length,
+    )[0];
+  return best ? { node: best.node, path: best.path } : undefined;
+}
+
+interface Identity {
+  attr: string;
+  value: string;
+}
+
+function xpathTag(type: string): string {
+  return XPATH_TAG_RE.test(type) ? type : '*';
+}
+
+function isAttrValueSafe(value: string | undefined): value is string {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0 || value.length > MAX_ATTR_VALUE_LENGTH) return false;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) return `'${value}'`;
+  if (!value.includes('"')) return `"${value}"`;
+
+  const args: string[] = [];
+  const parts = value.split("'");
+  for (let index = 0; index < parts.length; index++) {
+    args.push(`'${parts[index]}'`);
+    if (index < parts.length - 1) args.push(`"'"`);
+  }
+  return `concat(${args.join(',')})`;
+}
+
+function exactNodeXpath(node: UiNode, identities: Identity[]): string {
+  const predicates = identities
+    .map(({ attr, value }) => `[@${attr}=${xpathLiteral(value)}]`)
+    .join('');
+  return `//${xpathTag(node.type)}${predicates}`;
+}
+
+function collectNodes(root: UiNode): UiNode[] {
+  const nodes: UiNode[] = [];
+  const visit = (node: UiNode) => {
+    nodes.push(node);
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  return nodes;
+}
+
+function matchesIdentities(node: UiNode, identities: Identity[]): boolean {
+  return identities.every(({ attr, value }) => node.attrs[attr] === value);
+}
+
+function identitiesAreUnique(
+  root: UiNode,
+  target: UiNode,
+  identities: Identity[],
+  requireType: boolean,
+): boolean {
+  const matches = collectNodes(root).filter(
+    (node) =>
+      (!requireType || node.type === target.type) &&
+      matchesIdentities(node, identities),
+  );
+  return matches.length === 1 && matches[0] === target;
+}
+
+function identityIsGloballyUnique(
+  root: UiNode,
+  target: UiNode,
+  identity: Identity,
+): boolean {
+  return identitiesAreUnique(root, target, [identity], false);
+}
+
+function targetIdentities(
+  node: UiNode,
+  options: InspectionXpathOptions | undefined,
+): Identity[] {
+  const identities: Identity[] = [];
+  const seen = new Set<string>();
+  for (const attr of [
+    ...(options?.stableAttrs ?? []),
+    ...(options?.textAttrs ?? []),
+  ]) {
+    if (seen.has(attr)) continue;
+    const value = node.attrs[attr];
+    if (!isAttrValueSafe(value)) continue;
+    identities.push({ attr, value });
+    seen.add(attr);
+  }
+  return identities;
+}
+
+function nearestSemanticAncestorHit(
+  hit: { node: UiNode; path: UiNode[] },
+  options: InspectionXpathOptions | undefined,
+): { node: UiNode; path: UiNode[] } {
+  if (targetIdentities(hit.node, options).length > 0) return hit;
+
+  for (let pathIndex = hit.path.length - 2; pathIndex >= 1; pathIndex--) {
+    const ancestor = hit.path[pathIndex];
+    if (options?.excludedTargetTypes?.includes(ancestor.type)) break;
+    const hasSemanticIdentity = (options?.textAttrs ?? []).some((attr) =>
+      isAttrValueSafe(ancestor.attrs[attr]),
+    );
+    if (hasSemanticIdentity) {
+      return {
+        node: ancestor,
+        path: hit.path.slice(0, pathIndex + 1),
+      };
+    }
+  }
+  return hit;
+}
+
+export function findInspectionTargetAtPoint(
+  root: UiNode,
+  point: PointXY,
+  options?: InspectionXpathOptions,
+): { node: UiNode; path: UiNode[] } {
+  const pointHit = options?.expectedRect
+    ? (findNodeAtPointByExpectedRect(root, point, options.expectedRect) ??
+      findNodeAtPoint(root, point))
+    : findNodeAtPoint(root, point);
+  if (!pointHit) {
+    throw new Error(
+      `findInspectionTargetAtPoint: no node found at point (${point.x}, ${point.y})`,
+    );
+  }
+  if (
+    pointHit.path.length === 1 ||
+    options?.excludedTargetTypes?.includes(pointHit.node.type)
+  ) {
+    throw new Error(
+      `findInspectionTargetAtPoint: target node is not exposed (目标节点未暴露); matched structural node ${pointHit.node.type}`,
+    );
+  }
+  return nearestSemanticAncestorHit(pointHit, options);
+}
+
+function siblingIndex(parent: UiNode, target: UiNode, tag: string): number {
+  let index = 0;
+  for (const sibling of parent.children) {
+    if (tag === '*' || sibling.type === tag) {
+      index++;
+      if (sibling === target) return index;
+    }
+  }
+  throw new Error(
+    'generateInspectionXpathCandidates: inconsistent UI tree path',
+  );
+}
+
+function buildPositionalXpath(path: UiNode[]): string {
+  return path
+    .map((node, index) => {
+      const tag = xpathTag(node.type);
+      const position =
+        index === 0 ? 1 : siblingIndex(path[index - 1], node, tag);
+      return `/${tag}[${position}]`;
+    })
+    .join('');
+}
+
+function uniqueStableAncestorXpath(
+  root: UiNode,
+  path: UiNode[],
+  target: UiNode,
+  identities: Identity[],
+  stableAttrs: readonly string[] | undefined,
+): string | undefined {
+  for (let pathIndex = path.length - 2; pathIndex >= 1; pathIndex--) {
+    const ancestor = path[pathIndex];
+    for (const attr of stableAttrs ?? []) {
+      const value = ancestor.attrs[attr];
+      if (!isAttrValueSafe(value)) continue;
+      const ancestorXpath = `//*[@${attr}=${xpathLiteral(value)}]`;
+      if (
+        !identityIsGloballyUnique(root, ancestor, {
+          attr,
+          value,
+        })
+      ) {
+        continue;
+      }
+
+      for (const identity of identities) {
+        const childXpath = exactNodeXpath(target, [identity]).slice(2);
+        const xpath = `${ancestorXpath}//${childXpath}`;
+        if (identitiesAreUnique(ancestor, target, [identity], true)) {
+          return xpath;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Generate ranked XPath candidates for inspecting a node in a saved UI tree.
+ * Semantic and positional selectors are allowed because the result is
+ * evaluated against the same historical snapshot.
+ */
+export function generateInspectionXpathCandidates(
+  root: UiNode,
+  point: PointXY,
+  options?: InspectionXpathOptions,
+): string[] {
+  const hit = findInspectionTargetAtPoint(root, point, options);
+
+  const configuredMax = options?.max ?? DEFAULT_MAX_CANDIDATES;
+  const max =
+    Number.isInteger(configuredMax) && configuredMax > 0
+      ? configuredMax
+      : DEFAULT_MAX_CANDIDATES;
+  const candidates: string[] = [];
+  const append = (xpath: string, uniquelyMatchesTarget: boolean) => {
+    if (
+      candidates.length < max &&
+      !candidates.includes(xpath) &&
+      uniquelyMatchesTarget
+    ) {
+      candidates.push(xpath);
+    }
+  };
+
+  for (const attr of options?.stableAttrs ?? []) {
+    const value = hit.node.attrs[attr];
+    if (isAttrValueSafe(value)) {
+      const identity = { attr, value };
+      append(
+        `//*[@${attr}=${xpathLiteral(value)}]`,
+        identityIsGloballyUnique(root, hit.node, identity),
+      );
+    }
+  }
+
+  for (const attr of options?.textAttrs ?? []) {
+    const value = hit.node.attrs[attr];
+    const identity = isAttrValueSafe(value) ? { attr, value } : undefined;
+    if (identity && identityIsGloballyUnique(root, hit.node, identity)) {
+      append(exactNodeXpath(hit.node, [identity]), true);
+    }
+  }
+
+  const identities = targetIdentities(hit.node, options);
+  if (candidates.length === 0) {
+    for (let first = 0; first < identities.length; first++) {
+      for (let second = first + 1; second < identities.length; second++) {
+        const pair = [identities[first], identities[second]];
+        append(
+          exactNodeXpath(hit.node, pair),
+          identitiesAreUnique(root, hit.node, pair, true),
+        );
+      }
+    }
+
+    const ancestorScoped = uniqueStableAncestorXpath(
+      root,
+      hit.path,
+      hit.node,
+      identities,
+      options?.stableAttrs,
+    );
+    if (ancestorScoped) append(ancestorScoped, true);
+  }
+
+  append(buildPositionalXpath(hit.path), true);
+  return candidates;
+}

--- a/packages/core/src/agent/inspection-xpath.ts
+++ b/packages/core/src/agent/inspection-xpath.ts
@@ -1,4 +1,4 @@
-import type { Rect, UiNode } from '@/types';
+import type { Rect, UITreeIdentityCount, UiNode } from '@/types';
 
 const DEFAULT_MAX_CANDIDATES = 5;
 const MAX_ATTR_VALUE_LENGTH = 256;
@@ -15,6 +15,8 @@ export interface InspectionXpathOptions {
   stableAttrs?: readonly string[];
   textAttrs?: readonly string[];
   max?: number;
+  treeScope?: 'full' | 'target-lineage';
+  pageIdentityCounts?: readonly UITreeIdentityCount[];
 }
 
 interface PointHit {
@@ -194,7 +196,14 @@ function identityIsGloballyUnique(
   root: UiNode,
   target: UiNode,
   identity: Identity,
+  options?: InspectionXpathOptions,
 ): boolean {
+  if (options?.treeScope === 'target-lineage') {
+    const pageCount = options.pageIdentityCounts?.find(
+      ({ attr, value }) => attr === identity.attr && value === identity.value,
+    )?.count;
+    return target.attrs[identity.attr] === identity.value && pageCount === 1;
+  }
   return identitiesAreUnique(root, target, [identity], false);
 }
 
@@ -223,12 +232,15 @@ function nearestSemanticAncestorHit(
 ): { node: UiNode; path: UiNode[] } {
   if (targetIdentities(hit.node, options).length > 0) return hit;
 
-  for (let pathIndex = hit.path.length - 2; pathIndex >= 1; pathIndex--) {
+  for (let pathIndex = hit.path.length - 2; pathIndex >= 0; pathIndex--) {
     const ancestor = hit.path[pathIndex];
-    if (options?.excludedTargetTypes?.includes(ancestor.type)) break;
-    const hasSemanticIdentity = (options?.textAttrs ?? []).some((attr) =>
-      isAttrValueSafe(ancestor.attrs[attr]),
-    );
+    if (options?.excludedTargetTypes?.includes(ancestor.type)) {
+      throw new Error(
+        `findInspectionTargetAtPoint: target node is not exposed (目标节点未暴露); matched structural node ${ancestor.type}`,
+      );
+    }
+    if (pathIndex === 0) continue;
+    const hasSemanticIdentity = targetIdentities(ancestor, options).length > 0;
     if (hasSemanticIdentity) {
       return {
         node: ancestor,
@@ -324,8 +336,9 @@ function uniqueStableAncestorXpath(
 
 /**
  * Generate ranked XPath candidates for inspecting a node in a saved UI tree.
- * Semantic and positional selectors are allowed because the result is
- * evaluated against the same historical snapshot.
+ * Full snapshots may return semantic, scoped, and positional selectors.
+ * Target-lineage snapshots return only semantic selectors whose uniqueness was
+ * measured against the complete page before pruning.
  */
 export function generateInspectionXpathCandidates(
   root: UiNode,
@@ -356,7 +369,7 @@ export function generateInspectionXpathCandidates(
       const identity = { attr, value };
       append(
         `//*[@${attr}=${xpathLiteral(value)}]`,
-        identityIsGloballyUnique(root, hit.node, identity),
+        identityIsGloballyUnique(root, hit.node, identity, options),
       );
     }
   }
@@ -364,13 +377,17 @@ export function generateInspectionXpathCandidates(
   for (const attr of options?.textAttrs ?? []) {
     const value = hit.node.attrs[attr];
     const identity = isAttrValueSafe(value) ? { attr, value } : undefined;
-    if (identity && identityIsGloballyUnique(root, hit.node, identity)) {
+    if (
+      identity &&
+      identityIsGloballyUnique(root, hit.node, identity, options)
+    ) {
       append(exactNodeXpath(hit.node, [identity]), true);
     }
   }
 
   const identities = targetIdentities(hit.node, options);
-  if (candidates.length === 0) {
+  const isTargetLineage = options?.treeScope === 'target-lineage';
+  if (!isTargetLineage && candidates.length === 0) {
     for (let first = 0; first < identities.length; first++) {
       for (let second = first + 1; second < identities.length; second++) {
         const pair = [identities[first], identities[second]];
@@ -391,6 +408,13 @@ export function generateInspectionXpathCandidates(
     if (ancestorScoped) append(ancestorScoped, true);
   }
 
-  append(buildPositionalXpath(hit.path), true);
+  if (!isTargetLineage) {
+    append(buildPositionalXpath(hit.path), true);
+  }
+  if (candidates.length === 0) {
+    throw new Error(
+      'generateInspectionXpathCandidates: no stable XPath candidate; target requires positional identity (顺序敏感)',
+    );
+  }
   return candidates;
 }

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -430,7 +430,7 @@ export class TaskBuilder {
         );
 
         if (!uiContext) {
-          uiContext = await this.service.contextRetrieverFn();
+          uiContext = await this.service.contextRetrieverFn('locate');
         }
 
         assert(uiContext, 'uiContext is required for Service task');

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -165,10 +165,16 @@ export class TaskExecutor {
   ) {
     return new ExecutionSession(
       title,
-      () =>
+      (task) =>
         options?.uiContext
           ? Promise.resolve(options.uiContext)
-          : Promise.resolve(this.service.contextRetrieverFn()),
+          : Promise.resolve(
+              this.service.contextRetrieverFn(
+                task?.type === 'Planning' && task.subType === 'Locate'
+                  ? 'locate'
+                  : undefined,
+              ),
+            ),
       {
         onTaskStart: this.onTaskStartCallback,
         tasks: options?.tasks,

--- a/packages/core/src/agent/ui-tree-snapshot.ts
+++ b/packages/core/src/agent/ui-tree-snapshot.ts
@@ -1,0 +1,61 @@
+import type { Rect, UITreeSnapshot, UiNode } from '@/types';
+import { findInspectionTargetAtPoint } from './inspection-xpath';
+
+interface PointXY {
+  x: number;
+  y: number;
+}
+
+function hasResourceId(node: UiNode): boolean {
+  return Boolean(node.attrs['resource-id']?.trim());
+}
+
+function cloneAncestorChain(path: UiNode[], rootIndex: number): UiNode {
+  let branch: UiNode = {
+    ...path[path.length - 1],
+    attrs: { ...path[path.length - 1].attrs },
+    children: [],
+  };
+
+  for (let index = path.length - 2; index >= rootIndex; index--) {
+    branch = {
+      ...path[index],
+      attrs: { ...path[index].attrs },
+      children: [branch],
+    };
+  }
+
+  return branch;
+}
+
+/**
+ * Reduce a captured Android tree to the located target's direct ancestor chain.
+ * The closest ancestor carrying a resource-id becomes the snapshot root; when
+ * no such ancestor exists, the original tree root is retained. The located
+ * target remains the only leaf (even when it has its own resource-id), so the
+ * report can display the located element and its direct context without
+ * serializing unrelated branches.
+ */
+export function pruneUITreeSnapshotToTarget(
+  snapshot: UITreeSnapshot,
+  point: PointXY,
+  expectedRect?: Rect,
+): UITreeSnapshot {
+  const hit = findInspectionTargetAtPoint(snapshot.root, point, {
+    ...snapshot.xpathPolicy,
+    expectedRect,
+  });
+
+  let rootIndex = 0;
+  for (let index = hit.path.length - 2; index >= 0; index--) {
+    if (hasResourceId(hit.path[index])) {
+      rootIndex = index;
+      break;
+    }
+  }
+
+  return {
+    ...snapshot,
+    root: cloneAncestorChain(hit.path, rootIndex),
+  };
+}

--- a/packages/core/src/agent/ui-tree-snapshot.ts
+++ b/packages/core/src/agent/ui-tree-snapshot.ts
@@ -1,4 +1,9 @@
-import type { Rect, UITreeSnapshot, UiNode } from '@/types';
+import type {
+  Rect,
+  UITreeIdentityCount,
+  UITreeSnapshot,
+  UiNode,
+} from '@/types';
 import { findInspectionTargetAtPoint } from './inspection-xpath';
 
 interface PointXY {
@@ -26,6 +31,41 @@ function cloneAncestorChain(path: UiNode[], rootIndex: number): UiNode {
   }
 
   return branch;
+}
+
+function identityKey(attr: string, value: string): string {
+  return JSON.stringify([attr, value]);
+}
+
+function collectPageIdentityCounts(
+  root: UiNode,
+  retainedPath: UiNode[],
+  attributes: string[],
+): UITreeIdentityCount[] {
+  const identities = new Map<string, UITreeIdentityCount>();
+  const uniqueAttributes = [...new Set(attributes)];
+
+  for (const node of retainedPath) {
+    for (const attr of uniqueAttributes) {
+      const value = node.attrs[attr];
+      if (!value) continue;
+      const key = identityKey(attr, value);
+      if (!identities.has(key)) {
+        identities.set(key, { attr, value, count: 0 });
+      }
+    }
+  }
+
+  const visit = (node: UiNode) => {
+    for (const identity of identities.values()) {
+      if (node.attrs[identity.attr] === identity.value) {
+        identity.count++;
+      }
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  return [...identities.values()];
 }
 
 /**
@@ -57,5 +97,16 @@ export function pruneUITreeSnapshotToTarget(
   return {
     ...snapshot,
     root: cloneAncestorChain(hit.path, rootIndex),
+    inspection: {
+      scope: 'target-lineage',
+      pageIdentityCounts: collectPageIdentityCounts(
+        snapshot.root,
+        hit.path.slice(rootIndex),
+        [
+          ...snapshot.xpathPolicy.stableAttrs,
+          ...snapshot.xpathPolicy.textAttrs,
+        ],
+      ),
+    },
   };
 }

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -37,6 +37,9 @@ import type { TaskCache } from './task-cache';
 import { debug as cacheDebug } from './task-cache';
 
 const agentDebug = getDebug('agent');
+const uiTreeWarning = getDebug('commonContextParser:ui-tree', {
+  console: true,
+});
 const screenshotDataUrlPattern = /^data:image\/[a-zA-Z0-9.+-]+;base64,/i;
 
 const inferBase64ImageFormat = (base64Body: string) => {
@@ -87,6 +90,7 @@ export async function commonContextParser(
   _opt: {
     uploadServerUrl?: string;
     screenshotShrinkFactor?: number;
+    captureUITree?: boolean;
   },
 ): Promise<UIContext> {
   const debug = getDebug('commonContextParser');
@@ -131,6 +135,18 @@ export async function commonContextParser(
   const screenshotBase64 = await interfaceInstance.screenshotBase64();
   const screenshotCapturedAt = Date.now();
   assert(screenshotBase64!, 'screenshotBase64 is required');
+
+  let uiTreeCapture: Pick<UIContext, 'uiTree' | 'uiTreeError'> = {};
+  if (_opt.captureUITree && interfaceInstance.getUITree) {
+    try {
+      uiTreeCapture = { uiTree: await interfaceInstance.getUITree() };
+    } catch (error) {
+      const uiTreeError =
+        error instanceof Error ? error.message : String(error);
+      uiTreeWarning(`Failed to capture UI tree: ${uiTreeError}`);
+      uiTreeCapture = { uiTreeError };
+    }
+  }
 
   // Get physical screenshot dimensions
   debug('will get screenshot dimensions');
@@ -201,6 +217,7 @@ export async function commonContextParser(
       deprecatedDpr: dpr,
       screenshot: ScreenshotItem.create(resizedBase64, screenshotCapturedAt),
       shrunkShotToLogicalRatio,
+      ...uiTreeCapture,
     };
   } else {
     // For screenshots that do not need shrinking, convert PNG to JPEG to reduce the image payload in model requests and reports. (Shrunk images are already JPEG.)
@@ -232,6 +249,7 @@ export async function commonContextParser(
         screenshotCapturedAt,
       ),
       shrunkShotToLogicalRatio,
+      ...uiTreeCapture,
     };
   }
 }

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -10,7 +10,13 @@ import type { ElementNode } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 import { z } from 'zod';
-import type { ElementCacheFeature, Rect, Size, UIContext } from '../types';
+import type {
+  ElementCacheFeature,
+  Rect,
+  Size,
+  UIContext,
+  UITreeSnapshot,
+} from '../types';
 
 export interface FileChooserHandler {
   accept(files: string[]): Promise<void>;
@@ -180,6 +186,8 @@ export abstract class AbstractInterface {
   abstract rectMatchesCacheFeature?(
     feature: ElementCacheFeature,
   ): Promise<Rect>;
+
+  abstract getUITree?(): Promise<UITreeSnapshot>;
 
   abstract destroy?(): Promise<void>;
 

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -22,6 +22,7 @@ import type {
   PartialServiceDumpFromSDK,
   PlanningLocateParam,
   Rect,
+  ServiceAction,
   ServiceExtractOption,
   ServiceExtractParam,
   ServiceExtractResult,
@@ -75,12 +76,16 @@ interface LocateSearchAreaResult {
 const debug = getDebug('ai:service');
 
 export default class Service {
-  contextRetrieverFn: () => Promise<UIContext> | UIContext;
+  contextRetrieverFn: (
+    action?: ServiceAction,
+  ) => Promise<UIContext> | UIContext;
 
   taskInfo?: Omit<ServiceTaskInfo, 'durationMs'>;
 
   constructor(
-    context: UIContext | (() => Promise<UIContext> | UIContext),
+    context:
+      | UIContext
+      | ((action?: ServiceAction) => Promise<UIContext> | UIContext),
     opt?: ServiceOptions,
   ) {
     assert(context, 'context is required for Service');
@@ -111,7 +116,7 @@ export default class Service {
       throw new Error(defaultModelFamilyRequiredForLocateMessage);
     }
 
-    const context = opt?.context || (await this.contextRetrieverFn());
+    const context = opt?.context || (await this.contextRetrieverFn('locate'));
 
     const searchArea = await this.resolveLocateSearchArea({
       query,
@@ -416,7 +421,7 @@ export default class Service {
     },
   ): Promise<Pick<AIDescribeElementResponse, 'description'>> {
     assert(target, 'target is required for service.describe');
-    const context = opt?.context || (await this.contextRetrieverFn());
+    const context = opt?.context || (await this.contextRetrieverFn('describe'));
     const { shotSize } = context;
     const screenshotBase64 = context.screenshot.base64;
     assert(screenshotBase64, 'screenshot is required for service.describe');

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -1,3 +1,4 @@
+import { pruneUITreeSnapshotToTarget } from '@/agent/ui-tree-snapshot';
 import type { ScreenshotItem } from '@/screenshot-item';
 import { setTimingFieldOnce } from '@/task-timing';
 import {
@@ -18,6 +19,63 @@ import { assert, uuid } from '@midscene/shared/utils';
 
 const debug = getDebug('task-runner');
 const UI_CONTEXT_CACHE_TTL_MS = 300;
+
+type UIContextKind = 'default' | 'locate';
+
+function uiContextKindForTask(task?: ExecutionTask): UIContextKind {
+  return task?.type === 'Planning' && task.subType === 'Locate'
+    ? 'locate'
+    : 'default';
+}
+
+function uiContextWithoutTree(
+  uiContext: UIContext,
+  preserveTreeError = false,
+): UIContext {
+  const { uiTree: _uiTree, uiTreeError, ...contextWithoutTree } = uiContext;
+  return {
+    ...contextWithoutTree,
+    ...(preserveTreeError && uiTreeError ? { uiTreeError } : {}),
+  } as UIContext;
+}
+
+function locateReportUIContext(
+  uiContext: UIContext,
+  element: ExecutionTaskPlanningLocateOutput['element'] | undefined,
+): UIContext {
+  const contextWithoutTree = uiContextWithoutTree(uiContext, true);
+  if (!uiContext.uiTree || !element) {
+    return contextWithoutTree;
+  }
+
+  const ratio = uiContext.shrunkShotToLogicalRatio;
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    debug('skip locate UI tree: invalid shrunkShotToLogicalRatio %s', ratio);
+    return contextWithoutTree;
+  }
+
+  try {
+    return {
+      ...contextWithoutTree,
+      uiTree: pruneUITreeSnapshotToTarget(
+        uiContext.uiTree,
+        {
+          x: element.center[0] / ratio,
+          y: element.center[1] / ratio,
+        },
+        {
+          left: element.rect.left / ratio,
+          top: element.rect.top / ratio,
+          width: element.rect.width / ratio,
+          height: element.rect.height / ratio,
+        },
+      ),
+    };
+  } catch (error) {
+    debug('skip locate UI tree: target could not be mapped: %s', error);
+    return contextWithoutTree;
+  }
+}
 
 /**
  * A native, per-task lifecycle notification. The runner is the single source
@@ -72,7 +130,9 @@ export class TaskRunner {
 
   onTaskStart?: ExecutionTaskProgressOptions['onTaskStart'];
 
-  private readonly uiContextBuilder: () => Promise<UIContext>;
+  private readonly uiContextBuilder: (
+    task?: ExecutionTask,
+  ) => Promise<UIContext>;
 
   private readonly onSnapshotChange?:
     | ((runner: TaskRunner, error?: TaskExecutionError) => Promise<void> | void)
@@ -84,7 +144,7 @@ export class TaskRunner {
 
   constructor(
     name: string,
-    uiContextBuilder: () => Promise<UIContext>,
+    uiContextBuilder: (task?: ExecutionTask) => Promise<UIContext>,
     options?: TaskRunnerInitOptions,
   ) {
     this.id = uuid();
@@ -125,15 +185,19 @@ export class TaskRunner {
   private lastUiContext?: {
     context: UIContext;
     capturedAt: number;
+    kind: UIContextKind;
   };
 
-  private async getUiContext(options?: { forceRefresh?: boolean }): Promise<
-    UIContext | undefined
-  > {
+  private async getUiContext(
+    task?: ExecutionTask,
+    options?: { forceRefresh?: boolean },
+  ): Promise<UIContext | undefined> {
     const now = Date.now();
+    const kind = uiContextKindForTask(task);
     const shouldReuse =
       !options?.forceRefresh &&
       this.lastUiContext &&
+      this.lastUiContext.kind === kind &&
       now - this.lastUiContext.capturedAt <= UI_CONTEXT_CACHE_TTL_MS;
 
     if (shouldReuse && this.lastUiContext?.context) {
@@ -144,11 +208,12 @@ export class TaskRunner {
     }
 
     try {
-      const uiContext = await this.uiContextBuilder();
+      const uiContext = await this.uiContextBuilder(task);
       if (uiContext) {
         this.lastUiContext = {
           context: uiContext,
           capturedAt: Date.now(),
+          kind,
         };
       } else {
         this.lastUiContext = undefined;
@@ -162,7 +227,9 @@ export class TaskRunner {
 
   private async captureScreenshot(): Promise<ScreenshotItem | undefined> {
     try {
-      const uiContext = await this.getUiContext({ forceRefresh: true });
+      const uiContext = await this.getUiContext(undefined, {
+        forceRefresh: true,
+      });
       return uiContext?.screenshot;
     } catch (error) {
       console.error('error while capturing screenshot', error);
@@ -310,10 +377,15 @@ export class TaskRunner {
         // to ensure we have the latest UI state after any preceding actions
         const forceRefresh = task.type === 'Insight';
         setTimingFieldOnce(task.timing, 'getUiContextStart');
-        const uiContext = await this.getUiContext({ forceRefresh });
+        const uiContext = await this.getUiContext(task, { forceRefresh });
         setTimingFieldOnce(task.timing, 'getUiContextEnd');
 
-        task.uiContext = uiContext;
+        task.uiContext = uiContext
+          ? uiContextWithoutTree(
+              uiContext,
+              uiContextKindForTask(task) === 'locate',
+            )
+          : uiContext;
         const executorContext: ExecutorContext = {
           task,
           element: previousFindOutput?.element,
@@ -337,6 +409,12 @@ export class TaskRunner {
             previousFindOutput = (
               returnValue as ExecutionTaskReturn<ExecutionTaskPlanningLocateOutput>
             )?.output;
+            if (uiContext) {
+              task.uiContext = locateReportUIContext(
+                uiContext,
+                previousFindOutput?.element,
+              );
+            }
           }
         } else if (task.type === 'Action Space') {
           returnValue = await task.executor(param, executorContext);

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -18,6 +18,7 @@ import { getDebug } from '@midscene/shared/logger';
 import { assert, uuid } from '@midscene/shared/utils';
 
 const debug = getDebug('task-runner');
+const uiTreeWarning = getDebug('task-runner:ui-tree', { console: true });
 const UI_CONTEXT_CACHE_TTL_MS = 300;
 
 type UIContextKind = 'default' | 'locate';
@@ -50,8 +51,9 @@ function locateReportUIContext(
 
   const ratio = uiContext.shrunkShotToLogicalRatio;
   if (!Number.isFinite(ratio) || ratio <= 0) {
-    debug('skip locate UI tree: invalid shrunkShotToLogicalRatio %s', ratio);
-    return contextWithoutTree;
+    const uiTreeError = `Failed to map captured UI tree to located target: invalid shrunkShotToLogicalRatio ${String(ratio)}`;
+    uiTreeWarning(uiTreeError);
+    return { ...contextWithoutTree, uiTreeError };
   }
 
   try {
@@ -72,8 +74,10 @@ function locateReportUIContext(
       ),
     };
   } catch (error) {
-    debug('skip locate UI tree: target could not be mapped: %s', error);
-    return contextWithoutTree;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const uiTreeError = `Failed to map captured UI tree to located target: ${errorMessage}`;
+    uiTreeWarning(uiTreeError);
+    return { ...contextWithoutTree, uiTreeError };
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -130,6 +130,25 @@ export interface AgentDescribeElementAtPointResult {
  * context
  */
 
+export interface UiNode {
+  type: string;
+  attrs: Record<string, string | undefined>;
+  bounds: Rect;
+  children: UiNode[];
+}
+
+export interface UITreeSnapshot {
+  platform: 'android';
+  capturedAt: number;
+  root: UiNode;
+  xpathPolicy: {
+    stableAttrs: string[];
+    textAttrs: string[];
+    excludedTargetTypes: string[];
+    max: number;
+  };
+}
+
 export abstract class UIContext {
   /**
    * screenshot of the current UI state. which size is shotSize(be shrunk by screenshotShrinkFactor),
@@ -162,6 +181,12 @@ export abstract class UIContext {
    * - To map back to logical coordinates: 1500 / shrunkShotToLogicalRatio = 500px
    */
   abstract shrunkShotToLogicalRatio: number;
+
+  /** Accessibility tree captured alongside {@link screenshot}, when enabled. */
+  abstract uiTree?: UITreeSnapshot;
+
+  /** Non-fatal error raised while capturing {@link uiTree}. */
+  abstract uiTreeError?: string;
 
   abstract _isFrozen?: boolean;
 
@@ -980,6 +1005,16 @@ export interface AgentOpt {
    * @default 1 (no shrinking, uses original physical screenshot)
    */
   screenshotShrinkFactor?: number;
+
+  /**
+   * Capture an Android accessibility tree for Locate tasks. The task report
+   * retains only the located target's direct ancestor chain up to its nearest
+   * resource-id ancestor. Tree capture failures are recorded on UIContext
+   * without failing the AI task.
+   *
+   * @default false
+   */
+  captureUITree?: boolean;
 
   /**
    * Custom OpenAI client factory function

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,6 +137,24 @@ export interface UiNode {
   children: UiNode[];
 }
 
+export interface UITreeIdentityCount {
+  attr: string;
+  value: string;
+  count: number;
+}
+
+export interface UITreeInspectionMetadata {
+  /** The serialized root contains only the located target's retained lineage. */
+  scope: 'target-lineage';
+
+  /**
+   * Occurrence counts measured against the complete captured page before it was
+   * reduced to {@link scope}. Only identities present on the retained lineage
+   * are included.
+   */
+  pageIdentityCounts: UITreeIdentityCount[];
+}
+
 export interface UITreeSnapshot {
   platform: 'android';
   capturedAt: number;
@@ -147,6 +165,8 @@ export interface UITreeSnapshot {
     excludedTargetTypes: string[];
     max: number;
   };
+  /** Inspection evidence retained when {@link root} is a lossy report view. */
+  inspection?: UITreeInspectionMetadata;
 }
 
 export abstract class UIContext {

--- a/packages/core/tests/unit-test/agent-xpath-inspection.test.ts
+++ b/packages/core/tests/unit-test/agent-xpath-inspection.test.ts
@@ -1,0 +1,108 @@
+import { Agent } from '@/agent';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { UIContext, UITreeSnapshot, UiNode } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+const target: UiNode = {
+  type: 'android.widget.Button',
+  attrs: { 'resource-id': 'com.example:id/submit', text: 'Submit' },
+  bounds: { left: 40, top: 40, width: 20, height: 20 },
+  children: [],
+};
+
+const snapshot: UITreeSnapshot = {
+  platform: 'android',
+  capturedAt: 100,
+  root: {
+    type: 'android.widget.FrameLayout',
+    attrs: {},
+    bounds: { left: 0, top: 0, width: 80, height: 80 },
+    children: [target],
+  },
+  xpathPolicy: {
+    stableAttrs: ['resource-id'],
+    textAttrs: ['content-desc', 'text'],
+    excludedTargetTypes: ['android.webkit.WebView'],
+    max: 3,
+  },
+};
+
+const context = (uiTree: UITreeSnapshot | undefined = snapshot): UIContext =>
+  ({
+    screenshot: ScreenshotItem.create('data:image/png;base64,', 99),
+    shotSize: { width: 200, height: 200 },
+    shrunkShotToLogicalRatio: 2,
+    uiTree,
+  }) as UIContext;
+
+const agent = Object.create(Agent.prototype) as Agent;
+
+describe('Agent.getXpathsByPoint', () => {
+  it('converts screenshot coordinates to logical coordinates by default', async () => {
+    await expect(
+      agent.getXpathsByPoint(context(), { x: 100, y: 100 }),
+    ).resolves.toEqual([
+      "//*[@resource-id='com.example:id/submit']",
+      "//android.widget.Button[@text='Submit']",
+      '/android.widget.FrameLayout[1]/android.widget.Button[1]',
+    ]);
+  });
+
+  it('accepts logical coordinates without scaling', async () => {
+    await expect(
+      agent.getXpathsByPoint(
+        context(),
+        { x: 50, y: 50 },
+        { coordinateSpace: 'logical' },
+      ),
+    ).resolves.toContain("//*[@resource-id='com.example:id/submit']");
+  });
+
+  it('throws when the saved UI tree is missing', async () => {
+    const missingTreeContext = context();
+    missingTreeContext.uiTree = undefined;
+    await expect(
+      agent.getXpathsByPoint(missingTreeContext, { x: 10, y: 10 }),
+    ).rejects.toThrow('UI tree is missing');
+  });
+
+  it('throws for a non-Android snapshot', async () => {
+    const wrongPlatform = {
+      ...snapshot,
+      platform: 'ios',
+    } as unknown as UITreeSnapshot;
+    await expect(
+      agent.getXpathsByPoint(context(wrongPlatform), { x: 10, y: 10 }),
+    ).rejects.toThrow('only android is supported');
+  });
+
+  it('throws for invalid and out-of-bounds points', async () => {
+    await expect(
+      agent.getXpathsByPoint(context(), { x: Number.NaN, y: 10 }),
+    ).rejects.toThrow('finite, non-negative');
+    await expect(
+      agent.getXpathsByPoint(context(), { x: 200, y: 10 }),
+    ).rejects.toThrow('outside screenshot bounds');
+  });
+
+  it('throws when an in-bounds point does not hit the saved tree', async () => {
+    await expect(
+      agent.getXpathsByPoint(context(), { x: 180, y: 180 }),
+    ).rejects.toThrow('no node found');
+  });
+
+  it('rejects a structural-only point hit', async () => {
+    const structural = {
+      ...snapshot,
+      root: {
+        type: 'android.webkit.WebView',
+        attrs: {},
+        bounds: { left: 0, top: 0, width: 100, height: 100 },
+        children: [],
+      },
+    };
+    await expect(
+      agent.getXpathsByPoint(context(structural), { x: 100, y: 100 }),
+    ).rejects.toThrow('目标节点未暴露');
+  });
+});

--- a/packages/core/tests/unit-test/agent-xpath-inspection.test.ts
+++ b/packages/core/tests/unit-test/agent-xpath-inspection.test.ts
@@ -58,6 +58,66 @@ describe('Agent.getXpathsByPoint', () => {
     ).resolves.toContain("//*[@resource-id='com.example:id/submit']");
   });
 
+  it('uses full-page identity counts for a target-lineage snapshot', async () => {
+    const lineageSnapshot: UITreeSnapshot = {
+      ...snapshot,
+      root: {
+        type: 'Panel',
+        attrs: { 'resource-id': 'panel-b' },
+        bounds: { left: 0, top: 0, width: 80, height: 80 },
+        children: [
+          {
+            type: 'Button',
+            attrs: { text: 'Pay' },
+            bounds: { left: 20, top: 20, width: 20, height: 20 },
+            children: [],
+          },
+        ],
+      },
+      inspection: {
+        scope: 'target-lineage',
+        pageIdentityCounts: [
+          { attr: 'resource-id', value: 'panel-b', count: 1 },
+          { attr: 'text', value: 'Pay', count: 1 },
+        ],
+      },
+    };
+
+    await expect(
+      agent.getXpathsByPoint(context(lineageSnapshot), { x: 50, y: 50 }),
+    ).resolves.toEqual(["//Button[@text='Pay']"]);
+  });
+
+  it('rejects a target-lineage snapshot when only positional identity remains', async () => {
+    const lineageSnapshot: UITreeSnapshot = {
+      ...snapshot,
+      root: {
+        type: 'Panel',
+        attrs: { 'resource-id': 'panel-b' },
+        bounds: { left: 0, top: 0, width: 80, height: 80 },
+        children: [
+          {
+            type: 'Button',
+            attrs: { text: 'Pay' },
+            bounds: { left: 20, top: 20, width: 20, height: 20 },
+            children: [],
+          },
+        ],
+      },
+      inspection: {
+        scope: 'target-lineage',
+        pageIdentityCounts: [
+          { attr: 'resource-id', value: 'panel-b', count: 1 },
+          { attr: 'text', value: 'Pay', count: 2 },
+        ],
+      },
+    };
+
+    await expect(
+      agent.getXpathsByPoint(context(lineageSnapshot), { x: 50, y: 50 }),
+    ).rejects.toThrow('requires positional identity');
+  });
+
   it('throws when the saved UI tree is missing', async () => {
     const missingTreeContext = context();
     missingTreeContext.uiTree = undefined;

--- a/packages/core/tests/unit-test/inspection-xpath.test.ts
+++ b/packages/core/tests/unit-test/inspection-xpath.test.ts
@@ -1,0 +1,199 @@
+import { generateInspectionXpathCandidates } from '@/agent/inspection-xpath';
+import type { UiNode } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+const node = (
+  type: string,
+  attrs: Record<string, string | undefined>,
+  bounds: { left: number; top: number; width: number; height: number },
+  children: UiNode[] = [],
+): UiNode => ({ type, attrs, bounds, children });
+
+const windowWith = (children: UiNode[]) =>
+  node('Window', {}, { left: 0, top: 0, width: 500, height: 500 }, children);
+
+const androidPolicy = {
+  stableAttrs: ['resource-id'],
+  textAttrs: ['content-desc', 'text'],
+  excludedTargetTypes: ['android.webkit.WebView'],
+  max: 5,
+};
+
+describe('generateInspectionXpathCandidates', () => {
+  it('sorts unique resource-id, content-desc, and text candidates first', () => {
+    const target = node(
+      'android.widget.Button',
+      {
+        'resource-id': 'com.example:id/login',
+        'content-desc': 'Login action',
+        text: 'Log in',
+      },
+      { left: 20, top: 40, width: 120, height: 60 },
+    );
+    const root = windowWith([target]);
+
+    const xpaths = generateInspectionXpathCandidates(
+      root,
+      { x: 50, y: 60 },
+      androidPolicy,
+    );
+
+    expect(xpaths.slice(0, 3)).toEqual([
+      "//*[@resource-id='com.example:id/login']",
+      "//android.widget.Button[@content-desc='Login action']",
+      "//android.widget.Button[@text='Log in']",
+    ]);
+  });
+
+  it('uses a unique attribute combination when individual values repeat', () => {
+    const target = node(
+      'Button',
+      { 'resource-id': 'action', text: 'Save' },
+      { left: 20, top: 20, width: 80, height: 40 },
+    );
+    const root = windowWith([
+      target,
+      node(
+        'Button',
+        { 'resource-id': 'action', text: 'Delete' },
+        { left: 120, top: 20, width: 80, height: 40 },
+      ),
+      node(
+        'Button',
+        { 'resource-id': 'secondary', text: 'Save' },
+        { left: 220, top: 20, width: 80, height: 40 },
+      ),
+    ]);
+
+    expect(
+      generateInspectionXpathCandidates(
+        root,
+        { x: 40, y: 40 },
+        androidPolicy,
+      )[0],
+    ).toBe("//Button[@resource-id='action'][@text='Save']");
+  });
+
+  it('does not treat semantic text as unique when another node type shares it', () => {
+    const target = node(
+      'Button',
+      { 'content-desc': 'Shared action' },
+      { left: 20, top: 20, width: 80, height: 40 },
+    );
+    const root = windowWith([
+      target,
+      node(
+        'Image',
+        { 'content-desc': 'Shared action' },
+        { left: 120, top: 20, width: 80, height: 40 },
+      ),
+    ]);
+
+    expect(
+      generateInspectionXpathCandidates(root, { x: 40, y: 40 }, androidPolicy),
+    ).toEqual(['/Window[1]/Button[1]']);
+  });
+
+  it('uses a unique stable ancestor to scope a repeated text target', () => {
+    const target = node(
+      'Button',
+      { text: 'More' },
+      { left: 220, top: 20, width: 60, height: 40 },
+    );
+    const root = windowWith([
+      node(
+        'Panel',
+        { 'resource-id': 'card-a' },
+        { left: 0, top: 0, width: 180, height: 200 },
+        [
+          node(
+            'Button',
+            { text: 'More' },
+            { left: 20, top: 20, width: 60, height: 40 },
+          ),
+        ],
+      ),
+      node(
+        'Panel',
+        { 'resource-id': 'card-b' },
+        { left: 200, top: 0, width: 180, height: 200 },
+        [target],
+      ),
+    ]);
+
+    expect(
+      generateInspectionXpathCandidates(
+        root,
+        { x: 240, y: 40 },
+        androidPolicy,
+      )[0],
+    ).toBe("//*[@resource-id='card-b']//Button[@text='More']");
+  });
+
+  it('promotes an anonymous nested hit to the nearest semantic Lynx node', () => {
+    const icon = node(
+      'android.view.ViewGroup',
+      {},
+      { left: 40, top: 40, width: 40, height: 40 },
+    );
+    const walletAction = node(
+      'android.view.ViewGroup',
+      { 'content-desc': '抖音月付  按钮', focusable: 'true' },
+      { left: 20, top: 20, width: 100, height: 100 },
+      [icon],
+    );
+    const root = windowWith([walletAction]);
+
+    expect(
+      generateInspectionXpathCandidates(
+        root,
+        { x: 60, y: 60 },
+        androidPolicy,
+      )[0],
+    ).toBe("//android.view.ViewGroup[@content-desc='抖音月付  按钮']");
+  });
+
+  it('falls back to an absolute positional XPath', () => {
+    const target = node(
+      'Button',
+      {},
+      { left: 120, top: 20, width: 80, height: 40 },
+    );
+    const root = windowWith([
+      node('Button', {}, { left: 20, top: 20, width: 80, height: 40 }),
+      target,
+    ]);
+
+    expect(
+      generateInspectionXpathCandidates(root, { x: 140, y: 40 }, androidPolicy),
+    ).toEqual(['/Window[1]/Button[2]']);
+  });
+
+  it('throws when the point does not hit any node', () => {
+    expect(() =>
+      generateInspectionXpathCandidates(
+        windowWith([]),
+        { x: 800, y: 800 },
+        androidPolicy,
+      ),
+    ).toThrow('no node found');
+  });
+
+  it('rejects structural nodes when the inner target is not exposed', () => {
+    const root = windowWith([
+      node(
+        'android.webkit.WebView',
+        { 'resource-id': 'web-content' },
+        { left: 0, top: 0, width: 500, height: 500 },
+      ),
+    ]);
+
+    expect(() =>
+      generateInspectionXpathCandidates(
+        root,
+        { x: 100, y: 100 },
+        androidPolicy,
+      ),
+    ).toThrow('目标节点未暴露');
+  });
+});

--- a/packages/core/tests/unit-test/inspection-xpath.test.ts
+++ b/packages/core/tests/unit-test/inspection-xpath.test.ts
@@ -153,6 +153,28 @@ describe('generateInspectionXpathCandidates', () => {
     ).toBe("//android.view.ViewGroup[@content-desc='抖音月付  按钮']");
   });
 
+  it('promotes an anonymous nested hit to the nearest resource-id node', () => {
+    const icon = node(
+      'android.view.View',
+      {},
+      { left: 40, top: 40, width: 40, height: 40 },
+    );
+    const button = node(
+      'android.widget.Button',
+      { 'resource-id': 'com.example:id/search' },
+      { left: 20, top: 20, width: 100, height: 100 },
+      [icon],
+    );
+
+    expect(
+      generateInspectionXpathCandidates(
+        windowWith([button]),
+        { x: 60, y: 60 },
+        androidPolicy,
+      )[0],
+    ).toBe("//*[@resource-id='com.example:id/search']");
+  });
+
   it('falls back to an absolute positional XPath', () => {
     const target = node(
       'Button',
@@ -194,6 +216,27 @@ describe('generateInspectionXpathCandidates', () => {
         { x: 100, y: 100 },
         androidPolicy,
       ),
+    ).toThrow('目标节点未暴露');
+  });
+
+  it('rejects an anonymous descendant whose nearest boundary is structural', () => {
+    const root = windowWith([
+      node(
+        'android.webkit.WebView',
+        {},
+        { left: 0, top: 0, width: 500, height: 500 },
+        [
+          node(
+            'android.view.View',
+            {},
+            { left: 20, top: 20, width: 100, height: 100 },
+          ),
+        ],
+      ),
+    ]);
+
+    expect(() =>
+      generateInspectionXpathCandidates(root, { x: 40, y: 40 }, androidPolicy),
     ).toThrow('目标节点未暴露');
   });
 });

--- a/packages/core/tests/unit-test/merge-browser-parse.test.ts
+++ b/packages/core/tests/unit-test/merge-browser-parse.test.ts
@@ -22,6 +22,7 @@ import {
   type ReportMeta,
   type UIContext,
 } from '@/types';
+import { getReportTpl } from '@/utils';
 import { uuid } from '@midscene/shared/utils';
 import { antiEscapeScriptTag, escapeScriptTag } from '@midscene/shared/utils';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -162,9 +163,12 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     // Read the full merged HTML
     const mergedHtml = readFileSync(mergedPath!, 'utf-8');
 
-    // Verify merged file is not bloated with garbage from streamImageScriptsToFile
-    const mergedSizeMB = mergedHtml.length / 1024 / 1024;
-    expect(mergedSizeMB).toBeLessThan(15);
+    // Verify the merge adds only bounded metadata instead of duplicating the
+    // report application or leaking directory-mode screenshots into the HTML.
+    const maxMergeOverheadBytes = 1024 * 1024;
+    expect(mergedHtml.length).toBeLessThan(
+      getReportTpl().length + maxMergeOverheadBytes,
+    );
 
     // Verify base URL fix script is injected
     expect(mergedHtml).toContain('document.createElement("base")');

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -19,6 +19,7 @@ class MockInterface extends AbstractInterface {
     undefined;
   override afterInvokeAction: AbstractInterface['afterInvokeAction'] =
     undefined;
+  override getUITree: AbstractInterface['getUITree'] = undefined;
   override getElementsNodeTree: AbstractInterface['getElementsNodeTree'] =
     undefined;
   override url: AbstractInterface['url'] = undefined;

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -185,12 +185,14 @@ describe(
           ],
         },
       };
-      const contextBuilder = vi.fn(async () => ({
+      const contextBuilder = vi.fn<
+        (task?: ExecutionTaskApply) => Promise<UIContext>
+      >(async () => ({
         screenshot: ScreenshotItem.create('', Date.now()),
         shotSize: { width: 400, height: 400 },
         shrunkShotToLogicalRatio: 2,
         uiTree,
-      })) as (task?: ExecutionTaskApply) => Promise<UIContext>;
+      }));
       const locateTask: ExecutionTaskPlanningLocateApply = {
         type: 'Planning',
         subType: 'Locate',
@@ -200,13 +202,14 @@ describe(
             element: {
               center: [80, 80],
               rect: { left: 40, top: 40, width: 80, height: 80 },
+              description: 'Pay',
             },
           },
         }),
       };
       const actionTask: ExecutionTaskActionApply = {
         type: 'Action Space',
-        executor: async () => ({ output: 'done' }),
+        executor: async () => {},
       };
       const runner = new TaskRunner('tree-scope', contextBuilder, {
         tasks: [locateTask, actionTask],

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -7,6 +7,7 @@ import type {
   ExecutionTaskPlanningLocate,
   ExecutionTaskPlanningLocateApply,
   UIContext,
+  UITreeSnapshot,
 } from '@/index';
 import Service from '@/service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -144,6 +145,94 @@ describe(
       expect(dump.logTime).toBeTruthy();
 
       expect(flushResult?.output).toBe(flushResultData);
+    });
+
+    it('stores a pruned tree only on Locate tasks and isolates context reuse', async () => {
+      const uiTree: UITreeSnapshot = {
+        platform: 'android',
+        capturedAt: 1,
+        xpathPolicy: {
+          stableAttrs: ['resource-id'],
+          textAttrs: ['content-desc', 'text'],
+          excludedTargetTypes: [],
+          max: 5,
+        },
+        root: {
+          type: 'Window',
+          attrs: {},
+          bounds: { left: 0, top: 0, width: 200, height: 200 },
+          children: [
+            {
+              type: 'Card',
+              attrs: { 'resource-id': 'wallet-card' },
+              bounds: { left: 10, top: 10, width: 100, height: 100 },
+              children: [
+                {
+                  type: 'Button',
+                  attrs: { 'resource-id': 'pay-button', text: 'Pay' },
+                  bounds: { left: 20, top: 20, width: 40, height: 40 },
+                  children: [
+                    {
+                      type: 'TextView',
+                      attrs: { text: 'Pay' },
+                      bounds: { left: 35, top: 35, width: 10, height: 10 },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      const contextBuilder = vi.fn(async () => ({
+        screenshot: ScreenshotItem.create('', Date.now()),
+        shotSize: { width: 400, height: 400 },
+        shrunkShotToLogicalRatio: 2,
+        uiTree,
+      })) as (task?: ExecutionTaskApply) => Promise<UIContext>;
+      const locateTask: ExecutionTaskPlanningLocateApply = {
+        type: 'Planning',
+        subType: 'Locate',
+        param: { prompt: 'Pay' },
+        executor: async () => ({
+          output: {
+            element: {
+              center: [80, 80],
+              rect: { left: 40, top: 40, width: 80, height: 80 },
+            },
+          },
+        }),
+      };
+      const actionTask: ExecutionTaskActionApply = {
+        type: 'Action Space',
+        executor: async () => ({ output: 'done' }),
+      };
+      const runner = new TaskRunner('tree-scope', contextBuilder, {
+        tasks: [locateTask, actionTask],
+      });
+
+      await runner.flush();
+
+      expect(runner.tasks[0].uiContext?.uiTree?.root).toMatchObject({
+        type: 'Card',
+        attrs: { 'resource-id': 'wallet-card' },
+        children: [
+          {
+            type: 'Button',
+            attrs: { 'resource-id': 'pay-button' },
+            children: [],
+          },
+        ],
+      });
+      expect(runner.tasks[1].uiContext?.uiTree).toBeUndefined();
+      expect(contextBuilder.mock.calls[0][0]).toMatchObject({
+        type: 'Planning',
+        subType: 'Locate',
+      });
+      expect(contextBuilder.mock.calls[1][0]).toMatchObject({
+        type: 'Action Space',
+      });
     });
 
     it('insight - init and append', async () => {

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -238,6 +238,56 @@ describe(
       });
     });
 
+    it('records an error when a captured tree cannot be mapped to the located element', async () => {
+      const uiTree: UITreeSnapshot = {
+        platform: 'android',
+        capturedAt: 1,
+        xpathPolicy: {
+          stableAttrs: ['resource-id'],
+          textAttrs: ['content-desc', 'text'],
+          excludedTargetTypes: [],
+          max: 5,
+        },
+        root: {
+          type: 'Window',
+          attrs: {},
+          bounds: { left: 0, top: 0, width: 100, height: 100 },
+          children: [],
+        },
+      };
+      const contextBuilder = vi.fn(async () => ({
+        screenshot: ScreenshotItem.create('', Date.now()),
+        shotSize: { width: 400, height: 400 },
+        shrunkShotToLogicalRatio: 2,
+        uiTree,
+      }));
+      const locateTask: ExecutionTaskPlanningLocateApply = {
+        type: 'Planning',
+        subType: 'Locate',
+        param: { prompt: 'Outside the tree' },
+        executor: async () => ({
+          output: {
+            element: {
+              center: [300, 300],
+              rect: { left: 280, top: 280, width: 40, height: 40 },
+              description: 'Outside the tree',
+            },
+          },
+        }),
+      };
+      const runner = new TaskRunner('tree-mapping-error', contextBuilder, {
+        tasks: [locateTask],
+      });
+
+      await runner.flush();
+
+      expect(runner.tasks[0].uiContext?.uiTree).toBeUndefined();
+      expect(runner.tasks[0].uiContext?.uiTreeError).toContain(
+        'Failed to map captured UI tree to located target',
+      );
+      expect(runner.tasks[0].uiContext?.uiTreeError).toContain('no node found');
+    });
+
     it('insight - init and append', async () => {
       const initRunner = new TaskRunner('test', fakeUIContextBuilder);
       expect(initRunner.status).toBe('init');

--- a/packages/core/tests/unit-test/ui-tree-report-serialization.test.ts
+++ b/packages/core/tests/unit-test/ui-tree-report-serialization.test.ts
@@ -1,0 +1,62 @@
+import { ExecutionDump, ReportActionDump } from '@/dump/report-action-dump';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { ExecutionTask, UIContext, UITreeSnapshot } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+describe('UI tree report serialization', () => {
+  it('keeps the captured tree directly on ExecutionTask.uiContext', () => {
+    const uiTree: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 123,
+      root: {
+        type: 'android.widget.FrameLayout',
+        attrs: { package: 'com.example' },
+        bounds: { left: 0, top: 0, width: 100, height: 200 },
+        children: [
+          {
+            type: 'android.widget.Button',
+            attrs: { 'resource-id': 'submit', text: 'Submit' },
+            bounds: { left: 10, top: 20, width: 80, height: 40 },
+            children: [],
+          },
+        ],
+      },
+      xpathPolicy: {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['content-desc', 'text'],
+        excludedTargetTypes: ['android.webkit.WebView'],
+        max: 3,
+      },
+    };
+    const uiContext = {
+      screenshot: ScreenshotItem.create('data:image/png;base64,AAA', 122),
+      shotSize: { width: 100, height: 200 },
+      shrunkShotToLogicalRatio: 1,
+      uiTree,
+    } as UIContext;
+    const task = {
+      type: 'Log',
+      taskId: 'tree-task',
+      status: 'finished',
+      uiContext,
+      executor: async () => undefined,
+    } as unknown as ExecutionTask;
+    const dump = new ReportActionDump({
+      sdkVersion: 'test',
+      groupName: 'Android tree',
+      modelBriefs: [],
+      executions: [
+        new ExecutionDump({
+          logTime: 1,
+          name: 'capture tree',
+          tasks: [task],
+        }),
+      ],
+      deviceType: 'android',
+    });
+
+    const restored = ReportActionDump.fromSerializedString(dump.serialize());
+
+    expect(restored.executions[0].tasks[0].uiContext?.uiTree).toEqual(uiTree);
+  });
+});

--- a/packages/core/tests/unit-test/ui-tree-snapshot.test.ts
+++ b/packages/core/tests/unit-test/ui-tree-snapshot.test.ts
@@ -1,0 +1,162 @@
+import { pruneUITreeSnapshotToTarget } from '@/agent/ui-tree-snapshot';
+import type { UITreeSnapshot, UiNode } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+const node = (
+  type: string,
+  attrs: Record<string, string | undefined>,
+  bounds: { left: number; top: number; width: number; height: number },
+  children: UiNode[] = [],
+): UiNode => ({ type, attrs, bounds, children });
+
+const policy = {
+  stableAttrs: ['resource-id'],
+  textAttrs: ['content-desc', 'text'],
+  excludedTargetTypes: ['android.webkit.WebView'],
+  max: 5,
+};
+
+describe('pruneUITreeSnapshotToTarget', () => {
+  it('keeps only the target lineage and stops at the nearest resource-id ancestor', () => {
+    const target = node(
+      'android.widget.TextView',
+      { text: 'Pay now', index: '2' },
+      { left: 40, top: 40, width: 80, height: 40 },
+    );
+    const snapshot: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 123,
+      xpathPolicy: policy,
+      root: node('Window', {}, { left: 0, top: 0, width: 500, height: 500 }, [
+        node(
+          'Page',
+          { 'resource-id': 'page-root' },
+          { left: 0, top: 0, width: 500, height: 500 },
+          [
+            node(
+              'Card',
+              { 'resource-id': 'wallet-card' },
+              { left: 20, top: 20, width: 200, height: 120 },
+              [
+                node(
+                  'IgnoredSibling',
+                  {},
+                  { left: 20, top: 20, width: 10, height: 10 },
+                ),
+                target,
+              ],
+            ),
+            node(
+              'IgnoredBranch',
+              {},
+              { left: 300, top: 20, width: 100, height: 100 },
+            ),
+          ],
+        ),
+      ]),
+    };
+
+    const pruned = pruneUITreeSnapshotToTarget(snapshot, { x: 60, y: 60 });
+
+    expect(pruned.capturedAt).toBe(123);
+    expect(pruned.root.attrs['resource-id']).toBe('wallet-card');
+    expect(pruned.root.children).toHaveLength(1);
+    expect(pruned.root.children[0]).toMatchObject({
+      type: 'android.widget.TextView',
+      attrs: { text: 'Pay now', index: '2' },
+      children: [],
+    });
+  });
+
+  it('retains the original root when no node in the lineage has a resource-id', () => {
+    const snapshot: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 1,
+      xpathPolicy: policy,
+      root: node('Window', {}, { left: 0, top: 0, width: 100, height: 100 }, [
+        node(
+          'Button',
+          { text: 'Continue' },
+          { left: 10, top: 10, width: 50, height: 30 },
+        ),
+      ]),
+    };
+
+    expect(
+      pruneUITreeSnapshotToTarget(snapshot, { x: 20, y: 20 }).root,
+    ).toMatchObject({
+      type: 'Window',
+      children: [{ type: 'Button', attrs: { text: 'Continue' }, children: [] }],
+    });
+  });
+
+  it('keeps the nearest id ancestor as context when the target has its own id', () => {
+    const snapshot: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 1,
+      xpathPolicy: policy,
+      root: node('Window', {}, { left: 0, top: 0, width: 100, height: 100 }, [
+        node(
+          'Toolbar',
+          { 'resource-id': 'toolbar' },
+          { left: 0, top: 0, width: 100, height: 50 },
+          [
+            node(
+              'Button',
+              { 'resource-id': 'search' },
+              { left: 50, top: 0, width: 50, height: 50 },
+            ),
+          ],
+        ),
+      ]),
+    };
+
+    const pruned = pruneUITreeSnapshotToTarget(snapshot, { x: 75, y: 25 });
+
+    expect(pruned.root).toMatchObject({
+      type: 'Toolbar',
+      attrs: { 'resource-id': 'toolbar' },
+      children: [
+        {
+          type: 'Button',
+          attrs: { 'resource-id': 'search' },
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it('uses the located rect to avoid promoting a smaller child at the center point', () => {
+    const snapshot: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 1,
+      xpathPolicy: policy,
+      root: node('Window', {}, { left: 0, top: 0, width: 200, height: 100 }, [
+        node(
+          'Button',
+          { 'resource-id': 'checkout' },
+          { left: 20, top: 20, width: 120, height: 60 },
+          [
+            node(
+              'TextView',
+              { text: 'Pay' },
+              { left: 60, top: 35, width: 30, height: 20 },
+            ),
+          ],
+        ),
+      ]),
+    };
+
+    const pruned = pruneUITreeSnapshotToTarget(
+      snapshot,
+      { x: 75, y: 45 },
+      { left: 20, top: 20, width: 120, height: 60 },
+    );
+
+    expect(pruned.root.children[0]).toMatchObject({
+      type: 'Button',
+      attrs: { 'resource-id': 'checkout' },
+      children: [],
+    });
+  });
+});

--- a/packages/core/tests/unit-test/ui-tree-snapshot.test.ts
+++ b/packages/core/tests/unit-test/ui-tree-snapshot.test.ts
@@ -66,6 +66,47 @@ describe('pruneUITreeSnapshotToTarget', () => {
       attrs: { text: 'Pay now', index: '2' },
       children: [],
     });
+    expect(pruned.inspection).toEqual({
+      scope: 'target-lineage',
+      pageIdentityCounts: [
+        { attr: 'resource-id', value: 'wallet-card', count: 1 },
+        { attr: 'text', value: 'Pay now', count: 1 },
+      ],
+    });
+  });
+
+  it('records identity counts from the full page before removing siblings', () => {
+    const snapshot: UITreeSnapshot = {
+      platform: 'android',
+      capturedAt: 1,
+      xpathPolicy: policy,
+      root: node('Window', {}, { left: 0, top: 0, width: 300, height: 200 }, [
+        node(
+          'Button',
+          { text: 'Pay' },
+          { left: 20, top: 20, width: 40, height: 40 },
+        ),
+        node(
+          'Panel',
+          { 'resource-id': 'panel-b' },
+          { left: 100, top: 0, width: 100, height: 100 },
+          [
+            node(
+              'Button',
+              { text: 'Pay' },
+              { left: 120, top: 20, width: 40, height: 40 },
+            ),
+          ],
+        ),
+      ]),
+    };
+
+    const pruned = pruneUITreeSnapshotToTarget(snapshot, { x: 130, y: 30 });
+
+    expect(pruned.inspection?.pageIdentityCounts).toEqual([
+      { attr: 'resource-id', value: 'panel-b', count: 1 },
+      { attr: 'text', value: 'Pay', count: 2 },
+    ]);
   });
 
   it('retains the original root when no node in the lineage has a resource-id', () => {


### PR DESCRIPTION
## Summary

- capture Android accessibility UI trees only for Locate contexts and persist the located target lineage on the task UIContext
- add a searchable, virtualized per-task UI Tree report view with node details and horizontal scrolling
- add `Agent.getXpathsByPoint` for generating ranked XPath candidates from a saved Android UIContext without reconnecting to the device
- keep screenshot and tree capture aligned while preserving usable UIContext data when tree capture fails
- implement inspection XPath generation independently from native cache generation and replay

## Review fixes

- preserve full-page identity occurrence counts before pruning so text uniqueness is not inferred from a target-only lineage
- return only page-proven semantic XPath candidates for pruned report trees; order-sensitive targets do not get a positional fallback
- reject anonymous descendants hidden inside structural containers such as WebView
- expose tree-to-locate mapping failures through `uiTreeError`
- initialize Android DPR for direct `getUITree()` calls
- cap accessibility capture at one total three-attempt retry budget

## Scope

- Android only
- no dependency on `fix/cache-xpath-replay`
- no cache generation or replay behavior changes
- no tree capture for recorder or screenshot sequences
- no report screenshot-to-tree reverse selection

## Documentation and live report

- [Implementation guide](https://bytedance.larkoffice.com/docx/XtdsdYusuoF6iQxiyafcWBG5nVh)
- [Live Samsung Galaxy S23 Settings report](https://midscene-android-ui-tree-pr2866.gf-preview.bytedance.net/)

The live report was generated from this rebased PR on a real Samsung Galaxy S23 running Android 15. The Locate target is the exposed Settings search button (`content-desc="搜索设置"`). The saved UI tree contains 3 target-lineage nodes and serializes to 2,166 bytes. The report is 24,924,587 bytes.

`Agent.getXpathsByPoint` converted screenshot point `(969, 792)` to logical point `(323, 264)` with ratio `3` and returned one page-proven candidate:

```xpath
//android.widget.Button[@content-desc='搜索设置']
```

The published report was also verified in a browser: the screenshot marker is on the search button, the UI Tree expands and selects the same node, attrs and bounds render correctly, and searching for `搜索设置` keeps the matching node visible.

## Validation

- `pnpm run lint`
- `pnpm run type-check:tests`
- `pnpm exec nx test @midscene/core` (127 files, 1,369 passed, 8 skipped)
- `pnpm exec nx build @midscene/core`
- `pnpm exec nx test @midscene/android`
- `pnpm exec nx build @midscene/android`
- `pnpm exec nx test @midscene/report` (17 files, 97 passed)
- `pnpm exec nx build @midscene/report`
