### PR TITLE
fix(harmony): resolve mapped explicit launch targets

### DIFF
--- a/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/en/automate-with-scripts-in-yaml.mdx
@@ -470,9 +470,10 @@ harmony:
   # Whether to auto dismiss keyboard after input, optional, defaults to false.
   autoDismissKeyboard: <boolean>
 
-  # Custom mapping of app names to bundle names, optional. User-provided mappings take precedence over defaults.
+  # Custom mapping of app names to bundle names or explicit bundle/ability targets, optional.
+  # User-provided mappings take precedence over defaults.
   appNameMapping:
-    <app-name>: <bundle-name>
+    <app-name>: <bundle-name-or-bundle/ability>
 
   # The path to the JSON file for outputting aiQuery/aiAssert results, optional.
   output: <path-to-output-file>
@@ -484,16 +485,18 @@ harmony:
 
 **`launch` - Launch App**
 
-Launch a HarmonyOS app by its bundle name.
+Launch a HarmonyOS app by its bundle name or an explicit `bundle/Ability` target.
 
 ```yaml
 harmony:
   deviceId: 'test-device'
+  appNameMapping:
+    Video: com.example.video/PhoneAbility
 
 tasks:
   - name: Launch app
     flow:
-      - launch: com.example.app
+      - launch: Video
 ```
 
 **`terminate` - Terminate App**

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -2694,13 +2694,15 @@ import { HarmonyAgent } from '@midscene/harmony';
 
 ```ts
 const agent = new HarmonyAgent(device, {
-  // common Agent options...
+  appNameMapping: {
+    Video: 'com.example.video/PhoneAbility',
+  },
 });
 ```
 
 **HarmonyOS-specific options**
 
-- `appNameMapping?: Record<string, string>` — Map friendly app names to bundle names. When you pass an app name to `launch(target)`, the Agent uses the mapped bundle name when available; otherwise, it launches `target` as provided.
+- `appNameMapping?: Record<string, string>` — Map friendly app names to bundle names or explicit `bundle/Ability` targets. Bundle-only values use bundle metadata to resolve the declared launch ability; explicit targets bypass that lookup. When you pass an app name to `launch(target)`, the Agent uses the mapped target when available; otherwise, it launches `target` as provided.
 - All other fields match the [common constructor parameters](#common-parameters), including `generateReport`, `reportFileName`, `aiActContext`, `modelConfig`, `cache`, `createOpenAIClient`, and `onTaskStartTip`.
 
 **Usage notes**
@@ -2726,11 +2728,12 @@ Launch a HarmonyOS app.
 function launch(uri: string): Promise<void>;
 ```
 
-- `uri: string` — App bundle name, app name registered in `appNameMapping`, or HTTP/HTTPS URL. Midscene opens HTTP and HTTPS URLs in the browser.
+- `uri: string` — App bundle name, explicit `bundle/Ability` target, app name registered in `appNameMapping`, or HTTP/HTTPS URL. Midscene opens HTTP and HTTPS URLs in the browser.
 
 ```ts
 await agent.launch('com.huawei.hmos.settings'); // Open Settings
 await agent.launch('com.huawei.hmos.camera');    // Open Camera
+await agent.launch('Video'); // Open the mapped explicit ability
 ```
 
 <a id="harmonyos-agentrunhdcshell"></a>

--- a/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
+++ b/apps/site/docs/zh/automate-with-scripts-in-yaml.mdx
@@ -475,9 +475,10 @@ harmony:
   # 输入完成后是否自动收起键盘,可选,默认为 false。
   autoDismissKeyboard: <boolean>
 
-  # 应用名到 Bundle 名的自定义映射,可选。用户提供的映射优先级高于默认映射。
+  # 应用名到 bundle name 或显式 bundle/Ability 目标的自定义映射,可选。
+  # 用户提供的映射优先级高于默认映射。
   appNameMapping:
-    <app-name>: <bundle-name>
+    <app-name>: <bundle-name-or-bundle/ability>
 
   # 用于输出 aiQuery/aiAssert 结果的 JSON 文件路径,可选。
   output: <path-to-output-file>
@@ -489,16 +490,18 @@ harmony:
 
 **`launch` - 启动应用**
 
-通过 Bundle 名启动 HarmonyOS 应用。
+通过 bundle name 或显式 `bundle/Ability` 目标启动 HarmonyOS 应用。
 
 ```yaml
 harmony:
   deviceId: 'test-device'
+  appNameMapping:
+    视频: com.example.video/PhoneAbility
 
 tasks:
   - name: 启动应用
     flow:
-      - launch: com.example.app
+      - launch: 视频
 ```
 
 **`terminate` - 终止应用**

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -2644,13 +2644,15 @@ import { HarmonyAgent } from '@midscene/harmony';
 
 ```ts
 const agent = new HarmonyAgent(device, {
-  // 通用 Agent 参数...
+  appNameMapping: {
+    视频: 'com.example.video/PhoneAbility',
+  },
 });
 ```
 
 **HarmonyOS 特有选项**
 
-- `appNameMapping?: Record<string, string>` —— 将友好的应用名称映射到 bundle name。当你在 `launch(target)` 里传入应用名称时，Agent 会在此映射中查找对应的 bundle name；若未找到映射，则按原样尝试启动 `target`。
+- `appNameMapping?: Record<string, string>` —— 将友好的应用名称映射到 bundle name 或显式 `bundle/Ability` 目标。仅填写 bundle name 时，Agent 会读取 bundle 元数据并解析其声明的启动 Ability；显式目标会跳过该查询。当你在 `launch(target)` 里传入应用名称时，Agent 会在此映射中查找对应目标；若未找到映射，则按原样尝试启动 `target`。
 - 其余字段与[通用构造参数](#common-parameters)一致，包括 `generateReport`、`reportFileName`、`aiActContext`、`modelConfig`、`cache`、`createOpenAIClient` 和 `onTaskStartTip` 等。
 
 **使用说明**
@@ -2676,11 +2678,12 @@ const agent = new HarmonyAgent(device, {
 function launch(uri: string): Promise<void>;
 ```
 
-- `uri: string` —— 可以是应用 bundle name（如 `com.huawei.hmos.settings`），也可以是在 `appNameMapping` 中注册的应用名称。如果传入 `http://` 或 `https://` 开头的 URL，将通过浏览器打开。
+- `uri: string` —— 可以是应用 bundle name（如 `com.huawei.hmos.settings`）、显式 `bundle/Ability` 目标，也可以是在 `appNameMapping` 中注册的应用名称。如果传入 `http://` 或 `https://` 开头的 URL，将通过浏览器打开。
 
 ```ts
 await agent.launch('com.huawei.hmos.settings'); // 打开系统设置
 await agent.launch('com.huawei.hmos.camera');    // 打开相机
+await agent.launch('视频'); // 打开映射的指定 Ability
 ```
 
 <a id="harmonyos-agentrunhdcshell"></a>

--- a/packages/cli/tests/unit-test/create-yaml-player.test.ts
+++ b/packages/cli/tests/unit-test/create-yaml-player.test.ts
@@ -702,14 +702,14 @@ describe('create-yaml-player', () => {
       );
     });
 
-    test('should pass all HarmonyOS device options from YAML to agentFromHdcDevice', async () => {
+    test('should launch a mapped explicit HarmonyOS ability from YAML', async () => {
       const mockHarmonyOptions = {
         deviceId: 'harmony-device-1',
         hdcPath: '/custom/path/to/hdc',
         autoDismissKeyboard: true,
         keyboardDismissStrategy: 'esc-first' as const,
-        appNameMapping: { 携程: 'com.ctrip.harmonynext' },
-        launch: 'com.example.app',
+        appNameMapping: { XXX: 'com.XXX/PhoneAbility' },
+        launch: 'XXX',
       };
 
       const mockScript: MidsceneYamlScript = {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -256,10 +256,12 @@ export interface MidsceneYamlScriptHarmonyEnv
   // The HarmonyOS device ID to connect to, optional, will use the first device if not specified
   deviceId?: string;
 
-  // The app package to launch, optional, will use the current screen if not specified
+  // The bundle name, bundle/Ability target, or mapped app name to launch, optional,
+  // will use the current screen if not specified
   launch?: string;
 
-  // Custom mapping of app names to bundle names, user-provided mappings take precedence over defaults
+  // Custom mapping of app names to bundle names or explicit bundle/Ability targets;
+  // user-provided mappings take precedence over defaults
   appNameMapping?: Record<string, string>;
 }
 

--- a/packages/core/tests/unit-test/yaml-player-output.test.ts
+++ b/packages/core/tests/unit-test/yaml-player-output.test.ts
@@ -1,10 +1,33 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { ScriptPlayer } from '@/yaml/player';
+import { parseYamlScript } from '@/yaml/utils';
 import { describe, expect, test, vi } from 'vitest';
 
 describe('YAML player output', () => {
+  test.each([
+    ['legacy target', 'target', 'abc.json'],
+    ['web', 'web', 'def.json'],
+  ])(
+    'resolves configured output paths for the %s environment without launching an agent',
+    (_label, environmentKey, fileName) => {
+      const setupAgent = vi.fn();
+      const relativeOutput = `./midscene_run/output/${fileName}`;
+      const script = parseYamlScript(`
+${environmentKey}:
+  url: https://example.test
+  output: ${relativeOutput}
+tasks: []
+`);
+
+      const player = new ScriptPlayer(script, setupAgent);
+
+      expect(player.output).toBe(resolve(process.cwd(), relativeOutput));
+      expect(setupAgent).not.toHaveBeenCalled();
+    },
+  );
+
   test('flushes assertion result before marking the task as failed', async () => {
     const outputDir = mkdtempSync(join(tmpdir(), 'midscene-yaml-output-'));
     const outputPath = join(outputDir, 'result.json');

--- a/packages/harmony/src/agent.ts
+++ b/packages/harmony/src/agent.ts
@@ -19,8 +19,9 @@ const debugAgent = getDebug('harmony:agent');
 
 export type HarmonyAgentOpt = AgentOpt & {
   /**
-   * Custom mapping of app names to bundle names
-   * User-provided mappings will take precedence over default mappings
+   * Custom mapping of app names to bundle names or explicit bundle/ability
+   * targets. Bundle-only targets use bundle metadata to resolve their declared
+   * launch ability. User-provided mappings take precedence over defaults.
    */
   appNameMapping?: Record<string, string>;
 };
@@ -38,16 +39,14 @@ export class HarmonyAgent extends PageAgent<HarmonyDevice> {
   home!: WrappedAction<DeviceActionHarmonyHomeButton>;
   recentApps!: WrappedAction<DeviceActionHarmonyRecentAppsButton>;
 
-  private appNameMapping: Record<string, string>;
-
   constructor(device: HarmonyDevice, opts?: HarmonyAgentOpt) {
     super(device, opts);
-    this.appNameMapping = mergeAndNormalizeAppNameMapping(
+    const appNameMapping = mergeAndNormalizeAppNameMapping(
       defaultAppNameMapping,
       opts?.appNameMapping,
     );
 
-    device.setAppNameMapping(this.appNameMapping);
+    device.setAppNameMapping(appNameMapping);
 
     this.back =
       this.createActionWrapper<DeviceActionHarmonyBackButton>(

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -22,7 +22,11 @@ import { getTmpFile, sleep } from '@midscene/core/utils';
 import type { ElementInfo } from '@midscene/shared/extractor';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
-import { normalizeForComparison, repeat } from '@midscene/shared/utils';
+import {
+  mergeAndNormalizeAppNameMapping,
+  normalizeForComparison,
+  repeat,
+} from '@midscene/shared/utils';
 import { HdcClient } from './hdc';
 import { resolveHarmonyKeyCodes } from './keycode';
 
@@ -297,13 +301,28 @@ export class HarmonyDevice implements AbstractInterface {
     return this.connecting;
   }
 
+  /**
+   * Set app-name aliases used by launch and terminate.
+   * Keys are normalized here so callers do not need to know the internal
+   * comparison format.
+   */
   public setAppNameMapping(mapping: Record<string, string>): void {
-    this.appNameMapping = mapping;
+    this.appNameMapping = mergeAndNormalizeAppNameMapping({}, mapping);
   }
 
-  private resolvePackageName(appName: string): string | undefined {
+  private resolveMappedAppTarget(appName: string): string | undefined {
     const normalizedAppName = normalizeForComparison(appName);
     return this.appNameMapping[normalizedAppName];
+  }
+
+  private resolveBundleNameForTerminate(target: string): string {
+    const mappedTarget = this.resolveMappedAppTarget(target);
+    if (mappedTarget) return mappedTarget.split('/')[0];
+
+    const [bundleOrAppName] = target.split('/');
+    return (
+      this.resolveMappedAppTarget(bundleOrAppName) ?? bundleOrAppName
+    ).split('/')[0];
   }
 
   public async launch(uri: string): Promise<HarmonyDevice> {
@@ -313,22 +332,22 @@ export class HarmonyDevice implements AbstractInterface {
 
     try {
       debugDevice(`Launching app: ${uri}`);
-      if (
-        uri.startsWith('http://') ||
-        uri.startsWith('https://') ||
-        uri.includes('://')
-      ) {
+      // Preserve direct URI behavior while allowing mapped targets to use any
+      // launch shape supported by this method.
+      const target = uri.includes('://')
+        ? uri
+        : (this.resolveMappedAppTarget(uri) ?? uri);
+      if (target.includes('://')) {
         // URI with scheme - use aa start -U
-        const sanitizedUri = uri.replace(/[`$\\;"'|&<>(){}]/g, '');
+        const sanitizedUri = target.replace(/[`$\\;"'|&<>(){}]/g, '');
         await hdc.shell(`aa start -U ${sanitizedUri}`);
-      } else if (uri.includes('/')) {
+      } else if (target.includes('/')) {
         // Format: bundleName/abilityName
-        const [bundleName, abilityName] = uri.split('/');
+        const [bundleName, abilityName] = target.split('/');
         await hdc.startAbility(bundleName, abilityName);
       } else {
         // Bundle name or app name
-        const bundleName = this.resolvePackageName(uri) ?? uri;
-        await hdc.launchBundle(bundleName);
+        await hdc.launchBundle(target);
       }
       debugDevice(`Successfully launched: ${uri}`);
     } catch (error: any) {
@@ -347,16 +366,15 @@ export class HarmonyDevice implements AbstractInterface {
    * If uri contains "/" (e.g. com.example.app/MainAbility), only the bundle part is used.
    */
   public async terminate(uri: string): Promise<void> {
-    const bundlePart = uri.includes('/') ? uri.split('/')[0] : uri;
-    const resolved = this.resolvePackageName(bundlePart) ?? bundlePart;
+    const bundleName = this.resolveBundleNameForTerminate(uri);
     const hdc = await this.getHdc();
     try {
-      debugDevice(`Terminating app: ${resolved}`);
-      await hdc.forceStop(resolved);
-      debugDevice(`Successfully terminated: ${resolved}`);
+      debugDevice(`Terminating app: ${bundleName}`);
+      await hdc.forceStop(bundleName);
+      debugDevice(`Successfully terminated: ${bundleName}`);
     } catch (error: any) {
-      debugDevice(`Error terminating ${resolved}: ${error}`);
-      throw new Error(`Failed to terminate ${resolved}: ${error.message}`, {
+      debugDevice(`Error terminating ${bundleName}: ${error}`);
+      throw new Error(`Failed to terminate ${bundleName}: ${error.message}`, {
         cause: error,
       });
     }

--- a/packages/harmony/tests/unit-test/agent.test.ts
+++ b/packages/harmony/tests/unit-test/agent.test.ts
@@ -74,6 +74,24 @@ describe('HarmonyAgent', () => {
         }),
       );
     });
+
+    it('should preserve an explicit ability in a custom app mapping', () => {
+      const mockPage = new HarmonyDevice('test-device');
+      const setAppNameMappingSpy = rs.spyOn(mockPage, 'setAppNameMapping');
+
+      new HarmonyAgent(mockPage, {
+        modelConfig: mockedModelConfig,
+        appNameMapping: {
+          XXX: 'com.XXX/PhoneAbility',
+        },
+      });
+
+      expect(setAppNameMappingSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          xxx: 'com.XXX/PhoneAbility',
+        }),
+      );
+    });
   });
 
   describe('launch', () => {

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -489,6 +489,15 @@ describe('HarmonyDevice', () => {
       expect(mockHdc.shell).toHaveBeenCalledWith('aa start -U myapp://page');
     });
 
+    it('should not replace a direct URI with an app name mapping', async () => {
+      device.setAppNameMapping({
+        'myapp://page': 'com.example.app/MainAbility',
+      });
+      await device.launch('myapp://page');
+      expect(mockHdc.shell).toHaveBeenCalledWith('aa start -U myapp://page');
+      expect(mockHdc.startAbility).not.toHaveBeenCalled();
+    });
+
     it('should use startAbility for bundleName/abilityName format', async () => {
       await device.launch('com.example.app/MainAbility');
       expect(mockHdc.startAbility).toHaveBeenCalledWith(
@@ -537,6 +546,22 @@ describe('HarmonyDevice', () => {
       });
       await device.terminate('Music');
       expect(mockHdc.forceStop).toHaveBeenCalledWith('com.huawei.hmsapp.music');
+    });
+
+    it('should use only the bundle part of a mapped bundle/ability target', async () => {
+      device.setAppNameMapping({
+        Video: 'com.example.video/PhoneAbility',
+      });
+      await device.terminate('Video');
+      expect(mockHdc.forceStop).toHaveBeenCalledWith('com.example.video');
+    });
+
+    it('should resolve the mapped bundle part of an explicit ability target', async () => {
+      device.setAppNameMapping({
+        Video: 'com.example.video/PhoneAbility',
+      });
+      await device.terminate('video/MainAbility');
+      expect(mockHdc.forceStop).toHaveBeenCalledWith('com.example.video');
     });
 
     it('should throw on terminate failure', async () => {
@@ -770,6 +795,19 @@ describe('HarmonyDevice', () => {
       expect(mockHdc.launchBundle).toHaveBeenCalledWith(
         'com.huawei.hmos.browser',
       );
+    });
+
+    it('should start an explicit ability from app name mapping', async () => {
+      await device.connect();
+      device.setAppNameMapping({
+        'Video App': 'com.example.video/PhoneAbility',
+      });
+      await device.launch('video-app');
+      expect(mockHdc.startAbility).toHaveBeenCalledWith(
+        'com.example.video',
+        'PhoneAbility',
+      );
+      expect(mockHdc.launchBundle).not.toHaveBeenCalled();
     });
 
     it('should fall back to original name if not in mapping', async () => {

--- a/packages/web-integration/tests/ai/web/puppeteer/yaml-player.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/yaml-player.test.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'node:path';
 import { puppeteerAgentForTarget } from '@/puppeteer/agent-launcher';
 import type { MidsceneYamlScriptWebEnv } from '@midscene/core';
 import { ScriptPlayer, parseYamlScript } from '@midscene/core/yaml';
@@ -15,9 +14,14 @@ const runYaml = async (yamlString: string, ignoreStatusAssertion = false) => {
   );
   await player.run();
   if (!ignoreStatusAssertion) {
+    const taskError = player.taskStatusList.find(
+      (taskStatus) => taskStatus.status === 'error',
+    )?.error;
     assert(
       player.status === 'done',
-      player.errorInSetup?.message || 'unknown error',
+      player.errorInSetup?.message ||
+        taskError?.message ||
+        `YAML player ended with status "${player.status}"`,
     );
     expect(statusUpdate).toHaveBeenCalled();
   }
@@ -30,36 +34,6 @@ const runYaml = async (yamlString: string, ignoreStatusAssertion = false) => {
 describe(
   'YAML player - AI e2e',
   () => {
-    test('set output path correctly', async () => {
-      const yamlString = `
-      target:
-        url: https://bing.com
-        output: ./midscene_run/output/abc.json
-      tasks:
-        - name: check content
-          flow:
-            - aiQuery: title of the page
-      `;
-      const { player } = await runYaml(yamlString);
-      expect(player.output).toBe(
-        resolve(process.cwd(), './midscene_run/output/abc.json'),
-      );
-
-      const yamlString2 = `
-      web:
-        url: https://bing.com
-        output: ./midscene_run/output/def.json
-      tasks:
-        - name: check content
-          flow:
-            - aiQuery: title of the page
-      `;
-      const { player: player2 } = await runYaml(yamlString2);
-      expect(player2.output).toBe(
-        resolve(process.cwd(), './midscene_run/output/def.json'),
-      );
-    });
-
     test('cookie', async () => {
       const yamlString = `
       target:


### PR DESCRIPTION
## Summary

- resolve `appNameMapping` values before classifying HarmonyOS launch targets, so aliases mapped to `bundle/Ability` work in both TypeScript and YAML
- normalize mapping keys at the `HarmonyDevice` boundary and preserve direct URI and terminate behavior
- document the supported mapping forms in English and Chinese and add Harmony plus CLI regression coverage
- move YAML output-path plumbing coverage out of AI E2E and surface the underlying task error when a YAML AI test fails

## Root cause

Harmony launch classified the original input before resolving `appNameMapping`. An alias such as `XXX` was therefore treated as a bundle-only target even when it mapped to `com.XXX/PhoneAbility`, and the mapped value was passed to bundle metadata lookup instead of `startAbility`. YAML uses the same Agent and Device path, so `launch: XXX` had the same behavior.

## Impact

The following forms now behave consistently:

```ts
const agent = new HarmonyAgent(device, {
  appNameMapping: {
    XXX: 'com.XXX/PhoneAbility',
  },
});

await agent.launch('XXX');
```

```yaml
harmony:
  appNameMapping:
    XXX: com.XXX/PhoneAbility
  launch: XXX
```

Bundle-only mappings continue to use `bm dump` to resolve the declared launch module and Ability.

## CI stability

The YAML output-path test only verifies `ScriptPlayer.output`, which is resolved during construction, but previously launched two external Bing pages and made two model calls. The second Chromium target could close under the parallel AI test load. The same `target` and `web` coverage now runs as deterministic Core unit tests without launching an Agent. The AI E2E helper also reports the actual failed task error instead of `unknown error`.

## Validation

- `npx nx test @midscene/harmony` — 268 tests passed
- `npx nx test @midscene/cli` — 203 tests passed
- `pnpm exec nx test @midscene/core -- tests/unit-test/yaml-player-output.test.ts` — 3 tests passed
- `pnpm exec nx test @midscene/core` — 1,407 tests passed, 8 skipped
- `pnpm run lint` — 1,447 files checked
- `npx nx build @midscene/harmony`
- `npx nx build @midscene/cli`
- real HarmonyOS device `MJE0223906089471`: TypeScript explicit mapping, mapped terminate, and direct YAML launch all succeeded; screenshots confirmed HUAWEI Video in the foreground

## Release

- `@midscene/harmony@1.10.13-beta-20260817074825.0`
- [Release workflow](https://github.com/web-infra-dev/midscene/actions/runs/32007219474)

Follow-up to #2963.
