### PR TITLE
fix(android): support scrcpy with remote ADB servers

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -2155,7 +2155,7 @@ const device = new AndroidDevice(deviceId, {
 - `scrcpyConfig?: object` — High-performance scrcpy screenshot configuration:
   - `enabled?: boolean` — Whether to enable scrcpy screenshots. Default: `false`.
   - `maxSize?: number` — Maximum video dimension in pixels. `0` disables scaling. Default: `0`.
-  - `videoBitRate?: number` — H.264 encoding bitrate in bits per second. Default: `2000000`.
+  - `videoBitRate?: number` — H.264 encoding bitrate in bits per second. Default: `100000000`.
   - `idleTimeoutMs?: number` — Idle time before disconnecting the scrcpy stream. `0` disables automatic disconnection. Default: `30000`.
 
 `device.getScrcpyStatus()` returns the current `enabled`, `connected`, `lastError`, and `retryAfter` state. `device.retryScrcpy()` immediately retries the scrcpy connection and returns `Promise<void>`.

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -2112,7 +2112,7 @@ const device = new AndroidDevice(deviceId, {
 - `scrcpyConfig?: object` —— scrcpy 截图配置，默认关闭。
   - `enabled?: boolean` —— 是否启用 scrcpy 截图，默认 `false`。
   - `maxSize?: number` —— 视频流最大宽度或高度，默认 `0`，表示不缩放。
-  - `videoBitRate?: number` —— H.264 编码码率，单位为 bps，默认 `2000000`。
+  - `videoBitRate?: number` —— H.264 编码码率，单位为 bps，默认 `100000000`。
   - `idleTimeoutMs?: number` —— 空闲连接的断开时间，单位为毫秒，默认 `30000`；设为 `0` 时禁用。
 
 - `device.getScrcpyStatus()` —— 返回 `enabled`、`connected`、`lastError` 和 `retryAfter`。

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1209,7 +1209,7 @@ ${Object.keys(size)
         debugDevice('screenshotBase64 end (scrcpy mode)');
         return result;
       } catch (error) {
-        debugDevice(
+        warnDevice(
           `Scrcpy screenshot failed, falling back to standard ADB method.\nError: ${error}`,
         );
         // Continue to standard ADB path

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -123,8 +123,7 @@ export class ScrcpyDeviceAdapter {
    * Resolve scrcpy config.
    * maxSize defaults to 0 (no scaling, full physical resolution) so the Agent layer
    * receives the highest quality image for AI processing.
-   * videoBitRate is auto-scaled based on physical pixel count to ensure
-   * sufficient quality for all-I-frame H.264 encoding.
+   * videoBitRate uses the shared default unless explicitly configured.
    */
   resolveConfig(deviceInfo: DevicePhysicalInfo): ResolvedScrcpyConfig {
     if (this.resolvedConfig) return this.resolvedConfig;

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -190,9 +190,7 @@ export class ScrcpyScreenshotManager {
       this.isConnecting = true;
       debugScrcpy('Starting scrcpy connection...');
 
-      const { AdbScrcpyClient, AdbScrcpyOptions3_3_3 } = await import(
-        '@yume-chan/adb-scrcpy'
-      );
+      const { AdbScrcpyClient } = await import('@yume-chan/adb-scrcpy');
       const { ReadableStream } = await import('@yume-chan/stream-extra');
       const { DefaultServerPath } = await import('@yume-chan/scrcpy');
 
@@ -203,15 +201,7 @@ export class ScrcpyScreenshotManager {
         ReadableStream.from(createReadStream(serverBinPath)),
       );
 
-      const scrcpyOptions = new AdbScrcpyOptions3_3_3({
-        audio: false,
-        control: false,
-        maxSize: this.options.maxSize,
-        videoBitRate: this.options.videoBitRate,
-        maxFps: 10,
-        sendFrameMeta: true,
-        videoCodecOptions: 'i-frame-interval=0,bitrate-mode=2',
-      });
+      const scrcpyOptions = await this.createScrcpyOptions();
 
       this.scrcpyClient = await AdbScrcpyClient.start(
         this.adb,
@@ -254,6 +244,24 @@ export class ScrcpyScreenshotManager {
     } finally {
       this.isConnecting = false;
     }
+  }
+
+  private async createScrcpyOptions(): Promise<any> {
+    const [{ AdbScrcpyOptions3_3_3 }, { ScrcpyInstanceId }] = await Promise.all(
+      [import('@yume-chan/adb-scrcpy'), import('@yume-chan/scrcpy')],
+    );
+
+    return new AdbScrcpyOptions3_3_3({
+      audio: false,
+      control: false,
+      tunnelForward: true,
+      scid: ScrcpyInstanceId.random(),
+      maxSize: this.options.maxSize,
+      videoBitRate: this.options.videoBitRate,
+      maxFps: 10,
+      sendFrameMeta: true,
+      videoCodecOptions: 'i-frame-interval=0,bitrate-mode=2',
+    });
   }
 
   private async collectServerOutput(

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -114,6 +114,25 @@ describe('ScrcpyScreenshotManager', () => {
   });
 
   describe('ensureConnected', () => {
+    it('should use a forward tunnel with a fresh scrcpy instance id', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any, {
+        maxSize: 1024,
+        videoBitRate: 8_000_000,
+      });
+
+      const firstOptions = await (manager as any).createScrcpyOptions();
+      const secondOptions = await (manager as any).createScrcpyOptions();
+
+      expect(firstOptions.value).toMatchObject({
+        tunnelForward: true,
+        maxSize: 1024,
+        videoBitRate: 8_000_000,
+      });
+      expect(firstOptions.value.scid).toBeDefined();
+      expect(secondOptions.value.scid).toBeDefined();
+      expect(firstOptions.value.scid).not.toBe(secondOptions.value.scid);
+    });
+
     it('should throw instead of recursing when isConnecting is true', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).isConnecting = true;

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -119,7 +119,7 @@ export type AndroidDeviceOpt = {
     /**
      * Video bit rate for H.264 encoding in bits per second.
      * Higher values improve quality but increase bandwidth usage.
-     * @default 2000000 (2 Mbps)
+     * @default 100000000 (100 Mbps)
      */
     videoBitRate?: number;
   };


### PR DESCRIPTION
## Summary

- force the scrcpy client to use a forward tunnel so remote ADB servers, including SSH-forwarded endpoints, connect back through the selected device transport
- assign a fresh scrcpy instance ID for every connection to avoid collisions with orphaned server sockets
- surface runtime scrcpy-to-ADB fallback as a warning and synchronize the documented 100 Mbps default bitrate in English and Chinese

## Testing

- `fnm exec --using=20.20.2 -- pnpm --filter @midscene/android exec vitest --run tests/unit-test/scrcpy-manager.test.ts`
- `fnm exec --using=20.20.2 -- pnpm exec nx build @midscene/android`
- `fnm exec --using=20.20.2 -- pnpm run lint`
- verified the generated scrcpy arguments include `tunnel_forward=true` and a randomized `scid=<8 hex digits>`

Full `pnpm exec nx test @midscene/android` was also attempted with a 16 GB Node heap, but Vite/V8 aborted during test collection with `Fatal JavaScript invalid size error` before running assertions.
