### PR TITLE
test(ios): retry transient simulator input false-successes

### DIFF
--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -360,11 +360,14 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
         value: string | undefined;
         sourceFile: string;
       }> = [];
+      const inputAgent = agent;
       const observedInput = await inputUntilObserved({
         expectedValue: SUBMITTED_TEXT,
         performInput: async () => {
-          await agent.callActionInActionSpace('Tap', { locate: targetLocate });
-          await agent.callActionInActionSpace('Input', {
+          await inputAgent.callActionInActionSpace('Tap', {
+            locate: targetLocate,
+          });
+          await inputAgent.callActionInActionSpace('Input', {
             value: SUBMITTED_TEXT,
             mode: 'replace',
             autoDismissKeyboard: false,
@@ -372,7 +375,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
           });
         },
         readValue: async (attempt) => {
-          const response = (await agent.runWdaRequest({
+          const response = (await inputAgent.runWdaRequest({
             method: 'GET',
             endpoint: '/source',
           })) as WdaValueResponse<string>;

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -13,6 +13,7 @@ import {
 import { imageInfoOfBase64 } from '@midscene/shared/img';
 import { describe, expect, it, vi } from 'vitest';
 import { type IOSAgent, agentFromWebDriverAgent } from '../../src';
+import { inputUntilObserved } from '../ios-simulator-input-retry';
 
 const RUN_LIVE_SMOKE =
   process.env.AI_TEST_TYPE === 'iOS' &&
@@ -354,39 +355,65 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
         screenSize.scale,
         INPUT_ACCESSIBILITY_ID,
       );
-      await agent.callActionInActionSpace('Tap', { locate: targetLocate });
-      await agent.callActionInActionSpace('Input', {
-        value: SUBMITTED_TEXT,
-        mode: 'typeOnly',
-        autoDismissKeyboard: false,
-        locate: targetLocate,
+      const inputAttempts: Array<{
+        attempt: number;
+        value: string | undefined;
+        sourceFile: string;
+      }> = [];
+      const observedInput = await inputUntilObserved({
+        expectedValue: SUBMITTED_TEXT,
+        performInput: async () => {
+          await agent.callActionInActionSpace('Tap', { locate: targetLocate });
+          await agent.callActionInActionSpace('Input', {
+            value: SUBMITTED_TEXT,
+            mode: 'replace',
+            autoDismissKeyboard: false,
+            locate: targetLocate,
+          });
+        },
+        readValue: async (attempt) => {
+          const response = (await agent.runWdaRequest({
+            method: 'GET',
+            endpoint: '/source',
+          })) as WdaValueResponse<string>;
+          const attemptSourceFile = path.join(
+            diagnosticsDir,
+            `safari-after-input-attempt-${attempt}.xml`,
+          );
+          await Promise.all([
+            writeFile(attemptSourceFile, response.value, 'utf8'),
+            writeFile(postInputSourceFile, response.value, 'utf8'),
+          ]);
+          const inputNode = (
+            response.value.match(/<XCUIElementTypeTextField\b[^>]*>/g) ?? []
+          ).find(
+            (nodeTag) =>
+              xmlAttribute(nodeTag, 'name') === INPUT_ACCESSIBILITY_ID,
+          );
+          const value = inputNode
+            ? xmlAttribute(inputNode, 'value')
+            : undefined;
+          inputAttempts.push({
+            attempt,
+            value,
+            sourceFile: attemptSourceFile,
+          });
+          return value;
+        },
+        onRetry: ({ attempt, nextAttempt, actualValue }) => {
+          console.log(
+            `iOS Simulator input attempt ${attempt} observed ${JSON.stringify(actualValue)}; retrying with idempotent replace input (attempt ${nextAttempt})`,
+          );
+        },
       });
       await agent.callActionInActionSpace('KeyboardPress', {
         keyName: 'Enter',
         locate: targetLocate,
       });
 
-      const postInputSourceResponse = (await agent.runWdaRequest({
-        method: 'GET',
-        endpoint: '/source',
-      })) as WdaValueResponse<string>;
-      await writeFile(
-        postInputSourceFile,
-        postInputSourceResponse.value,
-        'utf8',
-      );
-      const postInputNode = (
-        postInputSourceResponse.value.match(
-          /<XCUIElementTypeTextField\b[^>]*>/g,
-        ) ?? []
-      ).find(
-        (nodeTag) => xmlAttribute(nodeTag, 'name') === INPUT_ACCESSIBILITY_ID,
-      );
-      const inputText = postInputNode
-        ? xmlAttribute(postInputNode, 'value')
-        : undefined;
-      evidence.inputText = inputText;
-      expect(inputText).toBe(SUBMITTED_TEXT);
+      evidence.inputAttempts = inputAttempts;
+      evidence.inputText = observedInput.value;
+      expect(observedInput.value).toBe(SUBMITTED_TEXT);
       await agent.interface
         .screenshotBase64()
         .then((base64) =>
@@ -407,7 +434,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(3);
+      expect(locateTasks).toHaveLength(observedInput.attempts * 2 + 1);
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -432,7 +459,7 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(3);
+      expect(reportLocateTasks).toHaveLength(observedInput.attempts * 2 + 1);
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -13,7 +13,10 @@ import {
 import { imageInfoOfBase64 } from '@midscene/shared/img';
 import { describe, expect, it, vi } from 'vitest';
 import { type IOSAgent, agentFromWebDriverAgent } from '../../src';
-import { inputUntilObserved } from '../ios-simulator-input-retry';
+import {
+  inputUntilObserved,
+  readIOSSimulatorInputValue,
+} from '../ios-simulator-input-retry';
 
 const RUN_LIVE_SMOKE =
   process.env.AI_TEST_TYPE === 'iOS' &&
@@ -46,6 +49,7 @@ interface WdaRect {
 interface ReportTask {
   type?: string;
   subType?: string;
+  param?: { mode?: string; [key: string]: unknown };
   hitBy?: { from?: string };
   timing?: { callAiStart?: number; callAiEnd?: number };
   usage?: unknown;
@@ -86,10 +90,6 @@ function locate(rect: WdaRect, screenshotScale: number, prompt: string) {
       Math.round((rect.y + rect.height) * screenshotScale),
     ] as [number, number, number, number],
   };
-}
-
-function xmlAttribute(nodeTag: string, attribute: string): string | undefined {
-  return new RegExp(`${attribute}="([^"]*)"`).exec(nodeTag)?.[1];
 }
 
 function parseReportDumps(html: string): ReportDump[] {
@@ -363,13 +363,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const inputAgent = agent;
       const observedInput = await inputUntilObserved({
         expectedValue: SUBMITTED_TEXT,
-        performInput: async () => {
+        performInput: async (attempt) => {
           await inputAgent.callActionInActionSpace('Tap', {
             locate: targetLocate,
           });
           await inputAgent.callActionInActionSpace('Input', {
             value: SUBMITTED_TEXT,
-            mode: 'replace',
+            mode: attempt === 1 ? 'typeOnly' : 'replace',
             autoDismissKeyboard: false,
             locate: targetLocate,
           });
@@ -387,15 +387,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
             writeFile(attemptSourceFile, response.value, 'utf8'),
             writeFile(postInputSourceFile, response.value, 'utf8'),
           ]);
-          const inputNode = (
-            response.value.match(/<XCUIElementTypeTextField\b[^>]*>/g) ?? []
-          ).find(
-            (nodeTag) =>
-              xmlAttribute(nodeTag, 'name') === INPUT_ACCESSIBILITY_ID,
+          const value = readIOSSimulatorInputValue(
+            response.value,
+            INPUT_ACCESSIBILITY_ID,
           );
-          const value = inputNode
-            ? xmlAttribute(inputNode, 'value')
-            : undefined;
           inputAttempts.push({
             attempt,
             value,
@@ -409,6 +404,10 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
           );
         },
       });
+      const expectedInputModes = Array.from(
+        { length: observedInput.attempts },
+        (_, index) => (index === 0 ? 'typeOnly' : 'replace'),
+      );
       await agent.callActionInActionSpace('KeyboardPress', {
         keyName: 'Enter',
         locate: targetLocate,
@@ -437,7 +436,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
+      const inputTasks = dumpTasks.filter(
+        (task) => task.type === 'Action Space' && task.subType === 'Input',
+      );
       expect(locateTasks).toHaveLength(observedInput.attempts * 2 + 1);
+      expect(inputTasks.map((task) => task.param?.mode)).toEqual(
+        expectedInputModes,
+      );
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -462,7 +467,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
+      const reportInputTasks = reportTasks.filter(
+        (task) => task.type === 'Action Space' && task.subType === 'Input',
+      );
       expect(reportLocateTasks).toHaveLength(observedInput.attempts * 2 + 1);
+      expect(reportInputTasks.map((task) => task.param?.mode)).toEqual(
+        expectedInputModes,
+      );
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/ios/tests/ios-simulator-input-retry.ts
+++ b/packages/ios/tests/ios-simulator-input-retry.ts
@@ -1,0 +1,79 @@
+export interface IOSSimulatorInputRetryContext {
+  attempt: number;
+  nextAttempt: number;
+  actualValue: string | undefined;
+}
+
+export interface InputUntilObservedOptions {
+  expectedValue: string;
+  performInput: (attempt: number) => Promise<void>;
+  readValue: (attempt: number) => Promise<string | undefined>;
+  maxAttempts?: number;
+  retryIntervalMs?: number;
+  onRetry?: (context: IOSSimulatorInputRetryContext) => Promise<void> | void;
+}
+
+export interface ObservedInputValue {
+  value: string;
+  attempts: number;
+}
+
+export class IOSSimulatorInputValueError extends Error {
+  constructor(
+    readonly expectedValue: string,
+    readonly actualValue: string | undefined,
+    readonly attempts: number,
+  ) {
+    super(
+      `iOS Simulator input did not reach ${JSON.stringify(expectedValue)} after ${attempts} attempts; last observed value: ${JSON.stringify(actualValue)}`,
+    );
+    this.name = 'IOSSimulatorInputValueError';
+  }
+}
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+export async function inputUntilObserved(
+  options: InputUntilObservedOptions,
+): Promise<ObservedInputValue> {
+  const {
+    expectedValue,
+    performInput,
+    readValue,
+    maxAttempts = 3,
+    retryIntervalMs = 500,
+    onRetry,
+  } = options;
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error(
+      'iOS Simulator input maxAttempts must be a positive integer',
+    );
+  }
+
+  let actualValue: string | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    await performInput(attempt);
+    actualValue = await readValue(attempt);
+    if (actualValue === expectedValue) {
+      return { value: actualValue, attempts: attempt };
+    }
+
+    if (attempt < maxAttempts) {
+      await onRetry?.({
+        attempt,
+        nextAttempt: attempt + 1,
+        actualValue,
+      });
+      await sleep(retryIntervalMs);
+    }
+  }
+
+  throw new IOSSimulatorInputValueError(
+    expectedValue,
+    actualValue,
+    maxAttempts,
+  );
+}

--- a/packages/ios/tests/ios-simulator-input-retry.ts
+++ b/packages/ios/tests/ios-simulator-input-retry.ts
@@ -18,6 +18,27 @@ export interface ObservedInputValue {
   attempts: number;
 }
 
+function xmlAttribute(nodeTag: string, attribute: string): string | undefined {
+  return new RegExp(`${attribute}="([^"]*)"`).exec(nodeTag)?.[1];
+}
+
+export function readIOSSimulatorInputValue(
+  source: string,
+  accessibilityId: string,
+): string | undefined {
+  const inputNode = (
+    source.match(/<XCUIElementTypeTextField\b[^>]*>/g) ?? []
+  ).find((nodeTag) => xmlAttribute(nodeTag, 'name') === accessibilityId);
+
+  if (!inputNode) {
+    throw new Error(
+      `iOS Simulator input ${JSON.stringify(accessibilityId)} is missing from WDA source`,
+    );
+  }
+
+  return xmlAttribute(inputNode, 'value');
+}
+
 export class IOSSimulatorInputValueError extends Error {
   constructor(
     readonly expectedValue: string,

--- a/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
+++ b/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  IOSSimulatorInputValueError,
+  inputUntilObserved,
+} from '../ios-simulator-input-retry';
+
+const EXPECTED_VALUE = 'Midscene iOS input 2026';
+
+describe('iOS Simulator input retry', () => {
+  it('returns the first observed value without retrying', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => EXPECTED_VALUE);
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).resolves.toEqual({
+      value: EXPECTED_VALUE,
+      attempts: 1,
+    });
+    expect(performInput).toHaveBeenCalledWith(1);
+    expect(readValue).toHaveBeenCalledWith(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('retries only after observing an unexpected input value', async () => {
+    const observedValues = [undefined, EXPECTED_VALUE];
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => observedValues.shift());
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).resolves.toEqual({
+      value: EXPECTED_VALUE,
+      attempts: 2,
+    });
+    expect(performInput).toHaveBeenNthCalledWith(1, 1);
+    expect(performInput).toHaveBeenNthCalledWith(2, 2);
+    expect(onRetry).toHaveBeenCalledWith({
+      attempt: 1,
+      nextAttempt: 2,
+      actualValue: undefined,
+    });
+  });
+
+  it.each([
+    {
+      name: 'input action failure',
+      performInput: async () => {
+        throw new Error('tap failed');
+      },
+      readValue: async () => EXPECTED_VALUE,
+      message: 'tap failed',
+    },
+    {
+      name: 'source read failure',
+      performInput: async () => undefined,
+      readValue: async () => {
+        throw new Error('source failed');
+      },
+      message: 'source failed',
+    },
+  ])('fails immediately on an unknown $name', async (testCase) => {
+    const performInput = vi.fn(testCase.performInput);
+    const readValue = vi.fn(testCase.readValue);
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).rejects.toThrow(testCase.message);
+    expect(performInput).toHaveBeenCalledTimes(1);
+    expect(readValue).toHaveBeenCalledTimes(
+      testCase.name === 'input action failure' ? 0 : 1,
+    );
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('throws the last observed value after exhausting attempts', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => 'partial input');
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        maxAttempts: 3,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).rejects.toEqual(
+      new IOSSimulatorInputValueError(EXPECTED_VALUE, 'partial input', 3),
+    );
+    expect(performInput).toHaveBeenCalledTimes(3);
+    expect(readValue).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an invalid attempt count before performing input', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => EXPECTED_VALUE);
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        maxAttempts: 0,
+      }),
+    ).rejects.toThrow(
+      'iOS Simulator input maxAttempts must be a positive integer',
+    );
+    expect(performInput).not.toHaveBeenCalled();
+    expect(readValue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
+++ b/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
@@ -2,9 +2,42 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   IOSSimulatorInputValueError,
   inputUntilObserved,
+  readIOSSimulatorInputValue,
 } from '../ios-simulator-input-retry';
 
 const EXPECTED_VALUE = 'Midscene iOS input 2026';
+
+describe('readIOSSimulatorInputValue', () => {
+  it('returns the value of the matching text field', () => {
+    expect(
+      readIOSSimulatorInputValue(
+        `<XCUIElementTypeTextField name="Other Input" value="other" />
+<XCUIElementTypeTextField name="Midscene Smoke Input" value="${EXPECTED_VALUE}" />`,
+        'Midscene Smoke Input',
+      ),
+    ).toBe(EXPECTED_VALUE);
+  });
+
+  it('returns undefined when the matching text field has no value', () => {
+    expect(
+      readIOSSimulatorInputValue(
+        '<XCUIElementTypeTextField name="Midscene Smoke Input" />',
+        'Midscene Smoke Input',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('fails when the matching text field is missing', () => {
+    expect(() =>
+      readIOSSimulatorInputValue(
+        '<XCUIElementTypeTextField name="Other Input" value="other" />',
+        'Midscene Smoke Input',
+      ),
+    ).toThrow(
+      'iOS Simulator input "Midscene Smoke Input" is missing from WDA source',
+    );
+  });
+});
 
 describe('iOS Simulator input retry', () => {
   it('returns the first observed value without retrying', async () => {


### PR DESCRIPTION
## Summary

- retry the deterministic iOS Simulator input step only when WDA source XML shows that the target field did not receive the expected value
- preserve the original `typeOnly` first attempt, replay only observed value mismatches in idempotent `replace` mode, submit after the expected value is observed, and keep every attempt's XML in diagnostics
- update report assertions to account for the exact number of targeted action attempts
- cover first-attempt success, the permitted value-mismatch retry, immediate propagation of action/source failures, retry exhaustion, and invalid configuration

## Why this retry boundary

The same deterministic smoke failed twice on two different GitHub-hosted runners because `/wda/keys` returned successfully while the Safari text field still had no `value`. WDA logged both taps at the expected coordinates, and the TodoMVC test passed afterward, so the simulator and Midscene session remained healthy.

- [PR #2857 run attempt 1](https://github.com/web-infra-dev/midscene/actions/runs/30076543486/attempts/1) failed with `expected undefined to be 'Midscene iOS input 2026'`.
- [PR #2857 run attempt 2](https://github.com/web-infra-dev/midscene/actions/runs/30076543486/attempts/2) reproduced the identical false-success on another runner.
- [PR #2855 run attempt 2](https://github.com/web-infra-dev/midscene/actions/runs/30076500255/attempts/2) passed the same smoke without a code change, confirming the WDA behavior is transient.

This helper does not retry the full test or arbitrary exceptions. Tap/Input failures, `/source` request failures, and a missing target field still fail immediately. Only an observed value mismatch on the existing target field is retried, up to three total attempts.

## Validation

- `pnpm install --frozen-lockfile` (prepare built all 27 non-doc projects)
- `pnpm run lint`
- `pnpm run type-check:tests`
- `pnpm exec nx test @midscene/ios --output-style=static` (13 files, 155 tests passed)
- `AI_TEST_TYPE=iOS MIDSCENE_IOS_SIMULATOR_SMOKE=1 pnpm --filter @midscene/ios exec vitest list tests/ai/ios-simulator-smoke.test.ts`