### PR TITLE
feat(core): add model request tracing headers

### DIFF
--- a/apps/site/docs/en/model-debugging-observability.mdx
+++ b/apps/site/docs/en/model-debugging-observability.mdx
@@ -96,7 +96,7 @@ midscene_run/model-requests/<start-time>-<pid>.jsonl
 
 Each process creates one file, with one JSON event per line. Local recording is available only in Node.js and Electron. Browsers and Workers do not write local files. Codex App Server records also include available protocol metadata.
 
-Every event has a `type` of `request`, `chunk`, `response`, or `error`. It also includes an `executionId` that groups calls from the same report execution, including retries. Calls outside a report execution, such as connectivity checks, use a generated ID prefixed with `unscoped-`.
+Every event has a `type` of `request`, `chunk`, `response`, or `error`. It also includes an `executionId` that groups calls and retries under the same execution ID. For HTTP model requests, this value is also sent in the `x-midscene-execution-id` header. Calls outside a report execution, such as connectivity checks, use a generated ID prefixed with `unscoped-`.
 
 :::warning Important notes
 
@@ -105,6 +105,17 @@ Files contain request bodies, including custom `extraBody`, response headers and
 These files may be sensitive and large. Enable recording only while troubleshooting, and protect or delete the files afterward. The record format is not stable across versions.
 
 :::
+
+### Request tracing headers
+
+Midscene automatically adds the following headers to OpenAI-compatible HTTP model requests:
+
+| Header | Value | Purpose |
+| --- | --- | --- |
+| `x-midscene-version` | The current `@midscene/core` version | Identify the Midscene version that sent the request |
+| `x-midscene-execution-id` | The current execution ID | Group all model requests and retries under the same execution ID, such as an `aiAct` call |
+
+Calls outside a report execution, such as connectivity checks, use a generated execution ID prefixed with `unscoped-`. These two headers are sent by default; if headers with the same names are customized in `MIDSCENE_*_INIT_CONFIG_JSON`, Midscene overrides them.
 
 ## Observability platforms
 

--- a/apps/site/docs/zh/model-debugging-observability.mdx
+++ b/apps/site/docs/zh/model-debugging-observability.mdx
@@ -96,7 +96,7 @@ midscene_run/model-requests/<启动时间>-<pid>.jsonl
 
 每个进程生成一个文件，每行对应一个 JSON 事件。只有 Node.js 和 Electron 支持写入本地文件。浏览器和 Worker 不会写入本地文件。使用 Codex App Server 时，记录还会包含可获取的协议元数据。
 
-每个事件的 `type` 为 `request`、`chunk`、`response` 或 `error`。事件还包含 `executionId`，用于关联同一个报告 execution 内的调用及其重试。不属于报告 execution 的调用，例如连接检查，会使用带 `unscoped-` 前缀的生成 ID。
+每个事件的 `type` 为 `request`、`chunk`、`response` 或 `error`。事件还包含 `executionId`，用于关联同一个 execution ID 下的调用及其重试。对于 HTTP 模型请求，这个值也会通过 `x-midscene-execution-id` Header 发送。不属于报告 execution 的调用（例如连接检查）会使用带 `unscoped-` 前缀的生成 ID。
 
 :::warning 注意事项
 
@@ -105,6 +105,17 @@ midscene_run/model-requests/<启动时间>-<pid>.jsonl
 这些文件可能包含敏感信息，且体积较大。请仅在排查问题时启用记录，并在使用后妥善保管或删除文件。记录格式不保证跨版本兼容。
 
 :::
+
+### 请求追踪 Header
+
+Midscene 会自动为 OpenAI-compatible HTTP 模型请求添加以下 Header：
+
+| Header | 值 | 用途 |
+| --- | --- | --- |
+| `x-midscene-version` | 当前 `@midscene/core` 版本 | 标识发起请求的 Midscene 版本 |
+| `x-midscene-execution-id` | 当前 execution ID | 关联同一个 execution ID 下的全部模型请求及其重试，例如一次 `aiAct` 调用 |
+
+不属于报告 execution 的调用（例如连接检查）会使用带 `unscoped-` 前缀的生成 execution ID。这两个 Header 会被默认发送，如果 `MIDSCENE_*_INIT_CONFIG_JSON` 中自定义了同名 Header，则会被 Midscene 覆盖。
 
 ## 可观测性平台
 

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -40,6 +40,7 @@ import { assert, ifInBrowser, uuid } from '@midscene/shared/utils';
 import OpenAI from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
 import type { Stream } from 'openai/streaming';
+import { getVersion } from '../../utils';
 import {
   isModelCallRecordingEnabled,
   recordModelCallEvent,
@@ -152,9 +153,11 @@ function appendAIRequestFailureSummary<T extends Error>(
 
 export async function createChatClient({
   modelConfig,
+  executionId,
   recordEvent,
 }: {
   modelConfig: IModelConfig;
+  executionId: string;
   recordEvent?: (event: Record<string, unknown>) => void;
 }): Promise<{
   completion: OpenAI.Chat.Completions;
@@ -279,6 +282,18 @@ export async function createChatClient({
     // Note: Type assertion needed due to undici version mismatch between dependencies
     ...(proxyAgent ? { fetchOptions: { dispatcher: proxyAgent as any } } : {}),
     ...openaiExtraConfig,
+    // Midscene exposes this setting through MIDSCENE_*_INIT_CONFIG_JSON, so
+    // defaultHeaders is expected to be a plain JSON object rather than another
+    // HeadersLike representation supported by the OpenAI SDK.
+    defaultHeaders: {
+      ...(openaiExtraConfig?.defaultHeaders as
+        | Record<string, string>
+        | undefined),
+      // These Midscene-owned headers intentionally override user-supplied
+      // headers with the same names.
+      'x-midscene-version': getVersion(),
+      'x-midscene-execution-id': executionId,
+    },
     fetch: wrapOpenAICompatibleFetch(openAIErrorResponseContext),
     // Midscene already handles retries in callAI(), so disable SDK-level retries
     // to avoid duplicate attempts and duplicated backoff latency.
@@ -487,6 +502,7 @@ export async function callAI(
     openAIErrorResponseContext,
   } = await createChatClient({
     modelConfig,
+    executionId,
     recordEvent,
   });
   const effectiveTimeoutMs = resolveEffectiveTimeoutMs(modelConfig);

--- a/packages/core/tests/unit-test/service-caller-timeout.test.ts
+++ b/packages/core/tests/unit-test/service-caller-timeout.test.ts
@@ -221,6 +221,46 @@ describe('service-caller request timeout', () => {
     expect(lastCallOptions?.maxRetries).toBe(0);
   });
 
+  it('adds Midscene tracing headers without replacing configured headers', async () => {
+    const { callAI } = await import('@/ai-model/service-caller');
+    const { getModelRuntime } = await import('@/ai-model/models');
+    const { getVersion } = await import('@/utils');
+    const executionId = 'execution-123';
+
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+
+    const modelRuntime = {
+      ...getModelRuntime(
+        baseConfig({
+          openaiExtraConfig: {
+            defaultHeaders: {
+              'x-provider-header': 'provider-value',
+              'x-midscene-version': 'incorrect-version',
+              'x-midscene-execution-id': 'incorrect-execution-id',
+            },
+          },
+        }),
+      ),
+      executionId,
+    };
+
+    await callAI([{ role: 'user', content: 'hello' }], modelRuntime);
+
+    const OpenAI = (await import('openai')).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const defaultHeaders = OpenAI.mock.calls.at(-1)?.[0]?.defaultHeaders as
+      | Record<string, string>
+      | undefined;
+
+    expect(defaultHeaders?.['x-provider-header']).toBe('provider-value');
+    expect(defaultHeaders?.['x-midscene-version']).toBe(getVersion());
+    expect(defaultHeaders?.['x-midscene-execution-id']).toBe(executionId);
+  });
+
   it('retries after a hard timeout and returns the next successful response', async () => {
     const { callAI } = await import('@/ai-model/service-caller');
     const { getModelRuntime } = await import('@/ai-model/models');


### PR DESCRIPTION
## Summary

- add `x-midscene-version` to OpenAI-compatible model requests
- add `x-midscene-execution-id` so requests and retries from the same execution can be correlated
- preserve custom default headers while letting Midscene-owned tracing headers override duplicate names
- document both headers in the English and Chinese observability guides

## Why

Model gateways need stable metadata to identify the Midscene version that issued a request and correlate every model call belonging to one `aiAct` execution. The execution header reuses the same ID already written by `MIDSCENE_RECORD_MODEL_CALL`, including the existing `unscoped-` fallback for calls outside a report execution.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/service-caller-timeout.test.ts` (18 tests passed)
- `pnpm exec nx test @midscene/core` (the new test passed; the full target has 3 unrelated existing failures in `model-adapter.test.ts` because `doubao-y` has no registered adapter)