### PR TITLE
fix(site): correct deep locate docs anchor

### DIFF
--- a/apps/site/docs/en/faq.md
+++ b/apps/site/docs/en/faq.md
@@ -190,7 +190,7 @@ await agent.aiTap('Login button', {
 });
 ```
 
-For more information about `deepLocate`, please refer to the [API documentation](/reference/#common).
+For more information about `deepLocate`, please refer to the [API documentation](/reference/#deep-locate-deeplocate).
 
 ### 6. Increase the browser DPR to 2 on web
 

--- a/apps/site/docs/zh/faq.md
+++ b/apps/site/docs/zh/faq.md
@@ -190,7 +190,7 @@ await agent.aiTap('登录按钮', {
 });
 ```
 
-更多关于 `deepLocate` 的说明，请参阅 [API 文档](/zh/reference/#common)。
+更多关于 `deepLocate` 的说明，请参阅 [API 文档](/zh/reference/#深度定位deeplocate)。
 
 ### 6. 在 web 浏览器中将 dpr 提高到 2
 


### PR DESCRIPTION
## Summary

- update the English FAQ link for `deepLocate` to target the dedicated Deep Locate API section
- update the matching Chinese FAQ link to its localized anchor

## Why

The FAQ links still pointed to the removed `#common` anchor, so readers landed at the top of the API reference instead of the `deepLocate` documentation.

## Impact

The “more information” links now navigate directly to the relevant Deep Locate section in both English and Chinese documentation.

## Validation

- `pnpm run lint`
- `git diff --check`