### PR TITLE
feat(android-playground): add live XPath audit

### DIFF
--- a/apps/android-playground/package.json
+++ b/apps/android-playground/package.json
@@ -9,6 +9,8 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
+    "@midscene/android": "workspace:*",
+    "@midscene/android-playground": "workspace:*",
     "@midscene/playground-app": "workspace:*",
     "@midscene/shared": "workspace:*",
     "react": "18.3.1",

--- a/apps/android-playground/src/App.tsx
+++ b/apps/android-playground/src/App.tsx
@@ -1,20 +1,7 @@
 import './App.less';
-import { PlaygroundApp } from '@midscene/playground-app';
-
-declare const __APP_VERSION__: string;
+import './android-audit/android-audit.less';
+import { AndroidAuditPlayground } from './android-audit/AndroidAuditPlayground';
 
 export default function App() {
-  return (
-    <PlaygroundApp
-      serverUrl={window.location.origin}
-      appVersion={__APP_VERSION__}
-      title="Android Playground"
-      offlineTitle="Midscene Android Playground"
-      defaultDeviceType="android"
-      branding={{
-        title: 'Android Playground',
-        targetName: 'android',
-      }}
-    />
-  );
+  return <AndroidAuditPlayground />;
 }

--- a/apps/android-playground/src/android-audit/AndroidAuditContext.tsx
+++ b/apps/android-playground/src/android-audit/AndroidAuditContext.tsx
@@ -1,0 +1,371 @@
+import type {
+  AndroidAuditDownloadBundle,
+  AndroidAuditState,
+} from '@midscene/android-playground';
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  chooseAndroidAuditDownloadDirectory,
+  writeAndroidAuditDownloadBundle,
+} from './downloadAndroidAuditReport';
+
+const EMPTY_STATE: AndroidAuditState = {
+  enabled: false,
+  overlays: [],
+  replay: { attempted: 0, hits: 0, misses: 0, wrongMappings: 0 },
+  revision: 0,
+  status: 'idle',
+  treeNodes: [],
+  visualElements: [],
+  visualScan: { status: 'idle' },
+};
+
+type InteractionMode = 'device' | 'inspect' | 'mark';
+
+interface AndroidAuditContextValue {
+  activate(): void;
+  addVisualElement(input: {
+    description: string;
+    name: string;
+    rect: { left: number; top: number; width: number; height: number };
+  }): Promise<void>;
+  capture(): Promise<void>;
+  deactivate(): void;
+  downloadingReport: boolean;
+  error?: string;
+  exportReport(): Promise<void>;
+  interactionMode: InteractionMode;
+  lastDownloadedReport?: string;
+  resume(): Promise<void>;
+  selectOverlay(nodeId: string | undefined, visualElementId?: string): void;
+  selectionRequest: number;
+  selectedNodeId?: string;
+  selectedVisualElementId?: string;
+  setInteractionMode(mode: InteractionMode): void;
+  setRevisitBaseline(): Promise<void>;
+  setSelectedNodeId(nodeId: string | undefined): void;
+  setSelectedVisualElementId(id: string | undefined): void;
+  scanVisualElements(): Promise<void>;
+  state: AndroidAuditState;
+  verifyRevisit(): Promise<void>;
+}
+
+const AndroidAuditContext = createContext<AndroidAuditContextValue | null>(
+  null,
+);
+
+async function requestJson<T>(
+  serverUrl: string,
+  path: string,
+  method: 'GET' | 'POST' = 'GET',
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(`${serverUrl}${path}`, {
+    method,
+    headers: {
+      Accept: 'application/json',
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const payload = (await response.json()) as T & {
+    error?: string;
+  };
+  if (!response.ok) {
+    throw new Error(
+      payload.error || `Android audit request failed (${response.status})`,
+    );
+  }
+  return payload;
+}
+
+const requestState = (
+  serverUrl: string,
+  path: string,
+  method?: 'GET' | 'POST',
+) => requestJson<AndroidAuditState>(serverUrl, path, method);
+
+export function AndroidAuditProvider({
+  children,
+  serverUrl,
+}: {
+  children: ReactNode;
+  serverUrl: string;
+}) {
+  const [state, setState] = useState<AndroidAuditState>(EMPTY_STATE);
+  const [error, setError] = useState<string>();
+  const [downloadingReport, setDownloadingReport] = useState(false);
+  const [lastDownloadedReport, setLastDownloadedReport] = useState<string>();
+  const [interactionMode, setInteractionMode] =
+    useState<InteractionMode>('device');
+  const [selectedNodeId, setSelectedNodeId] = useState<string>();
+  const [selectedVisualElementId, setSelectedVisualElementId] =
+    useState<string>();
+  const [selectionRequest, setSelectionRequest] = useState(0);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const activeRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await requestState(serverUrl, '/android-audit/state');
+      setState(next);
+      setError(next.error);
+      setSelectedNodeId((current) =>
+        current && !next.treeNodes.some((node) => node.nodeId === current)
+          ? undefined
+          : current,
+      );
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : String(requestError),
+      );
+    }
+  }, [serverUrl]);
+
+  const connectEvents = useCallback(() => {
+    eventSourceRef.current?.close();
+    const source = new EventSource(`${serverUrl}/android-audit/events`);
+    source.addEventListener('state', () => void refresh());
+    source.onerror = () => {
+      if (activeRef.current) {
+        setError(
+          'The live audit event stream disconnected. Waiting to reconnect.',
+        );
+      }
+    };
+    eventSourceRef.current = source;
+  }, [refresh, serverUrl]);
+
+  const activate = useCallback(() => {
+    if (activeRef.current) return;
+    activeRef.current = true;
+    setInteractionMode('inspect');
+    connectEvents();
+    void requestState(serverUrl, '/android-audit/start', 'POST')
+      .then((next) => {
+        setState(next);
+        setError(next.error);
+      })
+      .catch((requestError) => {
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : String(requestError),
+        );
+      });
+  }, [connectEvents, serverUrl]);
+
+  const deactivate = useCallback(() => {
+    if (!activeRef.current) return;
+    activeRef.current = false;
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+    setInteractionMode('device');
+    void requestState(serverUrl, '/android-audit/pause', 'POST')
+      .then((next) => setState(next))
+      .catch(() => undefined);
+  }, [serverUrl]);
+
+  const capture = useCallback(async () => {
+    try {
+      setError(undefined);
+      setState(await requestState(serverUrl, '/android-audit/capture', 'POST'));
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : String(requestError),
+      );
+    }
+  }, [serverUrl]);
+
+  const resume = useCallback(async () => {
+    try {
+      setError(undefined);
+      setState(await requestState(serverUrl, '/android-audit/start', 'POST'));
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : String(requestError),
+      );
+    }
+  }, [serverUrl]);
+
+  const runStateOperation = useCallback(
+    async (path: string) => {
+      try {
+        setError(undefined);
+        setState(await requestState(serverUrl, path, 'POST'));
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : String(requestError),
+        );
+      }
+    },
+    [serverUrl],
+  );
+
+  const setRevisitBaseline = useCallback(
+    () => runStateOperation('/android-audit/revisit-baseline'),
+    [runStateOperation],
+  );
+
+  const verifyRevisit = useCallback(
+    () => runStateOperation('/android-audit/revisit-verify'),
+    [runStateOperation],
+  );
+
+  const exportReport = useCallback(async () => {
+    try {
+      setError(undefined);
+      const directory = await chooseAndroidAuditDownloadDirectory();
+      if (!directory) return;
+      setDownloadingReport(true);
+      setLastDownloadedReport(undefined);
+      const bundle = await requestJson<AndroidAuditDownloadBundle>(
+        serverUrl,
+        '/android-audit/export',
+        'POST',
+      );
+      setLastDownloadedReport(
+        await writeAndroidAuditDownloadBundle(directory, bundle),
+      );
+      await refresh();
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : String(requestError),
+      );
+    } finally {
+      setDownloadingReport(false);
+    }
+  }, [refresh, serverUrl]);
+
+  const scanVisualElements = useCallback(
+    () => runStateOperation('/android-audit/visual-scan'),
+    [runStateOperation],
+  );
+
+  const addVisualElement = useCallback(
+    async (input: {
+      description: string;
+      name: string;
+      rect: { left: number; top: number; width: number; height: number };
+    }) => {
+      try {
+        const elements = [
+          ...state.visualElements.map((element) => ({
+            description: element.description,
+            id: element.id,
+            name: element.name,
+            rect: element.rect,
+            rectSource: element.rectSource,
+          })),
+          {
+            ...input,
+            id: `manual-${Date.now()}`,
+            rectSource: 'manual' as const,
+          },
+        ];
+        setState(
+          await requestJson<AndroidAuditState>(
+            serverUrl,
+            '/android-audit/visual-elements',
+            'POST',
+            { elements },
+          ),
+        );
+        setInteractionMode('inspect');
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : String(requestError),
+        );
+      }
+    },
+    [serverUrl, state.visualElements],
+  );
+
+  const selectOverlay = useCallback(
+    (nodeId: string | undefined, visualElementId?: string) => {
+      setSelectedNodeId(nodeId);
+      setSelectedVisualElementId(visualElementId);
+      setSelectionRequest((request) => request + 1);
+    },
+    [],
+  );
+
+  const value = useMemo<AndroidAuditContextValue>(
+    () => ({
+      activate,
+      addVisualElement,
+      capture,
+      deactivate,
+      downloadingReport,
+      error,
+      exportReport,
+      interactionMode,
+      lastDownloadedReport,
+      resume,
+      selectOverlay,
+      selectionRequest,
+      selectedNodeId,
+      selectedVisualElementId,
+      scanVisualElements,
+      setInteractionMode,
+      setRevisitBaseline,
+      setSelectedNodeId,
+      setSelectedVisualElementId,
+      state,
+      verifyRevisit,
+    }),
+    [
+      activate,
+      addVisualElement,
+      capture,
+      deactivate,
+      downloadingReport,
+      error,
+      exportReport,
+      interactionMode,
+      lastDownloadedReport,
+      resume,
+      selectOverlay,
+      selectionRequest,
+      selectedNodeId,
+      selectedVisualElementId,
+      scanVisualElements,
+      setRevisitBaseline,
+      state,
+      verifyRevisit,
+    ],
+  );
+
+  return (
+    <AndroidAuditContext.Provider value={value}>
+      {children}
+    </AndroidAuditContext.Provider>
+  );
+}
+
+export function useAndroidAudit(): AndroidAuditContextValue {
+  const context = useContext(AndroidAuditContext);
+  if (!context) {
+    throw new Error('useAndroidAudit must be used inside AndroidAuditProvider');
+  }
+  return context;
+}

--- a/apps/android-playground/src/android-audit/AndroidAuditInspector.tsx
+++ b/apps/android-playground/src/android-audit/AndroidAuditInspector.tsx
@@ -1,0 +1,414 @@
+import type {
+  AndroidAuditOverlay,
+  AndroidAuditTreeNode,
+} from '@midscene/android';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAndroidAudit } from './AndroidAuditContext';
+import { STATUS_DESCRIPTIONS, STATUS_LABELS } from './AndroidAuditOverlay';
+
+function nodeIdentity(node: AndroidAuditTreeNode): string {
+  return (
+    node.attrs['resource-id'] ||
+    node.attrs.text ||
+    node.attrs['content-desc'] ||
+    ''
+  );
+}
+
+function statusClass(status: AndroidAuditOverlay['status']): string {
+  return `status-${status}`;
+}
+
+function TreeNodeRow({
+  flat,
+  node,
+  overlay,
+  rowRef,
+}: {
+  flat: boolean;
+  node: AndroidAuditTreeNode;
+  overlay?: AndroidAuditOverlay;
+  rowRef(element: HTMLButtonElement | null): void;
+}) {
+  const audit = useAndroidAudit();
+  return (
+    <button
+      className={`android-audit-tree-row${audit.selectedNodeId === node.nodeId ? ' selected' : ''}`}
+      onClick={() => {
+        audit.setSelectedNodeId(node.nodeId);
+        audit.setSelectedVisualElementId(undefined);
+      }}
+      ref={rowRef}
+      style={{ paddingLeft: flat ? 10 : 10 + node.depth * 14 }}
+      type="button"
+    >
+      <span className="tree-node-id">{node.nodeId}</span>
+      <span className="tree-node-type">{node.type}</span>
+      {nodeIdentity(node) && (
+        <span className="tree-node-identity">{nodeIdentity(node)}</span>
+      )}
+      {overlay && (
+        <span
+          className={`tree-node-status ${statusClass(overlay.status)}`}
+          title={overlay.statusReason}
+        >
+          {STATUS_LABELS[overlay.status]}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function StatusLegend() {
+  const entries = Object.entries(STATUS_LABELS) as Array<
+    [keyof typeof STATUS_LABELS, string]
+  >;
+  return (
+    <div className="android-audit-legend">
+      {entries.map(([status, label]) => (
+        <button
+          aria-label={`${label}: ${STATUS_DESCRIPTIONS[status]}`}
+          className={`legend-item status-${status}`}
+          data-tooltip={STATUS_DESCRIPTIONS[status]}
+          key={status}
+          type="button"
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function AndroidAuditInspector() {
+  const audit = useAndroidAudit();
+  const [query, setQuery] = useState('');
+  const [onlyProblems, setOnlyProblems] = useState(false);
+  const treeListRef = useRef<HTMLDivElement>(null);
+  const treeNodeRefs = useRef(new Map<string, HTMLButtonElement>());
+  const handledSelectionRequestRef = useRef(0);
+
+  useEffect(() => {
+    audit.activate();
+    return () => audit.deactivate();
+  }, [audit.activate, audit.deactivate]);
+
+  const overlayByNodeId = useMemo(
+    () =>
+      new Map(
+        audit.state.overlays
+          .filter((overlay) => overlay.nodeId)
+          .map((overlay) => [overlay.nodeId, overlay]),
+      ),
+    [audit.state.overlays],
+  );
+  const visibleNodes = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return audit.state.treeNodes.filter((node) => {
+      const overlay = overlayByNodeId.get(node.nodeId);
+      if (onlyProblems && (!overlay || overlay.status === 'cache-xpath-hit')) {
+        return false;
+      }
+      if (!normalizedQuery) return true;
+      return [
+        node.nodeId,
+        node.type,
+        node.attrs['resource-id'],
+        node.attrs.text,
+        node.attrs['content-desc'],
+      ]
+        .filter(Boolean)
+        .some((value) => value?.toLowerCase().includes(normalizedQuery));
+    });
+  }, [audit.state.treeNodes, onlyProblems, overlayByNodeId, query]);
+  const selectedNode = audit.state.treeNodes.find(
+    (node) => node.nodeId === audit.selectedNodeId,
+  );
+  const selectedVisual = audit.state.visualElements.find(
+    (element) => element.id === audit.selectedVisualElementId,
+  );
+  const selectedOverlay = selectedNode
+    ? overlayByNodeId.get(selectedNode.nodeId)
+    : undefined;
+
+  useEffect(() => {
+    const selectedNodeId = audit.selectedNodeId;
+    const selectionRequest = audit.selectionRequest;
+    if (
+      !selectedNodeId ||
+      selectionRequest === 0 ||
+      handledSelectionRequestRef.current === selectionRequest
+    ) {
+      return;
+    }
+
+    if (!visibleNodes.some((node) => node.nodeId === selectedNodeId)) {
+      setQuery('');
+      setOnlyProblems(false);
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      const list = treeListRef.current;
+      const row = treeNodeRefs.current.get(selectedNodeId);
+      if (!list || !row) return;
+
+      const listRect = list.getBoundingClientRect();
+      const rowRect = row.getBoundingClientRect();
+      list.scrollTo({
+        behavior: 'smooth',
+        top:
+          list.scrollTop +
+          rowRect.top -
+          listRect.top -
+          (list.clientHeight - rowRect.height) / 2,
+      });
+      handledSelectionRequestRef.current = selectionRequest;
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [audit.selectedNodeId, audit.selectionRequest, visibleNodes]);
+
+  return (
+    <aside className="android-audit-inspector">
+      <header className="android-audit-header">
+        <div>
+          <h2>Android XPath Live Audit</h2>
+          <p>
+            {audit.state.source
+              ? `${audit.state.source.source} · ${audit.state.source.durationMs} ms · ${audit.state.treeNodes.length} nodes · tree only`
+              : 'Waiting for the first Accessibility tree'}
+          </p>
+        </div>
+        <span
+          className={`capture-state capture-${audit.state.status} ${audit.state.enabled ? 'is-live' : 'is-paused'}`}
+        >
+          {audit.state.status === 'capturing'
+            ? 'Capturing'
+            : audit.state.status === 'error'
+              ? 'Paused'
+              : audit.state.enabled
+                ? 'Live'
+                : 'Paused'}
+        </span>
+      </header>
+
+      <div className="android-audit-toolbar">
+        <button
+          onClick={() =>
+            void (audit.state.enabled ? audit.capture() : audit.resume())
+          }
+          type="button"
+        >
+          Recapture
+        </button>
+        <button
+          className="primary"
+          disabled={audit.downloadingReport}
+          onClick={() => void audit.exportReport()}
+          type="button"
+        >
+          {audit.downloadingReport ? 'Downloading…' : 'Download Report'}
+        </button>
+      </div>
+
+      {audit.state.visualScan.status === 'scanning' && (
+        <div aria-live="polite" className="android-audit-phase-state">
+          {audit.state.visualScan.automatic
+            ? 'Building the visual inventory for this WebView…'
+            : 'Scanning visible controls…'}
+        </div>
+      )}
+
+      {audit.state.visualScan.status === 'error' &&
+        audit.state.visualScan.automatic &&
+        audit.state.visualScan.error && (
+          <div aria-live="polite" className="android-audit-phase-state">
+            Automatic visual inventory was unavailable. Tree overlays remain
+            active: {audit.state.visualScan.error}
+          </div>
+        )}
+
+      {audit.lastDownloadedReport && (
+        <div aria-live="polite" className="android-audit-phase-state">
+          Report downloaded: <code>{audit.lastDownloadedReport}</code>
+        </div>
+      )}
+
+      {(audit.error || audit.state.error) && (
+        <div className="android-audit-error">
+          {audit.error || audit.state.error}
+          {audit.state.errorDetail && (
+            <details>
+              <summary>View Raw Error</summary>
+              <pre>{audit.state.errorDetail}</pre>
+            </details>
+          )}
+        </div>
+      )}
+
+      <StatusLegend />
+
+      <section className="android-audit-tree-panel">
+        <div className="tree-panel-title">
+          <h3>Complete UiNode Tree</h3>
+          <label>
+            <input
+              checked={onlyProblems}
+              onChange={(event) => setOnlyProblems(event.target.checked)}
+              type="checkbox"
+            />
+            Issues Only
+          </label>
+        </div>
+        <input
+          className="tree-search"
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search id, text, desc, or type"
+          type="search"
+          value={query}
+        />
+        <div className="android-audit-tree-list" ref={treeListRef}>
+          {visibleNodes.map((node) => (
+            <TreeNodeRow
+              flat={onlyProblems}
+              key={node.nodeId}
+              node={node}
+              overlay={overlayByNodeId.get(node.nodeId)}
+              rowRef={(element) => {
+                if (element) treeNodeRefs.current.set(node.nodeId, element);
+                else treeNodeRefs.current.delete(node.nodeId);
+              }}
+            />
+          ))}
+          {visibleNodes.length === 0 && (
+            <div className="android-audit-empty">No matching nodes</div>
+          )}
+        </div>
+      </section>
+
+      <section className="android-audit-detail-panel">
+        <h3>Element Details</h3>
+        {selectedVisual ? (
+          <>
+            <div className="detail-heading">
+              <strong>{selectedVisual.name}</strong>
+              <span className={statusClass(selectedVisual.status)}>
+                {STATUS_LABELS[selectedVisual.status]}
+              </span>
+            </div>
+            {selectedVisual.statusReason && (
+              <p className="detail-reason">{selectedVisual.statusReason}</p>
+            )}
+            <dl>
+              <div>
+                <dt>Rectangle Source</dt>
+                <dd>{selectedVisual.rectSource}</dd>
+              </div>
+              <div>
+                <dt>Mapped Node</dt>
+                <dd>{selectedVisual.mappedNodeId ?? 'Not exposed'}</dd>
+              </div>
+              <div className="detail-full-row">
+                <dt>Visual Rectangle</dt>
+                <dd>
+                  <code>{JSON.stringify(selectedVisual.rect)}</code>
+                </dd>
+              </div>
+              <div className="detail-full-row">
+                <dt>Structural XPath</dt>
+                <dd>
+                  <code>{selectedVisual.structuralXpath ?? 'None'}</code>
+                </dd>
+              </div>
+            </dl>
+            <details open>
+              <summary>Midscene Cache XPath Candidates</summary>
+              {selectedVisual.cacheFeatureXpaths.length ? (
+                <ol>
+                  {selectedVisual.cacheFeatureXpaths.map((xpath, index) => (
+                    <li key={xpath}>
+                      <span>
+                        {selectedVisual.cacheFeatureXpathSources[index] ||
+                          'Unknown source'}
+                      </span>
+                      <code>{xpath}</code>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <p>No production cache XPath</p>
+              )}
+            </details>
+          </>
+        ) : selectedNode ? (
+          <>
+            <div className="detail-heading">
+              <strong>{nodeIdentity(selectedNode) || selectedNode.type}</strong>
+              {selectedOverlay && (
+                <span className={statusClass(selectedOverlay.status)}>
+                  {STATUS_LABELS[selectedOverlay.status]}
+                </span>
+              )}
+            </div>
+            {selectedOverlay?.statusReason && (
+              <p className="detail-reason">{selectedOverlay.statusReason}</p>
+            )}
+            <dl>
+              <div>
+                <dt>Node</dt>
+                <dd>{selectedNode.nodeId}</dd>
+              </div>
+              <div>
+                <dt>Rectangle</dt>
+                <dd>
+                  <code>{JSON.stringify(selectedNode.bounds)}</code>
+                </dd>
+              </div>
+              <div className="detail-full-row">
+                <dt>Interaction Evidence</dt>
+                <dd>
+                  {selectedNode.interactionEvidence.length
+                    ? selectedNode.interactionEvidence.join(', ')
+                    : 'None'}
+                </dd>
+              </div>
+              <div className="detail-full-row">
+                <dt>Structural XPath</dt>
+                <dd>
+                  <code>{selectedNode.structuralXpath}</code>
+                </dd>
+              </div>
+            </dl>
+            <details open>
+              <summary>Midscene Cache XPath Candidates</summary>
+              {selectedNode.cacheFeatureXpaths.length ? (
+                <ol>
+                  {selectedNode.cacheFeatureXpaths.map((xpath, index) => (
+                    <li key={xpath}>
+                      <span>
+                        {selectedNode.cacheFeatureXpathSources[index] ||
+                          'Unknown source'}
+                      </span>
+                      <code>{xpath}</code>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <p>No production cache XPath</p>
+              )}
+            </details>
+            <details>
+              <summary>Accessibility Attributes</summary>
+              <pre>{JSON.stringify(selectedNode.attrs, null, 2)}</pre>
+            </details>
+          </>
+        ) : (
+          <div className="android-audit-empty">
+            Select a frame or a node from the complete tree
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/apps/android-playground/src/android-audit/AndroidAuditOverlay.tsx
+++ b/apps/android-playground/src/android-audit/AndroidAuditOverlay.tsx
@@ -1,0 +1,169 @@
+import { androidAuditMarkerLabelPlacement } from '@midscene/android-playground/android-audit-marker-presentation';
+import type { PreviewOverlayRenderContext } from '@midscene/playground-app';
+import {
+  type PointerEvent as ReactPointerEvent,
+  useMemo,
+  useState,
+} from 'react';
+import { useAndroidAudit } from './AndroidAuditContext';
+
+const STATUS_LABELS = {
+  'cache-xpath-hit': 'Cache XPath Hit',
+  'tree-only-positional': 'Structural XPath Only',
+  'exposed-no-safe-xpath': 'Exposed Without Safe XPath',
+  'not-exposed': 'Not Exposed in Tree',
+  'point-selected-other': 'Point Selected Another Node',
+  pending: 'Awaiting Fresh Validation',
+} as const;
+
+const STATUS_DESCRIPTIONS: Record<keyof typeof STATUS_LABELS, string> = {
+  'cache-xpath-hit':
+    'Green: A safe cache XPath was generated and matched the same target in a subsequent fresh tree.',
+  'tree-only-positional':
+    'Yellow: The node is present in the Accessibility tree, but only has an order-sensitive structural XPath and is not cached.',
+  'exposed-no-safe-xpath':
+    'Red: The node is present in the Accessibility tree, but its identity is duplicated or lacks fields that are safe to replay.',
+  'not-exposed':
+    'Red: The element comes from a visual scan or manual rectangle and has no corresponding Accessibility tree node.',
+  'point-selected-other':
+    'Purple: The visual point intersects overlapping nodes and production point selection chose another node.',
+  pending:
+    'Gray: A candidate was generated from the source tree and is awaiting validation against the next tree.',
+};
+
+export function AndroidAuditOverlay({
+  deviceSize,
+}: PreviewOverlayRenderContext) {
+  const audit = useAndroidAudit();
+  const [drag, setDrag] = useState<{
+    startX: number;
+    startY: number;
+    x: number;
+    y: number;
+  }>();
+  const logicalSize = audit.state.source?.logicalSize ?? deviceSize;
+  const overlays = useMemo(
+    () =>
+      audit.state.overlays.map((overlay, index) => ({
+        ...overlay,
+        index: index + 1,
+      })),
+    [audit.state.overlays],
+  );
+
+  const dragRect = drag
+    ? {
+        left: Math.min(drag.startX, drag.x),
+        top: Math.min(drag.startY, drag.y),
+        width: Math.abs(drag.x - drag.startX),
+        height: Math.abs(drag.y - drag.startY),
+      }
+    : undefined;
+
+  const eventPoint = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    return {
+      x: ((event.clientX - bounds.left) / bounds.width) * logicalSize.width,
+      y: ((event.clientY - bounds.top) / bounds.height) * logicalSize.height,
+    };
+  };
+
+  return (
+    <div
+      className={`android-audit-overlay${audit.interactionMode === 'mark' ? ' marking' : ''}`}
+      onPointerDown={(event) => {
+        if (audit.interactionMode !== 'mark') return;
+        const point = eventPoint(event);
+        event.currentTarget.setPointerCapture(event.pointerId);
+        setDrag({
+          startX: point.x,
+          startY: point.y,
+          x: point.x,
+          y: point.y,
+        });
+      }}
+      onPointerMove={(event) => {
+        if (!drag || audit.interactionMode !== 'mark') return;
+        const point = eventPoint(event);
+        setDrag((current) =>
+          current ? { ...current, x: point.x, y: point.y } : current,
+        );
+      }}
+      onPointerUp={(event) => {
+        if (!dragRect || audit.interactionMode !== 'mark') return;
+        event.currentTarget.releasePointerCapture(event.pointerId);
+        setDrag(undefined);
+        if (dragRect.width < 4 || dragRect.height < 4) return;
+        const name = window.prompt(
+          'What should this visual element be called?',
+          'Manually annotated element',
+        );
+        if (!name?.trim()) return;
+        const description = window.prompt(
+          'Add a locating description, such as its position, icon, or interaction semantics.',
+          name,
+        );
+        if (!description?.trim()) return;
+        void audit.addVisualElement({
+          description: description.trim(),
+          name: name.trim(),
+          rect: dragRect,
+        });
+      }}
+      style={{
+        pointerEvents: audit.interactionMode === 'mark' ? 'auto' : 'none',
+      }}
+    >
+      {overlays.map((overlay) => {
+        const selected = overlay.visualElementId
+          ? overlay.visualElementId === audit.selectedVisualElementId
+          : overlay.nodeId === audit.selectedNodeId;
+        const label = STATUS_LABELS[overlay.status];
+        const labelPlacement = androidAuditMarkerLabelPlacement(
+          overlay.rect.top,
+        );
+        return (
+          <button
+            aria-label={`${overlay.index}. ${overlay.name}: ${label}`}
+            className={`android-audit-marker status-${overlay.status} label-${labelPlacement}${selected ? ' selected' : ''}`}
+            data-tooltip={`${label}: ${overlay.statusReason || 'No additional details'}`}
+            key={`${overlay.nodeId ?? overlay.name}-${overlay.index}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              if (audit.interactionMode === 'inspect') {
+                audit.selectOverlay(
+                  overlay.nodeId ?? undefined,
+                  overlay.visualElementId,
+                );
+              }
+            }}
+            style={{
+              height: `${(overlay.rect.height / logicalSize.height) * 100}%`,
+              left: `${(overlay.rect.left / logicalSize.width) * 100}%`,
+              pointerEvents:
+                audit.interactionMode === 'inspect' ? 'auto' : 'none',
+              top: `${(overlay.rect.top / logicalSize.height) * 100}%`,
+              width: `${(overlay.rect.width / logicalSize.width) * 100}%`,
+            }}
+            type="button"
+          >
+            <span>{overlay.index}</span>
+          </button>
+        );
+      })}
+      {dragRect && (
+        <div
+          className="android-audit-draft-rect"
+          style={{
+            height: `${(dragRect.height / logicalSize.height) * 100}%`,
+            left: `${(dragRect.left / logicalSize.width) * 100}%`,
+            top: `${(dragRect.top / logicalSize.height) * 100}%`,
+            width: `${(dragRect.width / logicalSize.width) * 100}%`,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export { STATUS_DESCRIPTIONS, STATUS_LABELS };

--- a/apps/android-playground/src/android-audit/AndroidAuditPlayground.tsx
+++ b/apps/android-playground/src/android-audit/AndroidAuditPlayground.tsx
@@ -1,0 +1,57 @@
+import { PlaygroundApp } from '@midscene/playground-app';
+import { useState } from 'react';
+import { AndroidAuditProvider } from './AndroidAuditContext';
+import { AndroidAuditInspector } from './AndroidAuditInspector';
+import { AndroidAuditOverlay } from './AndroidAuditOverlay';
+
+declare const __APP_VERSION__: string;
+
+function AndroidPlaygroundContent({ serverUrl }: { serverUrl: string }) {
+  const [auditOpen, setAuditOpen] = useState(false);
+
+  return (
+    <div className="android-playground-shell">
+      <PlaygroundApp
+        appVersion={__APP_VERSION__}
+        branding={{ title: 'Android Playground', targetName: 'android' }}
+        defaultDeviceType="android"
+        inspectorOpen={auditOpen}
+        manualPreviewInteractionEnabled={!auditOpen}
+        offlineTitle="Midscene Android Playground"
+        renderHeaderActions={() => (
+          <button
+            aria-label={auditOpen ? 'Close XPath Audit' : 'Open XPath Audit'}
+            aria-pressed={auditOpen}
+            className={`android-audit-nav-button${auditOpen ? ' active' : ''}`}
+            onClick={() => setAuditOpen((open) => !open)}
+            title={auditOpen ? 'Close XPath Audit' : 'Open XPath Audit'}
+            type="button"
+          >
+            <svg aria-hidden="true" viewBox="0 0 16 16">
+              <path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2" />
+              <circle cx="8" cy="8" r="3.5" />
+              <circle cx="8" cy="8" r="1" />
+            </svg>
+          </button>
+        )}
+        renderInspector={() => <AndroidAuditInspector />}
+        renderPreviewOverlay={
+          auditOpen
+            ? (context) => <AndroidAuditOverlay {...context} />
+            : undefined
+        }
+        serverUrl={serverUrl}
+        title="Android Playground"
+      />
+    </div>
+  );
+}
+
+export function AndroidAuditPlayground() {
+  const serverUrl = window.location.origin;
+  return (
+    <AndroidAuditProvider serverUrl={serverUrl}>
+      <AndroidPlaygroundContent serverUrl={serverUrl} />
+    </AndroidAuditProvider>
+  );
+}

--- a/apps/android-playground/src/android-audit/android-audit.less
+++ b/apps/android-playground/src/android-audit/android-audit.less
@@ -1,0 +1,520 @@
+.android-playground-shell {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  --audit-primary: #2b83ff;
+  --audit-text: rgba(0, 0, 0, 0.88);
+  --audit-secondary-text: rgba(0, 0, 0, 0.45);
+  --audit-line: rgba(0, 0, 0, 0.06);
+}
+
+.android-audit-nav-button {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.65);
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.4;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(43, 131, 255, 0.08);
+    color: var(--audit-primary);
+    outline: none;
+  }
+
+  &.active {
+    background: rgba(43, 131, 255, 0.1);
+    color: var(--audit-primary);
+  }
+}
+
+.android-audit-overlay {
+  position: absolute;
+  inset: 0;
+
+  &.marking {
+    cursor: crosshair;
+    touch-action: none;
+  }
+}
+
+.android-audit-draft-rect {
+  position: absolute;
+  border: 2px dashed #2563eb;
+  background: #3b82f633;
+  pointer-events: none;
+}
+
+.android-audit-marker {
+  --audit-color: #64748b;
+  position: absolute;
+  min-width: 12px;
+  min-height: 12px;
+  padding: 0;
+  border: 2px solid var(--audit-color);
+  background: transparent;
+  cursor: help;
+
+  > span {
+    position: absolute;
+    top: -22px;
+    left: -2px;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 5px;
+    border-radius: 10px;
+    background: var(--audit-color);
+    color: #07111f;
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 20px;
+  }
+
+  &.label-inside > span {
+    top: 0;
+    left: 0;
+  }
+
+  &.selected {
+    z-index: 2;
+    background: color-mix(in srgb, var(--audit-color) 10%, transparent);
+    box-shadow: 0 0 0 3px #60a5fa88;
+  }
+
+  &::after {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 7px);
+    left: 0;
+    display: block;
+    width: max-content;
+    max-width: 320px;
+    padding: 7px 9px;
+    border: 1px solid #475569;
+    border-radius: 7px;
+    background: #0f172aef;
+    color: #f8fafc;
+    content: attr(data-tooltip);
+    font-size: 12px;
+    line-height: 1.45;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-3px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease;
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.status-cache-xpath-hit {
+  --audit-color: #10b981;
+  color: #047857;
+}
+.status-tree-only-positional {
+  --audit-color: #f59e0b;
+  color: #b45309;
+}
+.status-exposed-no-safe-xpath,
+.status-not-exposed {
+  --audit-color: #f43f5e;
+  color: #be123c;
+}
+.status-point-selected-other {
+  --audit-color: #a855f7;
+  color: #7e22ce;
+}
+.status-point-selected-other > span {
+  z-index: 30;
+}
+.status-pending {
+  --audit-color: #64748b;
+  color: #475569;
+}
+
+.android-audit-inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+  border-left: 1px solid var(--audit-line);
+  background: #fff;
+  color: var(--audit-text);
+  font-size: 12px;
+}
+
+.android-audit-header {
+  display: flex;
+  flex: none;
+  min-height: 60px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--audit-line);
+
+  h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 20px;
+  }
+  p {
+    margin: 2px 0 0;
+    color: var(--audit-secondary-text);
+    line-height: 18px;
+  }
+}
+
+.capture-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--audit-secondary-text);
+  white-space: nowrap;
+
+  &::before {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #bfbfbf;
+    content: '';
+  }
+
+  &.is-live::before {
+    background: #52c41a;
+  }
+  &.capture-capturing::before {
+    background: var(--audit-primary);
+  }
+  &.capture-error::before {
+    background: #ff4d4f;
+  }
+}
+
+.android-audit-toolbar {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--audit-line);
+
+  button {
+    height: 32px;
+    padding: 0 12px;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
+    background: #fff;
+    color: var(--audit-text);
+    cursor: pointer;
+    font: inherit;
+    transition:
+      border-color 160ms ease,
+      color 160ms ease,
+      background 160ms ease;
+
+    &:hover,
+    &:focus-visible {
+      border-color: var(--audit-primary);
+      color: var(--audit-primary);
+      outline: none;
+    }
+    &.primary {
+      border-color: var(--audit-primary);
+      background: var(--audit-primary);
+      color: #fff;
+    }
+    &.primary:hover,
+    &.primary:focus-visible {
+      border-color: #69b1ff;
+      background: #69b1ff;
+      color: #fff;
+    }
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.android-audit-phase-state {
+  flex: none;
+  padding: 7px 16px;
+  border-bottom: 1px solid var(--audit-line);
+  background: #fafafa;
+  color: rgba(0, 0, 0, 0.65);
+
+  code {
+    overflow-wrap: anywhere;
+  }
+}
+
+.android-audit-error {
+  flex: none;
+  margin: 10px 16px 0;
+  padding: 8px 10px;
+  border: 1px solid #ffccc7;
+  border-radius: 6px;
+  background: #fff2f0;
+  color: #cf1322;
+}
+
+.android-audit-legend {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--audit-line);
+}
+
+.legend-item {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.65);
+  cursor: help;
+  font: inherit;
+  font-size: 11px;
+
+  &::before {
+    width: 6px;
+    height: 6px;
+    flex: none;
+    border-radius: 50%;
+    background: var(--audit-color);
+    content: '';
+  }
+
+  &::after {
+    position: absolute;
+    z-index: 30;
+    top: calc(100% + 6px);
+    left: 0;
+    display: block;
+    width: 280px;
+    padding: 7px 9px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.88);
+    color: #fff;
+    content: attr(data-tooltip);
+    line-height: 1.45;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-3px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease;
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.android-audit-tree-panel,
+.android-audit-detail-panel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  padding: 12px 16px;
+
+  h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+  }
+}
+
+.android-audit-tree-panel {
+  flex: 1 1 55%;
+  border-bottom: 1px solid var(--audit-line);
+}
+
+.tree-panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--audit-secondary-text);
+  }
+}
+
+.tree-search {
+  flex: none;
+  margin: 8px 0;
+  height: 32px;
+  padding: 4px 10px;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: #fff;
+  color: var(--audit-text);
+  outline: none;
+
+  &:focus {
+    border-color: var(--audit-primary);
+    box-shadow: 0 0 0 2px rgba(43, 131, 255, 0.1);
+  }
+  &::placeholder {
+    color: rgba(0, 0, 0, 0.25);
+  }
+}
+
+.android-audit-tree-list {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.android-audit-tree-row {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 72px minmax(110px, 1fr);
+  gap: 3px 7px;
+  padding-top: 6px;
+  padding-right: 8px;
+  padding-bottom: 6px;
+  border: 0;
+  border-bottom: 1px solid #f5f5f5;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.65);
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: #fafafa;
+  }
+  &.selected {
+    background: #e6f4ff;
+  }
+}
+
+.tree-node-id {
+  color: var(--audit-primary);
+  font-family: ui-monospace, monospace;
+}
+.tree-node-type,
+.tree-node-identity {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tree-node-identity {
+  grid-column: 2;
+  color: var(--audit-secondary-text);
+}
+.tree-node-status {
+  grid-column: 2;
+  font-size: 11px;
+}
+
+.android-audit-detail-panel {
+  flex: 1 1 45%;
+  overflow: auto;
+
+  dl {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 7px;
+    margin: 8px 0;
+  }
+
+  dl div {
+    min-width: 0;
+    border-top: 1px solid #f0f0f0;
+    padding-top: 5px;
+  }
+  dt {
+    color: var(--audit-secondary-text);
+  }
+  dd {
+    margin: 2px 0;
+    overflow-wrap: anywhere;
+  }
+  code,
+  pre {
+    font:
+      11px/1.45 ui-monospace,
+      monospace;
+    overflow-wrap: anywhere;
+  }
+  pre {
+    white-space: pre-wrap;
+  }
+  details {
+    margin-top: 7px;
+  }
+  summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+  ol {
+    padding-left: 18px;
+  }
+  li span,
+  li code {
+    display: block;
+  }
+  li span {
+    color: var(--audit-secondary-text);
+  }
+}
+
+.detail-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.detail-reason {
+  margin: 6px 0;
+  color: var(--audit-secondary-text);
+}
+.detail-full-row {
+  grid-column: 1 / -1;
+}
+.android-audit-empty {
+  padding: 18px;
+  color: rgba(0, 0, 0, 0.25);
+  text-align: center;
+}

--- a/apps/android-playground/src/android-audit/downloadAndroidAuditReport.ts
+++ b/apps/android-playground/src/android-audit/downloadAndroidAuditReport.ts
@@ -1,0 +1,121 @@
+import type { AndroidAuditDownloadBundle } from '@midscene/android-playground';
+
+interface WritableFileStream {
+  close(): Promise<void>;
+  write(data: Blob): Promise<void>;
+}
+
+interface DownloadFileHandle {
+  createWritable(): Promise<WritableFileStream>;
+}
+
+export interface DownloadDirectoryHandle {
+  getDirectoryHandle(
+    name: string,
+    options: { create: true },
+  ): Promise<DownloadDirectoryHandle>;
+  getFileHandle(
+    name: string,
+    options: { create: true },
+  ): Promise<DownloadFileHandle>;
+  name: string;
+}
+
+interface DirectoryPickerWindow extends Window {
+  showDirectoryPicker?: (options: {
+    mode: 'readwrite';
+  }) => Promise<DownloadDirectoryHandle>;
+}
+
+function safePathSegments(relativePath: string): string[] {
+  const segments = relativePath.split('/');
+  if (
+    segments.length === 0 ||
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('\\'),
+    )
+  ) {
+    throw new Error(`Invalid Android audit download path: ${relativePath}`);
+  }
+  return segments;
+}
+
+function base64Blob(contentBase64: string): Blob {
+  const binary = window.atob(contentBase64);
+  const buffer = new ArrayBuffer(binary.length);
+  const bytes = new Uint8Array(buffer);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([buffer]);
+}
+
+function isPickerCancellation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'AbortError'
+  );
+}
+
+export async function chooseAndroidAuditDownloadDirectory(): Promise<
+  DownloadDirectoryHandle | undefined
+> {
+  const picker = (window as DirectoryPickerWindow).showDirectoryPicker;
+  if (!picker) {
+    throw new Error(
+      'Downloading a report folder requires a Chromium-based browser with directory access support.',
+    );
+  }
+  try {
+    return await picker.call(window, { mode: 'readwrite' });
+  } catch (error) {
+    if (isPickerCancellation(error)) return undefined;
+    throw error;
+  }
+}
+
+export async function writeAndroidAuditDownloadBundle(
+  parentDirectory: DownloadDirectoryHandle,
+  bundle: AndroidAuditDownloadBundle,
+): Promise<string> {
+  const [directoryName] = safePathSegments(bundle.directoryName);
+  if (directoryName !== bundle.directoryName) {
+    throw new Error(
+      `Invalid Android audit download directory: ${bundle.directoryName}`,
+    );
+  }
+  const reportDirectory = await parentDirectory.getDirectoryHandle(
+    directoryName,
+    { create: true },
+  );
+
+  for (const file of bundle.files) {
+    const segments = safePathSegments(file.relativePath);
+    const fileName = segments.pop();
+    if (!fileName) {
+      throw new Error(
+        `Android audit download path has no file name: ${file.relativePath}`,
+      );
+    }
+    let directory = reportDirectory;
+    for (const segment of segments) {
+      directory = await directory.getDirectoryHandle(segment, {
+        create: true,
+      });
+    }
+    const fileHandle = await directory.getFileHandle(fileName, {
+      create: true,
+    });
+    const writable = await fileHandle.createWritable();
+    await writable.write(base64Blob(file.contentBase64));
+    await writable.close();
+  }
+
+  return `${parentDirectory.name}/${directoryName}`;
+}

--- a/apps/android-playground/tsconfig.json
+++ b/apps/android-playground/tsconfig.json
@@ -7,6 +7,12 @@
   "include": ["src"],
   "references": [
     {
+      "path": "../../packages/android"
+    },
+    {
+      "path": "../../packages/android-playground"
+    },
+    {
       "path": "../../packages/playground-app"
     }
   ]

--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/es/index.mjs",
       "require": "./dist/lib/index.js"
     },
+    "./android-audit-marker-presentation": {
+      "types": "./dist/types/android-audit-marker-presentation.d.ts",
+      "import": "./dist/es/android-audit-marker-presentation.mjs",
+      "require": "./dist/lib/android-audit-marker-presentation.js"
+    },
     "./package.json": "./package.json"
   },
   "files": ["dist", "static", "bin", "README.md"],

--- a/packages/android-playground/rslib.config.ts
+++ b/packages/android-playground/rslib.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
   source: {
     tsconfigPath: 'tsconfig.build.json',
     entry: {
+      'android-audit-marker-presentation':
+        './src/android-audit-marker-presentation.ts',
       index: './src/index.ts',
       bin: './src/bin.ts',
     },

--- a/packages/android-playground/src/android-audit-export.ts
+++ b/packages/android-playground/src/android-audit-export.ts
@@ -1,0 +1,346 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  AndroidAccessibilitySnapshot,
+  AndroidAuditEnvironment,
+  AndroidAuditOverlay,
+  AndroidAuditReplayResult,
+  AndroidAuditReplaySummary,
+  AndroidAuditTechnologyMetadata,
+  AndroidAuditTreeNode,
+  AndroidAuditVisualElement,
+} from '@midscene/android';
+import {
+  ANDROID_AUDIT_SCHEMA_VERSION,
+  ANDROID_AUDIT_STATUS_LABELS,
+} from '@midscene/android';
+
+export interface AndroidAuditExportInput {
+  deviceId: string;
+  entryPath: string;
+  environment: AndroidAuditEnvironment;
+  fresh: AndroidAccessibilitySnapshot;
+  overlays: AndroidAuditOverlay[];
+  replay: AndroidAuditReplaySummary;
+  replayResults: AndroidAuditReplayResult[];
+  screenshotBase64: string;
+  screenshotCapturedAt: string;
+  source: AndroidAccessibilitySnapshot;
+  technology: AndroidAuditTechnologyMetadata;
+  treeNodes: AndroidAuditTreeNode[];
+  visualElements: AndroidAuditVisualElement[];
+  revisit?: {
+    replay: AndroidAuditReplaySummary;
+    snapshot: AndroidAccessibilitySnapshot;
+  };
+}
+
+export interface AndroidAuditExportResult {
+  indexHtml: string;
+  outputDir: string;
+  runId: string;
+}
+
+export interface AndroidAuditDownloadFile {
+  contentBase64: string;
+  relativePath: string;
+}
+
+export interface AndroidAuditDownloadBundle {
+  directoryName: string;
+  files: AndroidAuditDownloadFile[];
+  runId: string;
+}
+
+export interface AndroidAuditExportWithDownload {
+  download: AndroidAuditDownloadBundle;
+  result: AndroidAuditExportResult;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function html(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function screenshotBuffer(base64: string): Buffer {
+  const match = base64
+    .trim()
+    .match(/^data:image\/[a-zA-Z0-9.+-]+;base64,(.+)$/s);
+  const body = match?.[1] ?? base64.trim();
+  const buffer = Buffer.from(body, 'base64');
+  if (buffer.length === 0) {
+    throw new Error('Android audit screenshot is empty');
+  }
+  return buffer;
+}
+
+function runId(): string {
+  return `playground-${new Date().toISOString().replace(/[-:.]/g, '')}`;
+}
+
+interface AndroidAuditExportFile {
+  content: Buffer | string;
+  relativePath: string;
+}
+
+function statusCounts(overlays: AndroidAuditOverlay[]) {
+  const counts: Record<string, number> = {};
+  for (const overlay of overlays) {
+    counts[overlay.status] = (counts[overlay.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function renderAnnotatedReport(
+  input: AndroidAuditExportInput,
+  screenshotSrc: string,
+): string {
+  const size = input.source.logicalSize;
+  const markers = input.overlays
+    .map(
+      (overlay, index) =>
+        `<button class="marker status-${html(overlay.status)}" style="left:${(overlay.rect.left / size.width) * 100}%;top:${(overlay.rect.top / size.height) * 100}%;width:${(overlay.rect.width / size.width) * 100}%;height:${(overlay.rect.height / size.height) * 100}%" data-node="${html(overlay.nodeId ?? '')}" data-visual="${html(overlay.visualElementId ?? '')}" title="${html(`${ANDROID_AUDIT_STATUS_LABELS[overlay.status]}: ${overlay.statusReason ?? 'No additional details'}`)}"><span>${index + 1}</span></button>`,
+    )
+    .join('');
+  const rows = input.treeNodes
+    .map((node) => {
+      const identity =
+        node.attrs['resource-id'] ??
+        node.attrs.text ??
+        node.attrs['content-desc'] ??
+        '';
+      return `<button class="node" data-node="${html(node.nodeId)}" style="padding-left:${10 + node.depth * 14}px"><code>${html(node.nodeId)}</code><span>${html(node.type)}</span><small>${html(identity)}</small></button>`;
+    })
+    .join('');
+  const data = JSON.stringify({
+    overlays: input.overlays,
+    treeNodes: input.treeNodes,
+    visualElements: input.visualElements,
+  }).replaceAll('<', '\\u003c');
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Android XPath Audit</title>
+<style>
+*{box-sizing:border-box}body{margin:0;font:13px/1.45 system-ui;color:#0f172a;background:#f8fafc}.top{height:52px;display:flex;align-items:center;justify-content:space-between;padding:0 18px;border-bottom:1px solid #e2e8f0;background:#fff}.layout{height:calc(100vh - 52px);display:grid;grid-template-columns:minmax(360px,1fr) minmax(420px,42%)}.screen-wrap{display:grid;place-items:center;padding:20px;overflow:hidden}.screen{position:relative;max-width:100%;max-height:100%;aspect-ratio:${size.width}/${size.height}}.screen img{display:block;width:100%;height:100%;object-fit:contain}.marker{--c:#64748b;position:absolute;border:2px solid var(--c);background:color-mix(in srgb,var(--c) 16%,transparent);cursor:pointer}.marker span{position:absolute;top:-21px;left:-2px;min-width:20px;height:19px;padding:0 5px;border-radius:10px;background:var(--c);font-weight:800;line-height:19px}.status-cache-xpath-hit{--c:#10b981}.status-tree-only-positional{--c:#f59e0b}.status-exposed-no-safe-xpath,.status-not-exposed{--c:#f43f5e}.status-point-selected-other{--c:#a855f7}.status-pending{--c:#64748b}.right{min-width:0;display:grid;grid-template-rows:55% 45%;border-left:1px solid #e2e8f0;background:#fff}.tree,.detail{min-height:0;padding:12px;overflow:auto}.tree{border-bottom:1px solid #e2e8f0}.node{display:grid;width:100%;grid-template-columns:78px minmax(0,1fr);gap:2px 7px;padding-top:5px;padding-right:7px;padding-bottom:5px;border:0;border-bottom:1px solid #f1f5f9;background:#fff;text-align:left;cursor:pointer}.node:hover,.node.active{background:#dbeafe}.node code{color:#2563eb}.node span,.node small{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.node small{grid-column:2;color:#64748b}.legend{display:flex;gap:8px;flex-wrap:wrap}.legend i{width:10px;height:10px;border-radius:50%;display:inline-block;background:var(--c)}pre{white-space:pre-wrap;overflow-wrap:anywhere;font:11px/1.45 ui-monospace,monospace}h2,h3{margin:0 0 8px}
+</style></head><body>
+<header class="top"><div><strong>Android XPath Audit</strong> · ${html(input.deviceId)} · ${html(input.source.source)}</div><div>source ${html(input.source.capturedAt)} · fresh ${html(input.fresh.capturedAt)}</div></header>
+<main class="layout"><section class="screen-wrap"><div class="screen"><img src="${html(screenshotSrc)}" alt="Device screenshot">${markers}</div></section><aside class="right"><section class="tree"><h2>Complete UiNode Tree (${input.treeNodes.length})</h2>${rows}</section><section class="detail"><h3>Element Details</h3><p>Select a frame or tree node to inspect it.</p><pre id="detail">Nothing selected</pre></section></aside></main>
+<script>const data=${data};const detail=document.querySelector('#detail');function select(id,visualId){document.querySelectorAll('[data-node]').forEach((el)=>el.classList.toggle('active',Boolean((visualId&&el.dataset.visual===visualId)||(id&&el.dataset.node===id))));const node=data.treeNodes.find((item)=>item.nodeId===id);const visual=data.visualElements.find((item)=>item.id===visualId);const overlay=data.overlays.find((item)=>visualId?item.visualElementId===visualId:item.nodeId===id);detail.textContent=JSON.stringify({name:visual?.name,status:overlay?${JSON.stringify(ANDROID_AUDIT_STATUS_LABELS)}[overlay.status]:undefined,statusReason:overlay?.statusReason,rectSource:visual?.rectSource,mappedNodeId:visual?.mappedNodeId,structuralXpath:visual?.structuralXpath??node?.structuralXpath,cacheFeatureXpaths:visual?.cacheFeatureXpaths??node?.cacheFeatureXpaths,candidateDiagnostics:visual?.candidateDiagnostics??node?.candidateDiagnostics,attrs:node?.attrs,bounds:visual?.rect??node?.bounds},null,2)}document.addEventListener('click',(event)=>{const target=event.target.closest('[data-node]');if(target)select(target.dataset.node,target.dataset.visual)});</script></body></html>`;
+}
+
+/** Builds a browser-downloadable report without writing server-side files. */
+export function buildAndroidAuditDownloadBundle(
+  input: AndroidAuditExportInput,
+): AndroidAuditDownloadBundle {
+  const id = runId();
+  const screenshot = screenshotBuffer(input.screenshotBase64);
+  const generatedAt = new Date().toISOString();
+  const reportHtml = renderAnnotatedReport(input, 'screenshot.png');
+  const indexReportHtml = renderAnnotatedReport(
+    input,
+    'pages/playground-current/screenshot.png',
+  );
+  const metadata = {
+    schemaVersion: ANDROID_AUDIT_SCHEMA_VERSION,
+    reportKind: 'playground-live' as const,
+    pageId: 'playground-current',
+    createdAt: input.source.capturedAt,
+    updatedAt: generatedAt,
+    generatedAt,
+    ...input.environment,
+    entryPath: input.entryPath,
+    technology: input.technology,
+    sourceUsed: input.source.source,
+    captures: {
+      source: {
+        phase: 'source',
+        treeSource: input.source.source,
+        capturedAt: input.source.capturedAt,
+        durationMs: input.source.durationMs,
+        screenshot: {
+          file: 'screenshot.png',
+          capturedAt: input.screenshotCapturedAt,
+          bytes: screenshot.length,
+          sha256: sha256(screenshot),
+        },
+        usedXml: {
+          file: 'source-used.xml',
+          capturedAt: input.source.capturedAt,
+          bytes: Buffer.byteLength(input.source.sourceXml),
+          sha256: sha256(input.source.sourceXml),
+        },
+      },
+      fresh: {
+        phase: 'fresh',
+        treeSource: input.fresh.source,
+        capturedAt: input.fresh.capturedAt,
+        durationMs: input.fresh.durationMs,
+        usedXml: {
+          file: 'fresh-replay.xml',
+          capturedAt: input.fresh.capturedAt,
+          bytes: Buffer.byteLength(input.fresh.sourceXml),
+          sha256: sha256(input.fresh.sourceXml),
+        },
+      },
+      ...(input.revisit
+        ? {
+            revisit: {
+              phase: 'revisit',
+              treeSource: input.revisit.snapshot.source,
+              capturedAt: input.revisit.snapshot.capturedAt,
+              durationMs: input.revisit.snapshot.durationMs,
+              usedXml: {
+                file: 'revisit-replay.xml',
+                capturedAt: input.revisit.snapshot.capturedAt,
+                bytes: Buffer.byteLength(input.revisit.snapshot.sourceXml),
+                sha256: sha256(input.revisit.snapshot.sourceXml),
+              },
+            },
+          }
+        : {}),
+    },
+    transport: {
+      cdpUsed: false,
+      note: 'Android screenshot plus Accessibility tree; CDP was not used.',
+    },
+  };
+  const summary = {
+    schemaVersion: ANDROID_AUDIT_SCHEMA_VERSION,
+    reportKind: 'playground-live' as const,
+    generatedAt,
+    runId: id,
+    pages: 1,
+    treeNodes: input.treeNodes.length,
+    overlays: input.overlays.length,
+    statuses: statusCounts(input.overlays),
+    fresh: input.replay,
+    revisit: input.revisit?.replay,
+  };
+  const run = {
+    schemaVersion: ANDROID_AUDIT_SCHEMA_VERSION,
+    reportKind: 'playground-live' as const,
+    runId: id,
+    createdAt: generatedAt,
+    pages: ['playground-current'],
+  };
+  const replayResults = {
+    schemaVersion: ANDROID_AUDIT_SCHEMA_VERSION,
+    generatedAt,
+    fresh: input.replay,
+    results: input.replayResults,
+    revisit: input.revisit?.replay,
+  };
+  const files: AndroidAuditExportFile[] = [
+    { relativePath: 'run.json', content: json(run) },
+    { relativePath: 'summary.json', content: json(summary) },
+    { relativePath: 'index.html', content: indexReportHtml },
+    {
+      relativePath: 'pages/playground-current/metadata.json',
+      content: json(metadata),
+    },
+    {
+      relativePath: 'pages/playground-current/screenshot.png',
+      content: screenshot,
+    },
+    {
+      relativePath: 'pages/playground-current/source-used.xml',
+      content: input.source.sourceXml,
+    },
+    {
+      relativePath: `pages/playground-current/${input.source.source}.xml`,
+      content: input.source.sourceXml,
+    },
+    {
+      relativePath: 'pages/playground-current/fresh-replay.xml',
+      content: input.fresh.sourceXml,
+    },
+    ...(input.revisit
+      ? [
+          {
+            relativePath: 'pages/playground-current/revisit-replay.xml',
+            content: input.revisit.snapshot.sourceXml,
+          },
+        ]
+      : []),
+    {
+      relativePath: 'pages/playground-current/ui-tree.json',
+      content: json(input.source.root),
+    },
+    {
+      relativePath: 'pages/playground-current/visual-elements.json',
+      content: json({
+        schemaVersion: ANDROID_AUDIT_SCHEMA_VERSION,
+        coordinateSpace: 'logical',
+        reviewed: false,
+        elements: input.visualElements,
+      }),
+    },
+    {
+      relativePath: 'pages/playground-current/elements.json',
+      content: json({
+        treeNodes: input.treeNodes,
+        visualElements: input.visualElements,
+      }),
+    },
+    {
+      relativePath: 'pages/playground-current/replay-results.json',
+      content: json(replayResults),
+    },
+    {
+      relativePath: 'pages/playground-current/annotated.html',
+      content: reportHtml,
+    },
+  ];
+
+  return {
+    directoryName: id,
+    files: files.map((file) => ({
+      contentBase64: Buffer.from(file.content).toString('base64'),
+      relativePath: file.relativePath,
+    })),
+    runId: id,
+  };
+}
+
+export async function writeAndroidAuditExportWithDownload(
+  input: AndroidAuditExportInput,
+  outputRoot = path.join(process.cwd(), 'midscene_run', 'douyin-xpath-audit'),
+): Promise<AndroidAuditExportWithDownload> {
+  const download = buildAndroidAuditDownloadBundle(input);
+  const outputDir = path.join(outputRoot, download.runId);
+  await Promise.all(
+    download.files.map(async (file) => {
+      const outputPath = path.join(outputDir, ...file.relativePath.split('/'));
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, Buffer.from(file.contentBase64, 'base64'));
+    }),
+  );
+  return {
+    download,
+    result: {
+      indexHtml: path.join(outputDir, 'index.html'),
+      outputDir,
+      runId: download.runId,
+    },
+  };
+}
+
+export async function writeAndroidAuditExport(
+  input: AndroidAuditExportInput,
+  outputRoot = path.join(process.cwd(), 'midscene_run', 'douyin-xpath-audit'),
+): Promise<AndroidAuditExportResult> {
+  return (await writeAndroidAuditExportWithDownload(input, outputRoot)).result;
+}

--- a/packages/android-playground/src/android-audit-marker-presentation.ts
+++ b/packages/android-playground/src/android-audit-marker-presentation.ts
@@ -1,0 +1,5 @@
+export function androidAuditMarkerLabelPlacement(
+  rectTop: number,
+): 'inside' | 'outside' {
+  return rectTop <= 0 ? 'inside' : 'outside';
+}

--- a/packages/android-playground/src/android-audit-session.ts
+++ b/packages/android-playground/src/android-audit-session.ts
@@ -1,0 +1,1162 @@
+import { createHash } from 'node:crypto';
+import type {
+  AndroidAccessibilitySnapshot,
+  AndroidAgent,
+  AndroidAuditEnvironment,
+  AndroidAuditOverlay,
+  AndroidAuditReplaySummary,
+  AndroidAuditTreeNode,
+  AndroidAuditVisualElement,
+  AndroidAuditVisualElementInput,
+  AndroidLiveTreeAudit,
+} from '@midscene/android';
+import {
+  applyAndroidAuditReplayToSource,
+  buildAndroidLiveTreeAudit,
+  buildAndroidVisualAudit,
+} from '@midscene/android';
+import { getDebug } from '@midscene/shared/logger';
+import type { Application, Request, Response } from 'express';
+import express from 'express';
+import {
+  type AndroidAuditDownloadBundle,
+  buildAndroidAuditDownloadBundle,
+} from './android-audit-export';
+
+const debugAudit = getDebug('android:playground:audit');
+const warnAudit = getDebug('android:playground:audit', { console: true });
+
+const DEFAULT_CAPTURE_INTERVAL_MS = 1_000;
+const MAX_VISUAL_SCAN_ELEMENTS = 60;
+
+export interface AndroidAuditSnapshotSummary {
+  captureId: string;
+  capturedAt: string;
+  dpr: number;
+  durationMs: number;
+  logicalSize: { width: number; height: number };
+  rotation: number;
+  source: 'yadb' | 'uiautomator';
+}
+
+export interface AndroidAuditState {
+  deviceId?: string;
+  enabled: boolean;
+  error?: string;
+  errorDetail?: string;
+  overlays: AndroidAuditOverlay[];
+  replay: AndroidAuditReplaySummary;
+  revisit?: {
+    baselineCaptureId: string;
+    replay?: AndroidAuditReplaySummary;
+    status: 'baseline-ready' | 'verifying' | 'verified';
+    verifiedCaptureId?: string;
+  };
+  revision: number;
+  lastExport?: { runId: string };
+  source?: AndroidAuditSnapshotSummary;
+  status: 'idle' | 'capturing' | 'ready' | 'error';
+  treeNodes: AndroidAuditTreeNode[];
+  updatedAt?: string;
+  visualElements: AndroidAuditVisualElement[];
+  visualScan: {
+    automatic?: boolean;
+    error?: string;
+    status: 'idle' | 'scanning' | 'ready' | 'error';
+    updatedAt?: string;
+  };
+}
+
+export interface AndroidAuditDevice {
+  captureAuditEnvironment?(
+    snapshot: AndroidAccessibilitySnapshot,
+  ): Promise<AndroidAuditEnvironment>;
+  captureAccessibilitySnapshot(): Promise<AndroidAccessibilitySnapshot>;
+  screenshotBase64(): Promise<string>;
+}
+
+export interface AndroidAuditSessionOptions {
+  autoVisualScan?: boolean;
+  captureIntervalMs?: number;
+}
+
+function emptyReplay(): AndroidAuditReplaySummary {
+  return { attempted: 0, hits: 0, misses: 0, wrongMappings: 0 };
+}
+
+function emptyState(deviceId?: string): AndroidAuditState {
+  return {
+    deviceId,
+    enabled: false,
+    overlays: [],
+    replay: emptyReplay(),
+    revision: 0,
+    status: 'idle',
+    treeNodes: [],
+    visualElements: [],
+    visualScan: { status: 'idle' },
+  };
+}
+
+function snapshotSummary(
+  snapshot: AndroidAccessibilitySnapshot,
+): AndroidAuditSnapshotSummary {
+  return {
+    captureId: snapshot.captureId,
+    capturedAt: snapshot.capturedAt,
+    dpr: snapshot.dpr,
+    durationMs: snapshot.durationMs,
+    logicalSize: snapshot.logicalSize,
+    rotation: snapshot.rotation,
+    source: snapshot.source,
+  };
+}
+
+function fallbackAuditEnvironment(
+  deviceId: string,
+  snapshot: AndroidAccessibilitySnapshot,
+): AndroidAuditEnvironment {
+  return {
+    device: {
+      serial: deviceId,
+      manufacturer: 'unknown',
+      model: 'unknown',
+      androidVersion: 'unknown',
+      apiLevel: 'unknown',
+      resolution: {
+        physical: {
+          width: Math.round(snapshot.logicalSize.width * snapshot.dpr),
+          height: Math.round(snapshot.logicalSize.height * snapshot.dpr),
+        },
+        logical: snapshot.logicalSize,
+        screenshot: {
+          width: Math.round(snapshot.logicalSize.width * snapshot.dpr),
+          height: Math.round(snapshot.logicalSize.height * snapshot.dpr),
+        },
+      },
+      density: snapshot.dpr * 160,
+      dpr: snapshot.dpr,
+      rotation: snapshot.rotation,
+    },
+    app: {
+      expectedPackage: 'unknown',
+      package: 'unknown',
+      activity: 'unknown',
+      versionName: 'unknown',
+      versionCode: 'unknown',
+    },
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hashRecords(records: unknown[]): string {
+  return createHash('sha256').update(JSON.stringify(records)).digest('hex');
+}
+
+function treeFingerprint(
+  snapshot: AndroidAccessibilitySnapshot,
+  includeBounds: boolean,
+): string {
+  const records: unknown[] = [
+    snapshot.rotation,
+    snapshot.logicalSize.width,
+    snapshot.logicalSize.height,
+  ];
+  const visit = (node: AndroidAccessibilitySnapshot['root']) => {
+    const resourceId = node.attrs['resource-id'] || '';
+    const text = node.attrs.text || '';
+    const contentDescription = node.attrs['content-desc'] || '';
+    const webRole =
+      node.attrs['chrome-role'] ||
+      node.attrs.chromeRole ||
+      node.attrs.role ||
+      '';
+    records.push([
+      node.type,
+      node.attrs.package || '',
+      resourceId,
+      text,
+      contentDescription,
+      webRole,
+      node.attrs.clickable || '',
+      node.attrs.focusable || '',
+      node.attrs.actions || node.attrs['action-list'] || '',
+      node.attrs['target-url'] || node.attrs.targetUrl || '',
+      ...(includeBounds
+        ? [
+            Math.round(node.bounds.left),
+            Math.round(node.bounds.top),
+            Math.round(node.bounds.width),
+            Math.round(node.bounds.height),
+          ]
+        : []),
+    ]);
+    node.children.forEach(visit);
+  };
+  visit(snapshot.root);
+  return hashRecords(records);
+}
+
+function pageIdentityFingerprint(
+  snapshot: AndroidAccessibilitySnapshot,
+): string {
+  return treeFingerprint(snapshot, false);
+}
+
+function pageLayoutFingerprint(snapshot: AndroidAccessibilitySnapshot): string {
+  return treeFingerprint(snapshot, true);
+}
+
+function needsWebViewVisualInventory(audit: AndroidLiveTreeAudit): boolean {
+  return audit.treeNodes.some((node) =>
+    node.type.toLowerCase().includes('webview'),
+  );
+}
+
+function accessibilityCaptureError(detail: string): string {
+  if (
+    detail.includes('uiautomator') &&
+    (detail.includes('code 137') ||
+      detail.includes('No such file or directory'))
+  ) {
+    return 'Accessibility tree capture failed and live retries were paused automatically. YADB and UIAutomator could not establish a UiAutomation session. Another automation process, such as Maestro or Appium, may be holding the device. Release it, then click Recapture to resume live auditing.';
+  }
+  return 'Accessibility tree capture failed and live retries were paused automatically. Resolve the device error, then click Recapture to resume live auditing.';
+}
+
+function mergeVisualAndTreeOverlays(
+  treeAudit: AndroidLiveTreeAudit,
+  visualAudit: ReturnType<typeof buildAndroidVisualAudit> | null,
+): AndroidAuditOverlay[] {
+  if (!visualAudit) return treeAudit.overlays;
+  return visualAudit.overlays;
+}
+
+export class AndroidAuditSessionController {
+  private activeCaptureToken: object | null = null;
+  private agent: Pick<AndroidAgent, 'aiLocate' | 'aiQuery'> | null = null;
+  private autoVisualScanAttemptedPageFingerprint: string | null = null;
+  private autoVisualScanEnabled: boolean;
+  private autoVisualScanTimer: NodeJS.Timeout | null = null;
+  private captureIntervalMs: number;
+  private capturePromise: Promise<AndroidAuditState> | null = null;
+  private device: AndroidAuditDevice | null = null;
+  private generation = 0;
+  private latestSnapshot: AndroidAccessibilitySnapshot | null = null;
+  private latestPageFingerprint: string | null = null;
+  private latestTreeAudit: AndroidLiveTreeAudit | null = null;
+  private previousTreeNodes: AndroidAuditTreeNode[] = [];
+  private revisitBaseline: {
+    snapshot: AndroidAccessibilitySnapshot;
+    treeNodes: AndroidAuditTreeNode[];
+  } | null = null;
+  private revisitSnapshot: AndroidAccessibilitySnapshot | null = null;
+  private state = emptyState();
+  private subscribers = new Set<Response>();
+  private timer: NodeJS.Timeout | null = null;
+  private visualInputs: AndroidAuditVisualElementInput[] = [];
+  private visualInputsLayoutFingerprint: string | null = null;
+  private visualScanPromise: Promise<AndroidAuditState> | null = null;
+
+  constructor(options: AndroidAuditSessionOptions = {}) {
+    this.autoVisualScanEnabled = options.autoVisualScan ?? false;
+    this.captureIntervalMs =
+      options.captureIntervalMs ?? DEFAULT_CAPTURE_INTERVAL_MS;
+  }
+
+  attachDevice(
+    deviceId: string,
+    device: AndroidAuditDevice,
+    agent?: Pick<AndroidAgent, 'aiLocate' | 'aiQuery'>,
+  ): void {
+    const resume = this.state.enabled;
+    this.clearTimer();
+    this.clearAutoVisualScanTimer();
+    this.generation++;
+    this.activeCaptureToken = null;
+    this.capturePromise = null;
+    this.device = device;
+    this.agent = agent ?? null;
+    this.latestSnapshot = null;
+    this.latestPageFingerprint = null;
+    this.latestTreeAudit = null;
+    this.previousTreeNodes = [];
+    this.revisitBaseline = null;
+    this.revisitSnapshot = null;
+    this.visualInputs = [];
+    this.visualInputsLayoutFingerprint = null;
+    this.visualScanPromise = null;
+    this.autoVisualScanAttemptedPageFingerprint = null;
+    this.state = { ...emptyState(deviceId), enabled: resume };
+    this.emitState();
+    if (resume) this.scheduleCapture(0);
+  }
+
+  detachDevice(): void {
+    this.clearTimer();
+    this.clearAutoVisualScanTimer();
+    this.generation++;
+    this.activeCaptureToken = null;
+    this.capturePromise = null;
+    this.device = null;
+    this.agent = null;
+    this.latestSnapshot = null;
+    this.latestPageFingerprint = null;
+    this.latestTreeAudit = null;
+    this.previousTreeNodes = [];
+    this.revisitBaseline = null;
+    this.revisitSnapshot = null;
+    this.visualInputs = [];
+    this.visualInputsLayoutFingerprint = null;
+    this.visualScanPromise = null;
+    this.autoVisualScanAttemptedPageFingerprint = null;
+    this.state = emptyState();
+    this.emitState();
+  }
+
+  getState(): AndroidAuditState {
+    return this.state;
+  }
+
+  getLatestSnapshot(): AndroidAccessibilitySnapshot | null {
+    return this.latestSnapshot;
+  }
+
+  async start(): Promise<AndroidAuditState> {
+    if (!this.device) {
+      throw new Error('No Android device session is connected');
+    }
+    this.state = {
+      ...this.state,
+      enabled: true,
+      error: undefined,
+      errorDetail: undefined,
+    };
+    this.emitState();
+    return this.captureNow();
+  }
+
+  pause(): AndroidAuditState {
+    this.clearTimer();
+    this.state = { ...this.state, enabled: false };
+    this.emitState();
+    return this.state;
+  }
+
+  async setRevisitBaseline(): Promise<AndroidAuditState> {
+    if (!this.device) {
+      throw new Error('No Android device session is connected');
+    }
+    if (!this.latestSnapshot) await this.captureNow();
+    if (!this.latestSnapshot) {
+      throw new Error('Unable to capture a revisit baseline');
+    }
+    this.revisitBaseline = {
+      snapshot: this.latestSnapshot,
+      treeNodes: this.previousTreeNodes,
+    };
+    this.revisitSnapshot = null;
+    this.state = {
+      ...this.state,
+      revisit: {
+        baselineCaptureId: this.latestSnapshot.captureId,
+        status: 'baseline-ready',
+      },
+      revision: this.state.revision + 1,
+      updatedAt: new Date().toISOString(),
+    };
+    this.emitState();
+    return this.state;
+  }
+
+  async verifyRevisit(): Promise<AndroidAuditState> {
+    if (!this.revisitBaseline) {
+      throw new Error('Set a revisit baseline before verifying revisit');
+    }
+    this.state = {
+      ...this.state,
+      revisit: {
+        baselineCaptureId: this.revisitBaseline.snapshot.captureId,
+        status: 'verifying',
+      },
+    };
+    this.emitState();
+    const previousSnapshot = this.latestSnapshot;
+    await this.captureNow();
+    if (
+      !this.latestSnapshot ||
+      this.latestSnapshot === previousSnapshot ||
+      this.state.status !== 'ready'
+    ) {
+      this.state = {
+        ...this.state,
+        revisit: {
+          baselineCaptureId: this.revisitBaseline.snapshot.captureId,
+          status: 'baseline-ready',
+        },
+        revision: this.state.revision + 1,
+        updatedAt: new Date().toISOString(),
+      };
+      this.emitState();
+      throw new Error(
+        this.state.errorDetail || 'Unable to capture the revisit tree',
+      );
+    }
+    const revisitAudit = buildAndroidLiveTreeAudit(
+      this.latestSnapshot.root,
+      this.latestSnapshot.logicalSize,
+      this.revisitBaseline.treeNodes,
+    );
+    this.revisitSnapshot = this.latestSnapshot;
+    this.state = {
+      ...this.state,
+      revisit: {
+        baselineCaptureId: this.revisitBaseline.snapshot.captureId,
+        replay: revisitAudit.replay,
+        status: 'verified',
+        verifiedCaptureId: this.latestSnapshot.captureId,
+      },
+      revision: this.state.revision + 1,
+      updatedAt: new Date().toISOString(),
+    };
+    this.emitState();
+    return this.state;
+  }
+
+  async scanVisualElements(
+    options: {
+      automatic?: boolean;
+    } = {},
+  ): Promise<AndroidAuditState> {
+    if (this.visualScanPromise) return this.visualScanPromise;
+    const visualScanPromise = this.runVisualScan(Boolean(options.automatic));
+    this.visualScanPromise = visualScanPromise;
+    try {
+      return await visualScanPromise;
+    } finally {
+      if (this.visualScanPromise === visualScanPromise) {
+        this.visualScanPromise = null;
+      }
+    }
+  }
+
+  private async runVisualScan(automatic: boolean): Promise<AndroidAuditState> {
+    if (!this.device || !this.agent) {
+      throw new Error('No Android Agent session is connected');
+    }
+    if (!this.latestSnapshot || !this.latestTreeAudit) await this.captureNow();
+    if (!this.latestSnapshot || !this.latestTreeAudit) {
+      throw new Error(
+        this.state.errorDetail || 'Unable to capture a tree for visual scan',
+      );
+    }
+    const generation = this.generation;
+    const device = this.device;
+    const agent = this.agent;
+    const scanPageFingerprint = pageIdentityFingerprint(this.latestSnapshot);
+    const scanLayoutFingerprint = pageLayoutFingerprint(this.latestSnapshot);
+    this.clearTimer();
+    this.state = {
+      ...this.state,
+      ...(automatic ? {} : { error: undefined }),
+      visualScan: { automatic, status: 'scanning' },
+    };
+    this.emitState();
+
+    try {
+      const suggestions = await agent.aiQuery<unknown>(
+        automatic
+          ? '{name: string, description: string, rect: {left: number, top: number, width: number, height: number}}[], list every visible interactive control on the current screenshot. Return each bounding rectangle in a normalized 0-1000 coordinate system: (0, 0) is the screenshot top-left and (1000, 1000) is the bottom-right. Return the full tappable region instead of a child icon or text label. Treat adjacent labels, values, and chevrons that trigger one action as one control, and do not emit their children separately. Include buttons, links, tabs, inputs, toggles, icons with click actions, and floating controls. Exclude non-interactive video content, decorations, and bullet comments. Give repeated controls a position-specific unique description.'
+          : '{name: string, description: string}[], list every visible interactive control on the current screenshot. Include buttons, links, tabs, inputs, toggles, icons with click actions, and floating controls. Exclude non-interactive video content, decorations, and bullet comments. Give repeated controls a position-specific unique description.',
+        { domIncluded: false, screenshotIncluded: true },
+      );
+      if (generation !== this.generation || device !== this.device) {
+        throw new Error('Android device changed during the visual scan');
+      }
+      if (!Array.isArray(suggestions)) {
+        throw new Error('AI visual scan did not return an element list');
+      }
+      const normalized = suggestions
+        .map((suggestion) => {
+          if (!suggestion || typeof suggestion !== 'object') return null;
+          const record = suggestion as Record<string, unknown>;
+          const name =
+            typeof record.name === 'string' ? record.name.trim() : '';
+          const description =
+            typeof record.description === 'string'
+              ? record.description.trim()
+              : name;
+          const rawRect =
+            record.rect && typeof record.rect === 'object'
+              ? (record.rect as Record<string, unknown>)
+              : null;
+          const rect =
+            rawRect &&
+            ['left', 'top', 'width', 'height'].every((key) =>
+              Number.isFinite(rawRect[key]),
+            )
+              ? {
+                  left: Number(rawRect.left),
+                  top: Number(rawRect.top),
+                  width: Number(rawRect.width),
+                  height: Number(rawRect.height),
+                }
+              : undefined;
+          return name && description ? { name, description, rect } : null;
+        })
+        .filter(
+          (
+            suggestion,
+          ): suggestion is {
+            name: string;
+            description: string;
+            rect:
+              | {
+                  left: number;
+                  top: number;
+                  width: number;
+                  height: number;
+                }
+              | undefined;
+          } => Boolean(suggestion),
+        )
+        .slice(0, MAX_VISUAL_SCAN_ELEMENTS);
+      if (normalized.length === 0) {
+        throw new Error('AI visual scan found no visible interactive controls');
+      }
+
+      const inputs: AndroidAuditVisualElementInput[] = [];
+      for (const [index, suggestion] of normalized.entries()) {
+        let rect:
+          | {
+              left: number;
+              top: number;
+              width: number;
+              height: number;
+            }
+          | undefined;
+        if (automatic && suggestion.rect) {
+          const logicalSize = this.latestSnapshot?.logicalSize;
+          if (!logicalSize) {
+            throw new Error(
+              'The Accessibility snapshot disappeared during the visual scan',
+            );
+          }
+          rect = {
+            left: (suggestion.rect.left / 1000) * logicalSize.width,
+            top: (suggestion.rect.top / 1000) * logicalSize.height,
+            width: (suggestion.rect.width / 1000) * logicalSize.width,
+            height: (suggestion.rect.height / 1000) * logicalSize.height,
+          };
+        } else if (automatic) {
+          warnAudit(
+            `Automatic visual scan omitted a rectangle for "${suggestion.description}"`,
+          );
+          continue;
+        } else {
+          try {
+            const located = (await agent.aiLocate(suggestion.description, {
+              cacheable: false,
+            })) as {
+              dpr?: number;
+              rect?: {
+                left: number;
+                top: number;
+                width: number;
+                height: number;
+              };
+            };
+            if (located.rect) {
+              const dpr = located.dpr || this.latestSnapshot?.dpr || 1;
+              rect = {
+                left: located.rect.left / dpr,
+                top: located.rect.top / dpr,
+                width: located.rect.width / dpr,
+                height: located.rect.height / dpr,
+              };
+            }
+          } catch (error) {
+            warnAudit(
+              `Unable to locate visual control "${suggestion.description}": ${errorMessage(error)}`,
+            );
+            continue;
+          }
+        }
+        if (generation !== this.generation || device !== this.device) {
+          throw new Error('Android device changed during the visual scan');
+        }
+        if (!rect) continue;
+        if (
+          !Number.isFinite(rect.left) ||
+          !Number.isFinite(rect.top) ||
+          !Number.isFinite(rect.width) ||
+          !Number.isFinite(rect.height) ||
+          rect.width <= 0 ||
+          rect.height <= 0
+        ) {
+          continue;
+        }
+        inputs.push({
+          description: suggestion.description,
+          id: `ai-${Date.now()}-${index + 1}`,
+          name: suggestion.name,
+          rect,
+          rectSource: 'ai',
+        });
+      }
+      if (inputs.length === 0) {
+        throw new Error(
+          'AI visual scan could not locate any control rectangles',
+        );
+      }
+
+      this.visualInputs = inputs;
+      this.visualInputsLayoutFingerprint = scanLayoutFingerprint;
+      const previousSnapshot = this.latestSnapshot;
+      await this.captureNow();
+      if (
+        !this.latestSnapshot ||
+        this.latestSnapshot === previousSnapshot ||
+        this.state.status !== 'ready'
+      ) {
+        throw new Error(
+          this.state.errorDetail ||
+            'Unable to capture a fresh tree after the visual scan',
+        );
+      }
+      if (
+        this.latestPageFingerprint !== scanPageFingerprint ||
+        this.visualInputs.length === 0 ||
+        this.visualInputsLayoutFingerprint !== scanLayoutFingerprint
+      ) {
+        throw new Error(
+          'The Android page changed during the visual scan; stale visual boxes were discarded',
+        );
+      }
+      this.state = {
+        ...this.state,
+        revision: this.state.revision + 1,
+        updatedAt: new Date().toISOString(),
+        visualScan: {
+          automatic,
+          status: 'ready',
+          updatedAt: new Date().toISOString(),
+        },
+      };
+      this.emitState();
+      return this.state;
+    } catch (error) {
+      const message = errorMessage(error);
+      const captureFailed =
+        this.state.status === 'error' && Boolean(this.state.errorDetail);
+      this.state = {
+        ...this.state,
+        error: automatic
+          ? this.state.error
+          : captureFailed
+            ? this.state.error
+            : message,
+        errorDetail: captureFailed ? this.state.errorDetail : undefined,
+        revision: this.state.revision + 1,
+        updatedAt: new Date().toISOString(),
+        visualScan: {
+          automatic,
+          error: message,
+          status: 'error',
+          updatedAt: new Date().toISOString(),
+        },
+      };
+      this.emitState();
+      throw error;
+    } finally {
+      if (this.state.enabled) this.scheduleCapture(this.captureIntervalMs);
+    }
+  }
+
+  async setVisualElements(
+    inputs: AndroidAuditVisualElementInput[],
+  ): Promise<AndroidAuditState> {
+    if (!this.device || !this.latestSnapshot || !this.latestTreeAudit) {
+      throw new Error(
+        'Capture an Accessibility tree before adding visual elements',
+      );
+    }
+    if (this.capturePromise) await this.capturePromise;
+    this.clearTimer();
+    const generation = this.generation;
+    const device = this.device;
+    try {
+      if (generation !== this.generation || device !== this.device) {
+        throw new Error('Android device changed while adding visual elements');
+      }
+      const visualAudit = buildAndroidVisualAudit(
+        this.latestSnapshot.root,
+        this.latestSnapshot.logicalSize,
+        this.latestTreeAudit,
+        inputs,
+      );
+      this.visualInputs = inputs;
+      this.visualInputsLayoutFingerprint = inputs.length
+        ? pageLayoutFingerprint(this.latestSnapshot)
+        : null;
+      if (!inputs.length) {
+        this.autoVisualScanAttemptedPageFingerprint = null;
+      }
+      this.state = {
+        ...this.state,
+        overlays: mergeVisualAndTreeOverlays(
+          this.latestTreeAudit,
+          inputs.length ? visualAudit : null,
+        ),
+        revision: this.state.revision + 1,
+        updatedAt: new Date().toISOString(),
+        visualElements: visualAudit.visualElements,
+        visualScan: inputs.length
+          ? { status: 'ready', updatedAt: new Date().toISOString() }
+          : { status: 'idle' },
+      };
+      this.emitState();
+      return this.state;
+    } finally {
+      if (
+        generation === this.generation &&
+        device === this.device &&
+        this.state.enabled
+      ) {
+        this.scheduleCapture(this.captureIntervalMs);
+      }
+    }
+  }
+
+  async exportReport(): Promise<AndroidAuditDownloadBundle> {
+    if (!this.device || !this.state.deviceId) {
+      throw new Error('No Android device session is connected');
+    }
+    if (this.capturePromise) await this.capturePromise;
+    this.clearTimer();
+    const generation = this.generation;
+    const device = this.device;
+    const deviceId = this.state.deviceId;
+    this.state = {
+      ...this.state,
+      error: undefined,
+      errorDetail: undefined,
+      status: 'capturing',
+    };
+    this.emitState();
+
+    try {
+      const source = await device.captureAccessibilitySnapshot();
+      const screenshotBase64 = await device.screenshotBase64();
+      const screenshotCapturedAt = new Date().toISOString();
+      const fresh = await device.captureAccessibilitySnapshot();
+      const environment = device.captureAuditEnvironment
+        ? await device.captureAuditEnvironment(source)
+        : fallbackAuditEnvironment(deviceId, source);
+      if (generation !== this.generation || device !== this.device) {
+        throw new Error('Android device changed while exporting the audit');
+      }
+      const sourceAudit = buildAndroidLiveTreeAudit(
+        source.root,
+        source.logicalSize,
+      );
+      const freshAudit = buildAndroidLiveTreeAudit(
+        fresh.root,
+        fresh.logicalSize,
+        sourceAudit.treeNodes,
+      );
+      const sourceReportAudit = applyAndroidAuditReplayToSource(
+        source.root,
+        source.logicalSize,
+        sourceAudit,
+        freshAudit.replayResults,
+      );
+      const sourceVisualAudit = this.visualInputs.length
+        ? buildAndroidVisualAudit(
+            source.root,
+            source.logicalSize,
+            sourceReportAudit,
+            this.visualInputs,
+          )
+        : null;
+      const freshVisualAudit = this.visualInputs.length
+        ? buildAndroidVisualAudit(
+            fresh.root,
+            fresh.logicalSize,
+            freshAudit,
+            this.visualInputs,
+          )
+        : null;
+      const download = buildAndroidAuditDownloadBundle({
+        deviceId,
+        entryPath:
+          'Current Playground session; navigation was performed manually.',
+        environment,
+        fresh,
+        overlays: mergeVisualAndTreeOverlays(
+          sourceReportAudit,
+          sourceVisualAudit,
+        ),
+        replay: freshAudit.replay,
+        replayResults: freshAudit.replayResults,
+        screenshotBase64,
+        screenshotCapturedAt,
+        source,
+        technology: {
+          declaredStack: 'unknown',
+          confidence: 'unknown',
+          evidence: [
+            'No explicit technology declaration was supplied for this live Playground capture.',
+          ],
+        },
+        treeNodes: sourceReportAudit.treeNodes,
+        visualElements: sourceVisualAudit?.visualElements ?? [],
+        ...(this.revisitBaseline &&
+        this.revisitSnapshot &&
+        this.state.revisit?.replay
+          ? {
+              revisit: {
+                replay: this.state.revisit.replay,
+                snapshot: this.revisitSnapshot,
+              },
+            }
+          : {}),
+      });
+      this.latestSnapshot = fresh;
+      this.latestPageFingerprint = pageIdentityFingerprint(fresh);
+      this.latestTreeAudit = freshAudit;
+      this.previousTreeNodes = freshAudit.treeNodes;
+      this.visualInputsLayoutFingerprint = this.visualInputs.length
+        ? pageLayoutFingerprint(fresh)
+        : null;
+      this.state = {
+        ...this.state,
+        lastExport: { runId: download.runId },
+        overlays: mergeVisualAndTreeOverlays(freshAudit, freshVisualAudit),
+        replay: freshAudit.replay,
+        revision: this.state.revision + 1,
+        source: snapshotSummary(fresh),
+        status: 'ready',
+        treeNodes: freshAudit.treeNodes,
+        updatedAt: new Date().toISOString(),
+        visualElements: freshVisualAudit?.visualElements ?? [],
+      };
+      this.emitState();
+      return download;
+    } catch (error) {
+      const message = errorMessage(error);
+      this.state = {
+        ...this.state,
+        error: message,
+        revision: this.state.revision + 1,
+        status: 'error',
+        updatedAt: new Date().toISOString(),
+      };
+      this.emitState();
+      throw error;
+    } finally {
+      if (
+        generation === this.generation &&
+        device === this.device &&
+        this.state.enabled
+      ) {
+        this.scheduleCapture(this.captureIntervalMs);
+      }
+    }
+  }
+
+  async captureNow(): Promise<AndroidAuditState> {
+    if (!this.device) {
+      throw new Error('No Android device session is connected');
+    }
+    if (this.capturePromise) return this.capturePromise;
+
+    const generation = this.generation;
+    const device = this.device;
+    const captureToken = {};
+    this.activeCaptureToken = captureToken;
+    this.clearTimer();
+    this.state = {
+      ...this.state,
+      error: undefined,
+      errorDetail: undefined,
+      status: 'capturing',
+    };
+    this.emitState();
+
+    const capturePromise = (async () => {
+      try {
+        const snapshot = await device.captureAccessibilitySnapshot();
+        if (generation !== this.generation || device !== this.device) {
+          return this.state;
+        }
+        const previousSnapshot = this.latestSnapshot;
+        const nextPageFingerprint = pageIdentityFingerprint(snapshot);
+        const nextLayoutFingerprint = pageLayoutFingerprint(snapshot);
+        const geometryChanged =
+          Boolean(previousSnapshot) &&
+          (previousSnapshot?.rotation !== snapshot.rotation ||
+            previousSnapshot?.logicalSize.width !==
+              snapshot.logicalSize.width ||
+            previousSnapshot?.logicalSize.height !==
+              snapshot.logicalSize.height);
+        const pageChanged =
+          Boolean(this.latestPageFingerprint) &&
+          this.latestPageFingerprint !== nextPageFingerprint;
+        const visualLayoutChanged =
+          this.visualInputs.length > 0 &&
+          this.visualInputsLayoutFingerprint !== nextLayoutFingerprint;
+        if (geometryChanged || pageChanged) {
+          this.clearAutoVisualScanTimer();
+          this.previousTreeNodes = [];
+          this.autoVisualScanAttemptedPageFingerprint = null;
+        }
+        if (geometryChanged) {
+          this.revisitBaseline = null;
+          this.revisitSnapshot = null;
+        }
+        if (geometryChanged || pageChanged || visualLayoutChanged) {
+          this.resetVisualInputs(
+            geometryChanged
+              ? 'device geometry changed'
+              : pageChanged
+                ? 'page identity changed'
+                : 'page layout changed',
+          );
+        }
+        const audit = buildAndroidLiveTreeAudit(
+          snapshot.root,
+          snapshot.logicalSize,
+          this.previousTreeNodes,
+        );
+        this.previousTreeNodes = audit.treeNodes;
+        this.latestTreeAudit = audit;
+        this.latestSnapshot = snapshot;
+        this.latestPageFingerprint = nextPageFingerprint;
+        const visualAudit = this.visualInputs.length
+          ? buildAndroidVisualAudit(
+              snapshot.root,
+              snapshot.logicalSize,
+              audit,
+              this.visualInputs,
+            )
+          : null;
+        this.state = {
+          ...this.state,
+          error: undefined,
+          overlays: mergeVisualAndTreeOverlays(audit, visualAudit),
+          replay: audit.replay,
+          revision: this.state.revision + 1,
+          source: snapshotSummary(snapshot),
+          status: 'ready',
+          treeNodes: audit.treeNodes,
+          updatedAt: new Date().toISOString(),
+          visualElements: visualAudit?.visualElements ?? [],
+          visualScan:
+            geometryChanged || pageChanged || visualLayoutChanged
+              ? { status: 'idle' }
+              : this.state.visualScan,
+          ...(geometryChanged ? { revisit: undefined } : {}),
+        };
+        this.emitState();
+        return this.state;
+      } catch (error) {
+        if (generation !== this.generation || device !== this.device) {
+          return this.state;
+        }
+        const message = errorMessage(error);
+        warnAudit(`Accessibility audit capture failed: ${message}`);
+        this.state = {
+          ...this.state,
+          enabled: false,
+          error: accessibilityCaptureError(message),
+          errorDetail: message,
+          revision: this.state.revision + 1,
+          status: 'error',
+          updatedAt: new Date().toISOString(),
+        };
+        this.emitState();
+        return this.state;
+      } finally {
+        if (this.activeCaptureToken === captureToken) {
+          this.activeCaptureToken = null;
+          this.capturePromise = null;
+        }
+        if (
+          generation === this.generation &&
+          device === this.device &&
+          this.state.enabled
+        ) {
+          this.scheduleCapture(this.captureIntervalMs);
+          this.scheduleAutoVisualScanIfNeeded();
+        }
+      }
+    })();
+
+    this.capturePromise = capturePromise;
+    return capturePromise;
+  }
+
+  registerRoutes(app: Application): void {
+    app.use('/android-audit', express.json({ limit: '5mb' }));
+
+    app.get('/android-audit/state', (_req, res) => {
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(this.state);
+    });
+
+    app.get('/android-audit/events', (req, res) => {
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.flushHeaders();
+      this.subscribers.add(res);
+      this.writeEvent(res);
+      req.on('close', () => this.subscribers.delete(res));
+    });
+
+    app.post('/android-audit/start', async (_req, res) => {
+      await this.respond(res, () => this.start());
+    });
+
+    app.post('/android-audit/pause', (_req, res) => {
+      res.json(this.pause());
+    });
+
+    app.post('/android-audit/capture', async (_req, res) => {
+      await this.respond(res, () => this.captureNow());
+    });
+
+    app.post('/android-audit/revisit-baseline', async (_req, res) => {
+      await this.respond(res, () => this.setRevisitBaseline());
+    });
+
+    app.post('/android-audit/revisit-verify', async (_req, res) => {
+      await this.respond(res, () => this.verifyRevisit());
+    });
+
+    app.post('/android-audit/export', async (_req, res) => {
+      await this.respond(res, () => this.exportReport());
+    });
+
+    app.post('/android-audit/visual-scan', async (_req, res) => {
+      await this.respond(res, () => this.scanVisualElements());
+    });
+
+    app.post('/android-audit/visual-elements', async (req: Request, res) => {
+      const inputs = Array.isArray(req.body?.elements)
+        ? (req.body.elements as AndroidAuditVisualElementInput[])
+        : [];
+      await this.respond(res, () => this.setVisualElements(inputs));
+    });
+  }
+
+  close(): void {
+    this.detachDevice();
+    for (const subscriber of this.subscribers) subscriber.end();
+    this.subscribers.clear();
+  }
+
+  private clearTimer(): void {
+    if (!this.timer) return;
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private clearAutoVisualScanTimer(): void {
+    if (!this.autoVisualScanTimer) return;
+    clearTimeout(this.autoVisualScanTimer);
+    this.autoVisualScanTimer = null;
+  }
+
+  private scheduleCapture(delayMs: number): void {
+    this.clearTimer();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.captureNow();
+    }, delayMs);
+  }
+
+  private resetVisualInputs(reason: string): void {
+    if (this.visualInputs.length > 0 || this.visualInputsLayoutFingerprint) {
+      debugAudit('visual inputs cleared reason=%s', reason);
+    }
+    this.visualInputs = [];
+    this.visualInputsLayoutFingerprint = null;
+  }
+
+  private scheduleAutoVisualScanIfNeeded(): void {
+    if (
+      !this.autoVisualScanEnabled ||
+      !this.state.enabled ||
+      !this.agent ||
+      !this.device ||
+      !this.latestTreeAudit ||
+      !this.latestPageFingerprint ||
+      this.visualInputs.length > 0 ||
+      this.visualScanPromise ||
+      this.autoVisualScanTimer ||
+      this.autoVisualScanAttemptedPageFingerprint ===
+        this.latestPageFingerprint ||
+      !needsWebViewVisualInventory(this.latestTreeAudit)
+    ) {
+      return;
+    }
+    const generation = this.generation;
+    const device = this.device;
+    const pageFingerprint = this.latestPageFingerprint;
+    this.autoVisualScanAttemptedPageFingerprint = pageFingerprint;
+    this.autoVisualScanTimer = setTimeout(() => {
+      this.autoVisualScanTimer = null;
+      if (
+        generation !== this.generation ||
+        device !== this.device ||
+        pageFingerprint !== this.latestPageFingerprint ||
+        this.visualInputs.length > 0
+      ) {
+        return;
+      }
+      debugAudit('starting automatic WebView visual inventory');
+      void this.scanVisualElements({ automatic: true }).catch((error) => {
+        warnAudit(
+          `Automatic WebView visual inventory failed: ${errorMessage(error)}`,
+        );
+      });
+    }, 0);
+  }
+
+  private emitState(): void {
+    debugAudit(
+      'state revision=%d status=%s enabled=%s nodes=%d overlays=%d',
+      this.state.revision,
+      this.state.status,
+      this.state.enabled,
+      this.state.treeNodes.length,
+      this.state.overlays.length,
+    );
+    for (const subscriber of this.subscribers) this.writeEvent(subscriber);
+  }
+
+  private writeEvent(response: Response): void {
+    response.write(
+      `event: state\ndata: ${JSON.stringify({
+        revision: this.state.revision,
+        status: this.state.status,
+      })}\n\n`,
+    );
+  }
+
+  private async respond<T>(
+    response: Response,
+    operation: () => Promise<T>,
+  ): Promise<void> {
+    try {
+      response.json(await operation());
+    } catch (error) {
+      response.status(409).json({ error: errorMessage(error) });
+    }
+  }
+}

--- a/packages/android-playground/src/index.ts
+++ b/packages/android-playground/src/index.ts
@@ -1,3 +1,22 @@
 export { androidPlaygroundPlatform } from './platform';
 export type { AndroidPlatformOptions } from './platform';
 export { default as ScrcpyServer } from './scrcpy-server';
+export { AndroidAuditSessionController } from './android-audit-session';
+export type {
+  AndroidAuditDevice,
+  AndroidAuditSessionOptions,
+  AndroidAuditSnapshotSummary,
+  AndroidAuditState,
+} from './android-audit-session';
+export {
+  buildAndroidAuditDownloadBundle,
+  writeAndroidAuditExport,
+  writeAndroidAuditExportWithDownload,
+} from './android-audit-export';
+export type {
+  AndroidAuditDownloadBundle,
+  AndroidAuditDownloadFile,
+  AndroidAuditExportInput,
+  AndroidAuditExportResult,
+  AndroidAuditExportWithDownload,
+} from './android-audit-export';

--- a/packages/android-playground/src/platform.ts
+++ b/packages/android-playground/src/platform.ts
@@ -16,6 +16,7 @@ import {
   SCRCPY_SERVER_PORT,
 } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
+import { AndroidAuditSessionController } from './android-audit-session';
 export interface ScrcpyServerController {
   currentDeviceId: string | null;
   launch(port?: number): Promise<unknown>;
@@ -67,6 +68,7 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
   title: 'Midscene Android Playground',
   description: 'Android playground platform descriptor',
   async prepare(options) {
+    const auditController = new AndroidAuditSessionController();
     const staticDir =
       options?.staticDir || path.join(__dirname, '../../static');
     const [playgroundPort, resolvedScrcpyPort] = await Promise.all([
@@ -139,7 +141,9 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         const connectAgent = async () => {
           const device = new AndroidDevice(deviceId);
           await device.connect();
-          return new AndroidAgent(device, options?.getAgentOptions?.());
+          const agent = new AndroidAgent(device, options?.getAgentOptions?.());
+          auditController.attachDevice(deviceId, device, agent);
+          return agent;
         };
 
         if (options?.scrcpyServer) {
@@ -161,6 +165,9 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
             scrcpyPort,
           },
         };
+      },
+      async destroySession() {
+        auditController.detachDevice();
       },
     };
 
@@ -188,6 +195,7 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         staticPath: staticDir,
         configureServer(server) {
           server.scrcpyPort = scrcpyPort;
+          auditController.registerRoutes(server.app);
         },
       },
       preview: createScrcpyPreviewDescriptor(

--- a/packages/android-playground/tests/unit/android-audit-export.test.ts
+++ b/packages/android-playground/tests/unit/android-audit-export.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { writeAndroidAuditExportWithDownload } from '../../src/android-audit-export';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe('Android audit report export', () => {
+  it('writes the ignored report structure with raw XML and the full UiNode tree', async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), 'midscene-android-audit-export-'),
+    );
+    temporaryDirectories.push(outputRoot);
+    const root = {
+      attrs: {},
+      bounds: { left: 0, top: 0, width: 400, height: 800 },
+      children: [],
+      type: 'android.widget.FrameLayout',
+    };
+    const source = {
+      captureId: 'source',
+      capturedAt: '2026-07-22T01:00:00.000Z',
+      dpr: 1,
+      durationMs: 10,
+      logicalSize: { width: 400, height: 800 },
+      root,
+      rotation: 0,
+      source: 'yadb' as const,
+      sourceXml: '<hierarchy></hierarchy>',
+    };
+    const { download, result } = await writeAndroidAuditExportWithDownload(
+      {
+        deviceId: 'serial-1',
+        entryPath: 'Opened manually',
+        environment: {
+          device: {
+            serial: 'serial-1',
+            manufacturer: 'Fixture',
+            model: 'Phone',
+            androidVersion: '15',
+            apiLevel: '35',
+            resolution: {
+              physical: { width: 400, height: 800 },
+              logical: { width: 400, height: 800 },
+              screenshot: { width: 400, height: 800 },
+            },
+            density: 160,
+            dpr: 1,
+            rotation: 0,
+          },
+          app: {
+            expectedPackage: 'com.example.app',
+            package: 'com.example.app',
+            activity: '.MainActivity',
+            versionName: '1.2.3',
+            versionCode: '123',
+          },
+        },
+        fresh: { ...source, captureId: 'fresh' },
+        overlays: [],
+        replay: { attempted: 0, hits: 0, misses: 0, wrongMappings: 0 },
+        replayResults: [],
+        screenshotBase64: Buffer.from('fake-png').toString('base64'),
+        screenshotCapturedAt: '2026-07-22T01:00:00.500Z',
+        source,
+        technology: {
+          declaredStack: 'unknown',
+          confidence: 'unknown',
+          evidence: ['No declaration'],
+        },
+        treeNodes: [],
+        visualElements: [],
+      },
+      outputRoot,
+    );
+    const pageDir = path.join(result.outputDir, 'pages', 'playground-current');
+
+    await expect(
+      readFile(path.join(pageDir, 'source-used.xml'), 'utf8'),
+    ).resolves.toBe(source.sourceXml);
+    await expect(
+      readFile(path.join(pageDir, 'ui-tree.json'), 'utf8'),
+    ).resolves.toContain('android.widget.FrameLayout');
+    const indexHtml = await readFile(result.indexHtml, 'utf8');
+    expect(indexHtml).toContain('pages/playground-current/screenshot.png');
+    expect(indexHtml).toContain('<html lang="en">');
+    expect(indexHtml).toContain('Android XPath Audit');
+    expect(indexHtml).toContain('Complete UiNode Tree (0)');
+    expect(indexHtml).not.toMatch(/\p{Script=Han}/u);
+    const metadata = JSON.parse(
+      await readFile(path.join(pageDir, 'metadata.json'), 'utf8'),
+    );
+    expect(metadata).toMatchObject({
+      schemaVersion: 2,
+      reportKind: 'playground-live',
+      entryPath: 'Opened manually',
+      app: { package: 'com.example.app', versionName: '1.2.3' },
+      device: { manufacturer: 'Fixture', model: 'Phone' },
+      sourceUsed: 'yadb',
+      captures: {
+        source: {
+          screenshot: { capturedAt: '2026-07-22T01:00:00.500Z' },
+        },
+      },
+    });
+    expect(download).toMatchObject({
+      directoryName: result.runId,
+      runId: result.runId,
+    });
+    expect(download.files.map((file) => file.relativePath)).toEqual([
+      'run.json',
+      'summary.json',
+      'index.html',
+      'pages/playground-current/metadata.json',
+      'pages/playground-current/screenshot.png',
+      'pages/playground-current/source-used.xml',
+      'pages/playground-current/yadb.xml',
+      'pages/playground-current/fresh-replay.xml',
+      'pages/playground-current/ui-tree.json',
+      'pages/playground-current/visual-elements.json',
+      'pages/playground-current/elements.json',
+      'pages/playground-current/replay-results.json',
+      'pages/playground-current/annotated.html',
+    ]);
+    const screenshotFile = download.files.find(
+      (file) => file.relativePath === 'pages/playground-current/screenshot.png',
+    );
+    expect(screenshotFile).toBeDefined();
+    expect(
+      Buffer.from(screenshotFile!.contentBase64, 'base64').toString(),
+    ).toBe('fake-png');
+  });
+});

--- a/packages/android-playground/tests/unit/android-audit-marker.test.ts
+++ b/packages/android-playground/tests/unit/android-audit-marker.test.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { androidAuditMarkerLabelPlacement } from '../../src/android-audit-marker-presentation';
+
+describe('Android audit marker presentation', () => {
+  it('keeps a top-edge marker label inside the frame so its status color stays visible', () => {
+    expect(androidAuditMarkerLabelPlacement(0)).toBe('inside');
+  });
+
+  it('keeps an ordinary marker label outside the frame', () => {
+    expect(androidAuditMarkerLabelPlacement(1)).toBe('outside');
+  });
+
+  it('does not tint overlapping nodes until a marker is selected', async () => {
+    const source = await readFile(
+      new URL(
+        '../../../../apps/android-playground/src/android-audit/android-audit.less',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(source).toMatch(
+      /\.android-audit-marker\s*\{[^}]*background:\s*transparent;/s,
+    );
+    expect(source).toMatch(/&\.selected\s*\{[^}]*background:\s*color-mix\(/s);
+    expect(source).toMatch(
+      /\.status-point-selected-other\s*>\s*span\s*\{[^}]*z-index:\s*30;/s,
+    );
+  });
+});

--- a/packages/android-playground/tests/unit/android-audit-session.test.ts
+++ b/packages/android-playground/tests/unit/android-audit-session.test.ts
@@ -1,0 +1,653 @@
+import type { AndroidAccessibilitySnapshot } from '@midscene/android';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AndroidAuditSessionController } from '../../src/android-audit-session';
+
+function snapshot(top: number): AndroidAccessibilitySnapshot {
+  const sourceXml = `<?xml version="1.0"?><hierarchy><node class="android.widget.FrameLayout" bounds="[0,0][400,800]"><node class="android.widget.Button" resource-id="stable" clickable="true" bounds="[20,${top}][140,${top + 60}]"/></node></hierarchy>`;
+  return {
+    captureId: `capture-${top}`,
+    capturedAt: new Date().toISOString(),
+    dpr: 1,
+    durationMs: 10,
+    logicalSize: { width: 400, height: 800 },
+    root: {
+      attrs: {},
+      bounds: { left: 0, top: 0, width: 400, height: 800 },
+      children: [
+        {
+          attrs: { 'resource-id': 'stable', clickable: 'true' },
+          bounds: { left: 20, top, width: 120, height: 60 },
+          children: [],
+          type: 'android.widget.Button',
+        },
+      ],
+      type: 'android.widget.FrameLayout',
+    },
+    rotation: 0,
+    source: 'yadb',
+    sourceXml,
+  };
+}
+
+function webViewSnapshot(
+  pageId: string,
+  interactiveCount: number,
+): AndroidAccessibilitySnapshot {
+  const children = Array.from({ length: 14 }, (_, index) => ({
+    attrs: {
+      'resource-id': `${pageId}-control-${index + 1}`,
+      clickable: index < interactiveCount ? 'true' : 'false',
+      text: `Control ${index + 1}`,
+    },
+    bounds: {
+      left: 20 + (index % 2) * 180,
+      top: 40 + Math.floor(index / 2) * 80,
+      width: 160,
+      height: 60,
+    },
+    children: [],
+    type: 'android.view.View',
+  }));
+  return {
+    captureId: `${pageId}-${Date.now()}`,
+    capturedAt: new Date().toISOString(),
+    dpr: 1,
+    durationMs: 10,
+    logicalSize: { width: 400, height: 800 },
+    root: {
+      attrs: { package: 'com.example.webview' },
+      bounds: { left: 0, top: 0, width: 400, height: 800 },
+      children,
+      type: 'android.webkit.WebView',
+    },
+    rotation: 0,
+    source: 'yadb',
+    sourceXml: '<hierarchy />',
+  };
+}
+
+function semanticSnapshot(text: string): AndroidAccessibilitySnapshot {
+  return {
+    ...snapshot(20),
+    captureId: `capture-${text}`,
+    root: {
+      attrs: {},
+      bounds: { left: 0, top: 0, width: 400, height: 800 },
+      children: [
+        {
+          attrs: { focusable: 'true', text },
+          bounds: { left: 20, top: 20, width: 120, height: 60 },
+          children: [],
+          type: 'android.view.ViewGroup',
+        },
+      ],
+      type: 'android.widget.FrameLayout',
+    },
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('Timed out waiting for audit state');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('AndroidAuditSessionController', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not capture until audit mode is explicitly started', async () => {
+    const captureAccessibilitySnapshot = vi.fn(async () => snapshot(20));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    expect(controller.getState()).toMatchObject({
+      deviceId: 'serial-1',
+      enabled: false,
+      status: 'idle',
+    });
+    expect(captureAccessibilitySnapshot).not.toHaveBeenCalled();
+
+    await controller.start();
+    expect(captureAccessibilitySnapshot).toHaveBeenCalledTimes(1);
+    expect(controller.getState()).toMatchObject({
+      enabled: true,
+      status: 'ready',
+      revision: 1,
+    });
+    controller.close();
+  });
+
+  it('auto-pauses after a complete tree capture failure instead of retrying forever', async () => {
+    const captureAccessibilitySnapshot = vi.fn(async () => {
+      throw new Error(
+        'Unable to read hierarchy: yadb No such file or directory; uiautomator exited with code 137',
+      );
+    });
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 1,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    await controller.start();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captureAccessibilitySnapshot).toHaveBeenCalledTimes(1);
+    expect(controller.getState()).toMatchObject({
+      enabled: false,
+      status: 'error',
+    });
+    expect(controller.getState().error).toContain(
+      'live retries were paused automatically',
+    );
+    expect(controller.getState().errorDetail).toContain('code 137');
+    controller.close();
+  });
+
+  it('single-flights concurrent captures and validates on the next tree', async () => {
+    const pendingCapture = deferred<AndroidAccessibilitySnapshot>();
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockImplementationOnce(() => pendingCapture.promise)
+      .mockResolvedValueOnce(snapshot(40));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    const first = controller.captureNow();
+    const duplicate = controller.captureNow();
+    expect(captureAccessibilitySnapshot).toHaveBeenCalledTimes(1);
+    pendingCapture.resolve(snapshot(20));
+    await Promise.all([first, duplicate]);
+
+    await controller.captureNow();
+    expect(captureAccessibilitySnapshot).toHaveBeenCalledTimes(2);
+    expect(controller.getState().replay).toEqual({
+      attempted: 1,
+      hits: 1,
+      misses: 0,
+      wrongMappings: 0,
+    });
+    expect(controller.getState().overlays[0].status).toBe('cache-xpath-hit');
+    controller.close();
+  });
+
+  it('drops an in-flight result after the device is detached', async () => {
+    const pendingCapture = deferred<AndroidAccessibilitySnapshot>();
+    const controller = new AndroidAuditSessionController();
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot: () => pendingCapture.promise,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    const capture = controller.captureNow();
+    controller.detachDevice();
+    pendingCapture.resolve(snapshot(20));
+    await capture;
+
+    expect(controller.getState()).toMatchObject({
+      enabled: false,
+      revision: 0,
+      status: 'idle',
+    });
+    expect(controller.getState().deviceId).toBeUndefined();
+    controller.close();
+  });
+
+  it('keeps an explicit revisit baseline across navigation and verifies it later', async () => {
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockResolvedValueOnce(snapshot(20))
+      .mockResolvedValueOnce(snapshot(80));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    await controller.captureNow();
+    await controller.setRevisitBaseline();
+    expect(controller.getState().revisit).toMatchObject({
+      baselineCaptureId: 'capture-20',
+      status: 'baseline-ready',
+    });
+
+    await controller.verifyRevisit();
+    expect(controller.getState().revisit).toMatchObject({
+      replay: { attempted: 1, hits: 1, misses: 0, wrongMappings: 0 },
+      status: 'verified',
+      verifiedCaptureId: 'capture-80',
+    });
+    controller.close();
+  });
+
+  it('does not verify revisit with the previous tree when the fresh capture fails', async () => {
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockResolvedValueOnce(snapshot(20))
+      .mockRejectedValueOnce(new Error('fresh hierarchy unavailable'));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+    });
+
+    await controller.captureNow();
+    await controller.setRevisitBaseline();
+
+    await expect(controller.verifyRevisit()).rejects.toThrow(
+      'fresh hierarchy unavailable',
+    );
+    expect(controller.getState().revisit).toMatchObject({
+      baselineCaptureId: 'capture-20',
+      status: 'baseline-ready',
+    });
+    expect(controller.getState().revisit?.replay).toBeUndefined();
+    controller.close();
+  });
+
+  it('adds screenshot-only AI controls and classifies controls missing from the tree', async () => {
+    const captureAccessibilitySnapshot = vi.fn(async () => snapshot(20));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice(
+      'serial-1',
+      {
+        captureAccessibilitySnapshot,
+        screenshotBase64: vi.fn(async () => 'ZmFrZQ=='),
+      },
+      {
+        aiQuery: vi.fn(async () => [
+          { name: '按钮', description: '左上角按钮' },
+          { name: '客服', description: '右上角客服入口' },
+        ]),
+        aiLocate: vi
+          .fn()
+          .mockResolvedValueOnce({
+            dpr: 1,
+            rect: { left: 20, top: 20, width: 120, height: 60 },
+          })
+          .mockResolvedValueOnce({
+            dpr: 1,
+            rect: { left: 250, top: 40, width: 80, height: 80 },
+          }),
+      } as never,
+    );
+
+    await controller.captureNow();
+    await controller.scanVisualElements();
+
+    expect(controller.getState().visualElements).toHaveLength(2);
+    expect(controller.getState().visualElements[1]).toMatchObject({
+      mappedNodeId: null,
+      status: 'not-exposed',
+    });
+    expect(
+      controller
+        .getState()
+        .overlays.some((overlay) => overlay.status === 'not-exposed'),
+    ).toBe(true);
+    expect(controller.getState().overlays).toHaveLength(2);
+    expect(controller.getState().overlays[0].rectSource).toBe('tree');
+    expect(controller.getState().overlays[1].rectSource).toBe('ai');
+    controller.close();
+  });
+
+  it('keeps WebView auditing tree-only by default without invoking AI', async () => {
+    const aiQuery = vi.fn();
+    const aiLocate = vi.fn();
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice(
+      'serial-webview',
+      {
+        captureAccessibilitySnapshot: vi.fn(async () =>
+          webViewSnapshot('monthly-pay', 2),
+        ),
+        screenshotBase64: vi.fn(async () => 'unused'),
+      },
+      { aiLocate, aiQuery } as never,
+    );
+
+    await controller.start();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(aiQuery).not.toHaveBeenCalled();
+    expect(aiLocate).not.toHaveBeenCalled();
+    expect(controller.getState().visualScan).toEqual({ status: 'idle' });
+    expect(controller.getState().visualElements).toEqual([]);
+    expect(controller.getState().overlays).toHaveLength(14);
+    expect(
+      controller
+        .getState()
+        .overlays.every(
+          (overlay) =>
+            overlay.rectSource === 'tree' && !overlay.visualElementId,
+        ),
+    ).toBe(true);
+    controller.close();
+  });
+
+  it('automatically inventories a WebView once per page when explicitly enabled', async () => {
+    const captureAccessibilitySnapshot = vi.fn(async () =>
+      webViewSnapshot('monthly-pay', 2),
+    );
+    const aiQuery = vi.fn(async () => [
+      {
+        name: 'Control 1',
+        description: 'top left Control 1',
+        rect: { left: 50, top: 50, width: 400, height: 75 },
+      },
+      {
+        name: 'Customer service',
+        description: 'top right customer service',
+        rect: { left: 550, top: 50, width: 200, height: 75 },
+      },
+    ]);
+    const aiLocate = vi.fn();
+    const controller = new AndroidAuditSessionController({
+      autoVisualScan: true,
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice(
+      'serial-webview',
+      {
+        captureAccessibilitySnapshot,
+        screenshotBase64: vi.fn(async () => 'unused'),
+      },
+      { aiLocate, aiQuery } as never,
+    );
+
+    await controller.start();
+    await waitFor(() => controller.getState().visualScan.status === 'ready');
+
+    expect(aiQuery).toHaveBeenCalledTimes(1);
+    expect(aiLocate).not.toHaveBeenCalled();
+    expect(controller.getState().visualScan).toMatchObject({
+      automatic: true,
+      status: 'ready',
+    });
+    expect(controller.getState().visualElements).toHaveLength(2);
+    expect(controller.getState().overlays).toHaveLength(2);
+    expect(
+      controller
+        .getState()
+        .overlays.every((overlay) => Boolean(overlay.visualElementId)),
+    ).toBe(true);
+
+    await controller.captureNow();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(aiQuery).toHaveBeenCalledTimes(1);
+    controller.close();
+  });
+
+  it('automatically inventories a WebView regardless of clickable density', async () => {
+    const aiQuery = vi.fn(async () => [
+      {
+        name: 'Control 1',
+        description: 'top left Control 1',
+        rect: { left: 50, top: 50, width: 400, height: 75 },
+      },
+    ]);
+    const controller = new AndroidAuditSessionController({
+      autoVisualScan: true,
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice(
+      'serial-webview',
+      {
+        captureAccessibilitySnapshot: vi.fn(async () =>
+          webViewSnapshot('monthly-pay', 12),
+        ),
+        screenshotBase64: vi.fn(async () => 'unused'),
+      },
+      {
+        aiLocate: vi.fn(),
+        aiQuery,
+      } as never,
+    );
+
+    await controller.start();
+    await waitFor(() => controller.getState().visualScan.status === 'ready');
+
+    expect(aiQuery).toHaveBeenCalledTimes(1);
+    expect(aiQuery).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Return the full tappable region instead of a child icon or text label',
+      ),
+      expect.objectContaining({
+        domIncluded: false,
+        screenshotIncluded: true,
+      }),
+    );
+    expect(controller.getState().visualScan).toMatchObject({
+      automatic: true,
+      status: 'ready',
+    });
+    expect(controller.getState().overlays).toHaveLength(1);
+    controller.close();
+  });
+
+  it('does not retry a failed automatic visual inventory on every tree capture', async () => {
+    const aiQuery = vi.fn(async () => {
+      throw new Error('model unavailable');
+    });
+    const controller = new AndroidAuditSessionController({
+      autoVisualScan: true,
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice(
+      'serial-webview',
+      {
+        captureAccessibilitySnapshot: vi.fn(async () =>
+          webViewSnapshot('monthly-pay', 2),
+        ),
+        screenshotBase64: vi.fn(async () => 'unused'),
+      },
+      {
+        aiLocate: vi.fn(),
+        aiQuery,
+      } as never,
+    );
+
+    await controller.start();
+    await waitFor(() => controller.getState().visualScan.status === 'error');
+    await controller.captureNow();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(aiQuery).toHaveBeenCalledTimes(1);
+    expect(controller.getState().status).toBe('ready');
+    expect(controller.getState().visualScan).toMatchObject({
+      automatic: true,
+      error: 'model unavailable',
+      status: 'error',
+    });
+    controller.close();
+  });
+
+  it('keeps page-scoped visual boxes when only screenshot pixels change', async () => {
+    const captureAccessibilitySnapshot = vi.fn(async () => snapshot(20));
+    const screenshotBase64 = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('data:image/png;base64,page-a')
+      .mockResolvedValueOnce('data:image/png;base64,page-b');
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64,
+    });
+
+    await controller.captureNow();
+    await controller.setVisualElements([
+      {
+        description: '页面 A 上的视觉按钮',
+        id: 'visual-page-a',
+        name: '页面 A 按钮',
+        rect: { left: 250, top: 40, width: 80, height: 80 },
+        rectSource: 'manual',
+      },
+    ]);
+    expect(controller.getState().visualElements).toHaveLength(1);
+
+    await controller.captureNow();
+
+    expect(screenshotBase64).not.toHaveBeenCalled();
+    expect(controller.getState().visualElements).toHaveLength(1);
+    expect(
+      controller
+        .getState()
+        .overlays.some((overlay) => overlay.name === '页面 A 按钮'),
+    ).toBe(true);
+    controller.close();
+  });
+
+  it('exports source geometry with fresh replay results applied to source nodes', async () => {
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockResolvedValueOnce(snapshot(20))
+      .mockResolvedValueOnce(snapshot(80));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () =>
+        Buffer.from('fake-png').toString('base64'),
+      ),
+    });
+
+    const download = await controller.exportReport();
+    const readDownload = (relativePath: string): string => {
+      const file = download.files.find(
+        (candidate) => candidate.relativePath === relativePath,
+      );
+      if (!file) throw new Error(`Missing download file: ${relativePath}`);
+      return Buffer.from(file.contentBase64, 'base64').toString();
+    };
+    const elements = JSON.parse(
+      readDownload('pages/playground-current/elements.json'),
+    );
+    const sourceButton = elements.treeNodes.find(
+      (candidate: { attrs: Record<string, string> }) =>
+        candidate.attrs['resource-id'] === 'stable',
+    );
+    const reportHtml = readDownload('pages/playground-current/annotated.html');
+
+    expect(sourceButton).toMatchObject({
+      bounds: { left: 20, top: 20, width: 120, height: 60 },
+      replayVerified: true,
+    });
+    expect(reportHtml).toContain('top:2.5%');
+    expect(reportHtml).not.toContain('top:10%');
+    expect(controller.getState().source?.captureId).toBe('capture-80');
+    controller.close();
+  });
+
+  it('drops page-scoped visual boxes after the Accessibility layout changes', async () => {
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockResolvedValueOnce(snapshot(20))
+      .mockResolvedValueOnce(snapshot(80));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'unused'),
+    });
+
+    await controller.captureNow();
+    await controller.setVisualElements([
+      {
+        description: 'Visual button on page A',
+        id: 'visual-page-a',
+        name: 'Page A button',
+        rect: { left: 250, top: 40, width: 80, height: 80 },
+        rectSource: 'manual',
+      },
+    ]);
+    await controller.captureNow();
+
+    expect(controller.getState().visualElements).toEqual([]);
+    expect(
+      controller
+        .getState()
+        .overlays.some((overlay) => overlay.name === 'Page A button'),
+    ).toBe(false);
+    controller.close();
+  });
+
+  it('drops page-scoped visual boxes when semantics change at the same bounds', async () => {
+    const captureAccessibilitySnapshot = vi
+      .fn<() => Promise<AndroidAccessibilitySnapshot>>()
+      .mockResolvedValueOnce(semanticSnapshot('Page A'))
+      .mockResolvedValueOnce(semanticSnapshot('Page B'));
+    const controller = new AndroidAuditSessionController({
+      captureIntervalMs: 60_000,
+    });
+    controller.attachDevice('serial-1', {
+      captureAccessibilitySnapshot,
+      screenshotBase64: vi.fn(async () => 'unused'),
+    });
+
+    await controller.captureNow();
+    await controller.setVisualElements([
+      {
+        description: 'Visual control on Page A',
+        id: 'visual-page-a',
+        name: 'Page A control',
+        rect: { left: 250, top: 40, width: 80, height: 80 },
+        rectSource: 'manual',
+      },
+    ]);
+    await controller.captureNow();
+
+    expect(controller.getState().source?.captureId).toBe('capture-Page B');
+    expect(controller.getState().visualElements).toEqual([]);
+    expect(
+      controller
+        .getState()
+        .overlays.some((overlay) => overlay.name === 'Page A control'),
+    ).toBe(false);
+    controller.close();
+  });
+});

--- a/packages/android-playground/vitest.config.ts
+++ b/packages/android-playground/vitest.config.ts
@@ -1,7 +1,20 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { createCoverageConfig } from '../../scripts/vitest-coverage';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@midscene/android': path.resolve(__dirname, '../android/src/index.ts'),
+      '@midscene/core/internal/device-cache': path.resolve(
+        __dirname,
+        '../core/src/device-cache',
+      ),
+    },
+  },
+  ssr: {
+    external: ['@silvia-odwyer/photon'],
+  },
   test: {
     coverage: createCoverageConfig(__dirname),
     environment: 'node',

--- a/packages/playground-app/src/PlaygroundApp.less
+++ b/packages/playground-app/src/PlaygroundApp.less
@@ -79,6 +79,12 @@ h3 {
         gap: 10px;
         width: 100%;
       }
+
+      .playground-header-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
     }
 
     .playground-panel-playground {
@@ -103,6 +109,12 @@ h3 {
     padding: 0 24px 24px;
     overflow: hidden;
   }
+}
+
+.playground-extension-inspector {
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .server-offline-container {

--- a/packages/playground-app/src/PlaygroundApp.tsx
+++ b/packages/playground-app/src/PlaygroundApp.tsx
@@ -6,16 +6,29 @@ import {
   type UniversalPlaygroundConfig,
 } from '@midscene/visualizer';
 import { Layout } from 'antd';
-import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { DisconnectedPreview } from './DisconnectedPreview';
 import { PlaygroundPreview } from './PlaygroundPreview';
 import { PlaygroundThemeProvider } from './PlaygroundThemeProvider';
+import { PreviewInspectorLayout } from './PreviewInspectorLayout';
+import type { PlaygroundControllerResult } from './controller/types';
 import { usePlaygroundController } from './controller/usePlaygroundController';
 import ServerOfflineBackground from './icons/server-offline-background.svg';
 import ServerOfflineForeground from './icons/server-offline-foreground.svg';
 import { PlaygroundConversationPanel } from './panels/PlaygroundConversationPanel';
 import './PlaygroundApp.less';
+import type { PreviewOverlayRenderContext } from './PreviewOverlayLayer';
+
+export interface PlaygroundExtensionContext {
+  isUserOperating: boolean;
+  playgroundSDK: PlaygroundControllerResult['state']['playgroundSDK'];
+  runtimeInfo: PlaygroundControllerResult['state']['runtimeInfo'];
+  serverOnline: boolean;
+  serverUrl: string;
+  sessionConnected: boolean;
+}
 
 const { Content } = Layout;
 
@@ -29,6 +42,13 @@ export interface PlaygroundAppProps {
   offlineTitle?: string;
   offlineStatusText?: string;
   pollIntervalMs?: number;
+  manualPreviewInteractionEnabled?: boolean;
+  inspectorOpen?: boolean;
+  renderHeaderActions?: (context: PlaygroundExtensionContext) => ReactNode;
+  renderInspector?: (context: PlaygroundExtensionContext) => ReactNode;
+  renderPreviewOverlay?: (
+    context: PlaygroundExtensionContext & PreviewOverlayRenderContext,
+  ) => ReactNode;
 }
 
 export function PlaygroundApp({
@@ -41,14 +61,56 @@ export function PlaygroundApp({
   offlineTitle = 'Midscene Playground',
   offlineStatusText = 'Server offline...',
   pollIntervalMs = 5000,
+  manualPreviewInteractionEnabled = true,
+  inspectorOpen,
+  renderHeaderActions,
+  renderInspector,
+  renderPreviewOverlay,
 }: PlaygroundAppProps) {
   const [isNarrowScreen, setIsNarrowScreen] = useState(false);
+  const inspectorVisible = inspectorOpen ?? Boolean(renderInspector);
   const controller = usePlaygroundController({
     serverUrl,
     defaultDeviceType,
     countdownSeconds: playgroundConfig?.executionUx?.countdownSeconds,
     pollIntervalMs,
   });
+  const extensionContext = useMemo<PlaygroundExtensionContext>(
+    () => ({
+      isUserOperating: controller.state.isUserOperating,
+      playgroundSDK: controller.state.playgroundSDK,
+      runtimeInfo: controller.state.runtimeInfo,
+      serverOnline: controller.state.serverOnline,
+      serverUrl,
+      sessionConnected: controller.state.sessionViewState.connected,
+    }),
+    [
+      controller.state.isUserOperating,
+      controller.state.playgroundSDK,
+      controller.state.runtimeInfo,
+      controller.state.serverOnline,
+      controller.state.sessionViewState.connected,
+      serverUrl,
+    ],
+  );
+  const preview = controller.state.sessionViewState.connected ? (
+    <PlaygroundPreview
+      playgroundSDK={controller.state.playgroundSDK}
+      runtimeInfo={controller.state.runtimeInfo}
+      serverUrl={serverUrl}
+      serverOnline={controller.state.serverOnline}
+      isUserOperating={controller.state.isUserOperating}
+      manualInteractionEnabled={manualPreviewInteractionEnabled}
+      renderOverlay={
+        renderPreviewOverlay
+          ? (context) =>
+              renderPreviewOverlay({ ...extensionContext, ...context })
+          : undefined
+      }
+    />
+  ) : (
+    <DisconnectedPreview />
+  );
 
   useEffect(() => {
     const handleResize = () => {
@@ -98,11 +160,22 @@ export function PlaygroundApp({
                 <div className="playground-panel-header">
                   <div className="header-row">
                     <Logo />
-                    <NavActions
-                      showTooltipWhenEmpty={false}
-                      showModelName={false}
-                      playgroundSDK={controller.state.playgroundSDK}
-                    />
+                    {renderHeaderActions ? (
+                      <div className="playground-header-actions">
+                        {renderHeaderActions(extensionContext)}
+                        <NavActions
+                          showTooltipWhenEmpty={false}
+                          showModelName={false}
+                          playgroundSDK={controller.state.playgroundSDK}
+                        />
+                      </div>
+                    ) : (
+                      <NavActions
+                        showTooltipWhenEmpty={false}
+                        showModelName={false}
+                        playgroundSDK={controller.state.playgroundSDK}
+                      />
+                    )}
                   </div>
                 </div>
 
@@ -126,16 +199,19 @@ export function PlaygroundApp({
               className="app-panel right-panel"
             >
               <div className="panel-content right-panel-content">
-                {controller.state.sessionViewState.connected ? (
-                  <PlaygroundPreview
-                    playgroundSDK={controller.state.playgroundSDK}
-                    runtimeInfo={controller.state.runtimeInfo}
-                    serverUrl={serverUrl}
-                    serverOnline={controller.state.serverOnline}
-                    isUserOperating={controller.state.isUserOperating}
+                {renderInspector &&
+                controller.state.sessionViewState.connected ? (
+                  <PreviewInspectorLayout
+                    inspector={
+                      inspectorVisible
+                        ? renderInspector(extensionContext)
+                        : null
+                    }
+                    inspectorOpen={inspectorVisible}
+                    preview={preview}
                   />
                 ) : (
-                  <DisconnectedPreview />
+                  preview
                 )}
               </div>
             </Panel>

--- a/packages/playground-app/src/PlaygroundPreview.tsx
+++ b/packages/playground-app/src/PlaygroundPreview.tsx
@@ -4,6 +4,7 @@ import type {
 } from '@midscene/playground';
 import type { ScreenshotViewerMode } from '@midscene/visualizer';
 import type { CSSProperties, ReactNode } from 'react';
+import type { PreviewOverlayRenderContext } from './PreviewOverlayLayer';
 import { PreviewRenderer } from './PreviewRenderer';
 import type { ScrcpyErrorOverlayRenderer } from './ScrcpyPanel';
 import type { ScrcpyPreviewStatus } from './scrcpy-preview';
@@ -29,6 +30,8 @@ export interface PlaygroundPreviewProps {
   serverUrl: string;
   serverOnline: boolean;
   isUserOperating: boolean;
+  manualInteractionEnabled?: boolean;
+  renderOverlay?: (context: PreviewOverlayRenderContext) => ReactNode;
 }
 
 export function PlaygroundPreview(props: PlaygroundPreviewProps) {

--- a/packages/playground-app/src/PreviewInspectorLayout.tsx
+++ b/packages/playground-app/src/PreviewInspectorLayout.tsx
@@ -1,0 +1,33 @@
+import React, { type ReactNode } from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+
+export function PreviewInspectorLayout({
+  inspector,
+  inspectorOpen,
+  preview,
+}: {
+  inspector: ReactNode;
+  inspectorOpen: boolean;
+  preview: ReactNode;
+}) {
+  return (
+    <PanelGroup direction="horizontal">
+      <Panel defaultSize={64} id="playground-preview" minSize={35} order={1}>
+        {preview}
+      </Panel>
+      {inspectorOpen && (
+        <>
+          <PanelResizeHandle className="panel-resize-handle" />
+          <Panel
+            defaultSize={36}
+            id="playground-inspector"
+            minSize={24}
+            order={2}
+          >
+            <div className="playground-extension-inspector">{inspector}</div>
+          </Panel>
+        </>
+      )}
+    </PanelGroup>
+  );
+}

--- a/packages/playground-app/src/PreviewOverlayLayer.tsx
+++ b/packages/playground-app/src/PreviewOverlayLayer.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode, RefObject } from 'react';
+import { useEffect, useState } from 'react';
+import {
+  type DeviceSize,
+  inscribedContentRect,
+} from './DeviceInteractionLayer';
+
+interface ViewportRect {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
+export interface PreviewOverlayRenderContext {
+  deviceSize: DeviceSize;
+}
+
+export interface PreviewOverlayLayerProps {
+  contentRef: RefObject<HTMLElement>;
+  deviceSize: DeviceSize | null;
+  renderOverlay?: (context: PreviewOverlayRenderContext) => ReactNode;
+  rootRef: RefObject<HTMLElement>;
+}
+
+export function relativePreviewRect(
+  rootRect: ViewportRect,
+  contentRect: ViewportRect,
+  deviceSize: DeviceSize,
+): ViewportRect {
+  const screenRect = inscribedContentRect(contentRect, deviceSize);
+  return {
+    height: screenRect.height,
+    left: screenRect.left - rootRect.left,
+    top: screenRect.top - rootRect.top,
+    width: screenRect.width,
+  };
+}
+
+export function PreviewOverlayLayer({
+  contentRef,
+  deviceSize,
+  renderOverlay,
+  rootRef,
+}: PreviewOverlayLayerProps) {
+  const [rect, setRect] = useState<ViewportRect | null>(null);
+
+  useEffect(() => {
+    if (!deviceSize || !renderOverlay) {
+      setRect(null);
+      return;
+    }
+    const root = rootRef.current;
+    const content = contentRef.current;
+    if (!root || !content) {
+      setRect(null);
+      return;
+    }
+
+    const update = () => {
+      const next = relativePreviewRect(
+        root.getBoundingClientRect(),
+        content.getBoundingClientRect(),
+        deviceSize,
+      );
+      setRect((current) =>
+        current &&
+        current.left === next.left &&
+        current.top === next.top &&
+        current.width === next.width &&
+        current.height === next.height
+          ? current
+          : next,
+      );
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(() => update());
+    observer?.observe(root);
+    observer?.observe(content);
+    return () => {
+      window.removeEventListener('resize', update);
+      observer?.disconnect();
+    };
+  }, [contentRef, deviceSize, renderOverlay, rootRef]);
+
+  if (!deviceSize || !rect || !renderOverlay) return null;
+
+  return (
+    <div
+      data-midscene-preview-overlay-layer="true"
+      style={{
+        height: rect.height,
+        left: rect.left,
+        pointerEvents: 'none',
+        position: 'absolute',
+        top: rect.top,
+        width: rect.width,
+        zIndex: 6,
+      }}
+    >
+      {renderOverlay({ deviceSize })}
+    </div>
+  );
+}

--- a/packages/playground-app/src/PreviewRenderer.tsx
+++ b/packages/playground-app/src/PreviewRenderer.tsx
@@ -21,6 +21,10 @@ import {
   DeviceInteractionLayer,
   type DeviceSize,
 } from './DeviceInteractionLayer';
+import {
+  PreviewOverlayLayer,
+  type PreviewOverlayRenderContext,
+} from './PreviewOverlayLayer';
 import { type ScrcpyErrorOverlayRenderer, ScrcpyPanel } from './ScrcpyPanel';
 import {
   type ManualDragActionType,
@@ -45,6 +49,8 @@ interface PreviewRendererProps {
   serverUrl: string;
   serverOnline: boolean;
   isUserOperating: boolean;
+  manualInteractionEnabled?: boolean;
+  renderOverlay?: (context: PreviewOverlayRenderContext) => ReactNode;
 }
 
 function isNonLocalhostHttp(): boolean {
@@ -71,6 +77,8 @@ export function PreviewRenderer({
   serverUrl,
   serverOnline,
   isUserOperating,
+  manualInteractionEnabled = true,
+  renderOverlay,
 }: PreviewRendererProps) {
   const { message } = AntdApp.useApp();
   const previewConnection = resolvePreviewConnectionInfo(
@@ -98,6 +106,7 @@ export function PreviewRenderer({
   // and the interaction layer so pointer coords always project against the
   // real screen-mirror box, not the outer panel that may include chrome.
   const previewContentRef = useRef<HTMLDivElement>(null);
+  const previewRootRef = useRef<HTMLDivElement>(null);
   // Default to `screen-only` so the playground does not render chrome
   // (header / Refresh / timestamp) inside the same relative-positioned panel
   // that DeviceInteractionLayer overlays — embedding hosts (Studio) can opt
@@ -439,6 +448,7 @@ export function PreviewRenderer({
 
   return (
     <div
+      ref={previewRootRef}
       style={{ flex: 1, minHeight: 0, height: '100%', position: 'relative' }}
     >
       {showInsecureContextHint && (
@@ -541,7 +551,10 @@ export function PreviewRenderer({
       )}
       <DeviceInteractionLayer
         enabled={
-          manualControlEnabled && serverOnline && previewInteractionEnabled
+          manualInteractionEnabled &&
+          manualControlEnabled &&
+          serverOnline &&
+          previewInteractionEnabled
         }
         deviceSize={deviceSize}
         contentRef={previewContentRef}
@@ -553,6 +566,14 @@ export function PreviewRenderer({
         onTextInput={handleTextInput}
         onKeyboardPress={handleKeyboardPress}
       />
+      {renderOverlay && (
+        <PreviewOverlayLayer
+          contentRef={previewContentRef}
+          deviceSize={streamSize ?? deviceSize}
+          renderOverlay={renderOverlay}
+          rootRef={previewRootRef}
+        />
+      )}
     </div>
   );
 }

--- a/packages/playground-app/src/index.ts
+++ b/packages/playground-app/src/index.ts
@@ -9,7 +9,9 @@ export type {
 } from './DeviceInteractionLayer';
 export { PlaygroundConversationPanel } from './panels/PlaygroundConversationPanel';
 export type { PlaygroundAppProps } from './PlaygroundApp';
+export type { PlaygroundExtensionContext } from './PlaygroundApp';
 export type { PlaygroundPreviewProps } from './PlaygroundPreview';
+export type { PreviewOverlayRenderContext } from './PreviewOverlayLayer';
 export type { PlaygroundConversationPanelProps } from './panels/PlaygroundConversationPanel';
 export type { DeviceType } from '@midscene/visualizer';
 export type {

--- a/packages/playground-app/tests/preview-inspector-layout.test.ts
+++ b/packages/playground-app/tests/preview-inspector-layout.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { PreviewInspectorLayout } from '../src/PreviewInspectorLayout';
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('PreviewInspectorLayout', () => {
+  it('keeps the preview mounted while the inspector opens and closes', async () => {
+    let mounts = 0;
+    let unmounts = 0;
+    const Preview = () => {
+      useEffect(() => {
+        mounts += 1;
+        return () => {
+          unmounts += 1;
+        };
+      }, []);
+      return createElement('div', { 'data-testid': 'preview' });
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const render = async (inspectorOpen: boolean) => {
+      await act(async () => {
+        root.render(
+          createElement(PreviewInspectorLayout, {
+            inspector: createElement('aside', null, 'Inspector'),
+            inspectorOpen,
+            preview: createElement(Preview),
+          }),
+        );
+      });
+    };
+
+    await render(false);
+    await render(true);
+    await render(false);
+
+    expect(mounts).toBe(1);
+    expect(unmounts).toBe(0);
+    expect(container.querySelector('[data-testid="preview"]')).not.toBeNull();
+    expect(container.querySelector('aside')).toBeNull();
+
+    await act(async () => root.unmount());
+    expect(unmounts).toBe(1);
+    container.remove();
+  });
+});

--- a/packages/playground-app/tests/preview-overlay-layer.test.ts
+++ b/packages/playground-app/tests/preview-overlay-layer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { relativePreviewRect } from '../src/PreviewOverlayLayer';
+
+describe('relativePreviewRect', () => {
+  it('projects the device screen into the preview root after letterboxing', () => {
+    expect(
+      relativePreviewRect(
+        { left: 100, top: 50, width: 1000, height: 700 },
+        { left: 200, top: 100, width: 800, height: 600 },
+        { width: 100, height: 200 },
+      ),
+    ).toEqual({
+      left: 350,
+      top: 50,
+      width: 300,
+      height: 600,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,12 @@ importers:
 
   apps/android-playground:
     dependencies:
+      '@midscene/android':
+        specifier: workspace:*
+        version: link:../../packages/android
+      '@midscene/android-playground':
+        specifier: workspace:*
+        version: link:../../packages/android-playground
       '@midscene/playground-app':
         specifier: workspace:*
         version: link:../../packages/playground-app


### PR DESCRIPTION
## Summary

- add a live Android XPath audit mode to the existing Playground preview
- render tree-bound overlays, issue filters, node selection, and synchronized tree navigation
- add fresh recapture and a browser download flow for saving the complete audit report
- keep the existing Agent options and scrcpy preview lifecycle intact

## Stack

- depends on #2892, which depends on #2891
- contains only the live Playground UI and session integration relative to #2892

The three-PR stack is self-contained on `main` and does not rely on any other unmerged feature PR.

## Validation

- `pnpm exec nx run-many --target=test --projects=@midscene/android-playground,@midscene/playground-app --skip-nx-cache` (104 tests)
- `pnpm exec nx build android-playground --skip-nx-cache`
- `pnpm run lint`
