### PR TITLE
ci(workflow): use internal cache on self-hosted runners

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,40 @@
+name: Cache
+
+description: Route caches to GitHub storage or the self-hosted internal cache service
+
+inputs:
+  key:
+    description: An explicit key for restoring and saving the cache
+    required: true
+  path:
+    description: Files, directories, and wildcard patterns to cache
+    required: true
+  restore-keys:
+    description: Ordered prefixes used to restore stale caches
+    required: false
+
+outputs:
+  cache-hit:
+    description: Whether the primary cache key was restored
+    value: ${{ steps.github-cache.outputs.cache-hit == 'true' || steps.internal-cache.outputs.cache-hit == 'true' }}
+
+runs:
+  using: composite
+  steps:
+    - name: Cache with GitHub storage
+      id: github-cache
+      if: ${{ runner.environment == 'github-hosted' }}
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}
+        restore-keys: ${{ inputs.restore-keys }}
+
+    - name: Cache with internal storage
+      id: internal-cache
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: lynx-infra/cache@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}
+        restore-keys: ${{ inputs.restore-keys }}

--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -1,13 +1,13 @@
-name: Cache
+name: Restore cache
 
-description: Route caches to GitHub storage or the self-hosted internal cache service
+description: Restore a cache from GitHub storage or the self-hosted internal cache service
 
 inputs:
   key:
-    description: An explicit key for restoring and saving the cache
+    description: An explicit key for restoring the cache
     required: true
   path:
-    description: Files, directories, and wildcard patterns to cache
+    description: Files, directories, and wildcard patterns to restore
     required: true
   restore-keys:
     description: Ordered prefixes used to restore stale caches
@@ -21,19 +21,19 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Cache with GitHub storage
+    - name: Restore cache from GitHub storage
       id: github-cache
       if: ${{ runner.environment == 'github-hosted' }}
-      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+      uses: actions/cache/restore@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}
         restore-keys: ${{ inputs.restore-keys }}
 
-    - name: Cache with internal storage
+    - name: Restore cache from internal storage
       id: internal-cache
       if: ${{ runner.environment == 'self-hosted' }}
-      uses: lynx-infra/cache@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
+      uses: lynx-infra/cache/restore@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -1,0 +1,28 @@
+name: Save cache
+
+description: Save a cache to GitHub storage or the self-hosted internal cache service
+
+inputs:
+  key:
+    description: An explicit key for saving the cache
+    required: true
+  path:
+    description: Files, directories, and wildcard patterns to save
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Save cache to GitHub storage
+      if: ${{ runner.environment == 'github-hosted' }}
+      uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}
+
+    - name: Save cache to internal storage
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: lynx-infra/cache/save@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -1,0 +1,21 @@
+name: Cache pnpm store
+
+description: Cache the pnpm content-addressable store on the runner-appropriate backend
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve pnpm store
+      id: pnpm-store
+      shell: bash
+      run: |
+        echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/cache
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-

--- a/.github/actions/pnpm-cache/restore/action.yml
+++ b/.github/actions/pnpm-cache/restore/action.yml
@@ -16,12 +16,13 @@ runs:
       run: |
         echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
         echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
+        echo "node_version=$(node --version)" >> "$GITHUB_OUTPUT"
 
     - name: Restore pnpm store
       id: cache
       uses: ./.github/actions/cache/restore
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ steps.pnpm-store.outputs.node_version }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-
+          midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ steps.pnpm-store.outputs.node_version }}-

--- a/.github/actions/pnpm-cache/restore/action.yml
+++ b/.github/actions/pnpm-cache/restore/action.yml
@@ -1,6 +1,11 @@
-name: Cache pnpm store
+name: Restore pnpm store
 
-description: Cache the pnpm content-addressable store on the runner-appropriate backend
+description: Restore the pnpm content-addressable store from the runner-appropriate backend
+
+outputs:
+  cache-hit:
+    description: Whether the primary pnpm cache key was restored
+    value: ${{ steps.cache.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -12,8 +17,9 @@ runs:
         echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
         echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
 
-    - name: Cache pnpm store
-      uses: ./.github/actions/cache
+    - name: Restore pnpm store
+      id: cache
+      uses: ./.github/actions/cache/restore
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
         key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/pnpm-cache/save/action.yml
+++ b/.github/actions/pnpm-cache/save/action.yml
@@ -1,0 +1,19 @@
+name: Save pnpm store
+
+description: Save the pnpm content-addressable store to the runner-appropriate backend
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve pnpm store
+      id: pnpm-store
+      shell: bash
+      run: |
+        echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
+
+    - name: Save pnpm store
+      uses: ./.github/actions/cache/save
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/pnpm-cache/save/action.yml
+++ b/.github/actions/pnpm-cache/save/action.yml
@@ -11,9 +11,10 @@ runs:
       run: |
         echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
         echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
+        echo "node_version=$(node --version)" >> "$GITHUB_OUTPUT"
 
     - name: Save pnpm store
       uses: ./.github/actions/cache/save
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: midscene-pnpm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-store.outputs.version }}-${{ steps.pnpm-store.outputs.node_version }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/setup-headless-browser/action.yml
+++ b/.github/actions/setup-headless-browser/action.yml
@@ -28,7 +28,9 @@ runs:
           xvfb
           x11-xserver-utils
           imagemagick
+          fontconfig
           fonts-liberation
+          fonts-wqy-zenhei
           libasound2
           libatk-bridge2.0-0
           libdrm2
@@ -62,19 +64,26 @@ runs:
 
         if [ "${#missing[@]}" -eq 0 ]; then
           echo "All headless browser system dependencies are preinstalled"
-          exit 0
+        else
+          echo "Installing missing packages: ${missing[*]}"
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install \
+            --yes \
+            --no-install-recommends \
+            "${missing[@]}"
         fi
 
-        echo "Installing missing packages: ${missing[*]}"
-        sudo apt-get update
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get install \
-          --yes \
-          --no-install-recommends \
-          "${missing[@]}"
+        chinese_fonts="$(fc-list :lang=zh family)"
+        if [ -z "$chinese_fonts" ]; then
+          echo "::error::No Chinese font is available to the browser"
+          exit 1
+        fi
+        echo "Chinese browser fonts:"
+        printf '%s\n' "$chinese_fonts"
 
     - name: Setup Puppeteer browser
       id: browser
       uses: ./.github/actions/setup-puppeteer-browser
       with:
         package-directory: ${{ inputs.package-directory }}
-        expose-as-chromium: "true"
+        expose-as-chromium: 'true'

--- a/.github/actions/setup-headless-browser/action.yml
+++ b/.github/actions/setup-headless-browser/action.yml
@@ -1,0 +1,80 @@
+name: Setup headless browser
+
+description: Install missing Linux desktop libraries and restore a Puppeteer Chrome binary
+
+inputs:
+  package-directory:
+    description: Workspace package that provides the Puppeteer CLI
+    required: false
+    default: packages/web-integration
+
+outputs:
+  browser-path:
+    description: Absolute path to the Chrome for Testing executable
+    value: ${{ steps.browser.outputs.browser-path }}
+  browser-cache-hit:
+    description: Whether the Puppeteer browser cache was restored
+    value: ${{ steps.browser.outputs.browser-cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install missing system dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        packages=(
+          xvfb
+          x11-xserver-utils
+          imagemagick
+          fonts-liberation
+          libasound2
+          libatk-bridge2.0-0
+          libdrm2
+          libgbm1
+          libgtk-3-0
+          libnss3
+          libpango-1.0-0
+          libvulkan1
+          libx11-6
+          libx11-xcb1
+          libxcomposite1
+          libxdamage1
+          libxfixes3
+          libxinerama1
+          libxkbcommon-x11-0
+          libxkbcommon0
+          libxrandr2
+          libxshmfence1
+          libxss1
+          libxtst6
+          xdg-utils
+        )
+        missing=()
+
+        for package in "${packages[@]}"; do
+          status="$(dpkg-query -W -f='${Status}' "$package" 2>/dev/null || true)"
+          if [ "$status" != "install ok installed" ]; then
+            missing+=("$package")
+          fi
+        done
+
+        if [ "${#missing[@]}" -eq 0 ]; then
+          echo "All headless browser system dependencies are preinstalled"
+          exit 0
+        fi
+
+        echo "Installing missing packages: ${missing[*]}"
+        sudo apt-get update
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install \
+          --yes \
+          --no-install-recommends \
+          "${missing[@]}"
+
+    - name: Setup Puppeteer browser
+      id: browser
+      uses: ./.github/actions/setup-puppeteer-browser
+      with:
+        package-directory: ${{ inputs.package-directory }}
+        expose-as-chromium: "true"

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,57 @@
+name: Setup Node.js and pnpm
+
+description: Restore the Node.js toolcache on self-hosted runners, then set up Node.js and pnpm
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: 24.13.0
+  pnpm-version:
+    description: pnpm version to install
+    required: false
+    default: 9.3.0
+
+outputs:
+  node-cache-hit:
+    description: Whether the self-hosted Node.js toolcache was restored
+    value: ${{ steps.node-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Node.js toolcache
+      id: node-toolcache
+      if: ${{ runner.environment == 'self-hosted' }}
+      shell: bash
+      run: |
+        if [ -z "${RUNNER_TOOL_CACHE:-}" ]; then
+          echo "::error::RUNNER_TOOL_CACHE is not configured"
+          exit 1
+        fi
+        echo "path=$RUNNER_TOOL_CACHE/node/${{ inputs.node-version }}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Node.js toolcache
+      id: node-cache
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: ./.github/actions/cache/restore
+      with:
+        path: ${{ steps.node-toolcache.outputs.path }}
+        key: midscene-node-toolcache-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Save Node.js toolcache
+      if: ${{ runner.environment == 'self-hosted' && steps.node-cache.outputs.cache-hit != 'true' }}
+      uses: ./.github/actions/cache/save
+      with:
+        path: ${{ steps.node-toolcache.outputs.path }}
+        key: midscene-node-toolcache-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+      with:
+        version: ${{ inputs.pnpm-version }}

--- a/.github/actions/setup-puppeteer-browser/action.yml
+++ b/.github/actions/setup-puppeteer-browser/action.yml
@@ -50,17 +50,15 @@ runs:
         set -euo pipefail
 
         browser_path="$(
-          find "$HOME/.cache/puppeteer/chrome" \
-            -type f \
-            -path '*/chrome-linux64/chrome' \
-            -perm -u+x \
-            -print \
-            -quit
+          pnpm --dir "${{ inputs.package-directory }}" exec node -e \
+            'process.stdout.write(require("puppeteer").executablePath())'
         )"
-        if [ -z "$browser_path" ]; then
-          echo "::error::Chrome for Testing was not found in the Puppeteer cache"
+        if [ ! -x "$browser_path" ]; then
+          echo "::error::Puppeteer resolved a missing or non-executable browser: $browser_path"
           exit 1
         fi
+
+        echo "PUPPETEER_EXECUTABLE_PATH=$browser_path" >> "$GITHUB_ENV"
 
         if [ "${{ inputs.expose-as-chromium }}" = "true" ]; then
           bin_dir="$RUNNER_TEMP/midscene-browser-bin"

--- a/.github/actions/setup-puppeteer-browser/action.yml
+++ b/.github/actions/setup-puppeteer-browser/action.yml
@@ -1,0 +1,73 @@
+name: Setup Puppeteer browser
+
+description: Restore and install the Puppeteer Chrome for Testing binary
+
+inputs:
+  package-directory:
+    description: Workspace package that provides the Puppeteer CLI
+    required: false
+    default: packages/web-integration
+  expose-as-chromium:
+    description: Add a chromium alias for tests that discover browsers from PATH
+    required: false
+    default: "false"
+
+outputs:
+  browser-path:
+    description: Absolute path to the Chrome for Testing executable
+    value: ${{ steps.browser.outputs.path }}
+  browser-cache-hit:
+    description: Whether the Puppeteer browser cache was restored
+    value: ${{ steps.browser-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Puppeteer browser
+      id: browser-cache
+      uses: ./.github/actions/cache/restore
+      with:
+        path: ~/.cache/puppeteer
+        key: midscene-puppeteer-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          midscene-puppeteer-v1-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install Chrome for Testing
+      shell: bash
+      run: pnpm --dir "${{ inputs.package-directory }}" exec puppeteer browsers install chrome
+
+    - name: Save Puppeteer browser
+      if: ${{ steps.browser-cache.outputs.cache-hit != 'true' }}
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/puppeteer
+        key: midscene-puppeteer-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Resolve Chrome for Testing
+      id: browser
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        browser_path="$(
+          find "$HOME/.cache/puppeteer/chrome" \
+            -type f \
+            -path '*/chrome-linux64/chrome' \
+            -perm -u+x \
+            -print \
+            -quit
+        )"
+        if [ -z "$browser_path" ]; then
+          echo "::error::Chrome for Testing was not found in the Puppeteer cache"
+          exit 1
+        fi
+
+        if [ "${{ inputs.expose-as-chromium }}" = "true" ]; then
+          bin_dir="$RUNNER_TEMP/midscene-browser-bin"
+          mkdir -p "$bin_dir"
+          ln -sfn "$browser_path" "$bin_dir/chromium"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+        fi
+
+        echo "path=$browser_path" >> "$GITHUB_OUTPUT"
+        "$browser_path" --version

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -3,7 +3,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -59,8 +69,8 @@ jobs:
     - name: Setup Puppeteer browser
       uses: ./.github/actions/setup-puppeteer-browser
 
-    - name: Build project
-      run: pnpm run build
+    - name: Build AI unit test projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/core,@midscene/web,@midscene/cli"
     
     - name: Run tests with coverage
       # Keep model request concurrency comparable to the former 4-core hosted runner.

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -36,7 +36,6 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
-        fetch-depth: 0
         ref: ${{ github.event.inputs.branch || github.ref }}
 
     - name: Setup pnpm

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ai-unit-test-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   main:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -42,15 +42,8 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-  
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
@@ -63,10 +56,8 @@ jobs:
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
 
-    - name: Install puppeteer dependencies
-      run: |
-        cd packages/web-integration
-        npx puppeteer browsers install chrome
+    - name: Setup Puppeteer browser
+      uses: ./.github/actions/setup-puppeteer-browser
 
     - name: Build project
       run: pnpm run build

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -50,10 +50,15 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Install puppeteer dependencies
       run: |

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -48,7 +48,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -47,10 +47,11 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Cache Playwright dependencies
-      uses: ./.github/actions/cache
+      uses: ./.github/actions/cache/restore
       id: cache-playwright
       with:
         path: ~/.cache/ms-playwright
@@ -61,6 +62,10 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
+
     - name: Install Playwright dependencies
       run: |
         cd packages/web-integration
@@ -69,6 +74,13 @@ jobs:
         else
           npx playwright install-deps && npx playwright install
         fi
+
+    - name: Save Playwright dependencies
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Install puppeteer dependencies
       run: |
@@ -133,10 +145,11 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Cache Playwright dependencies
-      uses: ./.github/actions/cache
+      uses: ./.github/actions/cache/restore
       id: cache-playwright
       with:
         path: ~/.cache/ms-playwright
@@ -147,6 +160,10 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
+
     - name: Install Playwright dependencies
       run: |
         cd packages/web-integration
@@ -155,6 +172,13 @@ jobs:
         else
           npx playwright install-deps && npx playwright install
         fi
+
+    - name: Save Playwright dependencies
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Install puppeteer dependencies
       run: |

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ai-playwright-e2e-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
   MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -33,7 +33,6 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
-        fetch-depth: 0
         ref: ${{ github.event.inputs.branch || github.ref }}
 
     - name: Setup pnpm
@@ -131,7 +130,6 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
-        fetch-depth: 0
         ref: ${{ github.event.inputs.branch || github.ref }}
 
     - name: Setup pnpm

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -45,10 +45,12 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Cache Playwright dependencies
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: ./.github/actions/cache
       id: cache-playwright
       with:
         path: ~/.cache/ms-playwright
@@ -129,10 +131,12 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Cache Playwright dependencies
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: ./.github/actions/cache
       id: cache-playwright
       with:
         path: ~/.cache/ms-playwright

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -72,14 +72,11 @@ jobs:
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
 
-    - name: Install Playwright dependencies
-      run: |
-        cd packages/web-integration
-        if [ "${{ steps.cache-playwright.outputs.cache-hit }}" != "true" ]; then
-          npx playwright install --with-deps
-        else
-          npx playwright install-deps && npx playwright install
-        fi
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
+
+    - name: Install Playwright Chromium
+      run: pnpm --dir packages/web-integration exec playwright install chromium
 
     - name: Save Playwright dependencies
       if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -87,9 +84,6 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-
-    - name: Setup Puppeteer browser
-      uses: ./.github/actions/setup-puppeteer-browser
 
     - name: Build web e2e projects
       run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/web,@midscene/cli"

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -3,7 +3,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -81,8 +91,8 @@ jobs:
     - name: Setup Puppeteer browser
       uses: ./.github/actions/setup-puppeteer-browser
 
-    - name: Build project
-      run: pnpm run build
+    - name: Build web e2e projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/web,@midscene/cli"
 
     # Cache behavior uses explicit fixture configuration in the standard suite.
     # MIDSCENE_CACHE does not override those options, so a second full run is redundant.
@@ -134,15 +144,6 @@ jobs:
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Cache Playwright dependencies
-      uses: ./.github/actions/cache/restore
-      id: cache-playwright
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -150,27 +151,8 @@ jobs:
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
 
-    - name: Install Playwright dependencies
-      run: |
-        cd packages/web-integration
-        if [ "${{ steps.cache-playwright.outputs.cache-hit }}" != "true" ]; then
-          npx playwright install --with-deps
-        else
-          npx playwright install-deps && npx playwright install
-        fi
-
-    - name: Save Playwright dependencies
-      if: steps.cache-playwright.outputs.cache-hit != 'true'
-      uses: ./.github/actions/cache/save
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-
     - name: Setup Puppeteer browser
       uses: ./.github/actions/setup-puppeteer-browser
-
-    - name: Build project
-      run: pnpm run build
 
     - name: Run apps/report e2e tests
       run: cd apps/report && pnpm run e2e

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -39,15 +39,8 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
@@ -85,10 +78,8 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-    - name: Install puppeteer dependencies
-      run: |
-        cd packages/web-integration
-        npx puppeteer browsers install chrome
+    - name: Setup Puppeteer browser
+      uses: ./.github/actions/setup-puppeteer-browser
 
     - name: Build project
       run: pnpm run build
@@ -136,15 +127,8 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
@@ -182,10 +166,8 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-    - name: Install puppeteer dependencies
-      run: |
-        cd packages/web-integration
-        npx puppeteer browsers install chrome
+    - name: Setup Puppeteer browser
+      uses: ./.github/actions/setup-puppeteer-browser
 
     - name: Build project
       run: pnpm run build

--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -74,7 +74,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.13.0'
-          cache: 'pnpm'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/pnpm-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -30,9 +30,6 @@ concurrency:
 
 jobs:
   android-emulator:
-    concurrency:
-      group: ai-mobile-${{ github.event.pull_request.number || inputs.branch || github.ref }}
-      cancel-in-progress: false
     # The self-hosted Linux pool does not guarantee KVM passthrough.
     runs-on: ubuntu-22.04
     timeout-minutes: 55

--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -76,10 +76,15 @@ jobs:
           node-version: '24.13.0'
 
       - name: Cache pnpm store
-        uses: ./.github/actions/pnpm-cache
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
       - name: Build report and Android packages
         id: build

--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -30,6 +30,9 @@ concurrency:
 
 jobs:
   android-emulator:
+    concurrency:
+      group: ai-mobile-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+      cancel-in-progress: false
     # The self-hosted Linux pool does not guarantee KVM passthrough.
     runs-on: ubuntu-22.04
     timeout-minutes: 55

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache Puppeteer dependencies
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: ./.github/actions/cache
       id: cache-puppeteer
       with:
         path: ~/.cache/puppeteer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        fetch-depth: 0
 
     - name: Setup pnpm
       uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'apps/site/**'
+      - '.changeset/**'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache Puppeteer dependencies
-      uses: ./.github/actions/cache
+      uses: ./.github/actions/cache/restore
       id: cache-puppeteer
       with:
         path: ~/.cache/puppeteer
@@ -53,6 +53,13 @@ jobs:
       run: |
         cd packages/web-integration
         npx puppeteer browsers install chrome
+
+    - name: Save Puppeteer cache
+      if: steps.cache-puppeteer.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/puppeteer
+        key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Check tsconfig references
       run: pnpm run check:references

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -162,8 +162,6 @@ jobs:
       run: exit 1
 
   chrome-extension-bridge:
-    needs: chrome-extension
-    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -221,8 +219,6 @@ jobs:
       run: exit 1
 
   chrome-extension-playground:
-    needs: chrome-extension-bridge
-    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -337,8 +333,6 @@ jobs:
       run: exit 1
 
   chrome-extension-settings:
-    needs: chrome-extension-recorder
-    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -56,7 +56,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |
@@ -146,7 +148,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |
@@ -221,7 +225,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |
@@ -295,7 +301,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |
@@ -369,7 +377,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |
@@ -443,7 +453,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -162,6 +162,8 @@ jobs:
       run: exit 1
 
   chrome-extension-bridge:
+    needs: chrome-extension
+    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -87,7 +87,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -184,7 +184,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -265,7 +265,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -346,7 +346,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -427,7 +427,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -508,7 +508,7 @@ jobs:
         sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -186,6 +186,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Install Chrome for Testing
+      run: pnpm exec puppeteer browsers install chrome
+
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
@@ -266,6 +269,9 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Install Chrome for Testing
+      run: pnpm exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -348,6 +354,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Install Chrome for Testing
+      run: pnpm exec puppeteer browsers install chrome
+
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
@@ -429,6 +438,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Install Chrome for Testing
+      run: pnpm exec puppeteer browsers install chrome
+
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
@@ -509,6 +521,9 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Install Chrome for Testing
+      run: pnpm exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -272,7 +272,7 @@ jobs:
 
     - name: Run Bridge mode start/stop test
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-bridge.test.ts
-      timeout-minutes: 25
+      timeout-minutes: 40
       id: test-bridge
       continue-on-error: true
 

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -58,7 +58,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -83,6 +84,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -150,7 +155,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -175,6 +181,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -227,7 +237,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -251,6 +262,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -303,7 +318,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -327,6 +343,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -379,7 +399,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -403,6 +424,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -455,7 +480,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -479,6 +505,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Build project
       run: pnpm run build:skip-cache

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -68,8 +68,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build AI todo projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
 
     - name: Verify system setup
       run: |
@@ -140,8 +140,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build Chrome extension projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
     - name: Run Chrome extension test
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension.test.ts
@@ -197,8 +197,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build Chrome extension projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
     - name: Run Bridge mode start/stop test
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-bridge.test.ts
@@ -254,8 +254,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build Chrome extension projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
     - name: Run Playground advanced tests
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-playground.test.ts
@@ -311,8 +311,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build Chrome extension projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
     - name: Run Recorder mode tests
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-recorder.test.ts
@@ -368,8 +368,8 @@ jobs:
     - name: Setup headless browser
       uses: ./.github/actions/setup-headless-browser
 
-    - name: Build project
-      run: pnpm run build:skip-cache
+    - name: Build Chrome extension projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
     - name: Run Settings and cross-mode tests
       run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-settings.test.ts

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -187,7 +187,7 @@ jobs:
       run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Chrome for Testing
-      run: pnpm exec puppeteer browsers install chrome
+      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -271,7 +271,7 @@ jobs:
       run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Chrome for Testing
-      run: pnpm exec puppeteer browsers install chrome
+      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -355,7 +355,7 @@ jobs:
       run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Chrome for Testing
-      run: pnpm exec puppeteer browsers install chrome
+      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -439,7 +439,7 @@ jobs:
       run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Chrome for Testing
-      run: pnpm exec puppeteer browsers install chrome
+      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -523,7 +523,7 @@ jobs:
       run: pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Install Chrome for Testing
-      run: pnpm exec puppeteer browsers install chrome
+      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: headless-linux-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -51,40 +51,12 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
-
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        # Install Google Chrome (not snap chromium which can't access Xvfb)
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
@@ -92,6 +64,9 @@ jobs:
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -105,7 +80,7 @@ jobs:
         echo "--- import (imagemagick) ---"
         which import && echo "import: OK"
         echo "--- Browser ---"
-        google-chrome-stable --version || echo "Chrome not found"
+        chromium --version || echo "Chrome not found"
         echo "--- DISPLAY ---"
         echo "DISPLAY=${DISPLAY:-(not set)}"
 
@@ -148,50 +123,22 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        # Install Google Chrome (not snap chromium which can't access Xvfb)
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-
-    - name: Install Chrome for Testing
-      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -233,49 +180,22 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-
-    - name: Install Chrome for Testing
-      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -317,49 +237,22 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-
-    - name: Install Chrome for Testing
-      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -401,49 +294,22 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-
-    - name: Install Chrome for Testing
-      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache
@@ -485,49 +351,22 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          imagemagick \
-          libxtst6 \
-          libxinerama1 \
-          libx11-6 \
-          libxkbcommon-x11-0 \
-          libpng16-16 \
-          libnss3 \
-          libatk-bridge2.0-0 \
-          libdrm2 \
-          libgbm1 \
-          libasound2
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb || sudo apt-get -f install -y
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-
-    - name: Install Chrome for Testing
-      run: pnpm --dir packages/web-integration exec puppeteer browsers install chrome
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
 
     - name: Build project
       run: pnpm run build:skip-cache

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -221,6 +221,8 @@ jobs:
       run: exit 1
 
   chrome-extension-playground:
+    needs: chrome-extension-bridge
+    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -335,6 +337,8 @@ jobs:
       run: exit 1
 
   chrome-extension-settings:
+    needs: chrome-extension-recorder
+    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -31,6 +31,9 @@ concurrency:
 
 jobs:
   ios-simulator:
+    concurrency:
+      group: ai-mobile-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+      cancel-in-progress: false
     runs-on: ${{ fromJSON(vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"') }}
     timeout-minutes: 70
     env:

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -84,10 +84,15 @@ jobs:
           node-version: '24.13.0'
 
       - name: Cache pnpm store
-        uses: ./.github/actions/pnpm-cache
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
       - name: Build report and iOS packages
         id: build

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -73,15 +73,8 @@ jobs:
             xcrun simctl list devices available
           } 2>&1 | tee "$MIDSCENE_IOS_DIAGNOSTICS_DIR/runner-preflight.log"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-        with:
-          version: 9.3.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24.13.0'
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Cache pnpm store
         id: pnpm-cache

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -31,9 +31,6 @@ concurrency:
 
 jobs:
   ios-simulator:
-    concurrency:
-      group: ai-mobile-${{ github.event.pull_request.number || inputs.branch || github.ref }}
-      cancel-in-progress: false
     runs-on: ${{ fromJSON(vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"') }}
     timeout-minutes: 70
     env:

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -82,7 +82,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.13.0'
-          cache: 'pnpm'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/pnpm-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -8,12 +8,11 @@ jobs:
   reply-labeled:
     name: Reply need reproduction
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    if: github.repository == 'web-infra-dev/midscene'
+    if: github.repository == 'web-infra-dev/midscene' && github.event.label.name == 'need reproduction'
     permissions:
       issues: write
     steps:
       - name: need reproduction
-        if: github.event.label.name == 'need reproduction'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,15 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-  
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,10 +37,15 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Check Dependency Version
       run: pnpm run check-dependency-version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        fetch-depth: 0
-
-    - name: Fetch all branches
-      run: git fetch --all
 
     - name: Setup pnpm
       uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -83,7 +83,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.13.0'
-          cache: 'pnpm'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/pnpm-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -30,6 +30,9 @@ concurrency:
 
 jobs:
   macos-desktop:
+    concurrency:
+      group: ai-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+      cancel-in-progress: false
     # The self-hosted macOS runner is ARM and has no interactive GUI session.
     runs-on: macos-15-intel
     timeout-minutes: 50

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -30,9 +30,6 @@ concurrency:
 
 jobs:
   macos-desktop:
-    concurrency:
-      group: ai-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
-      cancel-in-progress: false
     # The self-hosted macOS runner is ARM and has no interactive GUI session.
     runs-on: macos-15-intel
     timeout-minutes: 50

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -85,10 +85,15 @@ jobs:
           node-version: '24.13.0'
 
       - name: Cache pnpm store
-        uses: ./.github/actions/pnpm-cache
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
       - name: Build report and computer packages
         id: build

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: PR Title
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened]
 
 permissions:
   contents: read
@@ -10,20 +10,14 @@ permissions:
 jobs:
   commitlint:
     name: Validate title
+    if: github.event.action != 'edited' || github.event.changes.title
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
 
     - name: Cache pnpm store
       id: pnpm-cache

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,7 +24,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -26,10 +26,15 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Validate PR title
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,7 @@ jobs:
       if: ${{ matrix.platform == 'win32' && steps.install-dependencies.outcome == 'failure' }}
       run: |
         Start-Sleep -Seconds 5
+        git clean -ffdx
         pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,7 +320,7 @@ jobs:
         pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      if: ${{ matrix.platform != 'win32' && steps.pnpm-cache.outputs.cache-hit != 'true' }}
       uses: ./.github/actions/pnpm-cache/save
 
     - name: Install @midscene/computer native build deps (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,13 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
+
     - name: Cache Puppeteer
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: ./.github/actions/cache
       with:
         path: ~/.cache/puppeteer
         key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
@@ -233,7 +235,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22.11.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Prepare macOS codesigning keychain
       if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
         - runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
           platform: win32
           arch: x64
-        - runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
+        - runner: '"macos-15"'
           platform: darwin
           arch: arm64
         - runner: '"macos-15-intel"'
@@ -268,40 +268,22 @@ jobs:
         : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS release packaging}"
 
         CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
-        DEVELOPER_ID_CA_PATH="$RUNNER_TEMP/DeveloperIDCA.cer"
-        DEVELOPER_ID_G2_CA_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
         KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
         KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
         printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
 
-        curl --fail --silent --show-error --location \
-          https://www.apple.com/certificateauthority/DeveloperIDCA.cer \
-          --output "$DEVELOPER_ID_CA_PATH"
-        curl --fail --silent --show-error --location \
-          https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
-          --output "$DEVELOPER_ID_G2_CA_PATH"
-        echo "7afc9d01a62f03a2de9637936d4afe68090d2de18d03f29c88cfb0b1ba63587f  $DEVELOPER_ID_CA_PATH" | shasum -a 256 --check
-        echo "f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a  $DEVELOPER_ID_G2_CA_PATH" | shasum -a 256 --check
-
         security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-        security import "$DEVELOPER_ID_CA_PATH" -k "$KEYCHAIN_PATH"
-        security import "$DEVELOPER_ID_G2_CA_PATH" -k "$KEYCHAIN_PATH"
         security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
         CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
         security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
-        security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
-
-        CODESIGN_TEST_PATH="$RUNNER_TEMP/midscene-codesign-test"
-        cp /usr/bin/true "$CODESIGN_TEST_PATH"
-        codesign --force --sign "$APPLE_CODESIGN_IDENTITY" --options runtime --timestamp "$CODESIGN_TEST_PATH"
-        codesign --verify --strict "$CODESIGN_TEST_PATH"
 
         echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
+        echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
         if [ -n "${APPLE_TEAM_ID:-}" ]; then
           echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,15 @@ jobs:
         fi
 
     - name: Install dependencies
+      id: install-dependencies
+      continue-on-error: ${{ matrix.platform == 'win32' }}
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Retry dependency installation on Windows
+      if: ${{ matrix.platform == 'win32' && steps.install-dependencies.outcome == 'failure' }}
+      run: |
+        Start-Sleep -Seconds 5
+        pnpm install --frozen-lockfile --ignore-scripts
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
       FORCE_COLOR: '0'
       MIDSCENE_REQUIRE_MAC_CODESIGN: ${{ needs.release.outputs.is_prerelease != 'true' }}
       MIDSCENE_REQUIRE_MAC_NOTARIZATION: ${{ needs.release.outputs.is_prerelease != 'true' }}
+      NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH: ${{ matrix.platform == 'win32' && '40' || '120' }}
       NO_COLOR: '1'
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    # npm Trusted Publishing currently requires a GitHub-hosted runner.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [24.13.0]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: '22.11.0'
+        node-version: '24.13.0'
 
     - name: Cache pnpm store
       id: pnpm-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,8 +296,12 @@ jobs:
         security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
         security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
 
+        CODESIGN_TEST_PATH="$RUNNER_TEMP/midscene-codesign-test"
+        cp /usr/bin/true "$CODESIGN_TEST_PATH"
+        codesign --force --sign "$APPLE_CODESIGN_IDENTITY" --options runtime --timestamp "$CODESIGN_TEST_PATH"
+        codesign --verify --strict "$CODESIGN_TEST_PATH"
+
         echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
-        echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
         if [ -n "${APPLE_TEAM_ID:-}" ]; then
           echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,12 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Cache Puppeteer
-      uses: ./.github/actions/cache
+      id: cache-puppeteer
+      uses: ./.github/actions/cache/restore
       with:
         path: ~/.cache/puppeteer
         key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
@@ -78,8 +80,19 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
+
     - name: Install Puppeteer browser
       run: cd packages/web-integration && npx puppeteer browsers install chrome
+
+    - name: Save Puppeteer cache
+      if: steps.cache-puppeteer.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/puppeteer
+        key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install @midscene/computer native build deps (linux/x64)
       # The prepublishOnly hook of @midscene/computer compiles
@@ -237,7 +250,8 @@ jobs:
         node-version: '22.11.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Prepare macOS codesigning keychain
       if: ${{ matrix.platform == 'darwin' }}
@@ -293,6 +307,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Install @midscene/computer native build deps (macOS)
       if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,19 +268,33 @@ jobs:
         : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS release packaging}"
 
         CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
+        DEVELOPER_ID_CA_PATH="$RUNNER_TEMP/DeveloperIDCA.cer"
+        DEVELOPER_ID_G2_CA_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
         KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
         KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
         printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
 
+        curl --fail --silent --show-error --location \
+          https://www.apple.com/certificateauthority/DeveloperIDCA.cer \
+          --output "$DEVELOPER_ID_CA_PATH"
+        curl --fail --silent --show-error --location \
+          https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
+          --output "$DEVELOPER_ID_G2_CA_PATH"
+        echo "7afc9d01a62f03a2de9637936d4afe68090d2de18d03f29c88cfb0b1ba63587f  $DEVELOPER_ID_CA_PATH" | shasum -a 256 --check
+        echo "f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a  $DEVELOPER_ID_G2_CA_PATH" | shasum -a 256 --check
+
         security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security import "$DEVELOPER_ID_CA_PATH" -k "$KEYCHAIN_PATH"
+        security import "$DEVELOPER_ID_G2_CA_PATH" -k "$KEYCHAIN_PATH"
         security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
         CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
         security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
 
         echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
         echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
-    # npm Trusted Publishing currently requires a GitHub-hosted runner.
-    runs-on: ubuntu-22.04
+    # npm Trusted Publishing requires a GitHub-hosted runner, and the native
+    # Linux package build requires freerdp3-dev from Ubuntu 24.04.
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [24.13.0]

--- a/.github/workflows/studio-headless-linux.yml
+++ b/.github/workflows/studio-headless-linux.yml
@@ -49,6 +49,15 @@ jobs:
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache/restore
 
+    - name: Cache Electron binary
+      id: electron-cache
+      uses: ./.github/actions/cache/restore
+      with:
+        path: ~/.cache/electron
+        key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Install system dependencies
       run: |
         sudo apt-get update
@@ -79,22 +88,24 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+      env:
+        PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     - name: Save pnpm store
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/pnpm-cache/save
 
-    - name: Install Puppeteer browser binary
-      # `pnpm install` normally triggers puppeteer's `postinstall` to fetch
-      # the Chrome binary into `~/.cache/puppeteer`, but the added
-      # `optionalDependencies` (appdmg) shifts the install layout enough
-      # that the postinstall sometimes does not fire on the headless Linux
-      # runner. The Studio Web playground session needs that Chrome to
-      # launch its puppeteer page; without it `createSession` throws
-      # "Could not find Chrome" and the web preview e2e asserts on a
-      # permanently disconnected device. Install it explicitly so the test
-      # environment is deterministic.
-      run: pnpm --dir apps/studio exec puppeteer browsers install chrome
+    - name: Save Electron binary
+      if: steps.electron-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache/save
+      with:
+        path: ~/.cache/electron
+        key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Setup Puppeteer browser
+      uses: ./.github/actions/setup-puppeteer-browser
+      with:
+        package-directory: apps/studio
 
     - name: Build Studio
       run: npx nx run-many --target=build --projects=studio,@midscene/report

--- a/.github/workflows/studio-headless-linux.yml
+++ b/.github/workflows/studio-headless-linux.yml
@@ -44,7 +44,9 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.13.0'
-        cache: 'pnpm'
+
+    - name: Cache pnpm store
+      uses: ./.github/actions/pnpm-cache
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/studio-headless-linux.yml
+++ b/.github/workflows/studio-headless-linux.yml
@@ -46,7 +46,8 @@ jobs:
         node-version: '24.13.0'
 
     - name: Cache pnpm store
-      uses: ./.github/actions/pnpm-cache
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
 
     - name: Install system dependencies
       run: |
@@ -78,6 +79,10 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
 
     - name: Install Puppeteer browser binary
       # `pnpm install` normally triggers puppeteer's `postinstall` to fetch

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -54,7 +54,8 @@ jobs:
           node-version: '22.11.0'
 
       - name: Cache pnpm store
-        uses: ./.github/actions/pnpm-cache
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
       - name: Prepare macOS codesigning keychain
         if: ${{ matrix.platform == 'darwin' }}
@@ -110,6 +111,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
       - name: Install @midscene/computer native build deps (macOS)
         if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22.11.0'
+          node-version: '24.13.0'
 
       - name: Cache pnpm store
         id: pnpm-cache

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -110,7 +110,15 @@ jobs:
           fi
 
       - name: Install dependencies
+        id: install-dependencies
+        continue-on-error: ${{ matrix.platform == 'win32' }}
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Retry dependency installation on Windows
+        if: ${{ matrix.platform == 'win32' && steps.install-dependencies.outcome == 'failure' }}
+        run: |
+          Start-Sleep -Seconds 5
+          pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Save pnpm store
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
@@ -123,6 +131,45 @@ jobs:
       - name: Build @midscene/computer native helpers
         if: ${{ matrix.platform == 'darwin' }}
         run: pnpm --filter @midscene/computer run build:native
+
+      - name: Build appdmg native bindings
+        if: ${{ matrix.platform == 'darwin' }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          ensure_native_pkg() {
+            local pkg="$1"
+            local version="$2"
+            local consumer="$3"
+            PKG_DIRS=(
+              node_modules/.pnpm/${pkg}@*/node_modules/${pkg}
+              node_modules/.pnpm/${consumer}@*/node_modules/${pkg}
+            )
+            if [ "${#PKG_DIRS[@]}" -eq 0 ]; then
+              CONSUMER_STORE_ROOTS=(node_modules/.pnpm/${consumer}@*)
+              if [ "${#CONSUMER_STORE_ROOTS[@]}" -eq 0 ]; then
+                echo "${consumer} store directory not found under node_modules/.pnpm" >&2
+                exit 1
+              fi
+              CONSUMER_STORE_ROOT="${CONSUMER_STORE_ROOTS[0]}"
+              echo "Installing ${pkg}@${version} under ${CONSUMER_STORE_ROOT}"
+              npm install --prefix "${CONSUMER_STORE_ROOT}" --no-save --no-package-lock --ignore-scripts "${pkg}@${version}"
+              PKG_DIRS=(
+                node_modules/.pnpm/${pkg}@*/node_modules/${pkg}
+                node_modules/.pnpm/${consumer}@*/node_modules/${pkg}
+              )
+              if [ "${#PKG_DIRS[@]}" -eq 0 ]; then
+                echo "${pkg} package directory not found under node_modules/.pnpm" >&2
+                exit 1
+              fi
+            fi
+            echo "Rebuilding ${pkg} in ${PKG_DIRS[0]}"
+            (cd "${PKG_DIRS[0]}" && npm rebuild)
+          }
+
+          ensure_native_pkg macos-alias 0.2.12 ds-store
+          ensure_native_pkg fs-xattr 0.3.1 appdmg
 
       - name: Build Studio and Nx dependencies
         run: npx nx build studio

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -23,7 +23,7 @@ jobs:
           - runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
             platform: win32
             arch: x64
-          - runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
+          - runner: '"macos-15"'
             platform: darwin
             arch: arm64
           - runner: '"macos-15-intel"'
@@ -70,40 +70,22 @@ jobs:
           : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS validation packaging}"
 
           CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
-          DEVELOPER_ID_CA_PATH="$RUNNER_TEMP/DeveloperIDCA.cer"
-          DEVELOPER_ID_G2_CA_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
           KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
           printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
 
-          curl --fail --silent --show-error --location \
-            https://www.apple.com/certificateauthority/DeveloperIDCA.cer \
-            --output "$DEVELOPER_ID_CA_PATH"
-          curl --fail --silent --show-error --location \
-            https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
-            --output "$DEVELOPER_ID_G2_CA_PATH"
-          echo "7afc9d01a62f03a2de9637936d4afe68090d2de18d03f29c88cfb0b1ba63587f  $DEVELOPER_ID_CA_PATH" | shasum -a 256 --check
-          echo "f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a  $DEVELOPER_ID_G2_CA_PATH" | shasum -a 256 --check
-
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$DEVELOPER_ID_CA_PATH" -k "$KEYCHAIN_PATH"
-          security import "$DEVELOPER_ID_G2_CA_PATH" -k "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
           security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
-
-          CODESIGN_TEST_PATH="$RUNNER_TEMP/midscene-codesign-test"
-          cp /usr/bin/true "$CODESIGN_TEST_PATH"
-          codesign --force --sign "$APPLE_CODESIGN_IDENTITY" --options runtime --timestamp "$CODESIGN_TEST_PATH"
-          codesign --verify --strict "$CODESIGN_TEST_PATH"
 
           echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
+          echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           if [ -n "${APPLE_TEAM_ID:-}" ]; then
             echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -98,8 +98,12 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
           security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
 
+          CODESIGN_TEST_PATH="$RUNNER_TEMP/midscene-codesign-test"
+          cp /usr/bin/true "$CODESIGN_TEST_PATH"
+          codesign --force --sign "$APPLE_CODESIGN_IDENTITY" --options runtime --timestamp "$CODESIGN_TEST_PATH"
+          codesign --verify --strict "$CODESIGN_TEST_PATH"
+
           echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
-          echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           if [ -n "${APPLE_TEAM_ID:-}" ]; then
             echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -52,7 +52,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.11.0'
-          cache: 'pnpm'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/pnpm-cache
 
       - name: Prepare macOS codesigning keychain
         if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -122,7 +122,7 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Save pnpm store
-        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        if: ${{ matrix.platform != 'win32' && steps.pnpm-cache.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/pnpm-cache/save
 
       - name: Install @midscene/computer native build deps (macOS)

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -36,6 +36,7 @@ jobs:
       FORCE_COLOR: '0'
       MIDSCENE_REQUIRE_MAC_CODESIGN: ${{ matrix.platform == 'darwin' }}
       MIDSCENE_REQUIRE_MAC_NOTARIZATION: ${{ matrix.platform == 'darwin' }}
+      NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH: ${{ matrix.platform == 'win32' && '40' || '120' }}
       NO_COLOR: '1'
       STUDIO_PACKAGE_VALIDATION_VERSION: v0.0.${{ github.run_number }}
     steps:

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -118,6 +118,7 @@ jobs:
         if: ${{ matrix.platform == 'win32' && steps.install-dependencies.outcome == 'failure' }}
         run: |
           Start-Sleep -Seconds 5
+          git clean -ffdx
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Save pnpm store

--- a/.github/workflows/studio-package-validation.yml
+++ b/.github/workflows/studio-package-validation.yml
@@ -70,19 +70,33 @@ jobs:
           : "${APPLE_CODESIGN_IDENTITY:?APPLE_CODESIGN_IDENTITY is required for macOS validation packaging}"
 
           CERT_PATH="$RUNNER_TEMP/midscene-codesign.p12"
+          DEVELOPER_ID_CA_PATH="$RUNNER_TEMP/DeveloperIDCA.cer"
+          DEVELOPER_ID_G2_CA_PATH="$RUNNER_TEMP/DeveloperIDG2CA.cer"
           KEYCHAIN_PATH="$RUNNER_TEMP/midscene-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
           printf '%s' "$APPLE_CERT_P12_BASE64" | base64 -D > "$CERT_PATH"
 
+          curl --fail --silent --show-error --location \
+            https://www.apple.com/certificateauthority/DeveloperIDCA.cer \
+            --output "$DEVELOPER_ID_CA_PATH"
+          curl --fail --silent --show-error --location \
+            https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer \
+            --output "$DEVELOPER_ID_G2_CA_PATH"
+          echo "7afc9d01a62f03a2de9637936d4afe68090d2de18d03f29c88cfb0b1ba63587f  $DEVELOPER_ID_CA_PATH" | shasum -a 256 --check
+          echo "f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a  $DEVELOPER_ID_G2_CA_PATH" | shasum -a 256 --check
+
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$DEVELOPER_ID_CA_PATH" -k "$KEYCHAIN_PATH"
+          security import "$DEVELOPER_ID_G2_CA_PATH" -k "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           CURRENT_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
           security list-keychains -d user -s "$KEYCHAIN_PATH" $CURRENT_KEYCHAINS
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq "$APPLE_CODESIGN_IDENTITY"
 
           echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
           echo "APPLE_CODESIGN_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -30,9 +30,6 @@ concurrency:
 
 jobs:
   windows-desktop:
-    concurrency:
-      group: ai-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
-      cancel-in-progress: false
     # The self-hosted Windows runner runs as a non-interactive service.
     runs-on: windows-2022
     timeout-minutes: 50

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -30,6 +30,9 @@ concurrency:
 
 jobs:
   windows-desktop:
+    concurrency:
+      group: ai-desktop-${{ github.event.pull_request.number || inputs.branch || github.ref }}
+      cancel-in-progress: false
     # The self-hosted Windows runner runs as a non-interactive service.
     runs-on: windows-2022
     timeout-minutes: 50

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -169,7 +169,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.13.0'
-          cache: 'pnpm'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/pnpm-cache
 
       - name: Install dependencies
         shell: pwsh

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -171,11 +171,16 @@ jobs:
           node-version: '24.13.0'
 
       - name: Cache pnpm store
-        uses: ./.github/actions/pnpm-cache
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
       - name: Install dependencies
         shell: pwsh
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
       - name: Build report and computer packages
         id: build

--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -5,21 +5,21 @@ tasks:
   - name: view screenshots tab
     flow:
       - sleep: 2000
-      - ai: Click on the first task row in the left sidebar that has type "Planning" or "Insight" or "Locate"
+      - aiTap: the first task row in the left sidebar that has type "Planning" or "Insight" or "Locate"
       - sleep: 2000
-      - ai: In the center task detail Replay/Screenshots/JSON View switcher, select "Screenshots" (not Replay or JSON View) and wait until screenshot thumbnails are displayed
+      - aiTap: the "Screenshots" option in the center task detail Replay/Screenshots/JSON View switcher
       - sleep: 1500
       - aiAssert: In the center task detail panel, the selected tab among Replay, Screenshots, and JSON View is Screenshots. The content below the tabs shows UI screenshot images for the selected task.
 
   - name: view JSON data tab
     flow:
-      - ai: In the center task detail area, click the "JSON View" option in the Replay/Screenshots/JSON View switcher and wait until the content changes to the text data view
+      - aiTap: the "JSON View" option in the center task detail Replay/Screenshots/JSON View switcher
       - sleep: 1000
       - aiAssert: In the center task detail panel, the selected tab among Replay, Screenshots, and JSON View is JSON View. The content below the tabs shows structured task details as JSON text instead of UI screenshot images.
 
   - name: inspect detail side sections
     flow:
-      - ai: Click on the first Planning task row in the left sidebar
+      - aiTap: the first Planning task row in the left sidebar
       - sleep: 1000
       - aiAssert: The right detail side panel shows collapsible section headers named Param and Output, and the Param section is expanded with task input data
       # Collapse both Param and the Output/Element section so the Meta section
@@ -35,6 +35,6 @@ tasks:
 
   - name: open in playground button
     flow:
-      - ai: Click on a task row in the sidebar that shows "Planning" type
+      - aiTap: a task row in the sidebar that shows "Planning" type
       - sleep: 2000
       - aiAssert: There is a "Open in Playground" button visible on the page

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -27,16 +27,3 @@ tasks:
           deepLocate: true
       - sleep: 1000
       - aiAssert: The player settings popup is open above the bottom-right control bar, showing options such as "Focus on cursor", "Subtitle", "Playback speed", and speed choices like "0.5x", "1x", "1.5x", or "2x".
-
-  # --- Dark mode ---
-  - name: toggle dark mode
-    flow:
-      - aiTap: theme toggle button in the top right header
-      - sleep: 2000
-      - aiAssert: The report UI is in dark theme; the top header, left sidebar, and page chrome are dark charcoal or black rather than white
-
-  - name: toggle back to light mode
-    flow:
-      - aiTap: theme toggle button in the top right header
-      - sleep: 2000
-      - aiAssert: The report UI is in light theme; the top header, left sidebar, and page chrome are light or white rather than dark charcoal or black

--- a/apps/report/e2e/timeline-interaction.yaml
+++ b/apps/report/e2e/timeline-interaction.yaml
@@ -9,6 +9,6 @@ tasks:
 
   - name: click timeline screenshot to navigate
     flow:
-      - ai: Click on a screenshot thumbnail in the timeline area
+      - aiTap: a screenshot thumbnail in the timeline area
       - sleep: 2000
       - aiAssert: The sidebar highlights a task row and the detail panel shows information for the selected task

--- a/apps/report/package.json
+++ b/apps/report/package.json
@@ -11,7 +11,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "generate-demo": "node scripts/generate-demo-report.mjs",
-    "e2e": "pnpm --dir ../.. exec nx build @midscene/report --verbose && node scripts/inject-report-template.mjs && node scripts/generate-demo-report.mjs && node ../../packages/cli/bin/midscene ./e2e/"
+    "e2e": "pnpm --dir ../.. exec nx run-many --target=build --projects=\"@midscene/report,@midscene/cli\" --verbose && node scripts/inject-report-template.mjs && node scripts/generate-demo-report.mjs && node ../../packages/cli/bin/midscene ./e2e/ --concurrent 2"
   },
   "dependencies": {
     "@ant-design/icons": "^5.3.1",

--- a/packages/computer/tests/ai/chrome-extension-bridge.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-bridge.test.ts
@@ -207,7 +207,7 @@ describe('chrome extension bridge mode start/stop (#2119)', () => {
         );
       }
     },
-    { timeout: 12 * 60 * 1000, retry: 0 },
+    { timeout: 20 * 60 * 1000, retry: 0 },
   );
 
   // ── Test: bridge connects to a real server ────────────────────────────

--- a/packages/computer/tests/ai/chrome-extension-helpers.ts
+++ b/packages/computer/tests/ai/chrome-extension-helpers.ts
@@ -45,6 +45,16 @@ const EXTENSION_ENV_KEYS = [
 // ─── Browser Helpers ────────────────────────────────────────────────────────
 
 function findExtensionCapableBrowser(): string {
+  const configuredBrowser = process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (configuredBrowser) {
+    if (!fs.existsSync(configuredBrowser)) {
+      throw new Error(
+        `PUPPETEER_EXECUTABLE_PATH does not exist: ${configuredBrowser}`,
+      );
+    }
+    return configuredBrowser;
+  }
+
   // Check puppeteer cache first (Chrome for Testing supports --load-extension)
   const puppeteerBase = path.join(
     process.env.HOME ?? '~',

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -74,6 +74,23 @@ describe('chrome extension playground advanced tests', () => {
     }
   });
 
+  it('action type switching changes the composer placeholder', async () => {
+    await agent.aiAct(`Click the "Query" button in ${SIDE_PANEL}`);
+    await sleep(500);
+    await agent.aiAssert(
+      `${SIDE_PANEL} shows an input area with placeholder text containing "query"`,
+    );
+
+    await agent.aiAct(`Click the "Assert" button in ${SIDE_PANEL}`);
+    await sleep(500);
+    await agent.aiAssert(
+      `${SIDE_PANEL} shows an input area with placeholder text containing "assert"`,
+    );
+
+    await agent.aiAct(`Click the "Action" button in ${SIDE_PANEL}`);
+    await sleep(500);
+  });
+
   it('aiQuery: extract page title and verify result', async () => {
     await agent.aiAct(`Click the "aiQuery" button in ${SIDE_PANEL}`);
     await sleep(500);

--- a/packages/computer/tests/ai/chrome-extension.test.ts
+++ b/packages/computer/tests/ai/chrome-extension.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Basic extension launch smoke test. Playground, Bridge, Recorder, and
+ * Settings behavior lives in their dedicated parallel suites.
+ */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
 import { beforeAll, describe, it, vi } from 'vitest';
@@ -11,9 +15,6 @@ import {
 } from './chrome-extension-helpers';
 
 vi.setConfig({ testTimeout: 360 * 1000 });
-
-const SIDE_PANEL =
-  'the Midscene side panel on the right side of the browser window';
 
 describe('chrome extension smoke test', () => {
   let agent: ComputerAgent;
@@ -36,8 +37,6 @@ describe('chrome extension smoke test', () => {
     console.log('Extension ID:', extId);
   });
 
-  // ── 1. Side Panel Launch ──────────────────────────────────────────────
-
   it('open side panel via extension icon', async () => {
     await agent.aiAct(
       'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
@@ -58,132 +57,5 @@ describe('chrome extension smoke test', () => {
       await reloadViaWebSocket(target.webSocketDebuggerUrl);
       await sleep(3000);
     }
-  });
-
-  // ── 2. Playground UI Elements ───────────────────────────────────────
-
-  it('playground: UI elements are rendered correctly', async () => {
-    await agent.aiAssert(
-      `${SIDE_PANEL} shows: (1) action type buttons like "Tap" and "Query", (2) a text input area with a "Run" button, (3) a gear/settings icon`,
-    );
-  });
-
-  // ── 3. Action Type Switching ──────────────────────────────────────────
-
-  it('playground: action type switching changes placeholder', async () => {
-    await agent.aiAct(`Click the "Query" button in ${SIDE_PANEL}`);
-    await sleep(500);
-    await agent.aiAssert(
-      `${SIDE_PANEL} shows an input area with placeholder text containing "query"`,
-    );
-
-    await agent.aiAct(`Click the "Assert" button in ${SIDE_PANEL}`);
-    await sleep(500);
-    await agent.aiAssert(
-      `${SIDE_PANEL} shows an input area with placeholder text containing "assert"`,
-    );
-
-    // Switch back to Tap mode for the next test.
-    await agent.aiAct(`Click the "Tap" button in ${SIDE_PANEL}`);
-    await sleep(500);
-  });
-
-  // ── 4. Run aiAct Task ─────────────────────────────────────────────────
-
-  it('playground: run aiAct to add a todo item', async () => {
-    await agent.aiAct(`Click the "Action" button in ${SIDE_PANEL}`);
-    await sleep(500);
-
-    await agent.aiAct(
-      `In ${SIDE_PANEL}, click the text input area and type: Enter "Learn JS today" in the task box, then press Enter`,
-    );
-    await sleep(500);
-
-    await agent.aiAct(`Click the "Run" button in ${SIDE_PANEL}`);
-    await sleep(20000);
-
-    await agent.aiAssert(
-      'The TodoMVC page on the left shows a todo item containing "Learn JS today" OR the side panel shows execution progress/result',
-    );
-  });
-
-  // ── 5. Mode Switching ──────────────────────────────────────────────────
-
-  it(
-    'mode switching: switch to Bridge and back',
-    { timeout: 12 * 60 * 1000, retry: 0 },
-    async () => {
-      // Switch to Bridge Mode with retry - the dropdown menu can be flaky in headless
-      const switchToBridge = async () => {
-        await agent.aiAct(
-          `In ${SIDE_PANEL}, find and click the hamburger menu icon (three horizontal lines "≡") at the top-left corner. It should open a dropdown menu.`,
-        );
-        await sleep(2000);
-        await agent.aiAct(
-          'In the dropdown menu that just appeared, click the menu item labeled "Bridge Mode" which has an API icon next to it',
-        );
-        await sleep(3000);
-      };
-
-      // First attempt
-      await switchToBridge();
-
-      // Verify or retry once if needed
-      try {
-        await agent.aiAssert(
-          `${SIDE_PANEL} shows Bridge mode UI with text containing "Listening" or "Disconnected" or "Bridge" connection status`,
-        );
-      } catch {
-        // Retry: the dropdown click may not have registered
-        console.log('Bridge mode switch failed, retrying...');
-        await switchToBridge();
-        await agent.aiAssert(
-          `${SIDE_PANEL} shows Bridge mode UI with text containing "Listening" or "Disconnected" or "Bridge" connection status`,
-        );
-      }
-
-      // Switch back to Playground
-      await agent.aiAct(
-        `In ${SIDE_PANEL}, find and click the hamburger menu icon (three horizontal lines "≡") at the top-left corner`,
-      );
-      await sleep(2000);
-      await agent.aiAct(
-        'In the dropdown menu that just appeared, click the menu item labeled "Playground"',
-      );
-      await sleep(3000);
-    },
-  );
-
-  // ── 6. Settings Modal ─────────────────────────────────────────────────
-
-  it('settings: open and close env config modal', async () => {
-    const openEnvConfigModal = async () => {
-      await agent.aiAct(
-        `Click the settings icon in the top-right header area of ${SIDE_PANEL}, next to the GitHub and help icons. Do not click the run configuration icon inside the prompt composer.`,
-      );
-      await sleep(1500);
-    };
-
-    await openEnvConfigModal();
-
-    try {
-      await agent.aiAssert(
-        'A modal titled "Model Env Config" is visible, and it contains a large text area for environment variable configuration.',
-      );
-    } catch {
-      await openEnvConfigModal();
-      await agent.aiAssert(
-        'A modal titled "Model Env Config" is visible, and it contains a large text area for environment variable configuration.',
-      );
-    }
-
-    await agent.aiAct(
-      'Click the X close button in the top-right corner of the "Model Env Config" modal.',
-    );
-    await sleep(1500);
-
-    await agent.aiAssert(
-      `The "Model Env Config" modal is closed, and ${SIDE_PANEL} is visible showing Playground UI without any modal overlay.`,
-    );
   });
 });

--- a/packages/web-integration/tests/ai/web/playwright-reporter-test/todo-report.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright-reporter-test/todo-report.spec.ts
@@ -18,9 +18,14 @@ test('ai report', async ({ page, aiAssert, aiQuery }, testInfo) => {
   const options = page.locator('.selector-content .option-item');
   await expect(options.first()).toBeVisible();
 
-  const aiTodoOption = options.filter({ hasText: /ai todo/i });
-  if ((await aiTodoOption.count()) > 0) {
-    await aiTodoOption.first().click();
+  const aiTodoOptions = options.filter({ hasText: /ai todo/i });
+  const successfulAiTodoOptions = aiTodoOptions.filter({
+    has: page.locator('[aria-label="check"]'),
+  });
+  if ((await successfulAiTodoOptions.count()) > 0) {
+    await successfulAiTodoOptions.last().click();
+  } else if ((await aiTodoOptions.count()) > 0) {
+    await aiTodoOptions.last().click();
   } else {
     await options.first().click();
   }


### PR DESCRIPTION
## Summary

- route eligible Linux, macOS, and Windows jobs through repository runner variables, while retaining GitHub-hosted runners where KVM or interactive desktop constraints require them
- route cache operations to GitHub storage on hosted runners and the internal TOS cache service on self-hosted runners, following the `web-infra-dev/rspack` pattern
- cache the Node toolcache, pnpm store, Playwright dependencies, Puppeteer Chrome for Testing, and Electron artifacts
- replace repeated full browser/system setup with reusable setup actions and install only missing runtime dependencies
- install and verify a Chinese browser font in the shared headless setup action
- use focused Nx builds, shallow checkouts where history is unnecessary, docs-only path filters, and cheaper trigger conditions
- remove duplicated report and extension AI scenarios while preserving dedicated AI coverage
- keep all current-commit AI and platform jobs independent for maximum concurrency; workflow-level cancellation only removes superseded PR runs
- make report validation select a successful Playwright retry instead of a failed first attempt when the suite ultimately passed

## Latest complete comparison

This compares complete runs triggered on the same day: main at `9048e9261` and this PR at `a80aa1d8c`. Both covered 10 workflows and 16 jobs, and both passed without a workflow rerun. Actual time is measured from `started_at` to `completed_at`; runner queue time is listed separately.

| Job | Runner | main actual / queue | PR actual / queue | Actual delta |
| --- | --- | ---: | ---: | ---: |
| AI unit | Linux large | 13:21 / 0:11 | 15:03 / 0:17 | +1:42 (+13%) |
| Lint | Linux mini | 1:37 / 0:12 | 0:44 / 0:12 | -0:53 (-55%) |
| AI e2e-web | Linux large | 14:10 / 0:13 | 15:20 / 0:17 | +1:10 (+8%) |
| AI e2e-report | Linux large | 22:00 / 5:45 | 11:11 / 0:16 | -10:49 (-49%) |
| CI | GitHub Ubuntu | 6:32 / 0:10 | 6:00 / 0:03 | -0:32 (-8%) |
| Headless AI Todo | Linux large | 12:53 / 0:13 | 14:03 / 0:15 | +1:10 (+9%) |
| Chrome Extension | Linux large | 27:43 / 0:12 | 3:20 / 0:16 | N/A (test redistribution) |
| Extension Bridge | Linux large | 15:37 / 0:13 | 10:23 / 0:14 | -5:14 (-34%) |
| Extension Playground | Linux large | 16:19 / 0:13 | 25:36 / 0:15 | N/A (test redistribution) |
| Extension Recorder | Linux large | 11:22 / 0:13 | 11:01 / 0:16 | -0:21 (-3%) |
| Extension Settings | Linux large | 18:36 / 0:22 | 15:31 / 0:16 | -3:05 (-17%) |
| Android | GitHub Ubuntu | 10:41 / 0:10 | 11:12 / 0:03 | +0:31 (+5%) |
| iOS | macOS medium | 7:49 / 7:17 | 7:03 / 9:12 | -0:46 (-10%) |
| Studio | GitHub Ubuntu | 4:31 / 0:04 | 4:50 / 0:03 | +0:19 (+7%) |
| Windows Desktop | GitHub Windows | 8:47 / 0:05 | 8:07 / 0:05 | -0:40 (-8%) |
| macOS Desktop | GitHub macOS | 17:45 / 0:06 | 10:17 / 0:17 | -7:28 (-42%) |

Chrome Extension and Extension Playground are not individually comparable because the existing action type switching scenario moved from the former suite to the dedicated Playground suite. Treating them as a parallel group, the critical actual path improved from 27:43 to 25:36 (-2:07, -8%); including queue time, it improved from 27:55 to 25:51 (-7%). The three common Playground tests improved from 11:36 to 11:04 (-5%). All six Headless pre-test phases became faster: Playground improved from 4:19 to 1:27, with savings across the six jobs ranging from 0:47 to 5:01. Of the remaining 14 directly comparable jobs, 9 ran faster and 5 ran slower. iOS actual time improved, but its queue increased from 7:17 to 9:12 because of self-hosted macOS runner capacity.

## Historical self-hosted migration comparison

This preserves the original migration baseline instead of replacing it with the latest main comparison. End-to-end time is actual plus runner queue.

| Job | GitHub runner actual / queue | Initial self-hosted actual / queue | Latest PR actual / queue | Latest vs GitHub end-to-end |
| --- | ---: | ---: | ---: | ---: |
| AI unit | 18:26 / 4:46 | 15:46 / 0:13 | 15:03 / 0:17 | -34% |
| AI e2e-web | 26:46 / 42:04 | 25:21 / 0:13 | 15:20 / 0:17 | -77% |
| AI e2e-report | 24:54 / 45:33 | 26:54 / 0:13 | 11:11 / 0:16 | -84% |
| iOS | 16:59 / 44:22 | 8:08 / 0:32 | 7:03 / 9:12 | -74% |
| Lint | 0:40 / 1:30:56 | 1:26 / 0:11 | 0:44 / 0:12 | -99% |

The latest iOS test execution remains faster than both historical samples. Its current end-to-end regression relative to the initial self-hosted sample is queue-only and indicates macOS runner capacity pressure.

## Validation

- `pnpm run lint`
- YAML parsing for all changed workflows and report scenarios
- `pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/core,@midscene/web,@midscene/cli" --skip-nx-cache`
- `pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache`
- `pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache`
- `pnpm exec nx test @midscene/report` (15 files, 82 tests)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir packages/computer exec vitest run tests/unit-test` (13 files, 88 tests)
- `pnpm --dir packages/core exec vitest run tests/unit-test/yaml-player-output.test.ts`
- validated report retry selection against the failed run's real merged HTML artifact
- `git diff --check`
- final full PR run on `a80aa1d8c`: 16/16 jobs passed without a workflow rerun
- final complete main run on `9048e9261`: 16/16 jobs passed without a workflow rerun
- [AI Playwright run 30808101776](https://github.com/web-infra-dev/midscene/actions/runs/30808101776): shared headless setup verified a Chinese font, both e2e jobs passed, and the downloaded `narrow-input-prompt` report rendered Chinese text correctly
- [PR checks](https://github.com/web-infra-dev/midscene/pull/2913/checks)
## Release and Studio packaging validation

- [Prepatch run 30870345357](https://github.com/web-infra-dev/midscene/actions/runs/30870345357): the Release job passed on GitHub-hosted `ubuntu-24.04` and published `@midscene/core@1.10.9-beta-20260804015945.0`; the original macOS ARM package job failed because the self-hosted runner could not build the Apple signing certificate chain (`errSecInternalComponent`).
- Signed macOS ARM release packaging now runs on GitHub-hosted `macos-15`; frequent macOS test jobs remain on the self-hosted macOS pool.
- Studio packaging now uses Node `24.13.0`, matching the repository CI baseline. Windows packaging uses shorter pnpm virtual-store paths and skips the slow explicit TOS cache write.
- [Final Studio Package Validation run 30874339417](https://github.com/web-infra-dev/midscene/actions/runs/30874339417) passed on all four targets: macOS ARM 8:08, Linux x64 8:53, Windows x64 6:14, and macOS Intel 15:48.
- Final full PR validation on `698681f6d`: 16 checks passed, 1 conditionally skipped, and 0 failed.