### PR TITLE
ci(workflow): publish generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
         tag_name: ${{ steps.get_version.outputs.version }}
         target_commitish: ${{ github.event.inputs.branch }}
         prerelease: ${{ contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'rc') }}
+        generate_release_notes: true
         files: |
           ${{ github.workspace }}/apps/chrome-extension/extension_output/**/*.zip
       env:
@@ -447,27 +448,50 @@ jobs:
           exit 0
         fi
 
+        ENCODED_RELEASE_VERSION="$(jq -rn --arg value "$RELEASE_VERSION" '$value | @uri')"
         RELEASE_JSON="$(
-          gh release view "$RELEASE_VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json name,publishedAt,url
+          curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${ENCODED_RELEASE_VERSION}"
         )"
+        jq -e \
+          --arg version "$RELEASE_VERSION" \
+          '
+            .tag_name == $version
+            and .draft == false
+            and (.html_url | type == "string" and length > 0)
+            and (.published_at | type == "string" and length > 0)
+          ' >/dev/null <<< "$RELEASE_JSON"
         RELEASE_NAME="$(jq -r '.name // empty' <<< "$RELEASE_JSON")"
-        RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
-        RELEASE_PUBLISHED_AT="$(jq -r '.publishedAt' <<< "$RELEASE_JSON")"
+        RELEASE_URL="$(jq -r '.html_url' <<< "$RELEASE_JSON")"
+        RELEASE_PUBLISHED_AT="$(jq -r '.published_at' <<< "$RELEASE_JSON")"
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
 
-        GENERATED_NOTES_JSON="$(
-          gh api --method POST \
-            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$RELEASE_VERSION" \
-            -f target_commitish="$RELEASE_TARGET"
-        )"
-        if ! RELEASE_BODY="$(
-          jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON"
-        )"; then
-          echo "GitHub generated empty release notes for the Discord notification." >&2
-          exit 1
+        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
+        if [[ ! "$RELEASE_BODY" =~ [^[:space:]] ]]; then
+          GENERATED_NOTES_JSON="$(
+            jq -cn \
+              --arg tag_name "$RELEASE_VERSION" \
+              --arg target_commitish "$RELEASE_TARGET" \
+              '{tag_name: $tag_name, target_commitish: $target_commitish}' \
+              | curl \
+                  --fail-with-body \
+                  --silent \
+                  --show-error \
+                  --request POST \
+                  --header 'Accept: application/vnd.github+json' \
+                  --header "Authorization: Bearer ${GH_TOKEN}" \
+                  --header 'Content-Type: application/json' \
+                  --header 'X-GitHub-Api-Version: 2022-11-28' \
+                  --data @- \
+                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes"
+          )"
+          RELEASE_BODY="$(jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON")"
         fi
 
         PAYLOAD="$(
@@ -709,27 +733,50 @@ jobs:
           )")
         done
 
+        ENCODED_RELEASE_VERSION="$(jq -rn --arg value "$RELEASE_VERSION" '$value | @uri')"
         RELEASE_JSON="$(
-          gh release view "$RELEASE_VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json name,url
+          curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${ENCODED_RELEASE_VERSION}"
         )"
+        jq -e \
+          --arg version "$RELEASE_VERSION" \
+          '
+            .tag_name == $version
+            and .draft == false
+            and (.html_url | type == "string" and length > 0)
+            and (.published_at | type == "string" and length > 0)
+          ' >/dev/null <<< "$RELEASE_JSON"
         RELEASE_NAME="$(jq -r '.name // empty' <<< "$RELEASE_JSON")"
-        RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
+        RELEASE_URL="$(jq -r '.html_url' <<< "$RELEASE_JSON")"
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
         NPM_URL="https://www.npmjs.com/package/@midscene/core/v/${PACKAGE_VERSION}"
 
-        GENERATED_NOTES_JSON="$(
-          gh api --method POST \
-            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$RELEASE_VERSION" \
-            -f target_commitish="$RELEASE_TARGET"
-        )"
-        if ! RELEASE_BODY="$(
-          jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON"
-        )"; then
-          echo "GitHub generated empty release notes for the Feishu notification." >&2
-          exit 1
+        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
+        if [[ ! "$RELEASE_BODY" =~ [^[:space:]] ]]; then
+          GENERATED_NOTES_JSON="$(
+            jq -cn \
+              --arg tag_name "$RELEASE_VERSION" \
+              --arg target_commitish "$RELEASE_TARGET" \
+              '{tag_name: $tag_name, target_commitish: $target_commitish}' \
+              | curl \
+                  --fail-with-body \
+                  --silent \
+                  --show-error \
+                  --request POST \
+                  --header 'Accept: application/vnd.github+json' \
+                  --header "Authorization: Bearer ${GH_TOKEN}" \
+                  --header 'Content-Type: application/json' \
+                  --header 'X-GitHub-Api-Version: 2022-11-28' \
+                  --data @- \
+                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes"
+          )"
+          RELEASE_BODY="$(jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON")"
         fi
 
         CARD_CONTENT="$(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,8 +576,8 @@ jobs:
                   end;
               def category_definitions:
                 [
-                  {key: "feat", label: "Features"},
-                  {key: "fix", label: "Fixes"}
+                  {key: "feat", label: "Features 🎉"},
+                  {key: "fix", label: "Fixes 🐞"}
                 ];
               def safe_title:
                 gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
@@ -860,8 +860,8 @@ jobs:
                   end;
               def category_definitions:
                 [
-                  {key: "feat", label: "Features"},
-                  {key: "fix", label: "Fixes"}
+                  {key: "feat", label: "Features 🎉"},
+                  {key: "fix", label: "Fixes 🐞"}
                 ];
               def safe_title:
                 gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,37 @@ jobs:
         if-no-files-found: error
         name: chrome_extension
         path: ${{ github.workspace }}/apps/chrome-extension/extension_output
+
+    - name: Generate ordered Release notes
+      if: ${{ steps.get_version.outputs.is_prerelease != 'true' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TARGET: ${{ github.event.inputs.branch }}
+        RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        REQUEST_BODY="$(
+          jq -cn \
+            --arg tag_name "$RELEASE_VERSION" \
+            --arg target_commitish "$RELEASE_TARGET" \
+            '{tag_name: $tag_name, target_commitish: $target_commitish}'
+        )"
+        curl \
+          --fail-with-body \
+          --silent \
+          --show-error \
+          --request POST \
+          --header 'Accept: application/vnd.github+json' \
+          --header "Authorization: Bearer ${GH_TOKEN}" \
+          --header 'Content-Type: application/json' \
+          --header 'X-GitHub-Api-Version: 2022-11-28' \
+          --data "$REQUEST_BODY" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+          | jq -er '.body | strings | select(test("\\S"))' \
+          > "$RUNNER_TEMP/generated-release-notes.md"
+        node ./scripts/format-release-notes.mjs \
+          < "$RUNNER_TEMP/generated-release-notes.md" \
+          > "$RUNNER_TEMP/release-notes.md"
+        test -s "$RUNNER_TEMP/release-notes.md"
         
     - name: Upload Release Assets
       if: ${{ steps.get_version.outputs.is_prerelease != 'true' }}
@@ -163,7 +194,7 @@ jobs:
         tag_name: ${{ steps.get_version.outputs.version }}
         target_commitish: ${{ github.event.inputs.branch }}
         prerelease: ${{ contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'rc') }}
-        generate_release_notes: true
+        body_path: ${{ runner.temp }}/release-notes.md
         files: |
           ${{ github.workspace }}/apps/chrome-extension/extension_output/**/*.zip
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,17 @@ jobs:
         node ./scripts/format-release-notes.mjs \
           < "$RUNNER_TEMP/generated-release-notes.md" \
           > "$RUNNER_TEMP/release-notes.md"
+        node ./scripts/format-release-notes.mjs --notification-json \
+          < "$RUNNER_TEMP/generated-release-notes.md" \
+          > "$RUNNER_TEMP/release-notification.json"
         test -s "$RUNNER_TEMP/release-notes.md"
+        jq -e '
+          .schemaVersion == 1
+          and (.changeCount | type == "number" and . >= 0)
+          and (.categoryCount | type == "number" and . >= 0)
+          and (.markdown | type == "string")
+          and (.groups | type == "array")
+        ' "$RUNNER_TEMP/release-notification.json" >/dev/null
         
     - name: Upload Release Assets
       if: ${{ steps.get_version.outputs.is_prerelease != 'true' }}
@@ -199,6 +209,16 @@ jobs:
           ${{ github.workspace }}/apps/chrome-extension/extension_output/**/*.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload Release notes metadata
+      if: ${{ steps.get_version.outputs.is_prerelease != 'true' }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        if-no-files-found: error
+        name: release_notes
+        path: |
+          ${{ runner.temp }}/release-notes.md
+          ${{ runner.temp }}/release-notification.json
 
   publish_chrome_web_store:
     needs: release
@@ -458,15 +478,20 @@ jobs:
     if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     permissions:
-      contents: write
+      contents: read
     steps:
+    - name: Download Release notes metadata
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: release_notes
+        path: ${{ runner.temp }}/release-notes
     - name: Publish release notification to Discord
       id: notify
       continue-on-error: true
       env:
         DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         GH_TOKEN: ${{ github.token }}
-        RELEASE_TARGET: ${{ github.event.inputs.branch }}
+        RELEASE_NOTES_METADATA_PATH: ${{ runner.temp }}/release-notes/release-notification.json
         RELEASE_VERSION: ${{ needs.release.outputs.version }}
       run: |
         set -euo pipefail
@@ -478,6 +503,31 @@ jobs:
           echo "Skipped because the repository secret \`DISCORD_WEBHOOK_URL\` is not configured." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
+
+        jq -e '
+          . as $metadata
+          | .schemaVersion == 1
+          and (.changeCount | type == "number" and . >= 0)
+          and (.categoryCount | type == "number" and . >= 0)
+          and (.markdown | type == "string")
+          and (.groups | type == "array")
+          and .categoryCount == (.groups | length)
+          and .changeCount == ([.groups[].items[]] | length)
+          and all(.groups[];
+            (.key | type == "string" and length > 0)
+            and (.label | type == "string" and length > 0)
+            and (.items | type == "array")
+            and all(.items[];
+              (.pr | type == "string" and length > 0)
+              and (.title | type == "string" and length > 0)
+              and (.url | type == "string" and length > 0)
+            )
+          )
+          and (if .changeCount > 0 then (.markdown | test("\\S")) else .markdown == "" end)
+        ' "$RELEASE_NOTES_METADATA_PATH" >/dev/null
+        NOTIFICATION_MARKDOWN="$(jq -r '.markdown' "$RELEASE_NOTES_METADATA_PATH")"
+        CHANGE_COUNT="$(jq -r '.changeCount' "$RELEASE_NOTES_METADATA_PATH")"
+        CATEGORY_COUNT="$(jq -r '.categoryCount' "$RELEASE_NOTES_METADATA_PATH")"
 
         ENCODED_RELEASE_VERSION="$(jq -rn --arg value "$RELEASE_VERSION" '$value | @uri')"
         RELEASE_JSON="$(
@@ -503,36 +553,16 @@ jobs:
         RELEASE_PUBLISHED_AT="$(jq -r '.published_at' <<< "$RELEASE_JSON")"
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
 
-        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
-        if [[ ! "$RELEASE_BODY" =~ [^[:space:]] ]]; then
-          GENERATED_NOTES_JSON="$(
-            jq -cn \
-              --arg tag_name "$RELEASE_VERSION" \
-              --arg target_commitish "$RELEASE_TARGET" \
-              '{tag_name: $tag_name, target_commitish: $target_commitish}' \
-              | curl \
-                  --fail-with-body \
-                  --silent \
-                  --show-error \
-                  --request POST \
-                  --header 'Accept: application/vnd.github+json' \
-                  --header "Authorization: Bearer ${GH_TOKEN}" \
-                  --header 'Content-Type: application/json' \
-                  --header 'X-GitHub-Api-Version: 2022-11-28' \
-                  --data @- \
-                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes"
-          )"
-          RELEASE_BODY="$(jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON")"
-        fi
-
         PAYLOAD="$(
           jq -cn \
-            --arg body "$RELEASE_BODY" \
+            --arg notes "$NOTIFICATION_MARKDOWN" \
             --arg package_version "$PACKAGE_VERSION" \
             --arg published_at "$RELEASE_PUBLISHED_AT" \
             --arg release_name "$RELEASE_NAME" \
             --arg release_url "$RELEASE_URL" \
             --arg version "$RELEASE_VERSION" \
+            --argjson category_count "$CATEGORY_COUNT" \
+            --argjson change_count "$CHANGE_COUNT" \
             '
               def release_title:
                 ($release_name | gsub("^\\s+|\\s+$"; "")) as $name
@@ -541,82 +571,7 @@ jobs:
                   else
                     $name
                   end;
-              def normalized_type:
-                ((try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other") // "other")
-                | ascii_downcase
-                | if . == "feat" then "feat"
-                  elif . == "fix" then "fix"
-                  elif . == "perf" then "perf"
-                  elif . == "refactor" then "refactor"
-                  elif . == "docs" then "docs"
-                  elif . == "test" or . == "tests" then "test"
-                  elif . == "build" then "build"
-                  elif . == "ci" then "ci"
-                  elif . == "chore" then "chore"
-                  else "other"
-                  end;
-              def normalized_scope:
-                ((try capture("^[A-Za-z]+\\((?<scope>[^)]*)\\)!?:").scope catch "") // "")
-                | ascii_downcase;
-              def parse_change:
-                . as $line
-                | if $line | test("^[*-] ") then
-                    (try
-                      ($line
-                        | capture("^[*-] (?<title>.+?) by @[^ ]+ in (?<url>https://github\\.com/[^ ]+/pull/(?<pr>[0-9]+))$")
-                      )
-                    catch
-                      {title: ($line | sub("^[*-] "; "")), url: "", pr: ""}
-                    )
-                    | .title |= gsub("^\\s+|\\s+$"; "")
-                    | .type = (.title | normalized_type)
-                    | .scope = (.title | normalized_scope)
-                  else
-                    empty
-                  end;
-              def category_definitions:
-                [
-                  {key: "feat", label: "Features 🎉"},
-                  {key: "fix", label: "Fixes 🐞"}
-                ];
-              def safe_title:
-                gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
-              def item_line:
-                if .pr != "" then
-                  "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"
-                else
-                  "- \(.title | safe_title)"
-                end;
-
-              ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
-              | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
-              | [
-                  $parsed_changes[]
-                  | select((.type == "feat" or .type == "fix") and .scope != "site")
-                ] as $changes
-              | [
-                  category_definitions[] as $category
-                  | [$changes[] | select(.type == $category.key)] as $items
-                  | select($items | length > 0)
-                  | $category + {items: $items}
-                ] as $groups
-              | ($changes | length) as $change_count
-              | ($groups | length) as $category_count
-              | ($groups
-                  | map("**\(.label)**\n" + (.items | map(item_line) | join("\n")))
-                  | join("\n\n")
-                ) as $grouped_notes
-              | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
-              | (if $change_count > 0 then
-                    $grouped_notes
-                  elif ($parsed_changes | length) > 0 then
-                    "Midscene.js \($version) is now available."
-                  elif $raw_notes != "" then
-                    $raw_notes
-                  else
-                    "Midscene.js \($version) is now available."
-                  end
-                ) as $notes
+              (if $change_count > 0 then $notes else "Midscene.js \($version) is now available." end) as $description_notes
               | (if $change_count > 0 then
                     "\($change_count) \(if $change_count == 1 then "change" else "changes" end)"
                     + " · \($category_count) \(if $category_count == 1 then "category" else "categories" end)"
@@ -626,7 +581,7 @@ jobs:
                 ) as $summary
               | ("Latest stable release\n\n"
                   + (if $change_count > 0 then "**\($summary)**\n\n" else "" end)
-                  + $notes
+                  + $description_notes
                   | if length > 3500 then .[0:3500] + "\n\n…" else . end
                 ) as $description
               | (release_title | .[0:256]) as $title
@@ -707,8 +662,13 @@ jobs:
     if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     permissions:
-      contents: write
+      contents: read
     steps:
+    - name: Download Release notes metadata
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: release_notes
+        path: ${{ runner.temp }}/release-notes
     - name: Publish release notification to Feishu
       id: notify
       continue-on-error: true
@@ -717,7 +677,7 @@ jobs:
         # {"url":"...","secret":"..."} webhook targets.
         FEISHU_WEBHOOK_TARGETS_JSON: ${{ secrets.FEISHU_WEBHOOK_TARGETS_JSON }}
         GH_TOKEN: ${{ github.token }}
-        RELEASE_TARGET: ${{ github.event.inputs.branch }}
+        RELEASE_NOTES_METADATA_PATH: ${{ runner.temp }}/release-notes/release-notification.json
         RELEASE_VERSION: ${{ needs.release.outputs.version }}
       run: |
         set -euo pipefail
@@ -764,6 +724,31 @@ jobs:
           )")
         done
 
+        jq -e '
+          . as $metadata
+          | .schemaVersion == 1
+          and (.changeCount | type == "number" and . >= 0)
+          and (.categoryCount | type == "number" and . >= 0)
+          and (.markdown | type == "string")
+          and (.groups | type == "array")
+          and .categoryCount == (.groups | length)
+          and .changeCount == ([.groups[].items[]] | length)
+          and all(.groups[];
+            (.key | type == "string" and length > 0)
+            and (.label | type == "string" and length > 0)
+            and (.items | type == "array")
+            and all(.items[];
+              (.pr | type == "string" and length > 0)
+              and (.title | type == "string" and length > 0)
+              and (.url | type == "string" and length > 0)
+            )
+          )
+          and (if .changeCount > 0 then (.markdown | test("\\S")) else .markdown == "" end)
+        ' "$RELEASE_NOTES_METADATA_PATH" >/dev/null
+        NOTIFICATION_MARKDOWN="$(jq -r '.markdown' "$RELEASE_NOTES_METADATA_PATH")"
+        CHANGE_COUNT="$(jq -r '.changeCount' "$RELEASE_NOTES_METADATA_PATH")"
+        CATEGORY_COUNT="$(jq -r '.categoryCount' "$RELEASE_NOTES_METADATA_PATH")"
+
         ENCODED_RELEASE_VERSION="$(jq -rn --arg value "$RELEASE_VERSION" '$value | @uri')"
         RELEASE_JSON="$(
           curl \
@@ -788,35 +773,15 @@ jobs:
         PACKAGE_VERSION="${RELEASE_VERSION#v}"
         NPM_URL="https://www.npmjs.com/package/@midscene/core/v/${PACKAGE_VERSION}"
 
-        RELEASE_BODY="$(jq -r '.body // empty' <<< "$RELEASE_JSON")"
-        if [[ ! "$RELEASE_BODY" =~ [^[:space:]] ]]; then
-          GENERATED_NOTES_JSON="$(
-            jq -cn \
-              --arg tag_name "$RELEASE_VERSION" \
-              --arg target_commitish "$RELEASE_TARGET" \
-              '{tag_name: $tag_name, target_commitish: $target_commitish}' \
-              | curl \
-                  --fail-with-body \
-                  --silent \
-                  --show-error \
-                  --request POST \
-                  --header 'Accept: application/vnd.github+json' \
-                  --header "Authorization: Bearer ${GH_TOKEN}" \
-                  --header 'Content-Type: application/json' \
-                  --header 'X-GitHub-Api-Version: 2022-11-28' \
-                  --data @- \
-                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes"
-          )"
-          RELEASE_BODY="$(jq -er '.body | strings | select(test("\\S"))' <<< "$GENERATED_NOTES_JSON")"
-        fi
-
         CARD_CONTENT="$(
           jq -cn \
-            --arg body "$RELEASE_BODY" \
+            --arg notes "$NOTIFICATION_MARKDOWN" \
             --arg release_name "$RELEASE_NAME" \
             --arg release_url "$RELEASE_URL" \
             --arg npm_url "$NPM_URL" \
             --arg version "$RELEASE_VERSION" \
+            --argjson category_count "$CATEGORY_COUNT" \
+            --argjson change_count "$CHANGE_COUNT" \
             '
               def release_title:
                 ($release_name | gsub("^\\s+|\\s+$"; "")) as $name
@@ -825,83 +790,8 @@ jobs:
                   else
                     $name
                   end;
-              def normalized_type:
-                ((try capture("^(?<type>[A-Za-z]+)(?:\\([^)]*\\))?!?:").type catch "other") // "other")
-                | ascii_downcase
-                | if . == "feat" then "feat"
-                  elif . == "fix" then "fix"
-                  elif . == "perf" then "perf"
-                  elif . == "refactor" then "refactor"
-                  elif . == "docs" then "docs"
-                  elif . == "test" or . == "tests" then "test"
-                  elif . == "build" then "build"
-                  elif . == "ci" then "ci"
-                  elif . == "chore" then "chore"
-                  else "other"
-                  end;
-              def normalized_scope:
-                ((try capture("^[A-Za-z]+\\((?<scope>[^)]*)\\)!?:").scope catch "") // "")
-                | ascii_downcase;
-              def parse_change:
-                . as $line
-                | if $line | test("^[*-] ") then
-                    (try
-                      ($line
-                        | capture("^[*-] (?<title>.+?) by @[^ ]+ in (?<url>https://github\\.com/[^ ]+/pull/(?<pr>[0-9]+))$")
-                      )
-                    catch
-                      {title: ($line | sub("^[*-] "; "")), url: "", pr: ""}
-                    )
-                    | .title |= gsub("^\\s+|\\s+$"; "")
-                    | .type = (.title | normalized_type)
-                    | .scope = (.title | normalized_scope)
-                  else
-                    empty
-                  end;
-              def category_definitions:
-                [
-                  {key: "feat", label: "Features 🎉"},
-                  {key: "fix", label: "Fixes 🐞"}
-                ];
-              def safe_title:
-                gsub("(?<char>[\\\\`*_~\\[\\]<>])"; "\\\\\(.char)");
-              def item_line:
-                if .pr != "" then
-                  "- \(.title | safe_title) · [PR #\(.pr)](\(.url))"
-                else
-                  "- \(.title | safe_title)"
-                end;
-
-              ($body | gsub("\\r"; "") | gsub("<!--[^\\n]*-->\\n*"; "")) as $clean_body
-              | [$clean_body | split("\n")[] | parse_change] as $parsed_changes
-              | [
-                  $parsed_changes[]
-                  | select((.type == "feat" or .type == "fix") and .scope != "site")
-                ] as $changes
-              | [
-                  category_definitions[] as $category
-                  | [$changes[] | select(.type == $category.key)] as $items
-                  | select($items | length > 0)
-                  | $category + {items: $items}
-                ] as $groups
-              | ($changes | length) as $change_count
-              | ($groups | length) as $category_count
-              | ($groups
-                  | map("**\(.label)**\n" + (.items | map(item_line) | join("\n")))
-                  | join("\n\n")
-                ) as $grouped_notes
-              | ($clean_body | gsub("^\\s+|\\s+$"; "")) as $raw_notes
-              | (if $change_count > 0 then
-                    $grouped_notes
-                  elif ($parsed_changes | length) > 0 then
-                    "Midscene.js \($version) is now available."
-                  elif $raw_notes != "" then
-                    $raw_notes
-                  else
-                    "Midscene.js \($version) is now available."
-                  end
-                ) as $notes
-              | ($notes
+              (if $change_count > 0 then $notes else "Midscene.js \($version) is now available." end)
+              | (.
                   | if length > 7500 then
                       .[0:7400] + "\n\n… [View the full release notes](\($release_url))"
                     else

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -316,6 +316,10 @@ describe('GitHub Release notes ordering', () => {
     expect(formatted).toContain('## Other Changes');
     expect(formatted.match(/^\* /gm)).toHaveLength(5);
     expect(formatted).toMatch(/\*\*Full Changelog\*\*: .*$/);
+    expect(formatted).toContain('## Features\n');
+    expect(formatted).toContain('## Fixes\n');
+    expect(formatted).not.toContain('## Features 🎉');
+    expect(formatted).not.toContain('## Fixes 🐞');
   });
 
   it('places breaking changes and maintenance in explicit categories', () => {

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -33,13 +33,29 @@ const loadFeishuNotificationScript = async () => {
   return match[1].replace(/^ {8}/gm, '');
 };
 
+const loadDiscordNotificationScript = async () => {
+  const workflow = await fs.readFile(
+    path.join(repositoryRoot, '.github/workflows/release.yml'),
+    'utf8',
+  );
+  const match = workflow.match(
+    / {4}- name: Publish release notification to Discord[\s\S]*?\n {6}run: \|\n([\s\S]*?)\n {4}- name: Summarize Discord notification failure/,
+  );
+  if (!match) {
+    throw new Error('Could not find the Discord release notification script');
+  }
+  return match[1].replace(/^ {8}/gm, '');
+};
+
 const createNotificationHarness = async () => {
   const root = await fs.mkdtemp(
     path.join(os.tmpdir(), 'midscene-release-notification-'),
   );
   temporaryDirectories.push(root);
   const binDirectory = path.join(root, 'bin');
+  const curlCommandLog = path.join(root, 'curl-command.log');
   const curlLog = path.join(root, 'curl.log');
+  const curlPayloadLog = path.join(root, 'curl-payload.log');
   const summaryPath = path.join(root, 'summary.md');
   await fs.mkdir(binDirectory);
 
@@ -47,19 +63,59 @@ const createNotificationHarness = async () => {
     path.join(binDirectory, 'gh'),
     `#!/usr/bin/env bash
 set -euo pipefail
-if [[ "$1 $2" == "release view" ]]; then
-  printf '%s\\n' '{"name":"Midscene.js v1.2.3","url":"https://github.com/web-infra-dev/midscene/releases/tag/v1.2.3"}'
-else
-  printf '%s\\n' '{"body":"* feat(core): support external groups by @example in https://github.com/web-infra-dev/midscene/pull/1"}'
-fi
+echo "The notification script must not depend on gh." >&2
+exit 99
 `,
   );
   await writeExecutable(
     path.join(binDirectory, 'curl'),
     `#!/usr/bin/env bash
 set -euo pipefail
-cat >> "$CURL_LOG"
+printf '%q ' "$@" >> "$CURL_COMMAND_LOG"
+printf '\\n' >> "$CURL_COMMAND_LOG"
+
+if [[ " $* " == *" https://api.github.com/repos/web-infra-dev/midscene/releases/tags/"* ]]; then
+  jq -cn \\
+    --arg body "\${MOCK_RELEASE_BODY-}" \\
+    --arg published_at "\${MOCK_RELEASE_PUBLISHED_AT-2026-08-04T12:25:00Z}" \\
+    '{
+      name: "Midscene.js v1.2.3",
+      tag_name: "v1.2.3",
+      draft: false,
+      html_url: "https://github.com/web-infra-dev/midscene/releases/tag/v1.2.3",
+      published_at: $published_at,
+      body: (if $body == "" then null else $body end)
+    }'
+  exit 0
+fi
+
+if [[ " $* " == *" https://api.github.com/repos/web-infra-dev/midscene/releases/generate-notes"* ]]; then
+  cat >/dev/null
+  jq -cn \\
+    --arg body "\${MOCK_GENERATED_NOTES_BODY-* feat(core): support external groups by @example in https://github.com/web-infra-dev/midscene/pull/1}" \\
+    '{body: $body}'
+  exit 0
+fi
+
+request_config="$(cat)"
+printf '%s' "$request_config" >> "$CURL_LOG"
 printf '\\n' >> "$CURL_LOG"
+arguments=("$@")
+for ((index = 0; index < \${#arguments[@]}; index += 1)); do
+  if [[ "\${arguments[$index]}" == "--data" ]]; then
+    printf '%s\\n' "\${arguments[$((index + 1))]}" >> "$CURL_PAYLOAD_LOG"
+  fi
+done
+
+if [[ "$request_config" == *"discord.com/api/webhooks/"* ]]; then
+  if [[ " $* " == *" --request POST "* ]]; then
+    printf '%s\\n' '{"id":"message-id","channel_id":"channel-id"}'
+  else
+    printf '%s\\n' '{"guild_id":"guild-id"}'
+  fi
+  exit 0
+fi
+
 printf '%s\\n' '{"code":0,"msg":"success"}'
 `,
   );
@@ -77,10 +133,14 @@ fi
   );
 
   return {
+    curlCommandLog,
     curlLog,
+    curlPayloadLog,
     env: {
       ...process.env,
+      CURL_COMMAND_LOG: curlCommandLog,
       CURL_LOG: curlLog,
+      CURL_PAYLOAD_LOG: curlPayloadLog,
       GH_TOKEN: 'test-token',
       GITHUB_REPOSITORY: 'web-infra-dev/midscene',
       GITHUB_STEP_SUMMARY: summaryPath,
@@ -100,6 +160,18 @@ afterEach(async () => {
 });
 
 describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
+  it('publishes generated notes as part of the GitHub Release', async () => {
+    const workflow = await fs.readFile(
+      path.join(repositoryRoot, '.github/workflows/release.yml'),
+      'utf8',
+    );
+    const releaseUpload = workflow.match(
+      /- name: Upload Release Assets[\s\S]*?\n\s+env:/,
+    )?.[0];
+
+    expect(releaseUpload).toContain('generate_release_notes: true');
+  });
+
   it('delivers to every JSON webhook target', async () => {
     const script = await loadFeishuNotificationScript();
     const harness = await createNotificationHarness();
@@ -121,7 +193,72 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
       expect(curlLog).toContain(`url = "${target.url}"`);
     }
     expect(curlLog.match(/^url = /gm)).toHaveLength(targets.length);
+
+    const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
+    expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
+    expect(curlCommandLog).toContain('/releases/generate-notes');
+
+    const payloads = (await fs.readFile(harness.curlPayloadLog, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(payloads).toHaveLength(targets.length);
+    expect(payloads[0].card.body.elements[0].content).toContain('**Features**');
   }, 15_000);
+
+  it('uses published release notes without generating them again', async () => {
+    const script = await loadFeishuNotificationScript();
+    const harness = await createNotificationHarness();
+
+    execFileSync('bash', ['-c', script], {
+      env: {
+        ...harness.env,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify([
+          {
+            url: 'https://open.feishu.cn/open-apis/bot/v2/hook/existing-notes',
+            secret: 'existing-notes-secret',
+          },
+        ]),
+        MOCK_RELEASE_BODY:
+          '* fix(core): preserve release notes by @example in https://github.com/web-infra-dev/midscene/pull/2',
+      },
+      stdio: 'pipe',
+    });
+
+    const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
+    expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
+    expect(curlCommandLog).not.toContain('/releases/generate-notes');
+
+    const payload = JSON.parse(
+      (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),
+    );
+    expect(payload.card.body.elements[0].content).toContain('**Fixes**');
+    expect(payload.card.body.elements[0].content).toContain('PR #2');
+  });
+
+  it('rejects incomplete release metadata before delivery', async () => {
+    const script = await loadFeishuNotificationScript();
+    const harness = await createNotificationHarness();
+
+    const result = spawnSync('bash', ['-c', script], {
+      encoding: 'utf8',
+      env: {
+        ...harness.env,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify([
+          {
+            url: 'https://open.feishu.cn/open-apis/bot/v2/hook/incomplete-release',
+            secret: 'incomplete-release-secret',
+          },
+        ]),
+        MOCK_RELEASE_PUBLISHED_AT: '',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    await expect(
+      fs.readFile(harness.curlPayloadLog, 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 
   it('rejects malformed JSON target configuration before delivery', async () => {
     const script = await loadFeishuNotificationScript();
@@ -144,5 +281,30 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
     await expect(fs.readFile(harness.curlLog, 'utf8')).rejects.toMatchObject({
       code: 'ENOENT',
     });
+  });
+});
+
+describe.skipIf(!supportsReleaseShell)('Discord release notification', () => {
+  it('fetches release metadata and generates notes without gh', async () => {
+    const script = await loadDiscordNotificationScript();
+    const harness = await createNotificationHarness();
+
+    execFileSync('bash', ['-c', script], {
+      env: {
+        ...harness.env,
+        DISCORD_WEBHOOK_URL:
+          'https://discord.com/api/webhooks/webhook-id/webhook-token',
+      },
+      stdio: 'pipe',
+    });
+
+    const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
+    expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
+    expect(curlCommandLog).toContain('/releases/generate-notes');
+
+    const payload = JSON.parse(
+      (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),
+    );
+    expect(payload.embeds[0].description).toContain('**Features**');
   });
 });

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -4,7 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
-import { formatReleaseNotes } from '../../../scripts/format-release-notes.mjs';
+import {
+  buildReleaseNotification,
+  formatReleaseNotes,
+} from '../../../scripts/format-release-notes.mjs';
 
 const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -15,38 +18,50 @@ const supportsReleaseShell =
   process.platform !== 'win32' &&
   spawnSync('bash', ['--version']).status === 0 &&
   spawnSync('jq', ['--version']).status === 0;
+const defaultGeneratedNotes =
+  '* feat(core): support external groups by @example in https://github.com/web-infra-dev/midscene/pull/1';
 
 const writeExecutable = async (filePath, content) => {
   await fs.writeFile(filePath, content, { mode: 0o755 });
 };
 
-const loadFeishuNotificationScript = async () => {
+const loadWorkflowRunScript = async (stepName, nextStepName) => {
   const workflow = await fs.readFile(
     path.join(repositoryRoot, '.github/workflows/release.yml'),
     'utf8',
   );
+  const escapePattern = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = workflow.match(
-    / {4}- name: Publish release notification to Feishu[\s\S]*?\n {6}run: \|\n([\s\S]*?)\n {4}- name: Summarize Feishu notification failure/,
+    new RegExp(
+      ` {4}- name: ${escapePattern(stepName)}[\\s\\S]*?\\n {6}run: \\|\\n([\\s\\S]*?)\\n {4}- name: ${escapePattern(nextStepName)}`,
+    ),
   );
   if (!match) {
-    throw new Error('Could not find the Feishu release notification script');
+    throw new Error(`Could not find the ${stepName} script`);
   }
   return match[1].replace(/^ {8}/gm, '');
 };
 
-const loadDiscordNotificationScript = async () => {
-  const workflow = await fs.readFile(
-    path.join(repositoryRoot, '.github/workflows/release.yml'),
-    'utf8',
+const loadReleaseNotesScript = () =>
+  loadWorkflowRunScript(
+    'Generate ordered Release notes',
+    'Upload Release Assets',
   );
-  const match = workflow.match(
-    / {4}- name: Publish release notification to Discord[\s\S]*?\n {6}run: \|\n([\s\S]*?)\n {4}- name: Summarize Discord notification failure/,
+
+const loadFeishuNotificationScript = () =>
+  loadWorkflowRunScript(
+    'Publish release notification to Feishu',
+    'Summarize Feishu notification failure',
   );
-  if (!match) {
-    throw new Error('Could not find the Discord release notification script');
-  }
-  return match[1].replace(/^ {8}/gm, '');
-};
+
+const loadDiscordNotificationScript = () =>
+  loadWorkflowRunScript(
+    'Publish release notification to Discord',
+    'Summarize Discord notification failure',
+  );
+
+const writeNotificationMetadata = (filePath, notes) =>
+  fs.writeFile(filePath, JSON.stringify(buildReleaseNotification(notes)));
 
 const createNotificationHarness = async () => {
   const root = await fs.mkdtemp(
@@ -57,14 +72,20 @@ const createNotificationHarness = async () => {
   const curlCommandLog = path.join(root, 'curl-command.log');
   const curlLog = path.join(root, 'curl.log');
   const curlPayloadLog = path.join(root, 'curl-payload.log');
+  const githubRequestLog = path.join(root, 'github-request.log');
+  const releaseNotesMetadataPath = path.join(root, 'release-notification.json');
   const summaryPath = path.join(root, 'summary.md');
   await fs.mkdir(binDirectory);
+  await writeNotificationMetadata(
+    releaseNotesMetadataPath,
+    defaultGeneratedNotes,
+  );
 
   await writeExecutable(
     path.join(binDirectory, 'gh'),
     `#!/usr/bin/env bash
 set -euo pipefail
-echo "The notification script must not depend on gh." >&2
+echo "The release workflow must not depend on gh." >&2
 exit 99
 `,
   );
@@ -77,24 +98,30 @@ printf '\\n' >> "$CURL_COMMAND_LOG"
 
 if [[ " $* " == *" https://api.github.com/repos/web-infra-dev/midscene/releases/tags/"* ]]; then
   jq -cn \\
-    --arg body "\${MOCK_RELEASE_BODY-}" \\
     --arg published_at "\${MOCK_RELEASE_PUBLISHED_AT-2026-08-04T12:25:00Z}" \\
     '{
       name: "Midscene.js v1.2.3",
       tag_name: "v1.2.3",
       draft: false,
       html_url: "https://github.com/web-infra-dev/midscene/releases/tag/v1.2.3",
-      published_at: $published_at,
-      body: (if $body == "" then null else $body end)
+      published_at: $published_at
     }'
   exit 0
 fi
 
 if [[ " $* " == *" https://api.github.com/repos/web-infra-dev/midscene/releases/generate-notes"* ]]; then
-  cat >/dev/null
-  jq -cn \\
-    --arg body "\${MOCK_GENERATED_NOTES_BODY-* feat(core): support external groups by @example in https://github.com/web-infra-dev/midscene/pull/1}" \\
-    '{body: $body}'
+  arguments=("$@")
+  for ((index = 0; index < \${#arguments[@]}; index += 1)); do
+    if [[ "\${arguments[$index]}" == "--data" ]]; then
+      printf '%s\\n' "\${arguments[$((index + 1))]}" >> "$GITHUB_REQUEST_LOG"
+    fi
+  done
+  if [[ "\${MOCK_GENERATED_NOTES_BODY+set}" == "set" ]]; then
+    generated_body="$MOCK_GENERATED_NOTES_BODY"
+  else
+    generated_body="${defaultGeneratedNotes}"
+  fi
+  jq -cn --arg body "$generated_body" '{body: $body}'
   exit 0
 fi
 
@@ -144,11 +171,17 @@ fi
       CURL_PAYLOAD_LOG: curlPayloadLog,
       GH_TOKEN: 'test-token',
       GITHUB_REPOSITORY: 'web-infra-dev/midscene',
+      GITHUB_REQUEST_LOG: githubRequestLog,
       GITHUB_STEP_SUMMARY: summaryPath,
       PATH: `${binDirectory}${path.delimiter}${process.env.PATH}`,
+      RELEASE_NOTES_METADATA_PATH: releaseNotesMetadataPath,
       RELEASE_TARGET: 'main',
       RELEASE_VERSION: 'v1.2.3',
+      RUNNER_TEMP: root,
     },
+    githubRequestLog,
+    releaseNotesMetadataPath,
+    root,
   };
 };
 
@@ -160,24 +193,160 @@ afterEach(async () => {
   );
 });
 
-describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
-  it('publishes ordered generated notes as part of the GitHub Release', async () => {
-    const workflow = await fs.readFile(
-      path.join(repositoryRoot, '.github/workflows/release.yml'),
-      'utf8',
-    );
-    const releaseUpload = workflow.match(
-      /- name: Upload Release Assets[\s\S]*?\n\s+env:/,
-    )?.[0];
+describe.skipIf(!supportsReleaseShell)(
+  'GitHub Release notes generation',
+  () => {
+    it('executes generated notes formatting and notification metadata creation', async () => {
+      const script = await loadReleaseNotesScript();
+      const harness = await createNotificationHarness();
+      const generatedNotes = [
+        "## What's Changed",
+        '* feat(core)!: replace legacy API by @example in https://github.com/web-infra-dev/midscene/pull/3',
+        '* fix(core): preserve notes by @example in https://github.com/web-infra-dev/midscene/pull/2',
+        '## New Contributors',
+        '* @example made their first contribution in https://github.com/web-infra-dev/midscene/pull/2',
+        '**Full Changelog**: https://github.com/web-infra-dev/midscene/compare/v1.2.2...v1.2.3',
+      ].join('\n');
 
-    expect(workflow).toContain('- name: Generate ordered Release notes');
-    expect(releaseUpload).toContain(
-      'body_path: ${{ runner.temp }}/release-notes.md',
+      execFileSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+        cwd: repositoryRoot,
+        env: {
+          ...harness.env,
+          MOCK_GENERATED_NOTES_BODY: generatedNotes,
+        },
+        stdio: 'pipe',
+      });
+
+      const releaseNotes = await fs.readFile(
+        path.join(harness.root, 'release-notes.md'),
+        'utf8',
+      );
+      expect(releaseNotes).toContain('## Breaking Changes 🍭');
+      expect(releaseNotes).toContain('## New Contributors');
+      expect(releaseNotes).toContain('@example made their first contribution');
+
+      const metadata = JSON.parse(
+        await fs.readFile(harness.releaseNotesMetadataPath, 'utf8'),
+      );
+      expect(metadata.groups.map((group) => group.key)).toEqual([
+        'breaking',
+        'fix',
+      ]);
+      expect(metadata.markdown).toContain('**Breaking Changes 🍭**');
+
+      const request = JSON.parse(
+        (await fs.readFile(harness.githubRequestLog, 'utf8')).trim(),
+      );
+      expect(request).toEqual({
+        tag_name: 'v1.2.3',
+        target_commitish: 'main',
+      });
+    });
+
+    it('fails when GitHub returns an empty generated body', async () => {
+      const script = await loadReleaseNotesScript();
+      const harness = await createNotificationHarness();
+
+      const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        env: {
+          ...harness.env,
+          MOCK_GENERATED_NOTES_BODY: '',
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+    });
+
+    it('publishes the formatted body and uploads notification metadata', async () => {
+      const workflow = await fs.readFile(
+        path.join(repositoryRoot, '.github/workflows/release.yml'),
+        'utf8',
+      );
+      const releaseUpload = workflow.match(
+        /- name: Upload Release Assets[\s\S]*?\n\s+env:/,
+      )?.[0];
+
+      expect(releaseUpload).toContain(
+        'body_path: ${{ runner.temp }}/release-notes.md',
+      );
+      expect(releaseUpload).not.toContain('generate_release_notes: true');
+      expect(workflow).toContain('- name: Upload Release notes metadata');
+      expect(
+        workflow.match(/- name: Download Release notes metadata/g),
+      ).toHaveLength(2);
+    });
+  },
+);
+
+describe('GitHub Release notes ordering', () => {
+  it('orders exact PR entries without consuming auxiliary sections', () => {
+    const notes = [
+      '<!-- generated -->',
+      '## Other Changes',
+      '* docs(site): refresh docs by @example in https://github.com/web-infra-dev/midscene/pull/4',
+      '* fix(core): second fix by @example in https://github.com/web-infra-dev/midscene/pull/3',
+      '* feat(web): first feature by @example in https://github.com/web-infra-dev/midscene/pull/2',
+      '* fix(ai): first fix by @example in https://github.com/web-infra-dev/midscene/pull/1',
+      '* release entry with an unexpected format',
+      '## New Contributors',
+      '* @new-user made their first contribution in https://github.com/web-infra-dev/midscene/pull/2',
+      '**Full Changelog**: https://github.com/web-infra-dev/midscene/compare/v1.0.0...v1.1.0',
+    ].join('\n');
+
+    const formatted = formatReleaseNotes(notes);
+
+    expect(formatted.indexOf('## Features')).toBeLessThan(
+      formatted.indexOf('## Fixes'),
     );
-    expect(releaseUpload).not.toContain('generate_release_notes: true');
+    expect(formatted.indexOf('## Fixes')).toBeLessThan(
+      formatted.indexOf('## Documentation'),
+    );
+    expect(formatted.indexOf('second fix')).toBeLessThan(
+      formatted.indexOf('first fix'),
+    );
+    expect(formatted).toContain(
+      '## Other Changes\n* release entry with an unexpected format',
+    );
+    expect(formatted).toContain(
+      '## New Contributors\n* @new-user made their first contribution',
+    );
+    expect(formatted.match(/^[*] /gm)).toHaveLength(6);
+    expect(formatted).toMatch(/\*\*Full Changelog\*\*: .*$/);
   });
 
-  it('delivers to every JSON webhook target', async () => {
+  it('classifies breaking changes once for release notes and notifications', () => {
+    const notes = [
+      '* BREAKING CHANGE: remove deprecated API by @example in https://github.com/web-infra-dev/midscene/pull/5',
+      '* fix(site): update website by @example in https://github.com/web-infra-dev/midscene/pull/4',
+      '* chore: update dependencies by @example in https://github.com/web-infra-dev/midscene/pull/3',
+      '* feat(core)!: change API by @example in https://github.com/web-infra-dev/midscene/pull/2',
+      '* ci(workflow): adjust release by @example in https://github.com/web-infra-dev/midscene/pull/1',
+    ].join('\n');
+
+    const formatted = formatReleaseNotes(notes);
+    const notification = buildReleaseNotification(notes);
+
+    expect(formatted).toContain('## Breaking Changes 🍭');
+    expect(formatted).toContain('## CI & Chore ⚙️');
+    expect(formatted.match(/^[*] /gm)).toHaveLength(5);
+    expect(notification.groups.map((group) => group.key)).toEqual(['breaking']);
+    expect(notification.changeCount).toBe(2);
+    expect(notification.markdown).toContain('BREAKING CHANGE: remove');
+    expect(notification.markdown).toContain('feat(core)!: change API');
+    expect(notification.markdown).not.toContain('update website');
+  });
+
+  it('leaves a body without generated change entries unchanged', () => {
+    expect(formatReleaseNotes('Manual release notes')).toBe(
+      'Manual release notes',
+    );
+  });
+});
+
+describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
+  it('delivers the shared metadata to every JSON webhook target', async () => {
     const script = await loadFeishuNotificationScript();
     const harness = await createNotificationHarness();
     const targets = Array.from({ length: 4 }, (_, index) => ({
@@ -201,7 +370,7 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
 
     const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
     expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
-    expect(curlCommandLog).toContain('/releases/generate-notes');
+    expect(curlCommandLog).not.toContain('/releases/generate-notes');
 
     const payloads = (await fs.readFile(harness.curlPayloadLog, 'utf8'))
       .trim()
@@ -213,34 +382,67 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
     );
   }, 15_000);
 
-  it('uses published release notes without generating them again', async () => {
+  it('renders breaking changes from the shared metadata', async () => {
     const script = await loadFeishuNotificationScript();
     const harness = await createNotificationHarness();
+    await writeNotificationMetadata(
+      harness.releaseNotesMetadataPath,
+      '* feat(core)!: remove API by @example in https://github.com/web-infra-dev/midscene/pull/2',
+    );
 
     execFileSync('bash', ['-c', script], {
       env: {
         ...harness.env,
         FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify([
           {
-            url: 'https://open.feishu.cn/open-apis/bot/v2/hook/existing-notes',
-            secret: 'existing-notes-secret',
+            url: 'https://open.feishu.cn/open-apis/bot/v2/hook/breaking',
+            secret: 'breaking-secret',
           },
         ]),
-        MOCK_RELEASE_BODY:
-          '* fix(core): preserve release notes by @example in https://github.com/web-infra-dev/midscene/pull/2',
       },
       stdio: 'pipe',
     });
 
-    const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
-    expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
-    expect(curlCommandLog).not.toContain('/releases/generate-notes');
-
     const payload = JSON.parse(
       (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),
     );
-    expect(payload.card.body.elements[0].content).toContain('**Fixes 🐞**');
+    expect(payload.card.body.elements[0].content).toContain(
+      '**Breaking Changes 🍭**',
+    );
     expect(payload.card.body.elements[0].content).toContain('PR #2');
+  });
+
+  it('rejects malformed notification metadata before delivery', async () => {
+    const script = await loadFeishuNotificationScript();
+    const harness = await createNotificationHarness();
+    await fs.writeFile(
+      harness.releaseNotesMetadataPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        changeCount: 2,
+        categoryCount: 0,
+        markdown: '',
+        groups: [],
+      }),
+    );
+
+    const result = spawnSync('bash', ['-c', script], {
+      encoding: 'utf8',
+      env: {
+        ...harness.env,
+        FEISHU_WEBHOOK_TARGETS_JSON: JSON.stringify([
+          {
+            url: 'https://open.feishu.cn/open-apis/bot/v2/hook/malformed',
+            secret: 'malformed-secret',
+          },
+        ]),
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    await expect(fs.readFile(harness.curlLog, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   it('rejects incomplete release metadata before delivery', async () => {
@@ -291,60 +493,8 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
   });
 });
 
-describe('GitHub Release notes ordering', () => {
-  it('uses the same feature-first category order as notifications', () => {
-    const notes = [
-      '<!-- generated -->',
-      '## Other Changes',
-      '* docs(site): refresh docs by @example in https://github.com/web-infra-dev/midscene/pull/4',
-      '* fix(core): second fix by @example in https://github.com/web-infra-dev/midscene/pull/3',
-      '* feat(web): first feature by @example in https://github.com/web-infra-dev/midscene/pull/2',
-      '* fix(ai): first fix by @example in https://github.com/web-infra-dev/midscene/pull/1',
-      '* release entry with an unexpected format',
-      '**Full Changelog**: https://github.com/web-infra-dev/midscene/compare/v1.0.0...v1.1.0',
-    ].join('\n');
-
-    const formatted = formatReleaseNotes(notes);
-
-    expect(formatted.indexOf('## Features')).toBeLessThan(
-      formatted.indexOf('## Fixes'),
-    );
-    expect(formatted.indexOf('## Fixes')).toBeLessThan(
-      formatted.indexOf('## Documentation'),
-    );
-    expect(formatted.indexOf('second fix')).toBeLessThan(
-      formatted.indexOf('first fix'),
-    );
-    expect(formatted).toContain('## Other Changes');
-    expect(formatted.match(/^\* /gm)).toHaveLength(5);
-    expect(formatted).toMatch(/\*\*Full Changelog\*\*: .*$/);
-    expect(formatted).toContain('## Features 🎉\n');
-    expect(formatted).toContain('## Fixes 🐞\n');
-  });
-
-  it('places breaking changes and maintenance in explicit categories', () => {
-    const notes = [
-      '* chore: update dependencies by @example in https://github.com/web-infra-dev/midscene/pull/3',
-      '* feat(core)!: change API by @example in https://github.com/web-infra-dev/midscene/pull/2',
-      '* ci(workflow): adjust release by @example in https://github.com/web-infra-dev/midscene/pull/1',
-    ].join('\n');
-
-    const formatted = formatReleaseNotes(notes);
-
-    expect(formatted).toContain('## Breaking Changes');
-    expect(formatted).toContain('## CI & Chore');
-    expect(formatted.match(/^\* /gm)).toHaveLength(3);
-  });
-
-  it('leaves a body without generated change entries unchanged', () => {
-    expect(formatReleaseNotes('Manual release notes')).toBe(
-      'Manual release notes',
-    );
-  });
-});
-
 describe.skipIf(!supportsReleaseShell)('Discord release notification', () => {
-  it('fetches release metadata and generates notes without gh', async () => {
+  it('fetches release metadata and renders shared notes without gh', async () => {
     const script = await loadDiscordNotificationScript();
     const harness = await createNotificationHarness();
 
@@ -359,7 +509,7 @@ describe.skipIf(!supportsReleaseShell)('Discord release notification', () => {
 
     const curlCommandLog = await fs.readFile(harness.curlCommandLog, 'utf8');
     expect(curlCommandLog).toContain('/releases/tags/v1.2.3');
-    expect(curlCommandLog).toContain('/releases/generate-notes');
+    expect(curlCommandLog).not.toContain('/releases/generate-notes');
 
     const payload = JSON.parse(
       (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { formatReleaseNotes } from '../../../scripts/format-release-notes.mjs';
 
 const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -160,7 +161,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
-  it('publishes generated notes as part of the GitHub Release', async () => {
+  it('publishes ordered generated notes as part of the GitHub Release', async () => {
     const workflow = await fs.readFile(
       path.join(repositoryRoot, '.github/workflows/release.yml'),
       'utf8',
@@ -169,7 +170,11 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
       /- name: Upload Release Assets[\s\S]*?\n\s+env:/,
     )?.[0];
 
-    expect(releaseUpload).toContain('generate_release_notes: true');
+    expect(workflow).toContain('- name: Generate ordered Release notes');
+    expect(releaseUpload).toContain(
+      'body_path: ${{ runner.temp }}/release-notes.md',
+    );
+    expect(releaseUpload).not.toContain('generate_release_notes: true');
   });
 
   it('delivers to every JSON webhook target', async () => {
@@ -281,6 +286,56 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
     await expect(fs.readFile(harness.curlLog, 'utf8')).rejects.toMatchObject({
       code: 'ENOENT',
     });
+  });
+});
+
+describe('GitHub Release notes ordering', () => {
+  it('uses the same feature-first category order as notifications', () => {
+    const notes = [
+      '<!-- generated -->',
+      '## Other Changes',
+      '* docs(site): refresh docs by @example in https://github.com/web-infra-dev/midscene/pull/4',
+      '* fix(core): second fix by @example in https://github.com/web-infra-dev/midscene/pull/3',
+      '* feat(web): first feature by @example in https://github.com/web-infra-dev/midscene/pull/2',
+      '* fix(ai): first fix by @example in https://github.com/web-infra-dev/midscene/pull/1',
+      '* release entry with an unexpected format',
+      '**Full Changelog**: https://github.com/web-infra-dev/midscene/compare/v1.0.0...v1.1.0',
+    ].join('\n');
+
+    const formatted = formatReleaseNotes(notes);
+
+    expect(formatted.indexOf('## Features')).toBeLessThan(
+      formatted.indexOf('## Fixes'),
+    );
+    expect(formatted.indexOf('## Fixes')).toBeLessThan(
+      formatted.indexOf('## Documentation'),
+    );
+    expect(formatted.indexOf('second fix')).toBeLessThan(
+      formatted.indexOf('first fix'),
+    );
+    expect(formatted).toContain('## Other Changes');
+    expect(formatted.match(/^\* /gm)).toHaveLength(5);
+    expect(formatted).toMatch(/\*\*Full Changelog\*\*: .*$/);
+  });
+
+  it('places breaking changes and maintenance in explicit categories', () => {
+    const notes = [
+      '* chore: update dependencies by @example in https://github.com/web-infra-dev/midscene/pull/3',
+      '* feat(core)!: change API by @example in https://github.com/web-infra-dev/midscene/pull/2',
+      '* ci(workflow): adjust release by @example in https://github.com/web-infra-dev/midscene/pull/1',
+    ].join('\n');
+
+    const formatted = formatReleaseNotes(notes);
+
+    expect(formatted).toContain('## Breaking Changes');
+    expect(formatted).toContain('## CI & Chore');
+    expect(formatted.match(/^\* /gm)).toHaveLength(3);
+  });
+
+  it('leaves a body without generated change entries unchanged', () => {
+    expect(formatReleaseNotes('Manual release notes')).toBe(
+      'Manual release notes',
+    );
   });
 });
 

--- a/apps/studio/tests/release-notification.test.mjs
+++ b/apps/studio/tests/release-notification.test.mjs
@@ -208,7 +208,9 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
       .split('\n')
       .map((line) => JSON.parse(line));
     expect(payloads).toHaveLength(targets.length);
-    expect(payloads[0].card.body.elements[0].content).toContain('**Features**');
+    expect(payloads[0].card.body.elements[0].content).toContain(
+      '**Features 🎉**',
+    );
   }, 15_000);
 
   it('uses published release notes without generating them again', async () => {
@@ -237,7 +239,7 @@ describe.skipIf(!supportsReleaseShell)('Feishu release notification', () => {
     const payload = JSON.parse(
       (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),
     );
-    expect(payload.card.body.elements[0].content).toContain('**Fixes**');
+    expect(payload.card.body.elements[0].content).toContain('**Fixes 🐞**');
     expect(payload.card.body.elements[0].content).toContain('PR #2');
   });
 
@@ -316,10 +318,8 @@ describe('GitHub Release notes ordering', () => {
     expect(formatted).toContain('## Other Changes');
     expect(formatted.match(/^\* /gm)).toHaveLength(5);
     expect(formatted).toMatch(/\*\*Full Changelog\*\*: .*$/);
-    expect(formatted).toContain('## Features\n');
-    expect(formatted).toContain('## Fixes\n');
-    expect(formatted).not.toContain('## Features 🎉');
-    expect(formatted).not.toContain('## Fixes 🐞');
+    expect(formatted).toContain('## Features 🎉\n');
+    expect(formatted).toContain('## Fixes 🐞\n');
   });
 
   it('places breaking changes and maintenance in explicit categories', () => {
@@ -364,6 +364,6 @@ describe.skipIf(!supportsReleaseShell)('Discord release notification', () => {
     const payload = JSON.parse(
       (await fs.readFile(harness.curlPayloadLog, 'utf8')).trim(),
     );
-    expect(payload.embeds[0].description).toContain('**Features**');
+    expect(payload.embeds[0].description).toContain('**Features 🎉**');
   });
 });

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -2,15 +2,15 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const categories = [
-  { key: 'breaking', title: 'Breaking Changes 🍭' },
-  { key: 'feat', title: 'Features 🎉' },
-  { key: 'fix', title: 'Fixes 🐞' },
-  { key: 'perf', title: 'Performance 🚀' },
-  { key: 'refactor', title: 'Refactors ♻️' },
-  { key: 'docs', title: 'Documentation 📖' },
-  { key: 'test', title: 'Testing 🧪' },
-  { key: 'build', title: 'Build 📦' },
-  { key: 'maintenance', title: 'CI & Chore ⚙️' },
+  { key: 'breaking', title: 'Breaking Changes' },
+  { key: 'feat', title: 'Features' },
+  { key: 'fix', title: 'Fixes' },
+  { key: 'perf', title: 'Performance' },
+  { key: 'refactor', title: 'Refactors' },
+  { key: 'docs', title: 'Documentation' },
+  { key: 'test', title: 'Testing' },
+  { key: 'build', title: 'Build' },
+  { key: 'maintenance', title: 'CI & Chore' },
   { key: 'other', title: 'Other Changes' },
 ];
 

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -13,19 +13,45 @@ const categories = [
   { key: 'maintenance', title: 'CI & Chore ⚙️' },
   { key: 'other', title: 'Other Changes' },
 ];
+const notificationCategoryKeys = new Set(['breaking', 'feat', 'fix']);
+const markdownSpecialCharacters = new Set([
+  '\\',
+  '`',
+  '*',
+  '_',
+  '~',
+  '[',
+  ']',
+  '<',
+  '>',
+]);
 
 const conventionalTitlePattern =
-  /^(?<type>[A-Za-z]+)(?:\([^)]*\))?(?<breaking>!)?:/;
+  /^(?<type>[A-Za-z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:/;
+const breakingTitlePattern = /^BREAKING(?:[ -]CHANGE)?:/i;
 const changeTitlePattern =
-  /^[*-] (?<title>.+?) by @[^ ]+ in https:\/\/github\.com\/[^ ]+\/pull\/\d+$/;
-const changeLinePattern = /^[*-] /;
+  /^[*-] (?<title>.+?) by @[^ ]+ in (?<url>https:\/\/github\.com\/[^ ]+\/pull\/(?<pr>\d+))$/;
+const sectionHeadingPattern = /^(?<marker>#{2,6}) (?<title>.+)$/;
+const fullChangelogPattern = /^\*\*Full Changelog\*\*:/;
 
-const categoryForLine = (line) => {
-  const title =
-    line.match(changeTitlePattern)?.groups?.title ??
-    line.replace(changeLinePattern, '');
-  const conventionalTitle = title?.match(conventionalTitlePattern)?.groups;
+const trimBlankLines = (lines) => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start].trim() === '') {
+    start += 1;
+  }
+  while (end > start && lines[end - 1].trim() === '') {
+    end -= 1;
+  }
+  return lines.slice(start, end);
+};
 
+const categoryKeyForTitle = (title) => {
+  if (breakingTitlePattern.test(title)) {
+    return 'breaking';
+  }
+
+  const conventionalTitle = title.match(conventionalTitlePattern)?.groups;
   if (!conventionalTitle) {
     return 'other';
   }
@@ -34,6 +60,9 @@ const categoryForLine = (line) => {
   }
 
   const type = conventionalTitle.type.toLowerCase();
+  if (type === 'breaking') {
+    return 'breaking';
+  }
   if (type === 'tests') {
     return 'test';
   }
@@ -46,34 +75,154 @@ const categoryForLine = (line) => {
   return 'other';
 };
 
-export const formatReleaseNotes = (markdown) => {
+const parseChangeLine = (line) => {
+  const match = line.match(changeTitlePattern)?.groups;
+  if (!match) {
+    return undefined;
+  }
+
+  const conventionalTitle = match.title.match(conventionalTitlePattern)?.groups;
+  return {
+    categoryKey: categoryKeyForTitle(match.title),
+    line,
+    pr: match.pr,
+    scope: conventionalTitle?.scope?.toLowerCase() ?? '',
+    title: match.title.trim(),
+    url: match.url,
+  };
+};
+
+const parseReleaseNotes = (markdown) => {
   const normalizedMarkdown = markdown.replaceAll('\r', '').trim();
-  const lines = normalizedMarkdown.split('\n');
-  const changeLines = lines.filter((line) => changeLinePattern.test(line));
+  const preamble = [];
+  const sections = [];
+  const fullChangelog = [];
+  const changes = [];
+  let currentSection;
 
-  if (changeLines.length === 0) {
-    return normalizedMarkdown;
+  for (const line of normalizedMarkdown.split('\n')) {
+    if (fullChangelogPattern.test(line)) {
+      fullChangelog.push(line);
+      continue;
+    }
+
+    const sectionHeading = line.match(sectionHeadingPattern)?.groups;
+    if (sectionHeading) {
+      currentSection = {
+        lines: [],
+        marker: sectionHeading.marker,
+        title: sectionHeading.title,
+      };
+      sections.push(currentSection);
+      continue;
+    }
+
+    const change = parseChangeLine(line);
+    if (change) {
+      changes.push(change);
+      continue;
+    }
+
+    (currentSection?.lines ?? preamble).push(line);
   }
 
-  const groupedChanges = new Map(
-    categories.map((category) => [category.key, []]),
-  );
-  for (const line of changeLines) {
-    groupedChanges.get(categoryForLine(line)).push(line);
-  }
+  return {
+    changes,
+    fullChangelog,
+    normalizedMarkdown,
+    preamble: trimBlankLines(preamble),
+    sections: sections
+      .map((section) => ({
+        ...section,
+        lines: trimBlankLines(section.lines),
+      }))
+      .filter((section) => section.lines.length > 0),
+  };
+};
 
-  const sections = categories.flatMap((category) => {
-    const changes = groupedChanges.get(category.key);
-    return changes.length > 0
-      ? [`## ${category.title}\n${changes.join('\n')}`]
-      : [];
+const groupChanges = (changes, categoryDefinitions = categories) =>
+  categoryDefinitions.flatMap((category) => {
+    const items = changes.filter(
+      (change) => change.categoryKey === category.key,
+    );
+    return items.length > 0 ? [{ ...category, items }] : [];
   });
-  const comments = lines.filter((line) => /^<!--.*-->$/.test(line.trim()));
-  const fullChangelog = lines.find((line) =>
-    line.startsWith('**Full Changelog**:'),
-  );
 
-  return [...comments, ...sections, fullChangelog].filter(Boolean).join('\n\n');
+const escapeNotificationTitle = (title) =>
+  [...title]
+    .map((character) =>
+      markdownSpecialCharacters.has(character) ? `\\${character}` : character,
+    )
+    .join('');
+
+const notificationItemLine = (change) =>
+  `- ${escapeNotificationTitle(change.title)} · [PR #${change.pr}](${change.url})`;
+
+export const buildReleaseNotification = (markdown) => {
+  const { changes } = parseReleaseNotes(markdown);
+  const notificationCategories = categories.filter((category) =>
+    notificationCategoryKeys.has(category.key),
+  );
+  const groups = groupChanges(
+    changes.filter((change) => change.scope !== 'site'),
+    notificationCategories,
+  ).map((group) => ({
+    key: group.key,
+    label: group.title,
+    items: group.items.map(({ pr, title, url }) => ({ pr, title, url })),
+  }));
+
+  return {
+    schemaVersion: 1,
+    changeCount: groups.reduce((count, group) => count + group.items.length, 0),
+    categoryCount: groups.length,
+    markdown: groups
+      .map(
+        (group) =>
+          `**${group.label}**\n${group.items
+            .map(notificationItemLine)
+            .join('\n')}`,
+      )
+      .join('\n\n'),
+    groups,
+  };
+};
+
+export const formatReleaseNotes = (markdown) => {
+  const parsedNotes = parseReleaseNotes(markdown);
+  if (parsedNotes.changes.length === 0) {
+    return parsedNotes.normalizedMarkdown;
+  }
+
+  const orderedSections = groupChanges(parsedNotes.changes).map((group) => ({
+    lines: group.items.map((item) => item.line),
+    title: group.title,
+  }));
+  const remainingSections = [];
+  for (const section of parsedNotes.sections) {
+    const matchingOrderedSection = orderedSections.find(
+      (orderedSection) => orderedSection.title === section.title,
+    );
+    if (matchingOrderedSection) {
+      matchingOrderedSection.lines.push(...section.lines);
+    } else {
+      remainingSections.push(section);
+    }
+  }
+
+  return [
+    parsedNotes.preamble.join('\n'),
+    ...orderedSections.map(
+      (section) => `## ${section.title}\n${section.lines.join('\n')}`,
+    ),
+    ...remainingSections.map(
+      (section) =>
+        `${section.marker} ${section.title}\n${section.lines.join('\n')}`,
+    ),
+    parsedNotes.fullChangelog.join('\n'),
+  ]
+    .filter(Boolean)
+    .join('\n\n');
 };
 
 const isCommandLineInvocation =
@@ -81,9 +230,19 @@ const isCommandLineInvocation =
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isCommandLineInvocation) {
+  const unknownArguments = process.argv
+    .slice(2)
+    .filter((argument) => argument !== '--notification-json');
+  if (unknownArguments.length > 0) {
+    throw new Error(`Unknown arguments: ${unknownArguments.join(', ')}`);
+  }
+
   let input = '';
   for await (const chunk of process.stdin) {
     input += chunk;
   }
-  process.stdout.write(`${formatReleaseNotes(input)}\n`);
+  const output = process.argv.includes('--notification-json')
+    ? JSON.stringify(buildReleaseNotification(input), null, 2)
+    : formatReleaseNotes(input);
+  process.stdout.write(`${output}\n`);
 }

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -1,0 +1,89 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const categories = [
+  { key: 'breaking', title: 'Breaking Changes 🍭' },
+  { key: 'feat', title: 'Features 🎉' },
+  { key: 'fix', title: 'Fixes 🐞' },
+  { key: 'perf', title: 'Performance 🚀' },
+  { key: 'refactor', title: 'Refactors ♻️' },
+  { key: 'docs', title: 'Documentation 📖' },
+  { key: 'test', title: 'Testing 🧪' },
+  { key: 'build', title: 'Build 📦' },
+  { key: 'maintenance', title: 'CI & Chore ⚙️' },
+  { key: 'other', title: 'Other Changes' },
+];
+
+const conventionalTitlePattern =
+  /^(?<type>[A-Za-z]+)(?:\([^)]*\))?(?<breaking>!)?:/;
+const changeTitlePattern =
+  /^[*-] (?<title>.+?) by @[^ ]+ in https:\/\/github\.com\/[^ ]+\/pull\/\d+$/;
+const changeLinePattern = /^[*-] /;
+
+const categoryForLine = (line) => {
+  const title =
+    line.match(changeTitlePattern)?.groups?.title ??
+    line.replace(changeLinePattern, '');
+  const conventionalTitle = title?.match(conventionalTitlePattern)?.groups;
+
+  if (!conventionalTitle) {
+    return 'other';
+  }
+  if (conventionalTitle.breaking) {
+    return 'breaking';
+  }
+
+  const type = conventionalTitle.type.toLowerCase();
+  if (type === 'tests') {
+    return 'test';
+  }
+  if (type === 'ci' || type === 'chore') {
+    return 'maintenance';
+  }
+  if (categories.some((category) => category.key === type)) {
+    return type;
+  }
+  return 'other';
+};
+
+export const formatReleaseNotes = (markdown) => {
+  const normalizedMarkdown = markdown.replaceAll('\r', '').trim();
+  const lines = normalizedMarkdown.split('\n');
+  const changeLines = lines.filter((line) => changeLinePattern.test(line));
+
+  if (changeLines.length === 0) {
+    return normalizedMarkdown;
+  }
+
+  const groupedChanges = new Map(
+    categories.map((category) => [category.key, []]),
+  );
+  for (const line of changeLines) {
+    groupedChanges.get(categoryForLine(line)).push(line);
+  }
+
+  const sections = categories.flatMap((category) => {
+    const changes = groupedChanges.get(category.key);
+    return changes.length > 0
+      ? [`## ${category.title}\n${changes.join('\n')}`]
+      : [];
+  });
+  const comments = lines.filter((line) => /^<!--.*-->$/.test(line.trim()));
+  const fullChangelog = lines.find((line) =>
+    line.startsWith('**Full Changelog**:'),
+  );
+
+  return [...comments, ...sections, fullChangelog].filter(Boolean).join('\n\n');
+};
+
+const isCommandLineInvocation =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCommandLineInvocation) {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  process.stdout.write(`${formatReleaseNotes(input)}\n`);
+}

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -2,15 +2,15 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const categories = [
-  { key: 'breaking', title: 'Breaking Changes' },
-  { key: 'feat', title: 'Features' },
-  { key: 'fix', title: 'Fixes' },
-  { key: 'perf', title: 'Performance' },
-  { key: 'refactor', title: 'Refactors' },
-  { key: 'docs', title: 'Documentation' },
-  { key: 'test', title: 'Testing' },
-  { key: 'build', title: 'Build' },
-  { key: 'maintenance', title: 'CI & Chore' },
+  { key: 'breaking', title: 'Breaking Changes 🍭' },
+  { key: 'feat', title: 'Features 🎉' },
+  { key: 'fix', title: 'Fixes 🐞' },
+  { key: 'perf', title: 'Performance 🚀' },
+  { key: 'refactor', title: 'Refactors ♻️' },
+  { key: 'docs', title: 'Documentation 📖' },
+  { key: 'test', title: 'Testing 🧪' },
+  { key: 'build', title: 'Build 📦' },
+  { key: 'maintenance', title: 'CI & Chore ⚙️' },
   { key: 'other', title: 'Other Changes' },
 ];
 


### PR DESCRIPTION
## Summary

- generate GitHub release notes once in the release job, publish the ordered Markdown body, and upload a versioned notification metadata artifact
- classify exact GitHub PR entries centrally, including `feat!`, `feat(scope)!`, `BREAKING CHANGE:`, and `BREAKING-CHANGE:` as Breaking Changes 🍭
- preserve auxiliary generated sections such as `New Contributors` and leave unrecognized bullets in their original sections
- keep Feishu and Discord concise with the same centrally generated Breaking Changes 🍭, Features 🎉, and Fixes 🐞 groups while excluding `site` changes
- make both notification jobs consume the shared artifact, fetch only published Release metadata with `curl`, and remove duplicated parsers and secondary `generate-notes` calls
- reduce notification job permissions from `contents: write` to `contents: read`

## Validation

- `pnpm run lint`
- `pnpm --dir apps/studio exec vitest run tests/release-notification.test.mjs` (12 tests passed)
- parsed `.github/workflows/release.yml` with `js-yaml`
- replayed the live `v1.10.7` Release body and verified `New Contributors` plus its contributor entry remain intact
- executed the extracted `Generate ordered Release notes`, Feishu, and Discord shell steps in tests, including empty-body and malformed-metadata failures
- `pnpm exec nx test studio --outputStyle=stream` (local workspace was not clean: 350 tests passed; 12 unrelated tests failed because workspace package `dist` entries were absent and existing `ModelEnvConfigModal` mocks resolved an undefined component)