### PR TITLE
fix(visualizer): preserve SDK context during model verification

### DIFF
--- a/packages/visualizer/src/component/env-config/index.tsx
+++ b/packages/visualizer/src/component/env-config/index.tsx
@@ -44,7 +44,11 @@ export function EnvConfig({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const midsceneModelName = config.MIDSCENE_MODEL_NAME;
   const componentRef = useRef<HTMLDivElement>(null);
-  const verifyModel = onVerify ?? playgroundSDK?.runConnectivityTest;
+  const verifyModel =
+    onVerify ??
+    (playgroundSDK?.runConnectivityTest
+      ? playgroundSDK.runConnectivityTest.bind(playgroundSDK)
+      : undefined);
 
   const showModal = (event: React.MouseEvent) => {
     syncFromStorage();


### PR DESCRIPTION
## Summary

- bind `PlaygroundSDK.runConnectivityTest` to its SDK instance before passing it to the shared config modal
- preserve explicit `onVerify` overrides unchanged
- fix model verification in Android Playground and other SDK-backed playground surfaces

## Root cause

The shared `EnvConfig` component extracted `playgroundSDK.runConnectivityTest` into a standalone function. Calling that unbound method lost its receiver, so `PlaygroundSDK.runConnectivityTest` attempted to read `this.adapter` from `undefined`.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/visualizer` (115 tests passed)
- `pnpm exec nx build @midscene/visualizer`
- `pnpm exec nx build android-playground --skip-nx-cache`
- manually rebuilt Android Playground static assets for local verification