### PR TITLE
docs(site): add Doubao Seed Android showcase cost data

### DIFF
--- a/apps/site/docs/en/showcases-android.mdx
+++ b/apps/site/docs/en/showcases-android.mdx
@@ -3,3 +3,21 @@
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking2.mp4" poster="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.png" height="300" controls />
 
 View the full report of this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.html)
+
+### Doubao Seed 2.1 Turbo cost reference
+
+The following figures come from five Android test cases for the ranking filters in the Dongchedi app, run with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.
+
+| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Input cache ratio | Cost |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | ¥0.215 |
+| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | ¥0.212 |
+| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | ¥0.299 |
+| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | ¥0.474 |
+| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | ¥0.378 |
+| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **¥1.578** |
+| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **¥0.316** |
+
+:::info Pricing assumptions
+Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. CNY costs use an estimated exchange rate of `$1 ≈ ¥7.2`. The five cases average approximately 182,253 tokens and ¥0.316 per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+:::

--- a/apps/site/docs/en/showcases-android.mdx
+++ b/apps/site/docs/en/showcases-android.mdx
@@ -3,21 +3,3 @@
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking2.mp4" poster="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.png" height="300" controls />
 
 View the full report of this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.html)
-
-### Doubao Seed 2.1 Turbo cost reference
-
-The following figures come from five Android test cases for the ranking filters in the Dongchedi app, run with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.
-
-| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Input cache ratio | Cost (USD) |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | $0.0299 |
-| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | $0.0295 |
-| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | $0.0415 |
-| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | $0.0658 |
-| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | $0.0525 |
-| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **$0.2192** |
-| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **$0.0438** |
-
-:::info Pricing assumptions
-Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
-:::

--- a/apps/site/docs/en/showcases-android.mdx
+++ b/apps/site/docs/en/showcases-android.mdx
@@ -8,16 +8,16 @@ View the full report of this task: [report.html](https://lf3-static.bytednsdoc.c
 
 The following figures come from five Android test cases for the ranking filters in the Dongchedi app, run with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.
 
-| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Input cache ratio | Cost |
+| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Input cache ratio | Cost (USD) |
 | --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | ¥0.203 |
-| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | ¥0.200 |
-| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | ¥0.283 |
-| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | ¥0.448 |
-| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | ¥0.357 |
-| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **¥1.491** |
-| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **¥0.298** |
+| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | $0.0299 |
+| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | $0.0295 |
+| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | $0.0415 |
+| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | $0.0658 |
+| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | $0.0525 |
+| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **$0.2192** |
+| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **$0.0438** |
 
 :::info Pricing assumptions
-Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. CNY costs use an estimated exchange rate of `$1 ≈ ¥6.8`. The five cases average approximately 182,253 tokens and ¥0.298 per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
 :::

--- a/apps/site/docs/en/showcases-android.mdx
+++ b/apps/site/docs/en/showcases-android.mdx
@@ -10,14 +10,14 @@ The following figures come from five Android test cases for the ranking filters 
 
 | Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Input cache ratio | Cost |
 | --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | ¥0.215 |
-| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | ¥0.212 |
-| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | ¥0.299 |
-| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | ¥0.474 |
-| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | ¥0.378 |
-| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **¥1.578** |
-| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **¥0.316** |
+| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | 70.7% | ¥0.203 |
+| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | 72.8% | ¥0.200 |
+| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | 69.3% | ¥0.283 |
+| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | 68.6% | ¥0.448 |
+| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | 69.9% | ¥0.357 |
+| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **70.0%** | **¥1.491** |
+| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **70.0%** | **¥0.298** |
 
 :::info Pricing assumptions
-Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. CNY costs use an estimated exchange rate of `$1 ≈ ¥7.2`. The five cases average approximately 182,253 tokens and ¥0.316 per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. CNY costs use an estimated exchange rate of `$1 ≈ ¥6.8`. The five cases average approximately 182,253 tokens and ¥0.298 per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
 :::

--- a/apps/site/docs/en/showcases-computer.mdx
+++ b/apps/site/docs/en/showcases-computer.mdx
@@ -1,4 +1,4 @@
-#### macOS
+**macOS**
 
 **Prompt:** Help me post a tweet promoting Midscene's support for AutoGLM through safari, with the following requirements:
 1. Text content: Midscene now supports AutoGLM!
@@ -14,7 +14,7 @@ View the full report for this task: [report.html](https://lf3-static.bytednsdoc.
 
 View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/weather-computer-2026-01-14_11-26-38-9592ecf5.html)
 
-#### Windows
+**Windows**
 
 **Prompt:** Open Sauce Demo e-commerce site, login and add items to cart
 
@@ -22,7 +22,7 @@ View the full report for this task: [report.html](https://lf3-static.bytednsdoc.
 
 View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
 
-#### Linux
+**Linux**
 
 **Prompt:** Open TodoMVC, add multiple tasks and filter them
 

--- a/apps/site/docs/en/showcases-computer.mdx
+++ b/apps/site/docs/en/showcases-computer.mdx
@@ -1,4 +1,6 @@
-**Prompt** (**macOS**): Help me post a tweet promoting Midscene's support for AutoGLM through safari, with the following requirements:
+#### macOS
+
+**Prompt:** Help me post a tweet promoting Midscene's support for AutoGLM through safari, with the following requirements:
 1. Text content: Midscene now supports AutoGLM!
 2. Media content: Use the AutoGLM video from the download folder!
 
@@ -6,19 +8,23 @@
 
 View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/pc-twitter2-midscene_report.html)
 
-**Prompt** (**Windows**): Open Sauce Demo e-commerce site, login and add items to cart
-
-<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/windows.mov" height="300" controls />
-
-View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
-
-**Prompt** (**macOS**): Open Google and query San Jose tomorrow weather temperature
+**Prompt:** Open Google and query San Jose tomorrow weather temperature
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/mac.mov" height="300" controls />
 
 View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/weather-computer-2026-01-14_11-26-38-9592ecf5.html)
 
-**Prompt** (**Linux**): Open TodoMVC, add multiple tasks and filter them
+#### Windows
+
+**Prompt:** Open Sauce Demo e-commerce site, login and add items to cart
+
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/windows.mov" height="300" controls />
+
+View the full report for this task: [report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
+
+#### Linux
+
+**Prompt:** Open TodoMVC, add multiple tasks and filter them
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/linux.mov" height="300" controls />
 

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -32,9 +32,11 @@ This page introduces cross-platform GUI Agent, E2E test, and community showcases
 
 ## E2E Test Scenarios
 
+### Dongchedi App: Doubao Seed 2.1 Turbo
+
 The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ranking filters in the Android Dongchedi app on a device with a 720 × 1600 resolution.
 
-### Case 1: Sales ranking test
+#### Case 1: Sales ranking test
 
 - **Test scope:** Verify that the sales ranking correctly applies the combined filters for sedan, the month before last, fuel, and a preset CNY 180,000–250,000 price range, and displays the corresponding results
 - **Steps:** 8 / 16 (script / model calls)
@@ -42,7 +44,7 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Cost:** $0.0299
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
 
-### Case 2: Sales ranking combined-filter test
+#### Case 2: Sales ranking combined-filter test
 
 - **Test scope:** Verify that the sales ranking correctly applies the combined filters for SUV, the previous month, and plug-in hybrid, and displays the corresponding results
 - **Steps:** 4 / 14 (script / model calls)
@@ -50,7 +52,7 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Cost:** $0.0295
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
 
-### Case 3: New-energy ranking test
+#### Case 3: New-energy ranking test
 
 - **Test scope:** Verify that the new-energy ranking correctly applies the combined filters for SUV, the last six months, battery electric, and a preset CNY 180,000–250,000 price range, and displays the corresponding results
 - **Steps:** 8 / 18 (script / model calls)
@@ -58,7 +60,7 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Cost:** $0.0415
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
 
-### Case 4: Price-drop ranking test
+#### Case 4: Price-drop ranking test
 
 - **Test scope:** Verify that the price-drop ranking correctly applies the combined filters for MPV, the last year, new energy, and a custom CNY 150,000–300,000 price range, and displays the corresponding results
 - **Steps:** 13 / 29 (script / model calls)
@@ -66,7 +68,7 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Cost:** $0.0658
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
 
-### Case 5: Ranking switch and filter reset test
+#### Case 5: Ranking switch and filter reset test
 
 - **Test scope:** Verify that switching from the sales ranking to the new-energy ranking resets dependent filters correctly, and that subsequent filtering and reset-to-default behavior work as expected
 - **Steps:** 16 / 28 (script / model calls)
@@ -74,8 +76,32 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Cost:** $0.0525
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
-:::info Pricing assumptions
+:::info Doubao pricing assumptions
 Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+:::
+
+### Reddit App: Qwen 3.7 Plus
+
+The following two test cases use `qwen/qwen3.7-plus` to test community search, joining, and post upvoting in the Android Reddit app on a device with a 720 × 1600 resolution.
+
+#### Case 1: Search for and join the Midscene community
+
+- **Test scope:** Search Reddit for Midscene, open the exact `r/midscene` community, join it if needed, and verify that the account has joined
+- **Steps:** 7 / 17 (script / model calls)
+- **Tokens:** Input 147,127 (34,816 cached) / output 3,418
+- **Cost:** $0.0425
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/01-search-and-join-midscene-community.html)
+
+#### Case 2: Upvote the first post in the Midscene community
+
+- **Test scope:** Open the exact `r/midscene` community, upvote the first post in its post list if needed, and verify that it is upvoted
+- **Steps:** 6 / 12 (script / model calls)
+- **Tokens:** Input 103,231 (8,704 cached) / output 3,142
+- **Cost:** $0.0348
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/02-upvote-first-post-in-midscene-community.html)
+
+:::info Qwen pricing assumptions
+Input tokens are priced at `$0.32 / M tokens`, cache reads at `$0.064 / M tokens`, and output tokens at `$1.28 / M tokens`. The two cases cost approximately `$0.0774` in total and average `$0.0387` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
 :::
 
 

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -6,26 +6,50 @@ import ShowcaseAndroid from './showcases-android.mdx';
 import ShowcaseHarmony from './showcases-harmony.mdx';
 import ShowcaseComputer from './showcases-computer.mdx';
 
+## Platform Demos
 
-## Web
+Midscene GUI automation capabilities across platforms, organized by target device.
+
+### Web
 
 <ShowcaseWeb />
 
-## iOS
+### iOS
 
 <ShowcaseIOS />
 
-## Android
+### Android
 
 <ShowcaseAndroid />
 
-## HarmonyOS
+### HarmonyOS
 
 <ShowcaseHarmony />
 
-## Computer
+### Desktop
 
 <ShowcaseComputer />
+
+## Real-world Metrics
+
+### Doubao Seed 2.1 Turbo cost reference
+
+The following figures come from five Android test cases for the ranking filters in the Dongchedi app, run with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.
+
+| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Cost (USD) |
+| --- | --- | --- | ---: | ---: | ---: |
+| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | $0.0299 |
+| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | $0.0295 |
+| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | $0.0415 |
+| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | $0.0658 |
+| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | $0.0525 |
+| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **$0.2192** |
+| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **$0.0438** |
+
+:::info Pricing assumptions
+Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+:::
+
 
 ## Community showcases
 

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -6,9 +6,9 @@ import ShowcaseAndroid from './showcases-android.mdx';
 import ShowcaseHarmony from './showcases-harmony.mdx';
 import ShowcaseComputer from './showcases-computer.mdx';
 
-## Platform Demos
+This page introduces cross-platform GUI Agent, E2E test, and community showcases built with Midscene.
 
-Midscene GUI automation capabilities across platforms, organized by target device.
+## Cross-platform GUI Agent Showcases
 
 ### Web
 
@@ -30,7 +30,7 @@ Midscene GUI automation capabilities across platforms, organized by target devic
 
 <ShowcaseComputer />
 
-## Real-world Task Tests
+## E2E Test Scenarios
 
 The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ranking filters in the Android Dongchedi app on a device with a 720 × 1600 resolution.
 

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -30,21 +30,49 @@ Midscene GUI automation capabilities across platforms, organized by target devic
 
 <ShowcaseComputer />
 
-## Real-world Metrics
+## Real-world Task Tests
 
-### Doubao Seed 2.1 Turbo cost reference
+The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ranking filters in the Android Dongchedi app on a device with a 720 × 1600 resolution.
 
-The following figures come from five Android test cases for the ranking filters in the Dongchedi app, run with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.
+### Case 1: Sales ranking test
 
-| Case | Scenario | Test report | Steps (script / model calls / loops) | Tokens (input / output) | Cost (USD) |
-| --- | --- | --- | ---: | ---: | ---: |
-| 1 | Sales ranking: sedan, fuel, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044 (126,935 / 3,109) | $0.0299 |
-| 2 | Sales ranking: SUV and plug-in hybrid | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782 (137,310 / 2,472) | $0.0295 |
-| 3 | New-energy ranking: SUV, battery electric, and preset price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275 (149,996 / 6,279) | $0.0415 |
-| 4 | Price-drop ranking: MPV, new energy, and custom price | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194 (253,991 / 8,203) | $0.0658 |
-| 5 | Ranking switch and filter reset | [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971 (217,283 / 5,688) | $0.0525 |
-| **Total** | 5 cases | — | **49 / 105 / 75** | **911,266 (885,515 / 25,751)** | **$0.2192** |
-| **Average** | Per case | — | **9.8 / 21 / 15** | **182,253.2 (177,103 / 5,150.2)** | **$0.0438** |
+- **Test scope:** Filter by sedan, fuel, and a preset price range
+- **Steps:** 8 / 16 / 11 (script / model calls / loops)
+- **Tokens:** 130,044 (126,935 input / 3,109 output)
+- **Cost:** $0.0299
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
+
+### Case 2: Sales ranking combined-filter test
+
+- **Test scope:** Filter by SUV and plug-in hybrid
+- **Steps:** 4 / 14 / 12 (script / model calls / loops)
+- **Tokens:** 139,782 (137,310 input / 2,472 output)
+- **Cost:** $0.0295
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
+
+### Case 3: New-energy ranking test
+
+- **Test scope:** Filter by SUV, battery electric, and a preset price range
+- **Steps:** 8 / 18 / 13 (script / model calls / loops)
+- **Tokens:** 156,275 (149,996 input / 6,279 output)
+- **Cost:** $0.0415
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
+
+### Case 4: Price-drop ranking test
+
+- **Test scope:** Filter by MPV, new energy, and a custom price range
+- **Steps:** 13 / 29 / 20 (script / model calls / loops)
+- **Tokens:** 262,194 (253,991 input / 8,203 output)
+- **Cost:** $0.0658
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
+
+### Case 5: Ranking switch and filter reset test
+
+- **Test scope:** Switch rankings and reset all filter conditions
+- **Steps:** 16 / 28 / 19 (script / model calls / loops)
+- **Tokens:** 222,971 (217,283 input / 5,688 output)
+- **Cost:** $0.0525
+- **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
 :::info Pricing assumptions
 Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -82,7 +82,7 @@ Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tok
 
 ### Reddit App: Qwen 3.7 Plus
 
-The following two test cases use `qwen/qwen3.7-plus` to test community search, joining, and post upvoting in the Android Reddit app on a device with a 720 × 1600 resolution.
+The following two test cases use [`qwen/qwen3.7-plus`](https://openrouter.ai/qwen/qwen3.7-plus) to test community search, joining, and post upvoting in the Android Reddit app on a device with a 720 × 1600 resolution.
 
 #### Case 1: Search for and join the Midscene community
 

--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -36,41 +36,41 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 
 ### Case 1: Sales ranking test
 
-- **Test scope:** Filter by sedan, fuel, and a preset price range
-- **Steps:** 8 / 16 / 11 (script / model calls / loops)
-- **Tokens:** 130,044 (126,935 input / 3,109 output)
+- **Test scope:** Verify that the sales ranking correctly applies the combined filters for sedan, the month before last, fuel, and a preset CNY 180,000–250,000 price range, and displays the corresponding results
+- **Steps:** 8 / 16 (script / model calls)
+- **Tokens:** Input 126,935 (89,760 cached) / output 3,109
 - **Cost:** $0.0299
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
 
 ### Case 2: Sales ranking combined-filter test
 
-- **Test scope:** Filter by SUV and plug-in hybrid
-- **Steps:** 4 / 14 / 12 (script / model calls / loops)
-- **Tokens:** 139,782 (137,310 input / 2,472 output)
+- **Test scope:** Verify that the sales ranking correctly applies the combined filters for SUV, the previous month, and plug-in hybrid, and displays the corresponding results
+- **Steps:** 4 / 14 (script / model calls)
+- **Tokens:** Input 137,310 (100,000 cached) / output 2,472
 - **Cost:** $0.0295
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
 
 ### Case 3: New-energy ranking test
 
-- **Test scope:** Filter by SUV, battery electric, and a preset price range
-- **Steps:** 8 / 18 / 13 (script / model calls / loops)
-- **Tokens:** 156,275 (149,996 input / 6,279 output)
+- **Test scope:** Verify that the new-energy ranking correctly applies the combined filters for SUV, the last six months, battery electric, and a preset CNY 180,000–250,000 price range, and displays the corresponding results
+- **Steps:** 8 / 18 (script / model calls)
+- **Tokens:** Input 149,996 (103,896 cached) / output 6,279
 - **Cost:** $0.0415
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
 
 ### Case 4: Price-drop ranking test
 
-- **Test scope:** Filter by MPV, new energy, and a custom price range
-- **Steps:** 13 / 29 / 20 (script / model calls / loops)
-- **Tokens:** 262,194 (253,991 input / 8,203 output)
+- **Test scope:** Verify that the price-drop ranking correctly applies the combined filters for MPV, the last year, new energy, and a custom CNY 150,000–300,000 price range, and displays the corresponding results
+- **Steps:** 13 / 29 (script / model calls)
+- **Tokens:** Input 253,991 (174,176 cached) / output 8,203
 - **Cost:** $0.0658
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
 
 ### Case 5: Ranking switch and filter reset test
 
-- **Test scope:** Switch rankings and reset all filter conditions
-- **Steps:** 16 / 28 / 19 (script / model calls / loops)
-- **Tokens:** 222,971 (217,283 input / 5,688 output)
+- **Test scope:** Verify that switching from the sales ranking to the new-energy ranking resets dependent filters correctly, and that subsequent filtering and reset-to-default behavior work as expected
+- **Steps:** 16 / 28 (script / model calls)
+- **Tokens:** Input 217,283 (151,848 cached) / output 5,688
 - **Cost:** $0.0525
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 

--- a/apps/site/docs/zh/showcases-android.mdx
+++ b/apps/site/docs/zh/showcases-android.mdx
@@ -16,14 +16,14 @@
 
 | Case | 测试内容 | 测试报告 | 步骤数（脚本 / 模型调用 / Loop） | Token（输入 / 输出） | 输入缓存占比 | 费用 |
 | --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | 70.7% | ¥0.215 |
-| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | 72.8% | ¥0.212 |
-| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | 69.3% | ¥0.299 |
-| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | 68.6% | ¥0.474 |
-| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | 69.9% | ¥0.378 |
-| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **70.0%** | **¥1.578** |
-| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **70.0%** | **¥0.316** |
+| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | 70.7% | ¥0.203 |
+| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | 72.8% | ¥0.200 |
+| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | 69.3% | ¥0.283 |
+| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | 68.6% | ¥0.448 |
+| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | 69.9% | ¥0.357 |
+| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **70.0%** | **¥1.491** |
+| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **70.0%** | **¥0.298** |
 
 :::info 计价口径
-输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥7.2` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.316。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::

--- a/apps/site/docs/zh/showcases-android.mdx
+++ b/apps/site/docs/zh/showcases-android.mdx
@@ -9,21 +9,3 @@
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking2.mp4" poster="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.png" height="300" controls />
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.html)
-
-### Doubao Seed 2.1 Turbo 运行费用参考
-
-以下数据来自使用 `doubao-seed-2-1-turbo-260628` 对 Android 端懂车帝 App 排行榜筛选功能运行的 5 个测试 Case。测试设备分辨率为 720 × 1600。
-
-| Case | 测试内容 | 测试报告 | 步骤数（脚本 / 模型调用 / Loop） | Token（输入 / 输出） | 输入缓存占比 | 费用 |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | 70.7% | ¥0.203 |
-| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | 72.8% | ¥0.200 |
-| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | 69.3% | ¥0.283 |
-| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | 68.6% | ¥0.448 |
-| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | 69.9% | ¥0.357 |
-| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **70.0%** | **¥1.491** |
-| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **70.0%** | **¥0.298** |
-
-:::info 计价口径
-输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
-:::

--- a/apps/site/docs/zh/showcases-android.mdx
+++ b/apps/site/docs/zh/showcases-android.mdx
@@ -9,3 +9,21 @@
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking2.mp4" poster="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.png" height="300" controls />
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/booking.html)
+
+### Doubao Seed 2.1 Turbo 运行费用参考
+
+以下数据来自使用 `doubao-seed-2-1-turbo-260628` 对 Android 端懂车帝 App 排行榜筛选功能运行的 5 个测试 Case。测试设备分辨率为 720 × 1600。
+
+| Case | 测试内容 | 测试报告 | 步骤数（脚本 / 模型调用 / Loop） | Token（输入 / 输出） | 输入缓存占比 | 费用 |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | 70.7% | ¥0.215 |
+| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | 72.8% | ¥0.212 |
+| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | 69.3% | ¥0.299 |
+| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | 68.6% | ¥0.474 |
+| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | 69.9% | ¥0.378 |
+| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **70.0%** | **¥1.578** |
+| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **70.0%** | **¥0.316** |
+
+:::info 计价口径
+输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥7.2` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.316。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+:::

--- a/apps/site/docs/zh/showcases-computer.mdx
+++ b/apps/site/docs/zh/showcases-computer.mdx
@@ -1,4 +1,4 @@
-#### macOS
+**macOS**
 
 **Prompt**：通过 Safari 发一条推文宣传 Midscene 支持 AutoGLM，要求如下：
 1. 文案内容：Midscene now supports AutoGLM!
@@ -14,7 +14,7 @@
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/weather-computer-2026-01-14_11-26-38-9592ecf5.html)
 
-#### Windows
+**Windows**
 
 **Prompt**：打开 Sauce Demo 电商网站，登录并添加商品到购物车
 
@@ -22,7 +22,7 @@
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
 
-#### Linux
+**Linux**
 
 **Prompt**：打开 TodoMVC，添加多个任务并筛选
 

--- a/apps/site/docs/zh/showcases-computer.mdx
+++ b/apps/site/docs/zh/showcases-computer.mdx
@@ -1,24 +1,30 @@
-**Prompt** (**macOS**): Help me post a tweet promoting Midscene's support for AutoGLM through safari, with the following requirements:
-1. Text content: Midscene now supports AutoGLM!
-2. Media content: Use the AutoGLM video from the download folder!
+#### macOS
+
+**Prompt**：通过 Safari 发一条推文宣传 Midscene 支持 AutoGLM，要求如下：
+1. 文案内容：Midscene now supports AutoGLM!
+2. 媒体内容：使用下载文件夹里的 AutoGLM 视频！
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/pc-twitter2.mp4" height="300" controls />
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/pc-twitter2-midscene_report.html)
 
-**Prompt** (**Windows**): 打开 Sauce Demo 电商网站，登录并添加商品到购物车
-
-<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/windows.mov" height="300" controls />
-
-查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
-
-**Prompt** (**macOS**): 打开 Google 查询圣何塞明天天气温度
+**Prompt**：打开 Google 查询圣何塞明天天气温度
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/mac.mov" height="300" controls />
 
 查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/weather-computer-2026-01-14_11-26-38-9592ecf5.html)
 
-**Prompt** (**Linux**): 打开 TodoMVC，添加多个任务并筛选
+#### Windows
+
+**Prompt**：打开 Sauce Demo 电商网站，登录并添加商品到购物车
+
+<video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/windows.mov" height="300" controls />
+
+查看此次任务的完整报告：[report.html](https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/shop-computer-2026-01-14_11-57-36-f8411b8f.html)
+
+#### Linux
+
+**Prompt**：打开 TodoMVC，添加多个任务并筛选
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/linux.mov" height="300" controls />
 

--- a/apps/site/docs/zh/showcases-web.mdx
+++ b/apps/site/docs/zh/showcases-web.mdx
@@ -1,4 +1,4 @@
-**指令**：填写 GitHub 注册表单并通过表单校验，但不要提交。
+**Prompt**：填写 GitHub 注册表单并通过表单校验，但不要提交。
 
 <video src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github2.mp4" poster="https://lf3-static.bytednsdoc.com/obj/eden-cn/nupipfups/Midscene/1.0-showcases/github.png" height="300" controls />
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -82,7 +82,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 ### Reddit App：Qwen 3.7 Plus
 
-以下 2 个用例使用 `qwen/qwen3.7-plus`，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
+以下 2 个用例使用 [`qwen/qwen3.7-plus`](https://openrouter.ai/qwen/qwen3.7-plus)，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
 
 #### 用例 1：搜索并加入 Midscene 社区
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -30,24 +30,52 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 <ShowcaseComputer />
 
-## 实测数据
+## 真实任务实测
 
-### Doubao Seed 2.1 Turbo 运行费用参考
+以下 5 个用例使用 `doubao-seed-2-1-turbo-260628`，测试 Android 端懂车帝 App 的排行榜筛选功能。测试设备分辨率为 720 × 1600。
 
-以下数据来自使用 `doubao-seed-2-1-turbo-260628` 对 Android 端懂车帝 App 排行榜筛选功能运行的 5 个测试 Case。测试设备分辨率为 720 × 1600。
+### 用例 1：销量榜功能测试
 
-| Case | 测试内容 | 测试报告 | 步骤数（脚本 / 模型调用 / Loop） | Token（输入 / 输出） | 费用 |
-| --- | --- | --- | ---: | ---: | ---: |
-| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | ¥0.203 |
-| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | ¥0.200 |
-| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | ¥0.283 |
-| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | ¥0.448 |
-| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | ¥0.357 |
-| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **¥1.491** |
-| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **¥0.298** |
+- **测试内容：** 筛选轿车、燃油车和预设价格
+- **步骤数：** 8 / 16 / 11（脚本 / 模型调用 / Loop）
+- **Token 量：** 130,044（输入 126,935 / 输出 3,109）
+- **费用：** ¥0.203
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
+
+### 用例 2：销量榜组合筛选测试
+
+- **测试内容：** 筛选 SUV 和插电式混动
+- **步骤数：** 4 / 14 / 12（脚本 / 模型调用 / Loop）
+- **Token 量：** 139,782（输入 137,310 / 输出 2,472）
+- **费用：** ¥0.200
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
+
+### 用例 3：新能源榜功能测试
+
+- **测试内容：** 筛选 SUV、纯电动和预设价格
+- **步骤数：** 8 / 18 / 13（脚本 / 模型调用 / Loop）
+- **Token 量：** 156,275（输入 149,996 / 输出 6,279）
+- **费用：** ¥0.283
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
+
+### 用例 4：降价榜功能测试
+
+- **测试内容：** 筛选 MPV、新能源和自定义价格
+- **步骤数：** 13 / 29 / 20（脚本 / 模型调用 / Loop）
+- **Token 量：** 262,194（输入 253,991 / 输出 8,203）
+- **费用：** ¥0.448
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
+
+### 用例 5：榜单切换与筛选重置测试
+
+- **测试内容：** 切换榜单并重置筛选条件
+- **步骤数：** 16 / 28 / 19（脚本 / 模型调用 / Loop）
+- **Token 量：** 222,971（输入 217,283 / 输出 5,688）
+- **费用：** ¥0.357
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
 :::info 计价口径
-输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个用例平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::
 
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -6,25 +6,50 @@ import ShowcaseAndroid from './showcases-android.mdx';
 import ShowcaseHarmony from './showcases-harmony.mdx';
 import ShowcaseComputer from './showcases-computer.mdx';
 
-## Web
+## 平台 Demo
+
+按平台分类展示 Midscene 在各端的 GUI 自动化能力。
+
+### Web
 
 <ShowcaseWeb />
 
-## iOS
+### iOS
 
 <ShowcaseIOS />
 
-## Android
+### Android
 
 <ShowcaseAndroid />
 
-## HarmonyOS
+### HarmonyOS
 
 <ShowcaseHarmony />
 
-## Computer
+### 桌面端
 
 <ShowcaseComputer />
+
+## 实测数据
+
+### Doubao Seed 2.1 Turbo 运行费用参考
+
+以下数据来自使用 `doubao-seed-2-1-turbo-260628` 对 Android 端懂车帝 App 排行榜筛选功能运行的 5 个测试 Case。测试设备分辨率为 720 × 1600。
+
+| Case | 测试内容 | 测试报告 | 步骤数（脚本 / 模型调用 / Loop） | Token（输入 / 输出） | 费用 |
+| --- | --- | --- | ---: | ---: | ---: |
+| 1 | 销量榜：轿车、燃油车与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html) | 8 / 16 / 11 | 130,044（126,935 / 3,109） | ¥0.203 |
+| 2 | 销量榜：SUV 与插电式混动 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html) | 4 / 14 / 12 | 139,782（137,310 / 2,472） | ¥0.200 |
+| 3 | 新能源榜：SUV、纯电动与预设价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html) | 8 / 18 / 13 | 156,275（149,996 / 6,279） | ¥0.283 |
+| 4 | 降价榜：MPV、新能源与自定义价格 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html) | 13 / 29 / 20 | 262,194（253,991 / 8,203） | ¥0.448 |
+| 5 | 榜单切换与筛选重置 | [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html) | 16 / 28 / 19 | 222,971（217,283 / 5,688） | ¥0.357 |
+| **合计** | 5 个 Case | — | **49 / 105 / 75** | **911,266（885,515 / 25,751）** | **¥1.491** |
+| **平均** | 每个 Case | — | **9.8 / 21 / 15** | **182,253.2（177,103 / 5,150.2）** | **¥0.298** |
+
+:::info 计价口径
+输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个 Case 平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+:::
+
 
 ## 社区案例
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -36,41 +36,41 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 ### 用例 1：销量榜功能测试
 
-- **测试内容：** 筛选轿车、燃油车和预设价格
-- **步骤数：** 8 / 16 / 11（脚本 / 模型调用 / Loop）
-- **Token 量：** 130,044（输入 126,935 / 输出 3,109）
+- **测试内容：** 验证销量榜在选择“轿车 + 上上个月 + 燃油车 + 18–25 万”时，组合筛选和结果展示是否正确
+- **步骤数：** 8 / 16（脚本 / 模型调用）
+- **Token 量：** 输入 126,935（缓存 89,760）/ 输出 3,109
 - **费用：** ¥0.203
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
 
 ### 用例 2：销量榜组合筛选测试
 
-- **测试内容：** 筛选 SUV 和插电式混动
-- **步骤数：** 4 / 14 / 12（脚本 / 模型调用 / Loop）
-- **Token 量：** 139,782（输入 137,310 / 输出 2,472）
+- **测试内容：** 验证销量榜在选择“SUV + 上个月 + 插电式混动”时，组合筛选和结果展示是否正确
+- **步骤数：** 4 / 14（脚本 / 模型调用）
+- **Token 量：** 输入 137,310（缓存 100,000）/ 输出 2,472
 - **费用：** ¥0.200
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
 
 ### 用例 3：新能源榜功能测试
 
-- **测试内容：** 筛选 SUV、纯电动和预设价格
-- **步骤数：** 8 / 18 / 13（脚本 / 模型调用 / Loop）
-- **Token 量：** 156,275（输入 149,996 / 输出 6,279）
+- **测试内容：** 验证新能源榜在选择“SUV + 近半年 + 纯电动 + 18–25 万”时，组合筛选和结果展示是否正确
+- **步骤数：** 8 / 18（脚本 / 模型调用）
+- **Token 量：** 输入 149,996（缓存 103,896）/ 输出 6,279
 - **费用：** ¥0.283
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
 
 ### 用例 4：降价榜功能测试
 
-- **测试内容：** 筛选 MPV、新能源和自定义价格
-- **步骤数：** 13 / 29 / 20（脚本 / 模型调用 / Loop）
-- **Token 量：** 262,194（输入 253,991 / 输出 8,203）
+- **测试内容：** 验证降价榜在选择“MPV + 近一年 + 新能源”并设置 15–30 万自定义价格时，组合筛选和结果展示是否正确
+- **步骤数：** 13 / 29（脚本 / 模型调用）
+- **Token 量：** 输入 253,991（缓存 174,176）/ 输出 8,203
 - **费用：** ¥0.448
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
 
 ### 用例 5：榜单切换与筛选重置测试
 
-- **测试内容：** 切换榜单并重置筛选条件
-- **步骤数：** 16 / 28 / 19（脚本 / 模型调用 / Loop）
-- **Token 量：** 222,971（输入 217,283 / 输出 5,688）
+- **测试内容：** 验证从销量榜切换至新能源榜时关联筛选条件是否正确重置，并验证后续筛选及恢复默认状态是否正确
+- **步骤数：** 16 / 28（脚本 / 模型调用）
+- **Token 量：** 输入 217,283（缓存 151,848）/ 输出 5,688
 - **费用：** ¥0.357
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -32,9 +32,11 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 ## E2E 测试场景
 
+### 懂车帝 App：Doubao Seed 2.1 Turbo
+
 以下 5 个用例使用 `doubao-seed-2-1-turbo-260628`，测试 Android 端懂车帝 App 的排行榜筛选功能。测试设备分辨率为 720 × 1600。
 
-### 用例 1：销量榜功能测试
+#### 用例 1：销量榜功能测试
 
 - **测试内容：** 验证销量榜在选择“轿车 + 上上个月 + 燃油车 + 18–25 万”时，组合筛选和结果展示是否正确
 - **步骤数：** 8 / 16（脚本 / 模型调用）
@@ -42,7 +44,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **费用：** ¥0.203
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/01-sales-sedan-fuel-preset-price.html)
 
-### 用例 2：销量榜组合筛选测试
+#### 用例 2：销量榜组合筛选测试
 
 - **测试内容：** 验证销量榜在选择“SUV + 上个月 + 插电式混动”时，组合筛选和结果展示是否正确
 - **步骤数：** 4 / 14（脚本 / 模型调用）
@@ -50,7 +52,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **费用：** ¥0.200
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/02-sales-suv-hybrid.html)
 
-### 用例 3：新能源榜功能测试
+#### 用例 3：新能源榜功能测试
 
 - **测试内容：** 验证新能源榜在选择“SUV + 近半年 + 纯电动 + 18–25 万”时，组合筛选和结果展示是否正确
 - **步骤数：** 8 / 18（脚本 / 模型调用）
@@ -58,7 +60,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **费用：** ¥0.283
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/03-new-energy-suv-pure-electric-preset-price.html)
 
-### 用例 4：降价榜功能测试
+#### 用例 4：降价榜功能测试
 
 - **测试内容：** 验证降价榜在选择“MPV + 近一年 + 新能源”并设置 15–30 万自定义价格时，组合筛选和结果展示是否正确
 - **步骤数：** 13 / 29（脚本 / 模型调用）
@@ -66,7 +68,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **费用：** ¥0.448
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/04-price-drop-mpv-new-energy-custom-price.html)
 
-### 用例 5：榜单切换与筛选重置测试
+#### 用例 5：榜单切换与筛选重置测试
 
 - **测试内容：** 验证从销量榜切换至新能源榜时关联筛选条件是否正确重置，并验证后续筛选及恢复默认状态是否正确
 - **步骤数：** 16 / 28（脚本 / 模型调用）
@@ -74,8 +76,32 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **费用：** ¥0.357
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
-:::info 计价口径
+:::info Doubao 计价口径
 输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个用例平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+:::
+
+### Reddit App：Qwen 3.7 Plus
+
+以下 2 个用例使用 `qwen/qwen3.7-plus`，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
+
+#### 用例 1：搜索并加入 Midscene 社区
+
+- **测试内容：** 搜索 Midscene，打开准确的 `r/midscene` 社区，按需加入并验证账号已处于加入状态
+- **步骤数：** 7 / 17（脚本 / 模型调用）
+- **Token 量：** 输入 147,127（缓存 34,816）/ 输出 3,418
+- **费用：** ¥0.289
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/01-search-and-join-midscene-community.html)
+
+#### 用例 2：点赞 Midscene 社区首篇帖子
+
+- **测试内容：** 打开准确的 `r/midscene` 社区，按需点赞帖子列表中的首篇帖子，并验证其已处于点赞状态
+- **步骤数：** 6 / 12（脚本 / 模型调用）
+- **Token 量：** 输入 103,231（缓存 8,704）/ 输出 3,142
+- **费用：** ¥0.237
+- **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/02-upvote-first-post-in-midscene-community.html)
+
+:::info Qwen 计价口径
+输入单价按 `$0.32 / M Tokens`、缓存读取单价按 `$0.064 / M Tokens`、输出单价按 `$1.28 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。2 个用例平均消耗约 128,459 Token，平均费用约 ¥0.263。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::
 
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -6,9 +6,9 @@ import ShowcaseAndroid from './showcases-android.mdx';
 import ShowcaseHarmony from './showcases-harmony.mdx';
 import ShowcaseComputer from './showcases-computer.mdx';
 
-## 平台 Demo
+本文介绍了跨平台 GUI Agent、E2E 测试和社区实践等案例。
 
-按平台分类展示 Midscene 在各端的 GUI 自动化能力。
+## 跨平台 GUI Agent 案例
 
 ### Web
 
@@ -30,7 +30,7 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 <ShowcaseComputer />
 
-## 真实任务实测
+## E2E 测试场景
 
 以下 5 个用例使用 `doubao-seed-2-1-turbo-260628`，测试 Android 端懂车帝 App 的排行榜筛选功能。测试设备分辨率为 720 × 1600。
 


### PR DESCRIPTION
## Summary

Add a bilingual cost reference for running Android UI automation test cases with Doubao Seed 2.1 Turbo.

The benchmark covers five Dongchedi ranking-filter scenarios executed with `doubao-seed-2-1-turbo-260628` on a device with a 720 × 1600 resolution.

## Changes

- Add the benchmark results to both the English and Chinese Android showcase pages.
- Include direct links to the five publicly accessible Midscene test reports.
- Document the script steps, model calls, loops, input and output tokens, input cache ratio, and cost for each case.
- Add total and per-case average statistics:
  - 911,266 total tokens
  - 70.0% input cache ratio
  - ¥1.578 total cost
  - Approximately 182,253 tokens and ¥0.316 per case
- Document the pricing and exchange-rate assumptions used in the calculation.
- Clarify that actual costs may vary with task complexity, cache hit rate, and model pricing.

## Validation

- Ran `pnpm run lint`.
- Started the documentation site with `pnpm --filter doc dev --host 127.0.0.1`.
- Verified that the Chinese showcase page compiled successfully and returned HTTP 200 at `/zh/showcases#android`.
- Verified that all five public test report links are accessible.