### PR TITLE
feat(android): add standalone accessibility XPath audit core

### DIFF
--- a/packages/android/src/accessibility-snapshot.ts
+++ b/packages/android/src/accessibility-snapshot.ts
@@ -1,0 +1,18 @@
+import type { UiNode } from '@midscene/core/internal/device-cache';
+
+export type AndroidAccessibilityTreeSource = 'yadb' | 'uiautomator';
+
+export interface AndroidAccessibilitySnapshot {
+  captureId: string;
+  capturedAt: string;
+  durationMs: number;
+  source: AndroidAccessibilityTreeSource;
+  sourceXml: string;
+  root: UiNode;
+  dpr: number;
+  rotation: number;
+  logicalSize: {
+    width: number;
+    height: number;
+  };
+}

--- a/packages/android/src/audit-metadata.ts
+++ b/packages/android/src/audit-metadata.ts
@@ -1,0 +1,197 @@
+import type { ADB } from 'appium-adb';
+
+/** Current on-disk schema for Android accessibility audit reports. */
+export const ANDROID_AUDIT_SCHEMA_VERSION = 2 as const;
+
+export type AndroidAuditReportKind = 'cli-capture' | 'playground-live';
+export type AndroidAuditTechnologyConfidence =
+  | 'confirmed'
+  | 'strong'
+  | 'suspected'
+  | 'unknown';
+
+export interface AndroidAuditTechnologyMetadata {
+  confidence: AndroidAuditTechnologyConfidence;
+  declaredStack: string;
+  evidence: string[];
+}
+
+export interface AndroidAuditEnvironment {
+  app: {
+    activity: string;
+    expectedPackage: string;
+    package: string;
+    versionCode: string;
+    versionName: string;
+  };
+  device: {
+    androidVersion: string;
+    apiLevel: string;
+    density: number;
+    dpr: number;
+    manufacturer: string;
+    model: string;
+    resolution: {
+      logical: { width: number; height: number };
+      override?: { width: number; height: number };
+      physical: { width: number; height: number };
+      screenshot: { width: number; height: number };
+    };
+    rotation: number;
+    serial: string;
+  };
+}
+
+export interface CollectAndroidAuditEnvironmentOptions {
+  deviceId: string;
+  expectedPackage?: string;
+  logicalSize?: { width: number; height: number };
+  rotation?: number;
+  screenshotSize: { width: number; height: number };
+}
+
+function parseWmDimension(
+  output: string,
+  label: 'Physical' | 'Override',
+): { width: number; height: number } | undefined {
+  const match = output.match(new RegExp(`${label} size:\\s*(\\d+)x(\\d+)`));
+  return match
+    ? {
+        width: Number.parseInt(match[1], 10),
+        height: Number.parseInt(match[2], 10),
+      }
+    : undefined;
+}
+
+async function requiredShellValue(
+  adb: ADB,
+  command: string,
+  label: string,
+): Promise<string> {
+  const value = (await adb.shell(command)).trim();
+  if (!value) throw new Error(`Unable to read ${label} with: ${command}`);
+  return value;
+}
+
+async function getRotation(adb: ADB): Promise<number> {
+  const input = await adb.shell('dumpsys input');
+  const inputMatch = input.match(/SurfaceOrientation:\s*(\d)/);
+  if (inputMatch) return Number.parseInt(inputMatch[1], 10);
+  const display = await adb.shell('dumpsys display');
+  const displayMatch = display.match(/mCurrentOrientation=(\d)/);
+  if (displayMatch) return Number.parseInt(displayMatch[1], 10);
+  throw new Error('Unable to determine Android display rotation');
+}
+
+async function getFocusedApp(adb: ADB): Promise<{
+  package: string;
+  activity: string;
+}> {
+  const activityDump = await adb.shell('dumpsys activity activities');
+  const activityLines = activityDump
+    .split(/\r?\n/)
+    .filter((line) =>
+      /mResumedActivity|topResumedActivity|ResumedActivity/.test(line),
+    );
+  const windowDump = await adb.shell('dumpsys window windows');
+  const windowLines = windowDump
+    .split(/\r?\n/)
+    .filter((line) => /mCurrentFocus|mFocusedApp/.test(line));
+  for (const line of [...activityLines, ...windowLines]) {
+    const match = line.match(/([A-Za-z0-9_.]+)\/([A-Za-z0-9_.$]+)/);
+    if (match) return { package: match[1], activity: match[2] };
+  }
+  throw new Error('Unable to determine the focused Android package/activity');
+}
+
+async function getAppVersion(
+  adb: ADB,
+  packageName: string,
+): Promise<{ versionName: string; versionCode: string }> {
+  if (!/^[A-Za-z0-9_.]+$/.test(packageName)) {
+    throw new Error(`Invalid Android package name: ${packageName}`);
+  }
+  const dump = await adb.shell(`dumpsys package ${packageName}`);
+  const versionName = dump.match(/\bversionName=([^\s]+)/)?.[1];
+  const versionCode = dump.match(/\bversionCode=(\d+)/)?.[1];
+  if (!versionName || !versionCode) {
+    throw new Error(`Unable to read installed version for ${packageName}`);
+  }
+  return { versionName, versionCode };
+}
+
+/**
+ * Collects the canonical device and foreground-app metadata shared by the
+ * command-line and Playground Android audit reports.
+ */
+export async function collectAndroidAuditEnvironment(
+  adb: ADB,
+  options: CollectAndroidAuditEnvironmentOptions,
+): Promise<AndroidAuditEnvironment> {
+  const [manufacturer, model, androidVersion, apiLevel, wmSize, focused] =
+    await Promise.all([
+      requiredShellValue(
+        adb,
+        'getprop ro.product.manufacturer',
+        'manufacturer',
+      ),
+      requiredShellValue(adb, 'getprop ro.product.model', 'model'),
+      requiredShellValue(
+        adb,
+        'getprop ro.build.version.release',
+        'Android version',
+      ),
+      requiredShellValue(
+        adb,
+        'getprop ro.build.version.sdk',
+        'Android API level',
+      ),
+      adb.shell('wm size'),
+      getFocusedApp(adb),
+    ]);
+  if (options.expectedPackage && focused.package !== options.expectedPackage) {
+    throw new Error(
+      `Focused package ${focused.package} does not match requested app ${options.expectedPackage}`,
+    );
+  }
+  const [densityValue, appVersion, rotation] = await Promise.all([
+    adb.getScreenDensity(),
+    getAppVersion(adb, focused.package),
+    options.rotation === undefined
+      ? getRotation(adb)
+      : Promise.resolve(options.rotation),
+  ]);
+  const density = densityValue ?? 160;
+  const dpr = density / 160;
+  const physical = parseWmDimension(wmSize, 'Physical') ??
+    parseWmDimension(wmSize, 'Override') ?? { ...options.screenshotSize };
+  const override = parseWmDimension(wmSize, 'Override');
+
+  return {
+    device: {
+      serial: options.deviceId,
+      manufacturer,
+      model,
+      androidVersion,
+      apiLevel,
+      resolution: {
+        physical,
+        ...(override ? { override } : {}),
+        logical: options.logicalSize ?? {
+          width: options.screenshotSize.width / dpr,
+          height: options.screenshotSize.height / dpr,
+        },
+        screenshot: options.screenshotSize,
+      },
+      density,
+      dpr,
+      rotation,
+    },
+    app: {
+      expectedPackage: options.expectedPackage ?? focused.package,
+      package: focused.package,
+      activity: focused.activity,
+      ...appVersion,
+    },
+  };
+}

--- a/packages/android/src/cache-policy.ts
+++ b/packages/android/src/cache-policy.ts
@@ -1,0 +1,28 @@
+import type { XpathCandidateOptions } from '@midscene/core/internal/device-cache';
+
+export const ANDROID_CACHE_EXCLUDED_TARGET_TYPES = [
+  'android.widget.GridView',
+  'android.widget.ListView',
+  'android.widget.ScrollView',
+  'android.widget.HorizontalScrollView',
+  'android.widget.RecyclerView',
+  'android.support.v7.widget.RecyclerView',
+  'androidx.recyclerview.widget.RecyclerView',
+  'android.support.v4.view.ViewPager',
+  'androidx.viewpager.widget.ViewPager',
+  'androidx.viewpager2.widget.ViewPager2',
+  'android.webkit.WebView',
+] as const;
+
+/**
+ * Android accessibility trees expose resource IDs when an app supplies them,
+ * followed by semantic accessibility descriptions and visible text. Keeping
+ * this policy in one module makes production replay and fixture validation use
+ * exactly the same candidate ranking.
+ */
+export const ANDROID_CACHE_CANDIDATE_OPTIONS: XpathCandidateOptions = {
+  excludedTargetTypes: ANDROID_CACHE_EXCLUDED_TARGET_TYPES,
+  stableAttrs: ['resource-id'],
+  textAttrs: ['content-desc', 'text'],
+  max: 3,
+};

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -36,6 +36,11 @@ import {
 } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import { normalizeForComparison, repeat } from '@midscene/shared/utils';
+import type {
+  AndroidAccessibilitySnapshot,
+  AndroidAccessibilityTreeSource,
+} from './accessibility-snapshot';
+import { uiautomatorXmlToUiNode } from './uiautomator-tree';
 
 import type { ADB } from 'appium-adb';
 import { createAndroidAdb } from './adb';
@@ -43,6 +48,10 @@ import {
   buildRunAdbShellPlanningFeedback,
   runAdbShellStdoutOrThrow,
 } from './adb-shell';
+import {
+  type AndroidAuditEnvironment,
+  collectAndroidAuditEnvironment,
+} from './audit-metadata';
 import {
   type DevicePhysicalInfo,
   ScrcpyDeviceAdapter,
@@ -61,12 +70,43 @@ const defaultScrollUntilTimes = 10;
 const defaultFastScrollDuration = 100;
 const defaultNormalScrollDuration = 1000;
 
+const ACCESSIBILITY_DUMP_ATTEMPTS = 3;
+const ACCESSIBILITY_DUMP_TIMEOUT_MS = 5_000;
+const ACCESSIBILITY_DUMP_RETRY_DELAY_MS = 250;
+const YADB_LAYOUT_PATH = '/data/local/tmp/midscene_yadb_layout_dump.xml';
+const UIAUTOMATOR_LAYOUT_PATH = '/sdcard/midscene_window_dump.xml';
+
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 
 const debugDevice = getDebug('android:device');
 const warnDevice = getDebug('android:device', { console: true });
+const debugAudit = getDebug('android:xpath-audit');
+
+interface AndroidAccessibilityDump {
+  capturedAt: string;
+  durationMs: number;
+  source: AndroidAccessibilityTreeSource;
+  xml: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validateHierarchyXml(
+  xml: unknown,
+  source: AndroidAccessibilityTreeSource,
+): asserts xml is string {
+  if (
+    typeof xml !== 'string' ||
+    !/<hierarchy(?:\s|>)/.test(xml) ||
+    !xml.includes('</hierarchy>')
+  ) {
+    throw new Error(`${source} did not produce valid hierarchy XML`);
+  }
+}
 
 /**
  * Escape text for safe use in shell single-quoted strings.
@@ -692,6 +732,124 @@ ${Object.keys(size)
       node: null,
       children: [],
     };
+  }
+
+  private async dumpAccessibilityXmlAttempt(
+    source: AndroidAccessibilityTreeSource,
+  ): Promise<string> {
+    const adb = await this.getAdb();
+    const path = source === 'yadb' ? YADB_LAYOUT_PATH : UIAUTOMATOR_LAYOUT_PATH;
+
+    if (source === 'yadb') {
+      await this.ensureYadb();
+    }
+
+    // Both tools can fail before replacing their destination. Removing it on
+    // every attempt prevents a previous application tree from being replayed.
+    await runAdbShellStdoutOrThrow(adb, `rm -f ${path}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const command =
+      source === 'yadb'
+        ? `app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -layout ${path}`
+        : `uiautomator dump --compressed ${path}`;
+    await runAdbShellStdoutOrThrow(adb, command, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    const xml = await runAdbShellStdoutOrThrow(adb, `cat ${path}`, {
+      timeout: ACCESSIBILITY_DUMP_TIMEOUT_MS,
+    });
+    validateHierarchyXml(xml, source);
+    return xml;
+  }
+
+  /**
+   * Read a fresh Android accessibility tree for XPath auditing. YADB's
+   * UiAutomation layout path avoids UIAutomator's wait-for-idle gate.
+   * UIAutomator remains a bounded fallback and the only source for non-default
+   * displays because YADB currently targets display 0.
+   */
+  private async dumpAccessibilityHierarchy(): Promise<AndroidAccessibilityDump> {
+    const sources: AndroidAccessibilityTreeSource[] =
+      (this.options?.displayId ?? 0) === 0
+        ? ['yadb', 'uiautomator']
+        : ['uiautomator'];
+    const failures: string[] = [];
+
+    for (const source of sources) {
+      for (let attempt = 1; attempt <= ACCESSIBILITY_DUMP_ATTEMPTS; attempt++) {
+        const startedAt = Date.now();
+        try {
+          const xml = await this.dumpAccessibilityXmlAttempt(source);
+          const capturedAt = new Date().toISOString();
+          const durationMs = Date.now() - startedAt;
+          debugAudit(
+            'tree source=%s attempt=%d durationMs=%d bytes=%d',
+            source,
+            attempt,
+            durationMs,
+            xml.length,
+          );
+          return { capturedAt, durationMs, source, xml };
+        } catch (error) {
+          const failure = `${source} attempt ${attempt}/${ACCESSIBILITY_DUMP_ATTEMPTS}: ${errorMessage(error)}`;
+          failures.push(failure);
+          debugAudit(
+            'tree miss source=%s attempt=%d durationMs=%d error=%s',
+            source,
+            attempt,
+            Date.now() - startedAt,
+            errorMessage(error),
+          );
+          if (attempt < ACCESSIBILITY_DUMP_ATTEMPTS) {
+            await sleep(ACCESSIBILITY_DUMP_RETRY_DELAY_MS);
+          }
+        }
+      }
+    }
+
+    throw new Error(
+      `Unable to read Android accessibility hierarchy after ${failures.length} attempt(s): ${failures.join('; ')}`,
+    );
+  }
+
+  /** Capture raw XML, normalized UiNode tree, and coordinate metadata. */
+  async captureAccessibilitySnapshot(): Promise<AndroidAccessibilitySnapshot> {
+    const captureStartedAt = Date.now();
+    await this.initializeDevicePixelRatio();
+    const dump = await this.dumpAccessibilityHierarchy();
+    const [logicalSize, screenInfo] = await Promise.all([
+      this.size(),
+      this.getScreenSize(),
+    ]);
+
+    return {
+      captureId: `${captureStartedAt.toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+      capturedAt: dump.capturedAt,
+      durationMs: Date.now() - captureStartedAt,
+      source: dump.source,
+      sourceXml: dump.xml,
+      root: uiautomatorXmlToUiNode(dump.xml, this.devicePixelRatio || 1),
+      dpr: this.devicePixelRatio || 1,
+      rotation: screenInfo.orientation,
+      logicalSize,
+    };
+  }
+
+  /** Collect device and foreground-app metadata for an accessibility audit. */
+  async captureAuditEnvironment(
+    snapshot: AndroidAccessibilitySnapshot,
+  ): Promise<AndroidAuditEnvironment> {
+    const adb = await this.getAdb();
+    return collectAndroidAuditEnvironment(adb, {
+      deviceId: this.deviceId,
+      logicalSize: snapshot.logicalSize,
+      rotation: snapshot.rotation,
+      screenshotSize: {
+        width: Math.round(snapshot.logicalSize.width * snapshot.dpr),
+        height: Math.round(snapshot.logicalSize.height * snapshot.dpr),
+      },
+    });
   }
 
   async getScreenSize(): Promise<{

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -1,4 +1,45 @@
 export { AndroidDevice } from './device';
+export {
+  ANDROID_AUDIT_SCHEMA_VERSION,
+  collectAndroidAuditEnvironment,
+} from './audit-metadata';
+export type {
+  AndroidAuditEnvironment,
+  AndroidAuditReportKind,
+  AndroidAuditTechnologyConfidence,
+  AndroidAuditTechnologyMetadata,
+  CollectAndroidAuditEnvironmentOptions,
+} from './audit-metadata';
+export type {
+  AndroidAccessibilitySnapshot,
+  AndroidAccessibilityTreeSource,
+} from './accessibility-snapshot';
+export {
+  ANDROID_AUDIT_STATUS_LABELS,
+  applyAndroidAuditReplayToSource,
+  buildAndroidAuditTree,
+  buildAndroidLiveTreeAudit,
+  buildAndroidVisualAudit,
+  enumerateAndroidUiTree,
+  getAndroidInteractionEvidence,
+} from './xpath-audit';
+export type {
+  AndroidAuditCandidateDiagnostic,
+  AndroidAuditEnumeratedNode,
+  AndroidAuditEnumeratedTree,
+  AndroidAuditOverlay,
+  AndroidAuditRectSource,
+  AndroidAuditReplaySummary,
+  AndroidAuditReplayOutcome,
+  AndroidAuditReplayResult,
+  AndroidAuditStatus,
+  AndroidAuditTreeNode,
+  AndroidAuditVisualElement,
+  AndroidAuditVisualElementInput,
+  AndroidInteractionEvidenceSource,
+  AndroidVisualAudit,
+  AndroidLiveTreeAudit,
+} from './xpath-audit';
 export { AndroidAgent, agentFromAdbDevice } from './agent';
 export type { AndroidAgentOpt } from './agent';
 export { AndroidMidsceneTools } from './agent-tools';

--- a/packages/android/src/uiautomator-tree.ts
+++ b/packages/android/src/uiautomator-tree.ts
@@ -1,0 +1,65 @@
+import {
+  type UiNode,
+  type XmlElement,
+  parseXml,
+} from '@midscene/core/internal/device-cache';
+
+const BOUNDS_RE = /^\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]$/;
+
+/**
+ * `uiautomator dump` emits bounds in **physical pixels**, formatted as
+ * "[x1,y1][x2,y2]". Midscene's cache pipeline operates in logical pixels
+ * (same space as the AI's locate result), so divide by the device pixel
+ * ratio when materializing UiNode bounds.
+ */
+function parseBounds(raw: string | undefined, dpr: number): UiNode['bounds'] {
+  if (!raw) return { left: 0, top: 0, width: 0, height: 0 };
+  const match = BOUNDS_RE.exec(raw);
+  if (!match) return { left: 0, top: 0, width: 0, height: 0 };
+  const x1 = Number.parseInt(match[1], 10);
+  const y1 = Number.parseInt(match[2], 10);
+  const x2 = Number.parseInt(match[3], 10);
+  const y2 = Number.parseInt(match[4], 10);
+  const safeDpr = dpr > 0 ? dpr : 1;
+  return {
+    left: x1 / safeDpr,
+    top: y1 / safeDpr,
+    width: Math.max(0, x2 - x1) / safeDpr,
+    height: Math.max(0, y2 - y1) / safeDpr,
+  };
+}
+
+function toUiNode(element: XmlElement, dpr: number): UiNode {
+  // The semantic "type" for an Android view is its `class` attribute
+  // (e.g. android.widget.Button) — the XML tag is always "node".
+  const attrs: Record<string, string> = {};
+  for (const [k, v] of Object.entries(element.attrs)) {
+    if (k === 'bounds') continue;
+    attrs[k] = v;
+  }
+  const type = element.attrs.class || element.name;
+  return {
+    type,
+    attrs,
+    bounds: parseBounds(element.attrs.bounds, dpr),
+    children: element.children.map((c) => toUiNode(c, dpr)),
+  };
+}
+
+/**
+ * Convert a `uiautomator dump` XML payload into the platform-neutral `UiNode`
+ * tree. `dpr` (device pixel ratio) is required because uiautomator emits
+ * physical pixels and the rest of Midscene operates in logical pixels.
+ *
+ * The root `<hierarchy>` element is unwrapped — most real trees have a single
+ * top-level `<node>` child which becomes our UiNode root. If `<hierarchy>`
+ * has multiple children (multi-window scenarios), we keep `<hierarchy>` as
+ * the synthetic root so all top-level windows are reachable.
+ */
+export function uiautomatorXmlToUiNode(xml: string, dpr: number): UiNode {
+  const root = parseXml(xml);
+  if (root.name === 'hierarchy' && root.children.length === 1) {
+    return toUiNode(root.children[0], dpr);
+  }
+  return toUiNode(root, dpr);
+}

--- a/packages/android/src/xpath-audit.ts
+++ b/packages/android/src/xpath-audit.ts
@@ -1,0 +1,1481 @@
+import type {
+  UiNode,
+  XpathCacheFeature,
+  XpathCandidateSource,
+} from '@midscene/core/internal/device-cache';
+import {
+  evaluateXpath,
+  generateXpathCacheFeature,
+  matchRectByXpathCache,
+} from '@midscene/core/internal/device-cache';
+import type { Rect, Size } from '@midscene/shared/types';
+import { ANDROID_CACHE_CANDIDATE_OPTIONS } from './cache-policy';
+
+export type AndroidAuditStatus =
+  | 'cache-xpath-hit'
+  | 'tree-only-positional'
+  | 'exposed-no-safe-xpath'
+  | 'not-exposed'
+  | 'point-selected-other'
+  | 'pending';
+
+/** English labels shared by live and saved Android audit presentations. */
+export const ANDROID_AUDIT_STATUS_LABELS: Record<AndroidAuditStatus, string> = {
+  'cache-xpath-hit': 'Cache XPath Hit',
+  'tree-only-positional': 'Structural XPath Only',
+  'exposed-no-safe-xpath': 'Exposed Without Safe XPath',
+  'not-exposed': 'Not Exposed in Tree',
+  'point-selected-other': 'Point Selected Another Node',
+  pending: 'Awaiting Fresh Validation',
+};
+
+export type AndroidAuditRectSource = 'tree' | 'ai' | 'manual' | 'adjusted';
+
+export type AndroidInteractionEvidenceSource =
+  | 'accessibility-flag'
+  | 'click-action'
+  | 'web-role'
+  | 'clickable-score'
+  | 'target-url';
+
+export interface AndroidAuditCandidateDiagnostic {
+  matchCount: number;
+  selectsNode: boolean;
+  source?: XpathCandidateSource;
+  xpath: string;
+}
+
+export interface AndroidAuditTreeNode {
+  attrs: Record<string, string | undefined>;
+  bounds: Rect;
+  cacheFeature?: XpathCacheFeature;
+  cacheFeatureXpaths: string[];
+  cacheFeatureXpathSources: XpathCandidateSource[];
+  cacheSelectedNodeId?: string;
+  candidateDiagnostics: AndroidAuditCandidateDiagnostic[];
+  center: { x: number; y: number };
+  childIndex: number;
+  cacheSelectedOther: boolean;
+  depth: number;
+  failureReason?: string;
+  interactive: boolean;
+  interactionEvidence: AndroidInteractionEvidenceSource[];
+  nodeId: string;
+  parentNodeId: string | null;
+  replayVerified: boolean;
+  sourceUnique: boolean;
+  structuralXpath: string;
+  type: string;
+  typeSiblingIndex: number;
+  visible: boolean;
+}
+
+export interface AndroidAuditOverlay {
+  description: string;
+  name: string;
+  nodeId: string | null;
+  rect: Rect;
+  rectSource: AndroidAuditRectSource;
+  status: AndroidAuditStatus;
+  statusReason?: string;
+  visualElementId?: string;
+}
+
+export interface AndroidAuditVisualElementInput {
+  description: string;
+  id: string;
+  name: string;
+  rect: Rect;
+  rectSource: Exclude<AndroidAuditRectSource, 'tree'>;
+}
+
+export interface AndroidAuditVisualElement
+  extends AndroidAuditVisualElementInput {
+  cacheFeature?: XpathCacheFeature;
+  cacheFeatureXpaths: string[];
+  cacheFeatureXpathSources: XpathCandidateSource[];
+  candidateDiagnostics: AndroidAuditCandidateDiagnostic[];
+  mappedNodeId: string | null;
+  point: { x: number; y: number };
+  productionSelectedNodeId?: string;
+  sourceUnique: boolean;
+  status: AndroidAuditStatus;
+  statusReason?: string;
+  structuralXpath?: string;
+}
+
+export interface AndroidVisualAudit {
+  overlays: AndroidAuditOverlay[];
+  visualElements: AndroidAuditVisualElement[];
+}
+
+export interface AndroidAuditReplaySummary {
+  attempted: number;
+  hits: number;
+  misses: number;
+  wrongMappings: number;
+}
+
+export type AndroidAuditReplayOutcome = 'hit' | 'miss' | 'wrong-mapping';
+
+export interface AndroidAuditReplayResult {
+  failureReason?: string;
+  matchedNodeId?: string;
+  outcome: AndroidAuditReplayOutcome;
+  sourceNodeId: string;
+  xpath?: string;
+  xpathSource?: XpathCandidateSource;
+}
+
+export interface AndroidLiveTreeAudit {
+  overlays: AndroidAuditOverlay[];
+  replay: AndroidAuditReplaySummary;
+  replayResults: AndroidAuditReplayResult[];
+  treeNodes: AndroidAuditTreeNode[];
+}
+
+const ANDROID_SYSTEM_BAR_RESOURCE_IDS = new Set([
+  'android:id/navigationBarBackground',
+  'android:id/statusBarBackground',
+]);
+const MAX_VISUAL_MAPPING_NODE_AREA_RATIO = 12;
+const MAX_SEMANTIC_CONTAINER_AREA_RATIO = 24;
+const MAX_NEARBY_VISUAL_DISTANCE = 24;
+const MAX_TREE_ID_AREA_RATIO = 0.25;
+const MAX_TREE_DIRECT_AREA_RATIO = 0.25;
+const MAX_TREE_TEXT_IMAGE_AREA_RATIO = 0.2;
+const MAX_TREE_MULTI_TEXT_AREA_RATIO = 0.12;
+const MAX_TREE_STRUCTURAL_AREA_RATIO = 0.3;
+const MIN_TREE_STRUCTURAL_COVERAGE_RATIO = 0.8;
+const MAX_TREE_STRUCTURAL_OVERLAP_RATIO = 1.1;
+const MAX_ADJACENT_IMAGE_SIZE = 20;
+const CACHE_XPATH_HIT_REASON =
+  'The cache XPath from the previous capture uniquely matched the same identity in the current tree';
+
+export interface AndroidAuditEnumeratedNode {
+  childIndex: number;
+  depth: number;
+  node: UiNode;
+  nodeId: string;
+  parent: UiNode | null;
+  parentNodeId: string | null;
+  structuralXpath: string;
+  typeSiblingIndex: number;
+}
+
+export interface AndroidAuditEnumeratedTree {
+  idByNode: Map<UiNode, string>;
+  nodeById: Map<string, UiNode>;
+  nodes: AndroidAuditEnumeratedNode[];
+}
+
+function xpathTag(type: string): string {
+  return /^[A-Za-z_*][A-Za-z0-9_.\-:*]*$/.test(type) ? type : '*';
+}
+
+export function enumerateAndroidUiTree(
+  root: UiNode,
+): AndroidAuditEnumeratedTree {
+  const nodes: AndroidAuditEnumeratedNode[] = [];
+  const nodeById = new Map<string, UiNode>();
+  const idByNode = new Map<UiNode, string>();
+  let sequence = 0;
+
+  const visit = (
+    node: UiNode,
+    parent: UiNode | null,
+    parentNodeId: string | null,
+    depth: number,
+    childIndex: number,
+    parentXpath: string,
+  ) => {
+    sequence++;
+    const nodeId = `node-${String(sequence).padStart(4, '0')}`;
+    const tag = xpathTag(node.type);
+    const siblings = parent?.children ?? [node];
+    let typeSiblingIndex = 0;
+    for (const sibling of siblings) {
+      if (tag === '*' || sibling.type === node.type) typeSiblingIndex++;
+      if (sibling === node) break;
+    }
+    const structuralXpath = `${parentXpath}/${tag}[${typeSiblingIndex}]`;
+    nodes.push({
+      childIndex,
+      depth,
+      node,
+      nodeId,
+      parent,
+      parentNodeId,
+      structuralXpath,
+      typeSiblingIndex,
+    });
+    nodeById.set(nodeId, node);
+    idByNode.set(node, nodeId);
+    node.children.forEach((child, index) =>
+      visit(child, node, nodeId, depth + 1, index, structuralXpath),
+    );
+  };
+
+  visit(root, null, null, 0, 0, '');
+  return { idByNode, nodeById, nodes };
+}
+
+function attrIsTrue(value: string | undefined): boolean {
+  return value === 'true';
+}
+
+const INTERACTIVE_WEB_ROLES = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'treeitem',
+]);
+
+function firstAttr(node: UiNode, names: string[]): string | undefined {
+  return names
+    .map((name) => node.attrs[name]?.trim())
+    .find((value): value is string => Boolean(value));
+}
+
+function hasClickAction(node: UiNode): boolean {
+  const actions = firstAttr(node, [
+    'actions',
+    'action-list',
+    'accessibility-actions',
+  ]);
+  if (!actions) return false;
+  return actions
+    .split(/[\s,|;]+/)
+    .some((action) => /^(?:16|action[_-]?click|click)$/i.test(action));
+}
+
+function hasInteractiveWebRole(node: UiNode): boolean {
+  const role = firstAttr(node, [
+    'chrome-role',
+    'chromeRole',
+    'role',
+    'role-description',
+    'roleDescription',
+  ]);
+  if (!role) return false;
+  const normalized = role.toLowerCase().replace(/[\s_-]+/g, '');
+  return (
+    INTERACTIVE_WEB_ROLES.has(normalized) ||
+    /(?:按钮|链接|复选框|单选框|开关|输入框|选项卡)$/.test(role)
+  );
+}
+
+function hasPositiveClickableScore(node: UiNode): boolean {
+  const score = firstAttr(node, [
+    'clickable-score',
+    'clickableScore',
+    'chrome-clickable-score',
+  ]);
+  if (!score) return false;
+  const numericScore = Number(score);
+  return Number.isFinite(numericScore) && numericScore > 0;
+}
+
+export function getAndroidInteractionEvidence(
+  node: UiNode,
+): AndroidInteractionEvidenceSource[] {
+  const evidence: AndroidInteractionEvidenceSource[] = [];
+  const hasAccessibilityFlag = [
+    'clickable',
+    'long-clickable',
+    'focusable',
+    'scrollable',
+    'checkable',
+    'editable',
+  ].some((attr) => attrIsTrue(node.attrs[attr]));
+  if (hasAccessibilityFlag) evidence.push('accessibility-flag');
+  if (hasClickAction(node)) evidence.push('click-action');
+  if (hasInteractiveWebRole(node)) evidence.push('web-role');
+  if (hasPositiveClickableScore(node)) evidence.push('clickable-score');
+  if (
+    firstAttr(node, ['target-url', 'targetUrl', 'chrome-target-url', 'url'])
+  ) {
+    evidence.push('target-url');
+  }
+  return evidence;
+}
+
+function isVisible(rect: Rect, viewport: Rect): boolean {
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    rect.left < viewport.width &&
+    rect.top < viewport.height &&
+    rect.left + rect.width > 0 &&
+    rect.top + rect.height > 0
+  );
+}
+
+function identityDescription(node: UiNode): string {
+  return [
+    node.attrs['resource-id'],
+    node.attrs['content-desc'],
+    node.attrs.text,
+    node.type,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(' ');
+}
+
+function displayName(node: UiNode): string {
+  const ownName = node.attrs.text || node.attrs['content-desc'];
+  if (ownName) return ownName;
+
+  const descendantNames: string[] = [];
+  const collectNames = (current: UiNode): void => {
+    for (const child of current.children) {
+      const name = child.attrs.text || child.attrs['content-desc'];
+      if (name && !descendantNames.includes(name)) {
+        descendantNames.push(name);
+      }
+      if (descendantNames.length < 2) collectNames(child);
+    }
+  };
+  collectNames(node);
+  return (
+    descendantNames.slice(0, 2).join(' · ') ||
+    node.attrs['resource-id'] ||
+    node.type
+  );
+}
+
+function hasIdentity(node: UiNode): boolean {
+  return ['resource-id', 'content-desc', 'text'].some((attr) =>
+    Boolean(node.attrs[attr]),
+  );
+}
+
+function pointInRect(point: { x: number; y: number }, rect: Rect): boolean {
+  return (
+    point.x >= rect.left &&
+    point.x <= rect.left + rect.width &&
+    point.y >= rect.top &&
+    point.y <= rect.top + rect.height
+  );
+}
+
+function intersectionArea(a: Rect, b: Rect): number {
+  const left = Math.max(a.left, b.left);
+  const top = Math.max(a.top, b.top);
+  const right = Math.min(a.left + a.width, b.left + b.width);
+  const bottom = Math.min(a.top + a.height, b.top + b.height);
+  return Math.max(0, right - left) * Math.max(0, bottom - top);
+}
+
+function rectArea(rect: Rect): number {
+  return rect.width * rect.height;
+}
+
+function rectDistance(a: Rect, b: Rect): number {
+  const horizontalGap = Math.max(
+    0,
+    Math.max(a.left, b.left) - Math.min(a.left + a.width, b.left + b.width),
+  );
+  const verticalGap = Math.max(
+    0,
+    Math.max(a.top, b.top) - Math.min(a.top + a.height, b.top + b.height),
+  );
+  return Math.hypot(horizontalGap, verticalGap);
+}
+
+function isAndroidSystemBar(node: AndroidAuditTreeNode): boolean {
+  return ANDROID_SYSTEM_BAR_RESOURCE_IDS.has(node.attrs['resource-id'] ?? '');
+}
+
+function hasDirectInteractionSemantics(node: AndroidAuditTreeNode): boolean {
+  const hasDescribedFocusTarget =
+    attrIsTrue(node.attrs.focusable) &&
+    Boolean(node.attrs.text || node.attrs['content-desc']);
+  return (
+    node.type.endsWith('.Button') ||
+    ['clickable', 'long-clickable', 'checkable', 'editable'].some((attr) =>
+      attrIsTrue(node.attrs[attr]),
+    ) ||
+    hasDescribedFocusTarget ||
+    node.interactionEvidence.some(
+      (evidence) => evidence !== 'accessibility-flag',
+    )
+  );
+}
+
+function hasTreeText(node: AndroidAuditTreeNode): boolean {
+  return Boolean(node.attrs.text || node.attrs['content-desc']);
+}
+
+function hasTreeResourceId(node: AndroidAuditTreeNode): boolean {
+  return Boolean(node.attrs['resource-id']?.trim());
+}
+
+function isTreeImage(node: AndroidAuditTreeNode): boolean {
+  return /\.(?:Image|ImageView)$/.test(node.type);
+}
+
+interface TreeSubtreeStats {
+  images: number;
+  resourceIds: number;
+  texts: number;
+}
+
+function selectTreeOverlayNodes(
+  nodes: AndroidAuditTreeNode[],
+  logicalSize: Size,
+): AndroidAuditTreeNode[] {
+  const nodeById = new Map(nodes.map((node) => [node.nodeId, node]));
+  const childrenById = new Map<string, AndroidAuditTreeNode[]>();
+  for (const node of nodes) {
+    if (!node.parentNodeId) continue;
+    const siblings = childrenById.get(node.parentNodeId) ?? [];
+    siblings.push(node);
+    childrenById.set(node.parentNodeId, siblings);
+  }
+
+  const subtreeStats = new Map<string, TreeSubtreeStats>();
+  const statsFor = (node: AndroidAuditTreeNode): TreeSubtreeStats => {
+    const cached = subtreeStats.get(node.nodeId);
+    if (cached) return cached;
+    const stats = {
+      images: isTreeImage(node) ? 1 : 0,
+      resourceIds: hasTreeResourceId(node) ? 1 : 0,
+      texts: hasTreeText(node) ? 1 : 0,
+    };
+    for (const child of childrenById.get(node.nodeId) ?? []) {
+      const childStats = statsFor(child);
+      stats.images += childStats.images;
+      stats.resourceIds += childStats.resourceIds;
+      stats.texts += childStats.texts;
+    }
+    subtreeStats.set(node.nodeId, stats);
+    return stats;
+  };
+
+  const isInsideWebView = (node: AndroidAuditTreeNode): boolean => {
+    let current: AndroidAuditTreeNode | undefined = node;
+    while (current) {
+      if (current.type.toLowerCase().includes('webview')) return true;
+      current = current.parentNodeId
+        ? nodeById.get(current.parentNodeId)
+        : undefined;
+    }
+    return false;
+  };
+
+  const visibleImages = nodes.filter(
+    (node) => node.visible && isTreeImage(node) && isInsideWebView(node),
+  );
+  const hasAdjacentSmallImage = (node: AndroidAuditTreeNode): boolean => {
+    if (!hasTreeText(node)) return false;
+    const right = node.bounds.left + node.bounds.width;
+    return visibleImages.some((image) => {
+      const horizontalGap = image.bounds.left - right;
+      const verticalOverlap = Math.max(
+        0,
+        Math.min(
+          node.bounds.top + node.bounds.height,
+          image.bounds.top + image.bounds.height,
+        ) - Math.max(node.bounds.top, image.bounds.top),
+      );
+      return (
+        image.bounds.width <= MAX_ADJACENT_IMAGE_SIZE &&
+        image.bounds.height <= MAX_ADJACENT_IMAGE_SIZE &&
+        horizontalGap >= -10 &&
+        horizontalGap <= MAX_NEARBY_VISUAL_DISTANCE &&
+        verticalOverlap >=
+          Math.min(node.bounds.height, image.bounds.height) * 0.3
+      );
+    });
+  };
+
+  const isImageClusterLeaf = (node: AndroidAuditTreeNode): boolean => {
+    if (!isTreeImage(node) || !node.parentNodeId) return false;
+    const parent = nodeById.get(node.parentNodeId);
+    const grandparent = parent?.parentNodeId
+      ? nodeById.get(parent.parentNodeId)
+      : undefined;
+    if (
+      !parent ||
+      !grandparent ||
+      rectArea(parent.bounds) > rectArea(node.bounds) * 1.6
+    ) {
+      return false;
+    }
+    const imageOnlySiblings = (
+      childrenById.get(grandparent.nodeId) ?? []
+    ).filter((sibling) => {
+      const stats = statsFor(sibling);
+      return (
+        stats.images > 0 &&
+        stats.texts === 0 &&
+        rectArea(sibling.bounds) <= rectArea(node.bounds) * 2
+      );
+    });
+    return imageOnlySiblings.length >= 2;
+  };
+
+  const viewportArea = logicalSize.width * logicalSize.height;
+  const supportsUnnamedVirtualStructure =
+    !nodes.some((node) => node.type.toLowerCase().includes('webview')) &&
+    nodes.some(
+      (node) =>
+        node.visible &&
+        node.type.endsWith('.ViewGroup') &&
+        attrIsTrue(node.attrs.focusable) &&
+        !attrIsTrue(node.attrs.clickable) &&
+        hasTreeText(node),
+    );
+
+  const shouldUseStructuralBoundary = (
+    node: AndroidAuditTreeNode,
+    childUnits: AndroidAuditTreeNode[],
+    areaRatio: number,
+  ): boolean => {
+    if (
+      !supportsUnnamedVirtualStructure ||
+      node.type !== 'android.view.ViewGroup' ||
+      node.bounds.width < 24 ||
+      node.bounds.height < 12 ||
+      areaRatio > MAX_TREE_STRUCTURAL_AREA_RATIO
+    ) {
+      return false;
+    }
+    const nodeArea = rectArea(node.bounds);
+    const childCoverageRatio =
+      childUnits.reduce(
+        (coveredArea, child) =>
+          coveredArea + intersectionArea(node.bounds, child.bounds),
+        0,
+      ) / nodeArea;
+    return (
+      childCoverageRatio < MIN_TREE_STRUCTURAL_COVERAGE_RATIO ||
+      childCoverageRatio > MAX_TREE_STRUCTURAL_OVERLAP_RATIO
+    );
+  };
+
+  const isDirectBoundary = (
+    node: AndroidAuditTreeNode,
+    insideWebView: boolean,
+    areaRatio: number,
+  ): boolean => {
+    const weakWebViewTextInteraction =
+      insideWebView &&
+      node.type.endsWith('.TextView') &&
+      node.interactionEvidence.length > 0 &&
+      node.interactionEvidence.every(
+        (evidence) => evidence === 'accessibility-flag',
+      );
+    return (
+      hasDirectInteractionSemantics(node) &&
+      !weakWebViewTextInteraction &&
+      (node.type.endsWith('.Button') || areaRatio <= MAX_TREE_DIRECT_AREA_RATIO)
+    );
+  };
+
+  const isStableIdBoundary = (
+    node: AndroidAuditTreeNode,
+    insideWebView: boolean,
+    areaRatio: number,
+  ): boolean =>
+    insideWebView &&
+    hasTreeResourceId(node) &&
+    areaRatio <= MAX_TREE_ID_AREA_RATIO &&
+    !node.attrs['resource-id']?.startsWith('android:id/');
+
+  const isCompositeBoundary = (
+    node: AndroidAuditTreeNode,
+    insideWebView: boolean,
+    areaRatio: number,
+  ): boolean => {
+    if (
+      !insideWebView ||
+      node.type.endsWith('.TextView') ||
+      isTreeImage(node) ||
+      node.bounds.width < 24 ||
+      node.bounds.height < 12
+    ) {
+      return false;
+    }
+    const stats = statsFor(node);
+    return (
+      (areaRatio <= MAX_TREE_TEXT_IMAGE_AREA_RATIO &&
+        stats.texts >= 1 &&
+        stats.images >= 1) ||
+      (areaRatio <= MAX_TREE_MULTI_TEXT_AREA_RATIO &&
+        stats.texts >= 2 &&
+        (childrenById.get(node.nodeId)?.length ?? 0) >= 2)
+    );
+  };
+
+  const contributesContentOutside = (
+    parent: AndroidAuditTreeNode,
+    child: AndroidAuditTreeNode,
+  ): boolean => {
+    const parentStats = statsFor(parent);
+    const childStats = statsFor(child);
+    return (
+      parentStats.images > childStats.images ||
+      parentStats.resourceIds > childStats.resourceIds ||
+      parentStats.texts > childStats.texts
+    );
+  };
+
+  interface MinimalUnitSelection {
+    hasIndependentBoundary: boolean;
+    // Preserve sibling units exposed by a nested stable container.
+    splitStableBoundary: boolean;
+    units: AndroidAuditTreeNode[];
+  }
+
+  const selectMinimalUnits = (
+    node: AndroidAuditTreeNode,
+  ): MinimalUnitSelection => {
+    const childBranches = (childrenById.get(node.nodeId) ?? []).map(
+      (child) => ({ child, selection: selectMinimalUnits(child) }),
+    );
+    const activeBranches = childBranches.filter(
+      ({ selection }) => selection.units.length > 0,
+    );
+    const childSelection = {
+      hasIndependentBoundary: activeBranches.some(
+        ({ selection }) => selection.hasIndependentBoundary,
+      ),
+      splitStableBoundary: activeBranches.some(
+        ({ selection }) => selection.splitStableBoundary,
+      ),
+      units: activeBranches.flatMap(({ selection }) => selection.units),
+    };
+    if (!node.visible || isAndroidSystemBar(node)) return childSelection;
+
+    const insideWebView = isInsideWebView(node);
+    const areaRatio = rectArea(node.bounds) / viewportArea;
+    if (isDirectBoundary(node, insideWebView, areaRatio)) {
+      return {
+        hasIndependentBoundary: true,
+        splitStableBoundary: false,
+        units: [node],
+      };
+    }
+    if (shouldUseStructuralBoundary(node, childSelection.units, areaRatio)) {
+      return {
+        hasIndependentBoundary: false,
+        splitStableBoundary: false,
+        units: [node],
+      };
+    }
+    if (!insideWebView) return childSelection;
+
+    const stableIdBoundary = isStableIdBoundary(node, insideWebView, areaRatio);
+    const compositeBoundary = isCompositeBoundary(
+      node,
+      insideWebView,
+      areaRatio,
+    );
+    const adjacentImageBoundary = hasAdjacentSmallImage(node);
+    const imageClusterBoundary = isImageClusterLeaf(node);
+    if (
+      !stableIdBoundary &&
+      !compositeBoundary &&
+      !adjacentImageBoundary &&
+      !imageClusterBoundary
+    ) {
+      return childSelection;
+    }
+
+    const independentBranches = activeBranches.filter(
+      ({ selection }) => selection.hasIndependentBoundary,
+    ).length;
+    if (stableIdBoundary) {
+      if (
+        independentBranches >= 2 ||
+        (activeBranches.length === 1 &&
+          activeBranches[0].selection.splitStableBoundary)
+      ) {
+        return {
+          ...childSelection,
+          splitStableBoundary: true,
+        };
+      }
+      return {
+        hasIndependentBoundary: true,
+        splitStableBoundary: false,
+        units: [node],
+      };
+    }
+    if (compositeBoundary) {
+      if (activeBranches.length >= 2) return childSelection;
+      if (
+        activeBranches.length === 1 &&
+        !contributesContentOutside(node, activeBranches[0].child)
+      ) {
+        return childSelection;
+      }
+      return {
+        hasIndependentBoundary: childSelection.hasIndependentBoundary,
+        splitStableBoundary: false,
+        units: [node],
+      };
+    }
+    return {
+      hasIndependentBoundary: imageClusterBoundary,
+      splitStableBoundary: false,
+      units: [node],
+    };
+  };
+
+  const primaryUnits = nodes
+    .filter((node) => !node.parentNodeId)
+    .flatMap((node) => selectMinimalUnits(node).units);
+  if (!supportsUnnamedVirtualStructure) return primaryUnits;
+
+  const isUnnamedStructuralUnit = (node: AndroidAuditTreeNode): boolean =>
+    !hasTreeText(node) &&
+    !hasTreeResourceId(node) &&
+    !hasDirectInteractionSemantics(node);
+  const isDetailType = (node: AndroidAuditTreeNode): boolean =>
+    /\.(?:ViewGroup|View|Image|ImageView|TextView|Button)$/.test(node.type);
+  const rectKey = (node: AndroidAuditTreeNode): string =>
+    [node.bounds.left, node.bounds.top, node.bounds.width, node.bounds.height]
+      .map((value) => value.toFixed(3))
+      .join(':');
+  const detailPriority = (node: AndroidAuditTreeNode): number =>
+    (hasTreeText(node) || hasTreeResourceId(node) ? 2 : 0) +
+    (hasDirectInteractionSemantics(node) ? 2 : 0) +
+    node.depth / 1000;
+
+  const structuralDetailsFor = (
+    unit: AndroidAuditTreeNode,
+  ): AndroidAuditTreeNode[] => {
+    const detailsByRect = new Map<string, AndroidAuditTreeNode>();
+    const visit = (node: AndroidAuditTreeNode, relativeDepth: number): void => {
+      for (const child of childrenById.get(node.nodeId) ?? []) {
+        if (!child.visible || isAndroidSystemBar(child)) continue;
+        const childArea = rectArea(child.bounds);
+        if (
+          relativeDepth <= 4 &&
+          isDetailType(child) &&
+          child.bounds.width >= 8 &&
+          child.bounds.height >= 4 &&
+          childArea < rectArea(unit.bounds) * 0.98
+        ) {
+          const key = rectKey(child);
+          const existing = detailsByRect.get(key);
+          if (!existing || detailPriority(child) > detailPriority(existing)) {
+            detailsByRect.set(key, child);
+          }
+        }
+        if (relativeDepth < 4) visit(child, relativeDepth + 1);
+      }
+    };
+    visit(unit, 1);
+    return [...detailsByRect.values()];
+  };
+
+  const expandedUnits: AndroidAuditTreeNode[] = [];
+  const expandedNodeIds = new Set<string>();
+  for (const unit of primaryUnits) {
+    const expanded = [
+      unit,
+      ...(isUnnamedStructuralUnit(unit) ? structuralDetailsFor(unit) : []),
+    ];
+    for (const node of expanded) {
+      if (expandedNodeIds.has(node.nodeId)) continue;
+      expandedNodeIds.add(node.nodeId);
+      expandedUnits.push(node);
+    }
+  }
+  return expandedUnits;
+}
+
+function visualGeometryScore(
+  visualRect: Rect,
+  point: { x: number; y: number },
+  node: AndroidAuditTreeNode,
+): number {
+  const visualArea = rectArea(visualRect);
+  const nodeArea = rectArea(node.bounds);
+  if (
+    visualArea <= 0 ||
+    nodeArea <= 0 ||
+    nodeArea > visualArea * MAX_SEMANTIC_CONTAINER_AREA_RATIO
+  ) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  const distance = rectDistance(visualRect, node.bounds);
+  if (
+    intersectionArea(visualRect, node.bounds) <= 0 &&
+    distance > MAX_NEARBY_VISUAL_DISTANCE
+  ) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  const overlap = intersectionArea(visualRect, node.bounds);
+  const overlapRatio = overlap / Math.max(1, Math.min(visualArea, nodeArea));
+  const areaSimilarity =
+    Math.min(visualArea, nodeArea) / Math.max(visualArea, nodeArea);
+  const axisSimilarity =
+    (Math.min(visualRect.width, node.bounds.width) /
+      Math.max(visualRect.width, node.bounds.width) +
+      Math.min(visualRect.height, node.bounds.height) /
+        Math.max(visualRect.height, node.bounds.height)) /
+    2;
+  return (
+    overlapRatio * 100 +
+    areaSimilarity * 120 +
+    axisSimilarity * 80 +
+    (pointInRect(point, node.bounds) ? 20 : 0) -
+    distance * 4 +
+    node.depth * 0.01
+  );
+}
+
+function visualMappingScore(
+  visualRect: Rect,
+  point: { x: number; y: number },
+  node: AndroidAuditTreeNode,
+): number {
+  const overlap = intersectionArea(visualRect, node.bounds);
+  if (overlap <= 0) return Number.NEGATIVE_INFINITY;
+  const visualArea = visualRect.width * visualRect.height;
+  const nodeArea = node.bounds.width * node.bounds.height;
+  const overlapRatio = overlap / Math.max(1, Math.min(visualArea, nodeArea));
+  const containsCenter = pointInRect(point, node.bounds);
+  const identityScore = node.attrs['resource-id']
+    ? 200
+    : node.attrs['content-desc'] || node.attrs.text
+      ? 100
+      : 0;
+  if (!containsCenter && overlapRatio < 0.35) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  if (nodeArea > visualArea * MAX_VISUAL_MAPPING_NODE_AREA_RATIO) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  const areaSimilarity =
+    Math.min(visualArea, nodeArea) / Math.max(visualArea, nodeArea);
+  const axisSimilarity =
+    (Math.min(visualRect.width, node.bounds.width) /
+      Math.max(visualRect.width, node.bounds.width) +
+      Math.min(visualRect.height, node.bounds.height) /
+        Math.max(visualRect.height, node.bounds.height)) /
+    2;
+  return (
+    overlapRatio * 100 +
+    areaSimilarity * 120 +
+    axisSimilarity * 80 +
+    (containsCenter ? 20 : 0) +
+    identityScore +
+    node.depth * 0.01
+  );
+}
+
+function normalizeSemanticText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '');
+}
+
+function semanticMatchScore(query: string, node: AndroidAuditTreeNode): number {
+  return [node.attrs.text, node.attrs['content-desc']].reduce((best, value) => {
+    if (!value) return best;
+    const normalized = normalizeSemanticText(value);
+    if (normalized.length < 2) return best;
+    if (query.includes(normalized)) {
+      return Math.max(best, normalized.length);
+    }
+    if (normalized.includes(query) && query.length >= 2) {
+      return Math.max(best, query.length);
+    }
+    return best;
+  }, 0);
+}
+
+function lowestCommonAncestor(
+  first: AndroidAuditTreeNode,
+  second: AndroidAuditTreeNode,
+  nodeById: Map<string, AndroidAuditTreeNode>,
+): AndroidAuditTreeNode | undefined {
+  const firstAncestorIds = new Set<string>();
+  let current: AndroidAuditTreeNode | undefined = first;
+  while (current) {
+    firstAncestorIds.add(current.nodeId);
+    current = current.parentNodeId
+      ? nodeById.get(current.parentNodeId)
+      : undefined;
+  }
+
+  current = second;
+  while (current) {
+    if (firstAncestorIds.has(current.nodeId)) return current;
+    current = current.parentNodeId
+      ? nodeById.get(current.parentNodeId)
+      : undefined;
+  }
+  return undefined;
+}
+
+function isDescendantOf(
+  node: AndroidAuditTreeNode,
+  ancestorNodeId: string,
+  nodeById: Map<string, AndroidAuditTreeNode>,
+): boolean {
+  let parentNodeId = node.parentNodeId;
+  while (parentNodeId) {
+    if (parentNodeId === ancestorNodeId) return true;
+    parentNodeId = nodeById.get(parentNodeId)?.parentNodeId ?? null;
+  }
+  return false;
+}
+
+function containsSeparateInteractiveControl(
+  container: AndroidAuditTreeNode,
+  visualRect: Rect,
+  candidates: AndroidAuditTreeNode[],
+  nodeById: Map<string, AndroidAuditTreeNode>,
+): boolean {
+  return candidates.some(
+    (node) =>
+      node.nodeId !== container.nodeId &&
+      (node.interactive || node.type.endsWith('.Button')) &&
+      isDescendantOf(node, container.nodeId, nodeById) &&
+      intersectionArea(node.bounds, visualRect) <= 0,
+  );
+}
+
+function semanticContainerForVisual(
+  input: AndroidAuditVisualElementInput,
+  point: { x: number; y: number },
+  candidates: AndroidAuditTreeNode[],
+  nodeById: Map<string, AndroidAuditTreeNode>,
+): AndroidAuditTreeNode | undefined {
+  const query = normalizeSemanticText(`${input.name} ${input.description}`);
+  const semanticAnchor = candidates
+    .map((node) => ({
+      distance: rectDistance(input.rect, node.bounds),
+      node,
+      score: semanticMatchScore(query, node),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.distance - b.distance ||
+        b.node.depth - a.node.depth,
+    )[0]?.node;
+  if (!semanticAnchor) return undefined;
+
+  const spatialAnchor = candidates
+    .map((node) => ({
+      node,
+      score: visualGeometryScore(input.rect, point, node),
+    }))
+    .filter((candidate) => Number.isFinite(candidate.score))
+    .sort((a, b) => b.score - a.score || b.node.depth - a.node.depth)[0]?.node;
+  if (!spatialAnchor) return undefined;
+
+  const container = lowestCommonAncestor(
+    semanticAnchor,
+    spatialAnchor,
+    nodeById,
+  );
+  if (!container || isAndroidSystemBar(container)) return undefined;
+  const visualArea = rectArea(input.rect);
+  if (
+    !container.visible ||
+    rectArea(container.bounds) >
+      visualArea * MAX_SEMANTIC_CONTAINER_AREA_RATIO ||
+    containsSeparateInteractiveControl(
+      container,
+      input.rect,
+      candidates,
+      nodeById,
+    )
+  ) {
+    return undefined;
+  }
+  return container;
+}
+
+function validateVisualInput(input: AndroidAuditVisualElementInput): void {
+  if (!input.id.trim() || !input.name.trim() || !input.description.trim()) {
+    throw new Error('Visual audit elements require id, name, and description');
+  }
+  if (
+    !Number.isFinite(input.rect.left) ||
+    !Number.isFinite(input.rect.top) ||
+    !Number.isFinite(input.rect.width) ||
+    !Number.isFinite(input.rect.height) ||
+    input.rect.width <= 0 ||
+    input.rect.height <= 0
+  ) {
+    throw new Error(`Visual audit element ${input.id} has an invalid rect`);
+  }
+}
+
+function featureDiagnostics(
+  root: UiNode,
+  feature: XpathCacheFeature,
+  expectedNode: UiNode,
+): AndroidAuditCandidateDiagnostic[] {
+  return feature.xpaths.map((xpath, index) => {
+    try {
+      const matches = evaluateXpath(root, xpath);
+      return {
+        xpath,
+        source: feature.xpathSources?.[index],
+        matchCount: matches.length,
+        selectsNode: matches.length === 1 && matches[0] === expectedNode,
+      };
+    } catch {
+      return {
+        xpath,
+        source: feature.xpathSources?.[index],
+        matchCount: 0,
+        selectsNode: false,
+      };
+    }
+  });
+}
+
+export function buildAndroidAuditTree(
+  root: UiNode,
+  logicalSize: Size,
+): AndroidAuditTreeNode[] {
+  const enumerated = enumerateAndroidUiTree(root);
+  const viewport = {
+    left: 0,
+    top: 0,
+    width: logicalSize.width,
+    height: logicalSize.height,
+  };
+
+  return enumerated.nodes.map((entry) => {
+    const point = {
+      x: entry.node.bounds.left + entry.node.bounds.width / 2,
+      y: entry.node.bounds.top + entry.node.bounds.height / 2,
+    };
+    const feature = generateXpathCacheFeature(root, point, 'android', {
+      ...ANDROID_CACHE_CANDIDATE_OPTIONS,
+      targetDescription: identityDescription(entry.node),
+      expectedRect: entry.node.bounds,
+    });
+    let cacheSelectedNodeId: string | undefined;
+    let failureReason: string | undefined;
+    if (feature) {
+      try {
+        const match = matchRectByXpathCache(root, feature, 'android');
+        const matches = evaluateXpath(root, match.xpath);
+        cacheSelectedNodeId =
+          matches.length === 1
+            ? enumerated.idByNode.get(matches[0])
+            : undefined;
+        if (matches.length !== 1) {
+          failureReason = `${match.xpath} matched ${matches.length} nodes`;
+        }
+      } catch (error) {
+        failureReason = error instanceof Error ? error.message : String(error);
+      }
+    }
+    const candidateDiagnostics = feature
+      ? featureDiagnostics(root, feature, entry.node)
+      : [];
+    const sourceUnique =
+      cacheSelectedNodeId === entry.nodeId &&
+      candidateDiagnostics.length > 0 &&
+      candidateDiagnostics.every(
+        (candidate) => candidate.matchCount === 1 && candidate.selectsNode,
+      );
+
+    const interactionEvidence = getAndroidInteractionEvidence(entry.node);
+    return {
+      attrs: entry.node.attrs,
+      bounds: entry.node.bounds,
+      cacheFeature: feature,
+      cacheFeatureXpaths: feature?.xpaths ?? [],
+      cacheFeatureXpathSources: feature?.xpathSources ?? [],
+      cacheSelectedNodeId,
+      cacheSelectedOther:
+        Boolean(cacheSelectedNodeId) && cacheSelectedNodeId !== entry.nodeId,
+      candidateDiagnostics,
+      center: point,
+      childIndex: entry.childIndex,
+      depth: entry.depth,
+      failureReason,
+      interactive: interactionEvidence.length > 0,
+      interactionEvidence,
+      nodeId: entry.nodeId,
+      parentNodeId: entry.parentNodeId,
+      replayVerified: false,
+      sourceUnique,
+      structuralXpath: entry.structuralXpath,
+      type: entry.node.type,
+      typeSiblingIndex: entry.typeSiblingIndex,
+      visible: isVisible(entry.node.bounds, viewport),
+    };
+  });
+}
+
+function replaySummary(
+  results: AndroidAuditReplayResult[],
+): AndroidAuditReplaySummary {
+  return results.reduce<AndroidAuditReplaySummary>(
+    (summary, result) => {
+      summary.attempted++;
+      if (result.outcome === 'hit') summary.hits++;
+      else if (result.outcome === 'wrong-mapping') summary.wrongMappings++;
+      else summary.misses++;
+      return summary;
+    },
+    { attempted: 0, hits: 0, misses: 0, wrongMappings: 0 },
+  );
+}
+
+function unresolvedStatus(record: AndroidAuditTreeNode): {
+  reason?: string;
+  status: AndroidAuditStatus;
+} {
+  if (
+    record.cacheSelectedNodeId &&
+    record.cacheSelectedNodeId !== record.nodeId
+  ) {
+    return {
+      status: 'point-selected-other',
+      reason: `Production point selection chose ${record.cacheSelectedNodeId}`,
+    };
+  }
+  if (
+    !record.cacheFeature &&
+    !hasIdentity({
+      attrs: record.attrs,
+      bounds: record.bounds,
+      children: [],
+      type: record.type,
+    })
+  ) {
+    return {
+      status: 'tree-only-positional',
+      reason:
+        'The node has no resource-id, content-desc, or text and only has a structural XPath',
+    };
+  }
+  if (record.cacheFeature && record.sourceUnique) {
+    return {
+      status: 'pending',
+      reason: 'Waiting for the next tree to validate the cache XPath',
+    };
+  }
+  return {
+    status: 'exposed-no-safe-xpath',
+    reason:
+      record.failureReason ??
+      'The production generator did not produce a cache XPath that is safe to replay',
+  };
+}
+
+export function buildAndroidLiveTreeAudit(
+  currentRoot: UiNode,
+  logicalSize: Size,
+  previousTreeNodes: AndroidAuditTreeNode[] = [],
+): AndroidLiveTreeAudit {
+  const currentEnumerated = enumerateAndroidUiTree(currentRoot);
+  const currentTreeNodes = buildAndroidAuditTree(currentRoot, logicalSize);
+  const verifiedNodeIds = new Set<string>();
+  const replayResults: AndroidAuditReplayResult[] = [];
+
+  for (const previous of previousTreeNodes) {
+    if (!previous.cacheFeature || !previous.sourceUnique) continue;
+    try {
+      const match = matchRectByXpathCache(
+        currentRoot,
+        previous.cacheFeature,
+        'android',
+      );
+      const matches = evaluateXpath(currentRoot, match.xpath);
+      const nodeId =
+        matches.length === 1
+          ? currentEnumerated.idByNode.get(matches[0])
+          : undefined;
+      if (nodeId) {
+        verifiedNodeIds.add(nodeId);
+        replayResults.push({
+          matchedNodeId: nodeId,
+          outcome: 'hit',
+          sourceNodeId: previous.nodeId,
+          xpath: match.xpath,
+          ...(match.source ? { xpathSource: match.source } : {}),
+        });
+      } else {
+        replayResults.push({
+          failureReason: `${match.xpath} did not resolve to one current tree node`,
+          outcome: 'miss',
+          sourceNodeId: previous.nodeId,
+          xpath: match.xpath,
+          ...(match.source ? { xpathSource: match.source } : {}),
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      replayResults.push({
+        failureReason: message,
+        outcome: message.includes('different target')
+          ? 'wrong-mapping'
+          : 'miss',
+        sourceNodeId: previous.nodeId,
+      });
+    }
+  }
+
+  const replayedTreeNodes = currentTreeNodes.map((record) =>
+    verifiedNodeIds.has(record.nodeId)
+      ? { ...record, replayVerified: true }
+      : record,
+  );
+  const overlays = selectTreeOverlayNodes(replayedTreeNodes, logicalSize).map(
+    (record): AndroidAuditOverlay => {
+      const node = currentEnumerated.nodeById.get(record.nodeId);
+      if (!node) {
+        throw new Error(`Unable to resolve current tree node ${record.nodeId}`);
+      }
+      const unresolved = unresolvedStatus(record);
+      const verified = record.replayVerified;
+      return {
+        description: identityDescription(node),
+        name: displayName(node),
+        nodeId: record.nodeId,
+        rect: record.bounds,
+        rectSource: 'tree',
+        status: verified ? 'cache-xpath-hit' : unresolved.status,
+        statusReason: verified ? CACHE_XPATH_HIT_REASON : unresolved.reason,
+      };
+    },
+  );
+
+  return {
+    overlays,
+    replay: replaySummary(replayResults),
+    replayResults,
+    treeNodes: replayedTreeNodes,
+  };
+}
+
+/**
+ * Apply replay outcomes from a fresh capture to the source tree while keeping
+ * every node id and rectangle in the source coordinate snapshot. Reports use
+ * this projection so their screenshot, tree, and overlays describe one moment.
+ */
+export function applyAndroidAuditReplayToSource(
+  sourceRoot: UiNode,
+  logicalSize: Size,
+  sourceAudit: AndroidLiveTreeAudit,
+  replayResults: AndroidAuditReplayResult[],
+): AndroidLiveTreeAudit {
+  const verifiedSourceNodeIds = new Set(
+    replayResults
+      .filter((result) => result.outcome === 'hit')
+      .map((result) => result.sourceNodeId),
+  );
+  const treeNodes = sourceAudit.treeNodes.map((node) => ({
+    ...node,
+    replayVerified: verifiedSourceNodeIds.has(node.nodeId),
+  }));
+  const enumerated = enumerateAndroidUiTree(sourceRoot);
+  const overlays = selectTreeOverlayNodes(treeNodes, logicalSize).map(
+    (record): AndroidAuditOverlay => {
+      const node = enumerated.nodeById.get(record.nodeId);
+      if (!node) {
+        throw new Error(`Unable to resolve source tree node ${record.nodeId}`);
+      }
+      const unresolved = unresolvedStatus(record);
+      return {
+        description: identityDescription(node),
+        name: displayName(node),
+        nodeId: record.nodeId,
+        rect: record.bounds,
+        rectSource: 'tree',
+        status: record.replayVerified ? 'cache-xpath-hit' : unresolved.status,
+        statusReason: record.replayVerified
+          ? CACHE_XPATH_HIT_REASON
+          : unresolved.reason,
+      };
+    },
+  );
+  return {
+    overlays,
+    replay: replaySummary(replayResults),
+    replayResults,
+    treeNodes,
+  };
+}
+
+export function buildAndroidVisualAudit(
+  root: UiNode,
+  logicalSize: Size,
+  treeAudit: AndroidLiveTreeAudit,
+  inputs: AndroidAuditVisualElementInput[],
+): AndroidVisualAudit {
+  const enumerated = enumerateAndroidUiTree(root);
+  const nodeById = new Map(
+    treeAudit.treeNodes.map((node) => [node.nodeId, node]),
+  );
+  const overlayByNodeId = new Map(
+    treeAudit.overlays
+      .filter((overlay) => overlay.nodeId)
+      .map((overlay) => [overlay.nodeId, overlay]),
+  );
+  const viewport: Rect = {
+    left: 0,
+    top: 0,
+    width: logicalSize.width,
+    height: logicalSize.height,
+  };
+
+  const visualElements = inputs.map((input): AndroidAuditVisualElement => {
+    validateVisualInput(input);
+    const point = {
+      x: input.rect.left + input.rect.width / 2,
+      y: input.rect.top + input.rect.height / 2,
+    };
+    const mappingCandidates = treeAudit.treeNodes.filter(
+      (node) =>
+        node.visible &&
+        !isAndroidSystemBar(node) &&
+        intersectionArea(node.bounds, viewport) > 0,
+    );
+    const mappedNode =
+      semanticContainerForVisual(input, point, mappingCandidates, nodeById) ??
+      mappingCandidates
+        .map((node) => ({
+          node,
+          score: visualMappingScore(input.rect, point, node),
+        }))
+        .filter((candidate) => Number.isFinite(candidate.score))
+        .sort((a, b) => b.score - a.score)[0]?.node;
+    const expectedNode = mappedNode
+      ? enumerated.nodeById.get(mappedNode.nodeId)
+      : undefined;
+    const feature = generateXpathCacheFeature(root, point, 'android', {
+      ...ANDROID_CACHE_CANDIDATE_OPTIONS,
+      expectedRect: input.rect,
+      targetDescription: input.description,
+    });
+    let productionSelectedNodeId: string | undefined;
+    if (feature) {
+      try {
+        const match = matchRectByXpathCache(root, feature, 'android');
+        const matches = evaluateXpath(root, match.xpath);
+        if (matches.length === 1) {
+          productionSelectedNodeId = enumerated.idByNode.get(matches[0]);
+        }
+      } catch {
+        // Candidate diagnostics below retain the exact source-tree result.
+      }
+    }
+    const candidateDiagnostics =
+      feature && expectedNode
+        ? featureDiagnostics(root, feature, expectedNode)
+        : [];
+    const sourceUnique =
+      Boolean(mappedNode) &&
+      productionSelectedNodeId === mappedNode?.nodeId &&
+      candidateDiagnostics.length > 0 &&
+      candidateDiagnostics.every(
+        (candidate) => candidate.matchCount === 1 && candidate.selectsNode,
+      );
+
+    let status: AndroidAuditStatus;
+    let statusReason: string | undefined;
+    if (!mappedNode) {
+      status = productionSelectedNodeId
+        ? 'point-selected-other'
+        : 'not-exposed';
+      statusReason = productionSelectedNodeId
+        ? `The visual element has no reliable tree mapping, but production point selection chose ${productionSelectedNodeId}`
+        : 'The interactive element visible in the screenshot has no corresponding Accessibility tree node';
+    } else if (
+      productionSelectedNodeId &&
+      productionSelectedNodeId !== mappedNode.nodeId
+    ) {
+      status = 'point-selected-other';
+      statusReason = `Production point selection chose ${productionSelectedNodeId}, while the visual element maps to ${mappedNode.nodeId}`;
+    } else {
+      const treeOverlay = overlayByNodeId.get(mappedNode.nodeId);
+      const unresolved = unresolvedStatus(mappedNode);
+      status = mappedNode.replayVerified
+        ? 'cache-xpath-hit'
+        : (treeOverlay?.status ?? unresolved.status);
+      statusReason = mappedNode.replayVerified
+        ? CACHE_XPATH_HIT_REASON
+        : (treeOverlay?.statusReason ?? unresolved.reason);
+    }
+
+    return {
+      ...input,
+      cacheFeature: feature,
+      cacheFeatureXpaths: feature?.xpaths ?? [],
+      cacheFeatureXpathSources: feature?.xpathSources ?? [],
+      candidateDiagnostics,
+      mappedNodeId: mappedNode?.nodeId ?? null,
+      point,
+      productionSelectedNodeId,
+      sourceUnique,
+      status,
+      statusReason,
+      structuralXpath: mappedNode?.structuralXpath,
+    };
+  });
+
+  const overlays: AndroidAuditOverlay[] = [];
+  const overlaidNodeIds = new Set<string>();
+
+  for (const element of visualElements) {
+    if (element.mappedNodeId) {
+      if (overlaidNodeIds.has(element.mappedNodeId)) {
+        continue;
+      }
+      const mappedNode = nodeById.get(element.mappedNodeId);
+      if (!mappedNode) {
+        throw new Error(
+          `Unable to resolve visual tree node ${element.mappedNodeId}`,
+        );
+      }
+      overlays.push({
+        description: element.description,
+        name: element.name,
+        nodeId: mappedNode.nodeId,
+        rect: mappedNode.bounds,
+        rectSource: 'tree',
+        status: element.status,
+        statusReason: element.statusReason,
+        visualElementId: element.id,
+      });
+      overlaidNodeIds.add(mappedNode.nodeId);
+      continue;
+    }
+    overlays.push({
+      description: element.description,
+      name: element.name,
+      nodeId: null,
+      rect: element.rect,
+      rectSource: element.rectSource,
+      status: element.status,
+      statusReason: element.statusReason,
+      visualElementId: element.id,
+    });
+  }
+
+  return { visualElements, overlays };
+}

--- a/packages/android/tests/fixtures/cache-compatibility/compose.replay.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/compose.replay.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.openai.chatgpt" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="Continue" resource-id="" class="android.widget.Button" package="com.openai.chatgpt" content-desc="" bounds="[20,80][380,130]"/>
+    <node index="1" text="Welcome" resource-id="com.openai.chatgpt:id/welcome" class="android.widget.TextView" package="com.openai.chatgpt" content-desc="" bounds="[40,300][360,400]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/compose.source.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/compose.source.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.openai.chatgpt" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="Welcome" resource-id="com.openai.chatgpt:id/welcome" class="android.widget.TextView" package="com.openai.chatgpt" content-desc="" bounds="[40,100][360,200]"/>
+    <node index="1" text="System" resource-id="" class="android.widget.TextView" package="com.openai.chatgpt" content-desc="" bounds="[20,650][180,700]"/>
+    <node index="2" text="System" resource-id="" class="android.widget.TextView" package="com.openai.chatgpt" content-desc="" bounds="[220,650][380,700]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/flutter.replay.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/flutter.replay.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="org.localsend.localsend_app" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="" resource-id="" class="android.view.View" package="org.localsend.localsend_app" content-desc="Receive" bounds="[20,80][380,130]"/>
+    <node index="1" text="" resource-id="" class="android.view.View" package="org.localsend.localsend_app" content-desc="Downloads" clickable="true" bounds="[40,300][360,400]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/flutter.source.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/flutter.source.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="org.localsend.localsend_app" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="" resource-id="" class="android.view.View" package="org.localsend.localsend_app" content-desc="Downloads" clickable="true" bounds="[40,100][360,200]"/>
+    <node index="1" text="" resource-id="" class="android.view.View" package="org.localsend.localsend_app" content-desc="System" bounds="[20,650][180,700]"/>
+    <node index="2" text="" resource-id="" class="android.view.View" package="org.localsend.localsend_app" content-desc="System" bounds="[220,650][380,700]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/lynx.replay.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/lynx.replay.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.ss.android.ugc.aweme" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="Feed" resource-id="" class="android.widget.TextView" package="com.ss.android.ugc.aweme" content-desc="" bounds="[20,80][380,130]"/>
+    <node index="1" text="" resource-id="" class="android.view.ViewGroup" package="com.ss.android.ugc.aweme" content-desc="Search [video] for &quot;O'Reilly&quot;" clickable="true" bounds="[40,300][360,400]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/lynx.source.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/lynx.source.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.ss.android.ugc.aweme" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="" resource-id="" class="android.view.ViewGroup" package="com.ss.android.ugc.aweme" content-desc="Search [video] for &quot;O'Reilly&quot;" clickable="true" bounds="[40,100][360,200]"/>
+    <node index="1" text="System" resource-id="" class="android.widget.TextView" package="com.ss.android.ugc.aweme" content-desc="" bounds="[20,650][180,700]"/>
+    <node index="2" text="System" resource-id="" class="android.widget.TextView" package="com.ss.android.ugc.aweme" content-desc="" bounds="[220,650][380,700]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/manifest.ts
+++ b/packages/android/tests/fixtures/cache-compatibility/manifest.ts
@@ -1,0 +1,69 @@
+export interface AndroidCacheCompatibilityFixture {
+  framework:
+    | 'React Native'
+    | 'Flutter'
+    | 'Jetpack Compose'
+    | 'Lynx'
+    | 'WebView';
+  packageName: string;
+  sourceFile: string;
+  replayFile: string;
+  prompt: string;
+  sourcePoint: { x: number; y: number };
+  replayRect: { left: number; top: number; width: number; height: number };
+  safeMissPoint: { x: number; y: number };
+}
+
+export const ANDROID_CACHE_COMPATIBILITY_FIXTURES: AndroidCacheCompatibilityFixture[] =
+  [
+    {
+      framework: 'React Native',
+      packageName: 'com.discord',
+      sourceFile: 'react-native.source.xml',
+      replayFile: 'react-native.replay.xml',
+      prompt: 'the React Native Register action',
+      sourcePoint: { x: 200, y: 150 },
+      replayRect: { left: 40, top: 300, width: 320, height: 100 },
+      safeMissPoint: { x: 100, y: 675 },
+    },
+    {
+      framework: 'Flutter',
+      packageName: 'org.localsend.localsend_app',
+      sourceFile: 'flutter.source.xml',
+      replayFile: 'flutter.replay.xml',
+      prompt: 'the Flutter Downloads action',
+      sourcePoint: { x: 200, y: 150 },
+      replayRect: { left: 40, top: 300, width: 320, height: 100 },
+      safeMissPoint: { x: 100, y: 675 },
+    },
+    {
+      framework: 'Jetpack Compose',
+      packageName: 'com.openai.chatgpt',
+      sourceFile: 'compose.source.xml',
+      replayFile: 'compose.replay.xml',
+      prompt: 'the Compose Welcome element',
+      sourcePoint: { x: 200, y: 150 },
+      replayRect: { left: 40, top: 300, width: 320, height: 100 },
+      safeMissPoint: { x: 100, y: 675 },
+    },
+    {
+      framework: 'Lynx',
+      packageName: 'com.ss.android.ugc.aweme',
+      sourceFile: 'lynx.source.xml',
+      replayFile: 'lynx.replay.xml',
+      prompt: 'the Lynx search action',
+      sourcePoint: { x: 200, y: 150 },
+      replayRect: { left: 40, top: 300, width: 320, height: 100 },
+      safeMissPoint: { x: 100, y: 675 },
+    },
+    {
+      framework: 'WebView',
+      packageName: 'com.example.hybrid',
+      sourceFile: 'webview.source.xml',
+      replayFile: 'webview.replay.xml',
+      prompt: 'the WebView Continue checkout action',
+      sourcePoint: { x: 200, y: 150 },
+      replayRect: { left: 40, top: 300, width: 320, height: 100 },
+      safeMissPoint: { x: 100, y: 675 },
+    },
+  ];

--- a/packages/android/tests/fixtures/cache-compatibility/react-native.replay.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/react-native.replay.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.discord" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="News" resource-id="" class="android.widget.TextView" package="com.discord" content-desc="" bounds="[20,80][380,130]"/>
+    <node index="1" text="Register" resource-id="" class="android.widget.TextView" package="com.discord" content-desc="Create account" clickable="true" bounds="[40,300][360,400]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/react-native.source.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/react-native.source.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.discord" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="Register" resource-id="" class="android.widget.TextView" package="com.discord" content-desc="Create account" clickable="true" bounds="[40,100][360,200]"/>
+    <node index="1" text="System" resource-id="" class="android.widget.TextView" package="com.discord" content-desc="" bounds="[20,650][180,700]"/>
+    <node index="2" text="System" resource-id="" class="android.widget.TextView" package="com.discord" content-desc="" bounds="[220,650][380,700]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/webview.replay.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/webview.replay.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.example.hybrid" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="" resource-id="" class="android.webkit.WebView" package="com.example.hybrid" content-desc="Account" bounds="[0,40][400,700]">
+      <node index="0" text="Headline" resource-id="" class="android.widget.TextView" package="com.example.hybrid" content-desc="" bounds="[20,80][380,130]"/>
+      <node index="1" text="Continue" resource-id="" class="android.widget.Button" package="com.example.hybrid" content-desc="Continue checkout" clickable="true" bounds="[40,300][360,400]"/>
+    </node>
+  </node>
+</hierarchy>

--- a/packages/android/tests/fixtures/cache-compatibility/webview.source.xml
+++ b/packages/android/tests/fixtures/cache-compatibility/webview.source.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.example.hybrid" content-desc="" bounds="[0,0][400,800]">
+    <node index="0" text="" resource-id="" class="android.webkit.WebView" package="com.example.hybrid" content-desc="Account" bounds="[0,40][400,600]">
+      <node index="0" text="Continue" resource-id="" class="android.widget.Button" package="com.example.hybrid" content-desc="Continue checkout" clickable="true" bounds="[40,100][360,200]"/>
+    </node>
+    <node index="1" text="System" resource-id="" class="android.widget.TextView" package="com.example.hybrid" content-desc="" bounds="[20,650][180,700]"/>
+    <node index="2" text="System" resource-id="" class="android.widget.TextView" package="com.example.hybrid" content-desc="" bounds="[220,650][380,700]"/>
+  </node>
+</hierarchy>

--- a/packages/android/tests/unit-test/audit-metadata.test.ts
+++ b/packages/android/tests/unit-test/audit-metadata.test.ts
@@ -1,0 +1,69 @@
+import type { ADB } from 'appium-adb';
+import { describe, expect, it, vi } from 'vitest';
+import { collectAndroidAuditEnvironment } from '../../src/audit-metadata';
+
+function adbFixture(packageName = 'com.example.app'): ADB {
+  const outputByCommand: Record<string, string> = {
+    'getprop ro.product.manufacturer': 'Example',
+    'getprop ro.product.model': 'Phone X',
+    'getprop ro.build.version.release': '15',
+    'getprop ro.build.version.sdk': '35',
+    'wm size': 'Physical size: 1080x2400\nOverride size: 900x2000',
+    'dumpsys activity activities': `mResumedActivity: ActivityRecord{0 u0 ${packageName}/.MainActivity t1}`,
+    'dumpsys window windows': '',
+    'dumpsys input': 'SurfaceOrientation: 0',
+    [`dumpsys package ${packageName}`]: 'versionCode=398000 versionName=39.8.0',
+  };
+  return {
+    getScreenDensity: vi.fn(async () => 480),
+    shell: vi.fn(async (command: string) => outputByCommand[command] ?? ''),
+  } as unknown as ADB;
+}
+
+describe('Android audit metadata', () => {
+  it('collects the canonical device and foreground-app environment', async () => {
+    await expect(
+      collectAndroidAuditEnvironment(adbFixture(), {
+        deviceId: 'serial-1',
+        expectedPackage: 'com.example.app',
+        screenshotSize: { width: 900, height: 2000 },
+      }),
+    ).resolves.toEqual({
+      device: {
+        serial: 'serial-1',
+        manufacturer: 'Example',
+        model: 'Phone X',
+        androidVersion: '15',
+        apiLevel: '35',
+        resolution: {
+          physical: { width: 1080, height: 2400 },
+          override: { width: 900, height: 2000 },
+          logical: { width: 300, height: 2000 / 3 },
+          screenshot: { width: 900, height: 2000 },
+        },
+        density: 480,
+        dpr: 3,
+        rotation: 0,
+      },
+      app: {
+        expectedPackage: 'com.example.app',
+        package: 'com.example.app',
+        activity: '.MainActivity',
+        versionName: '39.8.0',
+        versionCode: '398000',
+      },
+    });
+  });
+
+  it('rejects metadata captured from the wrong foreground package', async () => {
+    await expect(
+      collectAndroidAuditEnvironment(adbFixture('com.example.other'), {
+        deviceId: 'serial-1',
+        expectedPackage: 'com.example.app',
+        screenshotSize: { width: 900, height: 2000 },
+      }),
+    ).rejects.toThrow(
+      'Focused package com.example.other does not match requested app com.example.app',
+    );
+  });
+});

--- a/packages/android/tests/unit-test/cache-compatibility.test.ts
+++ b/packages/android/tests/unit-test/cache-compatibility.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  generateXpathCacheFeature,
+  matchRectByXpathCache,
+} from '@midscene/core/internal/device-cache';
+import { describe, expect, it } from 'vitest';
+import { ANDROID_CACHE_CANDIDATE_OPTIONS } from '../../src/cache-policy';
+import { uiautomatorXmlToUiNode } from '../../src/uiautomator-tree';
+import { ANDROID_CACHE_COMPATIBILITY_FIXTURES } from '../fixtures/cache-compatibility/manifest';
+
+const FIXTURE_DIR = join(__dirname, '../fixtures/cache-compatibility');
+
+function readTree(fileName: string) {
+  return uiautomatorXmlToUiNode(
+    readFileSync(join(FIXTURE_DIR, fileName), 'utf8'),
+    1,
+  );
+}
+
+describe('Android cache compatibility fixture matrix', () => {
+  it.each(ANDROID_CACHE_COMPATIBILITY_FIXTURES)(
+    '$framework replays the same semantic element after it moves',
+    (fixture) => {
+      const source = readTree(fixture.sourceFile);
+      const replay = readTree(fixture.replayFile);
+      const feature = generateXpathCacheFeature(
+        source,
+        fixture.sourcePoint,
+        'android',
+        {
+          ...ANDROID_CACHE_CANDIDATE_OPTIONS,
+          targetDescription: fixture.prompt,
+        },
+      );
+
+      expect(feature).toBeDefined();
+      expect(feature?.xpaths).toHaveLength(feature?.xpathSources?.length ?? 0);
+      expect(feature?.xpaths.length).toBeLessThanOrEqual(3);
+      expect(matchRectByXpathCache(replay, feature!, 'android')).toMatchObject({
+        rect: fixture.replayRect,
+      });
+    },
+  );
+
+  it.each(ANDROID_CACHE_COMPATIBILITY_FIXTURES)(
+    '$framework safely skips duplicated semantic labels',
+    (fixture) => {
+      const source = readTree(fixture.sourceFile);
+      expect(
+        generateXpathCacheFeature(source, fixture.safeMissPoint, 'android', {
+          ...ANDROID_CACHE_CANDIDATE_OPTIONS,
+          targetDescription: fixture.prompt,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it('does not cache a WebView shell when its inner control is unexposed', () => {
+    const source = readTree('webview.source.xml');
+    expect(
+      generateXpathCacheFeature(
+        source,
+        { x: 10, y: 300 },
+        'android',
+        ANDROID_CACHE_CANDIDATE_OPTIONS,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -185,6 +185,158 @@ describe('AndroidDevice', () => {
     });
   });
 
+  describe('accessibility snapshot', () => {
+    const hierarchy = (children: string) => `<?xml version="1.0"?>
+<hierarchy rotation="0">
+  <node class="android.widget.FrameLayout" bounds="[0,0][400,800]">
+    ${children}
+  </node>
+</hierarchy>`;
+
+    const mockYadbHierarchy = (xml: string) => {
+      mockAdb.shell.mockImplementation(async (command) => {
+        if (
+          String(command) ===
+          'cat /data/local/tmp/midscene_yadb_layout_dump.xml'
+        ) {
+          return xml;
+        }
+        return '';
+      });
+    };
+
+    const mockSnapshotScreen = (
+      target: AndroidDevice = device,
+      density = 160,
+    ) => {
+      vi.spyOn(target, 'getDisplayDensity').mockResolvedValue(density);
+      vi.spyOn(target, 'getScreenSize').mockResolvedValue({
+        override: '',
+        physical: '400x800',
+        orientation: 0,
+        isCurrentOrientation: false,
+      });
+    };
+
+    it('captures the hierarchy with raw XML and coordinate metadata', async () => {
+      const xml = hierarchy(
+        '<node class="android.widget.Button" resource-id="snapshot-target" bounds="[20,40][180,100]"/>',
+      );
+      mockYadbHierarchy(xml);
+      mockSnapshotScreen(device, 320);
+
+      const snapshot = await device.captureAccessibilitySnapshot();
+
+      expect(snapshot).toMatchObject({
+        source: 'yadb',
+        sourceXml: xml,
+        dpr: 2,
+        rotation: 0,
+        logicalSize: { width: 200, height: 400 },
+        root: {
+          type: 'android.widget.FrameLayout',
+          children: [
+            {
+              type: 'android.widget.Button',
+              bounds: { left: 10, top: 20, width: 80, height: 30 },
+            },
+          ],
+        },
+      });
+      expect(snapshot.captureId).toMatch(/^[a-z0-9]+-[a-z0-9]+$/);
+      expect(snapshot.capturedAt).toBeTruthy();
+      expect(snapshot.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('falls back to bounded UIAutomator retries after YADB fails', async () => {
+      mockSnapshotScreen();
+      let uiautomatorAttempts = 0;
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value.includes('com.ysbing.yadb.Main -layout')) {
+          throw new Error('YADB layout unavailable');
+        }
+        if (value.startsWith('uiautomator dump')) {
+          uiautomatorAttempts++;
+          if (uiautomatorAttempts < 3) {
+            throw new Error('ERROR: could not get idle state');
+          }
+        }
+        if (value === 'cat /sdcard/midscene_window_dump.xml') {
+          return hierarchy(
+            '<node class="android.widget.Button" resource-id="retry-target" bounds="[20,40][180,100]"/>',
+          );
+        }
+        return '';
+      });
+
+      await expect(
+        device.captureAccessibilitySnapshot(),
+      ).resolves.toMatchObject({
+        source: 'uiautomator',
+        root: {
+          children: [
+            {
+              attrs: { 'resource-id': 'retry-target' },
+            },
+          ],
+        },
+      });
+      expect(uiautomatorAttempts).toBe(3);
+      expect(mockAdb.shell).toHaveBeenCalledWith(
+        'uiautomator dump --compressed /sdcard/midscene_window_dump.xml',
+        expect.objectContaining({ timeout: 5_000 }),
+      );
+    });
+
+    it('removes stale files on every attempt and reports all failures', async () => {
+      mockAdb.shell.mockImplementation(async (command) => {
+        const value = String(command);
+        if (value.startsWith('rm -f ')) return '';
+        if (value.startsWith('cat ')) {
+          return 'cat: layout dump does not exist';
+        }
+        return 'ERROR: could not get idle state.';
+      });
+
+      await expect(device.captureAccessibilitySnapshot()).rejects.toThrow(
+        /Unable to read Android accessibility hierarchy after 6 attempt\(s\).*yadb did not produce valid hierarchy XML.*uiautomator did not produce valid hierarchy XML/,
+      );
+      expect(
+        mockAdb.shell.mock.calls.filter(([command]) =>
+          String(command).startsWith('rm -f '),
+        ),
+      ).toHaveLength(6);
+    });
+
+    it('uses UIAutomator directly for a non-default display', async () => {
+      const secondaryDisplayDevice = new AndroidDevice('test-device', {
+        displayId: 1,
+        minScreenshotBufferSize: 0,
+        scrcpyConfig: { enabled: false },
+      });
+      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      mockSnapshotScreen(secondaryDisplayDevice);
+      mockAdb.shell.mockImplementation(async (command) => {
+        if (String(command) === 'cat /sdcard/midscene_window_dump.xml') {
+          return hierarchy(
+            '<node class="android.widget.Button" resource-id="display-target" bounds="[20,40][180,100]"/>',
+          );
+        }
+        return '';
+      });
+
+      await expect(
+        secondaryDisplayDevice.captureAccessibilitySnapshot(),
+      ).resolves.toMatchObject({ source: 'uiautomator' });
+      expect(mockAdb.push).not.toHaveBeenCalled();
+      expect(mockAdb.shell).not.toHaveBeenCalledWith(
+        expect.stringContaining('com.ysbing.yadb.Main -layout'),
+        expect.anything(),
+      );
+    });
+  });
+
   describe('launch', () => {
     it('should start URI for http/https links', async () => {
       const uri = 'https://example.com';

--- a/packages/android/tests/unit-test/uiautomator-tree.test.ts
+++ b/packages/android/tests/unit-test/uiautomator-tree.test.ts
@@ -1,0 +1,129 @@
+import {
+  evaluateXpath,
+  generateXpathCandidates,
+} from '@midscene/core/internal/device-cache';
+import { describe, expect, it } from 'vitest';
+import { uiautomatorXmlToUiNode } from '../../src/uiautomator-tree';
+
+const SAMPLE_UIAUTOMATOR_DUMP = `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.example.app" content-desc="" enabled="true" bounds="[0,0][1080,2400]">
+    <node index="0" text="" resource-id="com.example.app:id/root" class="android.widget.LinearLayout" package="com.example.app" content-desc="" enabled="true" bounds="[0,0][1080,2400]">
+      <node index="0" text="账号" resource-id="com.example.app:id/username_label" class="android.widget.TextView" package="com.example.app" content-desc="" enabled="true" bounds="[40,200][200,260]"/>
+      <node index="1" text="" resource-id="com.example.app:id/username_input" class="android.widget.EditText" package="com.example.app" content-desc="请输入账号" enabled="true" bounds="[40,280][1040,400]"/>
+      <node index="2" text="登录" resource-id="com.example.app:id/login_btn" class="android.widget.Button" package="com.example.app" content-desc="登录按钮" enabled="true" clickable="true" bounds="[40,500][1040,640]"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+describe('uiautomatorXmlToUiNode', () => {
+  it('parses bounds and divides by DPR for logical coords', () => {
+    const root = uiautomatorXmlToUiNode(SAMPLE_UIAUTOMATOR_DUMP, 2);
+    // physical [0,0][1080,2400] / DPR 2 -> logical 540 x 1200
+    expect(root.bounds).toEqual({
+      left: 0,
+      top: 0,
+      width: 540,
+      height: 1200,
+    });
+  });
+
+  it('uses the class attribute as the type, drops the bounds attr', () => {
+    const root = uiautomatorXmlToUiNode(SAMPLE_UIAUTOMATOR_DUMP, 2);
+    expect(root.type).toBe('android.widget.FrameLayout');
+    expect(root.attrs.bounds).toBeUndefined();
+    expect(root.attrs['resource-id']).toBe('');
+    expect(root.attrs.class).toBe('android.widget.FrameLayout');
+  });
+
+  it('emits resource-id selector for the deepest hit', () => {
+    const root = uiautomatorXmlToUiNode(SAMPLE_UIAUTOMATOR_DUMP, 2);
+    // tap center of login_btn -> physical (540, 570) / 2 = logical (270, 285)
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 270, y: 285 },
+      {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['text', 'content-desc'],
+        targetDescription: '登录',
+      },
+    );
+    expect(xpaths[0]).toBe("//*[@resource-id='com.example.app:id/login_btn']");
+    for (const xp of xpaths) {
+      const matches = evaluateXpath(root, xp);
+      expect(matches).toHaveLength(1);
+      expect(matches[0].attrs['resource-id']).toBe(
+        'com.example.app:id/login_btn',
+      );
+    }
+  });
+
+  it('falls back to text when resource-id is empty but text is set', () => {
+    const noIdDump = `<?xml version='1.0'?>
+<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][1000,2000]">
+    <node text="登录" resource-id="" class="android.widget.Button" content-desc="" bounds="[100,500][900,640]"/>
+  </node>
+</hierarchy>`;
+    const root = uiautomatorXmlToUiNode(noIdDump, 1);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 500, y: 570 },
+      {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['text', 'content-desc'],
+        targetDescription: '登录',
+      },
+    );
+    expect(xpaths[0]).toBe("//android.widget.Button[@text='登录']");
+  });
+
+  it('falls back to content-desc when text is empty', () => {
+    const onlyDescDump = `<?xml version='1.0'?>
+<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][1000,2000]">
+    <node text="" resource-id="" class="android.widget.ImageButton" content-desc="返回" bounds="[20,40][100,120]"/>
+  </node>
+</hierarchy>`;
+    const root = uiautomatorXmlToUiNode(onlyDescDump, 1);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 60, y: 80 },
+      {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['text', 'content-desc'],
+        targetDescription: '返回',
+      },
+    );
+    expect(xpaths[0]).toBe(
+      "//android.widget.ImageButton[@content-desc='返回']",
+    );
+  });
+
+  it('survives missing or malformed bounds attribute', () => {
+    const dump = `<?xml version='1.0'?>
+<hierarchy>
+  <node class="X" bounds="garbage"/>
+</hierarchy>`;
+    const root = uiautomatorXmlToUiNode(dump, 1);
+    expect(root.bounds).toEqual({ left: 0, top: 0, width: 0, height: 0 });
+  });
+
+  it('preserves the hierarchy root when there are multiple top-level nodes', () => {
+    const multi = `<?xml version='1.0'?>
+<hierarchy>
+  <node class="A" resource-id="a" bounds="[0,0][100,100]"/>
+  <node class="B" resource-id="b" bounds="[100,0][200,100]"/>
+</hierarchy>`;
+    const root = uiautomatorXmlToUiNode(multi, 1);
+    expect(root.type).toBe('hierarchy');
+    expect(root.children).toHaveLength(2);
+
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 50 },
+      { stableAttrs: ['resource-id'] },
+    );
+    expect(xpaths).toContain("//*[@resource-id='b']");
+  });
+});

--- a/packages/android/tests/unit-test/xpath-audit.test.ts
+++ b/packages/android/tests/unit-test/xpath-audit.test.ts
@@ -1,0 +1,1699 @@
+import type { UiNode } from '@midscene/core/internal/device-cache';
+import { describe, expect, it } from 'vitest';
+import {
+  applyAndroidAuditReplayToSource,
+  buildAndroidLiveTreeAudit,
+  buildAndroidVisualAudit,
+  enumerateAndroidUiTree,
+  getAndroidInteractionEvidence,
+} from '../../src/xpath-audit';
+
+function node(
+  type: string,
+  bounds: { left: number; top: number; width: number; height: number },
+  attrs: Record<string, string> = {},
+  children: UiNode[] = [],
+): UiNode {
+  return { attrs, bounds, children, type };
+}
+
+function auditTree(buttonTop = 20): UiNode {
+  return node(
+    'android.widget.FrameLayout',
+    { left: 0, top: 0, width: 400, height: 800 },
+    {},
+    [
+      node(
+        'android.widget.Button',
+        { left: 20, top: buttonTop, width: 120, height: 60 },
+        { 'resource-id': 'stable-button', clickable: 'true', text: '打开' },
+      ),
+      node(
+        'android.view.View',
+        { left: 20, top: 120, width: 120, height: 60 },
+        { clickable: 'true' },
+      ),
+    ],
+  );
+}
+
+describe('Android live XPath audit', () => {
+  it.each([
+    [{ clickable: 'true' }, ['accessibility-flag']],
+    [{ actions: 'ACTION_CLICK,ACTION_FOCUS' }, ['click-action']],
+    [{ 'chrome-role': 'button' }, ['web-role']],
+    [{ 'role-description': '链接' }, ['web-role']],
+    [{ 'clickable-score': '0.85' }, ['clickable-score']],
+    [{ 'target-url': 'https://example.com' }, ['target-url']],
+  ])(
+    'accepts interaction evidence beyond a single device clickable flag: %j',
+    (attrs, expectedEvidence) => {
+      const evidenceNode = node(
+        'android.view.View',
+        { left: 20, top: 20, width: 120, height: 60 },
+        attrs,
+      );
+      expect(getAndroidInteractionEvidence(evidenceNode)).toEqual(
+        expectedEvidence,
+      );
+
+      const root = node(
+        'android.webkit.WebView',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [evidenceNode],
+      );
+      const audit = buildAndroidLiveTreeAudit(root, {
+        width: 400,
+        height: 800,
+      });
+      expect(audit.overlays).toHaveLength(1);
+      expect(audit.treeNodes[1]).toMatchObject({
+        interactionEvidence: expectedEvidence,
+        interactive: true,
+      });
+    },
+  );
+
+  it('does not treat a static Web role or ordinary text as interaction evidence', () => {
+    const staticNodes = [
+      node(
+        'android.widget.TextView',
+        { left: 20, top: 20, width: 120, height: 60 },
+        { role: 'heading', text: '账户总额' },
+      ),
+      node(
+        'android.view.View',
+        { left: 20, top: 100, width: 120, height: 60 },
+        { 'clickable-score': '0', text: '说明' },
+      ),
+    ];
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      staticNodes,
+    );
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays).toEqual([]);
+    expect(audit.treeNodes.slice(1)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          interactionEvidence: [],
+          interactive: false,
+        }),
+      ]),
+    );
+  });
+
+  it('draws actionable tree controls without full-page containers or nested duplicates', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      { focusable: 'true' },
+      [
+        node(
+          'android.view.View',
+          { left: 0, top: 0, width: 400, height: 800 },
+          { scrollable: 'true' },
+          [
+            node(
+              'android.view.View',
+              { left: 20, top: 20, width: 200, height: 100 },
+              { clickable: 'true', 'content-desc': '账单卡片' },
+              [
+                node(
+                  'android.widget.TextView',
+                  { left: 40, top: 40, width: 120, height: 40 },
+                  { clickable: 'true', text: '查看账单' },
+                ),
+              ],
+            ),
+            node(
+              'android.widget.Button',
+              { left: 20, top: 160, width: 160, height: 60 },
+              { clickable: 'true', text: '分期还款' },
+            ),
+            node(
+              'android.widget.Button',
+              { left: 220, top: 160, width: 160, height: 60 },
+              { clickable: 'true', text: '提前还款' },
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0003',
+      'node-0005',
+      'node-0006',
+    ]);
+    expect(audit.overlays.map((overlay) => overlay.rect)).toEqual([
+      { left: 20, top: 20, width: 200, height: 100 },
+      { left: 20, top: 160, width: 160, height: 60 },
+      { left: 220, top: 160, width: 160, height: 60 },
+    ]);
+  });
+
+  it('infers semantic WebView controls when Lynx omits clickable flags', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      { focusable: 'true' },
+      [
+        node(
+          'android.view.View',
+          { left: 0, top: 0, width: 400, height: 80 },
+          { 'resource-id': 'full-header' },
+          [
+            node(
+              'android.widget.Button',
+              { left: 0, top: 10, width: 60, height: 60 },
+              { clickable: 'true', 'content-desc': '返回' },
+            ),
+            node(
+              'android.view.View',
+              { left: 300, top: 10, width: 90, height: 60 },
+              {},
+              [
+                node(
+                  'android.view.View',
+                  { left: 300, top: 20, width: 30, height: 30 },
+                  {},
+                  [
+                    node('android.widget.Image', {
+                      left: 300,
+                      top: 20,
+                      width: 30,
+                      height: 30,
+                    }),
+                  ],
+                ),
+                node(
+                  'android.view.View',
+                  { left: 350, top: 20, width: 30, height: 30 },
+                  {},
+                  [
+                    node('android.widget.Image', {
+                      left: 350,
+                      top: 20,
+                      width: 30,
+                      height: 30,
+                    }),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 70 },
+          { 'resource-id': 'fullfill' },
+          [
+            node(
+              'android.widget.TextView',
+              { left: 40, top: 120, width: 120, height: 30 },
+              { text: '安全保障中' },
+            ),
+            node('android.widget.Image', {
+              left: 340,
+              top: 125,
+              width: 16,
+              height: 16,
+            }),
+          ],
+        ),
+        node(
+          'android.view.View',
+          { left: 60, top: 190, width: 280, height: 30 },
+          {},
+          [
+            node(
+              'android.widget.TextView',
+              { left: 60, top: 190, width: 100, height: 30 },
+              { text: '招商银行' },
+            ),
+            node(
+              'android.widget.TextView',
+              { left: 160, top: 190, width: 120, height: 30 },
+              { text: '自动扣款' },
+            ),
+            node('android.widget.Image', {
+              left: 290,
+              top: 197,
+              width: 16,
+              height: 16,
+            }),
+          ],
+        ),
+        node(
+          'android.view.View',
+          { left: 20, top: 250, width: 360, height: 100 },
+          { 'resource-id': 'icon-container' },
+          [
+            node(
+              'android.view.View',
+              { left: 20, top: 250, width: 160, height: 100 },
+              { 'resource-id': 'icon-consumer' },
+              [
+                node('android.widget.Image', {
+                  left: 80,
+                  top: 260,
+                  width: 40,
+                  height: 40,
+                }),
+                node(
+                  'android.widget.TextView',
+                  { left: 60, top: 310, width: 80, height: 30 },
+                  { text: '消费明细' },
+                ),
+              ],
+            ),
+            node(
+              'android.view.View',
+              { left: 220, top: 250, width: 160, height: 100 },
+              { 'resource-id': 'icon-points' },
+              [
+                node('android.widget.Image', {
+                  left: 280,
+                  top: 260,
+                  width: 40,
+                  height: 40,
+                }),
+                node(
+                  'android.widget.TextView',
+                  { left: 270, top: 310, width: 60, height: 30 },
+                  { text: '月付金' },
+                ),
+              ],
+            ),
+          ],
+        ),
+        node(
+          'android.widget.TextView',
+          { left: 20, top: 390, width: 160, height: 30 },
+          { text: '普通静态说明' },
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0003',
+      'node-0006',
+      'node-0008',
+      'node-0009',
+      'node-0012',
+      'node-0017',
+      'node-0020',
+    ]);
+    expect(audit.overlays.map((overlay) => overlay.name)).toEqual([
+      '返回',
+      'android.widget.Image',
+      'android.widget.Image',
+      '安全保障中',
+      '招商银行 · 自动扣款',
+      '消费明细',
+      '月付金',
+    ]);
+  });
+
+  it('infers described Lynx controls without a WebView ancestor', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.widget.ScrollView',
+          { left: 0, top: 80, width: 400, height: 720 },
+          {
+            'content-desc': '钱包页面',
+            focusable: 'true',
+            scrollable: 'true',
+          },
+          [
+            node(
+              'android.view.ViewGroup',
+              { left: 20, top: 120, width: 90, height: 72 },
+              {
+                clickable: 'false',
+                'content-desc': '放心借  按钮',
+                focusable: 'true',
+              },
+            ),
+            node(
+              'android.view.ViewGroup',
+              { left: 110, top: 120, width: 90, height: 72 },
+              {
+                clickable: 'false',
+                'content-desc': '抖音月付  按钮',
+                focusable: 'true',
+              },
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays).toEqual([
+      expect.objectContaining({
+        name: '放心借  按钮',
+        nodeId: 'node-0003',
+        rect: { left: 20, top: 120, width: 90, height: 72 },
+      }),
+      expect.objectContaining({
+        name: '抖音月付  按钮',
+        nodeId: 'node-0004',
+        rect: { left: 110, top: 120, width: 90, height: 72 },
+      }),
+    ]);
+  });
+
+  it('covers unnamed Lynx regions with minimal structural units', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.widget.FrameLayout',
+          { left: 0, top: 0, width: 400, height: 800 },
+          { focusable: 'true' },
+          [
+            node('android.view.ViewGroup', {
+              left: 0,
+              top: 0,
+              width: 400,
+              height: 80,
+            }),
+            node(
+              'android.widget.ScrollView',
+              { left: 0, top: 80, width: 400, height: 720 },
+              { focusable: 'true', scrollable: 'true' },
+              [
+                node(
+                  'android.widget.LinearLayout',
+                  { left: 0, top: 80, width: 400, height: 720 },
+                  { focusable: 'true' },
+                  [
+                    node(
+                      'android.view.ViewGroup',
+                      { left: 20, top: 100, width: 360, height: 180 },
+                      {},
+                      [
+                        node(
+                          'android.view.ViewGroup',
+                          { left: 20, top: 110, width: 360, height: 170 },
+                          {},
+                          [
+                            node(
+                              'android.view.ViewGroup',
+                              { left: 20, top: 110, width: 360, height: 80 },
+                              {},
+                              [
+                                node('android.view.ViewGroup', {
+                                  left: 100,
+                                  top: 120,
+                                  width: 16,
+                                  height: 16,
+                                }),
+                              ],
+                            ),
+                            ...[40, 120, 200, 280].map((left) =>
+                              node('android.view.ViewGroup', {
+                                left,
+                                top: 210,
+                                width: 30,
+                                height: 60,
+                              }),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    node(
+                      'android.view.ViewGroup',
+                      { left: 20, top: 300, width: 360, height: 160 },
+                      {},
+                      [
+                        node(
+                          'android.view.ViewGroup',
+                          { left: 20, top: 320, width: 360, height: 140 },
+                          {},
+                          [
+                            node(
+                              'android.view.ViewGroup',
+                              { left: 20, top: 320, width: 180, height: 140 },
+                              {
+                                clickable: 'false',
+                                'content-desc': '放心借  按钮',
+                                focusable: 'true',
+                              },
+                            ),
+                            node(
+                              'android.view.ViewGroup',
+                              { left: 200, top: 320, width: 180, height: 140 },
+                              {
+                                clickable: 'false',
+                                'content-desc': '抖音月付  按钮',
+                                focusable: 'true',
+                              },
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0003',
+      'node-0007',
+      'node-0008',
+      'node-0009',
+      'node-0010',
+      'node-0011',
+      'node-0012',
+      'node-0013',
+      'node-0016',
+      'node-0017',
+    ]);
+    expect(
+      audit.overlays.every((overlay) => overlay.rectSource === 'tree'),
+    ).toBe(true);
+    expect(
+      audit.overlays
+        .filter((overlay) => {
+          const sequence = Number(overlay.nodeId?.slice(-4));
+          return sequence >= 7 && sequence <= 13;
+        })
+        .every((overlay) => overlay.status !== 'cache-xpath-hit'),
+    ).toBe(true);
+  });
+
+  it('ignores full-page clickable wrappers when selecting WebView controls', () => {
+    const buildAudit = (clickable: string) => {
+      const root = node(
+        'android.webkit.WebView',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.view.View',
+            { left: 0, top: 0, width: 400, height: 800 },
+            { clickable },
+            [
+              node(
+                'android.view.View',
+                { left: 0, top: 0, width: 400, height: 800 },
+                { clickable, 'resource-id': 'root' },
+                [
+                  node(
+                    'android.view.View',
+                    { left: 20, top: 100, width: 360, height: 70 },
+                    { clickable, 'resource-id': 'fullfill' },
+                    [
+                      node(
+                        'android.widget.TextView',
+                        { left: 40, top: 120, width: 120, height: 30 },
+                        { text: '安全保障中' },
+                      ),
+                      node('android.widget.Image', {
+                        left: 340,
+                        top: 125,
+                        width: 16,
+                        height: 16,
+                      }),
+                    ],
+                  ),
+                  node(
+                    'android.widget.Button',
+                    { left: 20, top: 200, width: 160, height: 60 },
+                    { clickable: 'true', text: '分期还款' },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+      return buildAndroidLiveTreeAudit(root, {
+        width: 400,
+        height: 800,
+      });
+    };
+
+    const clickableAudit = buildAudit('true');
+    const nonClickableAudit = buildAudit('false');
+
+    expect(clickableAudit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0004',
+      'node-0007',
+    ]);
+    expect(clickableAudit.overlays.map((overlay) => overlay.rect)).toEqual(
+      nonClickableAudit.overlays.map((overlay) => overlay.rect),
+    );
+  });
+
+  it('does not turn a WebView text label into a control only because clickable changes', () => {
+    const buildAudit = (clickable: string) => {
+      const root = node(
+        'android.webkit.WebView',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.widget.TextView',
+            { left: 20, top: 100, width: 120, height: 30 },
+            { clickable, text: '平台协议更新公告' },
+          ),
+          node(
+            'android.widget.TextView',
+            { left: 300, top: 100, width: 40, height: 30 },
+            { clickable, text: '查看' },
+          ),
+          node('android.widget.Image', {
+            left: 342,
+            top: 105,
+            width: 16,
+            height: 16,
+          }),
+        ],
+      );
+      return buildAndroidLiveTreeAudit(root, {
+        width: 400,
+        height: 800,
+      });
+    };
+
+    const clickableAudit = buildAudit('true');
+    const nonClickableAudit = buildAudit('false');
+
+    expect(clickableAudit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0003',
+    ]);
+    expect(clickableAudit.overlays.map((overlay) => overlay.rect)).toEqual(
+      nonClickableAudit.overlays.map((overlay) => overlay.rect),
+    );
+  });
+
+  it('keeps the same semantic text and image container when clickable changes', () => {
+    const buildAudit = (clickable: string) => {
+      const root = node(
+        'android.webkit.WebView',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.view.View',
+            { left: 80, top: 100, width: 240, height: 30 },
+            { clickable },
+            [
+              node(
+                'android.widget.TextView',
+                { left: 80, top: 100, width: 70, height: 30 },
+                { text: '将优先从' },
+              ),
+              node(
+                'android.widget.TextView',
+                { left: 150, top: 100, width: 100, height: 30 },
+                { text: '招商银行' },
+              ),
+              node(
+                'android.widget.TextView',
+                { left: 250, top: 100, width: 50, height: 30 },
+                { text: '自动扣款' },
+              ),
+              node('android.widget.Image', {
+                left: 302,
+                top: 107,
+                width: 16,
+                height: 16,
+              }),
+            ],
+          ),
+        ],
+      );
+      return buildAndroidLiveTreeAudit(root, {
+        width: 400,
+        height: 800,
+      });
+    };
+
+    const clickableAudit = buildAudit('true');
+    const nonClickableAudit = buildAudit('false');
+
+    for (const audit of [clickableAudit, nonClickableAudit]) {
+      expect(audit.overlays).toEqual([
+        expect.objectContaining({
+          nodeId: 'node-0002',
+          rect: { left: 80, top: 100, width: 240, height: 30 },
+          rectSource: 'tree',
+        }),
+      ]);
+    }
+  });
+
+  it('treats UIAutomator ImageView nodes as image semantics', () => {
+    const buildAudit = (imageType: string) => {
+      const root = node(
+        'android.webkit.WebView',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.view.View',
+            { left: 20, top: 100, width: 180, height: 80 },
+            {},
+            [
+              node(
+                'android.widget.TextView',
+                { left: 40, top: 120, width: 100, height: 30 },
+                { text: 'Details' },
+              ),
+              node(imageType, {
+                left: 150,
+                top: 120,
+                width: 20,
+                height: 20,
+              }),
+            ],
+          ),
+        ],
+      );
+      return buildAndroidLiveTreeAudit(root, { width: 400, height: 800 });
+    };
+
+    expect(buildAudit('android.widget.ImageView').overlays).toEqual(
+      buildAudit('android.widget.Image').overlays,
+    );
+  });
+
+  it('selects the smallest complete semantic unit instead of a wrapper with identical content', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 140 },
+          {},
+          [
+            node(
+              'android.view.View',
+              { left: 60, top: 120, width: 200, height: 80 },
+              {},
+              [
+                node(
+                  'android.widget.TextView',
+                  { left: 80, top: 140, width: 80, height: 30 },
+                  { text: '消费明细' },
+                ),
+                node('android.widget.Image', {
+                  left: 180,
+                  top: 140,
+                  width: 20,
+                  height: 20,
+                }),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays).toEqual([
+      expect.objectContaining({
+        nodeId: 'node-0003',
+        rect: { left: 60, top: 120, width: 200, height: 80 },
+      }),
+    ]);
+  });
+
+  it('lifts a semantic unit when its parent contributes additional content', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 120 },
+          {},
+          [
+            node(
+              'android.widget.TextView',
+              { left: 40, top: 115, width: 100, height: 30 },
+              { text: '自动扣款' },
+            ),
+            node(
+              'android.view.View',
+              { left: 40, top: 155, width: 220, height: 40 },
+              {},
+              [
+                node(
+                  'android.widget.TextView',
+                  { left: 40, top: 160, width: 120, height: 30 },
+                  { text: '招商银行(2479)' },
+                ),
+                node('android.widget.Image', {
+                  left: 180,
+                  top: 165,
+                  width: 16,
+                  height: 16,
+                }),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays).toEqual([
+      expect.objectContaining({
+        nodeId: 'node-0002',
+        rect: { left: 20, top: 100, width: 360, height: 120 },
+      }),
+    ]);
+  });
+
+  it('keeps sibling buttons separate inside a compact semantic container', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 70 },
+          {},
+          [
+            node(
+              'android.widget.Button',
+              { left: 20, top: 100, width: 170, height: 70 },
+              { clickable: 'true', text: '分期还款' },
+            ),
+            node(
+              'android.widget.Button',
+              { left: 210, top: 100, width: 170, height: 70 },
+              { clickable: 'true', text: '提前还款' },
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0003',
+      'node-0004',
+    ]);
+  });
+
+  it('preserves sibling units through nested stable containers', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 100 },
+          { 'resource-id': 'entry-list' },
+          [
+            node(
+              'android.view.View',
+              { left: 20, top: 100, width: 360, height: 100 },
+              { 'resource-id': 'entry-grid' },
+              [
+                node(
+                  'android.view.View',
+                  { left: 20, top: 100, width: 170, height: 100 },
+                  { 'resource-id': 'entry-left' },
+                  [
+                    node(
+                      'android.widget.TextView',
+                      { left: 60, top: 130, width: 80, height: 30 },
+                      { text: '消费明细' },
+                    ),
+                  ],
+                ),
+                node(
+                  'android.view.View',
+                  { left: 210, top: 100, width: 170, height: 100 },
+                  { 'resource-id': 'entry-right' },
+                  [
+                    node(
+                      'android.widget.TextView',
+                      { left: 250, top: 130, width: 80, height: 30 },
+                      { text: '月付金' },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays.map((overlay) => overlay.nodeId)).toEqual([
+      'node-0004',
+      'node-0006',
+    ]);
+  });
+
+  it('keeps a stable business boundary around internal action fragments', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 20, top: 100, width: 360, height: 100 },
+          { 'resource-id': 'campaign-card' },
+          [
+            node(
+              'android.view.View',
+              { left: 20, top: 100, width: 360, height: 100 },
+              {},
+              [
+                node(
+                  'android.view.View',
+                  { left: 20, top: 100, width: 280, height: 100 },
+                  { clickable: 'true', text: '领取红包' },
+                ),
+                node(
+                  'android.view.View',
+                  { left: 300, top: 100, width: 80, height: 100 },
+                  { clickable: 'true', text: '下一张' },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    const audit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+
+    expect(audit.overlays).toEqual([
+      expect.objectContaining({
+        nodeId: 'node-0002',
+        rect: { left: 20, top: 100, width: 360, height: 100 },
+      }),
+    ]);
+  });
+
+  it('enumerates every node with deterministic structural XPath', () => {
+    const enumerated = enumerateAndroidUiTree(auditTree());
+    expect(enumerated.nodes.map((entry) => entry.nodeId)).toEqual([
+      'node-0001',
+      'node-0002',
+      'node-0003',
+    ]);
+    expect(enumerated.nodes.map((entry) => entry.structuralXpath)).toEqual([
+      '/android.widget.FrameLayout[1]',
+      '/android.widget.FrameLayout[1]/android.widget.Button[1]',
+      '/android.widget.FrameLayout[1]/android.view.View[1]',
+    ]);
+  });
+
+  it('keeps safe nodes pending until a fresh tree validates them', () => {
+    const source = buildAndroidLiveTreeAudit(auditTree(), {
+      width: 400,
+      height: 800,
+    });
+
+    expect(source.overlays.map((overlay) => overlay.status)).toEqual([
+      'pending',
+      'tree-only-positional',
+    ]);
+
+    const fresh = buildAndroidLiveTreeAudit(
+      auditTree(40),
+      { width: 400, height: 800 },
+      source.treeNodes,
+    );
+    expect(fresh.replay).toEqual({
+      attempted: 1,
+      hits: 1,
+      misses: 0,
+      wrongMappings: 0,
+    });
+    expect(fresh.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 20, top: 40, width: 120, height: 60 },
+      status: 'cache-xpath-hit',
+    });
+    expect(fresh.overlays[1].status).toBe('tree-only-positional');
+  });
+
+  it('projects fresh replay results back onto source geometry for reports', () => {
+    const sourceRoot = auditTree(20);
+    const source = buildAndroidLiveTreeAudit(sourceRoot, {
+      width: 400,
+      height: 800,
+    });
+    const fresh = buildAndroidLiveTreeAudit(
+      auditTree(80),
+      { width: 400, height: 800 },
+      source.treeNodes,
+    );
+
+    const report = applyAndroidAuditReplayToSource(
+      sourceRoot,
+      { width: 400, height: 800 },
+      source,
+      fresh.replayResults,
+    );
+
+    expect(report.replay).toEqual(fresh.replay);
+    expect(report.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 20, top: 20, width: 120, height: 60 },
+      status: 'cache-xpath-hit',
+    });
+    expect(report.treeNodes[1]).toMatchObject({
+      bounds: { left: 20, top: 20, width: 120, height: 60 },
+      replayVerified: true,
+    });
+  });
+
+  it('carries fresh replay hits to visual overlays mapped to non-interactive nodes', () => {
+    const createTree = (top: number) =>
+      node(
+        'android.widget.FrameLayout',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.view.View',
+            { left: 20, top, width: 120, height: 60 },
+            { 'resource-id': 'stable-lynx-control' },
+          ),
+        ],
+      );
+    const source = buildAndroidLiveTreeAudit(createTree(20), {
+      width: 400,
+      height: 800,
+    });
+    const freshRoot = createTree(40);
+    const fresh = buildAndroidLiveTreeAudit(
+      freshRoot,
+      { width: 400, height: 800 },
+      source.treeNodes,
+    );
+    const visual = buildAndroidVisualAudit(
+      freshRoot,
+      { width: 400, height: 800 },
+      fresh,
+      [
+        {
+          description: 'stable Lynx control',
+          id: 'visual-lynx-control',
+          name: 'Lynx control',
+          rect: { left: 20, top: 40, width: 120, height: 60 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(fresh.overlays).toEqual([]);
+    expect(fresh.replay).toEqual({
+      attempted: 1,
+      hits: 1,
+      misses: 0,
+      wrongMappings: 0,
+    });
+    expect(visual.visualElements[0].status).toBe('cache-xpath-hit');
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      status: 'cache-xpath-hit',
+    });
+  });
+
+  it('maps visual controls to tree nodes and keeps missing controls in the denominator', () => {
+    const root = auditTree();
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: '打开按钮',
+          id: 'visual-open',
+          name: '打开',
+          rect: { left: 10, top: 10, width: 160, height: 100 },
+          rectSource: 'manual',
+        },
+        {
+          description: '截图可见但没有 Accessibility 节点的客服入口',
+          id: 'visual-service',
+          name: '客服',
+          rect: { left: 250, top: 40, width: 80, height: 80 },
+          rectSource: 'manual',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0]).toMatchObject({
+      mappedNodeId: 'node-0002',
+      rect: { left: 10, top: 10, width: 160, height: 100 },
+      status: 'pending',
+    });
+    expect(visual.visualElements[1]).toMatchObject({
+      mappedNodeId: null,
+      status: 'not-exposed',
+    });
+    expect(visual.overlays).toHaveLength(2);
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 20, top: 20, width: 120, height: 60 },
+      rectSource: 'tree',
+    });
+    expect(visual.overlays[1]).toMatchObject({
+      nodeId: null,
+      rect: { left: 250, top: 40, width: 80, height: 80 },
+      rectSource: 'manual',
+      status: 'not-exposed',
+      visualElementId: 'visual-service',
+    });
+  });
+
+  it('does not map an app visual control to the Android navigation bar background', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 0, top: 780, width: 400, height: 20 },
+          { 'resource-id': 'android:id/navigationBarBackground' },
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: 'bottom cash promotion button',
+          id: 'visual-cash',
+          name: 'Claim cash',
+          rect: { left: 40, top: 755, width: 160, height: 40 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBeNull();
+    expect(visual.overlays).toEqual([
+      expect.objectContaining({
+        nodeId: null,
+        rect: { left: 40, top: 755, width: 160, height: 40 },
+        rectSource: 'ai',
+        status: 'not-exposed',
+      }),
+    ]);
+  });
+
+  it('always uses tree bounds when the mapped tree node is much larger', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node('android.view.View', {
+          left: 50,
+          top: 50,
+          width: 200,
+          height: 100,
+        }),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: 'small control inside a tree card',
+          id: 'visual-inside-card',
+          name: 'Card control',
+          rect: { left: 100, top: 80, width: 80, height: 40 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBe('node-0002');
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 50, top: 50, width: 200, height: 100 },
+      rectSource: 'tree',
+    });
+  });
+
+  it('does not expand an AI-confirmed tree control into descendant overlays', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 100, top: 500, width: 100, height: 100 },
+          { 'resource-id': 'payment-entry' },
+          [
+            node('android.widget.Image', {
+              left: 125,
+              top: 510,
+              width: 30,
+              height: 30,
+            }),
+            node(
+              'android.widget.TextView',
+              { left: 110, top: 550, width: 80, height: 20 },
+              { text: '月付金' },
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: 'payment entry with an icon and label',
+          id: 'visual-payment-entry',
+          name: 'Payment entry',
+          rect: { left: 105, top: 505, width: 90, height: 75 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBe('node-0002');
+    expect(visual.overlays).toEqual([
+      expect.objectContaining({
+        nodeId: 'node-0002',
+        rect: { left: 100, top: 500, width: 100, height: 100 },
+        rectSource: 'tree',
+        visualElementId: 'visual-payment-entry',
+      }),
+    ]);
+    expect(
+      visual.overlays.every((overlay) => overlay.rectSource === 'tree'),
+    ).toBe(true);
+  });
+
+  it('prefers a nearby control over a row container when the AI rectangle is slightly shifted', () => {
+    const root = node(
+      'android.widget.FrameLayout',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 16, top: 610, width: 375, height: 60 },
+          { 'resource-id': 'icon-container' },
+          [
+            node(
+              'android.view.View',
+              { left: 272, top: 622, width: 66, height: 48 },
+              { 'resource-id': 'icon-repayment-assistant' },
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: 'repayment assistant control in the bottom row',
+          id: 'visual-repayment-assistant',
+          name: 'Repayment assistant',
+          rect: { left: 305, top: 621, width: 74, height: 92 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBe('node-0003');
+  });
+
+  it('maps to the same semantic node when only its container clickable flag changes', () => {
+    const runAudit = (clickable: string) => {
+      const root = node(
+        'android.widget.FrameLayout',
+        { left: 0, top: 0, width: 400, height: 800 },
+        {},
+        [
+          node(
+            'android.view.View',
+            { left: 100, top: 100, width: 100, height: 100 },
+            { clickable },
+            [
+              node(
+                'android.view.View',
+                { left: 110, top: 110, width: 80, height: 80 },
+                { 'resource-id': 'stable-lynx-control' },
+              ),
+            ],
+          ),
+        ],
+      );
+      const treeAudit = buildAndroidLiveTreeAudit(root, {
+        width: 400,
+        height: 800,
+      });
+      return buildAndroidVisualAudit(
+        root,
+        { width: 400, height: 800 },
+        treeAudit,
+        [
+          {
+            description: 'stable Lynx control',
+            id: 'visual-stable-control',
+            name: 'Stable control',
+            rect: { left: 105, top: 105, width: 90, height: 90 },
+            rectSource: 'ai',
+          },
+        ],
+      );
+    };
+
+    const clickableAudit = runAudit('true');
+    const nonClickableAudit = runAudit('false');
+
+    for (const audit of [clickableAudit, nonClickableAudit]) {
+      expect(audit.visualElements[0].mappedNodeId).toBe('node-0003');
+      expect(audit.overlays).toEqual([
+        expect.objectContaining({
+          nodeId: 'node-0003',
+          rect: { left: 110, top: 110, width: 80, height: 80 },
+          rectSource: 'tree',
+        }),
+      ]);
+    }
+  });
+
+  it('prefers the control-sized node over an interactive full-page WebView container', () => {
+    const button = node('android.widget.Image', {
+      left: 320,
+      top: 38,
+      width: 28,
+      height: 28,
+    });
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 400, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 0, top: 0, width: 400, height: 800 },
+          {
+            'resource-id': 'Page_layout_scroll',
+            scrollable: 'true',
+          },
+          [
+            node(
+              'android.view.View',
+              { left: 320, top: 38, width: 71, height: 28 },
+              {},
+              [button],
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 400,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 400, height: 800 },
+      treeAudit,
+      [
+        {
+          description: 'top-right customer service icon',
+          id: 'visual-service',
+          name: 'Customer service',
+          rect: { left: 323, top: 40, width: 30, height: 49 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBe('node-0004');
+  });
+
+  it('maps a shifted arrow rectangle to the surrounding semantic control', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 360, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 88, top: 296, width: 183, height: 15 },
+          { clickable: 'true' },
+          [
+            node(
+              'android.widget.TextView',
+              { left: 89, top: 296, width: 47, height: 15 },
+              { text: '将优先从' },
+            ),
+            node(
+              'android.widget.TextView',
+              { left: 214, top: 296, width: 48, height: 15 },
+              { text: '自动扣款' },
+            ),
+            node(
+              'android.view.View',
+              { left: 261, top: 297, width: 10, height: 11 },
+              { clickable: 'true' },
+              [
+                node('android.widget.Image', {
+                  left: 261,
+                  top: 297,
+                  width: 10,
+                  height: 11,
+                }),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 360,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 360, height: 800 },
+      treeAudit,
+      [
+        {
+          description: '查看或设置自动扣款的按钮',
+          id: 'visual-auto-debit',
+          name: '自动扣款设置',
+          rect: { left: 264, top: 305, width: 18, height: 18 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0]).toMatchObject({
+      mappedNodeId: 'node-0002',
+    });
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 88, top: 296, width: 183, height: 15 },
+      rectSource: 'tree',
+    });
+  });
+
+  it('maps a partial link rectangle to the card containing all semantic labels', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 360, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 21, top: 397, width: 318, height: 55 },
+          { clickable: 'true', 'resource-id': 'card-repay' },
+          [
+            node(
+              'android.widget.TextView',
+              { left: 36, top: 417, width: 55, height: 15 },
+              { text: '全部账单' },
+            ),
+            node(
+              'android.widget.TextView',
+              { left: 289, top: 417, width: 25, height: 14 },
+              { text: '查看' },
+            ),
+            node(
+              'android.view.View',
+              { left: 312, top: 418, width: 12, height: 12 },
+              { clickable: 'true' },
+              [
+                node('android.widget.Image', {
+                  left: 312,
+                  top: 418,
+                  width: 12,
+                  height: 12,
+                }),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 360,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 360, height: 800 },
+      treeAudit,
+      [
+        {
+          description: '查看全部账单详情的按钮',
+          id: 'visual-all-bills',
+          name: '查看全部账单',
+          rect: { left: 288, top: 423, width: 39, height: 25 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0]).toMatchObject({
+      mappedNodeId: 'node-0002',
+    });
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 21, top: 397, width: 318, height: 55 },
+      rectSource: 'tree',
+    });
+  });
+
+  it('prefers the semantic card container over one matching descendant label', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 360, height: 800 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 34, top: 468, width: 97, height: 68 },
+          { clickable: 'true' },
+          [
+            node(
+              'android.widget.TextView',
+              { left: 48, top: 486, width: 69, height: 14 },
+              { text: '抖音月付卡' },
+            ),
+            node(
+              'android.widget.TextView',
+              { left: 47, top: 506, width: 71, height: 13 },
+              { text: '微信上也可用' },
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 360,
+      height: 800,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 360, height: 800 },
+      treeAudit,
+      [
+        {
+          description: '查看抖音月付卡详情的区域',
+          id: 'visual-monthly-pay-card',
+          name: '抖音月付卡',
+          rect: { left: 47, top: 484, width: 115, height: 61 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0]).toMatchObject({
+      mappedNodeId: 'node-0002',
+    });
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0002',
+      rect: { left: 34, top: 468, width: 97, height: 68 },
+      rectSource: 'tree',
+    });
+  });
+
+  it('does not expand a semantic match across separate controls in a large ancestor', () => {
+    const root = node(
+      'android.webkit.WebView',
+      { left: 0, top: 0, width: 411, height: 882 },
+      {},
+      [
+        node(
+          'android.view.View',
+          { left: 16, top: 186, width: 380, height: 328 },
+          {},
+          [
+            node(
+              'android.widget.TextView',
+              { left: 153, top: 254, width: 106, height: 17 },
+              { text: '8月6日待还 (元)' },
+            ),
+            node(
+              'android.view.View',
+              { left: 145, top: 280, width: 151, height: 39 },
+              {},
+              [
+                node(
+                  'android.widget.TextView',
+                  { left: 145, top: 280, width: 122, height: 39 },
+                  { text: '153.00' },
+                ),
+                node('android.widget.Image', {
+                  left: 270,
+                  top: 287,
+                  width: 25,
+                  height: 25,
+                }),
+              ],
+            ),
+            node(
+              'android.widget.TextView',
+              { left: 105, top: 328, width: 201, height: 16 },
+              { text: '将优先从招商银行(2479)自动扣款' },
+            ),
+            node(
+              'android.widget.Button',
+              { left: 42, top: 368, width: 157, height: 41 },
+              { clickable: 'true', text: '分期还款' },
+            ),
+          ],
+        ),
+      ],
+    );
+    const treeAudit = buildAndroidLiveTreeAudit(root, {
+      width: 411,
+      height: 882,
+    });
+    const visual = buildAndroidVisualAudit(
+      root,
+      { width: 411, height: 882 },
+      treeAudit,
+      [
+        {
+          description: '查看8月6日待还账单详情',
+          id: 'visual-bill-amount',
+          name: '待还金额区域',
+          rect: { left: 140, top: 273, width: 259, height: 88 },
+          rectSource: 'ai',
+        },
+      ],
+    );
+
+    expect(visual.visualElements[0].mappedNodeId).toBe('node-0005');
+    expect(visual.overlays[0]).toMatchObject({
+      nodeId: 'node-0005',
+      rect: { left: 145, top: 280, width: 122, height: 39 },
+      rectSource: 'tree',
+    });
+  });
+});

--- a/packages/android/vitest.config.ts
+++ b/packages/android/vitest.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      '@midscene/core/internal/device-cache': path.resolve(
+        __dirname,
+        '../core/src/device-cache',
+      ),
     },
   },
   test: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/es/dump/task-service-dump.mjs",
       "require": "./dist/lib/dump/task-service-dump.js"
     },
+    "./internal/device-cache": {
+      "types": "./dist/types/device-cache/index.d.ts",
+      "import": "./dist/es/device-cache/index.mjs",
+      "require": "./dist/lib/device-cache/index.js"
+    },
     "./agent": {
       "types": "./dist/types/agent/index.d.ts",
       "import": "./dist/es/agent/index.mjs",
@@ -74,6 +79,7 @@
       "device": ["./dist/types/device.d.ts"],
       "dump": ["./dist/types/dump/index.d.ts"],
       "dump/task-service-dump": ["./dist/types/dump/task-service-dump.d.ts"],
+      "internal/device-cache": ["./dist/types/device-cache/index.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
       "skill": ["./dist/types/skill/index.d.ts"]

--- a/packages/core/src/device-cache/index.ts
+++ b/packages/core/src/device-cache/index.ts
@@ -1,0 +1,29 @@
+/** @internal Shared XPath primitives used by accessibility audit tooling. */
+export type {
+  ExplicitXpathFeature,
+  NativeXpathCachePlatform,
+  UiNode,
+  XpathCacheFeature,
+  XpathCacheIdentity,
+  XpathCacheTarget,
+  XpathCacheTargetContext,
+  XpathCandidateSource,
+  XpathCandidateOptions,
+} from './types';
+export {
+  EXPLICIT_XPATH_FEATURE_KIND,
+  NATIVE_XPATH_CACHE_KIND,
+  NATIVE_XPATH_CACHE_SCHEMA_VERSION,
+} from './types';
+export {
+  findNodeAtPoint,
+  generateXpathCacheFeature,
+  generateXpathCandidates,
+} from './xpath-tree';
+export {
+  evaluateXpath,
+  findRectByXpath,
+  matchRectByXpathCache,
+} from './xpath-query';
+export type { XmlElement } from './parse-xml';
+export { parseXml } from './parse-xml';

--- a/packages/core/src/device-cache/parse-xml.ts
+++ b/packages/core/src/device-cache/parse-xml.ts
@@ -1,0 +1,139 @@
+/**
+ * Minimal XML parser tailored to the shapes Midscene's mobile adapters need:
+ *   - WebDriverAgent `/source` (iOS XCUIElement tree)
+ *   - `uiautomator dump` (Android view hierarchy)
+ *
+ * Both produce well-formed XML that consists only of element nodes with
+ * attributes (no mixed text content, no CDATA, no namespaces, no DTDs beyond
+ * the `<?xml ?>` prolog and an optional doctype). This parser deliberately
+ * does NOT try to be a general-purpose XML implementation; anything outside
+ * the supported subset throws or is ignored to keep the surface small.
+ *
+ * The parser is regex-driven over a single linear pass — O(n) on the input
+ * length and zero npm dependencies.
+ */
+export interface XmlElement {
+  /** Element tag name as it appeared in the source (case preserved). */
+  name: string;
+  attrs: Record<string, string>;
+  children: XmlElement[];
+}
+
+const TAG_RE = /<(\/?)([A-Za-z_][A-Za-z0-9_.\-:]*)([^>]*?)(\/?)>/g;
+const ATTR_RE = /([A-Za-z_][A-Za-z0-9_.\-:]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+
+const ENTITY_TABLE: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+function decodeEntities(value: string): string {
+  if (!value.includes('&')) return value;
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (full, body) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) {
+      const code = Number.parseInt(body.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    if (body.startsWith('#')) {
+      const code = Number.parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : full;
+    }
+    return ENTITY_TABLE[body] ?? full;
+  });
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((m = ATTR_RE.exec(raw))) {
+    const name = m[1];
+    const rawValue = m[3] ?? m[4] ?? '';
+    out[name] = decodeEntities(rawValue);
+  }
+  return out;
+}
+
+/**
+ * Strip XML prolog (`<?xml ?>`), DOCTYPE declarations and comments. We do this
+ * up-front so the main tag scanner does not need to know about them.
+ */
+function stripNonElement(input: string): string {
+  return input
+    .replace(/<\?xml[\s\S]*?\?>/g, '')
+    .replace(/<!DOCTYPE[\s\S]*?>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/**
+ * Parse an XML document into a single root element. Throws on:
+ *   - empty input
+ *   - more than one top-level element
+ *   - unbalanced open/close tags
+ *
+ * Whitespace-only text between tags is skipped silently. Any other text
+ * content is also skipped (these payloads do not carry meaningful text).
+ */
+export function parseXml(input: string): XmlElement {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    throw new Error('parseXml: input is empty');
+  }
+
+  const cleaned = stripNonElement(input);
+  TAG_RE.lastIndex = 0;
+
+  const stack: XmlElement[] = [];
+  let root: XmlElement | undefined;
+  let m: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((m = TAG_RE.exec(cleaned))) {
+    const isClose = m[1] === '/';
+    const name = m[2];
+    const rawAttrs = m[3] ?? '';
+    const isSelfClosing = m[4] === '/';
+
+    if (isClose) {
+      const top = stack.pop();
+      if (!top || top.name !== name) {
+        throw new Error(
+          `parseXml: unbalanced close tag </${name}> (expected </${top?.name ?? '<empty>'}>)`,
+        );
+      }
+      continue;
+    }
+
+    const element: XmlElement = {
+      name,
+      attrs: parseAttrs(rawAttrs),
+      children: [],
+    };
+
+    const parent = stack[stack.length - 1];
+    if (parent) {
+      parent.children.push(element);
+    } else if (root) {
+      throw new Error('parseXml: more than one top-level element');
+    } else {
+      root = element;
+    }
+
+    if (!isSelfClosing) {
+      stack.push(element);
+    }
+  }
+
+  if (stack.length !== 0) {
+    throw new Error(
+      `parseXml: unclosed tag(s): ${stack.map((e) => e.name).join(', ')}`,
+    );
+  }
+  if (!root) {
+    throw new Error('parseXml: no root element found');
+  }
+  return root;
+}

--- a/packages/core/src/device-cache/types.ts
+++ b/packages/core/src/device-cache/types.ts
@@ -1,0 +1,115 @@
+import type { Rect } from '@midscene/shared/types';
+
+/**
+ * Generic UI tree node used by non-web platforms (iOS, Android, HarmonyOS,
+ * desktop) to feed the shared xpath cache pipeline. Each platform adapter is
+ * responsible for parsing its native accessibility / UI inspector payload into
+ * this shape; the xpath generator and query evaluator only ever see UiNode.
+ *
+ * `bounds` must be in the same logical coordinate space the rest of Midscene
+ * expects (i.e. before the screenshot shrink ratio is applied). Off-screen or
+ * zero-sized nodes are allowed but will be skipped by the point-hit search.
+ */
+export interface UiNode {
+  type: string;
+  attrs: Record<string, string | undefined>;
+  bounds: Rect;
+  children: UiNode[];
+}
+
+export interface XpathCacheIdentity {
+  attr: string;
+  value: string;
+}
+
+export interface XpathCacheTargetContext extends XpathCacheIdentity {
+  type: string;
+  additionalAttrs?: XpathCacheIdentity[];
+}
+
+/** Exact identity that a replayed native xpath must still satisfy. */
+export interface XpathCacheTarget extends XpathCacheTargetContext {
+  /**
+   * Optional stable ancestor used to scope an otherwise repeated child label.
+   * Replay still requires the complete child + ancestor fingerprint to resolve
+   * to exactly one node.
+   */
+  ancestor?: XpathCacheTargetContext;
+}
+
+export const NATIVE_XPATH_CACHE_KIND = 'native-xpath' as const;
+export const NATIVE_XPATH_CACHE_SCHEMA_VERSION = 1 as const;
+export const EXPLICIT_XPATH_FEATURE_KIND = 'explicit-xpath' as const;
+
+export type NativeXpathCachePlatform =
+  | 'android'
+  | 'ios'
+  | 'harmony'
+  | 'darwin'
+  | 'win32'
+  | 'linux';
+
+export type ExplicitXpathFeature = Record<string, unknown> & {
+  kind: typeof EXPLICIT_XPATH_FEATURE_KIND;
+  xpaths: string[];
+};
+
+export type XpathCandidateSource =
+  | 'stable-attribute'
+  | 'semantic-attribute'
+  | 'compound-attributes'
+  | 'ancestor-scoped'
+  | 'positional-fallback';
+
+/** Native element cache payload written by the shared xpath cache pipeline. */
+export type XpathCacheFeature = Record<string, unknown> & {
+  kind: typeof NATIVE_XPATH_CACHE_KIND;
+  schemaVersion: typeof NATIVE_XPATH_CACHE_SCHEMA_VERSION;
+  platform: NativeXpathCachePlatform;
+  xpaths: string[];
+  /** Parallel to `xpaths`; absent on cache entries written by older versions. */
+  xpathSources?: XpathCandidateSource[];
+  target: XpathCacheTarget;
+};
+
+export interface XpathCandidateOptions {
+  /**
+   * Natural-language target description used to verify semantic identities.
+   * A text-like attribute is eligible only when its value appears here.
+   */
+  targetDescription?: string;
+  /**
+   * Model-located target rect in the same logical coordinate space as `bounds`.
+   * When provided, only sufficiently overlapping tree nodes are considered.
+   */
+  expectedRect?: Rect;
+  /**
+   * Platform structural node types that must never become element cache
+   * targets. These nodes may cover the located point and carry a unique name,
+   * but their bounds describe an application/window container rather than the
+   * unexposed control the model located.
+   */
+  excludedTargetTypes?: readonly string[];
+  /**
+   * Attribute names that count as "stable identifiers" when present. Searched
+   * in priority order; the first safe value that uniquely identifies the node
+   * is used to emit a top-priority `//*[@attr='value']` candidate. Examples per
+   * platform:
+   *   iOS    : ['accessibility-id', 'name']
+   *   Android: ['resource-id']
+   *   Harmony: ['inspectorKey']
+   *   macOS  : ['AXIdentifier']
+   *   Windows: ['AutomationId']
+   *   Linux  : ['AccessibleId', 'id', 'automation-id']
+   */
+  stableAttrs?: string[];
+  /**
+   * Attribute names whose values describe the element semantically (label,
+   * text, content). When no stable id is available, the generator emits a
+   * `//Type[@attr='value']` candidate from the first safe, unique value that is
+   * grounded in `targetDescription`.
+   */
+  textAttrs?: string[];
+  /** Maximum number of candidates to return. Defaults to 3. */
+  max?: number;
+}

--- a/packages/core/src/device-cache/xpath-query.ts
+++ b/packages/core/src/device-cache/xpath-query.ts
@@ -1,0 +1,499 @@
+import { getDebug } from '@midscene/shared/logger';
+import type { Rect } from '@midscene/shared/types';
+import type {
+  NativeXpathCachePlatform,
+  UiNode,
+  XpathCacheIdentity,
+  XpathCacheTarget,
+  XpathCacheTargetContext,
+  XpathCandidateSource,
+} from './types';
+import {
+  EXPLICIT_XPATH_FEATURE_KIND,
+  NATIVE_XPATH_CACHE_KIND,
+  NATIVE_XPATH_CACHE_SCHEMA_VERSION,
+} from './types';
+
+type Axis = 'child' | 'descendant';
+
+type Predicate =
+  | { kind: 'attr'; attr: string; value: string }
+  | { kind: 'index'; index: number };
+
+interface Step {
+  axis: Axis;
+  tag: string; // '*' for wildcard
+  predicates: Predicate[];
+}
+
+const TAG_RE = /^([A-Za-z_*][A-Za-z0-9_.\-:*]*)/;
+const ATTR_PRED_RE = /^@([A-Za-z_][A-Za-z0-9_\-:]*)=([\s\S]+)$/;
+const INDEX_PRED_RE = /^(\d+)$/;
+const debugXpath = getDebug('cache:xpath');
+
+function parseQuotedXpathLiteral(
+  input: string,
+  start: number,
+): { value: string; next: number } {
+  const quote = input[start];
+  if (quote !== "'" && quote !== '"') {
+    throw new Error(`Expected quoted XPath literal at position ${start}`);
+  }
+  const end = input.indexOf(quote, start + 1);
+  if (end === -1) {
+    throw new Error(`Unclosed XPath literal at position ${start}`);
+  }
+  return { value: input.slice(start + 1, end), next: end + 1 };
+}
+
+function parseConcatXpathLiteral(expression: string): string {
+  if (!expression.startsWith('concat(') || !expression.endsWith(')')) {
+    throw new Error(`Unsupported XPath literal expression "${expression}"`);
+  }
+  const input = expression.slice('concat('.length, -1);
+  const values: string[] = [];
+  let index = 0;
+  while (index < input.length) {
+    while (/\s/.test(input[index] ?? '')) index++;
+    const parsed = parseQuotedXpathLiteral(input, index);
+    values.push(parsed.value);
+    index = parsed.next;
+    while (/\s/.test(input[index] ?? '')) index++;
+    if (index === input.length) break;
+    if (input[index] !== ',') {
+      throw new Error(`Expected ',' at position ${index} in "${expression}"`);
+    }
+    index++;
+  }
+  if (values.length < 2) {
+    throw new Error('XPath concat() requires at least two literal arguments');
+  }
+  return values.join('');
+}
+
+function parseXpathLiteral(expression: string): string {
+  const input = expression.trim();
+  if (input.startsWith("'") || input.startsWith('"')) {
+    const parsed = parseQuotedXpathLiteral(input, 0);
+    if (parsed.next !== input.length) {
+      throw new Error(`Unexpected text after XPath literal in "${expression}"`);
+    }
+    return parsed.value;
+  }
+  return parseConcatXpathLiteral(input);
+}
+
+function parseXpath(xpath: string): Step[] {
+  const steps: Step[] = [];
+  let i = 0;
+  while (i < xpath.length) {
+    let axis: Axis;
+    if (xpath.startsWith('//', i)) {
+      axis = 'descendant';
+      i += 2;
+    } else if (xpath.startsWith('/', i)) {
+      axis = 'child';
+      i += 1;
+    } else {
+      throw new Error(`Expected '/' or '//' at position ${i} in "${xpath}"`);
+    }
+
+    const tagMatch = TAG_RE.exec(xpath.slice(i));
+    if (!tagMatch) {
+      throw new Error(`Expected tag at position ${i} in "${xpath}"`);
+    }
+    const tag = tagMatch[1];
+    i += tag.length;
+
+    const predicates: Predicate[] = [];
+    while (xpath[i] === '[') {
+      const close = findPredicateEnd(xpath, i);
+      const body = xpath.slice(i + 1, close).trim();
+      const attrMatch = ATTR_PRED_RE.exec(body);
+      const indexMatch = INDEX_PRED_RE.exec(body);
+      if (attrMatch) {
+        predicates.push({
+          kind: 'attr',
+          attr: attrMatch[1],
+          value: parseXpathLiteral(attrMatch[2]),
+        });
+      } else if (indexMatch) {
+        predicates.push({
+          kind: 'index',
+          index: Number.parseInt(indexMatch[1], 10),
+        });
+      } else {
+        throw new Error(`Unsupported predicate "[${body}]" in "${xpath}"`);
+      }
+      i = close + 1;
+    }
+
+    steps.push({ axis, tag, predicates });
+  }
+  return steps;
+}
+
+// Find the matching ']' for the '[' at startIdx, respecting nested quoted strings.
+function findPredicateEnd(xpath: string, startIdx: number): number {
+  let i = startIdx + 1;
+  let quote: string | null = null;
+  while (i < xpath.length) {
+    const c = xpath[i];
+    if (quote) {
+      if (c === quote) quote = null;
+    } else if (c === "'" || c === '"') {
+      quote = c;
+    } else if (c === ']') {
+      return i;
+    }
+    i++;
+  }
+  throw new Error(
+    `Unclosed predicate starting at position ${startIdx} in "${xpath}"`,
+  );
+}
+
+function collectDescendants(node: UiNode, out: UiNode[]): void {
+  for (const child of node.children) {
+    out.push(child);
+    collectDescendants(child, out);
+  }
+}
+
+function matchesNameAndAttrs(node: UiNode, step: Step): boolean {
+  if (step.tag !== '*' && node.type !== step.tag) return false;
+  for (const pred of step.predicates) {
+    if (pred.kind !== 'attr') continue;
+    if ((node.attrs?.[pred.attr] ?? '') !== pred.value) return false;
+  }
+  return true;
+}
+
+function applyIndexPredicate(nodes: UiNode[], step: Step): UiNode[] {
+  let result = nodes;
+  for (const pred of step.predicates) {
+    if (pred.kind !== 'index') continue;
+    if (pred.index < 1 || pred.index > result.length) return [];
+    result = [result[pred.index - 1]];
+  }
+  return result;
+}
+
+function evaluateStep(context: UiNode[], step: Step): UiNode[] {
+  const out: UiNode[] = [];
+  for (const node of context) {
+    let candidates: UiNode[];
+    if (step.axis === 'child') {
+      candidates = node.children;
+    } else {
+      candidates = [];
+      collectDescendants(node, candidates);
+    }
+    const filtered = candidates.filter((n) => matchesNameAndAttrs(n, step));
+    out.push(...applyIndexPredicate(filtered, step));
+  }
+  return out;
+}
+
+/**
+ * Evaluate an xpath expression against a UiNode tree and return all matching
+ * nodes. Walks the tree in a single pass per step, so cost is O(N) per step.
+ *
+ * Supported subset (intentionally small — the cache writer only emits these):
+ *   - Axes:        `/Tag` (child) and `//Tag` (descendant-or-self)
+ *   - Name tests:  exact tag match or `*` wildcard
+ *   - Predicates:  `[@attr='value']`, `[@attr="value"]`, `[N]` (1-based)
+ *
+ * Anything outside this subset throws.
+ */
+export function evaluateXpath(root: UiNode, xpath: string): UiNode[] {
+  const steps = parseXpath(xpath);
+  if (steps.length === 0) return [];
+
+  // The first step's axis is interpreted relative to the *virtual* parent of
+  // root: `/Tag` matches the root iff its name matches, `//Tag` searches root
+  // and all descendants.
+  const first = steps[0];
+  let context: UiNode[];
+  if (first.axis === 'child') {
+    const matched = matchesNameAndAttrs(root, first) ? [root] : [];
+    context = applyIndexPredicate(matched, first);
+  } else {
+    const all: UiNode[] = [root];
+    collectDescendants(root, all);
+    const filtered = all.filter((n) => matchesNameAndAttrs(n, first));
+    context = applyIndexPredicate(filtered, first);
+  }
+
+  for (let i = 1; i < steps.length; i++) {
+    if (context.length === 0) return [];
+    context = evaluateStep(context, steps[i]);
+  }
+  return context;
+}
+
+/**
+ * Resolve the bounds of the first node matched by `xpath`. Returns `undefined`
+ * if no node matches. The caller (rectMatchesCacheFeature) is responsible for
+ * deciding whether absence is a soft miss or an error.
+ */
+export function findRectByXpath(root: UiNode, xpath: string): Rect | undefined {
+  const matches = evaluateXpath(root, xpath);
+  return matches[0]?.bounds;
+}
+
+export interface XpathCacheMatch {
+  xpath: string;
+  rect: Rect;
+  source?: XpathCandidateSource;
+}
+
+function validateCacheFeatureScope(
+  feature: unknown,
+  expectedPlatform: NativeXpathCachePlatform,
+): 'native' | 'explicit' {
+  if (!feature || typeof feature !== 'object') {
+    throw new Error('matchRectByXpathCache: invalid cache feature');
+  }
+  const record = feature as Record<string, unknown>;
+  if (record.kind === EXPLICIT_XPATH_FEATURE_KIND) return 'explicit';
+  if (record.kind !== NATIVE_XPATH_CACHE_KIND) {
+    throw new Error('matchRectByXpathCache: cache feature is not native xpath');
+  }
+  if (record.schemaVersion !== NATIVE_XPATH_CACHE_SCHEMA_VERSION) {
+    throw new Error(
+      `matchRectByXpathCache: unsupported native xpath schema version ${String(record.schemaVersion)}`,
+    );
+  }
+  if (record.platform !== expectedPlatform) {
+    throw new Error(
+      `matchRectByXpathCache: cache platform ${String(record.platform)} does not match ${expectedPlatform}`,
+    );
+  }
+  return 'native';
+}
+
+function getCacheFeatureXpaths(feature: unknown): string[] {
+  const maybeXpaths = (feature as { xpaths?: unknown } | undefined)?.xpaths;
+  return Array.isArray(maybeXpaths)
+    ? maybeXpaths.filter(
+        (x): x is string => typeof x === 'string' && x.length > 0,
+      )
+    : [];
+}
+
+const XPATH_CANDIDATE_SOURCES = new Set<XpathCandidateSource>([
+  'stable-attribute',
+  'semantic-attribute',
+  'compound-attributes',
+  'ancestor-scoped',
+  'positional-fallback',
+]);
+
+function getCacheFeatureXpathSources(feature: unknown): XpathCandidateSource[] {
+  const value = (feature as { xpathSources?: unknown } | undefined)
+    ?.xpathSources;
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (source): source is XpathCandidateSource =>
+      typeof source === 'string' &&
+      XPATH_CANDIDATE_SOURCES.has(source as XpathCandidateSource),
+  );
+}
+
+function parseCacheIdentity(value: unknown): XpathCacheIdentity | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const { attr, value: identityValue } = value as Record<string, unknown>;
+  if (
+    typeof attr !== 'string' ||
+    attr.length === 0 ||
+    typeof identityValue !== 'string' ||
+    identityValue.length === 0
+  ) {
+    return undefined;
+  }
+  return { attr, value: identityValue };
+}
+
+function parseTargetContext(
+  value: unknown,
+): XpathCacheTargetContext | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  const identity = parseCacheIdentity(record);
+  if (
+    !identity ||
+    typeof record.type !== 'string' ||
+    record.type.length === 0
+  ) {
+    return undefined;
+  }
+
+  let additionalAttrs: XpathCacheIdentity[] | undefined;
+  if (record.additionalAttrs !== undefined) {
+    if (!Array.isArray(record.additionalAttrs)) return undefined;
+    additionalAttrs = record.additionalAttrs
+      .map(parseCacheIdentity)
+      .filter((item): item is XpathCacheIdentity => item !== undefined);
+    if (additionalAttrs.length !== record.additionalAttrs.length) {
+      return undefined;
+    }
+    const attrs = new Set([identity.attr]);
+    for (const additional of additionalAttrs) {
+      if (attrs.has(additional.attr)) return undefined;
+      attrs.add(additional.attr);
+    }
+  }
+
+  return {
+    type: record.type,
+    ...identity,
+    ...(additionalAttrs?.length ? { additionalAttrs } : {}),
+  };
+}
+
+function getCacheFeatureTarget(feature: unknown): XpathCacheTarget | undefined {
+  if (!feature || typeof feature !== 'object' || !('target' in feature)) {
+    return undefined;
+  }
+
+  const rawTarget = (feature as { target: unknown }).target;
+  const target = parseTargetContext(rawTarget);
+  if (!target) {
+    throw new Error('matchRectByXpathCache: invalid cache target');
+  }
+
+  const rawAncestor = (rawTarget as Record<string, unknown>).ancestor;
+  if (rawAncestor === undefined) return target;
+  const ancestor = parseTargetContext(rawAncestor);
+  if (!ancestor) {
+    throw new Error('matchRectByXpathCache: invalid cache target ancestor');
+  }
+  return { ...target, ancestor };
+}
+
+function matchesTargetContext(
+  node: UiNode,
+  target: XpathCacheTargetContext,
+): boolean {
+  if (node.type !== target.type || node.attrs[target.attr] !== target.value) {
+    return false;
+  }
+  return (target.additionalAttrs ?? []).every(
+    ({ attr, value }) => node.attrs[attr] === value,
+  );
+}
+
+function collectTargetContextMatches(
+  node: UiNode,
+  target: XpathCacheTargetContext,
+  matches: UiNode[],
+): void {
+  if (matchesTargetContext(node, target)) matches.push(node);
+  for (const child of node.children) {
+    collectTargetContextMatches(child, target, matches);
+  }
+}
+
+function resolveExpectedTarget(root: UiNode, target: XpathCacheTarget): UiNode {
+  let searchRoot = root;
+  if (target.ancestor) {
+    const ancestors: UiNode[] = [];
+    collectTargetContextMatches(root, target.ancestor, ancestors);
+    if (ancestors.length !== 1) {
+      throw new Error(
+        `matchRectByXpathCache: cache ancestor matched ${ancestors.length} node(s)`,
+      );
+    }
+    searchRoot = ancestors[0];
+  }
+
+  const targetMatches: UiNode[] = [];
+  if (!target.ancestor && matchesTargetContext(searchRoot, target)) {
+    targetMatches.push(searchRoot);
+  }
+  for (const child of searchRoot.children) {
+    collectTargetContextMatches(child, target, targetMatches);
+  }
+  if (targetMatches.length !== 1) {
+    throw new Error(
+      `matchRectByXpathCache: cache target matched ${targetMatches.length} node(s)`,
+    );
+  }
+  return targetMatches[0];
+}
+
+/**
+ * Resolve xpath candidates to a single, non-ambiguous rect. Native cache
+ * entries include target metadata, which must still identify exactly one node
+ * and agree with the resolved xpath. A feature marked as explicit xpath may
+ * omit target metadata, but its xpath must still resolve uniquely.
+ */
+export function matchRectByXpathCache(
+  root: UiNode,
+  feature: unknown,
+  expectedPlatform: NativeXpathCachePlatform,
+): XpathCacheMatch {
+  const scope = validateCacheFeatureScope(feature, expectedPlatform);
+  const xpaths = getCacheFeatureXpaths(feature);
+  const xpathSources = getCacheFeatureXpathSources(feature);
+  const target = getCacheFeatureTarget(feature);
+  if (xpaths.length === 0) {
+    debugXpath('replay miss reason=no-xpath');
+    throw new Error('matchRectByXpathCache: no xpath in cache feature');
+  }
+
+  if (scope === 'native' && !target) {
+    throw new Error(
+      'matchRectByXpathCache: native xpath cache target is missing',
+    );
+  }
+  if (scope === 'explicit' && target) {
+    throw new Error(
+      'matchRectByXpathCache: explicit xpath must not carry a target',
+    );
+  }
+  const expectedTarget = target
+    ? resolveExpectedTarget(root, target)
+    : undefined;
+
+  const misses: string[] = [];
+  for (let index = 0; index < xpaths.length; index++) {
+    const xpath = xpaths[index];
+    let matches: UiNode[];
+    try {
+      matches = evaluateXpath(root, xpath);
+    } catch (error) {
+      misses.push(`${xpath} failed: ${error}`);
+      continue;
+    }
+
+    if (matches.length !== 1) {
+      misses.push(`${xpath} matched ${matches.length} node(s)`);
+      continue;
+    }
+
+    const match = matches[0];
+    if (expectedTarget && match !== expectedTarget) {
+      misses.push(`${xpath} matched a different target`);
+      continue;
+    }
+
+    const rect = match.bounds;
+    if (rect.width > 0 && rect.height > 0) {
+      const source = xpathSources[index];
+      debugXpath(
+        'replay hit source=%s xpath=%s rect=%o',
+        source ?? 'legacy-or-explicit',
+        xpath,
+        rect,
+      );
+      return source ? { xpath, rect, source } : { xpath, rect };
+    }
+    misses.push(`${xpath} matched a zero-size node`);
+  }
+
+  const message = `matchRectByXpathCache: no unique xpath matched (tried ${xpaths.length}; ${misses.join('; ')})`;
+  debugXpath('replay miss reason=no-unique-xpath details=%s', message);
+  throw new Error(message);
+}

--- a/packages/core/src/device-cache/xpath-tree.ts
+++ b/packages/core/src/device-cache/xpath-tree.ts
@@ -1,0 +1,633 @@
+import { getDebug } from '@midscene/shared/logger';
+import type {
+  NativeXpathCachePlatform,
+  UiNode,
+  XpathCacheFeature,
+  XpathCacheIdentity,
+  XpathCacheTarget,
+  XpathCacheTargetContext,
+  XpathCandidateOptions,
+  XpathCandidateSource,
+} from './types';
+import {
+  NATIVE_XPATH_CACHE_KIND,
+  NATIVE_XPATH_CACHE_SCHEMA_VERSION,
+} from './types';
+import { evaluateXpath } from './xpath-query';
+
+const DEFAULT_MAX_CANDIDATES = 3;
+const MAX_ATTR_VALUE_LENGTH = 256;
+
+interface PointXY {
+  x: number;
+  y: number;
+}
+
+interface PointHit {
+  node: UiNode;
+  path: UiNode[];
+  order: number;
+}
+
+interface XpathBuildResult {
+  candidates: XpathCandidate[];
+  target: XpathCacheTarget;
+}
+
+interface XpathCandidate {
+  xpath: string;
+  source: XpathCandidateSource;
+}
+
+interface RankedIdentity extends XpathCacheIdentity {
+  kind: 'stable' | 'semantic';
+}
+
+const XPATH_TAG_RE = /^[A-Za-z_*][A-Za-z0-9_.\-:*]*$/;
+const debugXpath = getDebug('cache:xpath');
+
+function pointInBounds(node: UiNode, point: PointXY): boolean {
+  const { left, top, width, height } = node.bounds;
+  if (width <= 0 || height <= 0) return false;
+  return (
+    point.x >= left &&
+    point.x < left + width &&
+    point.y >= top &&
+    point.y < top + height
+  );
+}
+
+/**
+ * Find the smallest node whose bounds contain `point`. Depth and document order
+ * break ties, mirroring the typical deepest/topmost element semantic.
+ */
+export function findNodeAtPoint(
+  root: UiNode,
+  point: PointXY,
+): { node: UiNode; path: UiNode[] } | undefined {
+  const best = pickBestPointHit(collectNodesAtPoint(root, point));
+  return best ? { node: best.node, path: best.path } : undefined;
+}
+
+function collectNodesAtPoint(root: UiNode, point: PointXY): PointHit[] {
+  const hits: PointHit[] = [];
+
+  const visit = (node: UiNode, path: UiNode[]) => {
+    const containsPoint = pointInBounds(node, point);
+    const hasBounds = node.bounds.width > 0 && node.bounds.height > 0;
+    if (!containsPoint && hasBounds) return;
+
+    if (containsPoint) {
+      hits.push({ node, path, order: hits.length });
+    }
+    for (const child of node.children) {
+      visit(child, [...path, child]);
+    }
+  };
+  visit(root, [root]);
+  return hits;
+}
+
+/**
+ * Return a parser-safe tag, falling back to wildcard for native class names
+ * such as Android inner classes that contain `$`.
+ */
+function xpathTag(type: string): string {
+  return XPATH_TAG_RE.test(type) ? type : '*';
+}
+
+/** 1-based positional index among siblings matched by `tag`. */
+function siblingIndex(parent: UiNode, target: UiNode, tag: string): number {
+  let idx = 0;
+  for (const sibling of parent.children) {
+    if (tag === '*' || sibling.type === tag) {
+      idx++;
+      if (sibling === target) return idx;
+    }
+  }
+  throw new Error(
+    'siblingIndex: target is not a child of parent (path inconsistency)',
+  );
+}
+
+function buildPositionalXpath(path: UiNode[]): string {
+  let xpath = '';
+  for (let i = 0; i < path.length; i++) {
+    const node = path[i];
+    const tag = xpathTag(node.type);
+    if (i === 0) {
+      xpath += `/${tag}[1]`;
+    } else {
+      const parent = path[i - 1];
+      xpath += `/${tag}[${siblingIndex(parent, node, tag)}]`;
+    }
+  }
+  return xpath;
+}
+
+function isAttrValueSafe(value: string | undefined): value is string {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0 || value.length > MAX_ATTR_VALUE_LENGTH) return false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    // XML 1.0 permits tab, LF, and CR but not the other C0 controls.
+    if (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Serialize a string as an exact XPath 1.0 literal. */
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) return `'${value}'`;
+  if (!value.includes('"')) return `"${value}"`;
+
+  const args: string[] = [];
+  const parts = value.split("'");
+  for (let index = 0; index < parts.length; index++) {
+    args.push(`'${parts[index]}'`);
+    if (index < parts.length - 1) args.push(`"'"`);
+  }
+  return `concat(${args.join(',')})`;
+}
+
+function pickFirstUniqueAttr(
+  root: UiNode,
+  node: UiNode,
+  attrNames: readonly string[] | undefined,
+  buildXpath: (identity: { attr: string; value: string }) => string,
+  acceptValue: (value: string) => boolean = () => true,
+): { identity: { attr: string; value: string }; xpath: string } | undefined {
+  if (!attrNames) return undefined;
+  for (const attr of attrNames) {
+    const value = node.attrs?.[attr];
+    if (isAttrValueSafe(value) && acceptValue(value)) {
+      const identity = { attr, value };
+      const xpath = buildXpath(identity);
+      if (matchesUniquely(root, xpath, node)) {
+        return { identity, xpath };
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeSemanticText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+const GENERIC_SEMANTIC_TOKENS = new Set([
+  'action',
+  'button',
+  'control',
+  'element',
+  'field',
+  'input',
+  'item',
+  'link',
+  'tab',
+  'view',
+  '元素',
+  '按钮',
+  '控件',
+  '操作',
+  '点击',
+  '标签',
+  '视图',
+  '输入',
+  '链接',
+]);
+
+function meaningfulSemanticTokens(value: string): Set<string> {
+  const result = new Set<string>();
+  for (const token of value.match(/[\p{L}\p{N}]+/gu) ?? []) {
+    const characters = [...token];
+    if (/\p{Script=Han}/u.test(token) && characters.length >= 2) {
+      for (let index = 0; index < characters.length - 1; index++) {
+        const bigram = `${characters[index]}${characters[index + 1]}`;
+        if (!GENERIC_SEMANTIC_TOKENS.has(bigram)) result.add(bigram);
+      }
+      continue;
+    }
+    if (token.length >= 3 && !GENERIC_SEMANTIC_TOKENS.has(token)) {
+      result.add(token);
+    }
+  }
+  return result;
+}
+
+function isSemanticValueGrounded(
+  value: string,
+  targetDescription: string | undefined,
+): boolean {
+  if (!targetDescription) return false;
+  const normalizedValue = normalizeSemanticText(value);
+  const normalizedDescription = normalizeSemanticText(targetDescription);
+  if (
+    normalizedValue.length > 0 &&
+    normalizedDescription.includes(normalizedValue)
+  ) {
+    return true;
+  }
+
+  const descriptionTokens = meaningfulSemanticTokens(normalizedDescription);
+  return [...meaningfulSemanticTokens(normalizedValue)].some((token) =>
+    descriptionTokens.has(token),
+  );
+}
+
+/**
+ * Returns true iff exactly one node in the tree matches `xpath` and that node
+ * is `target`. Cheap uniqueness check used to drop ambiguous candidates before
+ * we commit them to the cache file.
+ */
+function matchesUniquely(root: UiNode, xpath: string, target: UiNode): boolean {
+  const matches = evaluateXpath(root, xpath);
+  return matches.length === 1 && matches[0] === target;
+}
+
+function toCacheTarget(
+  node: UiNode,
+  identities: XpathCacheIdentity[],
+  ancestor?: XpathCacheTargetContext,
+): XpathCacheTarget {
+  const [identity, ...additionalAttrs] = identities;
+  return {
+    type: node.type,
+    attr: identity.attr,
+    value: identity.value,
+    ...(additionalAttrs.length > 0 ? { additionalAttrs } : {}),
+    ...(ancestor ? { ancestor } : {}),
+  };
+}
+
+function rankedIdentities(
+  node: UiNode,
+  options: XpathCandidateOptions | undefined,
+): RankedIdentity[] {
+  const identities: RankedIdentity[] = [];
+  const seen = new Set<string>();
+  const append = (
+    names: readonly string[] | undefined,
+    kind: RankedIdentity['kind'],
+  ) => {
+    for (const attr of names ?? []) {
+      if (seen.has(attr)) continue;
+      const value = node.attrs[attr];
+      if (!isAttrValueSafe(value)) continue;
+      if (
+        kind === 'semantic' &&
+        !isSemanticValueGrounded(value, options?.targetDescription)
+      ) {
+        continue;
+      }
+      identities.push({ attr, value, kind });
+      seen.add(attr);
+    }
+  };
+  append(options?.stableAttrs, 'stable');
+  append(options?.textAttrs, 'semantic');
+  return identities;
+}
+
+function exactNodeXpath(
+  node: UiNode,
+  identities: XpathCacheIdentity[],
+): string {
+  const predicates = identities
+    .map(({ attr, value }) => `[@${attr}=${xpathLiteral(value)}]`)
+    .join('');
+  return `//${xpathTag(node.type)}${predicates}`;
+}
+
+function findCompoundIdentity(
+  root: UiNode,
+  node: UiNode,
+  options: XpathCandidateOptions | undefined,
+): { identities: XpathCacheIdentity[]; xpath: string } | undefined {
+  const identities = rankedIdentities(node, options);
+  for (let first = 0; first < identities.length; first++) {
+    for (let second = first + 1; second < identities.length; second++) {
+      const pair = [identities[first], identities[second]].map(
+        ({ attr, value }) => ({ attr, value }),
+      );
+      const xpath = exactNodeXpath(node, pair);
+      if (matchesUniquely(root, xpath, node)) {
+        return { identities: pair, xpath };
+      }
+    }
+  }
+  return undefined;
+}
+
+function uniqueStableAncestorIdentity(
+  root: UiNode,
+  node: UiNode,
+  options: XpathCandidateOptions | undefined,
+): { identity: XpathCacheIdentity; xpath: string } | undefined {
+  for (const attr of options?.stableAttrs ?? []) {
+    const value = node.attrs[attr];
+    if (!isAttrValueSafe(value)) continue;
+    const xpath = `//*[@${attr}=${xpathLiteral(value)}]`;
+    if (matchesUniquely(root, xpath, node)) {
+      return { identity: { attr, value }, xpath };
+    }
+  }
+  return undefined;
+}
+
+function findAncestorScopedIdentity(
+  root: UiNode,
+  hit: Pick<PointHit, 'node' | 'path'>,
+  options: XpathCandidateOptions | undefined,
+):
+  | {
+      childIdentity: XpathCacheIdentity;
+      ancestor: XpathCacheTargetContext;
+      xpath: string;
+    }
+  | undefined {
+  const childIdentities = rankedIdentities(hit.node, options);
+  if (childIdentities.length === 0) return undefined;
+
+  // Skip path[0], the normalized application/window root. Nearest-first keeps
+  // the contextual identity as small as possible without promoting the click.
+  for (let index = hit.path.length - 2; index >= 1; index--) {
+    const ancestorNode = hit.path[index];
+    const stableAncestor = uniqueStableAncestorIdentity(
+      root,
+      ancestorNode,
+      options,
+    );
+    if (!stableAncestor) continue;
+
+    for (const childIdentity of childIdentities) {
+      const childXpath = exactNodeXpath(hit.node, [childIdentity]).slice(2);
+      const xpath = `${stableAncestor.xpath}//${childXpath}`;
+      if (!matchesUniquely(root, xpath, hit.node)) continue;
+      return {
+        childIdentity,
+        ancestor: {
+          type: ancestorNode.type,
+          attr: stableAncestor.identity.attr,
+          value: stableAncestor.identity.value,
+        },
+        xpath,
+      };
+    }
+  }
+  return undefined;
+}
+
+function buildXpathCandidatesForHit(
+  root: UiNode,
+  hit: Pick<PointHit, 'node' | 'path'>,
+  options: XpathCandidateOptions | undefined,
+): XpathBuildResult | undefined {
+  const max = options?.max ?? DEFAULT_MAX_CANDIDATES;
+  const candidates: XpathCandidate[] = [];
+  let target: XpathCacheTarget | undefined;
+  const { node, path } = hit;
+
+  // A native tree root represents an application/window hierarchy, not the
+  // control located by the model. Platform-declared structural nodes have the
+  // same problem when the actual inner control is absent from accessibility.
+  if (path.length === 1 || options?.excludedTargetTypes?.includes(node.type)) {
+    return undefined;
+  }
+
+  const stable = pickFirstUniqueAttr(
+    root,
+    node,
+    options?.stableAttrs,
+    ({ attr, value }) => `//*[@${attr}=${xpathLiteral(value)}]`,
+  );
+  if (stable) {
+    candidates.push({ xpath: stable.xpath, source: 'stable-attribute' });
+    target = toCacheTarget(node, [stable.identity]);
+  }
+
+  if (candidates.length < max) {
+    const semantic = pickFirstUniqueAttr(
+      root,
+      node,
+      options?.textAttrs,
+      ({ attr, value }) =>
+        `//${xpathTag(node.type)}[@${attr}=${xpathLiteral(value)}]`,
+      (value) => isSemanticValueGrounded(value, options?.targetDescription),
+    );
+    if (
+      semantic &&
+      !candidates.some((candidate) => candidate.xpath === semantic.xpath)
+    ) {
+      candidates.push({
+        xpath: semantic.xpath,
+        source: 'semantic-attribute',
+      });
+      target ??= toCacheTarget(node, [semantic.identity]);
+    }
+  }
+
+  if (!target) {
+    const compound = findCompoundIdentity(root, node, options);
+    if (compound) {
+      candidates.push({
+        xpath: compound.xpath,
+        source: 'compound-attributes',
+      });
+      target = toCacheTarget(node, compound.identities);
+    }
+  }
+
+  if (!target) {
+    const contextual = findAncestorScopedIdentity(root, hit, options);
+    if (contextual) {
+      candidates.push({
+        xpath: contextual.xpath,
+        source: 'ancestor-scoped',
+      });
+      target = toCacheTarget(
+        node,
+        [contextual.childIdentity],
+        contextual.ancestor,
+      );
+    }
+  }
+
+  if (!target) return undefined;
+
+  if (candidates.length < max) {
+    const positional = buildPositionalXpath(path);
+    if (!candidates.some((candidate) => candidate.xpath === positional)) {
+      candidates.push({ xpath: positional, source: 'positional-fallback' });
+    }
+  }
+
+  return {
+    candidates: candidates.slice(0, max),
+    target,
+  };
+}
+
+function nodeArea(node: UiNode): number {
+  return Math.max(0, node.bounds.width) * Math.max(0, node.bounds.height);
+}
+
+function rectIntersectionOverUnion(
+  node: UiNode,
+  expectedRect: NonNullable<XpathCandidateOptions['expectedRect']>,
+): number {
+  const left = Math.max(node.bounds.left, expectedRect.left);
+  const top = Math.max(node.bounds.top, expectedRect.top);
+  const right = Math.min(
+    node.bounds.left + node.bounds.width,
+    expectedRect.left + expectedRect.width,
+  );
+  const bottom = Math.min(
+    node.bounds.top + node.bounds.height,
+    expectedRect.top + expectedRect.height,
+  );
+  const intersection = Math.max(0, right - left) * Math.max(0, bottom - top);
+  const union =
+    nodeArea(node) +
+    Math.max(0, expectedRect.width) * Math.max(0, expectedRect.height) -
+    intersection;
+  return union > 0 ? intersection / union : 0;
+}
+
+const MIN_EXPECTED_RECT_IOU = 0.5;
+
+function rankPointHits(
+  hits: PointHit[],
+  expectedRect: XpathCandidateOptions['expectedRect'],
+): PointHit[] {
+  if (!expectedRect) {
+    const best = pickBestPointHit(hits);
+    return best ? [best] : [];
+  }
+
+  return hits
+    .map((hit) => ({
+      hit,
+      overlap: rectIntersectionOverUnion(hit.node, expectedRect),
+    }))
+    .filter(({ overlap }) => overlap >= MIN_EXPECTED_RECT_IOU)
+    .sort((a, b) => {
+      const overlapDelta = b.overlap - a.overlap;
+      if (overlapDelta !== 0) return overlapDelta;
+      const depthDelta = b.hit.path.length - a.hit.path.length;
+      if (depthDelta !== 0) return depthDelta;
+      return b.hit.order - a.hit.order;
+    })
+    .map(({ hit }) => hit);
+}
+
+function pickBestPointHit(hits: PointHit[]): PointHit | undefined {
+  if (hits.length === 0) return undefined;
+
+  return [...hits].sort((a, b) => {
+    const areaDelta = nodeArea(a.node) - nodeArea(b.node);
+    if (areaDelta !== 0) return areaDelta;
+
+    const depthDelta = b.path.length - a.path.length;
+    if (depthDelta !== 0) return depthDelta;
+
+    return b.order - a.order;
+  })[0];
+}
+
+/**
+ * Generate a small, ranked list of xpath candidates for a tree node that
+ * agrees with both `point` and, when provided, the model-located rect.
+ *
+ *   1) `//*[@<stableAttr>='value']`  — when the hit carries a stable id
+ *   2) `//<Type>[@<textAttr>='value']` — when the hit carries a semantic label
+ *   3) `//<Type>[@a='x'][@b='y']` — exact compound identity
+ *   4) `//*[@parentId='p']//<Type>[@label='x']` — stable ancestor scope
+ *   5) `/Root[1]/Child[i]/.../Target[k]` — identity-checked fallback
+ *
+ * Candidates that match more than one node in the current tree are dropped so
+ * we never persist an ambiguous selector. Targets without a unique stable id
+ * or prompt-grounded semantic identity are not cached because a positional
+ * path alone cannot prove that it still points to the intended element.
+ */
+export function generateXpathCacheFeature(
+  root: UiNode,
+  point: PointXY,
+  platform: NativeXpathCachePlatform,
+  options?: XpathCandidateOptions,
+): XpathCacheFeature | undefined {
+  const hits = rankPointHits(
+    collectNodesAtPoint(root, point),
+    options?.expectedRect,
+  );
+  if (hits.length === 0) {
+    debugXpath('generate miss reason=no-point-hit point=%o', point);
+    return undefined;
+  }
+
+  let selected: { hit: PointHit; result: XpathBuildResult } | undefined;
+  for (const hit of hits) {
+    const result = buildXpathCandidatesForHit(root, hit, options);
+    if (result?.candidates.length) {
+      selected = { hit, result };
+      break;
+    }
+  }
+
+  if (!selected) {
+    const hit = hits[0];
+    const reason =
+      hit.path.length === 1 ||
+      options?.excludedTargetTypes?.includes(hit.node.type)
+        ? 'structural-target'
+        : 'no-verifiable-identity';
+    debugXpath(
+      'generate miss reason=%s targetType=%s point=%o',
+      reason,
+      hit.node.type,
+      point,
+    );
+    return undefined;
+  }
+
+  const { result } = selected;
+
+  const xpaths = result.candidates.map((candidate) => candidate.xpath);
+  const xpathSources = result.candidates.map((candidate) => candidate.source);
+  debugXpath(
+    'generate hit targetType=%s targetAttr=%s sources=%o candidates=%d',
+    result.target.type,
+    result.target.attr,
+    xpathSources,
+    xpaths.length,
+  );
+
+  return {
+    kind: NATIVE_XPATH_CACHE_KIND,
+    schemaVersion: NATIVE_XPATH_CACHE_SCHEMA_VERSION,
+    platform,
+    xpaths,
+    xpathSources,
+    target: result.target,
+  };
+}
+
+export function generateXpathCandidates(
+  root: UiNode,
+  point: PointXY,
+  options?: XpathCandidateOptions,
+): string[] {
+  const hits = rankPointHits(
+    collectNodesAtPoint(root, point),
+    options?.expectedRect,
+  );
+  for (const hit of hits) {
+    const result = buildXpathCandidatesForHit(root, hit, options);
+    if (result?.candidates.length) {
+      return result.candidates.map((candidate) => candidate.xpath);
+    }
+  }
+  return [];
+}

--- a/packages/core/tests/unit-test/device-cache/parse-xml.test.ts
+++ b/packages/core/tests/unit-test/device-cache/parse-xml.test.ts
@@ -1,0 +1,73 @@
+import { parseXml } from '@/device-cache';
+import { describe, expect, it } from 'vitest';
+
+describe('parseXml', () => {
+  it('parses a single self-closing root', () => {
+    const root = parseXml('<Window x="0" y="0"/>');
+    expect(root.name).toBe('Window');
+    expect(root.attrs).toEqual({ x: '0', y: '0' });
+    expect(root.children).toEqual([]);
+  });
+
+  it('parses nested elements with attributes', () => {
+    const xml =
+      '<root id="r"><child name="a"/><child name="b"><leaf k="v"/></child></root>';
+    const root = parseXml(xml);
+    expect(root.name).toBe('root');
+    expect(root.children).toHaveLength(2);
+    expect(root.children[0].attrs).toEqual({ name: 'a' });
+    expect(root.children[1].children[0].name).toBe('leaf');
+    expect(root.children[1].children[0].attrs).toEqual({ k: 'v' });
+  });
+
+  it('strips xml prolog and comments', () => {
+    const xml = '<?xml version="1.0"?><!-- a comment --><root><a/></root>';
+    const root = parseXml(xml);
+    expect(root.name).toBe('root');
+    expect(root.children).toHaveLength(1);
+  });
+
+  it('decodes common XML entities in attribute values', () => {
+    const root = parseXml(
+      '<node label="A &amp; B" name="&lt;ok&gt;" tag="&quot;x&quot;"/>',
+    );
+    expect(root.attrs.label).toBe('A & B');
+    expect(root.attrs.name).toBe('<ok>');
+    expect(root.attrs.tag).toBe('"x"');
+  });
+
+  it('decodes numeric entities', () => {
+    const root = parseXml('<n v="&#65;&#x42;"/>');
+    expect(root.attrs.v).toBe('AB');
+  });
+
+  it('throws on unbalanced tags', () => {
+    expect(() => parseXml('<a><b></a>')).toThrow();
+  });
+
+  it('throws on more than one top-level element', () => {
+    expect(() => parseXml('<a/><b/>')).toThrow();
+  });
+
+  it('throws on empty input', () => {
+    expect(() => parseXml('')).toThrow();
+  });
+
+  it('handles tag names with dots and dashes (android.widget.Button)', () => {
+    const root = parseXml(
+      '<hierarchy><node class="android.widget.Button"><other-tag/></node></hierarchy>',
+    );
+    expect(root.children[0].attrs.class).toBe('android.widget.Button');
+    expect(root.children[0].children[0].name).toBe('other-tag');
+  });
+
+  it('preserves whitespace inside attribute values', () => {
+    const root = parseXml('<n label="hello world  trailing"/>');
+    expect(root.attrs.label).toBe('hello world  trailing');
+  });
+
+  it('handles single-quoted attribute values', () => {
+    const root = parseXml(`<n name='it"s ok'/>`);
+    expect(root.attrs.name).toBe('it"s ok');
+  });
+});

--- a/packages/core/tests/unit-test/device-cache/xpath-cross-state.test.ts
+++ b/packages/core/tests/unit-test/device-cache/xpath-cross-state.test.ts
@@ -1,0 +1,150 @@
+import {
+  type UiNode,
+  generateXpathCacheFeature,
+  matchRectByXpathCache,
+} from '@/device-cache';
+import { describe, expect, it } from 'vitest';
+
+const bounds = (left: number, top: number, width = 100, height = 40) => ({
+  left,
+  top,
+  width,
+  height,
+});
+
+const node = (
+  type: string,
+  attrs: Record<string, string | undefined>,
+  nodeBounds = bounds(0, 0, 400, 800),
+  children: UiNode[] = [],
+): UiNode => ({ type, attrs, bounds: nodeBounds, children });
+
+const root = (children: UiNode[]) => node('Window', {}, undefined, children);
+
+function featureFor(
+  tree: UiNode,
+  point: { x: number; y: number },
+  options: {
+    stableAttrs?: string[];
+    textAttrs?: string[];
+    targetDescription?: string;
+  },
+) {
+  const feature = generateXpathCacheFeature(tree, point, 'android', options);
+  if (!feature) throw new Error('Expected source tree to generate a feature');
+  return feature;
+}
+
+describe('native xpath cache cross-state replay', () => {
+  it('replays after an application restart when the stable target moved', () => {
+    const source = root([
+      node('Button', { id: 'login' }, bounds(20, 600, 160, 50)),
+    ]);
+    const feature = featureFor(
+      source,
+      { x: 100, y: 625 },
+      { stableAttrs: ['id'] },
+    );
+    const replay = root([
+      node('Button', { id: 'login' }, bounds(40, 520, 180, 54)),
+    ]);
+
+    expect(matchRectByXpathCache(replay, feature, 'android').rect).toEqual(
+      bounds(40, 520, 180, 54),
+    );
+  });
+
+  it('ignores sibling reorder when stable identity still resolves uniquely', () => {
+    const source = root([
+      node('Button', { id: 'cancel' }, bounds(20, 100)),
+      node('Button', { id: 'save' }, bounds(140, 100)),
+    ]);
+    const feature = featureFor(
+      source,
+      { x: 180, y: 120 },
+      { stableAttrs: ['id'] },
+    );
+    const replay = root([
+      node('Button', { id: 'save' }, bounds(20, 160)),
+      node('Button', { id: 'cancel' }, bounds(140, 160)),
+    ]);
+
+    expect(matchRectByXpathCache(replay, feature, 'android').rect).toEqual(
+      bounds(20, 160),
+    );
+  });
+
+  it('misses safely after localization changes a semantic-only identity', () => {
+    const source = root([
+      node('Text', { label: 'Settings' }, bounds(20, 80, 180, 40)),
+    ]);
+    const feature = featureFor(
+      source,
+      { x: 100, y: 100 },
+      { textAttrs: ['label'], targetDescription: 'Settings' },
+    );
+    const replay = root([
+      node('Text', { label: 'Parametres' }, bounds(20, 80, 180, 40)),
+    ]);
+
+    expect(() => matchRectByXpathCache(replay, feature, 'android')).toThrow(
+      /cache target matched 0 node/,
+    );
+  });
+
+  it('misses safely when a previously unique label becomes duplicated', () => {
+    const source = root([node('Button', { label: 'More' }, bounds(20, 80))]);
+    const feature = featureFor(
+      source,
+      { x: 60, y: 100 },
+      { textAttrs: ['label'], targetDescription: 'More' },
+    );
+    const replay = root([
+      node('Button', { label: 'More' }, bounds(20, 80)),
+      node('Button', { label: 'More' }, bounds(20, 180)),
+    ]);
+
+    expect(() => matchRectByXpathCache(replay, feature, 'android')).toThrow(
+      /cache target matched 2 node/,
+    );
+  });
+
+  it('uses the current bounds after scrolling moves a stable target', () => {
+    const source = root([
+      node('Button', { id: 'download' }, bounds(20, 650, 180, 50)),
+    ]);
+    const feature = featureFor(
+      source,
+      { x: 100, y: 675 },
+      { stableAttrs: ['id'] },
+    );
+    const replay = root([
+      node('Button', { id: 'download' }, bounds(20, 220, 180, 50)),
+    ]);
+
+    expect(matchRectByXpathCache(replay, feature, 'android').rect).toEqual(
+      bounds(20, 220, 180, 50),
+    );
+  });
+
+  it('misses safely when an overlay duplicates the recorded identity', () => {
+    const source = root([
+      node('Button', { id: 'confirm' }, bounds(20, 600, 180, 50)),
+    ]);
+    const feature = featureFor(
+      source,
+      { x: 100, y: 625 },
+      { stableAttrs: ['id'] },
+    );
+    const replay = root([
+      node('Button', { id: 'confirm' }, bounds(20, 600, 180, 50)),
+      node('Dialog', {}, bounds(0, 0, 400, 800), [
+        node('Button', { id: 'confirm' }, bounds(100, 300, 180, 50)),
+      ]),
+    ]);
+
+    expect(() => matchRectByXpathCache(replay, feature, 'android')).toThrow(
+      /cache target matched 2 node/,
+    );
+  });
+});

--- a/packages/core/tests/unit-test/device-cache/xpath-query.test.ts
+++ b/packages/core/tests/unit-test/device-cache/xpath-query.test.ts
@@ -1,0 +1,414 @@
+import {
+  type UiNode,
+  evaluateXpath,
+  findRectByXpath,
+  matchRectByXpathCache,
+} from '@/device-cache';
+import { describe, expect, it } from 'vitest';
+
+const node = (
+  type: string,
+  attrs: Record<string, string | undefined>,
+  children: UiNode[] = [],
+  bounds = { left: 0, top: 0, width: 100, height: 100 },
+): UiNode => ({ type, attrs, bounds, children });
+
+const matchNative = (root: UiNode, feature: Record<string, unknown>) =>
+  matchRectByXpathCache(
+    root,
+    {
+      kind: 'native-xpath',
+      schemaVersion: 1,
+      platform: 'android',
+      ...feature,
+    },
+    'android',
+  );
+
+describe('evaluateXpath', () => {
+  it('matches root by child axis when name matches', () => {
+    const root = node('Window', {});
+    expect(evaluateXpath(root, '/Window')).toEqual([root]);
+  });
+
+  it('does not match root by child axis when name differs', () => {
+    const root = node('Window', {});
+    expect(evaluateXpath(root, '/Other')).toEqual([]);
+  });
+
+  it('walks children with the child axis', () => {
+    const child = node('Button', { name: 'a' });
+    const root = node('Window', {}, [child]);
+    expect(evaluateXpath(root, '/Window/Button')).toEqual([child]);
+  });
+
+  it('walks all descendants with the descendant axis', () => {
+    const inner = node('Button', { name: 'a' });
+    const outer = node('Group', {}, [inner]);
+    const root = node('Window', {}, [outer]);
+    expect(evaluateXpath(root, '//Button')).toEqual([inner]);
+  });
+
+  it('respects attribute predicates with single quotes', () => {
+    const a = node('Button', { name: 'login' });
+    const b = node('Button', { name: 'cancel' });
+    const root = node('Window', {}, [a, b]);
+    expect(evaluateXpath(root, "//Button[@name='login']")).toEqual([a]);
+  });
+
+  it('respects attribute predicates with double quotes', () => {
+    const a = node('Button', { name: "it's me" });
+    const root = node('Window', {}, [a]);
+    expect(evaluateXpath(root, '//Button[@name="it\'s me"]')).toEqual([a]);
+  });
+
+  it('parses concat literals and quoted brackets exactly', () => {
+    const value = `line [one] with 'single' and "double"`;
+    const target = node('Button', { name: value });
+    const root = node('Window', {}, [target]);
+    expect(
+      evaluateXpath(
+        root,
+        `//Button[@name=concat('line [one] with ',"'",'single',"'",' and "double"')]`,
+      ),
+    ).toEqual([target]);
+  });
+
+  it('rejects non-literal concat arguments', () => {
+    const root = node('Window', {}, [node('Button', { name: 'login' })]);
+    expect(() =>
+      evaluateXpath(root, "//Button[@name=concat('log',@other)]"),
+    ).toThrow(/Expected quoted XPath literal/);
+  });
+
+  it('respects 1-based positional predicates', () => {
+    const a = node('Button', { idx: 'first' });
+    const b = node('Button', { idx: 'second' });
+    const c = node('Button', { idx: 'third' });
+    const root = node('Window', {}, [a, b, c]);
+    expect(evaluateXpath(root, '/Window/Button[2]')).toEqual([b]);
+  });
+
+  it('combines attribute and positional predicates', () => {
+    const a = node('Button', { name: 'foo' });
+    const b = node('Button', { name: 'foo' });
+    const c = node('Button', { name: 'bar' });
+    const root = node('Window', {}, [a, b, c]);
+    expect(evaluateXpath(root, "/Window/Button[@name='foo'][2]")).toEqual([b]);
+  });
+
+  it('uses the wildcard tag for any name', () => {
+    const a = node('Button', { id: 'x' });
+    const b = node('Image', { id: 'x' });
+    const root = node('Window', {}, [a, b]);
+    expect(evaluateXpath(root, "//*[@id='x']")).toEqual([a, b]);
+  });
+
+  it('returns empty when an intermediate step has no match', () => {
+    const a = node('Button', { name: 'a' });
+    const root = node('Window', {}, [a]);
+    expect(evaluateXpath(root, '/Window/Group/Button')).toEqual([]);
+  });
+
+  it('throws on an unsupported predicate', () => {
+    const root = node('Window', {});
+    expect(() => evaluateXpath(root, '/Window[name()="Window"]')).toThrow();
+  });
+
+  it('throws on a missing axis prefix', () => {
+    const root = node('Window', {});
+    expect(() => evaluateXpath(root, 'Window')).toThrow();
+  });
+});
+
+describe('findRectByXpath', () => {
+  it('returns the bounds of the first matching node', () => {
+    const target = node('Button', { name: 'a' }, [], {
+      left: 10,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const root = node('Window', {}, [target]);
+    expect(findRectByXpath(root, '//Button')).toEqual({
+      left: 10,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it('returns undefined when no node matches', () => {
+    const root = node('Window', {});
+    expect(findRectByXpath(root, '//Button')).toBeUndefined();
+  });
+});
+
+describe('matchRectByXpathCache', () => {
+  it('replays a compound target identity when each attribute is ambiguous', () => {
+    const target = node('Button', { id: 'action', text: 'Save' }, [], {
+      left: 40,
+      top: 50,
+      width: 80,
+      height: 30,
+    });
+    const root = node('Window', {}, [
+      target,
+      node('Button', { id: 'action', text: 'Delete' }),
+      node('Button', { id: 'secondary', text: 'Save' }),
+    ]);
+
+    expect(
+      matchNative(root, {
+        xpaths: ["//Button[@id='action'][@text='Save']"],
+        xpathSources: ['compound-attributes'],
+        target: {
+          type: 'Button',
+          attr: 'id',
+          value: 'action',
+          additionalAttrs: [{ attr: 'text', value: 'Save' }],
+        },
+      }),
+    ).toEqual({
+      xpath: "//Button[@id='action'][@text='Save']",
+      source: 'compound-attributes',
+      rect: { left: 40, top: 50, width: 80, height: 30 },
+    });
+  });
+
+  it('replays a repeated child only inside its unique stable ancestor', () => {
+    const target = node('Button', { text: 'More' }, [], {
+      left: 220,
+      top: 30,
+      width: 60,
+      height: 30,
+    });
+    const root = node('Window', {}, [
+      node('Panel', { id: 'card-a' }, [node('Button', { text: 'More' })]),
+      node('Panel', { id: 'card-b' }, [target]),
+    ]);
+
+    expect(
+      matchNative(root, {
+        xpaths: ["//*[@id='card-b']//Button[@text='More']"],
+        xpathSources: ['ancestor-scoped'],
+        target: {
+          type: 'Button',
+          attr: 'text',
+          value: 'More',
+          ancestor: { type: 'Panel', attr: 'id', value: 'card-b' },
+        },
+      }),
+    ).toEqual({
+      xpath: "//*[@id='card-b']//Button[@text='More']",
+      source: 'ancestor-scoped',
+      rect: { left: 220, top: 30, width: 60, height: 30 },
+    });
+  });
+
+  it('rejects ancestor-scoped identity when the ancestor is no longer unique', () => {
+    const root = node('Window', {}, [
+      node('Panel', { id: 'card' }, [node('Button', { text: 'More' })]),
+      node('Panel', { id: 'card' }, [node('Button', { text: 'Other' })]),
+    ]);
+
+    expect(() =>
+      matchNative(root, {
+        xpaths: ["//*[@id='card']//Button[@text='More']"],
+        target: {
+          type: 'Button',
+          attr: 'text',
+          value: 'More',
+          ancestor: { type: 'Panel', attr: 'id', value: 'card' },
+        },
+      }),
+    ).toThrow(/cache ancestor matched 2 node/);
+  });
+
+  it('treats ambiguous xpath matches as cache misses and tries the next xpath', () => {
+    const first = node('Label', { name: 'same' }, [], {
+      left: 10,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const second = node('Button', { name: 'same' }, [], {
+      left: 60,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const root = node('Window', {}, [first, second]);
+
+    expect(
+      matchNative(root, {
+        xpaths: ["//*[@name='same']", '/Window/Button[1]'],
+        target: { type: 'Button', attr: 'name', value: 'same' },
+      }),
+    ).toEqual({
+      xpath: '/Window/Button[1]',
+      rect: {
+        left: 60,
+        top: 20,
+        width: 30,
+        height: 40,
+      },
+    });
+  });
+
+  it('throws when every xpath is missing, ambiguous, or zero-sized', () => {
+    const first = node('Button', { name: 'same' }, [], {
+      left: 10,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const second = node('Button', { name: 'same' }, [], {
+      left: 60,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const zeroSized = node('Button', { name: 'zero' }, [], {
+      left: 0,
+      top: 0,
+      width: 0,
+      height: 0,
+    });
+    const root = node('Window', {}, [first, second, zeroSized]);
+
+    expect(() =>
+      matchNative(root, {
+        xpaths: [
+          "//Button[@name='same']",
+          "//Button[@name='zero']",
+          '//Missing',
+        ],
+        target: { type: 'Button', attr: 'name', value: 'zero' },
+      }),
+    ).toThrow(/no unique xpath matched/);
+  });
+
+  it('rejects a positional fallback that now points to another target', () => {
+    const replacement = node('Button', { id: 'archive', text: 'Archive' }, [], {
+      left: 100,
+      top: 100,
+      width: 80,
+      height: 40,
+    });
+    const root = node('Window', {}, [
+      node('Button', { id: 'keep', text: 'Keep' }),
+      replacement,
+    ]);
+
+    expect(() =>
+      matchNative(root, {
+        xpaths: [
+          "//*[@id='delete']",
+          "//Button[@text='Delete']",
+          '/Window[1]/Button[2]',
+        ],
+        target: { type: 'Button', attr: 'id', value: 'delete' },
+      }),
+    ).toThrow(/cache target matched 0 node/);
+  });
+
+  it('accepts an identity-checked positional fallback', () => {
+    const target = node('Button', { id: 'login' }, [], {
+      left: 60,
+      top: 20,
+      width: 30,
+      height: 40,
+    });
+    const root = node('Window', {}, [
+      node('Button', { id: 'other' }),
+      target,
+      node('Image', { id: 'login' }),
+    ]);
+
+    expect(
+      matchNative(root, {
+        xpaths: ["//*[@id='login']", '/Window[1]/Button[2]'],
+        target: { type: 'Button', attr: 'id', value: 'login' },
+      }),
+    ).toEqual({
+      xpath: '/Window[1]/Button[2]',
+      rect: { left: 60, top: 20, width: 30, height: 40 },
+    });
+  });
+
+  it('rejects malformed target metadata instead of skipping validation', () => {
+    const root = node('Window', {}, [node('Button', { id: 'login' })]);
+
+    expect(() =>
+      matchNative(root, {
+        xpaths: ['/Window/Button[1]'],
+        target: { type: 'Button' },
+      }),
+    ).toThrow(/invalid cache target/);
+  });
+
+  it('accepts a unique explicit xpath without cache target metadata', () => {
+    const target = node('Button', { id: 'login' }, [], {
+      left: 20,
+      top: 30,
+      width: 80,
+      height: 40,
+    });
+    const root = node('Window', {}, [target]);
+
+    expect(
+      matchRectByXpathCache(
+        root,
+        {
+          kind: 'explicit-xpath',
+          xpaths: ["//*[@id='login']"],
+        },
+        'android',
+      ),
+    ).toEqual({
+      xpath: "//*[@id='login']",
+      rect: { left: 20, top: 30, width: 80, height: 40 },
+    });
+  });
+
+  it('rejects an unscoped Web cache entry on a native platform', () => {
+    const root = node('Window', {}, [node('Button', { id: 'login' })]);
+
+    expect(() =>
+      matchRectByXpathCache(root, { xpaths: ["//*[@id='login']"] }, 'android'),
+    ).toThrow(/cache feature is not native xpath/);
+  });
+
+  it('rejects a native cache entry from another platform', () => {
+    const root = node('Window', {}, [node('Button', { id: 'login' })]);
+
+    expect(() =>
+      matchRectByXpathCache(
+        root,
+        {
+          kind: 'native-xpath',
+          schemaVersion: 1,
+          platform: 'ios',
+          xpaths: ["//*[@id='login']"],
+          target: { type: 'Button', attr: 'id', value: 'login' },
+        },
+        'android',
+      ),
+    ).toThrow(/cache platform ios does not match android/);
+  });
+
+  it('rejects a target identity that is no longer unique', () => {
+    const root = node('Window', {}, [
+      node('Button', { id: 'delete' }),
+      node('Button', { id: 'delete' }),
+    ]);
+
+    expect(() =>
+      matchNative(root, {
+        xpaths: ['/Window[1]/Button[2]'],
+        target: { type: 'Button', attr: 'id', value: 'delete' },
+      }),
+    ).toThrow(/cache target matched 2 node/);
+  });
+});

--- a/packages/core/tests/unit-test/device-cache/xpath-tree.test.ts
+++ b/packages/core/tests/unit-test/device-cache/xpath-tree.test.ts
@@ -1,0 +1,765 @@
+import {
+  type UiNode,
+  evaluateXpath,
+  findNodeAtPoint,
+  generateXpathCacheFeature,
+  generateXpathCandidates,
+} from '@/device-cache';
+import { describe, expect, it } from 'vitest';
+
+const node = (
+  type: string,
+  attrs: Record<string, string | undefined>,
+  bounds: { left: number; top: number; width: number; height: number },
+  children: UiNode[] = [],
+): UiNode => ({ type, attrs, bounds, children });
+
+describe('findNodeAtPoint', () => {
+  it('returns the deepest containing node', () => {
+    const inner = node(
+      'Button',
+      { name: 'a' },
+      {
+        left: 10,
+        top: 10,
+        width: 20,
+        height: 20,
+      },
+    );
+    const outer = node(
+      'Group',
+      {},
+      { left: 0, top: 0, width: 100, height: 100 },
+      [inner],
+    );
+    const root = node(
+      'Window',
+      {},
+      { left: 0, top: 0, width: 100, height: 100 },
+      [outer],
+    );
+    const hit = findNodeAtPoint(root, { x: 15, y: 15 });
+    expect(hit?.node).toBe(inner);
+    expect(hit?.path.map((n) => n.type)).toEqual(['Window', 'Group', 'Button']);
+  });
+
+  it('returns undefined when point is outside root', () => {
+    const root = node('Window', {}, { left: 0, top: 0, width: 50, height: 50 });
+    expect(findNodeAtPoint(root, { x: 200, y: 200 })).toBeUndefined();
+  });
+
+  it('skips zero-area nodes', () => {
+    const ghost = node('Other', {}, { left: 0, top: 0, width: 0, height: 0 });
+    const real = node('Button', {}, { left: 0, top: 0, width: 50, height: 50 });
+    const root = node(
+      'Window',
+      {},
+      { left: 0, top: 0, width: 100, height: 100 },
+      [ghost, real],
+    );
+    const hit = findNodeAtPoint(root, { x: 10, y: 10 });
+    expect(hit?.node).toBe(real);
+  });
+
+  it('prefers the last sibling in document order on overlap', () => {
+    const a = node(
+      'Button',
+      { name: 'a' },
+      { left: 0, top: 0, width: 50, height: 50 },
+    );
+    const b = node(
+      'Button',
+      { name: 'b' },
+      { left: 0, top: 0, width: 50, height: 50 },
+    );
+    const root = node(
+      'Window',
+      {},
+      { left: 0, top: 0, width: 100, height: 100 },
+      [a, b],
+    );
+    const hit = findNodeAtPoint(root, { x: 10, y: 10 });
+    expect(hit?.node).toBe(b);
+  });
+});
+
+describe('generateXpathCandidates', () => {
+  const win = (children: UiNode[]) =>
+    node(
+      'Window',
+      {},
+      { left: 0, top: 0, width: 1000, height: 1000 },
+      children,
+    );
+
+  it('emits a stable-id candidate when a stable attr is set and unique', () => {
+    const target = node(
+      'Button',
+      { 'accessibility-id': 'login_btn', name: '登录' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const noise = node(
+      'Button',
+      { 'accessibility-id': 'cancel_btn' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target, noise]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      {
+        stableAttrs: ['accessibility-id'],
+        textAttrs: ['name'],
+        targetDescription: '点击登录',
+      },
+    );
+    expect(xpaths[0]).toBe("//*[@accessibility-id='login_btn']");
+    // verify each emitted xpath actually resolves to the target
+    for (const xp of xpaths) {
+      expect(evaluateXpath(root, xp)).toEqual([target]);
+    }
+  });
+
+  it('falls back to type+text when stable id missing', () => {
+    const target = node(
+      'Button',
+      { name: '登录' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const noise = node(
+      'Button',
+      { name: '取消' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target, noise]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      {
+        stableAttrs: ['accessibility-id'],
+        textAttrs: ['name'],
+        targetDescription: '点击登录',
+      },
+    );
+    expect(xpaths[0]).toBe("//Button[@name='登录']");
+  });
+
+  it('tries later stable attributes when an earlier value is ambiguous', () => {
+    const target = node(
+      'Button',
+      { AccessibleId: 'shared', id: 'cache-target' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const noise = node(
+      'Button',
+      { AccessibleId: 'shared', id: 'other' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target, noise]);
+
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 150, y: 125 },
+      'android',
+      { stableAttrs: ['AccessibleId', 'id'] },
+    );
+
+    expect(feature?.xpaths[0]).toBe("//*[@id='cache-target']");
+    expect(feature?.target).toEqual({
+      type: 'Button',
+      attr: 'id',
+      value: 'cache-target',
+    });
+  });
+
+  it('tries later semantic attributes when an earlier value is ambiguous', () => {
+    const target = node(
+      'Button',
+      { Name: 'Action', Description: 'Save changes' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const noise = node(
+      'Button',
+      { Name: 'Action', Description: 'Discard changes' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target, noise]);
+
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 150, y: 125 },
+      'android',
+      {
+        textAttrs: ['Name', 'Description'],
+        targetDescription: 'Save changes',
+      },
+    );
+
+    expect(feature?.xpaths[0]).toBe("//Button[@Description='Save changes']");
+    expect(feature?.target).toEqual({
+      type: 'Button',
+      attr: 'Description',
+      value: 'Save changes',
+    });
+  });
+
+  it('does not cache a positional path without verifiable identity', () => {
+    const target = node(
+      'Button',
+      {}, // no usable attrs
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const sibling = node(
+      'Button',
+      {},
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([sibling, target]);
+    const xpaths = generateXpathCandidates(root, { x: 150, y: 125 }, {});
+    expect(xpaths).toEqual([]);
+  });
+
+  it('prefers a smaller semantic target over a later fullscreen container', () => {
+    const target = node(
+      'Button',
+      { name: 'login' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const overlayContainer = node(
+      'Other',
+      { name: 'fullscreen container' },
+      { left: 0, top: 0, width: 1000, height: 1000 },
+    );
+    const root = win([target, overlayContainer]);
+
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      {
+        stableAttrs: ['name'],
+        textAttrs: ['name'],
+      },
+    );
+
+    expect(xpaths[0]).toBe("//*[@name='login']");
+    expect(evaluateXpath(root, xpaths[0])).toEqual([target]);
+  });
+
+  it('does not cache when every identity selector is ambiguous', () => {
+    const dupA = node(
+      'Button',
+      { id: 'shared' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const dupB = node(
+      'Button',
+      { id: 'shared' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const root = win([dupA, dupB]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 350, y: 125 },
+      { stableAttrs: ['id'] },
+    );
+    expect(xpaths).toEqual([]);
+  });
+
+  it('serializes attribute values containing both quote styles with concat', () => {
+    const target = node(
+      'Button',
+      { label: `weird "value" with 'both'` },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      { stableAttrs: ['label'] },
+    );
+    expect(xpaths[0]).toContain('concat(');
+    expect(evaluateXpath(root, xpaths[0])).toEqual([target]);
+  });
+
+  it('preserves legal whitespace and brackets in attribute values', () => {
+    const target = node(
+      'Button',
+      { label: 'line1\n[Downloads]\tline2' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      { stableAttrs: ['label'] },
+    );
+    expect(xpaths[0]).toContain('[Downloads]');
+    expect(evaluateXpath(root, xpaths[0])).toEqual([target]);
+  });
+
+  it('rejects XML-illegal control characters', () => {
+    const target = node(
+      'Button',
+      { label: 'before\u0000after' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target]);
+    expect(
+      generateXpathCandidates(
+        root,
+        { x: 150, y: 125 },
+        { stableAttrs: ['label'] },
+      ),
+    ).toEqual([]);
+  });
+
+  it('round-trips a corpus of legal XPath attribute values', () => {
+    const values = [
+      'plain',
+      'with [brackets]',
+      'line1\nline2',
+      'tab\tvalue',
+      `single ' quote`,
+      'double " quote',
+      `both 'single' and "double"`,
+      '中文 semantics',
+    ];
+
+    for (const value of values) {
+      const target = node(
+        'Button',
+        { label: value },
+        { left: 100, top: 100, width: 100, height: 50 },
+      );
+      const root = win([target]);
+      const xpath = generateXpathCandidates(
+        root,
+        { x: 150, y: 125 },
+        { stableAttrs: ['label'] },
+      )[0];
+      expect(evaluateXpath(root, xpath), value).toEqual([target]);
+    }
+  });
+
+  it('uses a compound identity when individual attributes are ambiguous', () => {
+    const target = node(
+      'Button',
+      { id: 'action', text: 'Save' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const sameId = node(
+      'Button',
+      { id: 'action', text: 'Delete' },
+      { left: 300, top: 100, width: 100, height: 50 },
+    );
+    const sameText = node(
+      'Button',
+      { id: 'secondary', text: 'Save' },
+      { left: 500, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target, sameId, sameText]);
+
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 150, y: 125 },
+      'android',
+      {
+        stableAttrs: ['id'],
+        textAttrs: ['text'],
+        targetDescription: 'Save',
+      },
+    );
+
+    expect(feature?.xpaths[0]).toBe("//Button[@id='action'][@text='Save']");
+    expect(feature?.xpathSources?.[0]).toBe('compound-attributes');
+    expect(feature?.target).toEqual({
+      type: 'Button',
+      attr: 'id',
+      value: 'action',
+      additionalAttrs: [{ attr: 'text', value: 'Save' }],
+    });
+  });
+
+  it('uses a stable ancestor to scope a repeated child label', () => {
+    const first = node(
+      'Panel',
+      { id: 'card-a' },
+      { left: 0, top: 0, width: 300, height: 300 },
+      [
+        node(
+          'Button',
+          { text: 'More' },
+          { left: 20, top: 20, width: 80, height: 40 },
+        ),
+      ],
+    );
+    const target = node(
+      'Button',
+      { text: 'More' },
+      { left: 320, top: 20, width: 80, height: 40 },
+    );
+    const second = node(
+      'Panel',
+      { id: 'card-b' },
+      { left: 300, top: 0, width: 300, height: 300 },
+      [target],
+    );
+    const root = win([first, second]);
+
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 350, y: 40 },
+      'android',
+      {
+        stableAttrs: ['id'],
+        textAttrs: ['text'],
+        targetDescription: 'More',
+      },
+    );
+
+    expect(feature?.xpaths[0]).toBe("//*[@id='card-b']//Button[@text='More']");
+    expect(feature?.xpathSources?.[0]).toBe('ancestor-scoped');
+    expect(feature?.target).toEqual({
+      type: 'Button',
+      attr: 'text',
+      value: 'More',
+      ancestor: { type: 'Panel', attr: 'id', value: 'card-b' },
+    });
+    expect(evaluateXpath(root, feature!.xpaths[0])).toEqual([target]);
+  });
+
+  it('returns empty when point hits nothing', () => {
+    const root = win([]);
+    const xpaths = generateXpathCandidates(root, { x: 5000, y: 5000 }, {});
+    expect(xpaths).toEqual([]);
+  });
+
+  it('respects max candidate count', () => {
+    const target = node(
+      'Button',
+      { 'accessibility-id': 'x', name: '登录' },
+      { left: 100, top: 100, width: 100, height: 50 },
+    );
+    const root = win([target]);
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 150, y: 125 },
+      {
+        stableAttrs: ['accessibility-id'],
+        textAttrs: ['name'],
+        max: 1,
+      },
+    );
+    expect(xpaths).toHaveLength(1);
+  });
+
+  it('does not promote a cacheable ancestor over the smaller target', () => {
+    const target = node(
+      'Button',
+      {},
+      { left: 100, top: 100, width: 100, height: 40 },
+    );
+    const parent = node(
+      'Panel',
+      { id: 'form' },
+      { left: 0, top: 0, width: 500, height: 500 },
+      [target],
+    );
+    const root = win([parent]);
+
+    expect(
+      generateXpathCacheFeature(root, { x: 150, y: 120 }, 'android', {
+        stableAttrs: ['id'],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does not cache a uniquely identifiable structural root', () => {
+    const root = node(
+      'AXWindow',
+      { AXName: 'cmux' },
+      { left: 0, top: 0, width: 1000, height: 800 },
+    );
+
+    expect(
+      generateXpathCacheFeature(root, { x: 400, y: 300 }, 'android', {
+        textAttrs: ['AXName'],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does not cache an excluded window when its inner target is absent', () => {
+    const window = node(
+      'AXWindow',
+      { AXName: 'cmux' },
+      { left: 0, top: 0, width: 1000, height: 800 },
+    );
+    const root = node(
+      'AXApplication',
+      { AXName: 'cmux' },
+      { left: 0, top: 0, width: 0, height: 0 },
+      [window],
+    );
+
+    expect(
+      generateXpathCacheFeature(root, { x: 400, y: 300 }, 'android', {
+        excludedTargetTypes: ['AXApplication', 'AXWindow'],
+        textAttrs: ['AXName'],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('caches an exposed child inside an excluded window', () => {
+    const target = node(
+      'AXButton',
+      { AXIdentifier: 'cache-target' },
+      { left: 100, top: 100, width: 120, height: 40 },
+    );
+    const window = node(
+      'AXWindow',
+      { AXName: 'Demo' },
+      { left: 0, top: 0, width: 1000, height: 800 },
+      [target],
+    );
+    const root = node(
+      'AXApplication',
+      {},
+      { left: 0, top: 0, width: 0, height: 0 },
+      [window],
+    );
+
+    expect(
+      generateXpathCacheFeature(root, { x: 150, y: 120 }, 'android', {
+        excludedTargetTypes: ['AXApplication', 'AXWindow'],
+        stableAttrs: ['AXIdentifier'],
+        textAttrs: ['AXName'],
+      })?.target,
+    ).toEqual({
+      type: 'AXButton',
+      attr: 'AXIdentifier',
+      value: 'cache-target',
+    });
+  });
+
+  it('traverses a zero-sized structural root', () => {
+    const target = node(
+      'Button',
+      { id: 'login' },
+      { left: 100, top: 0, width: 100, height: 100 },
+    );
+    const root = node(
+      'hierarchy',
+      {},
+      { left: 0, top: 0, width: 0, height: 0 },
+      [target],
+    );
+
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 150, y: 50 },
+      'android',
+      { stableAttrs: ['id'] },
+    );
+    expect(feature?.xpaths).toContain("//*[@id='login']");
+    expect(feature?.target).toEqual({
+      type: 'Button',
+      attr: 'id',
+      value: 'login',
+    });
+  });
+
+  it('uses wildcard steps for native types outside the xpath tag subset', () => {
+    const target = node(
+      'com.example.Custom$View',
+      { 'resource-id': 'login', text: 'Login' },
+      { left: 0, top: 0, width: 100, height: 50 },
+    );
+    const root = win([target]);
+    const feature = generateXpathCacheFeature(
+      root,
+      { x: 10, y: 10 },
+      'android',
+      {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['text'],
+        targetDescription: 'Login',
+      },
+    );
+
+    expect(feature?.xpaths).toEqual([
+      "//*[@resource-id='login']",
+      "//*[@text='Login']",
+      '/Window[1]/*[1]',
+    ]);
+    for (const xpath of feature?.xpaths ?? []) {
+      expect(evaluateXpath(root, xpath)).toEqual([target]);
+    }
+  });
+
+  it('does not treat an unrelated semantic value as target identity', () => {
+    const target = node(
+      'Button',
+      { label: 'Active' },
+      { left: 20, top: 100, width: 120, height: 40 },
+    );
+
+    expect(
+      generateXpathCacheFeature(win([target]), { x: 80, y: 120 }, 'android', {
+        textAttrs: ['label'],
+        targetDescription: 'click the primary action',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('grounds a detailed semantic description by a meaningful prompt token', () => {
+    const target = node(
+      'Button',
+      { description: `Search [video] for "O'Reilly"` },
+      { left: 20, top: 100, width: 120, height: 40 },
+    );
+
+    expect(
+      generateXpathCacheFeature(win([target]), { x: 80, y: 120 }, 'android', {
+        textAttrs: ['description'],
+        targetDescription: 'the Lynx search action',
+      })?.target,
+    ).toEqual({
+      type: 'Button',
+      attr: 'description',
+      value: `Search [video] for "O'Reilly"`,
+    });
+  });
+
+  it('grounds a longer CJK description by a shared semantic phrase', () => {
+    const target = node(
+      'Button',
+      { description: '搜索视频内容' },
+      { left: 20, top: 100, width: 120, height: 40 },
+    );
+
+    expect(
+      generateXpathCacheFeature(win([target]), { x: 80, y: 120 }, 'android', {
+        textAttrs: ['description'],
+        targetDescription: '点击搜索入口',
+      })?.target.value,
+    ).toBe('搜索视频内容');
+  });
+
+  it('uses a stable wrapper only when it agrees with the model rect', () => {
+    const inner = node(
+      'Text',
+      {},
+      { left: 100, top: 100, width: 100, height: 40 },
+    );
+    const wrapper = node(
+      'Button',
+      { id: 'submit' },
+      { left: 90, top: 95, width: 120, height: 50 },
+      [inner],
+    );
+
+    expect(
+      generateXpathCacheFeature(win([wrapper]), { x: 150, y: 120 }, 'android', {
+        stableAttrs: ['id'],
+        expectedRect: wrapper.bounds,
+      })?.target,
+    ).toEqual({ type: 'Button', attr: 'id', value: 'submit' });
+  });
+
+  it('rejects a full-window wrapper that does not agree with the model rect', () => {
+    const wrapper = node(
+      'AXGroup',
+      { AXIdentifier: 'content' },
+      { left: 0, top: 0, width: 1000, height: 1000 },
+    );
+
+    expect(
+      generateXpathCacheFeature(win([wrapper]), { x: 150, y: 120 }, 'darwin', {
+        stableAttrs: ['AXIdentifier'],
+        expectedRect: { left: 100, top: 100, width: 100, height: 40 },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('handles realistic iOS WDA-shaped trees end-to-end', () => {
+    // Simulates a slice of XCUIElement output: window > navigation > button.
+    const cancel = node(
+      'XCUIElementTypeButton',
+      { name: '取消' },
+      { left: 0, top: 40, width: 80, height: 40 },
+    );
+    const login = node(
+      'XCUIElementTypeButton',
+      { name: '登录', 'accessibility-id': 'login_btn' },
+      { left: 280, top: 40, width: 80, height: 40 },
+    );
+    const navBar = node(
+      'XCUIElementTypeNavigationBar',
+      { name: 'AccountNav' },
+      { left: 0, top: 40, width: 360, height: 40 },
+      [cancel, login],
+    );
+    const window = node(
+      'XCUIElementTypeWindow',
+      {},
+      { left: 0, top: 0, width: 360, height: 800 },
+      [navBar],
+    );
+    const xpaths = generateXpathCandidates(
+      window,
+      { x: 320, y: 60 },
+      {
+        stableAttrs: ['accessibility-id'],
+        textAttrs: ['name', 'label'],
+      },
+    );
+    expect(xpaths).toContain("//*[@accessibility-id='login_btn']");
+    for (const xp of xpaths) {
+      expect(evaluateXpath(window, xp)).toEqual([login]);
+    }
+  });
+
+  it('handles realistic Android-shaped trees end-to-end', () => {
+    const username = node(
+      'android.widget.EditText',
+      {
+        'resource-id': 'com.example:id/username',
+        text: '',
+      },
+      { left: 40, top: 200, width: 1000, height: 120 },
+    );
+    const password = node(
+      'android.widget.EditText',
+      {
+        'resource-id': 'com.example:id/password',
+      },
+      { left: 40, top: 360, width: 1000, height: 120 },
+    );
+    const loginBtn = node(
+      'android.widget.Button',
+      {
+        'resource-id': 'com.example:id/login',
+        text: '登录',
+      },
+      { left: 40, top: 520, width: 1000, height: 140 },
+    );
+    const root = node(
+      'android.widget.FrameLayout',
+      {},
+      { left: 0, top: 0, width: 1080, height: 1920 },
+      [username, password, loginBtn],
+    );
+    const xpaths = generateXpathCandidates(
+      root,
+      { x: 540, y: 590 },
+      {
+        stableAttrs: ['resource-id'],
+        textAttrs: ['text', 'content-desc'],
+      },
+    );
+    expect(xpaths[0]).toBe("//*[@resource-id='com.example:id/login']");
+    for (const xp of xpaths) {
+      expect(evaluateXpath(root, xp)).toEqual([loginBtn]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add internal XML parsing, structural XPath, candidate generation, and replay-query primitives used by the audit workflow
- capture the exact Android accessibility XML source with YADB-to-UIAutomator fallback and normalize it into a complete UiNode tree
- add source/fresh/revisit audit modeling, metadata collection, report data generation, and cross-stack fixtures

## Scope

This PR is self-contained on `main`. It does not enable production XPath caching, add a cache feature flag, or depend on another unmerged PR. The internal XPath primitives are introduced only to support the audit tool in this stack.

Stack order:

1. this PR: audit core and Android capture support
2. `feat/android-xpath-audit-cli-standalone`: capture CLI and static HTML report
3. `feat/android-xpath-audit-playground-standalone`: live Playground audit UI

## Validation

- `pnpm --filter @midscene/core exec vitest --config vitest.config.ts --run tests/unit-test/device-cache/parse-xml.test.ts tests/unit-test/device-cache/xpath-cross-state.test.ts tests/unit-test/device-cache/xpath-query.test.ts tests/unit-test/device-cache/xpath-tree.test.ts` (77 tests)
- `pnpm --filter @midscene/android exec vitest --config vitest.config.ts --run tests/unit-test/audit-metadata.test.ts tests/unit-test/cache-compatibility.test.ts tests/unit-test/page.test.ts tests/unit-test/uiautomator-tree.test.ts tests/unit-test/xpath-audit.test.ts` (231 tests)
- `pnpm exec nx run-many --target=build --projects=@midscene/core,@midscene/android --skip-nx-cache`
- `pnpm run lint`
