### PR TITLE
test(report): verify screenshot pixel integrity

### DIFF
--- a/packages/core/tests/unit-test/report-generator-directory.test.ts
+++ b/packages/core/tests/unit-test/report-generator-directory.test.ts
@@ -12,6 +12,8 @@ import { ScreenshotItem } from '@/screenshot-item';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   createExecution,
+  createPatternedPngFixture,
+  decodeImagePixels,
   defaultReportMeta,
   fakeBase64,
   getReportGeneratorTmpDir,
@@ -33,6 +35,34 @@ describe('ReportGenerator directory mode', () => {
     if (existsSync(temporaryDirectory)) {
       rmSync(temporaryDirectory, { recursive: true, force: true });
     }
+  });
+
+  it('preserves exact screenshot pixels in external assets', async () => {
+    const reportDirectory = join(temporaryDirectory, 'pixel-integrity');
+    const reportPath = join(reportDirectory, 'index.html');
+    const generator = new ReportGenerator({
+      reportPath,
+      screenshotMode: 'directory',
+      autoPrint: false,
+    });
+    const { dataUri, expectedImage } = await createPatternedPngFixture();
+    const screenshot = ScreenshotItem.create(dataUri, Date.now());
+
+    generator.onExecutionUpdate(
+      createExecution([screenshot]),
+      defaultReportMeta,
+    );
+    await generator.finalize();
+
+    const screenshotPath = join(
+      reportDirectory,
+      'screenshots',
+      `${screenshot.id}.png`,
+    );
+    expect(existsSync(screenshotPath)).toBe(true);
+    await expect(
+      decodeImagePixels(readFileSync(screenshotPath)),
+    ).resolves.toEqual(expectedImage);
   });
 
   it('writes each PNG/JPEG once with typed file references', async () => {

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -19,6 +19,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildIncrementalExecution,
   createExecution,
+  createPatternedPngFixture,
+  decodeImagePixels,
   defaultReportMeta,
   fakeBase64,
   getReportGeneratorTmpDir,
@@ -71,6 +73,32 @@ describe('ReportGenerator — append-only model', () => {
   });
 
   describe('inline mode — append-only strategy', () => {
+    it('preserves exact screenshot pixels in the HTML report', async () => {
+      const reportPath = join(tmpDir, 'pixel-integrity.html');
+      const generator = new ReportGenerator({
+        reportPath,
+        screenshotMode: 'inline',
+        autoPrint: false,
+      });
+      const { dataUri, expectedImage } = await createPatternedPngFixture();
+      const screenshot = ScreenshotItem.create(dataUri, Date.now());
+
+      generator.onExecutionUpdate(
+        createExecution([screenshot]),
+        defaultReportMeta,
+      );
+      await generator.finalize();
+
+      const imageMap = parseImageScripts(readFileSync(reportPath, 'utf-8'));
+      const outputDataUri = imageMap[screenshot.id];
+      expect(outputDataUri).toBeDefined();
+      const outputBase64 = outputDataUri.split(',', 2)[1];
+      expect(outputBase64).toBeDefined();
+      await expect(
+        decodeImagePixels(Buffer.from(outputBase64, 'base64')),
+      ).resolves.toEqual(expectedImage);
+    });
+
     it('should write each screenshot image tag exactly once across multiple updates', async () => {
       const reportPath = join(tmpDir, 'inline-test.html');
       const generator = new ReportGenerator({

--- a/packages/core/tests/unit-test/test-helpers/report-generator.ts
+++ b/packages/core/tests/unit-test/test-helpers/report-generator.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ScreenshotItem } from '@/screenshot-item';
 import { ExecutionDump, type ReportMeta } from '@/types';
+import sharp from 'sharp';
 
 /** Create a valid-looking image data URL with a predictable payload size. */
 export function fakeBase64(
@@ -69,4 +70,35 @@ export function parseScriptAttributes(openTag: string): Record<string, string> {
     attributes[match[1]] = decodeURIComponent(match[2]);
   }
   return attributes;
+}
+
+export async function decodeImagePixels(image: Buffer) {
+  const { data, info } = await sharp(image)
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  return {
+    width: info.width,
+    height: info.height,
+    channels: info.channels,
+    pixels: data,
+  };
+}
+
+export async function createPatternedPngFixture() {
+  const width = 2;
+  const height = 2;
+  const channels = 3;
+  const pixels = Buffer.from([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]);
+  const png = await sharp(pixels, {
+    raw: { width, height, channels },
+  })
+    .png()
+    .toBuffer();
+
+  return {
+    dataUri: `data:image/png;base64,${png.toString('base64')}`,
+    expectedImage: { width, height, channels, pixels },
+  };
 }


### PR DESCRIPTION
## Summary

Add pixel-integrity regression coverage for screenshots embedded in Midscene HTML reports.

Existing tests verify screenshot references and file counts but do not decode output images. A screenshot could therefore exist while its pixels are corrupted or entirely black.

The tests generate a deterministic non-black PNG with `sharp`, pass it through `ReportGenerator`, decode the output, and verify non-black, non-uniform pixels.

## Coverage

- inline mode: decode the base64 image stored in generated HTML
- directory mode: decode the external PNG under `screenshots/`

This is test-only and does not modify production behavior.

## AI assistance

Developed with AI assistance; image generation and decoding assertions were manually reviewed.
