### PR TITLE
refactor(core): unify locator schema detection

### DIFF
--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -4,6 +4,10 @@ import type {
   PlanningAction,
 } from '@/types';
 import { isPlainObject } from '@midscene/shared/utils';
+import {
+  isMidsceneLocatorField,
+  markMidsceneLocatorField,
+} from '@midscene/shared/zod-schema-utils';
 import { z } from 'zod';
 
 export function findActionInActionSpaceOrThrow(
@@ -130,18 +134,20 @@ export const userPromptToMultimodalPrompt = (
 };
 
 // Schema for locator field input (when users provide locate parameters)
-const MidsceneLocationInput = z
-  .object({
-    prompt: TUserPromptSchema,
-    deepLocate: z.boolean().optional(),
-    deepThink: z
-      .boolean()
-      .optional()
-      .describe('@deprecated Use `deepLocate` instead.'),
-    cacheable: z.boolean().optional(),
-    xpath: z.union([z.string(), z.boolean()]).optional(),
-  })
-  .passthrough();
+const MidsceneLocationInput = markMidsceneLocatorField(
+  z
+    .object({
+      prompt: TUserPromptSchema,
+      deepLocate: z.boolean().optional(),
+      deepThink: z
+        .boolean()
+        .optional()
+        .describe('@deprecated Use `deepLocate` instead.'),
+      cacheable: z.boolean().optional(),
+      xpath: z.union([z.string(), z.boolean()]).optional(),
+    })
+    .passthrough(),
+);
 
 /**
  * Returns the schema for locator fields.
@@ -149,26 +155,6 @@ const MidsceneLocationInput = z
  */
 export const getMidsceneLocationSchema = () => {
   return MidsceneLocationInput;
-};
-
-export const ifMidsceneLocatorField = (field: any): boolean => {
-  // Handle optional fields by getting the inner type
-  let actualField = field;
-  if (actualField._def?.typeName === 'ZodOptional') {
-    actualField = actualField._def.innerType;
-  }
-
-  // Check if this is a ZodObject
-  if (actualField._def?.typeName === 'ZodObject') {
-    const shape = actualField._def.shape();
-
-    // Input schema has 'prompt' as a required field
-    if ('prompt' in shape && shape.prompt) {
-      return true;
-    }
-  }
-
-  return false;
 };
 
 const formatPromptWithImages = (
@@ -196,9 +182,7 @@ export const findAllMidsceneLocatorField = (
     const keys = Object.keys(zodObject.shape);
     return keys.filter((key) => {
       const field = zodObject.shape[key];
-      // TODO: A similar locator-field check exists as isMidsceneLocatorField in
-      // @midscene/shared/zod-schema-utils.
-      if (!ifMidsceneLocatorField(field)) {
+      if (!isMidsceneLocatorField(field)) {
         return false;
       }
 

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -519,6 +519,19 @@ describe('insertScriptBeforeClosingHtml', () => {
     expect(result).toEqual([]);
   });
 
+  it('findAllMidsceneLocatorField - does not infer locator from prompt alone', () => {
+    const result = findAllMidsceneLocatorField(
+      z.object({
+        request: z.object({
+          prompt: z.string(),
+          temperature: z.number(),
+        }),
+      }),
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it('findAllMidsceneLocatorField - requiredOnly parameter', () => {
     const schema = z.object({
       a: getMidsceneLocationSchema(),

--- a/packages/shared/src/zod-schema-utils.ts
+++ b/packages/shared/src/zod-schema-utils.ts
@@ -1,5 +1,27 @@
 import type { z } from 'zod';
 
+const MIDSCENE_LOCATOR_FIELD_MARKER = Symbol.for(
+  '@midscene/shared/midscene-locator-field',
+);
+
+type MarkedZodDefinition = {
+  [MIDSCENE_LOCATOR_FIELD_MARKER]?: true;
+};
+
+/**
+ * Mark a Zod schema as a Midscene locator field.
+ *
+ * The marker lives on the unwrapped Zod definition object so schema clones
+ * created by helpers such as `.describe()` retain it, regardless of whether
+ * wrapper schemas are applied before or after this function.
+ */
+export function markMidsceneLocatorField<T extends z.ZodTypeAny>(field: T): T {
+  const actualField = unwrapZodField(field) as z.ZodTypeAny;
+  (actualField._def as MarkedZodDefinition)[MIDSCENE_LOCATOR_FIELD_MARKER] =
+    true;
+  return field;
+}
+
 /**
  * Recursively unwrap optional, nullable, default, and effects wrapper types
  * to get the actual inner Zod type
@@ -32,23 +54,11 @@ export function unwrapZodField(field: unknown): unknown {
 }
 
 /**
- * Check if a field is a Midscene locator field
- * Locator input schemas are identified by their prompt field.
+ * Check if a field is explicitly marked as a Midscene locator field.
  */
 export function isMidsceneLocatorField(field: unknown): boolean {
-  const actualField = unwrapZodField(field) as {
-    _def?: { typeName?: string; shape?: () => Record<string, unknown> };
-  };
-
-  if (actualField._def?.typeName === 'ZodObject') {
-    const shape = actualField._def.shape?.();
-    if (shape) {
-      if ('prompt' in shape && shape.prompt) {
-        return true;
-      }
-    }
-  }
-  return false;
+  const actualField = unwrapZodField(field) as { _def?: MarkedZodDefinition };
+  return actualField._def?.[MIDSCENE_LOCATOR_FIELD_MARKER] === true;
 }
 
 /**

--- a/packages/shared/tests/unit-test/tool-generator.test.ts
+++ b/packages/shared/tests/unit-test/tool-generator.test.ts
@@ -20,6 +20,7 @@ import { composeUserPrompt } from '@/agent-tools/user-prompt';
 import { withCliVerboseContext } from '@/cli';
 import * as cliInterrupt from '@/cli/interrupt';
 import { createRecordCliCommand } from '@/cli/record-command';
+import { markMidsceneLocatorField } from '@/zod-schema-utils';
 import { describe, expect, it, rs } from '@rstest/core';
 import { z } from 'zod';
 
@@ -36,15 +37,17 @@ const multimodalPromptSchema = z.object({
   convertHttpImage2Base64: z.boolean().optional(),
 });
 
-const locateSchema = z
-  .object({
-    prompt: z.union([z.string(), multimodalPromptSchema]),
-    deepLocate: z.boolean().optional(),
-    deepThink: z.boolean().optional(),
-    cacheable: z.boolean().optional(),
-    xpath: z.union([z.string(), z.boolean()]).optional(),
-  })
-  .passthrough();
+const locateSchema = markMidsceneLocatorField(
+  z
+    .object({
+      prompt: z.union([z.string(), multimodalPromptSchema]),
+      deepLocate: z.boolean().optional(),
+      deepThink: z.boolean().optional(),
+      cacheable: z.boolean().optional(),
+      xpath: z.union([z.string(), z.boolean()]).optional(),
+    })
+    .passthrough(),
+);
 
 const actionSpace = [
   {

--- a/packages/shared/tests/unit-test/zod-schema-utils.test.ts
+++ b/packages/shared/tests/unit-test/zod-schema-utils.test.ts
@@ -2,6 +2,7 @@ import {
   getZodDescription,
   getZodTypeName,
   isMidsceneLocatorField,
+  markMidsceneLocatorField,
   unwrapZodField,
 } from '@/zod-schema-utils';
 import { describe, expect, it } from '@rstest/core';
@@ -173,36 +174,59 @@ describe('zod-schema-utils', () => {
       expect(isMidsceneLocatorField(z.number())).toBe(false);
     });
 
-    it('should return true for object with prompt field', () => {
-      const schema = z.object({
-        prompt: z.string(),
-        deepLocate: z.boolean().optional(),
-      });
+    it('should return true for the canonical locator schema', () => {
+      const schema = markMidsceneLocatorField(
+        z.object({
+          prompt: z.string(),
+          deepLocate: z.boolean().optional(),
+        }),
+      );
       expect(isMidsceneLocatorField(schema)).toBe(true);
     });
 
-    it('should return false for object without prompt field', () => {
+    it('should return false for an unmarked object with prompt field', () => {
       const schema = z.object({
-        command: z.string(),
+        prompt: z.string(),
       });
       expect(isMidsceneLocatorField(schema)).toBe(false);
     });
 
-    it('should handle optional locator field', () => {
-      const schema = z
-        .object({
-          prompt: z.string(),
-        })
+    it('should handle optional and described locator fields', () => {
+      const schema = markMidsceneLocatorField(z.object({ prompt: z.string() }))
+        .describe('target element')
         .optional();
       expect(isMidsceneLocatorField(schema)).toBe(true);
+    });
+
+    it('should handle nested nullable and optional locator wrappers', () => {
+      const schema = markMidsceneLocatorField(z.object({ prompt: z.string() }))
+        .nullable()
+        .optional();
+      expect(isMidsceneLocatorField(schema)).toBe(true);
+    });
+
+    it('should handle wrappers applied before marking the locator field', () => {
+      const schema = markMidsceneLocatorField(
+        z.object({ prompt: z.string() }).nullable().optional(),
+      );
+      expect(isMidsceneLocatorField(schema)).toBe(true);
+    });
+
+    it('should handle default and transform locator wrappers', () => {
+      const locatorSchema = markMidsceneLocatorField(
+        z.object({ prompt: z.string() }),
+      );
+      const defaultSchema = locatorSchema.default({ prompt: 'default target' });
+      const transformedSchema = locatorSchema.transform((value) => value);
+
+      expect(isMidsceneLocatorField(defaultSchema)).toBe(true);
+      expect(isMidsceneLocatorField(transformedSchema)).toBe(true);
     });
 
     it('should handle z.preprocess wrapping locator field', () => {
       const schema = z.preprocess(
         (val) => val,
-        z.object({
-          prompt: z.string(),
-        }),
+        markMidsceneLocatorField(z.object({ prompt: z.string() })),
       );
       expect(isMidsceneLocatorField(schema)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- mark the canonical Midscene locator schema explicitly instead of inferring locator fields from a `prompt` property
- reuse the shared locator predicate in core and remove the duplicate core implementation
- remove the unused `dumpMidsceneLocatorField` helper
- cover wrapped locator schemas and prevent ordinary `{ prompt: ... }` objects from being misidentified
- store the marker on the unwrapped schema so wrappers can be applied before or after marking

## Why

Core and the shared action-tool adapter maintained separate structural locator checks. Besides duplicating logic, treating every object with a `prompt` field as a locator could misclassify unrelated custom action parameters.

The locator schema now carries an explicit marker. Both core and shared read the same marker after unwrapping supported Zod wrappers, while prompt and location schema ownership remains in core.

## Impact

Built-in actionSpace behavior is unchanged. Custom actions should use `getMidsceneLocationSchema()` for locator parameters instead of relying on a structurally similar object with a `prompt` field.

## Validation

- `pnpm run lint`
- `pnpm nx build @midscene/core`
- `pnpm exec nx build @midscene/shared`
- `pnpm --filter @midscene/shared test -- tests/unit-test/zod-schema-utils.test.ts tests/unit-test/tool-generator.test.ts`
- `pnpm --filter @midscene/core test -- tests/unit-test/utils.test.ts -t findAllMidsceneLocatorField`