### PR TITLE
test(computer): align config modal dark theme assertion

### DIFF
--- a/packages/computer/tests/ai/chrome-extension-settings.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-settings.test.ts
@@ -93,7 +93,7 @@ describe('chrome extension settings and cross-mode tests', () => {
 
     // 2. Verify the dark-theme rendering and compact first viewport visually.
     await agent.aiAssert(
-      `A light-colored "Config" modal is fully visible on top of ${SIDE_PANEL}, which remains dark. The modal's title, "Model Env Config" section, textarea contents, input borders, close icon, and action buttons are clearly visible and readable. The first visible modal viewport reaches the "Agent Option Config" heading, with no clipped or overlapping content.`,
+      `A dark-themed "Config" modal is fully visible on top of ${SIDE_PANEL}, which also remains dark. The modal's title, "Model Env Config" section, textarea contents, input borders, close icon, and action buttons have sufficient contrast and are clearly visible and readable. The first visible modal viewport reaches the "Agent Option Config" heading, with no clipped or overlapping content.`,
     );
 
     // 3. Verify the text area contains env config (injected earlier)


### PR DESCRIPTION
## Summary

- update the Chrome Extension settings AI assertion to expect a dark-themed Config modal
- retain checks for readable contrast, visible controls, and unclipped layout

## Root cause

PR #2944 changed the Config modal to follow the Chrome Extension dark theme, but the headless AI test still required a light-colored modal. The UI was rendered correctly, while the stale color expectation caused `Headless Linux / chrome-extension-settings` to fail consistently.

## Validation

- `pnpm run lint`
- `pnpm exec biome check packages/computer/tests/ai/chrome-extension-settings.test.ts`

The model-backed headless test was not reproduced locally; it is expected to run in CI.