### PR TITLE
feat(studio): enforce single-instance lock and focus existing window

### DIFF
--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -28,6 +28,7 @@ import {
   type OpenDialogOptions,
   app,
   dialog,
+  autoUpdater as electronAutoUpdater,
   ipcMain,
   nativeImage,
   nativeTheme,
@@ -51,19 +52,31 @@ import {
   generateRecorderMetadataInMain,
 } from './recorder/codegen';
 import { configureStudioShellEnvHydration } from './shell-env';
+import {
+  acquireStudioSingleInstanceLock,
+  restoreAndFocusStudioWindow,
+} from './single-instance';
 import { StudioArtifactCleanup } from './studio-artifact-cleanup';
 import { studioUpdater } from './updater';
 import { registerUpdaterHandlers } from './updater-handlers';
-import { registerWindowRevealHandlers } from './window-reveal';
+import {
+  type WindowRevealController,
+  registerWindowRevealHandlers,
+} from './window-reveal';
+
+const shouldBootstrapStudio = acquireStudioSingleInstanceLock(app);
 
 // macOS GUI launches (Finder, Dock) skip the user's login shell, so
 // `ANDROID_HOME`, `PATH` additions for adb/hdc/xcrun, etc. never reach
 // `process.env`. Configure the hydrator once here, but only run it lazily
 // from the device-specific paths that actually need those binaries.
-configureStudioShellEnvHydration({
-  isPackaged: app.isPackaged,
-  log: (message, error) => console.warn(`[studio:shell-env] ${message}`, error),
-});
+if (shouldBootstrapStudio) {
+  configureStudioShellEnvHydration({
+    isPackaged: app.isPackaged,
+    log: (message, error) =>
+      console.warn(`[studio:shell-env] ${message}`, error),
+  });
+}
 
 /**
  * Main process owns native shell concerns only.
@@ -72,11 +85,13 @@ configureStudioShellEnvHydration({
  */
 
 let mainWindow: BrowserWindow | null = null;
+let mainWindowRevealController: WindowRevealController | null = null;
 let cachedAppIcon: NativeImage | null = null;
 let playgroundRuntimePromise: Promise<PlaygroundRuntimeService> | null = null;
 let deviceDiscoveryServicePromise: Promise<DeviceDiscoveryService> | null =
   null;
 let studioRunDir: string | null = null;
+let isQuitting = false;
 const isStudioSmokeTest = process.env.MIDSCENE_STUDIO_SMOKE_TEST === '1';
 const isStudioE2ETest = process.env.MIDSCENE_STUDIO_E2E_TEST === '1';
 const STUDIO_SMOKE_READY_MARKER = 'MIDSCENE_STUDIO_SMOKE_READY';
@@ -89,7 +104,7 @@ const STUDIO_E2E_FAILED_MARKER = 'MIDSCENE_STUDIO_E2E_FAILED';
 // the renderer without the user keeping DevTools open. Production builds never
 // set this — it would be a liability. The port can be overridden with the
 // MIDSCENE_STUDIO_CDP_PORT env var when multiple dev instances are running.
-if (!app.isPackaged) {
+if (shouldBootstrapStudio && !app.isPackaged) {
   const cdpPort = process.env.MIDSCENE_STUDIO_CDP_PORT ?? '9224';
   app.commandLine.appendSwitch('remote-debugging-port', cdpPort);
   // Bind to loopback so the debug endpoint isn't reachable from the network.
@@ -411,7 +426,9 @@ const createMainWindow = () => {
     },
   });
 
-  registerWindowRevealHandlers({
+  mainWindow = window;
+
+  const revealController = registerWindowRevealHandlers({
     isDestroyed: () => window.isDestroyed(),
     onDidFailLoad: (listener) =>
       window.webContents.once('did-fail-load', listener),
@@ -420,6 +437,7 @@ const createMainWindow = () => {
     onReadyToShow: (listener) => window.once('ready-to-show', listener),
     show: () => window.show(),
   });
+  mainWindowRevealController = revealController;
 
   if (isStudioSmokeTest || isStudioE2ETest) {
     window.webContents.once('did-finish-load', () => {
@@ -464,18 +482,16 @@ const createMainWindow = () => {
     });
   }
 
-  mainWindow = window;
-
   // Push every OS appearance change to the renderer so system-follow keeps
   // working even after `themeSource` has been toggled. The renderer
   // matchMedia listener silently stops firing across some Electron versions
   // once themeSource is explicitly set, so we keep nativeTheme as the
   // authoritative signal here.
   const handleNativeThemeUpdated = () => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
+    if (window.isDestroyed()) {
       return;
     }
-    mainWindow.webContents.send(
+    window.webContents.send(
       IPC_CHANNELS.systemThemeChanged,
       nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
     );
@@ -483,7 +499,51 @@ const createMainWindow = () => {
   nativeTheme.on('updated', handleNativeThemeUpdated);
   window.once('closed', () => {
     nativeTheme.off('updated', handleNativeThemeUpdated);
+    if (mainWindow === window) {
+      mainWindow = null;
+      if (mainWindowRevealController === revealController) {
+        mainWindowRevealController = null;
+      }
+    }
   });
+
+  return window;
+};
+
+const ensureMainWindow = (): BrowserWindow => {
+  if (!app.isReady()) {
+    throw new Error('Cannot create the Studio window before Electron is ready');
+  }
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    return mainWindow;
+  }
+
+  return createMainWindow();
+};
+
+const activateMainWindow = (): BrowserWindow | null => {
+  if (isQuitting) {
+    return null;
+  }
+
+  const window = ensureMainWindow();
+  const revealController = mainWindowRevealController;
+  if (!revealController) {
+    throw new Error('Studio window reveal controller is not configured');
+  }
+
+  revealController.requestActivation(() => {
+    if (isQuitting || mainWindow !== window || window.isDestroyed()) {
+      return;
+    }
+
+    restoreAndFocusStudioWindow(
+      window,
+      process.platform === 'darwin' ? app : undefined,
+    );
+  });
+
+  return window;
 };
 
 const registerIpcHandlers = () => {
@@ -771,63 +831,94 @@ const registerIpcHandlers = () => {
   );
 };
 
-app.whenReady().then(() => {
-  ensureStudioRunDir();
-  const stopEventLoopWatchdog = startStudioEventLoopWatchdog();
-  app.once('before-quit', stopEventLoopWatchdog);
+if (shouldBootstrapStudio) {
+  const markStudioQuitting = () => {
+    isQuitting = true;
+  };
 
-  if (process.platform === 'darwin' && app.dock) {
-    app.dock.setIcon(getAppIcon());
-  }
+  app.on('before-quit', markStudioQuitting);
+  electronAutoUpdater.on('before-quit-for-update', markStudioQuitting);
 
-  void getDeviceDiscoveryService()
-    .then((service) =>
-      service.subscribe((devices) => {
-        if (!mainWindow || mainWindow.isDestroyed()) {
-          return;
-        }
+  const primaryReady = app.whenReady().then(() => {
+    if (isQuitting) {
+      return;
+    }
 
-        mainWindow.webContents.send(
-          IPC_CHANNELS.discoveredDevicesUpdated,
-          devices,
-        );
-      }),
-    )
-    .catch((error) => {
-      console.error('Failed to initialize device discovery service:', error);
-    });
+    ensureStudioRunDir();
+    const stopEventLoopWatchdog = startStudioEventLoopWatchdog();
+    app.once('before-quit', stopEventLoopWatchdog);
 
-  registerIpcHandlers();
-  registerUpdaterHandlers(studioUpdater);
-  createMainWindow();
+    if (process.platform === 'darwin' && app.dock) {
+      app.dock.setIcon(getAppIcon());
+    }
 
-  // studioUpdater.init() no-ops when !app.isPackaged, and we skip the
-  // call entirely when running under the smoke/e2e harness so test runs
-  // do not hit the GitHub Releases API.
-  if (!isStudioSmokeTest && !isStudioE2ETest) {
-    studioUpdater.init(() => mainWindow);
-  }
+    void getDeviceDiscoveryService()
+      .then((service) =>
+        service.subscribe((devices) => {
+          if (!mainWindow || mainWindow.isDestroyed()) {
+            return;
+          }
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createMainWindow();
+          mainWindow.webContents.send(
+            IPC_CHANNELS.discoveredDevicesUpdated,
+            devices,
+          );
+        }),
+      )
+      .catch((error) => {
+        console.error('Failed to initialize device discovery service:', error);
+      });
+
+    registerIpcHandlers();
+    registerUpdaterHandlers(studioUpdater);
+    ensureMainWindow();
+
+    // studioUpdater.init() no-ops when !app.isPackaged, and we skip the
+    // call entirely when running under the smoke/e2e harness so test runs
+    // do not hit the GitHub Releases API.
+    if (!isStudioSmokeTest && !isStudioE2ETest) {
+      studioUpdater.init(() => mainWindow);
     }
   });
-});
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
+  const requestMainWindowActivation = () => {
+    if (isQuitting) {
+      return;
+    }
+
+    void primaryReady
+      .then(() => {
+        if (!isQuitting) {
+          activateMainWindow();
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to activate Studio window:', error);
+      });
+  };
+
+  if (app.isPackaged) {
+    app.on('second-instance', requestMainWindowActivation);
   }
-});
+  app.on('activate', requestMainWindowActivation);
 
-app.on('before-quit', () => {
-  void closePlaygroundRuntime();
-  void getDeviceDiscoveryService()
-    .then((service) => {
-      service.close();
-    })
-    .catch(() => {
-      // ignore cleanup failures during shutdown
-    });
-});
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  });
+
+  app.on('before-quit', () => {
+    void closePlaygroundRuntime();
+    const discoveryService = deviceDiscoveryServicePromise;
+    if (discoveryService) {
+      void discoveryService
+        .then((service) => {
+          service.close();
+        })
+        .catch(() => {
+          // ignore cleanup failures during shutdown
+        });
+    }
+  });
+}

--- a/apps/studio/src/main/single-instance.ts
+++ b/apps/studio/src/main/single-instance.ts
@@ -1,0 +1,54 @@
+interface StudioSingleInstanceApp {
+  isPackaged: boolean;
+  quit: () => void;
+  requestSingleInstanceLock: () => boolean;
+}
+
+interface ActivatableStudioWindow {
+  focus: () => void;
+  isDestroyed: () => boolean;
+  isMinimized: () => boolean;
+  isVisible: () => boolean;
+  restore: () => void;
+  show: () => void;
+}
+
+interface RevealableStudioApp {
+  isHidden: () => boolean;
+  show: () => void;
+}
+
+export function acquireStudioSingleInstanceLock(
+  application: StudioSingleInstanceApp,
+): boolean {
+  if (!application.isPackaged) {
+    return true;
+  }
+
+  const acquired = application.requestSingleInstanceLock();
+  if (!acquired) {
+    application.quit();
+  }
+
+  return acquired;
+}
+
+export function restoreAndFocusStudioWindow(
+  window: ActivatableStudioWindow,
+  application?: RevealableStudioApp,
+): void {
+  if (window.isDestroyed()) {
+    return;
+  }
+
+  if (application?.isHidden()) {
+    application.show();
+  }
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  if (!window.isVisible()) {
+    window.show();
+  }
+  window.focus();
+}

--- a/apps/studio/src/main/window-reveal.ts
+++ b/apps/studio/src/main/window-reveal.ts
@@ -6,6 +6,11 @@ interface RevealableWindow {
   show: () => void;
 }
 
+export interface WindowRevealController {
+  hasRevealed: () => boolean;
+  requestActivation: (listener: () => void) => void;
+}
+
 const windowRevealFallbackDelayMs = 2000;
 
 /**
@@ -13,15 +18,19 @@ const windowRevealFallbackDelayMs = 2000;
  * Studio shell, which leaves the app running without a visible window. Reveal
  * the window on the first reliable renderer lifecycle event instead.
  */
-export function registerWindowRevealHandlers(window: RevealableWindow): void {
+export function registerWindowRevealHandlers(
+  window: RevealableWindow,
+): WindowRevealController {
   let revealed = false;
   let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingActivation: (() => void) | null = null;
 
   const reveal = () => {
     if (revealed) {
       return;
     }
     if (window.isDestroyed?.()) {
+      pendingActivation = null;
       return;
     }
 
@@ -30,6 +39,10 @@ export function registerWindowRevealHandlers(window: RevealableWindow): void {
       clearTimeout(fallbackTimer);
     }
     window.show();
+
+    const activation = pendingActivation;
+    pendingActivation = null;
+    activation?.();
   };
 
   fallbackTimer = setTimeout(reveal, windowRevealFallbackDelayMs);
@@ -38,4 +51,19 @@ export function registerWindowRevealHandlers(window: RevealableWindow): void {
   window.onReadyToShow(reveal);
   window.onDidFinishLoad(reveal);
   window.onDidFailLoad(reveal);
+
+  return {
+    hasRevealed: () => revealed,
+    requestActivation: (listener) => {
+      if (window.isDestroyed?.()) {
+        return;
+      }
+      if (revealed) {
+        listener();
+        return;
+      }
+
+      pendingActivation ??= listener;
+    },
+  };
 }

--- a/apps/studio/tests/single-instance.test.ts
+++ b/apps/studio/tests/single-instance.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  acquireStudioSingleInstanceLock,
+  restoreAndFocusStudioWindow,
+} from '../src/main/single-instance';
+
+function createApplication({
+  acquired = true,
+  isPackaged = true,
+}: {
+  acquired?: boolean;
+  isPackaged?: boolean;
+} = {}) {
+  return {
+    isPackaged,
+    quit: vi.fn(),
+    requestSingleInstanceLock: vi.fn(() => acquired),
+  };
+}
+
+function createWindow({
+  calls = [] as string[],
+  destroyed = false,
+  minimized = false,
+  visible = true,
+} = {}) {
+  let isMinimized = minimized;
+  let isVisible = visible;
+
+  return {
+    calls,
+    window: {
+      focus: () => calls.push('focus'),
+      isDestroyed: () => destroyed,
+      isMinimized: () => isMinimized,
+      isVisible: () => isVisible,
+      restore: () => {
+        calls.push('restore');
+        isMinimized = false;
+        isVisible = true;
+      },
+      show: () => {
+        calls.push('show-window');
+        isVisible = true;
+      },
+    },
+  };
+}
+
+describe('Studio single-instance lock', () => {
+  it('keeps unpackaged development instances independent', () => {
+    const application = createApplication({ isPackaged: false });
+
+    expect(acquireStudioSingleInstanceLock(application)).toBe(true);
+    expect(application.requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(application.quit).not.toHaveBeenCalled();
+  });
+
+  it('continues bootstrapping when the packaged instance acquires the lock', () => {
+    const application = createApplication();
+
+    expect(acquireStudioSingleInstanceLock(application)).toBe(true);
+    expect(application.requestSingleInstanceLock).toHaveBeenCalledOnce();
+    expect(application.quit).not.toHaveBeenCalled();
+  });
+
+  it('quits a packaged secondary instance immediately', () => {
+    const application = createApplication({ acquired: false });
+
+    expect(acquireStudioSingleInstanceLock(application)).toBe(false);
+    expect(application.requestSingleInstanceLock).toHaveBeenCalledOnce();
+    expect(application.quit).toHaveBeenCalledOnce();
+  });
+
+  it('does not silently continue when Electron cannot request the lock', () => {
+    const application = createApplication();
+    application.requestSingleInstanceLock.mockImplementation(() => {
+      throw new Error('lock unavailable');
+    });
+
+    expect(() => acquireStudioSingleInstanceLock(application)).toThrow(
+      'lock unavailable',
+    );
+    expect(application.quit).not.toHaveBeenCalled();
+  });
+});
+
+describe('Studio window activation', () => {
+  it('focuses an already visible window without changing its state', () => {
+    const { calls, window } = createWindow();
+
+    restoreAndFocusStudioWindow(window);
+
+    expect(calls).toEqual(['focus']);
+  });
+
+  it('restores a minimized window before focusing it', () => {
+    const { calls, window } = createWindow({
+      minimized: true,
+      visible: false,
+    });
+
+    restoreAndFocusStudioWindow(window);
+
+    expect(calls).toEqual(['restore', 'focus']);
+  });
+
+  it('shows a hidden window before focusing it', () => {
+    const { calls, window } = createWindow({ visible: false });
+
+    restoreAndFocusStudioWindow(window);
+
+    expect(calls).toEqual(['show-window', 'focus']);
+  });
+
+  it('unhides the macOS application before restoring its window', () => {
+    const calls: string[] = [];
+    const { window } = createWindow({
+      calls,
+      minimized: true,
+      visible: false,
+    });
+    const application = {
+      isHidden: () => true,
+      show: () => calls.push('show-application'),
+    };
+
+    restoreAndFocusStudioWindow(window, application);
+
+    expect(calls).toEqual(['show-application', 'restore', 'focus']);
+  });
+
+  it('does not activate a destroyed window', () => {
+    const calls: string[] = [];
+    const { window } = createWindow({ calls, destroyed: true });
+    const application = {
+      isHidden: () => true,
+      show: () => calls.push('show-application'),
+    };
+
+    restoreAndFocusStudioWindow(window, application);
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/studio/tests/window-reveal.test.ts
+++ b/apps/studio/tests/window-reveal.test.ts
@@ -17,7 +17,7 @@ class FakeWindow extends EventEmitter {
 }
 
 function register(window: FakeWindow) {
-  registerWindowRevealHandlers({
+  return registerWindowRevealHandlers({
     isDestroyed: () => window.isDestroyed(),
     onDidFailLoad: (listener) =>
       window.webContents.once('did-fail-load', listener),
@@ -90,5 +90,60 @@ describe('window reveal handlers', () => {
     vi.advanceTimersByTime(2000);
 
     expect(window.showCalls).toBe(1);
+  });
+
+  it('defers activation until the initial reveal completes', () => {
+    const window = new FakeWindow();
+    const controller = register(window);
+    const activate = vi.fn();
+
+    controller.requestActivation(activate);
+
+    expect(controller.hasRevealed()).toBe(false);
+    expect(activate).not.toHaveBeenCalled();
+
+    window.emit('ready-to-show');
+
+    expect(controller.hasRevealed()).toBe(true);
+    expect(window.showCalls).toBe(1);
+    expect(activate).toHaveBeenCalledOnce();
+  });
+
+  it('runs activation immediately after the window has been revealed', () => {
+    const window = new FakeWindow();
+    const controller = register(window);
+    const activate = vi.fn();
+
+    window.webContents.emit('did-finish-load');
+    controller.requestActivation(activate);
+
+    expect(activate).toHaveBeenCalledOnce();
+  });
+
+  it('coalesces repeated activation requests before reveal', () => {
+    const window = new FakeWindow();
+    const controller = register(window);
+    const firstActivation = vi.fn();
+    const secondActivation = vi.fn();
+
+    controller.requestActivation(firstActivation);
+    controller.requestActivation(secondActivation);
+    window.emit('ready-to-show');
+
+    expect(firstActivation).toHaveBeenCalledOnce();
+    expect(secondActivation).not.toHaveBeenCalled();
+  });
+
+  it('drops activation requests for a destroyed window', () => {
+    const window = new FakeWindow();
+    const controller = register(window);
+    const activate = vi.fn();
+    window.destroyed = true;
+
+    controller.requestActivation(activate);
+    window.emit('ready-to-show');
+
+    expect(controller.hasRevealed()).toBe(false);
+    expect(activate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Ensure that packaged Midscene Studio runs as a single application instance. Repeated launches now reuse the primary instance and restore and focus its window, while unpackaged development keeps the existing multi-instance behavior.

Fixes #2931.

## Changes

- Acquire Electron's single-instance lock before bootstrapping packaged Studio.
- Exit secondary instances without initializing IPC handlers, device discovery, the updater, or a new window.
- Handle `second-instance` and macOS `activate` events through a shared window activation path.
- Reuse an existing window or recreate it when needed, then unhide, restore, show, and focus it.
- Defer activation until the initial window reveal completes and coalesce repeated activation requests during startup.
- Prevent activation from recreating a window while Studio is quitting or installing an update.
- Add unit coverage for lock acquisition, secondary-instance exit, window restoration, macOS app visibility, and reveal-time activation.

## Validation

- [x] `pnpm run lint`
- [x] `npx nx build studio`
- [x] `npx nx test studio` — 60 files passed, 3 skipped; 443 tests passed, 3 skipped
- [x] `pnpm --dir apps/studio exec vitest run tests/single-instance.test.ts tests/window-reveal.test.ts` — 19 tests passed
- [x] Packaged macOS arm64 `.app` double-launch smoke passed: the secondary instance exited successfully while the primary instance remained running

## Notes

- Windows and Linux packaged double-launch behavior should be verified by the package validation CI or platform-specific manual testing.