### PR TITLE
feat(core): add Step 3.7 Flash model family

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -136,6 +136,53 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # If you use another Qwen version, replace
   </ModelConfigTab>
 </ModelConfigTabs>
 
+### StepFun Step 3.7 Flash {#step}
+
+- Common model provider: [StepFun](https://platform.stepfun.com/)
+
+<div className="model-series-table">
+
+| Model version | Commonly used model names | Corresponding MODEL_FAMILY | Notes |
+| --- | --- | --- | --- |
+| Step 3.7 Flash | `step-3.7-flash` | `step` | Currently the only Step model with multimodal input. |
+
+</div>
+
+Environment variable configuration example:
+
+<ModelConfigTabs>
+  <ModelConfigTab type="default">
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="step-3.7-flash"
+MIDSCENE_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="planning">
+
+```bash
+MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_PLANNING_MODEL_API_KEY="......"
+MIDSCENE_PLANNING_MODEL_NAME="step-3.7-flash"
+MIDSCENE_PLANNING_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="insight">
+
+```bash
+MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_INSIGHT_MODEL_API_KEY="......"
+MIDSCENE_INSIGHT_MODEL_NAME="step-3.7-flash"
+MIDSCENE_INSIGHT_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+</ModelConfigTabs>
+
 ### Google Gemini Series {#gemini}
 
 - Common model provider: [Google Gemini](https://gemini.google.com/)

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -136,6 +136,53 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # 如果你使用了其他版本的 Qwen�
   </ModelConfigTab>
 </ModelConfigTabs>
 
+### 阶跃星辰 Step 3.7 Flash {#step}
+
+- 常用模型供应商：[阶跃星辰](https://platform.stepfun.com/)
+
+<div className="model-series-table">
+
+| 模型版本 | 常用模型名称 | 对应 MODEL_FAMILY | 备注 |
+| --- | --- | --- | --- |
+| Step 3.7 Flash | `step-3.7-flash` | `step` | Step 系列目前仅该模型支持多模态输入。 |
+
+</div>
+
+环境变量配置示例：
+
+<ModelConfigTabs>
+  <ModelConfigTab type="default">
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="step-3.7-flash"
+MIDSCENE_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="planning">
+
+```bash
+MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_PLANNING_MODEL_API_KEY="......"
+MIDSCENE_PLANNING_MODEL_NAME="step-3.7-flash"
+MIDSCENE_PLANNING_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="insight">
+
+```bash
+MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.stepfun.com/v1"
+MIDSCENE_INSIGHT_MODEL_API_KEY="......"
+MIDSCENE_INSIGHT_MODEL_NAME="step-3.7-flash"
+MIDSCENE_INSIGHT_MODEL_FAMILY="step"
+```
+
+  </ModelConfigTab>
+</ModelConfigTabs>
+
 ### Google Gemini 系列 {#gemini}
 
 - 常用模型供应商：[Google Gemini](https://gemini.google.com/)

--- a/packages/core/src/ai-model/models/registry.ts
+++ b/packages/core/src/ai-model/models/registry.ts
@@ -15,6 +15,7 @@ import { gptAdapters } from './gpt';
 import { kimiAdapters } from './kimi';
 import { mimoAdapters } from './mimo';
 import { qwenAdapters } from './qwen';
+import { stepAdapters } from './step';
 import { uiTarsAdapters } from './ui-tars/adapter';
 
 export const MODEL_ADAPTER_CONFIGS = {
@@ -24,6 +25,7 @@ export const MODEL_ADAPTER_CONFIGS = {
   ...uiTarsAdapters,
   ...glmAdapters,
   ...autoGlmAdapters,
+  ...stepAdapters,
   ...gptAdapters,
   ...kimiAdapters,
   ...mimoAdapters,

--- a/packages/core/src/ai-model/models/step.ts
+++ b/packages/core/src/ai-model/models/step.ts
@@ -1,0 +1,55 @@
+import type { TModelFamily } from '@midscene/shared/env';
+import type {
+  ChatCompletionCallContext,
+  ChatCompletionParamsResult,
+  ModelAdapterDefinition,
+} from '../model-adapter/types';
+
+const stepCoordinatesMeta = {
+  shape: 'bbox',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
+
+const buildStepChatCompletionParams = (
+  input: ChatCompletionCallContext,
+): ChatCompletionParamsResult => {
+  const { midsceneDefaults, userConfig } = input;
+
+  return {
+    config: {
+      ...midsceneDefaults,
+      ...(userConfig.temperature === undefined
+        ? {}
+        : { temperature: userConfig.temperature }),
+    },
+  };
+};
+
+/**
+ * Step 3.7 Flash follows Midscene's standard VLM prompt and grounding flow.
+ * Its OpenAI-compatible API returns reasoning in `reasoning` (and may return
+ * `reasoning_content` when configured for a DeepSeek-style response).
+ */
+export const stepAdapters = {
+  step: {
+    chatCompletion: {
+      unsupportedUserConfig: [
+        'reasoningEnabled',
+        'reasoningEffort',
+        'reasoningBudget',
+      ],
+      buildChatCompletionParams: buildStepChatCompletionParams,
+      messageExtraction: {
+        kind: 'default',
+        reasoningContentKeys: ['reasoning', 'reasoning_content'],
+      },
+      useReasoningAsContentFallback: true,
+    },
+    locate: {
+      resultAdapter: {
+        coordinates: stepCoordinatesMeta,
+      },
+    },
+  },
+} satisfies Pick<Record<TModelFamily, ModelAdapterDefinition>, 'step'>;

--- a/packages/core/tests/unit-test/model-adapter/step.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/step.test.ts
@@ -28,9 +28,9 @@ describe('Step model adapter', () => {
     }
     expect(
       chatCompletion.buildChatCompletionParams({
-        midsceneDefaults: { temperature: 0, seed: 1 },
+        midsceneDefaults: { temperature: 0 },
         userConfig: { temperature: 0.7 },
       }).config,
-    ).toEqual({ temperature: 0.7, seed: 1 });
+    ).toEqual({ temperature: 0.7 });
   });
 });

--- a/packages/core/tests/unit-test/model-adapter/step.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/step.test.ts
@@ -1,0 +1,36 @@
+import { ResolvedModelAdapter } from '@/ai-model/model-adapter/resolve';
+import { stepAdapters } from '@/ai-model/models/step';
+import { describe, expect, it } from 'vitest';
+
+describe('Step model adapter', () => {
+  it('uses the standard normalized grounding contract', () => {
+    const adapter = new ResolvedModelAdapter(stepAdapters.step, 'step');
+
+    expect(adapter.locate.kind).toBe('standard');
+    if (adapter.locate.kind !== 'standard') {
+      throw new Error('Step should use standard locate');
+    }
+    expect(
+      adapter.locate.resultAdapter.adaptElementLocateResultToPixelBbox(
+        { bbox: [100, 200, 900, 800] },
+        {
+          preparedSize: { width: 1000, height: 1000 },
+          contentSize: { width: 1000, height: 1000 },
+        },
+      ),
+    ).toEqual([100, 200, 899, 799]);
+  });
+
+  it('does not send provider-specific reasoning parameters', () => {
+    const chatCompletion = stepAdapters.step.chatCompletion;
+    if (!chatCompletion?.buildChatCompletionParams) {
+      throw new Error('Step chat completion params should be defined');
+    }
+    expect(
+      chatCompletion.buildChatCompletionParams({
+        midsceneDefaults: { temperature: 0, seed: 1 },
+        userConfig: { temperature: 0.7 },
+      }).config,
+    ).toEqual({ temperature: 0.7, seed: 1 });
+  });
+});

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -308,6 +308,7 @@ export type TModelFamily =
   | 'glm-v'
   | 'auto-glm'
   | 'auto-glm-multilingual'
+  | 'step'
   | 'gpt-5'
   | 'kimi'
   | 'kimi3'
@@ -328,6 +329,7 @@ export const MODEL_FAMILY_VALUES: TModelFamily[] = [
   'glm-v',
   'auto-glm',
   'auto-glm-multilingual',
+  'step',
   'gpt-5',
   'kimi',
   'kimi3',


### PR DESCRIPTION
## Summary

- add the `step` model family for Step 3.7 Flash through its OpenAI-compatible API
- register its normalized coordinate adapter and reasoning output handling
- document Step 3.7 Flash as a supported standalone model section, with default, Planning, and Insight configuration examples

## Validation

- `pnpm --dir packages/core exec vitest run tests/unit-test/model-adapter/step.test.ts`
- `pnpm run lint`
- `pnpm exec nx build @midscene/core`