### PR TITLE
fix(android): use native ADB tap for reliable WebView input

### DIFF
--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -36,6 +36,8 @@
     "build:watch": "rslib build --watch --no-clean",
     "prepack": "node scripts/download-scrcpy-server.mjs && node scripts/download-yadb.mjs",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
+    "build:webview-tap-repro": "node scripts/build-webview-tap-repro.mjs",
+    "repro:webview-tap": "tsx scripts/reproduce-webview-first-tap.ts",
     "test": "vitest --run",
     "test:u": "vitest --run -u",
     "test:ai": "AI_TEST_TYPE=android vitest --run",

--- a/packages/android/scripts/build-webview-tap-repro.mjs
+++ b/packages/android/scripts/build-webview-tap-repro.mjs
@@ -1,0 +1,288 @@
+import { spawnSync } from 'node:child_process';
+import { constants } from 'node:fs';
+import { access, copyFile, mkdir, readdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDir = path.resolve(
+  scriptDir,
+  '../tests/fixtures/webview-tap-repro',
+);
+const outputDir = path.join(fixtureDir, '.temp');
+const buildDir = path.join(outputDir, 'build');
+const classesDir = path.join(buildDir, 'classes');
+const dexDir = path.join(buildDir, 'dex');
+const apkPath = path.join(outputDir, 'webview-tap-repro-debug.apk');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') {
+      // pnpm may forward its argument separator to package scripts.
+    } else if (argument === '--sdk-root') {
+      args.sdkRoot = readOptionValue(argv, index, argument);
+      index += 1;
+    } else if (argument === '--java-home') {
+      args.javaHome = readOptionValue(argv, index, argument);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return args;
+}
+
+function readOptionValue(argv, optionIndex, optionName) {
+  const value = argv[optionIndex + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return value;
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed (${result.status}): ${command} ${args.join(' ')}`,
+    );
+  }
+}
+
+async function isExecutable(filePath) {
+  try {
+    await access(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveJavaHome(explicitJavaHome) {
+  const candidates = [explicitJavaHome, process.env.JAVA_HOME].filter(Boolean);
+  if (process.platform === 'darwin') {
+    const result = spawnSync('/usr/libexec/java_home', ['-v', '17'], {
+      encoding: 'utf8',
+    });
+    if (result.status === 0 && result.stdout.trim()) {
+      candidates.push(result.stdout.trim());
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (await isExecutable(path.join(candidate, 'bin', 'javac'))) {
+      return path.resolve(candidate);
+    }
+  }
+
+  throw new Error(
+    'JDK 17 was not found. Set JAVA_HOME or pass --java-home <path>.',
+  );
+}
+
+async function resolveSdkRoot(explicitSdkRoot) {
+  const candidates = [
+    explicitSdkRoot,
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+    process.platform === 'darwin'
+      ? path.join(process.env.HOME ?? '', 'Library/Android/sdk')
+      : path.join(process.env.HOME ?? '', 'Android/Sdk'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      await access(path.join(candidate, 'platforms'));
+      await access(path.join(candidate, 'build-tools'));
+      return path.resolve(candidate);
+    } catch {
+      // Try the next conventional SDK location.
+    }
+  }
+
+  throw new Error(
+    'Android SDK platforms/build-tools were not found. Set ANDROID_HOME or pass --sdk-root <path>.',
+  );
+}
+
+function versionParts(version) {
+  return version.split(/[.-]/).map((part) => Number(part) || 0);
+}
+
+function compareVersions(left, right) {
+  const leftParts = versionParts(left);
+  const rightParts = versionParts(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+async function latestDirectory(parent, filter) {
+  const entries = await readdir(parent, { withFileTypes: true });
+  const names = entries
+    .filter((entry) => entry.isDirectory() && filter(entry.name))
+    .map((entry) => entry.name)
+    .sort(compareVersions);
+  const latest = names.at(-1);
+  if (!latest) {
+    throw new Error(`No compatible directory found under ${parent}`);
+  }
+  return path.join(parent, latest);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const javaHome = await resolveJavaHome(args.javaHome);
+  const sdkRoot = await resolveSdkRoot(args.sdkRoot);
+  const platformDir = await latestDirectory(
+    path.join(sdkRoot, 'platforms'),
+    (name) => /^android-\d+$/.test(name),
+  );
+  const buildToolsDir = await latestDirectory(
+    path.join(sdkRoot, 'build-tools'),
+    (name) => /^\d+(?:\.\d+)*$/.test(name),
+  );
+  const targetApi = path.basename(platformDir).replace('android-', '');
+  const androidJar = path.join(platformDir, 'android.jar');
+  const javaBin = path.join(javaHome, 'bin');
+  const aapt2 = path.join(buildToolsDir, 'aapt2');
+  const d8 = path.join(buildToolsDir, 'd8');
+  const zipalign = path.join(buildToolsDir, 'zipalign');
+  const apksigner = path.join(buildToolsDir, 'apksigner');
+
+  for (const executable of [aapt2, d8, zipalign, apksigner]) {
+    if (!(await isExecutable(executable))) {
+      throw new Error(`Required Android build tool is missing: ${executable}`);
+    }
+  }
+
+  await rm(buildDir, { recursive: true, force: true });
+  await mkdir(classesDir, { recursive: true });
+  await mkdir(dexDir, { recursive: true });
+
+  const resourcesApk = path.join(buildDir, 'resources.apk');
+  run(aapt2, [
+    'link',
+    '-o',
+    resourcesApk,
+    '-I',
+    androidJar,
+    '--manifest',
+    path.join(fixtureDir, 'AndroidManifest.xml'),
+    '--min-sdk-version',
+    '23',
+    '--target-sdk-version',
+    targetApi,
+    '-A',
+    path.join(fixtureDir, 'assets'),
+  ]);
+
+  const javaSource = path.join(
+    fixtureDir,
+    'src/io/midscene/taprepro/MainActivity.java',
+  );
+  run(path.join(javaBin, 'javac'), [
+    '-encoding',
+    'UTF-8',
+    '-source',
+    '7',
+    '-target',
+    '7',
+    '-Xlint:-options',
+    '-bootclasspath',
+    androidJar,
+    '-d',
+    classesDir,
+    javaSource,
+  ]);
+
+  const classesJar = path.join(buildDir, 'classes.jar');
+  run(path.join(javaBin, 'jar'), [
+    '--create',
+    '--file',
+    classesJar,
+    '-C',
+    classesDir,
+    '.',
+  ]);
+  run(d8, [
+    '--lib',
+    androidJar,
+    '--min-api',
+    '23',
+    '--output',
+    dexDir,
+    classesJar,
+  ]);
+
+  const unsignedApk = path.join(buildDir, 'unsigned.apk');
+  await copyFile(resourcesApk, unsignedApk);
+  run(path.join(javaBin, 'jar'), [
+    '--update',
+    '--file',
+    unsignedApk,
+    '-C',
+    dexDir,
+    'classes.dex',
+  ]);
+
+  const alignedApk = path.join(buildDir, 'aligned.apk');
+  run(zipalign, ['-f', '4', unsignedApk, alignedApk]);
+
+  const keystore = path.join(outputDir, 'debug.keystore');
+  try {
+    await access(keystore);
+  } catch {
+    await mkdir(outputDir, { recursive: true });
+    run(path.join(javaBin, 'keytool'), [
+      '-genkeypair',
+      '-keystore',
+      keystore,
+      '-storepass',
+      'android',
+      '-alias',
+      'androiddebugkey',
+      '-keypass',
+      'android',
+      '-dname',
+      'CN=Android Debug,O=Android,C=US',
+      '-keyalg',
+      'RSA',
+      '-keysize',
+      '2048',
+      '-validity',
+      '10000',
+    ]);
+  }
+
+  await rm(apkPath, { force: true });
+  run(apksigner, [
+    'sign',
+    '--ks',
+    keystore,
+    '--ks-pass',
+    'pass:android',
+    '--key-pass',
+    'pass:android',
+    '--out',
+    apkPath,
+    alignedApk,
+  ]);
+  run(apksigner, ['verify', '--verbose', apkPath]);
+
+  console.log(`WebView tap reproduction APK: ${apkPath}`);
+}
+
+await main();

--- a/packages/android/scripts/reproduce-webview-first-tap.ts
+++ b/packages/android/scripts/reproduce-webview-first-tap.ts
@@ -1,0 +1,444 @@
+import { spawnSync } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { AndroidDevice } from '../src/device';
+
+const TAG = 'MidsceneTapRepro';
+const PACKAGE_NAME = 'io.midscene.taprepro';
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDir = path.resolve(
+  scriptDir,
+  '../tests/fixtures/webview-tap-repro',
+);
+const defaultApkPath = path.join(
+  fixtureDir,
+  '.temp/webview-tap-repro-debug.apk',
+);
+
+interface RunnerOptions {
+  apkPath: string;
+  build: boolean;
+  deviceId?: string;
+  install: boolean;
+  iterations: number;
+  mode: 'deterministic' | 'natural';
+  waitMs: number;
+}
+
+interface BaseCaseResult {
+  firstAttemptTapCount: number;
+  firstAttemptScreenshot: string;
+  firstAttemptSwallowed: boolean;
+  runId: string;
+}
+
+interface LegacySwipeCaseResult extends BaseCaseResult {
+  caseName: 'legacy-swipe';
+  secondAttemptScreenshot: string;
+  secondAttemptTapCount: number;
+}
+
+interface NativeTapCaseResult extends BaseCaseResult {
+  caseName: 'native-tap';
+}
+
+type CaseResult = LegacySwipeCaseResult | NativeTapCaseResult;
+
+function readOptionValue(
+  argv: string[],
+  optionIndex: number,
+  optionName: string,
+): string {
+  const value = argv[optionIndex + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return value;
+}
+
+export function parseArgs(argv: string[]): RunnerOptions {
+  const options: RunnerOptions = {
+    apkPath: defaultApkPath,
+    build: true,
+    install: true,
+    iterations: 1,
+    mode: 'deterministic',
+    waitMs: 500,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') {
+      // pnpm may forward its argument separator to package scripts.
+    } else if (argument === '--device-id') {
+      options.deviceId = readOptionValue(argv, index, argument);
+      index += 1;
+    } else if (argument === '--apk') {
+      options.apkPath = path.resolve(readOptionValue(argv, index, argument));
+      options.build = false;
+      index += 1;
+    } else if (argument === '--iterations') {
+      options.iterations = Number(readOptionValue(argv, index, argument));
+      index += 1;
+    } else if (argument === '--wait-ms') {
+      options.waitMs = Number(readOptionValue(argv, index, argument));
+      index += 1;
+    } else if (argument === '--mode') {
+      const mode = readOptionValue(argv, index, argument);
+      if (mode !== 'deterministic' && mode !== 'natural') {
+        throw new Error('--mode must be deterministic or natural');
+      }
+      options.mode = mode;
+      index += 1;
+    } else if (argument === '--no-build') {
+      options.build = false;
+    } else if (argument === '--no-install') {
+      options.install = false;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!Number.isInteger(options.iterations) || options.iterations < 1) {
+    throw new Error('--iterations must be a positive integer');
+  }
+  if (!Number.isFinite(options.waitMs) || options.waitMs < 0) {
+    throw new Error('--wait-ms must be a non-negative number');
+  }
+  return options;
+}
+
+function execute(
+  command: string,
+  args: string[],
+  options: { print?: boolean } = {},
+): string {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  if (options.print && output) console.log(output);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed (${result.status}): ${command} ${args.join(' ')}\n${output}`,
+    );
+  }
+  return output;
+}
+
+function adb(deviceId: string, args: string[]): string {
+  return execute('adb', ['-s', deviceId, ...args]);
+}
+
+function connectedDevices(): string[] {
+  return execute('adb', ['devices'])
+    .split('\n')
+    .slice(1)
+    .map((line) => line.trim().split(/\s+/))
+    .filter(([, state]) => state === 'device')
+    .map(([deviceId]) => deviceId);
+}
+
+function resolveDeviceId(explicitDeviceId?: string): string {
+  const devices = connectedDevices();
+  if (explicitDeviceId) {
+    if (!devices.includes(explicitDeviceId)) {
+      throw new Error(
+        `Android device ${explicitDeviceId} is not connected. Connected devices: ${devices.join(', ') || 'none'}`,
+      );
+    }
+    return explicitDeviceId;
+  }
+  if (devices.length !== 1) {
+    throw new Error(
+      `Expected exactly one connected Android device, found ${devices.length}. Pass --device-id.`,
+    );
+  }
+  return devices[0];
+}
+
+function sleep(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
+function caseLogs(deviceId: string): string {
+  return adb(deviceId, ['logcat', '-d', '-s', `${TAG}:I`, '*:S']);
+}
+
+export function tapCountForRun(logs: string, runId: string): number {
+  const matches = Array.from(
+    logs.matchAll(
+      new RegExp(
+        `run=${runId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} tap_count=(\\d+)`,
+        'g',
+      ),
+    ),
+  );
+  return matches.length ? Number(matches.at(-1)?.[1]) : 0;
+}
+
+async function waitForLog(
+  deviceId: string,
+  pattern: string,
+  timeoutMs = 10_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let logs = '';
+  while (Date.now() < deadline) {
+    logs = caseLogs(deviceId);
+    if (logs.includes(pattern)) return logs;
+    await sleep(100);
+  }
+  throw new Error(
+    `Timed out waiting for log ${JSON.stringify(pattern)}\n${logs}`,
+  );
+}
+
+async function launchCase(
+  deviceId: string,
+  runId: string,
+  guardEnabled: boolean,
+): Promise<void> {
+  adb(deviceId, ['logcat', '-c']);
+  const uri = `midscene-tap-repro://open?run=${encodeURIComponent(runId)}&guard=${guardEnabled ? '1' : '0'}`;
+  // Quotes must be part of the argument passed to ADB because `adb shell`
+  // rebuilds a remote shell command. Local-only quoting does not protect `&`
+  // from the device shell.
+  const shellQuotedUri = `'${uri}'`;
+  adb(deviceId, [
+    'shell',
+    'am',
+    'start',
+    '-W',
+    '-a',
+    'android.intent.action.VIEW',
+    '-d',
+    shellQuotedUri,
+    PACKAGE_NAME,
+  ]);
+  await waitForLog(deviceId, `run=${runId} ready`);
+  const focusedWindow = adb(deviceId, ['shell', 'dumpsys', 'window']);
+  const currentFocus =
+    focusedWindow.match(/^\s*mCurrentFocus=.*$/m)?.[0] ??
+    'mCurrentFocus missing';
+  if (!currentFocus.includes(PACKAGE_NAME)) {
+    throw new Error(
+      `Reproduction fixture is not foreground after deeplink: ${currentFocus}`,
+    );
+  }
+}
+
+async function captureScreenshot(
+  deviceId: string,
+  destination: string,
+): Promise<void> {
+  const result = spawnSync('adb', [
+    '-s',
+    deviceId,
+    'exec-out',
+    'screencap',
+    '-p',
+  ]);
+  if (result.error) throw result.error;
+  if (result.status !== 0 || !result.stdout?.length) {
+    throw new Error(`Failed to capture screenshot for ${deviceId}`);
+  }
+  await writeFile(destination, result.stdout);
+}
+
+function physicalScreenCenter(deviceId: string): { x: number; y: number } {
+  const output = adb(deviceId, ['shell', 'wm', 'size']);
+  const override = /Override size:\s*(\d+)x(\d+)/.exec(output);
+  const physical = /Physical size:\s*(\d+)x(\d+)/.exec(output);
+  const match = override ?? physical;
+  if (!match)
+    throw new Error(`Unable to parse Android screen size:\n${output}`);
+  return {
+    x: Math.round(Number(match[1]) / 2),
+    y: Math.round(Number(match[2]) / 2),
+  };
+}
+
+async function runLegacySwipeCase(
+  deviceId: string,
+  runId: string,
+  guardEnabled: boolean,
+  waitMs: number,
+  outputDir: string,
+): Promise<LegacySwipeCaseResult> {
+  await launchCase(deviceId, runId, guardEnabled);
+  const center = physicalScreenCenter(deviceId);
+  adb(deviceId, [
+    'shell',
+    'input',
+    'swipe',
+    String(center.x),
+    String(center.y),
+    String(center.x),
+    String(center.y),
+    '150',
+  ]);
+  await sleep(waitMs);
+  let logs = caseLogs(deviceId);
+  const firstAttemptTapCount = tapCountForRun(logs, runId);
+  const firstAttemptSwallowed = logs.includes(`run=${runId} guard_swallowed`);
+  const firstAttemptScreenshot = path.join(outputDir, `${runId}-first.png`);
+  await captureScreenshot(deviceId, firstAttemptScreenshot);
+
+  adb(deviceId, [
+    'shell',
+    'input',
+    'swipe',
+    String(center.x),
+    String(center.y),
+    String(center.x),
+    String(center.y),
+    '150',
+  ]);
+  await sleep(waitMs);
+  logs = caseLogs(deviceId);
+  const secondAttemptTapCount = tapCountForRun(logs, runId);
+  const secondAttemptScreenshot = path.join(outputDir, `${runId}-second.png`);
+  await captureScreenshot(deviceId, secondAttemptScreenshot);
+  return {
+    caseName: 'legacy-swipe',
+    firstAttemptTapCount,
+    firstAttemptScreenshot,
+    firstAttemptSwallowed,
+    runId,
+    secondAttemptScreenshot,
+    secondAttemptTapCount,
+  };
+}
+
+async function runNativeTapCase(
+  device: AndroidDevice,
+  deviceId: string,
+  runId: string,
+  guardEnabled: boolean,
+  waitMs: number,
+  outputDir: string,
+): Promise<NativeTapCaseResult> {
+  await launchCase(deviceId, runId, guardEnabled);
+  const size = await device.size();
+  await device.inputPrimitives.pointer.tap({
+    x: Math.round(size.width / 2),
+    y: Math.round(size.height / 2),
+  });
+  await sleep(waitMs);
+  const logs = caseLogs(deviceId);
+  const firstAttemptScreenshot = path.join(outputDir, `${runId}-first.png`);
+  await captureScreenshot(deviceId, firstAttemptScreenshot);
+  return {
+    caseName: 'native-tap',
+    firstAttemptTapCount: tapCountForRun(logs, runId),
+    firstAttemptScreenshot,
+    firstAttemptSwallowed: logs.includes(`run=${runId} guard_swallowed`),
+    runId,
+  };
+}
+
+export function assertDeterministicResults(results: CaseResult[]): void {
+  for (const result of results) {
+    if (
+      result.caseName === 'legacy-swipe' &&
+      !(
+        result.firstAttemptTapCount === 0 &&
+        result.firstAttemptSwallowed &&
+        result.secondAttemptTapCount >= 1
+      )
+    ) {
+      throw new Error(
+        `Legacy swipe did not reproduce the expected first-attempt failure: ${JSON.stringify(result)}`,
+      );
+    }
+    if (
+      result.caseName === 'native-tap' &&
+      (result.firstAttemptTapCount < 1 || result.firstAttemptSwallowed)
+    ) {
+      throw new Error(
+        `Native tap did not succeed on the first attempt: ${JSON.stringify(result)}`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.build) {
+    execute(
+      process.execPath,
+      [path.join(scriptDir, 'build-webview-tap-repro.mjs')],
+      { print: true },
+    );
+  }
+
+  const deviceId = resolveDeviceId(options.deviceId);
+  if (options.install) {
+    execute('adb', ['-s', deviceId, 'install', '-r', options.apkPath], {
+      print: true,
+    });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outputDir = path.join(fixtureDir, '.temp/results', timestamp);
+  await mkdir(outputDir, { recursive: true });
+  const guardEnabled = options.mode === 'deterministic';
+  // Use the same PATH-resolved adb binary as the raw comparison commands.
+  // This also keeps the fixture independent from a globally configured SDK.
+  const device = new AndroidDevice(deviceId, { androidAdbPath: 'adb' });
+  const results: CaseResult[] = [];
+
+  try {
+    for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
+      results.push(
+        await runLegacySwipeCase(
+          deviceId,
+          `legacy-${iteration}`,
+          guardEnabled,
+          options.waitMs,
+          outputDir,
+        ),
+      );
+      results.push(
+        await runNativeTapCase(
+          device,
+          deviceId,
+          `native-${iteration}`,
+          guardEnabled,
+          options.waitMs,
+          outputDir,
+        ),
+      );
+    }
+  } finally {
+    await device.destroy();
+  }
+
+  const summary = {
+    deviceId,
+    mode: options.mode,
+    generatedAt: new Date().toISOString(),
+    results,
+  };
+  const resultPath = path.join(outputDir, 'result.json');
+  await writeFile(resultPath, `${JSON.stringify(summary, null, 2)}\n`);
+
+  if (guardEnabled) {
+    assertDeterministicResults(results);
+  }
+
+  console.log(JSON.stringify(summary, null, 2));
+  console.log(`Reproduction result: ${resultPath}`);
+}
+
+const isDirectExecution =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isDirectExecution) {
+  void main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -1888,8 +1888,10 @@ ${Object.keys(size)
       point.x,
       point.y,
     );
+    // Keep tap semantics distinct from swipe: even a zero-distance swipe emits
+    // MOVE events for its entire duration.
     await adb.shell(
-      `input${this.getDisplayArg()} swipe ${adjustedX} ${adjustedY} ${adjustedX} ${adjustedY} 150`,
+      `input${this.getDisplayArg()} tap ${adjustedX} ${adjustedY}`,
     );
   }
 

--- a/packages/android/tests/fixtures/webview-tap-repro/AndroidManifest.xml
+++ b/packages/android/tests/fixtures/webview-tap-repro/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.midscene.taprepro">
+  <application
+    android:allowBackup="false"
+    android:debuggable="true"
+    android:label="Midscene Tap Repro"
+    android:supportsRtl="true"
+    android:theme="@android:style/Theme.Material.Light.NoActionBar">
+    <activity
+      android:name=".MainActivity"
+      android:exported="true"
+      android:launchMode="singleTop"
+      android:screenOrientation="portrait">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+          android:host="open"
+          android:scheme="midscene-tap-repro" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/packages/android/tests/fixtures/webview-tap-repro/README.md
+++ b/packages/android/tests/fixtures/webview-tap-repro/README.md
@@ -1,0 +1,57 @@
+# Android WebView first-tap reproduction
+
+This fixture models [issue #2927](https://github.com/web-infra-dev/midscene/issues/2927): after deeplink navigation, a zero-distance 150 ms ADB swipe may not register as the first tap, while a second attempt succeeds.
+
+The APK has two modes:
+
+- `deterministic` deliberately models the affected WebView state. The first gesture containing an Android `ACTION_MOVE` is swallowed. This makes the old `input swipe x y x y 150` fail once and the native `input tap x y` succeed immediately on every device.
+- `natural` does not swallow input. Use it on the affected Android 16/cloud-device environment to check whether the platform reproduces the behavior by itself.
+
+This distinction matters: deterministic mode is a regression harness for the input semantics, not proof that every Android WebView has the OEM/cloud-device bug.
+
+## Prerequisites
+
+- A macOS or Linux host
+- JDK 17 (`JAVA_HOME` must point to it)
+- Android SDK with one installed platform and one installed build-tools version
+- An ADB-connected Android device
+
+The fixture uses `aapt2`, `javac`, `d8`, `zipalign`, and `apksigner` directly, so Gradle and Android Studio are not required.
+
+To use an APK that is already built, pass `--apk <path>`. Supplying this option disables the build step. Use `--no-install` only when `io.midscene.taprepro` is already installed on the selected device.
+
+## Run
+
+From the repository root:
+
+```bash
+pnpm --filter @midscene/android repro:webview-tap -- \
+  --device-id <adb-device-id> \
+  --mode deterministic \
+  --iterations 3
+```
+
+To probe the device without the deterministic guard:
+
+```bash
+pnpm --filter @midscene/android repro:webview-tap -- \
+  --device-id <adb-device-id> \
+  --mode natural \
+  --iterations 10
+```
+
+The runner builds and installs the APK, opens it through the `midscene-tap-repro://open` deeplink, and compares:
+
+1. legacy `input swipe x y x y 150` (two attempts), and
+2. the current local `AndroidDevice.pointer.tap` implementation (one attempt).
+
+Screenshots and `result.json` are saved under `.temp/results/`.
+
+## 中文说明
+
+这个 fixture 用来模拟 issue #2927 的关键输入差异：deeplink 导航后，旧版同点 `swipe` 会产生 `ACTION_MOVE`，在受影响的 WebView 状态下第一次可能被吞掉；原生 `tap` 只有 DOWN/UP，第一次即可生效。
+
+- `deterministic` 模式会主动模拟该脆弱状态，适合稳定回归测试。
+- `natural` 模式不注入任何吞手势逻辑，适合拿到原 Android 16 云机和 WebView 环境后验证系统是否自然复现。
+
+因此，`deterministic` 的通过只能证明修复覆盖了输入语义差异，不能替代原 Samsung Android 16 / 网络 ADB 环境的真机结论。

--- a/packages/android/tests/fixtures/webview-tap-repro/assets/index.html
+++ b/packages/android/tests/fixtures/webview-tap-repro/assets/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Midscene WebView tap reproduction</title>
+    <style>
+      :root {
+        color: #172033;
+        font-family: system-ui, -apple-system, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        overflow: hidden;
+        background: #f4f7fb;
+      }
+
+      header {
+        padding: 5vh 7vw 0;
+      }
+
+      h1 {
+        margin: 0 0 1.5vh;
+        font-size: clamp(28px, 7vw, 46px);
+        line-height: 1.05;
+      }
+
+      p {
+        margin: 0;
+        color: #536078;
+        font-size: clamp(16px, 4vw, 24px);
+        line-height: 1.35;
+      }
+
+      #target {
+        position: fixed;
+        top: 42vh;
+        right: 8vw;
+        left: 8vw;
+        height: 20vh;
+        border: 0;
+        border-radius: 28px;
+        background: #1769e0;
+        box-shadow: 0 14px 32px rgb(23 105 224 / 25%);
+        color: white;
+        font-size: clamp(28px, 9vw, 56px);
+        font-weight: 800;
+        touch-action: manipulation;
+      }
+
+      #target:active {
+        background: #0d4fae;
+      }
+
+      #result {
+        position: fixed;
+        right: 8vw;
+        bottom: 10vh;
+        left: 8vw;
+        min-height: 15vh;
+        padding: 3vh 5vw;
+        border: 2px solid #ccd5e4;
+        border-radius: 22px;
+        background: white;
+        font-size: clamp(18px, 4.5vw, 28px);
+        line-height: 1.45;
+      }
+
+      #count {
+        color: #0b7a3e;
+        font-size: 1.35em;
+        font-weight: 800;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>WebView first-tap repro</h1>
+      <p id="mode">Loading deeplink state…</p>
+    </header>
+
+    <button id="target" type="button">TAP TARGET</button>
+
+    <section id="result" aria-live="polite">
+      <div>Tap count: <span id="count">0</span></div>
+      <div id="state">Waiting for WebView…</div>
+    </section>
+
+    <script>
+      const params = new URLSearchParams(location.search);
+      const runId = params.get('run') || 'manual';
+      const guarded = params.get('guard') === '1';
+      const mode = document.querySelector('#mode');
+      const count = document.querySelector('#count');
+      const state = document.querySelector('#state');
+      const target = document.querySelector('#target');
+      let tapCount = 0;
+
+      mode.textContent = guarded
+        ? 'Deterministic mode: the first MOVE gesture after deeplink is swallowed.'
+        : 'Natural mode: no gesture is swallowed by the fixture.';
+
+      window.onNativeState = (nextState, detail) => {
+        state.textContent = `${nextState.toUpperCase()}: ${detail}`;
+      };
+
+      target.addEventListener('click', () => {
+        tapCount += 1;
+        count.textContent = String(tapCount);
+        state.textContent = `REGISTERED: tap ${tapCount} at ${new Date().toISOString()}`;
+        document.title = `tap-count:${tapCount}`;
+        window.AndroidBridge?.onTap(runId, tapCount);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/android/tests/fixtures/webview-tap-repro/src/io/midscene/taprepro/MainActivity.java
+++ b/packages/android/tests/fixtures/webview-tap-repro/src/io/midscene/taprepro/MainActivity.java
@@ -1,0 +1,151 @@
+package io.midscene.taprepro;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import org.json.JSONObject;
+
+public final class MainActivity extends Activity {
+  private static final String TAG = "MidsceneTapRepro";
+  private static final String PAGE_URL = "file:///android_asset/index.html";
+
+  private WebView webView;
+  private boolean guardEnabled;
+  private boolean guardArmed;
+  private boolean consumingGesture;
+  private boolean gestureGuardCandidate;
+  private String runId = "manual";
+  private int loadGeneration;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    WebView.setWebContentsDebuggingEnabled(true);
+    webView = new WebView(this);
+    webView.getSettings().setJavaScriptEnabled(true);
+    webView.getSettings().setDomStorageEnabled(true);
+    webView.addJavascriptInterface(new ReproBridge(), "AndroidBridge");
+    webView.setWebViewClient(
+        new WebViewClient() {
+          @Override
+          public void onPageFinished(WebView view, String url) {
+            final int generation = loadGeneration;
+            view.postDelayed(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    if (generation != loadGeneration) return;
+                    guardArmed = guardEnabled;
+                    consumingGesture = false;
+                    gestureGuardCandidate = false;
+                    notifyPage("ready", guardEnabled ? "guard armed" : "natural mode");
+                    Log.i(
+                        TAG, "run=" + runId + " ready guard=" + (guardEnabled ? 1 : 0));
+                  }
+                },
+                250);
+          }
+        });
+    webView.setOnTouchListener(
+        new View.OnTouchListener() {
+          @Override
+          public boolean onTouch(View view, MotionEvent event) {
+            return handleTouch(event);
+          }
+        });
+    setContentView(webView);
+    loadFromIntent(getIntent());
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    setIntent(intent);
+    loadFromIntent(intent);
+  }
+
+  private void loadFromIntent(Intent intent) {
+    Uri uri = intent == null ? null : intent.getData();
+    String requestedRunId = uri == null ? null : uri.getQueryParameter("run");
+    runId = requestedRunId == null || requestedRunId.isEmpty() ? "manual" : requestedRunId;
+    guardEnabled = uri != null && "1".equals(uri.getQueryParameter("guard"));
+    guardArmed = false;
+    consumingGesture = false;
+    gestureGuardCandidate = false;
+    loadGeneration += 1;
+    String page =
+        PAGE_URL
+            + "?run="
+            + Uri.encode(runId)
+            + "&guard="
+            + (guardEnabled ? "1" : "0");
+    webView.loadUrl(page);
+  }
+
+  private boolean handleTouch(MotionEvent event) {
+    switch (event.getActionMasked()) {
+      case MotionEvent.ACTION_DOWN:
+        consumingGesture = false;
+        gestureGuardCandidate = guardArmed;
+        Log.i(TAG, "run=" + runId + " event=DOWN");
+        return false;
+      case MotionEvent.ACTION_MOVE:
+        if (guardArmed && gestureGuardCandidate && !consumingGesture) {
+          guardArmed = false;
+          consumingGesture = true;
+          MotionEvent cancel = MotionEvent.obtain(event);
+          cancel.setAction(MotionEvent.ACTION_CANCEL);
+          webView.onTouchEvent(cancel);
+          cancel.recycle();
+          notifyPage("ignored", "first gesture contained MOVE and was swallowed");
+          Log.i(TAG, "run=" + runId + " guard_swallowed event=MOVE");
+        }
+        return consumingGesture;
+      case MotionEvent.ACTION_UP:
+        if (consumingGesture) {
+          consumingGesture = false;
+          gestureGuardCandidate = false;
+          Log.i(TAG, "run=" + runId + " event=UP consumed=1");
+          return true;
+        }
+        if (guardArmed && gestureGuardCandidate) {
+          guardArmed = false;
+          Log.i(TAG, "run=" + runId + " first_tap_accepted");
+        }
+        gestureGuardCandidate = false;
+        return false;
+      case MotionEvent.ACTION_CANCEL:
+        boolean wasConsuming = consumingGesture;
+        consumingGesture = false;
+        gestureGuardCandidate = false;
+        return wasConsuming;
+      default:
+        return consumingGesture;
+    }
+  }
+
+  private void notifyPage(String state, String detail) {
+    if (webView == null) return;
+    String script =
+        "window.onNativeState && window.onNativeState("
+            + JSONObject.quote(state)
+            + ","
+            + JSONObject.quote(detail)
+            + ")";
+    webView.evaluateJavascript(script, null);
+  }
+
+  private final class ReproBridge {
+    @JavascriptInterface
+    public void onTap(String pageRunId, int tapCount) {
+      Log.i(TAG, "run=" + pageRunId + " tap_count=" + tapCount);
+    }
+  }
+}

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -749,9 +749,7 @@ Stdout:
       });
 
       await device.inputPrimitives.pointer.tap({ x: 100, y: 200 });
-      expect(mockAdb.shell).toHaveBeenCalledWith(
-        'input swipe 200 400 200 400 150',
-      );
+      expect(mockAdb.shell).toHaveBeenCalledWith('input tap 200 400');
     });
 
     it('should handle 1:1 scale (no scaling)', async () => {
@@ -1136,16 +1134,14 @@ Stdout:
     });
   });
 
-  describe('mouse', () => {
-    it('click should call shell with adjusted coordinates', async () => {
+  describe('pointer input', () => {
+    it('tap should use the native adb tap command with adjusted coordinates', async () => {
       vi.spyOn(device as any, 'adjustCoordinates').mockResolvedValue({
         x: 200,
         y: 300,
       });
       await device.inputPrimitives.pointer.tap({ x: 100, y: 150 });
-      expect(mockAdb.shell).toHaveBeenCalledWith(
-        'input swipe 200 300 200 300 150',
-      );
+      expect(mockAdb.shell).toHaveBeenCalledWith('input tap 200 300');
     });
 
     it('drag should call shell with adjusted coordinates', async () => {
@@ -2833,13 +2829,13 @@ Stdout:
         // Set device pixel ratio for coordinate adjustment
         (deviceWithDisplay as any).devicePixelRatio = 1;
 
-        // Test mouse click command
+        // Test pointer tap command
         await deviceWithDisplay.inputPrimitives.pointer.tap({
           x: 100,
           y: 200,
         });
         expect(mockAdbInstance.shell).toHaveBeenCalledWith(
-          expect.stringContaining('input -d 2 swipe'),
+          expect.stringMatching(/^input -d 2 tap \d+ \d+$/),
         );
       });
 
@@ -2974,10 +2970,10 @@ Stdout:
       // Set device pixel ratio for coordinate adjustment
       (deviceWithDisplay as any).devicePixelRatio = 1;
 
-      // Test mouse click command
+      // Test pointer tap command
       await deviceWithDisplay.inputPrimitives.pointer.tap({ x: 100, y: 200 });
       expect(mockAdbInstance.shell).toHaveBeenCalledWith(
-        expect.stringContaining('input swipe'),
+        expect.stringMatching(/^input tap \d+ \d+$/),
       );
       expect(mockAdbInstance.shell).not.toHaveBeenCalledWith(
         expect.stringContaining('input -d'),

--- a/packages/android/tests/unit-test/webview-tap-repro.test.ts
+++ b/packages/android/tests/unit-test/webview-tap-repro.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertDeterministicResults,
+  parseArgs,
+  tapCountForRun,
+} from '../../scripts/reproduce-webview-first-tap';
+
+describe('WebView first-tap reproduction runner', () => {
+  describe('parseArgs', () => {
+    it('accepts pnpm separators and parses supported options', () => {
+      expect(
+        parseArgs([
+          '--',
+          '--device-id',
+          'device-1',
+          '--mode',
+          'natural',
+          '--iterations',
+          '3',
+          '--wait-ms',
+          '250',
+          '--no-install',
+        ]),
+      ).toMatchObject({
+        build: true,
+        deviceId: 'device-1',
+        install: false,
+        iterations: 3,
+        mode: 'natural',
+        waitMs: 250,
+      });
+    });
+
+    it('uses a supplied APK without rebuilding it', () => {
+      const options = parseArgs(['--apk', './fixture.apk']);
+
+      expect(options.build).toBe(false);
+      expect(options.apkPath).toMatch(/fixture\.apk$/);
+    });
+
+    it.each(['--device-id', '--apk', '--iterations', '--wait-ms', '--mode'])(
+      'rejects a missing value for %s',
+      (option) => {
+        expect(() => parseArgs([option])).toThrow(`${option} requires a value`);
+      },
+    );
+
+    it('rejects invalid modes and numeric ranges', () => {
+      expect(() => parseArgs(['--mode', 'simulated'])).toThrow(
+        '--mode must be deterministic or natural',
+      );
+      expect(() => parseArgs(['--iterations', '0'])).toThrow(
+        '--iterations must be a positive integer',
+      );
+      expect(() => parseArgs(['--wait-ms', '-1'])).toThrow(
+        '--wait-ms must be a non-negative number',
+      );
+    });
+  });
+
+  it('reads the latest tap count for an exact run id', () => {
+    const logs = [
+      'MidsceneTapRepro: run=native.1 tap_count=1',
+      'MidsceneTapRepro: run=nativeX1 tap_count=9',
+      'MidsceneTapRepro: run=native.1 tap_count=2',
+    ].join('\n');
+
+    expect(tapCountForRun(logs, 'native.1')).toBe(2);
+    expect(tapCountForRun(logs, 'missing')).toBe(0);
+  });
+
+  it('accepts the expected deterministic comparison', () => {
+    expect(() =>
+      assertDeterministicResults([
+        {
+          caseName: 'legacy-swipe',
+          firstAttemptScreenshot: 'legacy-first.png',
+          firstAttemptSwallowed: true,
+          firstAttemptTapCount: 0,
+          runId: 'legacy-1',
+          secondAttemptScreenshot: 'legacy-second.png',
+          secondAttemptTapCount: 1,
+        },
+        {
+          caseName: 'native-tap',
+          firstAttemptScreenshot: 'native-first.png',
+          firstAttemptSwallowed: false,
+          firstAttemptTapCount: 1,
+          runId: 'native-1',
+        },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects legacy swipes that register on the first attempt', () => {
+    expect(() =>
+      assertDeterministicResults([
+        {
+          caseName: 'legacy-swipe',
+          firstAttemptScreenshot: 'legacy-first.png',
+          firstAttemptSwallowed: false,
+          firstAttemptTapCount: 1,
+          runId: 'legacy-1',
+          secondAttemptScreenshot: 'legacy-second.png',
+          secondAttemptTapCount: 2,
+        },
+      ]),
+    ).toThrow('Legacy swipe did not reproduce');
+  });
+
+  it('rejects native taps that fail on the first attempt', () => {
+    expect(() =>
+      assertDeterministicResults([
+        {
+          caseName: 'native-tap',
+          firstAttemptScreenshot: 'native-first.png',
+          firstAttemptSwallowed: true,
+          firstAttemptTapCount: 0,
+          runId: 'native-1',
+        },
+      ]),
+    ).toThrow('Native tap did not succeed');
+  });
+});

--- a/packages/android/tsconfig.json
+++ b/packages/android/tsconfig.json
@@ -6,7 +6,7 @@
     "declarationDir": "dist/types",
     "types": ["node"]
   },
-  "include": ["src", "tests", "scripts/*.mjs"],
+  "include": ["src", "tests", "scripts/*.mjs", "scripts/*.ts"],
   "references": [
     {
       "path": "../core"


### PR DESCRIPTION
## Summary

- replace zero-distance 150 ms ADB swipes with the native ADB tap command for Android pointer taps
- add a deterministic WebView deeplink reproduction fixture that compares the legacy swipe behavior with the fixed tap behavior
- add unit coverage for tap command generation, reproduction CLI parsing, log parsing, and deterministic result validation

## Root cause

Android pointer taps were implemented as zero-distance swipes lasting 150 ms. Those gestures emit MOVE events, and an affected WebView can swallow the first gesture after deeplink navigation. The native tap command emits the expected tap semantics and succeeds without a warm-up input.

## Impact

Android aiTap calls now use native tap delivery while coordinate scaling and display selection remain unchanged. Drag and scroll gestures continue to use swipe commands. The fixture provides deterministic regression coverage and a natural mode for probing affected cloud-device environments.

Closes #2927

## Validation

- `pnpm run lint`
- `pnpm exec tsc --noEmit -p packages/android/tsconfig.json --pretty false`
- `pnpm exec nx test @midscene/android`: 19 files and 370 tests passed
- `pnpm exec nx build @midscene/android`
- deterministic APK build, install, deeplink launch, and input comparison on Samsung SM-N9860 Android 13: legacy first swipe was swallowed, second swipe succeeded, and native tap succeeded on the first attempt

## Prepatch release

- published `@midscene/android@1.10.12-beta-20260812094659.0` under the npm `beta` dist-tag
- [Release workflow run](https://github.com/web-infra-dev/midscene/actions/runs/31584287534)