### PR TITLE
fix(core): preserve deep locate failure dumps

### DIFF
--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -64,6 +64,7 @@ interface ServiceOptions {
 
 interface LocateSearchAreaResult {
   config?: SearchAreaConfig;
+  error?: string;
   trace: {
     sourceRect?: Rect;
     rawResponse?: string;
@@ -113,6 +114,7 @@ export default class Service {
 
     const context = opt?.context || (await this.contextRetrieverFn());
 
+    const searchAreaStartTime = Date.now();
     const searchArea = await this.resolveLocateSearchArea({
       query,
       queryPrompt,
@@ -121,6 +123,27 @@ export default class Service {
       modelRuntime,
       abortSignal,
     });
+
+    if (!searchArea.config && searchArea.error) {
+      const errorMessage = `cannot find search area for "${queryPrompt}": ${searchArea.error}`;
+      const taskInfo: ServiceTaskInfo = {
+        ...(this.taskInfo ? this.taskInfo : {}),
+        durationMs: Date.now() - searchAreaStartTime,
+        searchAreaRawResponse: searchArea.trace.rawResponse,
+        searchAreaRawChoiceMessage: searchArea.trace.rawChoiceMessage,
+        searchAreaUsage: searchArea.trace.usage,
+      };
+      const dump = createServiceDump({
+        type: 'locate',
+        userQuery: { element: queryPrompt },
+        matchedElement: [],
+        data: null,
+        taskInfo,
+        deepLocate: true,
+        error: errorMessage,
+      });
+      throw new ServiceError(errorMessage, dump);
+    }
 
     const startTime = Date.now();
     const {
@@ -243,12 +266,16 @@ export default class Service {
         abortSignal,
       });
       const { searchAreaConfig } = searchAreaResponse;
-      assert(
-        searchAreaConfig,
-        `cannot find search area for "${queryPrompt}"${
-          searchAreaResponse.error ? `: ${searchAreaResponse.error}` : ''
-        }`,
-      );
+      if (!searchAreaConfig) {
+        return {
+          error: searchAreaResponse.error || 'unknown search area error',
+          trace: {
+            rawResponse: searchAreaResponse.rawResponse,
+            rawChoiceMessage: searchAreaResponse.rawChoiceMessage,
+            usage: searchAreaResponse.usage,
+          },
+        };
+      }
 
       return {
         config: searchAreaConfig,

--- a/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
+++ b/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
@@ -1,6 +1,6 @@
 import { getModelRuntime } from '@/ai-model/models';
 import Service from '@/service';
-import { ServiceError } from '@/types';
+import { type AIUsageInfo, ServiceError } from '@/types';
 import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeContext } from '../utils';
@@ -129,7 +129,19 @@ describe('service.locate deepLocate routing', () => {
       content: '{"bbox":["invalid bbox"]}',
       role: 'assistant',
     };
-    const usage = { prompt_tokens: 12, completion_tokens: 6 };
+    const usage: AIUsageInfo = {
+      prompt_tokens: 12,
+      completion_tokens: 6,
+      total_tokens: 18,
+      cached_input: undefined,
+      time_cost: undefined,
+      model_name: undefined,
+      model_description: undefined,
+      response_model_name: undefined,
+      intent: undefined,
+      slot: undefined,
+      request_id: undefined,
+    };
     vi.mocked(AiLocateSection).mockResolvedValue({
       searchAreaConfig: undefined,
       error: 'invalid bbox data',

--- a/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
+++ b/packages/core/tests/unit-test/service-locate-deeplocate.test.ts
@@ -1,5 +1,6 @@
 import { getModelRuntime } from '@/ai-model/models';
 import Service from '@/service';
+import { ServiceError } from '@/types';
 import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeContext } from '../utils';
@@ -120,6 +121,44 @@ describe('service.locate deepLocate routing', () => {
     );
     expect(AiLocateElement).toHaveBeenCalledTimes(1);
     expect(buildSearchAreaConfig).not.toHaveBeenCalled();
+  });
+
+  it('records search-area model data when section locate fails', async () => {
+    const service = new Service(createFakeContext());
+    const rawChoiceMessage = {
+      content: '{"bbox":["invalid bbox"]}',
+      role: 'assistant',
+    };
+    const usage = { prompt_tokens: 12, completion_tokens: 6 };
+    vi.mocked(AiLocateSection).mockResolvedValue({
+      searchAreaConfig: undefined,
+      error: 'invalid bbox data',
+      rawResponse: '{"bbox":["invalid bbox"]}',
+      rawChoiceMessage,
+      usage,
+    });
+
+    const error = await service
+      .locate({ prompt: 'target', deepLocate: true }, {}, modelRuntime)
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(ServiceError);
+    expect((error as ServiceError).message).toBe(
+      'cannot find search area for "target": invalid bbox data',
+    );
+    expect((error as ServiceError).dump).toMatchObject({
+      type: 'locate',
+      userQuery: { element: 'target' },
+      matchedElement: [],
+      deepLocate: true,
+      error: 'cannot find search area for "target": invalid bbox data',
+      taskInfo: {
+        searchAreaRawResponse: '{"bbox":["invalid bbox"]}',
+        searchAreaRawChoiceMessage: rawChoiceMessage,
+        searchAreaUsage: usage,
+      },
+    });
+    expect(AiLocateElement).not.toHaveBeenCalled();
   });
 
   it('uses first-pass locate when the model does not support search-area locate', async () => {


### PR DESCRIPTION
## Summary

- Preserve search-area model response, raw assistant message, and usage when deepLocate fails before element locating.
- Surface the failure through `ServiceError` so the Locate task receives its dump.
- Add unit coverage for the failed section-locate path.

## Root cause

A missing search-area config previously threw a plain assertion error before `Service.locate` created its dump, so reports lost the failed model-call diagnostics.

## Validation

- `pnpm run lint`
- `npx nx test @midscene/core`