### PR TITLE
fix(playwright): remove finalized source reports

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -105,6 +105,26 @@ function isDirectoryBasedReport(reportFilePath: string): boolean {
 }
 
 /**
+ * Remove a complete report artifact from disk.
+ *
+ * Standalone reports own only their HTML file, while directory-based reports
+ * own the directory containing `index.html`. Callers must decide whether they
+ * own the source artifact and should only invoke this after its replacement
+ * has been produced successfully.
+ *
+ * @param reportFilePath Path to the standalone report or directory report's
+ * `index.html` entry point.
+ * @throws When the owned report artifact cannot be removed.
+ */
+export function removeReportArtifact(reportFilePath: string): void {
+  if (isDirectoryBasedReport(reportFilePath)) {
+    rmSync(path.dirname(reportFilePath), { recursive: true, force: true });
+    return;
+  }
+  unlinkSync(reportFilePath);
+}
+
+/**
  * Deduplicate executions by stable id, keeping only the last occurrence.
  * Old-format executions without id are always preserved.
  */
@@ -429,22 +449,21 @@ export class ReportMergingTool {
 
       // Remove original reports if needed
       if (rmOriginalReports) {
+        let removedReportCount = 0;
+        let reportCountWithFilePath = 0;
         for (const info of this.reportInfos) {
           if (!info.reportFilePath) continue;
+          reportCountWithFilePath += 1;
           try {
-            if (isDirectoryBasedReport(info.reportFilePath)) {
-              // The report owns its directory (`{name}/index.html`) — remove the
-              // whole folder, whether screenshots are external or inlined.
-              const reportDir = path.dirname(info.reportFilePath);
-              rmSync(reportDir, { recursive: true, force: true });
-            } else {
-              unlinkSync(info.reportFilePath);
-            }
+            removeReportArtifact(info.reportFilePath);
+            removedReportCount += 1;
           } catch (error) {
             logMsg(`Error deleting report ${info.reportFilePath}: ${error}`);
           }
         }
-        logMsg(`Removed ${this.reportInfos.length} original reports`);
+        logMsg(
+          `Removed ${removedReportCount}/${reportCountWithFilePath} original reports`,
+        );
       }
       return outputFilePath;
     } catch (error) {

--- a/packages/core/tests/unit-test/report.test.ts
+++ b/packages/core/tests/unit-test/report.test.ts
@@ -72,6 +72,11 @@ describe('reportMergingTool', () => {
     expectedContents.forEach((content) => {
       expect(mergedReportContent).contains(content);
     });
+    // Public merge callers own their input reports unless they explicitly opt
+    // into rmOriginalReports.
+    getReportInfos(tool).forEach((el) => {
+      expect(existsSync(el.reportFilePath)).toBe(true);
+    });
   });
 
   it('should merge 3 mocked reports, and delete original reports after that.', async () => {

--- a/packages/web-integration/src/playwright/reporter/index.ts
+++ b/packages/web-integration/src/playwright/reporter/index.ts
@@ -1,10 +1,11 @@
 import { copyFileSync, cpSync, existsSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import type { ReportFileWithAttributes, TestStatus } from '@midscene/core';
 import { getReportFileName, printReportMsg } from '@midscene/core/agent';
 import {
   ReportMergingTool,
   isDirectoryModeReport,
+  removeReportArtifact,
 } from '@midscene/core/report';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import {
@@ -90,7 +91,14 @@ class MidsceneReporter implements Reporter {
     mkdirSync(getMidsceneRunSubDir('report'), { recursive: true });
   }
 
-  private copyReport(reportFilePath: string, targetPath: string): void {
+  private finalizeSingleReport(
+    reportFilePath: string,
+    targetPath: string,
+  ): void {
+    if (resolve(reportFilePath) === resolve(targetPath)) {
+      return;
+    }
+
     if (isDirectoryModeReport(reportFilePath)) {
       const targetDir = dirname(targetPath);
       mkdirSync(targetDir, { recursive: true });
@@ -98,11 +106,26 @@ class MidsceneReporter implements Reporter {
         recursive: true,
         force: true,
       });
-      return;
+    } else {
+      mkdirSync(dirname(targetPath), { recursive: true });
+      copyFileSync(reportFilePath, targetPath);
     }
 
-    mkdirSync(dirname(targetPath), { recursive: true });
-    copyFileSync(reportFilePath, targetPath);
+    try {
+      removeReportArtifact(reportFilePath);
+    } catch (error) {
+      logMsg(`Error deleting report ${reportFilePath}: ${error}`);
+    }
+  }
+
+  private mergeOwnedReports(
+    tool: ReportMergingTool,
+    targetName: string,
+  ): string | null {
+    return tool.mergeReports(targetName, {
+      overwrite: true,
+      rmOriginalReports: true,
+    });
   }
 
   private collectReportInfo(test: TestCase, result: TestResult) {
@@ -181,23 +204,19 @@ class MidsceneReporter implements Reporter {
       }
       if (firstReport.reportFilePath) {
         const targetPath = this.getReportPath();
-        this.copyReport(firstReport.reportFilePath, targetPath);
+        this.finalizeSingleReport(firstReport.reportFilePath, targetPath);
         printReportMsg(targetPath);
         return;
       }
 
-      const mergedReportPath = tool.mergeReports(targetName, {
-        overwrite: true,
-      });
+      const mergedReportPath = this.mergeOwnedReports(tool, targetName);
       if (mergedReportPath) {
         printReportMsg(mergedReportPath);
       }
       return;
     }
 
-    const mergedReportPath = tool.mergeReports(targetName, {
-      overwrite: true,
-    });
+    const mergedReportPath = this.mergeOwnedReports(tool, targetName);
     if (mergedReportPath) {
       printReportMsg(mergedReportPath);
     }
@@ -211,16 +230,14 @@ class MidsceneReporter implements Reporter {
         const firstReport = entry.reports[0];
         if (firstReport.reportFilePath) {
           const targetPath = this.getReportPath(entry.testTitle);
-          this.copyReport(firstReport.reportFilePath, targetPath);
+          this.finalizeSingleReport(firstReport.reportFilePath, targetPath);
           printReportMsg(targetPath);
           continue;
         }
 
         const tool = new ReportMergingTool();
         tool.append(firstReport);
-        const reportPath = tool.mergeReports(targetName, {
-          overwrite: true,
-        });
+        const reportPath = this.mergeOwnedReports(tool, targetName);
         if (reportPath) {
           printReportMsg(reportPath);
         }
@@ -231,9 +248,7 @@ class MidsceneReporter implements Reporter {
       for (const report of entry.reports) {
         tool.append(report);
       }
-      const reportPath = tool.mergeReports(targetName, {
-        overwrite: true,
-      });
+      const reportPath = this.mergeOwnedReports(tool, targetName);
       if (reportPath) {
         printReportMsg(reportPath);
       }

--- a/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-ai-fixture-report-filename.test.ts
@@ -21,15 +21,19 @@
  * synthesizes, then invoke `fixture.ai({page}, ...)` which is the cheapest
  * code path that runs `createOrReuseAgentForPage`.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockState = vi.hoisted(() => ({
   ctorOpts: [] as any[],
+  reportFile: undefined as string | undefined,
 }));
 
 vi.mock('@/playwright/index', () => {
   class MockPlaywrightAgent {
-    reportFile?: string;
+    reportFile = mockState.reportFile;
 
     constructor(_page: any, opts: any) {
       mockState.ctorOpts.push(opts);
@@ -55,8 +59,16 @@ const runAi = async (testInfo: any) => {
 };
 
 describe('PlaywrightAiFixture reportFileName derivation', () => {
+  let tempDir: string;
+
   beforeEach(() => {
     mockState.ctorOpts.length = 0;
+    mockState.reportFile = undefined;
+    tempDir = mkdtempSync(join(tmpdir(), 'midscene-fixture-report-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('uses the human-readable test title and drops the Playwright UUID testId', async () => {
@@ -160,5 +172,39 @@ describe('PlaywrightAiFixture reportFileName derivation', () => {
     // groupName keeps the original hierarchy-carrying separators.
     expect(opts.groupName).toContain('/');
     expect(opts.groupName).toContain('\\');
+  });
+
+  it('preserves its finalized report when the Playwright reporter is not configured', async () => {
+    const reportPath = join(tempDir, 'fixture-owned-report.html');
+    writeFileSync(reportPath, 'fixture report', 'utf-8');
+    mockState.reportFile = reportPath;
+
+    const fixture = PlaywrightAiFixture();
+    const page = createPage();
+    const testInfo = {
+      testId: 'fixture-only-test',
+      titlePath: ['fixture-only.spec.ts', 'keeps its report'],
+      annotations: [],
+      retry: 0,
+    } as any;
+    let getAgent: any;
+
+    await fixture.agentForPage(
+      { page },
+      async (fn: any) => {
+        getAgent = fn;
+      },
+      testInfo,
+    );
+    await getAgent(page);
+
+    const [finalizeReports] = fixture._midsceneFinalizeReports as any;
+    await finalizeReports({}, async () => {}, testInfo);
+
+    expect(existsSync(reportPath)).toBe(true);
+    expect(testInfo.annotations).toContainEqual({
+      type: 'MIDSCENE_DUMP_ANNOTATION',
+      description: reportPath,
+    });
   });
 });

--- a/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
+++ b/packages/web-integration/tests/unit-test/playwright-reporter.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -9,6 +10,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import MidsceneReporter from '@/playwright/reporter';
+import { ReportMergingTool } from '@midscene/core/report';
 import type { TestCase, TestResult } from '@playwright/test/reporter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -47,11 +49,13 @@ describe('MidsceneReporter', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(tempDir, { recursive: true, force: true });
   });
 
   function createReportFile(name: string, content = 'report-data'): string {
-    const reportPath = join(tempDir, `${name}.html`);
+    mkdirSync(outputDir, { recursive: true });
+    const reportPath = join(outputDir, `${name}.html`);
     writeFileSync(reportPath, content, 'utf-8');
     return reportPath;
   }
@@ -103,7 +107,7 @@ describe('MidsceneReporter', () => {
       expect(readdirSync(outputDir)).toEqual([]);
     });
 
-    it('should copy a single report file in merged mode', async () => {
+    it('should finalize a single report in merged mode and remove the source', async () => {
       const reporter = new MidsceneReporter({ type: 'merged' });
       const reportPath = createReportFile(
         'single-report',
@@ -123,15 +127,18 @@ describe('MidsceneReporter', () => {
 
       await reporter.onEnd();
 
-      const [mergedFileName] = readdirSync(outputDir).filter((fileName) =>
+      const reportFiles = readdirSync(outputDir).filter((fileName) =>
         fileName.endsWith('.html'),
       );
+      expect(reportFiles).toHaveLength(1);
+      const [mergedFileName] = reportFiles;
       const mergedPath = join(outputDir, mergedFileName);
       expect(existsSync(mergedPath)).toBe(true);
       expect(readFileSync(mergedPath, 'utf-8')).toBe('single-report-data');
+      expect(existsSync(reportPath)).toBe(false);
     });
 
-    it('should merge multiple reports in merged mode', async () => {
+    it('should merge multiple reports in merged mode and remove the sources', async () => {
       const reporter = new MidsceneReporter({ type: 'merged' });
       const reportPathA = createReportFile(
         'report-a',
@@ -166,10 +173,12 @@ describe('MidsceneReporter', () => {
       await reporter.onEnd();
 
       const outputEntries = readdirSync(outputDir);
-      expect(outputEntries.length).toBeGreaterThan(0);
+      expect(outputEntries).toHaveLength(1);
+      expect(existsSync(reportPathA)).toBe(false);
+      expect(existsSync(reportPathB)).toBe(false);
     });
 
-    it('should copy a single report file in separate mode', async () => {
+    it('should finalize a single report in separate mode and remove the source', async () => {
       const reporter = new MidsceneReporter({ type: 'separate' });
       const reportPath = createReportFile('separate-report', 'separate-data');
 
@@ -186,7 +195,102 @@ describe('MidsceneReporter', () => {
 
       await reporter.onEnd();
 
-      expect(readdirSync(outputDir).length).toBeGreaterThan(0);
+      expect(readdirSync(outputDir)).toHaveLength(1);
+      expect(existsSync(reportPath)).toBe(false);
+    });
+
+    it('should merge multiple page reports in separate mode and remove the sources', async () => {
+      const reporter = new MidsceneReporter({ type: 'separate' });
+      const reportPathA = createReportFile(
+        'separate-page-a',
+        '<!doctype html><html><body><script type="midscene_web_dump" data-group-id="a">{"groupName":"a","executions":[]}</script></body></html>',
+      );
+      const reportPathB = createReportFile(
+        'separate-page-b',
+        '<!doctype html><html><body><script type="midscene_web_dump" data-group-id="b">{"groupName":"b","executions":[]}</script></body></html>',
+      );
+
+      reporter.onTestEnd(
+        {
+          id: 'test-id-multi-page',
+          title: 'Separate Multi Page Test',
+          annotations: [
+            { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPathA },
+            { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPathB },
+          ],
+        } as TestCase,
+        { status: 'passed', duration: 50 } as TestResult,
+      );
+
+      await reporter.onEnd();
+
+      expect(readdirSync(outputDir)).toHaveLength(1);
+      expect(existsSync(reportPathA)).toBe(false);
+      expect(existsSync(reportPathB)).toBe(false);
+    });
+
+    it('should remove the whole source directory after copying a directory-based report', async () => {
+      const reporter = new MidsceneReporter({
+        type: 'merged',
+        outputFormat: 'html-and-external-assets',
+      });
+      const sourceDir = join(outputDir, 'directory-report');
+      const reportPath = join(sourceDir, 'index.html');
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(reportPath, 'directory-report-data', 'utf-8');
+
+      reporter.onTestEnd(
+        {
+          id: 'test-id-directory',
+          title: 'Directory Report Test',
+          annotations: [
+            { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
+          ],
+        } as TestCase,
+        { status: 'passed', duration: 50 } as TestResult,
+      );
+
+      await reporter.onEnd();
+
+      const outputEntries = readdirSync(outputDir);
+      expect(outputEntries).toHaveLength(1);
+      const [finalReportDir] = outputEntries;
+      expect(existsSync(join(outputDir, finalReportDir, 'index.html'))).toBe(
+        true,
+      );
+      expect(existsSync(sourceDir)).toBe(false);
+    });
+
+    it('should preserve source reports when final report generation fails', async () => {
+      const reporter = new MidsceneReporter({ type: 'merged' });
+      const reportPathA = createReportFile('failed-merge-source-a');
+      const reportPathB = createReportFile('failed-merge-source-b');
+      vi.spyOn(
+        ReportMergingTool.prototype,
+        'mergeReports',
+      ).mockImplementationOnce(() => {
+        throw new Error('merge failed');
+      });
+
+      for (const [id, reportPath] of [
+        ['a', reportPathA],
+        ['b', reportPathB],
+      ]) {
+        reporter.onTestEnd(
+          {
+            id: `test-id-failed-${id}`,
+            title: `Failed ${id}`,
+            annotations: [
+              { type: 'MIDSCENE_DUMP_ANNOTATION', description: reportPath },
+            ],
+          } as TestCase,
+          { status: 'failed', duration: 50 } as TestResult,
+        );
+      }
+
+      await expect(reporter.onEnd()).rejects.toThrow('merge failed');
+      expect(existsSync(reportPathA)).toBe(true);
+      expect(existsSync(reportPathB)).toBe(true);
     });
 
     it('should include project name and retry in collected test title', async () => {


### PR DESCRIPTION
## Summary

- make the Playwright Reporter own and clean fixture-produced source reports after a final report is created successfully
- centralize cleanup for merged/separate and single/multiple-report paths, including directory-based report artifacts
- keep ReportMergingTool and public CLI preservation defaults unchanged, and keep fixture-only usage non-destructive
- preserve source reports when final report generation fails and report partial cleanup accurately

## Why PR #2717 was not sufficient

PR #2717 fixed deletion granularity inside ReportMergingTool when rmOriginalReports was already true. The Playwright Reporter never enabled that option, and its single-report fast path copied the file directly without cleanup, so its intermediate reports remained.

## Validation

- pnpm run lint
- pnpm --filter @midscene/core test -- tests/unit-test/report.test.ts
- pnpm --filter @midscene/web test -- tests/unit-test/playwright-reporter.test.ts tests/unit-test/playwright-ai-fixture-report-filename.test.ts
- npx nx test @midscene/core
- npx nx test @midscene/web
- npx nx build @midscene/web