### PR TITLE
test(web-integration): expand input E2E coverage

### DIFF
--- a/packages/web-integration/tests/ai/web/input-e2e-page.ts
+++ b/packages/web-integration/tests/ai/web/input-e2e-page.ts
@@ -1,0 +1,304 @@
+import { type Server, createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const FIELD_STYLES = `
+  body {
+    box-sizing: border-box;
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 28px;
+    color: #172033;
+    background: #f5f7fb;
+    font-family: Arial, sans-serif;
+  }
+  .field {
+    display: grid;
+    gap: 6px;
+    margin: 18px 0;
+  }
+  label, .label {
+    font-weight: 700;
+  }
+  input, textarea, [contenteditable='true'] {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 46px;
+    padding: 10px 12px;
+    color: #172033;
+    background: white;
+    border: 2px solid #9aa6bd;
+    border-radius: 8px;
+    font: 18px/1.4 Arial, sans-serif;
+  }
+  textarea, [contenteditable='true'] {
+    min-height: 78px;
+  }
+  .summary {
+    margin-top: 22px;
+    padding: 16px;
+    background: #eaf4ff;
+    border: 2px solid #4085c6;
+    border-radius: 8px;
+    font-size: 18px;
+    line-height: 1.6;
+  }
+  iframe {
+    width: 100%;
+    height: 330px;
+    border: 3px solid #6558d3;
+    border-radius: 10px;
+  }
+`;
+
+const stateScript = (fieldIds: string[]) => `
+  const fieldIds = ${JSON.stringify(fieldIds)};
+  window.__midsceneInputEvents = [];
+
+  function fieldValue(field) {
+    return field.isContentEditable ? field.textContent : field.value;
+  }
+
+  function displayValue(value) {
+    return value === '' ? '[empty]' : value.replace(/\\n/g, ' / ');
+  }
+
+  function updateInputSummary() {
+    const values = fieldIds.map((id) => {
+      const field = document.getElementById(id);
+      return '<div data-summary="' + id + '">' +
+        field.dataset.summaryLabel + ': ' +
+        displayValue(fieldValue(field)) + '</div>';
+    });
+    const counts = window.__midsceneInputEvents.reduce((result, event) => {
+      result[event.type] = (result[event.type] || 0) + 1;
+      return result;
+    }, {});
+    values.push(
+      '<div data-summary="events">Events: beforeinput=' +
+        (counts.beforeinput || 0) + ', input=' + (counts.input || 0) +
+        ', change=' + (counts.change || 0) + '</div>',
+    );
+    document.getElementById('input-summary').innerHTML = values.join('');
+  }
+
+  for (const id of fieldIds) {
+    const field = document.getElementById(id);
+    for (const type of ['beforeinput', 'input', 'change']) {
+      field.addEventListener(type, () => {
+        window.__midsceneInputEvents.push({ id, type, value: fieldValue(field) });
+        updateInputSummary();
+      });
+    }
+  }
+
+  window.__midsceneInputState = () => ({
+    values: Object.fromEntries(
+      fieldIds.map((id) => {
+        const field = document.getElementById(id);
+        return [id, fieldValue(field)];
+      }),
+    ),
+    events: window.__midsceneInputEvents,
+  });
+  updateInputSummary();
+`;
+
+const TOP_LEVEL_HTML = `
+  <!doctype html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <title>Midscene input modes</title>
+      <style>${FIELD_STYLES}</style>
+    </head>
+    <body>
+      <h1>Input mode test page</h1>
+      <div class="field">
+        <label for="text-input">Text input</label>
+        <input
+          id="text-input"
+          data-summary-label="Text input value"
+          value="Alpha value"
+        />
+      </div>
+      <div class="field">
+        <label for="notes">Notes textarea</label>
+        <textarea
+          id="notes"
+          data-summary-label="Textarea value"
+        >Bravo notes</textarea>
+      </div>
+      <div class="field">
+        <div class="label" id="rich-label">Rich text editor</div>
+        <div
+          id="rich-editor"
+          data-summary-label="Rich text value"
+          contenteditable="true"
+          role="textbox"
+          aria-labelledby="rich-label"
+        >Charlie rich text</div>
+      </div>
+      <div id="input-summary" class="summary" aria-label="Input state summary"></div>
+      <script>${stateScript(['text-input', 'notes', 'rich-editor'])}</script>
+    </body>
+  </html>
+`;
+
+const FRAME_HTML = `
+  <!doctype html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <title>Iframe input editor</title>
+      <style>${FIELD_STYLES}</style>
+    </head>
+    <body>
+      <h2>Iframe input editor</h2>
+      <div class="field">
+        <label for="frame-input">Iframe text input</label>
+        <input
+          id="frame-input"
+          data-summary-label="Iframe input value"
+          value="Frame initial value"
+        />
+      </div>
+      <div id="input-summary" class="summary" aria-label="Iframe input state summary"></div>
+      <script>${stateScript(['frame-input'])}</script>
+    </body>
+  </html>
+`;
+
+const CONTROLLED_HTML = `
+  <!doctype html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <title>Controlled input replacement</title>
+      <style>${FIELD_STYLES}</style>
+    </head>
+    <body>
+      <h1>Controlled input replacement</h1>
+      <form id="controlled-form" class="field">
+        <label for="controlled-input">Controlled text input</label>
+        <input id="controlled-input" value="Initial controlled value" />
+      </form>
+      <div id="controlled-summary" class="summary"></div>
+      <script>
+        let replacementCount = 0;
+        let replacementScheduled = false;
+
+        function updateControlledSummary(input) {
+          const value = input.value === '' ? '[empty]' : input.value;
+          document.getElementById('controlled-summary').textContent =
+            'Controlled value: ' + value +
+            ' | Replacement count: ' + replacementCount;
+        }
+
+        function attachControlledInput(input) {
+          input.addEventListener('input', () => {
+            updateControlledSummary(input);
+            if (replacementScheduled || input.value !== '') return;
+            replacementScheduled = true;
+            setTimeout(() => {
+              const replacement = document.createElement('input');
+              replacement.id = 'controlled-input';
+              replacement.value = '';
+              input.replaceWith(replacement);
+              replacement.focus();
+              replacementCount += 1;
+              attachControlledInput(replacement);
+              updateControlledSummary(replacement);
+            }, 250);
+          });
+        }
+
+        const initialInput = document.getElementById('controlled-input');
+        attachControlledInput(initialInput);
+        updateControlledSummary(initialInput);
+        window.__midsceneControlledState = () => ({
+          replacementCount,
+          value: document.getElementById('controlled-input').value,
+        });
+      </script>
+    </body>
+  </html>
+`;
+
+type InputTestServers = {
+  close(): Promise<void>;
+  controlledUrl: string;
+  iframeUrl(mode: 'same-origin' | 'cross-origin'): string;
+  topLevelUrl: string;
+};
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const address = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+export async function startInputTestServers(): Promise<InputTestServers> {
+  const crossOriginServer = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(FRAME_HTML);
+  });
+  const crossOrigin = await listen(crossOriginServer);
+
+  let parentOrigin = '';
+  const parentServer = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? '/', parentOrigin);
+    let html = TOP_LEVEL_HTML;
+
+    if (requestUrl.pathname === '/controlled') {
+      html = CONTROLLED_HTML;
+    } else if (requestUrl.pathname === '/frame') {
+      html = FRAME_HTML;
+    } else if (requestUrl.pathname === '/iframe') {
+      const frameSource =
+        requestUrl.searchParams.get('mode') === 'cross-origin'
+          ? `${crossOrigin}/frame`
+          : '/frame';
+      html = `
+        <!doctype html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <title>Iframe input host</title>
+            <style>${FIELD_STYLES}</style>
+          </head>
+          <body>
+            <h1>Iframe input host</h1>
+            <iframe title="Input editor frame" src="${frameSource}"></iframe>
+          </body>
+        </html>
+      `;
+    }
+
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(html);
+  });
+  parentOrigin = await listen(parentServer);
+
+  return {
+    topLevelUrl: `${parentOrigin}/`,
+    controlledUrl: `${parentOrigin}/controlled`,
+    iframeUrl: (mode) => `${parentOrigin}/iframe?mode=${mode}`,
+    close: async () => {
+      await Promise.all([
+        closeServer(parentServer),
+        closeServer(crossOriginServer),
+      ]);
+    },
+  };
+}

--- a/packages/web-integration/tests/ai/web/input-e2e-page.ts
+++ b/packages/web-integration/tests/ai/web/input-e2e-page.ts
@@ -63,22 +63,31 @@ const stateScript = (fieldIds: string[]) => `
   }
 
   function updateInputSummary() {
-    const values = fieldIds.map((id) => {
+    const summary = document.getElementById('input-summary');
+    const fragment = document.createDocumentFragment();
+
+    for (const id of fieldIds) {
       const field = document.getElementById(id);
-      return '<div data-summary="' + id + '">' +
-        field.dataset.summaryLabel + ': ' +
-        displayValue(fieldValue(field)) + '</div>';
-    });
+      const row = document.createElement('div');
+      row.dataset.summary = id;
+      row.textContent =
+        field.dataset.summaryLabel + ': ' + displayValue(fieldValue(field));
+      fragment.append(row);
+    }
+
     const counts = window.__midsceneInputEvents.reduce((result, event) => {
       result[event.type] = (result[event.type] || 0) + 1;
       return result;
     }, {});
-    values.push(
-      '<div data-summary="events">Events: beforeinput=' +
-        (counts.beforeinput || 0) + ', input=' + (counts.input || 0) +
-        ', change=' + (counts.change || 0) + '</div>',
-    );
-    document.getElementById('input-summary').innerHTML = values.join('');
+    const eventRow = document.createElement('div');
+    eventRow.dataset.summary = 'events';
+    eventRow.textContent =
+      'Events: beforeinput=' + (counts.beforeinput || 0) +
+      ', input=' + (counts.input || 0) +
+      ', change=' + (counts.change || 0);
+    fragment.append(eventRow);
+
+    summary.replaceChildren(fragment);
   }
 
   for (const id of fieldIds) {
@@ -224,7 +233,7 @@ const CONTROLLED_HTML = `
   </html>
 `;
 
-type InputTestServers = {
+export type InputTestServers = {
   close(): Promise<void>;
   controlledUrl: string;
   iframeUrl(mode: 'same-origin' | 'cross-origin'): string;

--- a/packages/web-integration/tests/ai/web/input-e2e-scenarios.ts
+++ b/packages/web-integration/tests/ai/web/input-e2e-scenarios.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert';
+import type { InputTestServers } from './input-e2e-page';
+
+export type InputMode = 'replace' | 'clear' | 'typeOnly';
+export type FrameMode = 'same-origin' | 'cross-origin';
+
+export type InputState = {
+  events: Array<{ id: string; type: string; value: string }>;
+  values: Record<string, string>;
+};
+
+export type ControlledInputState = {
+  replacementCount: number;
+  value: string;
+};
+
+export type InputTarget = {
+  selector: string;
+  frame?: FrameMode;
+};
+
+export type InputAction = {
+  keyboardTypeDelay?: number;
+  mode: InputMode;
+  value: string;
+};
+
+export interface InputScenarioHarness {
+  aiAssert(prompt: string): Promise<void>;
+  blur(): Promise<void>;
+  input(
+    target: InputTarget,
+    description: string,
+    action: InputAction,
+  ): Promise<void>;
+  isFrameSameOrigin(mode: FrameMode): Promise<boolean>;
+  publicInput(prompt: string, value: string): Promise<void>;
+  readControlledState(): Promise<ControlledInputState>;
+  readInputState(frame?: FrameMode): Promise<InputState>;
+  readValue(target: InputTarget): Promise<string>;
+  setCaret(target: InputTarget, offset: number): Promise<void>;
+}
+
+export type InputE2EScenario = {
+  name: string;
+  run(harness: InputScenarioHarness): Promise<void>;
+  url(servers: InputTestServers): string;
+};
+
+type InputTestWindow = Window & {
+  __midsceneControlledState?: () => ControlledInputState;
+  __midsceneInputState?: () => InputState;
+};
+
+export function readEditableValue(element: Element): string {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return element.value;
+  }
+  return element.textContent ?? '';
+}
+
+export function setEditableCaret(element: Element, offset: number): void {
+  (element as HTMLElement).focus();
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    element.setSelectionRange(offset, offset);
+    return;
+  }
+
+  const textNode = element.firstChild;
+  if (!textNode) {
+    throw new Error('Cannot set a caret on an element without text content');
+  }
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error('Cannot set a caret because Selection is unavailable');
+  }
+  const range = document.createRange();
+  range.setStart(textNode, offset);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+export function readInputStateFromWindow(): InputState {
+  const readState = (window as InputTestWindow).__midsceneInputState;
+  if (!readState) {
+    throw new Error('Input test state is unavailable');
+  }
+  return readState();
+}
+
+export function readControlledStateFromWindow(): ControlledInputState {
+  const readState = (window as InputTestWindow).__midsceneControlledState;
+  if (!readState) {
+    throw new Error('Controlled input test state is unavailable');
+  }
+  return readState();
+}
+
+const editableFields = [
+  {
+    description: 'Text input',
+    eventTypes: ['beforeinput', 'input', 'change'],
+    id: 'text-input',
+    insertedValue: 'Alpha[inserted] value',
+    replacementValue: 'Input replaced',
+    selector: '#text-input',
+  },
+  {
+    description: 'Notes textarea',
+    eventTypes: ['beforeinput', 'input', 'change'],
+    id: 'notes',
+    insertedValue: 'Bravo[inserted] notes',
+    replacementValue: 'Textarea replaced',
+    selector: '#notes',
+  },
+  {
+    description: 'Rich text editor',
+    eventTypes: ['beforeinput', 'input'],
+    id: 'rich-editor',
+    insertedValue: 'Charl[inserted]ie rich text',
+    replacementValue: 'Rich text replaced',
+    selector: '#rich-editor',
+  },
+] as const;
+
+function assertExpectedEvents(state: InputState): void {
+  for (const field of editableFields) {
+    const actualTypes = new Set(
+      state.events.filter(({ id }) => id === field.id).map(({ type }) => type),
+    );
+    for (const expectedType of field.eventTypes) {
+      assert(
+        actualTypes.has(expectedType),
+        `${field.id} should emit ${expectedType}; received: ${[
+          ...actualTypes,
+        ].join(', ')}`,
+      );
+    }
+  }
+}
+
+const topLevelUrl = (servers: InputTestServers) => servers.topLevelUrl;
+
+const replaceScenario: InputE2EScenario = {
+  name: 'replaces input, textarea, and contenteditable values and emits browser events',
+  url: topLevelUrl,
+  run: async (harness) => {
+    for (const field of editableFields) {
+      await harness.input({ selector: field.selector }, field.description, {
+        mode: 'replace',
+        value: field.replacementValue,
+      });
+    }
+    await harness.blur();
+
+    const state = await harness.readInputState();
+    assert.deepStrictEqual(
+      state.values,
+      Object.fromEntries(
+        editableFields.map(({ id, replacementValue }) => [
+          id,
+          replacementValue,
+        ]),
+      ),
+    );
+    assertExpectedEvents(state);
+    await harness.aiAssert(
+      'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
+    );
+  },
+};
+
+const publicInputScenario: InputE2EScenario = {
+  name: 'uses public aiInput to locate and replace a text input from its initial value',
+  url: topLevelUrl,
+  run: async (harness) => {
+    const target = { selector: '#text-input' };
+    assert.strictEqual(await harness.readValue(target), 'Alpha value');
+    await harness.publicInput(
+      'the text input labeled Text input',
+      'Public replacement complete',
+    );
+    assert.strictEqual(
+      await harness.readValue(target),
+      'Public replacement complete',
+    );
+    await harness.aiAssert(
+      'The state summary shows Text input value: Public replacement complete.',
+    );
+  },
+};
+
+const clearScenario: InputE2EScenario = {
+  name: 'clears input, textarea, and contenteditable values and emits browser events',
+  url: topLevelUrl,
+  run: async (harness) => {
+    for (const field of editableFields) {
+      await harness.input({ selector: field.selector }, field.description, {
+        mode: 'clear',
+        value: '',
+      });
+    }
+    await harness.blur();
+
+    const state = await harness.readInputState();
+    assert.deepStrictEqual(
+      state.values,
+      Object.fromEntries(editableFields.map(({ id }) => [id, ''])),
+    );
+    assertExpectedEvents(state);
+    await harness.aiAssert(
+      'The state summary shows [empty] for the text input, textarea, and rich text editor, with non-zero beforeinput, input, and change event counts.',
+    );
+  },
+};
+
+const typeOnlyScenario: InputE2EScenario = {
+  name: 'inserts typeOnly text at the current caret in each editable field',
+  url: topLevelUrl,
+  run: async (harness) => {
+    for (const field of editableFields) {
+      const target = { selector: field.selector };
+      await harness.setCaret(target, 5);
+      await harness.input(target, field.description, {
+        mode: 'typeOnly',
+        value: '[inserted]',
+      });
+    }
+
+    const state = await harness.readInputState();
+    assert.deepStrictEqual(
+      state.values,
+      Object.fromEntries(
+        editableFields.map(({ id, insertedValue }) => [id, insertedValue]),
+      ),
+    );
+    await harness.aiAssert(
+      'The state summary shows the inserted marker in the middle of all three values: Alpha[inserted] value, Bravo[inserted] notes, and Charl[inserted]ie rich text.',
+    );
+  },
+};
+
+function iframeScenario(mode: FrameMode): InputE2EScenario {
+  return {
+    name: `replaces and clears an input in a ${mode} iframe`,
+    url: (servers) => servers.iframeUrl(mode),
+    run: async (harness) => {
+      assert.strictEqual(
+        await harness.isFrameSameOrigin(mode),
+        mode === 'same-origin',
+      );
+      const target = { frame: mode, selector: '#frame-input' };
+
+      await harness.input(target, `${mode} iframe input`, {
+        mode: 'replace',
+        value: `${mode} replacement`,
+      });
+      assert.strictEqual(
+        await harness.readValue(target),
+        `${mode} replacement`,
+      );
+      await harness.aiAssert(
+        `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
+      );
+
+      await harness.input(target, `${mode} iframe input`, {
+        mode: 'clear',
+        value: '',
+      });
+      assert.strictEqual(await harness.readValue(target), '');
+      await harness.aiAssert(
+        'Inside the iframe, the state summary shows Iframe input value: [empty].',
+      );
+    },
+  };
+}
+
+const controlledInputScenario: InputE2EScenario = {
+  name: 'keeps every character when a controlled input is replaced after clearing',
+  url: (servers) => servers.controlledUrl,
+  run: async (harness) => {
+    await harness.input(
+      { selector: '#controlled-input' },
+      'Controlled text input',
+      {
+        keyboardTypeDelay: 40,
+        mode: 'replace',
+        value: 'Stable controlled text',
+      },
+    );
+    assert.deepStrictEqual(await harness.readControlledState(), {
+      replacementCount: 1,
+      value: 'Stable controlled text',
+    });
+    await harness.aiAssert(
+      'The controlled input summary shows Controlled value: Stable controlled text and Replacement count: 1.',
+    );
+  },
+};
+
+export const inputE2EScenarios: readonly InputE2EScenario[] = [
+  replaceScenario,
+  publicInputScenario,
+  clearScenario,
+  typeOnlyScenario,
+  iframeScenario('same-origin'),
+  iframeScenario('cross-origin'),
+  controlledInputScenario,
+];

--- a/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
@@ -1,48 +1,100 @@
 import type { Agent } from '@midscene/core/agent';
 import type { Frame, Page } from '@playwright/test';
-import { expect } from '@playwright/test';
+import type { InputTestServers } from '../input-e2e-page';
 import { startInputTestServers } from '../input-e2e-page';
+import {
+  type FrameMode,
+  type InputAction,
+  type InputScenarioHarness,
+  type InputTarget,
+  inputE2EScenarios,
+  readControlledStateFromWindow,
+  readEditableValue,
+  readInputStateFromWindow,
+  setEditableCaret,
+} from '../input-e2e-scenarios';
 import { test } from './fixture';
-
-type InputMode = 'replace' | 'clear' | 'typeOnly';
-
-type InputState = {
-  events: Array<{ id: string; type: string; value: string }>;
-  values: Record<string, string>;
-};
 
 type DirectLocate = {
   locatedPixelBbox: [number, number, number, number];
   prompt: string;
 };
 
-const inputAction = async (
-  agent: Agent,
-  param: {
-    keyboardTypeDelay?: number;
-    locate: DirectLocate;
-    mode: InputMode;
-    value: string;
-  },
-) => {
-  await agent.callActionInActionSpace('Input', param);
-};
+function findFrame(page: Page, mode: FrameMode): Frame {
+  const frame = page
+    .frames()
+    .find((candidate) => candidate.url().endsWith('/frame'));
+  if (!frame) throw new Error(`Missing ${mode} iframe`);
+  return frame;
+}
 
-const centerOf = async (
-  frame: Page | Frame,
-  selector: string,
+function contextForTarget(page: Page, target: InputTarget): Page | Frame {
+  return target.frame ? findFrame(page, target.frame) : page;
+}
+
+async function locateTarget(
+  page: Page,
+  target: InputTarget,
   description: string,
-): Promise<DirectLocate> => {
-  const box = await frame.locator(selector).boundingBox();
-  if (!box) throw new Error(`Missing bounding box: ${selector}`);
+): Promise<DirectLocate> {
+  const box = await contextForTarget(page, target)
+    .locator(target.selector)
+    .boundingBox();
+  if (!box) throw new Error(`Missing bounding box: ${target.selector}`);
   return {
     locatedPixelBbox: [box.x, box.y, box.x + box.width, box.y + box.height],
     prompt: description,
   };
-};
+}
+
+function createHarness(
+  page: Page,
+  agent: Agent,
+  aiAssert: (prompt: string) => Promise<unknown>,
+): InputScenarioHarness {
+  return {
+    aiAssert: async (prompt) => {
+      await aiAssert(prompt);
+    },
+    blur: async () => {
+      await page.locator('h1').click();
+    },
+    input: async (
+      target: InputTarget,
+      description: string,
+      action: InputAction,
+    ) => {
+      await agent.callActionInActionSpace('Input', {
+        ...action,
+        locate: await locateTarget(page, target, description),
+      });
+    },
+    isFrameSameOrigin: async (mode) => {
+      const frame = findFrame(page, mode);
+      return new URL(frame.url()).origin === new URL(page.url()).origin;
+    },
+    publicInput: async (prompt, value) => {
+      await agent.aiInput(prompt, { value });
+    },
+    readControlledState: () => page.evaluate(readControlledStateFromWindow),
+    readInputState: (frame) =>
+      (frame ? findFrame(page, frame) : page).evaluate(
+        readInputStateFromWindow,
+      ),
+    readValue: (target) =>
+      contextForTarget(page, target)
+        .locator(target.selector)
+        .evaluate(readEditableValue),
+    setCaret: async (target, offset) => {
+      await contextForTarget(page, target)
+        .locator(target.selector)
+        .evaluate(setEditableCaret, offset);
+    },
+  };
+}
 
 test.describe('comprehensive input actions in Playwright', () => {
-  let servers: Awaited<ReturnType<typeof startInputTestServers>>;
+  let servers: InputTestServers;
 
   test.beforeAll(async () => {
     servers = await startInputTestServers();
@@ -52,222 +104,11 @@ test.describe('comprehensive input actions in Playwright', () => {
     await servers?.close();
   });
 
-  test('replaces input, textarea, and contenteditable values and emits browser events', async ({
-    agentForPage,
-    aiAssert,
-    page,
-  }) => {
-    await page.goto(servers.topLevelUrl);
-    const agent = await agentForPage(page);
-
-    await inputAction(agent, {
-      locate: await centerOf(page, '#text-input', 'Text input'),
-      mode: 'replace',
-      value: 'Input replaced',
-    });
-    await inputAction(agent, {
-      locate: await centerOf(page, '#notes', 'Notes textarea'),
-      mode: 'replace',
-      value: 'Textarea replaced',
-    });
-    await inputAction(agent, {
-      locate: await centerOf(page, '#rich-editor', 'Rich text editor'),
-      mode: 'replace',
-      value: 'Rich text replaced',
-    });
-    await page.locator('h1').click();
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': 'Input replaced',
-      notes: 'Textarea replaced',
-      'rich-editor': 'Rich text replaced',
-    });
-    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await aiAssert(
-      'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
-    );
-  });
-
-  test('uses public aiInput to locate and replace a text input from its initial value', async ({
-    agentForPage,
-    aiAssert,
-    page,
-  }) => {
-    await page.goto(servers.topLevelUrl);
-    const agent = await agentForPage(page);
-
-    await expect(page.locator('#text-input')).toHaveValue('Alpha value');
-    await agent.aiInput('the text input labeled Text input', {
-      value: 'Public replacement complete',
-    });
-    await expect(page.locator('#text-input')).toHaveValue(
-      'Public replacement complete',
-    );
-    await aiAssert(
-      'The state summary shows Text input value: Public replacement complete.',
-    );
-  });
-
-  test('clears input, textarea, and contenteditable values and emits browser events', async ({
-    agentForPage,
-    aiAssert,
-    page,
-  }) => {
-    await page.goto(servers.topLevelUrl);
-    const agent = await agentForPage(page);
-
-    for (const [selector, description] of [
-      ['#text-input', 'Text input'],
-      ['#notes', 'Notes textarea'],
-      ['#rich-editor', 'Rich text editor'],
-    ] as const) {
-      await inputAction(agent, {
-        locate: await centerOf(page, selector, description),
-        mode: 'clear',
-        value: '',
-      });
-    }
-    await page.locator('h1').click();
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': '',
-      notes: '',
-      'rich-editor': '',
-    });
-    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await aiAssert(
-      'The state summary shows [empty] for the text input, textarea, and rich text editor, with non-zero beforeinput, input, and change event counts.',
-    );
-  });
-
-  test('inserts typeOnly text at the current caret in each editable field', async ({
-    agentForPage,
-    aiAssert,
-    page,
-  }) => {
-    await page.goto(servers.topLevelUrl);
-    const agent = await agentForPage(page);
-
-    const cases = [
-      ['#text-input', 'Text input'],
-      ['#notes', 'Notes textarea'],
-      ['#rich-editor', 'Rich text editor'],
-    ] as const;
-    for (const [selector, description] of cases) {
-      await page.locator(selector).evaluate((element) => {
-        (element as HTMLElement).focus();
-        if (
-          element instanceof HTMLInputElement ||
-          element instanceof HTMLTextAreaElement
-        ) {
-          element.setSelectionRange(5, 5);
-          return;
-        }
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.setStart(element.firstChild!, 5);
-        range.collapse(true);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      });
-      await inputAction(agent, {
-        locate: await centerOf(page, selector, description),
-        mode: 'typeOnly',
-        value: '[inserted]',
-      });
-    }
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': 'Alpha[inserted] value',
-      notes: 'Bravo[inserted] notes',
-      'rich-editor': 'Charl[inserted]ie rich text',
-    });
-    await aiAssert(
-      'The state summary shows the inserted marker in the middle of all three values: Alpha[inserted] value, Bravo[inserted] notes, and Charl[inserted]ie rich text.',
-    );
-  });
-
-  for (const mode of ['same-origin', 'cross-origin'] as const) {
-    test(`replaces and clears an input in a ${mode} iframe`, async ({
-      agentForPage,
-      aiAssert,
-      page,
-    }) => {
-      await page.goto(servers.iframeUrl(mode));
+  for (const scenario of inputE2EScenarios) {
+    test(scenario.name, async ({ agentForPage, aiAssert, page }) => {
+      await page.goto(scenario.url(servers));
       const agent = await agentForPage(page);
-      const frame = page
-        .frames()
-        .find((candidate) => candidate.url().endsWith('/frame'));
-      if (!frame) throw new Error(`Missing ${mode} iframe`);
-      expect(new URL(frame.url()).origin === new URL(page.url()).origin).toBe(
-        mode === 'same-origin',
-      );
-
-      await inputAction(agent, {
-        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
-        mode: 'replace',
-        value: `${mode} replacement`,
-      });
-      await expect(frame.locator('#frame-input')).toHaveValue(
-        `${mode} replacement`,
-      );
-      await aiAssert(
-        `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
-      );
-
-      await inputAction(agent, {
-        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
-        mode: 'clear',
-        value: '',
-      });
-      await expect(frame.locator('#frame-input')).toHaveValue('');
-      await aiAssert(
-        'Inside the iframe, the state summary shows Iframe input value: [empty].',
-      );
+      await scenario.run(createHarness(page, agent, aiAssert));
     });
   }
-
-  test('keeps every character when a controlled input is replaced after clearing', async ({
-    agentForPage,
-    aiAssert,
-    page,
-  }) => {
-    await page.goto(servers.controlledUrl);
-    const agent = await agentForPage(page);
-
-    await inputAction(agent, {
-      keyboardTypeDelay: 40,
-      locate: await centerOf(
-        page,
-        '#controlled-input',
-        'Controlled text input',
-      ),
-      mode: 'replace',
-      value: 'Stable controlled text',
-    });
-
-    const state = await page.evaluate(() =>
-      (window as any).__midsceneControlledState(),
-    );
-    expect(state).toEqual({
-      replacementCount: 1,
-      value: 'Stable controlled text',
-    });
-    await aiAssert(
-      'The controlled input summary shows Controlled value: Stable controlled text and Replacement count: 1.',
-    );
-  });
 });

--- a/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
@@ -103,13 +103,13 @@ test.describe('comprehensive input actions in Playwright', () => {
 
     await expect(page.locator('#text-input')).toHaveValue('Alpha value');
     await agent.aiInput('the text input labeled Text input', {
-      value: 'Public aiInput replacement',
+      value: 'Public replacement complete',
     });
     await expect(page.locator('#text-input')).toHaveValue(
-      'Public aiInput replacement',
+      'Public replacement complete',
     );
     await aiAssert(
-      'The state summary shows Text input value: Public aiInput replacement.',
+      'The state summary shows Text input value: Public replacement complete.',
     );
   });
 

--- a/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
@@ -1,5 +1,4 @@
-import { WebPage as PlaywrightWebPage } from '@/playwright/page';
-import type { ElementInfo } from '@midscene/shared/extractor';
+import type { Agent } from '@midscene/core/agent';
 import type { Frame, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { startInputTestServers } from '../input-e2e-page';
@@ -12,29 +11,34 @@ type InputState = {
   values: Record<string, string>;
 };
 
+type DirectLocate = {
+  locatedPixelBbox: [number, number, number, number];
+  prompt: string;
+};
+
 const inputAction = async (
-  webPage: PlaywrightWebPage,
+  agent: Agent,
   param: {
     keyboardTypeDelay?: number;
-    locate: ElementInfo;
+    locate: DirectLocate;
     mode: InputMode;
     value: string;
   },
 ) => {
-  const action = webPage.actionSpace().find(({ name }) => name === 'Input');
-  expect(action).toBeDefined();
-  await action!.call(param, {} as any);
+  await agent.callActionInActionSpace('Input', param);
 };
 
 const centerOf = async (
   frame: Page | Frame,
   selector: string,
-): Promise<ElementInfo> => {
+  description: string,
+): Promise<DirectLocate> => {
   const box = await frame.locator(selector).boundingBox();
   if (!box) throw new Error(`Missing bounding box: ${selector}`);
   return {
-    center: [box.x + box.width / 2, box.y + box.height / 2],
-  } as ElementInfo;
+    locatedPixelBbox: [box.x, box.y, box.x + box.width, box.y + box.height],
+    prompt: description,
+  };
 };
 
 test.describe('comprehensive input actions in Playwright', () => {
@@ -54,21 +58,20 @@ test.describe('comprehensive input actions in Playwright', () => {
     page,
   }) => {
     await page.goto(servers.topLevelUrl);
-    const webPage = new PlaywrightWebPage(page);
     const agent = await agentForPage(page);
 
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#text-input'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#text-input', 'Text input'),
       mode: 'replace',
       value: 'Input replaced',
     });
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#notes'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#notes', 'Notes textarea'),
       mode: 'replace',
       value: 'Textarea replaced',
     });
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#rich-editor'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#rich-editor', 'Rich text editor'),
       mode: 'replace',
       value: 'Rich text replaced',
     });
@@ -85,24 +88,46 @@ test.describe('comprehensive input actions in Playwright', () => {
     expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
     expect(state.events.some(({ type }) => type === 'input')).toBe(true);
     expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await agent.aiInput('the text input labeled Text input', {
-      value: 'Input replaced',
-    });
     await aiAssert(
       'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
     );
   });
 
-  test('clears input, textarea, and contenteditable values and emits browser events', async ({
+  test('uses public aiInput to locate and replace a text input from its initial value', async ({
+    agentForPage,
     aiAssert,
     page,
   }) => {
     await page.goto(servers.topLevelUrl);
-    const webPage = new PlaywrightWebPage(page);
+    const agent = await agentForPage(page);
 
-    for (const selector of ['#text-input', '#notes', '#rich-editor']) {
-      await inputAction(webPage, {
-        locate: await centerOf(page, selector),
+    await expect(page.locator('#text-input')).toHaveValue('Alpha value');
+    await agent.aiInput('the text input labeled Text input', {
+      value: 'Public aiInput replacement',
+    });
+    await expect(page.locator('#text-input')).toHaveValue(
+      'Public aiInput replacement',
+    );
+    await aiAssert(
+      'The state summary shows Text input value: Public aiInput replacement.',
+    );
+  });
+
+  test('clears input, textarea, and contenteditable values and emits browser events', async ({
+    agentForPage,
+    aiAssert,
+    page,
+  }) => {
+    await page.goto(servers.topLevelUrl);
+    const agent = await agentForPage(page);
+
+    for (const [selector, description] of [
+      ['#text-input', 'Text input'],
+      ['#notes', 'Notes textarea'],
+      ['#rich-editor', 'Rich text editor'],
+    ] as const) {
+      await inputAction(agent, {
+        locate: await centerOf(page, selector, description),
         mode: 'clear',
         value: '',
       });
@@ -126,14 +151,19 @@ test.describe('comprehensive input actions in Playwright', () => {
   });
 
   test('inserts typeOnly text at the current caret in each editable field', async ({
+    agentForPage,
     aiAssert,
     page,
   }) => {
     await page.goto(servers.topLevelUrl);
-    const webPage = new PlaywrightWebPage(page);
+    const agent = await agentForPage(page);
 
-    const selectors = ['#text-input', '#notes', '#rich-editor'];
-    for (const selector of selectors) {
+    const cases = [
+      ['#text-input', 'Text input'],
+      ['#notes', 'Notes textarea'],
+      ['#rich-editor', 'Rich text editor'],
+    ] as const;
+    for (const [selector, description] of cases) {
       await page.locator(selector).evaluate((element) => {
         (element as HTMLElement).focus();
         if (
@@ -150,8 +180,8 @@ test.describe('comprehensive input actions in Playwright', () => {
         selection?.removeAllRanges();
         selection?.addRange(range);
       });
-      await inputAction(webPage, {
-        locate: await centerOf(page, selector),
+      await inputAction(agent, {
+        locate: await centerOf(page, selector, description),
         mode: 'typeOnly',
         value: '[inserted]',
       });
@@ -172,11 +202,12 @@ test.describe('comprehensive input actions in Playwright', () => {
 
   for (const mode of ['same-origin', 'cross-origin'] as const) {
     test(`replaces and clears an input in a ${mode} iframe`, async ({
+      agentForPage,
       aiAssert,
       page,
     }) => {
       await page.goto(servers.iframeUrl(mode));
-      const webPage = new PlaywrightWebPage(page);
+      const agent = await agentForPage(page);
       const frame = page
         .frames()
         .find((candidate) => candidate.url().endsWith('/frame'));
@@ -185,8 +216,8 @@ test.describe('comprehensive input actions in Playwright', () => {
         mode === 'same-origin',
       );
 
-      await inputAction(webPage, {
-        locate: await centerOf(frame, '#frame-input'),
+      await inputAction(agent, {
+        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
         mode: 'replace',
         value: `${mode} replacement`,
       });
@@ -197,8 +228,8 @@ test.describe('comprehensive input actions in Playwright', () => {
         `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
       );
 
-      await inputAction(webPage, {
-        locate: await centerOf(frame, '#frame-input'),
+      await inputAction(agent, {
+        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
         mode: 'clear',
         value: '',
       });
@@ -210,15 +241,20 @@ test.describe('comprehensive input actions in Playwright', () => {
   }
 
   test('keeps every character when a controlled input is replaced after clearing', async ({
+    agentForPage,
     aiAssert,
     page,
   }) => {
     await page.goto(servers.controlledUrl);
-    const webPage = new PlaywrightWebPage(page);
+    const agent = await agentForPage(page);
 
-    await inputAction(webPage, {
+    await inputAction(agent, {
       keyboardTypeDelay: 40,
-      locate: await centerOf(page, '#controlled-input'),
+      locate: await centerOf(
+        page,
+        '#controlled-input',
+        'Controlled text input',
+      ),
       mode: 'replace',
       value: 'Stable controlled text',
     });

--- a/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/input-comprehensive.spec.ts
@@ -1,0 +1,237 @@
+import { WebPage as PlaywrightWebPage } from '@/playwright/page';
+import type { ElementInfo } from '@midscene/shared/extractor';
+import type { Frame, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { startInputTestServers } from '../input-e2e-page';
+import { test } from './fixture';
+
+type InputMode = 'replace' | 'clear' | 'typeOnly';
+
+type InputState = {
+  events: Array<{ id: string; type: string; value: string }>;
+  values: Record<string, string>;
+};
+
+const inputAction = async (
+  webPage: PlaywrightWebPage,
+  param: {
+    keyboardTypeDelay?: number;
+    locate: ElementInfo;
+    mode: InputMode;
+    value: string;
+  },
+) => {
+  const action = webPage.actionSpace().find(({ name }) => name === 'Input');
+  expect(action).toBeDefined();
+  await action!.call(param, {} as any);
+};
+
+const centerOf = async (
+  frame: Page | Frame,
+  selector: string,
+): Promise<ElementInfo> => {
+  const box = await frame.locator(selector).boundingBox();
+  if (!box) throw new Error(`Missing bounding box: ${selector}`);
+  return {
+    center: [box.x + box.width / 2, box.y + box.height / 2],
+  } as ElementInfo;
+};
+
+test.describe('comprehensive input actions in Playwright', () => {
+  let servers: Awaited<ReturnType<typeof startInputTestServers>>;
+
+  test.beforeAll(async () => {
+    servers = await startInputTestServers();
+  });
+
+  test.afterAll(async () => {
+    await servers?.close();
+  });
+
+  test('replaces input, textarea, and contenteditable values and emits browser events', async ({
+    agentForPage,
+    aiAssert,
+    page,
+  }) => {
+    await page.goto(servers.topLevelUrl);
+    const webPage = new PlaywrightWebPage(page);
+    const agent = await agentForPage(page);
+
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#text-input'),
+      mode: 'replace',
+      value: 'Input replaced',
+    });
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#notes'),
+      mode: 'replace',
+      value: 'Textarea replaced',
+    });
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#rich-editor'),
+      mode: 'replace',
+      value: 'Rich text replaced',
+    });
+    await page.locator('h1').click();
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': 'Input replaced',
+      notes: 'Textarea replaced',
+      'rich-editor': 'Rich text replaced',
+    });
+    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
+    await agent.aiInput('the text input labeled Text input', {
+      value: 'Input replaced',
+    });
+    await aiAssert(
+      'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
+    );
+  });
+
+  test('clears input, textarea, and contenteditable values and emits browser events', async ({
+    aiAssert,
+    page,
+  }) => {
+    await page.goto(servers.topLevelUrl);
+    const webPage = new PlaywrightWebPage(page);
+
+    for (const selector of ['#text-input', '#notes', '#rich-editor']) {
+      await inputAction(webPage, {
+        locate: await centerOf(page, selector),
+        mode: 'clear',
+        value: '',
+      });
+    }
+    await page.locator('h1').click();
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': '',
+      notes: '',
+      'rich-editor': '',
+    });
+    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
+    await aiAssert(
+      'The state summary shows [empty] for the text input, textarea, and rich text editor, with non-zero beforeinput, input, and change event counts.',
+    );
+  });
+
+  test('inserts typeOnly text at the current caret in each editable field', async ({
+    aiAssert,
+    page,
+  }) => {
+    await page.goto(servers.topLevelUrl);
+    const webPage = new PlaywrightWebPage(page);
+
+    const selectors = ['#text-input', '#notes', '#rich-editor'];
+    for (const selector of selectors) {
+      await page.locator(selector).evaluate((element) => {
+        (element as HTMLElement).focus();
+        if (
+          element instanceof HTMLInputElement ||
+          element instanceof HTMLTextAreaElement
+        ) {
+          element.setSelectionRange(5, 5);
+          return;
+        }
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.setStart(element.firstChild!, 5);
+        range.collapse(true);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+      await inputAction(webPage, {
+        locate: await centerOf(page, selector),
+        mode: 'typeOnly',
+        value: '[inserted]',
+      });
+    }
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': 'Alpha[inserted] value',
+      notes: 'Bravo[inserted] notes',
+      'rich-editor': 'Charl[inserted]ie rich text',
+    });
+    await aiAssert(
+      'The state summary shows the inserted marker in the middle of all three values: Alpha[inserted] value, Bravo[inserted] notes, and Charl[inserted]ie rich text.',
+    );
+  });
+
+  for (const mode of ['same-origin', 'cross-origin'] as const) {
+    test(`replaces and clears an input in a ${mode} iframe`, async ({
+      aiAssert,
+      page,
+    }) => {
+      await page.goto(servers.iframeUrl(mode));
+      const webPage = new PlaywrightWebPage(page);
+      const frame = page
+        .frames()
+        .find((candidate) => candidate.url().endsWith('/frame'));
+      if (!frame) throw new Error(`Missing ${mode} iframe`);
+      expect(new URL(frame.url()).origin === new URL(page.url()).origin).toBe(
+        mode === 'same-origin',
+      );
+
+      await inputAction(webPage, {
+        locate: await centerOf(frame, '#frame-input'),
+        mode: 'replace',
+        value: `${mode} replacement`,
+      });
+      await expect(frame.locator('#frame-input')).toHaveValue(
+        `${mode} replacement`,
+      );
+      await aiAssert(
+        `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
+      );
+
+      await inputAction(webPage, {
+        locate: await centerOf(frame, '#frame-input'),
+        mode: 'clear',
+        value: '',
+      });
+      await expect(frame.locator('#frame-input')).toHaveValue('');
+      await aiAssert(
+        'Inside the iframe, the state summary shows Iframe input value: [empty].',
+      );
+    });
+  }
+
+  test('keeps every character when a controlled input is replaced after clearing', async ({
+    aiAssert,
+    page,
+  }) => {
+    await page.goto(servers.controlledUrl);
+    const webPage = new PlaywrightWebPage(page);
+
+    await inputAction(webPage, {
+      keyboardTypeDelay: 40,
+      locate: await centerOf(page, '#controlled-input'),
+      mode: 'replace',
+      value: 'Stable controlled text',
+    });
+
+    const state = await page.evaluate(() =>
+      (window as any).__midsceneControlledState(),
+    );
+    expect(state).toEqual({
+      replacementCount: 1,
+      value: 'Stable controlled text',
+    });
+    await aiAssert(
+      'The controlled input summary shows Controlled value: Stable controlled text and Replacement count: 1.',
+    );
+  });
+});

--- a/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
@@ -1,6 +1,4 @@
 import { PuppeteerAgent } from '@/puppeteer';
-import { PuppeteerWebPage } from '@/puppeteer/page';
-import type { ElementInfo } from '@midscene/shared/extractor';
 import puppeteer, { type Browser, type Frame, type Page } from 'puppeteer';
 import {
   afterAll,
@@ -22,31 +20,36 @@ type InputState = {
   values: Record<string, string>;
 };
 
+type DirectLocate = {
+  locatedPixelBbox: [number, number, number, number];
+  prompt: string;
+};
+
 const inputAction = async (
-  webPage: PuppeteerWebPage,
+  agent: PuppeteerAgent,
   param: {
     keyboardTypeDelay?: number;
-    locate: ElementInfo;
+    locate: DirectLocate;
     mode: InputMode;
     value: string;
   },
 ) => {
-  const action = webPage.actionSpace().find(({ name }) => name === 'Input');
-  expect(action).toBeDefined();
-  await action!.call(param, {} as any);
+  await agent.callActionInActionSpace('Input', param);
 };
 
 const centerOf = async (
   frame: Page | Frame,
   selector: string,
-): Promise<ElementInfo> => {
+  description: string,
+): Promise<DirectLocate> => {
   const element = await frame.$(selector);
   if (!element) throw new Error(`Missing element: ${selector}`);
   const box = await element.boundingBox();
   if (!box) throw new Error(`Missing bounding box: ${selector}`);
   return {
-    center: [box.x + box.width / 2, box.y + box.height / 2],
-  } as ElementInfo;
+    locatedPixelBbox: [box.x, box.y, box.x + box.width, box.y + box.height],
+    prompt: description,
+  };
 };
 
 describe('comprehensive input actions in Puppeteer', () => {
@@ -79,20 +82,19 @@ describe('comprehensive input actions in Puppeteer', () => {
     page = await browser.newPage();
     await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
     agent = new PuppeteerAgent(page);
-    const webPage = new PuppeteerWebPage(page);
 
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#text-input'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#text-input', 'Text input'),
       mode: 'replace',
       value: 'Input replaced',
     });
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#notes'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#notes', 'Notes textarea'),
       mode: 'replace',
       value: 'Textarea replaced',
     });
-    await inputAction(webPage, {
-      locate: await centerOf(page, '#rich-editor'),
+    await inputAction(agent, {
+      locate: await centerOf(page, '#rich-editor', 'Rich text editor'),
       mode: 'replace',
       value: 'Rich text replaced',
     });
@@ -109,11 +111,33 @@ describe('comprehensive input actions in Puppeteer', () => {
     expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
     expect(state.events.some(({ type }) => type === 'input')).toBe(true);
     expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await agent.aiInput('the text input labeled Text input', {
-      value: 'Input replaced',
-    });
     await agent.aiAssert(
       'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
+    );
+  });
+
+  it('uses public aiInput to locate and replace a text input from its initial value', async () => {
+    page = await browser.newPage();
+    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
+    agent = new PuppeteerAgent(page);
+
+    expect(
+      await page.$eval(
+        '#text-input',
+        (element) => (element as HTMLInputElement).value,
+      ),
+    ).toBe('Alpha value');
+    await agent.aiInput('the text input labeled Text input', {
+      value: 'Public aiInput replacement',
+    });
+    expect(
+      await page.$eval(
+        '#text-input',
+        (element) => (element as HTMLInputElement).value,
+      ),
+    ).toBe('Public aiInput replacement');
+    await agent.aiAssert(
+      'The state summary shows Text input value: Public aiInput replacement.',
     );
   });
 
@@ -121,11 +145,14 @@ describe('comprehensive input actions in Puppeteer', () => {
     page = await browser.newPage();
     await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
     agent = new PuppeteerAgent(page);
-    const webPage = new PuppeteerWebPage(page);
 
-    for (const selector of ['#text-input', '#notes', '#rich-editor']) {
-      await inputAction(webPage, {
-        locate: await centerOf(page, selector),
+    for (const [selector, description] of [
+      ['#text-input', 'Text input'],
+      ['#notes', 'Notes textarea'],
+      ['#rich-editor', 'Rich text editor'],
+    ] as const) {
+      await inputAction(agent, {
+        locate: await centerOf(page, selector, description),
         mode: 'clear',
         value: '',
       });
@@ -152,14 +179,13 @@ describe('comprehensive input actions in Puppeteer', () => {
     page = await browser.newPage();
     await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
     agent = new PuppeteerAgent(page);
-    const webPage = new PuppeteerWebPage(page);
 
     const cases = [
-      ['#text-input', 'text-input'],
-      ['#notes', 'notes'],
-      ['#rich-editor', 'rich-editor'],
+      ['#text-input', 'Text input'],
+      ['#notes', 'Notes textarea'],
+      ['#rich-editor', 'Rich text editor'],
     ] as const;
-    for (const [selector] of cases) {
+    for (const [selector, description] of cases) {
       await page.$eval(selector, (element) => {
         (element as HTMLElement).focus();
         if (
@@ -176,8 +202,8 @@ describe('comprehensive input actions in Puppeteer', () => {
         selection?.removeAllRanges();
         selection?.addRange(range);
       });
-      await inputAction(webPage, {
-        locate: await centerOf(page, selector),
+      await inputAction(agent, {
+        locate: await centerOf(page, selector, description),
         mode: 'typeOnly',
         value: '[inserted]',
       });
@@ -202,7 +228,6 @@ describe('comprehensive input actions in Puppeteer', () => {
       page = await browser.newPage();
       await page.goto(servers.iframeUrl(mode), { waitUntil: 'networkidle0' });
       agent = new PuppeteerAgent(page);
-      const webPage = new PuppeteerWebPage(page);
       const frame = page
         .frames()
         .find((candidate) => candidate.url().endsWith('/frame'));
@@ -211,8 +236,8 @@ describe('comprehensive input actions in Puppeteer', () => {
         mode === 'same-origin',
       );
 
-      await inputAction(webPage, {
-        locate: await centerOf(frame, '#frame-input'),
+      await inputAction(agent, {
+        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
         mode: 'replace',
         value: `${mode} replacement`,
       });
@@ -226,8 +251,8 @@ describe('comprehensive input actions in Puppeteer', () => {
         `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
       );
 
-      await inputAction(webPage, {
-        locate: await centerOf(frame, '#frame-input'),
+      await inputAction(agent, {
+        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
         mode: 'clear',
         value: '',
       });
@@ -247,11 +272,14 @@ describe('comprehensive input actions in Puppeteer', () => {
     page = await browser.newPage();
     await page.goto(servers.controlledUrl, { waitUntil: 'networkidle0' });
     agent = new PuppeteerAgent(page);
-    const webPage = new PuppeteerWebPage(page);
 
-    await inputAction(webPage, {
+    await inputAction(agent, {
       keyboardTypeDelay: 40,
-      locate: await centerOf(page, '#controlled-input'),
+      locate: await centerOf(
+        page,
+        '#controlled-input',
+        'Controlled text input',
+      ),
       mode: 'replace',
       value: 'Stable controlled text',
     });

--- a/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
@@ -1,5 +1,4 @@
 import { PuppeteerAgent } from '@/puppeteer';
-import puppeteer, { type Browser, type Frame, type Page } from 'puppeteer';
 import {
   afterAll,
   afterEach,
@@ -7,11 +6,12 @@ import {
   describe,
   expect,
   it,
-  vi,
-} from 'vitest';
+  rs,
+} from '@rstest/core';
+import puppeteer, { type Browser, type Frame, type Page } from 'puppeteer';
 import { startInputTestServers } from '../input-e2e-page';
 
-vi.setConfig({ testTimeout: 180_000 });
+rs.setConfig({ testTimeout: 180_000 });
 
 type InputMode = 'replace' | 'clear' | 'typeOnly';
 

--- a/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
@@ -128,16 +128,16 @@ describe('comprehensive input actions in Puppeteer', () => {
       ),
     ).toBe('Alpha value');
     await agent.aiInput('the text input labeled Text input', {
-      value: 'Public aiInput replacement',
+      value: 'Public replacement complete',
     });
     expect(
       await page.$eval(
         '#text-input',
         (element) => (element as HTMLInputElement).value,
       ),
-    ).toBe('Public aiInput replacement');
+    ).toBe('Public replacement complete');
     await agent.aiAssert(
-      'The state summary shows Text input value: Public aiInput replacement.',
+      'The state summary shows Text input value: Public replacement complete.',
     );
   });
 

--- a/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
@@ -1,0 +1,270 @@
+import { PuppeteerAgent } from '@/puppeteer';
+import { PuppeteerWebPage } from '@/puppeteer/page';
+import type { ElementInfo } from '@midscene/shared/extractor';
+import puppeteer, { type Browser, type Frame, type Page } from 'puppeteer';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { startInputTestServers } from '../input-e2e-page';
+
+vi.setConfig({ testTimeout: 180_000 });
+
+type InputMode = 'replace' | 'clear' | 'typeOnly';
+
+type InputState = {
+  events: Array<{ id: string; type: string; value: string }>;
+  values: Record<string, string>;
+};
+
+const inputAction = async (
+  webPage: PuppeteerWebPage,
+  param: {
+    keyboardTypeDelay?: number;
+    locate: ElementInfo;
+    mode: InputMode;
+    value: string;
+  },
+) => {
+  const action = webPage.actionSpace().find(({ name }) => name === 'Input');
+  expect(action).toBeDefined();
+  await action!.call(param, {} as any);
+};
+
+const centerOf = async (
+  frame: Page | Frame,
+  selector: string,
+): Promise<ElementInfo> => {
+  const element = await frame.$(selector);
+  if (!element) throw new Error(`Missing element: ${selector}`);
+  const box = await element.boundingBox();
+  if (!box) throw new Error(`Missing bounding box: ${selector}`);
+  return {
+    center: [box.x + box.width / 2, box.y + box.height / 2],
+  } as ElementInfo;
+};
+
+describe('comprehensive input actions in Puppeteer', () => {
+  let agent: PuppeteerAgent | undefined;
+  let browser: Browser;
+  let page: Page | undefined;
+  let servers: Awaited<ReturnType<typeof startInputTestServers>>;
+
+  beforeAll(async () => {
+    servers = await startInputTestServers();
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+  });
+
+  afterEach(async () => {
+    await agent?.destroy();
+    agent = undefined;
+    await page?.close();
+    page = undefined;
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await servers?.close();
+  });
+
+  it('replaces input, textarea, and contenteditable values and emits browser events', async () => {
+    page = await browser.newPage();
+    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
+    agent = new PuppeteerAgent(page);
+    const webPage = new PuppeteerWebPage(page);
+
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#text-input'),
+      mode: 'replace',
+      value: 'Input replaced',
+    });
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#notes'),
+      mode: 'replace',
+      value: 'Textarea replaced',
+    });
+    await inputAction(webPage, {
+      locate: await centerOf(page, '#rich-editor'),
+      mode: 'replace',
+      value: 'Rich text replaced',
+    });
+    await page.click('h1');
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': 'Input replaced',
+      notes: 'Textarea replaced',
+      'rich-editor': 'Rich text replaced',
+    });
+    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
+    await agent.aiInput('the text input labeled Text input', {
+      value: 'Input replaced',
+    });
+    await agent.aiAssert(
+      'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
+    );
+  });
+
+  it('clears input, textarea, and contenteditable values and emits browser events', async () => {
+    page = await browser.newPage();
+    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
+    agent = new PuppeteerAgent(page);
+    const webPage = new PuppeteerWebPage(page);
+
+    for (const selector of ['#text-input', '#notes', '#rich-editor']) {
+      await inputAction(webPage, {
+        locate: await centerOf(page, selector),
+        mode: 'clear',
+        value: '',
+      });
+    }
+    await page.click('h1');
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': '',
+      notes: '',
+      'rich-editor': '',
+    });
+    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
+    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
+    await agent.aiAssert(
+      'The state summary shows [empty] for the text input, textarea, and rich text editor, with non-zero beforeinput, input, and change event counts.',
+    );
+  });
+
+  it('inserts typeOnly text at the current caret in each editable field', async () => {
+    page = await browser.newPage();
+    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
+    agent = new PuppeteerAgent(page);
+    const webPage = new PuppeteerWebPage(page);
+
+    const cases = [
+      ['#text-input', 'text-input'],
+      ['#notes', 'notes'],
+      ['#rich-editor', 'rich-editor'],
+    ] as const;
+    for (const [selector] of cases) {
+      await page.$eval(selector, (element) => {
+        (element as HTMLElement).focus();
+        if (
+          element instanceof HTMLInputElement ||
+          element instanceof HTMLTextAreaElement
+        ) {
+          element.setSelectionRange(5, 5);
+          return;
+        }
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.setStart(element.firstChild!, 5);
+        range.collapse(true);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+      await inputAction(webPage, {
+        locate: await centerOf(page, selector),
+        mode: 'typeOnly',
+        value: '[inserted]',
+      });
+    }
+
+    const state = await page.evaluate(
+      () => (window as any).__midsceneInputState() as InputState,
+    );
+    expect(state.values).toEqual({
+      'text-input': 'Alpha[inserted] value',
+      notes: 'Bravo[inserted] notes',
+      'rich-editor': 'Charl[inserted]ie rich text',
+    });
+    await agent.aiAssert(
+      'The state summary shows the inserted marker in the middle of all three values: Alpha[inserted] value, Bravo[inserted] notes, and Charl[inserted]ie rich text.',
+    );
+  });
+
+  it.each(['same-origin', 'cross-origin'] as const)(
+    'replaces and clears an input in a %s iframe',
+    async (mode) => {
+      page = await browser.newPage();
+      await page.goto(servers.iframeUrl(mode), { waitUntil: 'networkidle0' });
+      agent = new PuppeteerAgent(page);
+      const webPage = new PuppeteerWebPage(page);
+      const frame = page
+        .frames()
+        .find((candidate) => candidate.url().endsWith('/frame'));
+      if (!frame) throw new Error(`Missing ${mode} iframe`);
+      expect(new URL(frame.url()).origin === new URL(page.url()).origin).toBe(
+        mode === 'same-origin',
+      );
+
+      await inputAction(webPage, {
+        locate: await centerOf(frame, '#frame-input'),
+        mode: 'replace',
+        value: `${mode} replacement`,
+      });
+      expect(
+        await frame.$eval(
+          '#frame-input',
+          (element) => (element as HTMLInputElement).value,
+        ),
+      ).toBe(`${mode} replacement`);
+      await agent.aiAssert(
+        `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
+      );
+
+      await inputAction(webPage, {
+        locate: await centerOf(frame, '#frame-input'),
+        mode: 'clear',
+        value: '',
+      });
+      expect(
+        await frame.$eval(
+          '#frame-input',
+          (element) => (element as HTMLInputElement).value,
+        ),
+      ).toBe('');
+      await agent.aiAssert(
+        'Inside the iframe, the state summary shows Iframe input value: [empty].',
+      );
+    },
+  );
+
+  it('keeps every character when a controlled input is replaced after clearing', async () => {
+    page = await browser.newPage();
+    await page.goto(servers.controlledUrl, { waitUntil: 'networkidle0' });
+    agent = new PuppeteerAgent(page);
+    const webPage = new PuppeteerWebPage(page);
+
+    await inputAction(webPage, {
+      keyboardTypeDelay: 40,
+      locate: await centerOf(page, '#controlled-input'),
+      mode: 'replace',
+      value: 'Stable controlled text',
+    });
+
+    const state = await page.evaluate(() =>
+      (window as any).__midsceneControlledState(),
+    );
+    expect(state).toEqual({
+      replacementCount: 1,
+      value: 'Stable controlled text',
+    });
+    await agent.aiAssert(
+      'The controlled input summary shows Controlled value: Stable controlled text and Replacement count: 1.',
+    );
+  });
+});

--- a/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/input-comprehensive.test.ts
@@ -1,62 +1,105 @@
 import { PuppeteerAgent } from '@/puppeteer';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  rs,
-} from '@rstest/core';
+import { afterAll, afterEach, beforeAll, describe, it, rs } from '@rstest/core';
 import puppeteer, { type Browser, type Frame, type Page } from 'puppeteer';
+import type { InputTestServers } from '../input-e2e-page';
 import { startInputTestServers } from '../input-e2e-page';
+import {
+  type FrameMode,
+  type InputAction,
+  type InputScenarioHarness,
+  type InputTarget,
+  inputE2EScenarios,
+  readControlledStateFromWindow,
+  readEditableValue,
+  readInputStateFromWindow,
+  setEditableCaret,
+} from '../input-e2e-scenarios';
 
 rs.setConfig({ testTimeout: 180_000 });
-
-type InputMode = 'replace' | 'clear' | 'typeOnly';
-
-type InputState = {
-  events: Array<{ id: string; type: string; value: string }>;
-  values: Record<string, string>;
-};
 
 type DirectLocate = {
   locatedPixelBbox: [number, number, number, number];
   prompt: string;
 };
 
-const inputAction = async (
-  agent: PuppeteerAgent,
-  param: {
-    keyboardTypeDelay?: number;
-    locate: DirectLocate;
-    mode: InputMode;
-    value: string;
-  },
-) => {
-  await agent.callActionInActionSpace('Input', param);
-};
+function findFrame(page: Page, mode: FrameMode): Frame {
+  const frame = page
+    .frames()
+    .find((candidate) => candidate.url().endsWith('/frame'));
+  if (!frame) throw new Error(`Missing ${mode} iframe`);
+  return frame;
+}
 
-const centerOf = async (
-  frame: Page | Frame,
-  selector: string,
+function contextForTarget(page: Page, target: InputTarget): Page | Frame {
+  return target.frame ? findFrame(page, target.frame) : page;
+}
+
+async function locateTarget(
+  page: Page,
+  target: InputTarget,
   description: string,
-): Promise<DirectLocate> => {
-  const element = await frame.$(selector);
-  if (!element) throw new Error(`Missing element: ${selector}`);
+): Promise<DirectLocate> {
+  const context = contextForTarget(page, target);
+  const element = await context.$(target.selector);
+  if (!element) throw new Error(`Missing element: ${target.selector}`);
   const box = await element.boundingBox();
-  if (!box) throw new Error(`Missing bounding box: ${selector}`);
+  if (!box) throw new Error(`Missing bounding box: ${target.selector}`);
   return {
     locatedPixelBbox: [box.x, box.y, box.x + box.width, box.y + box.height],
     prompt: description,
   };
-};
+}
+
+function createHarness(
+  page: Page,
+  agent: PuppeteerAgent,
+): InputScenarioHarness {
+  return {
+    aiAssert: async (prompt) => {
+      await agent.aiAssert(prompt);
+    },
+    blur: async () => {
+      await page.click('h1');
+    },
+    input: async (
+      target: InputTarget,
+      description: string,
+      action: InputAction,
+    ) => {
+      await agent.callActionInActionSpace('Input', {
+        ...action,
+        locate: await locateTarget(page, target, description),
+      });
+    },
+    isFrameSameOrigin: async (mode) => {
+      const frame = findFrame(page, mode);
+      return new URL(frame.url()).origin === new URL(page.url()).origin;
+    },
+    publicInput: async (prompt, value) => {
+      await agent.aiInput(prompt, { value });
+    },
+    readControlledState: () => page.evaluate(readControlledStateFromWindow),
+    readInputState: (frame) =>
+      (frame ? findFrame(page, frame) : page).evaluate(
+        readInputStateFromWindow,
+      ),
+    readValue: (target) =>
+      contextForTarget(page, target).$eval(target.selector, readEditableValue),
+    setCaret: async (target, offset) => {
+      await contextForTarget(page, target).$eval(
+        target.selector,
+        setEditableCaret,
+        offset,
+      );
+    },
+  };
+}
 
 describe('comprehensive input actions in Puppeteer', () => {
   let agent: PuppeteerAgent | undefined;
   let browser: Browser;
   let page: Page | undefined;
-  let servers: Awaited<ReturnType<typeof startInputTestServers>>;
+  let servers: InputTestServers;
 
   beforeAll(async () => {
     servers = await startInputTestServers();
@@ -78,221 +121,12 @@ describe('comprehensive input actions in Puppeteer', () => {
     await servers?.close();
   });
 
-  it('replaces input, textarea, and contenteditable values and emits browser events', async () => {
-    page = await browser.newPage();
-    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
-    agent = new PuppeteerAgent(page);
-
-    await inputAction(agent, {
-      locate: await centerOf(page, '#text-input', 'Text input'),
-      mode: 'replace',
-      value: 'Input replaced',
-    });
-    await inputAction(agent, {
-      locate: await centerOf(page, '#notes', 'Notes textarea'),
-      mode: 'replace',
-      value: 'Textarea replaced',
-    });
-    await inputAction(agent, {
-      locate: await centerOf(page, '#rich-editor', 'Rich text editor'),
-      mode: 'replace',
-      value: 'Rich text replaced',
-    });
-    await page.click('h1');
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': 'Input replaced',
-      notes: 'Textarea replaced',
-      'rich-editor': 'Rich text replaced',
-    });
-    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await agent.aiAssert(
-      'The state summary shows Text input value: Input replaced, Textarea value: Textarea replaced, and Rich text value: Rich text replaced. It also shows non-zero beforeinput, input, and change event counts.',
-    );
-  });
-
-  it('uses public aiInput to locate and replace a text input from its initial value', async () => {
-    page = await browser.newPage();
-    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
-    agent = new PuppeteerAgent(page);
-
-    expect(
-      await page.$eval(
-        '#text-input',
-        (element) => (element as HTMLInputElement).value,
-      ),
-    ).toBe('Alpha value');
-    await agent.aiInput('the text input labeled Text input', {
-      value: 'Public replacement complete',
-    });
-    expect(
-      await page.$eval(
-        '#text-input',
-        (element) => (element as HTMLInputElement).value,
-      ),
-    ).toBe('Public replacement complete');
-    await agent.aiAssert(
-      'The state summary shows Text input value: Public replacement complete.',
-    );
-  });
-
-  it('clears input, textarea, and contenteditable values and emits browser events', async () => {
-    page = await browser.newPage();
-    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
-    agent = new PuppeteerAgent(page);
-
-    for (const [selector, description] of [
-      ['#text-input', 'Text input'],
-      ['#notes', 'Notes textarea'],
-      ['#rich-editor', 'Rich text editor'],
-    ] as const) {
-      await inputAction(agent, {
-        locate: await centerOf(page, selector, description),
-        mode: 'clear',
-        value: '',
-      });
-    }
-    await page.click('h1');
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': '',
-      notes: '',
-      'rich-editor': '',
-    });
-    expect(state.events.some(({ type }) => type === 'beforeinput')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'input')).toBe(true);
-    expect(state.events.some(({ type }) => type === 'change')).toBe(true);
-    await agent.aiAssert(
-      'The state summary shows [empty] for the text input, textarea, and rich text editor, with non-zero beforeinput, input, and change event counts.',
-    );
-  });
-
-  it('inserts typeOnly text at the current caret in each editable field', async () => {
-    page = await browser.newPage();
-    await page.goto(servers.topLevelUrl, { waitUntil: 'networkidle0' });
-    agent = new PuppeteerAgent(page);
-
-    const cases = [
-      ['#text-input', 'Text input'],
-      ['#notes', 'Notes textarea'],
-      ['#rich-editor', 'Rich text editor'],
-    ] as const;
-    for (const [selector, description] of cases) {
-      await page.$eval(selector, (element) => {
-        (element as HTMLElement).focus();
-        if (
-          element instanceof HTMLInputElement ||
-          element instanceof HTMLTextAreaElement
-        ) {
-          element.setSelectionRange(5, 5);
-          return;
-        }
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.setStart(element.firstChild!, 5);
-        range.collapse(true);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      });
-      await inputAction(agent, {
-        locate: await centerOf(page, selector, description),
-        mode: 'typeOnly',
-        value: '[inserted]',
-      });
-    }
-
-    const state = await page.evaluate(
-      () => (window as any).__midsceneInputState() as InputState,
-    );
-    expect(state.values).toEqual({
-      'text-input': 'Alpha[inserted] value',
-      notes: 'Bravo[inserted] notes',
-      'rich-editor': 'Charl[inserted]ie rich text',
-    });
-    await agent.aiAssert(
-      'The state summary shows the inserted marker in the middle of all three values: Alpha[inserted] value, Bravo[inserted] notes, and Charl[inserted]ie rich text.',
-    );
-  });
-
-  it.each(['same-origin', 'cross-origin'] as const)(
-    'replaces and clears an input in a %s iframe',
-    async (mode) => {
+  for (const scenario of inputE2EScenarios) {
+    it(scenario.name, async () => {
       page = await browser.newPage();
-      await page.goto(servers.iframeUrl(mode), { waitUntil: 'networkidle0' });
+      await page.goto(scenario.url(servers), { waitUntil: 'networkidle0' });
       agent = new PuppeteerAgent(page);
-      const frame = page
-        .frames()
-        .find((candidate) => candidate.url().endsWith('/frame'));
-      if (!frame) throw new Error(`Missing ${mode} iframe`);
-      expect(new URL(frame.url()).origin === new URL(page.url()).origin).toBe(
-        mode === 'same-origin',
-      );
-
-      await inputAction(agent, {
-        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
-        mode: 'replace',
-        value: `${mode} replacement`,
-      });
-      expect(
-        await frame.$eval(
-          '#frame-input',
-          (element) => (element as HTMLInputElement).value,
-        ),
-      ).toBe(`${mode} replacement`);
-      await agent.aiAssert(
-        `Inside the iframe, the state summary shows Iframe input value: ${mode} replacement.`,
-      );
-
-      await inputAction(agent, {
-        locate: await centerOf(frame, '#frame-input', `${mode} iframe input`),
-        mode: 'clear',
-        value: '',
-      });
-      expect(
-        await frame.$eval(
-          '#frame-input',
-          (element) => (element as HTMLInputElement).value,
-        ),
-      ).toBe('');
-      await agent.aiAssert(
-        'Inside the iframe, the state summary shows Iframe input value: [empty].',
-      );
-    },
-  );
-
-  it('keeps every character when a controlled input is replaced after clearing', async () => {
-    page = await browser.newPage();
-    await page.goto(servers.controlledUrl, { waitUntil: 'networkidle0' });
-    agent = new PuppeteerAgent(page);
-
-    await inputAction(agent, {
-      keyboardTypeDelay: 40,
-      locate: await centerOf(
-        page,
-        '#controlled-input',
-        'Controlled text input',
-      ),
-      mode: 'replace',
-      value: 'Stable controlled text',
+      await scenario.run(createHarness(page, agent));
     });
-
-    const state = await page.evaluate(() =>
-      (window as any).__midsceneControlledState(),
-    );
-    expect(state).toEqual({
-      replacementCount: 1,
-      value: 'Stable controlled text',
-    });
-    await agent.aiAssert(
-      'The controlled input summary shows Controlled value: Stable controlled text and Replacement count: 1.',
-    );
-  });
+  }
 });


### PR DESCRIPTION
## Summary

- add a shared local input fixture for browser-backed AI tests
- define seven typed input scenarios once and execute the same contract through Puppeteer and Playwright adapters
- require every test case to finish with `aiAssert`, while retaining exact DOM assertions for diagnosis
- validate `beforeinput`, `input`, and `change` delivery per editable control instead of relying on page-wide event totals
- route deterministic input actions through the Agent ActionSpace so reports show Locate, Input parameters, before/after screenshots, and Assert in sequence
- keep the public `aiInput` path as a distinct test that visibly changes the initial value
- render the visual state summary with DOM nodes and `textContent`

## Coverage

- `replace`, `clear`, and caret-preserving `typeOnly` modes
- text inputs, textareas, and contenteditable elements
- per-control `beforeinput`, `input`, and applicable `change` event delivery
- same-origin and cross-origin iframe input and clearing
- controlled inputs that replace their DOM node after clearing
- the public `aiInput` path on both Puppeteer and Playwright
- report evidence for every input action instead of only the final state

This is a test-only PR targeting `main`. The earlier parent changes were removed when the branch was rebased after #2938 merged.

## Validation

- `pnpm run lint`
- `pnpm run type-check:tests`
- `PUPPETEER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome AI_TEST_TYPE=web pnpm --filter @midscene/web test -- input-comprehensive.test.ts` (7 passed)
- `pnpm exec playwright test --config=tests/playwright.codex-local.config.ts tests/ai/web/playwright/input-comprehensive.spec.ts` (7 passed using a temporary, uncommitted config that points Playwright to the local Chrome executable)

Fresh PR CI is running against head `b107b0918`.
