### PR TITLE
feat(puppeteer): handle native alerts with virtual surfaces

### DIFF
--- a/packages/web-integration/src/common/virtual-web-surface.ts
+++ b/packages/web-integration/src/common/virtual-web-surface.ts
@@ -1,0 +1,65 @@
+import type {
+  ElementCacheFeature,
+  ElementTreeNode,
+  Rect,
+  Size,
+} from '@midscene/core';
+import type { ElementInfo } from '@midscene/shared/extractor';
+import type { KeyInput, MouseButton } from '../web-page';
+
+export type VirtualWebSurfaceAction =
+  | {
+      type: 'mouse.click';
+      x: number;
+      y: number;
+      button: MouseButton;
+      count: number;
+    }
+  | { type: 'mouse.wheel'; deltaX: number; deltaY: number }
+  | { type: 'mouse.move'; x: number; y: number }
+  | {
+      type: 'mouse.drag';
+      from: { x: number; y: number };
+      to: { x: number; y: number };
+    }
+  | { type: 'keyboard.type'; text: string; delay?: number }
+  | {
+      type: 'keyboard.press';
+      keys: Array<{ key: KeyInput; command?: string }>;
+    }
+  | { type: 'keyboard.down'; key: KeyInput }
+  | { type: 'keyboard.up'; key: KeyInput }
+  | { type: 'input.clear'; element?: ElementInfo }
+  | { type: 'navigation.navigate'; url: string }
+  | { type: 'navigation.reload' }
+  | { type: 'navigation.goBack' }
+  | { type: 'navigation.goForward' }
+  | {
+      type: 'gesture.swipe';
+      from: { x: number; y: number };
+      to: { x: number; y: number };
+      duration: number;
+    }
+  | { type: 'gesture.longPress'; x: number; y: number; duration: number }
+  | {
+      type: 'gesture.pinch';
+      centerX: number;
+      centerY: number;
+      startDistance: number;
+      endDistance: number;
+      duration: number;
+    };
+
+/**
+ * The minimum page-like contract presented to an Agent while the real page is
+ * temporarily unavailable (for example, while a native browser dialog pauses
+ * its JavaScript execution context).
+ */
+export interface VirtualWebSurface {
+  size(): Promise<Size>;
+  screenshotBase64(): Promise<string>;
+  getElementsNodeTree(): Promise<ElementTreeNode<ElementInfo>>;
+  cacheFeatureForPoint(center: [number, number]): Promise<ElementCacheFeature>;
+  rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect>;
+  dispatchAction(action: VirtualWebSurfaceAction): Promise<void>;
+}

--- a/packages/web-integration/src/common/web-surface-router.ts
+++ b/packages/web-integration/src/common/web-surface-router.ts
@@ -1,0 +1,349 @@
+export type WebSurfaceMode = 'real' | 'virtual' | 'resuming';
+
+export type WebSurfaceLease<VirtualSurface> = Readonly<{
+  mode: WebSurfaceMode;
+  epoch: number;
+  virtualSurface?: VirtualSurface;
+}>;
+
+export type WebSurfaceState<VirtualSurface> =
+  | Readonly<{
+      mode: 'real';
+      epoch: number;
+    }>
+  | Readonly<{
+      mode: 'virtual' | 'resuming';
+      epoch: number;
+      virtualSurface: VirtualSurface;
+    }>;
+
+export type WebSurfaceRoute<VirtualSurface, Result> = {
+  real: (lease: WebSurfaceLease<VirtualSurface>) => Result | Promise<Result>;
+  virtual: (
+    surface: VirtualSurface,
+    lease: WebSurfaceLease<VirtualSurface>,
+  ) => Result | Promise<Result>;
+  resuming?: (
+    surface: VirtualSurface,
+    lease: WebSurfaceLease<VirtualSurface>,
+  ) => Result | Promise<Result>;
+};
+
+export type InterruptibleWebOperationResult<VirtualSurface, Result> =
+  | {
+      status: 'completed';
+      value: Result;
+      lease: WebSurfaceLease<VirtualSurface>;
+    }
+  | {
+      status: 'interrupted';
+      lease: WebSurfaceLease<VirtualSurface>;
+    };
+
+type VirtualActivationWaiter<VirtualSurface> = {
+  afterEpoch: number;
+  resolve: (lease: WebSurfaceLease<VirtualSurface>) => void;
+};
+
+/**
+ * Routes web observations and actions between the real page and a temporary
+ * virtual surface. Transitions are synchronous and versioned so callers can
+ * retain an immutable lease for the lifetime of one operation.
+ */
+export class WebSurfaceRouter<VirtualSurface> {
+  private epoch = 0;
+
+  private state: WebSurfaceState<VirtualSurface> = {
+    mode: 'real',
+    epoch: this.epoch,
+  };
+
+  private readonly virtualActivationWaiters = new Set<
+    VirtualActivationWaiter<VirtualSurface>
+  >();
+
+  private readonly interruptedRealOperations = new Set<Promise<unknown>>();
+
+  getState(): WebSurfaceState<VirtualSurface> {
+    return this.state;
+  }
+
+  acquireLease(): WebSurfaceLease<VirtualSurface> {
+    return this.state;
+  }
+
+  isVirtualOrResuming(): boolean {
+    return this.state.mode !== 'real';
+  }
+
+  isCurrentLease(lease: WebSurfaceLease<VirtualSurface>): boolean {
+    return lease.epoch === this.state.epoch && lease.mode === this.state.mode;
+  }
+
+  get interruptedRealOperationCount(): number {
+    return this.interruptedRealOperations.size;
+  }
+
+  activateVirtualSurface(
+    virtualSurface: VirtualSurface,
+  ): WebSurfaceLease<VirtualSurface> {
+    if (this.state.mode === 'virtual') {
+      throw new Error(
+        '[midscene] Cannot activate a virtual web surface while another virtual surface is active.',
+      );
+    }
+
+    this.state = {
+      mode: 'virtual',
+      epoch: this.nextEpoch(),
+      virtualSurface,
+    };
+
+    const lease = this.acquireLease();
+    this.resolveVirtualActivationWaiters(lease);
+    return lease;
+  }
+
+  beginResuming(
+    expectedLease?: WebSurfaceLease<VirtualSurface>,
+  ): WebSurfaceLease<VirtualSurface> {
+    this.assertState('virtual', expectedLease);
+    if (this.state.mode !== 'virtual') {
+      throw new Error(
+        `[midscene] Expected web surface state "virtual", but current state is "${this.state.mode}".`,
+      );
+    }
+    const virtualSurface = this.state.virtualSurface;
+    this.state = {
+      mode: 'resuming',
+      epoch: this.nextEpoch(),
+      virtualSurface,
+    };
+    return this.acquireLease();
+  }
+
+  finishResuming(
+    expectedLease?: WebSurfaceLease<VirtualSurface>,
+  ): WebSurfaceLease<VirtualSurface> {
+    this.assertState('resuming', expectedLease);
+    if (this.interruptedRealOperations.size > 0) {
+      throw new Error(
+        '[midscene] Cannot finish resuming the real web surface before interrupted real operations have settled.',
+      );
+    }
+
+    this.state = {
+      mode: 'real',
+      epoch: this.nextEpoch(),
+    };
+    return this.acquireLease();
+  }
+
+  resetToReal(
+    expectedLease?: WebSurfaceLease<VirtualSurface>,
+  ): WebSurfaceLease<VirtualSurface> {
+    if (expectedLease && !this.isCurrentLease(expectedLease)) {
+      throw this.staleTransitionError(expectedLease);
+    }
+
+    if (this.interruptedRealOperations.size > 0) {
+      throw new Error(
+        '[midscene] Cannot reset to the real web surface before interrupted real operations have settled.',
+      );
+    }
+    this.state = {
+      mode: 'real',
+      epoch: this.nextEpoch(),
+    };
+    return this.acquireLease();
+  }
+
+  route<Result>(
+    handlers: WebSurfaceRoute<VirtualSurface, Result>,
+    lease: WebSurfaceLease<VirtualSurface> = this.acquireLease(),
+  ): Promise<Result> {
+    if (lease.mode === 'real') {
+      return Promise.resolve().then(() => handlers.real(lease));
+    }
+
+    if (!lease.virtualSurface) {
+      throw new Error(
+        `[midscene] Missing virtual web surface for ${lease.mode} lease at epoch ${lease.epoch}.`,
+      );
+    }
+    const virtualSurface = lease.virtualSurface;
+
+    if (lease.mode === 'resuming' && handlers.resuming) {
+      return Promise.resolve().then(() =>
+        handlers.resuming!(virtualSurface, lease),
+      );
+    }
+
+    return Promise.resolve().then(() =>
+      handlers.virtual(virtualSurface, lease),
+    );
+  }
+
+  routeObservation<Result>(
+    handlers: WebSurfaceRoute<VirtualSurface, Result>,
+    lease?: WebSurfaceLease<VirtualSurface>,
+  ): Promise<Result> {
+    return this.route(handlers, lease);
+  }
+
+  routeAction<Result>(
+    handlers: WebSurfaceRoute<VirtualSurface, Result>,
+    lease?: WebSurfaceLease<VirtualSurface>,
+  ): Promise<Result> {
+    return this.route(handlers, lease);
+  }
+
+  waitForVirtualActivation(
+    afterEpoch?: number,
+  ): Promise<WebSurfaceLease<VirtualSurface>> {
+    const threshold =
+      afterEpoch ??
+      (this.state.mode === 'virtual' ? this.state.epoch - 1 : this.state.epoch);
+    const waiter = this.createVirtualActivationWaiter(threshold);
+    return waiter.promise;
+  }
+
+  async runInterruptibleRealOperation<Result>(
+    operation: () => Result | Promise<Result>,
+    startLease: WebSurfaceLease<VirtualSurface> = this.acquireLease(),
+  ): Promise<InterruptibleWebOperationResult<VirtualSurface, Result>> {
+    if (startLease.mode !== 'real') {
+      throw new Error(
+        `[midscene] Cannot start a real web operation while the ${startLease.mode} surface is active.`,
+      );
+    }
+
+    if (!this.isCurrentLease(startLease)) {
+      return {
+        status: 'interrupted',
+        lease: this.acquireLease(),
+      };
+    }
+
+    const activationWaiter = this.createVirtualActivationWaiter(
+      startLease.epoch,
+    );
+    const operationPromise = Promise.resolve().then(operation);
+
+    try {
+      const result = await Promise.race([
+        operationPromise.then((value) => ({
+          status: 'completed' as const,
+          value,
+        })),
+        activationWaiter.promise.then((lease) => ({
+          status: 'interrupted' as const,
+          lease,
+        })),
+      ]);
+
+      if (result.status === 'interrupted') {
+        this.interruptedRealOperations.add(operationPromise);
+        return result;
+      }
+
+      // Prefer the surface transition if the operation and activation settle
+      // in the same turn and the operation promise wins the race by a microtask.
+      if (!this.isCurrentLease(startLease) && this.state.mode === 'virtual') {
+        this.interruptedRealOperations.add(operationPromise);
+        return {
+          status: 'interrupted',
+          lease: this.acquireLease(),
+        };
+      }
+
+      return {
+        status: 'completed',
+        value: result.value,
+        lease: startLease,
+      };
+    } finally {
+      activationWaiter.cancel();
+    }
+  }
+
+  async waitForInterruptedRealOperations(): Promise<void> {
+    const operations = [...this.interruptedRealOperations];
+    if (operations.length === 0) return;
+
+    const results = await Promise.allSettled(operations);
+    for (const operation of operations) {
+      this.interruptedRealOperations.delete(operation);
+    }
+
+    const errors = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        '[midscene] Interrupted real web operation failed while the virtual surface was active.',
+      );
+    }
+  }
+
+  private nextEpoch(): number {
+    this.epoch += 1;
+    return this.epoch;
+  }
+
+  private assertState(
+    expectedMode: 'virtual' | 'resuming',
+    expectedLease?: WebSurfaceLease<VirtualSurface>,
+  ): void {
+    if (expectedLease && !this.isCurrentLease(expectedLease)) {
+      throw this.staleTransitionError(expectedLease);
+    }
+    if (this.state.mode !== expectedMode) {
+      throw new Error(
+        `[midscene] Expected web surface state "${expectedMode}", but current state is "${this.state.mode}".`,
+      );
+    }
+  }
+
+  private staleTransitionError(lease: WebSurfaceLease<VirtualSurface>): Error {
+    return new Error(
+      `[midscene] Stale web surface transition from ${lease.mode} epoch ${lease.epoch}; current state is ${this.state.mode} epoch ${this.state.epoch}.`,
+    );
+  }
+
+  private createVirtualActivationWaiter(afterEpoch: number): {
+    promise: Promise<WebSurfaceLease<VirtualSurface>>;
+    cancel: () => void;
+  } {
+    if (this.state.mode === 'virtual' && this.state.epoch > afterEpoch) {
+      return {
+        promise: Promise.resolve(this.acquireLease()),
+        cancel: () => {},
+      };
+    }
+
+    let waiter: VirtualActivationWaiter<VirtualSurface>;
+    const promise = new Promise<WebSurfaceLease<VirtualSurface>>((resolve) => {
+      waiter = { afterEpoch, resolve };
+      this.virtualActivationWaiters.add(waiter);
+    });
+
+    return {
+      promise,
+      cancel: () => {
+        this.virtualActivationWaiters.delete(waiter);
+      },
+    };
+  }
+
+  private resolveVirtualActivationWaiters(
+    lease: WebSurfaceLease<VirtualSurface>,
+  ): void {
+    for (const waiter of this.virtualActivationWaiters) {
+      if (lease.epoch <= waiter.afterEpoch) continue;
+      this.virtualActivationWaiters.delete(waiter);
+      waiter.resolve(lease);
+    }
+  }
+}

--- a/packages/web-integration/src/puppeteer/alert-virtual-surface.ts
+++ b/packages/web-integration/src/puppeteer/alert-virtual-surface.ts
@@ -1,0 +1,173 @@
+import { Buffer } from 'node:buffer';
+import type {
+  ElementCacheFeature,
+  ElementTreeNode,
+  Rect,
+  Size,
+} from '@midscene/core';
+import type { ElementInfo } from '@midscene/shared/extractor';
+import {
+  convertImgBufferToJpeg,
+  createImgBase64ByFormat,
+} from '@midscene/shared/img';
+import type {
+  VirtualWebSurface,
+  VirtualWebSurfaceAction,
+} from '../common/virtual-web-surface';
+
+export type AlertVirtualSurfaceDecision = { type: 'accept' };
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function wrapMessage(message: string, maxCharacters: number): string[] {
+  const lines: string[] = [];
+  for (const sourceLine of message.split(/\r?\n/)) {
+    if (!sourceLine) {
+      lines.push('');
+      continue;
+    }
+    for (let offset = 0; offset < sourceLine.length; offset += maxCharacters) {
+      lines.push(sourceLine.slice(offset, offset + maxCharacters));
+    }
+  }
+  return lines.slice(0, 4);
+}
+
+function contains(rect: Rect, x: number, y: number): boolean {
+  return (
+    x >= rect.left &&
+    x <= rect.left + rect.width &&
+    y >= rect.top &&
+    y <= rect.top + rect.height
+  );
+}
+
+export class AlertVirtualSurface implements VirtualWebSurface {
+  readonly confirmRect: Rect;
+
+  private readonly dialogRect: Rect;
+
+  private readonly decisionPromise: Promise<AlertVirtualSurfaceDecision>;
+
+  private resolveDecision!: (decision: AlertVirtualSurfaceDecision) => void;
+
+  private accepted = false;
+
+  private screenshotPromise?: Promise<string>;
+
+  constructor(
+    private readonly message: string,
+    private readonly viewportSize: Size,
+  ) {
+    const dialogWidth = Math.min(
+      560,
+      Math.max(320, Math.round(viewportSize.width * 0.66)),
+    );
+    const messageLineCount = wrapMessage(
+      message || 'This page says',
+      56,
+    ).length;
+    const dialogHeight = Math.min(
+      220,
+      132 + Math.max(0, messageLineCount - 1) * 20,
+    );
+    this.dialogRect = {
+      left: Math.round((viewportSize.width - dialogWidth) / 2),
+      top: Math.min(32, Math.max(12, Math.round(viewportSize.height * 0.05))),
+      width: Math.round(dialogWidth),
+      height: Math.round(dialogHeight),
+    };
+    this.confirmRect = {
+      left: this.dialogRect.left + this.dialogRect.width - 81,
+      top: this.dialogRect.top + this.dialogRect.height - 49,
+      width: 65,
+      height: 33,
+    };
+    this.decisionPromise = new Promise((resolve) => {
+      this.resolveDecision = resolve;
+    });
+  }
+
+  size(): Promise<Size> {
+    return Promise.resolve(this.viewportSize);
+  }
+
+  screenshotBase64(): Promise<string> {
+    this.screenshotPromise ??= this.renderScreenshot();
+    return this.screenshotPromise;
+  }
+
+  getElementsNodeTree(): Promise<ElementTreeNode<ElementInfo>> {
+    return Promise.resolve({ node: null, children: [] });
+  }
+
+  cacheFeatureForPoint(): Promise<ElementCacheFeature> {
+    return Promise.resolve({ xpaths: [] });
+  }
+
+  rectMatchesCacheFeature(): Promise<Rect> {
+    throw new Error(
+      '[midscene] Element cache matching is unavailable on an alert virtual surface.',
+    );
+  }
+
+  dispatchAction(action: VirtualWebSurfaceAction): Promise<void> {
+    if (
+      action.type === 'mouse.click' &&
+      action.button === 'left' &&
+      contains(this.confirmRect, action.x, action.y)
+    ) {
+      this.accept();
+    }
+    return Promise.resolve();
+  }
+
+  waitForDecision(): Promise<AlertVirtualSurfaceDecision> {
+    return this.decisionPromise;
+  }
+
+  private accept(): void {
+    if (this.accepted) return;
+    this.accepted = true;
+    this.resolveDecision({ type: 'accept' });
+  }
+
+  private async renderScreenshot(): Promise<string> {
+    const { width, height } = this.viewportSize;
+    const messageLines = wrapMessage(this.message || 'This page says', 56);
+    const textLines = messageLines
+      .map(
+        (line, index) =>
+          `<text x="${this.dialogRect.left + 28}" y="${
+            this.dialogRect.top + 63 + index * 21
+          }" font-size="14" fill="#5f6368">${escapeXml(line)}</text>`,
+      )
+      .join('');
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+      <defs>
+        <filter id="chrome-dialog-shadow" x="-15%" y="-20%" width="130%" height="145%">
+          <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000000" flood-opacity="0.32"/>
+        </filter>
+      </defs>
+      <rect width="${width}" height="${height}" fill="#ffffff"/>
+      <g filter="url(#chrome-dialog-shadow)">
+        <rect x="${this.dialogRect.left}" y="${this.dialogRect.top}" width="${this.dialogRect.width}" height="${this.dialogRect.height}" rx="2" fill="#ffffff" stroke="#b8b8b8"/>
+        <text x="${this.dialogRect.left + 16}" y="${this.dialogRect.top + 34}" font-family="Arial, sans-serif" font-size="15" fill="#111111">This page says</text>
+        <g font-family="Arial, sans-serif">${textLines}</g>
+        <rect x="${this.confirmRect.left}" y="${this.confirmRect.top}" width="${this.confirmRect.width}" height="${this.confirmRect.height}" rx="3" fill="#4285f4"/>
+        <text x="${this.confirmRect.left + this.confirmRect.width / 2}" y="${this.confirmRect.top + 21}" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#ffffff">OK</text>
+      </g>
+    </svg>`;
+
+    const jpeg = await convertImgBufferToJpeg(Buffer.from(svg), 92);
+    return createImgBase64ByFormat('jpeg', jpeg.toString('base64'));
+  }
+}

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -42,6 +42,11 @@ import {
   judgeOrderSensitive,
   sanitizeXpaths,
 } from '../common/cache-helper';
+import type {
+  VirtualWebSurface,
+  VirtualWebSurfaceAction,
+} from '../common/virtual-web-surface';
+import { WebSurfaceRouter } from '../common/web-surface-router';
 import {
   type KeyInput,
   type MouseButton,
@@ -223,6 +228,7 @@ export class Page<
   private visualUpdateFlushQueued = false;
   private visualUpdateForceQueued = false;
   private visualUpdateFollowupTimer?: ReturnType<typeof setTimeout>;
+  readonly surfaceRouter = new WebSurfaceRouter<VirtualWebSurface>();
   interfaceType: AgentType;
 
   actionSpace(): DeviceAction[] {
@@ -232,6 +238,10 @@ export class Page<
     );
     const customActions = this.customActions || [];
     return [...defaultActions, ...customActions];
+  }
+
+  protected getLastKnownViewportSize(): Size | undefined {
+    return this.viewportSize ? { ...this.viewportSize } : undefined;
   }
 
   private async evaluate<R>(
@@ -275,7 +285,37 @@ export class Page<
   }
 
   async evaluateJavaScript<T = any>(script: string): Promise<T> {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      throw new Error(
+        '[midscene] evaluateJavaScript is unavailable while a virtual web surface is active.',
+      );
+    }
     return this.evaluate(script);
+  }
+
+  private async routeObservation<Result>(handlers: {
+    real: () => Promise<Result>;
+    virtual: (surface: VirtualWebSurface) => Promise<Result>;
+  }): Promise<Result> {
+    return this.surfaceRouter.routeObservation({
+      real: handlers.real,
+      virtual: handlers.virtual,
+    });
+  }
+
+  private async routeAction(
+    action: VirtualWebSurfaceAction,
+    realOperation: () => Promise<void>,
+  ): Promise<void> {
+    return this.surfaceRouter.routeAction({
+      real: async (lease) => {
+        await this.surfaceRouter.runInterruptibleRealOperation(
+          realOperation,
+          lease,
+        );
+      },
+      virtual: (surface) => surface.dispatchAction(action),
+    });
   }
 
   async waitForNavigation(
@@ -286,6 +326,9 @@ export class Page<
       | 'afterInvokeAction',
     actionName?: string,
   ) {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      return;
+    }
     if (this.waitForNavigationTimeout === 0) {
       debugPage('waitForNavigation timeout is 0, skip waiting');
       return;
@@ -317,6 +360,9 @@ export class Page<
     moment: 'afterInvokeAction',
     actionName?: string,
   ): Promise<void> {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      return;
+    }
     if (this.interfaceType === 'puppeteer') {
       if (this.waitForNetworkIdleTimeout === 0) {
         debugPage('waitForNetworkIdle timeout is 0, skip waiting');
@@ -381,6 +427,16 @@ export class Page<
     center: [number, number],
     options?: CacheFeatureOptions,
   ): Promise<ElementCacheFeature> {
+    return this.routeObservation({
+      real: () => this.cacheFeatureForPointOnRealPage(center, options),
+      virtual: (surface) => surface.cacheFeatureForPoint(center),
+    });
+  }
+
+  private async cacheFeatureForPointOnRealPage(
+    center: [number, number],
+    options?: CacheFeatureOptions,
+  ): Promise<ElementCacheFeature> {
     const point: Point = { left: center[0], top: center[1] };
 
     try {
@@ -398,6 +454,15 @@ export class Page<
   }
 
   async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
+    return this.routeObservation({
+      real: () => this.rectMatchesCacheFeatureOnRealPage(feature),
+      virtual: (surface) => surface.rectMatchesCacheFeature(feature),
+    });
+  }
+
+  private async rectMatchesCacheFeatureOnRealPage(
+    feature: ElementCacheFeature,
+  ): Promise<Rect> {
     const xpaths = sanitizeXpaths((feature as WebElementCacheFeature).xpaths);
     debugPage('rectMatchesCacheFeature: trying %d xpath(s)', xpaths.length);
 
@@ -430,7 +495,16 @@ export class Page<
     );
   }
 
-  async getElementsNodeTree() {
+  async getElementsNodeTree(): Promise<ElementTreeNode<ElementInfo>> {
+    return this.routeObservation({
+      real: () => this.getElementsNodeTreeOnRealPage(),
+      virtual: (surface) => surface.getElementsNodeTree(),
+    });
+  }
+
+  private async getElementsNodeTreeOnRealPage(): Promise<
+    ElementTreeNode<ElementInfo>
+  > {
     // ref: packages/web-integration/src/playwright/ai-fixture.ts popup logic
     // During test execution, a new page might be opened through a connection, and the page remains confined to the same page instance.
     // The page may go through opening, closing, and reopening; if the page is closed, evaluate may return undefined, which can lead to errors.
@@ -445,6 +519,13 @@ export class Page<
   }
 
   async size(): Promise<Size> {
+    return this.routeObservation({
+      real: () => this.sizeOnRealPage(),
+      virtual: (surface) => surface.size(),
+    });
+  }
+
+  private async sizeOnRealPage(): Promise<Size> {
     if (this.viewportSize) return this.viewportSize;
     const sizeInfo: Size = await this.evaluate(() => {
       return {
@@ -457,6 +538,13 @@ export class Page<
   }
 
   async screenshotBase64(): Promise<string> {
+    return this.routeObservation({
+      real: () => this.screenshotBase64OnRealPage(),
+      virtual: (surface) => surface.screenshotBase64(),
+    });
+  }
+
+  private async screenshotBase64OnRealPage(): Promise<string> {
     const imgType = 'jpeg' as const;
     const quality = 90;
     const startTime = Date.now();
@@ -585,6 +673,9 @@ export class Page<
     timeoutMs?: number;
     target?: ElementInfo;
   }): Promise<void> {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      return;
+    }
     const quietMs = opts?.quietMs ?? 100;
     const timeoutMs = opts?.timeoutMs ?? 500;
     const targetCenter = opts?.target?.center;
@@ -625,6 +716,9 @@ export class Page<
   }
 
   async flushPendingVisualUpdate(force = false): Promise<void> {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      return;
+    }
     const activeStream = this.activeMjpegStream;
     // A direct screenshot is normally only the fallback for an idle page that
     // has not emitted its first CDP screencast frame. Navigation actions force
@@ -975,84 +1069,112 @@ export class Page<
         y: number,
         options?: { button?: MouseButton; count?: number },
       ) => {
-        await this.mouse.move(x, y);
+        this.everMoved = true;
         const { button = 'left', count = 1 } = options || {};
-        debugPage(`mouse click ${x}, ${y}, ${button}, ${count}`);
-
-        if (count === 2 && this.interfaceType === 'playwright') {
-          await (this.underlyingPage as PlaywrightPage).mouse.dblclick(x, y, {
-            button,
-          });
-        } else if (this.interfaceType === 'puppeteer') {
-          const page = this.underlyingPage as PuppeteerPage;
-          if (button === 'left' && count === 1) {
-            await page.mouse.click(x, y);
-          } else {
-            await page.mouse.click(x, y, { button, count });
-          }
-        } else if (this.interfaceType === 'playwright') {
-          await (this.underlyingPage as PlaywrightPage).mouse.click(x, y, {
-            button,
-            clickCount: count,
-          });
-        }
+        return this.routeAction(
+          { type: 'mouse.click', x, y, button, count },
+          () => this.clickOnRealPage(x, y, button, count),
+        );
       },
       wheel: async (deltaX: number, deltaY: number) => {
-        debugPage(`mouse wheel ${deltaX}, ${deltaY}`);
-        if (this.interfaceType === 'puppeteer') {
-          await (this.underlyingPage as PuppeteerPage).mouse.wheel({
-            deltaX,
-            deltaY,
-          });
-        } else if (this.interfaceType === 'playwright') {
-          await (this.underlyingPage as PlaywrightPage).mouse.wheel(
-            deltaX,
-            deltaY,
-          );
-        }
+        return this.routeAction({ type: 'mouse.wheel', deltaX, deltaY }, () =>
+          this.wheelOnRealPage(deltaX, deltaY),
+        );
       },
       move: async (x: number, y: number) => {
         this.everMoved = true;
-        debugPage(`mouse move to ${x}, ${y}`);
-        return this.underlyingPage.mouse.move(x, y);
+        return this.routeAction({ type: 'mouse.move', x, y }, () =>
+          this.moveOnRealPage(x, y),
+        );
       },
       drag: async (
         from: { x: number; y: number },
         to: { x: number; y: number },
       ) => {
-        debugPage(
-          `begin mouse drag from ${from.x}, ${from.y} to ${to.x}, ${to.y}`,
-        );
-        await (this.underlyingPage as PlaywrightPage).mouse.move(
-          from.x,
-          from.y,
-        );
-        await sleep(200);
-        await (this.underlyingPage as PlaywrightPage).mouse.down();
-        await sleep(300);
-        await (this.underlyingPage as PlaywrightPage).mouse.move(to.x, to.y, {
-          steps: 20,
-        });
-        await sleep(500);
-        await (this.underlyingPage as PlaywrightPage).mouse.up();
-        await sleep(200);
-        debugPage(
-          `end mouse drag from ${from.x}, ${from.y} to ${to.x}, ${to.y}`,
+        return this.routeAction({ type: 'mouse.drag', from, to }, () =>
+          this.dragOnRealPage(from, to),
         );
       },
     };
+  }
+
+  private async clickOnRealPage(
+    x: number,
+    y: number,
+    button: MouseButton,
+    count: number,
+  ): Promise<void> {
+    await this.moveOnRealPage(x, y);
+    debugPage(`mouse click ${x}, ${y}, ${button}, ${count}`);
+    if (count === 2 && this.interfaceType === 'playwright') {
+      await (this.underlyingPage as PlaywrightPage).mouse.dblclick(x, y, {
+        button,
+      });
+    } else if (this.interfaceType === 'puppeteer') {
+      const page = this.underlyingPage as PuppeteerPage;
+      if (button === 'left' && count === 1) {
+        await page.mouse.click(x, y);
+      } else {
+        await page.mouse.click(x, y, { button, count });
+      }
+    } else if (this.interfaceType === 'playwright') {
+      await (this.underlyingPage as PlaywrightPage).mouse.click(x, y, {
+        button,
+        clickCount: count,
+      });
+    }
+  }
+
+  private async wheelOnRealPage(deltaX: number, deltaY: number): Promise<void> {
+    debugPage(`mouse wheel ${deltaX}, ${deltaY}`);
+    if (this.interfaceType === 'puppeteer') {
+      await (this.underlyingPage as PuppeteerPage).mouse.wheel({
+        deltaX,
+        deltaY,
+      });
+    } else if (this.interfaceType === 'playwright') {
+      await (this.underlyingPage as PlaywrightPage).mouse.wheel(deltaX, deltaY);
+    }
+  }
+
+  private async moveOnRealPage(x: number, y: number): Promise<void> {
+    debugPage(`mouse move to ${x}, ${y}`);
+    await this.underlyingPage.mouse.move(x, y);
+  }
+
+  private async dragOnRealPage(
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+  ): Promise<void> {
+    debugPage(`begin mouse drag from ${from.x}, ${from.y} to ${to.x}, ${to.y}`);
+    await (this.underlyingPage as PlaywrightPage).mouse.move(from.x, from.y);
+    await sleep(200);
+    await (this.underlyingPage as PlaywrightPage).mouse.down();
+    await sleep(300);
+    await (this.underlyingPage as PlaywrightPage).mouse.move(to.x, to.y, {
+      steps: 20,
+    });
+    await sleep(500);
+    await (this.underlyingPage as PlaywrightPage).mouse.up();
+    await sleep(200);
+    debugPage(`end mouse drag from ${from.x}, ${from.y} to ${to.x}, ${to.y}`);
   }
 
   get keyboard() {
     return {
       type: async (text: string, options?: { delay?: number }) => {
         const effectiveDelay = options?.delay ?? this.keyboardTypeDelay;
-        debugPage(
-          `keyboard type ${text}${effectiveDelay !== undefined ? ` (delay: ${effectiveDelay}ms)` : ''}`,
+        return this.routeAction(
+          { type: 'keyboard.type', text, delay: effectiveDelay },
+          async () => {
+            debugPage(
+              `keyboard type ${text}${effectiveDelay !== undefined ? ` (delay: ${effectiveDelay}ms)` : ''}`,
+            );
+            await this.underlyingPage.keyboard.type(text, {
+              delay: effectiveDelay,
+            });
+          },
         );
-        return this.underlyingPage.keyboard.type(text, {
-          delay: effectiveDelay,
-        });
       },
       press: async (
         action:
@@ -1060,22 +1182,28 @@ export class Page<
           | { key: KeyInput; command?: string }[],
       ) => {
         const keys = Array.isArray(action) ? action : [action];
-        debugPage('keyboard press', keys);
-        for (const k of keys) {
-          const commands = k.command ? [k.command] : [];
-          await this.underlyingPage.keyboard.down(k.key, { commands });
-        }
-        for (const k of [...keys].reverse()) {
-          await this.underlyingPage.keyboard.up(k.key);
-        }
+        return this.routeAction({ type: 'keyboard.press', keys }, async () => {
+          debugPage('keyboard press', keys);
+          for (const k of keys) {
+            const commands = k.command ? [k.command] : [];
+            await this.underlyingPage.keyboard.down(k.key, { commands });
+          }
+          for (const k of [...keys].reverse()) {
+            await this.underlyingPage.keyboard.up(k.key);
+          }
+        });
       },
       down: async (key: KeyInput) => {
-        debugPage(`keyboard down ${key}`);
-        return this.underlyingPage.keyboard.down(key);
+        return this.routeAction({ type: 'keyboard.down', key }, async () => {
+          debugPage(`keyboard down ${key}`);
+          await this.underlyingPage.keyboard.down(key);
+        });
       },
       up: async (key: KeyInput) => {
-        debugPage(`keyboard up ${key}`);
-        return this.underlyingPage.keyboard.up(key);
+        return this.routeAction({ type: 'keyboard.up', key }, async () => {
+          debugPage(`keyboard up ${key}`);
+          await this.underlyingPage.keyboard.up(key);
+        });
       },
     };
   }
@@ -1103,14 +1231,27 @@ export class Page<
   }
 
   async clearInput(element?: ElementInfo): Promise<void> {
+    return this.routeAction({ type: 'input.clear', element }, () =>
+      this.clearInputOnRealPage(element),
+    );
+  }
+
+  private async clearInputOnRealPage(element?: ElementInfo): Promise<void> {
     const backspace = async () => {
       await sleep(100);
-      await this.keyboard.press([{ key: 'Backspace' }]);
+      await this.underlyingPage.keyboard.down('Backspace', { commands: [] });
+      await this.underlyingPage.keyboard.up('Backspace');
     };
 
     debugPage('clearInput begin');
 
-    element && (await this.mouse.click(element.center[0], element.center[1]));
+    element &&
+      (await this.clickOnRealPage(
+        element.center[0],
+        element.center[1],
+        'left',
+        1,
+      ));
     try {
       await this.selectAllByCdp();
       await backspace();
@@ -1156,34 +1297,40 @@ export class Page<
   }
 
   async scrollUp(distance?: number, startingPoint?: Point): Promise<void> {
-    const innerHeight = await this.evaluate(() => window.innerHeight);
-    const scrollDistance = distance || innerHeight * 0.7;
+    const { height } = await this.size();
+    const scrollDistance = distance || height * 0.7;
     await this.moveToPointBeforeScroll(startingPoint);
     return this.mouse.wheel(0, -scrollDistance);
   }
 
   async scrollDown(distance?: number, startingPoint?: Point): Promise<void> {
-    const innerHeight = await this.evaluate(() => window.innerHeight);
-    const scrollDistance = distance || innerHeight * 0.7;
+    const { height } = await this.size();
+    const scrollDistance = distance || height * 0.7;
     await this.moveToPointBeforeScroll(startingPoint);
     return this.mouse.wheel(0, scrollDistance);
   }
 
   async scrollLeft(distance?: number, startingPoint?: Point): Promise<void> {
-    const innerWidth = await this.evaluate(() => window.innerWidth);
-    const scrollDistance = distance || innerWidth * 0.7;
+    const { width } = await this.size();
+    const scrollDistance = distance || width * 0.7;
     await this.moveToPointBeforeScroll(startingPoint);
     return this.mouse.wheel(-scrollDistance, 0);
   }
 
   async scrollRight(distance?: number, startingPoint?: Point): Promise<void> {
-    const innerWidth = await this.evaluate(() => window.innerWidth);
-    const scrollDistance = distance || innerWidth * 0.7;
+    const { width } = await this.size();
+    const scrollDistance = distance || width * 0.7;
     await this.moveToPointBeforeScroll(startingPoint);
     return this.mouse.wheel(scrollDistance, 0);
   }
 
   async navigate(url: string): Promise<void> {
+    return this.routeAction({ type: 'navigation.navigate', url }, () =>
+      this.navigateOnRealPage(url),
+    );
+  }
+
+  private async navigateOnRealPage(url: string): Promise<void> {
     debugPage(`navigate to ${url}`);
     if (this.interfaceType === 'puppeteer') {
       await (this.underlyingPage as PuppeteerPage).goto(url);
@@ -1195,6 +1342,12 @@ export class Page<
   }
 
   async reload(): Promise<void> {
+    return this.routeAction({ type: 'navigation.reload' }, () =>
+      this.reloadRealPage(),
+    );
+  }
+
+  private async reloadRealPage(): Promise<void> {
     debugPage('reload page');
     if (this.interfaceType === 'puppeteer') {
       await (this.underlyingPage as PuppeteerPage).reload();
@@ -1206,6 +1359,12 @@ export class Page<
   }
 
   async goBack(): Promise<void> {
+    return this.routeAction({ type: 'navigation.goBack' }, () =>
+      this.goBackOnRealPage(),
+    );
+  }
+
+  private async goBackOnRealPage(): Promise<void> {
     debugPage('go back');
     if (this.interfaceType === 'puppeteer') {
       await (this.underlyingPage as PuppeteerPage).goBack();
@@ -1217,6 +1376,12 @@ export class Page<
   }
 
   async goForward(): Promise<void> {
+    return this.routeAction({ type: 'navigation.goForward' }, () =>
+      this.goForwardOnRealPage(),
+    );
+  }
+
+  private async goForwardOnRealPage(): Promise<void> {
     debugPage('go forward');
     if (this.interfaceType === 'puppeteer') {
       await (this.underlyingPage as PuppeteerPage).goForward();
@@ -1246,6 +1411,9 @@ export class Page<
   }
 
   async navigationState(): Promise<{ isLoading: boolean }> {
+    if (this.surfaceRouter.isVirtualOrResuming()) {
+      return { isLoading: false };
+    }
     try {
       const readyState = await this.evaluate(() => document.readyState);
       return { isLoading: readyState !== 'complete' };
@@ -1262,10 +1430,12 @@ export class Page<
   }
 
   async afterInvokeAction(name: string, param: any): Promise<void> {
-    await Promise.all([
-      this.waitForNavigation('afterInvokeAction', name),
-      this.waitForNetworkIdle('afterInvokeAction', name),
-    ]);
+    if (!this.surfaceRouter.isVirtualOrResuming()) {
+      await Promise.all([
+        this.waitForNavigation('afterInvokeAction', name),
+        this.waitForNetworkIdle('afterInvokeAction', name),
+      ]);
+    }
 
     if (this.onAfterInvokeAction) {
       await this.onAfterInvokeAction(name, param);
@@ -1292,6 +1462,16 @@ export class Page<
       `mouse swipe from ${from.x}, ${from.y} to ${to.x}, ${to.y} with duration ${duration}ms`,
     );
 
+    return this.routeAction({ type: 'gesture.swipe', from, to, duration }, () =>
+      this.swipeOnRealPage(from, to, duration),
+    );
+  }
+
+  private async swipeOnRealPage(
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+    duration: number,
+  ): Promise<void> {
     if (this.interfaceType === 'puppeteer') {
       const page = this.underlyingPage as PuppeteerPage;
       await page.mouse.move(from.x, from.y);
@@ -1334,6 +1514,16 @@ export class Page<
       duration = MIN_LONG_PRESS_DURATION;
     }
     debugPage(`mouse longPress at ${x}, ${y} for ${duration}ms`);
+    return this.routeAction({ type: 'gesture.longPress', x, y, duration }, () =>
+      this.longPressOnRealPage(x, y, duration),
+    );
+  }
+
+  private async longPressOnRealPage(
+    x: number,
+    y: number,
+    duration: number,
+  ): Promise<void> {
     if (this.interfaceType === 'puppeteer') {
       const page = this.underlyingPage as PuppeteerPage;
       await page.mouse.move(x, y);
@@ -1355,6 +1545,33 @@ export class Page<
     startDistance: number,
     endDistance: number,
     duration = 500,
+  ): Promise<void> {
+    return this.routeAction(
+      {
+        type: 'gesture.pinch',
+        centerX,
+        centerY,
+        startDistance,
+        endDistance,
+        duration,
+      },
+      () =>
+        this.pinchOnRealPage(
+          centerX,
+          centerY,
+          startDistance,
+          endDistance,
+          duration,
+        ),
+    );
+  }
+
+  private async pinchOnRealPage(
+    centerX: number,
+    centerY: number,
+    startDistance: number,
+    endDistance: number,
+    duration: number,
   ): Promise<void> {
     const steps = 30;
     const delay = duration / steps;

--- a/packages/web-integration/src/puppeteer/page.ts
+++ b/packages/web-integration/src/puppeteer/page.ts
@@ -1,9 +1,53 @@
 import type { WebPageOpt } from '@/web-element';
-import type { Page as PuppeteerPageType } from 'puppeteer';
-import { Page as BasePage } from './base-page';
+import type {
+  Dialog as PuppeteerDialog,
+  Page as PuppeteerPageType,
+} from 'puppeteer';
+import { AlertVirtualSurface } from './alert-virtual-surface';
+import { Page as BasePage, debugPage } from './base-page';
 
 export class PuppeteerWebPage extends BasePage<'puppeteer', PuppeteerPageType> {
+  private readonly nativeDialogHandler = (dialog: PuppeteerDialog) => {
+    void this.handleNativeDialog(dialog).catch((error) => {
+      debugPage('native dialog handling failed: %s', error);
+    });
+  };
+
   constructor(page: PuppeteerPageType, opts?: WebPageOpt) {
     super(page, 'puppeteer', opts);
+    page.on('dialog', this.nativeDialogHandler);
+  }
+
+  private async handleNativeDialog(dialog: PuppeteerDialog): Promise<void> {
+    if (dialog.type() !== 'alert') return;
+
+    const viewportSize = this.getLastKnownViewportSize() ??
+      this.underlyingPage.viewport() ?? { width: 1280, height: 720 };
+    const surface = new AlertVirtualSurface(dialog.message(), viewportSize);
+    const virtualLease = this.surfaceRouter.activateVirtualSurface(surface);
+
+    try {
+      await surface.waitForDecision();
+      const resumingLease = this.surfaceRouter.beginResuming(virtualLease);
+      await dialog.accept();
+      await this.surfaceRouter.waitForInterruptedRealOperations();
+      if (this.surfaceRouter.isCurrentLease(resumingLease)) {
+        this.surfaceRouter.finishResuming(resumingLease);
+      }
+    } catch (error) {
+      await this.surfaceRouter
+        .waitForInterruptedRealOperations()
+        .catch(() => undefined);
+      const currentLease = this.surfaceRouter.acquireLease();
+      if (currentLease.mode !== 'real') {
+        this.surfaceRouter.resetToReal(currentLease);
+      }
+      throw error;
+    }
+  }
+
+  override async destroy(): Promise<void> {
+    this.underlyingPage.off('dialog', this.nativeDialogHandler);
+    await super.destroy();
   }
 }

--- a/packages/web-integration/tests/ai/fixtures/alert-blocking.html
+++ b/packages/web-integration/tests/ai/fixtures/alert-blocking.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Alert Blocking Test</title>
+    <style>
+      :root {
+        color: #172033;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+      }
+
+      body {
+        align-items: center;
+        background: #f4f6fb;
+        display: flex;
+        justify-content: center;
+        margin: 0;
+        min-height: 100vh;
+      }
+
+      main {
+        background: #fff;
+        border: 1px solid #dfe4ee;
+        border-radius: 16px;
+        box-shadow: 0 12px 32px rgba(23, 32, 51, 0.1);
+        padding: 32px;
+        width: min(520px, calc(100vw - 64px));
+      }
+
+      h1 {
+        font-size: 28px;
+        margin: 0 0 12px;
+      }
+
+      p {
+        color: #566074;
+        line-height: 1.6;
+        margin: 0 0 24px;
+      }
+
+      button {
+        background: #246bfd;
+        border: 0;
+        border-radius: 10px;
+        color: #fff;
+        cursor: pointer;
+        font-size: 17px;
+        font-weight: 600;
+        padding: 14px 22px;
+      }
+
+      button:hover {
+        background: #1557d5;
+      }
+
+      dl {
+        background: #f7f8fc;
+        border-radius: 12px;
+        display: grid;
+        gap: 12px;
+        grid-template-columns: 150px 1fr;
+        margin: 28px 0 0;
+        padding: 20px;
+      }
+
+      dt {
+        color: #697386;
+      }
+
+      dd {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        margin: 0;
+        overflow-wrap: anywhere;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Alert Blocking Test</h1>
+      <p>
+        Click the button to open a native JavaScript alert. The values below
+        are updated only after the alert returns.
+      </p>
+
+      <button id="trigger-alert" type="button">Open alert</button>
+
+      <dl aria-live="polite">
+        <dt>Execution state</dt>
+        <dd id="execution-state">Not started</dd>
+
+        <dt>Resumed at</dt>
+        <dd id="resumed-at">Not set</dd>
+
+        <dt>Blocked for</dt>
+        <dd id="blocked-for">Not measured</dd>
+      </dl>
+    </main>
+
+    <script>
+      const fixtureState = {
+        phase: 'idle',
+        beforeAlertAt: null,
+        afterAlertAt: null,
+        blockedForMs: null,
+      };
+
+      window.__alertBlockingFixture = fixtureState;
+
+      const triggerButton = document.getElementById('trigger-alert');
+      const executionState = document.getElementById('execution-state');
+      const resumedAt = document.getElementById('resumed-at');
+      const blockedFor = document.getElementById('blocked-for');
+
+      triggerButton.addEventListener('click', () => {
+        const startedAt = performance.now();
+        fixtureState.phase = 'alert-open';
+        fixtureState.beforeAlertAt = Date.now();
+        fixtureState.afterAlertAt = null;
+        fixtureState.blockedForMs = null;
+
+        alert('Alert blocking fixture');
+
+        const finishedAt = performance.now();
+        const timestamp = Date.now();
+        const blockedDuration = Math.round(finishedAt - startedAt);
+        const timestampText = new Date(timestamp).toISOString();
+
+        fixtureState.phase = 'resumed';
+        fixtureState.afterAlertAt = timestamp;
+        fixtureState.blockedForMs = blockedDuration;
+
+        executionState.textContent = 'Resumed after alert';
+        resumedAt.textContent = timestampText;
+        resumedAt.setAttribute('data-timestamp', String(timestamp));
+        blockedFor.textContent = `${blockedDuration} ms`;
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-integration/tests/ai/web/puppeteer/alert-blocking.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/alert-blocking.test.ts
@@ -1,0 +1,76 @@
+import { pathToFileURL } from 'node:url';
+import { PuppeteerAgent } from '@/puppeteer';
+import { sleep } from '@midscene/core/utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_TEST_TIMEOUT,
+  createTestContext,
+  getFixturePath,
+} from './test-utils';
+import { launchPage } from './utils';
+
+vi.setConfig({ testTimeout: DEFAULT_TEST_TIMEOUT });
+
+describe('puppeteer native alert virtual surface', () => {
+  const ctx = createTestContext();
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps JavaScript blocked until AI clicks OK on the fake alert image', async () => {
+    const fixtureUrl = pathToFileURL(
+      getFixturePath('alert-blocking.html'),
+    ).href;
+    const { originPage, reset } = await launchPage(fixtureUrl, {
+      viewport: { width: 900, height: 700, deviceScaleFactor: 1 },
+    });
+    ctx.resetFn = reset;
+    ctx.agent = new PuppeteerAgent(originPage);
+
+    let dialogSeenAt = 0;
+    originPage.once('dialog', () => {
+      dialogSeenAt = Date.now();
+    });
+
+    await ctx.agent.aiTap('the Open alert button');
+    expect(dialogSeenAt).toBeGreaterThan(0);
+
+    let blockedEvaluationSettled = false;
+    const blockedEvaluation = originPage
+      .evaluate(() => window.__alertBlockingFixture)
+      .then((value) => {
+        blockedEvaluationSettled = true;
+        return value;
+      });
+
+    await sleep(300);
+    expect(blockedEvaluationSettled).toBe(false);
+
+    await ctx.agent.aiTap('the blue OK button on the alert dialog');
+
+    const fixtureState = await blockedEvaluation;
+    expect(fixtureState.phase).toBe('resumed');
+    expect(fixtureState.afterAlertAt).toBeTypeOf('number');
+    expect(fixtureState.blockedForMs).toBeGreaterThanOrEqual(300);
+    expect(fixtureState.afterAlertAt).toBeGreaterThanOrEqual(dialogSeenAt);
+    expect(Math.abs(Date.now() - fixtureState.afterAlertAt)).toBeLessThan(
+      10_000,
+    );
+
+    await expect(
+      originPage.$eval('#execution-state', (node) => node.textContent),
+    ).resolves.toBe('Resumed after alert');
+  });
+});
+
+declare global {
+  interface Window {
+    __alertBlockingFixture: {
+      phase: string;
+      beforeAlertAt: number | null;
+      afterAlertAt: number | null;
+      blockedForMs: number | null;
+    };
+  }
+}

--- a/packages/web-integration/tests/unit-test/alert-virtual-surface.test.ts
+++ b/packages/web-integration/tests/unit-test/alert-virtual-surface.test.ts
@@ -1,0 +1,56 @@
+import { AlertVirtualSurface } from '@/puppeteer/alert-virtual-surface';
+import { imageInfoOfBase64 } from '@midscene/shared/img';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('AlertVirtualSurface', () => {
+  it('renders a full viewport JPEG without requiring an element tree', async () => {
+    const surface = new AlertVirtualSurface('Alert blocking fixture', {
+      width: 640,
+      height: 480,
+    });
+
+    const screenshot = await surface.screenshotBase64();
+
+    expect(screenshot).toMatch(/^data:image\/jpeg;base64,/);
+    await expect(imageInfoOfBase64(screenshot)).resolves.toEqual({
+      width: 640,
+      height: 480,
+    });
+    await expect(surface.getElementsNodeTree()).resolves.toEqual({
+      node: null,
+      children: [],
+    });
+    expect(surface.confirmRect.top).toBeLessThan(200);
+  });
+
+  it('accepts only a left click inside the OK button hot area', async () => {
+    const surface = new AlertVirtualSurface('Alert blocking fixture', {
+      width: 640,
+      height: 480,
+    });
+    const decision = vi.fn();
+    void surface.waitForDecision().then(decision);
+
+    await surface.dispatchAction({
+      type: 'mouse.click',
+      x: 10,
+      y: 10,
+      button: 'left',
+      count: 1,
+    });
+    expect(decision).not.toHaveBeenCalled();
+
+    await surface.dispatchAction({
+      type: 'mouse.click',
+      x: surface.confirmRect.left + surface.confirmRect.width / 2,
+      y: surface.confirmRect.top + surface.confirmRect.height / 2,
+      button: 'left',
+      count: 1,
+    });
+
+    await expect(surface.waitForDecision()).resolves.toEqual({
+      type: 'accept',
+    });
+    expect(decision).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-integration/tests/unit-test/base-page-surface-router.test.ts
+++ b/packages/web-integration/tests/unit-test/base-page-surface-router.test.ts
@@ -1,0 +1,158 @@
+import type { VirtualWebSurface } from '@/common/virtual-web-surface';
+import { Page } from '@/puppeteer/base-page';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+  logMsg: vi.fn(),
+}));
+
+vi.mock('@midscene/core/utils', async () => {
+  const actual = await vi.importActual('@midscene/core/utils');
+  return {
+    ...actual,
+    sleep: vi.fn(() => Promise.resolve()),
+  };
+});
+
+vi.mock('@midscene/shared/node', () => ({
+  getElementInfosScriptContent: vi.fn(() => ''),
+  getExtraReturnLogic: vi.fn(() => Promise.resolve('() => ({})')),
+}));
+
+vi.mock('@/web-page', () => ({
+  commonWebActionsForWebPage: vi.fn(() => []),
+}));
+
+function createRealPage() {
+  return {
+    url: vi.fn(() => 'https://example.com'),
+    evaluate: vi.fn().mockResolvedValue({ width: 1280, height: 720 }),
+    screenshot: vi.fn().mockResolvedValue('real-screenshot'),
+    waitForSelector: vi.fn().mockResolvedValue(true),
+    waitForNetworkIdle: vi.fn().mockResolvedValue(true),
+    mouse: {
+      click: vi.fn().mockResolvedValue(undefined),
+      move: vi.fn().mockResolvedValue(undefined),
+      wheel: vi.fn().mockResolvedValue(undefined),
+    },
+    keyboard: {
+      type: vi.fn().mockResolvedValue(undefined),
+      down: vi.fn().mockResolvedValue(undefined),
+      up: vi.fn().mockResolvedValue(undefined),
+    },
+  } as any;
+}
+
+function createVirtualSurface(): VirtualWebSurface {
+  return {
+    size: vi.fn().mockResolvedValue({ width: 640, height: 480 }),
+    screenshotBase64: vi.fn().mockResolvedValue('virtual-screenshot'),
+    getElementsNodeTree: vi.fn().mockResolvedValue({
+      node: null,
+      children: [],
+    }),
+    cacheFeatureForPoint: vi.fn().mockResolvedValue({ xpaths: ['virtual'] }),
+    rectMatchesCacheFeature: vi
+      .fn()
+      .mockResolvedValue({ left: 1, top: 2, width: 3, height: 4 }),
+    dispatchAction: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('BasePage surface router integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes UI observations and input to the active virtual surface', async () => {
+    const realPage = createRealPage();
+    const page = new Page(realPage, 'puppeteer');
+    const virtualSurface = createVirtualSurface();
+    page.surfaceRouter.activateVirtualSurface(virtualSurface);
+
+    await expect(page.size()).resolves.toEqual({ width: 640, height: 480 });
+    await expect(page.screenshotBase64()).resolves.toBe('virtual-screenshot');
+    await expect(page.getElementsNodeTree()).resolves.toEqual({
+      node: null,
+      children: [],
+    });
+    await page.mouse.click(12, 34);
+    await page.scrollDown();
+    await page.navigate('https://virtual.example.com');
+
+    expect(realPage.evaluate).not.toHaveBeenCalled();
+    expect(realPage.screenshot).not.toHaveBeenCalled();
+    expect(realPage.mouse.click).not.toHaveBeenCalled();
+    expect(virtualSurface.dispatchAction).toHaveBeenCalledWith({
+      type: 'mouse.click',
+      x: 12,
+      y: 34,
+      button: 'left',
+      count: 1,
+    });
+    expect(virtualSurface.dispatchAction).toHaveBeenCalledWith({
+      type: 'mouse.wheel',
+      deltaX: 0,
+      deltaY: 336,
+    });
+    expect(virtualSurface.dispatchAction).toHaveBeenCalledWith({
+      type: 'navigation.navigate',
+      url: 'https://virtual.example.com',
+    });
+  });
+
+  it('returns an in-flight real click when a virtual surface is activated', async () => {
+    let finishRealClick!: () => void;
+    const realPage = createRealPage();
+    realPage.mouse.click.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRealClick = resolve;
+        }),
+    );
+    const page = new Page(realPage, 'puppeteer');
+    const virtualSurface = createVirtualSurface();
+
+    const clickPromise = page.mouse.click(12, 34);
+    await vi.waitFor(() => expect(realPage.mouse.click).toHaveBeenCalled());
+    const virtualLease =
+      page.surfaceRouter.activateVirtualSurface(virtualSurface);
+
+    await expect(clickPromise).resolves.toBeUndefined();
+    expect(page.surfaceRouter.interruptedRealOperationCount).toBe(1);
+
+    finishRealClick();
+    const resumingLease = page.surfaceRouter.beginResuming(virtualLease);
+    await page.surfaceRouter.waitForInterruptedRealOperations();
+    page.surfaceRouter.finishResuming(resumingLease);
+
+    expect(page.surfaceRouter.getState().mode).toBe('real');
+  });
+
+  it('skips real-page settling while virtual but still invokes the after hook', async () => {
+    const realPage = createRealPage();
+    const afterHook = vi.fn();
+    const page = new Page(realPage, 'puppeteer', {
+      afterInvokeAction: afterHook,
+    });
+    page.surfaceRouter.activateVirtualSurface(createVirtualSurface());
+
+    await page.afterInvokeAction('Tap', { x: 12, y: 34 });
+
+    expect(realPage.waitForSelector).not.toHaveBeenCalled();
+    expect(realPage.waitForNetworkIdle).not.toHaveBeenCalled();
+    expect(afterHook).toHaveBeenCalledWith('Tap', { x: 12, y: 34 });
+  });
+
+  it('rejects real-DOM JavaScript evaluation while virtual', async () => {
+    const realPage = createRealPage();
+    const page = new Page(realPage, 'puppeteer');
+    page.surfaceRouter.activateVirtualSurface(createVirtualSurface());
+
+    await expect(page.evaluateJavaScript('document.title')).rejects.toThrow(
+      'evaluateJavaScript is unavailable while a virtual web surface is active',
+    );
+    expect(realPage.evaluate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-integration/tests/unit-test/puppeteer-alert-dialog.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer-alert-dialog.test.ts
@@ -1,0 +1,69 @@
+import type { AlertVirtualSurface } from '@/puppeteer/alert-virtual-surface';
+import { PuppeteerWebPage } from '@/puppeteer/page';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@midscene/shared/logger', () => ({
+  getDebug: vi.fn(() => vi.fn()),
+  logMsg: vi.fn(),
+}));
+
+vi.mock('@/web-page', () => ({
+  commonWebActionsForWebPage: vi.fn(() => []),
+}));
+
+describe('Puppeteer native alert routing', () => {
+  it('shows the virtual surface until its OK hot area accepts the dialog', async () => {
+    let dialogHandler: ((dialog: any) => void) | undefined;
+    const page = {
+      on: vi.fn((event: string, handler: (dialog: any) => void) => {
+        if (event === 'dialog') dialogHandler = handler;
+      }),
+      off: vi.fn(),
+      viewport: vi.fn(() => ({ width: 640, height: 480 })),
+      url: vi.fn(() => 'https://example.com'),
+      mouse: {
+        move: vi.fn().mockResolvedValue(undefined),
+        click: vi.fn().mockResolvedValue(undefined),
+      },
+      keyboard: {
+        type: vi.fn().mockResolvedValue(undefined),
+        down: vi.fn().mockResolvedValue(undefined),
+        up: vi.fn().mockResolvedValue(undefined),
+      },
+    } as any;
+    const dialog = {
+      type: vi.fn(() => 'alert'),
+      message: vi.fn(() => 'Alert blocking fixture'),
+      accept: vi.fn().mockResolvedValue(undefined),
+    };
+    const webPage = new PuppeteerWebPage(page);
+
+    expect(dialogHandler).toBeDefined();
+    dialogHandler!(dialog);
+    await vi.waitFor(() =>
+      expect(webPage.surfaceRouter.getState().mode).toBe('virtual'),
+    );
+
+    const state = webPage.surfaceRouter.getState();
+    expect(state.mode).toBe('virtual');
+    if (state.mode !== 'virtual') throw new Error('expected virtual surface');
+    const surface = state.virtualSurface as AlertVirtualSurface;
+    await expect(webPage.screenshotBase64()).resolves.toMatch(
+      /^data:image\/jpeg;base64,/,
+    );
+
+    await webPage.mouse.click(
+      surface.confirmRect.left + surface.confirmRect.width / 2,
+      surface.confirmRect.top + surface.confirmRect.height / 2,
+    );
+
+    await vi.waitFor(() =>
+      expect(webPage.surfaceRouter.getState().mode).toBe('real'),
+    );
+    expect(dialog.accept).toHaveBeenCalledTimes(1);
+    expect(page.mouse.click).not.toHaveBeenCalled();
+
+    await webPage.destroy();
+    expect(page.off).toHaveBeenCalledWith('dialog', dialogHandler);
+  });
+});

--- a/packages/web-integration/tests/unit-test/web-surface-router.test.ts
+++ b/packages/web-integration/tests/unit-test/web-surface-router.test.ts
@@ -1,0 +1,194 @@
+import { WebSurfaceRouter } from '@/common/web-surface-router';
+import { describe, expect, it, vi } from 'vitest';
+
+type TestSurface = {
+  id: string;
+};
+
+function createDeferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('WebSurfaceRouter', () => {
+  it('routes operations to the active surface', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const virtualSurface = { id: 'alert' };
+
+    await expect(
+      router.routeObservation({
+        real: () => 'real screenshot',
+        virtual: (surface) => `${surface.id} screenshot`,
+      }),
+    ).resolves.toBe('real screenshot');
+
+    const virtualLease = router.activateVirtualSurface(virtualSurface);
+    await expect(
+      router.routeObservation({
+        real: () => 'real screenshot',
+        virtual: (surface) => `${surface.id} screenshot`,
+      }),
+    ).resolves.toBe('alert screenshot');
+
+    const resumingLease = router.beginResuming(virtualLease);
+    await expect(
+      router.routeAction({
+        real: () => 'real action',
+        virtual: () => 'virtual action',
+      }),
+    ).resolves.toBe('virtual action');
+    await expect(
+      router.routeAction({
+        real: () => 'real action',
+        virtual: () => 'virtual action',
+        resuming: () => 'resuming action',
+      }),
+    ).resolves.toBe('resuming action');
+
+    router.finishResuming(resumingLease);
+    expect(router.getState().mode).toBe('real');
+  });
+
+  it('keeps a lease bound to the surface where the operation started', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const virtualLease = router.activateVirtualSurface({ id: 'alert' });
+    router.beginResuming(virtualLease);
+
+    await expect(
+      router.routeAction(
+        {
+          real: () => 'real',
+          virtual: (surface) => surface.id,
+          resuming: () => 'resuming',
+        },
+        virtualLease,
+      ),
+    ).resolves.toBe('alert');
+    expect(router.isCurrentLease(virtualLease)).toBe(false);
+  });
+
+  it('waits for virtual surface activation', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const waiting = router.waitForVirtualActivation();
+
+    const activatedLease = router.activateVirtualSurface({ id: 'alert' });
+
+    await expect(waiting).resolves.toEqual(activatedLease);
+    await expect(router.waitForVirtualActivation()).resolves.toEqual(
+      activatedLease,
+    );
+  });
+
+  it('interrupts a pending real operation when a virtual surface activates', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const operation = createDeferred<string>();
+    const operationStarted = vi.fn();
+
+    const running = router.runInterruptibleRealOperation(async () => {
+      operationStarted();
+      return await operation.promise;
+    });
+    await vi.waitFor(() => expect(operationStarted).toHaveBeenCalledOnce());
+
+    const virtualLease = router.activateVirtualSurface({ id: 'alert' });
+    await expect(running).resolves.toEqual({
+      status: 'interrupted',
+      lease: virtualLease,
+    });
+    expect(router.interruptedRealOperationCount).toBe(1);
+
+    const resumingLease = router.beginResuming(virtualLease);
+    expect(() => router.finishResuming(resumingLease)).toThrow(
+      'before interrupted real operations have settled',
+    );
+
+    operation.resolve('clicked');
+    await router.waitForInterruptedRealOperations();
+    expect(router.interruptedRealOperationCount).toBe(0);
+
+    router.finishResuming(resumingLease);
+    expect(router.getState().mode).toBe('real');
+  });
+
+  it('returns the result of a real operation that completes normally', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+
+    await expect(
+      router.runInterruptibleRealOperation(async () => 'clicked'),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: 'clicked',
+      lease: {
+        mode: 'real',
+        epoch: 0,
+      },
+    });
+
+    router.activateVirtualSurface({ id: 'later-alert' });
+    expect(router.interruptedRealOperationCount).toBe(0);
+  });
+
+  it('propagates failures from interrupted real operations', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const operation = createDeferred<void>();
+    const operationStarted = vi.fn();
+
+    const running = router.runInterruptibleRealOperation(async () => {
+      operationStarted();
+      return await operation.promise;
+    });
+    await vi.waitFor(() => expect(operationStarted).toHaveBeenCalledOnce());
+
+    const virtualLease = router.activateVirtualSurface({ id: 'alert' });
+    await expect(running).resolves.toMatchObject({ status: 'interrupted' });
+    router.beginResuming(virtualLease);
+
+    operation.reject(new Error('real click failed'));
+    await expect(router.waitForInterruptedRealOperations()).rejects.toThrow(
+      'Interrupted real web operation failed',
+    );
+    expect(router.interruptedRealOperationCount).toBe(0);
+  });
+
+  it('rejects stale transitions', () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const virtualLease = router.activateVirtualSurface({ id: 'alert' });
+    const resumingLease = router.beginResuming(virtualLease);
+
+    expect(() => router.finishResuming(virtualLease)).toThrow(
+      'Stale web surface transition',
+    );
+
+    router.finishResuming(resumingLease);
+  });
+
+  it('allows a new virtual surface to replace the resuming surface', () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    const firstLease = router.activateVirtualSurface({ id: 'first-alert' });
+    router.beginResuming(firstLease);
+
+    const secondLease = router.activateVirtualSurface({ id: 'second-alert' });
+
+    expect(secondLease).toMatchObject({
+      mode: 'virtual',
+      virtualSurface: { id: 'second-alert' },
+    });
+    expect(() => router.activateVirtualSurface({ id: 'third-alert' })).toThrow(
+      'another virtual surface is active',
+    );
+  });
+
+  it('does not start real operations while virtual routing is active', async () => {
+    const router = new WebSurfaceRouter<TestSurface>();
+    router.activateVirtualSurface({ id: 'alert' });
+
+    await expect(
+      router.runInterruptibleRealOperation(async () => 'clicked'),
+    ).rejects.toThrow('while the virtual surface is active');
+  });
+});


### PR DESCRIPTION
## Summary

- add a versioned web surface router that switches observations and actions between the real page and a temporary virtual surface
- render native Puppeteer `alert` dialogs as a Chrome-style virtual screenshot with an `OK` click hotspot
- keep the real browser dialog open so page JavaScript remains synchronously blocked, then accept it and restore the real surface after the virtual click
- add focused router, BasePage, renderer, dialog lifecycle, fixture, and AI e2e coverage

## Why

A native JavaScript alert pauses the page execution context. Puppeteer can observe and accept the dialog, but an AI agent cannot safely obtain a normal page context or interact with a custom DOM UI while the dialog is open. This change preserves the native blocking semantics while presenting a separate visual interaction surface to the agent.

## Behavior

1. Puppeteer observes a native `alert`.
2. Midscene activates an in-memory virtual surface and keeps the native dialog open.
3. The agent observes a generated `This page says` screenshot and clicks its `OK` hotspot.
4. Midscene accepts the native dialog, waits for interrupted real-page operations to settle, and restores normal routing.

The initial implementation handles `alert` only; `confirm` and `prompt` are intentionally out of scope.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/web test -- alert-virtual-surface.test.ts puppeteer-alert-dialog.test.ts base-page-surface-router.test.ts web-surface-router.test.ts`
- `pnpm --filter @midscene/web build`
- `AI_TEST_TYPE=web pnpm --filter @midscene/web exec vitest --run tests/ai/web/puppeteer/alert-blocking.test.ts` with the `mst dm` model profile

AI e2e report: https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/vhogeh7upfnuvog/zzy-2e2e-test/upload_3f737e6c540df8d47251deeabcee63c7.html