### PR TITLE
fix(cli): include setup scripts in batch summaries

### DIFF
--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -193,8 +193,17 @@ export function createRstestYamlProject(
   rmSync(outputDir, { recursive: true, force: true });
   mkdirSync(resultDir, { recursive: true });
 
+  // The batch executor reports setup as a first-class result. Reserve a result
+  // file for it too, otherwise the parent process drops it from the terminal
+  // and JSON summaries even though it ran inside the Rstest worker.
+  const resultYamlFiles = options.batchConfig
+    ? [
+        ...(options.batchConfig.setup ? [options.batchConfig.setup] : []),
+        ...options.batchConfig.files,
+      ]
+    : options.files;
   const virtualModules: Record<string, string> = {};
-  const cases = options.files.map((file, index) => {
+  const cases = resultYamlFiles.map((file, index) => {
     const yamlFile = resolve(file);
     const testName = resolveTestName(projectDir, yamlFile);
     const fileStem = safeFileStem(yamlFile, index);

--- a/packages/cli/tests/share_context_test_scripts/index.yaml
+++ b/packages/cli/tests/share_context_test_scripts/index.yaml
@@ -1,8 +1,9 @@
-# Index file to run both YAML files with shared browser context
+# Run the setup before the main YAML file with a shared browser context
 concurrent: 1
 continueOnError: true
 shareBrowserContext: true
 
+setup: 01-login.yaml
+
 files:
-  - 01-login.yaml
   - 02-check-login.yaml

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -6,7 +6,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { runFrameworkTestConfig } from '@/framework/command';
 import { describe, expect, test } from 'vitest';
 
@@ -106,15 +106,21 @@ export function defineYamlCaseTest(test: any, options: any) {
 
   test('uses one batch virtual entry when shareBrowserContext is enabled', async () => {
     const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
     const outputDir = join(root, 'generated-runner');
+    const setupYaml = join(root, 'setup.yaml');
     const yamlA = join(root, 'login.yaml');
     const yamlB = join(root, 'check-login.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(setupYaml, 'web:\n  url: about:blank\ntasks: []\n');
     writeFileSync(yamlA, 'web:\n  url: about:blank\ntasks: []\n');
     writeFileSync(yamlB, 'web:\n  url: about:blank\ntasks: []\n');
 
     try {
       const exitCode = await runFrameworkTestConfig(
         {
+          setup: setupYaml,
           files: [yamlA, yamlB],
           concurrent: 3,
           continueOnError: true,
@@ -144,6 +150,7 @@ export function defineYamlCaseTest(test: any, options: any) {
             expect(batchModule).toContain('"concurrent": 3');
             expect(batchModule).toContain('"shareBrowserContext": true');
             expect(project.cases.map((item) => item.yamlFile)).toEqual([
+              setupYaml,
               yamlA,
               yamlB,
             ]);
@@ -165,7 +172,21 @@ export function defineYamlCaseTest(test: any, options: any) {
         },
       );
       expect(exitCode).toBe(0);
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary).toMatchObject({ total: 3, successful: 3 });
+      expect(
+        summary.results.map((result: { script: string }) =>
+          basename(result.script),
+        ),
+      ).toEqual(['setup.yaml', 'login.yaml', 'check-login.yaml']);
     } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -207,8 +207,10 @@ describe('rstest yaml project generation', () => {
   test('generates a single batch virtual entry for shared browser context', () => {
     const root = createTempDir();
     const outputDir = join(root, 'runner');
+    const setupYaml = join(root, 'setup.yaml');
     const yamlA = join(root, 'login.yaml');
     const yamlB = join(root, 'check.yaml');
+    writeFileSync(setupYaml, 'web:\n  url: about:blank\ntasks: []\n');
     writeFileSync(yamlA, 'web:\n  url: about:blank\ntasks: []\n');
     writeFileSync(yamlB, 'web:\n  url: about:blank\ntasks: []\n');
 
@@ -220,6 +222,7 @@ describe('rstest yaml project generation', () => {
         frameworkImport: '@test/framework',
         rstestCoreImport: '@test/rstest-core',
         batchConfig: {
+          setup: setupYaml,
           files: [yamlA, yamlB],
           concurrent: 1,
           continueOnError: true,
@@ -242,7 +245,11 @@ describe('rstest yaml project generation', () => {
         testModule: 'virtual:midscene-yaml/batch.test.ts',
         testName: 'midscene yaml batch',
       });
-      expect(project.cases).toHaveLength(2);
+      expect(project.cases.map((item) => item.yamlFile)).toEqual([
+        setupYaml,
+        yamlA,
+        yamlB,
+      ]);
       expect(project.maxConcurrency).toBe(1);
       const generated = project.virtualModules[project.include[0]];
       expect(generated).toContain('import { test } from "@test/rstest-core"');
@@ -252,6 +259,7 @@ describe('rstest yaml project generation', () => {
       expect(generated).toContain('defineYamlBatchTest(test, testOptions)');
       expect(generated).not.toContain('defineYamlBatchTest(testOptions)');
       expect(generated).toContain('"shareBrowserContext": true');
+      expect(generated).toContain(JSON.stringify(setupYaml));
       expect(generated).toContain(JSON.stringify(yamlA));
       expect(generated).toContain(JSON.stringify(yamlB));
     } finally {

--- a/packages/cli/tests/unit-test/share-browser-context.test.ts
+++ b/packages/cli/tests/unit-test/share-browser-context.test.ts
@@ -1,4 +1,5 @@
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { createConfig } from '@/config-factory';
 import { runFrameworkTestConfig } from '@/framework/command';
 import { createServer } from 'http-server';
@@ -30,7 +31,7 @@ describe('shareBrowserContext - Storage Sharing', () => {
     server?.server.close();
   });
 
-  test('should preserve all storage types when shareBrowserContext is true', async () => {
+  test('should run setup before the main file and report both results', async () => {
     const scriptDir = join(__dirname, '../share_context_test_scripts');
     const indexYamlPath = join(scriptDir, 'index.yaml');
     const frameworkImport = join(
@@ -49,6 +50,18 @@ describe('shareBrowserContext - Storage Sharing', () => {
       });
 
       expect(exitCode).toBe(0);
+      const summary = JSON.parse(
+        readFileSync(
+          join(scriptDir, 'midscene_run', 'output', config.summary),
+          'utf8',
+        ),
+      );
+      expect(summary.summary).toMatchObject({ total: 2, successful: 2 });
+      expect(
+        summary.results.map((result: { script: string }) =>
+          basename(result.script),
+        ),
+      ).toEqual(['01-login.yaml', '02-check-login.yaml']);
     } finally {
       process.chdir(previousCwd);
     }


### PR DESCRIPTION
## Summary

- include the setup script in Rstest batch result mappings
- keep batch execution files derived from the batch configuration as the single source of truth
- cover setup-to-main browser state sharing and final summary output with regression tests

## Root cause

The batch executor returned results for both the setup script and the main files, but the generated Rstest project allocated result files only for the main files. The worker therefore dropped the setup result before the parent process generated terminal and JSON summaries.

## Validation

- pnpm run lint
- npx nx test @midscene/cli
- npx nx build @midscene/cli
- pnpm --filter @midscene/cli exec vitest --run tests/unit-test/framework/rstest-project.test.ts tests/unit-test/framework/command.test.ts tests/unit-test/framework/yaml-batch.test.ts tests/unit-test/share-browser-context.test.ts