### PR TITLE
fix(core): preserve YAML aiInput text values

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -612,7 +612,7 @@ tasks:
 
       # Input text into an element described by a prompt.
       - aiInput: <prompt> # The element to input text into.
-        value: <final text content of the input>
+        value: "<final text content of the input>" # Quotes are recommended to make the text intent explicit; unquoted numeric forms such as 00005 are also preserved verbatim.
         deepLocate: <boolean> # Optional, whether to enable Deep Locate for this element. Defaults to False.
         xpath: <xpath> # Optional, the xpath of the target element for the operation. If provided, Midscene will prioritize this xpath to find the element before using the cache and the AI model. Defaults to empty.
         cacheable: <boolean> # Optional, whether to cache the result of this API call when the [caching feature](./caching.mdx) is enabled. Defaults to True.

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -618,7 +618,7 @@ tasks:
 
       # 输入文本到一个元素，用 prompt 描述元素位置
       - aiInput: <prompt> # 要输入文本的元素
-        value: <输入框的最终文本内容>
+        value: "<输入框的最终文本内容>" # 建议使用引号明确表示文本；未加引号的数字形式（如 00005）也会按原始文本保留
         deepLocate: <boolean> # 可选，是否为该元素开启深度定位。默认值为 False
         xpath: <xpath> # 可选，目标元素的 xpath 路径，用于执行当前操作。如果提供了这个 xpath，Midscene 会优先使用该 xpath 来找到元素，然后依次使用缓存和 AI 模型。默认值为空
         cacheable: <boolean> # 可选，当启用 [缓存功能](./caching.mdx) 时，是否允许缓存当前 API 调用结果。默认值为 True

--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -7,10 +7,22 @@ import type {
 } from '@/types';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
-import yaml from 'js-yaml';
+import yaml, { type Type as YamlType } from 'js-yaml';
 import { buildLocatePromptWithContext } from '../agent/prompt-context';
 
 const debugUtils = getDebug('yaml:utils');
+
+const yamlTypes = (
+  yaml as typeof yaml & {
+    types: Record<'null' | 'bool' | 'int' | 'float', YamlType>;
+  }
+).types;
+
+// Keep implicit scalars as text while preserving support for the explicit tags
+// accepted by JSON_SCHEMA, such as !!int and !!bool.
+const rawTextSchema = yaml.FAILSAFE_SCHEMA.extend({
+  explicit: [yamlTypes.null, yamlTypes.bool, yamlTypes.int, yamlTypes.float],
+});
 
 const topLevelTasksPattern = /^tasks\s*:/;
 const topLevelYamlKeyPattern = /^[^\s#][^:]*:/;
@@ -26,6 +38,71 @@ export type ResolvedWebTarget = {
 export type WebTargetConfig = Partial<
   Record<WebTargetSource, Partial<MidsceneYamlScriptWebEnv>>
 >;
+
+type YamlRecord = Record<string, unknown>;
+
+function isYamlRecord(value: unknown): value is YamlRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwnYamlProperty(value: YamlRecord, property: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, property);
+}
+
+function preserveAiInputTextValues(
+  typedScript: MidsceneYamlScript,
+  textScript: unknown,
+): void {
+  if (!isYamlRecord(textScript) || !Array.isArray(textScript.tasks)) {
+    return;
+  }
+  const textTasks = textScript.tasks;
+
+  typedScript.tasks.forEach((typedTask, taskIndex) => {
+    const textTask = textTasks[taskIndex];
+    if (
+      !isYamlRecord(typedTask) ||
+      !Array.isArray(typedTask.flow) ||
+      !isYamlRecord(textTask)
+    ) {
+      return;
+    }
+
+    const textFlow = textTask.flow;
+    if (!Array.isArray(textFlow)) {
+      return;
+    }
+
+    typedTask.flow.forEach((typedFlowItem, flowItemIndex) => {
+      const textFlowItem = textFlow[flowItemIndex];
+      if (!isYamlRecord(typedFlowItem) || !isYamlRecord(textFlowItem)) {
+        return;
+      }
+
+      if (!hasOwnYamlProperty(typedFlowItem, 'aiInput')) {
+        return;
+      }
+
+      // Current format: aiInput is the locate prompt and value is the text.
+      if (
+        hasOwnYamlProperty(typedFlowItem, 'value') &&
+        hasOwnYamlProperty(textFlowItem, 'value')
+      ) {
+        typedFlowItem.value = textFlowItem.value;
+        return;
+      }
+
+      // Legacy format: aiInput is the text and the sibling locate field is the
+      // locate prompt.
+      if (
+        hasOwnYamlProperty(typedFlowItem, 'locate') &&
+        hasOwnYamlProperty(textFlowItem, 'aiInput')
+      ) {
+        typedFlowItem.aiInput = textFlowItem.aiInput;
+      }
+    });
+  });
+}
 
 const webTargetSources: WebTargetSource[] = [
   'page',
@@ -262,6 +339,12 @@ export function parseYamlScript(
     Array.isArray(obj.tasks),
     `property "tasks" must be an array in yaml script, but got ${obj.tasks}`,
   );
+
+  const textObj = yaml.load(interpolatedContent, {
+    schema: rawTextSchema,
+  });
+  preserveAiInputTextValues(obj, textObj);
+
   return obj;
 }
 

--- a/packages/web-integration/tests/unit-test/yaml/player.test.ts
+++ b/packages/web-integration/tests/unit-test/yaml/player.test.ts
@@ -900,6 +900,33 @@ tasks:
 });
 
 describe('YAML Player - aiInput with number values', () => {
+  test('should preserve leading zeros in an unquoted value', async () => {
+    const yamlString = `
+target:
+  url: "https://example.com"
+tasks:
+  - name: test_input_leading_zeros
+    flow:
+      - aiInput: 'input field'
+        value: 00005
+`;
+
+    const script = parseYamlScript(yamlString);
+    const mockAgent = await getMockAgent();
+    const player = new ScriptPlayer<MidsceneYamlScriptWebEnv>(
+      script,
+      async () => mockAgent,
+    );
+
+    await player.run();
+
+    expect(player.status).toBe('done');
+    expect(
+      (mockAgent.agent.callActionInActionSpace as MockedFunction<any>).mock
+        .calls[0][1].value,
+    ).toBe('00005');
+  });
+
   test('should accept integer value', async () => {
     const yamlString = `
 target:
@@ -1146,7 +1173,7 @@ tasks:
               "prompt": "salary field",
               "xpath": undefined,
             },
-            "value": "50000.5",
+            "value": "50000.50",
           },
         ],
         [

--- a/packages/web-integration/tests/unit-test/yaml/utils.test.ts
+++ b/packages/web-integration/tests/unit-test/yaml/utils.test.ts
@@ -126,6 +126,88 @@ tasks:
       expect(result.android?.deviceId).toBe('0aacde222');
     });
 
+    test('preserves implicit scalar text for current aiInput values', () => {
+      const yamlContent = `
+web:
+  url: "https://example.com"
+  viewportWidth: 1440
+  forceSameTabNavigation: false
+tasks:
+  - name: preserve input text
+    flow:
+      - aiInput: teller number input
+        value: 00005
+      - aiInput: decimal input
+        value: 50000.50
+      - aiInput: hexadecimal-looking input
+        value: 0x10
+      - aiInput: boolean-looking input
+        value: false
+      - aiInput: null-looking input
+        value: null
+      - runWdaRequest:
+          data:
+            retryCount: 5
+            enabled: false
+`;
+
+      const result = parseYamlScript(yamlContent);
+
+      expect(result.web?.viewportWidth).toBe(1440);
+      expect(result.web?.forceSameTabNavigation).toBe(false);
+      expect(result.tasks[0].flow).toMatchObject([
+        { aiInput: 'teller number input', value: '00005' },
+        { aiInput: 'decimal input', value: '50000.50' },
+        { aiInput: 'hexadecimal-looking input', value: '0x10' },
+        { aiInput: 'boolean-looking input', value: 'false' },
+        { aiInput: 'null-looking input', value: 'null' },
+        {
+          runWdaRequest: {
+            data: { retryCount: 5, enabled: false },
+          },
+        },
+      ]);
+    });
+
+    test('preserves implicit scalar text for legacy aiInput values', () => {
+      const yamlContent = `
+web:
+  url: "https://example.com"
+tasks:
+  - name: preserve legacy input text
+    flow:
+      - aiInput: 00005
+        locate: teller number input
+`;
+
+      const result = parseYamlScript(yamlContent);
+
+      expect(result.tasks[0].flow[0]).toMatchObject({
+        aiInput: '00005',
+        locate: 'teller number input',
+      });
+    });
+
+    test('keeps explicit YAML tags compatible with JSON schema', () => {
+      const yamlContent = `
+web:
+  url: "https://example.com"
+  viewportWidth: !!int 1440
+  forceSameTabNavigation: !!bool false
+tasks:
+  - name: explicit tags
+    flow:
+      - aiInput: teller number input
+        value: !!str 00005
+`;
+
+      const result = parseYamlScript(yamlContent);
+
+      expect(result.web?.viewportWidth).toBe(1440);
+      expect(result.web?.forceSameTabNavigation).toBe(false);
+      expect(result.tasks[0].flow[0]).toMatchObject({ value: '00005' });
+    });
+
     test('aiRightClick', () => {
       const yamlContent = `
 target:


### PR DESCRIPTION
## Summary

- parse YAML scripts with the existing `JSON_SCHEMA` plus a raw-text schema
- preserve the original scalar text only for modern `aiInput.value` and legacy `aiInput + locate`
- keep booleans, numbers, explicit YAML tags, and arbitrary payloads on the existing typed parse path
- document that quotes remain recommended while unquoted numeric-looking input is preserved verbatim

## Root cause

`js-yaml` resolves an unquoted value such as `00005` to the number `5` under `JSON_SCHEMA`. The YAML player later converts that number back to a string, but the leading zeros have already been lost.

## Implementation

The parser now creates two trees from the same interpolated YAML source:

1. a typed tree using `JSON_SCHEMA`
2. a text tree that keeps implicit scalars as text while retaining support for explicit tags such as `!!int` and `!!bool`

The typed tree remains authoritative. A field-aware merge restores raw text only for `aiInput` input values, including the legacy sibling-`locate` syntax. This leaves fields such as `sleep`, `continueOnError`, and `runWdaRequest.data` unchanged.

Design discussion: [Feishu document](https://bytedance.larkoffice.com/docx/MnFXdByGXoMxz4xmR6cclnQrnTh)

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/core`
- `pnpm exec nx test @midscene/web` — 427 passed, 1 skipped
- `pnpm exec nx test @midscene/web -- tests/unit-test/yaml/utils.test.ts tests/unit-test/yaml/player.test.ts` — 43 passed
