### PR TITLE
feat(ios): expose clipboard get/set in the iOS action space

### DIFF
--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -860,6 +860,20 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     await this.wdaBackend.pressHomeButton();
   }
 
+  /**
+   * Read the system pasteboard (clipboard). The only way to retrieve a value that an app
+   * exposes solely through a native "Copy" action -- e.g. a share sheet's "Copy Link" --
+   * since that value has no other on-screen representation to read.
+   */
+  async getClipboardText(): Promise<string> {
+    return await this.wdaBackend.getPasteboard();
+  }
+
+  /** Write plain text to the system pasteboard (clipboard). */
+  async setClipboardText(text: string): Promise<void> {
+    await this.wdaBackend.setPasteboard(text);
+  }
+
   async appSwitcher(): Promise<void> {
     try {
       // For iOS, use swipe up with slower/longer duration to trigger app switcher

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -1109,6 +1109,14 @@ type TerminateParam = z.infer<typeof terminateParamSchema>;
 
 export type DeviceActionTerminate = DeviceAction<TerminateParam, void>;
 
+const setClipboardParamSchema = z.object({
+  text: z
+    .string()
+    .describe('Plain text to write to the iOS system pasteboard (clipboard)'),
+});
+
+type SetClipboardParam = z.infer<typeof setClipboardParamSchema>;
+
 /**
  * Platform-specific action definitions for iOS
  * Single source of truth for both runtime behavior and type definitions
@@ -1180,9 +1188,39 @@ const createPlatformActions = (device: IOSDevice) => {
         await device.appSwitcher();
       },
     }),
+    IOSGetClipboard: defineAction<undefined, undefined, string>({
+      name: 'IOSGetClipboard',
+      description:
+        'Read the iOS system pasteboard (clipboard) and return its text. Use this to obtain a value that an app only exposes through a native "Copy" action -- e.g. a share sheet\'s "Copy Link" -- and that is therefore not rendered anywhere on screen.',
+      interfaceAlias: 'getClipboardText',
+      call: async () => {
+        return await device.getClipboardText();
+      },
+    }),
+    IOSSetClipboard: defineAction<
+      typeof setClipboardParamSchema,
+      SetClipboardParam,
+      void
+    >({
+      name: 'IOSSetClipboard',
+      description:
+        'Write plain text to the iOS system pasteboard (clipboard) so it can be pasted into an app.',
+      interfaceAlias: 'setClipboardText',
+      paramSchema: setClipboardParamSchema,
+      sample: {
+        text: 'https://example.com/invite/abc123',
+      },
+      call: async (param) => {
+        await device.setClipboardText(param.text);
+      },
+    }),
   } as const;
 };
 
 export type DeviceActionIOSHomeButton = DeviceAction<undefined, void>;
 
 export type DeviceActionIOSAppSwitcher = DeviceAction<undefined, void>;
+
+export type DeviceActionIOSGetClipboard = DeviceAction<undefined, string>;
+
+export type DeviceActionIOSSetClipboard = DeviceAction<SetClipboardParam, void>;

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -341,6 +341,57 @@ export class IOSWebDriverClient extends WebDriverClient {
     }
   }
 
+  /**
+   * Read the iOS pasteboard (system clipboard) via WDA's `wda/getPasteboard`.
+   * Useful for values only exposed through a native "Copy" action (e.g. a share
+   * sheet's "Copy Link"), which have no other readable representation on screen.
+   * @param contentType Pasteboard content type WDA should decode as; 'plaintext' covers
+   * the common case (copied text/URLs).
+   */
+  async getPasteboard(contentType = 'plaintext'): Promise<string> {
+    this.ensureSession();
+
+    try {
+      const response = await this.makeRequest(
+        'POST',
+        `/session/${this.sessionId}/wda/getPasteboard`,
+        { contentType },
+      );
+      const value = response?.value;
+      if (!value) {
+        return '';
+      }
+      return Buffer.from(value, 'base64').toString('utf8');
+    } catch (error) {
+      debugIOS(`Failed to read pasteboard: ${error}`);
+      throw new Error(`Failed to read pasteboard: ${error}`);
+    }
+  }
+
+  /**
+   * Write to the iOS pasteboard (system clipboard) via WDA's `wda/setPasteboard`.
+   * @param text Plain text to place on the pasteboard.
+   * @param contentType Pasteboard content type; 'plaintext' covers the common case.
+   */
+  async setPasteboard(text: string, contentType = 'plaintext'): Promise<void> {
+    this.ensureSession();
+
+    try {
+      await this.makeRequest(
+        'POST',
+        `/session/${this.sessionId}/wda/setPasteboard`,
+        {
+          content: Buffer.from(text, 'utf8').toString('base64'),
+          contentType,
+        },
+      );
+      debugIOS(`Wrote to pasteboard: "${text}"`);
+    } catch (error) {
+      debugIOS(`Failed to write pasteboard "${text}": ${error}`);
+      throw new Error(`Failed to write pasteboard: ${error}`);
+    }
+  }
+
   async tap(x: number, y: number): Promise<void> {
     this.ensureSession();
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -43,6 +43,8 @@ describe('IOSDevice', () => {
       clearActiveElement: vi.fn().mockResolvedValue(true),
       pressKey: vi.fn().mockResolvedValue(undefined),
       pressHomeButton: vi.fn().mockResolvedValue(undefined),
+      getPasteboard: vi.fn().mockResolvedValue('clipboard-text'),
+      setPasteboard: vi.fn().mockResolvedValue(undefined),
       launchApp: vi.fn().mockResolvedValue(undefined),
       terminateApp: vi.fn().mockResolvedValue(undefined),
       openUrl: vi.fn().mockResolvedValue(undefined),
@@ -411,6 +413,21 @@ describe('IOSDevice', () => {
 
       await device.appSwitcher();
       expect(mockWdaClient.swipe).toHaveBeenCalled();
+    });
+
+    it('should read the clipboard via the WDA pasteboard', async () => {
+      await device.connect();
+
+      const text = await device.getClipboardText();
+      expect(mockWdaClient.getPasteboard).toHaveBeenCalled();
+      expect(text).toBe('clipboard-text');
+    });
+
+    it('should write the clipboard via the WDA pasteboard', async () => {
+      await device.connect();
+
+      await device.setClipboardText('new-text');
+      expect(mockWdaClient.setPasteboard).toHaveBeenCalledWith('new-text');
     });
 
     it('should handle keyboard dismissal', async () => {

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -430,6 +430,33 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.setPasteboard).toHaveBeenCalledWith('new-text');
     });
 
+    it('should expose IOSGetClipboard in the action space and return its text', async () => {
+      await device.connect();
+
+      const action = device
+        .actionSpace()
+        .find((candidate) => candidate.name === 'IOSGetClipboard');
+      expect(action).toBeDefined();
+
+      const text = await action!.call(undefined as never);
+      expect(mockWdaClient.getPasteboard).toHaveBeenCalled();
+      expect(text).toBe('clipboard-text');
+    });
+
+    it('should expose IOSSetClipboard in the action space and forward its text', async () => {
+      await device.connect();
+
+      const action = device
+        .actionSpace()
+        .find((candidate) => candidate.name === 'IOSSetClipboard');
+      expect(action).toBeDefined();
+
+      await action!.call({ text: 'from-action-space' } as never);
+      expect(mockWdaClient.setPasteboard).toHaveBeenCalledWith(
+        'from-action-space',
+      );
+    });
+
     it('should handle keyboard dismissal', async () => {
       await device.connect();
 

--- a/packages/ios/tests/unit-test/structure.test.ts
+++ b/packages/ios/tests/unit-test/structure.test.ts
@@ -38,6 +38,8 @@ describe('iOS Package Structure', () => {
       expect(actionNames).toContain('LongPress');
       expect(actionNames).toContain('Swipe');
       expect(actionNames).toContain('IOSAppSwitcher');
+      expect(actionNames).toContain('IOSGetClipboard');
+      expect(actionNames).toContain('IOSSetClipboard');
     });
 
     it('should respect configuration options', () => {

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -1,6 +1,69 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
 import type { IOSWebDriverClient as IOSWebDriverClientType } from '../../src/ios-webdriver-client';
+
+function createClientWithSession() {
+  const client = new IOSWebDriverClient({
+    port: DEFAULT_WDA_PORT,
+    host: 'localhost',
+  });
+  // Bypass createSession() — we only want to observe outbound HTTP calls.
+  (client as any).sessionId = 'session-under-test';
+  const makeRequest = vi
+    .spyOn(client as any, 'makeRequest')
+    .mockResolvedValue(undefined);
+  return { client, makeRequest };
+}
+
+describe('IOSWebDriverClient pasteboard', () => {
+  it('getPasteboard POSTs contentType and base64-decodes the response', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockResolvedValue({
+      value: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+    });
+
+    const text = await client.getPasteboard();
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/getPasteboard',
+      { contentType: 'plaintext' },
+    );
+    expect(text).toBe('Hello 世界');
+  });
+
+  it('getPasteboard returns an empty string when WDA reports no value', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockResolvedValue({ value: '' });
+
+    await expect(client.getPasteboard()).resolves.toBe('');
+  });
+
+  it('getPasteboard rejects when the request itself fails', async () => {
+    const { client, makeRequest } = createClientWithSession();
+    makeRequest.mockRejectedValue(new Error('WDA HTTP error: 500'));
+
+    await expect(client.getPasteboard()).rejects.toThrow(
+      'Failed to read pasteboard',
+    );
+  });
+
+  it('setPasteboard POSTs base64-encoded content and contentType', async () => {
+    const { client, makeRequest } = createClientWithSession();
+
+    await client.setPasteboard('Hello 世界');
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/session/session-under-test/wda/setPasteboard',
+      {
+        content: Buffer.from('Hello 世界', 'utf8').toString('base64'),
+        contentType: 'plaintext',
+      },
+    );
+  });
+});
 
 describe('IOSWebDriverClient - Simple Tests', () => {
   describe('Module Structure', () => {
@@ -38,6 +101,8 @@ describe('IOSWebDriverClient - Simple Tests', () => {
         'tap',
         'swipe',
         'typeText',
+        'getPasteboard',
+        'setPasteboard',
         'pressKey',
         'launchApp',
         'openUrl',


### PR DESCRIPTION
> **Depends on #2954.** That PR adds the underlying `IOSDevice.getClipboardText()` /
> `.setClipboardText()` methods. Until it merges this PR shows both commits; the
> first one is #2954 and is not part of the review here.

## What

Registers two iOS-specific actions in `IOSDevice.actionSpace()`:

- `IOSGetClipboard` — no params, returns the pasteboard text
  (alias `agent.getClipboardText()`)
- `IOSSetClipboard` — `{ text }`, writes plain text to the pasteboard
  (alias `agent.setClipboardText()`)

## Why

#2954 adds the device-level pasteboard methods, but nothing wires them into the
action space — so they are reachable only from hand-written code. The planner has
no tool for them, which means a prompt like *"copy the invite link and read it
back"* cannot work today.

That is the case the capability exists for. A value behind a native "Copy" action
— a share sheet's "Copy Link", for instance — is rendered nowhere on screen, so it
cannot be located or extracted; and WDA's `GET /source` returns 500 while a share
sheet (`UIActivityViewController`) is presented, so the accessibility tree is no
help either. Reading the pasteboard is the only path, and it is only useful to an
agent if the agent can actually choose it.

## Design note

Both actions are registered locally in `packages/ios/src/device.ts`, following the
existing `IOSHomeButton` / `IOSAppSwitcher` pattern for iOS-specific actions,
rather than as canonical cross-platform actions in `@midscene/core`.

A canonical `ClipboardGet` / `ClipboardSet` pair would be defensible — three
backends already exist in the repo (iOS via WDA here, Android via `dumpsys`,
desktop via `clipboardy` in `packages/computer/src/device.ts`, currently used only
internally for `typeViaClipboard`). But that touches core's action registry and is
a naming/schema decision for maintainers, so it is deliberately left out of this
PR. Happy to open an issue for it if there is interest.

## Validation

- `npx nx test ios` — 13 files, 163 tests passed (2 new, covering dispatch through
  `actionSpace()` into the WDA client for both directions)
- `npx nx build ios` — success
- `pnpm run lint` — clean
