### PR TITLE
feat(shared): support reference images in the act CLI tool

### DIFF
--- a/packages/shared/src/agent-tools/tool-generator.ts
+++ b/packages/shared/src/agent-tools/tool-generator.ts
@@ -712,6 +712,7 @@ export function generateCommonTools(
           .describe(
             'Plan this action with deep thinking (richer context and sub-goal decomposition). Helps with complex multi-step instructions at the cost of speed. Defaults to the server --deep-think setting.',
           ),
+        ...promptInputExtraSchema,
         ...initArgSchema,
       },
       cli: mergeToolCliMetadata(undefined, initArgCliMetadata),
@@ -744,7 +745,13 @@ export function generateCommonTools(
             if (args.deepThink !== undefined) {
               actOptions.deepThink = args.deepThink;
             }
-            const result = await agent.aiAction(prompt, actOptions);
+            const userPrompt = composeUserPrompt({
+              prompt,
+              image: args.image,
+              imageName: args.imageName,
+              convertHttpImage2Base64: args.convertHttpImage2Base64,
+            });
+            const result = await agent.aiAction(userPrompt, actOptions);
             return await captureScreenshotResult(agent, 'act', result);
           } finally {
             unsubscribeVerbose();

--- a/packages/shared/src/agent-tools/types.ts
+++ b/packages/shared/src/agent-tools/types.ts
@@ -84,9 +84,10 @@ export interface ActionSpaceItem {
  * Structural shape compatible with @midscene/core `TUserPrompt`.
  * Declared locally to avoid a circular dep on `@midscene/core` from `@midscene/shared`.
  *
- * Currently consumed only by the `assert` tool in `generateCommonTools`.
- * `aiAction` and `aiWaitFor` stay string-only at the CLI surface because the
- * tools generator does not yet expose multimodal entry points for them.
+ * Consumed by the `assert` and `act` tools in `generateCommonTools`, both of
+ * which forward reference images to core (`aiAssert` / `aiAct`). `aiWaitFor`
+ * stays string-only at the CLI surface because the tools generator does not
+ * yet expose a multimodal entry point for it.
  */
 export type UserPromptLike =
   | string
@@ -148,7 +149,7 @@ export interface BaseAgent {
     params?: unknown,
   ) => Promise<unknown>;
   aiAction?: (
-    description: string,
+    description: UserPromptLike,
     params?: Record<string, unknown>,
   ) => Promise<unknown>;
   aiWaitFor?: (

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -620,12 +620,85 @@ describe('generateCommonTools — assert image prompts', () => {
     expect(assertSchema).not.toHaveProperty('images');
     expect(assertSchema).not.toHaveProperty('imageFiles');
 
-    // act schema stays string-only because the underlying core aiAct
-    // does not yet parse multimodal prompts.
+    // act mirrors assert: it exposes the same reference-image flags, which
+    // core aiAct forwards to the planner as reference images.
     const actSchema = tools.find((t) => t.name === 'act')!.schema;
     expect(actSchema).toHaveProperty('prompt');
+    expect(actSchema).toHaveProperty('image');
+    expect(actSchema).toHaveProperty('imageName');
+    expect(actSchema).toHaveProperty('convertHttpImage2Base64');
     expect(actSchema).not.toHaveProperty('images');
     expect(actSchema).not.toHaveProperty('imageFiles');
+  });
+});
+
+describe('generateCommonTools — act image prompts', () => {
+  const screenshotBase64 = 'data:image/png;base64,Zm9v';
+
+  it('passes the prompt through unchanged when no images are supplied', async () => {
+    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const tools = generateCommonTools(async () => ({
+      aiAction,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+
+    const act = tools.find((t) => t.name === 'act')!;
+    await act.handler({ prompt: 'click the login button' });
+
+    expect(aiAction).toHaveBeenCalledWith('click the login button', {
+      deepThink: false,
+    });
+  });
+
+  it('forwards images to aiAction as a TUserPrompt-style object', async () => {
+    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const tools = generateCommonTools(async () => ({
+      aiAction,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+
+    const act = tools.find((t) => t.name === 'act')!;
+    await act.handler({
+      prompt: 'tap the icon that matches the reference image',
+      image: 'https://example.com/icon.png',
+      imageName: 'target',
+    });
+
+    expect(aiAction).toHaveBeenCalledWith(
+      {
+        prompt: 'tap the icon that matches the reference image',
+        images: [{ name: 'target', url: 'https://example.com/icon.png' }],
+      },
+      { deepThink: false },
+    );
+  });
+
+  it('forwards a local-path url verbatim so core can resolve it', async () => {
+    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const tools = generateCommonTools(async () => ({
+      aiAction,
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+    }));
+
+    const act = tools.find((t) => t.name === 'act')!;
+    await act.handler({
+      prompt: 'tap the icon that matches the supplied image',
+      image: './fixtures/icon.png',
+      imageName: 'icon',
+      convertHttpImage2Base64: true,
+    });
+
+    expect(aiAction).toHaveBeenCalledWith(
+      {
+        prompt: 'tap the icon that matches the supplied image',
+        images: [{ name: 'icon', url: './fixtures/icon.png' }],
+        convertHttpImage2Base64: true,
+      },
+      { deepThink: false },
+    );
   });
 });
 


### PR DESCRIPTION
## What

Adds reference-image input to the `act` common tool, so platform CLIs
(`@midscene/web`, `@midscene/android`, `@midscene/ios`, …) can pass images to
`act` the same way they already can to `assert`:

```bash
npx @midscene/web act \
  --url https://example.com \
  --prompt "tap the icon that matches the reference image" \
  --image ./target.png \
  --image-name target
```

`--image` / `--image-name` may be repeated (counts must match) and remote URLs
can be inlined via `--convert-http-image2-base64 true`.

## Why

`act` was the odd one out: only `assert` exposed the image flags at the CLI
surface, even though core already supports multimodal prompts everywhere.
`aiAct` / `aiAction` accept a `TUserPrompt` and forward reference images to the
planner (`TaskExecutor.action` → `planImpl({ referenceImageMessages })`,
`packages/core/src/agent/tasks.ts`). So this is purely CLI wiring — no core
change was needed.

## How

- add `promptInputExtraSchema` (`image` / `imageName` / `convertHttpImage2Base64`)
  to the `act` tool schema
- compose a `UserPromptLike` via `composeUserPrompt(...)` before calling
  `aiAction`, mirroring `assert`
- widen `BaseAgent.aiAction` to accept `UserPromptLike`

Plan-cache correctness is preserved: the plan cache key is
`JSON.stringify(prompt)`, which already incorporates each image name/url, so
"same text, different image" does not hit a stale cached plan.

`aiWaitFor` intentionally stays string-only (no multimodal entry point yet); the
stale comment in `types.ts` is updated accordingly.

## Validation

- `npx nx test @midscene/shared -- tests/unit-test/tool-generator.test.ts` — 45 passed
  (new `generateCommonTools — act image prompts` cases: forwards images as a
  TUserPrompt object, forwards a local-path url verbatim, no-image prompt stays a
  bare string; updated schema assertions)
- `npx nx build @midscene/shared` — passed with the type checker enabled
- `npx nx build @midscene/android` — passed (downstream consumer of the widened
  `BaseAgent.aiAction` type)
- pre-commit `lint-staged` (biome) — passed on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)