### PR TITLE
docs(site): mention Bridge file upload permission

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -731,6 +731,7 @@ Notes:
 - `fileChooserAccept` is only available for web pages (Playwright, Puppeteer, or Chrome extension Bridge mode).
 - Relative paths are resolved from the current command working directory, not from the YAML file directory.
 - If a file does not exist, the script throws before the tap is executed.
+- In Chrome extension Bridge mode, local file uploads require the Midscene extension's "Allow access to file URLs" permission. Enable it in `chrome://extensions` > Midscene > "Details", then reconnect Bridge mode from the target `http(s)://` page.
 - Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
 
 #### Prompting with images

--- a/apps/site/docs/en/bridge-mode.mdx
+++ b/apps/site/docs/en/bridge-mode.mdx
@@ -28,6 +28,12 @@ check the demo project of bridge mode: [https://github.com/web-infra-dev/midscen
 
 Install [Midscene extension from Chrome web store](https://chromewebstore.google.com/detail/midscene/gbldofcpkknbggpkmbdaefngejllnief)
 
+:::info File upload permission
+
+If your Bridge mode script needs to upload local files, open `chrome://extensions`, find the Midscene extension, click "Details", and turn on "Allow access to file URLs". Then switch back to the target `http(s)://` page before reconnecting Bridge mode.
+
+:::
+
 ### Step 2. Install dependencies
 
 <PackageManagerTabs command="install @midscene/web tsx --save-dev" />

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -155,6 +155,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
     - `fileChooserAccept?: string | string[]` — When a file chooser pops up, specify the file path(s) to accept. Can be a single file path or an array of paths. Only available in web pages (Playwright, Puppeteer, or Chrome extension Bridge mode). This option is not constrained by `fileChooserAllowedDir`.
       - **Note**: If the file input does not support multiple files (no `multiple` attribute) but multiple files are provided, an error will be thrown.
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
+      - **Note**: In Chrome extension Bridge mode, local file uploads require the Midscene extension's "Allow access to file URLs" permission. Enable it in `chrome://extensions` > Midscene > "Details", then reconnect Bridge mode from the target `http(s)://` page.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
@@ -204,6 +205,8 @@ await agent.aiAct(
 For multiple uploads in one `aiAct`, name each relative path together with the action that should upload it. A later path replaces the previously configured file chooser path(s). Do not combine prompt-specified paths with `options.fileChooserAccept`: a later file chooser configuration generated during planning can override the option value.
 
 This capability is available for web pages (Playwright, Puppeteer, and Chrome extension Bridge mode). Use `fileChooserAllowedDir` when fixtures live outside the current working directory or when the same prompt must work in local and CI environments.
+
+When using Chrome extension Bridge mode for local file uploads, enable the Midscene extension's "Allow access to file URLs" permission in `chrome://extensions` > Midscene > "Details", then reconnect Bridge mode from the target `http(s)://` page.
 
 :::info
 

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -739,6 +739,7 @@ tasks:
 - `fileChooserAccept` 仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。
 - 相对路径会基于当前命令执行目录解析，而不是基于 YAML 文件所在目录解析。
 - 如果文件不存在，脚本会在执行点击前直接报错。
+- Chrome extension Bridge mode 上传本地文件时，需要在 `chrome://extensions` > Midscene > “Details” 中开启插件的 “Allow access to file URLs” 权限。开启后请从目标 `http(s)://` 页面重新连接桥接模式。
 - Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
 
 #### 使用图像提示

--- a/apps/site/docs/zh/bridge-mode.mdx
+++ b/apps/site/docs/zh/bridge-mode.mdx
@@ -28,6 +28,12 @@ Midscene Chrome 插件的桥接模式允许你使用本地脚本来控制桌面�
 
 安装 [Midscene Chrome 插件](https://chromewebstore.google.com/detail/midscene/gbldofcpkknbggpkmbdaefngejllnief)。
 
+:::info 文件上传权限
+
+如果桥接模式脚本需要上传本地文件，请打开 `chrome://extensions`，找到 Midscene 插件，进入 “Details”，开启 “Allow access to file URLs”。开启后请切回目标 `http(s)://` 页面，再重新连接桥接模式。
+
+:::
+
 ### 第二步：安装依赖
 
 <PackageManagerTabs command="install @midscene/web tsx --save-dev" />

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -153,6 +153,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
     - `fileChooserAccept?: string | string[]` - 当文件选择器弹出时，指定对应的文件路径。可以是单个文件路径或路径数组。仅在 web 页面（Playwright、Puppeteer 或 Chrome extension Bridge mode）中可用。该选项不受 `fileChooserAllowedDir` 限制。
       - **注意**：如果文件输入框不支持多文件（没有 `multiple` 属性），但是传入了多个文件，会抛出错误。
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
+      - **注意**：Chrome extension Bridge mode 上传本地文件时，需要在 `chrome://extensions` > Midscene > “Details” 中开启插件的 “Allow access to file URLs” 权限。开启后请从目标 `http(s)://` 页面重新连接桥接模式。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
@@ -199,6 +200,8 @@ await agent.aiAct(
 如果一次 `aiAct` 需要上传多个文件，请在提示词中把每个相对路径与对应的上传操作明确写出。后出现的路径会覆盖此前配置的文件选择器路径。不要将提示词中的文件路径与 `options.fileChooserAccept` 混用：模型在规划过程中生成的后续文件选择器配置可能覆盖该 option 的值。
 
 此能力仅适用于 web 页面（Playwright、Puppeteer 和 Chrome extension Bridge mode）。当 fixture 不在当前工作目录下，或需要让同一提示词在本地和 CI 环境中复用时，请配置 `fileChooserAllowedDir`。
+
+在 Chrome extension Bridge mode 中上传本地文件时，需要在 `chrome://extensions` > Midscene > “Details” 中开启插件的 “Allow access to file URLs” 权限。开启后请切回目标 `http(s)://` 页面，再重新连接桥接模式。
 
 :::info
 


### PR DESCRIPTION
## Summary
- Document that Chrome extension Bridge mode file uploads require enabling the Midscene extension's "Allow access to file URLs" permission.
- Add the note to the Bridge mode guide, API reference file-upload sections, and YAML file-upload notes in both English and Chinese docs.

## Validation
- `git diff --check`
- `pnpm run lint`