### PR TITLE
ci(workflow): unify Feishu release notification targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,66 +624,56 @@ jobs:
       id: notify
       continue-on-error: true
       env:
-        # Additional internal or external groups can be configured as a JSON
-        # array of {"url":"...","secret":"..."} webhook targets.
+        # All internal and external groups are configured as a JSON array of
+        # {"url":"...","secret":"..."} webhook targets.
         FEISHU_WEBHOOK_TARGETS_JSON: ${{ secrets.FEISHU_WEBHOOK_TARGETS_JSON }}
-        FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
-        FEISHU_WEBHOOK_SECRET_2: ${{ secrets.FEISHU_WEBHOOK_SECRET_2 }}
-        FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
-        FEISHU_WEBHOOK_URL_2: ${{ secrets.FEISHU_WEBHOOK_URL_2 }}
         GH_TOKEN: ${{ github.token }}
         RELEASE_TARGET: ${{ github.event.inputs.branch }}
         RELEASE_VERSION: ${{ needs.release.outputs.version }}
       run: |
         set -euo pipefail
 
-        WEBHOOK_URLS=("$FEISHU_WEBHOOK_URL" "$FEISHU_WEBHOOK_URL_2")
-        WEBHOOK_SECRETS=("$FEISHU_WEBHOOK_SECRET" "$FEISHU_WEBHOOK_SECRET_2")
-        if [[ -n "$FEISHU_WEBHOOK_TARGETS_JSON" ]]; then
-          if ! jq -e '
-            type == "array"
-            and all(.[];
-              type == "object"
-              and (.url | type) == "string"
-              and (.url | length) > 0
-              and (.secret | type) == "string"
-              and (.secret | length) > 0
-            )
-          ' >/dev/null <<< "$FEISHU_WEBHOOK_TARGETS_JSON"; then
-            echo "::warning::FEISHU_WEBHOOK_TARGETS_JSON must be a JSON array of non-empty url and secret strings."
-            exit 1
-          fi
-
-          JSON_TARGET_COUNT="$(jq 'length' <<< "$FEISHU_WEBHOOK_TARGETS_JSON")"
-          for ((JSON_TARGET_INDEX = 0; JSON_TARGET_INDEX < JSON_TARGET_COUNT; JSON_TARGET_INDEX += 1)); do
-            WEBHOOK_URLS+=("$(
-              jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].url' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
-            )")
-            WEBHOOK_SECRETS+=("$(
-              jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].secret' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
-            )")
-          done
-        fi
-
-        CONFIGURED_TARGETS=0
-        for TARGET_INDEX in "${!WEBHOOK_URLS[@]}"; do
-          if [[ -z "${WEBHOOK_URLS[$TARGET_INDEX]}" && -z "${WEBHOOK_SECRETS[$TARGET_INDEX]}" ]]; then
-            continue
-          fi
-          if [[ -z "${WEBHOOK_URLS[$TARGET_INDEX]}" || -z "${WEBHOOK_SECRETS[$TARGET_INDEX]}" ]]; then
-            echo "::warning::Feishu webhook target $((TARGET_INDEX + 1)) is only partially configured."
-            exit 1
-          fi
-          ((CONFIGURED_TARGETS += 1))
-        done
-
-        if [[ "$CONFIGURED_TARGETS" -eq 0 ]]; then
+        if [[ -z "$FEISHU_WEBHOOK_TARGETS_JSON" ]]; then
           echo "::warning::No Feishu webhook targets are configured; skipping the Feishu release notification."
           echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Skipped because no complete Feishu webhook URL and signing secret pair is configured." >> "$GITHUB_STEP_SUMMARY"
+          echo "Skipped because the repository secret \`FEISHU_WEBHOOK_TARGETS_JSON\` is not configured." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
+
+        if ! jq -e '
+          type == "array"
+          and all(.[];
+            type == "object"
+            and (.url | type) == "string"
+            and (.url | length) > 0
+            and (.secret | type) == "string"
+            and (.secret | length) > 0
+          )
+        ' >/dev/null <<< "$FEISHU_WEBHOOK_TARGETS_JSON"; then
+          echo "::warning::FEISHU_WEBHOOK_TARGETS_JSON must be a JSON array of non-empty url and secret strings."
+          exit 1
+        fi
+
+        JSON_TARGET_COUNT="$(jq 'length' <<< "$FEISHU_WEBHOOK_TARGETS_JSON")"
+        if [[ "$JSON_TARGET_COUNT" -eq 0 ]]; then
+          echo "::warning::FEISHU_WEBHOOK_TARGETS_JSON contains no webhook targets; skipping the Feishu release notification."
+          echo "## Feishu notification" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Skipped because \`FEISHU_WEBHOOK_TARGETS_JSON\` contains no webhook targets." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        WEBHOOK_URLS=()
+        WEBHOOK_SECRETS=()
+        for ((JSON_TARGET_INDEX = 0; JSON_TARGET_INDEX < JSON_TARGET_COUNT; JSON_TARGET_INDEX += 1)); do
+          WEBHOOK_URLS+=("$(
+            jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].url' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
+          )")
+          WEBHOOK_SECRETS+=("$(
+            jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].secret' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
+          )")
+        done
 
         RELEASE_JSON="$(
           gh release view "$RELEASE_VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,6 +624,9 @@ jobs:
       id: notify
       continue-on-error: true
       env:
+        # Additional internal or external groups can be configured as a JSON
+        # array of {"url":"...","secret":"..."} webhook targets.
+        FEISHU_WEBHOOK_TARGETS_JSON: ${{ secrets.FEISHU_WEBHOOK_TARGETS_JSON }}
         FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
         FEISHU_WEBHOOK_SECRET_2: ${{ secrets.FEISHU_WEBHOOK_SECRET_2 }}
         FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
@@ -636,6 +639,32 @@ jobs:
 
         WEBHOOK_URLS=("$FEISHU_WEBHOOK_URL" "$FEISHU_WEBHOOK_URL_2")
         WEBHOOK_SECRETS=("$FEISHU_WEBHOOK_SECRET" "$FEISHU_WEBHOOK_SECRET_2")
+        if [[ -n "$FEISHU_WEBHOOK_TARGETS_JSON" ]]; then
+          if ! jq -e '
+            type == "array"
+            and all(.[];
+              type == "object"
+              and (.url | type) == "string"
+              and (.url | length) > 0
+              and (.secret | type) == "string"
+              and (.secret | length) > 0
+            )
+          ' >/dev/null <<< "$FEISHU_WEBHOOK_TARGETS_JSON"; then
+            echo "::warning::FEISHU_WEBHOOK_TARGETS_JSON must be a JSON array of non-empty url and secret strings."
+            exit 1
+          fi
+
+          JSON_TARGET_COUNT="$(jq 'length' <<< "$FEISHU_WEBHOOK_TARGETS_JSON")"
+          for ((JSON_TARGET_INDEX = 0; JSON_TARGET_INDEX < JSON_TARGET_COUNT; JSON_TARGET_INDEX += 1)); do
+            WEBHOOK_URLS+=("$(
+              jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].url' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
+            )")
+            WEBHOOK_SECRETS+=("$(
+              jq -r --argjson index "$JSON_TARGET_INDEX" '.[$index].secret' <<< "$FEISHU_WEBHOOK_TARGETS_JSON"
+            )")
+          done
+        fi
+
         CONFIGURED_TARGETS=0
         for TARGET_INDEX in "${!WEBHOOK_URLS[@]}"; do
           if [[ -z "${WEBHOOK_URLS[$TARGET_INDEX]}" && -z "${WEBHOOK_SECRETS[$TARGET_INDEX]}" ]]; then

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -1,0 +1,159 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+const temporaryDirectories = [];
+const supportsReleaseShell =
+  process.platform !== 'win32' &&
+  spawnSync('bash', ['--version']).status === 0 &&
+  spawnSync('jq', ['--version']).status === 0;
+
+const writeExecutable = async (filePath, content) => {
+  await fs.writeFile(filePath, content, { mode: 0o755 });
+};
+
+const loadFeishuNotificationScript = async () => {
+  const workflow = await fs.readFile(
+    path.join(repositoryRoot, '.github/workflows/release.yml'),
+    'utf8',
+  );
+  const match = workflow.match(
+    / {4}- name: Publish release notification to Feishu[\s\S]*?\n {6}run: \|\n([\s\S]*?)\n {4}- name: Summarize Feishu notification failure/,
+  );
+  if (!match) {
+    throw new Error('Could not find the Feishu release notification script');
+  }
+  return match[1].replace(/^ {8}/gm, '');
+};
+
+const createNotificationHarness = async () => {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'midscene-release-notification-'),
+  );
+  temporaryDirectories.push(root);
+  const binDirectory = path.join(root, 'bin');
+  const curlLog = path.join(root, 'curl.log');
+  const summaryPath = path.join(root, 'summary.md');
+  await fs.mkdir(binDirectory);
+
+  await writeExecutable(
+    path.join(binDirectory, 'gh'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "release view" ]]; then
+  printf '%s\\n' '{"name":"Midscene.js v1.2.3","url":"https://github.com/web-infra-dev/midscene/releases/tag/v1.2.3"}'
+else
+  printf '%s\\n' '{"body":"* feat(core): support external groups by @example in https://github.com/web-infra-dev/midscene/pull/1"}'
+fi
+`,
+  );
+  await writeExecutable(
+    path.join(binDirectory, 'curl'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+cat >> "$CURL_LOG"
+printf '\\n' >> "$CURL_LOG"
+printf '%s\\n' '{"code":0,"msg":"success"}'
+`,
+  );
+  await writeExecutable(
+    path.join(binDirectory, 'openssl'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "dgst" ]]; then
+  printf 'digest'
+else
+  cat >/dev/null
+  printf 'test-signature'
+fi
+`,
+  );
+
+  return {
+    curlLog,
+    env: {
+      ...process.env,
+      CURL_LOG: curlLog,
+      FEISHU_WEBHOOK_SECRET: '',
+      FEISHU_WEBHOOK_SECRET_2: '',
+      FEISHU_WEBHOOK_URL: '',
+      FEISHU_WEBHOOK_URL_2: '',
+      GH_TOKEN: 'test-token',
+      GITHUB_REPOSITORY: 'web-infra-dev/midscene',
+      GITHUB_STEP_SUMMARY: summaryPath,
+      PATH: `${binDirectory}${path.delimiter}${process.env.PATH}`,
+      RELEASE_TARGET: 'main',
+      RELEASE_VERSION: 'v1.2.3',
+    },
+  };
+};
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
+  it('delivers to every legacy and JSON webhook target', async () => {
+    const script = await loadFeishuNotificationScript();
+    const harness = await createNotificationHarness();
+    const jsonTargets = Array.from({ length: 4 }, (_, index) => ({
+      url: `https://open.feishu.cn/open-apis/bot/v2/hook/external-${index + 1}`,
+      secret: `secret-${index + 1}`,
+    }));
+    const legacyTarget = {
+      url: 'https://open.feishu.cn/open-apis/bot/v2/hook/legacy',
+      secret: 'legacy-secret',
+    };
+    const targets = [legacyTarget, ...jsonTargets];
+
+    execFileSync('bash', ['-c', script], {
+      env: {
+        ...harness.env,
+        FEISHU_WEBHOOK_SECRET: legacyTarget.secret,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify(jsonTargets),
+        FEISHU_WEBHOOK_URL: legacyTarget.url,
+      },
+      stdio: 'pipe',
+    });
+
+    const curlLog = await fs.readFile(harness.curlLog, 'utf8');
+    for (const target of targets) {
+      expect(curlLog).toContain(`url = "${target.url}"`);
+    }
+    expect(curlLog.match(/^url = /gm)).toHaveLength(targets.length);
+  }, 15_000);
+
+  it('rejects malformed JSON target configuration before delivery', async () => {
+    const script = await loadFeishuNotificationScript();
+    const harness = await createNotificationHarness();
+
+    const result = spawnSync('bash', ['-c', script], {
+      encoding: 'utf8',
+      env: {
+        ...harness.env,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify([
+          { url: 'https://open.feishu.cn/open-apis/bot/v2/hook/incomplete' },
+        ]),
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain(
+      'FEISHU_WEBHOOK_TARGETS_JSON must be a JSON array',
+    );
+    await expect(fs.readFile(harness.curlLog, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+});

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -81,10 +81,6 @@ fi
     env: {
       ...process.env,
       CURL_LOG: curlLog,
-      FEISHU_WEBHOOK_SECRET: '',
-      FEISHU_WEBHOOK_SECRET_2: '',
-      FEISHU_WEBHOOK_URL: '',
-      FEISHU_WEBHOOK_URL_2: '',
       GH_TOKEN: 'test-token',
       GITHUB_REPOSITORY: 'web-infra-dev/midscene',
       GITHUB_STEP_SUMMARY: summaryPath,
@@ -104,25 +100,18 @@ afterEach(async () => {
 });
 
 describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
-  it('delivers to every legacy and JSON webhook target', async () => {
+  it('delivers to every JSON webhook target', async () => {
     const script = await loadFeishuNotificationScript();
     const harness = await createNotificationHarness();
-    const jsonTargets = Array.from({ length: 4 }, (_, index) => ({
+    const targets = Array.from({ length: 4 }, (_, index) => ({
       url: `https://open.feishu.cn/open-apis/bot/v2/hook/external-${index + 1}`,
       secret: `secret-${index + 1}`,
     }));
-    const legacyTarget = {
-      url: 'https://open.feishu.cn/open-apis/bot/v2/hook/legacy',
-      secret: 'legacy-secret',
-    };
-    const targets = [legacyTarget, ...jsonTargets];
 
     execFileSync('bash', ['-c', script], {
       env: {
         ...harness.env,
-        FEISHU_WEBHOOK_SECRET: legacyTarget.secret,
-        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify(jsonTargets),
-        FEISHU_WEBHOOK_URL: legacyTarget.url,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify(targets),
       },
       stdio: 'pipe',
     });

--- a/packages/core/tests/unit-test/yaml-player-output.test.ts
+++ b/packages/core/tests/unit-test/yaml-player-output.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ScriptPlayer } from '@/yaml/player';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('YAML player output', () => {
+  test('flushes assertion result before marking the task as failed', async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'midscene-yaml-output-'));
+    const outputPath = join(outputDir, 'result.json');
+    const assertionResult = {
+      pass: false,
+      thought: 'The page does not match the assertion.',
+      message: 'Expected assertion failure',
+    };
+    const agent = {
+      aiAssert: vi.fn().mockResolvedValue(assertionResult),
+      getActionSpace: vi.fn().mockResolvedValue([]),
+      onTaskStartTip: undefined,
+      reportFile: null,
+    };
+    const player = new ScriptPlayer(
+      {
+        target: {
+          output: outputPath,
+        },
+        tasks: [
+          {
+            name: 'check content',
+            flow: [
+              {
+                aiAssert: 'this is a food delivery service app',
+              },
+            ],
+          },
+        ],
+      } as any,
+      async () => ({
+        agent: agent as any,
+        freeFn: [],
+      }),
+    );
+
+    try {
+      await player.run();
+
+      expect(player.status).toBe('error');
+      expect(player.taskStatusList[0].status).toBe('error');
+      expect(player.taskStatusList[0].error?.message).toBe(
+        assertionResult.message,
+      );
+      expect(JSON.parse(readFileSync(outputPath, 'utf-8'))).toEqual({
+        0: assertionResult,
+      });
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/web-integration/tests/ai/web/puppeteer/yaml-player.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/yaml-player.test.ts
@@ -1,9 +1,8 @@
-import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { puppeteerAgentForTarget } from '@/puppeteer/agent-launcher';
 import type { MidsceneYamlScriptWebEnv } from '@midscene/core';
 import { ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
-import { assert, uuid } from '@midscene/shared/utils';
+import { assert } from '@midscene/shared/utils';
 import { describe, expect, test, vi } from 'vitest';
 
 const runYaml = async (yamlString: string, ignoreStatusAssertion = false) => {
@@ -31,32 +30,6 @@ const runYaml = async (yamlString: string, ignoreStatusAssertion = false) => {
 describe(
   'YAML player - AI e2e',
   () => {
-    test(
-      'flush output even if assertion failed',
-      async () => {
-        const outputPath = `./midscene_run/output/${uuid()}.json`;
-        const yamlString = `
-      target:
-        url: https://www.bing.com
-        output: ${outputPath}
-      tasks:
-        - name: local page
-          flow:
-            - aiQuery: >
-                the background color of the page, { color: 'white' | 'black' | 'red' | 'green' | 'blue' | 'yellow' | 'purple' | 'orange' | 'pink' | 'brown' | 'gray' | 'black' 
-        - name: check content
-          flow:
-            - aiAssert: this is a food delivery service app
-        `;
-        await expect(async () => {
-          await runYaml(yamlString);
-        }).rejects.toThrow();
-
-        expect(existsSync(outputPath)).toBe(true);
-      },
-      { timeout: 12 * 60 * 1000, retry: 0 },
-    );
-
     test('set output path correctly', async () => {
       const yamlString = `
       target:


### PR DESCRIPTION
## Summary

- migrate every internal and external Feishu/Lark release notification target to the encrypted `FEISHU_WEBHOOK_TARGETS_JSON` array
- remove workflow references to the four legacy per-group URL and signing-secret repository secrets
- validate the complete target array before sending and skip cleanly when the unified secret is absent or empty
- keep every target independently signed and attempted even when another webhook fails
- add executable workflow regression coverage for multiple unified targets and malformed configuration
- replace a flaky live-AI YAML output test with deterministic core coverage so provider timeouts cannot masquerade as the expected assertion-failure path

## Configuration

All targets now use one repository secret:

```json
[
  {"url":"https://open.larkoffice.com/open-apis/bot/v2/hook/...","secret":"..."},
  {"url":"https://open.larkoffice.com/open-apis/bot/v2/hook/...","secret":"..."}
]
```

The repository secret has been populated with the three current group targets. The legacy secrets remain stored until this PR merges so the current `main` release workflow keeps working during the transition; the updated workflow no longer references them.

## Validation

- `pnpm run lint`
- `pnpm --dir apps/studio exec vitest run tests/release-notification.test.mjs` (2 passed)
- `pnpm --filter @midscene/core test -- tests/unit-test/yaml-player-output.test.ts` (1 passed)
- parsed `.github/workflows/release.yml` with Ruby YAML
- `git diff --check`
- AI unit test run 30601713341 passed on commit `d4f5cc107`
- `npx nx test studio` reached 412 passed and 3 skipped; the unrelated existing `tests/main-content-overview.test.tsx` Vite transform exhausted the Node heap before collecting tests, and reproduced in isolation even with an 8 GB heap
- `pnpm exec nx test @midscene/core --verbose` ran the new regression successfully; unrelated report-merging tests generated oversized local artifacts and ended with 16 timeouts/size failures
