### PR TITLE
test(web-integration): stabilize todo e2e input text

### DIFF
--- a/packages/web-integration/tests/ai/web/playwright/ai-auto-todo.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/ai-auto-todo.spec.ts
@@ -45,7 +45,7 @@ test.describe('ai todo describe', () => {
     const expectedActiveTasks = [
       'Learn JS today',
       'Learn Rust tomorrow',
-      'Learning AI the day after tomorrow',
+      'Learning Midscene the day after tomorrow',
     ] as const;
 
     await ai('Type "Happy Birthday" in the task box, do NOT press Enter');
@@ -57,7 +57,7 @@ test.describe('ai todo describe', () => {
       'Type "Learn Rust tomorrow" in the task box, then press Enter to create',
     );
     await ai(
-      'Type "Learning AI the day after tomorrow" in the task box, then press Enter to create',
+      'Type "Learning Midscene the day after tomorrow" in the task box, then press Enter to create',
     );
 
     await expect(page.locator('.todo-list li label')).toHaveText(
@@ -71,7 +71,7 @@ test.describe('ai todo describe', () => {
     );
     expect(allTaskList).toContain('Learn JS today');
     expect(allTaskList).toContain('Learn Rust tomorrow');
-    expect(allTaskList).toContain('Learning AI the day after tomorrow');
+    expect(allTaskList).toContain('Learning Midscene the day after tomorrow');
 
     await ai(
       'Move your mouse over "Learn Rust tomorrow" in the task list to reveal the delete button',
@@ -79,19 +79,21 @@ test.describe('ai todo describe', () => {
     await ai(
       'Click the delete button (×) to the right of "Learn Rust tomorrow"',
     );
-    await ai('Click the checkbox next to "Learning AI the day after tomorrow"');
+    await ai(
+      'Click the checkbox next to "Learning Midscene the day after tomorrow"',
+    );
     await ai('Click the "Completed" status filter button below the task list');
 
     await expect(page.locator('.todo-list li label')).toHaveText([
-      'Learning AI the day after tomorrow',
+      'Learning Midscene the day after tomorrow',
     ]);
 
     const taskList = await queryVisibleTodoListWithRetry(
       aiQuery,
-      ['Learning AI the day after tomorrow'],
+      ['Learning Midscene the day after tomorrow'],
       'completedTaskList',
     );
-    expect(taskList).toContain('Learning AI the day after tomorrow');
+    expect(taskList).toContain('Learning Midscene the day after tomorrow');
 
     const placeholder = await aiQuery(
       'string, return the placeholder text in the input box',


### PR DESCRIPTION
## Summary

- replace the TodoMVC E2E task text `Learning AI...` with `Learning Midscene...` to avoid the recurring `AI` vs `Al` visual/input ambiguity
- keep the same TodoMVC creation, query, completion, and filter coverage

## Why

The failing CI run showed both `e2e (basic)` and `e2e:cache` failing because the task text was recorded as `Learning Al the day after tomorrow` while the assertion expected `Learning AI the day after tomorrow`. The abbreviation is not material to the test behavior and makes the assertion unnecessarily brittle.

## Validation

- `pnpm run lint`

`pnpm run lint` reports one existing warning under `.claude/worktrees/ecstatic-shtern-b56c94`, outside this change.