### PR TITLE
fix(chrome-extension): refine dark theme and config modal behavior

### DIFF
--- a/apps/chrome-extension/src/components/playground/index.less
+++ b/apps/chrome-extension/src/components/playground/index.less
@@ -12,6 +12,60 @@
   min-height: 0;
   flex: 1 1 auto;
 
+  .system-message-icon {
+    rect,
+    path {
+      fill: var(--midscene-accent, #2b83ff);
+    }
+  }
+
+  .prompt-input-wrapper {
+    .mode-radio-group-wrapper .mode-radio-group {
+      .ant-radio-button-wrapper.ant-radio-button-wrapper-checked,
+      .more-apis-button.selected-from-dropdown {
+        background: var(--midscene-accent, #2b83ff);
+        color: #fff;
+
+        &:hover {
+          background: var(--midscene-accent-hover, #1a6fe6);
+          color: #fff;
+        }
+      }
+    }
+
+    .form-controller-wrapper .ant-btn-primary {
+      background: var(--midscene-accent, #2b83ff);
+      border-color: var(--midscene-accent, #2b83ff);
+
+      &:not(:disabled):hover,
+      &:not(:disabled):focus {
+        background: var(--midscene-accent-hover, #1a6fe6);
+        border-color: var(--midscene-accent-hover, #1a6fe6);
+      }
+
+      &:disabled,
+      &.ant-btn-loading {
+        background: var(--midscene-accent, #2b83ff);
+        border-color: transparent;
+        color: rgba(255, 255, 255, 0.72);
+      }
+    }
+  }
+
+  .middle-dialog-area .scroll-to-bottom-button {
+    right: 8px;
+    bottom: 8px;
+    background: var(--midscene-accent, #2b83ff);
+    border-color: var(--midscene-accent, #2b83ff);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    color: #fff;
+
+    &:not(:disabled):hover {
+      background: var(--midscene-accent-hover, #1a6fe6);
+      border-color: var(--midscene-accent-hover, #1a6fe6);
+    }
+  }
+
   .command-form,
   .playground-timeline-region,
   .middle-dialog-area {
@@ -157,17 +211,32 @@
 
     .clear-button-container {
       position: absolute;
-      top: 24px;
+      top: 16px;
       right: 8px;
       z-index: 20;
+
+      .clear-button {
+        width: 32px;
+        height: 32px;
+        border: 1px solid var(--midscene-border-strong, rgba(0, 0, 0, 0.08));
+        border-radius: 8px;
+        background: var(--midscene-surface-elevated, #fff);
+        color: var(--midscene-text-secondary, #777);
+        opacity: 1;
+
+        &:hover {
+          background: var(--midscene-surface-muted, #f1f2f3);
+          color: var(--midscene-text-primary, #1f2329);
+        }
+      }
     }
 
     // The clear control occupies the timeline's right edge. Reserve its
-    // 24px hit area plus an 8px gap so a right-aligned user bubble never
+    // 32px hit area plus an 8px gap so a right-aligned user bubble never
     // sits underneath it.
     .user-message-container {
       box-sizing: border-box;
-      padding-right: 32px;
+      padding-right: 40px;
     }
 
     .middle-dialog-area .info-list-container {
@@ -253,10 +322,8 @@
     }
   }
 
-  // The shared dark theme restores this overflow fade with `!important`.
-  // It is intentionally disabled in the extension because it covers visible
-  // mode buttons beside the toolbar icons.
+  // The overflow fade covers visible mode buttons in the narrow side panel.
   &.playground-conversation-skin .mode-radio-group-wrapper .action-icons {
-    background: transparent !important;
+    background: transparent;
   }
 }

--- a/apps/chrome-extension/src/components/playground/index.tsx
+++ b/apps/chrome-extension/src/components/playground/index.tsx
@@ -157,6 +157,8 @@ export function BrowserExtensionPlayground({
         agentOptions,
         onAgentOptionsSave,
         configModalClassName: 'chrome-extension-model-env-config-modal',
+        configModalWidth: 360,
+        envTextareaAutoSize: false,
         envTextareaMinRows: 4,
       }}
       config={{

--- a/apps/chrome-extension/src/extension/popup/index.less
+++ b/apps/chrome-extension/src/extension/popup/index.less
@@ -20,6 +20,8 @@ html {
 
 html[data-theme='light'] {
   color-scheme: light;
+  --midscene-accent: #2b83ff;
+  --midscene-accent-hover: #1a6fe6;
   --midscene-surface: #fff;
   --midscene-surface-elevated: #fff;
   --midscene-surface-muted: #f1f2f3;
@@ -30,6 +32,8 @@ html[data-theme='light'] {
 
 html[data-theme='dark'] {
   color-scheme: dark;
+  --midscene-accent: #2d5290;
+  --midscene-accent-hover: #3767b5;
   --midscene-surface: #1f1f1f;
   --midscene-surface-elevated: #262626;
   --midscene-surface-muted: #2a2a2a;
@@ -58,23 +62,6 @@ html[data-theme='dark'] {
   .popup-wrapper .popup-nav .nav-right .nav-icon {
     color: var(--midscene-text-primary);
   }
-}
-
-// The extension popup keeps Config as a light floating surface even when the
-// surrounding recorder or playground follows the system dark theme.
-html[data-theme='dark'] .chrome-extension-model-env-config-modal {
-  --midscene-surface: #fff;
-  --midscene-surface-elevated: #fff;
-  --midscene-surface-muted: #f1f2f3;
-  --midscene-surface-hover: rgba(0, 0, 0, 0.05);
-  --midscene-text-primary: #0d0d0d;
-  --midscene-text-secondary: rgba(0, 0, 0, 0.7);
-  --midscene-text-tertiary: #797a7a;
-  --midscene-text-placeholder: #9d9fa0;
-  --midscene-border-control: #dadada;
-  --midscene-border-strong: rgba(0, 0, 0, 0.08);
-  --midscene-divider: rgba(0, 0, 0, 0.08);
-  --midscene-icon-muted: #b6b6b6;
 }
 
 #root {
@@ -306,7 +293,6 @@ html[data-theme='dark']
 // and actions remain visible.
 .chrome-extension-model-env-config-modal {
   max-width: 100vw;
-  width: 360px !important;
 
   .ant-modal-content {
     display: flex;
@@ -319,7 +305,12 @@ html[data-theme='dark']
     flex: 1 1 auto;
     min-height: 0;
     overflow: auto;
-    scrollbar-gutter: stable;
+    overscroll-behavior: contain;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   .ant-modal-header,
@@ -328,7 +319,7 @@ html[data-theme='dark']
   }
 
   .midscene-config-modal-env-textarea {
-    min-height: 160px !important;
+    min-height: 160px;
   }
 
   .midscene-config-modal-body-content,

--- a/apps/chrome-extension/src/extension/popup/index.tsx
+++ b/apps/chrome-extension/src/extension/popup/index.tsx
@@ -14,8 +14,8 @@ import {
   globalThemeConfig,
   useEnvConfig,
 } from '@midscene/visualizer';
-import { App as AntdApp, ConfigProvider, Dropdown } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { App as AntdApp, ConfigProvider, Dropdown, theme } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrowserExtensionPlayground } from '../../components/playground';
 import Bridge from '../bridge';
 import Recorder from '../recorder';
@@ -37,6 +37,21 @@ const extensionAgentForTab = (
 
 const STORAGE_KEY = 'midscene-popup-mode';
 const AGENT_OPTIONS_STORAGE_KEY = 'midscene-extension-agent-options';
+const EXTENSION_PRIMARY_COLORS = {
+  dark: '#2D5290',
+  light: '#2B83FF',
+} as const;
+
+type ExtensionThemeMode = keyof typeof EXTENSION_PRIMARY_COLORS;
+
+function getPreferredThemeMode(): ExtensionThemeMode {
+  if (typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
 
 async function runChromeConnectivityTest(config: Record<string, string>) {
   const modelConfigManager = new ModelConfigManager(config as TModelConfig);
@@ -95,6 +110,9 @@ export function PlaygroundPopup() {
   );
   const [agentOptions, setAgentOptions] =
     useState<CommonAgentOptions>(loadAgentOptions);
+  const [themeMode, setThemeMode] = useState<ExtensionThemeMode>(
+    getPreferredThemeMode,
+  );
   const [currentMode, setCurrentMode] = useState<
     'playground' | 'bridge' | 'recorder'
   >(() => {
@@ -103,23 +121,37 @@ export function PlaygroundPopup() {
   });
 
   // The extension has no user-selectable theme yet, so follow the system
-  // preference and expose the shared visualizer's data-theme contract.
+  // preference for both Ant Design portals and shared visualizer styles.
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') {
+      document.documentElement.dataset.theme = 'light';
       return;
     }
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const syncTheme = () => {
-      document.documentElement.dataset.theme = mediaQuery.matches
-        ? 'dark'
-        : 'light';
+      const nextThemeMode = mediaQuery.matches ? 'dark' : 'light';
+      document.documentElement.dataset.theme = nextThemeMode;
+      setThemeMode(nextThemeMode);
     };
 
     syncTheme();
     mediaQuery.addEventListener('change', syncTheme);
     return () => mediaQuery.removeEventListener('change', syncTheme);
   }, []);
+
+  const antdThemeConfig = useMemo(() => {
+    const baseTheme = globalThemeConfig();
+    return {
+      ...baseTheme,
+      algorithm:
+        themeMode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      token: {
+        ...baseTheme.token,
+        colorPrimary: EXTENSION_PRIMARY_COLORS[themeMode],
+      },
+    };
+  }, [themeMode]);
 
   const config = useEnvConfig((state) => state.config);
 
@@ -225,7 +257,7 @@ export function PlaygroundPopup() {
   };
 
   return (
-    <ConfigProvider theme={globalThemeConfig()}>
+    <ConfigProvider theme={antdThemeConfig}>
       <AntdApp component={false}>
         <div className="popup-wrapper">
           {/* top navigation bar */}
@@ -255,6 +287,8 @@ export function PlaygroundPopup() {
                 onVerify={runChromeConnectivityTest}
                 agentOptions={agentOptions}
                 configModalClassName="chrome-extension-model-env-config-modal"
+                configModalWidth={360}
+                envTextareaAutoSize={false}
                 envTextareaMinRows={4}
                 onAgentOptionsSave={handleAgentOptionsSave}
               />

--- a/apps/chrome-extension/tests/browser-extension-playground.test.tsx
+++ b/apps/chrome-extension/tests/browser-extension-playground.test.tsx
@@ -135,6 +135,8 @@ describe('BrowserExtensionPlayground', () => {
     expect(universalPlaygroundProps.at(-1)?.envConfigReminderProps).toEqual({
       agentOptions,
       configModalClassName: 'chrome-extension-model-env-config-modal',
+      configModalWidth: 360,
+      envTextareaAutoSize: false,
       envTextareaMinRows: 4,
       onAgentOptionsSave,
       onVerify,

--- a/apps/chrome-extension/tests/playground-popup.test.tsx
+++ b/apps/chrome-extension/tests/playground-popup.test.tsx
@@ -11,7 +11,10 @@ const setPopupTab = vi.fn();
 const getAgentRefs: Array<unknown> = [];
 const constructedAgentOptions: Array<unknown> = [];
 const verifyCallbacks: Array<unknown> = [];
+const configProviderThemes: Array<unknown> = [];
 let sdkSyncEffectCount = 0;
+let prefersDarkMode = false;
+let themeChangeListener: (() => void) | undefined;
 
 vi.mock('@midscene/core/ai-model', () => ({
   runConnectivityTest: vi.fn(),
@@ -43,7 +46,9 @@ vi.mock('@midscene/visualizer', () => ({
       </button>
     </>
   ),
-  globalThemeConfig: () => ({}),
+  globalThemeConfig: () => ({
+    token: { colorPrimary: '#base-primary' },
+  }),
   safeOverrideAIConfig: vi.fn(),
   useEnvConfig: (selector?: (state: Record<string, unknown>) => unknown) => {
     const state = {
@@ -70,8 +75,21 @@ vi.mock('antd', () => ({
       }),
     },
   ),
-  ConfigProvider: ({ children }: { children: React.ReactNode }) => children,
+  ConfigProvider: ({
+    children,
+    theme,
+  }: {
+    children: React.ReactNode;
+    theme?: unknown;
+  }) => {
+    configProviderThemes.push(theme);
+    return children;
+  },
   Dropdown: ({ children }: { children: React.ReactNode }) => children,
+  theme: {
+    darkAlgorithm: 'dark-algorithm',
+    defaultAlgorithm: 'default-algorithm',
+  },
 }));
 
 vi.mock('@midscene/shared/env', () => ({
@@ -127,11 +145,52 @@ describe('PlaygroundPopup', () => {
     getAgentRefs.length = 0;
     constructedAgentOptions.length = 0;
     verifyCallbacks.length = 0;
+    configProviderThemes.length = 0;
     sdkSyncEffectCount = 0;
+    prefersDarkMode = false;
+    themeChangeListener = undefined;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn(() => ({
+        addEventListener: (eventName: string, listener: () => void) => {
+          if (eventName === 'change') themeChangeListener = listener;
+        },
+        matches: prefersDarkMode,
+        media: '(prefers-color-scheme: dark)',
+        removeEventListener: vi.fn(),
+      })),
+    });
   });
 
   afterEach(() => {
     document.body.innerHTML = '';
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('uses Ant Design dark tokens for the system dark theme', async () => {
+    prefersDarkMode = true;
+    const { PlaygroundPopup } = await import('../src/extension/popup');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<PlaygroundPopup />);
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(configProviderThemes.at(-1)).toEqual(
+      expect.objectContaining({
+        algorithm: 'dark-algorithm',
+        token: expect.objectContaining({ colorPrimary: '#2D5290' }),
+      }),
+    );
+    expect(themeChangeListener).toEqual(expect.any(Function));
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   it('keeps getAgent stable when playground SDK state updates', async () => {

--- a/apps/studio/tests/model-env-config-modal.test.tsx
+++ b/apps/studio/tests/model-env-config-modal.test.tsx
@@ -87,7 +87,7 @@ describe('ModelEnvConfigModal', () => {
     expect(
       document.body.querySelector('.midscene-config-modal--text'),
     ).toBeTruthy();
-    const verifyButton = button('Verify and Save Model');
+    const verifyButton = button('Verify');
     expect(
       verifyButton.querySelector(
         'path[d="M5 8.00002V3.95856L8.5 5.97929L12 8.00002L8.5 10.0208L5 12.0415V8.00002Z"]',
@@ -115,7 +115,7 @@ describe('ModelEnvConfigModal', () => {
     const { root } = await renderModal({ onSave });
 
     await act(async () => {
-      button('Verify and Save Model').click();
+      button('Verify').click();
       await Promise.resolve();
     });
 
@@ -124,7 +124,16 @@ describe('ModelEnvConfigModal', () => {
       OPENAI_API_KEY: 'sk-example',
       OPENAI_BASE_URL: 'https://api.example.com/v1',
     });
-    expect(document.body.textContent).toContain('Test passed.');
+    expect(document.body.textContent).toContain('Verified');
+    const successAlert = document.body.querySelector(
+      '.midscene-config-modal-verify-alert.ant-alert-success',
+    );
+    expect(successAlert).toBeTruthy();
+    expect(
+      successAlert
+        ?.closest('.midscene-config-modal-verify-row')
+        ?.contains(button('Verify')),
+    ).toBe(true);
     expect(onSave).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -151,8 +160,7 @@ describe('ModelEnvConfigModal', () => {
     await act(async () => root.unmount());
   });
 
-  it('dismisses successful verification feedback without saving', async () => {
-    vi.useFakeTimers();
+  it('keeps successful verification feedback until the config changes', async () => {
     const onSave = vi.fn();
     vi.stubGlobal('studioRuntime', {
       runConnectivityTest: vi
@@ -162,19 +170,23 @@ describe('ModelEnvConfigModal', () => {
     const { root } = await renderModal({ onSave });
 
     await act(async () => {
-      button('Verify and Save Model').click();
+      button('Verify').click();
       await Promise.resolve();
     });
-    expect(document.body.textContent).toContain('Test passed.');
+    expect(document.body.textContent).toContain('Verified');
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1800);
+      await Promise.resolve();
     });
-    expect(document.body.textContent).not.toContain('Test passed.');
+    expect(document.body.textContent).toContain('Verified');
+
+    await act(async () => {
+      setTextarea(`${VALID_ENV_TEXT}\nMIDSCENE_DEBUG=true`);
+    });
+    expect(document.body.textContent).not.toContain('Verified');
     expect(onSave).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
-    vi.useRealTimers();
   });
 
   it('rejects invalid model configuration before verification', async () => {
@@ -185,7 +197,12 @@ describe('ModelEnvConfigModal', () => {
     });
 
     expect(document.body.textContent).toContain('Missing required keys:');
-    expect(button('Verify and Save Model').disabled).toBe(true);
+    expect(
+      document.body.querySelectorAll(
+        '.midscene-config-modal-verify-alert.ant-alert-error',
+      ),
+    ).toHaveLength(1);
+    expect(button('Verify').disabled).toBe(true);
     expect(runConnectivityTest).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
@@ -206,17 +223,19 @@ describe('ModelEnvConfigModal', () => {
     const { root } = await renderModal();
 
     await act(async () => {
-      button('Verify and Save Model').click();
+      button('Verify').click();
     });
+    expect(button('Verifying').disabled).toBe(true);
     await act(async () => {
       setTextarea(`${VALID_ENV_TEXT}\nMIDSCENE_DEBUG=true`);
     });
+    expect(button('Verify').disabled).toBe(false);
     await act(async () => {
       resolveVerification?.(PASSED_CONNECTIVITY_RESULT);
       await Promise.resolve();
     });
 
-    expect(document.body.textContent).not.toContain('Test passed.');
+    expect(document.body.textContent).not.toContain('Verified');
     await act(async () => root.unmount());
   });
 
@@ -230,11 +249,36 @@ describe('ModelEnvConfigModal', () => {
     const { root } = await renderModal();
 
     await act(async () => {
-      button('Verify and Save Model').click();
+      button('Verify').click();
       await Promise.resolve();
     });
 
     expect(document.body.textContent).toContain('Network down');
+    expect(
+      document.body.querySelector(
+        '.midscene-config-modal-verify-alert.ant-alert-error',
+      ),
+    ).toBeTruthy();
+    await act(async () => root.unmount());
+  });
+
+  it('shows connectivity errors thrown by Studio', async () => {
+    vi.stubGlobal('studioRuntime', {
+      runConnectivityTest: vi
+        .fn()
+        .mockRejectedValue(new Error('Request failed')),
+    });
+    const { root } = await renderModal();
+
+    await act(async () => {
+      button('Verify').click();
+      await Promise.resolve();
+    });
+
+    const errorAlert = document.body.querySelector(
+      '.midscene-config-modal-verify-alert.ant-alert-error',
+    );
+    expect(errorAlert?.textContent).toContain('Request failed');
     await act(async () => root.unmount());
   });
 

--- a/packages/visualizer/src/component/config-modal/index.less
+++ b/packages/visualizer/src/component/config-modal/index.less
@@ -78,6 +78,14 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 8px;
+
+    &--error {
+      grid-template-columns: minmax(0, 1fr);
+
+      .midscene-config-modal-verify-button {
+        justify-self: end;
+      }
+    }
   }
 
   .midscene-config-modal-verify-alert {

--- a/packages/visualizer/src/component/config-modal/index.less
+++ b/packages/visualizer/src/component/config-modal/index.less
@@ -53,9 +53,13 @@
   .midscene-config-modal-env-textarea {
     box-sizing: border-box;
     min-height: 274px;
+    overflow-x: auto;
     padding-inline: 12px;
     resize: none;
+    scrollbar-color: var(--midscene-border-control, rgba(0, 0, 0, 0.25))
+      transparent;
     scrollbar-width: thin;
+    white-space: pre;
 
     &::-webkit-scrollbar {
       width: 6px;

--- a/packages/visualizer/src/component/config-modal/index.less
+++ b/packages/visualizer/src/component/config-modal/index.less
@@ -1,34 +1,4 @@
 .midscene-config-modal {
-  .ant-modal-content {
-    padding: 0;
-  }
-
-  .ant-modal-header {
-    margin: 0;
-    padding: 16px 20px 12px;
-  }
-
-  .ant-modal-title {
-    color: var(--midscene-text-primary, #0d0d0d);
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 24px;
-  }
-
-  .ant-modal-close {
-    inset-inline-end: 16px;
-    top: 16px;
-  }
-
-  .ant-modal-body {
-    padding: 0 24px 24px;
-  }
-
-  .ant-modal-footer {
-    margin: 0;
-    padding: 24px;
-  }
-
   .midscene-config-modal-body-content,
   .midscene-config-modal-env-section,
   .midscene-config-modal-agent-options,
@@ -54,7 +24,6 @@
   }
 
   .midscene-config-modal-section-heading,
-  .midscene-config-modal-verify-row,
   .midscene-config-modal-option-field,
   .midscene-config-modal-footer-actions {
     align-items: center;
@@ -71,16 +40,9 @@
     min-width: 0;
   }
 
-  .midscene-config-modal-heading-copy > .ant-typography:first-child {
-    color: var(--midscene-text-primary, #0d0d0d);
+  .midscene-config-modal-heading-copy > .ant-typography {
     font-size: 14px;
-    line-height: 20px;
-  }
-
-  .midscene-config-modal-heading-copy > .ant-typography:last-child {
-    color: var(--midscene-text-secondary, rgba(0, 0, 0, 0.7));
-    font-size: 12px;
-    line-height: 20px;
+    line-height: 22px;
   }
 
   .midscene-config-modal-env-style-select {
@@ -88,82 +50,94 @@
     width: 200px;
   }
 
-  .ant-select-selector,
-  .ant-input,
-  .ant-input-affix-wrapper,
   .midscene-config-modal-env-textarea {
-    border-color: var(--midscene-border-control, #dadada) !important;
-    border-radius: 8px !important;
-  }
-
-  .ant-select-single {
-    height: 32px;
-  }
-
-  .ant-select-single .ant-select-selector {
-    height: 32px !important;
-    padding-inline: 16px !important;
-  }
-
-  .ant-select-single .ant-select-selection-item,
-  .ant-select-single .ant-select-selection-placeholder {
-    line-height: 30px !important;
-  }
-
-  .ant-input {
-    height: 36px;
-    padding-inline: 16px;
-  }
-
-  .midscene-config-modal-env-textarea {
+    box-sizing: border-box;
     min-height: 274px;
-    overflow-y: hidden;
-    padding: 16px;
+    padding-inline: 12px;
     resize: none;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 999px;
+      background: var(--midscene-border-control, rgba(0, 0, 0, 0.25));
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
   }
 
   .midscene-config-modal-verify-row {
-    gap: 8px;
-    justify-content: space-between;
+    display: grid;
     min-height: 32px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .midscene-config-modal-verify-alert {
+    width: 100%;
+    min-width: 0;
+    min-height: 32px;
+    max-height: 96px;
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding-block: 4px;
+    scrollbar-width: thin;
+
+    &.ant-alert-error {
+      align-items: flex-start;
+
+      .ant-alert-icon {
+        margin-top: 4px;
+      }
+    }
+
+    &.ant-alert-success {
+      width: fit-content;
+      justify-self: start;
+    }
+
+    .ant-alert-message {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    &::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 999px;
+      background: var(--midscene-border-control, rgba(0, 0, 0, 0.25));
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
   }
 
   .midscene-config-modal-verify-button {
-    min-width: 200px;
+    flex: none;
   }
 
   .midscene-config-modal-verify-icon {
-    align-items: center;
     display: inline-flex;
-    height: 16px;
-    justify-content: center;
     width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
   }
 
   .midscene-config-modal-spinner {
     animation: midscene-config-modal-spin 0.8s linear infinite;
-  }
-
-  .ant-btn-default:not(:disabled):hover {
-    background-color: var(
-      --midscene-surface-hover,
-      rgba(0, 0, 0, 0.05)
-    ) !important;
-    border-color: var(--midscene-border-control, #e9ecf3) !important;
-    color: var(--midscene-text-primary, #0d0d0d) !important;
-  }
-
-  .ant-btn:focus,
-  .ant-btn:focus-visible {
-    box-shadow: none;
-    outline: none;
-  }
-
-  .ant-select-focused .ant-select-selector,
-  .ant-select-selector:focus,
-  .ant-select-selector:focus-within {
-    border-color: var(--midscene-border-control, #e9ecf3) !important;
-    box-shadow: none !important;
   }
 
   .midscene-config-modal-agent-options > .ant-divider {
@@ -198,58 +172,5 @@
 @keyframes midscene-config-modal-spin {
   to {
     transform: rotate(360deg);
-  }
-}
-
-.midscene-config-modal-select-dropdown {
-  .ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
-    background-color: var(--midscene-surface-muted, #f2f4f7);
-    color: var(--midscene-text-primary, #0d0d0d);
-    font-weight: 500;
-  }
-
-  .ant-select-item-option-active:not(.ant-select-item-option-disabled) {
-    background-color: var(--midscene-surface-hover, rgba(0, 0, 0, 0.05));
-  }
-}
-
-[data-theme='dark'] .midscene-config-modal {
-  .ant-modal-content {
-    background-color: var(--midscene-surface-elevated, #262626);
-  }
-
-  .ant-modal-title,
-  .ant-typography,
-  .ant-modal-close,
-  .ant-btn-default {
-    color: var(--midscene-text-primary, rgba(255, 255, 255, 0.88));
-  }
-
-  .ant-typography.ant-typography-secondary {
-    color: var(--midscene-text-secondary, rgba(255, 255, 255, 0.65));
-  }
-
-  .ant-input,
-  .ant-select-selector {
-    background-color: var(--midscene-surface, #1f1f1f) !important;
-    color: var(--midscene-text-primary, rgba(255, 255, 255, 0.88));
-  }
-
-  .ant-input::placeholder,
-  .ant-select-selection-placeholder {
-    color: var(--midscene-text-placeholder, rgba(255, 255, 255, 0.45));
-  }
-
-  .ant-select-selection-item {
-    color: var(--midscene-text-primary, rgba(255, 255, 255, 0.88));
-  }
-
-  .ant-divider {
-    border-color: var(--midscene-divider, rgba(255, 255, 255, 0.14));
-  }
-
-  .ant-btn-default {
-    background-color: var(--midscene-surface-elevated, #262626);
-    border-color: var(--midscene-border-control, rgba(255, 255, 255, 0.14));
   }
 }

--- a/packages/visualizer/src/component/config-modal/index.tsx
+++ b/packages/visualizer/src/component/config-modal/index.tsx
@@ -1,5 +1,6 @@
 import type { AgentOpt, ConnectivityTestResult } from '@midscene/core';
 import { Alert, Button, Divider, Input, Modal, Select, Typography } from 'antd';
+import type { ModalProps } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import './index.less';
 
@@ -24,6 +25,7 @@ export interface ConfigModalEnvField {
 export interface ConfigModalProps {
   open: boolean;
   className?: string;
+  width?: ModalProps['width'];
   textValue?: string;
   agentOptionsValue?: CommonAgentOptions;
   initialTab?: ConfigModalTab;
@@ -44,7 +46,6 @@ export interface ConfigModalProps {
 }
 
 const EMPTY_AGENT_OPTIONS: CommonAgentOptions = {};
-const SUCCESS_FEEDBACK_DURATION_MS = 1800;
 const TEXT_PLACEHOLDER =
   'MIDSCENE_MODEL_BASE_URL=...\nMIDSCENE_MODEL_API_KEY=...\nMIDSCENE_MODEL_NAME=...\nMIDSCENE_MODEL_FAMILY=...';
 
@@ -213,6 +214,7 @@ function VerifyButtonIcon({ isLoading }: { isLoading: boolean }) {
 export function ConfigModal({
   open,
   className,
+  width = 640,
   textValue = '',
   agentOptionsValue = EMPTY_AGENT_OPTIONS,
   initialTab = 'text',
@@ -243,16 +245,8 @@ export function ConfigModal({
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const testRunIdRef = useRef(0);
-  const successDismissTimerRef = useRef<number | null>(null);
-
-  const clearSuccessDismissTimer = () => {
-    if (successDismissTimerRef.current === null) return;
-    window.clearTimeout(successDismissTimerRef.current);
-    successDismissTimerRef.current = null;
-  };
 
   useEffect(() => {
-    clearSuccessDismissTimer();
     if (!open) return;
     testRunIdRef.current += 1;
     setTab(initialTab);
@@ -261,13 +255,6 @@ export function ConfigModal({
     setTestStatus({ kind: 'idle' });
     setSaveError(null);
   }, [agentOptionsValue, initialTab, open, textValue]);
-
-  useEffect(
-    () => () => {
-      clearSuccessDismissTimer();
-    },
-    [],
-  );
 
   const envValues = useMemo(() => parseEnvText(text), [parseEnvText, text]);
   const parsedAgentOptions = useMemo(
@@ -279,7 +266,6 @@ export function ConfigModal({
     envError ?? (testStatus.kind === 'error' ? testStatus.message : null);
 
   const resetFeedback = () => {
-    clearSuccessDismissTimer();
     testRunIdRef.current += 1;
     setTestStatus((current) =>
       current.kind === 'idle' ? current : { kind: 'idle' },
@@ -292,19 +278,12 @@ export function ConfigModal({
 
     const testRunId = testRunIdRef.current + 1;
     testRunIdRef.current = testRunId;
-    clearSuccessDismissTimer();
     setTestStatus({ kind: 'running' });
     try {
       const result = await onVerify(envValues);
       if (testRunIdRef.current !== testRunId) return;
       if (result.passed) {
         setTestStatus({ kind: 'success' });
-        successDismissTimerRef.current = window.setTimeout(() => {
-          if (testRunIdRef.current === testRunId) {
-            setTestStatus({ kind: 'idle' });
-          }
-          successDismissTimerRef.current = null;
-        }, SUCCESS_FEEDBACK_DURATION_MS);
         return;
       }
       setTestStatus({
@@ -362,7 +341,7 @@ export function ConfigModal({
       onCancel={onClose}
       open={open}
       title="Config"
-      width={640}
+      width={width}
     >
       <div className="midscene-config-modal-body-content">
         <section className="midscene-config-modal-env-section">
@@ -371,11 +350,7 @@ export function ConfigModal({
               <Typography.Text strong>Model Env Config</Typography.Text>
               <Typography.Text type="secondary">
                 The format is KEY=VALUE and separated by new lines. These data
-                will be saved{' '}
-                <Typography.Text strong>
-                  locally in your browser
-                </Typography.Text>
-                .
+                will be saved <strong>locally in your browser</strong>.
               </Typography.Text>
             </div>
             {showEnvStyleSelect ? (
@@ -390,7 +365,6 @@ export function ConfigModal({
                   { label: '.env Style', value: 'text' },
                   { label: 'Form Style', value: 'form' },
                 ]}
-                popupClassName="midscene-config-modal-select-dropdown"
                 value={tab}
               />
             ) : null}
@@ -435,22 +409,25 @@ export function ConfigModal({
               placeholder={TEXT_PLACEHOLDER}
               rows={envTextareaMinRows}
               value={text}
-              wrap="off"
+              wrap="soft"
             />
           )}
-
-          {envError ? <Alert message={envError} showIcon type="error" /> : null}
 
           <div className="midscene-config-modal-verify-row">
             {testStatus.kind === 'success' ? (
               <Alert
-                message="Test passed."
+                className="midscene-config-modal-verify-alert"
+                message="Verified"
                 showIcon
-                style={{ height: 32, paddingBlock: 4 }}
                 type="success"
               />
             ) : statusError ? (
-              <Alert message={statusError} showIcon type="error" />
+              <Alert
+                className="midscene-config-modal-verify-alert"
+                message={statusError}
+                showIcon
+                type="error"
+              />
             ) : (
               <span />
             )}
@@ -463,7 +440,7 @@ export function ConfigModal({
                 }
                 onClick={() => void handleVerify()}
               >
-                Verify and Save Model
+                {testStatus.kind === 'running' ? 'Verifying' : 'Verify'}
               </Button>
             ) : null}
           </div>

--- a/packages/visualizer/src/component/config-modal/index.tsx
+++ b/packages/visualizer/src/component/config-modal/index.tsx
@@ -409,7 +409,7 @@ export function ConfigModal({
               placeholder={TEXT_PLACEHOLDER}
               rows={envTextareaMinRows}
               value={text}
-              wrap="soft"
+              wrap="off"
             />
           )}
 

--- a/packages/visualizer/src/component/config-modal/index.tsx
+++ b/packages/visualizer/src/component/config-modal/index.tsx
@@ -413,7 +413,11 @@ export function ConfigModal({
             />
           )}
 
-          <div className="midscene-config-modal-verify-row">
+          <div
+            className={`midscene-config-modal-verify-row${
+              statusError ? ' midscene-config-modal-verify-row--error' : ''
+            }`}
+          >
             {testStatus.kind === 'success' ? (
               <Alert
                 className="midscene-config-modal-verify-alert"

--- a/packages/visualizer/src/component/env-config-reminder/index.tsx
+++ b/packages/visualizer/src/component/env-config-reminder/index.tsx
@@ -12,6 +12,8 @@ export interface EnvConfigReminderProps
     | 'agentOptions'
     | 'onAgentOptionsSave'
     | 'configModalClassName'
+    | 'configModalWidth'
+    | 'envTextareaAutoSize'
     | 'envTextareaMinRows'
   > {
   className?: string;
@@ -24,6 +26,8 @@ export const EnvConfigReminder: React.FC<EnvConfigReminderProps> = ({
   agentOptions,
   onAgentOptionsSave,
   configModalClassName,
+  configModalWidth,
+  envTextareaAutoSize,
   envTextareaMinRows,
 }) => {
   const { config } = useEnvConfig();
@@ -42,6 +46,8 @@ export const EnvConfigReminder: React.FC<EnvConfigReminderProps> = ({
       <EnvConfig
         agentOptions={agentOptions}
         configModalClassName={configModalClassName}
+        configModalWidth={configModalWidth}
+        envTextareaAutoSize={envTextareaAutoSize}
         envTextareaMinRows={envTextareaMinRows}
         mode="text"
         onAgentOptionsSave={onAgentOptionsSave}

--- a/packages/visualizer/src/component/env-config/index.tsx
+++ b/packages/visualizer/src/component/env-config/index.tsx
@@ -21,6 +21,8 @@ export interface EnvConfigProps {
   agentOptions?: CommonAgentOptions;
   onAgentOptionsSave?: (options: CommonAgentOptions) => void | Promise<void>;
   configModalClassName?: string;
+  configModalWidth?: ConfigModalProps['width'];
+  envTextareaAutoSize?: ConfigModalProps['envTextareaAutoSize'];
   envTextareaMinRows?: ConfigModalProps['envTextareaMinRows'];
 }
 
@@ -34,6 +36,8 @@ export function EnvConfig({
   agentOptions,
   onAgentOptionsSave,
   configModalClassName,
+  configModalWidth,
+  envTextareaAutoSize,
   envTextareaMinRows,
 }: EnvConfigProps) {
   const { config, configString, loadConfig, syncFromStorage } = useEnvConfig();
@@ -94,7 +98,9 @@ export function EnvConfig({
       <ConfigModal
         agentOptionsValue={agentOptions}
         className={configModalClassName}
+        envTextareaAutoSize={envTextareaAutoSize}
         envTextareaMinRows={envTextareaMinRows}
+        width={configModalWidth}
         onClose={() => setIsModalOpen(false)}
         onSave={async ({ text, agentOptions: nextAgentOptions }) => {
           const previousConfigText = configString;

--- a/packages/visualizer/src/component/nav-actions/index.tsx
+++ b/packages/visualizer/src/component/nav-actions/index.tsx
@@ -20,6 +20,8 @@ export interface NavActionsProps {
   agentOptions?: CommonAgentOptions;
   onAgentOptionsSave?: (options: CommonAgentOptions) => void | Promise<void>;
   configModalClassName?: EnvConfigProps['configModalClassName'];
+  configModalWidth?: EnvConfigProps['configModalWidth'];
+  envTextareaAutoSize?: EnvConfigProps['envTextareaAutoSize'];
   envTextareaMinRows?: EnvConfigProps['envTextareaMinRows'];
 }
 
@@ -35,6 +37,8 @@ export function NavActions({
   agentOptions,
   onAgentOptionsSave,
   configModalClassName,
+  configModalWidth,
+  envTextareaAutoSize,
   envTextareaMinRows,
 }: NavActionsProps) {
   return (
@@ -53,6 +57,8 @@ export function NavActions({
           onVerify={onVerify}
           agentOptions={agentOptions}
           configModalClassName={configModalClassName}
+          configModalWidth={configModalWidth}
+          envTextareaAutoSize={envTextareaAutoSize}
           envTextareaMinRows={envTextareaMinRows}
           onAgentOptionsSave={onAgentOptionsSave}
         />

--- a/packages/visualizer/src/component/prompt-input/index.less
+++ b/packages/visualizer/src/component/prompt-input/index.less
@@ -735,7 +735,8 @@
 // Dropdown menu styling with scroll support
 .more-apis-dropdown {
   .ant-dropdown-menu {
-    max-height: 400px;
+    max-height: clamp(96px, calc(100dvh - 280px), 400px);
+    overscroll-behavior: contain;
     overflow-y: auto;
     scrollbar-width: thin;
 
@@ -772,27 +773,36 @@
     .mode-radio-group-wrapper {
       .mode-radio-group {
         .ant-radio-button-wrapper {
-          background-color: rgba(255, 255, 255, 0.08) !important;
-          color: #f8fafd !important;
+          background-color: var(
+            --midscene-surface-muted,
+            rgba(255, 255, 255, 0.08)
+          );
+          color: var(--midscene-text-primary, #f8fafd);
 
           &.ant-radio-button-wrapper-checked {
-            background-color: rgba(43, 131, 255, 0.32) !important;
-            border-color: transparent !important;
-            color: #fff !important;
+            background-color: var(--midscene-accent, #2b83ff);
+            border-color: transparent;
+            color: #fff;
           }
         }
 
         .more-apis-button {
-          background-color: rgba(255, 255, 255, 0.08) !important;
-          color: #f8fafd !important;
+          background-color: var(
+            --midscene-surface-muted,
+            rgba(255, 255, 255, 0.08)
+          );
+          color: var(--midscene-text-primary, #f8fafd);
 
           &:hover {
-            background-color: rgba(255, 255, 255, 0.12) !important;
+            background-color: var(
+              --midscene-surface-hover,
+              rgba(255, 255, 255, 0.12)
+            );
           }
 
           &.selected-from-dropdown {
-            background-color: rgba(43, 131, 255, 0.32) !important;
-            color: #fff !important;
+            background-color: var(--midscene-accent, #2b83ff);
+            color: #fff;
           }
         }
       }
@@ -805,7 +815,7 @@
           rgba(31, 31, 31, 0.8) 40%,
           rgba(31, 31, 31, 0.95) 60%,
           #1f1f1f 70%
-        ) !important;
+        );
       }
     }
 

--- a/packages/visualizer/src/component/universal-playground/index.less
+++ b/packages/visualizer/src/component/universal-playground/index.less
@@ -120,18 +120,18 @@
       z-index: 10;
       background: var(--midscene-surface-elevated, #fff);
       border: 1px solid var(--midscene-border-strong, rgba(0, 0, 0, 0.08));
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      color: var(--midscene-accent, #2b83ff);
 
-      &:hover {
-        background: #1890ff;
-
-        .anticon {
-          color: #fff;
-        }
+      &:not(:disabled):hover {
+        background: var(--midscene-accent, #2b83ff);
+        border-color: var(--midscene-accent, #2b83ff);
+        color: #fff;
       }
 
       .anticon {
         font-size: 16px;
-        color: #333333;
+        color: inherit;
       }
     }
   }

--- a/packages/visualizer/src/component/universal-playground/index.tsx
+++ b/packages/visualizer/src/component/universal-playground/index.tsx
@@ -754,6 +754,7 @@ export function UniversalPlayground({
                                 false && (
                                 <div className="system-message-header">
                                   <Icon
+                                    className="system-message-icon"
                                     component={branding.icon || PlaygroundIcon}
                                     style={{ fontSize: 20 }}
                                   />
@@ -819,12 +820,11 @@ export function UniversalPlayground({
                 showScrollToBottomButton &&
                 componentConfig.enableScrollToBottom !== false && (
                   <Button
+                    aria-label="Scroll to latest message"
                     className="scroll-to-bottom-button"
-                    type="primary"
                     shape="circle"
                     icon={<ArrowDownOutlined />}
                     onClick={handleScrollToBottom}
-                    size="large"
                   />
                 )}
             </div>,

--- a/packages/visualizer/tests/config-modal-options.test.ts
+++ b/packages/visualizer/tests/config-modal-options.test.ts
@@ -68,9 +68,6 @@ describe('ConfigModal Agent options', () => {
     expect(configModalStyles).toContain('overflow-x: auto;');
     expect(configModalStyles).toContain('white-space: pre;');
     expect(configModalStyles).toContain('scrollbar-color:');
-    expect(configModalStyles).toContain(
-      'var(--midscene-border-control, rgba(0, 0, 0, 0.25)) transparent;',
-    );
     expect(configModalStyles).toMatch(
       /&::\-webkit-scrollbar\s*\{\s*width: 6px;\s*height: 6px;/,
     );

--- a/packages/visualizer/tests/config-modal-options.test.ts
+++ b/packages/visualizer/tests/config-modal-options.test.ts
@@ -62,12 +62,28 @@ describe('ConfigModal Agent options', () => {
     ).toMatchObject({ options: null });
   });
 
+  it('keeps model environment entries horizontally scrollable', () => {
+    expect(configModalComponent).toContain('wrap="off"');
+    expect(configModalComponent).not.toContain('wrap="soft"');
+    expect(configModalStyles).toContain('overflow-x: auto;');
+    expect(configModalStyles).toContain('white-space: pre;');
+    expect(configModalStyles).toContain('scrollbar-color:');
+    expect(configModalStyles).toContain(
+      'var(--midscene-border-control, rgba(0, 0, 0, 0.25)) transparent;',
+    );
+    expect(configModalStyles).toMatch(
+      /&::\-webkit-scrollbar\s*\{\s*width: 6px;\s*height: 6px;/,
+    );
+    expect(configModalStyles).toMatch(
+      /&::\-webkit-scrollbar-thumb\s*\{\s*border-radius: 999px;\s*background: var\(--midscene-border-control, rgba\(0, 0, 0, 0\.25\)\);/,
+    );
+  });
+
   it('keeps verification failures compact on their own row', () => {
     expect(configModalComponent).not.toContain('Verify and Save Model');
     expect(configModalComponent).toContain("'Verifying' : 'Verify'");
     expect(configModalComponent).toContain('message="Verified"');
     expect(configModalComponent).not.toContain('Test passed.');
-    expect(configModalComponent).toContain('wrap="soft"');
     expect(configModalStyles).toContain(
       'grid-template-columns: minmax(0, 1fr) auto;',
     );

--- a/packages/visualizer/tests/config-modal-options.test.ts
+++ b/packages/visualizer/tests/config-modal-options.test.ts
@@ -62,7 +62,7 @@ describe('ConfigModal Agent options', () => {
     ).toMatchObject({ options: null });
   });
 
-  it('keeps verification failures readable without growing into the button', () => {
+  it('keeps verification failures compact on their own row', () => {
     expect(configModalComponent).not.toContain('Verify and Save Model');
     expect(configModalComponent).toContain("'Verifying' : 'Verify'");
     expect(configModalComponent).toContain('message="Verified"');
@@ -70,6 +70,15 @@ describe('ConfigModal Agent options', () => {
     expect(configModalComponent).toContain('wrap="soft"');
     expect(configModalStyles).toContain(
       'grid-template-columns: minmax(0, 1fr) auto;',
+    );
+    expect(configModalComponent).toContain(
+      "statusError ? ' midscene-config-modal-verify-row--error' : ''",
+    );
+    expect(configModalStyles).toMatch(
+      /&--error\s*\{\s*grid-template-columns: minmax\(0, 1fr\);/,
+    );
+    expect(configModalStyles).toMatch(
+      /\.midscene-config-modal-verify-button\s*\{\s*justify-self: end;/,
     );
     expect(configModalStyles).toContain('align-items: center;');
     expect(configModalStyles).toContain('padding-block: 4px;');

--- a/packages/visualizer/tests/config-modal-options.test.ts
+++ b/packages/visualizer/tests/config-modal-options.test.ts
@@ -1,8 +1,18 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   agentOptionsToFormValues,
   parseAgentOptionFormValues,
 } from '../src/component/config-modal';
+
+const configModalComponent = readFileSync(
+  new URL('../src/component/config-modal/index.tsx', import.meta.url),
+  'utf8',
+);
+const configModalStyles = readFileSync(
+  new URL('../src/component/config-modal/index.less', import.meta.url),
+  'utf8',
+);
 
 describe('ConfigModal Agent options', () => {
   it('renders persisted options as editable values', () => {
@@ -50,5 +60,39 @@ describe('ConfigModal Agent options', () => {
         waitAfterAction: '-1',
       }),
     ).toMatchObject({ options: null });
+  });
+
+  it('keeps verification failures readable without growing into the button', () => {
+    expect(configModalComponent).not.toContain('Verify and Save Model');
+    expect(configModalComponent).toContain("'Verifying' : 'Verify'");
+    expect(configModalComponent).toContain('message="Verified"');
+    expect(configModalComponent).not.toContain('Test passed.');
+    expect(configModalComponent).toContain('wrap="soft"');
+    expect(configModalStyles).toContain(
+      'grid-template-columns: minmax(0, 1fr) auto;',
+    );
+    expect(configModalStyles).toContain('align-items: center;');
+    expect(configModalStyles).toContain('padding-block: 4px;');
+    expect(configModalStyles).toContain('max-height: 96px;');
+    expect(configModalStyles).toMatch(
+      /&\.ant-alert-error\s*\{\s*align-items: flex-start;/,
+    );
+    expect(configModalStyles).toMatch(
+      /\.ant-alert-icon\s*\{\s*margin-top: 4px;/,
+    );
+    expect(configModalStyles).toMatch(
+      /&\.ant-alert-success\s*\{\s*width: fit-content;\s*justify-self: start;/,
+    );
+    expect(configModalStyles).toContain('overflow-wrap: anywhere;');
+    expect(configModalStyles).toContain('padding-inline: 12px;');
+  });
+
+  it('relies on Ant Design theme tokens instead of component dark overrides', () => {
+    expect(configModalStyles).not.toContain("[data-theme='dark']");
+    expect(configModalStyles).not.toContain('!important');
+    expect(configModalStyles).not.toContain('.ant-modal-content');
+    expect(configModalComponent).toContain(
+      '<strong>locally in your browser</strong>',
+    );
   });
 });

--- a/packages/visualizer/tests/conversation-timeline-styles.test.ts
+++ b/packages/visualizer/tests/conversation-timeline-styles.test.ts
@@ -17,6 +17,10 @@ const player = readFileSync(
   new URL('../src/component/player/index.tsx', import.meta.url),
   'utf8',
 );
+const promptInputStyles = readFileSync(
+  new URL('../src/component/prompt-input/index.less', import.meta.url),
+  'utf8',
+);
 
 describe('conversation timeline styles', () => {
   it('uses 13px text for every timeline message type', () => {
@@ -97,5 +101,12 @@ describe('conversation timeline styles', () => {
     expect(styles).toMatch(
       /\.playground-timeline-region\s*\{[\s\S]*?flex:\s*1\s+1\s+auto;/,
     );
+  });
+
+  it('keeps the More APIs menu inside compact viewports', () => {
+    expect(promptInputStyles).toMatch(
+      /\.more-apis-dropdown\s*\{[\s\S]*?max-height:\s*clamp\(96px, calc\(100dvh - 280px\), 400px\);/,
+    );
+    expect(promptInputStyles).toContain('overscroll-behavior: contain;');
   });
 });


### PR DESCRIPTION
## Summary

Improve the Chrome extension's dark-theme consistency and Config modal usability, especially in compact DevTools layouts.

## Changes

- Apply Ant Design theme algorithms based on the system color scheme and use extension-specific primary color tokens.
- Align Playground controls, selected actions, clear controls, and scroll-to-latest buttons with the extension theme.
- Make the shared Config modal width and textarea auto-sizing configurable, using a compact layout in the Chrome extension.
- Improve verification feedback with `Verify` / `Verifying` states, persistent `Verified` feedback, readable scrollable errors, aligned error icons, and content-sized success alerts.
- Constrain the More APIs dropdown height so it remains accessible in short viewports.
- Add and update Chrome Extension, Visualizer, and Studio tests for theme propagation, configuration handling, responsive styles, and verification states.

## Validation

- [x] `pnpm run lint`
- [x] `pnpm exec nx test @midscene/visualizer -- tests/config-modal-options.test.ts tests/conversation-timeline-styles.test.ts`
- [x] `pnpm exec nx test studio -- tests/model-env-config-modal.test.tsx`
- [x] `pnpm exec nx test chrome-extension -- tests/playground-popup.test.tsx tests/browser-extension-playground.test.tsx`
- [x] `pnpm exec nx build chrome-extension --skip-nx-cache`

## Screenshots

<img width="798" height="1564" alt="image" src="https://github.com/user-attachments/assets/af9c780a-95bf-4d32-af17-a631eed2a669" />
<img width="806" height="1460" alt="image" src="https://github.com/user-attachments/assets/e14bdd93-8598-4446-b4fc-f669905fa22f" />
<img width="796" height="1158" alt="image" src="https://github.com/user-attachments/assets/ef3ebcd3-f2ee-4d3d-9e97-46d6e49a7b88" />
