### PR TITLE
feat(ios): add clipboard/pasteboard get and set via WDA

### DIFF
--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -860,6 +860,20 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     await this.wdaBackend.pressHomeButton();
   }
 
+  /**
+   * Read the system pasteboard (clipboard). The only way to retrieve a value that an app
+   * exposes solely through a native "Copy" action -- e.g. a share sheet's "Copy Link" --
+   * since that value has no other on-screen representation to read.
+   */
+  async getClipboardText(): Promise<string> {
+    return await this.wdaBackend.getPasteboard();
+  }
+
+  /** Write plain text to the system pasteboard (clipboard). */
+  async setClipboardText(text: string): Promise<void> {
+    await this.wdaBackend.setPasteboard(text);
+  }
+
   async appSwitcher(): Promise<void> {
     try {
       // For iOS, use swipe up with slower/longer duration to trigger app switcher

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -341,6 +341,57 @@ export class IOSWebDriverClient extends WebDriverClient {
     }
   }
 
+  /**
+   * Read the iOS pasteboard (system clipboard) via WDA's `wda/getPasteboard`.
+   * Useful for values only exposed through a native "Copy" action (e.g. a share
+   * sheet's "Copy Link"), which have no other readable representation on screen.
+   * @param contentType Pasteboard content type WDA should decode as; 'plaintext' covers
+   * the common case (copied text/URLs).
+   */
+  async getPasteboard(contentType = 'plaintext'): Promise<string> {
+    this.ensureSession();
+
+    try {
+      const response = await this.makeRequest(
+        'POST',
+        `/session/${this.sessionId}/wda/getPasteboard`,
+        { contentType },
+      );
+      const value = response?.value;
+      if (!value) {
+        return '';
+      }
+      return Buffer.from(value, 'base64').toString('utf8');
+    } catch (error) {
+      debugIOS(`Failed to read pasteboard: ${error}`);
+      throw new Error(`Failed to read pasteboard: ${error}`);
+    }
+  }
+
+  /**
+   * Write to the iOS pasteboard (system clipboard) via WDA's `wda/setPasteboard`.
+   * @param text Plain text to place on the pasteboard.
+   * @param contentType Pasteboard content type; 'plaintext' covers the common case.
+   */
+  async setPasteboard(text: string, contentType = 'plaintext'): Promise<void> {
+    this.ensureSession();
+
+    try {
+      await this.makeRequest(
+        'POST',
+        `/session/${this.sessionId}/wda/setPasteboard`,
+        {
+          content: Buffer.from(text, 'utf8').toString('base64'),
+          contentType,
+        },
+      );
+      debugIOS(`Wrote to pasteboard: "${text}"`);
+    } catch (error) {
+      debugIOS(`Failed to write pasteboard "${text}": ${error}`);
+      throw new Error(`Failed to write pasteboard: ${error}`);
+    }
+  }
+
   async tap(x: number, y: number): Promise<void> {
     this.ensureSession();
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -43,6 +43,8 @@ describe('IOSDevice', () => {
       clearActiveElement: vi.fn().mockResolvedValue(true),
       pressKey: vi.fn().mockResolvedValue(undefined),
       pressHomeButton: vi.fn().mockResolvedValue(undefined),
+      getPasteboard: vi.fn().mockResolvedValue('clipboard-text'),
+      setPasteboard: vi.fn().mockResolvedValue(undefined),
       launchApp: vi.fn().mockResolvedValue(undefined),
       terminateApp: vi.fn().mockResolvedValue(undefined),
       openUrl: vi.fn().mockResolvedValue(undefined),
@@ -411,6 +413,21 @@ describe('IOSDevice', () => {
 
       await device.appSwitcher();
       expect(mockWdaClient.swipe).toHaveBeenCalled();
+    });
+
+    it('should read the clipboard via the WDA pasteboard', async () => {
+      await device.connect();
+
+      const text = await device.getClipboardText();
+      expect(mockWdaClient.getPasteboard).toHaveBeenCalled();
+      expect(text).toBe('clipboard-text');
+    });
+
+    it('should write the clipboard via the WDA pasteboard', async () => {
+      await device.connect();
+
+      await device.setClipboardText('new-text');
+      expect(mockWdaClient.setPasteboard).toHaveBeenCalledWith('new-text');
     });
 
     it('should handle keyboard dismissal', async () => {

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -1,6 +1,69 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
 import type { IOSWebDriverClient as IOSWebDriverClientType } from '../../src/ios-webdriver-client';
+
+function createClientWithSession() {
+  const client = new IOSWebDriverClient({
+    port: DEFAULT_WDA_PORT,
+    host: 'localhost',
+  });
+  // Bypass createSession() — we only want to observe outbound HTTP calls.
+  (client as any).sessionId = 'session-under-test';
+  const makeRequest = vi
+    .spyOn(client as any, 'makeRequest')
+    .mockResolvedValue(undefined);
+  return { client, makeRequest };
+}
+
+describe('IOSWebDriverClient pasteboard', () => {
+  it('getPasteboard POSTs contentType and base64-decodes the response', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockResolvedValue({
+      value: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+    });
+
+    const text = await client.getPasteboard();
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/getPasteboard',
+      { contentType: 'plaintext' },
+    );
+    expect(text).toBe('Hello 世界');
+  });
+
+  it('getPasteboard returns an empty string when WDA reports no value', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockResolvedValue({ value: '' });
+
+    await expect(client.getPasteboard()).resolves.toBe('');
+  });
+
+  it('getPasteboard rejects when the request itself fails', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockRejectedValue(new Error('WDA HTTP error: 500'));
+
+    await expect(client.getPasteboard()).rejects.toThrow(
+      'Failed to read pasteboard',
+    );
+  });
+
+  it('setPasteboard POSTs base64-encoded content and contentType', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.setPasteboard('Hello 世界');
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/setPasteboard',
+      {
+        content: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+        contentType: 'plaintext',
+      },
+    );
+  });
+});
 
 describe('IOSWebDriverClient - Simple Tests', () => {
   describe('Module Structure', () => {
@@ -38,6 +101,8 @@ describe('IOSWebDriverClient - Simple Tests', () => {
         'tap',
         'swipe',
         'typeText',
+        'getPasteboard',
+        'setPasteboard',
         'pressKey',
         'launchApp',
         'openUrl',


### PR DESCRIPTION
## What

Adds pasteboard (system clipboard) read/write for iOS:

- `IOSWebDriverClient.getPasteboard()` / `.setPasteboard()` — the low-level
  `POST /session/:id/wda/getPasteboard` and `.../wda/setPasteboard` calls
  (base64 content, `contentType: "plaintext"`).
- `IOSDevice.getClipboardText()` / `.setClipboardText()` — the public,
  ergonomic wrapper.

## Why

There was previously no way to read a value that an app exposes only through a
native "Copy" action — e.g. a share sheet's "Copy Link" for a generated
invite/meeting link. Such a value has no other on-screen representation to read,
and WDA's own `GET /source` cannot help either: it returns 500 while a native
share sheet (`UIActivityViewController`) is presented, because its accessibility
tree cannot be walked. The pasteboard is WDA-native and system-wide, so it works
regardless of what is on screen.

## Notes

The request shape (POST + JSON body, not GET + query string) is cross-checked
against #2628, which was closed unmerged but shipped passing unit tests against
this exact endpoint contract.

New unit tests cover the base64 round-trip in both directions (including
multi-byte UTF-8), the empty-value response, rejection when the request itself
fails, and the two device-level wrappers.

## Validation

- `npx nx test ios` — 13 files, 161 tests passed
- `npx nx build ios` — success
- `pnpm run lint` — clean

