### PR TITLE
fix(core): preserve assertion failure dumps

### DIFF
--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -966,9 +966,10 @@ export class TaskExecutor {
           }
         }
 
-        if (type === 'Assert' && !outputResult) {
-          task.thought = thought;
-          throw new Error(`Assertion failed: ${thought}`);
+        // Keep assertion failures in the task result so TaskRunner can persist
+        // the model dump before aiAssert turns the result into a thrown error.
+        if (type === 'Assert') {
+          outputResult = Boolean(outputResult);
         }
 
         return {

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -201,13 +201,26 @@ describe('TaskExecutor - Null Data Handling', () => {
         {},
       );
 
-      // For Assert with null data (falsy), should throw error
+      // Keep a falsy assertion result as task output. The caller turns it into
+      // an assertion error after TaskRunner persists the task dump.
       await expect(
         queryTask.executor({}, {
           task: queryTask,
           uiContext: await createEmptyUIContext(),
         } as any),
-      ).rejects.toThrow('Assertion failed: Could not verify assertion');
+      ).resolves.toMatchObject({
+        output: false,
+        thought: 'Could not verify assertion',
+      });
+
+      expect(queryTask.log).toMatchObject({
+        rawResponse: 'null',
+        dump: expect.objectContaining({
+          taskInfo: expect.objectContaining({
+            rawResponse: 'null',
+          }),
+        }),
+      });
 
       expect(mockInsight.extract).toHaveBeenCalledWith(
         {


### PR DESCRIPTION
## What changed

- Preserve falsy Assert results until TaskRunner records the task output, model dump, usage, and reasoning.
- Normalize falsy Assert results to `false` so report status remains failed.
- Add a regression test for a null Assert response and its captured raw response.

## Why

Assert previously threw inside the task executor as soon as the model returned a falsy result. This bypassed TaskRunner's normal result assignment, leaving failure reports without diagnostic dump information.

## Validation

- `pnpm --filter @midscene/core test -- tasks-null-data.test.ts`
- `pnpm run lint`

`pnpm exec nx test @midscene/core` was also run; the changed test passed, while five pre-existing unrelated failures remain (bare-quote JSON parsing and the `step` model adapter).