### PR TITLE
feat(llm): add planning prompt supplements

### DIFF
--- a/packages/core/src/ai-model/model-adapter/planning.ts
+++ b/packages/core/src/ai-model/model-adapter/planning.ts
@@ -62,5 +62,6 @@ export function resolvePlanning(
     defaultReplanningCycleLimit:
       planning?.defaultReplanningCycleLimit ?? defaultReplanningCycleLimit,
     supportsActionDeepLocate: planning?.supportsActionDeepLocate ?? true,
+    systemPromptSupplement: planning?.systemPromptSupplement,
   };
 }

--- a/packages/core/src/ai-model/model-adapter/types.ts
+++ b/packages/core/src/ai-model/model-adapter/types.ts
@@ -162,10 +162,21 @@ interface PlanningPolicy {
   supportsActionDeepLocate: boolean;
 }
 
+export interface StandardPlanningPromptContext {
+  includeLocateInPlanning: boolean;
+}
+
+interface StandardPlanningPromptSupplementPolicy {
+  systemPromptSupplement?: (
+    context: StandardPlanningPromptContext,
+  ) => string | undefined;
+}
+
 export type PlanningAdapter =
-  | (PlanningPolicy & {
-      kind: 'standard';
-    })
+  | (PlanningPolicy &
+      StandardPlanningPromptSupplementPolicy & {
+        kind: 'standard';
+      })
   | (PlanningPolicy & {
       kind: 'custom';
       planFn: PlanFn;
@@ -173,9 +184,10 @@ export type PlanningAdapter =
     });
 
 export type PlanningDefinition =
-  | (Partial<PlanningPolicy> & {
-      kind?: 'standard';
-    })
+  | (Partial<PlanningPolicy> &
+      StandardPlanningPromptSupplementPolicy & {
+        kind?: 'standard';
+      })
   | (Partial<PlanningPolicy> &
       (
         | {

--- a/packages/core/src/ai-model/models/qwen.ts
+++ b/packages/core/src/ai-model/models/qwen.ts
@@ -27,6 +27,13 @@ const qwen3BboxCoordinatesMeta = {
   normalizedBy: 1000,
 } as const;
 
+const qwen3PlanningCoordinateSupplement = `[CRITICAL COORDINATE RULE]
+Every bbox number MUST be an integer within [0, 1000]. Any bbox value greater
+than 1000 or less than 0 is INVALID and forbidden. bbox is normalized to the
+0-1000 space, it has NOTHING to do with the screenshot's pixel width/height.
+Before writing action-param-json, self-check all four bbox numbers; if any
+falls outside [0, 1000], recompute it in the 0-1000 normalized space.`;
+
 function topLeftPointToPixelBbox(x: number, y: number): PixelBbox {
   return [
     Math.round(x),
@@ -133,6 +140,10 @@ const buildQwen25ChatCompletionParams = (
 };
 
 const qwen3Adapter: ModelAdapterDefinition = {
+  planning: {
+    systemPromptSupplement: ({ includeLocateInPlanning }) =>
+      includeLocateInPlanning ? qwen3PlanningCoordinateSupplement : undefined,
+  },
   chatCompletion: {
     unsupportedUserConfig: ['reasoningEffort'],
     buildChatCompletionParams: buildQwenChatCompletionParams,

--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -237,12 +237,14 @@ export async function systemPromptToTaskPlanning({
   includeLocateInPlanning,
   includeThought,
   includeSubGoals,
+  systemPromptSupplement,
 }: {
   actionSpace: DeviceAction<any>[];
   locatePromptSpec?: LocateResultPromptSpec;
   includeLocateInPlanning: boolean;
   includeThought?: boolean;
   includeSubGoals?: boolean;
+  systemPromptSupplement?: string;
 }) {
   const preferredLanguage = getPreferredLanguage();
 
@@ -377,7 +379,7 @@ After some time, when the last sub-goal is also completed, you can mark it as do
   const checkGoalStepNumber = shouldIncludeSubGoals ? 3 : 2;
   const actionStepNumber = shouldIncludeSubGoals ? 4 : 3;
 
-  return `
+  return `${systemPromptSupplement ? `\n${systemPromptSupplement}` : ''}
 Target: You are an expert to manipulate the UI to accomplish the user's instruction. User will give you an instruction, some screenshots, background knowledge and previous logs indicating what have been done. Your task is to accomplish the instruction by thinking through the path to complete the task and give the next action to execute.
 
 ${step1Title}

--- a/packages/core/src/ai-model/workflows/planning/standard-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning.ts
@@ -141,6 +141,12 @@ export async function standardPlan(
 
   // Only enable sub-goals when aiAct is in deep-thinking planning mode.
   const includeSubGoals = opts.deepThink === true;
+  const systemPromptSupplement =
+    adapter.planning.kind === 'standard'
+      ? adapter.planning.systemPromptSupplement?.({
+          includeLocateInPlanning: opts.includeLocateInPlanning,
+        })
+      : undefined;
 
   const systemPrompt = await systemPromptToTaskPlanning({
     actionSpace: opts.actionSpace,
@@ -148,6 +154,7 @@ export async function standardPlan(
     includeLocateInPlanning: opts.includeLocateInPlanning,
     includeThought: true, // always include thought
     includeSubGoals,
+    systemPromptSupplement,
   });
 
   const preparedImage = await prepareModelImage({

--- a/packages/core/tests/unit-test/model-adapter.test.ts
+++ b/packages/core/tests/unit-test/model-adapter.test.ts
@@ -271,8 +271,46 @@ describe('ResolvedModelAdapter', () => {
       cacheEnabled: false,
       defaultReplanningCycleLimit: 7,
       supportsActionDeepLocate: false,
+      systemPromptSupplement: undefined,
     });
     expect(adapter.locate.supportsSearchArea).toBe(false);
+  });
+
+  it('keeps standard planning prompt supplements from adapter definitions', () => {
+    const systemPromptSupplement = ({
+      includeLocateInPlanning,
+    }: {
+      includeLocateInPlanning: boolean;
+    }) =>
+      includeLocateInPlanning
+        ? 'Coordinate values must be normalized.'
+        : undefined;
+    const adapter = new ResolvedModelAdapter(
+      {
+        planning: {
+          systemPromptSupplement,
+        },
+      },
+      'test-standard-prompt-supplement',
+    );
+
+    expect(adapter.planning.kind).toBe('standard');
+    if (adapter.planning.kind !== 'standard') {
+      throw new Error('adapter should use standard planning');
+    }
+    expect(adapter.planning.systemPromptSupplement).toBe(
+      systemPromptSupplement,
+    );
+    expect(
+      adapter.planning.systemPromptSupplement?.({
+        includeLocateInPlanning: true,
+      }),
+    ).toBe('Coordinate values must be normalized.');
+    expect(
+      adapter.planning.systemPromptSupplement?.({
+        includeLocateInPlanning: false,
+      }),
+    ).toBeUndefined();
   });
 
   it('throws for unknown json parser presets', () => {

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -296,6 +296,20 @@ describe('system prompts', () => {
     expect(prompt).toMatchSnapshot();
   });
 
+  it('prepends a standard planning prompt supplement', async () => {
+    const prompt = await systemPromptToTaskPlanning({
+      actionSpace: mockActionSpace,
+      locatePromptSpec: locatePromptSpecFor('qwen3'),
+      includeLocateInPlanning: true,
+      systemPromptSupplement: '[CRITICAL COORDINATE RULE]',
+    });
+
+    expect(prompt.trimStart().startsWith('[CRITICAL COORDINATE RULE]')).toBe(
+      true,
+    );
+    expect(prompt).toContain('Target: You are an expert');
+  });
+
   it('planning - qwen - cot without bbox', async () => {
     const prompt = await systemPromptToTaskPlanning({
       actionSpace: mockActionSpace,


### PR DESCRIPTION
## Summary

- add a standard-planning adapter hook that builds an optional system prompt supplement from planning context
- apply a normalized bbox-coordinate reminder to Qwen3 planning only when locate results are produced in planning
- cover adapter resolution and prompt insertion with focused unit tests

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter.test.ts tests/unit-test/prompt/prompt.test.ts`