### PR TITLE
test(ci): stabilize iOS and Android emulator smokes

### DIFF
--- a/packages/android/scripts/run-emulator-ci-smokes.sh
+++ b/packages/android/scripts/run-emulator-ci-smokes.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 : "${MIDSCENE_ANDROID_DIAGNOSTICS_DIR:?MIDSCENE_ANDROID_DIAGNOSTICS_DIR is required}"
 
 diagnostics_dir="$MIDSCENE_ANDROID_DIAGNOSTICS_DIR"
+run_dir="${MIDSCENE_RUN_DIR:-midscene_run}"
 todo_port="${MIDSCENE_ANDROID_TODO_PORT:-4173}"
 todo_url="http://10.0.2.2:${todo_port}/"
 todo_server_pid=""
@@ -17,6 +18,24 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+
+wait_for_report_file() {
+  local report_file="$1"
+  local label="$2"
+
+  for _ in {1..20}; do
+    if [[ -s "$report_file" ]]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  echo "Expected $label report file was not written: $report_file" >&2
+  if [[ -d "$(dirname "$report_file")" ]]; then
+    ls -la "$(dirname "$report_file")" >&2
+  fi
+  return 1
+}
 
 MIDSCENE_ANDROID_TODO_PORT="$todo_port" \
 node packages/android/scripts/serve-todo-fixture.mjs \
@@ -82,12 +101,25 @@ pnpm exec nx test @midscene/android --skip-nx-cache -- \
 todo_exit=${PIPESTATUS[0]}
 set -e
 
+report_exit=0
+if ((smoke_exit == 0)); then
+  wait_for_report_file \
+    "$run_dir/report/android-emulator-smoke.html" \
+    "Android emulator smoke" || report_exit=1
+fi
+if ((todo_exit == 0)); then
+  wait_for_report_file \
+    "$run_dir/report/todo-mvc-android.html" \
+    "Android TodoMVC" || report_exit=1
+fi
+
 adb logcat -d -t 2000 > "$diagnostics_dir/emulator-logcat.txt" 2>&1 || true
 adb exec-out screencap -p > "$diagnostics_dir/emulator-final.png" 2>/dev/null || true
 
 BROWSER_PREFLIGHT_EXIT="$browser_preflight_exit" \
 SMOKE_EXIT="$smoke_exit" \
 TODO_EXIT="$todo_exit" \
+REPORT_EXIT="$report_exit" \
 node -e '
   const fs = require("node:fs");
   const path = require("node:path");
@@ -95,6 +127,7 @@ node -e '
     browserPreflight: Number(process.env.BROWSER_PREFLIGHT_EXIT),
     deterministicSmoke: Number(process.env.SMOKE_EXIT),
     todoMvc: Number(process.env.TODO_EXIT),
+    requiredReports: Number(process.env.REPORT_EXIT),
   };
   fs.writeFileSync(
     path.join(process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR, "emulator-step-outcomes.json"),
@@ -102,7 +135,7 @@ node -e '
   );
 '
 
-if ((browser_preflight_exit != 0 || smoke_exit != 0 || todo_exit != 0)); then
-  echo "Android emulator validation failed: browser=$browser_preflight_exit smoke=$smoke_exit todo=$todo_exit" >&2
+if ((browser_preflight_exit != 0 || smoke_exit != 0 || todo_exit != 0 || report_exit != 0)); then
+  echo "Android emulator validation failed: browser=$browser_preflight_exit smoke=$smoke_exit todo=$todo_exit reports=$report_exit" >&2
   exit 1
 fi

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -13,6 +13,10 @@ import {
 import { imageInfoOfBase64 } from '@midscene/shared/img';
 import { describe, expect, it, vi } from 'vitest';
 import { type IOSAgent, agentFromWebDriverAgent } from '../../src';
+import {
+  inputUntilObserved,
+  readIOSSimulatorInputValue,
+} from '../ios-simulator-input-retry';
 
 const RUN_LIVE_SMOKE =
   process.env.AI_TEST_TYPE === 'iOS' &&
@@ -45,6 +49,7 @@ interface WdaRect {
 interface ReportTask {
   type?: string;
   subType?: string;
+  param?: { mode?: string; [key: string]: unknown };
   hitBy?: { from?: string };
   timing?: { callAiStart?: number; callAiEnd?: number };
   usage?: unknown;
@@ -85,10 +90,6 @@ function locate(rect: WdaRect, screenshotScale: number, prompt: string) {
       Math.round((rect.y + rect.height) * screenshotScale),
     ] as [number, number, number, number],
   };
-}
-
-function xmlAttribute(nodeTag: string, attribute: string): string | undefined {
-  return new RegExp(`${attribute}="([^"]*)"`).exec(nodeTag)?.[1];
 }
 
 function parseReportDumps(html: string): ReportDump[] {
@@ -354,39 +355,67 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
         screenSize.scale,
         INPUT_ACCESSIBILITY_ID,
       );
-      await agent.callActionInActionSpace('Tap', { locate: targetLocate });
-      await agent.callActionInActionSpace('Input', {
-        value: SUBMITTED_TEXT,
-        mode: 'typeOnly',
-        autoDismissKeyboard: false,
-        locate: targetLocate,
+      const inputAttempts: Array<{
+        attempt: number;
+        value: string | undefined;
+        sourceFile: string;
+      }> = [];
+      const inputAgent = agent;
+      const observedInput = await inputUntilObserved({
+        expectedValue: SUBMITTED_TEXT,
+        performInput: async (attempt) => {
+          await inputAgent.callActionInActionSpace('Tap', {
+            locate: targetLocate,
+          });
+          await inputAgent.callActionInActionSpace('Input', {
+            value: SUBMITTED_TEXT,
+            mode: attempt === 1 ? 'typeOnly' : 'replace',
+            autoDismissKeyboard: false,
+            locate: targetLocate,
+          });
+        },
+        readValue: async (attempt) => {
+          const response = (await inputAgent.runWdaRequest({
+            method: 'GET',
+            endpoint: '/source',
+          })) as WdaValueResponse<string>;
+          const attemptSourceFile = path.join(
+            diagnosticsDir,
+            `safari-after-input-attempt-${attempt}.xml`,
+          );
+          await Promise.all([
+            writeFile(attemptSourceFile, response.value, 'utf8'),
+            writeFile(postInputSourceFile, response.value, 'utf8'),
+          ]);
+          const value = readIOSSimulatorInputValue(
+            response.value,
+            INPUT_ACCESSIBILITY_ID,
+          );
+          inputAttempts.push({
+            attempt,
+            value,
+            sourceFile: attemptSourceFile,
+          });
+          return value;
+        },
+        onRetry: ({ attempt, nextAttempt, actualValue }) => {
+          console.log(
+            `iOS Simulator input attempt ${attempt} observed ${JSON.stringify(actualValue)}; retrying with idempotent replace input (attempt ${nextAttempt})`,
+          );
+        },
       });
+      const expectedInputModes = Array.from(
+        { length: observedInput.attempts },
+        (_, index) => (index === 0 ? 'typeOnly' : 'replace'),
+      );
       await agent.callActionInActionSpace('KeyboardPress', {
         keyName: 'Enter',
         locate: targetLocate,
       });
 
-      const postInputSourceResponse = (await agent.runWdaRequest({
-        method: 'GET',
-        endpoint: '/source',
-      })) as WdaValueResponse<string>;
-      await writeFile(
-        postInputSourceFile,
-        postInputSourceResponse.value,
-        'utf8',
-      );
-      const postInputNode = (
-        postInputSourceResponse.value.match(
-          /<XCUIElementTypeTextField\b[^>]*>/g,
-        ) ?? []
-      ).find(
-        (nodeTag) => xmlAttribute(nodeTag, 'name') === INPUT_ACCESSIBILITY_ID,
-      );
-      const inputText = postInputNode
-        ? xmlAttribute(postInputNode, 'value')
-        : undefined;
-      evidence.inputText = inputText;
-      expect(inputText).toBe(SUBMITTED_TEXT);
+      evidence.inputAttempts = inputAttempts;
+      evidence.inputText = observedInput.value;
+      expect(observedInput.value).toBe(SUBMITTED_TEXT);
       await agent.interface
         .screenshotBase64()
         .then((base64) =>
@@ -407,7 +436,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const locateTasks = dumpTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(locateTasks).toHaveLength(3);
+      const inputTasks = dumpTasks.filter(
+        (task) => task.type === 'Action Space' && task.subType === 'Input',
+      );
+      expect(locateTasks).toHaveLength(observedInput.attempts * 2 + 1);
+      expect(inputTasks.map((task) => task.param?.mode)).toEqual(
+        expectedInputModes,
+      );
       expect(locateTasks.every((task) => task.hitBy?.from === 'Plan')).toBe(
         true,
       );
@@ -432,7 +467,13 @@ describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
       const reportLocateTasks = reportTasks.filter(
         (task) => task.type === 'Planning' && task.subType === 'Locate',
       );
-      expect(reportLocateTasks).toHaveLength(3);
+      const reportInputTasks = reportTasks.filter(
+        (task) => task.type === 'Action Space' && task.subType === 'Input',
+      );
+      expect(reportLocateTasks).toHaveLength(observedInput.attempts * 2 + 1);
+      expect(reportInputTasks.map((task) => task.param?.mode)).toEqual(
+        expectedInputModes,
+      );
       expect(
         reportLocateTasks.every((task) => task.hitBy?.from === 'Plan'),
       ).toBe(true);

--- a/packages/ios/tests/ai/todo.test.ts
+++ b/packages/ios/tests/ai/todo.test.ts
@@ -47,6 +47,36 @@ async function queryVisibleTodoListWithRetry(
   return tasks;
 }
 
+async function tapFilterUntilVisible(
+  agent: IOSAgent,
+  filterName: 'Completed',
+  expectedTasks: readonly string[],
+): Promise<string[]> {
+  let tasks: string[] = [];
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await agent.aiTap(`the "${filterName}" status filter below the todo list`);
+    await sleep(1000);
+    tasks = await queryVisibleTodoListWithRetry(
+      agent,
+      expectedTasks,
+      `${filterName.toLowerCase()}FilterTaskList`,
+    );
+    if (
+      tasks.length === expectedTasks.length &&
+      expectedTasks.every((task) => tasks.includes(task))
+    ) {
+      return tasks;
+    }
+    console.log(
+      `${filterName} filter attempt ${attempt} did not show the expected tasks`,
+      tasks,
+    );
+  }
+
+  return tasks;
+}
+
 function screenshotBuffer(base64: string): Buffer {
   const match = /^data:image\/\w+;base64,(.+)$/s.exec(base64);
   if (!match) {
@@ -203,13 +233,10 @@ describe('Test todo list', () => {
       await agent.aiTap(
         'the checkbox immediately to the left of "Learning AI the day after tomorrow"',
       );
-      await agent.aiTap('the "Completed" status filter below the todo list');
 
-      const completedTasks = await queryVisibleTodoListWithRetry(
-        agent,
-        [completedTask],
-        'completedTaskList',
-      );
+      const completedTasks = await tapFilterUntilVisible(agent, 'Completed', [
+        completedTask,
+      ]);
       expect(completedTasks).toEqual([completedTask]);
 
       const placeholder = await agent.aiQuery<string>(

--- a/packages/ios/tests/ios-simulator-input-retry.ts
+++ b/packages/ios/tests/ios-simulator-input-retry.ts
@@ -1,0 +1,100 @@
+export interface IOSSimulatorInputRetryContext {
+  attempt: number;
+  nextAttempt: number;
+  actualValue: string | undefined;
+}
+
+export interface InputUntilObservedOptions {
+  expectedValue: string;
+  performInput: (attempt: number) => Promise<void>;
+  readValue: (attempt: number) => Promise<string | undefined>;
+  maxAttempts?: number;
+  retryIntervalMs?: number;
+  onRetry?: (context: IOSSimulatorInputRetryContext) => Promise<void> | void;
+}
+
+export interface ObservedInputValue {
+  value: string;
+  attempts: number;
+}
+
+function xmlAttribute(nodeTag: string, attribute: string): string | undefined {
+  return new RegExp(`${attribute}="([^"]*)"`).exec(nodeTag)?.[1];
+}
+
+export function readIOSSimulatorInputValue(
+  source: string,
+  accessibilityId: string,
+): string | undefined {
+  const inputNode = (
+    source.match(/<XCUIElementTypeTextField\b[^>]*>/g) ?? []
+  ).find((nodeTag) => xmlAttribute(nodeTag, 'name') === accessibilityId);
+
+  if (!inputNode) {
+    throw new Error(
+      `iOS Simulator input ${JSON.stringify(accessibilityId)} is missing from WDA source`,
+    );
+  }
+
+  return xmlAttribute(inputNode, 'value');
+}
+
+export class IOSSimulatorInputValueError extends Error {
+  constructor(
+    readonly expectedValue: string,
+    readonly actualValue: string | undefined,
+    readonly attempts: number,
+  ) {
+    super(
+      `iOS Simulator input did not reach ${JSON.stringify(expectedValue)} after ${attempts} attempts; last observed value: ${JSON.stringify(actualValue)}`,
+    );
+    this.name = 'IOSSimulatorInputValueError';
+  }
+}
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+export async function inputUntilObserved(
+  options: InputUntilObservedOptions,
+): Promise<ObservedInputValue> {
+  const {
+    expectedValue,
+    performInput,
+    readValue,
+    maxAttempts = 3,
+    retryIntervalMs = 500,
+    onRetry,
+  } = options;
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error(
+      'iOS Simulator input maxAttempts must be a positive integer',
+    );
+  }
+
+  let actualValue: string | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    await performInput(attempt);
+    actualValue = await readValue(attempt);
+    if (actualValue === expectedValue) {
+      return { value: actualValue, attempts: attempt };
+    }
+
+    if (attempt < maxAttempts) {
+      await onRetry?.({
+        attempt,
+        nextAttempt: attempt + 1,
+        actualValue,
+      });
+      await sleep(retryIntervalMs);
+    }
+  }
+
+  throw new IOSSimulatorInputValueError(
+    expectedValue,
+    actualValue,
+    maxAttempts,
+  );
+}

--- a/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
+++ b/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  IOSSimulatorInputValueError,
+  inputUntilObserved,
+  readIOSSimulatorInputValue,
+} from '../ios-simulator-input-retry';
+
+const EXPECTED_VALUE = 'Midscene iOS input 2026';
+
+describe('readIOSSimulatorInputValue', () => {
+  it('returns the value of the matching text field', () => {
+    expect(
+      readIOSSimulatorInputValue(
+        `<XCUIElementTypeTextField name="Other Input" value="other" />
+<XCUIElementTypeTextField name="Midscene Smoke Input" value="${EXPECTED_VALUE}" />`,
+        'Midscene Smoke Input',
+      ),
+    ).toBe(EXPECTED_VALUE);
+  });
+
+  it('returns undefined when the matching text field has no value', () => {
+    expect(
+      readIOSSimulatorInputValue(
+        '<XCUIElementTypeTextField name="Midscene Smoke Input" />',
+        'Midscene Smoke Input',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('fails when the matching text field is missing', () => {
+    expect(() =>
+      readIOSSimulatorInputValue(
+        '<XCUIElementTypeTextField name="Other Input" value="other" />',
+        'Midscene Smoke Input',
+      ),
+    ).toThrow(
+      'iOS Simulator input "Midscene Smoke Input" is missing from WDA source',
+    );
+  });
+});
+
+describe('iOS Simulator input retry', () => {
+  it('returns the first observed value without retrying', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => EXPECTED_VALUE);
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).resolves.toEqual({
+      value: EXPECTED_VALUE,
+      attempts: 1,
+    });
+    expect(performInput).toHaveBeenCalledWith(1);
+    expect(readValue).toHaveBeenCalledWith(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('retries only after observing an unexpected input value', async () => {
+    const observedValues = [undefined, EXPECTED_VALUE];
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => observedValues.shift());
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).resolves.toEqual({
+      value: EXPECTED_VALUE,
+      attempts: 2,
+    });
+    expect(performInput).toHaveBeenNthCalledWith(1, 1);
+    expect(performInput).toHaveBeenNthCalledWith(2, 2);
+    expect(onRetry).toHaveBeenCalledWith({
+      attempt: 1,
+      nextAttempt: 2,
+      actualValue: undefined,
+    });
+  });
+
+  it.each([
+    {
+      name: 'input action failure',
+      performInput: async () => {
+        throw new Error('tap failed');
+      },
+      readValue: async () => EXPECTED_VALUE,
+      message: 'tap failed',
+    },
+    {
+      name: 'source read failure',
+      performInput: async () => undefined,
+      readValue: async () => {
+        throw new Error('source failed');
+      },
+      message: 'source failed',
+    },
+  ])('fails immediately on an unknown $name', async (testCase) => {
+    const performInput = vi.fn(testCase.performInput);
+    const readValue = vi.fn(testCase.readValue);
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).rejects.toThrow(testCase.message);
+    expect(performInput).toHaveBeenCalledTimes(1);
+    expect(readValue).toHaveBeenCalledTimes(
+      testCase.name === 'input action failure' ? 0 : 1,
+    );
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('throws the last observed value after exhausting attempts', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => 'partial input');
+    const onRetry = vi.fn();
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        maxAttempts: 3,
+        retryIntervalMs: 0,
+        onRetry,
+      }),
+    ).rejects.toEqual(
+      new IOSSimulatorInputValueError(EXPECTED_VALUE, 'partial input', 3),
+    );
+    expect(performInput).toHaveBeenCalledTimes(3);
+    expect(readValue).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an invalid attempt count before performing input', async () => {
+    const performInput = vi.fn(async () => undefined);
+    const readValue = vi.fn(async () => EXPECTED_VALUE);
+
+    await expect(
+      inputUntilObserved({
+        expectedValue: EXPECTED_VALUE,
+        performInput,
+        readValue,
+        maxAttempts: 0,
+      }),
+    ).rejects.toThrow(
+      'iOS Simulator input maxAttempts must be a positive integer',
+    );
+    expect(performInput).not.toHaveBeenCalled();
+    expect(readValue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Retry transient iOS simulator input propagation before submitting text.
- Retry TodoMVC Completed filter taps before asserting completed items.
- Wait for Android emulator smoke and TodoMVC report files after successful tests so missing artifacts fail with clear script diagnostics.

## Validation
- bash -n packages/android/scripts/run-emulator-ci-smokes.sh
- pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/ios" --skip-nx-cache
- pnpm exec nx test @midscene/ios --skip-nx-cache
- pnpm run lint

## Stress validation evidence
- Android emulator workflow: 10/10 serial success on equivalent feature-branch tree 00a515692b10042e4b55a68b75fd89d7209ea832.
- iOS simulator workflow: 10/10 serial success on equivalent feature-branch tree 00a515692b10042e4b55a68b75fd89d7209ea832.

Note: main does not contain the Android cache-hit smoke test from the feature branch, so this main-base PR carries the Android report-file stability guard for the existing main Android emulator smokes.