### PR TITLE
feat(cli): analyze report actions

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,3 +3,16 @@
 CLI tool for running Midscene automation scripts in YAML format.
 
 See <https://midscenejs.com/yaml-script-runner.html>.
+
+## Extract reusable UI Actions
+
+Export each successful device operation in a Midscene HTML report as a
+standalone UI Action YAML file:
+
+```bash
+midscene analyze report.html
+```
+
+The command writes to a sibling `<report-name>-ui-actions` directory by
+default. Each generated YAML file contains exactly one operation and can be
+loaded by `agent.aiAct(..., { loadExtraActions: [...] })`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,12 +7,13 @@ import { createConfig, createFilesConfig } from './config-factory';
 import { loadDotenvConfig } from './dotenv-loader';
 import { runFrameworkTestConfig } from './framework';
 import { runModelCommand } from './model-command';
+import { normalizeReportCommandArgs } from './report-command';
 
 Promise.resolve(
   (async () => {
     const rawArgs = process.argv.slice(2);
     const [firstArg] = rawArgs;
-    if (firstArg === 'report-tool') {
+    if (firstArg === 'report-tool' || firstArg === 'analyze') {
       await runToolsCLI(
         {
           initTools: async () => undefined,
@@ -21,7 +22,7 @@ Promise.resolve(
         } as unknown as BaseMidsceneTools,
         'midscene',
         {
-          argv: rawArgs,
+          argv: normalizeReportCommandArgs(rawArgs),
           version,
           extraCommands: createReportCliCommands(),
         },

--- a/packages/cli/src/report-command.ts
+++ b/packages/cli/src/report-command.ts
@@ -1,0 +1,12 @@
+export function normalizeReportCommandArgs(rawArgs: string[]): string[] {
+  const [commandName, reportPath, ...restArgs] = rawArgs;
+  if (
+    commandName?.toLowerCase() !== 'analyze' ||
+    !reportPath ||
+    reportPath.startsWith('--')
+  ) {
+    return rawArgs;
+  }
+
+  return [commandName, '--htmlPath', reportPath, ...restArgs];
+}

--- a/packages/cli/tests/unit-test/report-command.test.ts
+++ b/packages/cli/tests/unit-test/report-command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeReportCommandArgs } from '../../src/report-command';
+
+describe('normalizeReportCommandArgs', () => {
+  it('maps the positional analyze report path to htmlPath', () => {
+    expect(
+      normalizeReportCommandArgs([
+        'analyze',
+        './report.html',
+        '--output-dir',
+        './actions',
+      ]),
+    ).toEqual([
+      'analyze',
+      '--htmlPath',
+      './report.html',
+      '--output-dir',
+      './actions',
+    ]);
+  });
+
+  it('preserves the explicit htmlPath form', () => {
+    expect(
+      normalizeReportCommandArgs(['analyze', '--htmlPath', './report.html']),
+    ).toEqual(['analyze', '--htmlPath', './report.html']);
+  });
+
+  it('does not change other commands', () => {
+    expect(
+      normalizeReportCommandArgs([
+        'report-tool',
+        '--htmlPath',
+        './report.html',
+      ]),
+    ).toEqual(['report-tool', '--htmlPath', './report.html']);
+  });
+});

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -696,6 +696,19 @@ export class TaskBuilder {
           };
         }
 
+        if (currentCacheEntry && !hitBy?.context.cacheToSave) {
+          if (hitBy) {
+            hitBy.context.cacheToSave = currentCacheEntry;
+          } else {
+            hitBy = {
+              from: 'AI',
+              context: {
+                cacheToSave: currentCacheEntry,
+              },
+            };
+          }
+        }
+
         const promptDisplay = param.promptDisplay;
         const elementForAction = promptDisplay
           ? {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,12 @@ export {
   type MergeReportFilesOptions,
   type MergeReportFilesResult,
 } from './report-cli';
+export {
+  analyzeReportActions,
+  type AnalyzeReportActionsOptions,
+  type AnalyzeReportActionsResult,
+  type UIActionDefinition,
+} from './report-analyzer';
 
 // ScreenshotItem
 export { ScreenshotItem } from './screenshot-item';

--- a/packages/core/src/report-analyzer.ts
+++ b/packages/core/src/report-analyzer.ts
@@ -1,0 +1,379 @@
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import { collectDedupedExecutions } from './report';
+import type { ExecutionTask } from './types';
+
+export interface UIActionDefinition {
+  name: string;
+  actionName: string;
+  actionParam: [unknown];
+}
+
+export interface AnalyzeReportActionsOptions {
+  htmlPath: string;
+  outputDir?: string;
+  overwrite?: boolean;
+}
+
+export interface AnalyzeReportActionsResult {
+  outputDir: string;
+  actionFiles: string[];
+  coordinateFallbackFiles: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(
+    (value): value is string =>
+      typeof value === 'string' && value.trim().length > 0,
+  );
+}
+
+function firstXpath(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const xpaths = value.xpaths;
+  if (!Array.isArray(xpaths)) return undefined;
+  return firstNonEmptyString(...xpaths);
+}
+
+function validLocatedPixelBbox(
+  value: unknown,
+): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === 'number' && Number.isFinite(item))
+  );
+}
+
+function isLocatedElement(value: unknown): value is Record<string, unknown> & {
+  description?: string;
+  rect: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+} {
+  if (!isRecord(value) || !isRecord(value.rect)) return false;
+  const { left, top, width, height } = value.rect;
+  return [left, top, width, height].every(
+    (item) => typeof item === 'number' && Number.isFinite(item),
+  );
+}
+
+function locatorFromTask(
+  locateTask: ExecutionTask | undefined,
+  locatedElement: Record<string, unknown> & {
+    description?: string;
+    rect: {
+      left: number;
+      top: number;
+      width: number;
+      height: number;
+    };
+  },
+): { value: Record<string, unknown>; usedCoordinateFallback: boolean } {
+  const sourceParam = isRecord(locateTask?.param) ? locateTask.param : {};
+  const hitContext = isRecord(locateTask?.hitBy?.context)
+    ? locateTask.hitBy.context
+    : {};
+
+  const prompt =
+    sourceParam.prompt ??
+    firstNonEmptyString(sourceParam.promptDisplay, locatedElement.description);
+  const xpath = firstNonEmptyString(
+    sourceParam.xpath,
+    hitContext.xpath,
+    firstXpath(hitContext.cacheToSave),
+    firstXpath(hitContext.cacheEntry),
+  );
+
+  if (xpath) {
+    return {
+      value: {
+        ...(prompt !== undefined ? { prompt } : {}),
+        xpath,
+      },
+      usedCoordinateFallback: false,
+    };
+  }
+
+  const sourceBbox = validLocatedPixelBbox(sourceParam.locatedPixelBbox)
+    ? sourceParam.locatedPixelBbox
+    : undefined;
+  const rectBbox: [number, number, number, number] = [
+    locatedElement.rect.left,
+    locatedElement.rect.top,
+    locatedElement.rect.left + locatedElement.rect.width,
+    locatedElement.rect.top + locatedElement.rect.height,
+  ];
+
+  return {
+    value: {
+      ...(prompt !== undefined ? { prompt } : {}),
+      locatedPixelBbox: sourceBbox ?? rectBbox,
+    },
+    usedCoordinateFallback: true,
+  };
+}
+
+function restoreStableLocators(
+  value: unknown,
+  locateTasks: ExecutionTask[],
+  locateIndex: { value: number },
+): { value: unknown; usedCoordinateFallback: boolean } {
+  if (isLocatedElement(value)) {
+    const result = locatorFromTask(locateTasks[locateIndex.value], value);
+    locateIndex.value += 1;
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    let usedCoordinateFallback = false;
+    const restored = value.map((item) => {
+      const result = restoreStableLocators(item, locateTasks, locateIndex);
+      usedCoordinateFallback ||= result.usedCoordinateFallback;
+      return result.value;
+    });
+    return { value: restored, usedCoordinateFallback };
+  }
+
+  if (isRecord(value)) {
+    let usedCoordinateFallback = false;
+    const restored = Object.fromEntries(
+      Object.entries(value).map(([key, item]) => {
+        const result = restoreStableLocators(item, locateTasks, locateIndex);
+        usedCoordinateFallback ||= result.usedCoordinateFallback;
+        return [key, result.value];
+      }),
+    );
+    return { value: restored, usedCoordinateFallback };
+  }
+
+  return { value, usedCoordinateFallback: false };
+}
+
+function flattenSingleLocatorShortcut(
+  originalParam: unknown,
+  restoredParam: unknown,
+): unknown {
+  if (!isRecord(originalParam) || !isRecord(restoredParam)) {
+    return restoredParam;
+  }
+
+  const locatorFields = Object.entries(originalParam).filter(([, value]) =>
+    isLocatedElement(value),
+  );
+  if (locatorFields.length !== 1) return restoredParam;
+
+  const [locatorField] = locatorFields[0];
+  const restoredLocator = restoredParam[locatorField];
+  if (!isRecord(restoredLocator)) return restoredParam;
+
+  return {
+    ...Object.fromEntries(
+      Object.entries(restoredParam).filter(([key]) => key !== locatorField),
+    ),
+    ...restoredLocator,
+  };
+}
+
+function actionNameFromTask(
+  task: ExecutionTask,
+  planLog: string | undefined,
+): string {
+  const actionName = task.subType || 'Action';
+  if (planLog) {
+    const sanitizedPlanLog = Array.from(planLog)
+      .map((character) => {
+        const codePoint = character.codePointAt(0);
+        const invalid =
+          character === '<' ||
+          character === '>' ||
+          codePoint === undefined ||
+          codePoint < 0x20 ||
+          (codePoint >= 0x7f && codePoint <= 0x9f) ||
+          codePoint === 0x2028 ||
+          codePoint === 0x2029;
+        return invalid ? ' ' : character;
+      })
+      .join('')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (
+      sanitizedPlanLog &&
+      sanitizedPlanLog.toLowerCase() !== actionName.toLowerCase()
+    ) {
+      return sanitizedPlanLog;
+    }
+  }
+
+  if (isRecord(task.param)) {
+    for (const value of Object.values(task.param)) {
+      if (isLocatedElement(value) && value.description) {
+        return `${actionName}: ${value.description}`;
+      }
+    }
+    const value = firstNonEmptyString(task.param.value);
+    if (value) return `${actionName}: ${value}`;
+  }
+  return `Replay ${actionName}`;
+}
+
+function extractUIActions(
+  executions: ReturnType<typeof collectDedupedExecutions>['executions'],
+): Array<{
+  definition: UIActionDefinition;
+  usedCoordinateFallback: boolean;
+}> {
+  const actions: Array<{
+    definition: UIActionDefinition;
+    usedCoordinateFallback: boolean;
+  }> = [];
+  const nameCounts = new Map<string, number>();
+
+  for (const execution of executions) {
+    let planLog: string | undefined;
+    let pendingLocateTasks: ExecutionTask[] = [];
+
+    for (const task of execution.tasks) {
+      if (task.type === 'Planning' && task.subType === 'Plan') {
+        planLog = isRecord(task.output)
+          ? firstNonEmptyString(task.output.log)
+          : undefined;
+        continue;
+      }
+
+      if (task.type === 'Planning' && task.subType === 'Locate') {
+        pendingLocateTasks.push(task);
+        continue;
+      }
+
+      if (task.type !== 'Action Space') continue;
+
+      const locateTasks = pendingLocateTasks;
+      pendingLocateTasks = [];
+      const currentPlanLog = planLog;
+      planLog = undefined;
+
+      if (task.status !== 'finished' || task.subType === 'Finished') {
+        continue;
+      }
+
+      const restored = restoreStableLocators(task.param, locateTasks, {
+        value: 0,
+      });
+      const baseName = actionNameFromTask(task, currentPlanLog);
+      const nameCount = (nameCounts.get(baseName) ?? 0) + 1;
+      nameCounts.set(baseName, nameCount);
+      actions.push({
+        definition: {
+          name: nameCount === 1 ? baseName : `${baseName} (${nameCount})`,
+          actionName: task.subType || 'Action',
+          actionParam: [
+            flattenSingleLocatorShortcut(task.param, restored.value),
+          ],
+        },
+        usedCoordinateFallback: restored.usedCoordinateFallback,
+      });
+    }
+  }
+
+  return actions;
+}
+
+function resolveReportHtmlPath(htmlPath: string): string {
+  const normalizedPath = path.resolve(htmlPath);
+
+  if (!existsSync(normalizedPath)) {
+    throw new Error(`analyzeReportActions: report does not exist: ${htmlPath}`);
+  }
+
+  const stats = statSync(normalizedPath);
+  if (!stats.isDirectory()) return normalizedPath;
+
+  const indexHtmlPath = path.join(normalizedPath, 'index.html');
+  if (!existsSync(indexHtmlPath)) {
+    throw new Error(
+      `analyzeReportActions: "${htmlPath}" is not an HTML report file, and no index.html was found under this directory.`,
+    );
+  }
+  return indexHtmlPath;
+}
+
+function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
+  const reportDir = path.dirname(resolvedHtmlPath);
+  const reportBaseName = path.basename(
+    resolvedHtmlPath,
+    path.extname(resolvedHtmlPath),
+  );
+
+  if (reportBaseName === 'index') {
+    return path.join(
+      path.dirname(reportDir),
+      `${path.basename(reportDir)}-ui-actions`,
+    );
+  }
+
+  return path.join(reportDir, `${reportBaseName}-ui-actions`);
+}
+
+export function analyzeReportActions(
+  options: AnalyzeReportActionsOptions,
+): AnalyzeReportActionsResult {
+  if (!options.htmlPath) {
+    throw new Error('analyzeReportActions: htmlPath is required');
+  }
+
+  const resolvedHtmlPath = resolveReportHtmlPath(options.htmlPath);
+  const outputDir = path.resolve(
+    options.outputDir ?? defaultAnalyzeOutputDir(resolvedHtmlPath),
+  );
+  const { executions } = collectDedupedExecutions(resolvedHtmlPath);
+  const actions = extractUIActions(executions);
+
+  if (actions.length === 0) {
+    throw new Error(
+      `analyzeReportActions: no successful UI actions found in ${options.htmlPath}`,
+    );
+  }
+
+  const actionFiles = actions.map((action, index) =>
+    path.join(
+      outputDir,
+      `${String(index + 1).padStart(3, '0')}-${action.definition.actionName.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'action'}.yaml`,
+    ),
+  );
+  const existingFiles = actionFiles.filter((file) => existsSync(file));
+  if (existingFiles.length > 0 && !options.overwrite) {
+    throw new Error(
+      `analyzeReportActions: output file already exists: ${existingFiles[0]}. Pass overwrite: true or --overwrite to replace generated UI Actions.`,
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  actions.forEach((action, index) => {
+    writeFileSync(
+      actionFiles[index],
+      yaml.dump(action.definition, {
+        indent: 2,
+        lineWidth: -1,
+        noRefs: true,
+      }),
+      'utf-8',
+    );
+  });
+
+  return {
+    outputDir,
+    actionFiles,
+    coordinateFallbackFiles: actionFiles.filter(
+      (_file, index) => actions[index].usedCoordinateFallback,
+    ),
+  };
+}

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -15,6 +15,7 @@ import {
   collectDedupedExecutions,
   splitReportHtmlByExecution,
 } from './report';
+import { analyzeReportActions } from './report-analyzer';
 import { reportToMarkdown } from './report-markdown';
 import type { MarkdownAttachment } from './report-markdown';
 import type { ReportFileAttributes, TestStatus } from './types';
@@ -456,11 +457,73 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
   },
 };
 
+const analyzeCommandDefinition: ReportCliCommandDefinition = {
+  name: 'analyze',
+  description:
+    'Extract successful UI actions from a Midscene HTML report into one reusable YAML file per device operation.',
+  schema: {
+    htmlPath: z
+      .string()
+      .optional()
+      .describe(
+        'Input report HTML path. The CLI also accepts it positionally: midscene analyze report.html.',
+      ),
+    outputDir: z
+      .string()
+      .optional()
+      .describe(
+        'Output directory. Defaults to a sibling <report-name>-ui-actions directory.',
+      ),
+    overwrite: z
+      .union([z.boolean(), z.string()])
+      .optional()
+      .describe('Overwrite generated UI Action files that already exist.'),
+  },
+  handler: async (args) => {
+    const { htmlPath, outputDir, overwrite } = args as {
+      htmlPath?: string;
+      outputDir?: string;
+      overwrite?: unknown;
+    };
+    if (!htmlPath) {
+      throw new Error(
+        'analyze: report HTML path is required (e.g. midscene analyze report.html)',
+      );
+    }
+
+    const overwriteFlag =
+      overwrite === true || overwrite === 'true' || overwrite === '1';
+    const result = analyzeReportActions({
+      htmlPath,
+      outputDir,
+      overwrite: overwriteFlag,
+    });
+    const fallbackMessage =
+      result.coordinateFallbackFiles.length > 0
+        ? ` ${result.coordinateFallbackFiles.length} action(s) use locatedPixelBbox because no XPath was recorded.`
+        : '';
+
+    return {
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: `Analyzed ${result.actionFiles.length} UI action(s). Output path: ${result.outputDir}.${fallbackMessage}`,
+        },
+      ],
+    };
+  },
+};
+
 export function createReportCliCommands(): ReportCliCommandEntry[] {
   return [
     {
       name: 'report-tool',
       def: reportCommandDefinition,
+    },
+    {
+      name: 'analyze',
+      def: analyzeCommandDefinition,
     },
   ];
 }

--- a/packages/core/tests/unit-test/bbox-locate-cache.test.ts
+++ b/packages/core/tests/unit-test/bbox-locate-cache.test.ts
@@ -207,6 +207,11 @@ describe('bbox locate cache fix', () => {
       expect(result).toBeDefined();
       expect(result!.output.element).toBeDefined();
       expect(result!.hitBy?.from).toBe('Plan');
+      expect(result!.hitBy?.context.cacheToSave).toEqual(
+        expect.objectContaining({
+          xpaths: ['/html/body/input[1]'],
+        }),
+      );
 
       // Verify cacheFeatureForPoint was called to write cache
       expect(mockInterface.cacheFeatureForPoint).toHaveBeenCalled();

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -8,9 +8,14 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCliArgs, runToolsCLI } from '@midscene/shared/cli';
+import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { loadExtraActions } from '../../src/agent/extra-actions';
+import { getMidsceneLocationSchema } from '../../src/ai-model';
 import { generateDumpScriptTag, generateImageScriptTag } from '../../src/dump';
 import type { ScreenshotRef } from '../../src/dump/screenshot-store';
+import { analyzeReportActions } from '../../src/report-analyzer';
 import {
   createReportCliCommands,
   mergeReportFiles,
@@ -59,6 +64,118 @@ function createExecution(
   });
 }
 
+function createActionExecution(options?: {
+  xpath?: string;
+  includeFailedAction?: boolean;
+}): ExecutionDump {
+  const locateHitBy = options?.xpath
+    ? {
+        from: 'Plan',
+        context: {
+          locatedPixelBbox: [10, 20, 110, 70],
+          cacheToSave: {
+            xpaths: [options.xpath],
+          },
+        },
+      }
+    : {
+        from: 'Plan',
+        context: {
+          locatedPixelBbox: [10, 20, 110, 70],
+        },
+      };
+
+  const tasks = [
+    {
+      taskId: 'plan-tap',
+      type: 'Planning',
+      subType: 'Plan',
+      param: {},
+      output: {
+        log: 'Click the confirm button',
+        actions: [],
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'locate-confirm',
+      type: 'Planning',
+      subType: 'Locate',
+      param: {
+        prompt: 'Confirm button',
+        locatedPixelBbox: [10, 20, 110, 70],
+      },
+      hitBy: locateHitBy,
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'tap-confirm',
+      type: 'Action Space',
+      subType: 'Tap',
+      param: {
+        locate: {
+          description: 'Confirm button',
+          rect: { left: 10, top: 20, width: 100, height: 50 },
+          center: [60, 45],
+        },
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'plan-input',
+      type: 'Planning',
+      subType: 'Plan',
+      param: {},
+      output: {
+        log: 'Type the saved value',
+        actions: [],
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'input-value',
+      type: 'Action Space',
+      subType: 'Input',
+      param: {
+        value: 'saved value',
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    ...(options?.includeFailedAction
+      ? [
+          {
+            taskId: 'failed-tap',
+            type: 'Action Space',
+            subType: 'Tap',
+            param: {},
+            executor: async () => undefined,
+            status: 'failed',
+          },
+        ]
+      : []),
+    {
+      taskId: 'finished-marker',
+      type: 'Action Space',
+      subType: 'Finished',
+      param: null,
+      executor: async () => undefined,
+      status: 'finished',
+    },
+  ];
+
+  return new ExecutionDump({
+    id: 'action-execution',
+    logTime: Date.now(),
+    name: 'action execution',
+    tasks: tasks as any,
+  });
+}
+
 describe('createReportCliCommands', () => {
   let tmpDir: string;
 
@@ -73,10 +190,146 @@ describe('createReportCliCommands', () => {
     }
   });
 
-  it('exposes report-tool as the only generic report command', () => {
-    const [command] = createReportCliCommands();
-    expect(command.name).toBe('report-tool');
-    expect('aliases' in command).toBe(false);
+  it('exposes report-tool and analyze as generic report commands', () => {
+    const commands = createReportCliCommands();
+    expect(commands.map((command) => command.name)).toEqual([
+      'report-tool',
+      'analyze',
+    ]);
+    expect(commands.every((command) => !('aliases' in command))).toBe(true);
+  });
+
+  it('exports one loadable UI Action file per successful device operation', async () => {
+    const reportPath = join(tmpDir, 'action-report.html');
+    const report = new ReportActionDump({
+      groupName: 'action-export',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [
+        createActionExecution({
+          xpath: '/html/body/button[1]',
+          includeFailedAction: true,
+        }),
+      ],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'action-export',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+
+    expect(result.actionFiles.map((file) => file.split('/').pop())).toEqual([
+      '001-tap.yaml',
+      '002-input.yaml',
+    ]);
+    expect(result.coordinateFallbackFiles).toEqual([]);
+    expect(yaml.load(readFileSync(result.actionFiles[0], 'utf-8'))).toEqual({
+      name: 'Click the confirm button',
+      actionName: 'Tap',
+      actionParam: [
+        {
+          prompt: 'Confirm button',
+          xpath: '/html/body/button[1]',
+        },
+      ],
+    });
+    expect(yaml.load(readFileSync(result.actionFiles[1], 'utf-8'))).toEqual({
+      name: 'Type the saved value',
+      actionName: 'Input',
+      actionParam: [{ value: 'saved value' }],
+    });
+
+    const loaded = await loadExtraActions(result.actionFiles, [
+      {
+        name: 'Tap',
+        description: 'Tap an element',
+        paramSchema: z.object({
+          locate: getMidsceneLocationSchema(),
+        }),
+        call: async () => undefined,
+      },
+      {
+        name: 'Input',
+        description: 'Input text',
+        paramSchema: z.object({
+          value: z.string(),
+        }),
+        call: async () => undefined,
+      },
+    ]);
+    expect(loaded.map((action) => action.plan)).toEqual([
+      expect.objectContaining({
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: 'Confirm button',
+            xpath: '/html/body/button[1]',
+          },
+        },
+      }),
+      expect.objectContaining({
+        type: 'Input',
+        param: { value: 'saved value' },
+      }),
+    ]);
+  });
+
+  it('falls back to locatedPixelBbox for reports without a recorded xpath', () => {
+    const reportPath = join(tmpDir, 'historical-report.html');
+    const report = new ReportActionDump({
+      groupName: 'historical-action-export',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createActionExecution()],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'historical-action-export',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const firstAction = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+
+    expect(result.coordinateFallbackFiles).toEqual([result.actionFiles[0]]);
+    expect(firstAction.actionParam[0]).toEqual({
+      prompt: 'Confirm button',
+      locatedPixelBbox: [10, 20, 110, 70],
+    });
+  });
+
+  it('does not overwrite generated UI Actions unless requested', () => {
+    const reportPath = join(tmpDir, 'overwrite-report.html');
+    const report = new ReportActionDump({
+      groupName: 'overwrite-action-export',
+      sdkVersion: '1.0.0-test',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button' })],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'overwrite-action-export',
+      }),
+      'utf-8',
+    );
+
+    const first = analyzeReportActions({ htmlPath: reportPath });
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'output file already exists',
+    );
+    expect(() =>
+      analyzeReportActions({ htmlPath: reportPath, overwrite: true }),
+    ).not.toThrow();
+    expect(existsSync(first.actionFiles[0])).toBe(true);
   });
 
   it('runs report split through the generic report command', async () => {


### PR DESCRIPTION
## Summary

- add `midscene analyze report.html` with optional output and overwrite flags
- export every successful report action as one standalone, loadable UI Action YAML file
- persist generated XPath cache metadata in new reports and fall back to `locatedPixelBbox` for historical reports
- skip failed actions and terminal `Finished` markers

## Stack dependency

Depends on #2910, which introduces `aiAct(..., { loadExtraActions })` and the one-operation-per-file UI Action protocol.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core exec vitest --run tests/unit-test/report-cli.test.ts tests/unit-test/bbox-locate-cache.test.ts`
- `pnpm --filter @midscene/cli exec vitest --run tests/unit-test/report-command.test.ts`
- `pnpm exec nx build @midscene/cli`
- built CLI against `packages/web-integration/midscene_run/report/pr-2910-evidence/baseline-a.report.html`: 12 standalone UI Actions exported; 6 historical locator actions explicitly reported as `locatedPixelBbox` fallbacks