### PR TITLE
fix(core): vary temperature on semantic retries

### DIFF
--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -43,6 +43,7 @@ import {
   AIResponseParseError,
   callAI,
   callAIWithObjectResponse,
+  parseAIObjectResponse,
 } from './service-caller/index';
 import { callAiAndParseWithRetry } from './service-caller/semantic-retry';
 import { prepareModelImage } from './workflows/image-preprocess';
@@ -271,57 +272,66 @@ export async function genericLocate(
 
   try {
     return await callAiAndParseWithRetry({
-      callAi: () =>
-        callAIWithObjectResponse<AIElementLocateResponse>(msgs, modelRuntime, {
+      callAi: (retryAttempt) =>
+        callAI(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
-          jsonParserSource: 'locate',
-          retryTimes: modelRuntime.config.retryCount,
-          retryInterval: modelRuntime.config.retryInterval,
+          expectedJsonObjectResponse: true,
+          semanticRetryAttempt: retryAttempt,
         }),
       parseResponse: (response): LocateModelResponse => {
-        const rawResponse = response.contentString;
-        const errors: string[] | undefined =
-          'errors' in response.content ? response.content.errors : [];
+        const result = parseAIObjectResponse<AIElementLocateResponse>(
+          response,
+          modelRuntime,
+          'locate',
+        );
+        const rawResponse = result.contentString;
+        const locateError = result.content.error;
         if (
-          !hasLocateResult(response.content, resultAdapter.promptSpec.resultKey)
+          !hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)
         ) {
           return {
             rawResponse,
-            rawChoiceMessage: response.rawChoiceMessage,
-            usage: response.usage,
-            reasoningContent: response.reasoning_content,
-            errors: errors as string[],
+            rawChoiceMessage: result.rawChoiceMessage,
+            usage: result.usage,
+            reasoningContent: result.reasoning_content,
+            errors: locateError ? [locateError] : [],
           };
         }
 
-        const locatedPixelBbox =
-          resultAdapter.adaptElementLocateResultToPixelBbox(response.content, {
-            preparedSize: preparedImage.preparedSize,
-            contentSize: preparedImage.contentSize,
-          });
-        return {
-          locatedPixelBbox,
-          rawResponse,
-          rawChoiceMessage: response.rawChoiceMessage,
-          usage: response.usage,
-          reasoningContent: response.reasoning_content,
-          errors: errors as string[],
-        };
+        try {
+          const locatedPixelBbox =
+            resultAdapter.adaptElementLocateResultToPixelBbox(result.content, {
+              preparedSize: preparedImage.preparedSize,
+              contentSize: preparedImage.contentSize,
+            });
+          return {
+            locatedPixelBbox,
+            rawResponse,
+            rawChoiceMessage: result.rawChoiceMessage,
+            usage: result.usage,
+            reasoningContent: result.reasoning_content,
+            errors: [],
+          };
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          const message = [
+            locateError && `error in locate result: ${locateError}`,
+            `coordinate parsing error: ${errorMessage}`,
+          ]
+            .filter(Boolean)
+            .join('\n');
+          throw new Error(message, { cause: error });
+        }
       },
       toParseError: (error, response) => {
         const parseErrorMessage =
           error instanceof Error
             ? `Failed to parse locate result: ${error.message}`
             : 'unknown error in locate result';
-        const modelErrors =
-          'errors' in response.content ? response.content.errors : undefined;
-        const message =
-          modelErrors && modelErrors.length > 0
-            ? `${modelErrors.join('\n')} (${parseErrorMessage})`
-            : parseErrorMessage;
         return new AIResponseParseError(
-          message,
-          response.contentString,
+          parseErrorMessage,
+          response.content,
           response.usage,
           response.rawChoiceMessage,
           response.reasoning_content,
@@ -432,14 +442,18 @@ export async function AiLocateSection(options: {
 
   try {
     parsedResult = await callAiAndParseWithRetry({
-      callAi: () =>
-        callAIWithObjectResponse<AISectionLocatorResponse>(msgs, modelRuntime, {
+      callAi: (retryAttempt) =>
+        callAI(msgs, modelRuntime, {
           abortSignal: options.abortSignal,
-          jsonParserSource: 'section-locator',
-          retryTimes: modelRuntime.config.retryCount,
-          retryInterval: modelRuntime.config.retryInterval,
+          expectedJsonObjectResponse: true,
+          semanticRetryAttempt: retryAttempt,
         }),
-      parseResponse: (result) => {
+      parseResponse: (response) => {
+        const result = parseAIObjectResponse<AISectionLocatorResponse>(
+          response,
+          modelRuntime,
+          'section-locator',
+        );
         const sectionError = result.content.error;
         if (
           !hasLocateResult(result.content, resultAdapter.promptSpec.resultKey)
@@ -447,35 +461,44 @@ export async function AiLocateSection(options: {
           return { result, sectionError };
         }
 
-        const adaptedResult =
-          resultAdapter.adaptSectionLocateResultToPixelBboxGroup(
-            result.content,
-            {
-              preparedSize: preparedImage.preparedSize,
-              contentSize: preparedImage.contentSize,
-            },
-          );
-        const mergedRect = mergePixelBboxesToRect([
-          adaptedResult.target,
-          ...(adaptedResult.references ?? []),
-        ]);
-        debugSection('mergedRect %j', mergedRect);
-        return { result, sectionError, mergedRect };
+        try {
+          const adaptedResult =
+            resultAdapter.adaptSectionLocateResultToPixelBboxGroup(
+              result.content,
+              {
+                preparedSize: preparedImage.preparedSize,
+                contentSize: preparedImage.contentSize,
+              },
+            );
+          const mergedRect = mergePixelBboxesToRect([
+            adaptedResult.target,
+            ...(adaptedResult.references ?? []),
+          ]);
+          debugSection('mergedRect %j', mergedRect);
+          return { result, sectionError, mergedRect };
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          const message = [
+            sectionError && `error in section locate result: ${sectionError}`,
+            `coordinate parsing error: ${errorMessage}`,
+          ]
+            .filter(Boolean)
+            .join('\n');
+          throw new Error(message, { cause: error });
+        }
       },
-      toParseError: (error, result) => {
+      toParseError: (error, response) => {
         const parseErrorMessage =
           error instanceof Error
             ? `Failed to parse section locate result: ${error.message}`
             : 'unknown error in section locate';
-        const message = result.content.error
-          ? `${result.content.error} (${parseErrorMessage})`
-          : parseErrorMessage;
         return new AIResponseParseError(
-          message,
-          result.contentString,
-          result.usage,
-          result.rawChoiceMessage,
-          result.reasoning_content,
+          parseErrorMessage,
+          response.content,
+          response.usage,
+          response.rawChoiceMessage,
+          response.reasoning_content,
         );
       },
       parseRetryTimes: modelRuntime.config.retryCount,
@@ -644,9 +667,10 @@ export async function AiExtractElementInfo<T>(options: {
   }
 
   return callAiAndParseWithRetry({
-    callAi: () =>
+    callAi: (retryAttempt) =>
       callAI(msgs, modelRuntime, {
         abortSignal: options.abortSignal,
+        semanticRetryAttempt: retryAttempt,
       }),
     parseResponse: (response) => {
       const {

--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -45,7 +45,10 @@ import {
   callAIWithObjectResponse,
   parseAIObjectResponse,
 } from './service-caller/index';
-import { callAiAndParseWithRetry } from './service-caller/semantic-retry';
+import {
+  callAiAndParseWithRetry,
+  withSemanticRetryFeedback,
+} from './service-caller/semantic-retry';
 import { prepareModelImage } from './workflows/image-preprocess';
 import {
   mergePixelBboxesToRect,
@@ -272,12 +275,16 @@ export async function genericLocate(
 
   try {
     return await callAiAndParseWithRetry({
-      callAi: (retryAttempt) =>
-        callAI(msgs, modelRuntime, {
-          abortSignal: options.abortSignal,
-          expectedJsonObjectResponse: true,
-          semanticRetryAttempt: retryAttempt,
-        }),
+      callAi: (retryAttempt, previousParseError) =>
+        callAI(
+          withSemanticRetryFeedback(msgs, previousParseError),
+          modelRuntime,
+          {
+            abortSignal: options.abortSignal,
+            expectedJsonObjectResponse: true,
+            semanticRetryAttempt: retryAttempt,
+          },
+        ),
       parseResponse: (response): LocateModelResponse => {
         const result = parseAIObjectResponse<AIElementLocateResponse>(
           response,
@@ -442,12 +449,16 @@ export async function AiLocateSection(options: {
 
   try {
     parsedResult = await callAiAndParseWithRetry({
-      callAi: (retryAttempt) =>
-        callAI(msgs, modelRuntime, {
-          abortSignal: options.abortSignal,
-          expectedJsonObjectResponse: true,
-          semanticRetryAttempt: retryAttempt,
-        }),
+      callAi: (retryAttempt, previousParseError) =>
+        callAI(
+          withSemanticRetryFeedback(msgs, previousParseError),
+          modelRuntime,
+          {
+            abortSignal: options.abortSignal,
+            expectedJsonObjectResponse: true,
+            semanticRetryAttempt: retryAttempt,
+          },
+        ),
       parseResponse: (response) => {
         const result = parseAIObjectResponse<AISectionLocatorResponse>(
           response,
@@ -667,11 +678,15 @@ export async function AiExtractElementInfo<T>(options: {
   }
 
   return callAiAndParseWithRetry({
-    callAi: (retryAttempt) =>
-      callAI(msgs, modelRuntime, {
-        abortSignal: options.abortSignal,
-        semanticRetryAttempt: retryAttempt,
-      }),
+    callAi: (retryAttempt, previousParseError) =>
+      callAI(
+        withSemanticRetryFeedback(msgs, previousParseError),
+        modelRuntime,
+        {
+          abortSignal: options.abortSignal,
+          semanticRetryAttempt: retryAttempt,
+        },
+      ),
     parseResponse: (response) => {
       const {
         content: rawResponse,

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -142,10 +142,11 @@ async function callAndParsePlanningResponse(
     locateResultContext,
   } = options;
   return callAiAndParseWithRetry({
-    callAi: () =>
+    callAi: (retryAttempt) =>
       callAI(messages, modelRuntime, {
         abortSignal,
         requiresOriginalImageDetail: includeLocateInPlanning,
+        semanticRetryAttempt: retryAttempt,
       }),
     parseResponse: (response) => {
       const planFromAI = parseXMLPlanningResponse(

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -17,7 +17,10 @@ import {
 } from './prompt/util';
 import { AIResponseParseError, callAI } from './service-caller/index';
 import type { JsonParser, JsonParserSource } from './service-caller/json';
-import { callAiAndParseWithRetry } from './service-caller/semantic-retry';
+import {
+  callAiAndParseWithRetry,
+  withSemanticRetryFeedback,
+} from './service-caller/semantic-retry';
 import type {
   LocateResultAdapter,
   LocateResultContext,
@@ -142,12 +145,16 @@ async function callAndParsePlanningResponse(
     locateResultContext,
   } = options;
   return callAiAndParseWithRetry({
-    callAi: (retryAttempt) =>
-      callAI(messages, modelRuntime, {
-        abortSignal,
-        requiresOriginalImageDetail: includeLocateInPlanning,
-        semanticRetryAttempt: retryAttempt,
-      }),
+    callAi: (retryAttempt, previousParseError) =>
+      callAI(
+        withSemanticRetryFeedback(messages, previousParseError),
+        modelRuntime,
+        {
+          abortSignal,
+          requiresOriginalImageDetail: includeLocateInPlanning,
+          semanticRetryAttempt: retryAttempt,
+        },
+      ),
     parseResponse: (response) => {
       const planFromAI = parseXMLPlanningResponse(
         response.content,

--- a/packages/core/src/ai-model/model-adapter/chat-completion.ts
+++ b/packages/core/src/ai-model/model-adapter/chat-completion.ts
@@ -82,7 +82,24 @@ export function resolveChatCompletion(
         userConfig: input.userConfig ?? {},
         midsceneDefaults: midsceneChatCompletionDefaults,
       };
-      return buildChatCompletionParams(context);
+      const params = buildChatCompletionParams(context);
+      const retryAttempt = input.semanticRetryAttempt ?? 0;
+      // Only perturb the default deterministic request after a semantic parse
+      // failure: preserve an explicit user temperature, and avoid adding a
+      // temperature to adapters whose normal parameters do not include one.
+      if (
+        retryAttempt > 0 &&
+        input.userConfig?.temperature === undefined &&
+        params.config.temperature === 0
+      ) {
+        return {
+          config: {
+            ...params.config,
+            temperature: 0.2,
+          },
+        };
+      }
+      return params;
     },
     resolveImageDetail: (input) =>
       resolveImageDetail({

--- a/packages/core/src/ai-model/model-adapter/types.ts
+++ b/packages/core/src/ai-model/model-adapter/types.ts
@@ -56,6 +56,11 @@ export type ChatCompletionUnsupportedUserConfig =
 export interface ChatCompletionCallInput {
   intent?: TIntent;
   userConfig?: ChatCompletionCallUserConfig;
+  /**
+   * Number of preceding semantic parsing failures for this request.
+   * This is execution context, not part of the user's model configuration.
+   */
+  semanticRetryAttempt?: number;
   requiresOriginalImageDetail?: boolean;
   /**
    * Whether this call expects a JSON object response.
@@ -71,6 +76,7 @@ export interface ChatCompletionCallInput {
 export interface ChatCompletionCallContext {
   intent?: TIntent;
   userConfig: ChatCompletionCallUserConfig;
+  semanticRetryAttempt?: number;
   requiresOriginalImageDetail?: boolean;
   expectedJsonObjectResponse?: boolean;
   midsceneDefaults: MidsceneChatCompletionDefaults;

--- a/packages/core/src/ai-model/prompt/llm-locator.ts
+++ b/packages/core/src/ai-model/prompt/llm-locator.ts
@@ -26,19 +26,18 @@ ${locateGroundingRules()}
 \`\`\`json
 {
   "${resultKey}": ${promptSpec.resultValueSchema},  // ${promptSpec.resultValueDescription}
-  "errors"?: string[]
+  "error"?: string
 }
 \`\`\`
 
 Fields:
 * \`${resultKey}\` is ${resultFieldDescription}
-* \`errors\` is an optional array of error messages (if any)
+* \`error\` is an optional error message (if any)
 
 For example, when an element is found:
 \`\`\`json
 {
-  "${resultKey}": ${exampleValueText},
-  "errors": []
+  "${resultKey}": ${exampleValueText}
 }
 \`\`\`
 
@@ -46,7 +45,7 @@ When no element is found:
 \`\`\`json
 {
   "${resultKey}": [],
-  "errors": ["I can see ..., but {some element} is not found. Use ${preferredLanguage}."]
+  "error": "I can see ..., but {some element} is not found. Use ${preferredLanguage}."
 }
 \`\`\`
 `;

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -330,6 +330,11 @@ interface CallAIOptions {
   abortSignal?: AbortSignal;
   requiresOriginalImageDetail?: boolean;
   expectedJsonObjectResponse?: boolean;
+  /**
+   * Number of preceding semantic parsing failures for this request.
+   * Network retries are intentionally excluded.
+   */
+  semanticRetryAttempt?: number;
 }
 
 export async function callAI(
@@ -358,6 +363,7 @@ export async function callAI(
       reasoningBudget: modelConfig.reasoningBudget,
       responseFormat: modelConfig.responseFormat,
     },
+    semanticRetryAttempt: options?.semanticRetryAttempt,
     requiresOriginalImageDetail: options?.requiresOriginalImageDetail,
     expectedJsonObjectResponse: options?.expectedJsonObjectResponse,
   };
@@ -772,6 +778,41 @@ export async function callAI(
   }
 }
 
+export type AIObjectResponse<T> = {
+  // TODO: `content` is a misleading name here because this is already the parsed object response. Consider renaming it to `object` or `data`.
+  content: T;
+  contentString: string;
+  usage?: AIUsageInfo;
+  reasoning_content?: string;
+  rawChoiceMessage?: unknown;
+};
+
+export function parseAIObjectResponse<T>(
+  response: Awaited<ReturnType<typeof callAI>>,
+  modelRuntime: ModelRuntime,
+  jsonParserSource: JsonParserSource = 'generic-object',
+): AIObjectResponse<T> {
+  const { config: modelConfig, adapter } = modelRuntime;
+  assert(response, 'empty response');
+  const jsonContent = adapter.jsonParser(response.content, {
+    source: jsonParserSource,
+  });
+  // This API expects a JSON object. Bare JSON primitives are valid JSON,
+  // but do not satisfy object-response callers.
+  if (!jsonContent || typeof jsonContent !== 'object') {
+    throw new Error(
+      `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,
+    );
+  }
+  return {
+    content: jsonContent as T,
+    contentString: response.content,
+    usage: response.usage,
+    reasoning_content: response.reasoning_content,
+    rawChoiceMessage: response.rawChoiceMessage,
+  };
+}
+
 export async function callAIWithObjectResponse<T>(
   messages: ChatCompletionMessageParam[],
   modelRuntime: ModelRuntime,
@@ -781,41 +822,21 @@ export async function callAIWithObjectResponse<T>(
     retryTimes?: number;
     retryInterval?: number;
   },
-): Promise<{
-  // TODO: `content` is a misleading name here because this is already the parsed object response. Consider renaming it to `object` or `data`.
-  content: T;
-  contentString: string;
-  usage?: AIUsageInfo;
-  reasoning_content?: string;
-  rawChoiceMessage?: unknown;
-}> {
-  const { config: modelConfig, adapter } = modelRuntime;
+): Promise<AIObjectResponse<T>> {
+  const { config: modelConfig } = modelRuntime;
   return callAiAndParseWithRetry({
-    callAi: () =>
+    callAi: (retryAttempt) =>
       callAI(messages, modelRuntime, {
         abortSignal: options?.abortSignal,
         expectedJsonObjectResponse: true,
+        semanticRetryAttempt: retryAttempt,
       }),
-    parseResponse: (response) => {
-      assert(response, 'empty response');
-      const jsonContent = adapter.jsonParser(response.content, {
-        source: options?.jsonParserSource ?? 'generic-object',
-      });
-      // This API expects a JSON object. Bare JSON primitives are valid JSON,
-      // but do not satisfy object-response callers.
-      if (!jsonContent || typeof jsonContent !== 'object') {
-        throw new Error(
-          `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,
-        );
-      }
-      return {
-        content: jsonContent as T,
-        contentString: response.content,
-        usage: response.usage,
-        reasoning_content: response.reasoning_content,
-        rawChoiceMessage: response.rawChoiceMessage,
-      };
-    },
+    parseResponse: (response) =>
+      parseAIObjectResponse<T>(
+        response,
+        modelRuntime,
+        options?.jsonParserSource,
+      ),
     toParseError: (error, response) => {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -58,7 +58,10 @@ import {
   resolveEffectiveTimeoutMs,
   restoreHardTimeoutError,
 } from './request-timeout';
-import { callAiAndParseWithRetry } from './semantic-retry';
+import {
+  callAiAndParseWithRetry,
+  withSemanticRetryFeedback,
+} from './semantic-retry';
 export {
   extractJSONFromCodeBlock,
   parseModelResponseJson,
@@ -825,12 +828,16 @@ export async function callAIWithObjectResponse<T>(
 ): Promise<AIObjectResponse<T>> {
   const { config: modelConfig } = modelRuntime;
   return callAiAndParseWithRetry({
-    callAi: (retryAttempt) =>
-      callAI(messages, modelRuntime, {
-        abortSignal: options?.abortSignal,
-        expectedJsonObjectResponse: true,
-        semanticRetryAttempt: retryAttempt,
-      }),
+    callAi: (retryAttempt, previousParseError) =>
+      callAI(
+        withSemanticRetryFeedback(messages, previousParseError),
+        modelRuntime,
+        {
+          abortSignal: options?.abortSignal,
+          expectedJsonObjectResponse: true,
+          semanticRetryAttempt: retryAttempt,
+        },
+      ),
     parseResponse: (response) =>
       parseAIObjectResponse<T>(
         response,

--- a/packages/core/src/ai-model/service-caller/semantic-retry.ts
+++ b/packages/core/src/ai-model/service-caller/semantic-retry.ts
@@ -1,10 +1,35 @@
+import type { ChatCompletionMessageParam } from 'openai/resources/index';
+
+export function withSemanticRetryFeedback(
+  messages: ChatCompletionMessageParam[],
+  previousParseError?: unknown,
+): ChatCompletionMessageParam[] {
+  if (!previousParseError) return messages;
+
+  const errorMessage =
+    previousParseError instanceof Error
+      ? previousParseError.message
+      : String(previousParseError);
+
+  return [
+    ...messages,
+    {
+      role: 'user',
+      content: `The previous response was invalid:\n${errorMessage}\n\nPlease avoid the validation error above in this response.`,
+    },
+  ];
+}
+
 export type CallAiAndParseWithRetryOptions<Response, Parsed> = {
   /** Sends a single model request. Request errors are always propagated as-is. */
   /**
    * `retryAttempt` is local to this retry loop: 0 for the initial request,
    * then incremented after each parsing failure.
    */
-  callAi: (retryAttempt: number) => Promise<Response>;
+  callAi: (
+    retryAttempt: number,
+    previousParseError?: unknown,
+  ) => Promise<Response>;
   /** Parses a successful model response. Only failures from this callback retry. */
   parseResponse: (response: Response) => Parsed | Promise<Parsed>;
   /** Converts the final parsing failure into the caller's domain error. */
@@ -45,8 +70,9 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
   const callAndParseOnce = async (
     remainingRetries: number,
     retryAttempt: number,
+    previousParseError?: unknown,
   ): Promise<Parsed> => {
-    const response = await callAi(retryAttempt);
+    const response = await callAi(retryAttempt, previousParseError);
 
     try {
       return await parseResponse(response);
@@ -61,7 +87,7 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
         if (abortSignal?.aborted) {
           throw toParseError(error, response);
         }
-        return callAndParseOnce(remainingRetries - 1, retryAttempt + 1);
+        return callAndParseOnce(remainingRetries - 1, retryAttempt + 1, error);
       }
       throw toParseError(error, response);
     }

--- a/packages/core/src/ai-model/service-caller/semantic-retry.ts
+++ b/packages/core/src/ai-model/service-caller/semantic-retry.ts
@@ -1,6 +1,10 @@
 export type CallAiAndParseWithRetryOptions<Response, Parsed> = {
   /** Sends a single model request. Request errors are always propagated as-is. */
-  callAi: () => Promise<Response>;
+  /**
+   * `retryAttempt` is local to this retry loop: 0 for the initial request,
+   * then incremented after each parsing failure.
+   */
+  callAi: (retryAttempt: number) => Promise<Response>;
   /** Parses a successful model response. Only failures from this callback retry. */
   parseResponse: (response: Response) => Parsed | Promise<Parsed>;
   /** Converts the final parsing failure into the caller's domain error. */
@@ -40,8 +44,9 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
 
   const callAndParseOnce = async (
     remainingRetries: number,
+    retryAttempt: number,
   ): Promise<Parsed> => {
-    const response = await callAi();
+    const response = await callAi(retryAttempt);
 
     try {
       return await parseResponse(response);
@@ -56,11 +61,11 @@ export async function callAiAndParseWithRetry<Response, Parsed>({
         if (abortSignal?.aborted) {
           throw toParseError(error, response);
         }
-        return callAndParseOnce(remainingRetries - 1);
+        return callAndParseOnce(remainingRetries - 1, retryAttempt + 1);
       }
       throw toParseError(error, response);
     }
   };
 
-  return callAndParseOnce(normalizedRetryTimes);
+  return callAndParseOnce(normalizedRetryTimes, 0);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,7 +77,7 @@ export type PixelBbox = Bbox;
 export interface AIElementLocateResponse {
   bbox?: LocateResultBbox;
   point?: LocateResultPoint;
-  errors?: string[];
+  error?: string;
 }
 
 export interface AIDataExtractionResponse<DataDemand> {

--- a/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
@@ -193,6 +193,11 @@ describe('AiExtractElementInfo prompt assembly', () => {
       expect.objectContaining({ semanticRetryAttempt: 0 }),
       expect.objectContaining({ semanticRetryAttempt: 1 }),
     ]);
+    const retryFeedback = vi.mocked(callAI).mock.calls[1]?.[0]?.at(-1);
+    expect(retryFeedback).toMatchObject({ role: 'user' });
+    expect(retryFeedback?.content).toEqual(
+      expect.stringContaining('Missing required field: data-json'),
+    );
     expect(result.parseResult.data).toEqual({ result: true });
   });
 });

--- a/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
+++ b/packages/core/tests/unit-test/inspect-extract-prompt.test.ts
@@ -162,6 +162,7 @@ describe('AiExtractElementInfo prompt assembly', () => {
 
     expect(vi.mocked(callAI).mock.calls[0]?.[2]).toEqual({
       abortSignal: abortController.signal,
+      semanticRetryAttempt: 0,
     });
   });
 
@@ -188,6 +189,10 @@ describe('AiExtractElementInfo prompt assembly', () => {
     });
 
     expect(callAI).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(callAI).mock.calls.map((call) => call[2])).toEqual([
+      expect.objectContaining({ semanticRetryAttempt: 0 }),
+      expect.objectContaining({ semanticRetryAttempt: 1 }),
+    ]);
     expect(result.parseResult.data).toEqual({ result: true });
   });
 });

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -1,6 +1,6 @@
 import { ResolvedModelAdapter } from '@/ai-model/model-adapter/resolve';
 import { getModelRuntime } from '@/ai-model/models';
-import { callAIWithObjectResponse } from '@/ai-model/service-caller/index';
+import { callAI, parseAIObjectResponse } from '@/ai-model/service-caller/index';
 import { AiLocateElement, AiLocateSection } from '@/ai-model/workflows/inspect';
 import type { LocateFn } from '@/ai-model/workflows/inspect/types';
 import type { IModelConfig } from '@midscene/shared/env';
@@ -13,7 +13,8 @@ vi.mock('@/ai-model/service-caller/index', async () => {
   >('@/ai-model/service-caller/index');
   return {
     ...actual,
-    callAIWithObjectResponse: vi.fn(),
+    callAI: vi.fn(),
+    parseAIObjectResponse: vi.fn(),
   };
 });
 
@@ -30,13 +31,14 @@ describe('locate not-found parsing', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(callAI).mockResolvedValue({ content: '{}', isStreamed: false });
   });
 
   it('keeps locate errors without parsing coordinates when result key is missing', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
-      content: { errors: ['target element is not found'] },
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
+      content: { error: 'target element is not found' },
       usage: undefined,
-      contentString: '{"errors":["target element is not found"]}',
+      contentString: '{"error":"target element is not found"}',
     });
 
     const result = await AiLocateElement({
@@ -53,7 +55,7 @@ describe('locate not-found parsing', () => {
   });
 
   it('skips coordinate parsing when result key is missing even without errors', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
       content: {},
       usage: undefined,
       contentString: '{}',
@@ -73,10 +75,10 @@ describe('locate not-found parsing', () => {
   });
 
   it('skips coordinate parsing when result key is an empty array', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
-      content: { bbox: [], errors: ['target element is not found'] },
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
+      content: { bbox: [], error: 'target element is not found' },
       usage: undefined,
-      contentString: '{"bbox":[],"errors":["target element is not found"]}',
+      contentString: '{"bbox":[],"error":"target element is not found"}',
     });
 
     const result = await AiLocateElement({
@@ -93,17 +95,17 @@ describe('locate not-found parsing', () => {
   });
 
   it('retries once when result adapter cannot map coordinates', async () => {
-    vi.mocked(callAIWithObjectResponse)
-      .mockResolvedValueOnce({
+    vi.mocked(parseAIObjectResponse)
+      .mockReturnValueOnce({
         content: {
           bbox: [100, Number.NaN, 300, 400],
-          errors: ['model returned invalid coordinates'],
+          error: 'model returned invalid coordinates',
         },
         usage: undefined,
         contentString:
-          '{"bbox":[100,null,300,400],"errors":["model returned invalid coordinates"]}',
+          '{"bbox":[100,null,300,400],"error":"model returned invalid coordinates"}',
       })
-      .mockResolvedValueOnce({
+      .mockReturnValueOnce({
         content: { bbox: [100, 200, 300, 400] },
         usage: undefined,
         contentString: '{"bbox":[100,200,300,400]}',
@@ -115,22 +117,67 @@ describe('locate not-found parsing', () => {
       modelRuntime: getModelRuntime(modelConfig),
     });
 
-    expect(callAIWithObjectResponse).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(callAIWithObjectResponse).mock.calls[0]?.[2]).toEqual(
-      expect.objectContaining({ retryTimes: 1 }),
-    );
+    expect(callAI).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(callAI).mock.calls.map((call) => call[2])).toEqual([
+      expect.objectContaining({ semanticRetryAttempt: 0 }),
+      expect.objectContaining({ semanticRetryAttempt: 1 }),
+    ]);
     expect(result.rect).toBeDefined();
     expect(result.parseResult.errors).toEqual([]);
   });
 
+  it('includes model errors when coordinate parsing ultimately fails', async () => {
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
+      content: {
+        bbox: [100, Number.NaN, 300, 400],
+        error: 'model returned invalid coordinates',
+      },
+      usage: undefined,
+      contentString:
+        '{"bbox":[100,null,300,400],"error":"model returned invalid coordinates"}',
+    });
+
+    const result = await AiLocateElement({
+      context: createFakeContext(),
+      targetElementDescription: 'invalid coordinate target',
+      modelRuntime: getModelRuntime({ ...modelConfig, retryCount: 0 }),
+    });
+
+    expect(result.rect).toBeUndefined();
+    expect(result.parseResult.errors?.[0]).toContain(
+      'model returned invalid coordinates',
+    );
+  });
+
+  it('retries JSON parsing through the same locate retry loop', async () => {
+    vi.mocked(parseAIObjectResponse)
+      .mockImplementationOnce(() => {
+        throw new Error('invalid JSON response');
+      })
+      .mockReturnValueOnce({
+        content: { bbox: [100, 200, 300, 400] },
+        usage: undefined,
+        contentString: '{"bbox":[100,200,300,400]}',
+      });
+
+    const result = await AiLocateElement({
+      context: createFakeContext(),
+      targetElementDescription: 'target with malformed JSON',
+      modelRuntime: getModelRuntime(modelConfig),
+    });
+
+    expect(result.rect).toBeDefined();
+    expect(callAI).toHaveBeenCalledTimes(2);
+  });
+
   it('retries once when section result adapter cannot map coordinates', async () => {
-    vi.mocked(callAIWithObjectResponse)
-      .mockResolvedValueOnce({
+    vi.mocked(parseAIObjectResponse)
+      .mockReturnValueOnce({
         content: { bbox: [100, Number.NaN, 300, 400] },
         usage: undefined,
         contentString: '{"bbox":[100,null,300,400]}',
       })
-      .mockResolvedValueOnce({
+      .mockReturnValueOnce({
         content: { bbox: [100, 200, 300, 400] },
         usage: undefined,
         contentString: '{"bbox":[100,200,300,400]}',
@@ -142,7 +189,7 @@ describe('locate not-found parsing', () => {
       modelRuntime: getModelRuntime(modelConfig),
     });
 
-    expect(callAIWithObjectResponse).toHaveBeenCalledTimes(2);
+    expect(callAI).toHaveBeenCalledTimes(2);
     expect(result.searchAreaConfig).toBeDefined();
   });
 
@@ -223,7 +270,7 @@ describe('locate not-found parsing', () => {
   });
 
   it('keeps section locate error without parsing coordinates when result key is missing', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
       content: { error: 'target section is not found' },
       usage: undefined,
       contentString: '{"error":"target section is not found"}',
@@ -240,7 +287,7 @@ describe('locate not-found parsing', () => {
   });
 
   it('keeps section locate error without parsing coordinates when result key is an empty array', async () => {
-    vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+    vi.mocked(parseAIObjectResponse).mockReturnValue({
       content: { bbox: [], error: 'target section is not found' },
       usage: undefined,
       contentString: '{"bbox":[],"error":"target section is not found"}',

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -122,6 +122,11 @@ describe('locate not-found parsing', () => {
       expect.objectContaining({ semanticRetryAttempt: 0 }),
       expect.objectContaining({ semanticRetryAttempt: 1 }),
     ]);
+    const retryFeedback = vi.mocked(callAI).mock.calls[1][0].at(-1);
+    expect(retryFeedback).toMatchObject({ role: 'user' });
+    expect(retryFeedback?.content).toEqual(
+      expect.stringContaining('coordinate parsing error'),
+    );
     expect(result.rect).toBeDefined();
     expect(result.parseResult.errors).toEqual([]);
   });
@@ -190,6 +195,11 @@ describe('locate not-found parsing', () => {
     });
 
     expect(callAI).toHaveBeenCalledTimes(2);
+    const retryFeedback = vi.mocked(callAI).mock.calls[1][0].at(-1);
+    expect(retryFeedback).toMatchObject({ role: 'user' });
+    expect(retryFeedback?.content).toEqual(
+      expect.stringContaining('coordinate parsing error'),
+    );
     expect(result.searchAreaConfig).toBeDefined();
   });
 

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -109,6 +109,11 @@ describe('plan XML parse retry', () => {
     });
 
     expect(callAI).toHaveBeenCalledTimes(3);
+    const retryFeedback = vi.mocked(callAI).mock.calls[1]?.[0]?.at(-1);
+    expect(retryFeedback).toMatchObject({ role: 'user' });
+    expect(retryFeedback?.content).toEqual(
+      expect.stringContaining('The previous response was invalid:'),
+    );
     expect(result.rawResponse).toContain('Tap button after retry');
     expect(result.actions).toEqual([{ type: 'Tap' }]);
   });

--- a/packages/core/tests/unit-test/model-adapter/chat-completion.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/chat-completion.test.ts
@@ -115,4 +115,20 @@ describe('chat completion content extraction', () => {
       reasoning_content: 'custom reasoning',
     });
   });
+
+  it('increases the default temperature on a semantic retry without changing user config', () => {
+    const adapter = resolveChatCompletion({});
+
+    expect(
+      adapter.buildChatCompletionParams({
+        semanticRetryAttempt: 2,
+      }),
+    ).toEqual({ config: { temperature: 0.2 } });
+    expect(
+      adapter.buildChatCompletionParams({
+        semanticRetryAttempt: 1,
+        userConfig: { temperature: 0 },
+      }),
+    ).toEqual({ config: { temperature: 0 } });
+  });
 });

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -194,13 +194,11 @@ describe('doubao model adapter', () => {
     "550 216",
     "550 216",
     "550 216"
-  ],
-  "errors": []
+  ]
 }
     `;
     expect(parser(input, context)).toEqual({
       bbox: ['550 216', '550 216', '550 216', '550 216'],
-      errors: [],
     });
   });
 
@@ -360,7 +358,7 @@ describe('doubao model adapter', () => {
     },
     {
       name: 'JSON repair output with an XML-style closing tag',
-      input: [410, 295, 885, '345<', '/bbox>,\n  "errors": []\n}'],
+      input: [410, 295, 885, '345<', '/bbox>,\n  "error": ""\n}'],
       result: {
         coordinates: [410, 295, 885, 345],
         coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },

--- a/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
+++ b/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
@@ -396,19 +396,18 @@ You are an AI assistant that helps identify UI elements.
 \`\`\`json
 {
   "bbox": [number, number, number, number],  // 2d bounding box, should be [ymin, xmin, ymax, xmax] normalized to 0-1000 relative to the screenshot. Do NOT use pixel coordinates or screenshot width/height.
-  "errors"?: string[]
+  "error"?: string
 }
 \`\`\`
 
 Fields:
 * \`bbox\` is the bounding box of the element that matches the user's description
-* \`errors\` is an optional array of error messages (if any)
+* \`error\` is an optional error message (if any)
 
 For example, when an element is found:
 \`\`\`json
 {
-  "bbox": [100, 100, 200, 200],
-  "errors": []
+  "bbox": [100, 100, 200, 200]
 }
 \`\`\`
 
@@ -416,7 +415,7 @@ When no element is found:
 \`\`\`json
 {
   "bbox": [],
-  "errors": ["I can see ..., but {some element} is not found. Use English."]
+  "error": "I can see ..., but {some element} is not found. Use English."
 }
 \`\`\`
 "
@@ -444,19 +443,18 @@ You are an AI assistant that helps identify UI elements.
 \`\`\`json
 {
   "bbox": [number, number, number, number],  // 2d bounding box, should be [xmin, ymin, xmax, ymax] in actual pixel coordinates relative to the screenshot.
-  "errors"?: string[]
+  "error"?: string
 }
 \`\`\`
 
 Fields:
 * \`bbox\` is the bounding box of the element that matches the user's description
-* \`errors\` is an optional array of error messages (if any)
+* \`error\` is an optional error message (if any)
 
 For example, when an element is found:
 \`\`\`json
 {
-  "bbox": [100, 100, 200, 200],
-  "errors": []
+  "bbox": [100, 100, 200, 200]
 }
 \`\`\`
 
@@ -464,7 +462,7 @@ When no element is found:
 \`\`\`json
 {
   "bbox": [],
-  "errors": ["I can see ..., but {some element} is not found. Use English."]
+  "error": "I can see ..., but {some element} is not found. Use English."
 }
 \`\`\`
 "

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -535,6 +535,7 @@ describe('system prompts', () => {
     const prompt = systemPromptToLocateElement(
       locatePromptSpecFor('qwen2.5-vl'),
     );
+    expect(prompt).toContain('"error"?: string');
     expect(prompt).toMatchSnapshot();
   });
 

--- a/packages/core/tests/unit-test/semantic-retry.test.ts
+++ b/packages/core/tests/unit-test/semantic-retry.test.ts
@@ -1,0 +1,27 @@
+import { callAiAndParseWithRetry } from '@/ai-model/service-caller/semantic-retry';
+import { describe, expect, it } from 'vitest';
+
+describe('callAiAndParseWithRetry', () => {
+  it('increments the semantic retry attempt after parsing failures', async () => {
+    const attempts: number[] = [];
+
+    const result = await callAiAndParseWithRetry({
+      callAi: async (retryAttempt) => {
+        attempts.push(retryAttempt);
+        return retryAttempt;
+      },
+      parseResponse: (response) => {
+        if (response === 0) {
+          throw new Error('invalid response');
+        }
+        return response;
+      },
+      toParseError: (error) =>
+        error instanceof Error ? error : new Error(String(error)),
+      parseRetryTimes: 1,
+    });
+
+    expect(result).toBe(1);
+    expect(attempts).toEqual([0, 1]);
+  });
+});

--- a/packages/core/tests/unit-test/semantic-retry.test.ts
+++ b/packages/core/tests/unit-test/semantic-retry.test.ts
@@ -1,13 +1,22 @@
-import { callAiAndParseWithRetry } from '@/ai-model/service-caller/semantic-retry';
+import {
+  callAiAndParseWithRetry,
+  withSemanticRetryFeedback,
+} from '@/ai-model/service-caller/semantic-retry';
 import { describe, expect, it } from 'vitest';
 
 describe('callAiAndParseWithRetry', () => {
   it('increments the semantic retry attempt after parsing failures', async () => {
     const attempts: number[] = [];
+    const previousErrors: Array<string | undefined> = [];
 
     const result = await callAiAndParseWithRetry({
-      callAi: async (retryAttempt) => {
+      callAi: async (retryAttempt, previousParseError) => {
         attempts.push(retryAttempt);
+        previousErrors.push(
+          previousParseError instanceof Error
+            ? previousParseError.message
+            : undefined,
+        );
         return retryAttempt;
       },
       parseResponse: (response) => {
@@ -23,5 +32,24 @@ describe('callAiAndParseWithRetry', () => {
 
     expect(result).toBe(1);
     expect(attempts).toEqual([0, 1]);
+    expect(previousErrors).toEqual([undefined, 'invalid response']);
+  });
+
+  it('adds the complete validation error message to retry feedback', () => {
+    const messages = withSemanticRetryFeedback(
+      [{ role: 'user', content: 'original request' }],
+      new Error(
+        'failed to parse LLM response into JSON. Response -\n{"untrusted":"raw response"}',
+      ),
+    );
+
+    expect(messages).toEqual([
+      { role: 'user', content: 'original request' },
+      {
+        role: 'user',
+        content:
+          'The previous response was invalid:\nfailed to parse LLM response into JSON. Response -\n{"untrusted":"raw response"}\n\nPlease avoid the validation error above in this response.',
+      },
+    ]);
   });
 });

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -183,7 +183,7 @@ describe('service-caller reasoning fallback', () => {
     const rawResponse = `\`\`\`json
 {
   "bbox": 37, 313, 55, 324,
-  "errors": []
+  "error": ""
 }
 \`\`\``;
 
@@ -306,11 +306,106 @@ describe('service-caller reasoning fallback', () => {
     const response = await callAIWithObjectResponse(
       [{ role: 'user', content: 'locate element' }],
       getModelRuntime(baseModelConfig),
-      { jsonParserSource: 'locate', retryTimes: 1 },
+      {
+        jsonParserSource: 'locate',
+        retryTimes: 1,
+      },
     );
 
     expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ temperature: 0 }),
+      expect.any(Object),
+    );
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ temperature: 0.2 }),
+      expect.any(Object),
+    );
     expect(response.content).toEqual({ bbox: [100, 200, 300, 400] });
+  });
+
+  it('keeps a non-zero adapter temperature during JSON parsing retries', async () => {
+    mockCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'not JSON' } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: '{"answer":true}' } }],
+      });
+
+    await callAIWithObjectResponse(
+      [{ role: 'user', content: 'return a json object' }],
+      getModelRuntime({
+        ...baseModelConfig,
+        modelFamily: 'doubao-seed',
+        temperature: 0.6,
+      }),
+      { retryTimes: 1 },
+    );
+
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ temperature: 0.6 }),
+      expect.any(Object),
+    );
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ temperature: 0.6 }),
+      expect.any(Object),
+    );
+  });
+
+  it('keeps an explicitly configured zero temperature during JSON parsing retries', async () => {
+    mockCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'not JSON' } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: '{"answer":true}' } }],
+      });
+
+    await callAIWithObjectResponse(
+      [{ role: 'user', content: 'return a json object' }],
+      getModelRuntime({
+        ...baseModelConfig,
+        modelFamily: 'doubao-seed',
+        temperature: 0,
+      }),
+      { retryTimes: 1 },
+    );
+
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ temperature: 0 }),
+      expect.any(Object),
+    );
+  });
+
+  it('does not add temperature on retries when the adapter disables it', async () => {
+    mockCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'not JSON' } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: '{"answer":true}' } }],
+      });
+
+    await callAIWithObjectResponse(
+      [{ role: 'user', content: 'return a json object' }],
+      getModelRuntime({
+        ...baseModelConfig,
+        modelFamily: 'kimi',
+      }),
+      { retryTimes: 1 },
+    );
+
+    expect(mockCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ temperature: undefined }),
+      expect.any(Object),
+    );
   });
 
   it('uses model retry settings for JSON parsing failures', async () => {

--- a/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
+++ b/packages/core/tests/unit-test/service-caller-reasoning-fallback.test.ts
@@ -323,6 +323,12 @@ describe('service-caller reasoning fallback', () => {
       expect.objectContaining({ temperature: 0.2 }),
       expect.any(Object),
     );
+    const retryFeedback = mockCreate.mock.calls[1]?.[0]?.messages.at(-1);
+    expect(retryFeedback).toMatchObject({ role: 'user' });
+    expect(retryFeedback?.content).toEqual(
+      expect.stringContaining('The previous response was invalid:'),
+    );
+    expect(retryFeedback?.content).toContain('not JSON');
     expect(response.content).toEqual({ bbox: [100, 200, 300, 400] });
   });
 

--- a/packages/core/tests/unit-test/task-runner/index.test.ts
+++ b/packages/core/tests/unit-test/task-runner/index.test.ts
@@ -14,11 +14,12 @@ import { createFakeContext } from '../../utils';
 
 // Mock AI service caller
 vi.mock('@/ai-model/service-caller/index', () => ({
-  callAIWithObjectResponse: vi.fn(),
+  callAI: vi.fn(),
+  parseAIObjectResponse: vi.fn(),
   AIResponseParseError: class AIResponseParseError extends Error {},
 }));
 
-import { callAIWithObjectResponse } from '@/ai-model/service-caller/index';
+import { callAI, parseAIObjectResponse } from '@/ai-model/service-caller/index';
 
 const insightFindTask = (shouldThrow?: boolean) => {
   const insightFindTask: ExecutionTaskPlanningLocateApply = {
@@ -81,7 +82,8 @@ describe(
   () => {
     beforeEach(() => {
       // Setup default mock implementation for AI calls
-      vi.mocked(callAIWithObjectResponse).mockResolvedValue({
+      vi.mocked(callAI).mockResolvedValue({ content: '{}', isStreamed: false });
+      vi.mocked(parseAIObjectResponse).mockReturnValue({
         content: {
           bbox: [0, 0, 100, 100] as [number, number, number, number],
           errors: [],


### PR DESCRIPTION
## Summary

- unify locate and JSON parsing failures under one semantic retry loop
- perturb only default `temperature: 0` retries to `0.2`
- retain model-provided locate errors when coordinate parsing fails

## Validation

- `pnpm run lint`
- `pnpm run type-check:tests`
- `pnpm --filter @midscene/core test`