### PR TITLE
chore(workflow): migrate shared, computer, android and ios to rstest

### DIFF
--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -36,10 +36,10 @@
     "build:watch": "rslib build --watch --no-clean",
     "prepack": "node scripts/download-scrcpy-server.mjs && node scripts/download-yadb.mjs",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
-    "test": "vitest --run",
-    "test:u": "vitest --run -u",
-    "test:ai": "AI_TEST_TYPE=android vitest --run",
-    "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=android vitest --run"
+    "test": "rstest",
+    "test:u": "rstest -u",
+    "test:ai": "AI_TEST_TYPE=android rstest",
+    "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=android rstest"
   },
   "dependencies": {
     "@midscene/core": "workspace:*",
@@ -58,12 +58,12 @@
   "devDependencies": {
     "@midscene/playground": "workspace:*",
     "@rslib/core": "^0.18.3",
+    "@rstest/core": "0.11.5",
     "@types/node": "^18.0.0",
     "dotenv": "^16.4.5",
-    "typescript": "^5.8.3",
     "tsx": "^4.19.2",
+    "typescript": "^5.8.3",
     "undici": "^6.0.0",
-    "vitest": "3.0.5",
     "zod": "^3.25.1"
   },
   "license": "MIT"

--- a/packages/android/rstest.config.ts
+++ b/packages/android/rstest.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
   coverage: createCoverageConfig(__dirname),
   include: testFiles,
   testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
-  errors: process.env.CI ? { unhandled: false } : undefined, // showcase.test.ts is not stable
   pool: { maxWorkers: 1 }, // disable parallel file test
   source: {
     define: defineVersion(version),

--- a/packages/android/rstest.config.ts
+++ b/packages/android/rstest.config.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
+import { defineConfig } from '@rstest/core';
 import dotenv from 'dotenv';
-import { defineConfig } from 'vitest/config';
-import { createCoverageConfig } from '../../scripts/vitest-coverage';
+import { createCoverageConfig } from '../../scripts/rstest-coverage';
+import { defineVersion, photonExternal } from '../../scripts/rstest-shared';
 import { version } from './package.json';
 
 /**
@@ -31,17 +32,15 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
-  test: {
-    coverage: createCoverageConfig(__dirname),
-    include: testFiles,
-    testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
-    dangerouslyIgnoreUnhandledErrors: !!process.env.CI, // showcase.test.ts is not stable
-    fileParallelism: false, // disable parallel file test
+  coverage: createCoverageConfig(__dirname),
+  include: testFiles,
+  testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
+  errors: process.env.CI ? { unhandled: false } : undefined, // showcase.test.ts is not stable
+  pool: { maxWorkers: 1 }, // disable parallel file test
+  source: {
+    define: defineVersion(version),
   },
-  define: {
-    __VERSION__: `'${version}'`,
-  },
-  ssr: {
-    external: ['@silvia-odwyer/photon'],
+  output: {
+    externals: photonExternal,
   },
 });

--- a/packages/android/tests/ai/android-emulator-smoke.test.ts
+++ b/packages/android/tests/ai/android-emulator-smoke.test.ts
@@ -10,8 +10,8 @@ import {
   MIDSCENE_MODEL_TIMEOUT,
 } from '@midscene/shared/env';
 import { imageInfoOfBase64 } from '@midscene/shared/img';
+import { describe, expect, it, rs } from '@rstest/core';
 import type ADB from 'appium-adb';
-import { describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 import { dumpUiHierarchyWithRetry } from '../android-emulator-ui-dump';
 
@@ -58,7 +58,7 @@ interface ReportDump {
   executions?: ReportExecution[];
 }
 
-vi.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
+rs.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
 
 function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));

--- a/packages/android/tests/ai/ebay.test.ts
+++ b/packages/android/tests/ai/ebay.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/android/tests/ai/merge-reports.test.ts
+++ b/packages/android/tests/ai/merge-reports.test.ts
@@ -6,7 +6,6 @@ import {
 import type { TestStatus } from '@midscene/core';
 import { ReportMergingTool } from '@midscene/core/report';
 import { sleep } from '@midscene/core/utils';
-import type ADB from 'appium-adb';
 import {
   afterAll,
   afterEach,
@@ -14,7 +13,8 @@ import {
   beforeEach,
   describe,
   it,
-} from 'vitest';
+} from '@rstest/core';
+import type ADB from 'appium-adb';
 
 describe('Test Setting', () => {
   let page: AndroidDevice;

--- a/packages/android/tests/ai/merge-reports.test.ts
+++ b/packages/android/tests/ai/merge-reports.test.ts
@@ -38,9 +38,9 @@ describe('Test Setting', () => {
   });
 
   afterEach((ctx) => {
-    if (ctx.task.result?.state === 'pass') {
+    if (ctx.task.result?.status === 'pass') {
       itTestStatus = 'passed';
-    } else if (ctx.task.result?.state === 'skip') {
+    } else if (ctx.task.result?.status === 'skip') {
       itTestStatus = 'skipped';
     } else if (ctx.task.result?.errors?.[0].message.includes('timed out')) {
       itTestStatus = 'timedOut';
@@ -53,7 +53,7 @@ describe('Test Setting', () => {
         testId: `${ctx.task.name}`, //ID is a unique identifier used by the front end to distinguish each use case!
         testTitle: `${ctx.task.name}`,
         testDescription: 'description',
-        testDuration: (Date.now() - ctx.task.result?.startTime!) | 0,
+        testDuration: (performance.now() - startTime) | 0,
         testStatus: itTestStatus,
       },
     });

--- a/packages/android/tests/ai/multi-display.test.ts
+++ b/packages/android/tests/ai/multi-display.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromAdbDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/android/tests/ai/pinch.test.ts
+++ b/packages/android/tests/ai/pinch.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromAdbDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/android/tests/ai/scroll-swipe.test.ts
+++ b/packages/android/tests/ai/scroll-swipe.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromAdbDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/android/tests/ai/setting.test.ts
+++ b/packages/android/tests/ai/setting.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromAdbDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/android/tests/ai/todo.test.ts
+++ b/packages/android/tests/ai/todo.test.ts
@@ -1,12 +1,12 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import type ADB from 'appium-adb';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 import { dumpUiHierarchyWithRetry } from '../android-emulator-ui-dump';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
   hookTimeout: 60 * 1000,
 });

--- a/packages/android/tests/ai/travel.test.ts
+++ b/packages/android/tests/ai/travel.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, rs } from '@rstest/core';
 import { AndroidAgent, AndroidDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/android/tests/ai/ui-observer.test.ts
+++ b/packages/android/tests/ai/ui-observer.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { agentFromAdbDevice, getConnectedDevices } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/android/tests/unit-test/adb.test.ts
+++ b/packages/android/tests/unit-test/adb.test.ts
@@ -1,14 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 
-const mocks = vi.hoisted(() => ({
-  adbConstructor: vi.fn(),
-  createADB: vi.fn(),
-  getEnvConfigValue: vi.fn(),
-  getSdkRootFromEnv: vi.fn(),
-  warnAdb: vi.fn(),
+const mocks = rs.hoisted(() => ({
+  adbConstructor: rs.fn(),
+  createADB: rs.fn(),
+  getEnvConfigValue: rs.fn(),
+  getSdkRootFromEnv: rs.fn(),
+  warnAdb: rs.fn(),
 }));
 
-vi.mock('@midscene/shared/env', () => ({
+rs.mock('@midscene/shared/env', () => ({
   MIDSCENE_ADB_PATH: 'MIDSCENE_ADB_PATH',
   MIDSCENE_ADB_REMOTE_HOST: 'MIDSCENE_ADB_REMOTE_HOST',
   MIDSCENE_ADB_REMOTE_PORT: 'MIDSCENE_ADB_REMOTE_PORT',
@@ -17,11 +17,11 @@ vi.mock('@midscene/shared/env', () => ({
   },
 }));
 
-vi.mock('@midscene/shared/logger', () => ({
-  getDebug: vi.fn(() => mocks.warnAdb),
+rs.mock('@midscene/shared/logger', () => ({
+  getDebug: rs.fn(() => mocks.warnAdb),
 }));
 
-vi.mock('appium-adb', () => {
+rs.mock('appium-adb', () => {
   class MockADB {
     static createADB = mocks.createADB;
 
@@ -40,7 +40,7 @@ import { createAndroidAdb } from '../../src/adb';
 
 describe('createAndroidAdb', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
     mocks.getEnvConfigValue.mockReturnValue(undefined);
     mocks.getSdkRootFromEnv.mockReturnValue('/android/sdk');
   });

--- a/packages/android/tests/unit-test/agent-tools.test.ts
+++ b/packages/android/tests/unit-test/agent-tools.test.ts
@@ -1,15 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { agentFromAdbDevice } from '../../src/agent';
 import { AndroidMidsceneTools } from '../../src/agent-tools';
 
-vi.mock('../../src/agent', () => ({
-  agentFromAdbDevice: vi.fn(),
+rs.mock('../../src/agent', () => ({
+  agentFromAdbDevice: rs.fn(),
 }));
 
-vi.mock('../../src/device', () => ({
-  AndroidDevice: vi.fn().mockImplementation(() => ({
-    actionSpace: vi.fn().mockReturnValue([]),
-    destroy: vi.fn(),
+rs.mock('../../src/device', () => ({
+  AndroidDevice: rs.fn().mockImplementation(() => ({
+    actionSpace: rs.fn().mockReturnValue([]),
+    destroy: rs.fn(),
   })),
 }));
 
@@ -19,20 +19,20 @@ const validPngBase64 =
 function createMockAgent() {
   return {
     page: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
-    aiAction: vi.fn().mockResolvedValue('done'),
-    destroy: vi.fn(),
+    aiAction: rs.fn().mockResolvedValue('done'),
+    destroy: rs.fn(),
   };
 }
 
 describe('AndroidMidsceneTools', () => {
   beforeEach(() => {
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(createMockAgent() as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(createMockAgent() as any);
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
   });
 
   it('passes top-level deviceId to take_screenshot', async () => {
@@ -95,7 +95,7 @@ describe('AndroidMidsceneTools', () => {
 
   it('passes nested android.deviceId to act', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
 
     const tools = new AndroidMidsceneTools();
     await tools.initTools();
@@ -189,7 +189,7 @@ describe('AndroidMidsceneTools', () => {
 
   it('reuses the Android agent when called twice with identical init args', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
 
     const tools = new AndroidMidsceneTools();
     await tools.initTools();
@@ -212,7 +212,7 @@ describe('AndroidMidsceneTools', () => {
   it('rebuilds the Android agent when init args change', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice)
+    rs.mocked(agentFromAdbDevice)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 
@@ -241,7 +241,7 @@ describe('AndroidMidsceneTools', () => {
   it('rebuilds the Android agent when init args are omitted after being set', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice)
+    rs.mocked(agentFromAdbDevice)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 

--- a/packages/android/tests/unit-test/agent.test.ts
+++ b/packages/android/tests/unit-test/agent.test.ts
@@ -4,7 +4,6 @@ import {
   OPENAI_API_KEY,
   OPENAI_BASE_URL,
 } from '@midscene/shared/env';
-import { ADB } from 'appium-adb';
 import {
   type Mock,
   afterEach,
@@ -12,15 +11,16 @@ import {
   describe,
   expect,
   it,
-  vi,
-} from 'vitest';
+  rs,
+} from '@rstest/core';
+import { ADB } from 'appium-adb';
 import { AndroidAgent, agentFromAdbDevice } from '../../src/agent';
 import { AndroidDevice } from '../../src/device';
 import * as Utils from '../../src/utils';
 
-vi.mock('appium-adb');
-vi.mock('../../src/device');
-vi.mock('../../src/utils');
+rs.mock('appium-adb');
+rs.mock('../../src/device');
+rs.mock('../../src/utils');
 
 const MockedAndroidDevice = AndroidDevice as unknown as Mock;
 
@@ -35,16 +35,16 @@ async function createActualAndroidDevice(
   options?: ConstructorParameters<typeof AndroidDevice>[1],
 ) {
   const { AndroidDevice: ActualAndroidDevice } =
-    await vi.importActual<typeof import('../../src/device')>(
+    await rs.importActual<typeof import('../../src/device')>(
       '../../src/device',
     );
   const device = new ActualAndroidDevice('test-device', options);
-  vi.spyOn(device, 'screenshotBase64').mockResolvedValue(
+  rs.spyOn(device, 'screenshotBase64').mockResolvedValue(
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
   );
-  vi.spyOn(device, 'size').mockResolvedValue({ width: 375, height: 812 });
-  vi.spyOn(device, 'getElementsInfo').mockResolvedValue([]);
-  vi.spyOn(device, 'url').mockResolvedValue('https://example.com');
+  rs.spyOn(device, 'size').mockResolvedValue({ width: 375, height: 812 });
+  rs.spyOn(device, 'getElementsInfo').mockResolvedValue([]);
+  rs.spyOn(device, 'url').mockResolvedValue('https://example.com');
   return device;
 }
 
@@ -53,20 +53,20 @@ describe('AndroidAgent', () => {
     MockedAndroidDevice.mockImplementation(() => {
       return {
         interfaceType: 'android',
-        actionSpace: vi.fn().mockReturnValue([]),
-        screenshotBase64: vi.fn(),
-        size: vi.fn(),
-        getElementsInfo: vi.fn(),
-        url: vi.fn(),
-        launch: vi.fn(),
-        destroy: vi.fn(),
-        setAppNameMapping: vi.fn(),
+        actionSpace: rs.fn().mockReturnValue([]),
+        screenshotBase64: rs.fn(),
+        size: rs.fn(),
+        getElementsInfo: rs.fn(),
+        url: rs.fn(),
+        launch: rs.fn(),
+        destroy: rs.fn(),
+        setAppNameMapping: rs.fn(),
       };
     });
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   describe('constructor', () => {
@@ -90,17 +90,17 @@ describe('AndroidAgent', () => {
       const mockPage = new AndroidDevice('test-device');
 
       // Add necessary mocks for the device
-      vi.spyOn(mockPage, 'screenshotBase64').mockResolvedValue(validPngBase64);
-      vi.spyOn(mockPage, 'size').mockResolvedValue({ width: 375, height: 812 });
-      vi.spyOn(mockPage, 'getElementsInfo').mockResolvedValue([]);
-      vi.spyOn(mockPage, 'url').mockResolvedValue('https://example.com');
+      rs.spyOn(mockPage, 'screenshotBase64').mockResolvedValue(validPngBase64);
+      rs.spyOn(mockPage, 'size').mockResolvedValue({ width: 375, height: 812 });
+      rs.spyOn(mockPage, 'getElementsInfo').mockResolvedValue([]);
+      rs.spyOn(mockPage, 'url').mockResolvedValue('https://example.com');
 
-      const launchSpy = vi
+      const launchSpy = rs
         .spyOn(mockPage, 'launch')
         .mockResolvedValue(mockPage);
 
       // Mock actionSpace to call the actual device methods
-      vi.spyOn(mockPage, 'actionSpace').mockReturnValue([
+      rs.spyOn(mockPage, 'actionSpace').mockReturnValue([
         {
           name: 'Launch',
           paramSchema: undefined,
@@ -143,17 +143,17 @@ describe('AndroidAgent', () => {
       const validPngBase64 =
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
       const mockPage = new AndroidDevice('test-device');
-      vi.spyOn(mockPage, 'screenshotBase64').mockResolvedValue(validPngBase64);
-      vi.spyOn(mockPage, 'size').mockResolvedValue({ width: 375, height: 812 });
-      vi.spyOn(mockPage, 'getElementsInfo').mockResolvedValue([]);
-      vi.spyOn(mockPage, 'url').mockResolvedValue('https://example.com');
+      rs.spyOn(mockPage, 'screenshotBase64').mockResolvedValue(validPngBase64);
+      rs.spyOn(mockPage, 'size').mockResolvedValue({ width: 375, height: 812 });
+      rs.spyOn(mockPage, 'getElementsInfo').mockResolvedValue([]);
+      rs.spyOn(mockPage, 'url').mockResolvedValue('https://example.com');
       if (typeof (mockPage as any).terminate !== 'function') {
-        (mockPage as any).terminate = vi.fn().mockResolvedValue(undefined);
+        (mockPage as any).terminate = rs.fn().mockResolvedValue(undefined);
       }
-      const terminateSpy = vi
+      const terminateSpy = rs
         .spyOn(mockPage as any, 'terminate')
         .mockResolvedValue(undefined);
-      vi.spyOn(mockPage, 'actionSpace').mockReturnValue([
+      rs.spyOn(mockPage, 'actionSpace').mockReturnValue([
         { name: 'Launch', paramSchema: undefined, call: async () => {} },
         {
           name: 'Terminate',
@@ -175,11 +175,11 @@ describe('AndroidAgent', () => {
   describe('runAdbShell', () => {
     it('should pass timeout options through the RunAdbShell action', async () => {
       const mockPage = await createActualAndroidDevice();
-      const shell = vi.fn().mockResolvedValue({
+      const shell = rs.fn().mockResolvedValue({
         stdout: 'adb-result',
         stderr: '',
       });
-      (mockPage as any).getAdb = vi.fn().mockResolvedValue({
+      (mockPage as any).getAdb = rs.fn().mockResolvedValue({
         shell,
         EXEC_OUTPUT_FORMAT: { FULL: 'full' },
       });
@@ -203,11 +203,11 @@ describe('AndroidAgent', () => {
         0x00000000: fffffffd 00000008 006f004e 00690020 '........N.o. .i.'
         0x00000010: 00650074 0073006d 00000000 000003a4 't.e.m.s.........'
       )`;
-      const shell = vi.fn().mockResolvedValue({
+      const shell = rs.fn().mockResolvedValue({
         stdout: rawOutput,
         stderr: '',
       });
-      (mockPage as any).getAdb = vi.fn().mockResolvedValue({
+      (mockPage as any).getAdb = rs.fn().mockResolvedValue({
         shell,
         EXEC_OUTPUT_FORMAT: { FULL: 'full' },
       });
@@ -227,11 +227,11 @@ describe('AndroidAgent', () => {
 
     it('should throw when adb shell exits zero with stderr output', async () => {
       const mockPage = await createActualAndroidDevice();
-      const shell = vi.fn().mockResolvedValue({
+      const shell = rs.fn().mockResolvedValue({
         stdout: '',
         stderr: 'No shell command implementation.',
       });
-      (mockPage as any).getAdb = vi.fn().mockResolvedValue({
+      (mockPage as any).getAdb = rs.fn().mockResolvedValue({
         shell,
         EXEC_OUTPUT_FORMAT: { FULL: 'full' },
       });
@@ -251,11 +251,11 @@ describe('AndroidAgent', () => {
 
     it('should truncate stdout and stderr in adb shell stderr errors', async () => {
       const mockPage = await createActualAndroidDevice();
-      const shell = vi.fn().mockResolvedValue({
+      const shell = rs.fn().mockResolvedValue({
         stdout: 'o'.repeat(240),
         stderr: 'e'.repeat(240),
       });
-      (mockPage as any).getAdb = vi.fn().mockResolvedValue({
+      (mockPage as any).getAdb = rs.fn().mockResolvedValue({
         shell,
         EXEC_OUTPUT_FORMAT: { FULL: 'full' },
       });
@@ -299,34 +299,34 @@ ${'o'.repeat(200)}
 
   describe('agentFromAdbDevice', () => {
     beforeEach(() => {
-      vi.stubEnv(MIDSCENE_USE_DOUBAO_VISION, 'true');
-      vi.stubEnv(MIDSCENE_MODEL_NAME, 'mock');
-      vi.stubEnv(OPENAI_API_KEY, 'mock');
-      vi.stubEnv(OPENAI_BASE_URL, 'mock');
+      rs.stubEnv(MIDSCENE_USE_DOUBAO_VISION, 'true');
+      rs.stubEnv(MIDSCENE_MODEL_NAME, 'mock');
+      rs.stubEnv(OPENAI_API_KEY, 'mock');
+      rs.stubEnv(OPENAI_BASE_URL, 'mock');
     });
 
     afterEach(() => {
-      vi.unstubAllEnvs();
+      rs.unstubAllEnvs();
     });
 
     it('should use the first device and forward ADB options if no deviceId is provided', async () => {
       const mockDevices = [{ udid: 'device-1' }, { udid: 'device-2' }];
-      vi.spyOn(Utils, 'getConnectedDevices').mockResolvedValue(
+      rs.spyOn(Utils, 'getConnectedDevices').mockResolvedValue(
         mockDevices as any,
       );
-      const mockConnect = vi.fn().mockResolvedValue(new ADB());
+      const mockConnect = rs.fn().mockResolvedValue(new ADB());
       MockedAndroidDevice.mockImplementation((deviceId, options) => {
         return {
           connect: mockConnect,
-          constructor: vi.fn(),
+          constructor: rs.fn(),
           interfaceType: 'android',
-          actionSpace: vi.fn().mockReturnValue([]),
-          screenshotBase64: vi.fn(),
-          size: vi.fn().mockResolvedValue({ width: 0, height: 0 }),
-          getElementsInfo: vi.fn(),
-          url: vi.fn(),
-          launch: vi.fn(),
-          setAppNameMapping: vi.fn(),
+          actionSpace: rs.fn().mockReturnValue([]),
+          screenshotBase64: rs.fn(),
+          size: rs.fn().mockResolvedValue({ width: 0, height: 0 }),
+          getElementsInfo: rs.fn(),
+          url: rs.fn(),
+          launch: rs.fn(),
+          setAppNameMapping: rs.fn(),
         };
       });
 
@@ -344,19 +344,19 @@ ${'o'.repeat(200)}
     });
 
     it('should use the specified deviceId', async () => {
-      const mockConnect = vi.fn().mockResolvedValue(new ADB());
+      const mockConnect = rs.fn().mockResolvedValue(new ADB());
       MockedAndroidDevice.mockImplementation((deviceId, options) => {
         return {
           connect: mockConnect,
-          constructor: vi.fn(),
+          constructor: rs.fn(),
           interfaceType: 'android',
-          actionSpace: vi.fn().mockReturnValue([]),
-          screenshotBase64: vi.fn(),
-          size: vi.fn().mockResolvedValue({ width: 0, height: 0 }),
-          getElementsInfo: vi.fn(),
-          url: vi.fn(),
-          launch: vi.fn(),
-          setAppNameMapping: vi.fn(),
+          actionSpace: rs.fn().mockReturnValue([]),
+          screenshotBase64: rs.fn(),
+          size: rs.fn().mockResolvedValue({ width: 0, height: 0 }),
+          getElementsInfo: rs.fn(),
+          url: rs.fn(),
+          launch: rs.fn(),
+          setAppNameMapping: rs.fn(),
         };
       });
 
@@ -371,19 +371,19 @@ ${'o'.repeat(200)}
     });
 
     it('should pass options to AndroidDevice', async () => {
-      const mockConnect = vi.fn().mockResolvedValue(new ADB());
+      const mockConnect = rs.fn().mockResolvedValue(new ADB());
       MockedAndroidDevice.mockImplementation((deviceId, options) => {
         return {
           connect: mockConnect,
-          constructor: vi.fn(),
+          constructor: rs.fn(),
           interfaceType: 'android',
-          actionSpace: vi.fn().mockReturnValue([]),
-          screenshotBase64: vi.fn(),
-          size: vi.fn().mockResolvedValue({ width: 0, height: 0 }),
-          getElementsInfo: vi.fn(),
-          url: vi.fn(),
-          launch: vi.fn(),
-          setAppNameMapping: vi.fn(),
+          actionSpace: rs.fn().mockReturnValue([]),
+          screenshotBase64: rs.fn(),
+          size: rs.fn().mockResolvedValue({ width: 0, height: 0 }),
+          getElementsInfo: rs.fn(),
+          url: rs.fn(),
+          launch: rs.fn(),
+          setAppNameMapping: rs.fn(),
         };
       });
 

--- a/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
+++ b/packages/android/tests/unit-test/android-emulator-ui-dump.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import {
   dumpUiHierarchyWithRetry,
   isTransientAdbTransportError,
@@ -12,14 +12,14 @@ type ShellResult = string | Error;
 
 function createAdbMock(results: ShellResult[]) {
   const queue = [...results];
-  const shell = vi.fn(async () => {
+  const shell = rs.fn(async () => {
     const result = queue.shift();
     if (result instanceof Error) {
       throw result;
     }
     return result ?? '';
   });
-  const waitForDevice = vi.fn(async () => undefined);
+  const waitForDevice = rs.fn(async () => undefined);
   const adb: UiDumpAdb = { shell, waitForDevice };
   return { adb, shell, waitForDevice };
 }
@@ -83,7 +83,7 @@ describe('Android emulator UI hierarchy dump', () => {
       '',
       '<hierarchy />',
     ]);
-    const onRetry = vi.fn();
+    const onRetry = rs.fn();
 
     await expect(
       dumpUiHierarchyWithRetry(adb, { ...options, onRetry }),
@@ -121,7 +121,7 @@ describe('Android emulator UI hierarchy dump', () => {
     phase: 'read' | 'validate';
   }>)('retries $name', async ({ results, phase }) => {
     const { adb } = createAdbMock(results);
-    const onRetry = vi.fn();
+    const onRetry = rs.fn();
 
     await expect(
       dumpUiHierarchyWithRetry(adb, { ...options, onRetry }),
@@ -164,7 +164,7 @@ describe('Android emulator UI hierarchy dump', () => {
 
   it('stops after the configured number of attempts', async () => {
     const failure = execError('uiautomator was not ready', 255);
-    const shell = vi.fn(async (command: string) => {
+    const shell = rs.fn(async (command: string) => {
       if (command.startsWith('uiautomator dump')) {
         throw failure;
       }
@@ -172,9 +172,9 @@ describe('Android emulator UI hierarchy dump', () => {
     });
     const adb: UiDumpAdb = {
       shell,
-      waitForDevice: vi.fn(async () => undefined),
+      waitForDevice: rs.fn(async () => undefined),
     };
-    const onRetry = vi.fn();
+    const onRetry = rs.fn();
 
     await expect(
       dumpUiHierarchyWithRetry(adb, {

--- a/packages/android/tests/unit-test/cli.test.ts
+++ b/packages/android/tests/unit-test/cli.test.ts
@@ -7,18 +7,18 @@
  * handler-level unit tests by locking down the CLI argument plumbing.
  */
 import { runToolsCLI } from '@midscene/shared/cli';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { agentFromAdbDevice } from '../../src/agent';
 import { AndroidMidsceneTools } from '../../src/agent-tools';
 
-vi.mock('../../src/agent', () => ({
-  agentFromAdbDevice: vi.fn(),
+rs.mock('../../src/agent', () => ({
+  agentFromAdbDevice: rs.fn(),
 }));
 
-vi.mock('../../src/device', () => ({
-  AndroidDevice: vi.fn().mockImplementation(() => ({
-    actionSpace: vi.fn().mockReturnValue([]),
-    destroy: vi.fn(),
+rs.mock('../../src/device', () => ({
+  AndroidDevice: rs.fn().mockImplementation(() => ({
+    actionSpace: rs.fn().mockReturnValue([]),
+    destroy: rs.fn(),
   })),
 }));
 
@@ -28,29 +28,29 @@ const validPngBase64 =
 function createMockAgent() {
   return {
     page: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
-    aiAction: vi.fn().mockResolvedValue('done'),
-    destroy: vi.fn(),
+    aiAction: rs.fn().mockResolvedValue('done'),
+    destroy: rs.fn(),
   };
 }
 
 describe('Android CLI integration', () => {
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof rs.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof rs.spyOn>;
 
   beforeEach(() => {
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(createMockAgent() as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(createMockAgent() as any);
     // Silence expected CLI log output without touching the module-level mocks
-    // set up via `vi.mock` — `restoreAllMocks` would reset those too.
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // set up via `rs.mock` — `restoreAllMocks` would reset those too.
+    consoleLogSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = rs.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
-    vi.mocked(agentFromAdbDevice).mockReset();
+    rs.mocked(agentFromAdbDevice).mockReset();
   });
 
   it('routes --device-id (preferred bare form) through the same pipeline', async () => {
@@ -111,7 +111,7 @@ describe('Android CLI integration', () => {
 
   it('threads init args through the act command alongside --prompt', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
 
     const tools = new AndroidMidsceneTools();
 
@@ -130,7 +130,7 @@ describe('Android CLI integration', () => {
 
   it('threads common agent behavior args through the generated CLI', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
 
     const tools = new AndroidMidsceneTools();
 
@@ -181,7 +181,7 @@ describe('Android CLI integration', () => {
 
   it('strips init args from the payload passed to the action', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
 
     const tools = new AndroidMidsceneTools();
 
@@ -199,7 +199,7 @@ describe('Android CLI integration', () => {
   it('renders bare flags first in single-platform command help', async () => {
     const tools = new AndroidMidsceneTools();
     const output: string[] = [];
-    const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    const logSpy = rs.spyOn(console, 'log').mockImplementation((...args) => {
       output.push(args.map(String).join(' '));
     });
 

--- a/packages/android/tests/unit-test/device-scrcpy-status.test.ts
+++ b/packages/android/tests/unit-test/device-scrcpy-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { AndroidDevice } from '../../src/device';
 
 const deviceInfo = {
@@ -20,7 +20,7 @@ describe('AndroidDevice scrcpy recovery API', () => {
       retryAfter: Date.now() + 5_000,
     };
     (device as any).scrcpyAdapter = {
-      getStatus: vi.fn().mockReturnValue(status),
+      getStatus: rs.fn().mockReturnValue(status),
     };
 
     expect(device.getScrcpyStatus()).toBe(status);
@@ -37,12 +37,12 @@ describe('AndroidDevice scrcpy recovery API', () => {
       retryAfter: null,
     };
     const adapter = {
-      isEnabled: vi.fn().mockReturnValue(true),
-      initialize: vi.fn().mockResolvedValue(undefined),
-      getStatus: vi.fn().mockReturnValue(status),
+      isEnabled: rs.fn().mockReturnValue(true),
+      initialize: rs.fn().mockResolvedValue(undefined),
+      getStatus: rs.fn().mockReturnValue(status),
     };
     (device as any).scrcpyAdapter = adapter;
-    (device as any).getDevicePhysicalInfo = vi
+    (device as any).getDevicePhysicalInfo = rs
       .fn()
       .mockResolvedValue(deviceInfo);
 

--- a/packages/android/tests/unit-test/download-retry.test.ts
+++ b/packages/android/tests/unit-test/download-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import {
   DEFAULT_DOWNLOAD_MAX_RETRIES,
   getDownloadMaxRetries,
@@ -29,13 +29,13 @@ describe('download retry helper', () => {
   });
 
   it('retries transient failures before resolving', async () => {
-    const download = vi
+    const download = rs
       .fn()
       .mockRejectedValueOnce(new Error('Response code 504 (Gateway Time-out)'))
       .mockRejectedValueOnce(new Error('Response code 502 (Bad Gateway)'))
       .mockResolvedValue(undefined);
-    const sleepImpl = vi.fn(async () => undefined);
-    const log = vi.fn();
+    const sleepImpl = rs.fn(async () => undefined);
+    const log = rs.fn();
 
     await retryDownload({
       download,
@@ -58,24 +58,24 @@ describe('download retry helper', () => {
 
     await expect(
       retryDownload({
-        download: vi.fn().mockRejectedValue(error),
+        download: rs.fn().mockRejectedValue(error),
         label: 'scrcpy',
-        log: vi.fn(),
+        log: rs.fn(),
         maxRetries: 2,
-        sleepImpl: vi.fn(async () => undefined),
+        sleepImpl: rs.fn(async () => undefined),
       }),
     ).rejects.toThrow(error);
   });
 
   it('always attempts the download at least once', async () => {
-    const download = vi.fn().mockResolvedValue(undefined);
+    const download = rs.fn().mockResolvedValue(undefined);
 
     await retryDownload({
       download,
       label: 'scrcpy',
-      log: vi.fn(),
+      log: rs.fn(),
       maxRetries: 0,
-      sleepImpl: vi.fn(async () => undefined),
+      sleepImpl: rs.fn(async () => undefined),
     });
 
     expect(download).toHaveBeenCalledTimes(1);

--- a/packages/android/tests/unit-test/escape-for-shell.test.ts
+++ b/packages/android/tests/unit-test/escape-for-shell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { escapeForShell } from '../../src/device';
 
 describe('escapeForShell', () => {

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { AndroidDevice } from '../../src/device';
 import {
   type RawKeyframe,
@@ -27,12 +27,12 @@ const calibrateFrameClock = (manager: ScrcpyScreenshotManager): void => {
     hostWallTimeMs: 2_000,
     roundTripUs: 10_000n,
   };
-  vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+  rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 };
 
 describe('ScrcpyScreenshotManager keyframe subscription', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('fans out raw keyframes (with header + ts) to subscribers', () => {
@@ -70,7 +70,7 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
   it('keeps the connection alive while subscribed (resets idle timer per frame)', () => {
     const manager = new ScrcpyScreenshotManager({} as any);
     calibrateFrameClock(manager);
-    const resetSpy = vi.spyOn(manager as any, 'resetIdleTimer');
+    const resetSpy = rs.spyOn(manager as any, 'resetIdleTimer');
     manager.subscribeKeyframes(() => {});
     resetSpy.mockClear();
 
@@ -124,14 +124,14 @@ describe('AndroidDevice frame-source capability', () => {
       capturedAt: 2000,
     };
     let latestFrame: RawKeyframe | null = frameA;
-    const decode = vi
+    const decode = rs
       .fn()
       .mockImplementation(async (f: RawKeyframe) => `decoded-${f.data[5]}`);
-    const unsubscribe = vi.fn();
+    const unsubscribe = rs.fn();
     (device as any).scrcpyAdapter = {
       isEnabled: () => true,
       getLatestRawKeyframe: () => latestFrame,
-      subscribeKeyframes: vi.fn().mockImplementation(async (_info, cb) => {
+      subscribeKeyframes: rs.fn().mockImplementation(async (_info, cb) => {
         listener = (frame) => {
           latestFrame = frame;
           cb(frame);
@@ -140,7 +140,7 @@ describe('AndroidDevice frame-source capability', () => {
       }),
       decodeRawKeyframeToJpegBase64: decode,
     };
-    (device as any).getDevicePhysicalInfo = vi.fn().mockResolvedValue({});
+    (device as any).getDevicePhysicalInfo = rs.fn().mockResolvedValue({});
 
     const source = await device.openFrameSource!();
     expect(source).toBeDefined();

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1,9 +1,12 @@
 import { execFile } from 'node:child_process';
 import fs, { unlink } from 'node:fs';
+import * as fsActual from 'node:fs' with { rstest: 'importActual' };
 import type { ExecutorContext } from '@midscene/core';
 import * as CoreUtils from '@midscene/core/utils';
 import * as ImgUtils from '@midscene/shared/img';
-import { ADB } from 'appium-adb';
+import * as sharedImgActual from '@midscene/shared/img' with {
+  rstest: 'importActual',
+};
 import {
   type Mock,
   type Mocked,
@@ -12,8 +15,9 @@ import {
   describe,
   expect,
   it,
-  vi,
-} from 'vitest';
+  rs,
+} from '@rstest/core';
+import { ADB } from 'appium-adb';
 import { AndroidDevice, escapeForShell } from '../../src/device';
 import { ScrcpyFreshFrameUnavailableError } from '../../src/scrcpy-manager';
 
@@ -27,19 +31,19 @@ const createMockAdb = () => ({
     FULL: 'full',
     STDOUT: 'stdout',
   },
-  startUri: vi.fn(),
-  startApp: vi.fn(),
-  activateApp: vi.fn(),
-  shell: vi.fn(),
-  getScreenDensity: vi.fn(),
-  takeScreenshot: vi.fn(),
-  pull: vi.fn(),
-  inputText: vi.fn(),
-  keyevent: vi.fn(),
-  clearTextField: vi.fn(),
-  hideKeyboard: vi.fn(),
-  push: vi.fn(),
-  isSoftKeyboardPresent: vi.fn().mockResolvedValue(false),
+  startUri: rs.fn(),
+  startApp: rs.fn(),
+  activateApp: rs.fn(),
+  shell: rs.fn(),
+  getScreenDensity: rs.fn(),
+  takeScreenshot: rs.fn(),
+  pull: rs.fn(),
+  inputText: rs.fn(),
+  keyevent: rs.fn(),
+  clearTextField: rs.fn(),
+  hideKeyboard: rs.fn(),
+  push: rs.fn(),
+  isSoftKeyboardPresent: rs.fn().mockResolvedValue(false),
 });
 
 let mockAdbInstance: ReturnType<typeof createMockAdb>;
@@ -58,15 +62,15 @@ const createValidPngBuffer = (size = 64) => {
   ]);
 };
 
-vi.mock('appium-adb', () => {
-  const MockADB = vi.fn(() => {
+rs.mock('appium-adb', () => {
+  const MockADB = rs.fn(() => {
     if (!mockAdbInstance) {
       mockAdbInstance = createMockAdb();
     }
     return mockAdbInstance;
   });
   Object.assign(MockADB, {
-    createADB: vi.fn(async () => {
+    createADB: rs.fn(async () => {
       if (!mockAdbInstance) {
         mockAdbInstance = createMockAdb();
       }
@@ -76,13 +80,13 @@ vi.mock('appium-adb', () => {
 
   return {
     ADB: MockADB,
-    getSdkRootFromEnv: vi.fn(() => undefined),
+    getSdkRootFromEnv: rs.fn(() => undefined),
   };
 });
 
-vi.mock('@midscene/core/utils');
-vi.mock('node:child_process', () => ({
-  execFile: vi.fn(
+rs.mock('@midscene/core/utils');
+rs.mock('node:child_process', () => ({
+  execFile: rs.fn(
     (
       _file: unknown,
       _args: unknown,
@@ -90,13 +94,12 @@ vi.mock('node:child_process', () => ({
       callback?: (error: Error | null) => void,
     ) => {
       callback?.(null);
-      return { unref: vi.fn() };
+      return { unref: rs.fn() };
     },
   ),
 }));
-vi.mock('@midscene/shared/img', async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import('@midscene/shared/img')>();
+rs.mock('@midscene/shared/img', () => {
+  const original = sharedImgActual;
   const validateScreenshotBuffer =
     original.validateScreenshotBuffer ??
     ((
@@ -123,16 +126,16 @@ vi.mock('@midscene/shared/img', async (importOriginal) => {
     });
   return {
     ...original,
-    createImgBase64ByFormat: vi.fn(),
-    resizeAndConvertImgBuffer: vi.fn(),
+    createImgBase64ByFormat: rs.fn(),
+    resizeAndConvertImgBuffer: rs.fn(),
     validateScreenshotBuffer,
   };
 });
-vi.mock('node:fs', async (importOriginal) => {
-  const original = (await importOriginal()) as {
+rs.mock('node:fs', () => {
+  const original = fsActual as unknown as {
     default: Record<string, unknown>;
   };
-  const unlink = vi.fn(
+  const unlink = rs.fn(
     (_path: unknown, callback: (error: NodeJS.ErrnoException | null) => void) =>
       callback(null),
   );
@@ -140,13 +143,13 @@ vi.mock('node:fs', async (importOriginal) => {
     ...original,
     unlink,
     promises: {
-      readFile: vi.fn(),
+      readFile: rs.fn(),
     },
     default: {
       ...original.default,
       unlink,
       promises: {
-        readFile: vi.fn(),
+        readFile: rs.fn(),
       },
     },
   };
@@ -158,7 +161,7 @@ describe('AndroidDevice', () => {
   let mockAdb: Mocked<ADB>;
 
   beforeEach(() => {
-    vi.mocked(execFile).mockClear();
+    rs.mocked(execFile).mockClear();
     // Ensure mockAdbInstance is available
     if (!mockAdbInstance) {
       mockAdbInstance = createMockAdb();
@@ -173,12 +176,12 @@ describe('AndroidDevice', () => {
       scrcpyConfig: { enabled: false },
     });
     // Manually assign the mocked adb instance
-    vi.spyOn(device, 'getAdb').mockResolvedValue(mockAdb);
+    rs.spyOn(device, 'getAdb').mockResolvedValue(mockAdb);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    vi.unstubAllEnvs();
+    rs.restoreAllMocks();
+    rs.unstubAllEnvs();
   });
 
   it('should throw error if deviceId is not provided', () => {
@@ -287,7 +290,7 @@ describe('AndroidDevice', () => {
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.shell.mockImplementation(async (command) => {
         const value = String(command);
         if (value === 'cat /sdcard/midscene_window_dump.xml') {
@@ -320,8 +323,8 @@ describe('AndroidDevice', () => {
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
-      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+      rs.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
         width: 400,
         height: 800,
       });
@@ -356,7 +359,7 @@ describe('AndroidDevice', () => {
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.shell.mockImplementation(async (command) => {
         const value = String(command);
         if (value === 'cat /sdcard/midscene_window_dump.xml') {
@@ -384,13 +387,13 @@ describe('AndroidDevice', () => {
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
-      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+      rs.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
         width: 400,
         height: 800,
       });
       let currentTime = 10;
-      vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+      rs.spyOn(Date, 'now').mockImplementation(() => currentTime);
       mockAdb.shell.mockImplementation(async (command) => {
         const value = String(command);
         if (value === 'cat /sdcard/midscene_window_dump.xml') {
@@ -424,8 +427,8 @@ describe('AndroidDevice', () => {
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
-      vi.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
+      rs.spyOn(secondaryDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(secondaryDisplayDevice, 'size').mockResolvedValue({
         width: 400,
         height: 800,
       });
@@ -531,12 +534,12 @@ describe('AndroidDevice', () => {
     });
 
     it('routes representative built-in action surfaces through one scrcpy barrier', async () => {
-      const markActionBarrier = vi.fn().mockResolvedValue(undefined);
+      const markActionBarrier = rs.fn().mockResolvedValue(undefined);
       (device as any).scrcpyAdapter = { markActionBarrier };
-      vi.spyOn(device as any, 'tapPoint').mockResolvedValue(undefined);
-      vi.spyOn(device as any, 'homeRaw').mockResolvedValue(undefined);
-      vi.spyOn(device as any, 'pullDownRaw').mockResolvedValue(undefined);
-      vi.spyOn(device as any, 'launchRaw').mockResolvedValue(device);
+      rs.spyOn(device as any, 'tapPoint').mockResolvedValue(undefined);
+      rs.spyOn(device as any, 'homeRaw').mockResolvedValue(undefined);
+      rs.spyOn(device as any, 'pullDownRaw').mockResolvedValue(undefined);
+      rs.spyOn(device as any, 'launchRaw').mockResolvedValue(device);
 
       const cases: Array<[string, () => Promise<unknown>]> = [
         [
@@ -570,8 +573,8 @@ describe('AndroidDevice', () => {
     });
 
     it('moves one scrcpy barrier for a composite action', async () => {
-      const markActionBarrier = vi.fn().mockResolvedValue(undefined);
-      const dragPoint = vi
+      const markActionBarrier = rs.fn().mockResolvedValue(undefined);
+      const dragPoint = rs
         .spyOn(device as any, 'dragPoint')
         .mockResolvedValue(undefined);
       (device as any).scrcpyAdapter = { markActionBarrier };
@@ -588,8 +591,8 @@ describe('AndroidDevice', () => {
 
     it('moves one scrcpy barrier when a composite action partially fails', async () => {
       const actionError = new Error('second swipe failed');
-      const markActionBarrier = vi.fn().mockResolvedValue(undefined);
-      vi.spyOn(device as any, 'dragPoint')
+      const markActionBarrier = rs.fn().mockResolvedValue(undefined);
+      rs.spyOn(device as any, 'dragPoint')
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(actionError);
       (device as any).scrcpyAdapter = { markActionBarrier };
@@ -761,7 +764,7 @@ Stdout:
 
   describe('size', () => {
     it('should calculate screen size', async () => {
-      vi.spyOn(device as any, 'getScreenSize').mockResolvedValue({
+      rs.spyOn(device as any, 'getScreenSize').mockResolvedValue({
         override: '1080x1920',
         physical: '1080x1920',
         orientation: 0,
@@ -774,13 +777,13 @@ Stdout:
       expect(size1).toEqual({ width: 540, height: 960 });
       expect(size2).toEqual(size1);
       // Caching is removed, so it should be called twice
-      expect(vi.spyOn(device as any, 'getScreenSize')).toHaveBeenCalledTimes(2);
+      expect(rs.spyOn(device as any, 'getScreenSize')).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('adjustCoordinates derives scale from size()', () => {
     const mockPhysicalInfo = (w: number, h: number) => {
-      vi.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue({
+      rs.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue({
         physicalWidth: w,
         physicalHeight: h,
         dpr: 2,
@@ -793,7 +796,7 @@ Stdout:
       // Physical 1080x1920, logical 540x960 → scale 0.5
       // coordinates: 200/0.5=400, 400/0.5=800
       mockPhysicalInfo(1080, 1920);
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 540,
         height: 960,
       });
@@ -806,7 +809,7 @@ Stdout:
       // Physical 1080x1920, user overrides size() → width=360
       // scaleX = 360/1080 = 1/3, so 100/(1/3)=300, 200/(1/3)=600
       mockPhysicalInfo(1080, 1920);
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 360,
         height: 640,
       });
@@ -819,7 +822,7 @@ Stdout:
       // Physical 1080x1920, logical 540x960 → scale 0.5
       // click at (100, 200) → physical (200, 400)
       mockPhysicalInfo(1080, 1920);
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 540,
         height: 960,
       });
@@ -832,7 +835,7 @@ Stdout:
 
     it('should handle 1:1 scale (no scaling)', async () => {
       mockPhysicalInfo(1080, 1920);
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 1080,
         height: 1920,
       });
@@ -846,7 +849,7 @@ Stdout:
       // scaleX = 540/1080 = 0.5, scaleY = 640/1920 = 1/3
       // x: 100/0.5=200, y: 100/(1/3)=300
       mockPhysicalInfo(1080, 1920);
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 540,
         height: 640,
       });
@@ -857,7 +860,7 @@ Stdout:
 
     it('should cache scale and not call size() repeatedly', async () => {
       mockPhysicalInfo(1080, 1920);
-      const sizeSpy = vi.spyOn(device, 'size').mockResolvedValue({
+      const sizeSpy = rs.spyOn(device, 'size').mockResolvedValue({
         width: 540,
         height: 960,
       });
@@ -879,7 +882,7 @@ Stdout:
         minScreenshotBufferSize: 0,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(displayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(displayDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.shell.mockImplementation(async (command: string | string[]) => {
         if (command === 'dumpsys display') {
           return `mDisplayId=1
@@ -956,11 +959,11 @@ Stdout:
 
   describe('screenshotBase64', () => {
     beforeEach(() => {
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 1080,
         height: 1920,
       });
-      vi.spyOn(ImgUtils, 'resizeAndConvertImgBuffer').mockImplementation(
+      rs.spyOn(ImgUtils, 'resizeAndConvertImgBuffer').mockImplementation(
         async (format, buffer) => ({
           buffer,
           format,
@@ -973,7 +976,7 @@ Stdout:
       mockAdb.takeScreenshot.mockResolvedValue(mockBuffer);
 
       // Mock createImgBase64ByFormat
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -988,14 +991,14 @@ Stdout:
         screenshotStrategy: 'always-yadb',
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(alwaysYadbDevice, 'getAdb').mockResolvedValue(mockAdb);
-      const forceScreenshotSpy = vi
+      rs.spyOn(alwaysYadbDevice, 'getAdb').mockResolvedValue(mockAdb);
+      const forceScreenshotSpy = rs
         .spyOn(alwaysYadbDevice, 'forceScreenshot')
         .mockResolvedValue();
       const mockBuffer = createValidPngBuffer();
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb.png');
       (fs.promises.readFile as Mock).mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1022,16 +1025,16 @@ Stdout:
         screenshotStrategy: 'always-yadb',
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(nonDefaultDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
-      const forceScreenshotSpy = vi
+      rs.spyOn(nonDefaultDisplayDevice, 'getAdb').mockResolvedValue(mockAdb);
+      const forceScreenshotSpy = rs
         .spyOn(nonDefaultDisplayDevice, 'forceScreenshot')
         .mockResolvedValue();
       const mockBuffer = createValidPngBuffer();
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue(
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue(
         '/tmp/yadb-non-default-display.png',
       );
       (fs.promises.readFile as Mock).mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1050,12 +1053,12 @@ Stdout:
         screenshotStrategy: 'always-yadb',
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(alwaysYadbDevice, 'getAdb').mockResolvedValue(mockAdb);
-      vi.spyOn(alwaysYadbDevice, 'forceScreenshot').mockResolvedValue();
+      rs.spyOn(alwaysYadbDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(alwaysYadbDevice, 'forceScreenshot').mockResolvedValue();
       const mockBuffer = createValidPngBuffer();
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb-remote.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb-remote.png');
       (fs.promises.readFile as Mock).mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1079,14 +1082,14 @@ Stdout:
     });
 
     it('should use yadb directly when configured through the environment', async () => {
-      vi.stubEnv('MIDSCENE_ANDROID_SCREENSHOT_STRATEGY', 'always-yadb');
-      const forceScreenshotSpy = vi
+      rs.stubEnv('MIDSCENE_ANDROID_SCREENSHOT_STRATEGY', 'always-yadb');
+      const forceScreenshotSpy = rs
         .spyOn(device, 'forceScreenshot')
         .mockResolvedValue();
       const mockBuffer = createValidPngBuffer();
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb-env.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/yadb-env.png');
       (fs.promises.readFile as Mock).mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1101,20 +1104,20 @@ Stdout:
     });
 
     it('should prefer an explicit auto strategy over the environment', async () => {
-      vi.stubEnv('MIDSCENE_ANDROID_SCREENSHOT_STRATEGY', 'always-yadb');
+      rs.stubEnv('MIDSCENE_ANDROID_SCREENSHOT_STRATEGY', 'always-yadb');
       const explicitAutoDevice = new AndroidDevice('test-device', {
         minScreenshotBufferSize: 0,
         screenshotStrategy: 'auto',
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(explicitAutoDevice, 'getAdb').mockResolvedValue(mockAdb);
-      const forceScreenshotSpy = vi.spyOn(
+      rs.spyOn(explicitAutoDevice, 'getAdb').mockResolvedValue(mockAdb);
+      const forceScreenshotSpy = rs.spyOn(
         explicitAutoDevice,
         'forceScreenshot',
       );
       const mockBuffer = createValidPngBuffer();
       mockAdb.takeScreenshot.mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1126,11 +1129,11 @@ Stdout:
 
     it('should recommend a network-aware videoBitRate when scrcpy falls back to ADB', async () => {
       const adapter = (device as any).getScrcpyAdapter();
-      vi.spyOn(adapter, 'isEnabled').mockReturnValue(true);
-      vi.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
+      rs.spyOn(adapter, 'isEnabled').mockReturnValue(true);
+      rs.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
         new Error('stream recovery failed'),
       );
-      vi.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue({
+      rs.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue({
         physicalWidth: 1080,
         physicalHeight: 1920,
         dpr: 1,
@@ -1138,10 +1141,10 @@ Stdout:
       });
       const mockBuffer = createValidPngBuffer();
       mockAdb.takeScreenshot.mockResolvedValue(mockBuffer);
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
       await expect(device.screenshotBase64()).resolves.toContain(
         mockBuffer.toString('base64'),
@@ -1156,11 +1159,11 @@ Stdout:
 
     it('starts scrcpy recovery only after the ADB fallback screenshot completes', async () => {
       const adapter = (device as any).getScrcpyAdapter();
-      vi.spyOn(adapter, 'isEnabled').mockReturnValue(true);
-      vi.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
+      rs.spyOn(adapter, 'isEnabled').mockReturnValue(true);
+      rs.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
         new ScrcpyFreshFrameUnavailableError('stale stream closed'),
       );
-      const recover = vi
+      const recover = rs
         .spyOn(adapter, 'recoverAfterAdbScreenshot')
         .mockImplementation(() => {});
       const deviceInfo = {
@@ -1169,7 +1172,7 @@ Stdout:
         dpr: 1,
         orientation: 0,
       };
-      vi.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue(
+      rs.spyOn(device as any, 'getDevicePhysicalInfo').mockResolvedValue(
         deviceInfo,
       );
       const mockBuffer = createValidPngBuffer();
@@ -1177,10 +1180,10 @@ Stdout:
         expect(recover).not.toHaveBeenCalled();
         return mockBuffer;
       });
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      rs.spyOn(console, 'warn').mockImplementation(() => {});
 
       await expect(device.screenshotBase64()).resolves.toContain(
         mockBuffer.toString('base64'),
@@ -1191,11 +1194,11 @@ Stdout:
     it('should fall back to screencap and pull if takeScreenshot fails', async () => {
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
       const mockBuffer = createValidPngBuffer();
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/test.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/test.png');
       (fs.promises.readFile as Mock).mockResolvedValue(mockBuffer);
 
       // Mock createImgBase64ByFormat
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
 
@@ -1214,13 +1217,13 @@ Stdout:
       const defaultDevice = new AndroidDevice('test-device', {
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(defaultDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(defaultDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
       const smallValidPng = createValidPngBuffer(7 * 1024);
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/small.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/small.png');
       (fs.promises.readFile as Mock).mockResolvedValue(smallValidPng);
 
-      vi.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
+      rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${smallValidPng.toString('base64')}`,
       );
 
@@ -1234,10 +1237,10 @@ Stdout:
       const defaultDevice = new AndroidDevice('test-device', {
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(defaultDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(defaultDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
       const tinyValidPng = createValidPngBuffer(512);
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/tiny.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/tiny.png');
       (fs.promises.readFile as Mock).mockResolvedValue(tinyValidPng);
 
       await expect(defaultDevice.screenshotBase64()).rejects.toThrow(
@@ -1251,7 +1254,7 @@ Stdout:
 
     it('should reject empty fallback screenshots', async () => {
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/empty.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/empty.png');
       (fs.promises.readFile as Mock).mockResolvedValue(Buffer.alloc(0));
 
       await expect(device.screenshotBase64()).rejects.toThrow(
@@ -1264,10 +1267,10 @@ Stdout:
         minScreenshotBufferSize: 10 * 1024,
         scrcpyConfig: { enabled: false },
       });
-      vi.spyOn(minSizeDevice, 'getAdb').mockResolvedValue(mockAdb);
+      rs.spyOn(minSizeDevice, 'getAdb').mockResolvedValue(mockAdb);
       mockAdb.takeScreenshot.mockRejectedValue(new Error('fail'));
       const smallValidPng = createValidPngBuffer(7 * 1024);
-      vi.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/small.png');
+      rs.spyOn(CoreUtils, 'getTmpFile').mockReturnValue('/tmp/small.png');
       (fs.promises.readFile as Mock).mockResolvedValue(smallValidPng);
 
       await expect(minSizeDevice.screenshotBase64()).rejects.toThrow(
@@ -1278,7 +1281,7 @@ Stdout:
 
   describe('mouse', () => {
     it('click should call shell with adjusted coordinates', async () => {
-      vi.spyOn(device as any, 'adjustCoordinates').mockResolvedValue({
+      rs.spyOn(device as any, 'adjustCoordinates').mockResolvedValue({
         x: 200,
         y: 300,
       });
@@ -1291,7 +1294,7 @@ Stdout:
     it('drag should call shell with adjusted coordinates', async () => {
       const from = { x: 10, y: 20 };
       const to = { x: 30, y: 40 };
-      vi.spyOn(device as any, 'adjustCoordinates')
+      rs.spyOn(device as any, 'adjustCoordinates')
         .mockResolvedValueOnce({ x: 20, y: 40 })
         .mockResolvedValueOnce({ x: 60, y: 80 });
       await device.inputPrimitives.pointer.dragAndDrop(from, to);
@@ -1447,8 +1450,8 @@ Stdout:
           imeStrategy: 'yadb-for-non-ascii',
           autoDismissKeyboard: false,
         };
-        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-        const execYadbRaw = vi
+        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        const execYadbRaw = rs
           .spyOn(device as any, 'execYadbRaw')
           .mockResolvedValue(undefined);
         // Keyboard typing is a composite visual action and now calls the raw
@@ -1851,7 +1854,7 @@ Stdout:
 
     it('type should hide keyboard when shown', async () => {
       device.options = { imeStrategy: 'yadb-for-non-ascii' };
-      vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+      rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
       // First call returns true (keyboard shown), second returns false (keyboard hidden)
       mockAdb.isSoftKeyboardPresent
         .mockResolvedValueOnce({
@@ -1933,7 +1936,7 @@ Stdout:
 
     describe('autoDismissKeyboard option', () => {
       beforeEach(() => {
-        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
       });
 
       it('should hide keyboard when autoDismissKeyboard is true (default)', async () => {
@@ -2030,7 +2033,7 @@ Stdout:
 
     describe('keyboardDismissStrategy option', () => {
       beforeEach(() => {
-        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
         mockAdb.isSoftKeyboardPresent.mockClear();
       });
 
@@ -2089,7 +2092,7 @@ Stdout:
 
         // Mock hideKeyboard to use a small timeout for faster test
         const originalHideKeyboard = (device as any).hideKeyboard.bind(device);
-        vi.spyOn(device as any, 'hideKeyboard').mockImplementation(
+        rs.spyOn(device as any, 'hideKeyboard').mockImplementation(
           async (options) => {
             // Use 150ms timeout to ensure at least one check in the loop
             const result = await originalHideKeyboard(options, 150);
@@ -2158,7 +2161,7 @@ Stdout:
 
         // Mock hideKeyboard to use a small timeout for faster test
         const originalHideKeyboard = (device as any).hideKeyboard.bind(device);
-        vi.spyOn(device as any, 'hideKeyboard').mockImplementation(
+        rs.spyOn(device as any, 'hideKeyboard').mockImplementation(
           async (options) => {
             // Use 150ms timeout to ensure at least one check in the loop
             const result = await originalHideKeyboard(options, 150);
@@ -2258,12 +2261,12 @@ Stdout:
 
         // Mock hideKeyboard to use a small timeout for faster test
         const originalHideKeyboard = (device as any).hideKeyboard.bind(device);
-        vi.spyOn(device as any, 'hideKeyboard').mockImplementation(
+        rs.spyOn(device as any, 'hideKeyboard').mockImplementation(
           (options) => originalHideKeyboard(options, 100), // Use 100ms timeout instead of default 1000ms
         );
 
         // Spy on console.warn to verify warning is logged
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
         // Should not throw error anymore
         await device.inputPrimitives.keyboard.typeText('hello', {
@@ -2301,14 +2304,14 @@ Stdout:
 
   describe('scrolling', () => {
     beforeEach(() => {
-      vi.spyOn(device, 'size').mockResolvedValue({
+      rs.spyOn(device, 'size').mockResolvedValue({
         width: 1080,
         height: 1920,
       });
     });
 
     it('scrollUp should call scroll with negative Y delta', async () => {
-      const wheelSpy = vi
+      const wheelSpy = rs
         .spyOn(device as any, 'scrollRaw')
         .mockResolvedValue(undefined);
       await device.scrollUp(100);
@@ -2316,7 +2319,7 @@ Stdout:
     });
 
     it('scrollDown should call scroll with positive Y delta', async () => {
-      const wheelSpy = vi
+      const wheelSpy = rs
         .spyOn(device as any, 'scrollRaw')
         .mockResolvedValue(undefined);
       await device.scrollDown(100);
@@ -2325,7 +2328,7 @@ Stdout:
 
     describe('scroll input validation', () => {
       beforeEach(() => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        rs.spyOn(console, 'warn').mockImplementation(() => {});
       });
 
       it('should throw error when both deltaX and deltaY are zero', async () => {
@@ -2335,7 +2338,7 @@ Stdout:
       });
 
       it('should allow scrolling with non-zero deltaX and zero deltaY', async () => {
-        vi.spyOn(device as any, 'adjustCoordinates')
+        rs.spyOn(device as any, 'adjustCoordinates')
           .mockResolvedValueOnce({ x: 270, y: 480 })
           .mockResolvedValueOnce({ x: 170, y: 480 });
 
@@ -2348,7 +2351,7 @@ Stdout:
       });
 
       it('should allow scrolling with zero deltaX and non-zero deltaY', async () => {
-        vi.spyOn(device as any, 'adjustCoordinates')
+        rs.spyOn(device as any, 'adjustCoordinates')
           .mockResolvedValueOnce({ x: 270, y: 480 })
           .mockResolvedValueOnce({ x: 270, y: 240 });
 
@@ -2361,7 +2364,7 @@ Stdout:
       });
 
       it('should allow symmetric horizontal range from the same start position', async () => {
-        const adjustCoordinatesSpy = vi
+        const adjustCoordinatesSpy = rs
           .spyOn(device as any, 'adjustCoordinates')
           .mockImplementation(async (...args: unknown[]) => {
             const [x, y] = args as [number, number];
@@ -2385,7 +2388,7 @@ Stdout:
         adjustCoordinatesSpy.mockRestore();
       });
       it('should allow scrolling with both deltaX and deltaY non-zero', async () => {
-        vi.spyOn(device as any, 'adjustCoordinates')
+        rs.spyOn(device as any, 'adjustCoordinates')
           .mockResolvedValueOnce({ x: 270, y: 480 })
           .mockResolvedValueOnce({ x: 220, y: 405 });
 
@@ -2398,7 +2401,7 @@ Stdout:
       });
 
       it('should warn when explicit scrollDown distance exceeds the swipe boundary', async () => {
-        vi.spyOn(device as any, 'adjustCoordinates').mockImplementation(
+        rs.spyOn(device as any, 'adjustCoordinates').mockImplementation(
           async (...args: unknown[]) => {
             const [x, y] = args as [number, number];
             return { x, y };
@@ -2414,7 +2417,7 @@ Stdout:
       });
 
       it('should not warn for internal scrollToBottom clamp behavior', async () => {
-        vi.spyOn(device as any, 'adjustCoordinates').mockImplementation(
+        rs.spyOn(device as any, 'adjustCoordinates').mockImplementation(
           async (...args: unknown[]) => {
             const [x, y] = args as [number, number];
             return { x, y };
@@ -2669,15 +2672,15 @@ Stdout:
 
     describe('scroll methods with calculateScrollEndPoint integration', () => {
       beforeEach(() => {
-        vi.spyOn(device as any, 'dragPoint').mockResolvedValue(undefined);
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        rs.spyOn(device as any, 'dragPoint').mockResolvedValue(undefined);
+        rs.spyOn(console, 'warn').mockImplementation(() => {});
       });
 
       it('scrollDown with startPoint should use calculateScrollEndPoint', async () => {
         const startPoint = { left: 100, top: 200 };
         const scrollDistance = 300;
 
-        const calculateScrollEndPointSpy = vi.spyOn(
+        const calculateScrollEndPointSpy = rs.spyOn(
           device as any,
           'calculateScrollEndPoint',
         );
@@ -2697,7 +2700,7 @@ Stdout:
         const startPoint = { left: 100, top: 200 };
         const scrollDistance = 300;
 
-        const calculateScrollEndPointSpy = vi.spyOn(
+        const calculateScrollEndPointSpy = rs.spyOn(
           device as any,
           'calculateScrollEndPoint',
         );
@@ -2717,7 +2720,7 @@ Stdout:
         const startPoint = { left: 100, top: 200 };
         const scrollDistance = 150;
 
-        const calculateScrollEndPointSpy = vi.spyOn(
+        const calculateScrollEndPointSpy = rs.spyOn(
           device as any,
           'calculateScrollEndPoint',
         );
@@ -2737,7 +2740,7 @@ Stdout:
         const startPoint = { left: 100, top: 200 };
         const scrollDistance = 150;
 
-        const calculateScrollEndPointSpy = vi.spyOn(
+        const calculateScrollEndPointSpy = rs.spyOn(
           device as any,
           'calculateScrollEndPoint',
         );
@@ -2758,7 +2761,7 @@ Stdout:
         const scrollDistance = 300;
         const mockEndPoint = { x: 100, y: 100 }; // Mocked calculated end point
 
-        vi.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
+        rs.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
           mockEndPoint,
         );
 
@@ -2775,7 +2778,7 @@ Stdout:
         const scrollDistance = 200;
         const mockEndPoint = { x: 150, y: 600 }; // Mocked calculated end point
 
-        vi.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
+        rs.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
           mockEndPoint,
         );
 
@@ -2792,7 +2795,7 @@ Stdout:
         const scrollDistance = 100;
         const mockEndPoint = { x: 600, y: 300 }; // Mocked calculated end point
 
-        vi.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
+        rs.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
           mockEndPoint,
         );
 
@@ -2809,7 +2812,7 @@ Stdout:
         const scrollDistance = 80;
         const mockEndPoint = { x: 120, y: 250 }; // Mocked calculated end point
 
-        vi.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
+        rs.spyOn(device as any, 'calculateScrollEndPoint').mockReturnValue(
           mockEndPoint,
         );
 
@@ -2824,7 +2827,7 @@ Stdout:
       it('scroll methods should use default scroll distance when not provided', async () => {
         const startPoint = { left: 100, top: 200 };
 
-        const calculateScrollEndPointSpy = vi.spyOn(
+        const calculateScrollEndPointSpy = rs.spyOn(
           device as any,
           'calculateScrollEndPoint',
         );
@@ -2896,7 +2899,7 @@ Stdout:
     };
 
     beforeEach(() => {
-      vi.spyOn(
+      rs.spyOn(
         AndroidDevice.prototype as any,
         'getScreenSize',
       ).mockResolvedValue({
@@ -2910,7 +2913,7 @@ Stdout:
       if (deviceWithDisplay) {
         deviceWithDisplay.destroy();
       }
-      vi.restoreAllMocks();
+      rs.restoreAllMocks();
     });
 
     describe('displayId', () => {
@@ -2947,7 +2950,7 @@ Stdout:
       };
 
       beforeEach(() => {
-        vi.spyOn(
+        rs.spyOn(
           AndroidDevice.prototype as any,
           'getScreenSize',
         ).mockResolvedValue({
@@ -2961,7 +2964,7 @@ Stdout:
         if (deviceWithDisplay) {
           deviceWithDisplay.destroy();
         }
-        vi.restoreAllMocks();
+        rs.restoreAllMocks();
       });
 
       it('should include display argument in shell commands when displayId is set', async () => {
@@ -2972,7 +2975,7 @@ Stdout:
         // Setup mock using global mockAdbInstance
         setupMockAdb(mockAdbInstance);
 
-        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
           mockAdbInstance as any,
         );
 
@@ -2999,10 +3002,10 @@ Stdout:
 
         setupMockAdb(mockAdbInstance);
 
-        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
           mockAdbInstance as any,
         );
-        vi.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
           undefined,
         );
         (deviceWithDisplay as any).devicePixelRatio = 1;
@@ -3030,10 +3033,10 @@ Stdout:
 
         setupMockAdb(mockAdbInstance);
 
-        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
           mockAdbInstance as any,
         );
-        vi.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
           undefined,
         );
         (deviceWithDisplay as any).devicePixelRatio = 1;
@@ -3064,10 +3067,10 @@ Stdout:
 
         setupMockAdb(mockAdbInstance);
 
-        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
           mockAdbInstance as any,
         );
-        vi.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
           undefined,
         );
         (deviceWithDisplay as any).devicePixelRatio = 1;
@@ -3095,7 +3098,7 @@ Stdout:
 
         setupMockAdb(mockAdbInstance);
 
-        vi.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
+        rs.spyOn(deviceWithDisplay, 'getAdb').mockResolvedValue(
           mockAdbInstance as any,
         );
         (deviceWithDisplay as any).devicePixelRatio = 1;
@@ -3302,7 +3305,7 @@ mDisplayId=2
       );
 
       // Mock size method
-      vi.spyOn(deviceWithDisplay, 'size').mockResolvedValue({
+      rs.spyOn(deviceWithDisplay, 'size').mockResolvedValue({
         width: 1080,
         height: 1920,
       });
@@ -3332,7 +3335,7 @@ mDisplayId=2
         Promise.resolve(mockAdbInstance);
 
       // Mock ensureYadb method
-      vi.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
+      rs.spyOn(deviceWithDisplay as any, 'ensureYadb').mockResolvedValue(
         undefined,
       );
 
@@ -3402,7 +3405,7 @@ mDisplayId=2
         Promise.resolve(mockAdbInstance);
 
       // Mock adjustCoordinates to pass through (this test focuses on displayId arg)
-      vi.spyOn(
+      rs.spyOn(
         deviceWithDisplay as any,
         'adjustCoordinates',
       ).mockImplementation(async (...args: unknown[]) => {
@@ -3452,7 +3455,7 @@ mDisplayId=2
       );
 
       // Mock size method
-      vi.spyOn(deviceWithDisplay, 'size').mockResolvedValue({
+      rs.spyOn(deviceWithDisplay, 'size').mockResolvedValue({
         width: 1080,
         height: 1920,
       });

--- a/packages/android/tests/unit-test/proxy-dispatcher.test.ts
+++ b/packages/android/tests/unit-test/proxy-dispatcher.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 
-vi.mock('undici', () => ({
-  ProxyAgent: vi.fn(),
+rs.mock('undici', () => ({
+  ProxyAgent: rs.fn(),
 }));
 
 import { ProxyAgent } from 'undici';
@@ -52,7 +52,7 @@ describe('proxy dispatcher helper', () => {
   });
 
   it('logs sanitized proxy url and creates dispatcher from env', () => {
-    const log = vi.fn();
+    const log = rs.fn();
 
     createLoggedProxyDispatcher({
       env: {

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { DevicePhysicalInfo } from '../../src/scrcpy-device-adapter';
 import { ScrcpyDeviceAdapter } from '../../src/scrcpy-device-adapter';
 import {
@@ -6,53 +6,51 @@ import {
   SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE,
   ScrcpyFreshFrameUnavailableError,
 } from '../../src/scrcpy-manager';
+import * as scrcpyManagerActual from '../../src/scrcpy-manager' with {
+  rstest: 'importActual',
+};
 
-const mocks = vi.hoisted(() => ({
-  AdbServerNodeTcpConnector: vi.fn(),
+const mocks = rs.hoisted(() => ({
+  AdbServerNodeTcpConnector: rs.fn(),
 }));
 
 // Mock @yume-chan packages (ESM-only, used via dynamic import in ensureManager)
-vi.mock('@yume-chan/adb', () => ({
-  Adb: vi.fn().mockImplementation(() => ({})),
-  AdbServerClient: vi.fn().mockImplementation(() => ({
-    createTransport: vi.fn().mockResolvedValue({}),
+rs.mock('@yume-chan/adb', () => ({
+  Adb: rs.fn().mockImplementation(() => ({})),
+  AdbServerClient: rs.fn().mockImplementation(() => ({
+    createTransport: rs.fn().mockResolvedValue({}),
   })),
 }));
 
-vi.mock('@yume-chan/adb-server-node-tcp', () => ({
+rs.mock('@yume-chan/adb-server-node-tcp', () => ({
   AdbServerNodeTcpConnector: mocks.AdbServerNodeTcpConnector,
 }));
 
 // Mock ScrcpyScreenshotManager returned by dynamic import in ensureManager
 const createMockManager = () => ({
-  validateEnvironment: vi.fn().mockResolvedValue(undefined),
-  ensureConnected: vi.fn().mockResolvedValue(undefined),
-  ensureFrameClockCalibration: vi.fn().mockResolvedValue(undefined),
-  prepareFreshFrame: vi.fn().mockResolvedValue(undefined),
-  setFreshnessBarrier: vi.fn().mockResolvedValue(1_000_000n),
-  subscribeKeyframes: vi.fn().mockReturnValue(vi.fn()),
-  getLatestRawKeyframe: vi.fn().mockReturnValue(null),
-  decodeRawKeyframeToJpeg: vi.fn().mockResolvedValue(Buffer.from('jpeg')),
-  isConnected: vi.fn().mockReturnValue(false),
-  getScreenshotJpeg: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
-  getResolution: vi.fn().mockReturnValue(null),
-  disconnect: vi.fn().mockResolvedValue(undefined),
+  validateEnvironment: rs.fn().mockResolvedValue(undefined),
+  ensureConnected: rs.fn().mockResolvedValue(undefined),
+  ensureFrameClockCalibration: rs.fn().mockResolvedValue(undefined),
+  prepareFreshFrame: rs.fn().mockResolvedValue(undefined),
+  setFreshnessBarrier: rs.fn().mockResolvedValue(1_000_000n),
+  subscribeKeyframes: rs.fn().mockReturnValue(rs.fn()),
+  getLatestRawKeyframe: rs.fn().mockReturnValue(null),
+  decodeRawKeyframeToJpeg: rs.fn().mockResolvedValue(Buffer.from('jpeg')),
+  isConnected: rs.fn().mockReturnValue(false),
+  getScreenshotJpeg: rs.fn().mockResolvedValue(Buffer.from('fake-png')),
+  getResolution: rs.fn().mockReturnValue(null),
+  disconnect: rs.fn().mockResolvedValue(undefined),
 });
 
 let currentMockManager: ReturnType<typeof createMockManager>;
 
-vi.mock('../../src/scrcpy-manager', async (importOriginal) => {
-  const original = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...original,
-    ScrcpyScreenshotManager: vi
-      .fn()
-      .mockImplementation(() => currentMockManager),
-  };
-});
+rs.mock('../../src/scrcpy-manager', () => ({
+  ...scrcpyManagerActual,
+  ScrcpyScreenshotManager: rs.fn().mockImplementation(() => currentMockManager),
+}));
 
-vi.mock('@midscene/shared/img', () => ({
-  createImgBase64ByFormat: vi
+rs.mock('@midscene/shared/img', () => ({
+  createImgBase64ByFormat: rs
     .fn()
     .mockReturnValue('data:image/png;base64,test'),
 }));
@@ -70,8 +68,8 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    vi.clearAllMocks();
+    rs.useRealTimers();
+    rs.clearAllMocks();
   });
 
   describe('isEnabled', () => {
@@ -296,7 +294,7 @@ describe('ScrcpyDeviceAdapter', () => {
     });
 
     it('should connect to the resolved ADB server endpoint', async () => {
-      const resolveAdbServerEndpoint = vi.fn().mockResolvedValue({
+      const resolveAdbServerEndpoint = rs.fn().mockResolvedValue({
         host: '192.168.1.10',
         port: 5038,
       });
@@ -373,7 +371,7 @@ describe('ScrcpyDeviceAdapter', () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
 
-      await adapter.subscribeKeyframes(defaultDeviceInfo, vi.fn());
+      await adapter.subscribeKeyframes(defaultDeviceInfo, rs.fn());
 
       expect(currentMockManager.ensureConnected).toHaveBeenCalledTimes(1);
       expect(
@@ -486,8 +484,8 @@ describe('ScrcpyDeviceAdapter', () => {
 
   describe('retry cooldown', () => {
     it('should fall back during cooldown and retry on a later screenshot', async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+      rs.useFakeTimers();
+      rs.setSystemTime(new Date('2026-07-15T00:00:00Z'));
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       currentMockManager.ensureConnected.mockRejectedValueOnce(
         new Error('codec not ready'),
@@ -501,7 +499,7 @@ describe('ScrcpyDeviceAdapter', () => {
       );
       expect(currentMockManager.getScreenshotJpeg).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(60_000);
+      rs.advanceTimersByTime(60_000);
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
         'data:image/png;base64,test',
       );
@@ -525,7 +523,7 @@ describe('ScrcpyDeviceAdapter', () => {
       expect((adapter as any).manager).toBeNull();
 
       adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
-      await vi.waitFor(() => {
+      await rs.waitFor(() => {
         expect(currentMockManager.prepareFreshFrame).toHaveBeenCalledTimes(1);
         expect(adapter.getStatus().lastError).toBeNull();
       });
@@ -549,7 +547,7 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(adapter.getStatus().retryAfter).toBeNull();
 
       adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
-      await vi.waitFor(() => {
+      await rs.waitFor(() => {
         expect(currentMockManager.prepareFreshFrame).toHaveBeenCalledTimes(1);
       });
     });
@@ -557,7 +555,7 @@ describe('ScrcpyDeviceAdapter', () => {
     it('reattaches active frame listeners after background recovery', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
-      const listener = vi.fn();
+      const listener = rs.fn();
       const unsubscribe = await adapter.subscribeKeyframes(
         defaultDeviceInfo,
         listener,
@@ -571,7 +569,7 @@ describe('ScrcpyDeviceAdapter', () => {
       );
       adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
 
-      await vi.waitFor(() => {
+      await rs.waitFor(() => {
         expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(2);
       });
       unsubscribe();

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import {
   ScrcpyFreshFrameUnavailableError,
   ScrcpyScreenshotManager,
@@ -20,20 +20,20 @@ const dataPacket = (tag: number, pts: bigint) => ({
 
 describe('ScrcpyScreenshotManager', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   describe('validateEnvironment', () => {
     it('should succeed when ffmpeg is available', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      vi.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
+      rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
 
       await expect(manager.validateEnvironment()).resolves.toBeUndefined();
     });
 
     it('should throw when ffmpeg is not available', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      vi.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(false);
+      rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(false);
 
       await expect(manager.validateEnvironment()).rejects.toThrow(
         'ffmpeg is not available',
@@ -42,7 +42,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('should throw when checkFfmpegAvailable throws an error', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      vi.spyOn(manager as any, 'checkFfmpegAvailable').mockRejectedValue(
+      rs.spyOn(manager as any, 'checkFfmpegAvailable').mockRejectedValue(
         new Error('unexpected error'),
       );
 
@@ -53,7 +53,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('should cache ffmpeg check result (only check once on success)', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const spy = vi
+      const spy = rs
         .spyOn(manager as any, 'checkFfmpegAvailable')
         .mockResolvedValue(true);
 
@@ -65,10 +65,10 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('should be independent from ensureConnected', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      vi.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
+      rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
 
       // validateEnvironment should not trigger ensureConnected logic
-      const ensureConnectedSpy = vi.spyOn(manager, 'ensureConnected');
+      const ensureConnectedSpy = rs.spyOn(manager, 'ensureConnected');
 
       await manager.validateEnvironment();
 
@@ -173,7 +173,7 @@ describe('ScrcpyScreenshotManager', () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).scrcpyClient = {};
       (manager as any).videoStream = {};
-      const readClock = vi
+      const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValue({
           deviceUptimeUs: 1_000_000n,
@@ -251,10 +251,10 @@ describe('ScrcpyScreenshotManager', () => {
         'The underlying readable ended before the struct was deserialized',
       );
       const reader = {
-        read: vi.fn().mockRejectedValue(streamError),
-        cancel: vi.fn().mockRejectedValue(streamError),
+        read: rs.fn().mockRejectedValue(streamError),
+        cancel: rs.fn().mockRejectedValue(streamError),
       };
-      const close = vi.fn().mockResolvedValue(undefined);
+      const close = rs.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = reader;
       (manager as any).scrcpyClient = { close };
       (manager as any).videoStream = {};
@@ -272,10 +272,10 @@ describe('ScrcpyScreenshotManager', () => {
     it('should disconnect the current session after a clean stream end', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       const reader = {
-        read: vi.fn().mockResolvedValue({ done: true }),
-        cancel: vi.fn().mockResolvedValue(undefined),
+        read: rs.fn().mockResolvedValue({ done: true }),
+        cancel: rs.fn().mockResolvedValue(undefined),
       };
-      const close = vi.fn().mockResolvedValue(undefined);
+      const close = rs.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = reader;
       (manager as any).scrcpyClient = { close };
       (manager as any).videoStream = {};
@@ -291,13 +291,13 @@ describe('ScrcpyScreenshotManager', () => {
     it('should not disconnect a replacement session when an obsolete reader ends', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       const obsoleteReader = {
-        read: vi.fn().mockResolvedValue({ done: true }),
-        cancel: vi.fn().mockResolvedValue(undefined),
+        read: rs.fn().mockResolvedValue({ done: true }),
+        cancel: rs.fn().mockResolvedValue(undefined),
       };
       const replacementReader = {
-        cancel: vi.fn().mockResolvedValue(undefined),
+        cancel: rs.fn().mockResolvedValue(undefined),
       };
-      const close = vi.fn().mockResolvedValue(undefined);
+      const close = rs.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = replacementReader;
       (manager as any).scrcpyClient = { close };
       (manager as any).videoStream = {};
@@ -324,7 +324,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('samples the device uptime and brackets it with host clocks', async () => {
-      const spawnWaitText = vi.fn().mockResolvedValue({
+      const spawnWaitText = rs.fn().mockResolvedValue({
         exitCode: 0,
         stdout: 'mLastWakeTime=1000 (50 ms ago)',
         stderr: '',
@@ -334,10 +334,10 @@ describe('ScrcpyScreenshotManager', () => {
           shellProtocol: { spawnWaitText },
         },
       } as any);
-      vi.spyOn(manager as any, 'monotonicTimeUs')
+      rs.spyOn(manager as any, 'monotonicTimeUs')
         .mockReturnValueOnce(10_000_000n)
         .mockReturnValueOnce(10_020_000n);
-      vi.spyOn(Date, 'now')
+      rs.spyOn(Date, 'now')
         .mockReturnValueOnce(2_000)
         .mockReturnValueOnce(2_020);
 
@@ -354,7 +354,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('drops frames captured before the device-clock barrier', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const listener = vi.fn();
+      const listener = rs.fn();
       manager.subscribeKeyframes(listener);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
@@ -362,7 +362,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
       const barrier = await manager.setFreshnessBarrier(
         'completed input action',
@@ -385,7 +385,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('projects every barrier from one stream-epoch clock sample', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const readClock = vi
+      const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValue({
           deviceUptimeUs: 1_000_000n,
@@ -394,7 +394,7 @@ describe('ScrcpyScreenshotManager', () => {
           roundTripUs: 10_000n,
         });
       await manager.ensureFrameClockCalibration();
-      vi.spyOn(manager as any, 'monotonicTimeUs')
+      rs.spyOn(manager as any, 'monotonicTimeUs')
         .mockReturnValueOnce(10_100_000n)
         .mockReturnValueOnce(10_250_000n);
 
@@ -418,7 +418,7 @@ describe('ScrcpyScreenshotManager', () => {
             roundTripUs: bigint;
           }) => void)
         | undefined;
-      const readClock = vi
+      const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockReturnValue(
           new Promise((resolve) => {
@@ -452,7 +452,7 @@ describe('ScrcpyScreenshotManager', () => {
             roundTripUs: bigint;
           }) => void)
         | undefined;
-      vi.spyOn(manager as any, 'readDeviceClockCalibration').mockReturnValue(
+      rs.spyOn(manager as any, 'readDeviceClockCalibration').mockReturnValue(
         new Promise((resolve) => {
           resolveClock = resolve;
         }),
@@ -473,7 +473,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('requires a stream-epoch clock anchor before arming a barrier', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const readClock = vi.spyOn(manager as any, 'readDeviceClockCalibration');
+      const readClock = rs.spyOn(manager as any, 'readDeviceClockCalibration');
 
       await expect(
         manager.setFreshnessBarrier('completed input action'),
@@ -484,7 +484,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('takes a new clock sample after the stream epoch is reset', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const readClock = vi
+      const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValueOnce({
           deviceUptimeUs: 1_000_000n,
@@ -517,7 +517,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
 
       (manager as any).processFrame(spsPacket());
       (manager as any).processFrame(dataPacket(0x01, 1_050_000n));
@@ -537,8 +537,8 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
-      vi.spyOn(Date, 'now').mockReturnValue(9_999_999_999_999);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
+      rs.spyOn(Date, 'now').mockReturnValue(9_999_999_999_999);
 
       expect((manager as any).estimateFrameAgeUs(1_050_000n)).toBe(50_000n);
     });
@@ -551,7 +551,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 5_000_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
       expect((manager as any).estimateFrameAge(1_000_000n)).toEqual({
         estimatedAgeUs: 0n,
@@ -569,7 +569,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 20_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
       expect((manager as any).isFrameAgeAcceptable(1_000_000n)).toBe(true);
 
@@ -585,7 +585,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
       (manager as any).processFrame(spsPacket());
       (manager as any).processFrame(dataPacket(0x01, 1_050_000n));
@@ -603,7 +603,7 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).processFrame(dataPacket(0x03, 1_200_000n));
       expect(manager.getLatestRawKeyframe()).toBeNull();
 
-      const readClock = vi
+      const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValue({
           deviceUptimeUs: 200_000n,
@@ -621,7 +621,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('hides over-age frames from continuous frame consumers', () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const listener = vi.fn();
+      const listener = rs.fn();
       manager.subscribeKeyframes(listener);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
@@ -629,7 +629,7 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
       (manager as any).processFrame(spsPacket());
       (manager as any).processFrame(dataPacket(0x01, 1_000_000n));
@@ -652,13 +652,13 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
 
-      vi.spyOn(manager, 'ensureConnected').mockResolvedValue();
-      vi.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
-      const waitForNext = vi.spyOn(manager as any, 'waitForNextKeyframe');
-      const setBarrier = vi.spyOn(manager, 'setFreshnessBarrier');
-      const decode = vi
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      const waitForNext = rs.spyOn(manager as any, 'waitForNextKeyframe');
+      const setBarrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      const decode = rs
         .spyOn(manager as any, 'decodeH264ToJpeg')
         .mockResolvedValue(Buffer.from('jpeg'));
 
@@ -684,18 +684,18 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
-      vi.spyOn(manager, 'ensureConnected').mockResolvedValue();
-      vi.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
-      vi.spyOn(manager as any, 'waitForNextKeyframe').mockResolvedValue({
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      rs.spyOn(manager as any, 'waitForNextKeyframe').mockResolvedValue({
         data: Buffer.from('current'),
         header: Buffer.from('header'),
         ptsUs: 2_006_000n,
         estimatedAgeMs: 0,
         capturedAt: 2_000,
       });
-      const barrier = vi.spyOn(manager, 'setFreshnessBarrier');
-      const decode = vi
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      const decode = rs
         .spyOn(manager as any, 'decodeH264ToJpeg')
         .mockResolvedValue(Buffer.from('jpeg'));
 
@@ -720,18 +720,18 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
-      vi.spyOn(manager, 'ensureConnected').mockResolvedValue();
-      vi.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
-      vi.spyOn(manager as any, 'waitForNextKeyframe').mockResolvedValue({
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      rs.spyOn(manager as any, 'waitForNextKeyframe').mockResolvedValue({
         data: Buffer.from('current'),
         header: Buffer.from('header'),
         ptsUs: 2_006_000n,
         estimatedAgeMs: 0,
         capturedAt: 2_000,
       });
-      const barrier = vi.spyOn(manager, 'setFreshnessBarrier');
-      vi.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
         Buffer.from('jpeg'),
       );
 
@@ -752,17 +752,17 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const ensureConnected = vi
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
+      const ensureConnected = rs
         .spyOn(manager, 'ensureConnected')
         .mockResolvedValue();
-      const disconnect = vi.spyOn(manager, 'disconnect').mockResolvedValue();
-      const barrier = vi.spyOn(manager, 'setFreshnessBarrier');
-      vi.spyOn(manager as any, 'waitForNextKeyframe').mockRejectedValue(
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      rs.spyOn(manager as any, 'waitForNextKeyframe').mockRejectedValue(
         new Error('no post-action frame'),
       );
-      const decode = vi.spyOn(manager as any, 'decodeH264ToJpeg');
+      const decode = rs.spyOn(manager as any, 'decodeH264ToJpeg');
 
       await expect(manager.getScreenshotJpeg()).rejects.toBeInstanceOf(
         ScrcpyFreshFrameUnavailableError,
@@ -799,8 +799,8 @@ describe('ScrcpyScreenshotManager', () => {
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
       };
-      vi.spyOn(manager, 'ensureConnected').mockResolvedValue();
-      vi.spyOn(manager, 'disconnect').mockResolvedValue();
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager, 'disconnect').mockResolvedValue();
 
       await expect(manager.getScreenshotJpeg()).rejects.toThrow(
         /has no PTS metadata/,
@@ -816,7 +816,7 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).lastRawKeyframe = Buffer.from('keyframe');
       (manager as any).isInitialized = true;
       (manager as any).keyframeResolvers = [() => {}];
-      (manager as any).streamReader = { cancel: vi.fn() };
+      (manager as any).streamReader = { cancel: rs.fn() };
       (manager as any).frameFreshnessBarrierPtsUs = 123n;
       (manager as any).deviceClockCalibration = {};
       (manager as any).lastFramePtsUs = 456n;
@@ -850,7 +850,7 @@ describe('ScrcpyScreenshotManager', () => {
     it('should handle scrcpyClient.close() error gracefully', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).scrcpyClient = {
-        close: vi.fn().mockRejectedValue(new Error('close failed')),
+        close: rs.fn().mockRejectedValue(new Error('close failed')),
       };
 
       // Should not throw
@@ -861,7 +861,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('should cancel streamReader to stop consumeFramesLoop', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      const cancelFn = vi.fn().mockResolvedValue(undefined);
+      const cancelFn = rs.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = { cancel: cancelFn };
 
       await manager.disconnect();
@@ -877,7 +877,7 @@ describe('ScrcpyScreenshotManager', () => {
         resolveCancel = resolve;
       });
       (manager as any).streamReader = {
-        cancel: vi.fn().mockReturnValue(cancelPromise),
+        cancel: rs.fn().mockReturnValue(cancelPromise),
       };
 
       let disconnected = false;
@@ -896,7 +896,7 @@ describe('ScrcpyScreenshotManager', () => {
     it('should handle streamReader.cancel() error gracefully', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).streamReader = {
-        cancel: vi.fn().mockRejectedValue(new Error('stream already errored')),
+        cancel: rs.fn().mockRejectedValue(new Error('stream already errored')),
       };
 
       await expect(manager.disconnect()).resolves.toBeUndefined();
@@ -907,7 +907,7 @@ describe('ScrcpyScreenshotManager', () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       let clientNulledBeforeClose = false;
       (manager as any).scrcpyClient = {
-        close: vi.fn().mockImplementation(async () => {
+        close: rs.fn().mockImplementation(async () => {
           // At this point, scrcpyClient should already be null
           clientNulledBeforeClose = (manager as any).scrcpyClient === null;
         }),

--- a/packages/android/tests/unit-test/scrcpy-server-version.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-server-version.test.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { AdbScrcpyOptions3_3_3 } from '@yume-chan/adb-scrcpy';
-import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   SCRCPY_PROTOCOL_VERSION,
   SCRCPY_SERVER_VERSION_TAG,
@@ -53,7 +53,7 @@ describe('scrcpy server version helper', () => {
     tempDirs.push(dirPath);
 
     const destinationPath = path.join(dirPath, 'scrcpy-server-v3.3.3');
-    const fetchImpl = vi.fn(async () => ({
+    const fetchImpl = rs.fn(async () => ({
       ok: true,
       arrayBuffer: async () => new TextEncoder().encode('server-binary').buffer,
       status: 200,
@@ -85,7 +85,7 @@ describe('scrcpy server version helper', () => {
     const destinationPath = path.join(dirPath, 'scrcpy-server-v3.3.3');
     const apiAssetUrl =
       'https://api.github.com/repos/Genymobile/scrcpy/releases/assets/123';
-    const fetchImpl = vi.fn(async (url: string) => {
+    const fetchImpl = rs.fn(async (url: string) => {
       if (
         url ===
         'https://github.com/Genymobile/scrcpy/releases/download/v3.3.3/scrcpy-server-v3.3.3'
@@ -182,7 +182,7 @@ describe('scrcpy server version helper', () => {
     await fs.writeFile(serverBinPath, 'old-server');
     await fs.writeFile(downloadedFile, 'new-server');
 
-    const rename = vi.fn(async (fromPath: string, toPath: string) => {
+    const rename = rs.fn(async (fromPath: string, toPath: string) => {
       if (fromPath === downloadedFile && toPath === serverBinPath) {
         throw new Error('rename failed');
       }

--- a/packages/android/tests/unit-test/ui-tree.test.ts
+++ b/packages/android/tests/unit-test/ui-tree.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { uiautomatorXmlToUiNode } from '../../src/ui-tree';
 
 describe('uiautomatorXmlToUiNode', () => {

--- a/packages/android/tests/unit-test/utils.test.ts
+++ b/packages/android/tests/unit-test/utils.test.ts
@@ -1,30 +1,30 @@
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import {
   getConnectedDevices,
   getConnectedDevicesWithDetails,
 } from '../../src/utils';
 
-const mocks = vi.hoisted(() => ({
+const mocks = rs.hoisted(() => ({
   adb: {
     executable: {
       path: '/mock/platform-tools/adb',
       defaultArgs: [],
     },
-    getConnectedDevices: vi.fn(),
-    setDeviceId: vi.fn(),
-    shell: vi.fn(),
-    getScreenDensity: vi.fn(),
+    getConnectedDevices: rs.fn(),
+    setDeviceId: rs.fn(),
+    shell: rs.fn(),
+    getScreenDensity: rs.fn(),
   },
-  createAndroidAdb: vi.fn(),
+  createAndroidAdb: rs.fn(),
 }));
 
-vi.mock('../../src/adb', () => ({
+rs.mock('../../src/adb', () => ({
   createAndroidAdb: mocks.createAndroidAdb,
 }));
 
 describe('Android Utils', () => {
   beforeEach(async () => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
     const mockAdbInstance = mocks.adb;
     mocks.createAndroidAdb.mockResolvedValue(mockAdbInstance);
     (mockAdbInstance.setDeviceId as Mock).mockImplementation(() => undefined);
@@ -150,7 +150,7 @@ describe('Android Utils', () => {
     });
 
     it('should timeout slow detail lookups and still return the basic device entry', async () => {
-      vi.useFakeTimers();
+      rs.useFakeTimers();
 
       try {
         const mockDevices = [{ udid: 'device-1', state: 'device' }];
@@ -165,7 +165,7 @@ describe('Android Utils', () => {
         (mockAdbInstance.getScreenDensity as Mock).mockResolvedValue(420);
 
         const devicesPromise = getConnectedDevicesWithDetails();
-        await vi.advanceTimersByTimeAsync(2500);
+        await rs.advanceTimersByTimeAsync(2500);
         const devices = await devicesPromise;
 
         expect(devices).toEqual([
@@ -178,7 +178,7 @@ describe('Android Utils', () => {
           },
         ]);
       } finally {
-        vi.useRealTimers();
+        rs.useRealTimers();
       }
     });
   });

--- a/packages/android/tests/unit-test/visual-action-registry.test.ts
+++ b/packages/android/tests/unit-test/visual-action-registry.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it, rs } from '@rstest/core';
 import ts from 'typescript';
-import { describe, expect, it, vi } from 'vitest';
 import { createVisualActionRegistry } from '../../src/visual-action-registry';
 
 const lowLevelVisualMutationMethods = new Set([
@@ -85,7 +85,7 @@ function calledVisualAction(call: ts.CallExpression): string | undefined {
 
 describe('createVisualActionRegistry', () => {
   it('runs the completion hook once with the registered action name', async () => {
-    const onActionSettled = vi.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         launch: async (uri: string) => `launched:${uri}`,
@@ -101,8 +101,8 @@ describe('createVisualActionRegistry', () => {
   });
 
   it('settles a composite action only once', async () => {
-    const dispatchStep = vi.fn().mockResolvedValue(undefined);
-    const onActionSettled = vi.fn().mockResolvedValue(undefined);
+    const dispatchStep = rs.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async (repeat: number) => {
@@ -123,11 +123,11 @@ describe('createVisualActionRegistry', () => {
 
   it('settles an action that fails after dispatch begins', async () => {
     const actionError = new Error('second gesture failed');
-    const dispatchStep = vi
+    const dispatchStep = rs
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(actionError);
-    const onActionSettled = vi.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async () => {

--- a/packages/android/tests/unit-test/yadb-download.test.ts
+++ b/packages/android/tests/unit-test/yadb-download.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import {
   YADB_VERSION,
   downloadYadbReleaseAsset,
@@ -31,7 +31,7 @@ describe('yadb download script', () => {
 
     const destinationPath = path.join(dirPath, 'yadb');
     const dispatcher = { kind: 'proxy-dispatcher' };
-    const fetchImpl = vi.fn(async () => ({
+    const fetchImpl = rs.fn(async () => ({
       ok: true,
       arrayBuffer: async () => new TextEncoder().encode('yadb-binary').buffer,
       status: 200,
@@ -61,7 +61,7 @@ describe('yadb download script', () => {
     const destinationPath = path.join(dirPath, 'yadb');
     const apiAssetUrl =
       'https://api.github.com/repos/ysbing/YADB/releases/assets/392259748';
-    const fetchImpl = vi.fn(async (url: string) => {
+    const fetchImpl = rs.fn(async (url: string) => {
       if (
         url === 'https://github.com/ysbing/YADB/releases/download/v1.1.1/yadb'
       ) {
@@ -119,7 +119,7 @@ describe('yadb download script', () => {
   });
 
   it('throws when the browser URL and API metadata fallback both fail', async () => {
-    const fetchImpl = vi.fn(async () => ({
+    const fetchImpl = rs.fn(async () => ({
       ok: false,
       status: 502,
       statusText: 'Bad Gateway',

--- a/packages/android/tests/unit-test/yaml-runAdbShell.test.ts
+++ b/packages/android/tests/unit-test/yaml-runAdbShell.test.ts
@@ -4,7 +4,7 @@ import type {
   MidsceneYamlScriptEnv,
 } from '@midscene/core/yaml';
 import { ScriptPlayer } from '@midscene/core/yaml';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
 const runAdbShellParamSchema = z.object({
@@ -20,15 +20,15 @@ describe('YAML runAdbShell support via ActionSpace', () => {
       description: 'Execute ADB shell command',
       interfaceAlias: 'runAdbShell',
       paramSchema: runAdbShellParamSchema,
-      call: vi.fn(async (param: { command: string }) => mockResult),
+      call: rs.fn(async (param: { command: string }) => mockResult),
     };
 
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runAdbShellAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runAdbShellAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           // Simulate the actual behavior of callActionInActionSpace
           if (actionName === 'RunAdbShell') {
@@ -78,15 +78,15 @@ describe('YAML runAdbShell support via ActionSpace', () => {
       description: 'Execute ADB shell command',
       interfaceAlias: 'runAdbShell',
       paramSchema: runAdbShellParamSchema,
-      call: vi.fn(async (param: { command: string }) => mockResult),
+      call: rs.fn(async (param: { command: string }) => mockResult),
     };
 
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runAdbShellAction]),
-      callActionInActionSpace: vi.fn(async () => mockResult),
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runAdbShellAction]),
+      callActionInActionSpace: rs.fn(async () => mockResult),
     };
 
     const script: MidsceneYamlScript = {
@@ -125,9 +125,9 @@ describe('YAML runAdbShell support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => []), // Empty actionSpace, no runAdbShell
-      callActionInActionSpace: vi.fn(),
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => []), // Empty actionSpace, no runAdbShell
+      callActionInActionSpace: rs.fn(),
     };
 
     const script: MidsceneYamlScript = {
@@ -167,15 +167,15 @@ describe('YAML runAdbShell support via ActionSpace', () => {
       description: 'Execute ADB shell command',
       interfaceAlias: 'runAdbShell',
       paramSchema: runAdbShellParamSchema,
-      call: vi.fn(async (param: { command: string }) => mockResult),
+      call: rs.fn(async (param: { command: string }) => mockResult),
     };
 
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runAdbShellAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runAdbShellAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           if (actionName === 'RunAdbShell') {
             return mockResult;
@@ -224,7 +224,7 @@ describe('YAML runAdbShell support via ActionSpace', () => {
       description: 'Execute ADB shell command',
       interfaceAlias: 'runAdbShell',
       paramSchema: runAdbShellParamSchema,
-      call: vi.fn(async (param: { command: string }) => {
+      call: rs.fn(async (param: { command: string }) => {
         if (!param.command) {
           throw new Error('Command is required for runAdbShell');
         }
@@ -235,9 +235,9 @@ describe('YAML runAdbShell support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runAdbShellAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runAdbShellAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           if (actionName === 'RunAdbShell') {
             // Call the actual action to trigger validation

--- a/packages/android/tsconfig.build.json
+++ b/packages/android/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "src",
+    "module": "ES2020"
   },
   "include": ["src"]
 }

--- a/packages/android/tsconfig.json
+++ b/packages/android/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../shared/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "module": "ES2020",
     "declarationDir": "dist/types",
     "types": ["node"]
   },

--- a/packages/computer/package.json
+++ b/packages/computer/package.json
@@ -28,9 +28,9 @@
     "build:native": "node ./scripts/build-native.mjs",
     "prepublishOnly": "node ./scripts/prepublish-native.mjs",
     "dev": "rslib build --watch",
-    "test": "vitest run",
-    "test:ai": "AI_TEST_TYPE=computer vitest run",
-    "test:ai:rdp": "AI_TEST_TYPE=computer-rdp vitest run"
+    "test": "rstest",
+    "test:ai": "AI_TEST_TYPE=computer rstest",
+    "test:ai:rdp": "AI_TEST_TYPE=computer-rdp rstest"
   },
   "dependencies": {
     "@computer-use/libnut": "^4.2.0",
@@ -44,11 +44,11 @@
   },
   "devDependencies": {
     "@rslib/core": "^0.18.3",
+    "@rstest/core": "0.11.5",
     "@types/node": "^18.0.0",
     "@types/screenshot-desktop": "1.15.0",
     "dotenv": "^16.4.5",
     "tsx": "^4.19.2",
-    "typescript": "^5.8.3",
-    "vitest": "3.0.5"
+    "typescript": "^5.8.3"
   }
 }

--- a/packages/computer/rstest.config.ts
+++ b/packages/computer/rstest.config.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
+import { defineConfig } from '@rstest/core';
 import dotenv from 'dotenv';
-import { defineConfig } from 'vitest/config';
-import { createCoverageConfig } from '../../scripts/vitest-coverage';
+import { createCoverageConfig } from '../../scripts/rstest-coverage';
+import { defineVersion, photonExternal } from '../../scripts/rstest-shared';
 import { version } from './package.json';
 
 /**
@@ -34,19 +35,17 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
-  test: {
-    coverage: createCoverageConfig(__dirname),
-    include: testFiles,
-    testTimeout: 3 * 60 * 1000, // Global timeout set to 3 minutes
-    hookTimeout: 3 * 60 * 1000,
-    retry: process.env.CI ? 1 : 0,
-    fileParallelism: false, // disable parallel file test for desktop automation
-    environment: 'node',
+  coverage: createCoverageConfig(__dirname),
+  include: testFiles,
+  testTimeout: 3 * 60 * 1000, // Global timeout set to 3 minutes
+  hookTimeout: 3 * 60 * 1000,
+  retry: process.env.CI ? 1 : 0,
+  pool: { maxWorkers: 1 }, // disable parallel file test for desktop automation
+  testEnvironment: 'node',
+  source: {
+    define: defineVersion(version),
   },
-  define: {
-    __VERSION__: `'${version}'`,
-  },
-  ssr: {
-    external: ['@silvia-odwyer/photon'],
+  output: {
+    externals: photonExternal,
   },
 });

--- a/packages/computer/tests/ai/ai-auto-todo.test.ts
+++ b/packages/computer/tests/ai/ai-auto-todo.test.ts
@@ -1,10 +1,10 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import { openBrowserAndNavigate } from './test-utils';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 
@@ -130,7 +130,7 @@ describe('computer todo app automation', () => {
     'should automate todo list operations',
     async () => {
       if (isCacheEnabled) {
-        vi.setConfig({ testTimeout: 1000 * 1000 });
+        rs.setConfig({ testTimeout: 1000 * 1000 });
       }
 
       if (!agent) {

--- a/packages/computer/tests/ai/ai-shop.test.ts
+++ b/packages/computer/tests/ai/ai-shop.test.ts
@@ -1,9 +1,9 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import { openBrowserAndNavigate } from './test-utils';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 
@@ -23,7 +23,7 @@ describe('computer shop app automation', () => {
     'should automate shop login and cart operations',
     async () => {
       if (isCacheEnabled) {
-        vi.setConfig({ testTimeout: 1000 * 1000 });
+        rs.setConfig({ testTimeout: 1000 * 1000 });
       }
 
       await openBrowserAndNavigate(agent, 'https://www.saucedemo.com/');

--- a/packages/computer/tests/ai/ai-weather.test.ts
+++ b/packages/computer/tests/ai/ai-weather.test.ts
@@ -1,8 +1,8 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import { openBrowserAndNavigate } from './test-utils';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 
@@ -22,7 +22,7 @@ describe('computer weather query automation', () => {
     'should query San Jose tomorrow weather temperature on Google',
     async () => {
       if (isCacheEnabled) {
-        vi.setConfig({ testTimeout: 1000 * 1000 });
+        rs.setConfig({ testTimeout: 1000 * 1000 });
       }
 
       await openBrowserAndNavigate(agent, 'https://www.google.com');

--- a/packages/computer/tests/ai/basic.test.ts
+++ b/packages/computer/tests/ai/basic.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { ComputerAgent, ComputerDevice } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 

--- a/packages/computer/tests/ai/chinese-input.test.ts
+++ b/packages/computer/tests/ai/chinese-input.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { ComputerAgent, ComputerDevice } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/computer/tests/ai/chrome-extension-bridge.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-bridge.test.ts
@@ -13,7 +13,7 @@
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   findExtensionPageTarget,
@@ -24,7 +24,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 360 * 1000 });
+rs.setConfig({ testTimeout: 360 * 1000 });
 
 const SIDE_PANEL =
   'the Midscene side panel on the right side of the browser window';

--- a/packages/computer/tests/ai/chrome-extension-bridge.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-bridge.test.ts
@@ -160,6 +160,7 @@ describe('chrome extension bridge mode start/stop (#2119)', () => {
 
   it(
     'open side panel and switch to Bridge Mode',
+    { timeout: 20 * 60 * 1000, retry: 0 },
     async () => {
       await agent.aiAct(
         'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
@@ -207,7 +208,6 @@ describe('chrome extension bridge mode start/stop (#2119)', () => {
         );
       }
     },
-    { timeout: 20 * 60 * 1000, retry: 0 },
   );
 
   // ── Test: bridge connects to a real server ────────────────────────────

--- a/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
@@ -6,7 +6,7 @@
  */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   bringPageToFront,
@@ -18,7 +18,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 600 * 1000 });
+rs.setConfig({ testTimeout: 600 * 1000 });
 
 const SIDE_PANEL =
   'the Midscene side panel on the right side of the browser window';

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -7,7 +7,7 @@
  */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   bringPageToFront,
@@ -19,7 +19,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 600 * 1000 });
+rs.setConfig({ testTimeout: 600 * 1000 });
 
 const SIDE_PANEL =
   'the Midscene side panel on the right side of the browser window';

--- a/packages/computer/tests/ai/chrome-extension-recorder.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-recorder.test.ts
@@ -9,7 +9,7 @@
  */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   findExtensionPageTarget,
@@ -19,7 +19,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 600 * 1000 });
+rs.setConfig({ testTimeout: 600 * 1000 });
 
 const SIDE_PANEL =
   'the Midscene side panel on the right side of the browser window';

--- a/packages/computer/tests/ai/chrome-extension-settings.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-settings.test.ts
@@ -9,7 +9,7 @@
  */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   findExtensionPageTarget,
@@ -19,7 +19,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 480 * 1000 });
+rs.setConfig({ testTimeout: 480 * 1000 });
 
 const SIDE_PANEL =
   'the Midscene side panel on the right side of the browser window';

--- a/packages/computer/tests/ai/chrome-extension.test.ts
+++ b/packages/computer/tests/ai/chrome-extension.test.ts
@@ -4,7 +4,7 @@
  */
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { type ComputerAgent, agentFromComputer } from '../../src';
 import {
   findExtensionPageTarget,
@@ -14,7 +14,7 @@ import {
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
 
-vi.setConfig({ testTimeout: 360 * 1000 });
+rs.setConfig({ testTimeout: 360 * 1000 });
 
 describe('chrome extension smoke test', () => {
   let agent: ComputerAgent;

--- a/packages/computer/tests/ai/keyboard.test.ts
+++ b/packages/computer/tests/ai/keyboard.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { ComputerAgent, ComputerDevice } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 

--- a/packages/computer/tests/ai/macos-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/macos-desktop-smoke.test.ts
@@ -20,7 +20,7 @@ import {
   MIDSCENE_MODEL_TIMEOUT,
 } from '@midscene/shared/env';
 import { cropByRect, imageInfoOfBase64 } from '@midscene/shared/img';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import {
   ComputerAgent,
   ComputerDevice,
@@ -103,7 +103,7 @@ interface ReportDump {
   executions?: ReportExecution[];
 }
 
-vi.setConfig({ testTimeout: 180_000, hookTimeout: 30_000 });
+rs.setConfig({ testTimeout: 180_000, hookTimeout: 30_000 });
 
 function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));

--- a/packages/computer/tests/ai/multi-display.test.ts
+++ b/packages/computer/tests/ai/multi-display.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { ComputerDevice, agentFromComputer } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 120 * 1000,
 });
 

--- a/packages/computer/tests/ai/rdp/login-form.test.ts
+++ b/packages/computer/tests/ai/rdp/login-form.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import type { Rect, Size } from '@midscene/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { ComputerAgent, RDPDevice } from '../../../src';
 import type {
   RDPBackendClient,

--- a/packages/computer/tests/ai/rdp/real-session-parity.test.ts
+++ b/packages/computer/tests/ai/rdp/real-session-parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { ComputerAgent, RDPDevice } from '../../../src';
 
 const realRdpEnv = {

--- a/packages/computer/tests/ai/rdp/real-session-protocol.test.ts
+++ b/packages/computer/tests/ai/rdp/real-session-protocol.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { ComputerAgent, RDPDevice } from '../../../src';
 
 const realRdpEnv = {

--- a/packages/computer/tests/ai/scroll.test.ts
+++ b/packages/computer/tests/ai/scroll.test.ts
@@ -1,10 +1,10 @@
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { ComputerAgent, ComputerDevice } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 360 * 1000,
 });
 

--- a/packages/computer/tests/ai/web-browser.test.ts
+++ b/packages/computer/tests/ai/web-browser.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import { ComputerAgent, ComputerDevice } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/computer/tests/ai/windows-desktop-smoke.test.ts
+++ b/packages/computer/tests/ai/windows-desktop-smoke.test.ts
@@ -12,7 +12,7 @@ import {
   MIDSCENE_MODEL_TIMEOUT,
 } from '@midscene/shared/env';
 import { imageInfoOfBase64 } from '@midscene/shared/img';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   ComputerAgent,
   ComputerDevice,

--- a/packages/computer/tests/unit-test/agent-tools.test.ts
+++ b/packages/computer/tests/unit-test/agent-tools.test.ts
@@ -1,19 +1,19 @@
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { getMidsceneRunBaseDir } from '@midscene/shared/common';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { agentForRDPComputer, agentFromComputer } from '../../src/agent';
 import { ComputerMidsceneTools } from '../../src/agent-tools';
 
-vi.mock('../../src/agent', () => ({
-  agentFromComputer: vi.fn(),
-  agentForRDPComputer: vi.fn(),
+rs.mock('../../src/agent', () => ({
+  agentFromComputer: rs.fn(),
+  agentForRDPComputer: rs.fn(),
 }));
 
-vi.mock('../../src/device', () => ({
-  ComputerDevice: vi.fn().mockImplementation(() => ({
-    actionSpace: vi.fn().mockReturnValue([]),
-    destroy: vi.fn(),
+rs.mock('../../src/device', () => ({
+  ComputerDevice: rs.fn().mockImplementation(() => ({
+    actionSpace: rs.fn().mockReturnValue([]),
+    destroy: rs.fn(),
   })),
 }));
 
@@ -23,13 +23,13 @@ const validPngBase64 =
 function createMockAgent() {
   return {
     interface: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
     page: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
-    aiAction: vi.fn().mockResolvedValue('done'),
-    destroy: vi.fn(),
+    aiAction: rs.fn().mockResolvedValue('done'),
+    destroy: rs.fn(),
   };
 }
 
@@ -43,12 +43,12 @@ function clearCliReportSession(): void {
 describe('ComputerMidsceneTools', () => {
   beforeEach(() => {
     clearCliReportSession();
-    vi.mocked(agentFromComputer).mockResolvedValue(createMockAgent() as any);
-    vi.mocked(agentForRDPComputer).mockResolvedValue(createMockAgent() as any);
+    rs.mocked(agentFromComputer).mockResolvedValue(createMockAgent() as any);
+    rs.mocked(agentForRDPComputer).mockResolvedValue(createMockAgent() as any);
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
     clearCliReportSession();
   });
 
@@ -108,7 +108,7 @@ describe('ComputerMidsceneTools', () => {
 
   it('passes top-level display-id alias to act', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromComputer).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromComputer).mockResolvedValue(mockAgent as any);
 
     const tools = new ComputerMidsceneTools();
     await tools.initTools();
@@ -287,7 +287,7 @@ describe('ComputerMidsceneTools', () => {
 
   it('reuses the Computer agent when called twice with identical init args', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromComputer).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromComputer).mockResolvedValue(mockAgent as any);
 
     const tools = new ComputerMidsceneTools();
     await tools.initTools();
@@ -310,7 +310,7 @@ describe('ComputerMidsceneTools', () => {
   it('rebuilds the Computer agent when init args change', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromComputer)
+    rs.mocked(agentFromComputer)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 
@@ -339,7 +339,7 @@ describe('ComputerMidsceneTools', () => {
   it('rebuilds the Computer agent when init args are omitted after being set', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromComputer)
+    rs.mocked(agentFromComputer)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 

--- a/packages/computer/tests/unit-test/agent.test.ts
+++ b/packages/computer/tests/unit-test/agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   ComputerAgent,
   ComputerDevice,

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -1,14 +1,14 @@
 import type { ExecutorContext } from '@midscene/core';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
-const mockState = vi.hoisted(() => {
-  const execSync = vi.fn();
+const mockState = rs.hoisted(() => {
+  const execSync = rs.fn();
   // 1x1 PNG, base64-encoded — what the Windows PowerShell capture prints.
   const FAKE_PNG_BASE64 =
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
   // Windows screenshot/listDisplays go through `powershell.exe -EncodedCommand`
   // now (issue #2150); answer based on which script is being run.
-  const execFileSync = vi.fn(
+  const execFileSync = rs.fn(
     (
       file?: string,
       args?: string[],
@@ -33,34 +33,34 @@ const mockState = vi.hoisted(() => {
     },
   );
 
-  const screenshot = vi.fn(async () => Buffer.from('png')) as ReturnType<
-    typeof vi.fn
+  const screenshot = rs.fn(async () => Buffer.from('png')) as ReturnType<
+    typeof rs.fn
   > & {
-    listDisplays: ReturnType<typeof vi.fn>;
+    listDisplays: ReturnType<typeof rs.fn>;
   };
-  screenshot.listDisplays = vi.fn(async () => [
+  screenshot.listDisplays = rs.fn(async () => [
     { id: 1, name: 'Display 1', primary: true },
   ]);
 
   let mousePos = { x: 10, y: 20 };
   const libnut = {
-    getScreenSize: vi.fn(() => ({ width: 800, height: 600 })),
-    getMousePos: vi.fn(() => ({ ...mousePos })),
-    moveMouse: vi.fn((x: number, y: number) => {
+    getScreenSize: rs.fn(() => ({ width: 800, height: 600 })),
+    getMousePos: rs.fn(() => ({ ...mousePos })),
+    moveMouse: rs.fn((x: number, y: number) => {
       mousePos = { x, y };
     }),
-    mouseClick: vi.fn(),
-    mouseToggle: vi.fn(),
-    scrollMouse: vi.fn(),
-    keyTap: vi.fn(),
-    typeString: vi.fn(),
-    getActiveWindow: vi.fn(() => 0),
-    getWindowRect: vi.fn(),
-    focusWindow: vi.fn(),
+    mouseClick: rs.fn(),
+    mouseToggle: rs.fn(),
+    scrollMouse: rs.fn(),
+    keyTap: rs.fn(),
+    typeString: rs.fn(),
+    getActiveWindow: rs.fn(() => 0),
+    getWindowRect: rs.fn(),
+    focusWindow: rs.fn(),
   };
 
-  const createRequire = vi.fn(() =>
-    vi.fn(() => ({
+  const createRequire = rs.fn(() =>
+    rs.fn(() => ({
       libnut,
     })),
   );
@@ -97,16 +97,16 @@ const mockState = vi.hoisted(() => {
   };
 });
 
-vi.mock('node:child_process', () => ({
+rs.mock('node:child_process', () => ({
   execSync: mockState.execSync,
   execFileSync: mockState.execFileSync,
 }));
 
-vi.mock('screenshot-desktop', () => ({
+rs.mock('screenshot-desktop', () => ({
   default: mockState.screenshot,
 }));
 
-vi.mock('node:module', () => ({
+rs.mock('node:module', () => ({
   createRequire: mockState.createRequire,
 }));
 
@@ -119,8 +119,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.useRealTimers();
-  vi.resetModules();
+  rs.useRealTimers();
+  rs.resetModules();
   Object.defineProperty(process, 'platform', { value: originalPlatform });
 });
 
@@ -216,7 +216,7 @@ describe('ComputerDevice destroy input gate', () => {
 
     const tapPromise = device.inputPrimitives.pointer.tap({ x: 200, y: 120 });
 
-    await vi.waitFor(() => {
+    await rs.waitFor(() => {
       expect(mockState.libnut.mouseToggle).toHaveBeenCalledWith('down', 'left');
     });
 
@@ -238,9 +238,9 @@ describe('ComputerInputDriver native arg handling', () => {
     const driver = new ComputerInputDriver({
       getLibnut: () => mockState.libnut,
       useAppleScript: () => false,
-      sendKeyViaAppleScript: vi.fn(),
-      runPhasedScroll: vi.fn(() => true),
-      debug: vi.fn(),
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
     });
 
     driver.mouseClick('right');
@@ -260,9 +260,9 @@ describe('ComputerInputDriver native arg handling', () => {
     const driver = new ComputerInputDriver({
       getLibnut: () => mockState.libnut,
       useAppleScript: () => false,
-      sendKeyViaAppleScript: vi.fn(),
-      runPhasedScroll: vi.fn(() => true),
-      debug: vi.fn(),
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
     });
 
     driver.keyTap('backspace');
@@ -334,16 +334,16 @@ describe('ComputerDevice pointer input', () => {
   it('holds tap until the requested duration elapses', async () => {
     const device = await createConnectedDevice();
 
-    vi.useFakeTimers();
+    rs.useFakeTimers();
     const tapPromise = device.inputPrimitives.pointer!.tap(
       { x: 100, y: 120 },
       { duration: 250 },
     );
 
-    await vi.advanceTimersByTimeAsync(64);
+    await rs.advanceTimersByTimeAsync(64);
     expect(mockState.libnut.mouseToggle).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(50);
+    await rs.advanceTimersByTimeAsync(50);
     expect(mockState.libnut.mouseToggle).toHaveBeenCalledTimes(1);
     expect(mockState.libnut.mouseToggle).toHaveBeenNthCalledWith(
       1,
@@ -351,10 +351,10 @@ describe('ComputerDevice pointer input', () => {
       'left',
     );
 
-    await vi.advanceTimersByTimeAsync(249);
+    await rs.advanceTimersByTimeAsync(249);
     expect(mockState.libnut.mouseToggle).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(1);
+    await rs.advanceTimersByTimeAsync(1);
     await tapPromise;
     expect(mockState.libnut.mouseToggle).toHaveBeenCalledTimes(2);
     expect(mockState.libnut.mouseToggle).toHaveBeenNthCalledWith(
@@ -371,13 +371,13 @@ describe('ComputerDevice pointer input', () => {
       .mockReturnValueOnce(Buffer.from('100\tElectron'))
       .mockReturnValueOnce(Buffer.from('200\tSafari'));
 
-    vi.useFakeTimers();
+    rs.useFakeTimers();
     const tapPromise = device.inputPrimitives.pointer!.tap({
       x: 100,
       y: 120,
     });
 
-    await vi.advanceTimersByTimeAsync(64 + 50 + 100 + 120 + 50 + 100);
+    await rs.advanceTimersByTimeAsync(64 + 50 + 100 + 120 + 50 + 100);
     await tapPromise;
 
     expect(mockState.execFileSync).toHaveBeenCalledTimes(2);

--- a/packages/computer/tests/unit-test/device.test.ts
+++ b/packages/computer/tests/unit-test/device.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { ComputerDevice, checkComputerEnvironment } from '../../src';
 
 const needsDisplay = process.platform === 'linux' && !process.env.DISPLAY;

--- a/packages/computer/tests/unit-test/display-coordinate.test.ts
+++ b/packages/computer/tests/unit-test/display-coordinate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   type DarwinDisplayGeometry,
   mapDisplayLocalPointToGlobal,

--- a/packages/computer/tests/unit-test/input-driver-scroll.test.ts
+++ b/packages/computer/tests/unit-test/input-driver-scroll.test.ts
@@ -1,24 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { LIBNUT_FALLBACK_EDGE_DETENTS } from '../../src/device';
 import { ComputerInputDriver, type LibNut } from '../../src/input-driver';
 
-function makeDriver(scrollMouse = vi.fn()) {
+function makeDriver(scrollMouse = rs.fn()) {
   const lib: LibNut = {
     getScreenSize: () => ({ width: 1, height: 1 }),
     getMousePos: () => ({ x: 0, y: 0 }),
-    moveMouse: vi.fn(),
-    mouseClick: vi.fn(),
-    mouseToggle: vi.fn(),
+    moveMouse: rs.fn(),
+    mouseClick: rs.fn(),
+    mouseToggle: rs.fn(),
     scrollMouse,
-    keyTap: vi.fn(),
-    typeString: vi.fn(),
+    keyTap: rs.fn(),
+    typeString: rs.fn(),
   };
   const driver = new ComputerInputDriver({
     getLibnut: () => lib,
     useAppleScript: () => false,
-    sendKeyViaAppleScript: vi.fn(),
-    runPhasedScroll: vi.fn().mockReturnValue(false),
-    debug: vi.fn(),
+    sendKeyViaAppleScript: rs.fn(),
+    runPhasedScroll: rs.fn().mockReturnValue(false),
+    debug: rs.fn(),
   });
   return { driver, scrollMouse };
 }
@@ -34,7 +34,7 @@ describe('ComputerInputDriver.emitScrollDetents', () => {
   });
 
   it('paces calls with the requested delay between them', async () => {
-    vi.useFakeTimers();
+    rs.useFakeTimers();
     try {
       const { driver, scrollMouse } = makeDriver();
       const promise = driver.emitScrollDetents(0, -120, 3, 50);
@@ -42,10 +42,10 @@ describe('ComputerInputDriver.emitScrollDetents', () => {
       // First call fires synchronously before any delay.
       expect(scrollMouse).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(50);
+      await rs.advanceTimersByTimeAsync(50);
       expect(scrollMouse).toHaveBeenCalledTimes(2);
 
-      await vi.advanceTimersByTimeAsync(50);
+      await rs.advanceTimersByTimeAsync(50);
       expect(scrollMouse).toHaveBeenCalledTimes(3);
 
       // No trailing delay after the last detent — the resolution scheduler
@@ -53,7 +53,7 @@ describe('ComputerInputDriver.emitScrollDetents', () => {
       await promise;
       expect(scrollMouse).toHaveBeenCalledTimes(3);
     } finally {
-      vi.useRealTimers();
+      rs.useRealTimers();
     }
   });
 
@@ -77,7 +77,7 @@ describe('ComputerInputDriver.emitScrollDetents', () => {
   });
 
   it('rejects in-flight detents when the driver is destroyed mid-scroll', async () => {
-    vi.useFakeTimers();
+    rs.useFakeTimers();
     try {
       const { driver, scrollMouse } = makeDriver();
       const promise = driver.emitScrollDetents(0, -120, 5, 50);
@@ -86,10 +86,10 @@ describe('ComputerInputDriver.emitScrollDetents', () => {
       driver.destroy();
       await expect(promise).rejects.toThrow(/destroyed/);
       // No further calls after destroy().
-      await vi.advanceTimersByTimeAsync(500);
+      await rs.advanceTimersByTimeAsync(500);
       expect(scrollMouse).toHaveBeenCalledTimes(1);
     } finally {
-      vi.useRealTimers();
+      rs.useRealTimers();
     }
   });
 });

--- a/packages/computer/tests/unit-test/input-strategy.test.ts
+++ b/packages/computer/tests/unit-test/input-strategy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { ComputerDevice } from '../../src';
 
 describe('Input Strategy', () => {
@@ -23,10 +23,10 @@ describe('Input Strategy', () => {
       keyboardTypeDelay: 80,
     });
     const inputDriver = (device as any).inputDriver;
-    const typeString = vi
+    const typeString = rs
       .spyOn(inputDriver, 'typeString')
       .mockImplementation(() => {});
-    const delay = vi.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
+    const delay = rs.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
 
     await device.inputPrimitives.keyboard!.typeText('A😀B');
 
@@ -40,13 +40,13 @@ describe('Input Strategy', () => {
       keyboardTypeDelay: 25,
     });
     const inputDriver = (device as any).inputDriver;
-    const typeString = vi
+    const typeString = rs
       .spyOn(inputDriver, 'typeString')
       .mockImplementation(() => {});
-    const sendKey = vi
+    const sendKey = rs
       .spyOn(inputDriver, 'sendKey')
       .mockImplementation(() => {});
-    vi.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
+    rs.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
 
     await device.inputPrimitives.keyboard!.typeText('a \r\n\tb');
 
@@ -56,7 +56,7 @@ describe('Input Strategy', () => {
 
   it('lets an action-level zero disable the device delay', async () => {
     const device = new ComputerDevice({ keyboardTypeDelay: 80 });
-    const smartTypeString = vi
+    const smartTypeString = rs
       .spyOn(device as any, 'smartTypeString')
       .mockResolvedValue(undefined);
 

--- a/packages/computer/tests/unit-test/linux-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/linux-screenshot.test.ts
@@ -1,9 +1,9 @@
 import { existsSync, writeFileSync } from 'node:fs';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 
-const screenshot = vi.hoisted(() => vi.fn());
+const screenshot = rs.hoisted(() => rs.fn());
 
-vi.mock('screenshot-desktop', () => ({
+rs.mock('screenshot-desktop', () => ({
   default: screenshot,
 }));
 
@@ -14,7 +14,7 @@ describe('Linux screenshots', () => {
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
     screenshot.mockReset();
-    vi.resetModules();
+    rs.resetModules();
   });
 
   it('captures to a temporary file instead of screenshot-desktop stdout', async () => {

--- a/packages/computer/tests/unit-test/phased-scroll.test.ts
+++ b/packages/computer/tests/unit-test/phased-scroll.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { getPhasedScrollBinary } from '../../src/device';
 
 describe('phased-scroll binary resolution', () => {

--- a/packages/computer/tests/unit-test/rdp/agent.test.ts
+++ b/packages/computer/tests/unit-test/rdp/agent.test.ts
@@ -3,7 +3,7 @@ import type {
   LocateResultElement,
   Size,
 } from '@midscene/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { ComputerAgent, RDPDevice, agentForRDPComputer } from '../../../src';
 import type {
   RDPBackendClient,

--- a/packages/computer/tests/unit-test/rdp/backend-client.test.ts
+++ b/packages/computer/tests/unit-test/rdp/backend-client.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   HelperProcessRDPBackendClient,
   type RDPHelperRequest,

--- a/packages/computer/tests/unit-test/rdp/helper-process.test.ts
+++ b/packages/computer/tests/unit-test/rdp/helper-process.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from '@rstest/core';
 import { getRdpHelperBinaryPath } from '../../../src/rdp/helper-binary';
 
 // These tests exercise the *real* compiled rdp-helper binary over its stdio

--- a/packages/computer/tests/unit-test/windows-screenshot.test.ts
+++ b/packages/computer/tests/unit-test/windows-screenshot.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 
 // A 1x1 PNG, base64-encoded, as PowerShell's CopyFromScreen path would print
 // to stdout.
@@ -8,16 +8,16 @@ const FAKE_PNG_BASE64 =
 
 // Typed params so `mock.calls[i]` is a `[file, args, options]` tuple the type
 // checker can index into.
-const execFileSync = vi.fn(
+const execFileSync = rs.fn(
   (_file: string, _args: string[], _options?: unknown): string =>
     FAKE_PNG_BASE64,
 );
 
-vi.mock('node:child_process', () => ({
+rs.mock('node:child_process', () => ({
   execFileSync: (file: string, args: string[], options?: unknown) =>
     execFileSync(file, args, options),
-  execSync: vi.fn(),
-  spawnSync: vi.fn(),
+  execSync: rs.fn(),
+  spawnSync: rs.fn(),
 }));
 
 /** Decode the -EncodedCommand argument back to the PowerShell script. */
@@ -33,7 +33,7 @@ describe('Windows screenshot via PowerShell (issue #2150)', () => {
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
     execFileSync.mockClear();
-    vi.resetModules();
+    rs.resetModules();
   });
 
   it('captures through powershell.exe and returns a PNG data URI', async () => {

--- a/packages/computer/tests/unit-test/xvfb.test.ts
+++ b/packages/computer/tests/unit-test/xvfb.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { existsSync } from 'node:fs';
 import { waitForCliInterrupt } from '@midscene/shared/cli/interrupt';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import {
   checkXvfbInstalled,
   createXvfbSigintCleanup,
@@ -9,15 +9,15 @@ import {
   needsXvfb,
 } from '../../src/xvfb';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(() => false),
+rs.mock('node:fs', () => ({
+  existsSync: rs.fn(() => false),
 }));
 
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(() => {
+rs.mock('node:child_process', () => ({
+  execSync: rs.fn(() => {
     throw new Error('not found');
   }),
-  spawn: vi.fn(),
+  spawn: rs.fn(),
 }));
 
 describe('needsXvfb', () => {
@@ -56,12 +56,12 @@ describe('needsXvfb', () => {
 
 describe('findAvailableDisplay', () => {
   it('should return startFrom when no lock files exist', () => {
-    vi.mocked(existsSync).mockReturnValue(false);
+    rs.mocked(existsSync).mockReturnValue(false);
     expect(findAvailableDisplay(99)).toBe(99);
   });
 
   it('should skip occupied display numbers', () => {
-    vi.mocked(existsSync)
+    rs.mocked(existsSync)
       .mockReturnValueOnce(true) // :99 occupied
       .mockReturnValueOnce(true) // :100 occupied
       .mockReturnValueOnce(false); // :101 free
@@ -69,7 +69,7 @@ describe('findAvailableDisplay', () => {
   });
 
   it('should throw if no display is available', () => {
-    vi.mocked(existsSync).mockReturnValue(true);
+    rs.mocked(existsSync).mockReturnValue(true);
     expect(() => findAvailableDisplay(99)).toThrow(
       'No available display number found',
     );
@@ -83,7 +83,7 @@ describe('checkXvfbInstalled', () => {
 
   it('should return true when Xvfb is installed', async () => {
     const { execSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValueOnce(Buffer.from('/usr/bin/Xvfb'));
+    rs.mocked(execSync).mockReturnValueOnce(Buffer.from('/usr/bin/Xvfb'));
     expect(checkXvfbInstalled()).toBe(true);
   });
 });
@@ -91,7 +91,7 @@ describe('checkXvfbInstalled', () => {
 describe('createXvfbSigintCleanup', () => {
   it('cleans up when the host only has unrelated SIGINT listeners', () => {
     const source = new EventEmitter();
-    const cleanup = vi.fn();
+    const cleanup = rs.fn();
     source.on('SIGINT', () => {});
     source.on('SIGINT', createXvfbSigintCleanup(cleanup, source));
 
@@ -102,7 +102,7 @@ describe('createXvfbSigintCleanup', () => {
 
   it('defers cleanup while a foreground recorder is handling SIGINT', async () => {
     const source = new EventEmitter();
-    const cleanup = vi.fn();
+    const cleanup = rs.fn();
     source.on('SIGINT', createXvfbSigintCleanup(cleanup, source));
     const stopped = waitForCliInterrupt(0, source);
 

--- a/packages/harmony/rstest.config.ts
+++ b/packages/harmony/rstest.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
   coverage: createCoverageConfig(__dirname),
   include: testFiles,
   testTimeout: 3 * 60 * 1000,
-  errors: process.env.CI ? { unhandled: false } : undefined,
   pool: { maxWorkers: 1 },
   source: {
     define: defineVersion(version),

--- a/packages/harmony/rstest.config.ts
+++ b/packages/harmony/rstest.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { defineConfig } from '@rstest/core';
 import dotenv from 'dotenv';
 import { createCoverageConfig } from '../../scripts/rstest-coverage';
+import { defineVersion, photonExternal } from '../../scripts/rstest-shared';
 import { version } from './package.json';
 
 dotenv.config({
@@ -33,13 +34,9 @@ export default defineConfig({
   errors: process.env.CI ? { unhandled: false } : undefined,
   pool: { maxWorkers: 1 },
   source: {
-    define: {
-      __VERSION__: `'${version}'`,
-    },
+    define: defineVersion(version),
   },
   output: {
-    externals: {
-      '@silvia-odwyer/photon': 'commonjs @silvia-odwyer/photon',
-    },
+    externals: photonExternal,
   },
 });

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -52,7 +52,7 @@ rs.mock('@midscene/shared/img', () => ({
     .mockReturnValue('data:image/jpeg;base64,fake'),
 }));
 
-// @ts-ignore package tsconfig keeps module=ES2020 for build compatibility; this test intentionally uses top-level dynamic import so mocks are registered first.
+// Top-level dynamic import so the mocks above are registered first.
 const { HarmonyDevice } = await import('../../src/device');
 
 describe('HarmonyDevice', () => {

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -32,8 +32,7 @@ rs.mock('node:util', () => ({
   promisify: () => mockExecFile,
 }));
 
-// Must import after mocks are set up.
-// @ts-ignore package tsconfig keeps module=ES2020 for build compatibility; this test intentionally uses top-level dynamic import so mocks are registered first.
+// Top-level dynamic import so the mocks above are registered first.
 const { HdcClient } = await import('../../src/hdc');
 
 describe('HdcClient', () => {

--- a/packages/harmony/tsconfig.build.json
+++ b/packages/harmony/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "src",
+    "module": "ES2020"
   },
   "include": ["src"]
 }

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -40,10 +40,10 @@
     "build": "rslib build",
     "build:watch": "rslib build --watch --no-clean",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
-    "test": "vitest --run",
-    "test:u": "vitest --run -u",
-    "test:ai": "AI_TEST_TYPE=iOS vitest --run",
-    "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=iOS vitest --run"
+    "test": "rstest",
+    "test:u": "rstest -u",
+    "test:ai": "AI_TEST_TYPE=iOS rstest",
+    "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=iOS rstest"
   },
   "dependencies": {
     "@midscene/core": "workspace:*",
@@ -55,11 +55,11 @@
   },
   "devDependencies": {
     "@rslib/core": "^0.18.3",
+    "@rstest/core": "0.11.5",
     "@types/node": "^18.0.0",
     "dotenv": "^16.4.5",
-    "typescript": "^5.8.3",
     "tsx": "^4.19.2",
-    "vitest": "3.0.5",
+    "typescript": "^5.8.3",
     "zod": "^3.25.1"
   },
   "license": "MIT"

--- a/packages/ios/rstest.config.ts
+++ b/packages/ios/rstest.config.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
+import { defineConfig } from '@rstest/core';
 import dotenv from 'dotenv';
-import { defineConfig } from 'vitest/config';
-import { createCoverageConfig } from '../../scripts/vitest-coverage';
+import { createCoverageConfig } from '../../scripts/rstest-coverage';
+import { defineVersion, photonExternal } from '../../scripts/rstest-shared';
 import { version } from './package.json';
 
 /**
@@ -31,16 +32,14 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
-  test: {
-    coverage: createCoverageConfig(__dirname),
-    include: testFiles,
-    testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
-    dangerouslyIgnoreUnhandledErrors: !!process.env.CI, // showcase.test.ts is not stable
+  coverage: createCoverageConfig(__dirname),
+  include: testFiles,
+  testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
+  errors: process.env.CI ? { unhandled: false } : undefined, // showcase.test.ts is not stable
+  source: {
+    define: defineVersion(version),
   },
-  define: {
-    __VERSION__: `'${version}'`,
-  },
-  ssr: {
-    external: ['@silvia-odwyer/photon'],
+  output: {
+    externals: photonExternal,
   },
 });

--- a/packages/ios/rstest.config.ts
+++ b/packages/ios/rstest.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
   coverage: createCoverageConfig(__dirname),
   include: testFiles,
   testTimeout: 3 * 60 * 1000, // Global timeout set to 10 seconds
-  errors: process.env.CI ? { unhandled: false } : undefined, // showcase.test.ts is not stable
   source: {
     define: defineVersion(version),
   },

--- a/packages/ios/tests/ai/ebay.test.ts
+++ b/packages/ios/tests/ai/ebay.test.ts
@@ -1,12 +1,12 @@
 import { sleep } from '@midscene/core/utils';
-import { beforeAll, describe, it, vi } from 'vitest';
+import { beforeAll, describe, it, rs } from '@rstest/core';
 import {
   type IOSAgent,
   agentFromWebDriverAgent,
   checkIOSEnvironment,
 } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
   hookTimeout: 240 * 1000, // Add hook timeout for beforeAll
 });

--- a/packages/ios/tests/ai/ios-app-switcher.test.ts
+++ b/packages/ios/tests/ai/ios-app-switcher.test.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import {
   type IOSAgent,
   agentFromWebDriverAgent,
@@ -15,7 +15,7 @@ const RUN_APP_SWITCHER_AI_E2E =
 const REPORT_FILE_NAME = 'ios-app-switcher-ai-e2e';
 const diagnosticsDir = process.env.MIDSCENE_IOS_DIAGNOSTICS_DIR;
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 300_000,
   hookTimeout: 60_000,
 });

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -11,7 +11,7 @@ import {
   MIDSCENE_MODEL_TIMEOUT,
 } from '@midscene/shared/env';
 import { imageInfoOfBase64 } from '@midscene/shared/img';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { type IOSAgent, agentFromWebDriverAgent } from '../../src';
 import {
   inputUntilObserved,
@@ -72,7 +72,7 @@ interface ReportDump {
   executions?: ReportExecution[];
 }
 
-vi.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
+rs.setConfig({ testTimeout: 240_000, hookTimeout: 30_000 });
 
 function sleep(timeMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeMs));

--- a/packages/ios/tests/ai/pinch.test.ts
+++ b/packages/ios/tests/ai/pinch.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent, checkIOSEnvironment } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/ios/tests/ai/scroll-swipe.test.ts
+++ b/packages/ios/tests/ai/scroll-swipe.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent, checkIOSEnvironment } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/ios/tests/ai/setting.test.ts
+++ b/packages/ios/tests/ai/setting.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent, checkIOSEnvironment } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 90 * 1000,
 });
 

--- a/packages/ios/tests/ai/todo.test.ts
+++ b/packages/ios/tests/ai/todo.test.ts
@@ -2,14 +2,14 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import {
   type IOSAgent,
   agentFromWebDriverAgent,
   checkIOSEnvironment,
 } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
   hookTimeout: 60 * 1000,
 });

--- a/packages/ios/tests/ai/ui-observer.test.ts
+++ b/packages/ios/tests/ai/ui-observer.test.ts
@@ -1,8 +1,8 @@
 import { sleep } from '@midscene/core/utils';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent, checkIOSEnvironment } from '../../src';
 
-vi.setConfig({
+rs.setConfig({
   testTimeout: 240 * 1000,
 });
 

--- a/packages/ios/tests/unit-test/agent-tools.test.ts
+++ b/packages/ios/tests/unit-test/agent-tools.test.ts
@@ -1,15 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent } from '../../src/agent';
 import { IOSMidsceneTools } from '../../src/agent-tools';
 
-vi.mock('../../src/agent', () => ({
-  agentFromWebDriverAgent: vi.fn(),
+rs.mock('../../src/agent', () => ({
+  agentFromWebDriverAgent: rs.fn(),
 }));
 
-vi.mock('../../src/device', () => ({
-  IOSDevice: vi.fn().mockImplementation(() => ({
-    actionSpace: vi.fn().mockReturnValue([]),
-    destroy: vi.fn(),
+rs.mock('../../src/device', () => ({
+  IOSDevice: rs.fn().mockImplementation(() => ({
+    actionSpace: rs.fn().mockReturnValue([]),
+    destroy: rs.fn(),
   })),
 }));
 
@@ -19,22 +19,22 @@ const validPngBase64 =
 function createMockAgent() {
   return {
     page: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
-    aiAction: vi.fn().mockResolvedValue('done'),
-    destroy: vi.fn(),
+    aiAction: rs.fn().mockResolvedValue('done'),
+    destroy: rs.fn(),
   };
 }
 
 describe('IOSMidsceneTools', () => {
   beforeEach(() => {
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(
       createMockAgent() as any,
     );
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
   });
 
   it('passes namespaced ios init args to take_screenshot', async () => {
@@ -75,7 +75,7 @@ describe('IOSMidsceneTools', () => {
 
   it('passes top-level ios aliases to act', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
 
     const tools = new IOSMidsceneTools();
     await tools.initTools();
@@ -139,7 +139,7 @@ describe('IOSMidsceneTools', () => {
 
   it('reuses the iOS agent when called twice with identical init args', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
 
     const tools = new IOSMidsceneTools();
     await tools.initTools();
@@ -158,7 +158,7 @@ describe('IOSMidsceneTools', () => {
   it('rebuilds the iOS agent when init args change', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent)
+    rs.mocked(agentFromWebDriverAgent)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 
@@ -179,7 +179,7 @@ describe('IOSMidsceneTools', () => {
   it('rebuilds the iOS agent when init args are omitted after being set', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent)
+    rs.mocked(agentFromWebDriverAgent)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 
@@ -197,7 +197,7 @@ describe('IOSMidsceneTools', () => {
 
     expect(agentFromWebDriverAgent).toHaveBeenCalledTimes(2);
     expect(firstAgent.destroy).toHaveBeenCalledTimes(1);
-    const lastAgentOptions = vi
+    const lastAgentOptions = rs
       .mocked(agentFromWebDriverAgent)
       .mock.calls.at(-1)?.[0];
     expect(lastAgentOptions).toEqual(
@@ -212,7 +212,7 @@ describe('IOSMidsceneTools', () => {
   it('rebuilds the iOS agent when only the external WDA session changes', async () => {
     const firstAgent = createMockAgent();
     const secondAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent)
+    rs.mocked(agentFromWebDriverAgent)
       .mockResolvedValueOnce(firstAgent as any)
       .mockResolvedValueOnce(secondAgent as any);
 

--- a/packages/ios/tests/unit-test/agent.test.ts
+++ b/packages/ios/tests/unit-test/agent.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   MIDSCENE_IOS_DEVICE_CLASS_OVERRIDE,
   MIDSCENE_MODEL_NAME,
@@ -5,19 +6,19 @@ import {
   OPENAI_API_KEY,
   OPENAI_BASE_URL,
 } from '@midscene/shared/env';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { IOSAgent, agentFromWebDriverAgent } from '../../src/agent';
 import { IOSDevice } from '../../src/device';
 
 // Mock dependencies
-vi.mock('../../src/device');
+rs.mock('../../src/device');
 
-const MockedIOSDevice = vi.mocked(IOSDevice);
-const doMockVirtual = vi.doMock as unknown as (
-  path: string,
-  factory: () => unknown,
-  options: { virtual: true },
-) => void;
+const MockedIOSDevice = rs.mocked(IOSDevice);
+
+declare global {
+  var __iosOverrideConnectFromOption: number | undefined;
+  var __iosOverrideConnectFromEnv: number | undefined;
+}
 
 const mockedModelConfig = {
   MIDSCENE_MODEL_NAME: 'mock',
@@ -32,10 +33,10 @@ describe('IOSAgent', () => {
 
   beforeEach(() => {
     // Set up environment variables for AI model
-    vi.stubEnv(MIDSCENE_USE_DOUBAO_VISION, 'true');
-    vi.stubEnv(MIDSCENE_MODEL_NAME, 'mock');
-    vi.stubEnv(OPENAI_API_KEY, 'mock');
-    vi.stubEnv(OPENAI_BASE_URL, 'mock');
+    rs.stubEnv(MIDSCENE_USE_DOUBAO_VISION, 'true');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, 'mock');
+    rs.stubEnv(OPENAI_API_KEY, 'mock');
+    rs.stubEnv(OPENAI_BASE_URL, 'mock');
 
     // Create a valid 1x1 PNG image in base64 with data URI prefix
     // This is a minimal valid PNG image (1x1 transparent pixel)
@@ -44,16 +45,16 @@ describe('IOSAgent', () => {
 
     // Create a mock device with actionSpace
     mockDevice = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      launch: vi.fn().mockResolvedValue(undefined),
-      terminate: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      runWdaRequest: vi.fn().mockResolvedValue({ success: true }),
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
-      size: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
-      getElementsInfo: vi.fn().mockResolvedValue([]),
-      url: vi.fn().mockResolvedValue('https://example.com'),
-      actionSpace: vi.fn().mockReturnValue([
+      connect: rs.fn().mockResolvedValue(undefined),
+      launch: rs.fn().mockResolvedValue(undefined),
+      terminate: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      runWdaRequest: rs.fn().mockResolvedValue({ success: true }),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
+      size: rs.fn().mockResolvedValue({ width: 375, height: 812 }),
+      getElementsInfo: rs.fn().mockResolvedValue([]),
+      url: rs.fn().mockResolvedValue('https://example.com'),
+      actionSpace: rs.fn().mockReturnValue([
         {
           name: 'Launch',
           paramSchema: undefined,
@@ -80,7 +81,7 @@ describe('IOSAgent', () => {
           },
         },
       ]),
-      setAppNameMapping: vi.fn(),
+      setAppNameMapping: rs.fn(),
     };
 
     MockedIOSDevice.mockImplementation(() => mockDevice as IOSDevice);
@@ -91,8 +92,8 @@ describe('IOSAgent', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllEnvs();
+    rs.clearAllMocks();
+    rs.unstubAllEnvs();
   });
 
   describe('Constructor', () => {
@@ -118,7 +119,7 @@ describe('IOSAgent', () => {
 
     it('should handle launch errors from actionSpace', async () => {
       const error = new Error('Launch failed');
-      mockDevice.launch = vi.fn().mockRejectedValue(error);
+      mockDevice.launch = rs.fn().mockRejectedValue(error);
 
       await expect(agent.launch('com.invalid.app')).rejects.toThrow(
         'Launch failed',
@@ -138,7 +139,7 @@ describe('IOSAgent', () => {
 
     it('should handle terminate errors from actionSpace', async () => {
       const error = new Error('Terminate failed');
-      mockDevice.terminate = vi.fn().mockRejectedValue(error);
+      mockDevice.terminate = rs.fn().mockRejectedValue(error);
 
       await expect(agent.terminate('com.invalid.app')).rejects.toThrow(
         'Terminate failed',
@@ -162,7 +163,7 @@ describe('IOSAgent', () => {
         value: { state: string };
       }
       const mockResponse: StatusResponse = { value: { state: 'ready' } };
-      mockDevice.runWdaRequest = vi.fn().mockResolvedValue(mockResponse);
+      mockDevice.runWdaRequest = rs.fn().mockResolvedValue(mockResponse);
 
       await agent.runWdaRequest({ method: 'GET', endpoint: '/status' });
 
@@ -175,7 +176,7 @@ describe('IOSAgent', () => {
 
     it('should pass data parameter correctly', async () => {
       const requestData = { key: 'value' };
-      mockDevice.runWdaRequest = vi.fn().mockResolvedValue({ success: true });
+      mockDevice.runWdaRequest = rs.fn().mockResolvedValue({ success: true });
 
       await agent.runWdaRequest({
         method: 'POST',
@@ -193,13 +194,13 @@ describe('IOSAgent', () => {
 
   describe('agentFromWebDriverAgent', () => {
     it('should create default IOSDevice when no override is provided', async () => {
-      const connectSpy = vi.fn().mockResolvedValue(undefined);
+      const connectSpy = rs.fn().mockResolvedValue(undefined);
       MockedIOSDevice.mockImplementationOnce(
         () =>
           ({
             connect: connectSpy,
-            actionSpace: vi.fn().mockReturnValue([]),
-            setAppNameMapping: vi.fn(),
+            actionSpace: rs.fn().mockReturnValue([]),
+            setAppNameMapping: rs.fn(),
           }) as unknown as IOSDevice,
       );
 
@@ -209,56 +210,44 @@ describe('IOSAgent', () => {
       expect(connectSpy).toHaveBeenCalledTimes(1);
     });
 
+    // `agent.ts` loads the override via `await import(overrideModule)` where
+    // `overrideModule` is a user-supplied runtime value, so the specifier can be
+    // neither turned into a static literal nor reached by rstest's build-time
+    // mock transform (web-infra-dev/rstest#1454). Instead of mocking, point the
+    // override at a real on-disk fixture module and observe its `connect()`
+    // through a global counter, which survives the module-realm split between
+    // rstest's registry and the native loader.
     it('should load override device class from documented option', async () => {
-      const connectSpy = vi.fn().mockResolvedValue(undefined);
-      const actionSpaceSpy = vi.fn().mockReturnValue([]);
-      const setAppNameMappingSpy = vi.fn();
-      const moduleName = 'test-ios-device-override';
-
-      doMockVirtual(
-        moduleName,
-        () => ({
-          IOSDevice: class {
-            connect = connectSpy;
-            actionSpace = actionSpaceSpy;
-            setAppNameMapping = setAppNameMappingSpy;
-          },
-        }),
-        { virtual: true },
+      const fixture = path.join(
+        __dirname,
+        'fixtures',
+        'ios-device-override.mjs',
       );
+      globalThis.__iosOverrideConnectFromOption = 0;
 
       await agentFromWebDriverAgent({
         modelConfig: mockedModelConfig,
-        iOSDeviceClassOverride: moduleName,
+        iOSDeviceClassOverride: fixture,
       });
 
-      expect(connectSpy).toHaveBeenCalledTimes(1);
-      vi.doUnmock(moduleName);
+      expect(globalThis.__iosOverrideConnectFromOption).toBe(1);
+      // the default device class must not be used when an override is provided
+      expect(MockedIOSDevice).not.toHaveBeenCalled();
     });
 
     it('should load override device class from env', async () => {
-      const connectSpy = vi.fn().mockResolvedValue(undefined);
-      const actionSpaceSpy = vi.fn().mockReturnValue([]);
-      const setAppNameMappingSpy = vi.fn();
-      const moduleName = 'test-ios-device-override-env';
-      vi.stubEnv(MIDSCENE_IOS_DEVICE_CLASS_OVERRIDE, moduleName);
-
-      doMockVirtual(
-        moduleName,
-        () => ({
-          default: class {
-            connect = connectSpy;
-            actionSpace = actionSpaceSpy;
-            setAppNameMapping = setAppNameMappingSpy;
-          },
-        }),
-        { virtual: true },
+      const fixture = path.join(
+        __dirname,
+        'fixtures',
+        'ios-device-override-env.mjs',
       );
+      rs.stubEnv(MIDSCENE_IOS_DEVICE_CLASS_OVERRIDE, fixture);
+      globalThis.__iosOverrideConnectFromEnv = 0;
 
       await agentFromWebDriverAgent({ modelConfig: mockedModelConfig });
 
-      expect(connectSpy).toHaveBeenCalledTimes(1);
-      vi.doUnmock(moduleName);
+      expect(globalThis.__iosOverrideConnectFromEnv).toBe(1);
+      expect(MockedIOSDevice).not.toHaveBeenCalled();
     });
 
     it('should throw clear error when override package is missing', async () => {

--- a/packages/ios/tests/unit-test/cli-launch.test.ts
+++ b/packages/ios/tests/unit-test/cli-launch.test.ts
@@ -1,13 +1,13 @@
 import { runToolsCLI } from '@midscene/shared/cli';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { agentFromWebDriverAgent } from '../../src/agent';
 import { IOSMidsceneTools } from '../../src/agent-tools';
 
 // Mock the agent entry point only. IOSDevice is intentionally NOT mocked so
 // that the real actionSpace (including Launch/Terminate) reaches the tool
 // generator — this is what drives the CLI surface we need to verify.
-vi.mock('../../src/agent', () => ({
-  agentFromWebDriverAgent: vi.fn(),
+rs.mock('../../src/agent', () => ({
+  agentFromWebDriverAgent: rs.fn(),
 }));
 
 const validPngBase64 =
@@ -16,28 +16,28 @@ const validPngBase64 =
 function createMockAgent() {
   return {
     page: {
-      screenshotBase64: vi.fn().mockResolvedValue(validPngBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(validPngBase64),
     },
-    callActionInActionSpace: vi.fn().mockResolvedValue(undefined),
-    destroy: vi.fn(),
+    callActionInActionSpace: rs.fn().mockResolvedValue(undefined),
+    destroy: rs.fn(),
   };
 }
 
 describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => {
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof rs.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof rs.spyOn>;
   let capturedStdout: string;
   let capturedStderr: string;
 
   beforeEach(() => {
     capturedStdout = '';
     capturedStderr = '';
-    consoleLogSpy = vi
+    consoleLogSpy = rs
       .spyOn(console, 'log')
       .mockImplementation((...args: unknown[]) => {
         capturedStdout += `${args.join(' ')}\n`;
       });
-    consoleErrorSpy = vi
+    consoleErrorSpy = rs
       .spyOn(console, 'error')
       .mockImplementation((...args: unknown[]) => {
         capturedStderr += `${args.join(' ')}\n`;
@@ -47,12 +47,12 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
   afterEach(() => {
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
-    vi.clearAllMocks();
+    rs.clearAllMocks();
   });
 
   it('routes `launch --uri <bundle>` through to callActionInActionSpace with { uri }', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
 
     await runToolsCLI(new IOSMidsceneTools(), 'midscene-ios', {
       stripPrefix: 'ios_',
@@ -68,7 +68,7 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
   });
 
   it('passes external WDA session args through `connect`', async () => {
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(
       createMockAgent() as any,
     );
 
@@ -98,7 +98,7 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
 
   it('routes `terminate --uri <bundle>` through to callActionInActionSpace with { uri }', async () => {
     const mockAgent = createMockAgent();
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(mockAgent as any);
 
     await runToolsCLI(new IOSMidsceneTools(), 'midscene-ios', {
       stripPrefix: 'ios_',
@@ -113,7 +113,7 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
   });
 
   it('rejects an unknown option like `--bundleId` with a clear error', async () => {
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(
       createMockAgent() as any,
     );
 
@@ -127,7 +127,7 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
   });
 
   it('`launch --help` lists --uri and no ZodString prototype leak', async () => {
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(
       createMockAgent() as any,
     );
 
@@ -152,7 +152,7 @@ describe('midscene-ios CLI argv path for launch/terminate (issue #2313)', () => 
   });
 
   it('`terminate --help` lists --uri and no ZodString prototype leak', async () => {
-    vi.mocked(agentFromWebDriverAgent).mockResolvedValue(
+    rs.mocked(agentFromWebDriverAgent).mockResolvedValue(
       createMockAgent() as any,
     );
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -1,14 +1,14 @@
 import type { DeviceAction, ExecutorContext } from '@midscene/core';
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import { WDAManager } from '@midscene/webdriver';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { IOSDevice } from '../../src/device';
 import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
 
 // Mock dependencies
-vi.mock('../../src/utils');
-vi.mock('../../src/ios-webdriver-client');
-vi.mock('@midscene/webdriver');
+rs.mock('../../src/utils');
+rs.mock('../../src/ios-webdriver-client');
+rs.mock('@midscene/webdriver');
 
 const mockExecutorContext = { task: {} } as ExecutorContext;
 const getInternalTextInput = (target: IOSDevice) =>
@@ -20,35 +20,35 @@ describe('IOSDevice', () => {
   let device: IOSDevice;
   let mockWdaClient: any;
 
-  const MockedWdaClient = vi.mocked(IOSWebDriverClient);
-  const MockedWdaManager = vi.mocked(WDAManager);
+  const MockedWdaClient = rs.mocked(IOSWebDriverClient);
+  const MockedWdaManager = rs.mocked(WDAManager);
 
   beforeEach(async () => {
     // Setup mock WDA client
     mockWdaClient = {
-      createSession: vi
+      createSession: rs
         .fn()
         .mockResolvedValue({ sessionId: 'test-session-id' }),
-      setupExistingSession: vi.fn().mockResolvedValue(undefined),
-      deleteSession: vi.fn().mockResolvedValue(undefined),
-      getWindowSize: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
-      takeScreenshot: vi.fn().mockResolvedValue('base64-screenshot'),
-      tap: vi.fn().mockResolvedValue(undefined),
-      doubleTap: vi.fn().mockResolvedValue(undefined),
-      tripleTap: vi.fn().mockResolvedValue(undefined),
-      longPress: vi.fn().mockResolvedValue(undefined),
-      swipe: vi.fn().mockResolvedValue(undefined),
-      appSwitcher: vi.fn().mockResolvedValue(undefined),
-      pinch: vi.fn().mockResolvedValue(undefined),
-      typeText: vi.fn().mockResolvedValue(undefined),
-      clearActiveElement: vi.fn().mockResolvedValue(true),
-      pressKey: vi.fn().mockResolvedValue(undefined),
-      pressHomeButton: vi.fn().mockResolvedValue(undefined),
-      launchApp: vi.fn().mockResolvedValue(undefined),
-      terminateApp: vi.fn().mockResolvedValue(undefined),
-      openUrl: vi.fn().mockResolvedValue(undefined),
-      dismissKeyboard: vi.fn().mockResolvedValue(true),
-      makeRequest: vi.fn().mockResolvedValue(null),
+      setupExistingSession: rs.fn().mockResolvedValue(undefined),
+      deleteSession: rs.fn().mockResolvedValue(undefined),
+      getWindowSize: rs.fn().mockResolvedValue({ width: 375, height: 812 }),
+      takeScreenshot: rs.fn().mockResolvedValue('base64-screenshot'),
+      tap: rs.fn().mockResolvedValue(undefined),
+      doubleTap: rs.fn().mockResolvedValue(undefined),
+      tripleTap: rs.fn().mockResolvedValue(undefined),
+      longPress: rs.fn().mockResolvedValue(undefined),
+      swipe: rs.fn().mockResolvedValue(undefined),
+      appSwitcher: rs.fn().mockResolvedValue(undefined),
+      pinch: rs.fn().mockResolvedValue(undefined),
+      typeText: rs.fn().mockResolvedValue(undefined),
+      clearActiveElement: rs.fn().mockResolvedValue(true),
+      pressKey: rs.fn().mockResolvedValue(undefined),
+      pressHomeButton: rs.fn().mockResolvedValue(undefined),
+      launchApp: rs.fn().mockResolvedValue(undefined),
+      terminateApp: rs.fn().mockResolvedValue(undefined),
+      openUrl: rs.fn().mockResolvedValue(undefined),
+      dismissKeyboard: rs.fn().mockResolvedValue(true),
+      makeRequest: rs.fn().mockResolvedValue(null),
       sessionInfo: {
         sessionId: 'test-session-id',
         capabilities: {},
@@ -56,26 +56,26 @@ describe('IOSDevice', () => {
     };
 
     // Add getDeviceInfo mock
-    mockWdaClient.getDeviceInfo = vi.fn().mockResolvedValue({
+    mockWdaClient.getDeviceInfo = rs.fn().mockResolvedValue({
       udid: 'test-device-udid',
       name: 'Test Device',
       model: 'iPhone 15',
     });
 
     // Add getScreenScale mock for new DPR detection
-    mockWdaClient.getScreenScale = vi.fn().mockResolvedValue(2);
+    mockWdaClient.getScreenScale = rs.fn().mockResolvedValue(2);
 
     MockedWdaClient.mockImplementation(() => mockWdaClient);
 
     // Setup mock WDA manager
     const mockWdaManager = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      isRunning: vi.fn().mockReturnValue(true),
-      getPort: vi.fn().mockReturnValue(DEFAULT_WDA_PORT),
+      start: rs.fn().mockResolvedValue(undefined),
+      stop: rs.fn().mockResolvedValue(undefined),
+      isRunning: rs.fn().mockReturnValue(true),
+      getPort: rs.fn().mockReturnValue(DEFAULT_WDA_PORT),
     };
 
-    MockedWdaManager.getInstance = vi.fn().mockReturnValue(mockWdaManager);
+    MockedWdaManager.getInstance = rs.fn().mockReturnValue(mockWdaManager);
 
     device = new IOSDevice({
       wdaPort: DEFAULT_WDA_PORT,
@@ -84,7 +84,7 @@ describe('IOSDevice', () => {
   });
 
   afterEach(async () => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
     if (device) {
       await device.destroy();
     }
@@ -180,7 +180,7 @@ describe('IOSDevice', () => {
       const customAction: DeviceAction = {
         name: 'CustomAction',
         description: 'A custom action for testing',
-        call: vi.fn(async () => undefined),
+        call: rs.fn(async () => undefined),
       };
 
       const deviceWithCustomActions = new IOSDevice({
@@ -276,7 +276,7 @@ describe('IOSDevice', () => {
     });
 
     it('should handle connection failure', async () => {
-      mockWdaClient.createSession = vi
+      mockWdaClient.createSession = rs
         .fn()
         .mockRejectedValue(new Error('Connection failed'));
 
@@ -323,7 +323,7 @@ describe('IOSDevice', () => {
     });
 
     it('should handle app terminate failure', async () => {
-      mockWdaClient.terminateApp = vi
+      mockWdaClient.terminateApp = rs
         .fn()
         .mockRejectedValue(new Error('App terminate failed'));
       await device.connect();
@@ -335,7 +335,7 @@ describe('IOSDevice', () => {
 
     it('should handle URL launch with HTTP URL', async () => {
       // Add openUrl method to mock
-      mockWdaClient.openUrl = vi.fn().mockResolvedValue(undefined);
+      mockWdaClient.openUrl = rs.fn().mockResolvedValue(undefined);
       await device.connect();
 
       await device.launch('https://www.apple.com');
@@ -346,7 +346,7 @@ describe('IOSDevice', () => {
 
     it('should handle URL launch with custom scheme', async () => {
       // Add openUrl method to mock
-      mockWdaClient.openUrl = vi.fn().mockResolvedValue(undefined);
+      mockWdaClient.openUrl = rs.fn().mockResolvedValue(undefined);
       await device.connect();
 
       await device.launch('myapp://deep/link');
@@ -355,13 +355,13 @@ describe('IOSDevice', () => {
 
     it('should fallback to Safari when direct URL opening fails', async () => {
       // Mock openUrl to fail, other methods to succeed
-      mockWdaClient.openUrl = vi
+      mockWdaClient.openUrl = rs
         .fn()
         .mockRejectedValue(new Error('Direct URL failed'));
-      mockWdaClient.terminateApp = vi.fn().mockResolvedValue(undefined);
-      mockWdaClient.launchApp = vi.fn().mockResolvedValue(undefined);
-      mockWdaClient.typeText = vi.fn().mockResolvedValue(undefined);
-      mockWdaClient.pressKey = vi.fn().mockResolvedValue(undefined);
+      mockWdaClient.terminateApp = rs.fn().mockResolvedValue(undefined);
+      mockWdaClient.launchApp = rs.fn().mockResolvedValue(undefined);
+      mockWdaClient.typeText = rs.fn().mockResolvedValue(undefined);
+      mockWdaClient.pressKey = rs.fn().mockResolvedValue(undefined);
       await device.connect();
 
       await device.launch('https://www.example.com');
@@ -489,7 +489,7 @@ describe('IOSDevice', () => {
     });
 
     it('should handle session creation timeout', async () => {
-      mockWdaClient.createSession = vi.fn().mockImplementation(() => {
+      mockWdaClient.createSession = rs.fn().mockImplementation(() => {
         return new Promise((_, reject) => {
           setTimeout(() => reject(new Error('Session creation timeout')), 100);
         });
@@ -502,7 +502,7 @@ describe('IOSDevice', () => {
 
     it('should handle screenshot failure gracefully', async () => {
       await device.connect();
-      mockWdaClient.takeScreenshot = vi
+      mockWdaClient.takeScreenshot = rs
         .fn()
         .mockRejectedValue(new Error('Screenshot failed'));
 
@@ -513,7 +513,7 @@ describe('IOSDevice', () => {
 
     it('should handle app launch failure', async () => {
       await device.connect();
-      mockWdaClient.launchApp = vi
+      mockWdaClient.launchApp = rs
         .fn()
         .mockRejectedValue(new Error('App launch failed'));
 
@@ -524,14 +524,14 @@ describe('IOSDevice', () => {
 
     it('should handle tap operation failure', async () => {
       await device.connect();
-      mockWdaClient.tap = vi.fn().mockRejectedValue(new Error('Tap failed'));
+      mockWdaClient.tap = rs.fn().mockRejectedValue(new Error('Tap failed'));
 
       await expect(device.tap(100, 200)).rejects.toThrow('Tap failed');
     });
 
     it('should handle text input failure', async () => {
       await device.connect();
-      mockWdaClient.typeText = vi
+      mockWdaClient.typeText = rs
         .fn()
         .mockRejectedValue(new Error('Type text failed'));
 
@@ -545,18 +545,18 @@ describe('IOSDevice', () => {
     beforeEach(async () => {
       await device.connect();
       // Mock makeRequest for keyboard operations
-      mockWdaClient.makeRequest = vi.fn().mockResolvedValue(null);
+      mockWdaClient.makeRequest = rs.fn().mockResolvedValue(null);
     });
 
     it('should handle keyboard dismissal with default strategy', async () => {
       // Mock dismissKeyboard to fail so it falls back to swipe gesture
-      mockWdaClient.dismissKeyboard = vi
+      mockWdaClient.dismissKeyboard = rs
         .fn()
         .mockRejectedValue(new Error('dismissKeyboard not available'));
-      mockWdaClient.getWindowSize = vi
+      mockWdaClient.getWindowSize = rs
         .fn()
         .mockResolvedValue({ width: 375, height: 812 });
-      mockWdaClient.swipe = vi.fn().mockResolvedValue(undefined);
+      mockWdaClient.swipe = rs.fn().mockResolvedValue(undefined);
 
       const result = await device.hideKeyboard();
       expect(result).toBe(true);
@@ -565,13 +565,13 @@ describe('IOSDevice', () => {
 
     it('should handle keyboard dismissal failure', async () => {
       // Mock both dismissKeyboard and swipe to fail to simulate total failure
-      mockWdaClient.dismissKeyboard = vi
+      mockWdaClient.dismissKeyboard = rs
         .fn()
         .mockRejectedValue(new Error('dismissKeyboard failed'));
-      mockWdaClient.getWindowSize = vi
+      mockWdaClient.getWindowSize = rs
         .fn()
         .mockResolvedValue({ width: 375, height: 812 });
-      mockWdaClient.swipe = vi
+      mockWdaClient.swipe = rs
         .fn()
         .mockRejectedValue(new Error('Swipe failed'));
 
@@ -583,14 +583,14 @@ describe('IOSDevice', () => {
       // Mock the WDA client before creating the device
       const mockBackend = {
         ...mockWdaClient,
-        createSession: vi.fn().mockResolvedValue({ sessionId: 'test-session' }),
-        typeText: vi.fn().mockResolvedValue(undefined),
-        dismissKeyboard: vi
+        createSession: rs.fn().mockResolvedValue({ sessionId: 'test-session' }),
+        typeText: rs.fn().mockResolvedValue(undefined),
+        dismissKeyboard: rs
           .fn()
           .mockRejectedValue(new Error('dismissKeyboard not available')),
-        getWindowSize: vi.fn().mockResolvedValue({ width: 375, height: 812 }),
-        getScreenScale: vi.fn().mockResolvedValue(2),
-        swipe: vi.fn().mockResolvedValue(undefined),
+        getWindowSize: rs.fn().mockResolvedValue({ width: 375, height: 812 }),
+        getScreenScale: rs.fn().mockResolvedValue(2),
+        swipe: rs.fn().mockResolvedValue(undefined),
         sessionInfo: { sessionId: 'test-session' }, // Ensure session info is available
       };
       MockedWdaClient.mockImplementation(() => mockBackend);
@@ -614,7 +614,7 @@ describe('IOSDevice', () => {
     });
 
     it('should handle different screen sizes', async () => {
-      mockWdaClient.getWindowSize = vi
+      mockWdaClient.getWindowSize = rs
         .fn()
         .mockResolvedValue({ width: 1920, height: 1080 });
 

--- a/packages/ios/tests/unit-test/executeRequest-session-prefix.test.ts
+++ b/packages/ios/tests/unit-test/executeRequest-session-prefix.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 
 /**
  * Regression test: executeRequest must auto-prepend /session/{id} to the endpoint.
@@ -21,7 +21,7 @@ describe('IOSWebDriverClient.executeRequest session prefix', () => {
     (client as any).sessionId = 'fake-session-id';
 
     // Spy on the underlying makeRequest to capture the actual endpoint
-    const makeRequestSpy = vi
+    const makeRequestSpy = rs
       .spyOn(client as any, 'makeRequest')
       .mockResolvedValue({ value: { success: true } });
 
@@ -47,7 +47,7 @@ describe('IOSWebDriverClient.executeRequest session prefix', () => {
 
     (client as any).sessionId = 'fake-session-id';
 
-    const makeRequestSpy = vi
+    const makeRequestSpy = rs
       .spyOn(client as any, 'makeRequest')
       .mockResolvedValue({ value: { ok: true } });
 

--- a/packages/ios/tests/unit-test/fixtures/ios-device-override-env.mjs
+++ b/packages/ios/tests/unit-test/fixtures/ios-device-override-env.mjs
@@ -1,0 +1,15 @@
+// Real on-disk fixture for agent.test.ts — covers the *default* export branch of
+// agentFromWebDriverAgent's override resolution (the option fixture covers the
+// named `IOSDevice` export). See agent.test.ts for the rationale.
+export default class {
+  async connect() {
+    globalThis.__iosOverrideConnectFromEnv =
+      (globalThis.__iosOverrideConnectFromEnv ?? 0) + 1;
+  }
+
+  actionSpace() {
+    return [];
+  }
+
+  setAppNameMapping() {}
+}

--- a/packages/ios/tests/unit-test/fixtures/ios-device-override.mjs
+++ b/packages/ios/tests/unit-test/fixtures/ios-device-override.mjs
@@ -1,0 +1,15 @@
+// Real on-disk fixture for agent.test.ts — covers the named `IOSDevice` export
+// branch of agentFromWebDriverAgent's override resolution. See agent.test.ts for
+// why a real fixture (observed via a global counter) is used instead of a mock.
+export class IOSDevice {
+  async connect() {
+    globalThis.__iosOverrideConnectFromOption =
+      (globalThis.__iosOverrideConnectFromOption ?? 0) + 1;
+  }
+
+  actionSpace() {
+    return [];
+  }
+
+  setAppNameMapping() {}
+}

--- a/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
+++ b/packages/ios/tests/unit-test/ios-simulator-input-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import {
   IOSSimulatorInputValueError,
   inputUntilObserved,
@@ -41,9 +41,9 @@ describe('readIOSSimulatorInputValue', () => {
 
 describe('iOS Simulator input retry', () => {
   it('returns the first observed value without retrying', async () => {
-    const performInput = vi.fn(async () => undefined);
-    const readValue = vi.fn(async () => EXPECTED_VALUE);
-    const onRetry = vi.fn();
+    const performInput = rs.fn(async () => undefined);
+    const readValue = rs.fn(async () => EXPECTED_VALUE);
+    const onRetry = rs.fn();
 
     await expect(
       inputUntilObserved({
@@ -64,9 +64,9 @@ describe('iOS Simulator input retry', () => {
 
   it('retries only after observing an unexpected input value', async () => {
     const observedValues = [undefined, EXPECTED_VALUE];
-    const performInput = vi.fn(async () => undefined);
-    const readValue = vi.fn(async () => observedValues.shift());
-    const onRetry = vi.fn();
+    const performInput = rs.fn(async () => undefined);
+    const readValue = rs.fn(async () => observedValues.shift());
+    const onRetry = rs.fn();
 
     await expect(
       inputUntilObserved({
@@ -107,9 +107,9 @@ describe('iOS Simulator input retry', () => {
       message: 'source failed',
     },
   ])('fails immediately on an unknown $name', async (testCase) => {
-    const performInput = vi.fn(testCase.performInput);
-    const readValue = vi.fn(testCase.readValue);
-    const onRetry = vi.fn();
+    const performInput = rs.fn(testCase.performInput);
+    const readValue = rs.fn(testCase.readValue);
+    const onRetry = rs.fn();
 
     await expect(
       inputUntilObserved({
@@ -128,9 +128,9 @@ describe('iOS Simulator input retry', () => {
   });
 
   it('throws the last observed value after exhausting attempts', async () => {
-    const performInput = vi.fn(async () => undefined);
-    const readValue = vi.fn(async () => 'partial input');
-    const onRetry = vi.fn();
+    const performInput = rs.fn(async () => undefined);
+    const readValue = rs.fn(async () => 'partial input');
+    const onRetry = rs.fn();
 
     await expect(
       inputUntilObserved({
@@ -150,8 +150,8 @@ describe('iOS Simulator input retry', () => {
   });
 
   it('rejects an invalid attempt count before performing input', async () => {
-    const performInput = vi.fn(async () => undefined);
-    const readValue = vi.fn(async () => EXPECTED_VALUE);
+    const performInput = rs.fn(async () => undefined);
+    const readValue = rs.fn(async () => EXPECTED_VALUE);
 
     await expect(
       inputUntilObserved({

--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { IOSWebDriverClient } from '../../src/ios-webdriver-client';
 
 describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
@@ -15,12 +15,12 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   describe('tap() fallback logic', () => {
     it('should use new endpoint when it succeeds', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
       makeRequestSpy.mockResolvedValueOnce({ status: 0 });
 
       await client.tap(100, 200);
@@ -35,7 +35,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should fallback to legacy endpoint when new endpoint fails', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       // First call (new endpoint) fails
       makeRequestSpy.mockRejectedValueOnce(new Error('New endpoint not found'));
@@ -61,7 +61,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should throw error when both endpoints fail', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       // Both calls fail
       makeRequestSpy.mockRejectedValueOnce(new Error('New endpoint failed'));
@@ -75,7 +75,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should handle different coordinate types', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
       makeRequestSpy.mockResolvedValue({ status: 0 });
 
       await client.tap(0, 0);
@@ -99,17 +99,17 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
 
   describe('appSwitcher()', () => {
     it('should use the native WDA drag endpoint with screen coordinates', async () => {
-      vi.useFakeTimers();
-      const getWindowSizeSpy = vi
+      rs.useFakeTimers();
+      const getWindowSizeSpy = rs
         .spyOn(client, 'getWindowSize')
         .mockResolvedValue({ width: 393, height: 852 });
-      const makeRequestSpy = vi
+      const makeRequestSpy = rs
         .spyOn(client as any, 'makeRequest')
         .mockResolvedValue({ status: 0 });
 
       try {
         const appSwitcherPromise = client.appSwitcher();
-        await vi.runAllTimersAsync();
+        await rs.runAllTimersAsync();
         await appSwitcherPromise;
 
         expect(getWindowSizeSpy).toHaveBeenCalledOnce();
@@ -126,14 +126,14 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
           },
         );
       } finally {
-        vi.useRealTimers();
+        rs.useRealTimers();
       }
     });
   });
 
   describe('pressKey()', () => {
     it('should reject key combinations before invoking WDA', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       await expect(client.pressKey('Control+A')).rejects.toThrow(
         'iOS keyboardPress does not support key combinations: "Control+A"',
@@ -144,7 +144,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
 
   describe('getScreenScale() fallback logic', () => {
     it('should return scale when endpoint succeeds with scale value', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
       makeRequestSpy.mockResolvedValueOnce({
         status: 0,
         value: { scale: 3 },
@@ -161,9 +161,9 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should enter fallback logic when endpoint succeeds but has no scale', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
-      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
-      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = rs.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = rs.spyOn(client, 'getWindowSize');
 
       // First call: endpoint succeeds but no scale
       makeRequestSpy.mockResolvedValueOnce({
@@ -188,9 +188,9 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should enter fallback logic when endpoint fails', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
-      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
-      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = rs.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = rs.spyOn(client, 'getWindowSize');
 
       // First call: endpoint fails
       makeRequestSpy.mockRejectedValueOnce(new Error('Endpoint not found'));
@@ -212,8 +212,8 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should return null when both endpoint and calculation fail', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
-      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = rs.spyOn(client, 'takeScreenshot');
 
       // First call: endpoint fails
       makeRequestSpy.mockRejectedValueOnce(new Error('Endpoint failed'));
@@ -228,9 +228,9 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should handle response without value field gracefully', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
-      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
-      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = rs.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = rs.spyOn(client, 'getWindowSize');
 
       // Endpoint returns response without value field
       makeRequestSpy.mockResolvedValueOnce({
@@ -254,9 +254,9 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should handle scale value of 0 as invalid and trigger fallback', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
-      const takeScreenshotSpy = vi.spyOn(client, 'takeScreenshot');
-      const getWindowSizeSpy = vi.spyOn(client, 'getWindowSize');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
+      const takeScreenshotSpy = rs.spyOn(client, 'takeScreenshot');
+      const getWindowSizeSpy = rs.spyOn(client, 'getWindowSize');
 
       // Endpoint returns scale: 0 (invalid)
       makeRequestSpy.mockResolvedValueOnce({
@@ -280,7 +280,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
 
   describe('Compatibility scenarios', () => {
     it('should work with WDA 5.x (legacy tap endpoint)', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       // Simulate WDA 5.x: new endpoint doesn't exist
       makeRequestSpy.mockRejectedValueOnce(
@@ -299,7 +299,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should work with WDA 6.x/7.x (new tap endpoint)', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       // Simulate WDA 6.x/7.x: new endpoint works
       makeRequestSpy.mockResolvedValueOnce({ status: 0 });
@@ -315,7 +315,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
 
     it('should handle WDA versions with different screen endpoint responses', async () => {
-      const makeRequestSpy = vi.spyOn(client as any, 'makeRequest');
+      const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');
 
       // Test different scale values
       const testCases = [1, 2, 3, 4];

--- a/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
+++ b/packages/ios/tests/unit-test/mjpeg-frame-source.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { IOSDevice } from '../../src/device';
 import {
   MjpegFrameSource,
@@ -93,7 +93,7 @@ describe('IOSDevice MJPEG frame source opt-in', () => {
       wdaMjpegPort: 9123,
       wdaMjpegFrameSource: { enabled: true },
     });
-    const stop = vi.fn();
+    const stop = rs.fn();
     const fakeMjpeg = {
       getLatest: () => ({
         base64: 'data:image/jpeg;base64,FRAME',
@@ -101,7 +101,7 @@ describe('IOSDevice MJPEG frame source opt-in', () => {
       }),
       stop,
     };
-    (device as any).ensureMjpegFrameSource = vi
+    (device as any).ensureMjpegFrameSource = rs
       .fn()
       .mockImplementation(async () => {
         (device as any).mjpegFrameSource = fakeMjpeg;

--- a/packages/ios/tests/unit-test/platform-session-manager.test.ts
+++ b/packages/ios/tests/unit-test/platform-session-manager.test.ts
@@ -1,14 +1,14 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, rs, test } from '@rstest/core';
 
-const agentFromWebDriverAgentMock = vi.fn();
-const getConnectedDeviceInfoMock = vi.fn();
-const findAvailablePortMock = vi.fn(async (port: number) => port);
+const agentFromWebDriverAgentMock = rs.fn();
+const getConnectedDeviceInfoMock = rs.fn();
+const findAvailablePortMock = rs.fn(async (port: number) => port);
 
-vi.mock('@midscene/shared/node', () => ({
+rs.mock('@midscene/shared/node', () => ({
   findAvailablePort: findAvailablePortMock,
 }));
 
-vi.mock('../../src/agent', () => ({
+rs.mock('../../src/agent', () => ({
   agentFromWebDriverAgent: agentFromWebDriverAgentMock,
 }));
 
@@ -16,12 +16,12 @@ const mockAgent = {
   interface: {
     getConnectedDeviceInfo: getConnectedDeviceInfoMock,
   },
-  destroy: vi.fn(),
+  destroy: rs.fn(),
 };
 
 describe('iosPlaygroundPlatform session manager', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
     agentFromWebDriverAgentMock.mockResolvedValue({
       ...mockAgent,
       interface: {

--- a/packages/ios/tests/unit-test/structure.test.ts
+++ b/packages/ios/tests/unit-test/structure.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import { WDAManager } from '@midscene/webdriver';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { IOSAgent } from '../../src/agent';
 import { IOSDevice } from '../../src/device';
 import { IOSWebDriverClient } from '../../src/ios-webdriver-client';

--- a/packages/ios/tests/unit-test/utils.test.ts
+++ b/packages/ios/tests/unit-test/utils.test.ts
@@ -1,26 +1,26 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
 // Mock the exec and execFile functions
-vi.mock('node:child_process', () => ({
-  exec: vi.fn(),
-  execFile: vi.fn(),
+rs.mock('node:child_process', () => ({
+  exec: rs.fn(),
+  execFile: rs.fn(),
 }));
 
 // Mock the os module for platform testing
-vi.mock('node:os', () => ({
-  platform: vi.fn(),
+rs.mock('node:os', () => ({
+  platform: rs.fn(),
 }));
 
 import { exec } from 'node:child_process';
 import { platform } from 'node:os';
 import { checkIOSEnvironment, checkMacOSPlatform } from '../../src/utils';
 
-const mockedExec = vi.mocked(exec);
-const mockedPlatform = vi.mocked(platform);
+const mockedExec = rs.mocked(exec);
+const mockedPlatform = rs.mocked(platform);
 
 describe('iOS Utils - Environment Checking', () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    rs.clearAllMocks();
   });
 
   describe('checkMacOSPlatform', () => {

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import type { IOSWebDriverClient as IOSWebDriverClientType } from '../../src/ios-webdriver-client';
 
 describe('IOSWebDriverClient - Simple Tests', () => {

--- a/packages/ios/tests/unit-test/yaml-runWdaRequest.test.ts
+++ b/packages/ios/tests/unit-test/yaml-runWdaRequest.test.ts
@@ -4,7 +4,7 @@ import type {
   MidsceneYamlScriptEnv,
 } from '@midscene/core/yaml';
 import { ScriptPlayer } from '@midscene/core/yaml';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
 describe('YAML runWdaRequest support via ActionSpace', () => {
@@ -24,7 +24,7 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
           .optional()
           .describe('Optional request body data as JSON object'),
       }),
-      call: vi.fn(
+      call: rs.fn(
         async (param: { method: string; endpoint: string; data?: any }) =>
           mockResult,
       ),
@@ -33,9 +33,9 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runWdaRequestAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runWdaRequestAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           // Simulate the actual behavior of callActionInActionSpace
           if (actionName === 'RunWdaRequest') {
@@ -89,9 +89,9 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => []), // Empty actionSpace, no runWdaRequest
-      callActionInActionSpace: vi.fn(),
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => []), // Empty actionSpace, no runWdaRequest
+      callActionInActionSpace: rs.fn(),
     };
 
     const script: MidsceneYamlScript = {
@@ -142,7 +142,7 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
           .optional()
           .describe('Optional request body data as JSON object'),
       }),
-      call: vi.fn(
+      call: rs.fn(
         async (param: { method: string; endpoint: string; data?: any }) =>
           mockResult,
       ),
@@ -151,9 +151,9 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runWdaRequestAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runWdaRequestAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           if (actionName === 'RunWdaRequest') {
             return mockResult;
@@ -216,7 +216,7 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
           .optional()
           .describe('Optional request body data as JSON object'),
       }),
-      call: vi.fn(
+      call: rs.fn(
         async (param: { method: string; endpoint: string; data?: any }) => {
           if (!param.method || !param.endpoint) {
             throw new Error(
@@ -231,9 +231,9 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runWdaRequestAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runWdaRequestAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           if (actionName === 'RunWdaRequest') {
             // Call the actual action to trigger validation
@@ -289,7 +289,7 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
           .optional()
           .describe('Optional request body data as JSON object'),
       }),
-      call: vi.fn(
+      call: rs.fn(
         async (param: { method: string; endpoint: string; data?: any }) =>
           mockResult,
       ),
@@ -298,9 +298,9 @@ describe('YAML runWdaRequest support via ActionSpace', () => {
     const mockAgent = {
       reportFile: null,
       onTaskStartTip: undefined,
-      _unstableLogContent: vi.fn(async () => ({})),
-      getActionSpace: vi.fn(async () => [runWdaRequestAction]),
-      callActionInActionSpace: vi.fn(
+      _unstableLogContent: rs.fn(async () => ({})),
+      getActionSpace: rs.fn(async () => [runWdaRequestAction]),
+      callActionInActionSpace: rs.fn(
         async (actionName: string, params: any) => {
           if (actionName === 'RunWdaRequest') {
             return mockResult;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -96,8 +96,8 @@
     "build:script": "rslib build -c ./rslib.inspect.config.ts",
     "build:watch": "npm run build:script && rslib build --watch --no-clean",
     "reset": "rimraf ./**/node_modules",
-    "test": "vitest --run",
-    "test:u": "vitest --run -u"
+    "test": "rstest",
+    "test:u": "rstest -u"
   },
   "dependencies": {
     "@silvia-odwyer/photon": "0.3.3",
@@ -110,13 +110,13 @@
   },
   "devDependencies": {
     "@rslib/core": "^0.18.3",
+    "@rstest/core": "0.11.5",
     "@types/debug": "4.1.12",
     "@types/node": "^18.0.0",
     "@ui-tars/shared": "1.2.0",
     "openai": "6.3.0",
     "rimraf": "~5.0.10",
-    "typescript": "^5.8.3",
-    "vitest": "3.0.5"
+    "typescript": "^5.8.3"
   },
   "sideEffects": [],
   "publishConfig": {

--- a/packages/shared/rstest.config.ts
+++ b/packages/shared/rstest.config.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
+import { defineConfig } from '@rstest/core';
 import dotenv from 'dotenv';
-import { defineConfig } from 'vitest/config';
-import { createCoverageConfig } from '../../scripts/vitest-coverage';
+import { createCoverageConfig } from '../../scripts/rstest-coverage';
+import { defineVersion, photonExternal } from '../../scripts/rstest-shared';
 import { version } from './package.json';
 
 /**
@@ -16,19 +17,17 @@ const enableAiTest = Boolean(process.env.AITEST);
 const basicTest = ['tests/unit-test/**/*.test.ts'];
 
 export default defineConfig({
-  test: {
-    coverage: createCoverageConfig(__dirname),
-    include: enableAiTest ? ['tests/ai/**/*.test.ts', ...basicTest] : basicTest,
-  },
+  coverage: createCoverageConfig(__dirname),
+  include: enableAiTest ? ['tests/ai/**/*.test.ts', ...basicTest] : basicTest,
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
   },
-  define: {
-    __VERSION__: JSON.stringify(version),
+  source: {
+    define: defineVersion(version),
   },
-  ssr: {
-    external: ['@silvia-odwyer/photon'],
+  output: {
+    externals: photonExternal,
   },
 });

--- a/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
+++ b/packages/shared/tests/unit-test/__snapshots__/cli-runner.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Rstest Snapshot v1
 
 exports[`runToolsCLI > --help output matches snapshot 1`] = `
 "test-cli v1.2.3

--- a/packages/shared/tests/unit-test/__snapshots__/tree.test.ts.snap
+++ b/packages/shared/tests/unit-test/__snapshots__/tree.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Rstest Snapshot v1
 
 exports[`utils > should be able to describe tree 1`] = `
 "<container id="1"  left="0" top="0" width="100" height="100">

--- a/packages/shared/tests/unit-test/chrome-path.test.ts
+++ b/packages/shared/tests/unit-test/chrome-path.test.ts
@@ -1,23 +1,30 @@
 import { existsSync } from 'node:fs';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  rs,
+  test,
+} from '@rstest/core';
 import {
   getSystemChromePath,
   resolveChromePath,
 } from '../../src/agent-tools/chrome-path';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
+rs.mock('node:fs', () => ({
+  existsSync: rs.fn(),
 }));
 
-vi.mock('../../src/logger', () => ({
-  getDebug: vi.fn(() => vi.fn()),
+rs.mock('../../src/logger', () => ({
+  getDebug: rs.fn(() => rs.fn()),
 }));
 
-vi.mock('../../src/env', () => ({
+rs.mock('../../src/env', () => ({
   MIDSCENE_CHROME_PATH: 'MIDSCENE_CHROME_PATH',
   MIDSCENE_MCP_CHROME_PATH: 'MIDSCENE_MCP_CHROME_PATH',
   globalConfigManager: {
-    getEnvConfigValue: vi.fn(),
+    getEnvConfigValue: rs.fn(),
   },
 }));
 
@@ -25,8 +32,8 @@ describe('Chrome Path Resolution', () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(existsSync).mockReturnValue(false);
+    rs.clearAllMocks();
+    rs.mocked(existsSync).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -41,7 +48,7 @@ describe('Chrome Path Resolution', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' });
       const macPath =
         '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-      vi.mocked(existsSync).mockImplementation((path) => path === macPath);
+      rs.mocked(existsSync).mockImplementation((path) => path === macPath);
 
       expect(getSystemChromePath()).toBe(macPath);
     });
@@ -50,7 +57,7 @@ describe('Chrome Path Resolution', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       const optPath = '/opt/google/chrome/chrome';
       const usrPath = '/usr/bin/google-chrome';
-      vi.mocked(existsSync).mockImplementation(
+      rs.mocked(existsSync).mockImplementation(
         (path) => path === optPath || path === usrPath,
       );
 
@@ -60,7 +67,7 @@ describe('Chrome Path Resolution', () => {
     test('should fallback to /usr/bin paths on Linux', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       const linuxPath = '/usr/bin/google-chrome';
-      vi.mocked(existsSync).mockImplementation((path) => path === linuxPath);
+      rs.mocked(existsSync).mockImplementation((path) => path === linuxPath);
 
       expect(getSystemChromePath()).toBe(linuxPath);
     });
@@ -69,7 +76,7 @@ describe('Chrome Path Resolution', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' });
       const winPath =
         'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
-      vi.mocked(existsSync).mockImplementation((path) => path === winPath);
+      rs.mocked(existsSync).mockImplementation((path) => path === winPath);
 
       expect(getSystemChromePath()).toBe(winPath);
     });
@@ -84,28 +91,28 @@ describe('Chrome Path Resolution', () => {
     test('should return env chrome path when valid', async () => {
       const envModule = await import('../../src/env');
       const customPath = '/custom/chrome/path';
-      vi.mocked(
+      rs.mocked(
         envModule.globalConfigManager.getEnvConfigValue,
       ).mockImplementation((key) =>
         key === 'MIDSCENE_CHROME_PATH' ? customPath : undefined,
       );
-      vi.mocked(existsSync).mockReturnValue(true);
+      rs.mocked(existsSync).mockReturnValue(true);
 
       expect(resolveChromePath()).toBe(customPath);
     });
 
     test('should fallback to legacy MCP chrome path when primary env is unset', async () => {
-      const consoleWarnSpy = vi
+      const consoleWarnSpy = rs
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
       const envModule = await import('../../src/env');
       const legacyPath = '/legacy/chrome/path';
-      vi.mocked(
+      rs.mocked(
         envModule.globalConfigManager.getEnvConfigValue,
       ).mockImplementation((key) =>
         key === 'MIDSCENE_MCP_CHROME_PATH' ? legacyPath : undefined,
       );
-      vi.mocked(existsSync).mockReturnValue(true);
+      rs.mocked(existsSync).mockReturnValue(true);
 
       expect(resolveChromePath()).toBe(legacyPath);
       consoleWarnSpy.mockRestore();
@@ -113,7 +120,7 @@ describe('Chrome Path Resolution', () => {
 
     test('should fallback to system path when env is auto', async () => {
       const envModule = await import('../../src/env');
-      vi.mocked(
+      rs.mocked(
         envModule.globalConfigManager.getEnvConfigValue,
       ).mockImplementation((key) =>
         key === 'MIDSCENE_CHROME_PATH' ? 'auto' : undefined,
@@ -124,7 +131,7 @@ describe('Chrome Path Resolution', () => {
 
     test('should throw when no Chrome found', async () => {
       const envModule = await import('../../src/env');
-      vi.mocked(
+      rs.mocked(
         envModule.globalConfigManager.getEnvConfigValue,
       ).mockReturnValue(undefined);
 

--- a/packages/shared/tests/unit-test/cli-interrupt.test.ts
+++ b/packages/shared/tests/unit-test/cli-interrupt.test.ts
@@ -3,11 +3,11 @@ import {
   hasActiveCliInterruptWaiter,
   waitForCliInterrupt,
 } from '@/cli/interrupt';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 
 describe('waitForCliInterrupt', () => {
   afterEach(() => {
-    vi.useRealTimers();
+    rs.useRealTimers();
   });
 
   it('resolves on SIGINT and removes its listener', async () => {
@@ -23,12 +23,12 @@ describe('waitForCliInterrupt', () => {
   });
 
   it('uses the watchdog to finalize a forgotten recording', async () => {
-    vi.useFakeTimers();
+    rs.useFakeTimers();
     const source = new EventEmitter();
     const stopped = waitForCliInterrupt(5000, source);
 
     expect(hasActiveCliInterruptWaiter(source)).toBe(true);
-    await vi.advanceTimersByTimeAsync(5000);
+    await rs.advanceTimersByTimeAsync(5000);
 
     await expect(stopped).resolves.toBe('watchdog');
     expect(hasActiveCliInterruptWaiter(source)).toBe(false);

--- a/packages/shared/tests/unit-test/cli-report-session.test.ts
+++ b/packages/shared/tests/unit-test/cli-report-session.test.ts
@@ -8,7 +8,7 @@ import type {
   BaseDevice,
   ToolDefinition,
 } from '@/agent-tools/types';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
 const screenshotBase64 = 'data:image/png;base64,Zm9v';
@@ -29,8 +29,8 @@ class FakeCliTools extends BaseMidsceneTools<BaseAgent> {
   }
   public readonly createdReportFileNames: Array<string | undefined> = [];
   public readonly createdReportGroupIds: Array<string | undefined> = [];
-  public readonly aiAction = vi.fn().mockResolvedValue(undefined);
-  public readonly aiAssert = vi.fn().mockResolvedValue(undefined);
+  public readonly aiAction = rs.fn().mockResolvedValue(undefined);
+  public readonly aiAssert = rs.fn().mockResolvedValue(undefined);
 
   protected createTemporaryDevice(): BaseDevice {
     return new FakeDevice();
@@ -46,11 +46,11 @@ class FakeCliTools extends BaseMidsceneTools<BaseAgent> {
       throw new Error('connect failed');
     }
     return {
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       aiAction: this.aiAction,
       aiAssert: this.aiAssert,
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     };
   }

--- a/packages/shared/tests/unit-test/cli-runner.test.ts
+++ b/packages/shared/tests/unit-test/cli-runner.test.ts
@@ -7,7 +7,7 @@ import {
   reportCLIError,
   runToolsCLI,
 } from '@/cli';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
 describe('parseValue', () => {
@@ -272,14 +272,14 @@ describe('CLIError', () => {
 
 describe('reportCLIError', () => {
   it('prints CLIError messages and returns their exit code', () => {
-    const log = vi.fn();
+    const log = rs.fn();
 
     expect(reportCLIError(new CLIError('bad args', 2), log)).toBe(2);
     expect(log).toHaveBeenCalledWith('bad args');
   });
 
   it('prints non-CLI errors and returns exit code 1', () => {
-    const log = vi.fn();
+    const log = rs.fn();
     const error = new Error('boom');
 
     expect(reportCLIError(error, log)).toBe(1);
@@ -295,9 +295,9 @@ describe('runToolsCLI', () => {
     }>,
   ) {
     return {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue(
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue(
         definitions.map((d) => ({
           name: d.name,
           description: `${d.name} command`,
@@ -310,7 +310,7 @@ describe('runToolsCLI', () => {
 
   it('prints help when no command given', async () => {
     const tools = createMockTools([]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
     await runToolsCLI(tools, 'test-cli', { argv: [] });
     expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
@@ -318,7 +318,7 @@ describe('runToolsCLI', () => {
 
   it('prints help for --help flag', async () => {
     const tools = createMockTools([]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
     await runToolsCLI(tools, 'test-cli', {
       argv: ['--help'],
       version: '1.2.3',
@@ -329,7 +329,7 @@ describe('runToolsCLI', () => {
 
   it('prints version for --version flag', async () => {
     const tools = createMockTools([]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['--version'],
@@ -342,7 +342,7 @@ describe('runToolsCLI', () => {
 
   it('prints version for version command', async () => {
     const tools = createMockTools([]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['version'],
@@ -354,12 +354,12 @@ describe('runToolsCLI', () => {
   });
 
   it('strips a global --deep-locate flag and applies deep locate defaults', async () => {
-    const handler = vi
+    const handler = rs
       .fn()
       .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
     const tools = createMockTools([{ name: 'tap', handler }]);
-    tools.setToolDefaults = vi.fn();
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    tools.setToolDefaults = rs.fn();
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     // The flag is placed before the command; it must be removed so 'tap'
     // resolves as the command instead of being treated as unknown.
@@ -376,12 +376,12 @@ describe('runToolsCLI', () => {
   });
 
   it('strips --deep-locate even when it follows the command', async () => {
-    const handler = vi
+    const handler = rs
       .fn()
       .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
     const tools = createMockTools([{ name: 'tap', handler }]);
-    tools.setToolDefaults = vi.fn();
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    tools.setToolDefaults = rs.fn();
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['tap', '--deep-locate', '--locate', 'btn'],
@@ -396,12 +396,12 @@ describe('runToolsCLI', () => {
   });
 
   it('does not set tool defaults without a behavior flag', async () => {
-    const handler = vi
+    const handler = rs
       .fn()
       .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
     const tools = createMockTools([{ name: 'tap', handler }]);
-    tools.setToolDefaults = vi.fn();
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    tools.setToolDefaults = rs.fn();
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['tap', '--locate', 'btn'],
@@ -413,12 +413,12 @@ describe('runToolsCLI', () => {
   });
 
   it('writes image tool results with an extension matching the mime type', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'image', data: 'aGVsbG8=', mimeType: 'image/jpeg' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'take_screenshot', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', { argv: ['take_screenshot'] });
 
@@ -434,12 +434,12 @@ describe('runToolsCLI', () => {
   });
 
   it('strips a global --deep-think flag and applies act defaults', async () => {
-    const handler = vi
+    const handler = rs
       .fn()
       .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
     const tools = createMockTools([{ name: 'act', handler }]);
-    tools.setToolDefaults = vi.fn();
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    tools.setToolDefaults = rs.fn();
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['--deep-think', 'act', '--prompt', 'open settings'],
@@ -453,12 +453,12 @@ describe('runToolsCLI', () => {
   });
 
   it('merges defaults when both flags are present', async () => {
-    const handler = vi
+    const handler = rs
       .fn()
       .mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
     const tools = createMockTools([{ name: 'act', handler }]);
-    tools.setToolDefaults = vi.fn();
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    tools.setToolDefaults = rs.fn();
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['act', '--deep-locate', '--deep-think', '--prompt', 'go'],
@@ -474,9 +474,9 @@ describe('runToolsCLI', () => {
 
   function createDetailedMockTools() {
     return {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'connect',
           description: 'Connect to a device for automation',
@@ -484,13 +484,13 @@ describe('runToolsCLI', () => {
             url: { description: 'The device URL to connect to' },
             timeout: { description: 'Connection timeout in ms' },
           },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
         {
           name: 'disconnect',
           description: 'Disconnect from the current device',
           schema: {},
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
         {
           name: 'take_screenshot',
@@ -498,7 +498,7 @@ describe('runToolsCLI', () => {
           schema: {
             format: { description: 'Image format (png or jpg)' },
           },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
         {
           name: 'tap',
@@ -508,7 +508,7 @@ describe('runToolsCLI', () => {
             x: { description: 'X coordinate to tap' },
             y: { description: 'Y coordinate to tap' },
           },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
       ]),
     } as any;
@@ -517,7 +517,7 @@ describe('runToolsCLI', () => {
   it('--help output matches snapshot', async () => {
     const tools = createDetailedMockTools();
     const lines: string[] = [];
-    const consoleSpy = vi
+    const consoleSpy = rs
       .spyOn(console, 'log')
       .mockImplementation((...args: any[]) => {
         lines.push(args.map(String).join(' '));
@@ -535,7 +535,7 @@ describe('runToolsCLI', () => {
   it('command --help output matches snapshot', async () => {
     const tools = createDetailedMockTools();
     const lines: string[] = [];
-    const consoleSpy = vi
+    const consoleSpy = rs
       .spyOn(console, 'log')
       .mockImplementation((...args: any[]) => {
         lines.push(args.map(String).join(' '));
@@ -551,9 +551,9 @@ describe('runToolsCLI', () => {
 
   it('prefers CLI display metadata for command help output', async () => {
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'android_connect',
           description: 'Connect to Android device',
@@ -570,12 +570,12 @@ describe('runToolsCLI', () => {
               },
             },
           },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
       ]),
     } as any;
     const lines: string[] = [];
-    const consoleSpy = vi
+    const consoleSpy = rs
       .spyOn(console, 'log')
       .mockImplementation((...args: any[]) => {
         lines.push(args.map(String).join(' '));
@@ -594,9 +594,9 @@ describe('runToolsCLI', () => {
 
   it('rejects disallowed dotted init-arg spellings via CLI schema', async () => {
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'android_connect',
           description: 'Connect to Android device',
@@ -613,7 +613,7 @@ describe('runToolsCLI', () => {
               },
             },
           },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
       ]),
     } as any;
@@ -635,23 +635,23 @@ describe('runToolsCLI', () => {
         handler: async () => ({ content: [], isError: false }),
       },
     ]);
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'error').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', { argv: ['unknown'] }),
     ).rejects.toThrow(CLIError);
 
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('executes matched command with parsed args', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Connected' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'test_connect', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       stripPrefix: 'test_',
@@ -664,13 +664,13 @@ describe('runToolsCLI', () => {
   });
 
   it('maps leading command positionals into handler arguments', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Recording started' }],
       isError: false,
     });
     const tools = {
       ...createMockTools([]),
-      getCliToolDefinitions: vi.fn().mockReturnValue([
+      getCliToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'record',
           description: 'record command',
@@ -683,7 +683,7 @@ describe('runToolsCLI', () => {
         },
       ]),
     } as any;
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['record', 'start', '--output', 'toast.json'],
@@ -697,12 +697,12 @@ describe('runToolsCLI', () => {
   });
 
   it('strips global --verbose and emits readable progress lines', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Connected' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'connect', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['--verbose', 'connect', '--url', 'https://example.com'],
@@ -719,12 +719,12 @@ describe('runToolsCLI', () => {
   });
 
   it('emits readable progress for record without an explicit verbose flag', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Observation passed' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'record', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['record', '--output', 'toast.json'],
@@ -740,12 +740,12 @@ describe('runToolsCLI', () => {
   });
 
   it('preserves structured command args in jsonl verbose progress events', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Tapped' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'tap', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: [
@@ -776,12 +776,12 @@ describe('runToolsCLI', () => {
   });
 
   it('strips platform prefix from command names', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'ok' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'android_disconnect', handler }]);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       stripPrefix: 'android_',
@@ -789,30 +789,30 @@ describe('runToolsCLI', () => {
     });
 
     expect(handler).toHaveBeenCalledWith({});
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('calls destroy after successful command', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'done' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'connect', handler }]);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', { argv: ['connect'] });
 
     expect(tools.destroy).toHaveBeenCalledOnce();
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('calls destroy before throwing on command error', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Something went wrong' }],
       isError: true,
     });
     const tools = createMockTools([{ name: 'fail_cmd', handler }]);
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    rs.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', {
@@ -822,13 +822,13 @@ describe('runToolsCLI', () => {
     ).rejects.toThrow(CLIError);
 
     expect(tools.destroy).toHaveBeenCalledOnce();
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('calls destroy when a command handler throws', async () => {
-    const handler = vi.fn().mockRejectedValue(new Error('boom'));
+    const handler = rs.fn().mockRejectedValue(new Error('boom'));
     const tools = createMockTools([{ name: 'explode', handler }]);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', {
@@ -837,13 +837,13 @@ describe('runToolsCLI', () => {
     ).rejects.toThrow('boom');
 
     expect(tools.destroy).toHaveBeenCalledOnce();
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('emits an aiAct failure line when an act command throws by default', async () => {
-    const handler = vi.fn().mockRejectedValue(new Error('boom'));
+    const handler = rs.fn().mockRejectedValue(new Error('boom'));
     const tools = createMockTools([{ name: 'act', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', {
@@ -854,16 +854,16 @@ describe('runToolsCLI', () => {
     const messages = consoleSpy.mock.calls.map(([message]) => String(message));
     expect(messages).toContain('[Midscene][aiAct] Failed: boom');
     expect(tools.destroy).toHaveBeenCalledOnce();
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('matches commands case-insensitively', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'tapped' }],
       isError: false,
     });
     const tools = createMockTools([{ name: 'Tap', handler }]);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     // Uppercase tool name should match lowercase user input
     await runToolsCLI(tools, 'test-cli', { argv: ['tap'] });
@@ -875,22 +875,22 @@ describe('runToolsCLI', () => {
     await runToolsCLI(tools, 'test-cli', { argv: ['Tap'] });
     expect(handler).toHaveBeenCalled();
 
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('displays command names as lowercase in help', async () => {
     const tools = createMockTools([
       {
         name: 'Tap',
-        handler: vi.fn().mockResolvedValue({ content: [], isError: false }),
+        handler: rs.fn().mockResolvedValue({ content: [], isError: false }),
       },
       {
         name: 'Scroll',
-        handler: vi.fn().mockResolvedValue({ content: [], isError: false }),
+        handler: rs.fn().mockResolvedValue({ content: [], isError: false }),
       },
     ]);
     const lines: string[] = [];
-    vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+    rs.spyOn(console, 'log').mockImplementation((...args: any[]) => {
       lines.push(args.map(String).join(' '));
     });
 
@@ -913,13 +913,13 @@ describe('runToolsCLI', () => {
       expect(cmdName).toBe(cmdName.toLowerCase());
     }
 
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('shows command help with --help after command name', async () => {
-    const handler = vi.fn();
+    const handler = rs.fn();
     const tools = createMockTools([{ name: 'connect', handler }]);
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: ['connect', '--help'],
@@ -932,10 +932,10 @@ describe('runToolsCLI', () => {
 
   it('shows foreground record help without session or end plumbing', async () => {
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([]),
-      getCliToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([]),
+      getCliToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'record',
           description: 'record command',
@@ -944,12 +944,12 @@ describe('runToolsCLI', () => {
             output: z.string().optional(),
           },
           cli: { positionals: ['action'] },
-          handler: vi.fn(),
+          handler: rs.fn(),
         },
       ]),
     } as any;
     const lines: string[] = [];
-    const consoleSpy = vi
+    const consoleSpy = rs
       .spyOn(console, 'log')
       .mockImplementation((...args: unknown[]) => {
         lines.push(args.map(String).join(' '));
@@ -969,11 +969,11 @@ describe('runToolsCLI', () => {
 
   it('supports shared extra commands', async () => {
     const tools = createMockTools([]);
-    const extraHandler = vi.fn().mockResolvedValue({
+    const extraHandler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'split done' }],
       isError: false,
     });
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: [
@@ -1008,14 +1008,14 @@ describe('runToolsCLI', () => {
   });
 
   it('canonicalizes kebab-case spellings to schema keys before dispatch', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'ok' }],
       isError: false,
     });
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'assert',
           description: 'assert',
@@ -1027,7 +1027,7 @@ describe('runToolsCLI', () => {
         },
       ]),
     } as any;
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'test-cli', {
       argv: [
@@ -1045,18 +1045,18 @@ describe('runToolsCLI', () => {
       prompt: 'p',
       imageName: ['a', 'b'],
     });
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('canonicalizes preferredName/aliases for namespaced fields', async () => {
-    const handler = vi.fn().mockResolvedValue({
+    const handler = rs.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'ok' }],
       isError: false,
     });
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'android_connect',
           description: 'connect',
@@ -1073,7 +1073,7 @@ describe('runToolsCLI', () => {
         },
       ]),
     } as any;
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await runToolsCLI(tools, 'midscene-android', {
       stripPrefix: 'android_',
@@ -1083,15 +1083,15 @@ describe('runToolsCLI', () => {
     expect(handler).toHaveBeenCalledWith({
       'android.deviceId': 'emulator-5554',
     });
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('throws CLIError when the same field is set under conflicting spellings', async () => {
-    const handler = vi.fn();
+    const handler = rs.fn();
     const tools = {
-      initTools: vi.fn().mockResolvedValue(undefined),
-      destroy: vi.fn().mockResolvedValue(undefined),
-      getToolDefinitions: vi.fn().mockReturnValue([
+      initTools: rs.fn().mockResolvedValue(undefined),
+      destroy: rs.fn().mockResolvedValue(undefined),
+      getToolDefinitions: rs.fn().mockReturnValue([
         {
           name: 'assert',
           description: 'assert',
@@ -1103,7 +1103,7 @@ describe('runToolsCLI', () => {
         },
       ]),
     } as any;
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    rs.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(
       runToolsCLI(tools, 'test-cli', {
@@ -1119,6 +1119,6 @@ describe('runToolsCLI', () => {
       }),
     ).rejects.toThrow(/Conflicting CLI options.*image-name/);
     expect(handler).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 });

--- a/packages/shared/tests/unit-test/common.test.ts
+++ b/packages/shared/tests/unit-test/common.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from '@rstest/core';
 import {
   getMidsceneRunDir,
   getMidsceneRunSubDir,

--- a/packages/shared/tests/unit-test/dependencies.test.ts
+++ b/packages/shared/tests/unit-test/dependencies.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 
 describe('Dependencies version validation', () => {
   it('should ensure uuid version in package.json is less than 13', () => {

--- a/packages/shared/tests/unit-test/env/decide-model.test.ts
+++ b/packages/shared/tests/unit-test/env/decide-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { decideModelConfigFromIntentConfig } from '../../../src/env/parse-model-config';
 
 const baseConfig = {

--- a/packages/shared/tests/unit-test/env/decide-sdk.test.ts
+++ b/packages/shared/tests/unit-test/env/decide-sdk.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   MIDSCENE_MODEL_API_KEY,
   MIDSCENE_MODEL_BASE_URL,

--- a/packages/shared/tests/unit-test/env/global-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/global-config-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import {
   MIDSCENE_ADB_PATH,
   MIDSCENE_CACHE,
@@ -16,7 +16,7 @@ import { GlobalConfigManager } from '../../../src/env/global-config-manager';
 
 describe('overrideAIConfig', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
+    rs.unstubAllEnvs();
   });
 
   it('should throw if called with invalid key', () => {
@@ -97,9 +97,9 @@ describe('overrideAIConfig', () => {
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
     // Set initial environment values
-    vi.stubEnv(MIDSCENE_ADB_PATH, '/original/adb/path');
-    vi.stubEnv(MIDSCENE_CACHE, 'false');
-    vi.stubEnv(MIDSCENE_MODEL_NAME, 'gpt-3.5-turbo');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '/original/adb/path');
+    rs.stubEnv(MIDSCENE_CACHE, 'false');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, 'gpt-3.5-turbo');
 
     // Override with new values
     globalConfigManager.overrideAIConfig({
@@ -123,9 +123,9 @@ describe('overrideAIConfig', () => {
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
     // Set initial environment values
-    vi.stubEnv(MIDSCENE_ADB_PATH, '/original/adb/path');
-    vi.stubEnv(MIDSCENE_CACHE, 'false');
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '/original/adb/path');
+    rs.stubEnv(MIDSCENE_CACHE, 'false');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
 
     // Override with extend mode
     globalConfigManager.overrideAIConfig(
@@ -152,7 +152,7 @@ describe('overrideAIConfig', () => {
   });
 
   it('should warn when overriding already read keys', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
@@ -213,8 +213,8 @@ describe('overrideAIConfig', () => {
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
     // Set initial environment values
-    vi.stubEnv(MIDSCENE_ADB_PATH, '/env/adb/path');
-    vi.stubEnv(MIDSCENE_CACHE, 'false');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '/env/adb/path');
+    rs.stubEnv(MIDSCENE_CACHE, 'false');
 
     // First override in extend mode
     globalConfigManager.overrideAIConfig(
@@ -260,7 +260,7 @@ describe('overrideAIConfig', () => {
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
 
     // Set initial environment values
-    vi.stubEnv(MIDSCENE_ADB_PATH, '/original/path');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '/original/path');
 
     // Get config to cache it
     expect(globalConfigManager.getEnvConfigValue(MIDSCENE_ADB_PATH)).toBe(
@@ -280,7 +280,7 @@ describe('overrideAIConfig', () => {
 
   it('should clear model config map when override is called', () => {
     const modelConfigManager = new ModelConfigManager();
-    const clearModelConfigMapSpy = vi.spyOn(
+    const clearModelConfigMapSpy = rs.spyOn(
       modelConfigManager,
       'clearModelConfigMap',
     );
@@ -305,13 +305,13 @@ describe('overrideAIConfig', () => {
 
 describe('getEnvConfigValueAsNumber', () => {
   beforeEach(() => {
-    vi.stubEnv(MIDSCENE_ADB_PATH, '<test-adb-path>');
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
-    vi.stubEnv(MIDSCENE_CACHE, '');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '<test-adb-path>');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
+    rs.stubEnv(MIDSCENE_CACHE, '');
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
+    rs.unstubAllEnvs();
   });
 
   it('should return number for valid numeric string values', () => {
@@ -326,7 +326,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should return undefined for non-numeric string values', () => {
-    vi.stubEnv(MIDSCENE_ADB_PATH, 'not-a-number');
+    rs.stubEnv(MIDSCENE_ADB_PATH, 'not-a-number');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -348,7 +348,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should return undefined for empty string values', () => {
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -361,7 +361,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should handle decimal values', () => {
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '123.45');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '123.45');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -374,7 +374,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should handle zero values', () => {
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '0');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '0');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -387,7 +387,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should handle negative values', () => {
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '-100');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '-100');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -400,7 +400,7 @@ describe('getEnvConfigValueAsNumber', () => {
   });
 
   it('should trim whitespace before conversion', () => {
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '  100  ');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '  100  ');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());
@@ -452,15 +452,15 @@ describe('getEnvConfigValueAsNumber', () => {
 
 describe('getEnvConfigValue', () => {
   beforeEach(() => {
-    vi.stubEnv(MIDSCENE_MODEL_NAME, '<test-model>');
-    vi.stubEnv(OPENAI_API_KEY, '<test-openai-api-key>');
-    vi.stubEnv(OPENAI_BASE_URL, '<test-openai-base-url>');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, '<test-model>');
+    rs.stubEnv(OPENAI_API_KEY, '<test-openai-api-key>');
+    rs.stubEnv(OPENAI_BASE_URL, '<test-openai-base-url>');
     // Reset MIDSCENE_CACHE to ensure tests start with clean state
-    vi.stubEnv(MIDSCENE_CACHE, '');
+    rs.stubEnv(MIDSCENE_CACHE, '');
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
+    rs.unstubAllEnvs();
   });
 
   it('should throw if key is not supported', () => {
@@ -496,9 +496,9 @@ describe('getEnvConfigValue', () => {
   });
 
   it('should return the correct value from process.env', () => {
-    vi.stubEnv(MIDSCENE_ADB_PATH, '<test-adb-path>');
-    vi.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
-    vi.stubEnv(MIDSCENE_CACHE, 'true');
+    rs.stubEnv(MIDSCENE_ADB_PATH, '<test-adb-path>');
+    rs.stubEnv(MIDSCENE_CACHE_MAX_FILENAME_LENGTH, '100');
+    rs.stubEnv(MIDSCENE_CACHE, 'true');
 
     const globalConfigManager = new GlobalConfigManager();
     globalConfigManager.registerModelConfigManager(new ModelConfigManager());

--- a/packages/shared/tests/unit-test/env/helper.test.ts
+++ b/packages/shared/tests/unit-test/env/helper.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { maskConfig } from '../../../src/env/helper';
 import type { IModelConfig } from '../../../src/env/types';
 

--- a/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
+++ b/packages/shared/tests/unit-test/env/modle-config-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { GlobalConfigManager } from '../../../src/env/global-config-manager';
 import { ModelConfigManager } from '../../../src/env/model-config-manager';
 import {
@@ -34,7 +34,7 @@ import {
 
 describe('ModelConfigManager', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
+    rs.unstubAllEnvs();
   });
 
   const baseMap = {
@@ -91,12 +91,12 @@ describe('ModelConfigManager', () => {
   });
 
   it('prefer MIDSCENE_MODEL', () => {
-    vi.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
-    vi.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
-    vi.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
-    vi.stubEnv(OPENAI_API_KEY, 'openai-api-env-key');
-    vi.stubEnv(OPENAI_BASE_URL, 'openai-base-url');
-    vi.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
+    rs.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
+    rs.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
+    rs.stubEnv(OPENAI_API_KEY, 'openai-api-env-key');
+    rs.stubEnv(OPENAI_BASE_URL, 'openai-base-url');
+    rs.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
 
     const manager = new ModelConfigManager();
     manager.registerGlobalConfigManager(new GlobalConfigManager());
@@ -110,10 +110,10 @@ describe('ModelConfigManager', () => {
   });
 
   it('reads from environment when no config function provided', () => {
-    vi.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
-    vi.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
-    vi.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
-    vi.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
+    rs.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
+    rs.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
+    rs.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
 
     const manager = new ModelConfigManager();
     manager.registerGlobalConfigManager(new GlobalConfigManager());
@@ -138,9 +138,9 @@ describe('ModelConfigManager', () => {
   });
 
   it('clears model config map when called by global manager', () => {
-    vi.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
-    vi.stubEnv(OPENAI_API_KEY, 'env-key');
-    vi.stubEnv(OPENAI_BASE_URL, 'https://env.example.com');
+    rs.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
+    rs.stubEnv(OPENAI_API_KEY, 'env-key');
+    rs.stubEnv(OPENAI_BASE_URL, 'https://env.example.com');
 
     const manager = new ModelConfigManager();
     manager.registerGlobalConfigManager(new GlobalConfigManager());
@@ -154,7 +154,7 @@ describe('ModelConfigManager', () => {
   });
 
   it('injects createOpenAIClient when provided', () => {
-    const createClient = vi.fn();
+    const createClient = rs.fn();
     const manager = new ModelConfigManager(baseMap, createClient);
 
     const config = manager.getModelConfig('default');
@@ -275,23 +275,23 @@ describe('ModelConfigManager', () => {
     });
 
     it('reads per-intent timeout from environment variables', () => {
-      vi.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
-      vi.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
-      vi.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
-      vi.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
-      vi.stubEnv(MIDSCENE_MODEL_TIMEOUT, '120000');
-      vi.stubEnv(MIDSCENE_INSIGHT_MODEL_NAME, 'insight-model');
-      vi.stubEnv(
+      rs.stubEnv(MIDSCENE_MODEL_NAME, 'env-model');
+      rs.stubEnv(MIDSCENE_MODEL_API_KEY, 'env-key');
+      rs.stubEnv(MIDSCENE_MODEL_BASE_URL, 'https://env.example.com');
+      rs.stubEnv(MIDSCENE_MODEL_FAMILY, 'qwen3-vl');
+      rs.stubEnv(MIDSCENE_MODEL_TIMEOUT, '120000');
+      rs.stubEnv(MIDSCENE_INSIGHT_MODEL_NAME, 'insight-model');
+      rs.stubEnv(
         MIDSCENE_INSIGHT_MODEL_BASE_URL,
         'https://insight.example.com',
       );
-      vi.stubEnv(MIDSCENE_INSIGHT_MODEL_TIMEOUT, '180000');
-      vi.stubEnv(MIDSCENE_PLANNING_MODEL_NAME, 'planning-model');
-      vi.stubEnv(
+      rs.stubEnv(MIDSCENE_INSIGHT_MODEL_TIMEOUT, '180000');
+      rs.stubEnv(MIDSCENE_PLANNING_MODEL_NAME, 'planning-model');
+      rs.stubEnv(
         MIDSCENE_PLANNING_MODEL_BASE_URL,
         'https://planning.example.com',
       );
-      vi.stubEnv(MIDSCENE_PLANNING_MODEL_TIMEOUT, '240000');
+      rs.stubEnv(MIDSCENE_PLANNING_MODEL_TIMEOUT, '240000');
 
       const manager = new ModelConfigManager();
       manager.registerGlobalConfigManager(new GlobalConfigManager());

--- a/packages/shared/tests/unit-test/env/parse.test.ts
+++ b/packages/shared/tests/unit-test/env/parse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { version } from '../../../package.json';
 import { DEFAULT_MODEL_CONFIG_KEYS } from '../../../src/env/constants';
 import {

--- a/packages/shared/tests/unit-test/env/utils.test.ts
+++ b/packages/shared/tests/unit-test/env/utils.test.ts
@@ -1,13 +1,13 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { MIDSCENE_RUN_DIR } from '../../../src/env';
 import { getBasicEnvValue } from '../../../src/env/basic';
 
 describe('getBasicEnvValue', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
+    rs.unstubAllEnvs();
   });
   it('should return the value of the given env key', () => {
-    vi.stubEnv(MIDSCENE_RUN_DIR, '<test-run-dir>');
+    rs.stubEnv(MIDSCENE_RUN_DIR, '<test-run-dir>');
     expect(getBasicEnvValue(MIDSCENE_RUN_DIR)).toBe('<test-run-dir>');
   });
 

--- a/packages/shared/tests/unit-test/error-formatter.test.ts
+++ b/packages/shared/tests/unit-test/error-formatter.test.ts
@@ -1,5 +1,5 @@
 import { getErrorMessage } from '@/agent-tools/error-formatter';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 
 describe('getErrorMessage', () => {
   it('returns the Error.message for Error instances', () => {

--- a/packages/shared/tests/unit-test/fs.test.ts
+++ b/packages/shared/tests/unit-test/fs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { getRunningPkgInfo } from '../../src/node/fs';
 
 describe('fs', () => {

--- a/packages/shared/tests/unit-test/generate-element-by-rect.test.ts
+++ b/packages/shared/tests/unit-test/generate-element-by-rect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { generateElementByRect } from '../../src/extractor/dom-util';
 
 describe('generateElementByRect', () => {

--- a/packages/shared/tests/unit-test/iife-bundle.test.ts
+++ b/packages/shared/tests/unit-test/iife-bundle.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test } from '@rstest/core';
 
 interface GlobalWithMidscene {
   midscene_element_inspector?: {

--- a/packages/shared/tests/unit-test/image/__snapshots__/index.test.ts.snap
+++ b/packages/shared/tests/unit-test/image/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Rstest Snapshot v1
 
 exports[`image utils > jpeg + base64 + imageInfo 1`] = `400`;
 

--- a/packages/shared/tests/unit-test/image/index.test.ts
+++ b/packages/shared/tests/unit-test/image/index.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
 import sharp from 'sharp';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   compositePointMarkerImg,
   httpImg2Base64,
@@ -366,7 +366,7 @@ describe('image utils', () => {
 
   it('httpImg2Base64', async () => {
     const mockResponse = Buffer.from('image-data');
-    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+    const fetchSpy = rs.spyOn(global, 'fetch').mockResolvedValue(
       new Response(mockResponse, {
         status: 200,
         headers: { 'content-type': 'image/svg+xml' },
@@ -480,12 +480,12 @@ describe('resizeAndConvertImgBuffer', () => {
   });
 
   describe('sharp failure', () => {
-    const metadataFn = vi.fn(() => {
+    const metadataFn = rs.fn(() => {
       throw new Error('sharp is not available');
     });
 
     beforeAll(() => {
-      vi.doMock('sharp', () => ({
+      rs.doMock('sharp', () => ({
         default: () => ({
           metadata: metadataFn,
         }),
@@ -493,7 +493,7 @@ describe('resizeAndConvertImgBuffer', () => {
     });
 
     afterAll(() => {
-      vi.resetAllMocks();
+      rs.resetAllMocks();
     });
 
     it('throws instead of loading the browser image backend', async () => {

--- a/packages/shared/tests/unit-test/keyboard.test.ts
+++ b/packages/shared/tests/unit-test/keyboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { isMac, transformHotkeyInput } from '../../src/us-keyboard-layout';
 
 describe('transformHotkeyInput', () => {

--- a/packages/shared/tests/unit-test/locator-svg-multiple.test.ts
+++ b/packages/shared/tests/unit-test/locator-svg-multiple.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from '@rstest/core';
 import { getXpathsByPoint } from '../../src/extractor/locator';
 
 // Mock DOM environment for testing

--- a/packages/shared/tests/unit-test/locator-svg-xpath-index-issue.test.ts
+++ b/packages/shared/tests/unit-test/locator-svg-xpath-index-issue.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from '@rstest/core';
 import { getXpathsByPoint } from '../../src/extractor/locator';
 
 // Test the exact scenario from user's issue

--- a/packages/shared/tests/unit-test/locator-svg-xpath-query.test.ts
+++ b/packages/shared/tests/unit-test/locator-svg-xpath-query.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from '@rstest/core';
 import { getNodeInfoByXpath } from '../../src/extractor/locator';
 
 // Setup a real DOM environment with SVG elements

--- a/packages/shared/tests/unit-test/locator.test.ts
+++ b/packages/shared/tests/unit-test/locator.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import {
   getElementInfoByXpath,
   getNodeInfoByXpath,

--- a/packages/shared/tests/unit-test/logger-backpressure.test.ts
+++ b/packages/shared/tests/unit-test/logger-backpressure.test.ts
@@ -1,42 +1,42 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 
-const mocks = vi.hoisted(() => {
+const mocks = rs.hoisted(() => {
   const listeners = new Map<string, () => void>();
   const stream = {
-    end: vi.fn(),
-    on: vi.fn(),
-    once: vi.fn((event: string, listener: () => void) => {
+    end: rs.fn(),
+    on: rs.fn(),
+    once: rs.fn((event: string, listener: () => void) => {
       listeners.set(event, listener);
       return stream;
     }),
-    write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    write: rs.fn().mockReturnValueOnce(false).mockReturnValue(true),
   };
-  const createWriteStream = vi.fn(() => stream);
+  const createWriteStream = rs.fn(() => stream);
 
   return {
     createWriteStream,
-    debugFn: vi.fn(),
+    debugFn: rs.fn(),
     listeners,
     stream,
   };
 });
 
-vi.mock('debug', () => ({
-  default: vi.fn(() => mocks.debugFn),
+rs.mock('debug', () => ({
+  default: rs.fn(() => mocks.debugFn),
 }));
 
-vi.mock('node:fs', () => ({
+rs.mock('node:fs', () => ({
   default: {
     createWriteStream: mocks.createWriteStream,
   },
   createWriteStream: mocks.createWriteStream,
 }));
 
-vi.mock('../../src/common', () => ({
-  getMidsceneRunSubDir: vi.fn(() => '/tmp/midscene-log'),
+rs.mock('../../src/common', () => ({
+  getMidsceneRunSubDir: rs.fn(() => '/tmp/midscene-log'),
 }));
 
-vi.mock('../../src/utils', () => ({
+rs.mock('../../src/utils', () => ({
   ifInNode: true,
 }));
 

--- a/packages/shared/tests/unit-test/logger.test.ts
+++ b/packages/shared/tests/unit-test/logger.test.ts
@@ -1,14 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 
-const mocks = vi.hoisted(() => ({
-  debugFn: vi.fn(),
+const mocks = rs.hoisted(() => ({
+  debugFn: rs.fn(),
 }));
 
-vi.mock('debug', () => ({
-  default: vi.fn(() => mocks.debugFn),
+rs.mock('debug', () => ({
+  default: rs.fn(() => mocks.debugFn),
 }));
 
-vi.mock('../../src/utils', () => ({
+rs.mock('../../src/utils', () => ({
   ifInNode: false,
 }));
 
@@ -16,12 +16,12 @@ import { getDebug } from '../../src/logger';
 
 describe('getDebug', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
     mocks.debugFn.mockClear();
   });
 
   it('does not throw when console logging cannot write', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+    const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {
       throw new Error('write EIO');
     });
     const debugLog = getDebug('logger:test', { console: true });

--- a/packages/shared/tests/unit-test/node-cache.test.ts
+++ b/packages/shared/tests/unit-test/node-cache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
 import { getXpathsById } from '../../src/extractor/locator';
 import {
   getNodeFromCacheList,

--- a/packages/shared/tests/unit-test/observation-record.test.ts
+++ b/packages/shared/tests/unit-test/observation-record.test.ts
@@ -13,7 +13,7 @@ import {
   readUIObservationRecord,
   writeUIObservationRecord,
 } from '@/agent-tools/observation-record';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from '@rstest/core';
 
 const directories: string[] = [];
 

--- a/packages/shared/tests/unit-test/recorder.test.ts
+++ b/packages/shared/tests/unit-test/recorder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import type { MidsceneRecorderEvent } from '../../src/recorder';
 import {
   DEFAULT_MIDSCENE_RECORDER_MARKDOWN_MAX_SCREENSHOTS,

--- a/packages/shared/tests/unit-test/tool-defaults.test.ts
+++ b/packages/shared/tests/unit-test/tool-defaults.test.ts
@@ -4,7 +4,7 @@ import {
   resolveToolDefaults,
   stripBehaviorFlags,
 } from '@/agent-tools/tool-defaults';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 
 describe('mergeToolDefaults', () => {
   it('merges locate and act bags with b winning', () => {

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -20,7 +20,7 @@ import { composeUserPrompt } from '@/agent-tools/user-prompt';
 import { withCliVerboseContext } from '@/cli';
 import * as cliInterrupt from '@/cli/interrupt';
 import { createRecordCliCommand } from '@/cli/record-command';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
 const multimodalPromptSchema = z.object({
@@ -70,13 +70,13 @@ function withObservationArtifactAdapter<T extends object>(
 
 describe('generateToolsFromActionSpace', () => {
   it('passes structured locate extras through callActionInActionSpace and keeps locate options at top level', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const page = {
-      screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+      screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
     };
     const [tool] = generateToolsFromActionSpace(actionSpace, async () => ({
       callActionInActionSpace,
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page,
     }));
 
@@ -115,12 +115,12 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('normalizes string locate shorthand before direct action execution', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(actionSpace, async () => ({
       callActionInActionSpace,
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     }));
 
@@ -147,9 +147,9 @@ describe('generateToolsFromActionSpace', () => {
         },
       ],
       async () => ({
-        getActionSpace: vi.fn().mockResolvedValue([]),
+        getActionSpace: rs.fn().mockResolvedValue([]),
         page: {
-          screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+          screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
         },
       }),
     );
@@ -158,12 +158,12 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('falls back to aiAction when direct action execution is unavailable', async () => {
-    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const aiAction = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(actionSpace, async () => ({
       aiAction,
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     }));
 
@@ -179,7 +179,7 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('includes direct action return values in the tool result', async () => {
-    const callActionInActionSpace = vi
+    const callActionInActionSpace = rs
       .fn()
       .mockResolvedValue('pm clear output');
     const [tool] = generateToolsFromActionSpace(
@@ -194,9 +194,9 @@ describe('generateToolsFromActionSpace', () => {
       ],
       async () => ({
         callActionInActionSpace,
-        getActionSpace: vi.fn().mockResolvedValue([]),
+        getActionSpace: rs.fn().mockResolvedValue([]),
         page: {
-          screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+          screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
         },
       }),
     );
@@ -218,14 +218,14 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('passes raw args to the agent getter while stripping init args from action payload', async () => {
-    const callActionInActionSpace = vi
+    const callActionInActionSpace = rs
       .fn()
       .mockResolvedValue('pm clear output');
-    const getAgent = vi.fn().mockResolvedValue({
+    const getAgent = rs.fn().mockResolvedValue({
       callActionInActionSpace,
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     });
     const [tool] = generateToolsFromActionSpace(
@@ -271,9 +271,9 @@ describe('generateToolsFromActionSpace', () => {
     const [actionTool] = generateToolsFromActionSpace(
       actionSpace,
       async () => ({
-        getActionSpace: vi.fn().mockResolvedValue([]),
+        getActionSpace: rs.fn().mockResolvedValue([]),
         page: {
-          screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+          screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
         },
       }),
       undefined,
@@ -282,9 +282,9 @@ describe('generateToolsFromActionSpace', () => {
     );
     const commonTools = generateCommonTools(
       async () => ({
-        getActionSpace: vi.fn().mockResolvedValue([]),
+        getActionSpace: rs.fn().mockResolvedValue([]),
         page: {
-          screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+          screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
         },
       }),
       initArgSchema,
@@ -312,7 +312,7 @@ describe('generateToolsFromActionSpace', () => {
 
     const recordTool = createRecordCliCommand(
       async () => ({
-        getActionSpace: vi.fn().mockResolvedValue([]),
+        getActionSpace: rs.fn().mockResolvedValue([]),
       }),
       initArgSchema,
       initArgCliMetadata,
@@ -351,12 +351,12 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('includes aiAction return values in the common act tool result', async () => {
-    const aiAction = vi.fn().mockResolvedValue('Midscene');
+    const aiAction = rs.fn().mockResolvedValue('Midscene');
     const commonTools = generateCommonTools(async () => ({
       aiAction,
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
@@ -387,8 +387,8 @@ describe('generateToolsFromActionSpace', () => {
     const output = join(tempDir, 'toast-observation.json');
     const sourceFrame = join(tempDir, 'source.png');
     writeFileSync(sourceFrame, Buffer.from('recorded-frame'));
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    const exportRecord = vi.fn().mockResolvedValue({
+    const dispose = rs.fn().mockResolvedValue(undefined);
+    const exportRecord = rs.fn().mockResolvedValue({
       type: 'midscene_ui_observation',
       version: 1,
       startedAt: 50,
@@ -403,34 +403,34 @@ describe('generateToolsFromActionSpace', () => {
       shotSize: { width: 100, height: 50 },
       shrunkShotToLogicalRatio: 1,
     });
-    const stop = vi.fn().mockResolvedValue({
+    const stop = rs.fn().mockResolvedValue({
       frameCount: 1,
       startedAt: 50,
       endedAt: 150,
-      aiAssert: vi.fn(),
+      aiAssert: rs.fn(),
     });
-    const startObserving = vi.fn().mockResolvedValue({
+    const startObserving = rs.fn().mockResolvedValue({
       stop,
       bufferedFrameCount: 1,
       dispose,
     });
-    const getAgent = vi.fn(async () =>
+    const getAgent = rs.fn(async () =>
       withObservationArtifactAdapter(
         {
           startObserving,
-          getActionSpace: vi.fn().mockResolvedValue([]),
+          getActionSpace: rs.fn().mockResolvedValue([]),
           page: {
-            screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+            screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
           },
         },
         {
           exportRecord,
-          loadRecord: vi.fn(),
+          loadRecord: rs.fn(),
         },
       ),
     );
     const recordTool = createRecordCliCommand(getAgent);
-    const interruptSpy = vi
+    const interruptSpy = rs
       .spyOn(cliInterrupt, 'waitForCliInterrupt')
       .mockResolvedValue('sigint');
 
@@ -471,13 +471,13 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('fails clearly when startObserving is unavailable', async () => {
-    const consoleErrorSpy = vi
+    const consoleErrorSpy = rs
       .spyOn(console, 'error')
       .mockImplementation(() => {});
     const recordTool = createRecordCliCommand(async () => ({
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
-        screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+        screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
       },
     }));
 
@@ -503,7 +503,7 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('rejects a missing record operation before creating an agent', async () => {
-    const getAgent = vi.fn();
+    const getAgent = rs.fn();
     const recordTool = createRecordCliCommand(getAgent);
 
     const missingAction = await recordTool.handler({});
@@ -521,10 +521,10 @@ describe('generateToolsFromActionSpace', () => {
   });
 
   it('records take_screenshot in reports with the captured screenshot', async () => {
-    const screenshotBase64Fn = vi.fn().mockResolvedValue(screenshotBase64);
-    const recordToReport = vi.fn().mockResolvedValue(undefined);
+    const screenshotBase64Fn = rs.fn().mockResolvedValue(screenshotBase64);
+    const recordToReport = rs.fn().mockResolvedValue(undefined);
     const commonTools = generateCommonTools(async () => ({
-      getActionSpace: vi.fn().mockResolvedValue([]),
+      getActionSpace: rs.fn().mockResolvedValue([]),
       page: {
         screenshotBase64: screenshotBase64Fn,
       },
@@ -717,11 +717,11 @@ describe('generateCommonTools — assert image prompts', () => {
   const screenshotBase64 = 'data:image/png;base64,Zm9v';
 
   it('passes prompt through unchanged when no images are supplied', async () => {
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAssert,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assert = tools.find((t) => t.name === 'assert')!;
@@ -731,11 +731,11 @@ describe('generateCommonTools — assert image prompts', () => {
   });
 
   it('forwards the custom failure message to aiAssert', async () => {
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAssert,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assert = tools.find((t) => t.name === 'assert')!;
@@ -778,10 +778,10 @@ describe('generateCommonTools — assert image prompts', () => {
       shrunkShotToLogicalRatio: 1,
     };
     writeFileSync(recordPath, JSON.stringify(observationRecord), 'utf8');
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
-    const observationAssert = vi.fn().mockResolvedValue(undefined);
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    const loadRecord = vi.fn().mockReturnValue({
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
+    const observationAssert = rs.fn().mockResolvedValue(undefined);
+    const dispose = rs.fn().mockResolvedValue(undefined);
+    const loadRecord = rs.fn().mockReturnValue({
       frameCount: 2,
       startedAt: 50,
       endedAt: 250,
@@ -792,13 +792,13 @@ describe('generateCommonTools — assert image prompts', () => {
       withObservationArtifactAdapter(
         {
           aiAssert,
-          getActionSpace: vi.fn().mockResolvedValue([]),
+          getActionSpace: rs.fn().mockResolvedValue([]),
           page: {
-            screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64),
+            screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64),
           },
         },
         {
-          exportRecord: vi.fn(),
+          exportRecord: rs.fn(),
           loadRecord,
         },
       ),
@@ -853,14 +853,14 @@ describe('generateCommonTools — assert image prompts', () => {
       }),
       'utf8',
     );
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
-    const consoleErrorSpy = vi
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
+    const consoleErrorSpy = rs
       .spyOn(console, 'error')
       .mockImplementation(() => {});
     const tools = generateCommonTools(async () => ({
       aiAssert,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assert = tools.find((tool) => tool.name === 'assert')!;
@@ -886,11 +886,11 @@ describe('generateCommonTools — assert image prompts', () => {
   });
 
   it('forwards images to aiAssert as a TUserPrompt-style object', async () => {
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAssert,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assert = tools.find((t) => t.name === 'assert')!;
@@ -910,11 +910,11 @@ describe('generateCommonTools — assert image prompts', () => {
   });
 
   it('forwards a local-path url verbatim so core can resolve it', async () => {
-    const aiAssert = vi.fn().mockResolvedValue(undefined);
+    const aiAssert = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAssert,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assert = tools.find((t) => t.name === 'assert')!;
@@ -935,8 +935,8 @@ describe('generateCommonTools — assert image prompts', () => {
 
   it('exposes images and convertHttpImage2Base64 on the assert schema (no imageFiles flag)', () => {
     const tools = generateCommonTools(async () => ({
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const assertSchema = tools.find((t) => t.name === 'assert')!.schema;
@@ -965,11 +965,11 @@ describe('generateCommonTools — act image prompts', () => {
   const screenshotBase64 = 'data:image/png;base64,Zm9v';
 
   it('passes the prompt through unchanged when no images are supplied', async () => {
-    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const aiAction = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAction,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const act = tools.find((t) => t.name === 'act')!;
@@ -981,11 +981,11 @@ describe('generateCommonTools — act image prompts', () => {
   });
 
   it('forwards images to aiAction as a TUserPrompt-style object', async () => {
-    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const aiAction = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAction,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const act = tools.find((t) => t.name === 'act')!;
@@ -1005,11 +1005,11 @@ describe('generateCommonTools — act image prompts', () => {
   });
 
   it('forwards a local-path url verbatim so core can resolve it', async () => {
-    const aiAction = vi.fn().mockResolvedValue(undefined);
+    const aiAction = rs.fn().mockResolvedValue(undefined);
     const tools = generateCommonTools(async () => ({
       aiAction,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     const act = tools.find((t) => t.name === 'act')!;
@@ -1033,13 +1033,13 @@ describe('generateCommonTools — act image prompts', () => {
 
 describe('toolDefaults (deep locate / deep think)', () => {
   it('defaults locate.deepLocate to true for action tools when enabled', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(
       actionSpace,
       async () => ({
         callActionInActionSpace,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1058,13 +1058,13 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('keeps an explicit locate.deepLocate=false even when forced', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(
       actionSpace,
       async () => ({
         callActionInActionSpace,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1085,13 +1085,13 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('treats an explicit deepThink alias as deepLocate already set', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(
       actionSpace,
       async () => ({
         callActionInActionSpace,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1112,11 +1112,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('does not inject deepLocate for action tools when disabled', async () => {
-    const callActionInActionSpace = vi.fn().mockResolvedValue(undefined);
+    const callActionInActionSpace = rs.fn().mockResolvedValue(undefined);
     const [tool] = generateToolsFromActionSpace(actionSpace, async () => ({
       callActionInActionSpace,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
 
     await tool.handler({ locate: 'the login button' });
@@ -1127,12 +1127,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('passes deepLocate to the act tool when enabled', async () => {
-    const aiAction = vi.fn().mockResolvedValue('done');
+    const aiAction = rs.fn().mockResolvedValue('done');
     const commonTools = generateCommonTools(
       async () => ({
         aiAction,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1155,7 +1155,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let progressListener:
       | ((event: Record<string, unknown>) => void)
       | undefined;
-    const unsubscribe = vi.fn();
+    const unsubscribe = rs.fn();
     const reportFile = join(
       process.cwd(),
       'midscene_run/report/midscene-report.html',
@@ -1337,7 +1337,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
         tasks,
       });
     };
-    const aiAction = vi.fn().mockImplementation(async () => {
+    const aiAction = rs.fn().mockImplementation(async () => {
       emitProgress({
         event: 'start',
         prompt: 'open settings',
@@ -1437,11 +1437,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       emitDump([plan1, locate1, tapFinished, plan2, sleepFinished, plan3]);
       return 'Settings opened.';
     });
-    const addDumpUpdateListener = vi.fn((listener) => {
+    const addDumpUpdateListener = rs.fn((listener) => {
       dumpListener = listener;
       return unsubscribe;
     });
-    const addProgressListener = vi.fn((listener) => {
+    const addProgressListener = rs.fn((listener) => {
       progressListener = listener;
       return unsubscribe;
     });
@@ -1450,11 +1450,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       addProgressListener,
       addDumpUpdateListener,
       reportFile,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await withCliVerboseContext(
       {
@@ -1523,17 +1523,17 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('does not render aiAct dump progress without core progress listener', async () => {
-    const unsubscribe = vi.fn();
-    const aiAction = vi.fn().mockResolvedValue('Settings opened.');
-    const addDumpUpdateListener = vi.fn(() => unsubscribe);
+    const unsubscribe = rs.fn();
+    const aiAction = rs.fn().mockResolvedValue('Settings opened.');
+    const addDumpUpdateListener = rs.fn(() => unsubscribe);
     const commonTools = generateCommonTools(async () => ({
       aiAction,
       addDumpUpdateListener,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await withCliVerboseContext(
       {
@@ -1564,7 +1564,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let progressListener:
       | ((event: Record<string, unknown>) => void)
       | undefined;
-    const unsubscribe = vi.fn();
+    const unsubscribe = rs.fn();
     const reportFile = join(
       process.cwd(),
       'midscene_run/report/midscene-report.html',
@@ -1579,7 +1579,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
         data,
       });
     };
-    const aiAction = vi.fn().mockImplementation(async () => {
+    const aiAction = rs.fn().mockImplementation(async () => {
       emitProgress({
         event: 'start',
         prompt: 'open settings',
@@ -1639,11 +1639,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       });
       throw new Error('Task failed: The settings entry is not visible.');
     });
-    const addDumpUpdateListener = vi.fn((listener) => {
+    const addDumpUpdateListener = rs.fn((listener) => {
       dumpListener = listener;
       return unsubscribe;
     });
-    const addProgressListener = vi.fn((listener) => {
+    const addProgressListener = rs.fn((listener) => {
       progressListener = listener;
       return unsubscribe;
     });
@@ -1652,12 +1652,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
       addProgressListener,
       addDumpUpdateListener,
       reportFile,
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const consoleErrorSpy = vi
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = rs
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
@@ -1698,7 +1698,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let progressListener:
       | ((event: Record<string, unknown>) => void)
       | undefined;
-    const unsubscribe = vi.fn();
+    const unsubscribe = rs.fn();
     const inlineScreenshot = {
       extension: 'png',
       rawBase64: 'Zm9v',
@@ -1710,7 +1710,7 @@ describe('toolDefaults (deep locate / deep think)', () => {
         storage: 'inline',
       }),
     };
-    const aiAction = vi.fn().mockImplementation(async () => {
+    const aiAction = rs.fn().mockImplementation(async () => {
       progressListener?.({
         scope: 'aiAct',
         sequence: 1,
@@ -1744,11 +1744,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       });
       return 'done';
     });
-    const addDumpUpdateListener = vi.fn((listener) => {
+    const addDumpUpdateListener = rs.fn((listener) => {
       dumpListener = listener;
       return unsubscribe;
     });
-    const addProgressListener = vi.fn((listener) => {
+    const addProgressListener = rs.fn((listener) => {
       progressListener = listener;
       return unsubscribe;
     });
@@ -1757,11 +1757,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       addProgressListener,
       addDumpUpdateListener,
       reportFile: '/tmp/midscene-report.html',
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await withCliVerboseContext(
       {
@@ -1802,8 +1802,8 @@ describe('toolDefaults (deep locate / deep think)', () => {
     let progressListener:
       | ((event: Record<string, unknown>) => void)
       | undefined;
-    const unsubscribe = vi.fn();
-    const aiAction = vi.fn().mockImplementation(async () => {
+    const unsubscribe = rs.fn();
+    const aiAction = rs.fn().mockImplementation(async () => {
       progressListener?.({
         scope: 'aiAct',
         sequence: 1,
@@ -1823,8 +1823,8 @@ describe('toolDefaults (deep locate / deep think)', () => {
       });
       return 'done';
     });
-    const addDumpUpdateListener = vi.fn(() => unsubscribe);
-    const addProgressListener = vi.fn((listener) => {
+    const addDumpUpdateListener = rs.fn(() => unsubscribe);
+    const addProgressListener = rs.fn((listener) => {
       progressListener = listener;
       return unsubscribe;
     });
@@ -1833,11 +1833,11 @@ describe('toolDefaults (deep locate / deep think)', () => {
       addProgressListener,
       addDumpUpdateListener,
       reportFile: '/tmp/midscene-report.html',
-      getActionSpace: vi.fn().mockResolvedValue([]),
-      page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+      getActionSpace: rs.fn().mockResolvedValue([]),
+      page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
     }));
     const actTool = commonTools.find((tool) => tool.name === 'act');
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     await withCliVerboseContext(
       {
@@ -1891,12 +1891,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('lets an explicit act deepLocate arg override the server default', async () => {
-    const aiAction = vi.fn().mockResolvedValue('done');
+    const aiAction = rs.fn().mockResolvedValue('done');
     const commonTools = generateCommonTools(
       async () => ({
         aiAction,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1913,12 +1913,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('plans the act tool with deepThink when enabled', async () => {
-    const aiAction = vi.fn().mockResolvedValue('done');
+    const aiAction = rs.fn().mockResolvedValue('done');
     const commonTools = generateCommonTools(
       async () => ({
         aiAction,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1934,12 +1934,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('lets an explicit act deepThink arg override the server default', async () => {
-    const aiAction = vi.fn().mockResolvedValue('done');
+    const aiAction = rs.fn().mockResolvedValue('done');
     const commonTools = generateCommonTools(
       async () => ({
         aiAction,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,
@@ -1955,12 +1955,12 @@ describe('toolDefaults (deep locate / deep think)', () => {
   });
 
   it('applies both locate and act defaults together', async () => {
-    const aiAction = vi.fn().mockResolvedValue('done');
+    const aiAction = rs.fn().mockResolvedValue('done');
     const commonTools = generateCommonTools(
       async () => ({
         aiAction,
-        getActionSpace: vi.fn().mockResolvedValue([]),
-        page: { screenshotBase64: vi.fn().mockResolvedValue(screenshotBase64) },
+        getActionSpace: rs.fn().mockResolvedValue([]),
+        page: { screenshotBase64: rs.fn().mockResolvedValue(screenshotBase64) },
       }),
       undefined,
       undefined,

--- a/packages/shared/tests/unit-test/transform.test.ts
+++ b/packages/shared/tests/unit-test/transform.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 import {
   inferBase64ImageFormat,
   normalizeBase64Image,
@@ -58,7 +58,7 @@ describe('preapareImageUrl', () => {
 
   it('http url will be converted to base64 if convertHttpImage2Base64 is true', async () => {
     const mockData = Buffer.from('image-data');
-    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+    const fetchSpy = rs.spyOn(global, 'fetch').mockResolvedValue(
       new Response(mockData, {
         status: 200,
         headers: { 'content-type': 'image/svg+xml' },
@@ -181,7 +181,7 @@ describe('scaleImage', () => {
   it('should throw when Sharp is unavailable in Node.js', async () => {
     // Mock getSharp to throw an error
     const getSharpModule = await import('../../src/img/get-sharp');
-    vi.spyOn(getSharpModule, 'default').mockRejectedValue(
+    rs.spyOn(getSharpModule, 'default').mockRejectedValue(
       new Error('Sharp not available'),
     );
 
@@ -189,23 +189,23 @@ describe('scaleImage', () => {
       'Sharp not available',
     );
 
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   it('should throw when Sharp fails during processing in Node.js', async () => {
     // Mock getSharp to return a mock Sharp that throws during processing
     const getSharpModule = await import('../../src/img/get-sharp');
-    const mockSharp = vi.fn(() => {
+    const mockSharp = rs.fn(() => {
       throw new Error('Sharp processing failed');
     });
 
-    vi.spyOn(getSharpModule, 'default').mockResolvedValue(mockSharp as any);
+    rs.spyOn(getSharpModule, 'default').mockResolvedValue(mockSharp as any);
 
     await expect(scaleImage(onePixelWhiteImage, 3)).rejects.toThrow(
       'Sharp processing failed',
     );
 
     // Restore
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 });

--- a/packages/shared/tests/unit-test/tree.test.ts
+++ b/packages/shared/tests/unit-test/tree.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { NodeType } from '../../src/constants';
 import { descriptionOfTree } from '../../src/extractor/tree';
 

--- a/packages/shared/tests/unit-test/utils.test.ts
+++ b/packages/shared/tests/unit-test/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import {
   mergeAndNormalizeAppNameMapping,
   normalizeForComparison,

--- a/packages/shared/tests/unit-test/zod-schema-utils.test.ts
+++ b/packages/shared/tests/unit-test/zod-schema-utils.test.ts
@@ -4,7 +4,7 @@ import {
   isMidsceneLocatorField,
   unwrapZodField,
 } from '@/zod-schema-utils';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from '@rstest/core';
 import { z } from 'zod';
 
 describe('zod-schema-utils', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.62))(typescript@5.8.3)
+      '@rstest/core':
+        specifier: 0.11.5
+        version: 0.11.5(core-js@3.47.0)(jsdom@29.0.2)
       '@types/node':
         specifier: ^18.0.0
         version: 18.19.62
@@ -706,9 +709,6 @@ importers:
       undici:
         specifier: ^6.0.0
         version: 6.22.0
-      vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
       zod:
         specifier: ^3.25.1
         version: 3.25.76
@@ -890,6 +890,9 @@ importers:
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.118))(typescript@5.8.3)
+      '@rstest/core':
+        specifier: 0.11.5
+        version: 0.11.5(core-js@3.47.0)(jsdom@29.0.2)
       '@types/node':
         specifier: ^18.0.0
         version: 18.19.118
@@ -905,9 +908,6 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
-      vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.118)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
 
   packages/computer-linux:
     dependencies:
@@ -1147,6 +1147,9 @@ importers:
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.118))(typescript@5.8.3)
+      '@rstest/core':
+        specifier: 0.11.5
+        version: 0.11.5(core-js@3.47.0)(jsdom@29.0.2)
       '@types/node':
         specifier: ^18.0.0
         version: 18.19.118
@@ -1159,9 +1162,6 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
-      vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.118)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
       zod:
         specifier: ^3.25.1
         version: 3.25.76
@@ -1356,6 +1356,9 @@ importers:
       '@rslib/core':
         specifier: ^0.18.3
         version: 0.18.3(@microsoft/api-extractor@7.52.10(@types/node@18.19.62))(typescript@5.8.3)
+      '@rstest/core':
+        specifier: 0.11.5
+        version: 0.11.5(core-js@3.47.0)(jsdom@29.0.2)
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -1374,9 +1377,6 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
-      vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
 
   packages/visualizer:
     dependencies:
@@ -15402,14 +15402,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1))':
-    dependencies:
-      '@vitest/spy': 3.0.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
-
   '@vitest/mocker@3.0.5(vite@5.4.10(@types/node@18.19.130)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1))':
     dependencies:
       '@vitest/spy': 3.0.5
@@ -23505,24 +23497,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.5(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@3.0.5(@types/node@18.19.130)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
@@ -23559,19 +23533,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.24.3
-    optionalDependencies:
-      '@types/node': 18.19.118
-      fsevents: 2.3.3
-      less: 4.3.0
-      lightningcss: 1.30.1
-      sass-embedded: 1.86.3
-      terser: 5.46.1
-
   vite@5.4.10(@types/node@18.19.130)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
     dependencies:
       esbuild: 0.21.5
@@ -23597,43 +23558,6 @@ snapshots:
       lightningcss: 1.30.1
       sass-embedded: 1.86.3
       terser: 5.46.1
-
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.118)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
-    dependencies:
-      '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1))
-      '@vitest/pretty-format': 3.1.1
-      '@vitest/runner': 3.0.5
-      '@vitest/snapshot': 3.0.5
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
-      chai: 5.2.0
-      debug: 4.4.0
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 5.4.10(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
-      vite-node: 3.0.5(@types/node@18.19.118)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 18.19.118
-      jsdom: 29.0.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.130)(jsdom@29.0.2)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.46.1):
     dependencies:

--- a/scripts/rstest-shared.ts
+++ b/scripts/rstest-shared.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared building blocks for the per-package `rstest.config.ts` files, so the
+ * same boilerplate is defined once instead of copy-pasted across packages.
+ */
+
+/**
+ * Externalize the photon native addon. Rspack cannot bundle its prebuilt
+ * binary, so every node-target test config marks it as a CommonJS external.
+ */
+export const photonExternal = {
+  '@silvia-odwyer/photon': 'commonjs @silvia-odwyer/photon',
+} as const;
+
+/**
+ * Build the `source.define` entry that injects a package version as the
+ * `__VERSION__` global. Centralizes the encoding so configs don't drift between
+ * `` `'${version}'` `` and `JSON.stringify(version)`.
+ */
+export function defineVersion(version: string): { __VERSION__: string } {
+  return { __VERSION__: JSON.stringify(version) };
+}

--- a/scripts/rstest-style-stub.ts
+++ b/scripts/rstest-style-stub.ts
@@ -1,3 +1,5 @@
+import type { Rspack, RstestConfig } from '@rstest/core';
+
 /**
  * Makes `.less` imports inert during rstest runs.
  *
@@ -27,11 +29,11 @@
  */
 export const stubStyleRules = {
   tools: {
-    rspack: (config: any) => {
+    rspack: (config: Rspack.Configuration) => {
       config.module ??= {};
       config.module.rules ??= [];
       config.module.rules.push({ test: /\.less$/, type: 'asset/source' });
       return config;
     },
   },
-};
+} satisfies Pick<RstestConfig, 'tools'>;

--- a/scripts/type-check-tests.mjs
+++ b/scripts/type-check-tests.mjs
@@ -45,10 +45,21 @@ const projects = readWorkspacePatterns()
   )
   .sort();
 
-function typeCheckProject(project) {
-  const projectPath = join(workspaceRoot, project);
-  const projectConfig = join(projectPath, 'tsconfig.json');
+// `scripts/**` and the per-project `rstest.config.ts` files sit outside every
+// package tsconfig's `include`, so nothing type-checked them until this entry
+// was added. A misplaced config key used to reach CI unnoticed.
+const targets = [
+  {
+    name: 'workspace tools',
+    config: join(workspaceRoot, 'tsconfig.tools.json'),
+  },
+  ...projects.map((project) => ({
+    name: project,
+    config: join(workspaceRoot, project, 'tsconfig.json'),
+  })),
+];
 
+function typeCheckProject({ name: project, config: projectConfig }) {
   return new Promise((resolve) => {
     let output = '';
     const child = spawn(
@@ -80,8 +91,8 @@ async function runTypeChecks() {
   const running = new Set();
   const results = [];
 
-  for (const project of projects) {
-    const task = typeCheckProject(project).then((result) => {
+  for (const target of targets) {
+    const task = typeCheckProject(target).then((result) => {
       running.delete(task);
       results.push(result);
 

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2020",
+    "types": ["node"]
+  },
+  "include": [
+    "scripts/**/*.ts",
+    "packages/*/rstest.config.ts",
+    "apps/*/rstest.config.ts"
+  ]
+}


### PR DESCRIPTION
Third batch of the vitest 3.0.5 -> rstest 0.11.5 migration, after #2921 and #2945: `shared`, `computer`, `android`, `ios`. 118 test files. Remaining after this: `cli` + `web-integration`, then `core`, then `studio` plus the vitest teardown.
All but five files are a pure `vitest` -> `@rstest/core` specifier swap plus `vi.` -> `rs.`. Those five are under "What actually needs eyes".

Test discovery is unchanged: **80 files / 1089 cases before and after** on the default unit include, and not just the totals — I diffed the full `file > test name` list from `rstest list` against `vitest list` on a worktree of the pre-migration tree, across all nine include modes these packages have (unit plus each `AITEST` / `AI_TEST_TYPE`). Every mode is identical. The AI suites need real devices and models so they are not executed here, but `rstest list` compiles them, which is what caught two of the type problems below.

## Performance

Roughly break-even overall, with the win concentrated in `shared`. Median of 3 runs per cell, runners alternated each round so machine drift hits both equally; cold clears the bundler caches first. Apple M3 Max, Node 26.5.0, both runners exit 0 on every sample.

| Package | Cold vitest | Cold rstest | | Warm vitest | Warm rstest | |
| :-- | --: | --: | --: | --: | --: | --: |
| shared | 2.96s | 1.66s | **1.78x** | 2.88s | 1.41s | **2.04x** |
| computer | 11.92s | 10.73s | 1.11x | 11.60s | 10.96s | 1.06x |
| android | 13.44s | 12.70s | 1.06x | 13.45s | 12.73s | 1.06x |
| ios | 18.04s | 18.30s | 0.99x | 17.83s | 18.14s | 0.98x |
| **total** | **46.36s** | **43.39s** | **1.07x** | **45.76s** | **43.24s** | **1.06x** |

The spread follows the same rule the `chrome-extension` result in #2945 did: **the gain tracks the compile-to-execute ratio, not the file count.** rstest's advantage is compilation, so a suite that barely compiles and mostly waits has nothing to win. rstest reports the split itself:

| Package | build | tests | build share |
| :-- | --: | --: | --: |
| shared | 71ms | 886ms | 7.4% |
| computer | 219ms | 10.1s | 2.1% |
| android | 275ms | 12.8s | 2.1% |
| ios | 229ms | 17.2s | 1.3% |

`shared` is 441 fast pure-function tests where compilation is the dominant movable cost, and it doubles warm. `ios` spends 1.3% of its run building, which caps any bundler-side gain at about 1.3% — inside the noise. Measured file by file, `device.test.ts` alone takes 17.38s wall while the whole package takes 17.4s, so it is the critical path; inside it the 48 cases account for only 2.26s and the remaining ~15s is `afterEach` calling `await device.destroy()` 48 times against a `src/device.ts` that sleeps for real (`sleep(100)`, `sleep(500)`, `sleep(800)`, `sleep(2000)`). `computer` and `android` are the same shape.

These four are here for uniformity, not speed; the batches that moved the needle were the cold ones in #2945. Unit tests only — `tests/ai/**` is outside the default include, so no model or network calls are involved.

## What actually needs eyes

**Async mock factories have no rstest equivalent** (android, 3 sites). rstest's `MockFactory` is synchronous, so `vi.mock('x', async (importOriginal) => ...)` is a hard error. `page.test.ts` (x2) and `scrcpy-adapter.test.ts` move to the import-attribute recipe `harmony` already uses in #2945:

```ts
import * as fsActual from 'node:fs' with { rstest: 'importActual' };
rs.mock('node:fs', () => { const original = fsActual; /* ... */ });
```

**`ios/tests/unit-test/agent.test.ts` stops mocking the device-class override.** Two blockers stack: `agentFromWebDriverAgent` resolves the override through `await import(overrideModule)` where the specifier is a user-supplied runtime value, which rstest's build-time mock transform cannot reach (web-infra-dev/rstest#1454); and rstest has no virtual-module mocking, its `MockModuleOptions` being only `{ spy: true } | { mock: true }`. The two cases now point at real `.mjs` fixtures and observe them through a global counter. Nothing is skipped, and the suite gains an assertion that the default device class stays unused, which the mock-based version could not express.

Worth knowing: the old code cast `vi.doMock` to a signature vitest does not have — `{ virtual: true }` is a Jest option, vitest's `MockOptions` is `{ spy?: boolean }`. Dropping that argument on the pre-migration tree leaves all 13 cases green, so it was decorative, and it meant the two success-path cases never exercised real module resolution while the failure-path case did.

**A dead flag, removed rather than translated.** `android`, `ios` and `harmony` carried `errors: process.env.CI ? { unhandled: false } : undefined`, translated from `dangerouslyIgnoreUnhandledErrors`. It never did that job: in rstest 0.11.5 `errors.unhandled` belongs to `MdReporterOptions`, not the top-level config, so at most it decides whether the markdown reporter prints an error section. A passing test that leaks a rejection exits 1 with the field and without it.

This PR deletes it instead of looking for a working equivalent. The flag was inherited rather than earned — its comment blames `showcase.test.ts`, a path that has never existed anywhere in this repository's history, and the teardowns it was meant to cover already await their work inside `try`/`catch`. Suppressing unhandled rejections hides exactly the failures worth seeing; if CI surfaces one, the leak is the thing to fix. `harmony` is included because the same line landed with #2945, inert there too.

**Three type errors nothing was checking.** The AI suites are compiled but not type-checked by lint or `nx test`, so these only surface under `tsc`:

- `android/tests/ai/merge-reports.test.ts` read `ctx.task.result.state` and `.startTime`; rstest names the field `status` and carries no start timestamp, so the duration now uses the `performance.now()` stamp the suite already takes.
- `computer/tests/ai/chrome-extension-bridge.test.ts` passed `{ timeout: 20 * 60 * 1000, retry: 0 }` as the third argument. rstest takes options in the second position; in the third it is **silently ignored**, so that suite would have quietly fallen back to the config's 3-minute `testTimeout`.
- `android/tsconfig.json` pinned `module: ES2020`, which rejects the import-attribute syntax. The pin moves to `tsconfig.build.json` so the production build keeps its module semantics while tests inherit `ESNext`. A stale `tsconfig.tsbuildinfo` masks this one if you reproduce locally.

**Nothing type-checked the tooling.** The misplaced `errors` key survived because `scripts/**` and every `rstest.config.ts` sit outside all package tsconfig `include` lists. `tsconfig.tools.json` now covers both and runs first in `pnpm run type-check:tests`; putting the bad key back produces `TS2769` at that line.

## Config translation

`test.*` moves to the top level, `ssr.external` -> `output.externals`, `define` -> `source.define`, `fileParallelism: false` -> `pool: { maxWorkers: 1 }` (computer, android). `computer`'s explicit `environment: 'node'` is kept as `testEnvironment: 'node'` rather than dropped as redundant.

`scripts/rstest-shared.ts` is new: the photon external and the `__VERSION__` define were repeated verbatim in every node-target config, so with five consumers they are defined once and `harmony` moves over too. Deferred from #2945, where `harmony` was the only consumer.

Also here, the follow-ups from the #2945 review: `harmony/tsconfig.build.json` pins `module: ES2020` again so the production build is decoupled from test-only syntax, two stale `@ts-ignore` comments are gone, and `scripts/rstest-style-stub.ts` types its rspack callback as `Rspack.Configuration` — the suggested `satisfies Pick<RstestConfig, 'tools'>` alone catches nothing there, because `tools.rspack` is a `ConfigChain` union.
