### PR TITLE
fix(harmony): resolve declared app launch ability

### DIFF
--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -328,22 +328,7 @@ export class HarmonyDevice implements AbstractInterface {
       } else {
         // Bundle name or app name
         const bundleName = this.resolvePackageName(uri) ?? uri;
-        try {
-          await hdc.startAbility(bundleName, 'EntryAbility');
-        } catch (e: any) {
-          if (!e.message?.includes('resolve ability')) throw e;
-          // EntryAbility not found, auto-discover the main ability
-          const mainAbility = await hdc.queryMainAbility(bundleName);
-          if (!mainAbility) {
-            throw new Error(
-              `Cannot find a launchable ability for ${bundleName}`,
-            );
-          }
-          debugDevice(
-            `EntryAbility not found, using discovered ability: ${mainAbility}`,
-          );
-          await hdc.startAbility(bundleName, mainAbility);
-        }
+        await hdc.launchBundle(bundleName);
       }
       debugDevice(`Successfully launched: ${uri}`);
     } catch (error: any) {

--- a/packages/harmony/src/hdc.ts
+++ b/packages/harmony/src/hdc.ts
@@ -55,6 +55,121 @@ export interface HdcOptions {
   timeout?: number;
 }
 
+interface HarmonyAbilityTarget {
+  readonly abilityName: string;
+  readonly moduleName: string;
+}
+
+interface BundleAbilityInfo {
+  name?: string;
+  skills?: Array<{
+    actions?: string[];
+    entities?: string[];
+  }>;
+}
+
+interface BundleModuleInfo {
+  abilityInfos?: BundleAbilityInfo[];
+  extensionInfos?: Array<{ name?: string }>;
+  mainAbility?: string;
+  mainElementName?: string;
+  moduleName?: string;
+  moduleType?: number | string;
+  name?: string;
+}
+
+interface BundleInfo {
+  entryModuleName?: string;
+  hapModuleInfos?: BundleModuleInfo[];
+  mainEntry?: string;
+}
+
+function parseBundleInfo(output: string, bundleName: string): BundleInfo {
+  const jsonStart = output.indexOf('{');
+  if (jsonStart < 0) {
+    throw new Error(`Cannot parse bundle information for ${bundleName}`);
+  }
+
+  try {
+    return JSON.parse(output.slice(jsonStart)) as BundleInfo;
+  } catch (error) {
+    throw new Error(`Cannot parse bundle information for ${bundleName}`, {
+      cause: error,
+    });
+  }
+}
+
+function isLauncherAbility(ability: BundleAbilityInfo): boolean {
+  return Boolean(
+    ability.skills?.some(
+      (skill) =>
+        skill.entities?.includes('entity.system.home') &&
+        skill.actions?.some(
+          (action) =>
+            action === 'action.system.home' ||
+            action === 'ohos.want.action.home',
+        ),
+    ),
+  );
+}
+
+function resolveModuleName(module: BundleModuleInfo): string | undefined {
+  return [module.moduleName, module.name].find((name): name is string =>
+    Boolean(name),
+  );
+}
+
+function componentNamesMatch(left: string, right: string): boolean {
+  return (
+    left === right || left.endsWith(`.${right}`) || right.endsWith(`.${left}`)
+  );
+}
+
+function declaredTargetFromModule(
+  module: BundleModuleInfo,
+): HarmonyAbilityTarget | undefined {
+  const moduleName = resolveModuleName(module);
+  if (!moduleName) return undefined;
+
+  const abilities = module.abilityInfos ?? [];
+  const declaredAbilityName = [module.mainElementName, module.mainAbility].find(
+    (name): name is string => Boolean(name),
+  );
+
+  if (declaredAbilityName) {
+    const matchedAbility = abilities.find(
+      (ability) =>
+        ability.name && componentNamesMatch(ability.name, declaredAbilityName),
+    );
+    const isDeclaredExtension = module.extensionInfos?.some(
+      (extension) =>
+        extension.name &&
+        componentNamesMatch(extension.name, declaredAbilityName),
+    );
+    if (!matchedAbility && (abilities.length > 0 || isDeclaredExtension)) {
+      return undefined;
+    }
+    return {
+      abilityName: matchedAbility?.name ?? declaredAbilityName,
+      moduleName,
+    };
+  }
+
+  return undefined;
+}
+
+function launcherTargetFromModule(
+  module: BundleModuleInfo,
+): HarmonyAbilityTarget | undefined {
+  const moduleName = resolveModuleName(module);
+  if (!moduleName) return undefined;
+
+  const launcherAbility = module.abilityInfos?.find(isLauncherAbility);
+  return launcherAbility?.name
+    ? { abilityName: launcherAbility.name, moduleName }
+    : undefined;
+}
+
 function resolveHdcPath(hdcPath?: string): string {
   if (hdcPath) return hdcPath;
 
@@ -85,6 +200,7 @@ export class HdcClient {
   private deviceId: string;
   private timeout: number;
   private execMutex: Promise<void> = Promise.resolve();
+  private launchAbilityCache = new Map<string, HarmonyAbilityTarget>();
 
   constructor(options: HdcOptions) {
     this.hdcPath = resolveHdcPath(options.hdcPath);
@@ -347,9 +463,14 @@ export class HdcClient {
     this.assertUiInputSucceeded('clearTextField', output);
   }
 
-  async startAbility(bundleName: string, abilityName: string): Promise<void> {
+  async startAbility(
+    bundleName: string,
+    abilityName: string,
+    moduleName?: string,
+  ): Promise<void> {
+    const moduleArg = moduleName ? ` -m ${moduleName}` : '';
     const output = await this.shell(
-      `aa start -a ${abilityName} -b ${bundleName}`,
+      `aa start -a ${abilityName} -b ${bundleName}${moduleArg}`,
     );
     if (output.includes('error:')) {
       throw new Error(
@@ -358,30 +479,94 @@ export class HdcClient {
     }
   }
 
-  async queryMainAbility(bundleName: string): Promise<string | undefined> {
+  private async queryLaunchAbility(
+    bundleName: string,
+  ): Promise<HarmonyAbilityTarget> {
     const output = await this.shell(`bm dump -n ${bundleName}`);
-    const names: string[] = [];
-    for (const match of output.matchAll(/"name"\s*:\s*"([^"]+)"/g)) {
-      names.push(match[1]);
-    }
-    // Prefer: EntryAbility > MainAbility > {bundleName}.MainAbility > first *Ability
-    for (const candidate of [
-      'EntryAbility',
-      'MainAbility',
-      `${bundleName}.MainAbility`,
-    ]) {
-      if (names.includes(candidate)) return candidate;
-    }
-    // Fallback: find first ability-like name that isn't the bundle itself
-    return names.find(
-      (n) =>
-        n !== bundleName &&
-        n.endsWith('Ability') &&
-        !n.includes('Extension') &&
-        !n.includes('Service') &&
-        !n.includes('Form') &&
-        !n.includes('Dialog'),
+    const bundleInfo = parseBundleInfo(output, bundleName);
+    const modules = bundleInfo.hapModuleInfos ?? [];
+    const entryModuleNames = new Set(
+      [bundleInfo.entryModuleName, bundleInfo.mainEntry].filter(
+        (name): name is string => Boolean(name),
+      ),
     );
+    const preferredModules = modules.filter(
+      (module) =>
+        entryModuleNames.has(module.moduleName ?? '') ||
+        entryModuleNames.has(module.name ?? ''),
+    );
+    const entryModules = modules.filter(
+      (module) =>
+        !preferredModules.includes(module) &&
+        (module.moduleType === 1 || module.moduleType === 'entry'),
+    );
+    const remainingModules = modules.filter(
+      (module) =>
+        !preferredModules.includes(module) && !entryModules.includes(module),
+    );
+
+    const entryModulesByPriority = [...preferredModules, ...entryModules];
+    for (const module of entryModulesByPriority) {
+      const target = declaredTargetFromModule(module);
+      if (target) return target;
+    }
+
+    for (const module of entryModulesByPriority) {
+      const target = launcherTargetFromModule(module);
+      if (target) return target;
+    }
+
+    for (const module of remainingModules) {
+      const target = launcherTargetFromModule(module);
+      if (target) return target;
+    }
+
+    for (const module of remainingModules) {
+      const target = declaredTargetFromModule(module);
+      if (target) return target;
+    }
+
+    throw new Error(`Cannot find a launchable ability for ${bundleName}`);
+  }
+
+  /**
+   * Launch an app by bundle name using its system-declared entry ability.
+   * Successful resolutions are cached for this HDC connection. If a cached
+   * target becomes stale, it is queried again and retried only when it changed.
+   */
+  async launchBundle(bundleName: string): Promise<void> {
+    const cachedTarget = this.launchAbilityCache.get(bundleName);
+    const target = cachedTarget ?? (await this.queryLaunchAbility(bundleName));
+
+    try {
+      await this.startAbility(
+        bundleName,
+        target.abilityName,
+        target.moduleName,
+      );
+      this.launchAbilityCache.set(bundleName, target);
+    } catch (error) {
+      this.launchAbilityCache.delete(bundleName);
+      if (!cachedTarget) throw error;
+
+      const refreshedTarget = await this.queryLaunchAbility(bundleName);
+      if (
+        refreshedTarget.abilityName === cachedTarget.abilityName &&
+        refreshedTarget.moduleName === cachedTarget.moduleName
+      ) {
+        throw error;
+      }
+
+      debugHdc(
+        `Cached launch ability changed from ${cachedTarget.moduleName}/${cachedTarget.abilityName} to ${refreshedTarget.moduleName}/${refreshedTarget.abilityName}`,
+      );
+      await this.startAbility(
+        bundleName,
+        refreshedTarget.abilityName,
+        refreshedTarget.moduleName,
+      );
+      this.launchAbilityCache.set(bundleName, refreshedTarget);
+    }
   }
 
   async forceStop(bundleName: string): Promise<void> {

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -21,7 +21,7 @@ const mockHdc = {
     ),
   fileRecv: rs.fn().mockResolvedValue(undefined),
   startAbility: rs.fn().mockResolvedValue(undefined),
-  queryMainAbility: rs.fn().mockResolvedValue(undefined),
+  launchBundle: rs.fn().mockResolvedValue(undefined),
   forceStop: rs.fn().mockResolvedValue(undefined),
   clearTextField: rs.fn().mockResolvedValue(undefined),
 };
@@ -497,12 +497,10 @@ describe('HarmonyDevice', () => {
       );
     });
 
-    it('should use startAbility with EntryAbility for plain bundle name', async () => {
+    it('should launch a plain bundle name through HDC bundle resolution', async () => {
       await device.launch('com.example.app');
-      expect(mockHdc.startAbility).toHaveBeenCalledWith(
-        'com.example.app',
-        'EntryAbility',
-      );
+
+      expect(mockHdc.launchBundle).toHaveBeenCalledWith('com.example.app');
     });
 
     it('should throw with descriptive error on launch failure', async () => {
@@ -769,9 +767,8 @@ describe('HarmonyDevice', () => {
         browser: 'com.huawei.hmos.browser',
       });
       await device.launch('Browser');
-      expect(mockHdc.startAbility).toHaveBeenCalledWith(
+      expect(mockHdc.launchBundle).toHaveBeenCalledWith(
         'com.huawei.hmos.browser',
-        'EntryAbility',
       );
     });
 
@@ -779,10 +776,7 @@ describe('HarmonyDevice', () => {
       await device.connect();
       device.setAppNameMapping({});
       await device.launch('com.unknown.app');
-      expect(mockHdc.startAbility).toHaveBeenCalledWith(
-        'com.unknown.app',
-        'EntryAbility',
-      );
+      expect(mockHdc.launchBundle).toHaveBeenCalledWith('com.unknown.app');
     });
   });
 

--- a/packages/harmony/tests/unit-test/fixtures/bm-dump-camera.txt
+++ b/packages/harmony/tests/unit-test/fixtures/bm-dump-camera.txt
@@ -1,0 +1,90 @@
+com.huawei.hmos.camera:
+{
+  "entryModuleName": "phone",
+  "mainEntry": "phone",
+  "hapModuleInfos": [
+    {
+      "moduleName": "phone",
+      "name": "phone",
+      "moduleType": 1,
+      "mainElementName": "com.huawei.hmos.camera.MainAbility",
+      "mainAbility": "com.huawei.hmos.camera.MainAbility",
+      "abilityInfos": [
+        {
+          "name": "com.huawei.hmos.camera.CollaborationAbility",
+          "moduleName": "phone",
+          "isLauncherAbility": false,
+          "skills": []
+        },
+        {
+          "name": "com.huawei.hmos.camera.MainAbility",
+          "moduleName": "phone",
+          "isLauncherAbility": false,
+          "skills": [
+            {
+              "actions": [
+                "action.system.home",
+                "ohos.want.action.home"
+              ],
+              "entities": [
+                "entity.system.home"
+              ]
+            }
+          ]
+        }
+      ],
+      "extensionInfos": [
+        {
+          "name": "AccessAbility",
+          "moduleName": "phone",
+          "extensionTypeName": "sys/commonUI"
+        },
+        {
+          "name": "BackupExtensionAbility",
+          "moduleName": "phone",
+          "extensionTypeName": "backup"
+        },
+        {
+          "name": "FormAbility",
+          "moduleName": "phone",
+          "extensionTypeName": "form"
+        },
+        {
+          "name": "com.huawei.hmos.camera.ServiceExtAbility",
+          "moduleName": "phone",
+          "extensionTypeName": "service"
+        }
+      ]
+    },
+    {
+      "moduleName": "picker",
+      "name": "picker",
+      "moduleType": 2,
+      "mainElementName": "",
+      "mainAbility": "",
+      "abilityInfos": [
+        {
+          "name": "PickerAbility",
+          "moduleName": "picker",
+          "isLauncherAbility": false,
+          "skills": [
+            {
+              "actions": [
+                "ohos.want.action.imageCapture",
+                "ohos.want.action.videoCapture"
+              ],
+              "entities": []
+            }
+          ]
+        }
+      ],
+      "extensionInfos": [
+        {
+          "name": "com.huawei.hmos.camera.ExtensionPickerAbility",
+          "moduleName": "picker",
+          "extensionTypeName": "sys/commonUI"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/harmony/tests/unit-test/fixtures/bm-dump-huawei-video.txt
+++ b/packages/harmony/tests/unit-test/fixtures/bm-dump-huawei-video.txt
@@ -1,0 +1,72 @@
+com.huawei.hmsapp.himovie:
+{
+  "entryModuleName": "entry",
+  "mainEntry": "entry",
+  "hapModuleInfos": [
+    {
+      "moduleName": "entry",
+      "name": "entry",
+      "moduleType": 1,
+      "mainElementName": "MainAbility",
+      "mainAbility": "MainAbility",
+      "abilityInfos": [
+        {
+          "name": "MainAbility",
+          "moduleName": "entry",
+          "isLauncherAbility": false,
+          "skills": [
+            {
+              "actions": [
+                "action.system.home"
+              ],
+              "entities": [
+                "entity.system.home"
+              ]
+            },
+            {
+              "actions": [
+                "action.system.home",
+                "ohos.want.action.viewData"
+              ],
+              "entities": [
+                "entity.system.home",
+                "entity.system.browsable"
+              ]
+            },
+            {
+              "actions": [
+                "action.system.home",
+                "ohos.want.action.viewData"
+              ],
+              "entities": [
+                "entity.system.home",
+                "entity.system.browsable"
+              ]
+            },
+            {
+              "actions": [
+                "action.system.home",
+                "wxentity.action.open"
+              ],
+              "entities": [
+                "entity.system.home"
+              ]
+            }
+          ]
+        }
+      ],
+      "extensionInfos": [
+        {
+          "name": "EntryFormAbility",
+          "moduleName": "entry",
+          "extensionTypeName": "form"
+        },
+        {
+          "name": "PrivacyStatementExtAbility",
+          "moduleName": "entry",
+          "extensionTypeName": "sys/commonUI"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -3,6 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
 const mockExecFile = rs.fn();
 
+function commandResult(stdout: string) {
+  return { stdout, stderr: '' };
+}
+
+function bundleDump(bundleInfo: Record<string, unknown>): string {
+  return `com.example.app:\n${JSON.stringify(bundleInfo)}`;
+}
+
+function shellCommands(): string[] {
+  return mockExecFile.mock.calls.map((call) => call[1][1] as string);
+}
+
 rs.mock('node:child_process', () => ({
   execFile: rs.fn(),
 }));
@@ -87,6 +99,368 @@ describe('HdcClient', () => {
         expect.any(Object),
       );
       expect(result).toBe('shell output');
+    });
+  });
+
+  describe('startAbility', () => {
+    it('should include the module name when provided', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const hdc = new HdcClient({});
+      await hdc.startAbility('com.example.app', 'AppAbility', 'video');
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        expect.any(String),
+        ['shell', 'aa start -a AppAbility -b com.example.app -m video'],
+        expect.any(Object),
+      );
+    });
+
+    it('should omit the module flag when no module name is provided', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const hdc = new HdcClient({});
+      await hdc.startAbility('com.example.app', 'AppAbility');
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        expect.any(String),
+        ['shell', 'aa start -a AppAbility -b com.example.app'],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('launchBundle', () => {
+    it('should launch the declared main element from the entry module', async () => {
+      mockExecFile
+        .mockResolvedValueOnce(
+          commandResult(
+            bundleDump({
+              entryModuleName: 'video',
+              hapModuleInfos: [
+                {
+                  moduleName: 'feature',
+                  moduleType: 2,
+                  mainElementName: 'FeatureAbility',
+                  abilityInfos: [{ name: 'FeatureAbility' }],
+                },
+                {
+                  moduleName: 'video',
+                  moduleType: 1,
+                  mainElementName: 'AppAbility',
+                  abilityInfos: [{ name: 'AppAbility' }],
+                },
+              ],
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m video',
+      ]);
+    });
+
+    it.each([
+      ['MainAbility', 'com.example.app.MainAbility'],
+      ['com.example.app.MainAbility', 'MainAbility'],
+    ])(
+      'should match short and fully-qualified ability names: %s / %s',
+      async (mainElementName, abilityName) => {
+        mockExecFile
+          .mockResolvedValueOnce(
+            commandResult(
+              bundleDump({
+                mainEntry: 'entry',
+                hapModuleInfos: [
+                  {
+                    moduleName: 'entry',
+                    mainElementName,
+                    abilityInfos: [{ name: abilityName }],
+                  },
+                ],
+              }),
+            ),
+          )
+          .mockResolvedValueOnce(commandResult(''));
+
+        const hdc = new HdcClient({});
+        await hdc.launchBundle('com.example.app');
+
+        expect(shellCommands()).toEqual([
+          'bm dump -n com.example.app',
+          `aa start -a ${abilityName} -b com.example.app -m entry`,
+        ]);
+      },
+    );
+
+    it.each(['action.system.home', 'ohos.want.action.home'])(
+      'should use the launcher skill when main element fields are absent: %s',
+      async (homeAction) => {
+        mockExecFile
+          .mockResolvedValueOnce(
+            commandResult(
+              bundleDump({
+                hapModuleInfos: [
+                  {
+                    moduleName: 'entry',
+                    moduleType: 'entry',
+                    abilityInfos: [
+                      { name: 'UnrelatedAbility' },
+                      {
+                        name: 'LauncherAbility',
+                        skills: [
+                          {
+                            actions: [homeAction],
+                            entities: ['entity.system.home'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ),
+          )
+          .mockResolvedValueOnce(commandResult(''));
+
+        const hdc = new HdcClient({});
+        await hdc.launchBundle('com.example.app');
+
+        expect(shellCommands()).toEqual([
+          'bm dump -n com.example.app',
+          'aa start -a LauncherAbility -b com.example.app -m entry',
+        ]);
+      },
+    );
+
+    it('should prefer a launcher skill over an unrelated module main element', async () => {
+      mockExecFile
+        .mockResolvedValueOnce(
+          commandResult(
+            bundleDump({
+              hapModuleInfos: [
+                {
+                  moduleName: 'feature',
+                  mainElementName: 'FeatureAbility',
+                  abilityInfos: [{ name: 'FeatureAbility' }],
+                },
+                {
+                  moduleName: 'app',
+                  abilityInfos: [
+                    {
+                      name: 'AppAbility',
+                      skills: [
+                        {
+                          actions: ['action.system.home'],
+                          entities: ['entity.system.home'],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m app',
+      ]);
+    });
+
+    it('should ignore a main element that refers to an extension', async () => {
+      mockExecFile
+        .mockResolvedValueOnce(
+          commandResult(
+            bundleDump({
+              entryModuleName: 'entry',
+              hapModuleInfos: [
+                {
+                  moduleName: 'entry',
+                  mainElementName: 'FormExtensionAbility',
+                  extensionInfos: [{ name: 'FormExtensionAbility' }],
+                  abilityInfos: [
+                    {
+                      name: 'AppAbility',
+                      skills: [
+                        {
+                          actions: ['ohos.want.action.home'],
+                          entities: ['entity.system.home'],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m entry',
+      ]);
+    });
+
+    it('should cache a successful launch target', async () => {
+      const dump = bundleDump({
+        mainEntry: 'entry',
+        hapModuleInfos: [
+          {
+            moduleName: 'entry',
+            mainElementName: 'AppAbility',
+            abilityInfos: [{ name: 'AppAbility' }],
+          },
+        ],
+      });
+      mockExecFile
+        .mockResolvedValueOnce(commandResult(dump))
+        .mockResolvedValueOnce(commandResult(''))
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m entry',
+        'aa start -a AppAbility -b com.example.app -m entry',
+      ]);
+    });
+
+    it('should refresh a stale cached target when the declaration changes', async () => {
+      const entryDump = bundleDump({
+        mainEntry: 'entry',
+        hapModuleInfos: [
+          {
+            moduleName: 'entry',
+            mainElementName: 'EntryAbility',
+            abilityInfos: [{ name: 'EntryAbility' }],
+          },
+        ],
+      });
+      const appDump = bundleDump({
+        mainEntry: 'video',
+        hapModuleInfos: [
+          {
+            moduleName: 'video',
+            mainElementName: 'AppAbility',
+            abilityInfos: [{ name: 'AppAbility' }],
+          },
+        ],
+      });
+      mockExecFile
+        .mockResolvedValueOnce(commandResult(entryDump))
+        .mockResolvedValueOnce(commandResult(''))
+        .mockResolvedValueOnce(commandResult('error: stale target'))
+        .mockResolvedValueOnce(commandResult(appDump))
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a EntryAbility -b com.example.app -m entry',
+        'aa start -a EntryAbility -b com.example.app -m entry',
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m video',
+      ]);
+    });
+
+    it('should preserve an error and clear the cache when the target is unchanged', async () => {
+      const dump = bundleDump({
+        mainEntry: 'entry',
+        hapModuleInfos: [
+          {
+            moduleName: 'entry',
+            mainElementName: 'AppAbility',
+            abilityInfos: [{ name: 'AppAbility' }],
+          },
+        ],
+      });
+      mockExecFile
+        .mockResolvedValueOnce(commandResult(dump))
+        .mockResolvedValueOnce(commandResult(''))
+        .mockResolvedValueOnce(commandResult('error: connection lost'))
+        .mockResolvedValueOnce(commandResult(dump))
+        .mockResolvedValueOnce(commandResult(dump))
+        .mockResolvedValueOnce(commandResult(''));
+
+      const hdc = new HdcClient({});
+      await hdc.launchBundle('com.example.app');
+      await expect(hdc.launchBundle('com.example.app')).rejects.toThrow(
+        'connection lost',
+      );
+      await hdc.launchBundle('com.example.app');
+
+      expect(shellCommands()).toEqual([
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m entry',
+        'aa start -a AppAbility -b com.example.app -m entry',
+        'bm dump -n com.example.app',
+        'bm dump -n com.example.app',
+        'aa start -a AppAbility -b com.example.app -m entry',
+      ]);
+    });
+
+    it('should throw when bundle information is malformed', async () => {
+      mockExecFile.mockResolvedValueOnce(
+        commandResult('error: failed to get bundle information'),
+      );
+
+      const hdc = new HdcClient({});
+
+      await expect(hdc.launchBundle('com.example.app')).rejects.toThrow(
+        'Cannot parse bundle information for com.example.app',
+      );
+    });
+
+    it('should throw when bundle information contains invalid JSON', async () => {
+      mockExecFile.mockResolvedValueOnce(commandResult('com.example.app: {'));
+
+      const hdc = new HdcClient({});
+
+      await expect(hdc.launchBundle('com.example.app')).rejects.toThrow(
+        'Cannot parse bundle information for com.example.app',
+      );
+    });
+
+    it('should throw rather than guessing an undeclared ability', async () => {
+      mockExecFile.mockResolvedValueOnce(
+        commandResult(
+          bundleDump({
+            hapModuleInfos: [
+              {
+                moduleName: 'entry',
+                abilityInfos: [{ name: 'SomeAbility' }],
+              },
+            ],
+          }),
+        ),
+      );
+
+      const hdc = new HdcClient({});
+
+      await expect(hdc.launchBundle('com.example.app')).rejects.toThrow(
+        'Cannot find a launchable ability for com.example.app',
+      );
     });
   });
 

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as nodeUtilActual from 'node:util' with { rstest: 'importActual' };
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
@@ -9,6 +11,12 @@ function commandResult(stdout: string) {
 
 function bundleDump(bundleInfo: Record<string, unknown>): string {
   return `com.example.app:\n${JSON.stringify(bundleInfo)}`;
+}
+
+// Captured from real HarmonyOS 5.0 `bm dump` output. The fixtures retain
+// launch-relevant fields while omitting device-specific and sensitive data.
+function realBundleDumpFixture(filename: string): string {
+  return readFileSync(join(__dirname, 'fixtures', filename), 'utf8');
 }
 
 function shellCommands(): string[] {
@@ -131,6 +139,33 @@ describe('HdcClient', () => {
   });
 
   describe('launchBundle', () => {
+    it.each([
+      [
+        'Huawei Video with a short main ability name',
+        'bm-dump-huawei-video.txt',
+        'com.huawei.hmsapp.himovie',
+        'aa start -a MainAbility -b com.huawei.hmsapp.himovie -m entry',
+      ],
+      [
+        'Camera with a fully-qualified main ability and multiple modules',
+        'bm-dump-camera.txt',
+        'com.huawei.hmos.camera',
+        'aa start -a com.huawei.hmos.camera.MainAbility -b com.huawei.hmos.camera -m phone',
+      ],
+    ])(
+      'should resolve a real bm dump fixture: %s',
+      async (_, fixture, bundle, command) => {
+        mockExecFile
+          .mockResolvedValueOnce(commandResult(realBundleDumpFixture(fixture)))
+          .mockResolvedValueOnce(commandResult(''));
+
+        const hdc = new HdcClient({});
+        await hdc.launchBundle(bundle);
+
+        expect(shellCommands()).toEqual([`bm dump -n ${bundle}`, command]);
+      },
+    );
+
     it('should launch the declared main element from the entry module', async () => {
       mockExecFile
         .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- resolve the system-declared HarmonyOS launch target from `bm dump` metadata instead of assuming `EntryAbility`
- pass both the module and ability names to `aa start`
- cache successful bundle launch targets in `HdcClient` and refresh stale entries
- preserve unrelated launch errors without relying on HDC error-message text
- add unit coverage for entry modules, launcher skills, fully qualified names, extensions, cache hits, and cache invalidation
- add redacted fixtures captured from real HarmonyOS 5.0 `bm dump` output for Huawei Video and Camera

## Root cause

`HarmonyDevice.launch()` initially tried `EntryAbility` and only queried another ability when the thrown error contained the legacy text `resolve ability`. Applications such as Tencent Video use a different entry name, and newer HDC versions report a different error message, so the fallback was skipped.

## User impact

Calling `agent.launch(bundleName)` now uses the application's declared HarmonyOS entry component regardless of whether it is named `EntryAbility`, `AppAbility`, or `MainAbility`.

Closes #2934.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/harmony exec rstest tests/unit-test/hdc.test.ts` — 59 tests passed
- `pnpm exec nx test @midscene/harmony` — 263 tests passed
- `pnpm exec nx build @midscene/harmony`
- compared both fixture payloads with live device output using the same launch-field filter — no differences
- real-device validation on `MJE0223906089471` with `com.huawei.hmsapp.himovie`
  - first launch resolved and started `entry/MainAbility`
  - second launch reused the cached target without another `bm dump`
