### PR TITLE
feat(core): support loading extra actions in aiAct

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -158,7 +158,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
-    - `loadExtraActions?: string[]` — Load pre-recorded UI action YAML files for this call. The default is `undefined`, which loads no extra actions. Each file becomes a parameterless action available to the generic planner. If selected, Midscene expands it into the recorded low-level actions before execution. This option is available only in Node.js and is not supported by custom planning adapters. Relative paths are resolved from the current working directory. Invalid files, duplicate names, unsupported planning adapters, and unavailable underlying actions throw errors before planning starts.
+    - `loadExtraActions?: string[]` — Load pre-recorded UI action YAML files for this call. The default is `undefined`, which loads no extra actions. Each file represents one device operation and becomes a parameterless action available to the generic planner. If selected, Midscene expands it into the recorded low-level action before execution. This option is available only in Node.js and is not supported by custom planning adapters. Relative paths are resolved from the current working directory. Invalid files, duplicate names, unsupported planning adapters, and unavailable underlying actions throw errors before planning starts.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
 
 - Return value:
@@ -192,7 +192,7 @@ await agent.aiAct('Complete the GitHub account registration form. The region mus
 
 ##### Load pre-recorded UI actions
 
-An extra action file names one reusable action, identifies an action from the current interface's Action Space, and provides the fixed parameter sequence to replay:
+An extra action file represents one reusable device operation. It names the operation, identifies an action from the current interface's Action Space, and provides exactly one parameter entry:
 
 ```yaml title="extra-action.yaml"
 name: Click the confirm button
@@ -211,7 +211,7 @@ await agent.aiAct('Fill in the form', {
 
 This Node.js-only option works with the generic planning adapter. If the configured model uses a custom planning adapter, such as UI-TARS or AutoGLM, `aiAct` throws an error before reading the files or calling the model.
 
-The extra action is visible only to this call's planner and does not modify the Agent's Action Space. `name` is the description shown to the planner. It must not contain angle brackets, line breaks, or control characters. `actionName` accepts an Action Space name or `interfaceAlias`, without regard to case. Midscene validates every `actionParam` entry against the referenced Action before planning starts.
+The extra action is visible only to this call's planner and does not modify the Agent's Action Space. `name` is the description shown to the planner. It must not contain angle brackets, line breaks, or control characters. `actionName` accepts an Action Space name or `interfaceAlias`, without regard to case. `actionParam` must contain exactly one item, which Midscene validates against the referenced Action before planning starts. To replay multiple operations, record each operation in a separate file and pass all file paths through `loadExtraActions`.
 
 For an Action with one locate field, a parameter containing `prompt`, `xpath`, or `locatedPixelBbox` can use the shortcut shown above. Midscene moves only locator properties into the locate field and keeps other Action parameters, such as Input's `value` and `mode`, at the top level. If a locator contains an XPath or `locatedPixelBbox` but no prompt, the extra action's `name` is used as the fallback locate prompt.
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -137,6 +137,7 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     fileChooserAllowedDir?: string;
+    loadExtraActions?: string[];
     abortSignal?: AbortSignal;
     context?: string;
   },
@@ -157,6 +158,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
+    - `loadExtraActions?: string[]` — Load pre-recorded UI action YAML files for this call. The default is `undefined`, which loads no extra actions. Each file becomes a parameterless action available to the generic planner. If selected, Midscene expands it into the recorded low-level actions before execution. This option is available only in Node.js and is not supported by custom planning adapters. Relative paths are resolved from the current working directory. Invalid files, duplicate names, unsupported planning adapters, and unavailable underlying actions throw errors before planning starts.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
 
 - Return value:
@@ -187,6 +189,31 @@ await agent.aiAct('Fill in the form and submit', {
 // For complex tasks, you can enable the deepThink parameter
 await agent.aiAct('Complete the GitHub account registration form. The region must be set to "Canada". Make sure no fields on the form are missed and all form fields pass validation. Just fill in the form fields without actually submitting the registration. Finally, return the actual content filled in the form fields', { deepThink: true });
 ```
+
+##### Load pre-recorded UI actions
+
+An extra action file names one reusable action, identifies an action from the current interface's Action Space, and provides the fixed parameter sequence to replay:
+
+```yaml title="extra-action.yaml"
+name: Click the confirm button
+actionName: tap
+actionParam:
+  - xpath: /path/to/#confirm-button
+```
+
+Pass one or more files to a single `aiAct` call:
+
+```typescript
+await agent.aiAct('Fill in the form', {
+  loadExtraActions: ['./extra-action.yaml'],
+});
+```
+
+This Node.js-only option works with the generic planning adapter. If the configured model uses a custom planning adapter, such as UI-TARS or AutoGLM, `aiAct` throws an error before reading the files or calling the model.
+
+The extra action is visible only to this call's planner and does not modify the Agent's Action Space. `name` is the description shown to the planner. It must not contain angle brackets, line breaks, or control characters. `actionName` accepts an Action Space name or `interfaceAlias`, without regard to case. Midscene validates every `actionParam` entry against the referenced Action before planning starts.
+
+For an Action with one locate field, a parameter containing `prompt`, `xpath`, or `locatedPixelBbox` can use the shortcut shown above. Midscene moves only locator properties into the locate field and keeps other Action parameters, such as Input's `value` and `mode`, at the top level. If a locator contains an XPath or `locatedPixelBbox` but no prompt, the extra action's `name` is used as the fallback locate prompt.
 
 ##### Upload files from an `aiAct` prompt
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -135,6 +135,7 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     fileChooserAllowedDir?: string;
+    loadExtraActions?: string[];
     abortSignal?: AbortSignal;
     context?: string;
   },
@@ -155,6 +156,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
+    - `loadExtraActions?: string[]`：为本次调用加载预先录制的 UI Action YAML 文件。默认值为 `undefined`，即不加载 Extra Action。每个文件会成为一个无参数 Action，供通用规划器使用。规划器选中后，Midscene 会在执行前将其展开为录制好的底层 Action。该选项仅支持 Node.js，不支持自定义规划适配器。相对路径基于当前工作目录解析。文件无效、名称重复、规划适配器不受支持或底层 Action 不可用时，Midscene 会在规划开始前抛出错误。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
 - 返回值：
@@ -182,6 +184,33 @@ await agent.aiAct('填写表单并提交', {
 // 对于复杂任务，可以启用 deepThink 参数
 await agent.aiAct('完成 github 账号注册的表单填写。地区必须选择「加拿大」。确保表单上没有遗漏的字段，确保所有的表单项能够通过校验。 只需要填写表单项即可，不需要发起真实的账号注册。 最终请返回表单上实际填写的字段内容', { deepThink: true });
 ```
+
+##### 加载预先录制的 UI Action
+
+一个 Extra Action 文件定义一个可复用 Action。
+
+`name` 是展示给规划器的名称。`actionName` 指向当前界面 `Action Space` 中已有的 Action。`actionParam` 是要依次执行的固定参数：
+
+```yaml title="extra-action.yaml"
+name: 点击确定按钮
+actionName: tap
+actionParam:
+  - xpath: /path/to/#confirm-button
+```
+
+在单次 `aiAct` 中传入一个或多个文件：
+
+```typescript
+await agent.aiAct('填写表单', {
+  loadExtraActions: ['./extra-action.yaml'],
+});
+```
+
+该选项仅支持 Node.js 和通用规划适配器。如果当前模型使用 UI-TARS、AutoGLM 等自定义规划适配器，`aiAct` 会在读取文件或调用模型之前抛出错误。
+
+Extra Action 只对本次调用的规划器可见，不会修改 Agent 的 `Action Space`。`name` 不能包含尖括号、换行符或控制字符。`actionName` 可以填写 Action 名称或 `interfaceAlias`，匹配时不区分大小写。规划开始前，Midscene 会根据目标 Action 校验每一项 `actionParam`。
+
+若底层 Action 只有一个定位字段，可以使用上面的简写。参数直接包含 `prompt`、`xpath` 或 `locatedPixelBbox` 即可。Midscene 只会把定位属性移入定位字段，`Input` 的 `value`、`mode` 等其他参数仍保留在顶层。如果定位参数包含 XPath 或 `locatedPixelBbox`，但没有提示词，Midscene 会使用 Extra Action 的 `name` 作为备用定位提示词。
 
 ##### 在 `aiAct` 提示词中上传文件
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -156,7 +156,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
-    - `loadExtraActions?: string[]`：为本次调用加载预先录制的 UI Action YAML 文件。默认值为 `undefined`，即不加载 Extra Action。每个文件会成为一个无参数 Action，供通用规划器使用。规划器选中后，Midscene 会在执行前将其展开为录制好的底层 Action。该选项仅支持 Node.js，不支持自定义规划适配器。相对路径基于当前工作目录解析。文件无效、名称重复、规划适配器不受支持或底层 Action 不可用时，Midscene 会在规划开始前抛出错误。
+    - `loadExtraActions?: string[]`：为本次调用加载预先录制的 UI Action YAML 文件。默认值为 `undefined`，即不加载 Extra Action。每个文件代表一次设备操作，并成为一个供通用规划器使用的无参数 Action。规划器选中后，Midscene 会在执行前将其展开为录制好的单个底层 Action。该选项仅支持 Node.js，不支持自定义规划适配器。相对路径基于当前工作目录解析。文件无效、名称重复、规划适配器不受支持或底层 Action 不可用时，Midscene 会在规划开始前抛出错误。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
 - 返回值：
@@ -187,9 +187,9 @@ await agent.aiAct('完成 github 账号注册的表单填写。地区必须选�
 
 ##### 加载预先录制的 UI Action
 
-一个 Extra Action 文件定义一个可复用 Action。
+一个 Extra Action 文件定义一次可复用的设备操作。
 
-`name` 是展示给规划器的名称。`actionName` 指向当前界面 `Action Space` 中已有的 Action。`actionParam` 是要依次执行的固定参数：
+`name` 是展示给规划器的操作名称。`actionName` 指向当前界面 `Action Space` 中已有的 Action。`actionParam` 必须且只能包含一项参数：
 
 ```yaml title="extra-action.yaml"
 name: 点击确定按钮
@@ -208,7 +208,7 @@ await agent.aiAct('填写表单', {
 
 该选项仅支持 Node.js 和通用规划适配器。如果当前模型使用 UI-TARS、AutoGLM 等自定义规划适配器，`aiAct` 会在读取文件或调用模型之前抛出错误。
 
-Extra Action 只对本次调用的规划器可见，不会修改 Agent 的 `Action Space`。`name` 不能包含尖括号、换行符或控制字符。`actionName` 可以填写 Action 名称或 `interfaceAlias`，匹配时不区分大小写。规划开始前，Midscene 会根据目标 Action 校验每一项 `actionParam`。
+Extra Action 只对本次调用的规划器可见，不会修改 Agent 的 `Action Space`。`name` 不能包含尖括号、换行符或控制字符。`actionName` 可以填写 Action 名称或 `interfaceAlias`，匹配时不区分大小写。`actionParam` 必须只包含一项，规划开始前 Midscene 会根据目标 Action 校验该参数。若要复用多次操作，请将每次操作分别录制为一个文件，再通过 `loadExtraActions` 传入全部文件路径。
 
 若底层 Action 只有一个定位字段，可以使用上面的简写。参数直接包含 `prompt`、`xpath` 或 `locatedPixelBbox` 即可。Midscene 只会把定位属性移入定位字段，`Input` 的 `value`、`mode` 等其他参数仍保留在顶层。如果定位参数包含 XPath 或 `locatedPixelBbox`，但没有提示词，Midscene 会使用 Extra Action 的 `name` 作为备用定位提示词。
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -70,6 +70,11 @@ import {
   defineActionSleep,
 } from '../device';
 import { validateAgentCacheInput } from './cache-config';
+import {
+  createExtraActionExecutionOptions,
+  extraActionsCacheKey,
+  loadExtraActions,
+} from './extra-actions';
 import { FileChooserAccepter } from './file-chooser';
 import { MetricsCollector, type MidsceneUsageMetrics } from './metrics';
 import { AgentProgressBus } from './progress';
@@ -115,6 +120,7 @@ export type AiActOptions = {
   cacheable?: boolean;
   fileChooserAccept?: string | string[];
   fileChooserAllowedDir?: string;
+  loadExtraActions?: string[];
   deepThink?: DeepThinkOption;
   deepLocate?: boolean;
   abortSignal?: AbortSignal;
@@ -1084,10 +1090,30 @@ export class Agent<
 
     const runAiAct = async () => {
       const planningModel = this.resolveModelRuntime('planning');
+      const extraActionPaths = opt?.loadExtraActions ?? [];
+      if (
+        extraActionPaths.length > 0 &&
+        planningModel.adapter.planning.kind === 'custom'
+      ) {
+        throw new Error(
+          `The "loadExtraActions" option is not supported by custom planning adapters (modelFamily: ${planningModel.config.modelFamily ?? 'unknown'}). Use a model with the generic planning adapter.`,
+        );
+      }
+      const extraActions = await loadExtraActions(
+        extraActionPaths,
+        this.fullActionSpace,
+      );
       const defaultModel = this.resolveModelRuntime('default');
       const aiActContext =
         opt?.context !== undefined ? opt.context : this.aiActContext;
-      const cachePrompt = buildPromptWithContext(taskPrompt, aiActContext);
+      const promptWithContext = buildPromptWithContext(
+        taskPrompt,
+        aiActContext,
+      );
+      const extraActionKey = extraActionsCacheKey(extraActions);
+      const cachePrompt = extraActionKey
+        ? `${promptWithContext}\n\n<midscene_extra_actions>${extraActionKey}</midscene_extra_actions>`
+        : promptWithContext;
       // Controls the aiAct planning mode, such as sub-goal prompts and locate result strategy.
       let deepThink = opt?.deepThink === true;
       if (deepThink && planningModel.adapter.planning.kind === 'custom') {
@@ -1160,15 +1186,17 @@ export class Agent<
         planningModel,
         defaultModel,
         includeLocateInPlanning,
-        aiActContext,
-        cacheable,
-        replanningCycleLimit,
-        imagesIncludeCount,
-        deepThink,
-        undefined,
-        deepLocate,
-        abortSignal,
-        internalReportDisplay,
+        {
+          aiActContext,
+          cacheable,
+          replanningCycleLimitOverride: replanningCycleLimit,
+          imagesIncludeCount,
+          deepThink,
+          deepLocate,
+          abortSignal,
+          reportOptions: internalReportDisplay,
+          extraActions: createExtraActionExecutionOptions(extraActions),
+        },
       );
 
       // update cache

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -216,7 +216,8 @@ function validateActionParam(
 function createPlanningAction(id: string, name: string): DeviceAction {
   return {
     name: id,
-    description: `Run the pre-recorded UI action "${name}". This action takes no parameters.`,
+    description: `Replay the known-good UI workflow ${JSON.stringify(name)}. If the user's request matches this workflow, always prefer this action over rebuilding the workflow from low-level actions. This action takes no parameters.`,
+    sample: {},
     call: () => {
       throw new Error(
         `Extra action "${name}" must be expanded before execution`,

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -6,13 +6,13 @@ import yaml from 'js-yaml';
 interface ExtraActionFile {
   name: string;
   actionName: string;
-  actionParam: unknown[];
+  actionParam: [unknown];
 }
 
 export interface LoadedExtraAction {
   name: string;
   planningAction: DeviceAction;
-  plans: PlanningAction[];
+  plan: PlanningAction;
 }
 
 const locatorShortcutFields = new Set([
@@ -82,16 +82,16 @@ function parseExtraActionFile(
       `Invalid extra action file "${sourcePath}": "name" must not contain angle brackets, line breaks, or control characters`,
     );
   }
-  if (!Array.isArray(parsed.actionParam) || parsed.actionParam.length === 0) {
+  if (!Array.isArray(parsed.actionParam) || parsed.actionParam.length !== 1) {
     throw new Error(
-      `Invalid extra action file "${sourcePath}": "actionParam" must be a non-empty array`,
+      `Invalid extra action file "${sourcePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
     );
   }
 
   return {
     name: parsed.name.trim(),
     actionName: parsed.actionName.trim(),
-    actionParam: parsed.actionParam,
+    actionParam: [parsed.actionParam[0]],
   };
 }
 
@@ -216,7 +216,7 @@ function validateActionParam(
 function createPlanningAction(id: string, name: string): DeviceAction {
   return {
     name: id,
-    description: `Replay the known-good UI workflow ${JSON.stringify(name)}. If the user's request matches this workflow, always prefer this action over rebuilding the workflow from low-level actions. This action takes no parameters.`,
+    description: `Replay the known-good UI action ${JSON.stringify(name)}. If the user's request matches this action, always prefer it over rebuilding the operation from a low-level action. This action takes no parameters.`,
     sample: {},
     call: () => {
       throw new Error(
@@ -272,28 +272,26 @@ export async function loadExtraActions(
     }
     knownProtocolIds.add(protocolId);
 
-    const plans = definition.actionParam.map((param, actionIndex) => {
-      const normalizedParam = normalizeActionParam(
+    const normalizedParam = normalizeActionParam(
+      referencedAction,
+      definition.actionParam[0],
+      definition.name,
+    );
+    const plan = {
+      type: referencedAction.name,
+      param: validateActionParam(
         referencedAction,
-        param,
-        definition.name,
-      );
-      return {
-        type: referencedAction.name,
-        param: validateActionParam(
-          referencedAction,
-          normalizedParam,
-          sourcePath,
-          actionIndex,
-        ),
-        thought: `Run extra action "${definition.name}"`,
-      };
-    });
+        normalizedParam,
+        sourcePath,
+        0,
+      ),
+      thought: `Run extra action "${definition.name}"`,
+    };
 
     loadedActions.push({
       name: definition.name,
       planningAction: createPlanningAction(protocolId, definition.name),
-      plans,
+      plan,
     });
   }
 
@@ -312,17 +310,17 @@ export function expandExtraActionPlans(
     extraActions.map((action) => [action.planningAction.name, action]),
   );
 
-  return plans.flatMap((plan) => {
+  return plans.map((plan) => {
     const extraAction = extraActionsByName.get(plan.type);
     if (!extraAction) {
-      return [plan];
+      return plan;
     }
 
-    return extraAction.plans.map((expandedPlan) => ({
-      ...expandedPlan,
-      param: structuredClone(expandedPlan.param),
-      thought: plan.thought || expandedPlan.thought,
-    }));
+    return {
+      ...extraAction.plan,
+      param: structuredClone(extraAction.plan.param),
+      thought: plan.thought || extraAction.plan.thought,
+    };
   });
 }
 
@@ -336,7 +334,7 @@ export function extraActionsCacheKey(
   return JSON.stringify(
     extraActions.map((action) => ({
       name: action.name,
-      plans: action.plans,
+      plan: action.plan,
     })),
   );
 }

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -1,0 +1,360 @@
+import { readFile } from 'node:fs/promises';
+import { findAllMidsceneLocatorField } from '@/ai-model';
+import type { DeviceAction, PlanningAction } from '@/types';
+import yaml from 'js-yaml';
+
+interface ExtraActionFile {
+  name: string;
+  actionName: string;
+  actionParam: unknown[];
+}
+
+export interface LoadedExtraAction {
+  name: string;
+  planningAction: DeviceAction;
+  plans: PlanningAction[];
+}
+
+const locatorShortcutFields = new Set([
+  'prompt',
+  'xpath',
+  'locatedPixelBbox',
+  'deepLocate',
+  'deepThink',
+  'cacheable',
+]);
+
+const hasInvalidProtocolNameCharacter = (name: string): boolean =>
+  Array.from(name).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      character === '<' ||
+      character === '>' ||
+      codePoint === undefined ||
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+function assertNonEmptyString(
+  value: unknown,
+  field: 'name' | 'actionName',
+  sourcePath: string,
+): asserts value is string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": "${field}" must be a non-empty string`,
+    );
+  }
+}
+
+function parseExtraActionFile(
+  content: string,
+  sourcePath: string,
+): ExtraActionFile {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA });
+  } catch (error) {
+    throw new Error(
+      `Failed to parse extra action file "${sourcePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": expected a YAML object`,
+    );
+  }
+
+  assertNonEmptyString(parsed.name, 'name', sourcePath);
+  assertNonEmptyString(parsed.actionName, 'actionName', sourcePath);
+  if (hasInvalidProtocolNameCharacter(parsed.name)) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": "name" must not contain angle brackets, line breaks, or control characters`,
+    );
+  }
+  if (!Array.isArray(parsed.actionParam) || parsed.actionParam.length === 0) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": "actionParam" must be a non-empty array`,
+    );
+  }
+
+  return {
+    name: parsed.name.trim(),
+    actionName: parsed.actionName.trim(),
+    actionParam: parsed.actionParam,
+  };
+}
+
+function findReferencedAction(
+  actionName: string,
+  actionSpace: DeviceAction[],
+  sourcePath: string,
+): DeviceAction {
+  const exactMatch = actionSpace.find(
+    (action) =>
+      action.name === actionName || action.interfaceAlias === actionName,
+  );
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const normalizedName = actionName.toLowerCase();
+  const caseInsensitiveMatch = actionSpace.find(
+    (action) =>
+      action.name.toLowerCase() === normalizedName ||
+      action.interfaceAlias?.toLowerCase() === normalizedName,
+  );
+  if (caseInsensitiveMatch) {
+    return caseInsensitiveMatch;
+  }
+
+  const availableActions = actionSpace
+    .flatMap((action) => [action.name, action.interfaceAlias])
+    .filter(Boolean)
+    .join(', ');
+  throw new Error(
+    `Invalid extra action file "${sourcePath}": action "${actionName}" is not in the current action space. Available actions: ${availableActions || '(none)'}`,
+  );
+}
+
+function normalizeActionParam(
+  action: DeviceAction,
+  actionParam: unknown,
+  fallbackPrompt: string,
+): unknown {
+  if (!action.paramSchema || !isPlainObject(actionParam)) {
+    return actionParam;
+  }
+
+  const locateFields = findAllMidsceneLocatorField(action.paramSchema);
+  if (locateFields.length !== 1) {
+    return actionParam;
+  }
+
+  const locateField = locateFields[0];
+  if (Object.prototype.hasOwnProperty.call(actionParam, locateField)) {
+    const locateParam = actionParam[locateField];
+    if (
+      isPlainObject(locateParam) &&
+      (locateParam.xpath || locateParam.locatedPixelBbox) &&
+      !locateParam.prompt
+    ) {
+      return {
+        ...actionParam,
+        [locateField]: {
+          prompt: fallbackPrompt,
+          ...locateParam,
+        },
+      };
+    }
+    return actionParam;
+  }
+
+  const isLocatorShortcut =
+    Object.prototype.hasOwnProperty.call(actionParam, 'prompt') ||
+    Object.prototype.hasOwnProperty.call(actionParam, 'xpath') ||
+    Object.prototype.hasOwnProperty.call(actionParam, 'locatedPixelBbox');
+  if (!isLocatorShortcut) {
+    return actionParam;
+  }
+
+  const locateParam: Record<string, unknown> = {};
+  const actionParamWithoutLocate: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(actionParam)) {
+    if (locatorShortcutFields.has(key)) {
+      locateParam[key] = value;
+    } else {
+      actionParamWithoutLocate[key] = value;
+    }
+  }
+
+  return {
+    ...actionParamWithoutLocate,
+    [locateField]: {
+      ...(!locateParam.prompt ? { prompt: fallbackPrompt } : {}),
+      ...locateParam,
+    },
+  };
+}
+
+function validateActionParam(
+  action: DeviceAction,
+  actionParam: unknown,
+  sourcePath: string,
+  actionIndex: number,
+): unknown {
+  if (!action.paramSchema) {
+    return actionParam;
+  }
+
+  const result = action.paramSchema.safeParse(actionParam);
+  if (result.success) {
+    return result.data;
+  }
+
+  const details = result.error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${field}: ${issue.message}`;
+    })
+    .join('; ');
+  throw new Error(
+    `Invalid extra action file "${sourcePath}": "actionParam[${actionIndex}]" does not match action "${action.name}": ${details}`,
+  );
+}
+
+function createPlanningAction(id: string, name: string): DeviceAction {
+  return {
+    name: id,
+    description: `Run the pre-recorded UI action "${name}". This action takes no parameters.`,
+    call: () => {
+      throw new Error(
+        `Extra action "${name}" must be expanded before execution`,
+      );
+    },
+  };
+}
+
+export async function loadExtraActions(
+  paths: string[],
+  actionSpace: DeviceAction[],
+): Promise<LoadedExtraAction[]> {
+  if (paths.length === 0) {
+    return [];
+  }
+
+  const loadedActions: LoadedExtraAction[] = [];
+  const knownNames = new Set(actionSpace.map((action) => action.name));
+  const knownProtocolIds = new Set(knownNames);
+
+  for (const sourcePath of paths) {
+    let content: string;
+    try {
+      content = await readFile(sourcePath, 'utf-8');
+    } catch (error) {
+      throw new Error(
+        `Failed to read extra action file "${sourcePath}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+
+    const definition = parseExtraActionFile(content, sourcePath);
+    if (knownNames.has(definition.name)) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+      );
+    }
+
+    const referencedAction = findReferencedAction(
+      definition.actionName,
+      actionSpace,
+      sourcePath,
+    );
+    knownNames.add(definition.name);
+    let protocolIndex = loadedActions.length + 1;
+    let protocolId = `MidsceneExtraAction_${protocolIndex}`;
+    while (knownProtocolIds.has(protocolId)) {
+      protocolIndex += 1;
+      protocolId = `MidsceneExtraAction_${protocolIndex}`;
+    }
+    knownProtocolIds.add(protocolId);
+
+    const plans = definition.actionParam.map((param, actionIndex) => {
+      const normalizedParam = normalizeActionParam(
+        referencedAction,
+        param,
+        definition.name,
+      );
+      return {
+        type: referencedAction.name,
+        param: validateActionParam(
+          referencedAction,
+          normalizedParam,
+          sourcePath,
+          actionIndex,
+        ),
+        thought: `Run extra action "${definition.name}"`,
+      };
+    });
+
+    loadedActions.push({
+      name: definition.name,
+      planningAction: createPlanningAction(protocolId, definition.name),
+      plans,
+    });
+  }
+
+  return loadedActions;
+}
+
+export function expandExtraActionPlans(
+  plans: PlanningAction[],
+  extraActions: LoadedExtraAction[],
+): PlanningAction[] {
+  if (extraActions.length === 0) {
+    return plans;
+  }
+
+  const extraActionsByName = new Map(
+    extraActions.map((action) => [action.planningAction.name, action]),
+  );
+
+  return plans.flatMap((plan) => {
+    const extraAction = extraActionsByName.get(plan.type);
+    if (!extraAction) {
+      return [plan];
+    }
+
+    return extraAction.plans.map((expandedPlan) => ({
+      ...expandedPlan,
+      param: structuredClone(expandedPlan.param),
+      thought: plan.thought || expandedPlan.thought,
+    }));
+  });
+}
+
+export function extraActionsCacheKey(
+  extraActions: LoadedExtraAction[],
+): string | undefined {
+  if (extraActions.length === 0) {
+    return undefined;
+  }
+
+  return JSON.stringify(
+    extraActions.map((action) => ({
+      name: action.name,
+      plans: action.plans,
+    })),
+  );
+}
+
+export function createExtraActionExecutionOptions(
+  extraActions: LoadedExtraAction[],
+) {
+  if (extraActions.length === 0) {
+    return undefined;
+  }
+
+  const extraActionNames = new Set(
+    extraActions.map((action) => action.planningAction.name),
+  );
+  return {
+    actionSpace: extraActions.map((action) => action.planningAction),
+    expandPlans: (plans: PlanningAction[]) => ({
+      plans: expandExtraActionPlans(plans, extraActions),
+      expanded: plans.some((plan) => extraActionNames.has(plan.type)),
+    }),
+  };
+}

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -5,6 +5,7 @@ import { genericXmlPlan } from '@/ai-model/workflows/planning';
 import {
   type TMultimodalPrompt,
   type TUserPrompt,
+  buildYamlFlowFromPlans,
   getReadableTimeString,
   multimodalPromptToChatMessages,
   userPromptToMultimodalPrompt,
@@ -73,6 +74,35 @@ export type ActionReportOptions = {
   type?: TaskTitleType;
   prompt?: string;
 };
+
+interface TaskExecutorActionOptions {
+  aiActContext?: string;
+  cacheable?: boolean;
+  replanningCycleLimitOverride?: number;
+  imagesIncludeCount?: number;
+  deepThink?: boolean;
+  fileChooserAccept?: string[];
+  deepLocate?: boolean;
+  abortSignal?: AbortSignal;
+  reportOptions?: ActionReportOptions;
+  extraActions?: {
+    actionSpace: DeviceAction[];
+    expandPlans: (plans: PlanningAction[]) => {
+      plans: PlanningAction[];
+      expanded: boolean;
+    };
+  };
+}
+
+type TaskExecutorActionResult = Promise<
+  ExecutionResult<
+    | {
+        yamlFlow?: MidsceneYamlFlowItem[];
+        output?: string;
+      }
+    | undefined
+  >
+>;
 
 const debug = getDebug('device-task-executor');
 const warnLog = getDebug('device-task-executor', { console: true });
@@ -361,6 +391,13 @@ export class TaskExecutor {
     planningModel: ModelRuntime,
     defaultModel: ModelRuntime,
     includeLocateInPlanning: boolean,
+    options?: TaskExecutorActionOptions,
+  ): TaskExecutorActionResult;
+  async action(
+    userPrompt: TUserPrompt,
+    planningModel: ModelRuntime,
+    defaultModel: ModelRuntime,
+    includeLocateInPlanning: boolean,
     aiActContext?: string,
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
@@ -370,31 +407,51 @@ export class TaskExecutor {
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
     reportOptions?: ActionReportOptions,
-  ): Promise<
-    ExecutionResult<
-      | {
-          yamlFlow?: MidsceneYamlFlowItem[]; // for cache use
-          output?: string;
-        }
-      | undefined
-    >
-  > {
-    return withFileChooser(this.interface, fileChooserAccept, async () => {
-      return this.runAction(
-        userPrompt,
-        planningModel,
-        defaultModel,
-        includeLocateInPlanning,
-        aiActContext,
-        cacheable,
-        replanningCycleLimitOverride,
-        imagesIncludeCount,
-        deepThink,
-        deepLocate,
-        abortSignal,
-        reportOptions,
-      );
-    });
+  ): TaskExecutorActionResult;
+  async action(
+    userPrompt: TUserPrompt,
+    planningModel: ModelRuntime,
+    defaultModel: ModelRuntime,
+    includeLocateInPlanning: boolean,
+    aiActContextOrOptions?: string | TaskExecutorActionOptions,
+    cacheable?: boolean,
+    replanningCycleLimitOverride?: number,
+    imagesIncludeCount?: number,
+    deepThink?: boolean,
+    fileChooserAccept?: string[],
+    deepLocate?: boolean,
+    abortSignal?: AbortSignal,
+    reportOptions?: ActionReportOptions,
+  ): TaskExecutorActionResult {
+    const options: TaskExecutorActionOptions =
+      typeof aiActContextOrOptions === 'object' &&
+      aiActContextOrOptions !== null
+        ? aiActContextOrOptions
+        : {
+            aiActContext: aiActContextOrOptions,
+            cacheable,
+            replanningCycleLimitOverride,
+            imagesIncludeCount,
+            deepThink,
+            fileChooserAccept,
+            deepLocate,
+            abortSignal,
+            reportOptions,
+          };
+
+    return withFileChooser(
+      this.interface,
+      options.fileChooserAccept,
+      async () => {
+        return this.runAction(
+          userPrompt,
+          planningModel,
+          defaultModel,
+          includeLocateInPlanning,
+          options,
+        );
+      },
+    );
   }
 
   /**
@@ -436,14 +493,7 @@ export class TaskExecutor {
     planningModel: ModelRuntime,
     defaultModel: ModelRuntime,
     includeLocateInPlanning: boolean,
-    aiActContext?: string,
-    cacheable?: boolean,
-    replanningCycleLimitOverride?: number,
-    imagesIncludeCount?: number,
-    deepThink?: boolean,
-    deepLocate?: boolean,
-    abortSignal?: AbortSignal,
-    reportOptions?: ActionReportOptions,
+    options: TaskExecutorActionOptions = {},
   ): Promise<
     ExecutionResult<
       | {
@@ -453,7 +503,23 @@ export class TaskExecutor {
       | undefined
     >
   > {
+    const {
+      aiActContext,
+      cacheable,
+      replanningCycleLimitOverride,
+      imagesIncludeCount,
+      deepThink,
+      deepLocate,
+      abortSignal,
+      reportOptions,
+      extraActions,
+    } = options;
     const conversationHistory = new ConversationHistory();
+    const baseActionSpace = this.getActionSpace();
+    const actionSpace = [
+      ...baseActionSpace,
+      ...(extraActions?.actionSpace ?? []),
+    ];
     const promptDisplay =
       reportOptions?.prompt || userPromptToString(userPrompt);
 
@@ -565,7 +631,6 @@ export class TaskExecutor {
               screenshot: planningUiContext.screenshot,
             });
 
-            const actionSpace = this.getActionSpace();
             debug(
               'actionSpace for this interface is:',
               actionSpace.map((action) => action.name).join(', '),
@@ -709,12 +774,20 @@ export class TaskExecutor {
 
       // Execute planned actions
       const plans = planResult?.actions || [];
-      yamlFlow.push(...(planResult?.yamlFlow || []));
+      const expansion = extraActions?.expandPlans(plans) ?? {
+        plans,
+        expanded: false,
+      };
+      yamlFlow.push(
+        ...(expansion.expanded
+          ? buildYamlFlowFromPlans(expansion.plans, baseActionSpace)
+          : planResult?.yamlFlow || []),
+      );
 
       let executables: Awaited<ReturnType<typeof this.convertPlanToExecutable>>;
       try {
         executables = await this.convertPlanToExecutable(
-          plans,
+          expansion.plans,
           planningModel,
           defaultModel,
           {

--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -41,6 +41,8 @@ const MEMORY_STEP_NOTES = [
 
 const RUN_ADB_SHELL_ACTION_GUIDANCE =
   "- If the user's task can be completed with the RunAdbShell action, prefer using the RunAdbShell action.";
+const EXTRA_ACTION_GUIDANCE =
+  '- Actions named MidsceneExtraAction_* are exact pre-recorded operations. When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action such as Tap or Input.';
 
 const buildActionStepNotes = (actionList: string) =>
   [
@@ -48,6 +50,9 @@ const buildActionStepNotes = (actionList: string) =>
     '',
     ...(actionList.includes('RunAdbShell')
       ? [RUN_ADB_SHELL_ACTION_GUIDANCE]
+      : []),
+    ...(actionList.includes('MidsceneExtraAction_')
+      ? [EXTRA_ACTION_GUIDANCE]
       : []),
     '- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.',
     '- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.',

--- a/packages/core/tests/unit-test/agent-context-option.test.ts
+++ b/packages/core/tests/unit-test/agent-context-option.test.ts
@@ -66,8 +66,10 @@ describe('Agent per-call context option', () => {
       'Context for this request:\nUse buyer checkout rules.\n\nClick the submit button',
     );
     expect(taskExecutor.action).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.action.mock.calls[0][4]).toBe(
-      'Use buyer checkout rules.',
+    expect(taskExecutor.action.mock.calls[0][4]).toEqual(
+      expect.objectContaining({
+        aiActContext: 'Use buyer checkout rules.',
+      }),
     );
   });
 
@@ -79,7 +81,11 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Context for this request:\nGlobal action context.\n\nClick the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][4]).toBe('Global action context.');
+    expect(taskExecutor.action.mock.calls[0][4]).toEqual(
+      expect.objectContaining({
+        aiActContext: 'Global action context.',
+      }),
+    );
   });
 
   it('allows blank per-call context to override global aiActContext', async () => {
@@ -92,7 +98,11 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Click the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][4]).toBe('');
+    expect(taskExecutor.action.mock.calls[0][4]).toEqual(
+      expect.objectContaining({
+        aiActContext: '',
+      }),
+    );
   });
 
   it('does not register a file chooser for an empty fileChooserAccept array', async () => {

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -558,8 +558,12 @@ describe('Agent with custom OpenAI client', () => {
       );
       expect(actionSpy).toHaveBeenCalled();
       expect(actionSpy.mock.calls[0][3]).toBe(true);
-      expect(actionSpy.mock.calls[0][7]).toBe(1);
-      expect(actionSpy.mock.calls[0][8]).toBe(false);
+      expect(actionSpy.mock.calls[0][4]).toEqual(
+        expect.objectContaining({
+          imagesIncludeCount: 1,
+          deepThink: false,
+        }),
+      );
     });
 
     it('should disable deepLocate before running custom planning', async () => {
@@ -588,7 +592,9 @@ describe('Agent with custom OpenAI client', () => {
         'The "deepLocate" option is not supported for aiAct with the current planning adapter (modelFamily: auto-glm). It will be ignored.',
       );
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][10]).toBe(false);
+      expect(actionSpy.mock.calls[0][4]).toEqual(
+        expect.objectContaining({ deepLocate: false }),
+      );
     });
   });
 });

--- a/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
+++ b/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
@@ -96,18 +96,16 @@ describe('aiAct extra action integration', () => {
       {
         name: '填写用户名',
         planningAction: extraPlanningAction,
-        plans: [
-          {
-            type: 'Input',
-            param: {
-              value: 'Alice',
-              locate: {
-                prompt: '填写用户名',
-                locatedPixelBbox: [0, 0, 1, 1],
-              },
+        plan: {
+          type: 'Input',
+          param: {
+            value: 'Alice',
+            locate: {
+              prompt: '填写用户名',
+              locatedPixelBbox: [0, 0, 1, 1],
             },
           },
-        ],
+        },
       },
     ];
 

--- a/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
+++ b/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
@@ -1,0 +1,267 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Agent } from '@/agent';
+import { createExtraActionExecutionOptions } from '@/agent/extra-actions';
+import { TaskExecutor } from '@/agent/tasks';
+import { getMidsceneLocationSchema } from '@/ai-model';
+import { getModelRuntime } from '@/ai-model/models';
+import { genericXmlPlan } from '@/ai-model/workflows/planning';
+import type { AbstractInterface } from '@/device';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { DeviceAction } from '@/types';
+import yaml from 'js-yaml';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type Service from '../../src';
+
+vi.mock('@/ai-model/workflows/planning', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@/ai-model/workflows/planning')>();
+  return {
+    ...original,
+    genericXmlPlan: vi.fn(),
+  };
+});
+
+const validBase64Image =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const modelRuntime = () =>
+  getModelRuntime({
+    modelName: 'mock-model',
+    modelDescription: 'mock-model',
+    intent: 'default',
+    slot: 'default',
+  });
+
+describe('aiAct extra action integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('expands an extra Input action and executes the underlying action', async () => {
+    const inputCall = vi.fn();
+    const inputAction: DeviceAction = {
+      name: 'Input',
+      description: 'Input text into an element',
+      interfaceAlias: 'aiInput',
+      paramSchema: z.object({
+        value: z.string(),
+        locate: getMidsceneLocationSchema(),
+      }),
+      call: inputCall,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const extraPlanningAction: DeviceAction = {
+      name: 'MidsceneExtraAction_1',
+      description: 'Run a recorded action',
+      call: vi.fn(),
+    };
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [inputAction],
+      cacheFeatureForPoint: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [inputAction],
+    });
+    vi.mocked(genericXmlPlan).mockResolvedValue({
+      actions: [
+        {
+          type: extraPlanningAction.name,
+          param: {},
+          thought: 'fill the username',
+        },
+      ],
+      yamlFlow: [{ MidsceneExtraAction_1: {} }],
+      shouldContinuePlanning: false,
+    } as any);
+
+    const extraActions = [
+      {
+        name: '填写用户名',
+        planningAction: extraPlanningAction,
+        plans: [
+          {
+            type: 'Input',
+            param: {
+              value: 'Alice',
+              locate: {
+                prompt: '填写用户名',
+                locatedPixelBbox: [0, 0, 1, 1],
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await taskExecutor.action(
+      '填写表单',
+      modelRuntime(),
+      modelRuntime(),
+      false,
+      {
+        extraActions: createExtraActionExecutionOptions(extraActions),
+      },
+    );
+
+    expect(vi.mocked(genericXmlPlan).mock.calls[0][1].actionSpace).toEqual([
+      inputAction,
+      extraPlanningAction,
+    ]);
+    expect(inputCall).toHaveBeenCalledOnce();
+    expect(inputCall.mock.calls[0][0]).toMatchObject({
+      value: 'Alice',
+      locate: {
+        center: expect.any(Array),
+        rect: expect.objectContaining({
+          left: expect.any(Number),
+          top: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        }),
+      },
+    });
+
+    const replayAction = vi.fn();
+    const replayAgent = {
+      callActionInActionSpace: replayAction,
+      getActionSpace: vi.fn().mockResolvedValue([inputAction]),
+      onTaskStartTip: undefined,
+    };
+    await Agent.prototype.runYaml.call(
+      replayAgent as any,
+      yaml.dump({
+        tasks: [
+          {
+            name: 'cached extra action',
+            flow: result.output?.yamlFlow,
+          },
+        ],
+      }),
+    );
+    expect(replayAction).toHaveBeenCalledWith(
+      'Input',
+      expect.objectContaining({
+        value: 'Alice',
+        locate: expect.objectContaining({ prompt: '填写用户名' }),
+      }),
+    );
+  });
+
+  it('loads files through the public aiAct option and separates its plan cache', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'midscene-ai-act-extra-action-'));
+    const filePath = join(dir, 'extra-action.yaml');
+    await writeFile(
+      filePath,
+      `name: 点击确定按钮
+actionName: tap
+actionParam:
+  - xpath: /path/to/#confirm-button
+`,
+    );
+
+    try {
+      const tapAction: DeviceAction = {
+        name: 'Tap',
+        description: 'Tap an element',
+        call: vi.fn(),
+      };
+      const agent = Object.create(Agent.prototype) as Agent<any>;
+      const action = vi.fn().mockResolvedValue({
+        output: {
+          output: 'done',
+          yamlFlow: [],
+        },
+      });
+      const matchPlanCache = vi.fn();
+      (agent as any).opts = {};
+      (agent as any).interface = { interfaceType: 'web' };
+      (agent as any).fullActionSpace = [tapAction];
+      (agent as any).taskExecutor = { action };
+      (agent as any).taskCache = {
+        matchPlanCache,
+        isCacheResultUsed: true,
+        updateOrAppendCacheRecord: vi.fn(),
+      };
+      (agent as any).resolveModelRuntime = vi.fn(() => modelRuntime());
+      (agent as any).resolveReplanningCycleLimit = vi.fn(() => 1);
+
+      await expect(
+        agent.aiAct('填写表单', { loadExtraActions: [filePath] }),
+      ).resolves.toBe('done');
+
+      expect(matchPlanCache.mock.calls[0][0]).toContain(
+        '<midscene_extra_actions>',
+      );
+      expect(matchPlanCache.mock.calls[0][0]).toContain(
+        '"name":"点击确定按钮"',
+      );
+      const executionOptions = action.mock.calls[0].at(-1);
+      expect(executionOptions).toEqual(
+        expect.objectContaining({
+          extraActions: expect.objectContaining({
+            actionSpace: [
+              expect.objectContaining({
+                name: 'MidsceneExtraAction_1',
+                description: expect.stringContaining('点击确定按钮'),
+              }),
+            ],
+            expandPlans: expect.any(Function),
+          }),
+        }),
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects loadExtraActions before planning with a custom adapter', async () => {
+    const agent = Object.create(Agent.prototype) as Agent<any>;
+    const action = vi.fn();
+    const customPlanningModel = {
+      ...modelRuntime(),
+      config: {
+        ...modelRuntime().config,
+        modelFamily: 'custom-test',
+      },
+      adapter: {
+        planning: {
+          kind: 'custom',
+        },
+      },
+    } as any;
+    (agent as any).opts = {};
+    (agent as any).interface = { interfaceType: 'web' };
+    (agent as any).fullActionSpace = [];
+    (agent as any).taskExecutor = { action };
+    (agent as any).resolveModelRuntime = vi.fn((intent: string) =>
+      intent === 'planning' ? customPlanningModel : modelRuntime(),
+    );
+
+    await expect(
+      agent.aiAct('填写表单', {
+        loadExtraActions: ['/path/that/does/not/need/to/exist.yaml'],
+      }),
+    ).rejects.toThrow(
+      'The "loadExtraActions" option is not supported by custom planning adapters (modelFamily: custom-test)',
+    );
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -54,7 +54,7 @@ actionParam:
     expect(loaded[0].planningAction).toMatchObject({
       name: 'MidsceneExtraAction_1',
       description: expect.stringContaining(
-        'always prefer this action over rebuilding the workflow',
+        'always prefer it over rebuilding the operation',
       ),
       sample: {},
     });
@@ -106,7 +106,7 @@ actionParam:
 
     const [loaded] = await loadExtraActions([filePath], [inputAction]);
 
-    expect(loaded.plans[0].param).toEqual({
+    expect(loaded.plan.param).toEqual({
       value: 'Alice',
       mode: 'typeOnly',
       locate: {
@@ -136,6 +136,72 @@ actionParam:
     await expect(loadExtraActions([filePath], [inputAction])).rejects.toThrow(
       `Invalid extra action file "${filePath}": "actionParam[0]" does not match action "Input": value: Required`,
     );
+  });
+
+  it('rejects multiple operations in one extra action file', async () => {
+    const filePath = await writeExtraAction(`
+name: 填写完整表单
+actionName: Tap
+actionParam:
+  - xpath: /html/body/input[1]
+  - xpath: /html/body/input[2]
+`);
+
+    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
+      `Invalid extra action file "${filePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
+    );
+  });
+
+  it('expands multiple files into one operation per planner action', async () => {
+    const firstPath = await writeExtraAction(`
+name: 点击第一个按钮
+actionName: Tap
+actionParam:
+  - xpath: /html/body/button[1]
+`);
+    const secondPath = await writeExtraAction(`
+name: 点击第二个按钮
+actionName: Tap
+actionParam:
+  - xpath: /html/body/button[2]
+`);
+
+    const loaded = await loadExtraActions(
+      [firstPath, secondPath],
+      [tapAction()],
+    );
+
+    expect(
+      expandExtraActionPlans(
+        loaded.map((action) => ({
+          type: action.planningAction.name,
+          param: {},
+          thought: `run ${action.name}`,
+        })),
+        loaded,
+      ),
+    ).toEqual([
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: '点击第一个按钮',
+            xpath: '/html/body/button[1]',
+          },
+        },
+        thought: 'run 点击第一个按钮',
+      },
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: '点击第二个按钮',
+            xpath: '/html/body/button[2]',
+          },
+        },
+        thought: 'run 点击第二个按钮',
+      },
+    ]);
   });
 
   it('rejects display names that can corrupt the planner protocol', async () => {

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -53,7 +53,10 @@ actionParam:
     expect(loaded).toHaveLength(1);
     expect(loaded[0].planningAction).toMatchObject({
       name: 'MidsceneExtraAction_1',
-      description: expect.stringContaining('点击确定按钮'),
+      description: expect.stringContaining(
+        'always prefer this action over rebuilding the workflow',
+      ),
+      sample: {},
     });
     expect(
       expandExtraActionPlans(

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  expandExtraActionPlans,
+  extraActionsCacheKey,
+  loadExtraActions,
+} from '@/agent/extra-actions';
+import { getMidsceneLocationSchema } from '@/ai-model';
+import type { DeviceAction } from '@/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+describe('extra actions', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function writeExtraAction(content: string) {
+    const dir = await mkdtemp(join(tmpdir(), 'midscene-extra-action-'));
+    tempDirs.push(dir);
+    const filePath = join(dir, 'extra-action.yaml');
+    await writeFile(filePath, content);
+    return filePath;
+  }
+
+  const tapAction = (): DeviceAction => ({
+    name: 'Tap',
+    interfaceAlias: 'aiTap',
+    description: 'Tap an element',
+    paramSchema: z.object({
+      locate: getMidsceneLocationSchema(),
+    }),
+    call: vi.fn(),
+  });
+
+  it('loads the documented YAML shape and expands its xpath shortcut', async () => {
+    const filePath = await writeExtraAction(`
+name: 点击确定按钮
+actionName: tap
+actionParam:
+  - xpath: /path/to/#confirm-button
+`);
+
+    const loaded = await loadExtraActions([filePath], [tapAction()]);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].planningAction).toMatchObject({
+      name: 'MidsceneExtraAction_1',
+      description: expect.stringContaining('点击确定按钮'),
+    });
+    expect(
+      expandExtraActionPlans(
+        [
+          {
+            type: loaded[0].planningAction.name,
+            param: {},
+            thought: 'confirm the form',
+          },
+        ],
+        loaded,
+      ),
+    ).toEqual([
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: '点击确定按钮',
+            xpath: '/path/to/#confirm-button',
+          },
+        },
+        thought: 'confirm the form',
+      },
+    ]);
+    expect(extraActionsCacheKey(loaded)).toContain('"name":"点击确定按钮"');
+  });
+
+  it('keeps non-locator fields at the top level for an Input shortcut', async () => {
+    const filePath = await writeExtraAction(`
+name: 填写用户名
+actionName: input
+actionParam:
+  - xpath: /html/body/input
+    value: Alice
+    mode: typeOnly
+`);
+    const inputAction: DeviceAction = {
+      name: 'Input',
+      interfaceAlias: 'aiInput',
+      paramSchema: z.object({
+        value: z.string(),
+        locate: getMidsceneLocationSchema().optional(),
+        mode: z.enum(['replace', 'clear', 'typeOnly']).default('replace'),
+      }),
+      call: vi.fn(),
+    };
+
+    const [loaded] = await loadExtraActions([filePath], [inputAction]);
+
+    expect(loaded.plans[0].param).toEqual({
+      value: 'Alice',
+      mode: 'typeOnly',
+      locate: {
+        prompt: '填写用户名',
+        xpath: '/html/body/input',
+      },
+    });
+  });
+
+  it('rejects parameters that do not match the referenced action schema', async () => {
+    const filePath = await writeExtraAction(`
+name: 填写用户名
+actionName: input
+actionParam:
+  - xpath: /html/body/input
+`);
+    const inputAction: DeviceAction = {
+      name: 'Input',
+      interfaceAlias: 'aiInput',
+      paramSchema: z.object({
+        value: z.string(),
+        locate: getMidsceneLocationSchema().optional(),
+      }),
+      call: vi.fn(),
+    };
+
+    await expect(loadExtraActions([filePath], [inputAction])).rejects.toThrow(
+      `Invalid extra action file "${filePath}": "actionParam[0]" does not match action "Input": value: Required`,
+    );
+  });
+
+  it('rejects display names that can corrupt the planner protocol', async () => {
+    const filePath = await writeExtraAction(`
+name: Click <Confirm>
+actionName: Tap
+actionParam:
+  - prompt: confirm button
+`);
+
+    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
+      '"name" must not contain angle brackets, line breaks, or control characters',
+    );
+  });
+
+  it('rejects an unknown referenced action with the source path', async () => {
+    const filePath = await writeExtraAction(`
+name: 点击确定按钮
+actionName: missing-action
+actionParam:
+  - xpath: /path/to/#confirm-button
+`);
+
+    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
+      `Invalid extra action file "${filePath}": action "missing-action" is not in the current action space`,
+    );
+  });
+
+  it('rejects duplicate extra action names', async () => {
+    const firstPath = await writeExtraAction(`
+name: 点击确定按钮
+actionName: Tap
+actionParam:
+  - locate:
+      prompt: confirm button
+`);
+    const secondPath = await writeExtraAction(`
+name: 点击确定按钮
+actionName: Tap
+actionParam:
+  - locate:
+      prompt: another confirm button
+`);
+
+    await expect(
+      loadExtraActions([firstPath, secondPath], [tapAction()]),
+    ).rejects.toThrow(
+      'action name "点击确定按钮" conflicts with another action',
+    );
+  });
+});

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -247,6 +247,24 @@ describe('action space', () => {
       "If the user's task can be completed with the RunAdbShell action, prefer using the RunAdbShell action",
     );
   });
+
+  it('requires matching pre-recorded operations when extra actions are available', async () => {
+    const extraAction = {
+      name: 'MidsceneExtraAction_1',
+      description: 'Fill the first name field with Alice',
+      sample: {},
+      call: async () => {},
+    };
+
+    const prompt = await systemPromptToTaskPlanning({
+      actionSpace: [...mockActionSpace, extraAction],
+      includeLocateInPlanning: false,
+    });
+
+    expect(prompt).toContain(
+      'When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action',
+    );
+  });
 });
 
 describe('system prompts', () => {

--- a/packages/web-integration/tests/unit-test/agent.test.ts
+++ b/packages/web-integration/tests/unit-test/agent.test.ts
@@ -705,9 +705,12 @@ describe('PageAgent aiAct abortSignal', () => {
       abortSignal: controller.signal,
     });
 
-    // Verify the abortSignal argument is passed before report options.
-    const callArgs = mockTaskExecutor.action.mock.calls[0];
-    expect(callArgs[callArgs.length - 2]).toBe(controller.signal);
+    const actionOptions = mockTaskExecutor.action.mock.calls[0][4];
+    expect(actionOptions).toEqual(
+      expect.objectContaining({
+        abortSignal: controller.signal,
+      }),
+    );
   });
 
   it('should work normally without abortSignal', async () => {
@@ -722,9 +725,12 @@ describe('PageAgent aiAct abortSignal', () => {
 
     await agent.aiAct('click the button');
 
-    // AbortSignal argument should be undefined when no signal is provided.
-    const callArgs = mockTaskExecutor.action.mock.calls[0];
-    expect(callArgs[callArgs.length - 2]).toBeUndefined();
+    const actionOptions = mockTaskExecutor.action.mock.calls[0][4];
+    expect(actionOptions).toEqual(
+      expect.objectContaining({
+        abortSignal: undefined,
+      }),
+    );
   });
 
   it('should throw with default reason when aborted without reason', async () => {


### PR DESCRIPTION
## Summary

- add `loadExtraActions` to `aiAct` for loading reusable UI action YAML files per call
- define one extra-action file as exactly one device operation: `actionParam` must contain one item, loading produces one `plan`, and planner expansion is one-to-one
- expose extra actions to generic planning, explicitly prefer a matching recorded operation, and isolate plan caches by action content
- validate referenced actions and parameters up front, preserve locator shortcuts, and document Node.js/custom-planner boundaries
- keep the existing positional `TaskExecutor.action` API compatible while using a call-options overload internally

## Runtime validation

A six-field Puppeteer form was executed with `openai_qwen3.5-plus`. The reuse variant loaded six independent YAML files, one `Input` operation per field. Every official sample used `MIDSCENE_MODEL_RETRY_COUNT=0`, generated a self-contained Midscene HTML report, and passed an exact comparison of all six final DOM values.

Baseline C/D mean versus single-operation Extra Action C/D mean:

| Scenario | Model calls | Total tokens | LLM time | Wall time |
| --- | ---: | ---: | ---: | ---: |
| Normal `aiAct` | 13 | 154,106 | 54.696 s | 66.382 s |
| Six matching single-operation actions, `deepThink: false` | 7 | 81,556 | 27.514 s | 37.332 s |

The corrected fine-grained replay reduced total tokens by 47.1%, LLM time by 49.7%, wall time by 43.8%, and model calls by 46.2%. Each reuse report dump contains exactly one selection of `MidsceneExtraAction_1` through `MidsceneExtraAction_6`.

One directional `deepThink: true` sample also passed with seven model calls. It used 101,444 tokens and 44.463 s wall time: 24.4% more tokens and 19.1% more wall time than the non-deepThink reuse mean. Reuse therefore does not depend on deep thinking.

This supersedes the earlier macro-style experiment, which incorrectly exposed six `Input` operations as one planner action. Its 86.5% token reduction did not answer the single-operation granularity question and is excluded from the corrected results.

The [formal validation document](https://bytedance.larkoffice.com/docx/Vo3SdngAFoWcQyxNN1BcxY5hnhg) contains the core implementation, all six complete YAML files, the reproduction harness, raw metrics, report-dump audit steps, downloadable evidence archives, and these hosted Midscene reports:

- [baseline-c](https://midscene-pr2910-single-op-baseline-c.gf-preview.bytedance.net/)
- [extra-c](https://midscene-pr2910-single-op-extra-c.gf-preview.bytedance.net/)
- [extra-deep-think-c](https://midscene-pr2910-single-op-deepthink-c.gf-preview.bytedance.net/)

Small-model replay is not yet confirmed: the candidate endpoint returned 401, so no successful auditable sample exists. Fast mode was not enabled in this comparison and should be measured separately.

## Validation commands

- `pnpm run lint`
- `pnpm exec nx build @midscene/core`
- focused Extra Action, `aiAct`, and planning-prompt unit tests (51 passed)
- `pnpm exec nx test @midscene/core` (125 files and 1,376 tests passed; 8 skipped; one unrelated report-size assertion failed)
- temporary real-model Puppeteer benchmark with `generateReport: true`, `outputFormat: 'single-html'`, and `MIDSCENE_MODEL_RETRY_COUNT=0` (five successful official samples; harness archived in the validation document and removed from the branch after measurement)

## Scope

This PR implements loading and replaying existing action YAML files. A future `midscene analyze report.html` command for generating those files from a report is not included.

## Known unrelated failure

- `merge-browser-parse.test.ts` expects a merged report below 15 MB, while this checkout generates about 28.35 MB. The failure reproduces in isolation and does not exercise Extra Action loading, planning, or expansion.
