### PR TITLE
docs(core): update platform doc links to the restructured site paths

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -3,8 +3,8 @@
 Playground is the fastest way to try Midscene without writing code.
 
 - **Web (Chrome Extension)**: <https://midscenejs.com/quick-start.html#chrome-extension>
-- **Android**: <https://midscenejs.com/android-getting-started.html#try-playground-no-code>
-- **iOS**: <https://midscenejs.com/ios-getting-started.html#try-playground-no-code>
-- **Computer (Desktop)**: <https://midscenejs.com/computer-getting-started.html#try-playground-no-code>
-- **HarmonyOS**: <https://midscenejs.com/harmony-getting-started.html#try-playground-zero-code>
+- **Android**: <https://midscenejs.com/platforms/android#try-playground-no-code>
+- **iOS**: <https://midscenejs.com/platforms/ios#try-playground-no-code>
+- **Computer (Desktop)**: <https://midscenejs.com/platforms/desktop#try-playground-no-code>
+- **HarmonyOS**: <https://midscenejs.com/platforms/harmonyos#try-playground-zero-code>
 - **Custom Interface**: <https://midscenejs.com/integrate-with-any-interface.html>

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -3,8 +3,8 @@
 Playground is the fastest way to try Midscene without writing code.
 
 - **Web (Chrome Extension)**: <https://midscenejs.com/quick-start.html#chrome-extension>
-- **Android**: <https://midscenejs.com/platforms/android#try-playground-no-code>
-- **iOS**: <https://midscenejs.com/platforms/ios#try-playground-no-code>
-- **Computer (Desktop)**: <https://midscenejs.com/platforms/desktop#try-playground-no-code>
-- **HarmonyOS**: <https://midscenejs.com/platforms/harmonyos#try-playground-zero-code>
+- **Android**: <https://midscenejs.com/platforms/android#launch-playground>
+- **iOS**: <https://midscenejs.com/platforms/ios#launch-playground>
+- **Computer (Desktop)**: <https://midscenejs.com/platforms/desktop#launch-playground>
+- **HarmonyOS**: <https://midscenejs.com/platforms/harmonyos#launch-playground>
 - **Custom Interface**: <https://midscenejs.com/integrate-with-any-interface.html>

--- a/packages/android-playground/README.md
+++ b/packages/android-playground/README.md
@@ -1,3 +1,3 @@
 # @midscene/android-playground
 
-See <https://midscenejs.com/platforms/android#try-playground-no-code>.
+See <https://midscenejs.com/platforms/android#launch-playground>.

--- a/packages/android-playground/README.md
+++ b/packages/android-playground/README.md
@@ -1,3 +1,3 @@
 # @midscene/android-playground
 
-See <https://midscenejs.com/android-getting-started.html#try-playground-no-code>.
+See <https://midscenejs.com/platforms/android#try-playground-no-code>.

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -2,4 +2,4 @@
 
 Android automation library for Midscene, providing AI-powered testing and automation capabilities for Android devices.
 
-See <https://midscenejs.com/android-introduction.html>.
+See <https://midscenejs.com/platforms/android>.

--- a/packages/computer-playground/README.md
+++ b/packages/computer-playground/README.md
@@ -2,4 +2,4 @@
 
 Midscene Computer Playground - PC desktop automation playground for Windows, macOS, and Linux.
 
-See <https://midscenejs.com/computer-getting-started.html>.
+See <https://midscenejs.com/platforms/desktop>.

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -5,7 +5,7 @@ Midscene.js Computer Desktop Automation - AI-powered desktop automation for:
 - local desktop control on Windows, macOS, and Linux
 - remote Windows desktop control over the RDP protocol
 
-See <https://midscenejs.com/computer-introduction.html>.
+See <https://midscenejs.com/platforms/desktop>.
 
 ## RDP support
 

--- a/packages/ios/README.md
+++ b/packages/ios/README.md
@@ -2,4 +2,4 @@
 
 iOS automation library for Midscene, providing AI-powered testing and automation capabilities for iOS simulators and devices.
 
-See <https://midscenejs.com/ios-introduction.html>.
+See <https://midscenejs.com/platforms/ios>.


### PR DESCRIPTION
The docs site restructured its platform-specific pages from flat `.html` paths to a `platforms/` hierarchy. These seven URLs in the repository package READMEs now 404:

| Old (404) | New (200, verified live) |
|---|---|
| `android-introduction.html` | `platforms/android` |
| `android-getting-started.html` | `platforms/android` |
| `computer-introduction.html` | `platforms/desktop` |
| `computer-getting-started.html` | `platforms/desktop` |
| `ios-introduction.html` | `platforms/ios` |
| `ios-getting-started.html` | `platforms/ios` |
| `harmony-getting-started.html` | `platforms/harmonyos` |

All replacement page paths were verified live with HTTP 200. Playground links now use the current `#launch-playground` heading anchor. 6 files, 9 link updates.

Note: URLs like `quick-start.html`, `bridge-mode.html`, and `integrate-with-playwright.html` still serve 200 through legacy redirects and were left untouched.

Validation:

- `pnpm run lint`
- `curl -sS -L` against the Android, iOS, Desktop, and HarmonyOS platform pages, confirming HTTP 200 and `id="launch-playground"`

Co-Authored-By: Riff