### PR TITLE
fix(web-integration): avoid enametoolong in playwright report filenames

### DIFF
--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -39,6 +39,7 @@ import {
 import { getReportTpl } from './utils';
 
 const warnReport = getDebug('report-generator', { console: true });
+const maxReportFilenameBytes = 255;
 
 export interface IReportGenerator {
   /**
@@ -160,7 +161,7 @@ export class ReportGenerator implements IReportGenerator {
     },
   ): IReportGenerator {
     assertReportGenerationOptions(opts);
-    validateReportFileName(reportFileName);
+    validateReportFileName(reportFileName, opts.outputFormat);
     if (opts.generateReport === false) return nullReportGenerator;
 
     // In browser environment, file system is not available
@@ -477,7 +478,10 @@ function ensureHtmlFileName(reportFileName: string): string {
     : `${reportFileName}.html`;
 }
 
-function validateReportFileName(reportFileName: string): void {
+function validateReportFileName(
+  reportFileName: string,
+  outputFormat?: 'single-html' | 'html-and-external-assets',
+): void {
   if (!reportFileName?.trim()) {
     throw new Error('reportFileName must be a non-empty string');
   }
@@ -491,6 +495,17 @@ function validateReportFileName(reportFileName: string): void {
   if (/[:*?"<>|]/.test(reportFileName)) {
     throw new Error(
       'reportFileName contains illegal filename characters: : * ? " < > |',
+    );
+  }
+
+  const filenameComponent =
+    outputFormat === 'html-and-external-assets'
+      ? reportFileName
+      : ensureHtmlFileName(reportFileName);
+  const filenameBytes = new TextEncoder().encode(filenameComponent).byteLength;
+  if (filenameBytes > maxReportFilenameBytes) {
+    throw new Error(
+      `reportFileName produces a filename component of ${filenameBytes} UTF-8 bytes; maximum is ${maxReportFilenameBytes}`,
     );
   }
 }

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -1232,6 +1232,34 @@ describe('ReportGenerator — append-only model', () => {
         'reportFileName contains illegal filename characters',
       );
     });
+
+    it('should validate single-html report names by their final UTF-8 byte length', () => {
+      expect(() =>
+        ReportGenerator.create('中'.repeat(83), { generateReport: false }),
+      ).not.toThrow();
+      expect(() =>
+        ReportGenerator.create('中'.repeat(84), { generateReport: false }),
+      ).toThrow(
+        'reportFileName produces a filename component of 257 UTF-8 bytes; maximum is 255',
+      );
+    });
+
+    it('should validate directory report names without reserving an HTML extension', () => {
+      expect(() =>
+        ReportGenerator.create('中'.repeat(85), {
+          generateReport: false,
+          outputFormat: 'html-and-external-assets',
+        }),
+      ).not.toThrow();
+      expect(() =>
+        ReportGenerator.create('中'.repeat(86), {
+          generateReport: false,
+          outputFormat: 'html-and-external-assets',
+        }),
+      ).toThrow(
+        'reportFileName produces a filename component of 258 UTF-8 bytes; maximum is 255',
+      );
+    });
   });
 
   describe('lazy loading — memory release behavior', () => {

--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { resolveBrowserAgentRuntimeOptions } from '@/common/browser-agent';
 import {
   PlaywrightAgent,
@@ -20,6 +21,34 @@ import type { Page as OriginPlaywrightPage } from 'playwright';
 export type APITestType = Pick<TestType<any, any>, 'step'>;
 
 const debugPage = getDebug('web:playwright:ai-fixture');
+
+const MAX_PLAYWRIGHT_REPORT_SLUG_BYTES = 120;
+
+function getCompactHash(value: string) {
+  return createHash('sha1').update(value).digest('hex').slice(0, 10);
+}
+
+function truncateUtf8ByBytes(value: string, maxBytes: number) {
+  let truncated = '';
+  for (const char of value) {
+    const nextValue = truncated + char;
+    if (Buffer.byteLength(nextValue, 'utf8') > maxBytes) {
+      break;
+    }
+    truncated = nextValue;
+  }
+  return truncated;
+}
+
+function buildPlaywrightReportTag(title: string, pageId: string) {
+  const readableTitle = title.replace(/[\\/]/g, '-');
+  const slug = truncateUtf8ByBytes(
+    readableTitle,
+    MAX_PLAYWRIGHT_REPORT_SLUG_BYTES,
+  );
+  const titleHash = getCompactHash(title);
+  return `playwright-${slug}-${titleHash}-${pageId}`;
+}
 
 const groupAndCaseForTest = (testInfo: TestInfo) => {
   let taskFile: string;
@@ -148,7 +177,7 @@ export const PlaywrightAiFixture = (options?: PlaywrightAiFixtureOptions) => {
       // so groupName/groupDescription can still carry hierarchy. But
       // ReportGenerator rejects path separators in the file name, so strip
       // them here for the report tag only.
-      const reportTag = `playwright-${title.replace(/[\\/]/g, '-')}-${idForPage}`;
+      const reportTag = buildPlaywrightReportTag(title, idForPage);
 
       if (autoFollowNewPage && forceSameTabNavigation === true) {
         throw new Error(

--- a/packages/web-integration/src/playwright/ai-fixture.ts
+++ b/packages/web-integration/src/playwright/ai-fixture.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { resolveBrowserAgentRuntimeOptions } from '@/common/browser-agent';
 import {
   PlaywrightAgent,
@@ -14,41 +13,13 @@ import {
   DEFAULT_WAIT_FOR_NETWORK_IDLE_TIMEOUT,
 } from '@midscene/shared/constants';
 import { getDebug } from '@midscene/shared/logger';
-import { uuid } from '@midscene/shared/utils';
-import { replaceIllegalPathCharsAndSpace } from '@midscene/shared/utils';
+import { replaceIllegalPathCharsAndSpace, uuid } from '@midscene/shared/utils';
 import { type TestInfo, type TestType, test } from '@playwright/test';
 import type { Page as OriginPlaywrightPage } from 'playwright';
+import { buildPlaywrightReportTag } from './report-filename';
 export type APITestType = Pick<TestType<any, any>, 'step'>;
 
 const debugPage = getDebug('web:playwright:ai-fixture');
-
-const MAX_PLAYWRIGHT_REPORT_SLUG_BYTES = 120;
-
-function getCompactHash(value: string) {
-  return createHash('sha1').update(value).digest('hex').slice(0, 10);
-}
-
-function truncateUtf8ByBytes(value: string, maxBytes: number) {
-  let truncated = '';
-  for (const char of value) {
-    const nextValue = truncated + char;
-    if (Buffer.byteLength(nextValue, 'utf8') > maxBytes) {
-      break;
-    }
-    truncated = nextValue;
-  }
-  return truncated;
-}
-
-function buildPlaywrightReportTag(title: string, pageId: string) {
-  const readableTitle = title.replace(/[\\/]/g, '-');
-  const slug = truncateUtf8ByBytes(
-    readableTitle,
-    MAX_PLAYWRIGHT_REPORT_SLUG_BYTES,
-  );
-  const titleHash = getCompactHash(title);
-  return `playwright-${slug}-${titleHash}-${pageId}`;
-}
 
 const groupAndCaseForTest = (testInfo: TestInfo) => {
   let taskFile: string;
@@ -175,8 +146,8 @@ export const PlaywrightAiFixture = (options?: PlaywrightAiFixtureOptions) => {
       const cacheConfig = processTestCacheConfig(testInfo);
       // `replaceIllegalPathCharsAndSpace` intentionally preserves `/` and `\`
       // so groupName/groupDescription can still carry hierarchy. But
-      // ReportGenerator rejects path separators in the file name, so strip
-      // them here for the report tag only.
+      // ReportGenerator rejects path separators in the file name, so the
+      // report tag builder strips them without changing the group metadata.
       const reportTag = buildPlaywrightReportTag(title, idForPage);
 
       if (autoFollowNewPage && forceSameTabNavigation === true) {

--- a/packages/web-integration/src/playwright/report-filename.ts
+++ b/packages/web-integration/src/playwright/report-filename.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto';
+import { replaceIllegalPathCharsAndSpace } from '@midscene/shared/utils';
+
+// Keep enough room below the common 255-byte filesystem component limit for
+// suffixes added later, such as `.html` or getReportFileName's timestamp/id.
+export const MAX_PLAYWRIGHT_REPORT_TAG_BYTES = 200;
+
+const playwrightReportPrefix = 'playwright-';
+const compactHashLength = 10;
+
+function getCompactHash(value: string): string {
+  return createHash('sha256')
+    .update(value)
+    .digest('hex')
+    .slice(0, compactHashLength);
+}
+
+function truncateUtf8ByBytes(value: string, maxBytes: number): string {
+  let byteLength = 0;
+  let truncated = '';
+
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (byteLength + characterBytes > maxBytes) {
+      break;
+    }
+    truncated += character;
+    byteLength += characterBytes;
+  }
+
+  return truncated;
+}
+
+export function buildPlaywrightReportTag(
+  title: string,
+  uniqueSuffix?: string,
+): string {
+  const safeTitle = replaceIllegalPathCharsAndSpace(title).replace(
+    /[\\/]/g,
+    '-',
+  );
+  const titleHash = getCompactHash(title);
+  const trailingSegments = uniqueSuffix
+    ? `-${titleHash}-${uniqueSuffix}`
+    : `-${titleHash}`;
+  const fixedBytes = Buffer.byteLength(
+    `${playwrightReportPrefix}${trailingSegments}`,
+    'utf8',
+  );
+  const titleByteBudget = MAX_PLAYWRIGHT_REPORT_TAG_BYTES - fixedBytes;
+
+  if (titleByteBudget < 0) {
+    throw new Error(
+      `Playwright report suffix exceeds the ${MAX_PLAYWRIGHT_REPORT_TAG_BYTES}-byte tag limit`,
+    );
+  }
+
+  const readableTitle = truncateUtf8ByBytes(safeTitle, titleByteBudget);
+  return `${playwrightReportPrefix}${readableTitle}${trailingSegments}`;
+}

--- a/packages/web-integration/src/playwright/report-filename.ts
+++ b/packages/web-integration/src/playwright/report-filename.ts
@@ -34,12 +34,13 @@ function truncateUtf8ByBytes(value: string, maxBytes: number): string {
 export function buildPlaywrightReportTag(
   title: string,
   uniqueSuffix?: string,
+  hashSource = title,
 ): string {
   const safeTitle = replaceIllegalPathCharsAndSpace(title).replace(
     /[\\/]/g,
     '-',
   );
-  const titleHash = getCompactHash(title);
+  const titleHash = getCompactHash(hashSource);
   const trailingSegments = uniqueSuffix
     ? `-${titleHash}-${uniqueSuffix}`
     : `-${titleHash}`;

--- a/packages/web-integration/src/playwright/reporter/index.ts
+++ b/packages/web-integration/src/playwright/reporter/index.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { copyFileSync, cpSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import type { ReportFileWithAttributes, TestStatus } from '@midscene/core';
@@ -9,10 +8,7 @@ import {
   removeReportArtifact,
 } from '@midscene/core/report';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
-import {
-  logMsg,
-  replaceIllegalPathCharsAndSpace,
-} from '@midscene/shared/utils';
+import { logMsg } from '@midscene/shared/utils';
 import type {
   FullConfig,
   Reporter,
@@ -20,36 +16,11 @@ import type {
   TestCase,
   TestResult,
 } from '@playwright/test/reporter';
+import { buildPlaywrightReportTag } from '../report-filename';
 
 interface MidsceneReporterOptions {
   type?: 'merged' | 'separate';
   outputFormat?: 'single-html' | 'html-and-external-assets';
-}
-
-const MAX_SEPARATE_REPORT_TITLE_BYTES = 120;
-
-function getCompactHash(value: string) {
-  return createHash('sha1').update(value).digest('hex').slice(0, 10);
-}
-
-function truncateUtf8ByBytes(value: string, maxBytes: number) {
-  let truncated = '';
-  for (const char of value) {
-    const nextValue = truncated + char;
-    if (Buffer.byteLength(nextValue, 'utf8') > maxBytes) {
-      break;
-    }
-    truncated = nextValue;
-  }
-  return truncated;
-}
-
-function getSeparatedReportTag(testTitle: string) {
-  const safeTitle = truncateUtf8ByBytes(
-    replaceIllegalPathCharsAndSpace(testTitle).replace(/[\\/]/g, '-'),
-    MAX_SEPARATE_REPORT_TITLE_BYTES,
-  );
-  return `playwright-${safeTitle}-${getCompactHash(testTitle)}`;
 }
 
 class MidsceneReporter implements Reporter {
@@ -85,7 +56,7 @@ class MidsceneReporter implements Reporter {
 
   private getSeparatedFilename(testTitle: string): string {
     if (!this.testTitleToFilename.has(testTitle)) {
-      const baseTag = getSeparatedReportTag(testTitle);
+      const baseTag = buildPlaywrightReportTag(testTitle);
       const generatedFilename = getReportFileName(baseTag);
       this.testTitleToFilename.set(testTitle, generatedFilename);
     }

--- a/packages/web-integration/src/playwright/reporter/index.ts
+++ b/packages/web-integration/src/playwright/reporter/index.ts
@@ -25,7 +25,7 @@ interface MidsceneReporterOptions {
 
 class MidsceneReporter implements Reporter {
   private mergedFilename?: string;
-  private testTitleToFilename = new Map<string, string>();
+  private testIdToFilename = new Map<string, string>();
   private reportsByTestId = new Map<
     string,
     {
@@ -54,16 +54,16 @@ class MidsceneReporter implements Reporter {
     return reporterType;
   }
 
-  private getSeparatedFilename(testTitle: string): string {
-    if (!this.testTitleToFilename.has(testTitle)) {
-      const baseTag = buildPlaywrightReportTag(testTitle);
+  private getSeparatedFilename(testTitle: string, testId: string): string {
+    if (!this.testIdToFilename.has(testId)) {
+      const baseTag = buildPlaywrightReportTag(testTitle, undefined, testId);
       const generatedFilename = getReportFileName(baseTag);
-      this.testTitleToFilename.set(testTitle, generatedFilename);
+      this.testIdToFilename.set(testId, generatedFilename);
     }
-    return this.testTitleToFilename.get(testTitle)!;
+    return this.testIdToFilename.get(testId)!;
   }
 
-  private getReportFilename(testTitle?: string): string {
+  private getReportFilename(testTitle?: string, testId?: string): string {
     if (this.mode === 'merged') {
       if (!this.mergedFilename) {
         this.mergedFilename = getReportFileName('playwright-merged');
@@ -72,13 +72,14 @@ class MidsceneReporter implements Reporter {
     }
     if (this.mode === 'separate') {
       if (!testTitle) throw new Error('testTitle is required in separate mode');
-      return this.getSeparatedFilename(testTitle);
+      if (!testId) throw new Error('testId is required in separate mode');
+      return this.getSeparatedFilename(testTitle, testId);
     }
     throw new Error(`Unknown mode: ${this.mode}`);
   }
 
-  private getReportPath(testTitle?: string): string {
-    const fileName = this.getReportFilename(testTitle);
+  private getReportPath(testTitle?: string, testId?: string): string {
+    const fileName = this.getReportFilename(testTitle, testId);
     if (this.outputFormat === 'html-and-external-assets') {
       return join(getMidsceneRunSubDir('report'), fileName, 'index.html');
     }
@@ -222,12 +223,12 @@ class MidsceneReporter implements Reporter {
 
   private finalizeSeparateReports(): void {
     this.ensureOutputRoot();
-    for (const entry of this.reportsByTestId.values()) {
-      const targetName = this.getReportFilename(entry.testTitle);
+    for (const [testId, entry] of this.reportsByTestId) {
+      const targetName = this.getReportFilename(entry.testTitle, testId);
       if (entry.reports.length === 1) {
         const firstReport = entry.reports[0];
         if (firstReport.reportFilePath) {
-          const targetPath = this.getReportPath(entry.testTitle);
+          const targetPath = this.getReportPath(entry.testTitle, testId);
           this.finalizeSingleReport(firstReport.reportFilePath, targetPath);
           printReportMsg(targetPath);
           continue;

--- a/packages/web-integration/src/playwright/reporter/index.ts
+++ b/packages/web-integration/src/playwright/reporter/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { copyFileSync, cpSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import type { ReportFileWithAttributes, TestStatus } from '@midscene/core';
@@ -23,6 +24,32 @@ import type {
 interface MidsceneReporterOptions {
   type?: 'merged' | 'separate';
   outputFormat?: 'single-html' | 'html-and-external-assets';
+}
+
+const MAX_SEPARATE_REPORT_TITLE_BYTES = 120;
+
+function getCompactHash(value: string) {
+  return createHash('sha1').update(value).digest('hex').slice(0, 10);
+}
+
+function truncateUtf8ByBytes(value: string, maxBytes: number) {
+  let truncated = '';
+  for (const char of value) {
+    const nextValue = truncated + char;
+    if (Buffer.byteLength(nextValue, 'utf8') > maxBytes) {
+      break;
+    }
+    truncated = nextValue;
+  }
+  return truncated;
+}
+
+function getSeparatedReportTag(testTitle: string) {
+  const safeTitle = truncateUtf8ByBytes(
+    replaceIllegalPathCharsAndSpace(testTitle).replace(/[\\/]/g, '-'),
+    MAX_SEPARATE_REPORT_TITLE_BYTES,
+  );
+  return `playwright-${safeTitle}-${getCompactHash(testTitle)}`;
 }
 
 class MidsceneReporter implements Reporter {
@@ -58,7 +85,7 @@ class MidsceneReporter implements Reporter {
 
   private getSeparatedFilename(testTitle: string): string {
     if (!this.testTitleToFilename.has(testTitle)) {
-      const baseTag = `playwright-${replaceIllegalPathCharsAndSpace(testTitle)}`;
+      const baseTag = getSeparatedReportTag(testTitle);
       const generatedFilename = getReportFileName(baseTag);
       this.testTitleToFilename.set(testTitle, generatedFilename);
     }

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
@@ -46,6 +46,7 @@ vi.mock('@/playwright/index', () => {
 });
 
 import { PlaywrightAiFixture } from '@/playwright/ai-fixture';
+import { MAX_PLAYWRIGHT_REPORT_TAG_BYTES } from '@/playwright/report-filename';
 
 const createPage = () =>
   ({
@@ -105,10 +106,11 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
     expect(opts.reportFileName).toContain('login-case(retry--2)');
   });
 
-  it('caps very long titles and appends a stable hash to avoid ENAMETOOLONG', async () => {
-    const longTitle = 'policy-template-name-duplicates-existing-name-'.repeat(
-      20,
-    );
+  it('caps Chinese titles by UTF-8 bytes and appends a stable hash', async () => {
+    const longTitle =
+      '1426803-【配置-策略模板配置】【创建策略模板】策略模板名称与当前存在的名称重复'.repeat(
+        10,
+      );
     const opts = await runAi({
       testId: 'uuid',
       titlePath: ['1426803.spec.ts', longTitle],
@@ -116,13 +118,13 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
       retry: 1,
     });
 
-    expect(Buffer.byteLength(opts.reportFileName, 'utf8')).toBeLessThan(200);
+    expect(Buffer.byteLength(opts.reportFileName, 'utf8')).toBeLessThanOrEqual(
+      MAX_PLAYWRIGHT_REPORT_TAG_BYTES,
+    );
     expect(opts.reportFileName).toMatch(
       /^playwright-.+-[0-9a-f]{10}-[0-9a-f-]{36}$/,
     );
-    expect(opts.groupName).toContain(
-      'policy-template-name-duplicates-existing-name',
-    );
+    expect(opts.groupName).toContain('策略模板名称与当前存在的名称重复');
   });
 
   it('preserves the page-level uuid suffix so multiple pages in one test do not clash', async () => {

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
@@ -105,6 +105,26 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
     expect(opts.reportFileName).toContain('login-case(retry--2)');
   });
 
+  it('caps very long titles and appends a stable hash to avoid ENAMETOOLONG', async () => {
+    const longTitle = 'policy-template-name-duplicates-existing-name-'.repeat(
+      20,
+    );
+    const opts = await runAi({
+      testId: 'uuid',
+      titlePath: ['1426803.spec.ts', longTitle],
+      annotations: [],
+      retry: 1,
+    });
+
+    expect(Buffer.byteLength(opts.reportFileName, 'utf8')).toBeLessThan(200);
+    expect(opts.reportFileName).toMatch(
+      /^playwright-.+-[0-9a-f]{10}-[0-9a-f-]{36}$/,
+    );
+    expect(opts.groupName).toContain(
+      'policy-template-name-duplicates-existing-name',
+    );
+  });
+
   it('preserves the page-level uuid suffix so multiple pages in one test do not clash', async () => {
     const fixture = PlaywrightAiFixture();
     const pageA = createPage();

--- a/packages/web-integration/tests/unit-test/playwright-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-report-filename.test.ts
@@ -1,0 +1,47 @@
+import {
+  MAX_PLAYWRIGHT_REPORT_TAG_BYTES,
+  buildPlaywrightReportTag,
+} from '@/playwright/report-filename';
+import { describe, expect, it } from 'vitest';
+
+describe('buildPlaywrightReportTag', () => {
+  it('truncates Chinese titles by UTF-8 bytes while keeping the tag valid', () => {
+    const title =
+      '1426803-【配置-策略模板配置】【创建策略模板】策略模板名称与当前存在的名称重复'.repeat(
+        10,
+      );
+    const tag = buildPlaywrightReportTag(
+      title,
+      '6d700a2d-ab99-45c3-9c4e-87ff85f4b11b',
+    );
+
+    expect(Buffer.byteLength(tag, 'utf8')).toBeLessThanOrEqual(
+      MAX_PLAYWRIGHT_REPORT_TAG_BYTES,
+    );
+    expect(tag).toMatch(/^playwright-.+-[0-9a-f]{10}-[0-9a-f-]{36}$/);
+    expect(Buffer.from(tag, 'utf8').toString('utf8')).toBe(tag);
+  });
+
+  it('does not split emoji at the byte boundary', () => {
+    const tag = buildPlaywrightReportTag('🧪'.repeat(100));
+
+    expect(Buffer.byteLength(tag, 'utf8')).toBeLessThanOrEqual(
+      MAX_PLAYWRIGHT_REPORT_TAG_BYTES,
+    );
+    expect(Buffer.from(tag, 'utf8').toString('utf8')).toBe(tag);
+  });
+
+  it('uses the full title for the hash when long prefixes match', () => {
+    const commonPrefix = '相同的超长标题前缀'.repeat(30);
+
+    expect(buildPlaywrightReportTag(`${commonPrefix}-甲`)).not.toBe(
+      buildPlaywrightReportTag(`${commonPrefix}-乙`),
+    );
+  });
+
+  it('rejects a suffix that leaves no room for a valid tag', () => {
+    expect(() => buildPlaywrightReportTag('title', 'x'.repeat(200))).toThrow(
+      'Playwright report suffix exceeds the 200-byte tag limit',
+    );
+  });
+});

--- a/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
@@ -323,33 +323,44 @@ describe('MidsceneReporter', () => {
       expect(readdirSync(outputDir).length).toBeGreaterThan(0);
     });
 
-    it('should shorten separate-mode filenames for very long titles', async () => {
-      const reporter = new MidsceneReporter({ type: 'separate' });
-      const reportPath = createReportFile(
-        'long-title-report',
-        'long-title-data',
-      );
-      const longTitle = 'policy-template-name-duplicates-existing-name-'.repeat(
-        20,
-      );
+    it.each([
+      ['single-html', '.html'],
+      ['html-and-external-assets', ''],
+    ] as const)(
+      'should keep separate-mode %s output names within the filesystem byte limit',
+      async (outputFormat, expectedExtension) => {
+        const reporter = new MidsceneReporter({
+          type: 'separate',
+          outputFormat,
+        });
+        const reportPath = createReportFile(
+          `long-title-report-${outputFormat}`,
+          'long-title-data',
+        );
+        const longTitle =
+          '1426803-【配置-策略模板配置】【创建策略模板】策略模板名称与当前存在的名称重复'.repeat(
+            10,
+          );
 
-      reporter.onTestEnd(
-        {
-          id: 'test-id-long',
-          title: longTitle,
-          annotations: [
-            { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
-          ],
-        } as TestCase,
-        { status: 'passed', duration: 50 } as TestResult,
-      );
+        reporter.onTestEnd(
+          {
+            id: `test-id-${outputFormat}`,
+            title: longTitle,
+            annotations: [
+              { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
+            ],
+          } as TestCase,
+          { status: 'passed', duration: 50 } as TestResult,
+        );
 
-      await reporter.onEnd();
+        await reporter.onEnd();
 
-      const [fileName] = readdirSync(outputDir);
-      expect(Buffer.byteLength(fileName, 'utf8')).toBeLessThan(200);
-      expect(fileName).toMatch(/^playwright-.+-[0-9a-f]{10}-\d{4}-/);
-    });
+        const [outputName] = readdirSync(outputDir);
+        expect(Buffer.byteLength(outputName, 'utf8')).toBeLessThanOrEqual(255);
+        expect(outputName.endsWith(expectedExtension)).toBe(true);
+        expect(outputName).toMatch(/^playwright-.+-[0-9a-f]{10}-\d{4}-/);
+      },
+    );
 
     it('should log and skip missing report paths', async () => {
       const reporter = new MidsceneReporter({ type: 'merged' });

--- a/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
@@ -323,6 +323,34 @@ describe('MidsceneReporter', () => {
       expect(readdirSync(outputDir).length).toBeGreaterThan(0);
     });
 
+    it('should shorten separate-mode filenames for very long titles', async () => {
+      const reporter = new MidsceneReporter({ type: 'separate' });
+      const reportPath = createReportFile(
+        'long-title-report',
+        'long-title-data',
+      );
+      const longTitle = 'policy-template-name-duplicates-existing-name-'.repeat(
+        20,
+      );
+
+      reporter.onTestEnd(
+        {
+          id: 'test-id-long',
+          title: longTitle,
+          annotations: [
+            { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
+          ],
+        } as TestCase,
+        { status: 'passed', duration: 50 } as TestResult,
+      );
+
+      await reporter.onEnd();
+
+      const [fileName] = readdirSync(outputDir);
+      expect(Buffer.byteLength(fileName, 'utf8')).toBeLessThan(200);
+      expect(fileName).toMatch(/^playwright-.+-[0-9a-f]{10}-\d{4}-/);
+    });
+
     it('should log and skip missing report paths', async () => {
       const reporter = new MidsceneReporter({ type: 'merged' });
       const { logMsg } = await import('@midscene/shared/utils');

--- a/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
@@ -229,6 +229,43 @@ describe('MidsceneReporter', () => {
       expect(existsSync(reportPathB)).toBe(false);
     });
 
+    it('should keep reports distinct when tests in different suites share a title', async () => {
+      const reporter = new MidsceneReporter({ type: 'separate' });
+      const reportPathA = createReportFile('same-title-suite-a', 'suite-a');
+      const reportPathB = createReportFile('same-title-suite-b', 'suite-b');
+
+      for (const [id, suiteTitle, reportPath] of [
+        ['test-id-suite-a', 'suite a', reportPathA],
+        ['test-id-suite-b', 'suite b', reportPathB],
+      ]) {
+        reporter.onTestEnd(
+          {
+            id,
+            title: 'same leaf title',
+            parent: { title: suiteTitle },
+            annotations: [
+              { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
+            ],
+          } as unknown as TestCase,
+          { status: 'passed', duration: 50 } as TestResult,
+        );
+      }
+
+      await reporter.onEnd();
+
+      const outputFiles = readdirSync(outputDir).filter((fileName) =>
+        fileName.endsWith('.html'),
+      );
+      expect(outputFiles).toHaveLength(2);
+      expect(
+        outputFiles.map((fileName) =>
+          readFileSync(join(outputDir, fileName), 'utf-8'),
+        ),
+      ).toEqual(expect.arrayContaining(['suite-a', 'suite-b']));
+      expect(existsSync(reportPathA)).toBe(false);
+      expect(existsSync(reportPathB)).toBe(false);
+    });
+
     it('should remove the whole source directory after copying a directory-based report', async () => {
       const reporter = new MidsceneReporter({
         type: 'merged',


### PR DESCRIPTION
Closes https://github.com/web-infra-dev/midscene/issues/2905

## Root cause

Playwright's readable report filenames included the full test title. Long Chinese titles can exceed the common 255-byte filesystem component limit because the limit is measured in UTF-8 bytes rather than JavaScript characters, causing ENAMETOOLONG.

## Changes

- Centralize Playwright report tag generation in a shared helper.
- Sanitize path-hostile characters and truncate readable prefixes by UTF-8 bytes.
- Preserve a stable 10-character hash and the page UUID for intermediate reports.
- Apply the same bounded naming strategy to separate-mode final reports.
- Validate the final report filename component in ReportGenerator, including the .html suffix for single-file output.
- Key separate-mode final filenames by retry-aware Playwright test ID so tests in different suites with the same leaf title cannot overwrite each other.

The fixture's intermediate filename and the reporter's final filename are intentionally different. The reporter receives the actual intermediate path through MIDSCENE_DUMP_ANNOTATION and copies or merges that path; it does not match reports by basename.

## Validation

- pnpm --dir packages/web-integration exec vitest run --config vitest.config.ts tests/unit-test/playwright-report-filename.test.ts tests/unit-test/playwright-ai-fixture-report-filename.test.ts tests/unit-test/playwright-reporter.test.ts
  - 3 test files passed, 27 tests passed.
- pnpm run lint
  - 1429 files checked, no fixes or errors.
- Focused @midscene/core tests passed.
- @midscene/core and @midscene/web builds passed.

Coverage includes long Chinese titles, emoji boundaries, stable hash differentiation, oversized suffix rejection, both reporter output formats, annotation-based source-to-target handling, and duplicate leaf titles across suites.
