### PR TITLE
docs(web): document per-action progress callbacks

### DIFF
--- a/apps/site/docs/en/integrate-with-playwright.mdx
+++ b/apps/site/docs/en/integrate-with-playwright.mdx
@@ -101,6 +101,65 @@ Promise.resolve(
 
 For more Agent API details, please refer to [API Reference](./reference/#interaction-methods).
 
+### Track every atomic action
+
+An `aiAct()` call may run several atomic actions. Subscribe to the Agent progress
+stream to receive each action result while the call is still running. Async
+listeners are awaited before the next action starts, so the listener can capture
+the current page, persist debugging data, or push live progress to another
+service.
+
+```typescript
+import { mkdir } from 'node:fs/promises';
+import { chromium } from 'playwright';
+import {
+  isAiActProgressEvent,
+  PlaywrightAgent,
+} from '@midscene/web/playwright';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const agent = new PlaywrightAgent(page);
+await mkdir('artifacts', { recursive: true });
+
+let actionIndex = 0;
+const removeProgressListener = agent.addProgressListener(async (event) => {
+  if (
+    !isAiActProgressEvent(event) ||
+    (event.phase !== 'action_done' && event.phase !== 'action_failed')
+  ) {
+    return;
+  }
+
+  actionIndex += 1;
+  const screenshotPath = `artifacts/action-${actionIndex}-${event.phase}.png`;
+  await page.screenshot({ path: screenshotPath });
+
+  // Replace this with a WebSocket, SSE, or your own progress sink.
+  console.log({
+    actionIndex,
+    action: event.data.action?.name,
+    status: event.phase,
+    durationMs: event.data.durationMs,
+    error: event.data.error,
+    screenshotPath,
+  });
+});
+
+try {
+  await agent.aiAct('type "midscene" in the search box and click search');
+} finally {
+  removeProgressListener();
+  await browser.close();
+}
+```
+
+The listener receives progress from every `aiAct()` call on that Agent. Filter
+on `event.scope`, remove the listener when its owner is disposed, and keep the
+callback reasonably fast because execution waits for it. `action_failed` is
+emitted at the failure site, allowing the callback to preserve the current page
+before `aiAct()` rejects.
+
 ### Step 3: Run the script
 
 Use `tsx` to run, and you will see the product information printed in the terminal:

--- a/apps/site/docs/zh/integrate-with-playwright.mdx
+++ b/apps/site/docs/zh/integrate-with-playwright.mdx
@@ -101,6 +101,62 @@ Promise.resolve(
 
 更多 Agent 的 API 讲解请参考 [API 参考](./reference/#interaction-methods)。
 
+### 跟踪每一个原子动作
+
+一次 `aiAct()` 可能执行多个原子动作。订阅 Agent 进度流后，可以在本次
+调用尚未结束时逐个收到动作结果。异步监听器会在下一个动作开始前执行完毕，
+因此可以在回调中截取当前页面、保存排错数据，或向其他服务推送实时进度。
+
+```typescript
+import { mkdir } from 'node:fs/promises';
+import { chromium } from 'playwright';
+import {
+  isAiActProgressEvent,
+  PlaywrightAgent,
+} from '@midscene/web/playwright';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const agent = new PlaywrightAgent(page);
+await mkdir('artifacts', { recursive: true });
+
+let actionIndex = 0;
+const removeProgressListener = agent.addProgressListener(async (event) => {
+  if (
+    !isAiActProgressEvent(event) ||
+    (event.phase !== 'action_done' && event.phase !== 'action_failed')
+  ) {
+    return;
+  }
+
+  actionIndex += 1;
+  const screenshotPath = `artifacts/action-${actionIndex}-${event.phase}.png`;
+  await page.screenshot({ path: screenshotPath });
+
+  // 可替换为 WebSocket、SSE 或自己的进度接收服务。
+  console.log({
+    actionIndex,
+    action: event.data.action?.name,
+    status: event.phase,
+    durationMs: event.data.durationMs,
+    error: event.data.error,
+    screenshotPath,
+  });
+});
+
+try {
+  await agent.aiAct('在搜索框输入「midscene」并点击搜索');
+} finally {
+  removeProgressListener();
+  await browser.close();
+}
+```
+
+监听器会收到该 Agent 上所有 `aiAct()` 调用的进度，因此应按 `event.scope`
+筛选，并在所属对象销毁时移除监听器。由于执行流程会等待回调完成，回调应尽量
+简短。`action_failed` 会在失败现场触发，可以在 `aiAct()` 抛出异常前保留当前
+页面截图。
+
 ### 第三步：运行
 
 使用 `tsx` 来运行，你会看到命令行打印出了耳机的商品信息：

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
   type IGroupedActionDump,
   type ReportMeta,
   type GroupMeta,
+  isAiActProgressEvent,
 } from './types';
 
 export { z };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -479,6 +479,19 @@ export interface AiActProgressData {
 
 export const aiActProgressScope = 'aiAct';
 
+export type AiActProgressEvent = AgentProgressEvent<
+  typeof aiActProgressScope,
+  AiActProgressData,
+  AiActProgressPhase
+>;
+
+/** Narrow a generic agent progress event to the structured `aiAct` stream. */
+export function isAiActProgressEvent(
+  event: AgentProgressEvent,
+): event is AiActProgressEvent {
+  return event.scope === aiActProgressScope;
+}
+
 export interface ExecutionRecorderItem {
   type: 'screenshot';
   ts: number;

--- a/packages/core/tests/unit-test/agent-progress-bus.test.ts
+++ b/packages/core/tests/unit-test/agent-progress-bus.test.ts
@@ -1,8 +1,30 @@
 import { AgentProgressBus } from '@/agent/progress';
-import type { AgentProgressEvent } from '@/types';
+import { type AgentProgressEvent, isAiActProgressEvent } from '@/types';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('AgentProgressBus', () => {
+  it('narrows only events from the aiAct progress stream', () => {
+    const aiActEvent: AgentProgressEvent = {
+      scope: 'aiAct',
+      phase: 'action_done',
+      sequence: 1,
+      data: { action: { name: 'Tap' }, durationMs: 20 },
+    };
+    const queryEvent: AgentProgressEvent = {
+      scope: 'aiQuery',
+      phase: 'complete',
+      sequence: 2,
+      data: { output: 'Midscene' },
+    };
+
+    expect(isAiActProgressEvent(aiActEvent)).toBe(true);
+    if (isAiActProgressEvent(aiActEvent)) {
+      expect(aiActEvent.data.action?.name).toBe('Tap');
+      expect(aiActEvent.data.durationMs).toBe(20);
+    }
+    expect(isAiActProgressEvent(queryEvent)).toBe(false);
+  });
+
   it('wraps payloads in an envelope and stamps a monotonic sequence', async () => {
     const bus = new AgentProgressBus();
     const events: AgentProgressEvent[] = [];

--- a/packages/web-integration/src/index.ts
+++ b/packages/web-integration/src/index.ts
@@ -3,6 +3,13 @@ export type { PlayWrightAiFixtureType } from './playwright';
 
 export { Agent as PageAgent, type AgentOpt } from '@midscene/core/agent';
 export {
+  isAiActProgressEvent,
+  type AiActProgressData,
+  type AiActProgressEvent,
+  type AiActProgressPhase,
+  type AgentProgressEvent,
+} from '@midscene/core';
+export {
   PuppeteerAgent,
   PuppeteerPageAgent,
   PuppeteerBrowserAgent,

--- a/packages/web-integration/src/playwright/index.ts
+++ b/packages/web-integration/src/playwright/index.ts
@@ -4,6 +4,13 @@ export type {
 } from './ai-fixture';
 export { PlaywrightAiFixture } from './ai-fixture';
 export { overrideAIConfig } from '@midscene/shared/env';
+export {
+  isAiActProgressEvent,
+  type AiActProgressData,
+  type AiActProgressEvent,
+  type AiActProgressPhase,
+  type AgentProgressEvent,
+} from '@midscene/core';
 export { WebPage as PlaywrightWebPage } from './page';
 export type { WebPageAgentOpt } from '@/web-element';
 export { PlaywrightPageAgent, PlaywrightAgent } from './page-agent';


### PR DESCRIPTION
## Summary

- document how to observe each atomic `aiAct` action and capture a Playwright screenshot before execution continues
- add `AiActProgressEvent` and `isAiActProgressEvent()` so consumers can narrow the generic progress stream without `any` or unsafe casts
- re-export the progress types and guard from both `@midscene/web` and `@midscene/web/playwright`
- keep the English and Chinese Playwright guides in sync, including failure-site capture and listener cleanup

Closes #2794.

## Validation

- `pnpm exec nx test @midscene/core` (123 files, 1350 passed, 8 skipped)
- `pnpm --filter @midscene/core exec vitest --run tests/unit-test/agent-progress-bus.test.ts` (8 passed)
- `pnpm exec nx run-many --target=build --projects=@midscene/core,@midscene/web`
- `pnpm exec nx build doc` (including search metadata checks)
- repository install/prepare full build (27 projects)
- `biome check . --diagnostic-level=info --no-errors-on-unmatched --fix` (1386 files, clean)
- repository pre-commit `lint-staged` and commitlint hooks

## Notes

The progress listener is awaited by the existing progress bus. The documented callback therefore captures the page after `action_done` or at the `action_failed` failure site, before the next action begins or `aiAct()` rejects.