### PR TITLE
feat(core): allow keyboard press without a locate target

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -435,7 +435,7 @@ Press a keyboard key.
 ```typescript
 // Recommended: locate first, then options with keyName
 function aiKeyboardPress(
-  locate: string | object,
+  locate: string | object | undefined,
   opt: {
     keyName: string;
     deepLocate?: boolean;
@@ -455,7 +455,7 @@ function aiKeyboardPress(
 - Parameters:
 
   **Recommended usage:**
-  - `locate: string | object` — A natural language description of the element to press the key on, or [prompting with images](#prompting-with-images).
+  - `locate: string | object | undefined` — An optional natural language description of the element to press the key on, or [prompting with images](#prompting-with-images). Pass `undefined` to press the key against the currently focused element without AI location or a preliminary click.
   - `opt: object` — Configuration:
     - `keyName: string` — **Required.** Keyboard key to press, such as `'Enter'`, `'Tab'`, or `'Escape'`. Use `aiInput()` to enter text. Web and Computer devices support modifier shortcuts such as `'Control+A'` and `'Shift+Enter'`; use `'+'` to join the keys. See the [shared key-name definitions](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts) for candidate names on non-mobile devices; actual support is platform-specific. The built-in Android, iOS, and Harmony devices support single keys only. Harmony supports a conservative set of named keys plus `A`-`Z` and `0`-`9`; output characters that do not have their own key code, such as `'?'`, are not key names. Unsupported keys and mobile key combinations throw an error. Support in custom devices depends on their implementation.
     - `deepLocate?: boolean` — Whether to enable [Deep Locate](#deep-locate-deeplocate). The deprecated `deepThink` name remains supported. Default: `false`.
@@ -479,13 +479,16 @@ function aiKeyboardPress(
 await agent.aiKeyboardPress('The search input box', { keyName: 'Enter' });
 await agent.aiKeyboardPress('The search input box', { keyName: 'Control+A' });
 
+// Pure keyboard operation on the currently focused element
+await agent.aiKeyboardPress(undefined, { keyName: 'Control+X' });
+
 // Backward compatible (not recommended)
 await agent.aiKeyboardPress('Enter', 'The search input box');
 ```
 
 :::note Signature update
 
-The recommended signature places the locate prompt first. The legacy signature `aiKeyboardPress(key, locate, options)` remains supported, but new code should use the recommended signature.
+The recommended signature places the optional locate prompt first. Pass `undefined` when the shortcut should operate on the current focus without locating or clicking an element. A valid model configuration is still required and is validated before the action runs, although this targetless form does not send a location request to the model. The legacy signature `aiKeyboardPress(key, locate, options)` remains supported, but new code should use the recommended signature.
 
 :::
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -424,7 +424,7 @@ await agent.aiInput('邮箱输入框', { value: 'user@example.com' });
 ```typescript
 // 推荐用法：定位提示在前，其他选项在 opt 中
 function aiKeyboardPress(
-  locate: string | object,
+  locate: string | object | undefined,
   opt: {
     keyName: string;
     deepLocate?: boolean;
@@ -444,7 +444,7 @@ function aiKeyboardPress(
 - 参数：
 
   **推荐用法**：
-  - `locate: string | object` - 用自然语言描述的元素定位，或[使用图片作为提示词](#使用图片作为提示词)。
+  - `locate: string | object | undefined` - 可选的元素定位描述，或[使用图片作为提示词](#使用图片作为提示词)。传入 `undefined` 时，不执行 AI 定位和预先点击，按键会直接作用于当前获得焦点的元素。
   - `opt: object` - 配置对象，包含：
     - `keyName: string` - **必填**，要按下的键，如 `Enter`、`Tab`、`Escape` 等；输入文本请使用 `aiInput()`。Web 和 Computer Device 支持 `Control+A`、`Shift+Enter` 等 modifier shortcut，使用 `+` 连接按键。可在[共享按键名称定义](https://github.com/web-infra-dev/midscene/blob/main/packages/shared/src/us-keyboard-layout.ts)中查看非移动端的候选名称，实际支持情况以平台为准。内置的 Android、iOS 和 Harmony Device 仅支持单键。Harmony 支持一组保守的具名键以及 `A`-`Z`、`0`-`9`；`?` 等没有独立键码的输出字符不属于按键名。不支持的按键和移动端组合键会抛出错误；自定义 Device 的支持情况取决于其实现。
     - `deepLocate?: boolean` - 是否开启[深度定位](#深度定位deeplocate)。该参数原来叫 `deepThink`，现已更名为 `deepLocate`。默认值为 false。
@@ -468,13 +468,16 @@ function aiKeyboardPress(
 await agent.aiKeyboardPress('搜索框', { keyName: 'Enter' });
 await agent.aiKeyboardPress('搜索框', { keyName: 'Control+A' });
 
+// 对当前获得焦点的元素执行纯键盘操作
+await agent.aiKeyboardPress(undefined, { keyName: 'Control+X' });
+
 // 兼容用法（不推荐）
 await agent.aiKeyboardPress('Enter', '搜索框');
 ```
 
 :::note 关于签名变更
 
-我们最近更新了 `aiKeyboardPress` 的 API 签名，将定位提示作为第一个参数，使得参数顺序更直观。旧的签名 `aiKeyboardPress(key, locate, options)` 仍然完全兼容，但建议新代码使用推荐的签名。
+我们最近更新了 `aiKeyboardPress` 的 API 签名，将可选的定位提示作为第一个参数，使得参数顺序更直观。如果快捷键应该直接作用于当前焦点，请传入 `undefined`，这样不会执行定位或点击。此时仍需提供有效的模型配置，系统会在执行 action 前完成配置校验，但不会向模型发起定位请求。旧的签名 `aiKeyboardPress(key, locate, options)` 仍然完全兼容，但建议新代码使用推荐的签名。
 
 :::
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -918,7 +918,7 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
 
   // New signature
   async aiKeyboardPress(
-    locatePrompt: TUserPrompt,
+    locatePrompt: TUserPrompt | undefined,
     opt: LocateOption & { keyName: string },
   ): Promise<void>;
 
@@ -934,7 +934,7 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
 
   // Implementation
   async aiKeyboardPress(
-    locatePromptOrKeyName: TUserPrompt | string,
+    locatePromptOrKeyName: TUserPrompt | string | undefined,
     locatePromptOrOpt:
       | TUserPrompt
       | (LocateOption & { keyName: string })

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -566,7 +566,9 @@ export const defineActionInput = (
 // KeyboardPress
 export const actionKeyboardPressParamSchema = z.object({
   locate: getMidsceneLocationSchema()
-    .describe('The element to be clicked before pressing the key')
+    .describe(
+      'The optional element to click before pressing the key. Omit this when the key should operate on the currently focused element, especially when copying or cutting an existing text selection.',
+    )
     .optional(),
   keyName: z
     .string()
@@ -588,7 +590,7 @@ export const defineActionKeyboardPress = (
   >({
     name: 'KeyboardPress',
     description:
-      'Press a key or key combination, like "Enter", "Tab", "Escape", or "Control+A", "Shift+Enter". Do not use this to type text.',
+      'Press a key or key combination, like "Enter", "Tab", "Escape", or "Control+A", "Shift+Enter". Do not use this to type text. Omit locate to operate on the current focus without clicking again, especially for Copy or Cut after text has been selected.',
     interfaceAlias: 'aiKeyboardPress',
     paramSchema: actionKeyboardPressParamSchema,
     sample: {

--- a/packages/core/tests/unit-test/action-keyboard-press.test.ts
+++ b/packages/core/tests/unit-test/action-keyboard-press.test.ts
@@ -1,0 +1,97 @@
+import { Agent } from '@/agent';
+import { parseActionParam } from '@/ai-model';
+import {
+  actionKeyboardPressParamSchema,
+  defineActionKeyboardPress,
+} from '@/device';
+import { ModelConfigManager } from '@midscene/shared/env';
+import { describe, expect, it, vi } from 'vitest';
+
+const createAgentStub = () => {
+  const agent = Object.create(Agent.prototype) as Agent<any>;
+  (agent as any).callActionInActionSpace = vi.fn(async () => undefined);
+  return agent;
+};
+
+describe('KeyboardPress Action', () => {
+  it('allows the action target to be omitted', () => {
+    const parsed = parseActionParam(
+      { keyName: 'Control+X' },
+      actionKeyboardPressParamSchema,
+    );
+
+    expect(parsed).toEqual({ keyName: 'Control+X' });
+  });
+
+  it('passes an undefined target to the keyboard primitive', async () => {
+    const keyboardPress = vi.fn(async () => undefined);
+    const action = defineActionKeyboardPress(keyboardPress);
+
+    await action.call({ keyName: 'Control+X' });
+
+    expect(keyboardPress).toHaveBeenCalledWith('Control+X', {
+      target: undefined,
+    });
+  });
+
+  it('supports the recommended signature without a locate prompt', async () => {
+    const agent = createAgentStub();
+    const callActionSpy = (agent as any).callActionInActionSpace as ReturnType<
+      typeof vi.fn
+    >;
+
+    await agent.aiKeyboardPress(undefined, { keyName: 'Control+X' });
+
+    expect(callActionSpy).toHaveBeenCalledWith('KeyboardPress', {
+      keyName: 'Control+X',
+      locate: undefined,
+    });
+  });
+
+  it('validates model configuration before a targetless keyboard action', async () => {
+    const agent = Object.create(Agent.prototype) as Agent<any>;
+    (agent as any).modelConfigManager = new ModelConfigManager({});
+
+    await expect(
+      agent.callActionInActionSpace('KeyboardPress', {
+        keyName: 'Control+X',
+      }),
+    ).rejects.toThrow(
+      'Model configuration is incomplete: model name (MIDSCENE_MODEL_NAME) is required',
+    );
+  });
+
+  it('keeps the legacy key-only signature working', async () => {
+    const agent = createAgentStub();
+    const callActionSpy = (agent as any).callActionInActionSpace as ReturnType<
+      typeof vi.fn
+    >;
+
+    await agent.aiKeyboardPress('Control+X');
+
+    expect(callActionSpy).toHaveBeenCalledWith('KeyboardPress', {
+      keyName: 'Control+X',
+      locate: undefined,
+    });
+  });
+
+  it('still builds a locate parameter when a target is provided', async () => {
+    const agent = createAgentStub();
+    const callActionSpy = (agent as any).callActionInActionSpace as ReturnType<
+      typeof vi.fn
+    >;
+
+    await agent.aiKeyboardPress('the search input', {
+      keyName: 'Enter',
+      xpath: '//input[@type="search"]',
+    });
+
+    expect(callActionSpy).toHaveBeenCalledWith('KeyboardPress', {
+      keyName: 'Enter',
+      locate: expect.objectContaining({
+        prompt: 'the search input',
+        xpath: '//input[@type="search"]',
+      }),
+    });
+  });
+});

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -6,7 +6,11 @@ import {
 } from '@/ai-model/prompt/llm-planning';
 import { systemPromptToLocateSection } from '@/ai-model/prompt/llm-section-locator';
 import type { LocateResultPromptSpec } from '@/ai-model/shared/model-locate-result';
-import { defineActionInput, defineActionSwipe } from '@/device';
+import {
+  defineActionInput,
+  defineActionKeyboardPress,
+  defineActionSwipe,
+} from '@/device';
 import { getMidsceneLocationSchema } from '@/index';
 import type { TModelFamily } from '@midscene/shared/env';
 import { describe, expect, it, vi } from 'vitest';
@@ -183,6 +187,22 @@ describe('action space', () => {
     expect(action).toContain(
       'should be set explicitly for incremental edits after moving the cursor',
     );
+  });
+
+  it('keyboard press tells the planner to omit locate for the current selection', () => {
+    const action = descriptionForAction(
+      defineActionKeyboardPress(async () => {}),
+      mockLocatorScheme,
+    );
+
+    expect(action).toContain('locate?:');
+    expect(action).toContain(
+      'Omit locate to operate on the current focus without clicking again',
+    );
+    expect(action).toContain(
+      'especially when copying or cutting an existing text selection',
+    );
+    expect(action).toContain('"keyName": "Enter"');
   });
 
   it('swipe action explains touch slider use', () => {

--- a/packages/web-integration/tests/ai/web/puppeteer/agent.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/agent.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { PuppeteerAgent } from '@/puppeteer';
 import { sleep } from '@midscene/core/utils';
@@ -67,6 +68,49 @@ describe('puppeteer integration', () => {
           - aiAssert: 'the text in the input box is "Amazon"'
     `,
     );
+  });
+
+  it('uses a targetless KeyboardPress on the current selection', async () => {
+    const htmlPath = getFixturePath('input-test.html');
+    const { originPage, reset } = await launchPage(`file://${htmlPath}`);
+    resetFn = reset;
+    await originPage.$eval('#searchInput', (element) => {
+      const input = element as HTMLInputElement;
+      input.value = 'selected text';
+      input.focus();
+      input.select();
+    });
+    agent = new PuppeteerAgent(originPage, {
+      generateReport: true,
+      reportFileName: 'targetless-ai-act-backspace',
+    });
+
+    await agent.aiAct(
+      'Press Backspace once to delete the text that is already selected in the currently focused search input. Do not locate or click the input before pressing the key.',
+    );
+    await agent.aiAssert(
+      'The search input box is empty and contains no entered text. The placeholder "Enter your search query..." may be visible and does not count as entered text.',
+    );
+
+    const log = await agent._unstableLogContent();
+    const keyboardTask = log.executions
+      .flatMap((execution) => execution.tasks)
+      .find((task) => task.subType === 'KeyboardPress');
+    expect(keyboardTask).toBeDefined();
+    expect(
+      (keyboardTask?.param as { locate?: unknown; keyName?: string }).locate,
+    ).toBeUndefined();
+    expect((keyboardTask?.param as { keyName?: string }).keyName).toBe(
+      'Backspace',
+    );
+    await expect(
+      originPage.$eval(
+        '#searchInput',
+        (element) => (element as HTMLInputElement).value,
+      ),
+    ).resolves.toBe('');
+    expect(agent.reportFile).toBeTruthy();
+    expect(existsSync(agent.reportFile!)).toBe(true);
   });
 
   it('agent with yaml script', async () => {

--- a/packages/web-integration/tests/unit-test/agent-keyboard-press-targetless-e2e.test.ts
+++ b/packages/web-integration/tests/unit-test/agent-keyboard-press-targetless-e2e.test.ts
@@ -1,0 +1,128 @@
+import { PlaywrightAgent } from '@/playwright/page-agent';
+import { PuppeteerAgent } from '@/puppeteer/page-agent';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_FAMILY,
+  MIDSCENE_MODEL_NAME,
+} from '@midscene/shared/env';
+import { type Browser as PlaywrightBrowser, chromium } from 'playwright';
+import puppeteer, { type Browser as PuppeteerBrowser } from 'puppeteer';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+const TEST_TIMEOUT_MS = 120_000;
+const MODEL_CONFIG = {
+  [MIDSCENE_MODEL_NAME]: 'targetless-keyboard-test',
+  [MIDSCENE_MODEL_API_KEY]: 'test-key',
+  [MIDSCENE_MODEL_BASE_URL]: 'https://model.invalid/v1',
+  [MIDSCENE_MODEL_FAMILY]: 'qwen2.5-vl' as const,
+};
+const INPUT_HTML = `
+  <!doctype html>
+  <html>
+    <body>
+      <input id="first" value="selected text" />
+      <input id="second" value="untouched text" />
+    </body>
+  </html>
+`;
+
+describe('targetless aiKeyboardPress end to end', () => {
+  describe('Puppeteer', () => {
+    let browser: PuppeteerBrowser;
+
+    beforeAll(async () => {
+      browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      });
+    }, TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      await browser?.close();
+    }, TEST_TIMEOUT_MS);
+
+    test('presses a key on the currently focused element', async () => {
+      const page = await browser.newPage();
+      const agent = new PuppeteerAgent(page, {
+        generateReport: false,
+        modelConfig: MODEL_CONFIG,
+      });
+      try {
+        await page.setContent(INPUT_HTML);
+        await page.$eval('#first', (element) => {
+          const input = element as HTMLInputElement;
+          input.focus();
+          input.select();
+        });
+
+        await agent.aiKeyboardPress(undefined, { keyName: 'Backspace' });
+
+        await expect(
+          page.evaluate(() => ({
+            activeElementId: document.activeElement?.id,
+            firstValue: (document.querySelector('#first') as HTMLInputElement)
+              .value,
+            secondValue: (document.querySelector('#second') as HTMLInputElement)
+              .value,
+          })),
+        ).resolves.toEqual({
+          activeElementId: 'first',
+          firstValue: '',
+          secondValue: 'untouched text',
+        });
+      } finally {
+        await agent.destroy();
+        await page.close();
+      }
+    });
+  });
+
+  describe('Playwright', () => {
+    let browser: PlaywrightBrowser;
+
+    beforeAll(async () => {
+      browser = await chromium.launch({
+        headless: true,
+        executablePath: puppeteer.executablePath(),
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      });
+    }, TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      await browser?.close();
+    }, TEST_TIMEOUT_MS);
+
+    test('presses a key on the currently focused element', async () => {
+      const page = await browser.newPage();
+      const agent = new PlaywrightAgent(page, {
+        generateReport: false,
+        modelConfig: MODEL_CONFIG,
+      });
+      try {
+        await page.setContent(INPUT_HTML);
+        await page.locator('#first').focus();
+        await page.locator('#first').selectText();
+
+        await agent.aiKeyboardPress(undefined, { keyName: 'Backspace' });
+
+        await expect(
+          page.evaluate(() => ({
+            activeElementId: document.activeElement?.id,
+            firstValue: (document.querySelector('#first') as HTMLInputElement)
+              .value,
+            secondValue: (document.querySelector('#second') as HTMLInputElement)
+              .value,
+          })),
+        ).resolves.toEqual({
+          activeElementId: 'first',
+          firstValue: '',
+          secondValue: 'untouched text',
+        });
+      } finally {
+        await agent.destroy();
+        await page.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- allow the recommended `aiKeyboardPress` signature to receive `undefined` as its `locate` argument
- omit locating and the preliminary click when the shortcut should operate on the currently focused element
- guide the planner to omit `locate` for Copy or Cut after text has already been selected
- document the API in English and Chinese while preserving eager model configuration validation
- cover direct Playwright and Puppeteer calls and an `aiAct`-planned targetless Backspace with a generated report

## Scope

This PR targets `main` directly and contains only the optional-`locate` API, planner guidance, documentation, and targetless tests. It does not contain the `focusElement` implementation or browser-side Cut command mapping from #2962.

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/core`
- `pnpm exec nx build @midscene/web`
- `pnpm exec tsc --noEmit -p packages/web-integration/tsconfig.json`
- `pnpm test -- tests/unit-test/action-keyboard-press.test.ts tests/unit-test/prompt/prompt.test.ts` in `packages/core` (46 tests passed)
- `PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm test -- tests/unit-test/agent-keyboard-press-targetless-e2e.test.ts` in `packages/web-integration` (2 tests passed)

## Merge order

Merge this PR into `main` first. #2962 is an independent browser-side follow-up.
