### PR TITLE
feat(android): expose accessibility UI tree snapshots

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -727,7 +727,6 @@ ${Object.keys(size)
       adb: await this.getAdb(),
       devicePixelRatio: this.devicePixelRatio,
       displayId: this.options?.displayId,
-      ensureYadb: () => this.ensureYadb(),
       getDisplaySize: () => this.size(),
     });
   }

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -12,7 +12,6 @@ import {
   type Point,
   type Size,
   type UITreeSnapshot,
-  type UiNode,
   getMidsceneLocationSchema,
   z,
 } from '@midscene/core';
@@ -51,10 +50,7 @@ import {
   type ScrcpyStatus,
 } from './scrcpy-device-adapter';
 import type { RawKeyframe } from './scrcpy-manager';
-import {
-  ANDROID_UI_TREE_XPATH_POLICY,
-  uiautomatorXmlToUiNode,
-} from './ui-tree';
+import { captureAndroidUITree } from './ui-tree-capture';
 
 // Re-export AndroidDeviceOpt and AndroidDeviceInputOpt for backward compatibility
 export type {
@@ -67,37 +63,12 @@ const defaultScrollUntilTimes = 10;
 const defaultFastScrollDuration = 100;
 const defaultNormalScrollDuration = 1000;
 
-const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
-const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
-const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
-const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
-const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
-
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
-type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
 
 const debugDevice = getDebug('android:device');
 const warnDevice = getDebug('android:device', { console: true });
-const debugUITree = getDebug('android:ui-tree');
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function validateHierarchyXml(
-  xml: unknown,
-  source: AndroidAccessibilityTreeSource,
-): asserts xml is string {
-  if (
-    typeof xml !== 'string' ||
-    !/<hierarchy(?:\s|>)/.test(xml) ||
-    !xml.includes('</hierarchy>')
-  ) {
-    throw new Error(`${source} did not produce valid hierarchy XML`);
-  }
-}
 
 function physicalDisplayIdForLogicalDisplay(
   displayDump: string,
@@ -129,81 +100,6 @@ function physicalDisplayIdForLogicalDisplay(
   }
 
   return null;
-}
-
-function focusedPackageForLogicalDisplay(
-  windowDump: string,
-  logicalDisplayId: number,
-): string | null {
-  const displayMatches = [
-    ...windowDump.matchAll(/^\s*Display: mDisplayId=(\d+)\b.*$/gm),
-  ];
-  const displayIndex = displayMatches.findIndex(
-    (match) => Number(match[1]) === logicalDisplayId,
-  );
-  if (displayIndex === -1) return null;
-
-  const start = displayMatches[displayIndex].index ?? 0;
-  const end = displayMatches[displayIndex + 1]?.index ?? windowDump.length;
-  const displayBlock = windowDump.slice(start, end);
-  for (const field of ['mCurrentFocus', 'mFocusedApp']) {
-    const value = displayBlock.match(
-      new RegExp(`^\\s*${field}=([^\\n]*)$`, 'm'),
-    )?.[1];
-    const packageName = value?.match(/\bu\d+\s+([A-Za-z0-9_$.-]+)\//)?.[1];
-    if (packageName) return packageName;
-  }
-  return null;
-}
-
-function firstTreePackage(root: UiNode): string | null {
-  if (root.attrs.package) return root.attrs.package;
-  for (const child of root.children) {
-    const packageName = firstTreePackage(child);
-    if (packageName) return packageName;
-  }
-  return null;
-}
-
-function windowDisplayIdsForPackage(
-  windowDump: string,
-  packageName: string,
-): number[] {
-  const windowMatches = [
-    ...windowDump.matchAll(/^\s*Window #\d+ Window\{.*$/gm),
-  ];
-  const displayIds = new Set<number>();
-
-  for (let index = 0; index < windowMatches.length; index++) {
-    const start = windowMatches[index].index ?? 0;
-    const end = windowMatches[index + 1]?.index ?? windowDump.length;
-    const windowBlock = windowDump.slice(start, end);
-    const ownerPackage = windowBlock.match(
-      /^\s*mOwnerUid=.*\bpackage=([A-Za-z0-9_$.-]+)\b/m,
-    )?.[1];
-    const headerPackage = windowMatches[index][0].match(
-      /\bu\d+\s+([A-Za-z0-9_$.-]+)\//,
-    )?.[1];
-    if (ownerPackage !== packageName && headerPackage !== packageName) {
-      continue;
-    }
-
-    const displayId = windowBlock.match(/^\s*mDisplayId=(\d+)\b/m)?.[1];
-    if (displayId !== undefined) displayIds.add(Number(displayId));
-  }
-
-  return [...displayIds];
-}
-
-function uiTreeExtent(root: UiNode): { right: number; bottom: number } {
-  let right = root.bounds.left + root.bounds.width;
-  let bottom = root.bounds.top + root.bounds.height;
-  for (const child of root.children) {
-    const childExtent = uiTreeExtent(child);
-    right = Math.max(right, childExtent.right);
-    bottom = Math.max(bottom, childExtent.bottom);
-  }
-  return { right, bottom };
 }
 
 /**
@@ -825,149 +721,15 @@ ${Object.keys(size)
     };
   }
 
-  private async dumpAccessibilityXml(
-    source: AndroidAccessibilityTreeSource,
-  ): Promise<string> {
-    const adb = await this.getAdb();
-    const destination =
-      source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
-
-    if (source === 'yadb') {
-      await this.ensureYadb();
-    }
-
-    await runAdbShellStdoutOrThrow(adb, `rm -f ${destination}`, {
-      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
-    });
-    const command =
-      source === 'yadb'
-        ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${destination}`
-        : `uiautomator dump --compressed ${destination}`;
-    await runAdbShellStdoutOrThrow(adb, command, {
-      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
-    });
-    const xml = await runAdbShellStdoutOrThrow(adb, `cat ${destination}`, {
-      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
-    });
-    validateHierarchyXml(xml, source);
-    return xml;
-  }
-
-  private async validateUITreeDisplay(root: UiNode): Promise<void> {
-    if (typeof this.options?.displayId !== 'number') return;
-
-    const displayId = this.options.displayId;
-    const adb = await this.getAdb();
-    const displayWindowDump = await runAdbShellStdoutOrThrow(
-      adb,
-      'dumpsys window displays',
-      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
-    );
-    const expectedPackage = focusedPackageForLogicalDisplay(
-      displayWindowDump,
-      displayId,
-    );
-    const treePackage = firstTreePackage(root);
-    if (!expectedPackage) {
-      throw new Error(
-        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no focused package found on the target display`,
-      );
-    }
-    if (!treePackage) {
-      throw new Error(
-        `Unable to verify Android UI tree display alignment for displayId=${displayId}: accessibility hierarchy has no package`,
-      );
-    }
-
-    const allWindowDump = await runAdbShellStdoutOrThrow(
-      adb,
-      'dumpsys window windows',
-      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
-    );
-    const treePackageDisplayIds = windowDisplayIdsForPackage(
-      allWindowDump,
-      treePackage,
-    );
-    if (treePackageDisplayIds.length === 0) {
-      throw new Error(
-        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no window display ownership found for accessibility package ${treePackage}`,
-      );
-    }
-    if (!treePackageDisplayIds.includes(displayId)) {
-      throw new Error(
-        `Android UI tree display mismatch for displayId=${displayId}: expected focused package ${expectedPackage}, but accessibility hierarchy belongs to ${treePackage} on displayId=${treePackageDisplayIds.join(',')}`,
-      );
-    }
-
-    const targetSize = await this.size();
-    const extent = uiTreeExtent(root);
-    const tolerance = 1;
-    if (
-      extent.right > targetSize.width + tolerance ||
-      extent.bottom > targetSize.height + tolerance
-    ) {
-      throw new Error(
-        `Android UI tree bounds exceed displayId=${displayId}: tree ${Math.round(extent.right)}x${Math.round(extent.bottom)} is outside target ${targetSize.width}x${targetSize.height}`,
-      );
-    }
-  }
-
   async getUITree(): Promise<UITreeSnapshot> {
     await this.initializeDevicePixelRatio();
-    const sources: AndroidAccessibilityTreeSource[] =
-      (this.options?.displayId ?? 0) === 0
-        ? ['yadb', 'uiautomator']
-        : ['uiautomator'];
-    const failures: string[] = [];
-
-    for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
-      const source = sources[Math.min(attempt - 1, sources.length - 1)];
-      const startedAt = Date.now();
-      try {
-        const xml = await this.dumpAccessibilityXml(source);
-        const capturedAt = Date.now();
-        const root = uiautomatorXmlToUiNode(xml, this.devicePixelRatio);
-        await this.validateUITreeDisplay(root);
-        debugUITree(
-          'capture source=%s attempt=%d durationMs=%d bytes=%d',
-          source,
-          attempt,
-          Date.now() - startedAt,
-          xml.length,
-        );
-        return {
-          platform: 'android',
-          capturedAt,
-          root,
-          xpathPolicy: {
-            ...ANDROID_UI_TREE_XPATH_POLICY,
-            stableAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.stableAttrs],
-            textAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.textAttrs],
-            excludedTargetTypes: [
-              ...ANDROID_UI_TREE_XPATH_POLICY.excludedTargetTypes,
-            ],
-          },
-        };
-      } catch (error) {
-        const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
-        failures.push(failure);
-        debugUITree(
-          'capture failed source=%s attempt=%d/%d durationMs=%d error=%s',
-          source,
-          attempt,
-          ACCESSIBILITY_DUMP_ATTEMPTS,
-          Date.now() - startedAt,
-          errorMessage(error),
-        );
-        if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
-          await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
-        }
-      }
-    }
-
-    throw new Error(
-      `Unable to capture Android UI tree after ${failures.length} attempt(s): ${failures.join('; ')}`,
-    );
+    return captureAndroidUITree({
+      adb: await this.getAdb(),
+      devicePixelRatio: this.devicePixelRatio,
+      displayId: this.options?.displayId,
+      ensureYadb: () => this.ensureYadb(),
+      getDisplaySize: () => this.size(),
+    });
   }
 
   async getScreenSize(): Promise<{

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -11,6 +11,8 @@ import {
   type LocateResultElement,
   type Point,
   type Size,
+  type UITreeSnapshot,
+  type UiNode,
   getMidsceneLocationSchema,
   z,
 } from '@midscene/core';
@@ -49,6 +51,10 @@ import {
   type ScrcpyStatus,
 } from './scrcpy-device-adapter';
 import type { RawKeyframe } from './scrcpy-manager';
+import {
+  ANDROID_UI_TREE_XPATH_POLICY,
+  uiautomatorXmlToUiNode,
+} from './ui-tree';
 
 // Re-export AndroidDeviceOpt and AndroidDeviceInputOpt for backward compatibility
 export type {
@@ -61,12 +67,144 @@ const defaultScrollUntilTimes = 10;
 const defaultFastScrollDuration = 100;
 const defaultNormalScrollDuration = 1000;
 
+const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
+const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
+const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
+const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
+const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
+
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
+type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
 
 const debugDevice = getDebug('android:device');
 const warnDevice = getDebug('android:device', { console: true });
+const debugUITree = getDebug('android:ui-tree');
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validateHierarchyXml(
+  xml: unknown,
+  source: AndroidAccessibilityTreeSource,
+): asserts xml is string {
+  if (
+    typeof xml !== 'string' ||
+    !/<hierarchy(?:\s|>)/.test(xml) ||
+    !xml.includes('</hierarchy>')
+  ) {
+    throw new Error(`${source} did not produce valid hierarchy XML`);
+  }
+}
+
+function physicalDisplayIdForLogicalDisplay(
+  displayDump: string,
+  logicalDisplayId: number,
+): string | null {
+  for (const viewportMatch of displayDump.matchAll(
+    /DisplayViewport\{([^}]*)\}/g,
+  )) {
+    const viewport = viewportMatch[1];
+    const displayId = viewport.match(/\bdisplayId=(\d+)\b/)?.[1];
+    const physicalId = viewport.match(/\buniqueId=['"]local:(\d+)['"]/)?.[1];
+    if (Number(displayId) === logicalDisplayId && physicalId) {
+      return physicalId;
+    }
+  }
+
+  const lines = displayDump.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const displayId = lines[index].match(/^\s*mDisplayId=(\d+)\b/)?.[1];
+    if (Number(displayId) !== logicalDisplayId) continue;
+
+    for (let cursor = index + 1; cursor < lines.length; cursor++) {
+      if (/^\s*mDisplayId=\d+\b/.test(lines[cursor])) break;
+      const physicalId = lines[cursor].match(
+        /mBaseDisplayInfo=.*\buniqueId "local:(\d+)"/,
+      )?.[1];
+      if (physicalId) return physicalId;
+    }
+  }
+
+  return null;
+}
+
+function focusedPackageForLogicalDisplay(
+  windowDump: string,
+  logicalDisplayId: number,
+): string | null {
+  const displayMatches = [
+    ...windowDump.matchAll(/^\s*Display: mDisplayId=(\d+)\b.*$/gm),
+  ];
+  const displayIndex = displayMatches.findIndex(
+    (match) => Number(match[1]) === logicalDisplayId,
+  );
+  if (displayIndex === -1) return null;
+
+  const start = displayMatches[displayIndex].index ?? 0;
+  const end = displayMatches[displayIndex + 1]?.index ?? windowDump.length;
+  const displayBlock = windowDump.slice(start, end);
+  for (const field of ['mCurrentFocus', 'mFocusedApp']) {
+    const value = displayBlock.match(
+      new RegExp(`^\\s*${field}=([^\\n]*)$`, 'm'),
+    )?.[1];
+    const packageName = value?.match(/\bu\d+\s+([A-Za-z0-9_$.-]+)\//)?.[1];
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function firstTreePackage(root: UiNode): string | null {
+  if (root.attrs.package) return root.attrs.package;
+  for (const child of root.children) {
+    const packageName = firstTreePackage(child);
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function windowDisplayIdsForPackage(
+  windowDump: string,
+  packageName: string,
+): number[] {
+  const windowMatches = [
+    ...windowDump.matchAll(/^\s*Window #\d+ Window\{.*$/gm),
+  ];
+  const displayIds = new Set<number>();
+
+  for (let index = 0; index < windowMatches.length; index++) {
+    const start = windowMatches[index].index ?? 0;
+    const end = windowMatches[index + 1]?.index ?? windowDump.length;
+    const windowBlock = windowDump.slice(start, end);
+    const ownerPackage = windowBlock.match(
+      /^\s*mOwnerUid=.*\bpackage=([A-Za-z0-9_$.-]+)\b/m,
+    )?.[1];
+    const headerPackage = windowMatches[index][0].match(
+      /\bu\d+\s+([A-Za-z0-9_$.-]+)\//,
+    )?.[1];
+    if (ownerPackage !== packageName && headerPackage !== packageName) {
+      continue;
+    }
+
+    const displayId = windowBlock.match(/^\s*mDisplayId=(\d+)\b/m)?.[1];
+    if (displayId !== undefined) displayIds.add(Number(displayId));
+  }
+
+  return [...displayIds];
+}
+
+function uiTreeExtent(root: UiNode): { right: number; bottom: number } {
+  let right = root.bounds.left + root.bounds.width;
+  let bottom = root.bounds.top + root.bounds.height;
+  for (const child of root.children) {
+    const childExtent = uiTreeExtent(child);
+    right = Math.max(right, childExtent.right);
+    bottom = Math.max(bottom, childExtent.bottom);
+  }
+  return { right, bottom };
+}
 
 /**
  * Escape text for safe use in shell single-quoted strings.
@@ -685,6 +823,151 @@ ${Object.keys(size)
       node: null,
       children: [],
     };
+  }
+
+  private async dumpAccessibilityXml(
+    source: AndroidAccessibilityTreeSource,
+  ): Promise<string> {
+    const adb = await this.getAdb();
+    const destination =
+      source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
+
+    if (source === 'yadb') {
+      await this.ensureYadb();
+    }
+
+    await runAdbShellStdoutOrThrow(adb, `rm -f ${destination}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const command =
+      source === 'yadb'
+        ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${destination}`
+        : `uiautomator dump --compressed ${destination}`;
+    await runAdbShellStdoutOrThrow(adb, command, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const xml = await runAdbShellStdoutOrThrow(adb, `cat ${destination}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    validateHierarchyXml(xml, source);
+    return xml;
+  }
+
+  private async validateUITreeDisplay(root: UiNode): Promise<void> {
+    if (typeof this.options?.displayId !== 'number') return;
+
+    const displayId = this.options.displayId;
+    const adb = await this.getAdb();
+    const displayWindowDump = await runAdbShellStdoutOrThrow(
+      adb,
+      'dumpsys window displays',
+      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+    );
+    const expectedPackage = focusedPackageForLogicalDisplay(
+      displayWindowDump,
+      displayId,
+    );
+    const treePackage = firstTreePackage(root);
+    if (!expectedPackage) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no focused package found on the target display`,
+      );
+    }
+    if (!treePackage) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: accessibility hierarchy has no package`,
+      );
+    }
+
+    const allWindowDump = await runAdbShellStdoutOrThrow(
+      adb,
+      'dumpsys window windows',
+      { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+    );
+    const treePackageDisplayIds = windowDisplayIdsForPackage(
+      allWindowDump,
+      treePackage,
+    );
+    if (treePackageDisplayIds.length === 0) {
+      throw new Error(
+        `Unable to verify Android UI tree display alignment for displayId=${displayId}: no window display ownership found for accessibility package ${treePackage}`,
+      );
+    }
+    if (!treePackageDisplayIds.includes(displayId)) {
+      throw new Error(
+        `Android UI tree display mismatch for displayId=${displayId}: expected focused package ${expectedPackage}, but accessibility hierarchy belongs to ${treePackage} on displayId=${treePackageDisplayIds.join(',')}`,
+      );
+    }
+
+    const targetSize = await this.size();
+    const extent = uiTreeExtent(root);
+    const tolerance = 1;
+    if (
+      extent.right > targetSize.width + tolerance ||
+      extent.bottom > targetSize.height + tolerance
+    ) {
+      throw new Error(
+        `Android UI tree bounds exceed displayId=${displayId}: tree ${Math.round(extent.right)}x${Math.round(extent.bottom)} is outside target ${targetSize.width}x${targetSize.height}`,
+      );
+    }
+  }
+
+  async getUITree(): Promise<UITreeSnapshot> {
+    await this.initializeDevicePixelRatio();
+    const sources: AndroidAccessibilityTreeSource[] =
+      (this.options?.displayId ?? 0) === 0
+        ? ['yadb', 'uiautomator']
+        : ['uiautomator'];
+    const failures: string[] = [];
+
+    for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+      const source = sources[Math.min(attempt - 1, sources.length - 1)];
+      const startedAt = Date.now();
+      try {
+        const xml = await this.dumpAccessibilityXml(source);
+        const capturedAt = Date.now();
+        const root = uiautomatorXmlToUiNode(xml, this.devicePixelRatio);
+        await this.validateUITreeDisplay(root);
+        debugUITree(
+          'capture source=%s attempt=%d durationMs=%d bytes=%d',
+          source,
+          attempt,
+          Date.now() - startedAt,
+          xml.length,
+        );
+        return {
+          platform: 'android',
+          capturedAt,
+          root,
+          xpathPolicy: {
+            ...ANDROID_UI_TREE_XPATH_POLICY,
+            stableAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.stableAttrs],
+            textAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.textAttrs],
+            excludedTargetTypes: [
+              ...ANDROID_UI_TREE_XPATH_POLICY.excludedTargetTypes,
+            ],
+          },
+        };
+      } catch (error) {
+        const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+        failures.push(failure);
+        debugUITree(
+          'capture failed source=%s attempt=%d/%d durationMs=%d error=%s',
+          source,
+          attempt,
+          ACCESSIBILITY_DUMP_ATTEMPTS,
+          Date.now() - startedAt,
+          errorMessage(error),
+        );
+        if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
+          await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
+        }
+      }
+    }
+
+    throw new Error(
+      `Unable to capture Android UI tree after ${failures.length} attempt(s): ${failures.join('; ')}`,
+    );
   }
 
   async getScreenSize(): Promise<{
@@ -2106,6 +2389,19 @@ ${Object.keys(size)
 
     const adb = await this.getAdb();
     try {
+      const displayDump = await adb.shell('dumpsys display');
+      const logicalDisplayPhysicalId = physicalDisplayIdForLogicalDisplay(
+        displayDump,
+        this.options.displayId,
+      );
+      if (logicalDisplayPhysicalId) {
+        this.cachedPhysicalDisplayId = logicalDisplayPhysicalId;
+        debugDevice(
+          `Found and cached physical display ID: ${logicalDisplayPhysicalId} for logical display ID: ${this.options.displayId}`,
+        );
+        return this.cachedPhysicalDisplayId;
+      }
+
       const stdout = await adb.shell(
         `dumpsys SurfaceFlinger --display-id ${this.options.displayId}`,
       );

--- a/packages/android/src/ui-tree-capture.ts
+++ b/packages/android/src/ui-tree-capture.ts
@@ -11,16 +11,12 @@ import {
 const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
 const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
 const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
-const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
 const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
-
-type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
 
 interface AndroidUITreeCaptureOptions {
   adb: ADB;
   devicePixelRatio: number;
   displayId?: number;
-  ensureYadb: () => Promise<void>;
   getDisplaySize: () => Promise<Size>;
 }
 
@@ -30,16 +26,13 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function validateHierarchyXml(
-  xml: unknown,
-  source: AndroidAccessibilityTreeSource,
-): asserts xml is string {
+function validateHierarchyXml(xml: unknown): asserts xml is string {
   if (
     typeof xml !== 'string' ||
     !/<hierarchy(?:\s|>)/.test(xml) ||
     !xml.includes('</hierarchy>')
   ) {
-    throw new Error(`${source} did not produce valid hierarchy XML`);
+    throw new Error('uiautomator did not produce valid hierarchy XML');
   }
 }
 
@@ -118,32 +111,25 @@ function uiTreeExtent(root: UiNode): { right: number; bottom: number } {
   return { right, bottom };
 }
 
-async function dumpAccessibilityXml(
-  adb: ADB,
-  source: AndroidAccessibilityTreeSource,
-  ensureYadb: () => Promise<void>,
-): Promise<string> {
-  const destination =
-    source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
-
-  if (source === 'yadb') {
-    await ensureYadb();
-  }
-
-  await runAdbShellStdoutOrThrow(adb, `rm -f ${destination}`, {
+async function dumpAccessibilityXml(adb: ADB): Promise<string> {
+  await runAdbShellStdoutOrThrow(adb, `rm -f ${UIAUTOMATOR_LAYOUT_PATH}`, {
     timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
   });
-  const command =
-    source === 'yadb'
-      ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${destination}`
-      : `uiautomator dump --compressed ${destination}`;
-  await runAdbShellStdoutOrThrow(adb, command, {
-    timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
-  });
-  const xml = await runAdbShellStdoutOrThrow(adb, `cat ${destination}`, {
-    timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
-  });
-  validateHierarchyXml(xml, source);
+  await runAdbShellStdoutOrThrow(
+    adb,
+    `uiautomator dump --compressed ${UIAUTOMATOR_LAYOUT_PATH}`,
+    {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    },
+  );
+  const xml = await runAdbShellStdoutOrThrow(
+    adb,
+    `cat ${UIAUTOMATOR_LAYOUT_PATH}`,
+    {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    },
+  );
+  validateHierarchyXml(xml);
   return xml;
 }
 
@@ -214,25 +200,18 @@ async function validateUITreeDisplay(
 export async function captureAndroidUITree(
   options: AndroidUITreeCaptureOptions,
 ): Promise<UITreeSnapshot> {
-  const sources: AndroidAccessibilityTreeSource[] =
-    (options.displayId ?? 0) === 0 ? ['yadb', 'uiautomator'] : ['uiautomator'];
   const failures: string[] = [];
 
   for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
-    const source = sources[Math.min(attempt - 1, sources.length - 1)];
     const startedAt = Date.now();
     try {
-      const xml = await dumpAccessibilityXml(
-        options.adb,
-        source,
-        options.ensureYadb,
-      );
+      const xml = await dumpAccessibilityXml(options.adb);
       const capturedAt = Date.now();
       const root = uiautomatorXmlToUiNode(xml, options.devicePixelRatio);
       await validateUITreeDisplay(root, options);
       debugUITree(
         'capture source=%s attempt=%d durationMs=%d bytes=%d',
-        source,
+        'uiautomator',
         attempt,
         Date.now() - startedAt,
         xml.length,
@@ -251,11 +230,11 @@ export async function captureAndroidUITree(
         },
       };
     } catch (error) {
-      const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+      const failure = `uiautomator attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
       failures.push(failure);
       debugUITree(
         'capture failed source=%s attempt=%d/%d durationMs=%d error=%s',
-        source,
+        'uiautomator',
         attempt,
         ACCESSIBILITY_DUMP_ATTEMPTS,
         Date.now() - startedAt,

--- a/packages/android/src/ui-tree-capture.ts
+++ b/packages/android/src/ui-tree-capture.ts
@@ -1,0 +1,273 @@
+import type { Size, UITreeSnapshot, UiNode } from '@midscene/core';
+import { sleep } from '@midscene/core/utils';
+import { getDebug } from '@midscene/shared/logger';
+import type { ADB } from 'appium-adb';
+import { runAdbShellStdoutOrThrow } from './adb-shell';
+import {
+  ANDROID_UI_TREE_XPATH_POLICY,
+  uiautomatorXmlToUiNode,
+} from './ui-tree';
+
+const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
+const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
+const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
+const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
+const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
+
+type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
+
+interface AndroidUITreeCaptureOptions {
+  adb: ADB;
+  devicePixelRatio: number;
+  displayId?: number;
+  ensureYadb: () => Promise<void>;
+  getDisplaySize: () => Promise<Size>;
+}
+
+const debugUITree = getDebug('android:ui-tree');
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validateHierarchyXml(
+  xml: unknown,
+  source: AndroidAccessibilityTreeSource,
+): asserts xml is string {
+  if (
+    typeof xml !== 'string' ||
+    !/<hierarchy(?:\s|>)/.test(xml) ||
+    !xml.includes('</hierarchy>')
+  ) {
+    throw new Error(`${source} did not produce valid hierarchy XML`);
+  }
+}
+
+function focusedPackageForLogicalDisplay(
+  windowDump: string,
+  logicalDisplayId: number,
+): string | null {
+  const displayMatches = [
+    ...windowDump.matchAll(/^\s*Display: mDisplayId=(\d+)\b.*$/gm),
+  ];
+  const displayIndex = displayMatches.findIndex(
+    (match) => Number(match[1]) === logicalDisplayId,
+  );
+  if (displayIndex === -1) return null;
+
+  const start = displayMatches[displayIndex].index ?? 0;
+  const end = displayMatches[displayIndex + 1]?.index ?? windowDump.length;
+  const displayBlock = windowDump.slice(start, end);
+  for (const field of ['mCurrentFocus', 'mFocusedApp']) {
+    const value = displayBlock.match(
+      new RegExp(`^\\s*${field}=([^\\n]*)$`, 'm'),
+    )?.[1];
+    const packageName = value?.match(/\bu\d+\s+([A-Za-z0-9_$.-]+)\//)?.[1];
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function firstTreePackage(root: UiNode): string | null {
+  if (root.attrs.package) return root.attrs.package;
+  for (const child of root.children) {
+    const packageName = firstTreePackage(child);
+    if (packageName) return packageName;
+  }
+  return null;
+}
+
+function windowDisplayIdsForPackage(
+  windowDump: string,
+  packageName: string,
+): number[] {
+  const windowMatches = [
+    ...windowDump.matchAll(/^\s*Window #\d+ Window\{.*$/gm),
+  ];
+  const displayIds = new Set<number>();
+
+  for (let index = 0; index < windowMatches.length; index++) {
+    const start = windowMatches[index].index ?? 0;
+    const end = windowMatches[index + 1]?.index ?? windowDump.length;
+    const windowBlock = windowDump.slice(start, end);
+    const ownerPackage = windowBlock.match(
+      /^\s*mOwnerUid=.*\bpackage=([A-Za-z0-9_$.-]+)\b/m,
+    )?.[1];
+    const headerPackage = windowMatches[index][0].match(
+      /\bu\d+\s+([A-Za-z0-9_$.-]+)\//,
+    )?.[1];
+    if (ownerPackage !== packageName && headerPackage !== packageName) {
+      continue;
+    }
+
+    const displayId = windowBlock.match(/^\s*mDisplayId=(\d+)\b/m)?.[1];
+    if (displayId !== undefined) displayIds.add(Number(displayId));
+  }
+
+  return [...displayIds];
+}
+
+function uiTreeExtent(root: UiNode): { right: number; bottom: number } {
+  let right = root.bounds.left + root.bounds.width;
+  let bottom = root.bounds.top + root.bounds.height;
+  for (const child of root.children) {
+    const childExtent = uiTreeExtent(child);
+    right = Math.max(right, childExtent.right);
+    bottom = Math.max(bottom, childExtent.bottom);
+  }
+  return { right, bottom };
+}
+
+async function dumpAccessibilityXml(
+  adb: ADB,
+  source: AndroidAccessibilityTreeSource,
+  ensureYadb: () => Promise<void>,
+): Promise<string> {
+  const destination =
+    source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
+
+  if (source === 'yadb') {
+    await ensureYadb();
+  }
+
+  await runAdbShellStdoutOrThrow(adb, `rm -f ${destination}`, {
+    timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+  });
+  const command =
+    source === 'yadb'
+      ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${destination}`
+      : `uiautomator dump --compressed ${destination}`;
+  await runAdbShellStdoutOrThrow(adb, command, {
+    timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+  });
+  const xml = await runAdbShellStdoutOrThrow(adb, `cat ${destination}`, {
+    timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+  });
+  validateHierarchyXml(xml, source);
+  return xml;
+}
+
+async function validateUITreeDisplay(
+  root: UiNode,
+  options: Pick<
+    AndroidUITreeCaptureOptions,
+    'adb' | 'displayId' | 'getDisplaySize'
+  >,
+): Promise<void> {
+  if (typeof options.displayId !== 'number') return;
+
+  const { adb, displayId } = options;
+  const displayWindowDump = await runAdbShellStdoutOrThrow(
+    adb,
+    'dumpsys window displays',
+    { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+  );
+  const expectedPackage = focusedPackageForLogicalDisplay(
+    displayWindowDump,
+    displayId,
+  );
+  const treePackage = firstTreePackage(root);
+  if (!expectedPackage) {
+    throw new Error(
+      `Unable to verify Android UI tree display alignment for displayId=${displayId}: no focused package found on the target display`,
+    );
+  }
+  if (!treePackage) {
+    throw new Error(
+      `Unable to verify Android UI tree display alignment for displayId=${displayId}: accessibility hierarchy has no package`,
+    );
+  }
+
+  const allWindowDump = await runAdbShellStdoutOrThrow(
+    adb,
+    'dumpsys window windows',
+    { timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS },
+  );
+  const treePackageDisplayIds = windowDisplayIdsForPackage(
+    allWindowDump,
+    treePackage,
+  );
+  if (treePackageDisplayIds.length === 0) {
+    throw new Error(
+      `Unable to verify Android UI tree display alignment for displayId=${displayId}: no window display ownership found for accessibility package ${treePackage}`,
+    );
+  }
+  if (!treePackageDisplayIds.includes(displayId)) {
+    throw new Error(
+      `Android UI tree display mismatch for displayId=${displayId}: expected focused package ${expectedPackage}, but accessibility hierarchy belongs to ${treePackage} on displayId=${treePackageDisplayIds.join(',')}`,
+    );
+  }
+
+  const targetSize = await options.getDisplaySize();
+  const extent = uiTreeExtent(root);
+  const tolerance = 1;
+  if (
+    extent.right > targetSize.width + tolerance ||
+    extent.bottom > targetSize.height + tolerance
+  ) {
+    throw new Error(
+      `Android UI tree bounds exceed displayId=${displayId}: tree ${Math.round(extent.right)}x${Math.round(extent.bottom)} is outside target ${targetSize.width}x${targetSize.height}`,
+    );
+  }
+}
+
+export async function captureAndroidUITree(
+  options: AndroidUITreeCaptureOptions,
+): Promise<UITreeSnapshot> {
+  const sources: AndroidAccessibilityTreeSource[] =
+    (options.displayId ?? 0) === 0 ? ['yadb', 'uiautomator'] : ['uiautomator'];
+  const failures: string[] = [];
+
+  for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+    const source = sources[Math.min(attempt - 1, sources.length - 1)];
+    const startedAt = Date.now();
+    try {
+      const xml = await dumpAccessibilityXml(
+        options.adb,
+        source,
+        options.ensureYadb,
+      );
+      const capturedAt = Date.now();
+      const root = uiautomatorXmlToUiNode(xml, options.devicePixelRatio);
+      await validateUITreeDisplay(root, options);
+      debugUITree(
+        'capture source=%s attempt=%d durationMs=%d bytes=%d',
+        source,
+        attempt,
+        Date.now() - startedAt,
+        xml.length,
+      );
+      return {
+        platform: 'android',
+        capturedAt,
+        root,
+        xpathPolicy: {
+          ...ANDROID_UI_TREE_XPATH_POLICY,
+          stableAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.stableAttrs],
+          textAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.textAttrs],
+          excludedTargetTypes: [
+            ...ANDROID_UI_TREE_XPATH_POLICY.excludedTargetTypes,
+          ],
+        },
+      };
+    } catch (error) {
+      const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+      failures.push(failure);
+      debugUITree(
+        'capture failed source=%s attempt=%d/%d durationMs=%d error=%s',
+        source,
+        attempt,
+        ACCESSIBILITY_DUMP_ATTEMPTS,
+        Date.now() - startedAt,
+        errorMessage(error),
+      );
+      if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
+        await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(
+    `Unable to capture Android UI tree after ${failures.length} attempt(s): ${failures.join('; ')}`,
+  );
+}

--- a/packages/android/src/ui-tree-capture.ts
+++ b/packages/android/src/ui-tree-capture.ts
@@ -3,10 +3,7 @@ import { sleep } from '@midscene/core/utils';
 import { getDebug } from '@midscene/shared/logger';
 import type { ADB } from 'appium-adb';
 import { runAdbShellStdoutOrThrow } from './adb-shell';
-import {
-  ANDROID_UI_TREE_XPATH_POLICY,
-  uiautomatorXmlToUiNode,
-} from './ui-tree';
+import { uiautomatorXmlToUiNode } from './ui-tree';
 
 const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
 const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
@@ -220,14 +217,6 @@ export async function captureAndroidUITree(
         platform: 'android',
         capturedAt,
         root,
-        xpathPolicy: {
-          ...ANDROID_UI_TREE_XPATH_POLICY,
-          stableAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.stableAttrs],
-          textAttrs: [...ANDROID_UI_TREE_XPATH_POLICY.textAttrs],
-          excludedTargetTypes: [
-            ...ANDROID_UI_TREE_XPATH_POLICY.excludedTargetTypes,
-          ],
-        },
       };
     } catch (error) {
       const failure = `uiautomator attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;

--- a/packages/android/src/ui-tree.ts
+++ b/packages/android/src/ui-tree.ts
@@ -1,0 +1,160 @@
+import type { UITreeSnapshot, UiNode } from '@midscene/core';
+
+export const ANDROID_UI_TREE_XPATH_POLICY: UITreeSnapshot['xpathPolicy'] = {
+  stableAttrs: ['resource-id'],
+  textAttrs: ['content-desc', 'text'],
+  excludedTargetTypes: [
+    'android.widget.GridView',
+    'android.widget.ListView',
+    'android.widget.ScrollView',
+    'android.widget.HorizontalScrollView',
+    'android.widget.RecyclerView',
+    'android.support.v7.widget.RecyclerView',
+    'androidx.recyclerview.widget.RecyclerView',
+    'android.support.v4.view.ViewPager',
+    'androidx.viewpager.widget.ViewPager',
+    'androidx.viewpager2.widget.ViewPager2',
+    'android.webkit.WebView',
+  ],
+  max: 3,
+};
+
+interface XmlElement {
+  name: string;
+  attrs: Record<string, string>;
+  children: XmlElement[];
+}
+
+const TAG_RE = /<(\/?)([A-Za-z_][A-Za-z0-9_.\-:]*)([^>]*?)(\/?)>/g;
+const ATTR_RE = /([A-Za-z_][A-Za-z0-9_.\-:]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+const BOUNDS_RE = /^\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]$/;
+const ENTITY_TABLE: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+function decodeEntities(value: string): string {
+  if (!value.includes('&')) return value;
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (full, body) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) {
+      const code = Number.parseInt(body.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    if (body.startsWith('#')) {
+      const code = Number.parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    return ENTITY_TABLE[body] ?? full;
+  });
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  ATTR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((match = ATTR_RE.exec(raw))) {
+    attrs[match[1]] = decodeEntities(match[3] ?? match[4] ?? '');
+  }
+  return attrs;
+}
+
+function parseXml(input: string): XmlElement {
+  if (input.trim().length === 0) {
+    throw new Error('parseAndroidUITreeXml: input is empty');
+  }
+  const cleaned = input
+    .replace(/<\?xml[\s\S]*?\?>/g, '')
+    .replace(/<!DOCTYPE[\s\S]*?>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+  TAG_RE.lastIndex = 0;
+
+  const stack: XmlElement[] = [];
+  let root: XmlElement | undefined;
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((match = TAG_RE.exec(cleaned))) {
+    const isClose = match[1] === '/';
+    const name = match[2];
+    if (isClose) {
+      const current = stack.pop();
+      if (!current || current.name !== name) {
+        throw new Error(
+          `parseAndroidUITreeXml: unbalanced close tag </${name}>`,
+        );
+      }
+      continue;
+    }
+
+    const element: XmlElement = {
+      name,
+      attrs: parseAttrs(match[3] ?? ''),
+      children: [],
+    };
+    const parent = stack[stack.length - 1];
+    if (parent) {
+      parent.children.push(element);
+    } else if (root) {
+      throw new Error('parseAndroidUITreeXml: more than one top-level element');
+    } else {
+      root = element;
+    }
+    if (match[4] !== '/') stack.push(element);
+  }
+
+  if (stack.length > 0) {
+    throw new Error('parseAndroidUITreeXml: unclosed element');
+  }
+  if (!root) {
+    throw new Error('parseAndroidUITreeXml: no root element');
+  }
+  return root;
+}
+
+function parseBounds(
+  raw: string | undefined,
+  devicePixelRatio: number,
+): UiNode['bounds'] {
+  const match = raw ? BOUNDS_RE.exec(raw) : undefined;
+  if (!match) return { left: 0, top: 0, width: 0, height: 0 };
+  const left = Number.parseInt(match[1], 10);
+  const top = Number.parseInt(match[2], 10);
+  const right = Number.parseInt(match[3], 10);
+  const bottom = Number.parseInt(match[4], 10);
+  const ratio = devicePixelRatio > 0 ? devicePixelRatio : 1;
+  return {
+    left: left / ratio,
+    top: top / ratio,
+    width: Math.max(0, right - left) / ratio,
+    height: Math.max(0, bottom - top) / ratio,
+  };
+}
+
+function toUiNode(element: XmlElement, devicePixelRatio: number): UiNode {
+  const attrs: Record<string, string> = {};
+  for (const [name, value] of Object.entries(element.attrs)) {
+    if (name !== 'bounds') attrs[name] = value;
+  }
+  return {
+    type: element.attrs.class || element.name,
+    attrs,
+    bounds: parseBounds(element.attrs.bounds, devicePixelRatio),
+    children: element.children.map((child) =>
+      toUiNode(child, devicePixelRatio),
+    ),
+  };
+}
+
+export function uiautomatorXmlToUiNode(
+  xml: string,
+  devicePixelRatio: number,
+): UiNode {
+  const root = parseXml(xml);
+  if (root.name === 'hierarchy' && root.children.length === 1) {
+    return toUiNode(root.children[0], devicePixelRatio);
+  }
+  return toUiNode(root, devicePixelRatio);
+}

--- a/packages/android/src/ui-tree.ts
+++ b/packages/android/src/ui-tree.ts
@@ -1,23 +1,4 @@
-import type { UITreeSnapshot, UiNode } from '@midscene/core';
-
-export const ANDROID_UI_TREE_XPATH_POLICY: UITreeSnapshot['xpathPolicy'] = {
-  stableAttrs: ['resource-id'],
-  textAttrs: ['content-desc', 'text'],
-  excludedTargetTypes: [
-    'android.widget.GridView',
-    'android.widget.ListView',
-    'android.widget.ScrollView',
-    'android.widget.HorizontalScrollView',
-    'android.widget.RecyclerView',
-    'android.support.v7.widget.RecyclerView',
-    'androidx.recyclerview.widget.RecyclerView',
-    'android.support.v4.view.ViewPager',
-    'androidx.viewpager.widget.ViewPager',
-    'androidx.viewpager2.widget.ViewPager2',
-    'android.webkit.WebView',
-  ],
-  max: 3,
-};
+import type { UiNode } from '@midscene/core';
 
 interface XmlElement {
   name: string;

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -185,6 +185,270 @@ describe('AndroidDevice', () => {
     });
   });
 
+  describe('UI tree', () => {
+    const hierarchy = (children: string) => `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" bounds="[0,0][400,800]">
+    ${children}
+  </node>
+</hierarchy>`;
+
+    const mockYadbHierarchy = (xml: string) => {
+      mockAdb.shell.mockImplementation(async (command) => {
+        if (
+          String(command) ===
+          'cat /data/local/tmp/midscene_yadb_layout_dump.xml'
+        ) {
+          return xml;
+        }
+        return '';
+      });
+    };
+
+    it('returns a snapshot from the accessibility hierarchy', async () => {
+      mockYadbHierarchy(
+        hierarchy(
+          '<node class="android.widget.Button" resource-id="submit" text="Submit" bounds="[20,40][180,100]"/>',
+        ),
+      );
+      mockAdb.getScreenDensity.mockResolvedValue(320);
+      const beforeCapture = Date.now();
+
+      const snapshot = await device.getUITree();
+
+      expect(snapshot).toMatchObject({
+        platform: 'android',
+        xpathPolicy: {
+          stableAttrs: ['resource-id'],
+          textAttrs: ['content-desc', 'text'],
+          max: 3,
+        },
+        root: {
+          type: 'android.widget.FrameLayout',
+          bounds: { left: 0, top: 0, width: 200, height: 400 },
+          children: [
+            {
+              type: 'android.widget.Button',
+              attrs: { 'resource-id': 'submit', text: 'Submit' },
+              bounds: { left: 10, top: 20, width: 80, height: 30 },
+            },
+          ],
+        },
+      });
+      expect(snapshot.capturedAt).toBeGreaterThanOrEqual(beforeCapture);
+      expect(snapshot.xpathPolicy.excludedTargetTypes).toContain(
+        'android.webkit.WebView',
+      );
+      expect(mockAdb.getScreenDensity).toHaveBeenCalledOnce();
+      expect(mockAdb.shell).toHaveBeenCalledWith(
+        'cat /data/local/tmp/midscene_yadb_layout_dump.xml',
+        expect.objectContaining({ timeout: 5_000 }),
+      );
+    });
+
+    it('shares one total retry budget across accessibility dump sources', async () => {
+      mockAdb.getScreenDensity.mockResolvedValue(160);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (
+          value.includes(' -layout ') ||
+          value.startsWith('uiautomator dump')
+        ) {
+          throw new Error('layout dump failed');
+        }
+        return '';
+      });
+
+      await expect(device.getUITree()).rejects.toThrow('layout dump failed');
+
+      const dumpCommands = mockAdb.shell.mock.calls
+        .map(([command]) => String(command))
+        .filter(
+          (command) =>
+            command.includes(' -layout ') ||
+            command.startsWith('uiautomator dump'),
+        );
+      expect(dumpCommands).toEqual([
+        'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout /data/local/tmp/midscene_yadb_layout_dump.xml',
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
+      ]);
+    });
+
+    it('rejects a tree captured from a different logical display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.wrong.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}
+  mFocusedApp=ActivityRecord{def u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.wrong.display/.MainActivity}:
+  mDisplayId=3 rootTaskId=10
+  mOwnerUid=10001 package=com.wrong.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /UI tree display mismatch.*displayId=2.*com\.expected\.display.*com\.wrong\.display/,
+      );
+    });
+
+    it('accepts a system overlay owned by the configured display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.android.systemui" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 StatusBar}:
+  mDisplayId=2 rootTaskId=1
+  mOwnerUid=10002 package=com.android.systemui`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).resolves.toMatchObject({
+        root: { attrs: { package: 'com.android.systemui' } },
+      });
+    });
+
+    it('rejects a tree whose display ownership cannot be verified', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.unknown.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') return '';
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /no window display ownership found.*com\.unknown\.display/,
+      );
+    });
+
+    it('records capturedAt immediately after reading the hierarchy', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      let currentTime = 10;
+      vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          currentTime = 100;
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.expected.display" bounds="[0,0][400,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          currentTime = 200;
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.expected.display/.MainActivity}:
+  mDisplayId=2 rootTaskId=10
+  mOwnerUid=10001 package=com.expected.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).resolves.toMatchObject({
+        capturedAt: 100,
+      });
+    });
+
+    it('rejects a tree whose bounds exceed the configured display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 2,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+        width: 400,
+        height: 800,
+      });
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.expected.display" bounds="[0,0][600,800]"/>
+</hierarchy>`;
+        }
+        if (value === 'dumpsys window displays') {
+          return `Display: mDisplayId=2 (organized)
+  mCurrentFocus=Window{abc u0 com.expected.display/.MainActivity}`;
+        }
+        if (value === 'dumpsys window windows') {
+          return `Window #0 Window{abc u0 com.expected.display/.MainActivity}:
+  mDisplayId=2 rootTaskId=10
+  mOwnerUid=10001 package=com.expected.display`;
+        }
+        return '';
+      });
+
+      await expect(secondaryDisplayDevice.getUITree()).rejects.toThrow(
+        /UI tree bounds exceed displayId=2.*600x800.*400x800/,
+      );
+    });
+  });
+
   describe('launch', () => {
     it('should start URI for http/https links', async () => {
       const uri = 'https://example.com';
@@ -2503,6 +2767,30 @@ Stdout:
         'dumpsys SurfaceFlinger --display-id 1',
       );
       expect(result).toBe('4630946423637606531');
+    });
+
+    it('maps a logical display ID to its physical unique ID', async () => {
+      deviceWithDisplay = new AndroidDevice('test-device', {
+        displayId: 0,
+      });
+      setupMockAdb(mockAdbInstance);
+      mockAdbInstance.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value === 'dumpsys display') {
+          return `mDisplayId=0
+    mBaseDisplayInfo=DisplayInfo{"Outer", displayId 0, uniqueId "local:222"}
+mDisplayId=2
+    mBaseDisplayInfo=DisplayInfo{"Inner", displayId 2, uniqueId "local:111"}`;
+        }
+        return '';
+      });
+
+      await expect(deviceWithDisplay.getPhysicalDisplayId()).resolves.toBe(
+        '222',
+      );
+      expect(mockAdbInstance.shell).not.toHaveBeenCalledWith(
+        'dumpsys SurfaceFlinger --display-id 0',
+      );
     });
 
     it('should use display-specific size when displayId is set', async () => {

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -193,12 +193,9 @@ describe('AndroidDevice', () => {
   </node>
 </hierarchy>`;
 
-    const mockYadbHierarchy = (xml: string) => {
+    const mockUiautomatorHierarchy = (xml: string) => {
       mockAdb.shell.mockImplementation(async (command) => {
-        if (
-          String(command) ===
-          'cat /data/local/tmp/midscene_yadb_layout_dump.xml'
-        ) {
+        if (String(command) === 'cat /sdcard/midscene_window_dump.xml') {
           return xml;
         }
         return '';
@@ -206,7 +203,7 @@ describe('AndroidDevice', () => {
     };
 
     it('returns a snapshot from the accessibility hierarchy', async () => {
-      mockYadbHierarchy(
+      mockUiautomatorHierarchy(
         hierarchy(
           '<node class="android.widget.Button" resource-id="submit" text="Submit" bounds="[20,40][180,100]"/>',
         ),
@@ -241,19 +238,16 @@ describe('AndroidDevice', () => {
       );
       expect(mockAdb.getScreenDensity).toHaveBeenCalledOnce();
       expect(mockAdb.shell).toHaveBeenCalledWith(
-        'cat /data/local/tmp/midscene_yadb_layout_dump.xml',
+        'cat /sdcard/midscene_window_dump.xml',
         expect.objectContaining({ timeout: 5_000 }),
       );
     });
 
-    it('shares one total retry budget across accessibility dump sources', async () => {
+    it('retries uiautomator within one total dump budget', async () => {
       mockAdb.getScreenDensity.mockResolvedValue(160);
       mockAdb.shell.mockImplementation(async (command) => {
         const value = String(command);
-        if (
-          value.includes(' -layout ') ||
-          value.startsWith('uiautomator dump')
-        ) {
+        if (value.startsWith('uiautomator dump')) {
           throw new Error('layout dump failed');
         }
         return '';
@@ -263,13 +257,9 @@ describe('AndroidDevice', () => {
 
       const dumpCommands = mockAdb.shell.mock.calls
         .map(([command]) => String(command))
-        .filter(
-          (command) =>
-            command.includes(' -layout ') ||
-            command.startsWith('uiautomator dump'),
-        );
+        .filter((command) => command.startsWith('uiautomator dump'));
       expect(dumpCommands).toEqual([
-        'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout /data/local/tmp/midscene_yadb_layout_dump.xml',
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
         'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
         'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
       ]);

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -215,11 +215,6 @@ describe('AndroidDevice', () => {
 
       expect(snapshot).toMatchObject({
         platform: 'android',
-        xpathPolicy: {
-          stableAttrs: ['resource-id'],
-          textAttrs: ['content-desc', 'text'],
-          max: 3,
-        },
         root: {
           type: 'android.widget.FrameLayout',
           bounds: { left: 0, top: 0, width: 200, height: 400 },
@@ -233,9 +228,6 @@ describe('AndroidDevice', () => {
         },
       });
       expect(snapshot.capturedAt).toBeGreaterThanOrEqual(beforeCapture);
-      expect(snapshot.xpathPolicy.excludedTargetTypes).toContain(
-        'android.webkit.WebView',
-      );
       expect(mockAdb.getScreenDensity).toHaveBeenCalledOnce();
       expect(mockAdb.shell).toHaveBeenCalledWith(
         'cat /sdcard/midscene_window_dump.xml',

--- a/packages/android/tests/unit-test/ui-tree.test.ts
+++ b/packages/android/tests/unit-test/ui-tree.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { uiautomatorXmlToUiNode } from '../../src/ui-tree';
+
+describe('uiautomatorXmlToUiNode', () => {
+  it('unwraps a hierarchy and converts physical bounds to logical bounds', () => {
+    const root = uiautomatorXmlToUiNode(
+      `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" package="com.example" bounds="[0,0][400,800]">
+    <node class="android.widget.Button" resource-id="submit" text="Pay &amp; continue" bounds="[20,40][180,100]"/>
+  </node>
+</hierarchy>`,
+      2,
+    );
+
+    expect(root).toMatchObject({
+      type: 'android.widget.FrameLayout',
+      attrs: { package: 'com.example' },
+      bounds: { left: 0, top: 0, width: 200, height: 400 },
+      children: [
+        {
+          type: 'android.widget.Button',
+          attrs: {
+            'resource-id': 'submit',
+            text: 'Pay & continue',
+          },
+          bounds: { left: 10, top: 20, width: 80, height: 30 },
+        },
+      ],
+    });
+    expect(root.attrs.bounds).toBeUndefined();
+  });
+
+  it('retains a synthetic hierarchy root for multi-window dumps', () => {
+    const root = uiautomatorXmlToUiNode(
+      `<hierarchy>
+        <node class="WindowA" bounds="[0,0][100,100]"/>
+        <node class="WindowB" bounds="[100,0][200,100]"/>
+      </hierarchy>`,
+      1,
+    );
+
+    expect(root.type).toBe('hierarchy');
+    expect(root.children.map((child) => child.type)).toEqual([
+      'WindowA',
+      'WindowB',
+    ]);
+  });
+
+  it('throws for malformed XML', () => {
+    expect(() =>
+      uiautomatorXmlToUiNode('<hierarchy><node></hierarchy>', 1),
+    ).toThrow('unbalanced close tag');
+  });
+});

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -10,7 +10,13 @@ import type { ElementNode } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 import { z } from 'zod';
-import type { ElementCacheFeature, Rect, Size, UIContext } from '../types';
+import type {
+  ElementCacheFeature,
+  Rect,
+  Size,
+  UIContext,
+  UITreeSnapshot,
+} from '../types';
 
 export interface FileChooserHandler {
   accept(files: string[]): Promise<void>;
@@ -180,6 +186,8 @@ export abstract class AbstractInterface {
   abstract rectMatchesCacheFeature?(
     feature: ElementCacheFeature,
   ): Promise<Rect>;
+
+  abstract getUITree?(): Promise<UITreeSnapshot>;
 
   abstract destroy?(): Promise<void>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -130,6 +130,45 @@ export interface AgentDescribeElementAtPointResult {
  * context
  */
 
+export interface UiNode {
+  type: string;
+  attrs: Record<string, string | undefined>;
+  bounds: Rect;
+  children: UiNode[];
+}
+
+export interface UITreeIdentityCount {
+  attr: string;
+  value: string;
+  count: number;
+}
+
+export interface UITreeInspectionMetadata {
+  /** The serialized root contains only the located target's retained lineage. */
+  scope: 'target-lineage';
+
+  /**
+   * Occurrence counts measured against the complete captured page before it was
+   * reduced to {@link scope}. Only identities present on the retained lineage
+   * are included.
+   */
+  pageIdentityCounts: UITreeIdentityCount[];
+}
+
+export interface UITreeSnapshot {
+  platform: 'android';
+  capturedAt: number;
+  root: UiNode;
+  xpathPolicy: {
+    stableAttrs: string[];
+    textAttrs: string[];
+    excludedTargetTypes: string[];
+    max: number;
+  };
+  /** Inspection evidence retained when {@link root} is a lossy report view. */
+  inspection?: UITreeInspectionMetadata;
+}
+
 export abstract class UIContext {
   /**
    * screenshot of the current UI state. which size is shotSize(be shrunk by screenshotShrinkFactor),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,36 +137,10 @@ export interface UiNode {
   children: UiNode[];
 }
 
-export interface UITreeIdentityCount {
-  attr: string;
-  value: string;
-  count: number;
-}
-
-export interface UITreeInspectionMetadata {
-  /** The serialized root contains only the located target's retained lineage. */
-  scope: 'target-lineage';
-
-  /**
-   * Occurrence counts measured against the complete captured page before it was
-   * reduced to {@link scope}. Only identities present on the retained lineage
-   * are included.
-   */
-  pageIdentityCounts: UITreeIdentityCount[];
-}
-
 export interface UITreeSnapshot {
   platform: 'android';
   capturedAt: number;
   root: UiNode;
-  xpathPolicy: {
-    stableAttrs: string[];
-    textAttrs: string[];
-    excludedTargetTypes: string[];
-    max: number;
-  };
-  /** Inspection evidence retained when {@link root} is a lossy report view. */
-  inspection?: UITreeInspectionMetadata;
 }
 
 export abstract class UIContext {

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -19,6 +19,7 @@ class MockInterface extends AbstractInterface {
     undefined;
   override afterInvokeAction: AbstractInterface['afterInvokeAction'] =
     undefined;
+  override getUITree: AbstractInterface['getUITree'] = undefined;
   override getElementsNodeTree: AbstractInterface['getElementsNodeTree'] =
     undefined;
   override url: AbstractInterface['url'] = undefined;


### PR DESCRIPTION
## Summary

- parse Android accessibility hierarchy XML into typed `UiNode` snapshots
- expose `AndroidDevice.getUITree()` with a minimal snapshot containing `platform`, `capturedAt`, and `root`
- validate screenshot/package/bounds alignment and retry inconsistent captures within a bounded budget
- isolate collection, retry, and display-alignment helpers in `ui-tree-capture.ts`, leaving `AndroidDevice.getUITree()` as a thin entry point

## Scope

This is PR 1 of 3. It contains Android snapshot collection only. Locate capture, task persistence, and the report UI are intentionally left to the dependent PRs. XPath generation is not part of the active stack.

The removed `Agent.getXpathsByPoint()` work is preserved on [`archive/agent-get-xpaths-by-point`](https://github.com/web-infra-dev/midscene/tree/archive/agent-get-xpaths-by-point).

## Stack

1. **This PR: #2873** — Android UI tree snapshot foundation
2. [#2874](https://github.com/web-infra-dev/midscene/pull/2874) — Core Locate capture and target-lineage persistence
3. [#2875](https://github.com/web-infra-dev/midscene/pull/2875) — Report UI tree viewer

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/core`
- `pnpm exec nx test @midscene/android` (347 tests passed)
- `pnpm exec nx build @midscene/android`
