### PR TITLE
fix(core): prevent nested report template bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Build project
       run: pnpm run build
 
+    - name: Check Report build feedback loop
+      run: pnpm run check:report-build-feedback-loop
+
     - name: Check CLI CJS bundle on minimum supported Node
       run: |
         node - <<'EOF'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "simple-git-hooks && pnpm run build",
     "check-dependency-version": "check-dependency-version-consistency .",
     "check:references": "node scripts/check-tsconfig-references.mjs",
+    "check:report-build-feedback-loop": "node scripts/check-report-build-feedback-loop.mjs",
     "lint": "npx biome check . --diagnostic-level=info --no-errors-on-unmatched --fix",
     "format:ci": "pretty-quick --since HEAD~1",
     "format": "pretty-quick --staged",

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -88,6 +88,13 @@ const reportGroupIdMap = new Map<string, string>();
 declare const __DEV_REPORT_PATH__: string;
 
 export function getReportTpl() {
+  // Report Viewer builds must not embed the report template from a previous
+  // Core build. Doing so creates a feedback loop where every Report rebuild
+  // contains another copy of the previous bundle.
+  if (IS_REPORT_BUILD) {
+    return '';
+  }
+
   if (typeof __DEV_REPORT_PATH__ === 'string' && __DEV_REPORT_PATH__) {
     return fs.readFileSync(__DEV_REPORT_PATH__, 'utf-8');
   }

--- a/packages/core/tests/unit-test/report-viewer-build.test.ts
+++ b/packages/core/tests/unit-test/report-viewer-build.test.ts
@@ -1,0 +1,13 @@
+import { getReportTpl, reportHTMLContent } from '@/utils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/constants', () => ({
+  IS_REPORT_BUILD: true,
+}));
+
+describe('Report Viewer build', () => {
+  it('excludes report generation and the embedded report template', () => {
+    expect(getReportTpl()).toBe('');
+    expect(reportHTMLContent('{}')).toBe('');
+  });
+});

--- a/scripts/check-report-build-feedback-loop.mjs
+++ b/scripts/check-report-build-feedback-loop.mjs
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const reportHtmlPath = path.join(
+  repositoryRoot,
+  'apps',
+  'report',
+  'dist',
+  'index.html',
+);
+
+function readReportSnapshot() {
+  const content = readFileSync(reportHtmlPath);
+  const html = content.toString('utf8');
+
+  return {
+    bytes: content.byteLength,
+    documentCount: html.match(/<!doctype html>/gi)?.length ?? 0,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function formatSnapshot(snapshot) {
+  return `${snapshot.bytes} bytes, ${snapshot.documentCount} HTML document(s), sha256=${snapshot.sha256}`;
+}
+
+const beforeRebuild = readReportSnapshot();
+
+if (beforeRebuild.documentCount === 0) {
+  throw new Error(
+    `Cannot check the Report build: ${reportHtmlPath} does not contain an HTML document.`,
+  );
+}
+
+execFileSync(
+  'pnpm',
+  ['exec', 'nx', 'build', '@midscene/report', '--skip-nx-cache'],
+  {
+    cwd: repositoryRoot,
+    stdio: 'inherit',
+  },
+);
+
+const afterRebuild = readReportSnapshot();
+// Rsbuild output hashes may vary between otherwise equivalent builds. The
+// feedback loop is identified by another embedded document and near-doubling.
+const hasEmbeddedDocument =
+  afterRebuild.documentCount > beforeRebuild.documentCount;
+const hasUnexpectedGrowth = afterRebuild.bytes > beforeRebuild.bytes * 1.5;
+
+if (hasEmbeddedDocument || hasUnexpectedGrowth) {
+  throw new Error(
+    [
+      'Report build feedback loop detected. The second build embedded a previous Report template.',
+      `Before: ${formatSnapshot(beforeRebuild)}`,
+      `After: ${formatSnapshot(afterRebuild)}`,
+    ].join('\n'),
+  );
+}
+
+console.log(
+  [
+    'Report build has no template feedback loop.',
+    `Before: ${formatSnapshot(beforeRebuild)}`,
+    `After: ${formatSnapshot(afterRebuild)}`,
+  ].join('\n'),
+);


### PR DESCRIPTION
## Summary

- prevent Report Viewer builds from embedding a report template from a previous Core build
- add regression coverage for Report Viewer template and report-generation exclusion
- add a CI guard that rebuilds Report and rejects embedded HTML documents or near-doubling output

## Root cause

Core injects the generated Report HTML into its built utilities. During a later Report build, that previously injected template could be bundled back into Report, creating a feedback loop. Repeated builds therefore grew the Report HTML and could eventually trigger the safety assertion that rejects Agent report-generation code in the viewer bundle.

## Impact

Report builds now exclude the embedded template at the template-owner boundary whenever `__MIDSCENE_REPORT_BUILD__` is enabled. Normal SDK, CLI, Playground, and report-generation behavior is unchanged.

The CI workflow now runs a second uncached Report build after the regular workspace build. It fails if another HTML document is embedded or the output grows by more than 50%, while allowing equivalent builds whose hashes differ because of bundler nondeterminism.

## Red/green verification

- Pre-fix revision: the first repeated build grew `apps/report/dist/index.html` from 2,599,607 bytes and 1 HTML document to 5,202,995 bytes and 2 HTML documents; the new guard failed as expected.
- Current revision: repeated builds stayed at 2,599,548 bytes and 1 HTML document; the same guard passed.

## Validation

- `pnpm exec nx test @midscene/core --skip-nx-cache`
- `pnpm exec nx build @midscene/report --skip-nx-cache`
- `pnpm run check:report-build-feedback-loop`
- pre-fix worktree: `node scripts/check-report-build-feedback-loop.mjs` (expected failure)
- `pnpm run lint`
- `git diff --check`
