### PR TITLE
chore(core): add experimental aiAct effort modes

### DIFF
--- a/apps/report/src/utils/report-task-tags.ts
+++ b/apps/report/src/utils/report-task-tags.ts
@@ -7,28 +7,28 @@ import type {
 type PlanningParam = NonNullable<ExecutionTaskPlanningParam>;
 type PlanningLocateParam = NonNullable<ExecutionTaskPlanningLocate['param']>;
 
-type DeepThinkParam = Pick<PlanningParam, 'deepThink'>;
+type EffortParam = Pick<PlanningParam, 'effort'>;
 type DeepLocateParam = Pick<PlanningLocateParam, 'deepLocate'>;
 
 type ConsumedDumpFlagKeys = {
-  deepThink: keyof Pick<PlanningParam, 'deepThink'>;
+  effort: keyof Pick<PlanningParam, 'effort'>;
   deepLocate: keyof Pick<PlanningLocateParam, 'deepLocate'>;
 };
 
 export const consumedDumpFlagKeys = {
-  deepThink: 'deepThink',
+  effort: 'effort',
   deepLocate: 'deepLocate',
 } as const satisfies ConsumedDumpFlagKeys;
 
 export function hasDeepThinkFlag(task: ExecutionTask): boolean {
-  // deepThink is an aiAct planning-phase flag, not a per-locate-task flag.
+  // effort is an aiAct planning-phase option, not a per-locate-task flag.
   if (task.type !== 'Planning' || task.subType === 'Locate') {
     return false;
   }
 
-  const param = task.param as Partial<DeepThinkParam> | undefined;
+  const param = task.param as Partial<EffortParam> | undefined;
 
-  return param?.[consumedDumpFlagKeys.deepThink] === true;
+  return param?.[consumedDumpFlagKeys.effort] === 'deepThink';
 }
 
 export function hasDeepLocateFlag(task: ExecutionTask): boolean {

--- a/apps/report/tests/report-task-tags.test.ts
+++ b/apps/report/tests/report-task-tags.test.ts
@@ -11,29 +11,43 @@ import {
 } from '../src/utils/report-task-tags';
 
 describe('report task tag flags', () => {
-  it('consumes deepThink from aiAct planning task dump params', () => {
+  it('shows DeepThink for deepThink effort in aiAct planning task dump params', () => {
     const task = {
       type: 'Planning',
       taskId: 'plan-deep-think',
       status: 'finished',
       param: {
-        deepThink: true,
+        effort: 'deepThink',
       },
     } satisfies Pick<ExecutionTask, 'type' | 'taskId' | 'status'> & {
-      param: Pick<ExecutionTaskPlanningParam, 'deepThink'>;
+      param: Pick<ExecutionTaskPlanningParam, 'effort'>;
     };
 
     expect(hasDeepThinkFlag(task as ExecutionTask)).toBe(true);
   });
 
-  it('does not mark planning tasks without deepThink', () => {
+  it.each(['balance', 'fast'] as const)(
+    'does not show DeepThink for %s effort',
+    (effort) => {
+      const task = {
+        type: 'Planning',
+        taskId: `plan-${effort}`,
+        status: 'finished',
+        param: { effort },
+      } satisfies Pick<ExecutionTask, 'type' | 'taskId' | 'status'> & {
+        param: Pick<ExecutionTaskPlanningParam, 'effort'>;
+      };
+
+      expect(hasDeepThinkFlag(task as ExecutionTask)).toBe(false);
+    },
+  );
+
+  it('does not read the legacy planning deepThink dump field', () => {
     const task = {
       type: 'Planning',
-      taskId: 'plan-normal',
+      taskId: 'plan-legacy-deep-think',
       status: 'finished',
-      param: {},
-    } satisfies Pick<ExecutionTask, 'type' | 'taskId' | 'status'> & {
-      param: Pick<ExecutionTaskPlanningParam, 'deepThink'>;
+      param: { deepThink: true },
     };
 
     expect(hasDeepThinkFlag(task as ExecutionTask)).toBe(false);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -16,6 +16,7 @@ import {
   type AgentOpt,
   type AgentProgressListener,
   type AgentWaitForOpt,
+  type AiActEffort,
   type AssertOptions,
   type DeepThinkOption,
   type DeviceAction,
@@ -118,6 +119,7 @@ export type AiActOptions = {
   cacheable?: boolean;
   fileChooserAccept?: string | string[];
   fileChooserAllowedDir?: string;
+  effort?: AiActEffort;
   deepThink?: DeepThinkOption;
   deepLocate?: boolean;
   abortSignal?: AbortSignal;
@@ -1135,14 +1137,31 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       const aiActContext =
         opt?.context !== undefined ? opt.context : this.aiActContext;
       const cachePrompt = buildPromptWithContext(taskPrompt, aiActContext);
-      // Controls the aiAct planning mode, such as sub-goal prompts and locate result strategy.
-      let deepThink = opt?.deepThink === true;
-      if (deepThink && planningModel.adapter.planning.kind === 'custom') {
-        warn(
-          `The "deepThink" option is not supported for aiAct with custom planning adapters (modelFamily: ${planningModel.config.modelFamily ?? 'unknown'}). It will be ignored.`,
-        );
-        deepThink = false;
-      }
+      // Resolve the public planning controls at the API boundary. Internal
+      // aiAct plumbing only uses effort from this point onward. The explicit
+      // effort option takes precedence over deepThink when both are provided.
+      const effort: AiActEffort = (() => {
+        const resolvedEffort =
+          opt?.effort ?? (opt?.deepThink === true ? 'deepThink' : 'balance');
+
+        if (opt?.effort !== undefined) {
+          warn(
+            'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
+          );
+        }
+
+        if (
+          resolvedEffort === 'deepThink' &&
+          planningModel.adapter.planning.kind === 'custom'
+        ) {
+          warn(
+            `The "deepThink" aiAct effort is not supported with custom planning adapters (modelFamily: ${planningModel.config.modelFamily ?? 'unknown'}). It will be ignored.`,
+          );
+          return 'balance';
+        }
+
+        return resolvedEffort;
+      })();
 
       let deepLocate = opt?.deepLocate;
       if (
@@ -1154,15 +1173,6 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
         );
         deepLocate = false;
       }
-
-      const noIndividualLocateModel = planningModel.config.slot === 'default';
-
-      const includeLocateInPlanning = !deepThink && noIndividualLocateModel;
-
-      debug('setting includeLocateInPlanning to', includeLocateInPlanning, {
-        deepThink,
-        noIndividualLocateModel,
-      });
 
       const cacheable = opt?.cacheable;
       const replanningCycleLimit =
@@ -1201,17 +1211,14 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       }
 
       // If cache matched but is not executable, fall through to normal execution
-      const imagesIncludeCount: number = deepThink ? 2 : 1;
       const { output: actionOutput } = await this.taskExecutor.action(
         taskPrompt,
         planningModel,
         defaultModel,
-        includeLocateInPlanning,
         aiActContext,
         cacheable,
         replanningCycleLimit,
-        imagesIncludeCount,
-        deepThink,
+        effort,
         undefined,
         deepLocate,
         abortSignal,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1151,6 +1151,15 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
         }
 
         if (
+          resolvedEffort === 'fast' &&
+          planningModel.adapter.planning.kind === 'custom'
+        ) {
+          throw new Error(
+            `The "fast" aiAct effort is not supported with custom planning adapters (modelFamily: ${planningModel.config.modelFamily ?? 'unknown'}).`,
+          );
+        }
+
+        if (
           resolvedEffort === 'deepThink' &&
           planningModel.adapter.planning.kind === 'custom'
         ) {

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -15,6 +15,7 @@ import type Service from '@/service';
 import type { TaskRunner, TaskRunnerEvent } from '@/task-runner';
 import { TaskExecutionError } from '@/task-runner';
 import type {
+  AiActEffort,
   AiActProgressData,
   AiActProgressPhase,
   DeviceAction,
@@ -362,12 +363,10 @@ export class TaskExecutor {
     userPrompt: TUserPrompt,
     planningModel: ModelRuntime,
     defaultModel: ModelRuntime,
-    includeLocateInPlanning: boolean,
     aiActContext?: string,
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
-    imagesIncludeCount?: number,
-    deepThink?: boolean,
+    effort: AiActEffort = 'balance',
     fileChooserAccept?: string[],
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
@@ -386,12 +385,10 @@ export class TaskExecutor {
         userPrompt,
         planningModel,
         defaultModel,
-        includeLocateInPlanning,
         aiActContext,
         cacheable,
         replanningCycleLimitOverride,
-        imagesIncludeCount,
-        deepThink,
+        effort,
         deepLocate,
         abortSignal,
         reportOptions,
@@ -437,12 +434,10 @@ export class TaskExecutor {
     userPrompt: TUserPrompt,
     planningModel: ModelRuntime,
     defaultModel: ModelRuntime,
-    includeLocateInPlanning: boolean,
     aiActContext?: string,
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
-    imagesIncludeCount?: number,
-    deepThink?: boolean,
+    effort: AiActEffort = 'balance',
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
     reportOptions?: ActionReportOptions,
@@ -478,6 +473,16 @@ export class TaskExecutor {
     const runner = session.getRunner();
     planningModel = { ...planningModel, executionId: runner.id };
     defaultModel = { ...defaultModel, executionId: runner.id };
+
+    const noIndividualLocateModel = planningModel.config.slot === 'default';
+    const includeLocateInPlanning =
+      effort !== 'deepThink' && noIndividualLocateModel;
+    const imagesIncludeCount = effort === 'deepThink' ? 2 : 1;
+
+    debug('setting includeLocateInPlanning to', includeLocateInPlanning, {
+      effort,
+      noIndividualLocateModel,
+    });
 
     let replanCount = 0;
     const yamlFlow: MidsceneYamlFlowItem[] = [];
@@ -554,13 +559,14 @@ export class TaskExecutor {
             replanningCycleLimit,
             aiActContext,
             imagesIncludeCount,
-            deepThink,
+            effort,
             ...(subGoalStatus ? { subGoalStatus } : {}),
             ...(memoriesStatus ? { memoriesStatus } : {}),
           },
           executor: async (param, executorContext) => {
             const { uiContext } = executorContext;
             assert(uiContext, 'uiContext is required for Planning task');
+            assert(param.effort, 'effort is required for Planning Plan task');
             const planningUiContext = uiContext as UIContext;
             const timing = executorContext.task.timing;
             await this.emitAiActProgress('plan_thinking', {
@@ -596,8 +602,8 @@ export class TaskExecutor {
                 modelRuntime: planningModel,
                 conversationHistory,
                 includeLocateInPlanning,
-                imagesIncludeCount,
-                deepThink,
+                imagesIncludeCount: param.imagesIncludeCount,
+                effort: param.effort,
                 referenceImageMessages,
                 abortSignal,
               });

--- a/packages/core/src/ai-model/prompt/planning/multi-turn-example.ts
+++ b/packages/core/src/ai-model/prompt/planning/multi-turn-example.ts
@@ -23,10 +23,14 @@ const sampleReturnEmailSubGoal = {
 
 export const buildPlanningMultiTurnExample = ({
   includeSubGoals,
+  includeThought,
+  includeLog,
   locatePromptSpec,
   actionOutputProtocol,
 }: {
   includeSubGoals: boolean;
+  includeThought: boolean;
+  includeLog: boolean;
   locatePromptSpec?: LocateResultPromptSpec;
   actionOutputProtocol: PlanningActionOutputProtocol;
 }) => {
@@ -72,10 +76,12 @@ Below is an example of a multi-turn conversation for "fill out the registration 
 **Your response:**
 
 ${buildPlanningResponseExample({
-  planning: `The user wants me to fill out the registration form with specific values and return the email address. I can see the form has two fields: Name and Email. Both are currently empty. ${renderSubGoalsContent(
-    "I'll break this down into sub-goals and start with the Name field.",
-    'I should start by clicking on the Name field.',
-  )} Note: The instruction is to fill the form only (not submit), and return the email at the end.`,
+  planning: includeThought
+    ? `The user wants me to fill out the registration form with specific values and return the email address. I can see the form has two fields: Name and Email. Both are currently empty. ${renderSubGoalsContent(
+        "I'll break this down into sub-goals and start with the Name field.",
+        'I should start by clicking on the Name field.',
+      )} Note: The instruction is to fill the form only (not submit), and return the email at the end.`
+    : undefined,
   updateSubGoals: includeSubGoals
     ? [
         {
@@ -92,7 +98,9 @@ ${buildPlanningResponseExample({
         },
       ]
     : undefined,
-  log: 'Click on the Name field to start filling the form',
+  log: includeLog
+    ? 'Click on the Name field to start filling the form'
+    : undefined,
   actionExample: tapNameFieldExample,
 })}
 
@@ -118,11 +126,13 @@ ${renderSubGoalsContent(
 **Your response:**
 
 ${buildPlanningResponseExample({
-  planning: `The Name field is now focused. I need to type 'John' into this field. ${renderSubGoalsContent(
-    'Current sub-goal is running, will be completed after input.',
-    "After this, I'll need to fill the Email field as well.",
-  )}`,
-  log: "Typing 'John' into the Name field",
+  planning: includeThought
+    ? `The Name field is now focused. I need to type 'John' into this field. ${renderSubGoalsContent(
+        'Current sub-goal is running, will be completed after input.',
+        "After this, I'll need to fill the Email field as well.",
+      )}`
+    : undefined,
+  log: includeLog ? "Typing 'John' into the Name field" : undefined,
   actionExample: inputNameExample,
 })}
 
@@ -151,15 +161,17 @@ ${renderSubGoalsContent(
 **Your response:**
 
 ${buildPlanningResponseExample({
-  planning: `The Name field now shows 'John'. ${renderSubGoalsContent(
-    'Sub-goal 1 is complete. Next, I need to fill the Email field for sub-goal 2.',
-    "Next, I need to fill the Email field with 'john@example.com'. I'll click on the Email field first.",
-  )}`,
+  planning: includeThought
+    ? `The Name field now shows 'John'. ${renderSubGoalsContent(
+        'Sub-goal 1 is complete. Next, I need to fill the Email field for sub-goal 2.',
+        "Next, I need to fill the Email field with 'john@example.com'. I'll click on the Email field first.",
+      )}`
+    : undefined,
   markSubGoalsDone: includeSubGoals ? [1] : undefined,
   memory: includeSubGoals
     ? "Name field has been filled with 'John'"
     : undefined,
-  log: 'Moving to the Email field',
+  log: includeLog ? 'Moving to the Email field' : undefined,
   actionExample: tapEmailFieldExample,
 })}
 
@@ -185,11 +197,13 @@ ${renderSubGoalsContent(
 **Your response:**
 
 ${buildPlanningResponseExample({
-  planning: `The Email field is now focused. I'll enter 'john@example.com'. ${renderSubGoalsContent(
-    'After this, sub-goal 2 will be complete and my task will be done.',
-    'After this, both required fields will be filled and my task will be complete.',
-  )}`,
-  log: 'Typing email address into the Email field',
+  planning: includeThought
+    ? `The Email field is now focused. I'll enter 'john@example.com'. ${renderSubGoalsContent(
+        'After this, sub-goal 2 will be complete and my task will be done.',
+        'After this, both required fields will be filled and my task will be complete.',
+      )}`
+    : undefined,
+  log: includeLog ? 'Typing email address into the Email field' : undefined,
   actionExample: inputEmailExample,
 })}
 
@@ -218,10 +232,12 @@ ${renderSubGoalsContent(
 **Your response:**
 
 ${buildPlanningResponseExample({
-  planning: `Both fields are now filled: Name shows 'John' and Email shows 'john@example.com'. ${renderSubGoalsContent(
-    "Sub-goal 2 is complete. The user asked me to return the filled email address, so I need to include 'john@example.com' in my response. All sub-goals are now finished.",
-    "The user asked me to return the filled email address, so I should include 'john@example.com' in my response. The instruction has been fulfilled.",
-  )}`,
+  planning: includeThought
+    ? `Both fields are now filled: Name shows 'John' and Email shows 'john@example.com'. ${renderSubGoalsContent(
+        "Sub-goal 2 is complete. The user asked me to return the filled email address, so I need to include 'john@example.com' in my response. All sub-goals are now finished.",
+        "The user asked me to return the filled email address, so I should include 'john@example.com' in my response. The instruction has been fulfilled.",
+      )}`
+    : undefined,
   markSubGoalsDone: includeSubGoals ? [2, 3] : undefined,
   complete: {
     success: true,

--- a/packages/core/src/ai-model/prompt/planning/planning-response-example.ts
+++ b/packages/core/src/ai-model/prompt/planning/planning-response-example.ts
@@ -7,7 +7,7 @@ type PlanningSubGoalExample = {
 };
 
 type PlanningResponseActionExample = {
-  log: string;
+  log?: string;
   actionExample: string | undefined;
   complete?: never;
 };
@@ -22,7 +22,7 @@ type PlanningResponseCompleteExample = {
 };
 
 type BuildPlanningResponseExampleInput = {
-  planning: string;
+  planning?: string;
   updateSubGoals?: PlanningSubGoalExample[];
   markSubGoalsDone?: number[];
   memory?: string;
@@ -31,7 +31,9 @@ type BuildPlanningResponseExampleInput = {
 export const buildPlanningResponseExample = (
   input: BuildPlanningResponseExampleInput,
 ) => {
-  const sections = [`<planning>${input.planning}</planning>`];
+  const sections = input.planning
+    ? [`<planning>${input.planning}</planning>`]
+    : [];
 
   if (input.updateSubGoals?.length) {
     const subGoals = input.updateSubGoals
@@ -64,7 +66,10 @@ export const buildPlanningResponseExample = (
         'Cannot build planning response example without an action example',
       );
     }
-    sections.push(`<log>${input.log}</log>`, input.actionExample);
+    if (input.log) {
+      sections.push(`<log>${input.log}</log>`);
+    }
+    sections.push(input.actionExample);
   }
 
   return sections.join('\n');

--- a/packages/core/src/ai-model/prompt/planning/system-prompt.ts
+++ b/packages/core/src/ai-model/prompt/planning/system-prompt.ts
@@ -14,6 +14,8 @@ import { buildPlanningMultiTurnExample } from './multi-turn-example';
 type BuildStandardPlanningSystemPromptInput = {
   actionSpace: DeviceAction<any>[];
   includeSubGoals?: boolean;
+  includeThought?: boolean;
+  includeLog?: boolean;
   actionOutputProtocol?: PlanningActionOutputProtocol;
 } & (
   | {
@@ -34,6 +36,8 @@ export async function buildStandardPlanningSystemPrompt(
     includeLocateInPlanning,
     locatePromptSpec,
     includeSubGoals,
+    includeThought = true,
+    includeLog = true,
     actionOutputProtocol = defaultMidsceneActionOutputProtocol,
   } = input;
   const preferredLanguage = getPreferredLanguage();
@@ -57,6 +61,10 @@ export async function buildStandardPlanningSystemPrompt(
   const shouldIncludeSubGoals = includeSubGoals ?? false;
   const renderSubGoalsContent = (content: string, fallbackContent = '') =>
     shouldIncludeSubGoals ? content : fallbackContent;
+  const renderThoughtContent = (content: string, fallbackContent = '') =>
+    includeThought ? content : fallbackContent;
+  const renderLogContent = (content: string, fallbackContent = '') =>
+    includeLog ? content : fallbackContent;
 
   // Step numbering adjusts based on whether sub-goals are included
   // When includeSubGoals=false, memory step is skipped
@@ -68,7 +76,7 @@ Target: You are an expert to manipulate the UI to accomplish the user's instruct
 
 ## Step 1: ${renderSubGoalsContent(
     'Observe and Plan (related tags: <planning>, <update-plan-content>, <mark-sub-goal-done>)',
-    'Observe (related tags: <planning>)',
+    renderThoughtContent('Observe (related tags: <planning>)', 'Observe'),
   )}
 
 First, observe the current screenshot and previous logs${renderSubGoalsContent(
@@ -81,16 +89,16 @@ ${renderSubGoalsContent(`### Observation Guidelines
 - Treat visible summaries, thumbnails, cropped content, and partially visible lists as potentially incomplete when the task depends on precise details.
 - If the current view does not provide enough information to decide safely, use available UI affordances such as opening details, expanding content, previewing, enlarging, zooming, or scrolling before acting.`)}
 
-### <planning> tag (REQUIRED)
+${renderThoughtContent(`### <planning> tag (REQUIRED)
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
 
 Include your planning details in the <planning> tag. It should answer: ${renderSubGoalsContent(
-    "What is the user's requirement? What is the current state based on the screenshot? Are all sub-goals completed? If not, what should be the next action?",
-    'What is the current state based on the screenshot? What should be the next action?',
-  )} Write it naturally without numbering or section headers.
+  "What is the user's requirement? What is the current state based on the screenshot? Are all sub-goals completed? If not, what should be the next action?",
+  'What is the current state based on the screenshot? What should be the next action?',
+)} Write it naturally without numbering or section headers.
 
-CRITICAL - Following Explicit Instructions: When the user gives you specific operation steps (not high-level goals), you MUST execute ONLY those exact steps - nothing more, nothing less. Do NOT add extra actions even if they seem logical. For example: "fill out the form" means only fill fields, do NOT submit; "click the button" means only click, do NOT wait for page load or verify results; "type 'hello'" means only type, do NOT press Enter.
+CRITICAL - Following Explicit Instructions: When the user gives you specific operation steps (not high-level goals), you MUST execute ONLY those exact steps - nothing more, nothing less. Do NOT add extra actions even if they seem logical. For example: "fill out the form" means only fill fields, do NOT submit; "click the button" means only click, do NOT wait for page load or verify results; "type 'hello'" means only type, do NOT press Enter.`)}
 
 ${renderSubGoalsContent(`### <update-plan-content> tag
 
@@ -240,7 +248,7 @@ ${renderSubGoalsContent(
   - the 'message' is the information that will be provided to the user. If the user asks for a specific format, strictly follow that.
 - If you output <complete>, do NOT output ${actionOutputTagsText}. The task ends here.
 
-## Step ${actionStepNumber}: Determine Next Action (related tags: <log>, ${actionOutputTagsText}, <error>)
+## Step ${actionStepNumber}: Determine Next Action (related tags: ${renderLogContent('<log>, ')}${actionOutputTagsText}, <error>)
 
 ONLY if the task is not complete: Think what the next action is according to the current screenshot${renderSubGoalsContent(' and the plan')}.
 
@@ -267,7 +275,7 @@ ${includeLocateInPlanning ? locateGroundingRules() : ''}
 
 ${actionList}
 
-### Log to give user feedback (preamble message)
+${renderLogContent(`### Log to give user feedback (preamble message)
 
 The <log> tag is a brief preamble message to the user explaining what you're about to do. It should follow these principles and examples:
 
@@ -280,7 +288,7 @@ The <log> tag is a brief preamble message to the user explaining what you're abo
 - <log>Click the login button</log>
 - <log>Scroll to find the 'Yes' button in popup</log>
 - <log>Previous actions failed to find the 'Yes' button, i will try again</log>
-- <log>Go back to find the login button</log>
+- <log>Go back to find the login button</log>`)}
 
 ### If there is some action to do ...
 
@@ -311,9 +319,9 @@ For example:
 
 Return in XML format following this decision flow:
 
-**Always include (REQUIRED):**
+${renderThoughtContent(`**Always include (REQUIRED):**
 <!-- Step 1: Observe and Plan -->
-<planning>Your planning details here. NEVER skip this tag.</planning>
+<planning>Your planning details here. NEVER skip this tag.</planning>`)}
 ${renderSubGoalsContent(`<!-- required when no update-plan-content is provided in the previous response -->
 <update-plan-content>...</update-plan-content>
 
@@ -332,7 +340,7 @@ ${renderSubGoalsContent(`<!-- required when no update-plan-content is provided i
 
 **Path B: If the ${renderSubGoalsContent('goal is NOT complete', 'instruction is NOT fulfilled')} yet (Step ${actionStepNumber})**
 <!-- Determine next action -->
-<log>...</log>
+${renderLogContent('<log>...</log>')}
 ${actionOutputProtocol.actionOutputPlaceholder}
 
 <!-- OR if there's an error -->
@@ -340,6 +348,8 @@ ${actionOutputProtocol.actionOutputPlaceholder}
 
 ${buildPlanningMultiTurnExample({
   includeSubGoals: shouldIncludeSubGoals,
+  includeThought,
+  includeLog,
   locatePromptSpec,
   actionOutputProtocol,
 })}`;

--- a/packages/core/src/ai-model/workflows/grounding/planning-action-locate.ts
+++ b/packages/core/src/ai-model/workflows/grounding/planning-action-locate.ts
@@ -52,6 +52,7 @@ async function buildPlanningTapLocatorPlanOptions(
     actionSpace: planningActionLocatorActionSpace,
     conversationHistory: new ConversationHistory(),
     includeLocateInPlanning: true,
+    effort: 'balance',
     referenceImageMessages: locateRequest.referenceImageMessages,
   };
 }

--- a/packages/core/src/ai-model/workflows/planning/index.ts
+++ b/packages/core/src/ai-model/workflows/planning/index.ts
@@ -3,4 +3,7 @@ export {
   type ConversationHistoryOptions,
 } from './conversation-history';
 export { standardPlan } from './standard-planning';
-export { parseXMLPlanningResponse } from './standard-planning-parser';
+export {
+  parseStandardPlanningResponse,
+  parseXMLPlanningResponse,
+} from './standard-planning-parser';

--- a/packages/core/src/ai-model/workflows/planning/planning-action-log.ts
+++ b/packages/core/src/ai-model/workflows/planning/planning-action-log.ts
@@ -1,0 +1,40 @@
+import { dumpActionParam } from '@/common';
+import type { DeviceAction, PlanningAction } from '@/types';
+
+const formatActionParamValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? String(value);
+};
+
+export function buildPlanningActionLog(
+  action: PlanningAction,
+  actionSpace: DeviceAction<any>[],
+): string {
+  const actionDefinition = actionSpace.find(
+    (item) => item.name === action.type,
+  );
+
+  if (!actionDefinition?.paramSchema) {
+    return JSON.stringify(action);
+  }
+
+  const param = action.param;
+  if (param === null || param === undefined) {
+    return action.type;
+  }
+  if (typeof param !== 'object' || Array.isArray(param)) {
+    return `${action.type} - ${formatActionParamValue(param)}`;
+  }
+
+  const paramForLog = dumpActionParam(param, actionDefinition.paramSchema);
+  const paramDescription = Object.entries(paramForLog)
+    .map(([key, value]) => `${key}: ${formatActionParamValue(value)}`)
+    .join(', ');
+
+  return [action.type, paramDescription].filter(Boolean).join(' - ');
+}

--- a/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
@@ -1,10 +1,12 @@
 import type {
+  DeviceAction,
   RawResponsePlanningAIResponse,
   SubGoal,
   SubGoalStatus,
 } from '@/types';
 import type { JsonParser } from '../../shared/json';
 import { extractXMLTag } from '../../shared/xml';
+import { buildPlanningActionLog } from './planning-action-log';
 
 /**
  * Parse sub-goals from XML content.
@@ -51,11 +53,14 @@ export function parseMarkFinishedIndexes(xmlContent: string): number[] {
 export function parseXMLPlanningResponse(
   xmlString: string,
   jsonParser: JsonParser,
+  options: { includeThought: boolean },
 ): RawResponsePlanningAIResponse {
   // Use <planning> instead of <thought> to avoid colliding with Gemini thought
   // summaries, which may also be emitted as <thought> in OpenAI-compatible
   // response content.
-  const thought = extractXMLTag(xmlString, 'planning');
+  const thought = options.includeThought
+    ? extractXMLTag(xmlString, 'planning')
+    : undefined;
   const memory = extractXMLTag(xmlString, 'memory');
   const log = extractXMLTag(xmlString, 'log') || '';
   const error = extractXMLTag(xmlString, 'error');
@@ -116,5 +121,38 @@ export function parseXMLPlanningResponse(
     ...(finalizeSuccess !== undefined ? { finalizeSuccess } : {}),
     ...(updateSubGoals?.length ? { updateSubGoals } : {}),
     ...(markFinishedIndexes?.length ? { markFinishedIndexes } : {}),
+  };
+}
+
+type ParseStandardPlanningResponseOptions = {
+  includeThought: boolean;
+} & (
+  | {
+      logSource?: 'model';
+    }
+  | {
+      logSource: 'action';
+      actionSpace: DeviceAction<any>[];
+    }
+);
+
+export function parseStandardPlanningResponse(
+  xmlString: string,
+  jsonParser: JsonParser,
+  options: ParseStandardPlanningResponseOptions,
+): RawResponsePlanningAIResponse {
+  const response = parseXMLPlanningResponse(xmlString, jsonParser, {
+    includeThought: options.includeThought,
+  });
+
+  if (options.logSource !== 'action') {
+    return response;
+  }
+
+  return {
+    ...response,
+    log: response.action
+      ? buildPlanningActionLog(response.action, options.actionSpace)
+      : 'No action',
   };
 }

--- a/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
@@ -136,6 +136,27 @@ type ParseStandardPlanningResponseOptions = {
     }
 );
 
+function buildNonActionPlanningLog(
+  response: RawResponsePlanningAIResponse,
+): string {
+  if (response.error) {
+    return `Error - ${response.error}`;
+  }
+
+  if (response.finalizeSuccess !== undefined) {
+    return [
+      `Complete - success: ${response.finalizeSuccess}`,
+      response.finalizeMessage
+        ? `message: ${response.finalizeMessage}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  return 'No action';
+}
+
 export function parseStandardPlanningResponse(
   xmlString: string,
   jsonParser: JsonParser,
@@ -153,6 +174,6 @@ export function parseStandardPlanningResponse(
     ...response,
     log: response.action
       ? buildPlanningActionLog(response.action, options.actionSpace)
-      : 'No action',
+      : buildNonActionPlanningLog(response),
   };
 }

--- a/packages/core/src/ai-model/workflows/planning/standard-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../shared/model-locate-result';
 import { planningModelFamilyRequiredForLocateMessage } from '../../shared/model-locate-result/errors';
 import { normalizePlanningActionLocateFields } from './locate-normalization';
-import { parseXMLPlanningResponse } from './standard-planning-parser';
+import { parseStandardPlanningResponse } from './standard-planning-parser';
 import type { PlanOptions } from './types';
 
 const debug = getDebug('planning');
@@ -29,7 +29,6 @@ const warnLog = getDebug('planning', { console: true });
 
 const noPreviousActionsText =
   'No previous actions have been executed in this aiAct execution yet. If the instruction asks for actions, choose the first action to execute.';
-
 type PlanningCallResponse = Awaited<ReturnType<typeof callAI>>;
 
 type CallAndParsePlanningResponseOptions = {
@@ -40,6 +39,8 @@ type CallAndParsePlanningResponseOptions = {
   actionSpace: PlanOptions['actionSpace'];
   locateResultAdapter?: LocateResultAdapter;
   locateResultContext: LocateResultContext;
+  includeThought: boolean;
+  includeLog: boolean;
 };
 
 async function callAndParsePlanningResponse(
@@ -58,6 +59,8 @@ async function callAndParsePlanningResponse(
     actionSpace,
     locateResultAdapter,
     locateResultContext,
+    includeThought,
+    includeLog,
   } = options;
   return callAiAndParseWithRetry({
     callAi: (retryAttempt, previousParseError) =>
@@ -71,9 +74,15 @@ async function callAndParsePlanningResponse(
         },
       ),
     parseResponse: (response) => {
-      const planFromAI = parseXMLPlanningResponse(
+      const planFromAI = parseStandardPlanningResponse(
         response.content,
         modelRuntime.adapter.jsonParser,
+        {
+          includeThought,
+          ...(includeLog
+            ? { logSource: 'model' }
+            : { logSource: 'action', actionSpace }),
+        },
       );
       if (planFromAI.action && planFromAI.finalizeSuccess !== undefined) {
         warnLog(
@@ -140,7 +149,9 @@ export async function standardPlan(
       : undefined;
 
   // Only enable sub-goals when aiAct is in deep-thinking planning mode.
-  const includeSubGoals = opts.deepThink === true;
+  const includeSubGoals = opts.effort === 'deepThink';
+  const includeThought = opts.effort !== 'fast';
+  const includeLog = opts.effort !== 'fast';
 
   if (opts.includeLocateInPlanning && !locateResultAdapter) {
     throw new Error(
@@ -150,6 +161,8 @@ export async function standardPlan(
 
   const systemPrompt = await buildStandardPlanningSystemPrompt({
     actionSpace: opts.actionSpace,
+    includeThought,
+    includeLog,
     includeSubGoals,
     ...(opts.includeLocateInPlanning && locateResultAdapter
       ? {
@@ -275,6 +288,8 @@ export async function standardPlan(
       preparedSize: preparedImage.preparedSize,
       contentSize: preparedImage.contentSize,
     },
+    includeThought,
+    includeLog,
   });
 
   let shouldContinuePlanning = true;

--- a/packages/core/src/ai-model/workflows/planning/types.ts
+++ b/packages/core/src/ai-model/workflows/planning/types.ts
@@ -1,5 +1,10 @@
 import type { TUserPrompt } from '@/common';
-import type { DeviceAction, PlanningAIResponse, UIContext } from '@/types';
+import type {
+  AiActEffort,
+  DeviceAction,
+  PlanningAIResponse,
+  UIContext,
+} from '@/types';
 import type { ChatCompletionUserMessageParam } from 'openai/resources/index';
 import type { ModelRuntime } from '../../models';
 import type { ConversationHistory } from './conversation-history';
@@ -13,7 +18,7 @@ export interface PlanOptions {
   includeLocateInPlanning: boolean;
   imagesIncludeCount?: number;
   // Controls aiAct planning prompt shape and state updates, such as sub-goals.
-  deepThink?: boolean;
+  effort: AiActEffort;
   referenceImageMessages?: ChatCompletionUserMessageParam[];
   abortSignal?: AbortSignal;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,6 +197,8 @@ export interface LocateResult {
 
 export type ThinkingLevel = 'off' | 'medium' | 'high';
 
+export type AiActEffort = 'fast' | 'balance' | 'deepThink';
+
 export type DeepThinkOption = 'unset' | true | false;
 
 export interface ServiceTaskInfo {
@@ -756,7 +758,7 @@ export interface ExecutionTaskPlanningParam {
   replanningCycleLimit?: number;
   aiActContext?: string;
   imagesIncludeCount?: number;
-  deepThink?: DeepThinkOption;
+  effort?: AiActEffort;
   subGoalStatus?: string;
   memoriesStatus?: string;
 }

--- a/packages/core/tests/ai/llm-planning/basic.test.ts
+++ b/packages/core/tests/ai/llm-planning/basic.test.ts
@@ -29,6 +29,7 @@ describe.skipIf(modelConfig.modelFamily)('automation - llm planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       },
     );
     expect(actions).toBeTruthy();
@@ -48,6 +49,7 @@ describe.skipIf(modelConfig.modelFamily)('automation - llm planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       },
     );
     expect(actions).toBeTruthy();
@@ -97,6 +99,7 @@ describe('planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       });
       expect(actions).toBeTruthy();
       // console.log(actions);
@@ -118,6 +121,7 @@ describe('planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       },
     );
     expect(actions).toBeTruthy();
@@ -136,6 +140,7 @@ describe('planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       },
     );
 
@@ -154,6 +159,7 @@ describe('planning', () => {
         modelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       },
     );
 

--- a/packages/core/tests/ai/llm-planning/input.test.ts
+++ b/packages/core/tests/ai/llm-planning/input.test.ts
@@ -27,6 +27,7 @@ describe('automation - planning input', () => {
         modelRuntime: defaultModelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       });
       expect(actions).toBeDefined();
       expect(actions?.length).toBeGreaterThan(0);
@@ -48,6 +49,7 @@ describe('automation - planning input', () => {
         modelRuntime: defaultModelRuntime,
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: true,
+        effort: 'balance',
       });
       expect(actions).toBeDefined();
       expect(actions?.length).toBeGreaterThan(0);

--- a/packages/core/tests/unit-test/agent-context-option.test.ts
+++ b/packages/core/tests/unit-test/agent-context-option.test.ts
@@ -66,7 +66,7 @@ describe('Agent per-call context option', () => {
       'Context for this request:\nUse buyer checkout rules.\n\nClick the submit button',
     );
     expect(taskExecutor.action).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.action.mock.calls[0][4]).toBe(
+    expect(taskExecutor.action.mock.calls[0][3]).toBe(
       'Use buyer checkout rules.',
     );
   });
@@ -79,7 +79,7 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Context for this request:\nGlobal action context.\n\nClick the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][4]).toBe('Global action context.');
+    expect(taskExecutor.action.mock.calls[0][3]).toBe('Global action context.');
   });
 
   it('allows blank per-call context to override global aiActContext', async () => {
@@ -92,7 +92,7 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Click the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][4]).toBe('');
+    expect(taskExecutor.action.mock.calls[0][3]).toBe('');
   });
 
   it('does not register a file chooser for an empty fileChooserAccept array', async () => {

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -479,7 +479,7 @@ describe('Agent with custom OpenAI client', () => {
   });
 
   describe('planning locate strategy', () => {
-    it('should not include bbox in planning when planning config is explicitly resolved', async () => {
+    it('should pass balance effort when planning config is explicitly resolved', async () => {
       const mockInterface = createMockInterface();
       const agent = new Agent(mockInterface, {
         modelConfig: {
@@ -503,13 +503,13 @@ describe('Agent with custom OpenAI client', () => {
       await agent.aiAct('click the submit button');
 
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][3]).toBe(false);
+      expect(actionSpy.mock.calls[0][6]).toBe('balance');
       expect(
         (agent as any).modelConfigManager.getModelConfig('planning').slot,
       ).toBe('planning');
     });
 
-    it('should include bbox in planning when planning config falls back to default', async () => {
+    it('should pass balance effort when planning config falls back to default', async () => {
       const mockInterface = createMockInterface();
       const agent = new Agent(mockInterface, {
         modelConfig: defaultModelConfig,
@@ -525,13 +525,116 @@ describe('Agent with custom OpenAI client', () => {
       await agent.aiAct('click the submit button');
 
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][3]).toBe(true);
+      expect(actionSpy.mock.calls[0][6]).toBe('balance');
       expect(
         (agent as any).modelConfigManager.getModelConfig('planning').slot,
       ).toBe('default');
     });
 
-    it('should disable deepThink before resolving custom planning strategy', async () => {
+    it('should prefer effort over deepThink and warn that effort is experimental', async () => {
+      const mockInterface = createMockInterface();
+      const agent = new Agent(mockInterface, {
+        modelConfig: defaultModelConfig,
+      });
+      const actionSpy = vi
+        .spyOn((agent as any).taskExecutor, 'action')
+        .mockResolvedValue({
+          output: {
+            yamlFlow: [],
+          },
+        });
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await agent.aiAct('click the submit button', {
+        deepThink: false,
+        effort: 'deepThink',
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Midscene]',
+        'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
+      );
+      expect(actionSpy.mock.calls[0][6]).toBe('deepThink');
+    });
+
+    it('should prefer balance effort over deepThink and use the experimental warning', async () => {
+      const mockInterface = createMockInterface();
+      const agent = new Agent(mockInterface, {
+        modelConfig: defaultModelConfig,
+      });
+      const actionSpy = vi
+        .spyOn((agent as any).taskExecutor, 'action')
+        .mockResolvedValue({
+          output: {
+            yamlFlow: [],
+          },
+        });
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await agent.aiAct('click the submit button', {
+        deepThink: true,
+        effort: 'balance',
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Midscene]',
+        'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
+      );
+      expect(actionSpy.mock.calls[0][6]).toBe('balance');
+    });
+
+    it('should keep supporting deepThink without an experimental warning', async () => {
+      const mockInterface = createMockInterface();
+      const agent = new Agent(mockInterface, {
+        modelConfig: defaultModelConfig,
+      });
+      const actionSpy = vi
+        .spyOn((agent as any).taskExecutor, 'action')
+        .mockResolvedValue({
+          output: {
+            yamlFlow: [],
+          },
+        });
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await agent.aiAct('click the submit button', { deepThink: true });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(actionSpy.mock.calls[0][6]).toBe('deepThink');
+    });
+
+    it('should use the unified experimental warning for fast effort', async () => {
+      const mockInterface = createMockInterface();
+      const agent = new Agent(mockInterface, {
+        modelConfig: defaultModelConfig,
+      });
+      const actionSpy = vi
+        .spyOn((agent as any).taskExecutor, 'action')
+        .mockResolvedValue({
+          output: {
+            yamlFlow: [],
+          },
+        });
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await agent.aiAct('click the submit button', { effort: 'fast' });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Midscene]',
+        'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
+      );
+      expect(actionSpy.mock.calls[0][6]).toBe('fast');
+    });
+
+    it('should support deepThink and normalize unsupported custom planning', async () => {
       const mockInterface = createMockInterface();
       const agent = new Agent(mockInterface, {
         modelConfig: {
@@ -554,12 +657,10 @@ describe('Agent with custom OpenAI client', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(
         '[Midscene]',
-        'The "deepThink" option is not supported for aiAct with custom planning adapters (modelFamily: auto-glm). It will be ignored.',
+        'The "deepThink" aiAct effort is not supported with custom planning adapters (modelFamily: auto-glm). It will be ignored.',
       );
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][3]).toBe(true);
-      expect(actionSpy.mock.calls[0][7]).toBe(1);
-      expect(actionSpy.mock.calls[0][8]).toBe(false);
+      expect(actionSpy.mock.calls[0][6]).toBe('balance');
     });
 
     it('should disable deepLocate before running custom planning', async () => {
@@ -588,7 +689,7 @@ describe('Agent with custom OpenAI client', () => {
         'The "deepLocate" option is not supported for aiAct with the current planning adapter (modelFamily: auto-glm). It will be ignored.',
       );
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][10]).toBe(false);
+      expect(actionSpy.mock.calls[0][8]).toBe(false);
     });
   });
 });

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -634,6 +634,26 @@ describe('Agent with custom OpenAI client', () => {
       expect(actionSpy.mock.calls[0][6]).toBe('fast');
     });
 
+    it('should reject fast effort before running custom planning', async () => {
+      const mockInterface = createMockInterface();
+      const agent = new Agent(mockInterface, {
+        modelConfig: {
+          ...defaultModelConfig,
+          [MIDSCENE_MODEL_FAMILY]: 'auto-glm',
+        },
+      });
+      const actionSpy = vi.spyOn((agent as any).taskExecutor, 'action');
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await expect(
+        agent.aiAct('click the submit button', { effort: 'fast' }),
+      ).rejects.toThrow(
+        'The "fast" aiAct effort is not supported with custom planning adapters (modelFamily: auto-glm).',
+      );
+
+      expect(actionSpy).not.toHaveBeenCalled();
+    });
+
     it('should support deepThink and normalize unsupported custom planning', async () => {
       const mockInterface = createMockInterface();
       const agent = new Agent(mockInterface, {

--- a/packages/core/tests/unit-test/aiaction-cacheable.test.ts
+++ b/packages/core/tests/unit-test/aiaction-cacheable.test.ts
@@ -224,7 +224,6 @@ describe('aiAction cacheable option propagation', () => {
         modelDescription: 'test model',
         intent: 'default',
       } as any),
-      true, // includeLocateInPlanning: true
       undefined,
       false, // cacheable: false
     );

--- a/packages/core/tests/unit-test/custom-planning.test.ts
+++ b/packages/core/tests/unit-test/custom-planning.test.ts
@@ -28,6 +28,7 @@ function createPlanOptions(
     } as any,
     conversationHistory,
     includeLocateInPlanning: true,
+    effort: 'balance',
   };
 }
 

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -78,6 +78,30 @@ describe('plan XML parse retry', () => {
     vi.mocked(buildYamlFlowFromPlans).mockClear();
   });
 
+  it('uses the action-only XML protocol for fast effort', async () => {
+    vi.mocked(callAI).mockResolvedValueOnce(
+      mockAIResponse(`<action-type>Tap</action-type>
+<action-param-json>{}</action-param-json>`),
+    );
+
+    const result = await standardPlan('tap the button', {
+      context: mockContext(),
+      actionSpace: mockActionSpace(),
+      modelRuntime: getModelRuntime(mockModelConfig()),
+      conversationHistory: new ConversationHistory(),
+      includeLocateInPlanning: false,
+      effort: 'fast',
+    });
+
+    const systemPrompt = vi.mocked(callAI).mock.calls[0]?.[0]?.[0]?.content;
+    expect(systemPrompt).not.toEqual(expect.stringContaining('<planning>'));
+    expect(systemPrompt).not.toEqual(expect.stringContaining('</planning>'));
+    expect(systemPrompt).not.toEqual(expect.stringContaining('<log>'));
+    expect(result.thought).toBeUndefined();
+    expect(result.log).toBe('{"type":"Tap","param":{}}');
+    expect(result.actions).toEqual([{ type: 'Tap', param: {} }]);
+  });
+
   it('uses model retry settings when XML response parsing fails', async () => {
     vi.mocked(callAI)
       .mockResolvedValueOnce(
@@ -105,7 +129,7 @@ describe('plan XML parse retry', () => {
       }),
       conversationHistory: new ConversationHistory(),
       includeLocateInPlanning: false,
-      deepThink: false,
+      effort: 'balance',
     });
 
     expect(callAI).toHaveBeenCalledTimes(3);
@@ -143,7 +167,7 @@ describe('plan XML parse retry', () => {
       modelRuntime: getModelRuntime(mockModelConfig('kimi3')),
       conversationHistory,
       includeLocateInPlanning: false,
-      deepThink: false,
+      effort: 'balance',
     } as const;
 
     await standardPlan('tap the button', options);
@@ -177,7 +201,7 @@ describe('plan XML parse retry', () => {
       modelRuntime: getModelRuntime(mockModelConfig()),
       conversationHistory,
       includeLocateInPlanning: false,
-      deepThink: false,
+      effort: 'balance',
     } as const;
 
     await standardPlan('tap the button', options);
@@ -207,7 +231,7 @@ describe('plan XML parse retry', () => {
         modelRuntime: getModelRuntime(mockModelConfig()),
         conversationHistory: new ConversationHistory(),
         includeLocateInPlanning: false,
-        deepThink: false,
+        effort: 'balance',
       }),
     ).rejects.toBe(requestError);
 
@@ -226,7 +250,7 @@ describe('plan XML parse retry', () => {
       modelRuntime: getModelRuntime(mockModelConfig()),
       conversationHistory: new ConversationHistory(),
       includeLocateInPlanning: false,
-      deepThink: false,
+      effort: 'balance',
     });
 
     const messages = vi.mocked(callAI).mock.calls[0]?.[0];
@@ -259,7 +283,7 @@ describe('plan XML parse retry', () => {
       }),
       conversationHistory: new ConversationHistory(),
       includeLocateInPlanning: true,
-      deepThink: false,
+      effort: 'balance',
     });
 
     expect(latestImageDetail()).toBe('high');
@@ -307,7 +331,7 @@ describe('plan XML parse retry', () => {
       }),
       conversationHistory: new ConversationHistory(),
       includeLocateInPlanning: true,
-      deepThink: false,
+      effort: 'balance',
     });
 
     expect(callAI).toHaveBeenCalledTimes(2);

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -552,7 +552,7 @@ describe('parseXMLPlanningResponse', () => {
     );
   });
 
-  it('should use a fallback log in fast mode when there is no action', () => {
+  it('should generate the log from a complete response in fast mode', () => {
     const result = parseStandardPlanningResponse(
       '<log>Model-generated completion log</log><complete success="true">done</complete>',
       getModelAdapter('doubao-vision').jsonParser,
@@ -563,8 +563,23 @@ describe('parseXMLPlanningResponse', () => {
       },
     );
 
-    expect(result.log).toBe('No action');
+    expect(result.log).toBe('Complete - success: true, message: done');
     expect(result.finalizeSuccess).toBe(true);
+  });
+
+  it('should generate the log from an error response in fast mode', () => {
+    const result = parseStandardPlanningResponse(
+      '<log>Model-generated error log</log><error>Button unavailable</error>',
+      getModelAdapter('doubao-vision').jsonParser,
+      {
+        includeThought: false,
+        logSource: 'action',
+        actionSpace: [],
+      },
+    );
+
+    expect(result.log).toBe('Error - Button unavailable');
+    expect(result.error).toBe('Button unavailable');
   });
 
   it('should parse XML response with null action', () => {

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -1,11 +1,15 @@
 import { getModelAdapter } from '@/ai-model/models';
-import { parseXMLPlanningResponse } from '@/ai-model/workflows/planning';
+import {
+  parseStandardPlanningResponse,
+  parseXMLPlanningResponse as parseXMLPlanningResponseWithOptions,
+} from '@/ai-model/workflows/planning';
 import {
   parseMarkFinishedIndexes,
   parseSubGoalsFromXML,
 } from '@/ai-model/workflows/planning/standard-planning-parser';
 import { getMidsceneLocationSchema } from '@/common';
 import { buildYamlFlowFromPlans } from '@/common';
+import { actionInputParamSchema, actionTapParamSchema } from '@/device';
 import {
   MIDSCENE_USE_DOUBAO_VISION,
   OPENAI_API_KEY,
@@ -13,6 +17,14 @@ import {
 } from '@midscene/shared/env';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+
+const parseXMLPlanningResponse = (
+  xmlString: string,
+  jsonParser: Parameters<typeof parseXMLPlanningResponseWithOptions>[1],
+) =>
+  parseXMLPlanningResponseWithOptions(xmlString, jsonParser, {
+    includeThought: true,
+  });
 
 describe('llm planning - doubao', () => {
   beforeEach(() => {
@@ -477,6 +489,82 @@ describe('parseXMLPlanningResponse', () => {
         },
       },
     });
+  });
+
+  it('should generate the log from the action in fast mode', () => {
+    const modelFamily = 'doubao-vision';
+    const xml = `
+<planning>This should not be exposed in fast mode</planning>
+<log>Tap the button</log>
+<action-type>Tap</action-type>
+<action-param-json>{"locate":{"prompt":"Button"}}</action-param-json>
+    `.trim();
+
+    const result = parseStandardPlanningResponse(
+      xml,
+      getModelAdapter(modelFamily).jsonParser,
+      {
+        includeThought: false,
+        logSource: 'action',
+        actionSpace: [
+          {
+            name: 'Tap',
+            paramSchema: actionTapParamSchema,
+            call: vi.fn(),
+          },
+        ],
+      },
+    );
+
+    expect(result).not.toHaveProperty('thought');
+    expect(result.log).toBe('Tap - locate: Button');
+    expect(result.action).toEqual({
+      type: 'Tap',
+      param: { locate: { prompt: 'Button' } },
+    });
+  });
+
+  it('should omit locate coordinates from a generated fast log', () => {
+    const modelFamily = 'doubao-vision';
+    const xml = `
+<action-type>Input</action-type>
+<action-param-json>{"value":"demo-user","locate":{"prompt":"Username input field","bbox":[375,445,625,505]}}</action-param-json>
+    `.trim();
+
+    const result = parseStandardPlanningResponse(
+      xml,
+      getModelAdapter(modelFamily).jsonParser,
+      {
+        includeThought: false,
+        logSource: 'action',
+        actionSpace: [
+          {
+            name: 'Input',
+            paramSchema: actionInputParamSchema,
+            call: vi.fn(),
+          },
+        ],
+      },
+    );
+
+    expect(result.log).toBe(
+      'Input - value: demo-user, locate: Username input field',
+    );
+  });
+
+  it('should use a fallback log in fast mode when there is no action', () => {
+    const result = parseStandardPlanningResponse(
+      '<log>Model-generated completion log</log><complete success="true">done</complete>',
+      getModelAdapter('doubao-vision').jsonParser,
+      {
+        includeThought: false,
+        logSource: 'action',
+        actionSpace: [],
+      },
+    );
+
+    expect(result.log).toBe('No action');
+    expect(result.finalizeSuccess).toBe(true);
   });
 
   it('should parse XML response with null action', () => {

--- a/packages/core/tests/unit-test/model-adapter/auto-glm/planning-messages.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/auto-glm/planning-messages.test.ts
@@ -77,6 +77,7 @@ function createPlanOptions(overrides: Partial<PlanOptions> = {}): PlanOptions {
     conversationHistory: new ConversationHistory(),
     includeLocateInPlanning: true,
     ...overrides,
+    effort: overrides.effort ?? 'balance',
   };
 }
 

--- a/packages/core/tests/unit-test/model-adapter/auto-glm/planning.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/auto-glm/planning.test.ts
@@ -77,6 +77,7 @@ function createPlanOptions(overrides: Partial<PlanOptions> = {}): PlanOptions {
     conversationHistory: new ConversationHistory(),
     includeLocateInPlanning: true,
     ...overrides,
+    effort: overrides.effort ?? 'balance',
   };
 }
 

--- a/packages/core/tests/unit-test/model-adapter/ui-tars/planning-response-parser.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/ui-tars/planning-response-parser.test.ts
@@ -41,6 +41,7 @@ function createPlanOptions(): PlanOptions {
     modelRuntime,
     conversationHistory: new ConversationHistory(),
     includeLocateInPlanning: true,
+    effort: 'balance',
   };
 }
 

--- a/packages/core/tests/unit-test/model-adapter/ui-tars/planning.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/ui-tars/planning.test.ts
@@ -54,6 +54,7 @@ function createPlanOptions(overrides: Partial<PlanOptions> = {}): PlanOptions {
     conversationHistory: new ConversationHistory(),
     includeLocateInPlanning: true,
     ...overrides,
+    effort: overrides.effort ?? 'balance',
   };
 }
 

--- a/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
+++ b/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
@@ -1214,6 +1214,342 @@ The previous action has been executed, here is the latest screenshot. Please con
 "
 `;
 
+exports[`system prompts > planning - fast output omits planning reasoning 1`] = `
+"
+Target: You are an expert to manipulate the UI to accomplish the user's instruction. User will give you an instruction, some screenshots, background knowledge and previous logs indicating what have been done. Your task is to accomplish the instruction by thinking through the path to complete the task and give the next action to execute.
+
+## Step 1: Observe
+
+First, observe the current screenshot and previous logs to understand the current state.
+
+
+
+
+
+
+
+
+
+## Step 2: Check if the Instruction is Fulfilled (related tags: <complete>)
+
+Determine if the entire task is completed.
+
+### CRITICAL: The User's Instruction is the Supreme Authority
+
+The user's instruction defines the EXACT scope of what you must accomplish. You MUST follow it precisely - nothing more, nothing less. Violating this rule may cause severe consequences such as data loss, unintended operations, or system failures.
+
+**Explicit instructions vs. High-level goals:**
+- If the user gives you **explicit operation steps** (e.g., "click X", "type Y", "fill out the form"), treat them as exact commands. Execute ONLY those steps, nothing more.
+- If the user gives you a **high-level goal** (e.g., "log in to the system", "complete the purchase"), you may determine the necessary steps to achieve it.
+
+**What "instruction fulfilled" means:**
+- The instruction is fulfilled when you have done EXACTLY what the user asked - no extra steps, no assumptions.
+- Do NOT perform any action beyond the explicit instruction, even if it seems logical or helpful.
+
+**Examples - Explicit instructions (execute exactly, no extra steps):**
+- "fill out the form" → Instruction fulfilled when all fields are filled. Do NOT submit the form.
+- "click the login button" → Instruction fulfilled once clicked. Do NOT wait for page load or verify login success.
+- "type 'hello' in the search box" → Instruction fulfilled when 'hello' is typed. Do NOT press Enter or trigger search.
+- "select the first item" → Instruction fulfilled when selected. Do NOT proceed to checkout.
+
+**Change completion:**
+- If the requested outcome is a durable change, such as create, edit, update, delete, save, send, submit, apply, or publish, do not stop at an unsaved draft, open editor, temporary input, transient selection, or staged value. Continue through the app/page's normal completion control such as Save, Done, Confirm, OK, Submit, Apply, Send, or Publish before completing, so the result remains after leaving the screen.
+- If the user only asks for an intermediate UI state, such as typing text, selecting an option, filling fields, or opening a screen without saving/submitting/applying, stop once that exact state is reached.
+
+**Special case - Scrollable option lists and dropdowns:**
+- When choosing an item from a scrollable select, dropdown, listbox, menu, or similar option list, first open the control if it is closed. Once the list is open, interact with the list itself, not the page.
+- If the target option is visible in the open list, Tap that exact option immediately.
+- If the list is open but the target option is not visible, try to find it by scrolling the open list/dropdown before giving up or interacting with other elements.
+- For an open dropdown/list, prefer small incremental Scroll actions with an explicit distance (typically 50-120 pixels) and a locate target describing the open list/dropdown. Do NOT omit distance while searching within a list, because the default scroll distance can skip over relevant options and cause oscillation.
+- While searching within an open dropdown/list, use short scrolls so intermediate options are not skipped.
+- After selecting the target, if the trigger text or result text shows the requested option, treat the current selection step as fulfilled and continue evaluating the remaining user instruction.
+
+**Special case - Text hidden by a narrow input field:**
+- CRITICAL PRIORITY OVERRIDE - Input verification after an input action:
+- This rule overrides the general requirement to verify the exact target text from the screenshot.
+- If the previous step already executed an input action, and the current input field is not empty, you MUST directly treat that input as successful.
+- In this situation, do NOT use the visible text in the screenshot to decide that the input is incomplete, incorrect, missing characters, out of order, or needs correction.
+- Do NOT perform ClearInput, another Input, KeyboardPress, or any other action intended to "fix the input content" just because the visible text looks different from the target text, has abnormal character order, missing characters, abnormal spacing, suspicious visual recognition results, or appears to have selected/highlighted text.
+- The general rule "do EXACTLY what the user asked" still applies to the intended input value you execute, but it MUST NOT be enforced by re-validating the visible text in the screenshot after the input action.
+- Differences in visible text must be assumed to be caused by clipping, horizontal scrolling, narrow input fields, text selection, caret position, or visual recognition errors rather than input failure.
+- Retry input only when the input field is clearly still empty, or when the page shows an explicit error message.
+
+**Special case - Assertion instructions:**
+- If the user's instruction includes an assertion (e.g., "verify that...", "check that...", "assert..."), and you observe from the screenshot that the assertion condition is NOT satisfied and cannot be satisfied, mark it as failed (success="false").
+- If the page is still loading (e.g., you see a loading spinner, skeleton screen, or progress bar), do NOT assert yet. Wait for the page to finish loading before evaluating the assertion.
+
+### Completion Criteria for Process-required Instructions
+
+If the user's instruction includes explicit operation steps, ordering requirements, or action requirements, it is a process-required instruction.
+
+For process-required instructions, do NOT treat the task as complete only because the current screenshot already shows the final expected state. Do NOT infer that earlier steps were executed from the final UI state.
+
+You may output <complete success="true"> only when the current execution history, previous logs, or the screenshot after the most recent action proves that every explicit step required by the user has been completed, and the final check condition is also satisfied.
+
+If any explicit step lacks completion evidence in the current execution history, continue with the next missing step instead of outputting <complete>, even if the current screenshot appears to satisfy the final condition.
+
+**Page navigation restriction:**
+- Unless the user's instruction explicitly asks you to click a link, jump to another page, or navigate to a URL, you MUST complete the task on the current page only.
+- Do NOT navigate away from the current page on your own initiative (e.g., do not click links that lead to other pages, do not use browser back/forward, do not open new URLs).
+- If the task cannot be accomplished on the current page and the user has not instructed you to navigate, report it as a failure (success="false") instead of attempting to navigate to other pages.
+
+### Output Rules
+
+- If the task is NOT complete, skip this section and continue to Step 3.
+- Use the <complete success="true|false">message</complete> tag to output the result if the goal is accomplished or failed.
+  - the 'success' attribute is required. No matter what errors occurred during execution, set success="true" only when the current execution history shows that all steps required by the user have been completed and the final state satisfies the requirement. If the user asks for explicit operation steps or an ordered workflow, do not treat those steps as completed only because the current screenshot already shows the final expected state. If the instruction is not fulfilled and cannot be fulfilled, set success="false".
+  - the 'message' is the information that will be provided to the user. If the user asks for a specific format, strictly follow that.
+- If you output <complete>, do NOT output <action-type>, <action-param-json>. The task ends here.
+
+## Step 3: Determine Next Action (related tags: <action-type>, <action-param-json>, <error>)
+
+ONLY if the task is not complete: Think what the next action is according to the current screenshot.
+
+- Don't give extra actions or plans beyond the instruction or the plan. For example, don't try to submit the form if the instruction is only to fill something.
+- Consider the current screenshot and give the action that is most likely to accomplish the instruction. For example, if the next step is to click a button but it's not visible in the screenshot, you should try to find it first instead of give a click action.
+- Make sure the previous actions are completed successfully. Otherwise, retry or do something else to recover.
+- Give just the next ONE action you should do (if any)
+- If there are some error messages reported by the previous actions, don't give up, try parse a new action to recover. If the error persists for more than 3 times, you should think this is an error and set the "error" field to the error message.
+
+### Action Guidelines
+
+
+- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.
+- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.
+- For insert/prepend/append edits, use CursorMove when the caret must be adjusted precisely, then use Input with mode "typeOnly" for inserted characters and KeyboardPress for newlines or deletion. If the caret lands in the wrong position, recover with CursorMove, KeyboardPress, or undo and retry cursor placement; do not switch to replace as a fallback for cursor placement failures.
+
+
+
+### Supporting actions list
+
+- type: Tap
+  description: Tap the element
+  param:
+    locate:
+      type: '{ prompt: string /* description of the target element */ }'
+      description: The element to be tapped
+- type: Sleep
+  description: Sleep for a period of time
+  param:
+    timeMs:
+      type: number
+      description: The duration of the sleep in milliseconds
+- type: Input
+  description: Input text into the input field
+  param:
+    value:
+      type: string
+      description: The value to be input
+    locate:
+      type: '{ prompt: string /* description of the target element */ }'
+      optional: true
+      description: The input field to target
+  sample: |-
+    <action-type>Input</action-type>
+    <action-param-json>
+    {
+      "value": "test@example.com",
+      "locate": {
+        "prompt": "the email input field"
+      }
+    }
+    </action-param-json>
+- type: KeyboardPress
+  description: Press a keyboard key
+  param:
+    value:
+      type: string
+      description: The key to be pressed
+    locate:
+      type: '{ prompt: string /* description of the target element */ }'
+      optional: true
+      description: The element to target for key press
+- type: Scroll
+  description: Scroll the page
+  param:
+    value:
+      type: string
+      description: The scroll direction or amount
+    locate:
+      type: '{ prompt: string /* description of the target element */ }'
+      optional: true
+      description: The element to scroll
+  sample: |-
+    <action-type>Scroll</action-type>
+    <action-param-json>
+    {
+      "value": "down",
+      "locate": {
+        "prompt": "the product list area"
+      }
+    }
+    </action-param-json>
+- type: DragAndDrop
+  description: Drag an element to another position
+  param:
+    from:
+      type: '{ prompt: string /* description of the target element */ }'
+      description: The element to drag
+    to:
+      type: '{ prompt: string /* description of the target element */ }'
+      description: The drop target
+  sample: |-
+    <action-type>DragAndDrop</action-type>
+    <action-param-json>
+    {
+      "from": {
+        "prompt": "the \\"report.pdf\\" file icon"
+      },
+      "to": {
+        "prompt": "the upload drop zone"
+      }
+    }
+    </action-param-json>
+
+
+
+### If there is some action to do ...
+
+- Use the <action-type> and <action-param-json> tags to output the action to be executed.
+- The value inside <action-type> MUST exactly match the 'type' field of one action in the Supporting actions list. 'complete' is NOT a valid action-type.
+- Parameter names are strict. Use EXACTLY the field names listed for the selected action. Do NOT invent alias fields. If the selected action provides a "sample" field, use the XML structure shown in that sample as the exact format for the action output.
+
+For example:
+<action-type>Tap</action-type>
+<action-param-json>
+{
+  "locate": {
+    "prompt": "Add to cart button for Sauce Labs Backpack"
+  }
+}
+</action-param-json>
+
+### If you think there is an error ...
+
+- Use the <error> tag to output the error message.
+
+For example:
+<error>Unable to find the required element on the page</error>
+
+### If there is no action to do ...
+
+- Don't output <action-type>, <action-param-json> if there is no action to do.
+
+## Return Format
+
+Return in XML format following this decision flow:
+
+
+
+
+**Then choose ONE of the following paths:**
+
+**Path A: If the instruction is fulfilled or failed (Step 2)**
+<complete success="true|false">...</complete>
+
+**Path B: If the instruction is NOT fulfilled yet (Step 3)**
+<!-- Determine next action -->
+
+<action-type>...</action-type>
+<action-param-json>...</action-param-json>
+
+<!-- OR if there's an error -->
+<error>...</error>
+
+
+## Multi-turn Conversation Example
+
+Below is an example of a multi-turn conversation for "fill out the registration form with name 'John' and email 'john@example.com', then return the filled email address":
+
+### Turn 1 - Initial instruction
+
+**User message:**
+<user_instruction>fill out the registration form with name 'John' and email 'john@example.com', then return the filled email address</user_instruction>
+
+**Screenshot:** [Shows a registration form with empty Name and Email fields]
+
+**Your response:**
+
+<action-type>Tap</action-type>
+<action-param-json>
+{
+  "locate": {
+    "prompt": "Name input field in the registration form"
+  }
+}
+</action-param-json>
+
+### Turn 2 - After clicking Name field
+
+**User message:**
+The previous action has been executed, here is the latest screenshot. Please continue according to the instruction.
+
+
+
+**Screenshot:** [Shows the form with Name field now focused/active]
+
+**Your response:**
+
+<action-type>Input</action-type>
+<action-param-json>
+{
+  "value": "John"
+}
+</action-param-json>
+
+### Turn 3 - After entering name
+
+**User message:**
+The previous action has been executed, here is the latest screenshot. Please continue according to the instruction.
+
+
+
+**Screenshot:** [Shows the form with Name field containing 'John']
+
+**Your response:**
+
+<action-type>Tap</action-type>
+<action-param-json>
+{
+  "locate": {
+    "prompt": "Email input field in the registration form"
+  }
+}
+</action-param-json>
+
+### Turn 4 - After clicking Email field
+
+**User message:**
+The previous action has been executed, here is the latest screenshot. Please continue according to the instruction.
+
+
+
+**Screenshot:** [Shows the form with Name='John' and Email field focused]
+
+**Your response:**
+
+<action-type>Input</action-type>
+<action-param-json>
+{
+  "value": "john@example.com"
+}
+</action-param-json>
+
+### Turn 5 - After entering email (Instruction fulfilled)
+
+**User message:**
+The previous action has been executed, here is the latest screenshot. Please continue according to the instruction.
+
+
+
+**Screenshot:** [Shows the form with Name='John' and Email='john@example.com']
+
+**Your response:**
+
+<complete success="true">john@example.com</complete>
+"
+`;
+
 exports[`system prompts > planning - gemini 1`] = `
 "
 Target: You are an expert to manipulate the UI to accomplish the user's instruction. User will give you an instruction, some screenshots, background knowledge and previous logs indicating what have been done. Your task is to accomplish the instruction by thinking through the path to complete the task and give the next action to execute.

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -219,6 +219,26 @@ describe('system prompts', () => {
     );
   });
 
+  it('planning - fast output omits planning reasoning', async () => {
+    const prompt = await buildStandardPlanningSystemPrompt({
+      actionSpace: mockActionSpace,
+      includeLocateInPlanning: false,
+      includeThought: false,
+      includeLog: false,
+      includeSubGoals: false,
+    });
+
+    expect(prompt).not.toContain('<planning>');
+    expect(prompt).not.toContain('</planning>');
+    expect(prompt).not.toContain('related tags: <planning>');
+    expect(prompt).not.toContain('<log>');
+    expect(prompt).not.toContain('</log>');
+    expect(prompt).not.toContain('related tags: <log>');
+    expect(prompt).toContain('<action-type>...</action-type>');
+    expect(prompt).toContain('<action-param-json>...</action-param-json>');
+    expect(prompt).toMatchSnapshot();
+  });
+
   it('planning - includeSubGoals true should contain sub-goal tags', async () => {
     const prompt = await buildStandardPlanningSystemPrompt({
       actionSpace: mockActionSpace,

--- a/packages/core/tests/unit-test/task-executor-concurrency.test.ts
+++ b/packages/core/tests/unit-test/task-executor-concurrency.test.ts
@@ -93,6 +93,76 @@ describe('TaskExecutor concurrency isolation', () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    {
+      effort: 'balance' as const,
+      useDefaultAsPlanning: true,
+      expectedIncludeLocateInPlanning: true,
+      expectedImagesIncludeCount: 1,
+    },
+    {
+      effort: 'balance' as const,
+      useDefaultAsPlanning: false,
+      expectedIncludeLocateInPlanning: false,
+      expectedImagesIncludeCount: 1,
+    },
+    {
+      effort: 'fast' as const,
+      useDefaultAsPlanning: true,
+      expectedIncludeLocateInPlanning: true,
+      expectedImagesIncludeCount: 1,
+    },
+    {
+      effort: 'deepThink' as const,
+      useDefaultAsPlanning: true,
+      expectedIncludeLocateInPlanning: false,
+      expectedImagesIncludeCount: 2,
+    },
+  ])(
+    'derives planning options for $effort effort',
+    async ({
+      effort,
+      useDefaultAsPlanning,
+      expectedIncludeLocateInPlanning,
+      expectedImagesIncludeCount,
+    }) => {
+      vi.mocked(standardPlan).mockResolvedValue({
+        actions: [],
+        yamlFlow: [],
+        shouldContinuePlanning: false,
+        log: '',
+        rawResponse: '',
+        finalizeSuccess: true,
+        finalizeMessage: 'done',
+      });
+
+      const resolvedPlanningModel = useDefaultAsPlanning
+        ? defaultModel()
+        : planningModel();
+      const result = await taskExecutor.action(
+        'prompt',
+        resolvedPlanningModel,
+        defaultModel(),
+        undefined,
+        undefined,
+        undefined,
+        effort,
+      );
+
+      expect(standardPlan).toHaveBeenCalledWith(
+        'prompt',
+        expect.objectContaining({
+          effort,
+          includeLocateInPlanning: expectedIncludeLocateInPlanning,
+          imagesIncludeCount: expectedImagesIncludeCount,
+        }),
+      );
+      expect(result.runner.tasks[0].param).toEqual(
+        expect.objectContaining({ effort }),
+      );
+    },
+  );
+
   it('should isolate conversation history between concurrent action calls', async () => {
     const waitForBothCalls = createDeferred();
     const releasePlans = createDeferred();
@@ -126,13 +196,11 @@ describe('TaskExecutor concurrency isolation', () => {
       'first prompt',
       planningModel(),
       defaultModel(),
-      true,
     );
     const actionPromiseB = taskExecutor.action(
       'second prompt',
       planningModel(),
       defaultModel(),
-      true,
     );
 
     await waitForBothCalls.promise;
@@ -227,7 +295,6 @@ describe('TaskExecutor concurrency isolation', () => {
       'A',
       planningModel(),
       defaultModel(),
-      true,
       undefined,
       undefined,
       5,
@@ -236,7 +303,6 @@ describe('TaskExecutor concurrency isolation', () => {
       'B',
       planningModel(),
       defaultModel(),
-      true,
       undefined,
       undefined,
       9,
@@ -327,12 +393,7 @@ describe('TaskExecutor concurrency isolation', () => {
       yamlFlow: [],
     } as any);
 
-    await taskExecutor.action(
-      'run noop',
-      planningModel(),
-      defaultModel(),
-      true,
-    );
+    await taskExecutor.action('run noop', planningModel(), defaultModel());
 
     expect(progressEvents).toEqual([
       'start|3|run noop',
@@ -392,7 +453,7 @@ describe('TaskExecutor concurrency isolation', () => {
         };
       });
 
-    await taskExecutor.action('prompt', planningModel(), defaultModel(), true);
+    await taskExecutor.action('prompt', planningModel(), defaultModel());
 
     expect(mockInterface.getDeviceLocalTimeString).toHaveBeenCalledWith(
       undefined,
@@ -472,7 +533,6 @@ Stdout:
       'check brightness with adb shell',
       planningModel(),
       defaultModel(),
-      true,
     );
 
     expect(seenPendingFeedback[0]).toBe('');
@@ -545,7 +605,6 @@ Stdout:
       'read big file with adb shell',
       planningModel(),
       defaultModel(),
-      true,
     );
 
     expect(seenPendingFeedback[1]).toContain('x'.repeat(500));
@@ -679,7 +738,6 @@ mCurrentFocus=Window{abc}`;
       'check brightness',
       planningModel(),
       defaultModel(),
-      true,
     );
 
     expect(
@@ -760,7 +818,6 @@ ${thirdPlanningFeedback}`);
       'copy clipboard',
       planningModel(),
       defaultModel(),
-      true,
     );
 
     expect(seenPendingFeedback[1]).not.toContain('WriteState');
@@ -811,7 +868,7 @@ ${thirdPlanningFeedback}`);
         };
       });
 
-    await taskExecutor.action('prompt', planningModel(), defaultModel(), true);
+    await taskExecutor.action('prompt', planningModel(), defaultModel());
 
     expect(seenPendingFeedback).toEqual([
       '',

--- a/packages/core/tests/unit-test/task-executor-custom-planning.test.ts
+++ b/packages/core/tests/unit-test/task-executor-custom-planning.test.ts
@@ -62,8 +62,8 @@ function createCustomPlanningModel(plannedActions: any[] = []): ModelRuntime {
     config: {
       modelName: 'custom-planning-model',
       modelDescription: 'custom-planning-model',
-      intent: 'planning',
-      slot: 'planning',
+      intent: 'default',
+      slot: 'default',
     },
     adapter: new ResolvedModelAdapter(
       {
@@ -156,8 +156,6 @@ describe('TaskExecutor custom planning adapters', () => {
       'prompt',
       customPlanningModel,
       defaultModel(),
-      true,
-      undefined,
       undefined,
       undefined,
       undefined,

--- a/packages/core/tests/unit-test/tasks-null-data.test.ts
+++ b/packages/core/tests/unit-test/tasks-null-data.test.ts
@@ -403,7 +403,6 @@ describe('TaskExecutor - Null Data Handling', () => {
         'complete the task',
         getModelRuntime(planningModelConfig),
         getModelRuntime(defaultModelConfig),
-        false,
       );
 
       const planningTask = result.runner.tasks[0];

--- a/packages/core/tests/unit-test/workflows/planning/planning-action-log.test.ts
+++ b/packages/core/tests/unit-test/workflows/planning/planning-action-log.test.ts
@@ -1,0 +1,98 @@
+import { buildPlanningActionLog } from '@/ai-model/workflows/planning/planning-action-log';
+import {
+  ActionSwipeParamSchema,
+  actionDragAndDropParamSchema,
+  actionScrollParamSchema,
+} from '@/device';
+import type { DeviceAction, PlanningAction } from '@/types';
+import { describe, expect, it, vi } from 'vitest';
+
+const actionDefinition = (
+  name: string,
+  paramSchema?: DeviceAction['paramSchema'],
+): DeviceAction => ({
+  name,
+  paramSchema,
+  call: vi.fn(),
+});
+
+describe('buildPlanningActionLog', () => {
+  it('keeps non-locator parameters and replaces locator results with prompts', () => {
+    const action: PlanningAction = {
+      type: 'Scroll',
+      param: {
+        scrollType: 'singleAction',
+        direction: 'down',
+        distance: 100,
+        locate: {
+          prompt: 'Product list',
+          bbox: [100, 100, 200, 200],
+        },
+      },
+    };
+
+    expect(
+      buildPlanningActionLog(action, [
+        actionDefinition('Scroll', actionScrollParamSchema),
+      ]),
+    ).toBe(
+      'Scroll - scrollType: singleAction, direction: down, distance: 100, locate: Product list',
+    );
+  });
+
+  it('handles multiple locator fields using the action schema', () => {
+    const action: PlanningAction = {
+      type: 'DragAndDrop',
+      param: {
+        from: { prompt: 'report.pdf', bbox: [10, 20, 30, 40] },
+        to: { prompt: 'Upload folder', bbox: [50, 60, 70, 80] },
+      },
+    };
+
+    expect(
+      buildPlanningActionLog(action, [
+        actionDefinition('DragAndDrop', actionDragAndDropParamSchema),
+      ]),
+    ).toBe('DragAndDrop - from: report.pdf, to: Upload folder');
+  });
+
+  it('handles start and end locator fields without losing other parameters', () => {
+    const action: PlanningAction = {
+      type: 'Swipe',
+      param: {
+        start: { prompt: 'Notification', bbox: [10, 20, 30, 40] },
+        end: { prompt: 'Upper edge', bbox: [50, 60, 70, 80] },
+        duration: 300,
+      },
+    };
+
+    expect(
+      buildPlanningActionLog(action, [
+        actionDefinition('Swipe', ActionSwipeParamSchema),
+      ]),
+    ).toBe('Swipe - start: Notification, end: Upper edge, duration: 300');
+  });
+
+  it('serializes the complete action when its schema is unavailable', () => {
+    const action: PlanningAction = {
+      type: 'CustomAction',
+      param: {
+        target: { prompt: 'Target', bbox: [10, 20, 30, 40] },
+        value: 'demo',
+      },
+    };
+
+    expect(
+      buildPlanningActionLog(action, [actionDefinition('CustomAction')]),
+    ).toBe(JSON.stringify(action));
+  });
+
+  it('serializes the complete action when it is absent from actionSpace', () => {
+    const action: PlanningAction = {
+      type: 'UnknownAction',
+      param: { value: 'demo' },
+    };
+
+    expect(buildPlanningActionLog(action, [])).toBe(JSON.stringify(action));
+  });
+});

--- a/packages/web-integration/tests/ai/web/playwright/__fixtures__/fast-login-popup/index.html
+++ b/packages/web-integration/tests/ai/web/playwright/__fixtures__/fast-login-popup/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login with Advertisement Popup</title>
+    <style>
+      :root {
+        color: #152033;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+        background: linear-gradient(145deg, #eef4ff, #f8faff 55%, #e8efff);
+      }
+
+      .login-card {
+        width: min(400px, calc(100vw - 40px));
+        padding: 40px;
+        border: 1px solid #dce4f2;
+        border-radius: 18px;
+        background: white;
+        box-shadow: 0 20px 60px rgb(43 61 96 / 16%);
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: 30px;
+      }
+
+      .subtitle {
+        margin: 0 0 30px;
+        color: #68758b;
+      }
+
+      .field {
+        display: grid;
+        gap: 8px;
+        margin-bottom: 20px;
+      }
+
+      label {
+        font-size: 14px;
+        font-weight: 650;
+      }
+
+      input {
+        width: 100%;
+        padding: 12px 14px;
+        border: 1px solid #bcc8da;
+        border-radius: 8px;
+        font: inherit;
+      }
+
+      input:focus {
+        border-color: #3267d6;
+        outline: 3px solid rgb(50 103 214 / 14%);
+      }
+
+      button {
+        border: 0;
+        border-radius: 8px;
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+      }
+
+      .login-button {
+        width: 100%;
+        padding: 13px 18px;
+        background: #3267d6;
+        color: white;
+      }
+
+      .login-button:hover {
+        background: #2556bd;
+      }
+
+      .success {
+        display: none;
+        text-align: center;
+      }
+
+      .success-icon {
+        display: grid;
+        width: 60px;
+        height: 60px;
+        margin: 0 auto 18px;
+        place-items: center;
+        border-radius: 50%;
+        background: #ddf7e8;
+        color: #16834b;
+        font-size: 30px;
+      }
+
+      .success p {
+        margin-bottom: 0;
+        color: #68758b;
+      }
+
+      .ad-overlay {
+        position: fixed;
+        z-index: 10;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        background: rgb(16 28 49 / 72%);
+      }
+
+      .ad-overlay[hidden] {
+        display: none;
+      }
+
+      .ad-dialog {
+        position: relative;
+        width: min(460px, calc(100vw - 48px));
+        min-height: 390px;
+        padding: 58px 42px 42px;
+        border: 4px solid #ffd45c;
+        border-radius: 22px;
+        background: linear-gradient(150deg, #fff8dc, #ffe18b);
+        box-shadow: 0 28px 90px rgb(0 0 0 / 38%);
+        text-align: center;
+      }
+
+      .ad-badge {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: #e8492f;
+        color: white;
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+      }
+
+      .ad-dialog h2 {
+        margin: 24px 0 12px;
+        color: #5c3510;
+        font-size: 34px;
+        line-height: 1.1;
+      }
+
+      .ad-dialog p {
+        margin: 0 auto;
+        max-width: 320px;
+        color: #79501f;
+        font-size: 18px;
+        line-height: 1.5;
+      }
+
+      .ad-offer {
+        margin-top: 26px;
+        color: #d74328;
+        font-size: 28px;
+        font-weight: 850;
+      }
+
+      .close-ad {
+        position: absolute;
+        top: 14px;
+        right: 14px;
+        display: grid;
+        width: 42px;
+        height: 42px;
+        place-items: center;
+        border: 2px solid #6c481c;
+        border-radius: 50%;
+        background: white;
+        color: #4e3213;
+        font-size: 25px;
+        line-height: 1;
+      }
+
+      .close-ad:hover {
+        background: #fff3cc;
+      }
+    </style>
+  </head>
+  <body data-login-state="signed-out">
+    <main class="login-card">
+      <form id="login-form">
+        <h1>Welcome back</h1>
+        <p class="subtitle">Sign in to continue to your account.</p>
+
+        <div class="field">
+          <label for="username">Username</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+          />
+        </div>
+
+        <div class="field">
+          <label for="password">Password</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+        </div>
+
+        <button class="login-button" type="submit">Log in</button>
+      </form>
+
+      <section class="success" id="success" aria-live="polite">
+        <div class="success-icon" aria-hidden="true">✓</div>
+        <h1>Login successful</h1>
+        <p>You are now signed in.</p>
+      </section>
+    </main>
+
+    <div class="ad-overlay" id="ad-overlay" hidden>
+      <section
+        class="ad-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ad-title"
+      >
+        <button class="close-ad" id="close-ad" type="button" aria-label="Close advertisement">
+          ×
+        </button>
+        <span class="ad-badge">SPECIAL OFFER</span>
+        <h2 id="ad-title">A surprise deal just for you!</h2>
+        <p>Upgrade today and unlock all premium features.</p>
+        <div class="ad-offer">Save 50%</div>
+      </section>
+    </div>
+
+    <script>
+      const form = document.querySelector('#login-form');
+      const username = document.querySelector('#username');
+      const overlay = document.querySelector('#ad-overlay');
+      const closeAd = document.querySelector('#close-ad');
+      const success = document.querySelector('#success');
+
+      let adHasOpened = false;
+      let openAdTimer;
+
+      username.addEventListener('input', () => {
+        if (adHasOpened || !username.value.trim()) {
+          return;
+        }
+
+        window.clearTimeout(openAdTimer);
+        openAdTimer = window.setTimeout(() => {
+          adHasOpened = true;
+          overlay.hidden = false;
+          closeAd.focus();
+        }, 250);
+      });
+
+      closeAd.addEventListener('click', () => {
+        overlay.hidden = true;
+        document.querySelector('#password').focus();
+      });
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+
+        if (!form.reportValidity()) {
+          return;
+        }
+
+        form.hidden = true;
+        success.style.display = 'block';
+        document.body.dataset.loginState = 'signed-in';
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-integration/tests/ai/web/playwright/fast-login-popup.spec.ts
+++ b/packages/web-integration/tests/ai/web/playwright/fast-login-popup.spec.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { expect } from '@playwright/test';
+import { test } from './fixture';
+
+test('fast aiAct handles an advertisement popup during login', async ({
+  agentForPage,
+  page,
+}) => {
+  const fixtureDir = path.resolve(__dirname, '__fixtures__/fast-login-popup');
+  await page.goto(pathToFileURL(path.join(fixtureDir, 'index.html')).href);
+
+  const agent = await agentForPage(page);
+  await agent.aiAct(
+    'Log in with username "demo-user" and password "demo-password".',
+    { effort: 'fast', cacheable: false },
+  );
+
+  await expect(page.locator('body')).toHaveAttribute(
+    'data-login-state',
+    'signed-in',
+  );
+  await expect(page.locator('#success')).toContainText('Login successful');
+});


### PR DESCRIPTION
## Summary

- add the experimental `effort: 'fast' | 'balance' | 'deepThink'` option to `aiAct`, while keeping the existing `deepThink` API compatible
- propagate `effort` through planning execution and report dumps, with DeepThink tags rendered from the recorded effort
- make fast planning use the action-only XML prompt/parse path without `<planning>` output
- reject `effort: 'fast'` before execution when the selected model uses a custom planning adapter
- add focused API, prompt snapshot, parser, execution, and report tests
- add a Playwright login fixture and AI e2e covering an advertisement popup that interrupts the login flow

## Compatibility

- `deepThink` remains supported and is not deprecated
- when both `deepThink` and `effort` are provided, `effort` takes precedence
- explicit `effort` usage emits the experimental-feature warning
- `effort: 'fast'` throws when used with custom planning adapters because they do not implement the fast response protocol
- Playground continues to use its existing `deepThink` option

## Validation

- `pnpm run lint`
- `pnpm exec nx run-many --target=build --projects=@midscene/core,@midscene/report`
- `pnpm exec nx test @midscene/core` (1443 passed, 8 skipped)
- focused core planning/unit tests (86 passed)
- focused report task-tag tests (9 passed)
- `pnpm --filter @midscene/core exec vitest --run tests/unit-test/prompt/prompt.test.ts` (40 passed)
- `pnpm --filter @midscene/core exec vitest --run tests/unit-test/agent-custom-model.test.ts` (18 passed)
- `pnpm exec playwright test --config=tests/playwright.config.ts tests/ai/web/playwright/fast-login-popup.spec.ts --project=e2e` with `mst dm` (1 passed)
