### PR TITLE
fix(report): exclude report generation from viewer bundle

### DIFF
--- a/apps/report/e2e/detail-panel.yaml
+++ b/apps/report/e2e/detail-panel.yaml
@@ -21,17 +21,17 @@ tasks:
     flow:
       - aiTap: the first Planning task row in the left sidebar
       - sleep: 1000
-      - aiAssert: The right detail side panel shows collapsible section headers named Param and Output, and the Param section is expanded with task input data
+      - aiAssert: The right detail side panel shows a collapsible Param section and a collapsible section named either Output or Element, and the Param section is expanded with task input data
       # Collapse both Param and the Output/Element section so the Meta section
       # (always rendered last) rises to the top of the panel with its heading
       # and first metadata rows fully on screen. This avoids depending on
       # scroll position: Meta is long, so any partial scroll leaves either the
       # heading or the type/status/start rows out of the viewport.
-      - aiTap: Output section header in the right detail side panel
+      - aiTap: the section header named either Output or Element in the right detail side panel
       - sleep: 500
       - aiTap: Param section header in the right detail side panel
       - sleep: 1000
-      - aiAssert: The Meta section is visible in the right detail side panel and shows entries such as type, status, start, end, or total time; the Param and Output headers remain visible above it, both sections are collapsed, and their content is hidden
+      - aiAssert: The Meta section is visible in the right detail side panel and shows entries such as type, status, start, end, or total time; the Param header and the header named either Output or Element remain visible above it, both sections are collapsed, and their content is hidden
 
   - name: open in playground button
     flow:

--- a/apps/report/rsbuild.config.ts
+++ b/apps/report/rsbuild.config.ts
@@ -52,6 +52,15 @@ const copyReportTemplate = () => ({
       const srcPath = path.join(__dirname, 'dist', 'index.html');
       const { sanitizedTplFileContent, finalContent } =
         buildReportTemplateInjection(fs.readFileSync(srcPath, 'utf-8'));
+      // This exact literal comes from reportHTMLContent() when it builds an
+      // Agent dump script. If that implementation is bundled into Report, the
+      // report-merging scanner may mistake the literal for a real dump tag.
+      assert(
+        !sanitizedTplFileContent.includes(
+          '<script type="midscene_web_dump" type="application/json" data-group-id="',
+        ),
+        'Report bundle must not include Agent report HTML generation code',
+      );
       assert(
         !sanitizedTplFileContent.includes(reportTemplateMagicString),
         'magic string should not be in the template file',
@@ -148,6 +157,11 @@ export default defineConfig({
   },
   source: {
     tsconfigPath: 'tsconfig.build.json',
+    define: {
+      // Identify this bundle as the Report Viewer build. Consumers can use
+      // this build context without changing standalone Playground or SDK builds.
+      __MIDSCENE_REPORT_BUILD__: 'true',
+    },
   },
   resolve: {
     alias: {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,5 +1,6 @@
 import { type ModelRuntime, getModelRuntime } from '@/ai-model/models';
 import { INTERNAL_CALL_ID_FIELD } from '@/ai-model/service-caller';
+import { IS_REPORT_BUILD } from '@/constants';
 import yaml from 'js-yaml';
 import type { TUserPrompt } from '../ai-model/index';
 import { ScreenshotItem } from '../screenshot-item';
@@ -695,6 +696,13 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
   }
 
   reportHTMLString(opt?: { inlineScreenshots?: boolean }) {
+    // Short-circuit at the call site because JavaScript evaluates function
+    // arguments first. This avoids serializing the dump (including inline
+    // screenshots) when the Report Viewer build does not need report HTML.
+    if (IS_REPORT_BUILD) {
+      return '';
+    }
+
     // dumpDataString() handles browser environment with inline screenshots
     return reportHTMLContent(this.dumpDataString(opt));
   }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,6 @@
+declare const __MIDSCENE_REPORT_BUILD__: boolean | undefined;
+
+// Consumer builds default to the normal SDK/Playground context. The Report
+// Viewer build explicitly replaces this value with true.
+export const IS_REPORT_BUILD =
+  typeof __MIDSCENE_REPORT_BUILD__ !== 'undefined' && __MIDSCENE_REPORT_BUILD__;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -21,6 +21,7 @@ import {
   ifInWorker,
   uuid,
 } from '@midscene/shared/utils';
+import { IS_REPORT_BUILD } from './constants';
 import type { Cache, Rect, ReportDumpWithAttributes } from './types';
 
 let logEnvReady = false;
@@ -150,6 +151,16 @@ export function reportHTMLContent(
   appendReport?: boolean,
   withTpl = true, // whether return with report template, default = true
 ): string {
+  // Short-circuit reportHTMLContent in Report builds so its generated
+  // <script type="midscene_web_dump" ... data-group-id="..."> literal is not
+  // bundled into the Report output. Report merging scans for this opening tag
+  // to locate dump JSON, so a copy inside bundled JS may be mistaken for a real
+  // dump tag. The embedded Playground does not support generating reports
+  // while replaying actions.
+  if (IS_REPORT_BUILD) {
+    return '';
+  }
+
   let tpl = '';
   if (withTpl) {
     tpl = getReportTpl();

--- a/packages/core/tests/unit-test/agent-report-html.test.ts
+++ b/packages/core/tests/unit-test/agent-report-html.test.ts
@@ -1,0 +1,42 @@
+import { Agent } from '@/agent';
+import type { AbstractInterface } from '@/device';
+import { reportHTMLContent } from '@/utils';
+import {
+  MIDSCENE_MODEL_API_KEY,
+  MIDSCENE_MODEL_BASE_URL,
+  MIDSCENE_MODEL_NAME,
+} from '@midscene/shared/env';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils')>();
+  return {
+    ...actual,
+    reportHTMLContent: vi.fn(() => '<html>report</html>'),
+  };
+});
+
+const modelConfig = {
+  [MIDSCENE_MODEL_NAME]: 'test-model',
+  [MIDSCENE_MODEL_API_KEY]: 'test-key',
+  [MIDSCENE_MODEL_BASE_URL]: 'https://api.test.com/v1',
+};
+
+function createMockInterface() {
+  return {
+    interfaceType: 'puppeteer',
+    actionSpace: () => [],
+  } as unknown as AbstractInterface;
+}
+
+describe('Agent report HTML', () => {
+  it('keeps report HTML generation enabled outside the Report Viewer build', () => {
+    const agent = new Agent(createMockInterface(), {
+      generateReport: false,
+      modelConfig,
+    });
+
+    expect(agent.reportHTMLString()).toBe('<html>report</html>');
+    expect(reportHTMLContent).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   },
   define: {
     __VERSION__: `'${version}'`,
+    __MIDSCENE_REPORT_BUILD__: 'false',
     __DEV_REPORT_PATH__: JSON.stringify(
       path.resolve(__dirname, '../../apps/report/dist/index.html'),
     ),


### PR DESCRIPTION
## Summary

- mark the Report Viewer bundle with a dedicated `IS_REPORT_BUILD` build context
- short-circuit `Agent.reportHTMLString()` before dump serialization and `reportHTMLContent()` before report-template generation
- add a build assertion that prevents the known `midscene_web_dump` opening-tag literal from re-entering the Report bundle
- cover the default SDK/Playground behavior with a focused Core unit test

## Root cause

The Report Viewer embeds Playground code backed by the full Core `Agent`. That dependency chain kept `reportHTMLContent()` reachable, so its generated `<script type="midscene_web_dump" ... data-group-id="...">` literal was bundled into the report template.

Report merging scans for that opening-tag shape to locate dump JSON. A matching literal inside bundled JavaScript could therefore be mistaken for a real dump tag and cause report merging to parse JavaScript as dump JSON.

## Impact

The Report Viewer build no longer contains Agent report-template generation code. Its embedded Playground continues to replay execution dumps directly, while standalone Playground and SDK builds keep the existing report generation behavior.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/core -- tests/unit-test/agent-report-html.test.ts`
- `pnpm exec nx build @midscene/report --skip-nx-cache`
- `pnpm exec nx build playground --skip-nx-cache`
- verified the dangerous dump-tag literal and report generation marker are absent from the Report bundle
