### PR TITLE
feat(core): support original image detail in Codex App Server

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -230,6 +230,8 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-5"
   </ModelConfigTab>
 </ModelConfigTabs>
 
+You can also use GPT through [**Use Codex App Server (OAuth, no API Key)**](./model-config#use-codex-app-server-oauth-no-api-key).
+
 :::warning GPT-5 notes
 
 - For UI localization with GPT, Midscene currently supports `gpt-5.4` and later models. To get the best localization quality, image requests need `"detail": "original"`. According to OpenAI, this option is available on `gpt-5.4` and future models, while smaller GPT-5 variants such as `gpt-5.4-mini` and `gpt-5.4-nano`, as well as older models, do not support `original` and will fail if you send it. See the [Images and Vision guide](https://developers.openai.com/api/docs/guides/images-vision) and the [Computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use).

--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -34,6 +34,12 @@ Notes:
 - Midscene will call `codex app-server` through stdio.
 - Make sure `codex` is available in your PATH and verify auth with `codex login status`.
 
+:::warning Known limitation
+
+Compared with calling an OpenAI-compatible API directly, we have observed that this route may take longer and consume more tokens. We are still investigating the cause.
+
+:::
+
 ## Advanced settings (optional)
 
 If you configure a dedicated Insight or Planning model, model-related `MIDSCENE_MODEL_*` settings in this section only take effect for the Insight or Planning intent when you configure the corresponding `MIDSCENE_INSIGHT_MODEL_*` or `MIDSCENE_PLANNING_MODEL_*` setting.

--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -33,7 +33,6 @@ Notes:
 - `MIDSCENE_MODEL_API_KEY` is not required in this mode.
 - Midscene will call `codex app-server` through stdio.
 - Make sure `codex` is available in your PATH and verify auth with `codex login status`.
-- In this mode, Midscene cannot set `"detail": "original"` when sending images, so it cannot achieve the best localization quality. See the [Images and Vision guide](https://developers.openai.com/api/docs/guides/images-vision) and the [Computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use).
 
 ## Advanced settings (optional)
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -230,6 +230,8 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-5"
   </ModelConfigTab>
 </ModelConfigTabs>
 
+你也可以通过[**使用 Codex App Server（OAuth，无需 API Key）**](./model-config#使用-codex-app-serveroauth无需-api-key) 使用 GPT。
+
 :::warning GPT-5 使用注意事项
 
 - 使用 GPT 做 UI 定位时，目前只支持使用 `gpt-5.4` 及以后的模型。因为为了获得最佳的定位效果，需要在发送图片时指定 `"detail": "original"` 参数，这一参数仅在 `gpt-5.4` 及后续模型上可用，`gpt-5.4-mini`、`gpt-5.4-nano` 等更小的 GPT-5 变体以及前代模型不支持 `original` 参数，会导致报错。详情请参考 [Images and Vision guide](https://developers.openai.com/api/docs/guides/images-vision) 和 [Computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use)。

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -31,7 +31,6 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 - 该模式下不需要 `MIDSCENE_MODEL_API_KEY`。
 - Midscene 会通过 stdio 调用 `codex app-server`。
 - 请确保 `codex` 在 PATH 中可用，并通过 `codex login status` 确认登录状态。
-- 使用该模式时，无法在发送图片时指定 `"detail": "original"` 参数，因此无法获得最佳的定位效果。详情请参考 [Images and Vision guide](https://developers.openai.com/api/docs/guides/images-vision) 和 [Computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use)。
 
 ## 高阶配置（可选）
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -32,6 +32,12 @@ export MIDSCENE_MODEL_FAMILY="gpt-5"
 - Midscene 会通过 stdio 调用 `codex app-server`。
 - 请确保 `codex` 在 PATH 中可用，并通过 `codex login status` 确认登录状态。
 
+:::warning 已知限制
+
+相比于直接调用 OpenAI 兼容 API，我们观察到这种方式可能耗时更长、token 消耗更多，具体原因还在排查中。
+
+:::
+
 ## 高阶配置（可选）
 
 如果你为 Insight 或 Planning 配置了独立模型，那么本节中的模型相关 `MIDSCENE_MODEL_*` 配置需要使用对应的 `MIDSCENE_INSIGHT_MODEL_*` 或 `MIDSCENE_PLANNING_MODEL_*` 配置才能在 Insight 或 Planning 意图时生效。

--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -57,17 +57,25 @@ type CodexTextInput = {
   text_elements: any[];
 };
 
+// Codex app-server v2 accepts `detail` on both image input variants:
+// https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L276-L329
+// Codex has also reported `original` as a supported value in production:
+// https://github.com/openai/codex/issues/24797
 type CodexImageInput = {
   type: 'image';
   url: string;
+  detail?: CodexImageDetail;
 };
 
 type CodexLocalImageInput = {
   type: 'localImage';
   path: string;
+  detail?: CodexImageDetail;
 };
 
 type CodexTurnInput = CodexTextInput | CodexImageInput | CodexLocalImageInput;
+
+type CodexImageDetail = 'auto' | 'low' | 'high' | 'original';
 
 type CodexTurnResult = {
   content: string;
@@ -147,6 +155,14 @@ const toNonEmptyString = (value: unknown): string | undefined => {
   return trimmed || undefined;
 };
 
+const toCodexImageDetail = (value: unknown): CodexImageDetail | undefined =>
+  value === 'auto' ||
+  value === 'low' ||
+  value === 'high' ||
+  value === 'original'
+    ? value
+    : undefined;
+
 export const normalizeCodexLocalImagePath = (
   imageUrl: string,
   platform: NodeJS.Platform = process.platform,
@@ -214,6 +230,7 @@ const extractTextFromMessage = (
 
 const extractImageInputs = (
   message: ChatCompletionMessageParam,
+  imageDetailOverride?: CodexImageDetail,
 ): Array<CodexImageInput | CodexLocalImageInput> => {
   const content = (message as any).content;
   if (!Array.isArray(content)) return [];
@@ -229,6 +246,11 @@ const extractImageInputs = (
         : partType === 'input_image'
           ? toNonEmptyString(part.image_url || part.url)
           : undefined;
+    const imageDetail =
+      imageDetailOverride ??
+      toCodexImageDetail(
+        partType === 'image_url' ? part.image_url?.detail : part.detail,
+      );
 
     if (!imageUrl) continue;
 
@@ -245,6 +267,7 @@ const extractImageInputs = (
       inputs.push({
         type: 'localImage',
         path,
+        ...(imageDetail ? { detail: imageDetail } : {}),
       });
       continue;
     }
@@ -252,6 +275,7 @@ const extractImageInputs = (
     inputs.push({
       type: 'image',
       url: imageUrl,
+      ...(imageDetail ? { detail: imageDetail } : {}),
     });
   }
 
@@ -265,9 +289,7 @@ export const resolveCodexReasoningEffort = ({
   reasoningEnabled?: TModelReasoningEnabled;
   modelConfig: IModelConfig;
 }): CodexReasoningEffort | undefined => {
-  if (reasoningEnabled === true) return 'high';
-  if (reasoningEnabled === false) return 'none';
-  if (reasoningEnabled === 'default') return undefined;
+  if (reasoningEnabled !== true) return 'none';
 
   const normalized = modelConfig.reasoningEffort?.trim().toLowerCase();
   if (
@@ -281,11 +303,12 @@ export const resolveCodexReasoningEffort = ({
     return normalized;
   }
 
-  return 'none';
+  return 'medium';
 };
 
 export const buildCodexTurnPayloadFromMessages = (
   messages: ChatCompletionMessageParam[],
+  imageDetailOverride?: CodexImageDetail,
 ): {
   developerInstructions?: string;
   input: CodexTurnInput[];
@@ -311,7 +334,7 @@ export const buildCodexTurnPayloadFromMessages = (
     }
 
     if (role === 'user') {
-      imageInputs.push(...extractImageInputs(message));
+      imageInputs.push(...extractImageInputs(message, imageDetailOverride));
     }
   }
 
@@ -399,6 +422,7 @@ class CodexAppServerConnection {
     onChunk,
     reasoningEnabled,
     abortSignal,
+    imageDetail,
   }: {
     messages: ChatCompletionMessageParam[];
     modelConfig: IModelConfig;
@@ -406,14 +430,17 @@ class CodexAppServerConnection {
     onChunk?: StreamingCallback;
     reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
+    imageDetail?: CodexImageDetail;
   }): Promise<CodexTurnResult> {
     const startTime = Date.now();
     const timeoutMs = modelConfig.timeout || CODEX_DEFAULT_TIMEOUT_MS;
     const deadlineAt = Date.now() + timeoutMs;
     const isStreaming = !!(stream && onChunk);
 
-    const { developerInstructions, input } =
-      buildCodexTurnPayloadFromMessages(messages);
+    const { developerInstructions, input } = buildCodexTurnPayloadFromMessages(
+      messages,
+      imageDetail,
+    );
     const effort = resolveCodexReasoningEffort({
       reasoningEnabled,
       modelConfig,
@@ -934,6 +961,7 @@ class CodexAppServerConnectionManager {
     onChunk,
     reasoningEnabled,
     abortSignal,
+    imageDetail,
   }: {
     messages: ChatCompletionMessageParam[];
     modelConfig: IModelConfig;
@@ -941,6 +969,7 @@ class CodexAppServerConnectionManager {
     onChunk?: StreamingCallback;
     reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
+    imageDetail?: CodexImageDetail;
   }): Promise<CodexTurnResult> {
     return this.runner.run(async () => {
       const connection = await this.getConnection();
@@ -952,6 +981,7 @@ class CodexAppServerConnectionManager {
           onChunk,
           reasoningEnabled,
           abortSignal,
+          imageDetail,
         });
       } catch (error) {
         if (connection.isClosed() || !isAbortError(error)) {
@@ -993,6 +1023,7 @@ export async function callAIWithCodexAppServer(
     onChunk?: StreamingCallback;
     reasoningEnabled?: TModelReasoningEnabled;
     abortSignal?: AbortSignal;
+    imageDetail?: CodexImageDetail;
   },
 ): Promise<CodexTurnResult> {
   if (ifInBrowser) {
@@ -1008,6 +1039,7 @@ export async function callAIWithCodexAppServer(
     onChunk: options?.onChunk,
     reasoningEnabled: options?.reasoningEnabled,
     abortSignal: options?.abortSignal,
+    imageDetail: options?.imageDetail,
   });
 }
 

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -349,6 +349,20 @@ export async function callAI(
   // across the onUsage callback and the task-dump-based collectUsageMetrics()
   // path when the provider does not return a request_id.
   const internalCallId = nextInternalCallId();
+  const chatCompletionInput = {
+    intent: modelConfig.intent,
+    userConfig: {
+      temperature: modelConfig.temperature,
+      reasoningEnabled: modelConfig.reasoningEnabled,
+      reasoningEffort: modelConfig.reasoningEffort,
+      reasoningBudget: modelConfig.reasoningBudget,
+      responseFormat: modelConfig.responseFormat,
+    },
+    requiresOriginalImageDetail: options?.requiresOriginalImageDetail,
+    expectedJsonObjectResponse: options?.expectedJsonObjectResponse,
+  };
+  const imageDetail =
+    adapter.chatCompletion.resolveImageDetail(chatCompletionInput);
 
   if (isCodexAppServerProvider(modelConfig.openaiBaseURL)) {
     const codexResult = await callAIWithCodexAppServer(messages, modelConfig, {
@@ -356,6 +370,7 @@ export async function callAI(
       onChunk: options?.onChunk,
       reasoningEnabled: modelConfig.reasoningEnabled,
       abortSignal: options?.abortSignal,
+      imageDetail,
     });
     if (codexResult.usage) {
       (codexResult.usage as any)[INTERNAL_CALL_ID_FIELD] = internalCallId;
@@ -387,18 +402,6 @@ export async function callAI(
   const startTime = Date.now();
 
   const isStreaming = options?.stream && options?.onChunk;
-  const chatCompletionInput = {
-    intent: modelConfig.intent,
-    userConfig: {
-      temperature: modelConfig.temperature,
-      reasoningEnabled: modelConfig.reasoningEnabled,
-      reasoningEffort: modelConfig.reasoningEffort,
-      reasoningBudget: modelConfig.reasoningBudget,
-      responseFormat: modelConfig.responseFormat,
-    },
-    requiresOriginalImageDetail: options?.requiresOriginalImageDetail,
-    expectedJsonObjectResponse: options?.expectedJsonObjectResponse,
-  };
   const { config: adapterChatCompletionParams } =
     adapter.chatCompletion.buildChatCompletionParams(chatCompletionInput);
   debugCall(
@@ -474,9 +477,6 @@ export async function callAI(
     ...(extraBody ?? {}),
   };
   const temperature = requestConfig.temperature;
-
-  const imageDetail =
-    adapter.chatCompletion.resolveImageDetail(chatCompletionInput);
 
   // Some adapters request original image detail to preserve screenshot
   // resolution for localization-sensitive tasks.

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -39,7 +39,7 @@ describe('codex app-server provider helper', () => {
         reasoningEnabled: true,
         modelConfig: baseModelConfig,
       }),
-    ).toBe('high');
+    ).toBe('medium');
 
     expect(
       resolveCodexReasoningEffort({
@@ -58,7 +58,7 @@ describe('codex app-server provider helper', () => {
           reasoningEffort: 'medium',
         },
       }),
-    ).toBe('medium');
+    ).toBe('none');
 
     expect(
       resolveCodexReasoningEffort({
@@ -67,7 +67,7 @@ describe('codex app-server provider helper', () => {
           reasoningEffort: 'minimal',
         },
       }),
-    ).toBe('minimal');
+    ).toBe('none');
 
     expect(
       resolveCodexReasoningEffort({
@@ -96,9 +96,12 @@ describe('codex app-server provider helper', () => {
     expect(
       resolveCodexReasoningEffort({
         reasoningEnabled: true,
-        modelConfig: baseModelConfig,
+        modelConfig: {
+          ...baseModelConfig,
+          reasoningEffort: 'xhigh',
+        },
       }),
-    ).toBe('high');
+    ).toBe('xhigh');
 
     expect(
       resolveCodexReasoningEffort({
@@ -125,7 +128,7 @@ describe('codex app-server provider helper', () => {
           reasoningEffort: 'medium',
         },
       }),
-    ).toBeUndefined();
+    ).toBe('none');
   });
 
   it('converts chat messages into codex turn payload', () => {
@@ -177,7 +180,7 @@ describe('codex app-server provider helper', () => {
     });
   });
 
-  it('does not include image detail in codex turn inputs', () => {
+  it('preserves image detail in codex turn inputs', () => {
     const messages: ChatCompletionMessageParam[] = [
       {
         role: 'user',
@@ -199,6 +202,32 @@ describe('codex app-server provider helper', () => {
     expect(payload.input).toContainEqual({
       type: 'image',
       url: 'https://example.com/img.png',
+      detail: 'high',
+    });
+  });
+
+  it('overrides image detail in codex turn inputs when required by adapter', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'file:///tmp/local-shot.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ];
+
+    const payload = buildCodexTurnPayloadFromMessages(messages, 'original');
+
+    expect(payload.input).toContainEqual({
+      type: 'localImage',
+      path: '/tmp/local-shot.png',
+      detail: 'original',
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve resolved image detail, including `original`, for Codex App Server image inputs
- align Codex reasoning enablement and default effort with the GPT adaptor
- remove the attempted generic `response_format` mapping because Codex App Server requires a strict JSON Schema and rejects `{ type: "object" }`
- link the GPT configuration docs to the Codex App Server OAuth setup and remove the obsolete image-detail limitation

## Root cause

Codex App Server accepts `outputSchema` as a strict JSON Schema, not Chat Completions `json_object` mode. The generic object schema was rejected by the backend because it lacks `additionalProperties: false`; adding that constraint would allow only an empty object and would not preserve Midscene's dynamic JSON output behavior.

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/codex-app-server-provider.test.ts`
- `pnpm run lint`