### PR TITLE
ci(workflow): add trace-backed harness scoring

### DIFF
--- a/.github/actions/harness-finalize/action.yml
+++ b/.github/actions/harness-finalize/action.yml
@@ -1,0 +1,98 @@
+name: Finalize CI harness
+
+description: Build, upload, summarize, and enforce a trace-backed CI harness scorecard
+
+inputs:
+  suite:
+    description: Stable suite identifier used in scorecards and artifact names
+    required: true
+  stages:
+    description: Optional inline stage contract; suite registry is used when omitted
+    required: false
+    default: ''
+  outcomes:
+    description: JSON object mapping registered stage ids to GitHub step outcomes
+    required: false
+    default: ''
+  report-roots:
+    description: Newline-separated report files or directories inside the workspace
+    required: false
+    default: ''
+  evidence-roots:
+    description: Newline-separated diagnostics directories inside the workspace
+    required: false
+    default: ''
+  output-dir:
+    description: Optional immutable output directory inside the workspace
+    required: false
+    default: ''
+  trace-base-url:
+    description: Optional access-controlled URL that serves the uploaded Trace Bundle root
+    required: false
+    default: ''
+  retention-days:
+    description: Trace Bundle artifact retention period
+    required: false
+    default: '7'
+
+outputs:
+  artifact-url:
+    description: GitHub URL for the uploaded Trace Bundle
+    value: ${{ steps.upload.outputs.artifact-url }}
+  conclusion:
+    description: Harness conclusion, success or failure
+    value: ${{ steps.finalize.outputs.conclusion }}
+  verdict:
+    description: Harness verdict, pass, fail, or infra_error
+    value: ${{ steps.finalize.outputs.verdict }}
+  scorecard-path:
+    description: Absolute path to scorecard.json
+    value: ${{ steps.finalize.outputs.scorecard-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build Trace Bundle
+      id: finalize
+      continue-on-error: true
+      shell: bash
+      env:
+        HARNESS_SUITE: ${{ inputs.suite }}
+        HARNESS_STAGES: ${{ inputs.stages }}
+        HARNESS_OUTCOMES: ${{ inputs.outcomes }}
+        HARNESS_REPORT_ROOTS: ${{ inputs.report-roots }}
+        HARNESS_EVIDENCE_ROOTS: ${{ inputs.evidence-roots }}
+        HARNESS_OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: node scripts/ci-harness/finalize.mjs
+
+    - name: Upload Trace Bundle
+      id: upload
+      if: always()
+      continue-on-error: true
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: harness-${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ steps.finalize.outputs.output-dir || 'midscene_run/harness' }}
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Publish harness summary
+      id: summary
+      if: always() && steps.finalize.outcome == 'success'
+      continue-on-error: true
+      shell: bash
+      env:
+        HARNESS_SCORECARD_PATH: ${{ steps.finalize.outputs.scorecard-path }}
+        HARNESS_ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        HARNESS_TRACE_BASE_URL: ${{ inputs.trace-base-url }}
+      run: node scripts/ci-harness/publish-summary.mjs
+
+    - name: Enforce harness result
+      if: always()
+      shell: bash
+      env:
+        HARNESS_FINALIZE_OUTCOME: ${{ steps.finalize.outcome }}
+        HARNESS_UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+        HARNESS_SUMMARY_OUTCOME: ${{ steps.summary.outcome }}
+        HARNESS_CONCLUSION: ${{ steps.finalize.outputs.conclusion }}
+      run: node scripts/ci-harness/enforce.mjs

--- a/.github/workflows/ai-unit-test.yml
+++ b/.github/workflows/ai-unit-test.yml
@@ -1,5 +1,12 @@
 name: AI unit test
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   push:
     branches:
       - main
@@ -41,69 +48,66 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
       # DEBUG: midscene:* # Disabled to prevent log overflow
       CI: 1
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup Puppeteer browser
-      uses: ./.github/actions/setup-puppeteer-browser
+      - name: Setup Puppeteer browser
+        uses: ./.github/actions/setup-puppeteer-browser
 
-    - name: Build AI unit test projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/core,@midscene/web,@midscene/cli"
-    
-    - name: Run tests with coverage
-      # Keep model request concurrency comparable to the former 4-core hosted runner.
-      run: MIDSCENE_COVERAGE_DIR=coverage-ai pnpm exec nx run-many --target=test:ai --projects=@midscene/core,@midscene/web,@midscene/cli --verbose -- --coverage --minWorkers=1 --maxWorkers=4
-      id: test-ai
-      continue-on-error: true
+      - name: Build AI unit test projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/core,@midscene/web,@midscene/cli"
 
-    - name: Upload test-ai output
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: test-ai-output
-        path: ${{ github.workspace }}/packages/web-integration/midscene_run/report
-        if-no-files-found: ignore
+      - name: Run tests with coverage
+        # Keep model request concurrency comparable to the former 4-core hosted runner.
+        run: MIDSCENE_COVERAGE_DIR=coverage-ai pnpm exec nx run-many --target=test:ai --projects=@midscene/core,@midscene/web,@midscene/cli --verbose -- --coverage --minWorkers=1 --maxWorkers=4
+        id: test-ai
+        continue-on-error: true
 
-    - name: Upload AI coverage reports
-      id: upload-ai-coverage
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: ai-coverage
-        path: coverage-ai
-        if-no-files-found: ignore
+      - name: Upload AI coverage reports
+        id: upload-ai-coverage
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ai-coverage
+          path: coverage-ai
+          if-no-files-found: ignore
 
-    - name: Write AI coverage summary
-      if: always()
-      env:
-        COVERAGE_DIR: coverage-ai
-        COVERAGE_TITLE: AI Test Coverage
-        COVERAGE_ARTIFACT_NAME: ai-coverage
-        COVERAGE_ARTIFACT_URL: ${{ steps.upload-ai-coverage.outputs.artifact-url }}
-      run: node scripts/github-coverage-summary.js
+      - name: Write AI coverage summary
+        if: always()
+        env:
+          COVERAGE_DIR: coverage-ai
+          COVERAGE_TITLE: AI Test Coverage
+          COVERAGE_ARTIFACT_NAME: ai-coverage
+          COVERAGE_ARTIFACT_URL: ${{ steps.upload-ai-coverage.outputs.artifact-url }}
+        run: node scripts/github-coverage-summary.js
 
-    - name: Check if script failed
-      if: steps.test-ai.outcome == 'failure'
-      run: exit 1
+      - name: Finalize AI unit harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: ai-unit
+          outcomes: >-
+            {"ai-unit-tests":"${{ steps.test-ai.outcome }}"}
+          report-roots: packages/web-integration/midscene_run/report

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -1,5 +1,12 @@
 name: AI - Playwright e2e
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   push:
     branches:
       - main
@@ -34,130 +41,128 @@ env:
   MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
   MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
   MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-  MIDSCENE_MODEL_RETRY_COUNT: "2"
-  MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-  MIDSCENE_REPORT_QUIET: "true"
+  MIDSCENE_MODEL_RETRY_COUNT: '2'
+  MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+  MIDSCENE_REPORT_QUIET: 'true'
   # Avoid intermittent Nx plugin worker IPC startup failures on self-hosted runners.
-  NX_ISOLATE_PLUGINS: "false"
+  NX_ISOLATE_PLUGINS: 'false'
   CI: 1
 
 jobs:
   e2e-web:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Cache Playwright dependencies
-      uses: ./.github/actions/cache/restore
-      id: cache-playwright
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
+      - name: Cache Playwright dependencies
+        uses: ./.github/actions/cache/restore
+        id: cache-playwright
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Install Playwright Chromium
-      run: pnpm --dir packages/web-integration exec playwright install chromium
+      - name: Install Playwright Chromium
+        run: pnpm --dir packages/web-integration exec playwright install chromium
 
-    - name: Save Playwright dependencies
-      if: steps.cache-playwright.outputs.cache-hit != 'true'
-      uses: ./.github/actions/cache/save
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Save Playwright dependencies
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache/save
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-    - name: Build web e2e projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/web,@midscene/cli"
+      - name: Build web e2e projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/web,@midscene/cli"
 
-    # Cache behavior uses explicit fixture configuration in the standard suite.
-    # MIDSCENE_CACHE does not override those options, so a second full run is redundant.
-    - name: Run e2e tests
-      run: pnpm run e2e
-      id: e2e-tests
-      continue-on-error: true
+      # Cache behavior uses explicit fixture configuration in the standard suite.
+      # MIDSCENE_CACHE does not override those options, so a second full run is redundant.
+      - name: Run e2e tests
+        run: pnpm run e2e
+        id: e2e-tests
+        continue-on-error: true
 
-    - name: Upload e2e report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: e2e-report
-        path: ${{ github.workspace }}/packages/web-integration/midscene_run/report
-        if-no-files-found: ignore
+      - name: Snapshot basic E2E Trace
+        id: snapshot-e2e
+        if: always()
+        continue-on-error: true
+        env:
+          HARNESS_SNAPSHOT_SOURCE: packages/web-integration/midscene_run/report
+          HARNESS_SNAPSHOT_DESTINATION: midscene_run/harness-input/ai-web-basic
+        run: node scripts/ci-harness/snapshot-reports.mjs
 
-    - name: Run e2e tests report
-      run: pnpm run e2e:report
-      id: e2e-tests-report
-      continue-on-error: true
+      - name: Run e2e tests report
+        run: pnpm run e2e:report
+        id: e2e-tests-report
+        continue-on-error: true
 
-    - name: Upload e2e report output
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: e2e-report-output
-        path: ${{ github.workspace }}/packages/web-integration/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check if tests failed
-      if: steps.e2e-tests.outcome == 'failure' || steps.e2e-tests-report.outcome == 'failure'
-      run: |
-        echo "::error::The following e2e tests failed:"
-        if [ "${{ steps.e2e-tests.outcome }}" == "failure" ]; then echo "  - e2e (basic)"; fi
-        if [ "${{ steps.e2e-tests-report.outcome }}" == "failure" ]; then echo "  - e2e:report"; fi
-        exit 1
+      - name: Finalize AI web harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: ai-web
+          outcomes: >-
+            {"snapshot-basic-trace":"${{ steps.snapshot-e2e.outcome }}","web-e2e":"${{ steps.e2e-tests.outcome }}","report-e2e":"${{ steps.e2e-tests-report.outcome }}"}
+          report-roots: |
+            midscene_run/harness-input/ai-web-basic
+            packages/web-integration/midscene_run/report
 
   e2e-report:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup Puppeteer browser
-      uses: ./.github/actions/setup-puppeteer-browser
+      - name: Setup Puppeteer browser
+        uses: ./.github/actions/setup-puppeteer-browser
 
-    - name: Run apps/report e2e tests
-      run: cd apps/report && pnpm run e2e
-      id: e2e-tests-app-report
+      - name: Run apps/report e2e tests
+        run: cd apps/report && pnpm run e2e
+        id: e2e-tests-app-report
+        continue-on-error: true
 
-    - name: Upload apps/report e2e report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: e2e-app-report-output
-        path: |
-          ${{ github.workspace }}/midscene_run/report
-          ${{ github.workspace }}/apps/report/midscene_run/report
-        if-no-files-found: ignore
+      - name: Finalize report app harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: ai-report-app
+          outcomes: >-
+            {"report-app-e2e":"${{ steps.e2e-tests-app-report.outcome }}"}
+          report-roots: |
+            midscene_run/report
+            apps/report/midscene_run/report

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -112,10 +112,14 @@ jobs:
           HARNESS_SNAPSHOT_MODE: copy
         run: node scripts/ci-harness/snapshot-reports.mjs
 
+      # This stage follows the basic E2E suite in the same job. Give it a
+      # separate run directory so each score links only to its own Trace.
       - name: Run e2e tests report
-        run: pnpm run e2e:report
         id: e2e-tests-report
         continue-on-error: true
+        env:
+          MIDSCENE_RUN_DIR: ${{ github.workspace }}/midscene_run/harness-input/ai-web-report
+        run: pnpm run e2e:report
 
       - name: Finalize AI web harness
         if: always()
@@ -126,7 +130,7 @@ jobs:
             {"snapshot-basic-trace":"${{ steps.snapshot-e2e.outcome }}","web-e2e":"${{ steps.e2e-tests.outcome }}","report-e2e":"${{ steps.e2e-tests-report.outcome }}"}
           report-roots: |
             midscene_run/harness-input/ai-web-basic
-            packages/web-integration/midscene_run/report
+            midscene_run/harness-input/ai-web-report/report
 
   e2e-report:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -109,6 +109,7 @@ jobs:
         env:
           HARNESS_SNAPSHOT_SOURCE: packages/web-integration/midscene_run/report
           HARNESS_SNAPSHOT_DESTINATION: midscene_run/harness-input/ai-web-basic
+          HARNESS_SNAPSHOT_MODE: copy
         run: node scripts/ci-harness/snapshot-reports.mjs
 
       - name: Run e2e tests report

--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -1,13 +1,22 @@
 name: Android Emulator
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/android-emulator.yml'
+      - '.github/actions/harness-finalize/**'
       - 'apps/report/**'
       - 'packages/android/**'
       - 'packages/core/**'
       - 'packages/shared/**'
+      - 'scripts/ci-harness/**'
       - 'scripts/report-template-utils.mjs'
       - 'nx.json'
       - 'package.json'
@@ -157,68 +166,12 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-save -noaudio -no-boot-anim -camera-back none
           script: bash packages/android/scripts/run-emulator-ci-smokes.sh
 
-      - name: Collect host step outcomes
+      - name: Finalize Android Emulator harness
         if: always()
-        shell: bash
-        env:
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          PACKAGE_OUTCOME: ${{ steps.package-smoke.outcome }}
-          UNIT_OUTCOME: ${{ steps.unit-tests.outcome }}
-          EMULATOR_OUTCOME: ${{ steps.emulator-tests.outcome }}
-        run: |
-          mkdir -p "$MIDSCENE_ANDROID_DIAGNOSTICS_DIR"
-          node -e '
-            const fs = require("node:fs");
-            const path = require("node:path");
-            const outcomes = {
-              build: process.env.BUILD_OUTCOME,
-              packageSmoke: process.env.PACKAGE_OUTCOME,
-              unitTests: process.env.UNIT_OUTCOME,
-              emulatorTests: process.env.EMULATOR_OUTCOME,
-            };
-            fs.writeFileSync(
-              path.join(process.env.MIDSCENE_ANDROID_DIAGNOSTICS_DIR, "host-step-outcomes.json"),
-              `${JSON.stringify(outcomes, null, 2)}\n`,
-            );
-          '
-
-      - name: Upload Android Emulator smoke report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/harness-finalize
         with:
-          name: android-emulator-smoke-report
-          path: midscene_run/report/android-emulator-smoke.html
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Upload Android TodoMVC report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: android-todo-mvc-report
-          path: midscene_run/report/todo-mvc-android.html
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Upload Android Emulator diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: android-emulator-diagnostics
-          path: midscene_run/android-emulator-diagnostics
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Check Android validation results
-        if: always()
-        shell: bash
-        run: |
-          failed=()
-          [[ '${{ steps.build.outcome }}' == success ]] || failed+=(build)
-          [[ '${{ steps.package-smoke.outcome }}' == success ]] || failed+=("package smoke")
-          [[ '${{ steps.unit-tests.outcome }}' == success ]] || failed+=("unit tests")
-          [[ '${{ steps.emulator-tests.outcome }}' == success ]] || failed+=("emulator tests")
-          if ((${#failed[@]} > 0)); then
-            printf 'Android validation failed: %s\n' "${failed[*]}" >&2
-            exit 1
-          fi
+          suite: android-emulator
+          outcomes: >-
+            {"build":"${{ steps.build.outcome }}","package-smoke":"${{ steps.package-smoke.outcome }}","unit-tests":"${{ steps.unit-tests.outcome }}","emulator-tests":"${{ steps.emulator-tests.outcome }}"}
+          report-roots: midscene_run/report
+          evidence-roots: midscene_run/android-emulator-diagnostics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   main:
     # The viewport e2e relies on the hosted image's Chrome window behavior.
@@ -33,107 +32,110 @@ jobs:
     # env:
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
-  
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+      - name: Setup pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9.3.0
 
-    - name: Cache Puppeteer dependencies
-      uses: ./.github/actions/cache/restore
-      id: cache-puppeteer
-      with:
-        path: ~/.cache/puppeteer
-        key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-puppeteer-
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.13.0'
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
-    
-    - name: Install puppeteer dependencies
-      run: |
-        cd packages/web-integration
-        npx puppeteer browsers install chrome
+      - name: Cache Puppeteer dependencies
+        uses: ./.github/actions/cache/restore
+        id: cache-puppeteer
+        with:
+          path: ~/.cache/puppeteer
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-puppeteer-
 
-    - name: Save Puppeteer cache
-      if: steps.cache-puppeteer.outputs.cache-hit != 'true'
-      uses: ./.github/actions/cache/save
-      with:
-        path: ~/.cache/puppeteer
-        key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Check tsconfig references
-      run: pnpm run check:references
+      - name: Install puppeteer dependencies
+        run: |
+          cd packages/web-integration
+          npx puppeteer browsers install chrome
 
-    - name: Build project
-      run: pnpm run build
+      - name: Save Puppeteer cache
+        if: steps.cache-puppeteer.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache/save
+        with:
+          path: ~/.cache/puppeteer
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
 
-    - name: Check CLI CJS bundle on minimum supported Node
-      run: |
-        node - <<'EOF'
-        const { readdirSync, readFileSync, statSync } = require('node:fs');
-        const { join } = require('node:path');
+      - name: Check tsconfig references
+        run: pnpm run check:references
 
-        const root = 'packages/cli/dist/lib';
-        const files = [];
-        const collectJsFiles = (dir) => {
-          for (const entry of readdirSync(dir)) {
-            const file = join(dir, entry);
-            if (statSync(file).isDirectory()) {
-              collectJsFiles(file);
-            } else if (file.endsWith('.js')) {
-              files.push(file);
+      - name: Build project
+        run: pnpm run build
+
+      - name: Check CLI CJS bundle on minimum supported Node
+        run: |
+          node - <<'EOF'
+          const { readdirSync, readFileSync, statSync } = require('node:fs');
+          const { join } = require('node:path');
+
+          const root = 'packages/cli/dist/lib';
+          const files = [];
+          const collectJsFiles = (dir) => {
+            for (const entry of readdirSync(dir)) {
+              const file = join(dir, entry);
+              if (statSync(file).isDirectory()) {
+                collectJsFiles(file);
+              } else if (file.endsWith('.js')) {
+                files.push(file);
+              }
+            }
+          };
+          collectJsFiles(root);
+
+          const staticRequirePatterns = [
+            {
+              name: '@rstest/core',
+              pattern: /require\((['"])@rstest\/core(?:\/[^'"]*)?\1\)/,
+            },
+            {
+              name: '@rsbuild/core',
+              pattern: /require\((['"])@rsbuild\/core(?:\/[^'"]*)?\1\)/,
+            },
+          ];
+
+          for (const file of files) {
+            const content = readFileSync(file, 'utf8');
+            for (const { name, pattern } of staticRequirePatterns) {
+              if (pattern.test(content)) {
+                throw new Error(`${file} contains a static require("${name}")`);
+              }
             }
           }
-        };
-        collectJsFiles(root);
+          EOF
+          npx -y node@20.19.0 packages/cli/dist/lib/index.js --version
 
-        const staticRequirePatterns = [
-          {
-            name: '@rstest/core',
-            pattern: /require\((['"])@rstest\/core(?:\/[^'"]*)?\1\)/,
-          },
-          {
-            name: '@rsbuild/core',
-            pattern: /require\((['"])@rsbuild\/core(?:\/[^'"]*)?\1\)/,
-          },
-        ];
+      - name: Type check tests
+        run: pnpm run type-check:tests
 
-        for (const file of files) {
-          const content = readFileSync(file, 'utf8');
-          for (const { name, pattern } of staticRequirePatterns) {
-            if (pattern.test(content)) {
-              throw new Error(`${file} contains a static require("${name}")`);
-            }
-          }
-        }
-        EOF
-        npx -y node@20.19.0 packages/cli/dist/lib/index.js --version
+      - name: Test CI harness contracts
+        run: pnpm run test:ci-harness
 
-    - name: Type check tests
-      run: pnpm run type-check:tests
+      - name: Run tests with coverage
+        run: pnpm run test:coverage
 
-    - name: Run tests with coverage
-      run: pnpm run test:coverage
+      - name: Upload coverage reports
+        id: upload-coverage
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage
+          path: coverage
+          if-no-files-found: ignore
 
-    - name: Upload coverage reports
-      id: upload-coverage
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: coverage
-        path: coverage
-        if-no-files-found: ignore
-
-    - name: Write coverage summary
-      if: always()
-      env:
-        COVERAGE_ARTIFACT_URL: ${{ steps.upload-coverage.outputs.artifact-url }}
-      run: node scripts/github-coverage-summary.js
+      - name: Write coverage summary
+        if: always()
+        env:
+          COVERAGE_ARTIFACT_URL: ${{ steps.upload-coverage.outputs.artifact-url }}
+        run: node scripts/github-coverage-summary.js

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -1,14 +1,23 @@
 name: Headless Linux
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/headless-linux.yml'
+      - '.github/actions/harness-finalize/**'
       - 'apps/chrome-extension/**'
       - 'apps/report/**'
       - 'packages/computer/**'
       - 'packages/core/**'
       - 'packages/shared/**'
+      - 'scripts/ci-harness/**'
       - 'scripts/report-template-utils.mjs'
       - 'nx.json'
       - 'package.json'
@@ -30,7 +39,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
 
 jobs:
   headless-linux-ai-todo:
@@ -40,67 +49,64 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build AI todo projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
+      - name: Build AI todo projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
 
-    - name: Verify system setup
-      run: |
-        echo "--- Xvfb ---"
-        which Xvfb && echo "Xvfb: OK"
-        echo "--- xrandr ---"
-        which xrandr && echo "xrandr: OK"
-        echo "--- import (imagemagick) ---"
-        which import && echo "import: OK"
-        echo "--- Browser ---"
-        chromium --version || echo "Chrome not found"
-        echo "--- DISPLAY ---"
-        echo "DISPLAY=${DISPLAY:-(not set)}"
+      - name: Verify system setup
+        run: |
+          echo "--- Xvfb ---"
+          which Xvfb && echo "Xvfb: OK"
+          echo "--- xrandr ---"
+          which xrandr && echo "xrandr: OK"
+          echo "--- import (imagemagick) ---"
+          which import && echo "import: OK"
+          echo "--- Browser ---"
+          chromium --version || echo "Chrome not found"
+          echo "--- DISPLAY ---"
+          echo "DISPLAY=${DISPLAY:-(not set)}"
 
-    - name: Run AI todo test with Xvfb
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/ai-auto-todo.test.ts
-      timeout-minutes: 25
-      id: test-ai
-      continue-on-error: true
+      - name: Run AI todo test with Xvfb
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/ai-auto-todo.test.ts
+        timeout-minutes: 25
+        id: test-ai
+        continue-on-error: true
 
-    - name: Upload test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: headless-linux-ai-report
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-ai.outcome == 'failure'
-      run: exit 1
+      - name: Finalize AI Todo harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: headless-linux-ai-todo
+          outcomes: >-
+            {"ai-todo":"${{ steps.test-ai.outcome }}"}
+          report-roots: packages/computer/midscene_run/report
 
   chrome-extension:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
@@ -110,56 +116,53 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
       # Env vars to inject into Chrome extension's config UI via CDP
-      MIDSCENE_USE_QWEN3_VL: "1"
+      MIDSCENE_USE_QWEN3_VL: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build Chrome extension projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
+      - name: Build Chrome extension projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
-    - name: Run Chrome extension test
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension.test.ts
-      timeout-minutes: 40
-      id: test-ext
-      continue-on-error: true
+      - name: Run Chrome extension test
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension.test.ts
+        timeout-minutes: 40
+        id: test-ext
+        continue-on-error: true
 
-    - name: Upload test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: chrome-extension-report
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-ext.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Chrome extension harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: chrome-extension
+          outcomes: >-
+            {"chrome-extension":"${{ steps.test-ext.outcome }}"}
+          report-roots: packages/computer/midscene_run/report
 
   chrome-extension-bridge:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
@@ -168,55 +171,52 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
-      MIDSCENE_USE_QWEN3_VL: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
+      MIDSCENE_USE_QWEN3_VL: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build Chrome extension projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
+      - name: Build Chrome extension projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
-    - name: Run Bridge mode start/stop test
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-bridge.test.ts
-      timeout-minutes: 40
-      id: test-bridge
-      continue-on-error: true
+      - name: Run Bridge mode start/stop test
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-bridge.test.ts
+        timeout-minutes: 40
+        id: test-bridge
+        continue-on-error: true
 
-    - name: Upload bridge test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: chrome-extension-bridge-report
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-bridge.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Bridge harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: chrome-extension-bridge
+          outcomes: >-
+            {"bridge-mode":"${{ steps.test-bridge.outcome }}"}
+          report-roots: packages/computer/midscene_run/report
 
   chrome-extension-playground:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
@@ -233,55 +233,52 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
-      MIDSCENE_USE_QWEN3_VL: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
+      MIDSCENE_USE_QWEN3_VL: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build Chrome extension projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
+      - name: Build Chrome extension projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
-    - name: Run Playground E2E test
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/${{ matrix.test.file }}
-      timeout-minutes: 40
-      id: test-playground
-      continue-on-error: true
+      - name: Run Playground E2E test
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/${{ matrix.test.file }}
+        timeout-minutes: 40
+        id: test-playground
+        continue-on-error: true
 
-    - name: Upload test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: ${{ matrix.test.report }}
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-playground.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Playground harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: ${{ matrix.test.report }}
+          outcomes: >-
+            {"playground-e2e":"${{ steps.test-playground.outcome }}"}
+          report-roots: packages/computer/midscene_run/report
 
   chrome-extension-recorder:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
@@ -290,55 +287,52 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
-      MIDSCENE_USE_QWEN3_VL: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
+      MIDSCENE_USE_QWEN3_VL: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build Chrome extension projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
+      - name: Build Chrome extension projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
-    - name: Run Recorder mode tests
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-recorder.test.ts
-      timeout-minutes: 40
-      id: test-recorder
-      continue-on-error: true
+      - name: Run Recorder mode tests
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-recorder.test.ts
+        timeout-minutes: 40
+        id: test-recorder
+        continue-on-error: true
 
-    - name: Upload test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: chrome-extension-recorder-report
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-recorder.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Recorder harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: chrome-extension-recorder
+          outcomes: >-
+            {"recorder-mode":"${{ steps.test-recorder.outcome }}"}
+          report-roots: packages/computer/midscene_run/report
 
   chrome-extension-settings:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
@@ -347,52 +341,49 @@ jobs:
       MIDSCENE_MODEL_BASE_URL: ${{ vars.MIDSCENE_MODEL_BASE_URL }}
       MIDSCENE_MODEL_NAME: ${{ vars.MIDSCENE_MODEL_NAME }}
       MIDSCENE_MODEL_FAMILY: ${{ vars.MIDSCENE_MODEL_FAMILY }}
-      MIDSCENE_MODEL_RETRY_COUNT: "2"
-      MIDSCENE_MODEL_RETRY_INTERVAL: "60000"
-      MIDSCENE_REPORT_QUIET: "true"
-      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
-      CI: "1"
-      MIDSCENE_USE_QWEN3_VL: "1"
+      MIDSCENE_MODEL_RETRY_COUNT: '2'
+      MIDSCENE_MODEL_RETRY_INTERVAL: '60000'
+      MIDSCENE_REPORT_QUIET: 'true'
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: 'true'
+      CI: '1'
+      MIDSCENE_USE_QWEN3_VL: '1'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup Node.js and pnpm
-      uses: ./.github/actions/setup-node-pnpm
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Setup headless browser
-      uses: ./.github/actions/setup-headless-browser
+      - name: Setup headless browser
+        uses: ./.github/actions/setup-headless-browser
 
-    - name: Build Chrome extension projects
-      run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
+      - name: Build Chrome extension projects
+        run: pnpm exec nx run-many --target=build --projects="@midscene/report,chrome-extension" --skip-nx-cache
 
-    - name: Run Settings and cross-mode tests
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-settings.test.ts
-      timeout-minutes: 30
-      id: test-settings
-      continue-on-error: true
+      - name: Run Settings and cross-mode tests
+        run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/chrome-extension-settings.test.ts
+        timeout-minutes: 30
+        id: test-settings
+        continue-on-error: true
 
-    - name: Upload test report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: chrome-extension-settings-report
-        path: packages/computer/midscene_run/report
-        if-no-files-found: ignore
-
-    - name: Check test result
-      if: steps.test-settings.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Settings harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: chrome-extension-settings
+          outcomes: >-
+            {"settings-and-cross-mode":"${{ steps.test-settings.outcome }}"}
+          report-roots: packages/computer/midscene_run/report

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -1,14 +1,23 @@
 name: iOS Simulator
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/ios-simulator.yml'
+      - '.github/actions/harness-finalize/**'
       - 'apps/report/**'
       - 'packages/ios/**'
       - 'packages/webdriver/**'
       - 'packages/core/**'
       - 'packages/shared/**'
+      - 'scripts/ci-harness/**'
       - 'scripts/report-template-utils.mjs'
       - 'nx.json'
       - 'package.json'
@@ -147,68 +156,12 @@ jobs:
         shell: bash
         run: bash packages/ios/scripts/run-simulator-ci-smokes.sh
 
-      - name: Collect step outcomes
+      - name: Finalize iOS Simulator harness
         if: always()
-        shell: bash
-        env:
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          PACKAGE_OUTCOME: ${{ steps.package-smoke.outcome }}
-          UNIT_OUTCOME: ${{ steps.unit-tests.outcome }}
-          SIMULATOR_OUTCOME: ${{ steps.simulator-tests.outcome }}
-        run: |
-          mkdir -p "$MIDSCENE_IOS_DIAGNOSTICS_DIR"
-          node -e '
-            const fs = require("node:fs");
-            const path = require("node:path");
-            const outcomes = {
-              build: process.env.BUILD_OUTCOME,
-              packageSmoke: process.env.PACKAGE_OUTCOME,
-              unitTests: process.env.UNIT_OUTCOME,
-              simulatorTests: process.env.SIMULATOR_OUTCOME,
-            };
-            fs.writeFileSync(
-              path.join(process.env.MIDSCENE_IOS_DIAGNOSTICS_DIR, "host-step-outcomes.json"),
-              `${JSON.stringify(outcomes, null, 2)}\n`,
-            );
-          '
-
-      - name: Upload iOS Simulator smoke report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/harness-finalize
         with:
-          name: ios-simulator-smoke-report
-          path: midscene_run/report/ios-simulator-smoke.html
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Upload iOS TodoMVC report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ios-todo-mvc-report
-          path: midscene_run/report/todo-mvc-ios.html
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Upload iOS Simulator diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ios-simulator-diagnostics
-          path: midscene_run/ios-simulator-diagnostics
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Check iOS validation results
-        if: always()
-        shell: bash
-        run: |
-          failed=()
-          [[ '${{ steps.build.outcome }}' == success ]] || failed+=(build)
-          [[ '${{ steps.package-smoke.outcome }}' == success ]] || failed+=("package smoke")
-          [[ '${{ steps.unit-tests.outcome }}' == success ]] || failed+=("unit tests")
-          [[ '${{ steps.simulator-tests.outcome }}' == success ]] || failed+=("simulator tests")
-          if ((${#failed[@]} > 0)); then
-            printf 'iOS validation failed: %s\n' "${failed[*]}" >&2
-            exit 1
-          fi
+          suite: ios-simulator
+          outcomes: >-
+            {"build":"${{ steps.build.outcome }}","package-smoke":"${{ steps.package-smoke.outcome }}","unit-tests":"${{ steps.unit-tests.outcome }}","simulator-tests":"${{ steps.simulator-tests.outcome }}"}
+          report-roots: midscene_run/report
+          evidence-roots: midscene_run/ios-simulator-diagnostics

--- a/.github/workflows/macos-desktop.yml
+++ b/.github/workflows/macos-desktop.yml
@@ -1,13 +1,22 @@
 name: macOS Desktop
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/macos-desktop.yml'
+      - '.github/actions/harness-finalize/**'
       - 'apps/report/**'
       - 'packages/computer/**'
       - 'packages/core/**'
       - 'packages/shared/**'
+      - 'scripts/ci-harness/**'
       - 'scripts/report-template-utils.mjs'
       - 'nx.json'
       - 'package.json'
@@ -173,71 +182,12 @@ jobs:
           pnpm exec nx test @midscene/computer --skip-nx-cache -- tests/ai/ai-auto-todo.test.ts --retry=0 2>&1 |
             tee "$MIDSCENE_MACOS_DIAGNOSTICS_DIR/todo-mvc.log"
 
-      - name: Collect step outcomes
+      - name: Finalize macOS desktop harness
         if: always()
-        shell: bash
-        env:
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          PACKAGE_OUTCOME: ${{ steps.package-smoke.outcome }}
-          UNIT_OUTCOME: ${{ steps.unit-tests.outcome }}
-          LIVE_OUTCOME: ${{ steps.live-smoke.outcome }}
-          TODO_OUTCOME: ${{ steps.todo-mvc.outcome }}
-        run: |
-          mkdir -p "$MIDSCENE_MACOS_DIAGNOSTICS_DIR"
-          node -e '
-            const fs = require("node:fs");
-            const path = require("node:path");
-            const outcomes = {
-              build: process.env.BUILD_OUTCOME,
-              packageSmoke: process.env.PACKAGE_OUTCOME,
-              unitTests: process.env.UNIT_OUTCOME,
-              liveSmoke: process.env.LIVE_OUTCOME,
-              todoMvc: process.env.TODO_OUTCOME,
-            };
-            fs.writeFileSync(
-              path.join(process.env.MIDSCENE_MACOS_DIAGNOSTICS_DIR, "step-outcomes.json"),
-              `${JSON.stringify(outcomes, null, 2)}\n`,
-            );
-          '
-
-      - name: Upload macOS desktop smoke report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/harness-finalize
         with:
-          name: macos-desktop-smoke-report
-          path: midscene_run/report/macos-desktop-smoke.html
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Upload macOS TodoMVC report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: macos-todo-mvc-report
-          path: midscene_run/report/todo-mvc-darwin.html
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Upload macOS desktop diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: macos-desktop-diagnostics
-          path: midscene_run/macos-desktop-diagnostics
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Check macOS validation results
-        if: always()
-        shell: bash
-        run: |
-          failed=()
-          [[ '${{ steps.build.outcome }}' == success ]] || failed+=(build)
-          [[ '${{ steps.package-smoke.outcome }}' == success ]] || failed+=("package smoke")
-          [[ '${{ steps.unit-tests.outcome }}' == success ]] || failed+=("unit tests")
-          [[ '${{ steps.live-smoke.outcome }}' == success ]] || failed+=("live desktop smoke")
-          [[ '${{ steps.todo-mvc.outcome }}' == success ]] || failed+=("TodoMVC")
-          if ((${#failed[@]} > 0)); then
-            printf 'macOS validation failed: %s\n' "${failed[*]}" >&2
-            exit 1
-          fi
+          suite: macos-desktop
+          outcomes: >-
+            {"build":"${{ steps.build.outcome }}","package-smoke":"${{ steps.package-smoke.outcome }}","unit-tests":"${{ steps.unit-tests.outcome }}","live-smoke":"${{ steps.live-smoke.outcome }}","todo-mvc":"${{ steps.todo-mvc.outcome }}"}
+          report-roots: midscene_run/report
+          evidence-roots: midscene_run/macos-desktop-diagnostics

--- a/.github/workflows/nightly-harness.yml
+++ b/.github/workflows/nightly-harness.yml
@@ -1,0 +1,114 @@
+name: Nightly Harness
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: nightly-harness-main
+  cancel-in-progress: false
+
+jobs:
+  ai-playwright:
+    uses: ./.github/workflows/ai.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  ai-unit:
+    uses: ./.github/workflows/ai-unit-test.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  headless-linux:
+    uses: ./.github/workflows/headless-linux.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  studio-headless-linux:
+    uses: ./.github/workflows/studio-headless-linux.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  macos-desktop:
+    uses: ./.github/workflows/macos-desktop.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  windows-desktop:
+    uses: ./.github/workflows/windows-desktop.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  android-emulator:
+    uses: ./.github/workflows/android-emulator.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  ios-simulator:
+    uses: ./.github/workflows/ios-simulator.yml
+    with:
+      branch: main
+    secrets: inherit
+
+  aggregate:
+    if: always()
+    needs:
+      - ai-playwright
+      - ai-unit
+      - headless-linux
+      - studio-headless-linux
+      - macos-desktop
+      - windows-desktop
+      - android-emulator
+      - ios-simulator
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Download harness Trace Bundles
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: harness-*
+          path: midscene_run/nightly-input
+
+      - name: Aggregate nightly scorecards
+        id: aggregate
+        continue-on-error: true
+        run: node scripts/ci-harness/aggregate.mjs
+
+      - name: Upload nightly aggregate
+        id: upload
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nightly-harness-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.aggregate.outputs.output-dir || 'midscene_run/nightly-aggregate' }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce nightly aggregate
+        if: always()
+        env:
+          HARNESS_FINALIZE_OUTCOME: ${{ steps.aggregate.outcome }}
+          HARNESS_UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+          HARNESS_CONCLUSION: ${{ steps.aggregate.outputs.conclusion }}
+        run: node scripts/ci-harness/enforce.mjs

--- a/.github/workflows/studio-headless-linux.yml
+++ b/.github/workflows/studio-headless-linux.yml
@@ -1,10 +1,19 @@
 name: Studio Headless Linux
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - 'apps/studio/**'
       - '.github/workflows/studio-headless-linux.yml'
+      - '.github/actions/harness-finalize/**'
+      - 'scripts/ci-harness/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -31,115 +40,116 @@ jobs:
       MIDSCENE_REPORT_QUIET: 'true'
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9.3.0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 9.3.0
 
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: '24.13.0'
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.13.0'
 
-    - name: Cache pnpm store
-      id: pnpm-cache
-      uses: ./.github/actions/pnpm-cache/restore
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: ./.github/actions/pnpm-cache/restore
 
-    - name: Cache Electron binary
-      id: electron-cache
-      uses: ./.github/actions/cache/restore
-      with:
-        path: ~/.cache/electron
-        key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-
+      - name: Cache Electron binary
+        id: electron-cache
+        uses: ./.github/actions/cache/restore
+        with:
+          path: ~/.cache/electron
+          key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          xvfb \
-          x11-xserver-utils \
-          libasound2 \
-          libatk-bridge2.0-0 \
-          libatk1.0-0 \
-          libcups2 \
-          libdrm2 \
-          libgbm1 \
-          libgtk-3-0 \
-          libnotify4 \
-          libnss3 \
-          libpango-1.0-0 \
-          libx11-xcb1 \
-          libxcomposite1 \
-          libxdamage1 \
-          libxfixes3 \
-          libxinerama1 \
-          libxkbcommon-x11-0 \
-          libxkbcommon0 \
-          libxrandr2 \
-          libxshmfence1 \
-          libxss1 \
-          libxtst6
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            x11-xserver-utils \
+            libasound2 \
+            libatk-bridge2.0-0 \
+            libatk1.0-0 \
+            libcups2 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnotify4 \
+            libnss3 \
+            libpango-1.0-0 \
+            libx11-xcb1 \
+            libxcomposite1 \
+            libxdamage1 \
+            libxfixes3 \
+            libxinerama1 \
+            libxkbcommon-x11-0 \
+            libxkbcommon0 \
+            libxrandr2 \
+            libxshmfence1 \
+            libxss1 \
+            libxtst6
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-      env:
-        PUPPETEER_SKIP_DOWNLOAD: 'true'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
 
-    - name: Save pnpm store
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/pnpm-cache/save
+      - name: Save pnpm store
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pnpm-cache/save
 
-    - name: Save Electron binary
-      if: steps.electron-cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/cache/save
-      with:
-        path: ~/.cache/electron
-        key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Save Electron binary
+        if: steps.electron-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache/save
+        with:
+          path: ~/.cache/electron
+          key: midscene-electron-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-    - name: Setup Puppeteer browser
-      uses: ./.github/actions/setup-puppeteer-browser
-      with:
-        package-directory: apps/studio
+      - name: Setup Puppeteer browser
+        uses: ./.github/actions/setup-puppeteer-browser
+        with:
+          package-directory: apps/studio
 
-    - name: Build Studio
-      run: npx nx run-many --target=build --projects=studio,@midscene/report
+      - name: Build Studio
+        run: npx nx run-many --target=build --projects=studio,@midscene/report
 
-    - name: Re-inject report template into @midscene/core dist
-      run: node apps/report/scripts/inject-report-template.mjs
+      - name: Re-inject report template into @midscene/core dist
+        run: node apps/report/scripts/inject-report-template.mjs
 
-    - name: Run Studio startup smoke test
-      run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke
-      env:
-        MIDSCENE_STUDIO_RUN_STARTUP_SMOKE: '1'
+      - name: Run Studio startup smoke test
+        id: startup-smoke
+        continue-on-error: true
+        run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke
+        env:
+          MIDSCENE_STUDIO_RUN_STARTUP_SMOKE: '1'
 
-    - name: Run Studio Web preview e2e test
-      run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:web-preview
-      timeout-minutes: 10
-      env:
-        MIDSCENE_STUDIO_RUN_WEB_PREVIEW_E2E: '1'
+      - name: Run Studio Web preview e2e test
+        id: web-preview
+        continue-on-error: true
+        run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:web-preview
+        timeout-minutes: 10
+        env:
+          MIDSCENE_STUDIO_RUN_WEB_PREVIEW_E2E: '1'
 
-    - name: Run Studio Midscene startup test
-      run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:ai
-      timeout-minutes: 25
-      id: test-ai
-      continue-on-error: true
-      env:
-        MIDSCENE_STUDIO_RUN_STARTUP_SMOKE_AI: '1'
+      - name: Run Studio Midscene startup test
+        run: xvfb-run -a --server-args="-screen 0 1920x1080x24" pnpm --dir apps/studio run test:smoke:ai
+        timeout-minutes: 25
+        id: test-ai
+        continue-on-error: true
+        env:
+          MIDSCENE_STUDIO_RUN_STARTUP_SMOKE_AI: '1'
 
-    - name: Upload Studio Midscene report
-      if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: studio-startup-ai-report
-        path: apps/studio/midscene_run/report/studio-startup-ai-report.html
-        if-no-files-found: error
-
-    - name: Check Studio Midscene startup result
-      if: steps.test-ai.outcome == 'failure'
-      run: exit 1
+      - name: Finalize Studio harness
+        if: always()
+        uses: ./.github/actions/harness-finalize
+        with:
+          suite: studio-headless-linux
+          outcomes: >-
+            {"studio-startup":"${{ steps.startup-smoke.outcome }}","studio-web-preview":"${{ steps.web-preview.outcome }}","studio-ai-startup":"${{ steps.test-ai.outcome }}"}
+          report-roots: apps/studio/midscene_run/report

--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -1,13 +1,22 @@
 name: Windows Desktop
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/windows-desktop.yml'
+      - '.github/actions/harness-finalize/**'
       - 'apps/report/**'
       - 'packages/computer/**'
       - 'packages/core/**'
       - 'packages/shared/**'
+      - 'scripts/ci-harness/**'
       - 'scripts/report-template-utils.mjs'
       - 'nx.json'
       - 'package.json'
@@ -302,60 +311,12 @@ jobs:
             throw "Windows TodoMVC test failed with exit code $testExitCode."
           }
 
-      - name: Collect step outcomes
+      - name: Finalize Windows desktop harness
         if: always()
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR | Out-Null
-          $outcomes = [ordered]@{
-            build = '${{ steps.build.outcome }}'
-            packageSmoke = '${{ steps.package-smoke.outcome }}'
-            unitTests = '${{ steps.unit-tests.outcome }}'
-            liveSmoke = '${{ steps.live-smoke.outcome }}'
-            todoMvc = '${{ steps.todo-mvc.outcome }}'
-          }
-          $outcomes | ConvertTo-Json |
-            Set-Content -LiteralPath (
-              Join-Path $env:MIDSCENE_WINDOWS_DIAGNOSTICS_DIR 'step-outcomes.json'
-            ) -Encoding utf8
-
-      - name: Upload Windows desktop report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/harness-finalize
         with:
-          name: windows-desktop-smoke-report
-          path: midscene_run/report/windows-desktop-smoke.html
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Upload Windows desktop diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: windows-desktop-diagnostics
-          path: midscene_run/windows-desktop-diagnostics
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Upload Windows TodoMVC report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: windows-todo-mvc-report
-          path: midscene_run/report/todo-mvc-win32.html
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Check Windows validation results
-        if: always()
-        shell: pwsh
-        run: |
-          $failed = @()
-          if ('${{ steps.build.outcome }}' -ne 'success') { $failed += 'build' }
-          if ('${{ steps.package-smoke.outcome }}' -ne 'success') { $failed += 'package smoke' }
-          if ('${{ steps.unit-tests.outcome }}' -ne 'success') { $failed += 'unit tests' }
-          if ('${{ steps.live-smoke.outcome }}' -ne 'success') { $failed += 'live desktop smoke' }
-          if ('${{ steps.todo-mvc.outcome }}' -ne 'success') { $failed += 'TodoMVC' }
-          if ($failed.Count -gt 0) {
-            throw "Windows validation failed: $($failed -join ', ')"
-          }
+          suite: windows-desktop
+          outcomes: >-
+            {"build":"${{ steps.build.outcome }}","package-smoke":"${{ steps.package-smoke.outcome }}","unit-tests":"${{ steps.unit-tests.outcome }}","live-smoke":"${{ steps.live-smoke.outcome }}","todo-mvc":"${{ steps.todo-mvc.outcome }}"}
+          report-roots: midscene_run/report
+          evidence-roots: midscene_run/windows-desktop-diagnostics

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "nx run-many --target=test --verbose -- --coverage",
     "test:ai": "nx run-many --target=test:ai --projects=@midscene/core,@midscene/web,@midscene/cli --verbose",
     "test:ai:coverage": "MIDSCENE_COVERAGE_DIR=coverage-ai nx run-many --target=test:ai --projects=@midscene/core,@midscene/web,@midscene/cli --verbose -- --coverage",
+    "test:ci-harness": "node --test scripts/ci-harness/tests/*.test.mjs",
     "e2e": "nx run @midscene/web:e2e --verbose --exclude-task-dependencies",
     "e2e:cache": "nx run @midscene/web:e2e:cache --verbose  --exclude-task-dependencies",
     "e2e:report": "nx run @midscene/web:e2e:report --verbose  --exclude-task-dependencies",

--- a/packages/ios/scripts/run-simulator-ci-smokes.sh
+++ b/packages/ios/scripts/run-simulator-ci-smokes.sh
@@ -130,6 +130,7 @@ xcrun simctl list devices > "$diagnostics_dir/simulator-devices-booted.txt"
 rm -rf "$derived_data_dir"
 USE_PORT="$wda_port" \
 MJPEG_SERVER_PORT="$mjpeg_port" \
+env -u MIDSCENE_MODEL_API_KEY \
 xcodebuild \
   -project "$wda_project" \
   -scheme WebDriverAgentRunner \

--- a/scripts/ci-harness/aggregate.mjs
+++ b/scripts/ci-harness/aggregate.mjs
@@ -1,0 +1,151 @@
+import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+async function findScorecards(root) {
+  const found = [];
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) found.push(...(await findScorecards(entryPath)));
+    else if (entry.isFile() && entry.name === 'scorecard.json') found.push(entryPath);
+  }
+  return found;
+}
+
+function summary(aggregate) {
+  const icon =
+    aggregate.verdict === 'pass'
+      ? '✅'
+      : aggregate.verdict === 'fail'
+        ? '❌'
+        : '⚠️';
+  const lines = [
+    `## ${icon} Nightly Harness`,
+    '',
+    `Verdict: **${aggregate.verdict}** · Suites: **${aggregate.suites.length}/${aggregate.expectedSuites.length}** · Scored cases: **${aggregate.totals.passed}/${aggregate.totals.scored} passed**`,
+    '',
+    '| Suite | Verdict | Trace | Cases | Tasks |',
+    '| --- | --- | --- | ---: | ---: |',
+  ];
+  for (const suite of aggregate.suites) {
+    lines.push(
+      `| ${suite.suite} | ${suite.verdict} | ${suite.traceHealth.status} | ${suite.cases.length} | ${suite.traceHealth.taskCount} |`,
+    );
+  }
+  if (aggregate.issues.length > 0) {
+    lines.push('', '### Aggregation issues', '');
+    for (const issue of aggregate.issues) lines.push(`- ${issue}`);
+  }
+  if (aggregate.runUrl) lines.push('', `[Open workflow run](${aggregate.runUrl})`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function setOutputs(outputs) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    `${Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n')}\n`,
+  );
+}
+
+try {
+  const workspace = path.resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+  const inputDir = path.resolve(
+    workspace,
+    process.env.HARNESS_AGGREGATE_INPUT ?? 'midscene_run/nightly-input',
+  );
+  const outputDir = path.resolve(
+    workspace,
+    process.env.HARNESS_AGGREGATE_OUTPUT ?? 'midscene_run/nightly-aggregate',
+  );
+  const expectedSuites = process.env.HARNESS_EXPECTED_SUITES
+    ? JSON.parse(process.env.HARNESS_EXPECTED_SUITES)
+    : Object.keys(
+        JSON.parse(
+          await readFile(
+            path.join(workspace, 'scripts', 'ci-harness', 'suites.json'),
+            'utf8',
+          ),
+        ),
+      );
+  const scorecardFiles = await findScorecards(inputDir);
+  const suites = [];
+  const issues = [];
+  for (const scorecardFile of scorecardFiles) {
+    try {
+      const scorecard = JSON.parse(await readFile(scorecardFile, 'utf8'));
+      if (!scorecard.suite || !scorecard.verdict || !scorecard.traceHealth) {
+        throw new Error('missing required scorecard fields');
+      }
+      suites.push(scorecard);
+    } catch (error) {
+      issues.push(
+        `Invalid scorecard ${path.relative(workspace, scorecardFile)}: ${error.message}`,
+      );
+    }
+  }
+
+  const suiteNames = suites.map((suite) => suite.suite);
+  for (const expected of expectedSuites) {
+    if (!suiteNames.includes(expected)) issues.push(`Missing suite: ${expected}`);
+  }
+  for (const suiteName of new Set(suiteNames)) {
+    if (suiteNames.filter((value) => value === suiteName).length > 1) {
+      issues.push(`Duplicate suite scorecard: ${suiteName}`);
+    }
+  }
+
+  suites.sort((a, b) => a.suite.localeCompare(b.suite));
+  const cases = suites.flatMap((suite) => suite.cases ?? []);
+  const verdict =
+    issues.length > 0 || suites.some((suite) => suite.verdict === 'infra_error')
+      ? 'infra_error'
+      : suites.some((suite) => suite.verdict === 'fail')
+        ? 'fail'
+        : 'pass';
+  const runId = process.env.GITHUB_RUN_ID;
+  const aggregate = {
+    schemaVersion: 1,
+    verdict,
+    conclusion: verdict === 'pass' ? 'success' : 'failure',
+    runId,
+    runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT ?? 1),
+    runUrl:
+      process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && runId
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${runId}`
+        : undefined,
+    expectedSuites,
+    totals: {
+      scored: cases.filter((item) => item.score === 0 || item.score === 1).length,
+      passed: cases.filter((item) => item.score === 1).length,
+      failed: cases.filter((item) => item.score === 0).length,
+    },
+    suites,
+    issues,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  const summaryContent = summary(aggregate);
+  const scorecardPath = path.join(outputDir, 'aggregate-scorecard.json');
+  await writeFile(scorecardPath, `${JSON.stringify(aggregate, null, 2)}\n`);
+  await writeFile(path.join(outputDir, 'summary.md'), summaryContent);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summaryContent}\n`);
+  }
+  await setOutputs({
+    conclusion: aggregate.conclusion,
+    verdict: aggregate.verdict,
+    'output-dir': outputDir,
+  });
+} catch (error) {
+  console.error(`::error::Nightly harness aggregation failed: ${error.stack || error}`);
+  process.exitCode = 1;
+}

--- a/scripts/ci-harness/aggregate.mjs
+++ b/scripts/ci-harness/aggregate.mjs
@@ -1,4 +1,10 @@
-import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 
 async function findScorecards(root) {
@@ -12,7 +18,8 @@ async function findScorecards(root) {
   for (const entry of entries) {
     const entryPath = path.join(root, entry.name);
     if (entry.isDirectory()) found.push(...(await findScorecards(entryPath)));
-    else if (entry.isFile() && entry.name === 'scorecard.json') found.push(entryPath);
+    else if (entry.isFile() && entry.name === 'scorecard.json')
+      found.push(entryPath);
   }
   return found;
 }
@@ -41,7 +48,8 @@ function summary(aggregate) {
     lines.push('', '### Aggregation issues', '');
     for (const issue of aggregate.issues) lines.push(`- ${issue}`);
   }
-  if (aggregate.runUrl) lines.push('', `[Open workflow run](${aggregate.runUrl})`);
+  if (aggregate.runUrl)
+    lines.push('', `[Open workflow run](${aggregate.runUrl})`);
   lines.push('');
   return lines.join('\n');
 }
@@ -95,7 +103,8 @@ try {
 
   const suiteNames = suites.map((suite) => suite.suite);
   for (const expected of expectedSuites) {
-    if (!suiteNames.includes(expected)) issues.push(`Missing suite: ${expected}`);
+    if (!suiteNames.includes(expected))
+      issues.push(`Missing suite: ${expected}`);
   }
   for (const suiteName of new Set(suiteNames)) {
     if (suiteNames.filter((value) => value === suiteName).length > 1) {
@@ -124,7 +133,8 @@ try {
         : undefined,
     expectedSuites,
     totals: {
-      scored: cases.filter((item) => item.score === 0 || item.score === 1).length,
+      scored: cases.filter((item) => item.score === 0 || item.score === 1)
+        .length,
       passed: cases.filter((item) => item.score === 1).length,
       failed: cases.filter((item) => item.score === 0).length,
     },
@@ -146,6 +156,8 @@ try {
     'output-dir': outputDir,
   });
 } catch (error) {
-  console.error(`::error::Nightly harness aggregation failed: ${error.stack || error}`);
+  console.error(
+    `::error::Nightly harness aggregation failed: ${error.stack || error}`,
+  );
   process.exitCode = 1;
 }

--- a/scripts/ci-harness/enforce.mjs
+++ b/scripts/ci-harness/enforce.mjs
@@ -1,0 +1,21 @@
+const failures = [];
+if (process.env.HARNESS_FINALIZE_OUTCOME !== 'success') {
+  failures.push('the harness finalizer did not complete');
+}
+if (process.env.HARNESS_UPLOAD_OUTCOME !== 'success') {
+  failures.push('the Trace Bundle was not uploaded');
+}
+if (
+  process.env.HARNESS_SUMMARY_OUTCOME &&
+  process.env.HARNESS_SUMMARY_OUTCOME !== 'success'
+) {
+  failures.push('the harness summary was not published');
+}
+if (process.env.HARNESS_CONCLUSION !== 'success') {
+  failures.push(`the harness conclusion is ${process.env.HARNESS_CONCLUSION || 'missing'}`);
+}
+
+if (failures.length > 0) {
+  console.error(`::error::Harness failed: ${failures.join('; ')}`);
+  process.exitCode = 1;
+}

--- a/scripts/ci-harness/enforce.mjs
+++ b/scripts/ci-harness/enforce.mjs
@@ -12,7 +12,9 @@ if (
   failures.push('the harness summary was not published');
 }
 if (process.env.HARNESS_CONCLUSION !== 'success') {
-  failures.push(`the harness conclusion is ${process.env.HARNESS_CONCLUSION || 'missing'}`);
+  failures.push(
+    `the harness conclusion is ${process.env.HARNESS_CONCLUSION || 'missing'}`,
+  );
 }
 
 if (failures.length > 0) {

--- a/scripts/ci-harness/finalize.mjs
+++ b/scripts/ci-harness/finalize.mjs
@@ -1,0 +1,46 @@
+import { appendFile } from 'node:fs/promises';
+import { finalizeHarnessRun, resolveStages } from './lib.mjs';
+
+function input(name, fallback = '') {
+  return process.env[name] ?? fallback;
+}
+
+async function setOutputs(outputs) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  const content = Object.entries(outputs)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  await appendFile(process.env.GITHUB_OUTPUT, `${content}\n`);
+}
+
+try {
+  const workspace = input('GITHUB_WORKSPACE', process.cwd());
+  const suite = input('HARNESS_SUITE');
+  const stages = await resolveStages({
+    workspace,
+    suite,
+    inlineStages: input('HARNESS_STAGES'),
+    outcomes: input('HARNESS_OUTCOMES'),
+  });
+  const result = await finalizeHarnessRun({
+    workspace,
+    suite,
+    stages,
+    reportRoots: input('HARNESS_REPORT_ROOTS'),
+    evidenceRoots: input('HARNESS_EVIDENCE_ROOTS'),
+    outputDir: input('HARNESS_OUTPUT_DIR') || undefined,
+    environment: process.env,
+  });
+  await setOutputs({
+    conclusion: result.scorecard.conclusion,
+    verdict: result.scorecard.verdict,
+    'output-dir': result.outputDir,
+    'scorecard-path': result.scorecardPath,
+  });
+  console.log(
+    `Harness ${result.scorecard.suite}: ${result.scorecard.verdict} (${result.scorecard.traceHealth.status} trace)`,
+  );
+} catch (error) {
+  console.error(`::error::Harness finalization failed: ${error.stack || error}`);
+  process.exitCode = 1;
+}

--- a/scripts/ci-harness/finalize.mjs
+++ b/scripts/ci-harness/finalize.mjs
@@ -41,6 +41,8 @@ try {
     `Harness ${result.scorecard.suite}: ${result.scorecard.verdict} (${result.scorecard.traceHealth.status} trace)`,
   );
 } catch (error) {
-  console.error(`::error::Harness finalization failed: ${error.stack || error}`);
+  console.error(
+    `::error::Harness finalization failed: ${error.stack || error}`,
+  );
   process.exitCode = 1;
 }

--- a/scripts/ci-harness/lib.mjs
+++ b/scripts/ci-harness/lib.mjs
@@ -13,12 +13,7 @@ import {
 } from 'node:fs/promises';
 import path from 'node:path';
 
-const VALID_OUTCOMES = new Set([
-  'success',
-  'failure',
-  'cancelled',
-  'skipped',
-]);
+const VALID_OUTCOMES = new Set(['success', 'failure', 'cancelled', 'skipped']);
 const VALID_STAGE_KINDS = new Set(['case', 'check', 'infrastructure']);
 const TEXT_FILE_EXTENSIONS = new Set([
   '.html',
@@ -101,7 +96,9 @@ function resolveWorkspacePath(workspace, inputPath) {
   const resolved = path.resolve(workspace, inputPath);
   const relative = path.relative(workspace, resolved);
   if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Harness evidence path must stay inside the workspace: ${inputPath}`);
+    throw new Error(
+      `Harness evidence path must stay inside the workspace: ${inputPath}`,
+    );
   }
   return resolved;
 }
@@ -147,8 +144,7 @@ export function parseStages(value) {
     }
 
     const reportPatterns = (
-      stage.reportPatterns ??
-      (stage.reportPattern ? [stage.reportPattern] : [])
+      stage.reportPatterns ?? (stage.reportPattern ? [stage.reportPattern] : [])
     ).map(String);
 
     return {
@@ -182,11 +178,20 @@ export async function resolveStages({
   } catch (error) {
     throw new Error(`Invalid HARNESS_OUTCOMES JSON: ${error.message}`);
   }
-  if (!outcomeMap || typeof outcomeMap !== 'object' || Array.isArray(outcomeMap)) {
+  if (
+    !outcomeMap ||
+    typeof outcomeMap !== 'object' ||
+    Array.isArray(outcomeMap)
+  ) {
     throw new Error('HARNESS_OUTCOMES must be a JSON object');
   }
 
-  const registryPath = path.join(workspace, 'scripts', 'ci-harness', 'suites.json');
+  const registryPath = path.join(
+    workspace,
+    'scripts',
+    'ci-harness',
+    'suites.json',
+  );
   const registry = JSON.parse(await readFile(registryPath, 'utf8'));
   const registeredStages = registry[suite];
   if (!Array.isArray(registeredStages)) {
@@ -233,7 +238,9 @@ function globToRegExp(pattern) {
 
 function reportMatches(report, pattern) {
   const matcher = globToRegExp(pattern);
-  return matcher.test(report.path) || matcher.test(path.posix.basename(report.path));
+  return (
+    matcher.test(report.path) || matcher.test(path.posix.basename(report.path))
+  );
 }
 
 async function copyRoots({ workspace, roots, outputDir, category, warnings }) {
@@ -287,7 +294,9 @@ async function scanDumpScripts(filePath) {
       }
       const previousCharacter = start === 0 ? '' : pending[start - 1];
       const startsHtmlTag =
-        start === 0 || previousCharacter === '>' || /\s/.test(previousCharacter);
+        start === 0 ||
+        previousCharacter === '>' ||
+        /\s/.test(previousCharacter);
       if (!startsHtmlTag) {
         pending = pending.slice(start + openPrefix.length);
         continue;
@@ -444,11 +453,7 @@ async function extractReport(reportFile, outputDir) {
       modelBriefs: metadata.modelBriefs ?? [],
       deviceType: metadata.deviceType,
       executions: [
-        rebaseFileReferences(
-          execution,
-          path.dirname(reportFile),
-          executionDir,
-        ),
+        rebaseFileReferences(execution, path.dirname(reportFile), executionDir),
       ],
     };
     await writeFile(dumpPath, `${JSON.stringify(executionDump, null, 2)}\n`);
@@ -522,7 +527,9 @@ function provenance(environment, suite, stages) {
   const modelBaseUrl = environment.MIDSCENE_MODEL_BASE_URL || '';
   const runId = environment.GITHUB_RUN_ID ?? 'local';
   const runUrl =
-    environment.GITHUB_SERVER_URL && environment.GITHUB_REPOSITORY && runId !== 'local'
+    environment.GITHUB_SERVER_URL &&
+    environment.GITHUB_REPOSITORY &&
+    runId !== 'local'
       ? `${environment.GITHUB_SERVER_URL}/${environment.GITHUB_REPOSITORY}/actions/runs/${runId}`
       : undefined;
   const environmentInfo = {
@@ -575,13 +582,13 @@ function aggregateVerdict(stages, harnessIssues) {
   const requiredStages = stages.filter((stage) => stage.required);
   if (
     requiredStages.some(
-      (stage) =>
-        stage.kind === 'infrastructure' && stage.outcome !== 'success',
+      (stage) => stage.kind === 'infrastructure' && stage.outcome !== 'success',
     )
   ) {
     return 'infra_error';
   }
-  if (requiredStages.some((stage) => stage.outcome === 'failure')) return 'fail';
+  if (requiredStages.some((stage) => stage.outcome === 'failure'))
+    return 'fail';
   if (
     requiredStages.some(
       (stage) => stage.outcome === 'cancelled' || stage.outcome === 'skipped',
@@ -603,9 +610,7 @@ async function writeCaseFiles(outputDir, attemptId, result) {
   const validator = {
     ...result.validator,
     evidenceRefs: [
-      ...result.trace.tasks.map(
-        (task) => `task:${task.taskId || 'missing'}`,
-      ),
+      ...result.trace.tasks.map((task) => `task:${task.taskId || 'missing'}`),
       ...new Set(
         result.trace.tasks.map(
           (task) => `execution-dump:${task.executionDump}`,
@@ -641,7 +646,9 @@ async function writeCaseFiles(outputDir, attemptId, result) {
 function secretValues(environment) {
   const sensitiveName = /(API_KEY|AUTH_TOKEN|PASSWORD|SECRET|TOKEN)$/i;
   return Object.entries(environment)
-    .filter(([key, value]) => sensitiveName.test(key) && String(value).length >= 8)
+    .filter(
+      ([key, value]) => sensitiveName.test(key) && String(value).length >= 8,
+    )
     .map(([, value]) => String(value));
 }
 
@@ -649,7 +656,10 @@ async function containsSecret(filePath, secrets) {
   if (!TEXT_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
     return false;
   }
-  const maxSecretLength = Math.max(0, ...secrets.map((secret) => secret.length));
+  const maxSecretLength = Math.max(
+    0,
+    ...secrets.map((secret) => secret.length),
+  );
   const overlap = Math.max(4096, maxSecretLength);
   let tail = '';
   for await (const chunk of createReadStream(filePath, { encoding: 'utf8' })) {
@@ -728,9 +738,7 @@ export function renderSummary(scorecard, options = {}) {
     const firstAnchor = result.trace.tasks.find((task) => task.anchor)?.anchor;
     const trace = target
       ? `[View Trace](${target})${
-          !traceBaseUrl && firstAnchor
-            ? `<br>${markdownCode(firstAnchor)}`
-            : ''
+          !traceBaseUrl && firstAnchor ? `<br>${markdownCode(firstAnchor)}` : ''
         }`
       : firstAnchor
         ? markdownCode(firstAnchor)
@@ -741,7 +749,13 @@ export function renderSummary(scorecard, options = {}) {
   }
 
   if (scorecard.checks.length > 0) {
-    lines.push('', '### Required checks', '', '| Check | Kind | Outcome |', '| --- | --- | --- |');
+    lines.push(
+      '',
+      '### Required checks',
+      '',
+      '| Check | Kind | Outcome |',
+      '| --- | --- | --- |',
+    );
     for (const check of scorecard.checks) {
       lines.push(
         `| ${markdown(check.name)} | ${check.kind} | ${check.outcome} |`,
@@ -751,11 +765,13 @@ export function renderSummary(scorecard, options = {}) {
 
   if (scorecard.harnessIssues.length > 0) {
     lines.push('', '### Harness issues', '');
-    for (const issue of scorecard.harnessIssues) lines.push(`- ${markdown(issue)}`);
+    for (const issue of scorecard.harnessIssues)
+      lines.push(`- ${markdown(issue)}`);
   }
   if (scorecard.warnings.length > 0) {
     lines.push('', '<details><summary>Collection warnings</summary>', '');
-    for (const warning of scorecard.warnings) lines.push(`- ${markdown(warning)}`);
+    for (const warning of scorecard.warnings)
+      lines.push(`- ${markdown(warning)}`);
     lines.push('', '</details>');
   }
 
@@ -876,7 +892,9 @@ export async function finalizeHarnessRun(options) {
       ),
   );
   if (await exists(outputDir)) {
-    throw new Error(`Harness output is immutable and already exists: ${outputDir}`);
+    throw new Error(
+      `Harness output is immutable and already exists: ${outputDir}`,
+    );
   }
   await mkdir(outputDir, { recursive: true });
 
@@ -924,17 +942,22 @@ export async function finalizeHarnessRun(options) {
       stage.reportPatterns.length === 0
         ? reports
         : reports.filter((report) =>
-            stage.reportPatterns.some((pattern) => reportMatches(report, pattern)),
+            stage.reportPatterns.some((pattern) =>
+              reportMatches(report, pattern),
+            ),
           );
     const tasks = flattenTasks(matchingReports);
     const traceProblems = [];
     if (stage.traceRequired && stage.required && stage.outcome !== 'skipped') {
       for (const pattern of stage.reportPatterns) {
         if (!reports.some((report) => reportMatches(report, pattern))) {
-          traceProblems.push(`required report pattern has no match: ${pattern}`);
+          traceProblems.push(
+            `required report pattern has no match: ${pattern}`,
+          );
         }
       }
-      if (matchingReports.length === 0) traceProblems.push('no report was collected');
+      if (matchingReports.length === 0)
+        traceProblems.push('no report was collected');
       if (tasks.length === 0) traceProblems.push('no Midscene task was found');
       if (tasks.some((task) => !task.taskId)) {
         traceProblems.push('one or more tasks are missing taskId');

--- a/scripts/ci-harness/lib.mjs
+++ b/scripts/ci-harness/lib.mjs
@@ -1,0 +1,1046 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import {
+  access,
+  copyFile,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+
+const VALID_OUTCOMES = new Set([
+  'success',
+  'failure',
+  'cancelled',
+  'skipped',
+]);
+const VALID_STAGE_KINDS = new Set(['case', 'check', 'infrastructure']);
+const TEXT_FILE_EXTENSIONS = new Set([
+  '.html',
+  '.json',
+  '.log',
+  '.md',
+  '.txt',
+  '.xml',
+  '.yaml',
+  '.yml',
+]);
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function shortHash(value) {
+  return sha256(value).slice(0, 12);
+}
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function safeSegment(value) {
+  const normalized = String(value)
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || 'unnamed';
+}
+
+function markdown(value) {
+  return String(value ?? '')
+    .replaceAll('|', '\\|')
+    .replaceAll('\n', '<br>');
+}
+
+function markdownCode(value) {
+  return `<code>${markdown(value)}</code>`;
+}
+
+function html(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listFiles(root) {
+  const files = [];
+  if (!(await exists(root))) return files;
+  const rootStat = await stat(root);
+  if (rootStat.isFile()) return [root];
+
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function resolveWorkspacePath(workspace, inputPath) {
+  const resolved = path.resolve(workspace, inputPath);
+  const relative = path.relative(workspace, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Harness evidence path must stay inside the workspace: ${inputPath}`);
+  }
+  return resolved;
+}
+
+function parseList(value) {
+  return String(value ?? '')
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function parseStages(value) {
+  let parsed;
+  try {
+    parsed = typeof value === 'string' ? JSON.parse(value) : value;
+  } catch (error) {
+    throw new Error(`Invalid HARNESS_STAGES JSON: ${error.message}`);
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error('HARNESS_STAGES must contain at least one stage');
+  }
+
+  const ids = new Set();
+  return parsed.map((stage, index) => {
+    if (!stage || typeof stage !== 'object' || Array.isArray(stage)) {
+      throw new Error(`Harness stage ${index} must be an object`);
+    }
+
+    const id = String(stage.id ?? '').trim();
+    if (!id) throw new Error(`Harness stage ${index} is missing id`);
+    if (ids.has(id)) throw new Error(`Duplicate harness stage id: ${id}`);
+    ids.add(id);
+
+    const kind = stage.kind ?? 'case';
+    if (!VALID_STAGE_KINDS.has(kind)) {
+      throw new Error(`Harness stage ${id} has invalid kind: ${kind}`);
+    }
+
+    const outcome = stage.outcome || 'skipped';
+    if (!VALID_OUTCOMES.has(outcome)) {
+      throw new Error(`Harness stage ${id} has invalid outcome: ${outcome}`);
+    }
+
+    const reportPatterns = (
+      stage.reportPatterns ??
+      (stage.reportPattern ? [stage.reportPattern] : [])
+    ).map(String);
+
+    return {
+      id,
+      name: String(stage.name ?? id),
+      kind,
+      outcome,
+      required: stage.required !== false,
+      traceRequired: stage.traceRequired === true,
+      reportPatterns,
+      validator: {
+        type: String(stage.validator?.type ?? 'command-exit'),
+        expected: String(
+          stage.validator?.expected ?? 'The command exits successfully',
+        ),
+      },
+    };
+  });
+}
+
+export async function resolveStages({
+  workspace,
+  suite,
+  inlineStages,
+  outcomes,
+}) {
+  if (String(inlineStages ?? '').trim()) return parseStages(inlineStages);
+  let outcomeMap;
+  try {
+    outcomeMap = JSON.parse(outcomes || '{}');
+  } catch (error) {
+    throw new Error(`Invalid HARNESS_OUTCOMES JSON: ${error.message}`);
+  }
+  if (!outcomeMap || typeof outcomeMap !== 'object' || Array.isArray(outcomeMap)) {
+    throw new Error('HARNESS_OUTCOMES must be a JSON object');
+  }
+
+  const registryPath = path.join(workspace, 'scripts', 'ci-harness', 'suites.json');
+  const registry = JSON.parse(await readFile(registryPath, 'utf8'));
+  const registeredStages = registry[suite];
+  if (!Array.isArray(registeredStages)) {
+    throw new Error(`No CI harness suite is registered for: ${suite}`);
+  }
+  const expectedIds = new Set(registeredStages.map((stage) => stage.id));
+  const suppliedIds = Object.keys(outcomeMap);
+  const missing = [...expectedIds].filter((id) => !(id in outcomeMap));
+  const unknown = suppliedIds.filter((id) => !expectedIds.has(id));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error(
+      `Harness outcomes do not match suite ${suite}: missing [${missing.join(', ')}], unknown [${unknown.join(', ')}]`,
+    );
+  }
+  return parseStages(
+    registeredStages.map((stage) => ({
+      ...stage,
+      outcome: outcomeMap[stage.id],
+    })),
+  );
+}
+
+function globToRegExp(pattern) {
+  const normalized = toPosix(pattern);
+  let expression = '^';
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character === '*') {
+      if (normalized[index + 1] === '*') {
+        const followedBySlash = normalized[index + 2] === '/';
+        expression += followedBySlash ? '(?:.*/)?' : '.*';
+        index += followedBySlash ? 2 : 1;
+      } else {
+        expression += '[^/]*';
+      }
+    } else if (character === '?') {
+      expression += '[^/]';
+    } else {
+      expression += character.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+    }
+  }
+  return new RegExp(`${expression}$`);
+}
+
+function reportMatches(report, pattern) {
+  const matcher = globToRegExp(pattern);
+  return matcher.test(report.path) || matcher.test(path.posix.basename(report.path));
+}
+
+async function copyRoots({ workspace, roots, outputDir, category, warnings }) {
+  const destinations = [];
+  for (const [index, inputRoot] of roots.entries()) {
+    const source = resolveWorkspacePath(workspace, inputRoot);
+    if (!(await exists(source))) {
+      warnings.push(`Missing ${category} path: ${inputRoot}`);
+      continue;
+    }
+
+    const sourceStat = await stat(source);
+    const destination = path.join(
+      outputDir,
+      category,
+      `${index + 1}-${safeSegment(path.basename(source))}`,
+    );
+    await mkdir(path.dirname(destination), { recursive: true });
+    if (sourceStat.isDirectory()) {
+      await cp(source, destination, { recursive: true, errorOnExist: true });
+    } else {
+      await copyFile(source, destination);
+    }
+    destinations.push(destination);
+  }
+  return destinations;
+}
+
+async function scanDumpScripts(filePath) {
+  const openPrefix = '<script type="midscene_web_dump"';
+  const closeTag = '</script>';
+  let pending = '';
+  const dumps = [];
+
+  for await (const chunk of createReadStream(filePath, { encoding: 'utf8' })) {
+    pending += chunk;
+    while (pending.length > 0) {
+      const start = pending.indexOf(openPrefix);
+      if (start === -1) {
+        pending = pending.slice(-openPrefix.length);
+        break;
+      }
+      const openEnd = pending.indexOf('>', start + openPrefix.length);
+      if (openEnd === -1) {
+        pending = pending.slice(start);
+        break;
+      }
+      const closeStart = pending.indexOf(closeTag, openEnd + 1);
+      if (closeStart === -1) {
+        pending = pending.slice(start);
+        break;
+      }
+
+      const serialized = pending
+        .slice(openEnd + 1, closeStart)
+        .trim()
+        .replaceAll('__midscene_lt__', '<')
+        .replaceAll('__midscene_gt__', '>');
+      try {
+        dumps.push(JSON.parse(serialized));
+      } catch (error) {
+        dumps.push({
+          __parseError: error.message,
+        });
+      }
+      pending = pending.slice(closeStart + closeTag.length);
+    }
+  }
+  return dumps;
+}
+
+function hasDeepKey(value, keyPattern, seen = new Set()) {
+  if (!value || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((item) => hasDeepKey(item, keyPattern, seen));
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (keyPattern.test(key)) return true;
+    if (hasDeepKey(child, keyPattern, seen)) return true;
+  }
+  return false;
+}
+
+function modelCall(source, usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  return {
+    source,
+    requestId: usage.request_id,
+    model: usage.response_model_name ?? usage.model_name,
+    intent: usage.intent,
+    slot: usage.slot,
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    totalTokens: usage.total_tokens,
+    cachedInputTokens: usage.cached_input,
+    timeCostMs: usage.time_cost,
+  };
+}
+
+function compactTask(task, reportPath, executionId, taskIndex) {
+  const taskId = String(task.taskId ?? '');
+  const modelCalls = [
+    modelCall('main', task.usage),
+    modelCall('searchArea', task.searchAreaUsage),
+  ].filter(Boolean);
+  return {
+    taskId,
+    executionId,
+    type: task.type ?? task.name ?? `task-${taskIndex + 1}`,
+    status: task.status ?? 'unknown',
+    errorMessage: task.errorMessage,
+    errorStack: task.errorStack,
+    timing: task.timing,
+    reasoning: Boolean(task.reasoning_content),
+    modelCalls,
+    evidence: {
+      rawResponse: hasDeepKey(task, /^(rawResponse|rawChoiceMessage)$/),
+      screenshot: hasDeepKey(task, /screenshot/i),
+      recorder: Array.isArray(task.recorder) && task.recorder.length > 0,
+    },
+    anchor: taskId ? `${reportPath}#task-${taskId}` : null,
+  };
+}
+
+function rebaseFileReferences(value, sourceDir, destinationDir) {
+  if (!value || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      rebaseFileReferences(item, sourceDir, destinationDir),
+    );
+  }
+  const rebased = {};
+  for (const [key, child] of Object.entries(value)) {
+    rebased[key] = rebaseFileReferences(child, sourceDir, destinationDir);
+  }
+  if (value.storage === 'file' && typeof value.path === 'string') {
+    const absoluteReference = path.resolve(sourceDir, value.path);
+    rebased.path = toPosix(path.relative(destinationDir, absoluteReference));
+  }
+  return rebased;
+}
+
+async function extractReport(reportFile, outputDir) {
+  const relativeReportPath = toPosix(path.relative(outputDir, reportFile));
+  const reportId = `report-${shortHash(relativeReportPath)}`;
+  const dumps = await scanDumpScripts(reportFile);
+  const parseErrors = dumps
+    .filter((dump) => dump?.__parseError)
+    .map((dump) => dump.__parseError);
+  const executionMap = new Map();
+  let metadata = {};
+  let anonymousExecutionIndex = 0;
+
+  for (const dump of dumps) {
+    if (dump?.__parseError) continue;
+    if (!Array.isArray(dump)) metadata = { ...metadata, ...dump };
+    const executions = Array.isArray(dump)
+      ? dump
+      : Array.isArray(dump?.executions)
+        ? dump.executions
+        : Array.isArray(dump?.tasks)
+          ? [dump]
+          : [];
+    for (const execution of executions) {
+      if (!execution || !Array.isArray(execution.tasks)) continue;
+      const executionId = String(
+        execution.id ??
+          `anonymous-${shortHash(
+            `${relativeReportPath}:${execution.name}:${anonymousExecutionIndex++}`,
+          )}`,
+      );
+      executionMap.set(executionId, { ...execution, id: executionId });
+    }
+  }
+
+  const executionDir = path.join(outputDir, 'executions', reportId);
+  await mkdir(executionDir, { recursive: true });
+  const executions = [];
+  let executionIndex = 0;
+  for (const execution of executionMap.values()) {
+    executionIndex += 1;
+    const dumpPath = path.join(
+      executionDir,
+      `${executionIndex}.execution.json`,
+    );
+    const executionDump = {
+      sdkVersion: metadata.sdkVersion ?? 'unknown',
+      groupName: metadata.groupName ?? path.basename(reportFile),
+      groupDescription: metadata.groupDescription,
+      modelBriefs: metadata.modelBriefs ?? [],
+      deviceType: metadata.deviceType,
+      executions: [
+        rebaseFileReferences(
+          execution,
+          path.dirname(reportFile),
+          executionDir,
+        ),
+      ],
+    };
+    await writeFile(dumpPath, `${JSON.stringify(executionDump, null, 2)}\n`);
+    executions.push({
+      executionId: execution.id,
+      name: execution.name ?? `execution-${executionIndex}`,
+      dumpPath: toPosix(path.relative(outputDir, dumpPath)),
+      tasks: execution.tasks.map((task, taskIndex) =>
+        compactTask(task, relativeReportPath, execution.id, taskIndex),
+      ),
+    });
+  }
+
+  return {
+    reportId,
+    path: relativeReportPath,
+    sdkVersion: metadata.sdkVersion,
+    groupName: metadata.groupName ?? path.basename(reportFile),
+    groupDescription: metadata.groupDescription,
+    deviceType: metadata.deviceType,
+    modelBriefs: metadata.modelBriefs ?? [],
+    executions,
+    parseErrors,
+  };
+}
+
+function flattenTasks(reports) {
+  return reports.flatMap((report) =>
+    report.executions.flatMap((execution) =>
+      execution.tasks.map((task) => ({
+        ...task,
+        reportId: report.reportId,
+        reportPath: report.path,
+        executionDump: execution.dumpPath,
+      })),
+    ),
+  );
+}
+
+function stageVerdict(stage) {
+  if (!stage.required) return { verdict: 'not_evaluated', score: null };
+  if (stage.outcome === 'success') {
+    return {
+      verdict: 'pass',
+      score: stage.kind === 'case' ? 1 : null,
+    };
+  }
+  if (stage.outcome === 'failure') {
+    return {
+      verdict: stage.kind === 'infrastructure' ? 'infra_error' : 'fail',
+      score: stage.kind === 'case' ? 0 : null,
+    };
+  }
+  return { verdict: 'infra_error', score: null };
+}
+
+function stageConfigHash(stage) {
+  return sha256(
+    JSON.stringify({
+      id: stage.id,
+      kind: stage.kind,
+      required: stage.required,
+      traceRequired: stage.traceRequired,
+      reportPatterns: stage.reportPatterns,
+      validator: stage.validator,
+    }),
+  );
+}
+
+function provenance(environment, suite, stages) {
+  const modelBaseUrl = environment.MIDSCENE_MODEL_BASE_URL || '';
+  const runId = environment.GITHUB_RUN_ID ?? 'local';
+  const runUrl =
+    environment.GITHUB_SERVER_URL && environment.GITHUB_REPOSITORY && runId !== 'local'
+      ? `${environment.GITHUB_SERVER_URL}/${environment.GITHUB_REPOSITORY}/actions/runs/${runId}`
+      : undefined;
+  const environmentInfo = {
+    repository: environment.GITHUB_REPOSITORY,
+    gitSha: environment.GITHUB_SHA,
+    ref: environment.GITHUB_REF,
+    eventName: environment.GITHUB_EVENT_NAME,
+    workflow: environment.GITHUB_WORKFLOW,
+    workflowRef: environment.GITHUB_WORKFLOW_REF,
+    workflowSha: environment.GITHUB_WORKFLOW_SHA,
+    job: environment.GITHUB_JOB,
+    runId,
+    runUrl,
+    runAttempt: Number(environment.GITHUB_RUN_ATTEMPT ?? 1),
+    runner: {
+      name: environment.RUNNER_NAME,
+      os: environment.RUNNER_OS ?? process.platform,
+      arch: environment.RUNNER_ARCH ?? process.arch,
+    },
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    model: {
+      name: environment.MIDSCENE_MODEL_NAME,
+      family: environment.MIDSCENE_MODEL_FAMILY,
+      baseUrlHash: modelBaseUrl ? sha256(modelBaseUrl) : undefined,
+    },
+    retryPolicy: {
+      modelRetryCount: Number(environment.MIDSCENE_MODEL_RETRY_COUNT ?? 0),
+      modelRetryIntervalMs: Number(
+        environment.MIDSCENE_MODEL_RETRY_INTERVAL ?? 0,
+      ),
+      runnerRetryCount: 0,
+    },
+    suite,
+    suiteConfigHash: sha256(
+      JSON.stringify(stages.map((stage) => stageConfigHash(stage))),
+    ),
+  };
+  return {
+    ...environmentInfo,
+    environmentHash: sha256(JSON.stringify(environmentInfo)),
+  };
+}
+
+function aggregateVerdict(stages, harnessIssues) {
+  if (harnessIssues.length > 0) return 'infra_error';
+  const requiredStages = stages.filter((stage) => stage.required);
+  if (
+    requiredStages.some(
+      (stage) =>
+        stage.kind === 'infrastructure' && stage.outcome !== 'success',
+    )
+  ) {
+    return 'infra_error';
+  }
+  if (requiredStages.some((stage) => stage.outcome === 'failure')) return 'fail';
+  if (
+    requiredStages.some(
+      (stage) => stage.outcome === 'cancelled' || stage.outcome === 'skipped',
+    )
+  ) {
+    return 'infra_error';
+  }
+  return 'pass';
+}
+
+async function writeCaseFiles(outputDir, attemptId, result) {
+  const caseDir = path.join(
+    outputDir,
+    'cases',
+    `${safeSegment(result.caseId)}-${shortHash(result.caseId)}`,
+    safeSegment(attemptId),
+  );
+  await mkdir(caseDir, { recursive: true });
+  const validator = {
+    ...result.validator,
+    evidenceRefs: [
+      ...result.trace.tasks.map(
+        (task) => `task:${task.taskId || 'missing'}`,
+      ),
+      ...new Set(
+        result.trace.tasks.map(
+          (task) => `execution-dump:${task.executionDump}`,
+        ),
+      ),
+      ...(result.provenance.runUrl
+        ? [`github-run:${result.provenance.runUrl}`]
+        : []),
+    ],
+  };
+  const traceIndex = {
+    schemaVersion: 1,
+    caseId: result.caseId,
+    attemptId,
+    reports: result.trace.reports,
+    tasks: result.trace.tasks,
+  };
+  const resultFile = path.join(caseDir, 'result.json');
+  const validatorFile = path.join(caseDir, 'validator.json');
+  const traceFile = path.join(caseDir, 'trace-index.json');
+  await Promise.all([
+    writeFile(resultFile, `${JSON.stringify(result, null, 2)}\n`),
+    writeFile(validatorFile, `${JSON.stringify(validator, null, 2)}\n`),
+    writeFile(traceFile, `${JSON.stringify(traceIndex, null, 2)}\n`),
+  ]);
+  return {
+    result: toPosix(path.relative(outputDir, resultFile)),
+    validator: toPosix(path.relative(outputDir, validatorFile)),
+    trace: toPosix(path.relative(outputDir, traceFile)),
+  };
+}
+
+function secretValues(environment) {
+  const sensitiveName = /(API_KEY|AUTH_TOKEN|PASSWORD|SECRET|TOKEN)$/i;
+  return Object.entries(environment)
+    .filter(([key, value]) => sensitiveName.test(key) && String(value).length >= 8)
+    .map(([, value]) => String(value));
+}
+
+async function containsSecret(filePath, secrets) {
+  if (!TEXT_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
+    return false;
+  }
+  const maxSecretLength = Math.max(0, ...secrets.map((secret) => secret.length));
+  const overlap = Math.max(4096, maxSecretLength);
+  let tail = '';
+  for await (const chunk of createReadStream(filePath, { encoding: 'utf8' })) {
+    const content = tail + chunk;
+    if (secrets.some((secret) => content.includes(secret))) return true;
+    tail = content.slice(-overlap);
+  }
+  return false;
+}
+
+async function removeFilesContainingSecrets(outputDir, environment) {
+  const findings = [];
+  const secrets = secretValues(environment);
+  const files = await listFiles(outputDir);
+  for (const file of files) {
+    if (await containsSecret(file, secrets)) {
+      findings.push(toPosix(path.relative(outputDir, file)));
+      await unlink(file);
+    }
+  }
+  return findings;
+}
+
+async function buildManifest(outputDir) {
+  const entries = [];
+  for (const file of await listFiles(outputDir)) {
+    const relative = toPosix(path.relative(outputDir, file));
+    if (relative === 'manifest.json') continue;
+    const content = await readFile(file);
+    entries.push({
+      path: relative,
+      bytes: content.byteLength,
+      sha256: sha256(content),
+    });
+  }
+  return {
+    schemaVersion: 1,
+    algorithm: 'sha256',
+    files: entries,
+  };
+}
+
+function traceTarget(result, { artifactUrl, traceBaseUrl }) {
+  const task = result.trace.tasks.find((item) => item.anchor);
+  if (traceBaseUrl && task?.anchor) {
+    return `${traceBaseUrl.replace(/\/$/, '')}/${task.anchor}`;
+  }
+  return artifactUrl || '';
+}
+
+export function renderSummary(scorecard, options = {}) {
+  const { artifactUrl = '', traceBaseUrl = '' } = options;
+  const icon =
+    scorecard.verdict === 'pass'
+      ? '✅'
+      : scorecard.verdict === 'fail'
+        ? '❌'
+        : '⚠️';
+  const lines = [
+    `## ${icon} Harness: ${scorecard.suite}`,
+    '',
+    `Verdict: **${scorecard.verdict}** · Trace: **${scorecard.traceHealth.status}** · Run: ${
+      scorecard.provenance.runUrl
+        ? `[${markdown(`${scorecard.provenance.runId}.${scorecard.provenance.runAttempt}`)}](${scorecard.provenance.runUrl})`
+        : markdownCode(
+            `${scorecard.provenance.runId}.${scorecard.provenance.runAttempt}`,
+          )
+    }`,
+    '',
+    '| Case | Score | Verdict | Retry visibility | Validator | Trace |',
+    '| --- | ---: | --- | --- | --- | --- |',
+  ];
+
+  for (const result of scorecard.cases) {
+    const target = traceTarget(result, { artifactUrl, traceBaseUrl });
+    const firstAnchor = result.trace.tasks.find((task) => task.anchor)?.anchor;
+    const trace = target
+      ? `[View Trace](${target})${
+          !traceBaseUrl && firstAnchor
+            ? `<br>${markdownCode(firstAnchor)}`
+            : ''
+        }`
+      : firstAnchor
+        ? markdownCode(firstAnchor)
+        : 'Unavailable';
+    lines.push(
+      `| ${markdown(result.name)} | ${result.score ?? '—'} | ${result.verdict} | ${result.stability} | ${markdown(result.validator.type)} | ${trace} |`,
+    );
+  }
+
+  if (scorecard.checks.length > 0) {
+    lines.push('', '### Required checks', '', '| Check | Kind | Outcome |', '| --- | --- | --- |');
+    for (const check of scorecard.checks) {
+      lines.push(
+        `| ${markdown(check.name)} | ${check.kind} | ${check.outcome} |`,
+      );
+    }
+  }
+
+  if (scorecard.harnessIssues.length > 0) {
+    lines.push('', '### Harness issues', '');
+    for (const issue of scorecard.harnessIssues) lines.push(`- ${markdown(issue)}`);
+  }
+  if (scorecard.warnings.length > 0) {
+    lines.push('', '<details><summary>Collection warnings</summary>', '');
+    for (const warning of scorecard.warnings) lines.push(`- ${markdown(warning)}`);
+    lines.push('', '</details>');
+  }
+
+  lines.push(
+    '',
+    `Model: ${markdownCode(scorecard.provenance.model.name || 'not configured')} · Runner: ${markdownCode(`${scorecard.provenance.runner.os}/${scorecard.provenance.runner.arch}`)} · Commit: ${markdownCode(scorecard.provenance.gitSha || 'local')}`,
+    '',
+  );
+  return lines.join('\n');
+}
+
+export function renderTraceIndex(scorecard) {
+  const caseCards = scorecard.cases
+    .map((result) => {
+      const taskRows = result.trace.tasks
+        .map((task) => {
+          const tokens = task.modelCalls.reduce(
+            (total, call) => total + Number(call.totalTokens ?? 0),
+            0,
+          );
+          const traceLink = task.anchor
+            ? `<a href="${html(task.anchor)}">Open task</a> · <a href="${html(task.executionDump)}">Execution JSON</a>`
+            : 'Missing task anchor';
+          const evidence = [
+            task.evidence.rawResponse ? 'raw response' : null,
+            task.evidence.screenshot || task.evidence.recorder
+              ? 'screenshot'
+              : null,
+          ]
+            .filter(Boolean)
+            .join(', ');
+          return `<tr><td><code>${html(task.taskId || 'missing')}</code></td><td>${html(task.type)}</td><td>${html(task.status)}</td><td>${tokens}</td><td>${html(evidence || 'none')}</td><td>${traceLink}</td></tr>`;
+        })
+        .join('');
+      const problems = result.trace.problems
+        .map((problem) => `<li>${html(problem)}</li>`)
+        .join('');
+      return `
+        <section class="case verdict-${html(result.verdict)}">
+          <h2>${html(result.name)} <span>${result.score ?? '—'}</span></h2>
+          <dl>
+            <dt>Verdict</dt><dd>${html(result.verdict)}</dd>
+            <dt>Validator</dt><dd>${html(result.validator.type)}</dd>
+            <dt>Expected</dt><dd>${html(result.validator.expected)}</dd>
+            <dt>Observed</dt><dd>${html(result.validator.observed)}</dd>
+            <dt>Retry visibility</dt><dd>${html(result.stability)}</dd>
+            <dt>Validator version</dt><dd><code>${html(result.validator.version)}</code></dd>
+          </dl>
+          ${problems ? `<div class="issues"><strong>Trace problems</strong><ul>${problems}</ul></div>` : ''}
+          <table><thead><tr><th>Task</th><th>Type</th><th>Status</th><th>Tokens</th><th>Evidence</th><th>Trace</th></tr></thead><tbody>${taskRows || '<tr><td colspan="6">No task trace collected</td></tr>'}</tbody></table>
+        </section>`;
+    })
+    .join('');
+  const harnessIssues = scorecard.harnessIssues
+    .map((issue) => `<li>${html(issue)}</li>`)
+    .join('');
+  const checkRows = scorecard.checks
+    .map(
+      (check) =>
+        `<tr><td>${html(check.name)}</td><td>${html(check.kind)}</td><td>${html(check.outcome)}</td></tr>`,
+    )
+    .join('');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Midscene Harness Trace - ${html(scorecard.suite)}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+    body { margin: 0 auto; max-width: 1120px; padding: 32px 20px 64px; line-height: 1.5; }
+    header, section { border: 1px solid #8b949e55; border-radius: 12px; margin: 0 0 20px; padding: 20px; }
+    header h1, section h2 { margin-top: 0; }
+    h2 span { float: right; font-size: 1.5em; }
+    dl { display: grid; grid-template-columns: minmax(130px, 190px) 1fr; gap: 6px 16px; }
+    dt { font-weight: 700; }
+    dd { margin: 0; overflow-wrap: anywhere; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid #8b949e55; padding: 9px; text-align: left; }
+    code { overflow-wrap: anywhere; }
+    .verdict-pass { border-left: 6px solid #2da44e; }
+    .verdict-fail { border-left: 6px solid #cf222e; }
+    .verdict-infra_error, .issues { border-left: 6px solid #bf8700; }
+    .issues { background: #bf870015; margin: 16px 0; padding: 12px 16px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Midscene Harness Trace</h1>
+    <p><strong>${html(scorecard.suite)}</strong> · verdict <strong>${html(scorecard.verdict)}</strong> · Trace <strong>${html(scorecard.traceHealth.status)}</strong></p>
+    <p>Run <code>${html(`${scorecard.provenance.runId}.${scorecard.provenance.runAttempt}`)}</code> · commit <code>${html(scorecard.provenance.gitSha || 'local')}</code> · model <code>${html(scorecard.provenance.model.name || 'not configured')}</code></p>
+    ${scorecard.provenance.runUrl ? `<p><a href="${html(scorecard.provenance.runUrl)}">Open GitHub job logs</a></p>` : ''}
+  </header>
+  ${harnessIssues ? `<section class="issues"><h2>Harness issues</h2><ul>${harnessIssues}</ul></section>` : ''}
+  ${caseCards || '<section><h2>No scored cases</h2></section>'}
+  ${checkRows ? `<section><h2>Required checks</h2><table><thead><tr><th>Check</th><th>Kind</th><th>Outcome</th></tr></thead><tbody>${checkRows}</tbody></table></section>` : ''}
+</body>
+</html>
+`;
+}
+
+export async function finalizeHarnessRun(options) {
+  const workspace = path.resolve(options.workspace ?? process.cwd());
+  const suite = String(options.suite ?? '').trim();
+  if (!suite) throw new Error('Harness suite is required');
+  const stages = parseStages(options.stages);
+  const environment = options.environment ?? process.env;
+  const runId = environment.GITHUB_RUN_ID ?? 'local';
+  const runAttempt = environment.GITHUB_RUN_ATTEMPT ?? '1';
+  const outputDir = resolveWorkspacePath(
+    workspace,
+    options.outputDir ??
+      path.join(
+        'midscene_run',
+        'harness',
+        `${safeSegment(suite)}-${safeSegment(runId)}-${safeSegment(runAttempt)}`,
+      ),
+  );
+  if (await exists(outputDir)) {
+    throw new Error(`Harness output is immutable and already exists: ${outputDir}`);
+  }
+  await mkdir(outputDir, { recursive: true });
+
+  const warnings = [];
+  const reportDestinations = await copyRoots({
+    workspace,
+    roots: parseList(options.reportRoots),
+    outputDir,
+    category: 'reports',
+    warnings,
+  });
+  await copyRoots({
+    workspace,
+    roots: parseList(options.evidenceRoots),
+    outputDir,
+    category: 'evidence',
+    warnings,
+  });
+
+  const reportFiles = (
+    await Promise.all(reportDestinations.map((root) => listFiles(root)))
+  )
+    .flat()
+    .filter((file) => path.extname(file).toLowerCase() === '.html');
+  const reports = [];
+  for (const reportFile of reportFiles) {
+    reports.push(await extractReport(reportFile, outputDir));
+  }
+
+  const harnessIssues = [];
+  for (const report of reports) {
+    if (report.parseErrors.length > 0) {
+      harnessIssues.push(`Report ${report.path} contains invalid dump JSON`);
+    }
+  }
+
+  const attemptId = `${runId}.${runAttempt}.${safeSegment(suite)}`;
+  const runProvenance = provenance(environment, suite, stages);
+  const cases = [];
+  const checks = [];
+
+  for (const stage of stages) {
+    const matchingReports =
+      stage.reportPatterns.length === 0
+        ? reports
+        : reports.filter((report) =>
+            stage.reportPatterns.some((pattern) => reportMatches(report, pattern)),
+          );
+    const tasks = flattenTasks(matchingReports);
+    const traceProblems = [];
+    if (stage.traceRequired && stage.required && stage.outcome !== 'skipped') {
+      for (const pattern of stage.reportPatterns) {
+        if (!reports.some((report) => reportMatches(report, pattern))) {
+          traceProblems.push(`required report pattern has no match: ${pattern}`);
+        }
+      }
+      if (matchingReports.length === 0) traceProblems.push('no report was collected');
+      if (tasks.length === 0) traceProblems.push('no Midscene task was found');
+      if (tasks.some((task) => !task.taskId)) {
+        traceProblems.push('one or more tasks are missing taskId');
+      }
+      if (!tasks.some((task) => task.modelCalls.length > 0)) {
+        traceProblems.push('no model usage or request id was found');
+      }
+      if (!tasks.some((task) => task.evidence.rawResponse)) {
+        traceProblems.push('no raw model response evidence was found');
+      }
+      if (
+        !tasks.some(
+          (task) => task.evidence.screenshot || task.evidence.recorder,
+        )
+      ) {
+        traceProblems.push('no screenshot evidence was found');
+      }
+    }
+    for (const problem of traceProblems) {
+      harnessIssues.push(`Stage ${stage.id}: ${problem}`);
+    }
+
+    const { verdict, score } = stageVerdict(stage);
+    const validator = {
+      id: `${stage.id}-validator`,
+      type: stage.validator.type,
+      version: stageConfigHash(stage),
+      expected: stage.validator.expected,
+      observed: stage.outcome,
+    };
+    const result = {
+      schemaVersion: 1,
+      caseId: stage.id,
+      name: stage.name,
+      attemptId,
+      verdict,
+      score,
+      stability:
+        runProvenance.retryPolicy.modelRetryCount > 0
+          ? 'retry_policy_enabled'
+          : 'single_attempt',
+      required: stage.required,
+      outcome: stage.outcome,
+      validator,
+      trace: {
+        complete: traceProblems.length === 0,
+        problems: traceProblems,
+        reports: matchingReports.map((report) => ({
+          reportId: report.reportId,
+          path: report.path,
+          groupName: report.groupName,
+          sdkVersion: report.sdkVersion,
+          deviceType: report.deviceType,
+          modelBriefs: report.modelBriefs,
+        })),
+        tasks,
+      },
+      provenance: runProvenance,
+    };
+    const files = await writeCaseFiles(outputDir, attemptId, result);
+    result.files = files;
+    if (stage.kind === 'case') cases.push(result);
+    else {
+      checks.push({
+        id: stage.id,
+        name: stage.name,
+        kind: stage.kind,
+        required: stage.required,
+        outcome: stage.outcome,
+        verdict,
+        files,
+      });
+    }
+  }
+
+  const securityFindings = await removeFilesContainingSecrets(
+    outputDir,
+    environment,
+  );
+  for (const file of securityFindings) {
+    harnessIssues.push(`Removed evidence containing a secret: ${file}`);
+  }
+
+  const verdict = aggregateVerdict(stages, harnessIssues);
+  const scorecard = {
+    schemaVersion: 1,
+    scorecardId: `${attemptId}.${shortHash(runProvenance.suiteConfigHash)}`,
+    suite,
+    verdict,
+    conclusion: verdict === 'pass' ? 'success' : 'failure',
+    traceHealth: {
+      status: harnessIssues.length === 0 ? 'complete' : 'incomplete',
+      reportCount: reports.length,
+      executionCount: reports.reduce(
+        (total, report) => total + report.executions.length,
+        0,
+      ),
+      taskCount: flattenTasks(reports).length,
+    },
+    cases,
+    checks,
+    harnessIssues,
+    warnings,
+    securityFindings,
+    provenance: runProvenance,
+  };
+
+  const scorecardPath = path.join(outputDir, 'scorecard.json');
+  const summaryPath = path.join(outputDir, 'summary.md');
+  const traceIndexPath = path.join(outputDir, 'index.html');
+  await writeFile(scorecardPath, `${JSON.stringify(scorecard, null, 2)}\n`);
+  await writeFile(summaryPath, renderSummary(scorecard));
+  await writeFile(traceIndexPath, renderTraceIndex(scorecard));
+  const manifest = await buildManifest(outputDir);
+  await writeFile(
+    path.join(outputDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  return {
+    outputDir,
+    scorecardPath,
+    summaryPath,
+    scorecard,
+  };
+}

--- a/scripts/ci-harness/lib.mjs
+++ b/scripts/ci-harness/lib.mjs
@@ -273,8 +273,15 @@ async function scanDumpScripts(filePath) {
     while (pending.length > 0) {
       const start = pending.indexOf(openPrefix);
       if (start === -1) {
-        pending = pending.slice(-openPrefix.length);
+        pending = pending.slice(-(openPrefix.length + 1));
         break;
+      }
+      const previousCharacter = start === 0 ? '' : pending[start - 1];
+      const startsHtmlTag =
+        start === 0 || previousCharacter === '>' || /\s/.test(previousCharacter);
+      if (!startsHtmlTag) {
+        pending = pending.slice(start + openPrefix.length);
+        continue;
       }
       const openEnd = pending.indexOf('>', start + openPrefix.length);
       if (openEnd === -1) {

--- a/scripts/ci-harness/lib.mjs
+++ b/scripts/ci-harness/lib.mjs
@@ -262,6 +262,15 @@ async function copyRoots({ workspace, roots, outputDir, category, warnings }) {
   return destinations;
 }
 
+async function removeHiddenFiles(root) {
+  for (const file of await listFiles(root)) {
+    const relative = path.relative(root, file);
+    if (relative.split(path.sep).some((segment) => segment.startsWith('.'))) {
+      await unlink(file);
+    }
+  }
+}
+
 async function scanDumpScripts(filePath) {
   const openPrefix = '<script type="midscene_web_dump"';
   const closeTag = '</script>';
@@ -886,6 +895,7 @@ export async function finalizeHarnessRun(options) {
     category: 'evidence',
     warnings,
   });
+  await removeHiddenFiles(outputDir);
 
   const reportFiles = (
     await Promise.all(reportDestinations.map((root) => listFiles(root)))

--- a/scripts/ci-harness/publish-summary.mjs
+++ b/scripts/ci-harness/publish-summary.mjs
@@ -1,0 +1,19 @@
+import { appendFile, readFile } from 'node:fs/promises';
+import { renderSummary } from './lib.mjs';
+
+try {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    throw new Error('GITHUB_STEP_SUMMARY is not available');
+  }
+  const scorecard = JSON.parse(
+    await readFile(process.env.HARNESS_SCORECARD_PATH, 'utf8'),
+  );
+  const summary = renderSummary(scorecard, {
+    artifactUrl: process.env.HARNESS_ARTIFACT_URL,
+    traceBaseUrl: process.env.HARNESS_TRACE_BASE_URL,
+  });
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+} catch (error) {
+  console.error(`::error::Unable to publish harness summary: ${error.stack || error}`);
+  process.exitCode = 1;
+}

--- a/scripts/ci-harness/publish-summary.mjs
+++ b/scripts/ci-harness/publish-summary.mjs
@@ -14,6 +14,8 @@ try {
   });
   await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 } catch (error) {
-  console.error(`::error::Unable to publish harness summary: ${error.stack || error}`);
+  console.error(
+    `::error::Unable to publish harness summary: ${error.stack || error}`,
+  );
   process.exitCode = 1;
 }

--- a/scripts/ci-harness/schemas/result.schema.json
+++ b/scripts/ci-harness/schemas/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://midscenejs.com/schemas/ci-harness/result.schema.json",
+  "title": "Midscene CI harness case result",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "caseId",
+    "attemptId",
+    "verdict",
+    "score",
+    "validator",
+    "trace",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "caseId": { "type": "string", "minLength": 1 },
+    "attemptId": { "type": "string", "minLength": 1 },
+    "verdict": {
+      "enum": ["pass", "fail", "infra_error", "not_evaluated"]
+    },
+    "score": { "type": ["integer", "null"], "enum": [0, 1, null] },
+    "validator": {
+      "type": "object",
+      "required": ["id", "type", "version", "expected", "observed"]
+    },
+    "trace": {
+      "type": "object",
+      "required": ["complete", "reports", "tasks"]
+    },
+    "provenance": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/scripts/ci-harness/schemas/scorecard.schema.json
+++ b/scripts/ci-harness/schemas/scorecard.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://midscenejs.com/schemas/ci-harness/scorecard.schema.json",
+  "title": "Midscene CI harness scorecard",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "scorecardId",
+    "suite",
+    "verdict",
+    "conclusion",
+    "traceHealth",
+    "cases",
+    "checks",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "scorecardId": { "type": "string", "minLength": 1 },
+    "suite": { "type": "string", "minLength": 1 },
+    "verdict": { "enum": ["pass", "fail", "infra_error"] },
+    "conclusion": { "enum": ["success", "failure"] },
+    "traceHealth": {
+      "type": "object",
+      "required": ["status", "reportCount", "executionCount", "taskCount"],
+      "properties": {
+        "status": { "enum": ["complete", "incomplete"] }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "$ref": "result.schema.json"
+      }
+    },
+    "checks": { "type": "array" },
+    "provenance": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/scripts/ci-harness/schemas/trace-index.schema.json
+++ b/scripts/ci-harness/schemas/trace-index.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://midscenejs.com/schemas/ci-harness/trace-index.schema.json",
+  "title": "Midscene CI harness Trace index",
+  "type": "object",
+  "required": ["schemaVersion", "caseId", "attemptId", "reports", "tasks"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "caseId": { "type": "string", "minLength": 1 },
+    "attemptId": { "type": "string", "minLength": 1 },
+    "reports": { "type": "array" },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["taskId", "executionId", "status", "anchor"]
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/ci-harness/snapshot-reports.mjs
+++ b/scripts/ci-harness/snapshot-reports.mjs
@@ -1,0 +1,39 @@
+import { access, mkdir, rename } from 'node:fs/promises';
+import path from 'node:path';
+
+function insideWorkspace(workspace, inputPath) {
+  if (!inputPath) throw new Error('Report snapshot path is required');
+  const resolved = path.resolve(workspace, inputPath);
+  const relative = path.relative(workspace, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Report snapshot path must stay inside the workspace: ${inputPath}`);
+  }
+  return resolved;
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+try {
+  const workspace = path.resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+  const source = insideWorkspace(workspace, process.env.HARNESS_SNAPSHOT_SOURCE);
+  const destination = insideWorkspace(
+    workspace,
+    process.env.HARNESS_SNAPSHOT_DESTINATION,
+  );
+  if (await exists(destination)) {
+    throw new Error(`Report snapshot is immutable and already exists: ${destination}`);
+  }
+  await mkdir(path.dirname(destination), { recursive: true });
+  if (await exists(source)) await rename(source, destination);
+  else await mkdir(destination, { recursive: true });
+} catch (error) {
+  console.error(`::error::Unable to snapshot reports: ${error.stack || error}`);
+  process.exitCode = 1;
+}

--- a/scripts/ci-harness/snapshot-reports.mjs
+++ b/scripts/ci-harness/snapshot-reports.mjs
@@ -1,4 +1,4 @@
-import { access, mkdir, rename } from 'node:fs/promises';
+import { access, cp, mkdir, rename } from 'node:fs/promises';
 import path from 'node:path';
 
 function insideWorkspace(workspace, inputPath) {
@@ -31,7 +31,13 @@ try {
     throw new Error(`Report snapshot is immutable and already exists: ${destination}`);
   }
   await mkdir(path.dirname(destination), { recursive: true });
-  if (await exists(source)) await rename(source, destination);
+  if (await exists(source)) {
+    if (process.env.HARNESS_SNAPSHOT_MODE === 'copy') {
+      await cp(source, destination, { recursive: true, errorOnExist: true });
+    } else {
+      await rename(source, destination);
+    }
+  }
   else await mkdir(destination, { recursive: true });
 } catch (error) {
   console.error(`::error::Unable to snapshot reports: ${error.stack || error}`);

--- a/scripts/ci-harness/snapshot-reports.mjs
+++ b/scripts/ci-harness/snapshot-reports.mjs
@@ -6,7 +6,9 @@ function insideWorkspace(workspace, inputPath) {
   const resolved = path.resolve(workspace, inputPath);
   const relative = path.relative(workspace, resolved);
   if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Report snapshot path must stay inside the workspace: ${inputPath}`);
+    throw new Error(
+      `Report snapshot path must stay inside the workspace: ${inputPath}`,
+    );
   }
   return resolved;
 }
@@ -22,13 +24,18 @@ async function exists(filePath) {
 
 try {
   const workspace = path.resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
-  const source = insideWorkspace(workspace, process.env.HARNESS_SNAPSHOT_SOURCE);
+  const source = insideWorkspace(
+    workspace,
+    process.env.HARNESS_SNAPSHOT_SOURCE,
+  );
   const destination = insideWorkspace(
     workspace,
     process.env.HARNESS_SNAPSHOT_DESTINATION,
   );
   if (await exists(destination)) {
-    throw new Error(`Report snapshot is immutable and already exists: ${destination}`);
+    throw new Error(
+      `Report snapshot is immutable and already exists: ${destination}`,
+    );
   }
   await mkdir(path.dirname(destination), { recursive: true });
   if (await exists(source)) {
@@ -37,8 +44,7 @@ try {
     } else {
       await rename(source, destination);
     }
-  }
-  else await mkdir(destination, { recursive: true });
+  } else await mkdir(destination, { recursive: true });
 } catch (error) {
   console.error(`::error::Unable to snapshot reports: ${error.stack || error}`);
   process.exitCode = 1;

--- a/scripts/ci-harness/suites.json
+++ b/scripts/ci-harness/suites.json
@@ -1,0 +1,311 @@
+{
+  "ai-web": [
+    {
+      "id": "snapshot-basic-trace",
+      "name": "Snapshot basic E2E Trace",
+      "kind": "infrastructure"
+    },
+    {
+      "id": "web-e2e",
+      "name": "Web E2E",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "reports/1-ai-web-basic/**/*.html",
+      "validator": {
+        "type": "test-runner",
+        "expected": "The browser E2E suite exits successfully"
+      }
+    },
+    {
+      "id": "report-e2e",
+      "name": "Report E2E",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "reports/2-report/**/*.html",
+      "validator": {
+        "type": "midscene.aiAssert",
+        "expected": "The generated report passes its AI assertions"
+      }
+    }
+  ],
+  "ai-report-app": [
+    {
+      "id": "report-app-e2e",
+      "name": "Report app E2E",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene.aiAssert",
+        "expected": "The report app passes its AI loading assertions"
+      }
+    }
+  ],
+  "ai-unit": [
+    {
+      "id": "ai-unit-tests",
+      "name": "AI unit tests",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "vitest-ai",
+        "expected": "All model-dependent unit tests pass"
+      }
+    }
+  ],
+  "headless-linux-ai-todo": [
+    {
+      "id": "ai-todo",
+      "name": "AI TodoMVC",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The computer agent completes the TodoMVC scenario"
+      }
+    }
+  ],
+  "chrome-extension": [
+    {
+      "id": "chrome-extension",
+      "name": "Chrome extension",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The Chrome extension scenario completes"
+      }
+    }
+  ],
+  "chrome-extension-bridge": [
+    {
+      "id": "bridge-mode",
+      "name": "Bridge mode",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "Bridge mode starts, operates, and stops successfully"
+      }
+    }
+  ],
+  "chrome-extension-playground-report": [
+    {
+      "id": "playground-e2e",
+      "name": "Playground E2E",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The extension playground scenario completes"
+      }
+    }
+  ],
+  "chrome-extension-playground-dark-timeline-report": [
+    {
+      "id": "playground-e2e",
+      "name": "Playground dark timeline E2E",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The extension dark timeline scenario completes"
+      }
+    }
+  ],
+  "chrome-extension-recorder": [
+    {
+      "id": "recorder-mode",
+      "name": "Recorder mode",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "Recorder mode scenarios complete"
+      }
+    }
+  ],
+  "chrome-extension-settings": [
+    {
+      "id": "settings-and-cross-mode",
+      "name": "Settings and cross-mode",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "**/*.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "Settings and cross-mode scenarios complete"
+      }
+    }
+  ],
+  "studio-headless-linux": [
+    {
+      "id": "studio-startup",
+      "name": "Studio startup",
+      "kind": "check"
+    },
+    {
+      "id": "studio-web-preview",
+      "name": "Studio Web preview",
+      "kind": "check"
+    },
+    {
+      "id": "studio-ai-startup",
+      "name": "Studio Midscene startup",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "studio-startup-ai-report.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "Studio starts and completes its Midscene AI startup scenario"
+      }
+    }
+  ],
+  "macos-desktop": [
+    {
+      "id": "build",
+      "name": "Build report and computer packages",
+      "kind": "check"
+    },
+    {
+      "id": "package-smoke",
+      "name": "Validate computer package outputs",
+      "kind": "check"
+    },
+    {
+      "id": "unit-tests",
+      "name": "Computer unit tests",
+      "kind": "check"
+    },
+    {
+      "id": "live-smoke",
+      "name": "Live macOS desktop smoke",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "macos-desktop-smoke.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The live macOS desktop scenario completes"
+      }
+    },
+    {
+      "id": "todo-mvc",
+      "name": "macOS TodoMVC",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "todo-mvc-darwin.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The computer agent completes TodoMVC"
+      }
+    }
+  ],
+  "windows-desktop": [
+    {
+      "id": "build",
+      "name": "Build report and computer packages",
+      "kind": "check"
+    },
+    {
+      "id": "package-smoke",
+      "name": "Validate computer package outputs",
+      "kind": "check"
+    },
+    {
+      "id": "unit-tests",
+      "name": "Computer unit tests",
+      "kind": "check"
+    },
+    {
+      "id": "live-smoke",
+      "name": "Live Windows desktop smoke",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "windows-desktop-smoke.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The live Windows desktop scenario completes"
+      }
+    },
+    {
+      "id": "todo-mvc",
+      "name": "Windows TodoMVC",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPattern": "todo-mvc-win32.html",
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The computer agent completes TodoMVC"
+      }
+    }
+  ],
+  "android-emulator": [
+    {
+      "id": "build",
+      "name": "Build report and Android packages",
+      "kind": "check"
+    },
+    {
+      "id": "package-smoke",
+      "name": "Validate Android package outputs",
+      "kind": "check"
+    },
+    {
+      "id": "unit-tests",
+      "name": "Android unit tests",
+      "kind": "check"
+    },
+    {
+      "id": "emulator-tests",
+      "name": "Android Emulator smoke and TodoMVC",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPatterns": [
+        "android-emulator-smoke.html",
+        "todo-mvc-android.html"
+      ],
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The Android smoke and TodoMVC scenarios complete"
+      }
+    }
+  ],
+  "ios-simulator": [
+    {
+      "id": "build",
+      "name": "Build report and iOS packages",
+      "kind": "check"
+    },
+    {
+      "id": "package-smoke",
+      "name": "Validate iOS package outputs",
+      "kind": "check"
+    },
+    {
+      "id": "unit-tests",
+      "name": "iOS unit tests",
+      "kind": "check"
+    },
+    {
+      "id": "simulator-tests",
+      "name": "iOS Simulator smoke and TodoMVC",
+      "kind": "case",
+      "traceRequired": true,
+      "reportPatterns": [
+        "ios-simulator-smoke.html",
+        "todo-mvc-ios.html"
+      ],
+      "validator": {
+        "type": "midscene-ai-test",
+        "expected": "The iOS smoke and TodoMVC scenarios complete"
+      }
+    }
+  ]
+}

--- a/scripts/ci-harness/suites.json
+++ b/scripts/ci-harness/suites.json
@@ -187,13 +187,7 @@
     {
       "id": "live-smoke",
       "name": "Live macOS desktop smoke",
-      "kind": "case",
-      "traceRequired": true,
-      "reportPattern": "macos-desktop-smoke.html",
-      "validator": {
-        "type": "midscene-ai-test",
-        "expected": "The live macOS desktop scenario completes"
-      }
+      "kind": "check"
     },
     {
       "id": "todo-mvc",
@@ -226,13 +220,7 @@
     {
       "id": "live-smoke",
       "name": "Live Windows desktop smoke",
-      "kind": "case",
-      "traceRequired": true,
-      "reportPattern": "windows-desktop-smoke.html",
-      "validator": {
-        "type": "midscene-ai-test",
-        "expected": "The live Windows desktop scenario completes"
-      }
+      "kind": "check"
     },
     {
       "id": "todo-mvc",

--- a/scripts/ci-harness/suites.json
+++ b/scripts/ci-harness/suites.json
@@ -286,10 +286,7 @@
       "name": "iOS Simulator smoke and TodoMVC",
       "kind": "case",
       "traceRequired": true,
-      "reportPatterns": [
-        "ios-simulator-smoke.html",
-        "todo-mvc-ios.html"
-      ],
+      "reportPatterns": ["ios-simulator-smoke.html", "todo-mvc-ios.html"],
       "validator": {
         "type": "midscene-ai-test",
         "expected": "The iOS smoke and TodoMVC scenarios complete"

--- a/scripts/ci-harness/tests/aggregate.test.mjs
+++ b/scripts/ci-harness/tests/aggregate.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const aggregateScript = fileURLToPath(new URL('../aggregate.mjs', import.meta.url));
+
+function runAggregate(environment) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [aggregateScript], {
+      env: { ...process.env, ...environment },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('aggregates suite scorecards and reports missing suites', async (t) => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-aggregate-'));
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const inputDir = path.join(workspace, 'midscene_run', 'nightly-input');
+  await mkdir(path.join(inputDir, 'harness-suite-a'), { recursive: true });
+  await writeFile(
+    path.join(inputDir, 'harness-suite-a', 'scorecard.json'),
+    JSON.stringify({
+      suite: 'suite-a',
+      verdict: 'pass',
+      traceHealth: { status: 'complete', taskCount: 3 },
+      cases: [{ score: 1 }],
+    }),
+  );
+  const githubOutput = path.join(workspace, 'github-output.txt');
+  const githubSummary = path.join(workspace, 'github-summary.md');
+
+  const execution = await runAggregate({
+    GITHUB_WORKSPACE: workspace,
+    GITHUB_OUTPUT: githubOutput,
+    GITHUB_STEP_SUMMARY: githubSummary,
+    HARNESS_EXPECTED_SUITES: '["suite-a","suite-b"]',
+  });
+  assert.equal(execution.code, 0, execution.stderr);
+
+  const aggregate = JSON.parse(
+    await readFile(
+      path.join(
+        workspace,
+        'midscene_run',
+        'nightly-aggregate',
+        'aggregate-scorecard.json',
+      ),
+      'utf8',
+    ),
+  );
+  assert.equal(aggregate.verdict, 'infra_error');
+  assert.deepEqual(aggregate.issues, ['Missing suite: suite-b']);
+  assert.equal(aggregate.totals.passed, 1);
+  assert.match(await readFile(githubOutput, 'utf8'), /conclusion=failure/);
+  assert.match(await readFile(githubSummary, 'utf8'), /Missing suite: suite-b/);
+});

--- a/scripts/ci-harness/tests/aggregate.test.mjs
+++ b/scripts/ci-harness/tests/aggregate.test.mjs
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-const aggregateScript = fileURLToPath(new URL('../aggregate.mjs', import.meta.url));
+const aggregateScript = fileURLToPath(
+  new URL('../aggregate.mjs', import.meta.url),
+);
 
 function runAggregate(environment) {
   return new Promise((resolve, reject) => {
@@ -28,7 +30,9 @@ function runAggregate(environment) {
 }
 
 test('aggregates suite scorecards and reports missing suites', async (t) => {
-  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-aggregate-'));
+  const workspace = await mkdtemp(
+    path.join(os.tmpdir(), 'midscene-aggregate-'),
+  );
   t.after(() => rm(workspace, { recursive: true, force: true }));
   const inputDir = path.join(workspace, 'midscene_run', 'nightly-input');
   await mkdir(path.join(inputDir, 'harness-suite-a'), { recursive: true });

--- a/scripts/ci-harness/tests/harness.test.mjs
+++ b/scripts/ci-harness/tests/harness.test.mjs
@@ -12,7 +12,7 @@ function reportHtml(dump) {
   const serialized = JSON.stringify(dump)
     .replaceAll('<', '__midscene_lt__')
     .replaceAll('>', '__midscene_gt__');
-  return `<html><body><script type="midscene_web_dump" type="application/json" data-group-id="test">${serialized}</script></body></html>`;
+  return `<html><body><script>const dumpTag = '<script type="midscene_web_dump">';</script><script type="midscene_web_dump" type="application/json" data-group-id="test">${serialized}</script></body></html>`;
 }
 
 function environment(overrides = {}) {
@@ -132,6 +132,25 @@ test('validates every registered scored suite has a report Trace contract', asyn
       assert.equal(stage.traceRequired, true, `${suite}/${stage.id}`);
       assert.ok(stage.reportPatterns.length > 0, `${suite}/${stage.id}`);
     }
+  }
+});
+
+test('keeps model-free desktop smokes outside Pass@k scoring', async () => {
+  for (const suite of ['macos-desktop', 'windows-desktop']) {
+    const stages = await resolveStages({
+      workspace: repositoryRoot,
+      suite,
+      outcomes: JSON.stringify({
+        build: 'success',
+        'package-smoke': 'success',
+        'unit-tests': 'success',
+        'live-smoke': 'success',
+        'todo-mvc': 'success',
+      }),
+    });
+    const liveSmoke = stages.find((stage) => stage.id === 'live-smoke');
+    assert.equal(liveSmoke.kind, 'check');
+    assert.equal(liveSmoke.traceRequired, false);
   }
 });
 

--- a/scripts/ci-harness/tests/harness.test.mjs
+++ b/scripts/ci-harness/tests/harness.test.mjs
@@ -118,6 +118,41 @@ test('resolves a versioned suite contract from outcome-only CI input', async () 
   );
 });
 
+test('isolates sequential AI web stage reports', async () => {
+  const workflow = await readFile(
+    path.join(repositoryRoot, '.github', 'workflows', 'ai.yml'),
+    'utf8',
+  );
+  const reportStageStart = workflow.indexOf(
+    '      - name: Run e2e tests report',
+  );
+  const finalizeStageStart = workflow.indexOf(
+    '      - name: Finalize AI web harness',
+    reportStageStart,
+  );
+  const nextJobStart = workflow.indexOf('\n  e2e-report:', finalizeStageStart);
+
+  assert.notEqual(reportStageStart, -1);
+  assert.notEqual(finalizeStageStart, -1);
+  assert.notEqual(nextJobStart, -1);
+
+  const reportStage = workflow.slice(reportStageStart, finalizeStageStart);
+  assert.match(
+    reportStage,
+    /MIDSCENE_RUN_DIR: \$\{\{ github\.workspace \}\}\/midscene_run\/harness-input\/ai-web-report/,
+  );
+
+  const finalizeStage = workflow.slice(finalizeStageStart, nextJobStart);
+  assert.match(
+    finalizeStage,
+    /midscene_run\/harness-input\/ai-web-report\/report/,
+  );
+  assert.doesNotMatch(
+    finalizeStage,
+    /packages\/web-integration\/midscene_run\/report/,
+  );
+});
+
 test('validates every registered scored suite has a report Trace contract', async () => {
   const registry = JSON.parse(
     await readFile(

--- a/scripts/ci-harness/tests/harness.test.mjs
+++ b/scripts/ci-harness/tests/harness.test.mjs
@@ -1,0 +1,291 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { finalizeHarnessRun, parseStages, resolveStages } from '../lib.mjs';
+
+const repositoryRoot = fileURLToPath(new URL('../../..', import.meta.url));
+
+function reportHtml(dump) {
+  const serialized = JSON.stringify(dump)
+    .replaceAll('<', '__midscene_lt__')
+    .replaceAll('>', '__midscene_gt__');
+  return `<html><body><script type="midscene_web_dump" type="application/json" data-group-id="test">${serialized}</script></body></html>`;
+}
+
+function environment(overrides = {}) {
+  return {
+    GITHUB_RUN_ID: '1234',
+    GITHUB_RUN_ATTEMPT: '2',
+    GITHUB_SHA: 'abc123',
+    GITHUB_WORKFLOW: 'Harness Test',
+    GITHUB_JOB: 'test',
+    RUNNER_OS: 'Linux',
+    RUNNER_ARCH: 'X64',
+    MIDSCENE_MODEL_NAME: 'test-model',
+    MIDSCENE_MODEL_RETRY_COUNT: '2',
+    ...overrides,
+  };
+}
+
+async function fixtureWorkspace() {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-harness-'));
+  const reportDir = path.join(workspace, 'midscene_run', 'report');
+  await mkdir(reportDir, { recursive: true });
+  await writeFile(
+    path.join(reportDir, 'case.html'),
+    reportHtml({
+      sdkVersion: '1.10.8',
+      groupName: 'Harness fixture',
+      deviceType: 'playwright',
+      modelBriefs: [{ intent: 'default', name: 'test-model' }],
+      executions: [
+        {
+          id: 'execution-1',
+          name: 'assert fixture',
+          tasks: [
+            {
+              taskId: 'task-1',
+              type: 'Assert',
+              status: 'finished',
+              timing: { start: 10, end: 30, cost: 20 },
+              usage: {
+                request_id: 'request-1',
+                model_name: 'test-model',
+                total_tokens: 42,
+              },
+              log: { rawResponse: '<result>true</result>' },
+              uiContext: { screenshot: { $screenshot: 'shot-1' } },
+              afterScreenshot: {
+                id: 'shot-file',
+                storage: 'file',
+                path: './screenshots/shot-file.png',
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  return workspace;
+}
+
+test('parseStages rejects duplicate stage ids', () => {
+  assert.throws(
+    () =>
+      parseStages([
+        { id: 'duplicate', outcome: 'success' },
+        { id: 'duplicate', outcome: 'success' },
+      ]),
+    /Duplicate harness stage id/,
+  );
+});
+
+test('resolves a versioned suite contract from outcome-only CI input', async () => {
+  const stages = await resolveStages({
+    workspace: repositoryRoot,
+    suite: 'android-emulator',
+    outcomes: JSON.stringify({
+      build: 'success',
+      'package-smoke': 'success',
+      'unit-tests': 'success',
+      'emulator-tests': 'failure',
+    }),
+  });
+  assert.equal(stages.length, 4);
+  assert.equal(stages[3].outcome, 'failure');
+  assert.deepEqual(stages[3].reportPatterns, [
+    'android-emulator-smoke.html',
+    'todo-mvc-android.html',
+  ]);
+
+  await assert.rejects(
+    resolveStages({
+      workspace: repositoryRoot,
+      suite: 'android-emulator',
+      outcomes: '{"build":"success"}',
+    }),
+    /missing \[package-smoke, unit-tests, emulator-tests\]/,
+  );
+});
+
+test('validates every registered scored suite has a report Trace contract', async () => {
+  const registry = JSON.parse(
+    await readFile(
+      path.join(repositoryRoot, 'scripts', 'ci-harness', 'suites.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(Object.keys(registry).length, 15);
+  for (const [suite, registeredStages] of Object.entries(registry)) {
+    const outcomes = Object.fromEntries(
+      registeredStages.map((stage) => [stage.id, 'success']),
+    );
+    const stages = await resolveStages({
+      workspace: repositoryRoot,
+      suite,
+      outcomes: JSON.stringify(outcomes),
+    });
+    for (const stage of stages.filter((item) => item.kind === 'case')) {
+      assert.equal(stage.traceRequired, true, `${suite}/${stage.id}`);
+      assert.ok(stage.reportPatterns.length > 0, `${suite}/${stage.id}`);
+    }
+  }
+});
+
+test('creates a trace-backed passing scorecard', async (t) => {
+  const workspace = await fixtureWorkspace();
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const result = await finalizeHarnessRun({
+    workspace,
+    suite: 'ai-web',
+    stages: [
+      {
+        id: 'report-load',
+        name: 'Report load',
+        kind: 'case',
+        outcome: 'success',
+        traceRequired: true,
+        reportPattern: 'case.html',
+        validator: {
+          type: 'midscene.aiAssert',
+          expected: 'The report is visible',
+        },
+      },
+    ],
+    reportRoots: 'midscene_run/report',
+    environment: environment(),
+  });
+
+  assert.equal(result.scorecard.verdict, 'pass');
+  assert.equal(result.scorecard.traceHealth.status, 'complete');
+  assert.equal(result.scorecard.cases[0].score, 1);
+  assert.equal(
+    result.scorecard.cases[0].stability,
+    'retry_policy_enabled',
+  );
+  assert.equal(result.scorecard.cases[0].trace.tasks[0].taskId, 'task-1');
+  assert.match(
+    result.scorecard.cases[0].trace.tasks[0].anchor,
+    /case\.html#task-task-1$/,
+  );
+  assert.equal(
+    result.scorecard.cases[0].trace.tasks[0].evidence.rawResponse,
+    true,
+  );
+  assert.equal(
+    result.scorecard.cases[0].trace.tasks[0].modelCalls[0].requestId,
+    'request-1',
+  );
+  const executionDump = JSON.parse(
+    await readFile(
+      path.join(
+        result.outputDir,
+        result.scorecard.cases[0].trace.tasks[0].executionDump,
+      ),
+      'utf8',
+    ),
+  );
+  assert.equal(
+    executionDump.executions[0].tasks[0].afterScreenshot.path,
+    '../../reports/1-report/screenshots/shot-file.png',
+  );
+
+  const manifest = JSON.parse(
+    await readFile(path.join(result.outputDir, 'manifest.json'), 'utf8'),
+  );
+  assert.ok(manifest.files.some((file) => file.path === 'scorecard.json'));
+  assert.ok(
+    manifest.files.some((file) => file.path.endsWith('1.execution.json')),
+  );
+  const traceIndex = await readFile(
+    path.join(result.outputDir, 'index.html'),
+    'utf8',
+  );
+  assert.match(traceIndex, /case\.html#task-task-1/);
+  assert.match(traceIndex, /The report is visible/);
+});
+
+test('fails harness health when a scored case has no trace', async (t) => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-harness-'));
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const result = await finalizeHarnessRun({
+    workspace,
+    suite: 'missing-trace',
+    stages: [
+      {
+        id: 'ai-case',
+        kind: 'case',
+        outcome: 'success',
+        traceRequired: true,
+        reportPattern: 'missing.html',
+      },
+    ],
+    reportRoots: 'midscene_run/report',
+    environment: environment({ GITHUB_RUN_ID: '5678' }),
+  });
+
+  assert.equal(result.scorecard.cases[0].score, 1);
+  assert.equal(result.scorecard.cases[0].trace.complete, false);
+  assert.equal(result.scorecard.verdict, 'infra_error');
+  assert.equal(result.scorecard.conclusion, 'failure');
+  assert.match(result.scorecard.harnessIssues.join('\n'), /no report/);
+});
+
+test('keeps product failure separate from infrastructure failure', async (t) => {
+  const workspace = await fixtureWorkspace();
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const productFailure = await finalizeHarnessRun({
+    workspace,
+    suite: 'product-failure',
+    stages: [
+      {
+        id: 'ai-case',
+        kind: 'case',
+        outcome: 'failure',
+        traceRequired: true,
+        reportPattern: 'case.html',
+      },
+    ],
+    reportRoots: 'midscene_run/report',
+    environment: environment({ GITHUB_RUN_ID: '9012' }),
+  });
+  assert.equal(productFailure.scorecard.verdict, 'fail');
+  assert.equal(productFailure.scorecard.cases[0].score, 0);
+
+  const infrastructureFailure = await finalizeHarnessRun({
+    workspace,
+    suite: 'infrastructure-failure',
+    stages: [
+      {
+        id: 'device',
+        kind: 'infrastructure',
+        outcome: 'failure',
+      },
+    ],
+    environment: environment({ GITHUB_RUN_ID: '3456' }),
+  });
+  assert.equal(infrastructureFailure.scorecard.verdict, 'infra_error');
+  assert.equal(infrastructureFailure.scorecard.cases.length, 0);
+});
+
+test('removes copied evidence that contains a configured secret', async (t) => {
+  const workspace = await fixtureWorkspace();
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const diagnostics = path.join(workspace, 'diagnostics');
+  await mkdir(diagnostics);
+  await writeFile(path.join(diagnostics, 'leak.log'), 'token=super-secret-value');
+
+  const result = await finalizeHarnessRun({
+    workspace,
+    suite: 'secret-scan',
+    stages: [{ id: 'check', kind: 'check', outcome: 'success' }],
+    evidenceRoots: 'diagnostics',
+    environment: environment({ MIDSCENE_MODEL_API_KEY: 'super-secret-value' }),
+  });
+  assert.equal(result.scorecard.verdict, 'infra_error');
+  assert.equal(result.scorecard.securityFindings.length, 1);
+  assert.match(result.scorecard.harnessIssues[0], /Removed evidence/);
+});

--- a/scripts/ci-harness/tests/harness.test.mjs
+++ b/scripts/ci-harness/tests/harness.test.mjs
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  access,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -307,4 +314,42 @@ test('removes copied evidence that contains a configured secret', async (t) => {
   assert.equal(result.scorecard.verdict, 'infra_error');
   assert.equal(result.scorecard.securityFindings.length, 1);
   assert.match(result.scorecard.harnessIssues[0], /Removed evidence/);
+});
+
+test('excludes hidden transient evidence from the artifact manifest', async (t) => {
+  const workspace = await fixtureWorkspace();
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const diagnostics = path.join(workspace, 'diagnostics');
+  await mkdir(diagnostics);
+  await writeFile(path.join(diagnostics, '.state.json.tmp'), 'partial');
+  await writeFile(path.join(diagnostics, 'state.json'), '{"ready":true}');
+
+  const result = await finalizeHarnessRun({
+    workspace,
+    suite: 'hidden-evidence',
+    stages: [{ id: 'check', kind: 'check', outcome: 'success' }],
+    evidenceRoots: 'diagnostics',
+    environment: environment({ GITHUB_RUN_ID: '7890' }),
+  });
+  const manifest = JSON.parse(
+    await readFile(path.join(result.outputDir, 'manifest.json'), 'utf8'),
+  );
+  assert.equal(
+    manifest.files.some((file) => file.path.includes('.state.json.tmp')),
+    false,
+  );
+  assert.equal(
+    manifest.files.some((file) => file.path.endsWith('/state.json')),
+    true,
+  );
+  await assert.rejects(
+    access(
+      path.join(
+        result.outputDir,
+        'evidence',
+        '1-diagnostics',
+        '.state.json.tmp',
+      ),
+    ),
+  );
 });

--- a/scripts/ci-harness/tests/harness.test.mjs
+++ b/scripts/ci-harness/tests/harness.test.mjs
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import {
   access,
-  mkdtemp,
   mkdir,
+  mkdtemp,
   readFile,
   rm,
   writeFile,
@@ -188,10 +188,7 @@ test('creates a trace-backed passing scorecard', async (t) => {
   assert.equal(result.scorecard.verdict, 'pass');
   assert.equal(result.scorecard.traceHealth.status, 'complete');
   assert.equal(result.scorecard.cases[0].score, 1);
-  assert.equal(
-    result.scorecard.cases[0].stability,
-    'retry_policy_enabled',
-  );
+  assert.equal(result.scorecard.cases[0].stability, 'retry_policy_enabled');
   assert.equal(result.scorecard.cases[0].trace.tasks[0].taskId, 'task-1');
   assert.match(
     result.scorecard.cases[0].trace.tasks[0].anchor,
@@ -302,7 +299,10 @@ test('removes copied evidence that contains a configured secret', async (t) => {
   t.after(() => rm(workspace, { recursive: true, force: true }));
   const diagnostics = path.join(workspace, 'diagnostics');
   await mkdir(diagnostics);
-  await writeFile(path.join(diagnostics, 'leak.log'), 'token=super-secret-value');
+  await writeFile(
+    path.join(diagnostics, 'leak.log'),
+    'token=super-secret-value',
+  );
 
   const result = await finalizeHarnessRun({
     workspace,

--- a/scripts/ci-harness/tests/snapshot.test.mjs
+++ b/scripts/ci-harness/tests/snapshot.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const snapshotScript = fileURLToPath(
+  new URL('../snapshot-reports.mjs', import.meta.url),
+);
+
+function runSnapshot(environment) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [snapshotScript], {
+      env: { ...process.env, ...environment },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stderr }));
+  });
+}
+
+test('moves one test stage report into an immutable snapshot', async (t) => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-snapshot-'));
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const source = path.join(workspace, 'midscene_run', 'report');
+  const destination = path.join(workspace, 'midscene_run', 'harness-input', 'basic');
+  await mkdir(source, { recursive: true });
+  await writeFile(path.join(source, 'case.html'), '<html></html>');
+
+  const execution = await runSnapshot({
+    GITHUB_WORKSPACE: workspace,
+    HARNESS_SNAPSHOT_SOURCE: 'midscene_run/report',
+    HARNESS_SNAPSHOT_DESTINATION: 'midscene_run/harness-input/basic',
+  });
+  assert.equal(execution.code, 0, execution.stderr);
+  await assert.rejects(access(source));
+  assert.equal(
+    await readFile(path.join(destination, 'case.html'), 'utf8'),
+    '<html></html>',
+  );
+
+  const repeated = await runSnapshot({
+    GITHUB_WORKSPACE: workspace,
+    HARNESS_SNAPSHOT_SOURCE: 'midscene_run/report',
+    HARNESS_SNAPSHOT_DESTINATION: 'midscene_run/harness-input/basic',
+  });
+  assert.equal(repeated.code, 1);
+  assert.match(repeated.stderr, /immutable and already exists/);
+});

--- a/scripts/ci-harness/tests/snapshot.test.mjs
+++ b/scripts/ci-harness/tests/snapshot.test.mjs
@@ -53,3 +53,30 @@ test('moves one test stage report into an immutable snapshot', async (t) => {
   assert.equal(repeated.code, 1);
   assert.match(repeated.stderr, /immutable and already exists/);
 });
+
+test('copies a report snapshot when a later stage consumes the source', async (t) => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-snapshot-'));
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  const source = path.join(workspace, 'midscene_run', 'report');
+  const destination = path.join(
+    workspace,
+    'midscene_run',
+    'harness-input',
+    'basic',
+  );
+  await mkdir(source, { recursive: true });
+  await writeFile(path.join(source, 'case.html'), '<html></html>');
+
+  const execution = await runSnapshot({
+    GITHUB_WORKSPACE: workspace,
+    HARNESS_SNAPSHOT_SOURCE: 'midscene_run/report',
+    HARNESS_SNAPSHOT_DESTINATION: 'midscene_run/harness-input/basic',
+    HARNESS_SNAPSHOT_MODE: 'copy',
+  });
+  assert.equal(execution.code, 0, execution.stderr);
+  assert.equal(await readFile(path.join(source, 'case.html'), 'utf8'), '<html></html>');
+  assert.equal(
+    await readFile(path.join(destination, 'case.html'), 'utf8'),
+    '<html></html>',
+  );
+});

--- a/scripts/ci-harness/tests/snapshot.test.mjs
+++ b/scripts/ci-harness/tests/snapshot.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -29,7 +36,12 @@ test('moves one test stage report into an immutable snapshot', async (t) => {
   const workspace = await mkdtemp(path.join(os.tmpdir(), 'midscene-snapshot-'));
   t.after(() => rm(workspace, { recursive: true, force: true }));
   const source = path.join(workspace, 'midscene_run', 'report');
-  const destination = path.join(workspace, 'midscene_run', 'harness-input', 'basic');
+  const destination = path.join(
+    workspace,
+    'midscene_run',
+    'harness-input',
+    'basic',
+  );
   await mkdir(source, { recursive: true });
   await writeFile(path.join(source, 'case.html'), '<html></html>');
 
@@ -74,7 +86,10 @@ test('copies a report snapshot when a later stage consumes the source', async (t
     HARNESS_SNAPSHOT_MODE: 'copy',
   });
   assert.equal(execution.code, 0, execution.stderr);
-  assert.equal(await readFile(path.join(source, 'case.html'), 'utf8'), '<html></html>');
+  assert.equal(
+    await readFile(path.join(source, 'case.html'), 'utf8'),
+    '<html></html>',
+  );
   assert.equal(
     await readFile(path.join(destination, 'case.html'), 'utf8'),
     '<html></html>',


### PR DESCRIPTION
## Summary

- add a centralized CI harness finalizer that produces immutable scorecards, Trace Bundles, task-level deep links, validator provenance, retry visibility, and secret-safe evidence
- register scored cases separately from infrastructure and deterministic checks across AI, report, headless, desktop, Android, and iOS workflows
- add nightly reusable-workflow orchestration and aggregate scoring
- preserve report inputs between dependent AI stages and reject incomplete or unreproducible artifacts
- add harness schemas and regression tests for report parsing, missing Trace, product versus infrastructure failures, secret scanning, snapshots, aggregation, and manifest integrity

## Validation

Local:
- pnpm run lint
- npx biome check . --diagnostic-level=warn --no-errors-on-unmatched
- pnpm run test:ci-harness
- pnpm dlx github-actionlint .github/workflows/ai.yml .github/workflows/ai-unit-test.yml .github/workflows/headless-linux.yml .github/workflows/studio-headless-linux.yml .github/workflows/macos-desktop.yml .github/workflows/windows-desktop.yml .github/workflows/android-emulator.yml .github/workflows/ios-simulator.yml .github/workflows/ci.yml .github/workflows/nightly-harness.yml
- bash -n packages/ios/scripts/run-simulator-ci-smokes.sh
- git diff --check

PR-native workflows on the final SHA:
- [CI](https://github.com/web-infra-dev/midscene/actions/runs/30971163092): success
- [Lint](https://github.com/web-infra-dev/midscene/actions/runs/30971163068): success
- [AI Playwright](https://github.com/web-infra-dev/midscene/actions/runs/30971163075): success
- [AI unit](https://github.com/web-infra-dev/midscene/actions/runs/30971163067): success
- [Headless Linux](https://github.com/web-infra-dev/midscene/actions/runs/30971163062): success
- [Android](https://github.com/web-infra-dev/midscene/actions/runs/30971163099): success
- [iOS](https://github.com/web-infra-dev/midscene/actions/runs/30971163061): success
- [Windows](https://github.com/web-infra-dev/midscene/actions/runs/30971163065): success
- [macOS](https://github.com/web-infra-dev/midscene/actions/runs/30971163037): success
- [Studio](https://github.com/web-infra-dev/midscene/actions/runs/30971163046): success
- [PR Title](https://github.com/web-infra-dev/midscene/actions/runs/30971025614): success

Artifact verification:
- Windows final-SHA bundle is pass/complete; all 51 manifest hashes match and hidden transient files are absent
- Studio bundle contains 8 tasks, 5 model calls, raw responses, screenshots, and task anchors; all 18 manifest hashes match
- AI report app contains 74 tasks and 43 model calls; AI web contains two trace-complete scored cases with 200 and 202 tasks; all 207 combined manifest entries match
- iOS bundle is pass/complete with no security finding after preventing the model API key from reaching the WebDriverAgent build process

Two earlier manual Headless runs caught the dark timeline assertion as a product failure while preserving complete Trace, request IDs, screenshots, raw responses, token usage, and reproducible manifests. The final PR-native rerun passed, so this is recorded as a flaky UI/model signal rather than a harness infrastructure failure.

The new Nightly Harness workflow cannot be manually registered until the workflow file exists on the default branch; its workflow graph is covered by actionlint and activates after merge.