### PR TITLE
fix(core): add model context to locate parse errors

### DIFF
--- a/packages/core/src/ai-model/inspect.ts
+++ b/packages/core/src/ai-model/inspect.ts
@@ -71,6 +71,11 @@ export type InspectAIArgs = [
 const debugInspect = getDebug('ai:inspect');
 const debugSection = getDebug('ai:section');
 
+function formatLocateModelContext(modelRuntime: ModelRuntime): string {
+  const { modelFamily, modelName } = modelRuntime.config;
+  return `modelName=${modelName ?? 'unset'} modelFamily=${modelFamily ?? 'unset'}`;
+}
+
 export {
   userPromptToString as extraTextFromUserPrompt,
   multimodalPromptToChatMessages as promptsToChatParam,
@@ -325,6 +330,7 @@ export async function genericLocate(
           const message = [
             locateError && `error in locate result: ${locateError}`,
             `coordinate parsing error: ${errorMessage}`,
+            formatLocateModelContext(modelRuntime),
           ]
             .filter(Boolean)
             .join('\n');
@@ -493,6 +499,7 @@ export async function AiLocateSection(options: {
           const message = [
             sectionError && `error in section locate result: ${sectionError}`,
             `coordinate parsing error: ${errorMessage}`,
+            formatLocateModelContext(modelRuntime),
           ]
             .filter(Boolean)
             .join('\n');

--- a/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/inspect-locate-not-found.test.ts
@@ -152,6 +152,9 @@ describe('locate not-found parsing', () => {
     expect(result.parseResult.errors?.[0]).toContain(
       'model returned invalid coordinates',
     );
+    expect(result.parseResult.errors?.[0]).toContain(
+      'modelName=test-model modelFamily=qwen2.5-vl',
+    );
   });
 
   it('retries JSON parsing through the same locate retry loop', async () => {


### PR DESCRIPTION
## What changed

- Include the configured `modelName` and `modelFamily` when locate-coordinate parsing fails.
- Apply the same context to element and section locate flows.
- Add regression coverage for the surfaced configuration context.

## Why

Out-of-range bounding boxes can result from a model-family coordinate-format mismatch. The runtime model context makes these failures diagnosable without exposing endpoint or credential details.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/inspect-locate-not-found.test.ts`
- `pnpm exec biome check packages/core/src/ai-model/inspect.ts packages/core/tests/unit-test/inspect-locate-not-found.test.ts`