### PR TITLE
feat(core): add reusable extra action manifests

### DIFF
--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 Repeat `--htmlReport` once per source report. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
 
+Export successful operations as an Action Manifest:
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+The command writes one `*.actions.yaml` file. Each device operation whose Action task finished becomes one manifest entry. Recorded XPath cache data is exported as `target`; actions without a stable target keep `locatedPixelBbox` as a fallback. If an action has multiple targets, such as a `Swipe` with `start` and `end`, all targets remain in the action parameters and the first target becomes `validWhenTargetExists`. A finished Action does not prove that it was part of the correct business path, so review recovery detours and mistaken clicks before treating an exported manifest as a reusable asset. Pass `--overwrite` to replace an existing manifest.
+
 ## Parse With The JavaScript SDK
 
 If you prefer to control report parsing in code, use `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` from `@midscene/core`.
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
+`analyzeReportActions`, `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
 
+- `analyzeReportActions` exports successful device operations as one `*.actions.yaml` manifest that can be loaded with `aiAct({ loadExtraActions })`. Every report dump that contains executions must declare the same `manifestInterface`; mixed-platform reports are rejected instead of assigning the wrong platform to an action.
 - `splitReportFile` generates JSON files for the original structured objects (one `*.execution.json` per execution). The JSON keeps the raw `ReportActionDump`-style data and exports screenshots alongside it. The returned `executionJsonFiles` and `screenshotFiles` are lists of generated file paths.
 - `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
 - `mergeReportFiles` combines several report files into one merged HTML report. It is a thin wrapper over [`ReportMergingTool`](./reference/#new-reportmergingtool) that derives `testTitle`/`testDescription` from each source report's `groupName` automatically. Use it when you run multiple CLI actions or tests and want to consolidate their reports.

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -161,7 +161,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
       - **Note**: In Chrome extension Bridge mode, local file uploads require the Midscene extension's "Allow access to file URLs" permission. Enable it in `chrome://extensions` > Midscene > "Details", then reconnect Bridge mode from the target `http(s)://` page.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
-    - `loadExtraActions?: string[]` — Load pre-recorded UI action YAML files for this call. The default is `undefined`, which loads no extra actions. Each file represents one device operation and becomes a parameterless action available to the generic planner. If selected, Midscene expands it into the recorded low-level action before execution. This option is available only in Node.js and is not supported by custom planning adapters. Relative paths are resolved from the current working directory. Invalid files, duplicate names, unsupported planning adapters, and unavailable underlying actions throw errors before planning starts.
+    - `loadExtraActions?: string[]` — Load one or more `*.actions.yaml` manifests for this call. Each manifest can contain multiple Extra Actions. Actions whose `validWhenTargetExists` target exists on the current page are placed before the generic Action Space; actions without this condition are always available. This Node.js-only option requires the generic planning adapter. Invalid manifests, duplicate names, interface mismatches, and unavailable underlying actions throw errors before planning starts.
     - `loadElementXpaths?: string[]` — Load YAML maps of known UI element names to XPath strings for this call. Midscene gives the map to the planner, then injects a matching XPath into the planned Action before execution. A matching XPath uses deterministic DOM resolution and skips model-based locating. Unmatched names or XPaths that no longer resolve fall back to normal AI locating. This option is available only in Node.js. Relative paths are resolved from the current working directory.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
 
@@ -207,28 +207,37 @@ await agent.aiAct('Complete the GitHub account registration form. The region mus
 
 ##### Load pre-recorded UI actions
 
-An extra action file represents one reusable device operation. It names the operation, identifies an action from the current interface's Action Space, and provides exactly one parameter entry:
+An Action Manifest contains one or more reusable operations. `action.name` references an existing Action Space action, and `action.param` uses that action's native parameter shape:
 
-```yaml title="extra-action.yaml"
-name: Click the confirm button
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: Click the checkout dialog confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout dialog confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 ```
 
-Pass one or more files to a single `aiAct` call:
-
 ```typescript
-await agent.aiAct('Fill in the form', {
-  loadExtraActions: ['./extra-action.yaml'],
+await agent.aiAct('Confirm checkout', {
+  loadExtraActions: ['./checkout.actions.yaml'],
 });
 ```
 
-This Node.js-only option works with the generic planning adapter. If the configured model uses a custom planning adapter, such as UI-TARS or AutoGLM, `aiAct` throws an error before reading the files or calling the model.
+Before each planning round, Midscene checks every `validWhenTargetExists` target without scrolling, focusing, clicking, or changing page state. Every matching action is exposed ahead of the generic actions. Each action keeps the same parameterless alias throughout the `aiAct` call, even when the disclosed set changes. The planner sees the alias and the action's `name`; it does not receive the selector. Midscene uses the same disclosure snapshot to expand the returned alias into exactly one native Action.
 
-The extra action is visible only to this call's planner and does not modify the Agent's Action Space. `name` is the description shown to the planner. It must not contain angle brackets, line breaks, or control characters. `actionName` accepts an Action Space name or `interfaceAlias`, without regard to case. `actionParam` must contain exactly one item, which Midscene validates against the referenced Action before planning starts. To replay multiple operations, record each operation in a separate file and pass all file paths through `loadExtraActions`.
+At execution time, `target` is resolved again to a fresh Rect. If it is stale or missing, Midscene falls back to the Locate Cache and then AI Locate. `target` is the canonical locator field. Existing assets that use `xpath` remain readable, but a locator cannot contain both `target` and `xpath`.
 
-For an Action with one locate field, a parameter containing `prompt`, `xpath`, or `locatedPixelBbox` can use the shortcut shown above. Midscene moves only locator properties into the locate field and keeps other Action parameters, such as Input's `value` and `mode`, at the top level. If a locator contains an XPath or `locatedPixelBbox` but no prompt, the extra action's `name` is used as the fallback locate prompt.
+This option is visible only to the current `aiAct` call and does not modify the Agent. It supports the generic planning adapter only; UI-TARS, AutoGLM, and other custom adapters are rejected before the model is called.
 
 ##### Load known element XPaths
 
@@ -252,7 +261,7 @@ await agent.aiAct(
 );
 ```
 
-The planner still decides which Action to use and generates dynamic parameters such as Input values. When an Action requires a locator for a mapped element, it uses the map key as the locator prompt and Midscene injects the corresponding XPath before building executable tasks. An Action that can operate on the currently focused element does not need to add a redundant locator. If the XPath resolves, the locate task makes no model call. If the planner uses an unmapped prompt or the XPath is stale, Midscene preserves the existing AI-locate fallback. The map is per-call, does not modify the Agent, and participates in the Plan Cache key. Cached YAML retains the XPath so cache replay also avoids model-based locating.
+The planner still decides which Action to use and generates dynamic parameters such as Input values. When an Action requires a locator for a mapped element, it uses the map key as the locator prompt and Midscene injects the corresponding XPath `target` before building executable tasks. An Action that can operate on the currently focused element does not need to add a redundant locator. If the target resolves, the locate task makes no model call. If the planner uses an unmapped prompt or the XPath is stale, Midscene preserves the existing AI-locate fallback. The map is per-call, does not modify the Agent, and participates in the Plan Cache key. Cached YAML retains the target so cache replay also avoids model-based locating.
 
 ##### Upload files from an `aiAct` prompt
 

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 每多合并一份报告就重复一次 `--htmlReport`。`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
 
+把成功执行的操作导出为 Action Manifest：
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+这个命令会生成一个 `*.actions.yaml` 文件。每个 Action 任务执行完成的设备操作对应一条 Manifest 记录。报告中的 XPath Cache 会导出为 `target`；没有稳定目标的动作保留 `locatedPixelBbox` 作为备用定位信息。如果一个动作包含多个 target，例如同时包含 `start` 和 `end` 的 `Swipe`，这些 target 都会保留在动作参数中，第一个 target 会作为 `validWhenTargetExists`。Action 执行完成不等于它属于正确的业务路径，因此，错误点击和恢复路径需要经过审核，才能作为可复用资产。已有同名文件时，使用 `--overwrite` 覆盖。
+
 ## 使用 JavaScript SDK 解析
 
 如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles`。
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
+`analyzeReportActions`、`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
 
+- `analyzeReportActions` 把成功执行的设备操作导出为一个 `*.actions.yaml` Manifest，可以通过 `aiAct({ loadExtraActions })` 加载。所有包含 execution 的报告 dump 必须声明相同的 `manifestInterface`；如果报告混合了多个平台，命令会直接报错，不会为动作写入错误的平台。
 - `splitReportFile` 会产出“原始对象”对应的 JSON 文件（每个 execution 一个 `*.execution.json`），内容是 `ReportActionDump` 的原始结构化数据，同时会导出截图文件。返回值中的 `executionJsonFiles` 和 `screenshotFiles` 都是生成后的文件路径列表。
 - `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
 - `mergeReportFiles` 会把多份报告合并成一份汇总 HTML 报告，是 [`ReportMergingTool`](./reference/#new-reportmergingtool) 的轻量封装：会自动从每份源报告里读取 `groupName` 作为 `testTitle`/`testDescription`，省去了手工准备 `reportAttributes` 的步骤。命令行多次调用或多个测试用例产生多份报告后，使用它进行汇总最为合适。

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -159,7 +159,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
       - **注意**：Chrome extension Bridge mode 上传本地文件时，需要在 `chrome://extensions` > Midscene > “Details” 中开启插件的 “Allow access to file URLs” 权限。开启后请从目标 `http(s)://` 页面重新连接桥接模式。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
-    - `loadExtraActions?: string[]`：为本次调用加载预先录制的 UI Action YAML 文件。默认值为 `undefined`，即不加载 Extra Action。每个文件代表一次设备操作，并成为一个供通用规划器使用的无参数 Action。规划器选中后，Midscene 会在执行前将其展开为录制好的单个底层 Action。该选项仅支持 Node.js，不支持自定义规划适配器。相对路径基于当前工作目录解析。文件无效、名称重复、规划适配器不受支持或底层 Action 不可用时，Midscene 会在规划开始前抛出错误。
+    - `loadExtraActions?: string[]`：为本次调用加载一个或多个 `*.actions.yaml` Manifest。每个文件可以包含多个 Extra Action。`validWhenTargetExists` 指向的元素存在时，动作会排在通用 Action Space 之前；没有这个条件的动作始终可用。该选项仅支持 Node.js 和通用规划适配器。Manifest 无效、名称重复、界面类型不匹配或底层 Action 不可用时，Midscene 会在规划前抛出错误。
     - `loadElementXpaths?: string[]`：为本次调用加载已知 UI 元素名称到 XPath 的 YAML 映射。Midscene 会把映射提供给规划器，并在执行前为匹配的 Action 注入 XPath。XPath 匹配成功时使用确定性的 DOM 解析，不调用定位模型；元素名未匹配或 XPath 已失效时，回退到普通 AI Locate。该选项仅支持 Node.js，相对路径基于当前工作目录解析。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
@@ -202,30 +202,37 @@ await agent.aiAct('完成 github 账号注册的表单填写。地区必须选�
 
 ##### 加载预先录制的 UI Action
 
-一个 Extra Action 文件定义一次可复用的设备操作。
+一个 Action Manifest 可以包含多个可复用操作。`action.name` 引用 Action Space 中的现有 Action，`action.param` 直接使用该 Action 的参数结构。
 
-`name` 是展示给规划器的操作名称。`actionName` 指向当前界面 `Action Space` 中已有的 Action。`actionParam` 必须且只能包含一项参数：
-
-```yaml title="extra-action.yaml"
-name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: 点击结算弹窗的确定按钮
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: 结算弹窗的确定按钮
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 ```
 
-在单次 `aiAct` 中传入一个或多个文件：
-
 ```typescript
-await agent.aiAct('填写表单', {
-  loadExtraActions: ['./extra-action.yaml'],
+await agent.aiAct('确认结算', {
+  loadExtraActions: ['./checkout.actions.yaml'],
 });
 ```
 
-该选项仅支持 Node.js 和通用规划适配器。如果当前模型使用 UI-TARS、AutoGLM 等自定义规划适配器，`aiAct` 会在读取文件或调用模型之前抛出错误。
+每轮规划前，Midscene 会检查所有 `validWhenTargetExists`，但不会滚动、聚焦、点击或改变页面状态。目标存在的动作会全部披露，并排在通用 Actions 之前。即使披露集合发生变化，同一个动作在本次 `aiAct` 中也始终使用同一个无参数别名。模型只会看到别名和动作 `name`，不会看到 selector。模型返回别名后，Midscene 使用本轮同一份披露快照，将它展开为一个内置 Action。
 
-Extra Action 只对本次调用的规划器可见，不会修改 Agent 的 `Action Space`。`name` 不能包含尖括号、换行符或控制字符。`actionName` 可以填写 Action 名称或 `interfaceAlias`，匹配时不区分大小写。`actionParam` 必须只包含一项，规划开始前 Midscene 会根据目标 Action 校验该参数。若要复用多次操作，请将每次操作分别录制为一个文件，再通过 `loadExtraActions` 传入全部文件路径。
+执行时，Midscene 会重新把 `target` 解析为最新 Rect。如果目标失效，会继续使用 Locate Cache，再回退到 AI Locate。`target` 是正式字段；旧资产中的 `xpath` 仍可读取，但同一个 locator 不能同时包含 `target` 和 `xpath`。
 
-若底层 Action 只有一个定位字段，可以使用上面的简写。参数直接包含 `prompt`、`xpath` 或 `locatedPixelBbox` 即可。Midscene 只会把定位属性移入定位字段，`Input` 的 `value`、`mode` 等其他参数仍保留在顶层。如果定位参数包含 XPath 或 `locatedPixelBbox`，但没有提示词，Midscene 会使用 Extra Action 的 `name` 作为备用定位提示词。
+Extra Action 仅对当前 `aiAct` 生效，不会修改 Agent。该能力只支持通用规划适配器。UI-TARS、AutoGLM 等自定义适配器会在调用模型前报错。
 
 ##### 加载已知元素 XPath
 
@@ -249,7 +256,7 @@ await agent.aiAct(
 );
 ```
 
-规划器仍然负责选择 Action，并生成 Input 值等动态参数。当 Action 需要定位映射内的元素时，规划器使用映射键作为定位提示词，Midscene 在生成可执行任务前注入对应 XPath。可直接作用于当前焦点元素的 Action 不需要重复添加 locator。XPath 解析成功时，Locate 任务不会调用模型；规划器使用了未映射的提示词或 XPath 已失效时，Midscene 保留现有的 AI Locate 回退。该映射仅对本次调用生效，不会修改 Agent，同时会进入 Plan Cache 的键。缓存 YAML 会保留 XPath，因此缓存回放也不需要调用定位模型。
+规划器仍然负责选择 Action，并生成 Input 值等动态参数。当 Action 需要定位映射内的元素时，规划器使用映射键作为定位提示词，Midscene 在生成可执行任务前把对应 XPath 注入为 `target`。可直接作用于当前焦点元素的 Action 不需要重复添加 locator。目标解析成功时，Locate 任务不会调用模型；规划器使用了未映射的提示词或 XPath 已失效时，Midscene 保留现有的 AI Locate 回退。该映射仅对本次调用生效，不会修改 Agent，同时会进入 Plan Cache 的键。缓存 YAML 会保留 target，因此缓存回放也不需要调用定位模型。
 
 ##### 在 `aiAct` 提示词中上传文件
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -84,7 +84,6 @@ import {
 } from './element-xpaths';
 import {
   createExtraActionExecutionOptions,
-  extraActionsCacheKey,
   loadExtraActions,
 } from './extra-actions';
 import { FileChooserAccepter } from './file-chooser';
@@ -623,6 +622,8 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       executions: [],
       modelBriefs: [],
       deviceType: this.interface.interfaceType,
+      manifestInterface:
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
     });
     this.executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
 
@@ -742,6 +743,7 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       sdkVersion: this.dump.sdkVersion,
       modelBriefs: this.dump.modelBriefs,
       deviceType: this.dump.deviceType,
+      manifestInterface: this.dump.manifestInterface,
     };
   }
 
@@ -1156,7 +1158,14 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       const extraActions = await loadExtraActions(
         extraActionPaths,
         this.fullActionSpace,
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
       );
+      const extraActionExecution = createExtraActionExecutionOptions(
+        extraActions,
+        this.interface,
+      );
+      let initialExtraActionSnapshot =
+        await extraActionExecution?.createSnapshot({ signal: abortSignal });
       const elementXpaths = await loadElementXpaths(
         opt?.loadElementXpaths ?? [],
       );
@@ -1173,10 +1182,13 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
         taskPrompt,
         aiActContext,
       );
-      const extraActionKey = extraActionsCacheKey(extraActions);
-      const cachePrompt = extraActionKey
-        ? `${promptWithContext}\n\n<midscene_extra_actions>${extraActionKey}</midscene_extra_actions>`
-        : promptWithContext;
+      const cachePromptForSnapshot = (fingerprint?: string) =>
+        fingerprint
+          ? `${promptWithContext}\n\n<midscene_extra_actions>${fingerprint}</midscene_extra_actions>`
+          : promptWithContext;
+      const cachePrompt = cachePromptForSnapshot(
+        initialExtraActionSnapshot?.fingerprint,
+      );
 
       // Resolve the public planning controls at the API boundary. Internal
       // aiAct plumbing only uses effort from this point onward. The explicit
@@ -1261,6 +1273,10 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          initialExtraActionSnapshot =
+            await extraActionExecution?.createSnapshot({
+              signal: abortSignal,
+            });
         }
       }
 
@@ -1279,7 +1295,12 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
           deepLocate,
           abortSignal,
           reportOptions: internalReportDisplay,
-          extraActions: createExtraActionExecutionOptions(extraActions),
+          extraActions: extraActionExecution
+            ? {
+                ...extraActionExecution,
+                initialSnapshot: initialExtraActionSnapshot,
+              }
+            : undefined,
           elementXpaths,
         },
       );

--- a/packages/core/src/agent/element-xpaths.ts
+++ b/packages/core/src/agent/element-xpaths.ts
@@ -1,7 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import { findAllMidsceneLocatorField } from '@/ai-model';
+import { xpathLocatorTarget } from '@/locator';
 import type { DeviceAction, PlanningAction } from '@/types';
 import yaml from 'js-yaml';
+import { getExtraActionSource, setExtraActionSource } from './extra-actions';
 
 interface ElementXpathFile {
   elements: Record<string, string>;
@@ -153,7 +155,10 @@ function locatorPromptText(locator: unknown): string | undefined {
 }
 
 function locatorAlreadyResolved(locator: unknown): boolean {
-  return isPlainObject(locator) && typeof locator.xpath === 'string';
+  return (
+    isPlainObject(locator) &&
+    (typeof locator.xpath === 'string' || locator.target !== undefined)
+  );
 }
 
 function xpathForLocatorPrompt(
@@ -193,9 +198,9 @@ function xpathForLocatorPrompt(
   return containedMatches[0].xpath;
 }
 
-function locatorWithXpath(locator: unknown, prompt: string, xpath: string) {
+function locatorWithTarget(locator: unknown, prompt: string, xpath: string) {
   if (typeof locator === 'string') {
-    return { prompt: locator, xpath };
+    return { prompt: locator, target: xpathLocatorTarget(xpath) };
   }
 
   const {
@@ -210,7 +215,7 @@ function locatorWithXpath(locator: unknown, prompt: string, xpath: string) {
   return {
     ...locatorWithoutCoordinates,
     prompt,
-    xpath,
+    target: xpathLocatorTarget(xpath),
   };
 }
 
@@ -251,11 +256,17 @@ export function applyElementXpathsToPlans(
       }
 
       transformedParam ??= { ...plan.param };
-      transformedParam[field] = locatorWithXpath(locator, prompt, xpath);
+      transformedParam[field] = locatorWithTarget(locator, prompt, xpath);
       mapped = true;
     }
 
-    return transformedParam ? { ...plan, param: transformedParam } : plan;
+    if (!transformedParam) return plan;
+    const transformedPlan = { ...plan, param: transformedParam };
+    const extraActionSource = getExtraActionSource(plan);
+    if (extraActionSource) {
+      setExtraActionSource(transformedPlan, extraActionSource);
+    }
+    return transformedPlan;
   });
 
   return { plans: transformedPlans, mapped };

--- a/packages/core/src/agent/extra-action-manifest.ts
+++ b/packages/core/src/agent/extra-action-manifest.ts
@@ -1,0 +1,157 @@
+import { type LocatorTarget, LocatorTargetSchema } from '@/locator';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+const hasInvalidProtocolNameCharacter = (name: string): boolean =>
+  Array.from(name).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      character === '<' ||
+      character === '>' ||
+      codePoint === undefined ||
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+
+const protocolNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((name) => !hasInvalidProtocolNameCharacter(name), {
+    message:
+      'must not contain angle brackets, line breaks, or control characters',
+  });
+
+const extraActionDefinitionSchema = z
+  .object({
+    name: protocolNameSchema,
+    validWhenTargetExists: LocatorTargetSchema.optional(),
+    action: z
+      .object({
+        name: z.string().trim().min(1),
+        param: z.unknown().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const extraActionManifestSchema = z
+  .object({
+    version: z.literal(1),
+    interface: z.string().trim().min(1),
+    actions: z.array(extraActionDefinitionSchema).min(1),
+  })
+  .strict();
+
+const legacyExtraActionFileSchema = z
+  .object({
+    name: protocolNameSchema,
+    actionName: z.string().trim().min(1),
+    actionParam: z.tuple([z.unknown()]),
+  })
+  .strict();
+
+export type ExtraActionDefinition = z.infer<typeof extraActionDefinitionSchema>;
+
+export type ExtraActionManifest = z.infer<typeof extraActionManifestSchema>;
+
+export interface ParsedExtraActionFile {
+  manifestInterface?: string;
+  definitions: ExtraActionDefinition[];
+  legacy: boolean;
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${field}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+function parseYaml(content: string, sourcePath: string): unknown {
+  try {
+    return yaml.load(content, { schema: yaml.JSON_SCHEMA });
+  } catch (error) {
+    throw new Error(
+      `Failed to parse extra action file "${sourcePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * The single parsing boundary for both loaded and generated action manifests.
+ * Legacy one-action files are accepted for reads, but all callers receive the
+ * same canonical definition shape.
+ */
+export function parseExtraActionFile(
+  content: string,
+  sourcePath: string,
+): ParsedExtraActionFile {
+  const parsed = parseYaml(content, sourcePath);
+  const looksLikeManifest =
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    ('version' in parsed || 'interface' in parsed || 'actions' in parsed);
+
+  if (looksLikeManifest) {
+    const result = extraActionManifestSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": ${formatIssues(result.error)}`,
+      );
+    }
+    return {
+      manifestInterface: result.data.interface,
+      definitions: result.data.actions,
+      legacy: false,
+    };
+  }
+
+  const legacy = legacyExtraActionFileSchema.safeParse(parsed);
+  if (!legacy.success) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": ${formatIssues(legacy.error)}`,
+    );
+  }
+  return {
+    definitions: [
+      {
+        name: legacy.data.name,
+        action: {
+          name: legacy.data.actionName,
+          param: legacy.data.actionParam[0],
+        },
+      },
+    ],
+    legacy: true,
+  };
+}
+
+/** Validate generated YAML through the same strict schema used by the loader. */
+export function parseExtraActionManifest(
+  content: string,
+  sourcePath: string,
+): ExtraActionManifest {
+  const parsed = parseExtraActionFile(content, sourcePath);
+  if (parsed.legacy || !parsed.manifestInterface) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": expected a versioned Action Manifest`,
+    );
+  }
+  return {
+    version: 1,
+    interface: parsed.manifestInterface,
+    actions: parsed.definitions,
+  };
+}
+
+export type { LocatorTarget };

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -1,99 +1,71 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { findAllMidsceneLocatorField } from '@/ai-model';
+import type { AbstractInterface } from '@/device';
+import type { LocatorTarget } from '@/locator';
 import type { DeviceAction, PlanningAction } from '@/types';
-import yaml from 'js-yaml';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionFile,
+} from './extra-action-manifest';
 
-interface ExtraActionFile {
-  name: string;
-  actionName: string;
-  actionParam: [unknown];
-}
+export type { ExtraActionDefinition, ExtraActionManifest };
 
 export interface LoadedExtraAction {
+  alias: string;
   name: string;
-  planningAction: DeviceAction;
+  sourcePath: string;
   plan: PlanningAction;
+  validWhenTargetExists?: LocatorTarget;
+}
+
+export interface ExtraActionSource {
+  type: 'extra-action';
+  name: string;
+  alias: string;
+  sourcePath: string;
+}
+
+export interface ExtraActionSnapshot {
+  readonly actionSpace: readonly DeviceAction[];
+  readonly fingerprint: string;
+  expandPlans: (plans: PlanningAction[]) => {
+    plans: PlanningAction[];
+    expanded: boolean;
+  };
+}
+
+const extraActionSourceByPlan = new WeakMap<
+  PlanningAction,
+  ExtraActionSource
+>();
+
+export function getExtraActionSource(
+  plan: PlanningAction,
+): ExtraActionSource | undefined {
+  return extraActionSourceByPlan.get(plan);
+}
+
+export function setExtraActionSource(
+  plan: PlanningAction,
+  source: ExtraActionSource,
+): void {
+  extraActionSourceByPlan.set(plan, source);
 }
 
 const locatorShortcutFields = new Set([
   'prompt',
   'xpath',
+  'target',
   'locatedPixelBbox',
   'deepLocate',
   'deepThink',
   'cacheable',
 ]);
 
-const hasInvalidProtocolNameCharacter = (name: string): boolean =>
-  Array.from(name).some((character) => {
-    const codePoint = character.codePointAt(0);
-    return (
-      character === '<' ||
-      character === '>' ||
-      codePoint === undefined ||
-      codePoint < 0x20 ||
-      (codePoint >= 0x7f && codePoint <= 0x9f) ||
-      codePoint === 0x2028 ||
-      codePoint === 0x2029
-    );
-  });
-
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
-
-function assertNonEmptyString(
-  value: unknown,
-  field: 'name' | 'actionName',
-  sourcePath: string,
-): asserts value is string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "${field}" must be a non-empty string`,
-    );
-  }
-}
-
-function parseExtraActionFile(
-  content: string,
-  sourcePath: string,
-): ExtraActionFile {
-  let parsed: unknown;
-  try {
-    parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA });
-  } catch (error) {
-    throw new Error(
-      `Failed to parse extra action file "${sourcePath}": ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-      { cause: error },
-    );
-  }
-
-  if (!isPlainObject(parsed)) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": expected a YAML object`,
-    );
-  }
-
-  assertNonEmptyString(parsed.name, 'name', sourcePath);
-  assertNonEmptyString(parsed.actionName, 'actionName', sourcePath);
-  if (hasInvalidProtocolNameCharacter(parsed.name)) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "name" must not contain angle brackets, line breaks, or control characters`,
-    );
-  }
-  if (!Array.isArray(parsed.actionParam) || parsed.actionParam.length !== 1) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
-    );
-  }
-
-  return {
-    name: parsed.name.trim(),
-    actionName: parsed.actionName.trim(),
-    actionParam: [parsed.actionParam[0]],
-  };
-}
 
 function findReferencedAction(
   actionName: string,
@@ -104,18 +76,21 @@ function findReferencedAction(
     (action) =>
       action.name === actionName || action.interfaceAlias === actionName,
   );
-  if (exactMatch) {
-    return exactMatch;
-  }
+  if (exactMatch) return exactMatch;
 
   const normalizedName = actionName.toLowerCase();
-  const caseInsensitiveMatch = actionSpace.find(
+  const caseInsensitiveMatches = actionSpace.filter(
     (action) =>
       action.name.toLowerCase() === normalizedName ||
       action.interfaceAlias?.toLowerCase() === normalizedName,
   );
-  if (caseInsensitiveMatch) {
-    return caseInsensitiveMatch;
+  if (caseInsensitiveMatches.length === 1) return caseInsensitiveMatches[0];
+  if (caseInsensitiveMatches.length > 1) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": action "${actionName}" is ambiguous. Matching actions: ${caseInsensitiveMatches
+        .map((action) => action.name)
+        .join(', ')}`,
+    );
   }
 
   const availableActions = actionSpace
@@ -127,7 +102,7 @@ function findReferencedAction(
   );
 }
 
-function normalizeActionParam(
+function normalizeLegacyActionParam(
   action: DeviceAction,
   actionParam: unknown,
   fallbackPrompt: string,
@@ -135,49 +110,42 @@ function normalizeActionParam(
   if (!action.paramSchema || !isPlainObject(actionParam)) {
     return actionParam;
   }
-
   const locateFields = findAllMidsceneLocatorField(action.paramSchema);
-  if (locateFields.length !== 1) {
-    return actionParam;
-  }
+  if (locateFields.length !== 1) return actionParam;
 
   const locateField = locateFields[0];
   if (Object.prototype.hasOwnProperty.call(actionParam, locateField)) {
     const locateParam = actionParam[locateField];
     if (
       isPlainObject(locateParam) &&
-      (locateParam.xpath || locateParam.locatedPixelBbox) &&
+      (locateParam.xpath ||
+        locateParam.target ||
+        locateParam.locatedPixelBbox) &&
       !locateParam.prompt
     ) {
       return {
         ...actionParam,
-        [locateField]: {
-          prompt: fallbackPrompt,
-          ...locateParam,
-        },
+        [locateField]: { prompt: fallbackPrompt, ...locateParam },
       };
     }
     return actionParam;
   }
 
-  const isLocatorShortcut =
-    Object.prototype.hasOwnProperty.call(actionParam, 'prompt') ||
-    Object.prototype.hasOwnProperty.call(actionParam, 'xpath') ||
-    Object.prototype.hasOwnProperty.call(actionParam, 'locatedPixelBbox');
-  if (!isLocatorShortcut) {
-    return actionParam;
-  }
+  const isLocatorShortcut = [
+    'prompt',
+    'xpath',
+    'target',
+    'locatedPixelBbox',
+  ].some((field) => Object.prototype.hasOwnProperty.call(actionParam, field));
+  if (!isLocatorShortcut) return actionParam;
 
   const locateParam: Record<string, unknown> = {};
   const actionParamWithoutLocate: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(actionParam)) {
-    if (locatorShortcutFields.has(key)) {
-      locateParam[key] = value;
-    } else {
-      actionParamWithoutLocate[key] = value;
-    }
+    (locatorShortcutFields.has(key) ? locateParam : actionParamWithoutLocate)[
+      key
+    ] = value;
   }
-
   return {
     ...actionParamWithoutLocate,
     [locateField]: {
@@ -187,6 +155,31 @@ function normalizeActionParam(
   };
 }
 
+function normalizeActionParamTargets(
+  action: DeviceAction,
+  actionParam: unknown,
+): unknown {
+  if (!action.paramSchema || !isPlainObject(actionParam)) return actionParam;
+  let normalized: Record<string, unknown> | undefined;
+  for (const field of findAllMidsceneLocatorField(action.paramSchema)) {
+    const locator = actionParam[field];
+    if (!isPlainObject(locator)) continue;
+    if (locator.target !== undefined && locator.xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
+    if (typeof locator.xpath !== 'string') continue;
+    const { xpath, ...withoutXpath } = locator;
+    normalized ??= { ...actionParam };
+    normalized[field] = {
+      ...withoutXpath,
+      target: { strategy: 'xpath', selector: xpath },
+    };
+  }
+  return normalized ?? actionParam;
+}
+
 function validateActionParam(
   action: DeviceAction,
   actionParam: unknown,
@@ -194,13 +187,19 @@ function validateActionParam(
   actionIndex: number,
 ): unknown {
   if (!action.paramSchema) {
-    return actionParam;
+    if (
+      actionParam !== undefined &&
+      (!isPlainObject(actionParam) || Object.keys(actionParam).length > 0)
+    ) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" must be omitted for parameterless action "${action.name}"`,
+      );
+    }
+    return undefined;
   }
 
   const result = action.paramSchema.safeParse(actionParam);
-  if (result.success) {
-    return result.data;
-  }
+  if (result.success) return result.data;
 
   const details = result.error.issues
     .map((issue) => {
@@ -209,14 +208,14 @@ function validateActionParam(
     })
     .join('; ');
   throw new Error(
-    `Invalid extra action file "${sourcePath}": "actionParam[${actionIndex}]" does not match action "${action.name}": ${details}`,
+    `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" does not match action "${action.name}": ${details}`,
   );
 }
 
-function createPlanningAction(id: string, name: string): DeviceAction {
+function createPlanningAction(alias: string, name: string): DeviceAction {
   return {
-    name: id,
-    description: `Replay the known-good UI action ${JSON.stringify(name)}. If the user's request matches this action, always prefer it over rebuilding the operation from a low-level action. This action takes no parameters.`,
+    name: alias,
+    description: `High-priority exact UI action: ${JSON.stringify(name)}. Use this parameterless action when it matches the next requested operation.`,
     sample: {},
     call: () => {
       throw new Error(
@@ -229,14 +228,30 @@ function createPlanningAction(id: string, name: string): DeviceAction {
 export async function loadExtraActions(
   paths: string[],
   actionSpace: DeviceAction[],
+  manifestInterface?: string,
 ): Promise<LoadedExtraAction[]> {
-  if (paths.length === 0) {
-    return [];
-  }
-
+  if (paths.length === 0) return [];
   const loadedActions: LoadedExtraAction[] = [];
-  const knownNames = new Set(actionSpace.map((action) => action.name));
-  const knownProtocolIds = new Set(knownNames);
+  const knownNames = new Set<string>();
+  const reservedAliases = new Set(
+    actionSpace.flatMap((action) =>
+      [action.name, action.interfaceAlias]
+        .filter((name): name is string => Boolean(name))
+        .map((name) => name.toLowerCase()),
+    ),
+  );
+  let nextAliasIndex = 1;
+
+  const allocateAlias = (): string => {
+    let alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    while (reservedAliases.has(alias.toLowerCase())) {
+      nextAliasIndex += 1;
+      alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    }
+    nextAliasIndex += 1;
+    reservedAliases.add(alias.toLowerCase());
+    return alias;
+  };
 
   for (const sourcePath of paths) {
     let content: string;
@@ -250,110 +265,193 @@ export async function loadExtraActions(
         { cause: error },
       );
     }
-
-    const definition = parseExtraActionFile(content, sourcePath);
-    if (knownNames.has(definition.name)) {
+    const parsed = parseExtraActionFile(content, sourcePath);
+    if (
+      parsed.manifestInterface &&
+      manifestInterface &&
+      parsed.manifestInterface !== manifestInterface
+    ) {
       throw new Error(
-        `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+        `Invalid extra action file "${sourcePath}": interface "${parsed.manifestInterface}" does not match current interface "${manifestInterface}"`,
       );
     }
 
-    const referencedAction = findReferencedAction(
-      definition.actionName,
-      actionSpace,
-      sourcePath,
-    );
-    knownNames.add(definition.name);
-    let protocolIndex = loadedActions.length + 1;
-    let protocolId = `MidsceneExtraAction_${protocolIndex}`;
-    while (knownProtocolIds.has(protocolId)) {
-      protocolIndex += 1;
-      protocolId = `MidsceneExtraAction_${protocolIndex}`;
-    }
-    knownProtocolIds.add(protocolId);
-
-    const normalizedParam = normalizeActionParam(
-      referencedAction,
-      definition.actionParam[0],
-      definition.name,
-    );
-    const plan = {
-      type: referencedAction.name,
-      param: validateActionParam(
-        referencedAction,
-        normalizedParam,
+    for (const [definitionIndex, definition] of parsed.definitions.entries()) {
+      if (knownNames.has(definition.name)) {
+        throw new Error(
+          `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+        );
+      }
+      const referencedAction = findReferencedAction(
+        definition.action.name,
+        actionSpace,
         sourcePath,
-        0,
-      ),
-      thought: `Run extra action "${definition.name}"`,
-    };
+      );
+      knownNames.add(definition.name);
 
-    loadedActions.push({
-      name: definition.name,
-      planningAction: createPlanningAction(protocolId, definition.name),
-      plan,
-    });
+      // Native manifests use Action Space's param shape directly. Only legacy
+      // one-action files get shortcut normalization; both formats accept
+      // `xpath` as a read-only compatibility alias for `target`.
+      const rawParamBeforeTargetNormalization = parsed.legacy
+        ? normalizeLegacyActionParam(
+            referencedAction,
+            definition.action.param,
+            definition.name,
+          )
+        : definition.action.param;
+      const rawParam = normalizeActionParamTargets(
+        referencedAction,
+        rawParamBeforeTargetNormalization,
+      );
+      const plan: PlanningAction = {
+        type: referencedAction.name,
+        param: validateActionParam(
+          referencedAction,
+          rawParam,
+          sourcePath,
+          definitionIndex,
+        ),
+        thought: `Run extra action "${definition.name}"`,
+      };
+
+      loadedActions.push({
+        alias: allocateAlias(),
+        name: definition.name,
+        sourcePath,
+        plan,
+        validWhenTargetExists: definition.validWhenTargetExists,
+      });
+    }
   }
-
   return loadedActions;
 }
 
-export function expandExtraActionPlans(
-  plans: PlanningAction[],
-  extraActions: LoadedExtraAction[],
-): PlanningAction[] {
-  if (extraActions.length === 0) {
-    return plans;
-  }
+interface SnapshotAction {
+  alias: string;
+  loaded: LoadedExtraAction;
+  planningAction: DeviceAction;
+}
 
-  const extraActionsByName = new Map(
-    extraActions.map((action) => [action.planningAction.name, action]),
-  );
-
-  return plans.map((plan) => {
-    const extraAction = extraActionsByName.get(plan.type);
-    if (!extraAction) {
-      return plan;
-    }
-
+function createSnapshotActions(
+  disclosed: LoadedExtraAction[],
+): SnapshotAction[] {
+  return disclosed.map((loaded) => {
     return {
-      ...extraAction.plan,
-      param: structuredClone(extraAction.plan.param),
-      thought: plan.thought || extraAction.plan.thought,
+      alias: loaded.alias,
+      loaded,
+      planningAction: Object.freeze(
+        createPlanningAction(loaded.alias, loaded.name),
+      ),
     };
   });
 }
 
-export function extraActionsCacheKey(
-  extraActions: LoadedExtraAction[],
-): string | undefined {
-  if (extraActions.length === 0) {
-    return undefined;
-  }
+function expandSnapshotPlans(
+  plans: PlanningAction[],
+  snapshotActions: SnapshotAction[],
+): PlanningAction[] {
+  const byAlias = new Map(snapshotActions.map((entry) => [entry.alias, entry]));
+  return plans.map((plan) => {
+    const entry = byAlias.get(plan.type);
+    if (!entry) return plan;
+    const expanded = {
+      ...entry.loaded.plan,
+      param: structuredClone(entry.loaded.plan.param),
+      thought: plan.thought || entry.loaded.plan.thought,
+    };
+    setExtraActionSource(expanded, {
+      type: 'extra-action',
+      name: entry.loaded.name,
+      alias: entry.alias,
+      sourcePath: entry.loaded.sourcePath,
+    });
+    return expanded;
+  });
+}
 
-  return JSON.stringify(
-    extraActions.map((action) => ({
+function targetKey(target: LocatorTarget): string {
+  return JSON.stringify(target);
+}
+
+export async function createExtraActionSnapshot(
+  extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
+  options: { signal?: AbortSignal } = {},
+): Promise<ExtraActionSnapshot> {
+  options.signal?.throwIfAborted();
+  const conditionalTargets = extraActions.flatMap((action) =>
+    action.validWhenTargetExists ? [action.validWhenTargetExists] : [],
+  );
+  const uniqueTargets = Array.from(
+    new Map(
+      conditionalTargets.map((target) => [targetKey(target), target]),
+    ).values(),
+  );
+  if (uniqueTargets.length > 0 && !interfaceInstance?.probeLocatorTargets) {
+    throw new Error(
+      'Extra actions use validWhenTargetExists, but the current interface cannot probe locator targets',
+    );
+  }
+  const existenceResult =
+    uniqueTargets.length === 0
+      ? []
+      : await interfaceInstance!.probeLocatorTargets!(uniqueTargets, options);
+  options.signal?.throwIfAborted();
+  if (!Array.isArray(existenceResult)) {
+    throw new Error('probeLocatorTargets must return a boolean array');
+  }
+  const existence = existenceResult as readonly unknown[];
+  if (existence.length !== uniqueTargets.length) {
+    throw new Error(
+      `probeLocatorTargets returned ${existence.length} result(s) for ${uniqueTargets.length} target(s)`,
+    );
+  }
+  if (existence.some((value) => typeof value !== 'boolean')) {
+    throw new Error('probeLocatorTargets must return only boolean results');
+  }
+  const existenceByTarget = new Map(
+    uniqueTargets.map((target, index) => [targetKey(target), existence[index]]),
+  );
+  const disclosed = extraActions.filter(
+    (action) =>
+      !action.validWhenTargetExists ||
+      existenceByTarget.get(targetKey(action.validWhenTargetExists)) === true,
+  );
+  const snapshotActions = createSnapshotActions(disclosed);
+  const aliases = new Set(snapshotActions.map((entry) => entry.alias));
+  const fingerprintPayload = JSON.stringify({
+    manifest: extraActions.map((action) => ({
       name: action.name,
+      validWhenTargetExists: action.validWhenTargetExists,
       plan: action.plan,
     })),
-  );
+    disclosed: snapshotActions.map((entry) => ({
+      alias: entry.alias,
+      name: entry.loaded.name,
+    })),
+  });
+  const fingerprint = `extra-actions-snapshot:v1:${createHash('sha256')
+    .update(fingerprintPayload)
+    .digest('hex')}`;
+  return {
+    actionSpace: Object.freeze(
+      snapshotActions.map((entry) => entry.planningAction),
+    ),
+    fingerprint,
+    expandPlans: (plans) => ({
+      plans: expandSnapshotPlans(plans, snapshotActions),
+      expanded: plans.some((plan) => aliases.has(plan.type)),
+    }),
+  };
 }
 
 export function createExtraActionExecutionOptions(
   extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
 ) {
-  if (extraActions.length === 0) {
-    return undefined;
-  }
-
-  const extraActionNames = new Set(
-    extraActions.map((action) => action.planningAction.name),
-  );
+  if (extraActions.length === 0) return undefined;
   return {
-    actionSpace: extraActions.map((action) => action.planningAction),
-    expandPlans: (plans: PlanningAction[]) => ({
-      plans: expandExtraActionPlans(plans, extraActions),
-      expanded: plans.some((plan) => extraActionNames.has(plan.type)),
-    }),
+    createSnapshot: (options?: { signal?: AbortSignal }) =>
+      createExtraActionSnapshot(extraActions, interfaceInstance, options),
   };
 }

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -2,6 +2,7 @@ import { findAllMidsceneLocatorField, parseActionParam } from '@/ai-model';
 import type { ModelRuntime } from '@/ai-model/models';
 import { findActionInActionSpaceOrThrow } from '@/common';
 import type { AbstractInterface } from '@/device';
+import { xpathLocatorTarget } from '@/locator';
 import type Service from '@/service';
 import { setTimingFieldOnce } from '@/task-timing';
 import type {
@@ -25,6 +26,7 @@ import { sleep } from '@/utils';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
+import { getExtraActionSource, setExtraActionSource } from './extra-actions';
 import type { TaskCache } from './task-cache';
 import { withUsageIntent } from './usage-intent';
 import {
@@ -83,9 +85,17 @@ function normalizeLocateParam(
   }
 
   const { deepThink, ...rest } = param as LocateParamWithDeprecatedAlias;
+  if (rest.target !== undefined && rest.xpath !== undefined) {
+    throw new Error('`target` and `xpath` cannot be used in the same locator');
+  }
   const deepLocate = rest.deepLocate ?? deepThink;
+  const { xpath, ...withoutXpath } = rest;
+  const normalized =
+    typeof xpath === 'string'
+      ? { ...withoutXpath, target: xpathLocatorTarget(xpath) }
+      : withoutXpath;
 
-  return deepLocate === undefined ? rest : { ...rest, deepLocate };
+  return deepLocate === undefined ? normalized : { ...normalized, deepLocate };
 }
 
 export function locatePlanForLocate(param: string | DetailedLocateParam) {
@@ -228,12 +238,17 @@ export class TaskBuilder {
       action.paramSchema,
       true,
     );
+    const extraActionSource = getExtraActionSource(plan);
 
     locateFields.forEach((field) => {
       if (param[field]) {
+        const locateParam = param[field];
         // Always use createLocateTask for all locate params.
         // This ensures cache writing happens even when locatedPixelBbox is available
-        const locatePlan = locatePlanForLocate(param[field]);
+        const locatePlan = locatePlanForLocate(locateParam);
+        if (extraActionSource) {
+          setExtraActionSource(locatePlan, extraActionSource);
+        }
         debug(
           'will prepend locate param for field',
           `action.type=${planType}`,
@@ -243,7 +258,7 @@ export class TaskBuilder {
         );
         const locateTask = this.createLocateTask(
           locatePlan,
-          param[field],
+          locateParam,
           context,
           (result) => {
             param[field] = result;
@@ -377,6 +392,17 @@ export class TaskBuilder {
 
         return {
           output: actionResult,
+          ...(extraActionSource
+            ? {
+                hitBy: {
+                  from: 'Extra Action',
+                  context: {
+                    extraActionName: extraActionSource.name,
+                    extraActionAlias: extraActionSource.alias,
+                  },
+                },
+              }
+            : {}),
         };
       },
     };
@@ -477,51 +503,69 @@ export class TaskBuilder {
           ? matchElementFromPlan(paramWithLocatedPixelBbox)
           : undefined;
 
-        // from locatedPixelBbox (direct plan hit)
-        // when deepLocate is enabled, locatedPixelBbox should be used as search
-        // area hint, not as a final direct hit
-        const elementFromPlan = param.deepLocate
-          ? undefined
-          : planLocatedElement;
-        const isPlanDirectHit = !!elementFromPlan;
-
-        // from xpath
-        let rectFromXpath: Rect | undefined;
-        if (
-          !isPlanDirectHit &&
-          param.xpath &&
-          this.interface.rectMatchesCacheFeature
-        ) {
+        // Resolve stable targets before using model-provided coordinates. The
+        // resolver returns a fresh logical-coordinate Rect on every execution.
+        let elementFromTarget: LocateResultElement | undefined;
+        let targetResolutionError: string | undefined;
+        if (param.target) {
           try {
-            rectFromXpath = await this.interface.rectMatchesCacheFeature({
-              xpaths: [param.xpath],
-            });
-          } catch {
-            // xpath locate failed, allow fallback to cache or AI locate
-          }
-        }
-
-        const elementFromXpath = rectFromXpath
-          ? generateElementByRect(
-              // rectFromXpath is in logical coordinates, which should be transformed to screenshot coordinates;
+            let rectFromTarget: Rect | undefined;
+            if (this.interface.resolveLocatorTarget) {
+              rectFromTarget = await this.interface.resolveLocatorTarget(
+                param.target,
+              );
+            } else if (
+              param.target.strategy === 'xpath' &&
+              this.interface.rectMatchesCacheFeature
+            ) {
+              rectFromTarget = await this.interface.rectMatchesCacheFeature({
+                targets: [param.target],
+              });
+            }
+            if (!rectFromTarget) {
+              throw new Error(
+                `Current interface cannot resolve locator target strategy: ${param.target.strategy}`,
+              );
+            }
+            const candidate = generateElementByRect(
+              // target Rect is in logical coordinates and actions use the
+              // screenshot coordinate space inside the task runner.
               transformLogicalRectToScreenshotRect(
-                rectFromXpath,
+                rectFromTarget,
                 shrunkShotToLogicalRatio,
               ),
               typeof param.prompt === 'string'
                 ? param.prompt
                 : param.prompt?.prompt || '',
-            )
-          : undefined;
+            );
+            const invalidTargetReason = invalidLocateElementReason(candidate);
+            if (invalidTargetReason) {
+              throw new Error(invalidTargetReason);
+            }
+            elementFromTarget = candidate;
+          } catch (error) {
+            targetResolutionError =
+              error instanceof Error ? error.message : String(error);
+            debug(
+              'target resolution failed, falling back to cache or AI locate: %s',
+              targetResolutionError,
+            );
+          }
+        }
+        const isTargetHit = !!elementFromTarget;
 
-        const isXpathHit = !!elementFromXpath;
+        // from locatedPixelBbox (direct plan hit). When deepLocate is enabled,
+        // the bbox remains a search-area hint rather than a final direct hit.
+        const elementFromPlan =
+          isTargetHit || param.deepLocate ? undefined : planLocatedElement;
+        const isPlanDirectHit = !!elementFromPlan;
 
         const cachePrompt = param.prompt;
         const locateCacheRecord = this.taskCache?.matchLocateCache(cachePrompt);
         const cacheEntry = locateCacheRecord?.cacheContent?.cache;
 
         const elementFromCacheResult =
-          isPlanDirectHit || isXpathHit
+          isPlanDirectHit || isTargetHit
             ? null
             : await matchElementFromCache(
                 {
@@ -545,7 +589,7 @@ export class TaskBuilder {
 
         let elementFromAiLocate: LocateResultElement | null | undefined;
         const timing = taskContext.task.timing;
-        if (!isXpathHit && !isCacheHit && !isPlanDirectHit) {
+        if (!isTargetHit && !isCacheHit && !isPlanDirectHit) {
           try {
             setTimingFieldOnce(timing, 'callAiStart');
             locateResult = await this.service.locate(
@@ -570,8 +614,8 @@ export class TaskBuilder {
         }
 
         const element =
+          elementFromTarget ||
           elementFromPlan ||
-          elementFromXpath ||
           elementFromCache ||
           elementFromAiLocate;
 
@@ -672,18 +716,31 @@ export class TaskBuilder {
 
         let hitBy: ExecutionTaskHitBy | undefined;
 
-        if (isPlanDirectHit && paramWithLocatedPixelBbox) {
+        const extraActionMetadata = getExtraActionSource(plan);
+        const attemptedTargetContext = param.target
+          ? {
+              target: param.target,
+              ...(targetResolutionError ? { targetResolutionError } : {}),
+              ...(extraActionMetadata?.name
+                ? { extraActionName: extraActionMetadata.name }
+                : {}),
+              ...(extraActionMetadata?.alias
+                ? { extraActionAlias: extraActionMetadata.alias }
+                : {}),
+            }
+          : {};
+
+        if (isTargetHit && param.target) {
+          hitBy = {
+            from: extraActionMetadata ? 'Extra Action target' : 'User target',
+            context: attemptedTargetContext,
+          };
+        } else if (isPlanDirectHit && paramWithLocatedPixelBbox) {
           hitBy = {
             from: 'Plan',
             context: {
               locatedPixelBbox: paramWithLocatedPixelBbox.locatedPixelBbox,
-            },
-          };
-        } else if (isXpathHit) {
-          hitBy = {
-            from: 'User expected path',
-            context: {
-              xpath: param.xpath,
+              ...attemptedTargetContext,
             },
           };
         } else if (isCacheHit) {
@@ -692,7 +749,13 @@ export class TaskBuilder {
             context: {
               cacheEntry,
               cacheToSave: currentCacheEntry,
+              ...attemptedTargetContext,
             },
+          };
+        } else {
+          hitBy = {
+            from: 'AI',
+            context: attemptedTargetContext,
           };
         }
 

--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import type { TUserPrompt } from '@/ai-model';
+import { LocatorTargetSchema, xpathLocatorTarget } from '@/locator';
 import type { ElementCacheFeature } from '@/types';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import {
@@ -34,6 +35,35 @@ export interface LocateCache {
   cache?: ElementCacheFeature;
   /** @deprecated kept for backward compatibility */
   xpaths?: string[];
+}
+
+function normalizeLegacyXpathCache(locateCache: LocateCache): LocateCache {
+  const cache = locateCache.cache ?? {};
+  const targets = Array.isArray(cache.targets)
+    ? cache.targets.flatMap((target) => {
+        const result = LocatorTargetSchema.safeParse(target);
+        return result.success ? [result.data] : [];
+      })
+    : [];
+  const nestedXpaths = Array.isArray(cache.xpaths) ? cache.xpaths : [];
+  const topLevelXpaths = Array.isArray(locateCache.xpaths)
+    ? locateCache.xpaths
+    : [];
+  const legacyTargets = [...nestedXpaths, ...topLevelXpaths]
+    .filter(
+      (xpath): xpath is string =>
+        typeof xpath === 'string' && xpath.trim().length > 0,
+    )
+    .map((xpath) => xpathLocatorTarget(xpath));
+  const { xpaths: _legacyXpaths, ...cacheWithoutXpaths } = cache;
+  locateCache.cache = {
+    ...cacheWithoutXpaths,
+    targets: targets.length > 0 ? targets : legacyTargets,
+  };
+  if ('xpaths' in locateCache) {
+    locateCache.xpaths = undefined;
+  }
+  return locateCache;
 }
 
 export interface MatchCacheResult<T extends PlanningCache | LocateCache> {
@@ -163,13 +193,7 @@ export class TaskCache {
         !this.matchedCacheIndices.has(key)
       ) {
         if (item.type === 'locate') {
-          const locateItem = item as LocateCache;
-          if (!locateItem.cache && Array.isArray(locateItem.xpaths)) {
-            locateItem.cache = { xpaths: locateItem.xpaths };
-          }
-          if ('xpaths' in locateItem) {
-            locateItem.xpaths = undefined;
-          }
+          normalizeLegacyXpathCache(item as LocateCache);
         }
         this.matchedCacheIndices.add(key);
         const consumeKey = `${type}:${promptStr}`;
@@ -267,6 +291,9 @@ export class TaskCache {
   }
 
   appendCache(cache: PlanningCache | LocateCache) {
+    if (cache.type === 'locate') {
+      normalizeLegacyXpathCache(cache);
+    }
     debug('will append cache', cache);
     this.cache.caches.push(cache);
 
@@ -390,11 +417,15 @@ export class TaskCache {
 
       // Sort caches to ensure plan entries come before locate entries for better readability
       // Create a sorted copy for writing to disk while keeping in-memory order unchanged
-      const sortedCaches = [...this.cache.caches].sort((a, b) => {
-        if (a.type === 'plan' && b.type === 'locate') return -1;
-        if (a.type === 'locate' && b.type === 'plan') return 1;
-        return 0;
-      });
+      const sortedCaches = this.cache.caches
+        .map((cache) =>
+          cache.type === 'locate' ? normalizeLegacyXpathCache(cache) : cache,
+        )
+        .sort((a, b) => {
+          if (a.type === 'plan' && b.type === 'locate') return -1;
+          if (a.type === 'locate' && b.type === 'plan') return 1;
+          return 0;
+        });
 
       const cacheToWrite = {
         ...this.cache,
@@ -429,7 +460,8 @@ export class TaskCache {
       (target as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
     } else {
       const locateCache = target as LocateCache;
-      locateCache.cache = newRecord.cache;
+      const normalizedRecord = normalizeLegacyXpathCache(newRecord);
+      locateCache.cache = normalizedRecord.cache;
       if ('xpaths' in locateCache) {
         locateCache.xpaths = undefined;
       }

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -44,6 +44,7 @@ import {
   applyElementXpathsToPlans,
 } from './element-xpaths';
 import { ExecutionSession } from './execution-session';
+import type { ExtraActionSnapshot } from './extra-actions';
 import { withFileChooser } from './file-chooser';
 import {
   type AgentProgressPublisher,
@@ -91,11 +92,10 @@ interface TaskExecutorActionOptions {
   abortSignal?: AbortSignal;
   reportOptions?: ActionReportOptions;
   extraActions?: {
-    actionSpace: DeviceAction[];
-    expandPlans: (plans: PlanningAction[]) => {
-      plans: PlanningAction[];
-      expanded: boolean;
-    };
+    initialSnapshot?: ExtraActionSnapshot;
+    createSnapshot: (options?: {
+      signal?: AbortSignal;
+    }) => Promise<ExtraActionSnapshot>;
   };
   elementXpaths?: LoadedElementXpath[];
 }
@@ -533,10 +533,10 @@ export class TaskExecutor {
     } = options;
     const conversationHistory = new ConversationHistory();
     const baseActionSpace = this.getActionSpace();
-    const actionSpace = [
-      ...baseActionSpace,
-      ...(extraActions?.actionSpace ?? []),
-    ];
+    let latestExtraActionSnapshot:
+      | Awaited<ReturnType<NonNullable<typeof extraActions>['createSnapshot']>>
+      | undefined;
+    let pendingInitialExtraActionSnapshot = extraActions?.initialSnapshot;
     const promptDisplay =
       reportOptions?.prompt || userPromptToString(userPrompt);
 
@@ -659,6 +659,14 @@ export class TaskExecutor {
             assert(uiContext, 'uiContext is required for Planning task');
             assert(param.effort, 'effort is required for Planning Plan task');
             const planningUiContext = uiContext as UIContext;
+            latestExtraActionSnapshot =
+              pendingInitialExtraActionSnapshot ??
+              (await extraActions?.createSnapshot({ signal: abortSignal }));
+            pendingInitialExtraActionSnapshot = undefined;
+            const actionSpace = [
+              ...(latestExtraActionSnapshot?.actionSpace ?? []),
+              ...baseActionSpace,
+            ];
             const timing = executorContext.task.timing;
             await this.emitAiActProgress('plan_thinking', {
               planIndex,
@@ -694,6 +702,8 @@ export class TaskExecutor {
                 includeLocateInPlanning,
                 imagesIncludeCount: param.imagesIncludeCount,
                 effort: param.effort,
+                hasExtraActions:
+                  (latestExtraActionSnapshot?.actionSpace.length ?? 0) > 0,
                 referenceImageMessages,
                 abortSignal,
               });
@@ -809,7 +819,7 @@ export class TaskExecutor {
 
       // Execute planned actions
       const plans = planResult?.actions || [];
-      const expansion = extraActions?.expandPlans(plans) ?? {
+      const expansion = latestExtraActionSnapshot?.expandPlans(plans) ?? {
         plans,
         expanded: false,
       };

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -399,6 +399,18 @@ export async function matchElementFromCache(
   try {
     const rect =
       await context.interfaceInstance.rectMatchesCacheFeature(cacheEntry);
+    const rectValues = [rect.left, rect.top, rect.width, rect.height];
+    if (
+      rectValues.some(
+        (value) => typeof value !== 'number' || !Number.isFinite(value),
+      ) ||
+      rect.width <= 0 ||
+      rect.height <= 0
+    ) {
+      throw new Error(
+        `Cache target returned an invalid rect: ${JSON.stringify(rect)}`,
+      );
+    }
     const element: LocateResultElement = {
       center: [
         Math.round(rect.left + rect.width / 2),

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -291,6 +291,7 @@ export async function plan(
     includeThought,
     includeLog,
     includeSubGoals,
+    hasExtraActions: opts.hasExtraActions,
   });
 
   const preparedImage = await prepareModelImage({

--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -44,16 +44,14 @@ const RUN_ADB_SHELL_ACTION_GUIDANCE =
 const EXTRA_ACTION_GUIDANCE =
   '- Actions named MidsceneExtraAction_* are exact pre-recorded operations. When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action such as Tap or Input.';
 
-const buildActionStepNotes = (actionList: string) =>
+const buildActionStepNotes = (actionList: string, hasExtraActions: boolean) =>
   [
     '### Action Guidelines',
     '',
     ...(actionList.includes('RunAdbShell')
       ? [RUN_ADB_SHELL_ACTION_GUIDANCE]
       : []),
-    ...(actionList.includes('MidsceneExtraAction_')
-      ? [EXTRA_ACTION_GUIDANCE]
-      : []),
+    ...(hasExtraActions ? [EXTRA_ACTION_GUIDANCE] : []),
     '- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.',
     '- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.',
     '- For insert/prepend/append edits, use CursorMove when the caret must be adjusted precisely, then use Input with mode "typeOnly" for inserted characters and KeyboardPress for newlines or deletion. If the caret lands in the wrong position, recover with CursorMove, KeyboardPress, or undo and retry cursor placement; do not switch to replace as a fallback for cursor placement failures.',
@@ -243,6 +241,7 @@ export async function systemPromptToTaskPlanning({
   includeThought,
   includeLog,
   includeSubGoals,
+  hasExtraActions = false,
 }: {
   actionSpace: DeviceAction<any>[];
   locatePromptSpec?: LocateResultPromptSpec;
@@ -250,6 +249,7 @@ export async function systemPromptToTaskPlanning({
   includeThought?: boolean;
   includeLog?: boolean;
   includeSubGoals?: boolean;
+  hasExtraActions?: boolean;
 }) {
   const preferredLanguage = getPreferredLanguage();
 
@@ -268,7 +268,7 @@ export async function systemPromptToTaskPlanning({
     );
   });
   const actionList = actionDescriptionList.join('\n');
-  const actionStepNotes = buildActionStepNotes(actionList);
+  const actionStepNotes = buildActionStepNotes(actionList, hasExtraActions);
 
   const shouldIncludeThought = includeThought ?? true;
   const shouldIncludeLog = includeLog ?? true;

--- a/packages/core/src/ai-model/workflows/planning/types.ts
+++ b/packages/core/src/ai-model/workflows/planning/types.ts
@@ -19,6 +19,7 @@ export interface PlanOptions {
   imagesIncludeCount?: number;
   // Controls aiAct planning prompt shape and state updates, such as sub-goals.
   effort: AiActEffort;
+  hasExtraActions?: boolean;
   referenceImageMessages?: ChatCompletionUserMessageParam[];
   abortSignal?: AbortSignal;
 }

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -16,6 +16,7 @@ import {
 import { assert, isPlainObject } from '@midscene/shared/utils';
 import type { ChatCompletionUserMessageParam } from 'openai/resources/index';
 import { z } from 'zod';
+import { LocatorTargetSchema } from './locator';
 
 /**
  * Expand the search area to at least 400 x 400 pixels
@@ -287,6 +288,7 @@ const MidsceneLocationInput = z
       .describe('@deprecated Use `deepLocate` instead.'),
     cacheable: z.boolean().optional(),
     xpath: z.union([z.string(), z.boolean()]).optional(),
+    target: LocatorTargetSchema.optional(),
   })
   .passthrough();
 
@@ -299,10 +301,23 @@ export const getMidsceneLocationSchema = () => {
 };
 
 export const ifMidsceneLocatorField = (field: any): boolean => {
-  // Handle optional fields by getting the inner type
+  // Unwrap optional/nullable/effect wrappers before checking the object shape.
   let actualField = field;
-  if (actualField._def?.typeName === 'ZodOptional') {
-    actualField = actualField._def.innerType;
+  const visited = new Set<unknown>();
+  while (actualField?._def && !visited.has(actualField)) {
+    visited.add(actualField);
+    if (
+      actualField._def.typeName === 'ZodOptional' ||
+      actualField._def.typeName === 'ZodNullable'
+    ) {
+      actualField = actualField._def.innerType;
+      continue;
+    }
+    if (actualField._def.typeName === 'ZodEffects') {
+      actualField = actualField._def.schema;
+      continue;
+    }
+    break;
   }
 
   // Check if this is a ZodObject
@@ -408,7 +423,9 @@ export const dumpActionParam = (
       } else if (typeof fieldValue === 'object') {
         // Check if this field is actually a MidsceneLocationType object
         if (fieldValue.prompt) {
-          const preserveLocatorObject = typeof fieldValue.xpath === 'string';
+          const preserveLocatorObject =
+            typeof fieldValue.xpath === 'string' ||
+            fieldValue.target !== undefined;
           // If prompt is a string, use it directly
           if (typeof fieldValue.prompt === 'string') {
             result[fieldName] = preserveLocatorObject

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -10,6 +10,7 @@ import type { ElementNode } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 import { z } from 'zod';
+import type { LocatorTarget } from '../locator';
 import type {
   ElementCacheFeature,
   Rect,
@@ -172,6 +173,9 @@ export interface ComputerInputPrimitives extends InputPrimitives {
 export abstract class AbstractInterface {
   abstract interfaceType: string;
 
+  /** Canonical platform name accepted by Extra Action manifests. */
+  manifestInterface?(): string;
+
   abstract screenshotBase64(): Promise<string>;
   abstract size(): Promise<Size>;
   abstract actionSpace(): DeviceAction[];
@@ -186,6 +190,13 @@ export abstract class AbstractInterface {
   abstract rectMatchesCacheFeature?(
     feature: ElementCacheFeature,
   ): Promise<Rect>;
+  /** Side-effect-free batch existence check used for conditional disclosure. */
+  probeLocatorTargets?(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]>;
+  /** Resolve a stable target to a fresh logical-coordinate Rect for execution. */
+  resolveLocatorTarget?(target: LocatorTarget): Promise<Rect>;
 
   abstract getUITree?(): Promise<UITreeSnapshot>;
 

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -160,8 +160,17 @@ export class ReportActionDump implements IReportActionDump {
   modelBriefs: IReportActionDump['modelBriefs'];
   executions: ExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 
   constructor(data: IReportActionDump) {
+    if (
+      typeof data.manifestInterface !== 'string' ||
+      !data.manifestInterface.trim()
+    ) {
+      throw new Error(
+        'ReportActionDump: manifestInterface must be a non-empty string',
+      );
+    }
     this.sdkVersion = data.sdkVersion;
     this.groupName = data.groupName;
     this.groupDescription = data.groupDescription;
@@ -170,6 +179,7 @@ export class ReportActionDump implements IReportActionDump {
       exec instanceof ExecutionDump ? exec : ExecutionDump.fromJSON(exec),
     );
     this.deviceType = data.deviceType;
+    this.manifestInterface = data.manifestInterface.trim();
   }
 
   /**
@@ -218,6 +228,7 @@ export class ReportActionDump implements IReportActionDump {
       modelBriefs: this.modelBriefs,
       executions: this.executions.map((exec) => exec.toJSON()),
       deviceType: this.deviceType,
+      manifestInterface: this.manifestInterface,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,12 @@ export {
 } from './types';
 
 export { z };
+export {
+  LocatorTargetSchema,
+  XPathLocatorTargetSchema,
+  xpathLocatorTarget,
+  type LocatorTarget,
+} from './locator';
 
 export default Service;
 export { TaskRunner, Service, getVersion };
@@ -125,6 +131,7 @@ export {
   type AnalyzeReportActionsOptions,
   type AnalyzeReportActionsResult,
   type UIActionDefinition,
+  type UIActionManifest,
 } from './report-analyzer';
 
 // ScreenshotItem

--- a/packages/core/src/locator.ts
+++ b/packages/core/src/locator.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/** Zod schema for a Web XPath locator target. */
+export const XPathLocatorTargetSchema = z
+  .object({
+    strategy: z.literal('xpath'),
+    selector: z.string().trim().min(1),
+  })
+  .strict();
+
+/**
+ * A stable, platform-specific reference that can be resolved to a fresh Rect.
+ * Additional strategies can be added as new discriminated-union members.
+ */
+export const LocatorTargetSchema = z.discriminatedUnion('strategy', [
+  XPathLocatorTargetSchema,
+]);
+
+export type LocatorTarget = z.infer<typeof LocatorTargetSchema>;
+
+/** Create and validate an XPath locator target. */
+export function xpathLocatorTarget(selector: string): LocatorTarget {
+  return LocatorTargetSchema.parse({ strategy: 'xpath', selector });
+}

--- a/packages/core/src/report-analyzer.ts
+++ b/packages/core/src/report-analyzer.ts
@@ -1,14 +1,21 @@
 import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionManifest,
+} from './agent/extra-action-manifest';
+import {
+  type LocatorTarget,
+  LocatorTargetSchema,
+  xpathLocatorTarget,
+} from './locator';
 import { collectDedupedExecutions } from './report';
 import type { ExecutionTask } from './types';
 
-export interface UIActionDefinition {
-  name: string;
-  actionName: string;
-  actionParam: [unknown];
-}
+export type UIActionDefinition = ExtraActionDefinition;
+export type UIActionManifest = ExtraActionManifest;
 
 export interface AnalyzeReportActionsOptions {
   htmlPath: string;
@@ -19,7 +26,9 @@ export interface AnalyzeReportActionsOptions {
 export interface AnalyzeReportActionsResult {
   outputDir: string;
   actionFiles: string[];
+  actionCount: number;
   coordinateFallbackFiles: string[];
+  coordinateFallbackActionCount: number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -33,11 +42,23 @@ function firstNonEmptyString(...values: unknown[]): string | undefined {
   );
 }
 
-function firstXpath(value: unknown): string | undefined {
-  if (!isRecord(value)) return undefined;
-  const xpaths = value.xpaths;
-  if (!Array.isArray(xpaths)) return undefined;
-  return firstNonEmptyString(...xpaths);
+function firstTarget(value: unknown): LocatorTarget | undefined {
+  if (!isRecord(value) || !Array.isArray(value.targets)) return undefined;
+  for (const target of value.targets) {
+    const parsed = LocatorTargetSchema.safeParse(target);
+    if (parsed.success) return parsed.data;
+  }
+  return undefined;
+}
+
+function firstLegacyXpath(value: unknown): string | undefined {
+  if (!isRecord(value) || !Array.isArray(value.xpaths)) return undefined;
+  return firstNonEmptyString(...value.xpaths);
+}
+
+function targetFromValue(value: unknown): LocatorTarget | undefined {
+  const parsed = LocatorTargetSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function validLocatedPixelBbox(
@@ -52,12 +73,7 @@ function validLocatedPixelBbox(
 
 function isLocatedElement(value: unknown): value is Record<string, unknown> & {
   description?: string;
-  rect: {
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-  };
+  rect: { left: number; top: number; width: number; height: number };
 } {
   if (!isRecord(value) || !isRecord(value.rect)) return false;
   const { left, top, width, height } = value.rect;
@@ -70,35 +86,46 @@ function locatorFromTask(
   locateTask: ExecutionTask | undefined,
   locatedElement: Record<string, unknown> & {
     description?: string;
-    rect: {
-      left: number;
-      top: number;
-      width: number;
-      height: number;
-    };
+    rect: { left: number; top: number; width: number; height: number };
   },
-): { value: Record<string, unknown>; usedCoordinateFallback: boolean } {
+): {
+  value: Record<string, unknown>;
+  target?: LocatorTarget;
+  usedCoordinateFallback: boolean;
+} {
   const sourceParam = isRecord(locateTask?.param) ? locateTask.param : {};
   const hitContext = isRecord(locateTask?.hitBy?.context)
     ? locateTask.hitBy.context
     : {};
-
   const prompt =
     sourceParam.prompt ??
     firstNonEmptyString(sourceParam.promptDisplay, locatedElement.description);
-  const xpath = firstNonEmptyString(
+  const attemptedTargetFailed =
+    typeof hitContext.targetResolutionError === 'string' &&
+    hitContext.targetResolutionError.trim().length > 0;
+  const target =
+    (!attemptedTargetFailed
+      ? (targetFromValue(sourceParam.target) ??
+        targetFromValue(hitContext.target))
+      : undefined) ??
+    firstTarget(hitContext.cacheToSave) ??
+    firstTarget(hitContext.cacheEntry);
+  const legacyXpath = firstNonEmptyString(
     sourceParam.xpath,
     hitContext.xpath,
-    firstXpath(hitContext.cacheToSave),
-    firstXpath(hitContext.cacheEntry),
+    firstLegacyXpath(hitContext.cacheToSave),
+    firstLegacyXpath(hitContext.cacheEntry),
   );
+  const normalizedTarget =
+    target ?? (legacyXpath ? xpathLocatorTarget(legacyXpath) : undefined);
 
-  if (xpath) {
+  if (normalizedTarget) {
     return {
       value: {
         ...(prompt !== undefined ? { prompt } : {}),
-        xpath,
+        target: normalizedTarget,
       },
+      target: normalizedTarget,
       usedCoordinateFallback: false,
     };
   }
@@ -112,7 +139,6 @@ function locatorFromTask(
     locatedElement.rect.left + locatedElement.rect.width,
     locatedElement.rect.top + locatedElement.rect.height,
   ];
-
   return {
     value: {
       ...(prompt !== undefined ? { prompt } : {}),
@@ -126,70 +152,68 @@ function restoreStableLocators(
   value: unknown,
   locateTasks: ExecutionTask[],
   locateIndex: { value: number },
-): { value: unknown; usedCoordinateFallback: boolean } {
+): {
+  value: unknown;
+  targets: LocatorTarget[];
+  usedCoordinateFallback: boolean;
+} {
   if (isLocatedElement(value)) {
     const result = locatorFromTask(locateTasks[locateIndex.value], value);
     locateIndex.value += 1;
-    return result;
+    return {
+      value: result.value,
+      targets: result.target ? [result.target] : [],
+      usedCoordinateFallback: result.usedCoordinateFallback,
+    };
   }
-
   if (Array.isArray(value)) {
-    let usedCoordinateFallback = false;
-    const restored = value.map((item) => {
-      const result = restoreStableLocators(item, locateTasks, locateIndex);
-      usedCoordinateFallback ||= result.usedCoordinateFallback;
-      return result.value;
-    });
-    return { value: restored, usedCoordinateFallback };
-  }
-
-  if (isRecord(value)) {
-    let usedCoordinateFallback = false;
-    const restored = Object.fromEntries(
-      Object.entries(value).map(([key, item]) => {
-        const result = restoreStableLocators(item, locateTasks, locateIndex);
-        usedCoordinateFallback ||= result.usedCoordinateFallback;
-        return [key, result.value];
-      }),
+    const restored = value.map((item) =>
+      restoreStableLocators(item, locateTasks, locateIndex),
     );
-    return { value: restored, usedCoordinateFallback };
+    return {
+      value: restored.map((item) => item.value),
+      targets: restored.flatMap((item) => item.targets),
+      usedCoordinateFallback: restored.some(
+        (item) => item.usedCoordinateFallback,
+      ),
+    };
   }
-
-  return { value, usedCoordinateFallback: false };
-}
-
-function flattenSingleLocatorShortcut(
-  originalParam: unknown,
-  restoredParam: unknown,
-): unknown {
-  if (!isRecord(originalParam) || !isRecord(restoredParam)) {
-    return restoredParam;
+  if (isRecord(value)) {
+    const restored = Object.entries(value).map(
+      ([key, item]) =>
+        [key, restoreStableLocators(item, locateTasks, locateIndex)] as const,
+    );
+    return {
+      value: Object.fromEntries(
+        restored.map(([key, item]) => [key, item.value]),
+      ),
+      targets: restored.flatMap(([, item]) => item.targets),
+      usedCoordinateFallback: restored.some(
+        ([, item]) => item.usedCoordinateFallback,
+      ),
+    };
   }
-
-  const locatorFields = Object.entries(originalParam).filter(([, value]) =>
-    isLocatedElement(value),
-  );
-  if (locatorFields.length !== 1) return restoredParam;
-
-  const [locatorField] = locatorFields[0];
-  const restoredLocator = restoredParam[locatorField];
-  if (!isRecord(restoredLocator)) return restoredParam;
-
-  return {
-    ...Object.fromEntries(
-      Object.entries(restoredParam).filter(([key]) => key !== locatorField),
-    ),
-    ...restoredLocator,
-  };
+  return { value, targets: [], usedCoordinateFallback: false };
 }
 
 function actionNameFromTask(
   task: ExecutionTask,
+  plannedAction: Record<string, unknown> | undefined,
   planLog: string | undefined,
 ): string {
   const actionName = task.subType || 'Action';
-  if (planLog) {
-    const sanitizedPlanLog = Array.from(planLog)
+  const extraActionName = isRecord(task.hitBy?.context)
+    ? firstNonEmptyString(task.hitBy.context.extraActionName)
+    : undefined;
+  if (task.hitBy?.from === 'Extra Action' && extraActionName) {
+    return extraActionName;
+  }
+  const planningDescription = firstNonEmptyString(
+    plannedAction?.thought,
+    planLog,
+  );
+  if (planningDescription) {
+    const sanitizedPlanningDescription = Array.from(planningDescription)
       .map((character) => {
         const codePoint = character.codePointAt(0);
         const invalid =
@@ -206,13 +230,12 @@ function actionNameFromTask(
       .replace(/\s+/g, ' ')
       .trim();
     if (
-      sanitizedPlanLog &&
-      sanitizedPlanLog.toLowerCase() !== actionName.toLowerCase()
+      sanitizedPlanningDescription &&
+      sanitizedPlanningDescription.toLowerCase() !== actionName.toLowerCase()
     ) {
-      return sanitizedPlanLog;
+      return sanitizedPlanningDescription;
     }
   }
-
   if (isRecord(task.param)) {
     for (const value of Object.values(task.param)) {
       if (isLocatedElement(value) && value.description) {
@@ -239,64 +262,72 @@ function extractUIActions(
 
   for (const execution of executions) {
     let planLog: string | undefined;
+    let plannedActions: Record<string, unknown>[] = [];
+    let planActionCount = 0;
     let pendingLocateTasks: ExecutionTask[] = [];
-
     for (const task of execution.tasks) {
       if (task.type === 'Planning' && task.subType === 'Plan') {
-        planLog = isRecord(task.output)
-          ? firstNonEmptyString(task.output.log)
-          : undefined;
+        const planOutput = isRecord(task.output) ? task.output : {};
+        planLog = firstNonEmptyString(planOutput.log);
+        plannedActions = Array.isArray(planOutput.actions)
+          ? planOutput.actions.filter(isRecord)
+          : [];
+        planActionCount = plannedActions.length;
+        pendingLocateTasks = [];
         continue;
       }
-
       if (task.type === 'Planning' && task.subType === 'Locate') {
-        pendingLocateTasks.push(task);
+        if (task.status === 'finished') {
+          pendingLocateTasks.push(task);
+        }
         continue;
       }
-
       if (task.type !== 'Action Space') continue;
+
+      if (task.subType === 'Finished') {
+        pendingLocateTasks = [];
+        continue;
+      }
 
       const locateTasks = pendingLocateTasks;
       pendingLocateTasks = [];
-      const currentPlanLog = planLog;
-      planLog = undefined;
-
-      if (task.status !== 'finished' || task.subType === 'Finished') {
-        continue;
-      }
+      const plannedAction = plannedActions.shift();
+      const currentPlanLog = planActionCount <= 1 ? planLog : undefined;
+      if (task.status !== 'finished') continue;
 
       const restored = restoreStableLocators(task.param, locateTasks, {
         value: 0,
       });
-      const baseName = actionNameFromTask(task, currentPlanLog);
+      const baseName = actionNameFromTask(task, plannedAction, currentPlanLog);
       const nameCount = (nameCounts.get(baseName) ?? 0) + 1;
       nameCounts.set(baseName, nameCount);
       actions.push({
         definition: {
           name: nameCount === 1 ? baseName : `${baseName} (${nameCount})`,
-          actionName: task.subType || 'Action',
-          actionParam: [
-            flattenSingleLocatorShortcut(task.param, restored.value),
-          ],
+          ...(restored.targets.length > 0
+            ? { validWhenTargetExists: restored.targets[0] }
+            : {}),
+          action: {
+            name: task.subType || 'Action',
+            ...(restored.value !== undefined && restored.value !== null
+              ? { param: restored.value }
+              : {}),
+          },
         },
         usedCoordinateFallback: restored.usedCoordinateFallback,
       });
     }
   }
-
   return actions;
 }
 
 function resolveReportHtmlPath(htmlPath: string): string {
   const normalizedPath = path.resolve(htmlPath);
-
   if (!existsSync(normalizedPath)) {
     throw new Error(`analyzeReportActions: report does not exist: ${htmlPath}`);
   }
-
   const stats = statSync(normalizedPath);
   if (!stats.isDirectory()) return normalizedPath;
-
   const indexHtmlPath = path.join(normalizedPath, 'index.html');
   if (!existsSync(indexHtmlPath)) {
     throw new Error(
@@ -306,21 +337,23 @@ function resolveReportHtmlPath(htmlPath: string): string {
   return indexHtmlPath;
 }
 
-function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
-  const reportDir = path.dirname(resolvedHtmlPath);
-  const reportBaseName = path.basename(
+function reportBaseName(resolvedHtmlPath: string): string {
+  const baseName = path.basename(
     resolvedHtmlPath,
     path.extname(resolvedHtmlPath),
   );
+  return baseName === 'index'
+    ? path.basename(path.dirname(resolvedHtmlPath))
+    : baseName;
+}
 
-  if (reportBaseName === 'index') {
-    return path.join(
-      path.dirname(reportDir),
-      `${path.basename(reportDir)}-ui-actions`,
-    );
-  }
-
-  return path.join(reportDir, `${reportBaseName}-ui-actions`);
+function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
+  const reportDir = path.dirname(resolvedHtmlPath);
+  const baseName = reportBaseName(resolvedHtmlPath);
+  return path.basename(resolvedHtmlPath, path.extname(resolvedHtmlPath)) ===
+    'index'
+    ? path.join(path.dirname(reportDir), `${baseName}-ui-actions`)
+    : path.join(reportDir, `${baseName}-ui-actions`);
 }
 
 export function analyzeReportActions(
@@ -329,51 +362,66 @@ export function analyzeReportActions(
   if (!options.htmlPath) {
     throw new Error('analyzeReportActions: htmlPath is required');
   }
-
   const resolvedHtmlPath = resolveReportHtmlPath(options.htmlPath);
   const outputDir = path.resolve(
     options.outputDir ?? defaultAnalyzeOutputDir(resolvedHtmlPath),
   );
-  const { executions } = collectDedupedExecutions(resolvedHtmlPath);
+  const { executions, manifestInterfaces } =
+    collectDedupedExecutions(resolvedHtmlPath);
+  const normalizedManifestInterfaces = manifestInterfaces.map((value) =>
+    value.trim(),
+  );
+  const uniqueManifestInterfaces = new Set(normalizedManifestInterfaces);
+  const manifestInterface = Array.from(uniqueManifestInterfaces)[0];
+  if (
+    !manifestInterface ||
+    uniqueManifestInterfaces.size !== 1 ||
+    manifestInterface === 'mixed' ||
+    manifestInterface === 'unknown'
+  ) {
+    throw new Error(
+      `analyzeReportActions: every report dump with executions must declare the same canonical manifestInterface; received ${JSON.stringify(normalizedManifestInterfaces)}`,
+    );
+  }
   const actions = extractUIActions(executions);
-
   if (actions.length === 0) {
     throw new Error(
       `analyzeReportActions: no successful UI actions found in ${options.htmlPath}`,
     );
   }
 
-  const actionFiles = actions.map((action, index) =>
-    path.join(
-      outputDir,
-      `${String(index + 1).padStart(3, '0')}-${action.definition.actionName.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'action'}.yaml`,
-    ),
+  const actionFile = path.join(
+    outputDir,
+    `${reportBaseName(resolvedHtmlPath)}.actions.yaml`,
   );
-  const existingFiles = actionFiles.filter((file) => existsSync(file));
-  if (existingFiles.length > 0 && !options.overwrite) {
+  if (existsSync(actionFile) && !options.overwrite) {
     throw new Error(
-      `analyzeReportActions: output file already exists: ${existingFiles[0]}. Pass overwrite: true or --overwrite to replace generated UI Actions.`,
+      `analyzeReportActions: output file already exists: ${actionFile}. Pass overwrite: true or --overwrite to replace the generated Action Manifest.`,
     );
   }
-
-  mkdirSync(outputDir, { recursive: true });
-  actions.forEach((action, index) => {
-    writeFileSync(
-      actionFiles[index],
-      yaml.dump(action.definition, {
-        indent: 2,
-        lineWidth: -1,
-        noRefs: true,
-      }),
-      'utf-8',
-    );
+  const manifest: UIActionManifest = {
+    version: 1,
+    interface: manifestInterface,
+    actions: actions.map((action) => action.definition),
+  };
+  const manifestYaml = yaml.dump(manifest, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
   });
+  parseExtraActionManifest(manifestYaml, actionFile);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(actionFile, manifestYaml, 'utf-8');
 
+  const coordinateFallbackActionCount = actions.filter(
+    (action) => action.usedCoordinateFallback,
+  ).length;
   return {
     outputDir,
-    actionFiles,
-    coordinateFallbackFiles: actionFiles.filter(
-      (_file, index) => actions[index].usedCoordinateFallback,
-    ),
+    actionFiles: [actionFile],
+    actionCount: actions.length,
+    coordinateFallbackFiles:
+      coordinateFallbackActionCount > 0 ? [actionFile] : [],
+    coordinateFallbackActionCount,
   };
 }

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -120,6 +120,7 @@ async function markdownFromReport(
     groupDescription: baseDump.groupDescription,
     modelBriefs: baseDump.modelBriefs,
     deviceType: baseDump.deviceType,
+    manifestInterface: baseDump.manifestInterface,
     executions,
   });
 
@@ -460,7 +461,7 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
 const analyzeCommandDefinition: ReportCliCommandDefinition = {
   name: 'analyze',
   description:
-    'Extract successful UI actions from a Midscene HTML report into one reusable YAML file per device operation.',
+    'Extract successful UI actions from a Midscene HTML report into a reusable *.actions.yaml manifest.',
   schema: {
     htmlPath: z
       .string()
@@ -499,8 +500,8 @@ const analyzeCommandDefinition: ReportCliCommandDefinition = {
       overwrite: overwriteFlag,
     });
     const fallbackMessage =
-      result.coordinateFallbackFiles.length > 0
-        ? ` ${result.coordinateFallbackFiles.length} action(s) use locatedPixelBbox because no XPath was recorded.`
+      result.coordinateFallbackActionCount > 0
+        ? ` ${result.coordinateFallbackActionCount} action(s) use locatedPixelBbox because no stable target was recorded.`
         : '';
 
     return {
@@ -508,7 +509,7 @@ const analyzeCommandDefinition: ReportCliCommandDefinition = {
       content: [
         {
           type: 'text',
-          text: `Analyzed ${result.actionFiles.length} UI action(s). Output path: ${result.outputDir}.${fallbackMessage}`,
+          text: `Analyzed ${result.actionCount} UI action(s) into ${result.actionFiles[0]}.${fallbackMessage}`,
         },
       ],
     };

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -327,6 +327,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: reportMeta.groupDescription,
       modelBriefs: reportMeta.modelBriefs,
       deviceType: reportMeta.deviceType,
+      manifestInterface: reportMeta.manifestInterface,
       executions: [execution],
     });
   }
@@ -414,6 +415,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: this.lastReportMeta.groupDescription,
       modelBriefs: this.lastReportMeta.modelBriefs,
       deviceType: this.lastReportMeta.deviceType,
+      manifestInterface: this.lastReportMeta.manifestInterface,
       executions: Array.from(this.executionsByKey.values()),
     });
     await appendFileAsync(

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -181,12 +181,17 @@ function mergedAgentReportComment(reports: ReportActionDump[]): string {
   const deviceTypes = Array.from(
     new Set(reports.map((report) => report.deviceType).filter(Boolean)),
   );
+  const manifestInterfaces = Array.from(
+    new Set(reports.map((report) => report.manifestInterface)),
+  );
   const mergedReport = new ReportActionDump({
     sdkVersion: reports[0].sdkVersion || getVersion(),
     groupName: 'Merged Midscene Report',
     groupDescription: 'Agent-readable summary for merged report HTML',
     modelBriefs: reports.flatMap((report) => report.modelBriefs ?? []),
     deviceType: deviceTypes.length === 1 ? deviceTypes[0] : 'mixed',
+    manifestInterface:
+      manifestInterfaces.length === 1 ? manifestInterfaces[0] : 'mixed',
     executions: reports.flatMap((report) => report.executions ?? []),
   });
   return generateAgentReportComment(mergedReport);
@@ -201,6 +206,7 @@ export class ReportMergingTool {
       groupName,
       groupDescription,
       modelBriefs: [],
+      manifestInterface: 'unknown',
       executions: [],
     }).serialize();
   }
@@ -254,11 +260,17 @@ export class ReportMergingTool {
     // id are always kept (they may be distinct despite sharing the same name).
     const base = ReportActionDump.fromSerializedString(unescaped[0]);
     const allExecutions = [...base.executions];
+    const manifestInterfaces = new Set([base.manifestInterface]);
     for (let i = 1; i < unescaped.length; i++) {
       const other = ReportActionDump.fromSerializedString(unescaped[i]);
       allExecutions.push(...other.executions);
+      manifestInterfaces.add(other.manifestInterface);
     }
     base.executions = dedupeExecutionsKeepLatest(allExecutions);
+    base.manifestInterface =
+      manifestInterfaces.size === 1
+        ? Array.from(manifestInterfaces)[0]
+        : 'mixed';
     return base.serialize();
   }
 
@@ -486,6 +498,7 @@ export interface SplitReportHtmlResult {
 export interface CollectedReportExecutions {
   baseDump: ReportActionDump;
   executions: IExecutionDump[];
+  manifestInterfaces: string[];
 }
 
 /**
@@ -517,6 +530,7 @@ export function collectDedupedExecutions(
   });
 
   const executions: IExecutionDump[] = [];
+  const manifestInterfaces: string[] = [];
   executionSerial = 0;
   streamDumpScriptsSync(htmlPath, (dumpScript) => {
     if (!dumpScript.openTag.includes('data-group-id')) {
@@ -528,6 +542,9 @@ export function collectDedupedExecutions(
     );
     if (!baseDump) {
       baseDump = groupedDump;
+    }
+    if (groupedDump.executions.length > 0) {
+      manifestInterfaces.push(groupedDump.manifestInterface);
     }
 
     for (const execution of groupedDump.executions) {
@@ -551,6 +568,7 @@ export function collectDedupedExecutions(
   return {
     baseDump,
     executions,
+    manifestInterfaces,
   };
 }
 
@@ -645,6 +663,7 @@ export function splitReportHtmlByExecution(
       groupDescription: baseDump.groupDescription,
       modelBriefs: baseDump.modelBriefs,
       deviceType: baseDump.deviceType,
+      manifestInterface: baseDump.manifestInterface,
       executions: [execution],
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -808,6 +808,7 @@ export interface ReportMeta {
   sdkVersion: string;
   modelBriefs: ModelBrief[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.
@@ -823,6 +824,7 @@ export interface IReportActionDump {
   modelBriefs: ModelBrief[];
   executions: IExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -4,6 +4,7 @@ import type {
   HarmonyDeviceOpt,
   IOSDeviceOpt,
 } from './device';
+import type { LocatorTarget } from './locator';
 import type { AgentOpt, LocateResultElement, Rect } from './types';
 import type { UIContext } from './types';
 
@@ -16,6 +17,8 @@ export interface LocateOption extends Partial<TMultimodalPrompt> {
   deepThink?: boolean; // alias for deepLocate
   cacheable?: boolean; // user can set this param to false to disable the cache for a single agent api
   xpath?: string; // only available in web
+  /** Stable locator reference. `xpath` remains supported as a legacy alias. */
+  target?: LocatorTarget;
   uiContext?: UIContext;
   fileChooserAccept?: string | string[]; // file path(s) to upload when tapping triggers a file chooser
 }

--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -287,7 +287,8 @@ export function buildDetailedLocateParam(
   let prompt = normalizedLocatePrompt || opt?.prompt || (opt as any)?.locate; // as a shortcut
   let deepLocate = false;
   let cacheable = true;
-  let xpath = undefined;
+  let xpath: LocateOption['xpath'];
+  let target: LocateOption['target'];
 
   if (typeof opt === 'object' && opt !== null) {
     // Backward-compatible: accept `deepThink` as a deprecated alias for `deepLocate`.
@@ -297,6 +298,12 @@ export function buildDetailedLocateParam(
     deepLocate = opt.deepLocate ?? opt.deepThink ?? false;
     cacheable = opt.cacheable ?? true;
     xpath = opt.xpath;
+    target = opt.target;
+    if (target !== undefined && xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
     if (locatePrompt && opt.prompt && locatePrompt !== opt.prompt) {
       console.warn(
         'conflict prompt for item',
@@ -339,7 +346,7 @@ export function buildDetailedLocateParam(
     ...(context ? { promptDisplay, context } : {}),
     deepLocate,
     cacheable,
-    xpath,
+    ...(target ? { target } : { xpath }),
   };
 }
 

--- a/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
+++ b/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
@@ -54,11 +54,6 @@ describe('aiAct extra action integration', () => {
       delayBeforeRunner: 0,
       delayAfterRunner: 0,
     };
-    const extraPlanningAction: DeviceAction = {
-      name: 'MidsceneExtraAction_1',
-      description: 'Run a recorded action',
-      call: vi.fn(),
-    };
     const mockInterface = {
       interfaceType: 'web',
       actionSpace: () => [inputAction],
@@ -83,7 +78,7 @@ describe('aiAct extra action integration', () => {
     vi.mocked(genericXmlPlan).mockResolvedValue({
       actions: [
         {
-          type: extraPlanningAction.name,
+          type: 'MidsceneExtraAction_1',
           param: {},
           thought: 'fill the username',
         },
@@ -94,14 +89,15 @@ describe('aiAct extra action integration', () => {
 
     const extraActions = [
       {
-        name: '填写用户名',
-        planningAction: extraPlanningAction,
+        alias: 'MidsceneExtraAction_1',
+        name: 'Fill the username',
+        sourcePath: '/tmp/example.actions.yaml',
         plan: {
           type: 'Input',
           param: {
             value: 'Alice',
             locate: {
-              prompt: '填写用户名',
+              prompt: 'Username input',
               locatedPixelBbox: [0, 0, 1, 1],
             },
           },
@@ -110,19 +106,28 @@ describe('aiAct extra action integration', () => {
     ];
 
     const result = await taskExecutor.action(
-      '填写表单',
+      'Fill the form',
       modelRuntime(),
       modelRuntime(),
       false,
       {
-        extraActions: createExtraActionExecutionOptions(extraActions),
+        extraActions: createExtraActionExecutionOptions(
+          extraActions,
+          undefined,
+        ),
       },
     );
 
     expect(vi.mocked(genericXmlPlan).mock.calls[0][1].actionSpace).toEqual([
+      expect.objectContaining({
+        name: 'MidsceneExtraAction_1',
+        description: expect.stringContaining('Fill the username'),
+      }),
       inputAction,
-      extraPlanningAction,
     ]);
+    expect(vi.mocked(genericXmlPlan).mock.calls[0][1].hasExtraActions).toBe(
+      true,
+    );
     expect(inputCall).toHaveBeenCalledOnce();
     expect(inputCall.mock.calls[0][0]).toMatchObject({
       value: 'Alice',
@@ -158,9 +163,113 @@ describe('aiAct extra action integration', () => {
       'Input',
       expect.objectContaining({
         value: 'Alice',
-        locate: expect.objectContaining({ prompt: '填写用户名' }),
+        locate: expect.objectContaining({ prompt: 'Username input' }),
       }),
     );
+  });
+
+  it('refreshes disclosure on every planning round while keeping aliases stable', async () => {
+    const tapCall = vi.fn();
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'Tap an element',
+      call: tapCall,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const probeLocatorTargets = vi
+      .fn()
+      .mockResolvedValueOnce([true, false])
+      .mockResolvedValueOnce([false, true]);
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [tapAction],
+      probeLocatorTargets,
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [tapAction],
+    });
+    vi.mocked(genericXmlPlan)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_1',
+            param: {},
+            thought: 'run the first action',
+          },
+        ],
+        shouldContinuePlanning: true,
+      } as any)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_2',
+            param: {},
+            thought: 'run the second action',
+          },
+        ],
+        shouldContinuePlanning: false,
+      } as any);
+
+    await taskExecutor.action(
+      'Complete both steps',
+      modelRuntime(),
+      modelRuntime(),
+      false,
+      {
+        extraActions: createExtraActionExecutionOptions(
+          [
+            {
+              alias: 'MidsceneExtraAction_1',
+              name: 'Run the first action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="first"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+            {
+              alias: 'MidsceneExtraAction_2',
+              name: 'Run the second action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="second"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+          ],
+          mockInterface,
+        ),
+      },
+    );
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(genericXmlPlan)
+        .mock.calls.map((call) =>
+          call[1].actionSpace.map((action) => action.name),
+        ),
+    ).toEqual([
+      ['MidsceneExtraAction_1', 'Tap'],
+      ['MidsceneExtraAction_2', 'Tap'],
+    ]);
+    expect(tapCall).toHaveBeenCalledTimes(2);
   });
 
   it('loads files through the public aiAct option and separates its plan cache', async () => {
@@ -168,10 +277,13 @@ describe('aiAct extra action integration', () => {
     const filePath = join(dir, 'extra-action.yaml');
     await writeFile(
       filePath,
-      `name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+      `version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: tap
+      param: {}
 `,
     );
 
@@ -185,10 +297,11 @@ actionParam:
       const action = vi.fn().mockResolvedValue({
         output: {
           output: 'done',
-          yamlFlow: [],
+          yamlFlow: [{ Tap: {} }],
         },
       });
       const matchPlanCache = vi.fn();
+      const updateOrAppendCacheRecord = vi.fn();
       (agent as any).opts = {};
       (agent as any).interface = { interfaceType: 'web' };
       (agent as any).fullActionSpace = [tapAction];
@@ -196,35 +309,46 @@ actionParam:
       (agent as any).taskCache = {
         matchPlanCache,
         isCacheResultUsed: true,
-        updateOrAppendCacheRecord: vi.fn(),
+        updateOrAppendCacheRecord,
       };
       (agent as any).resolveModelRuntime = vi.fn(() => modelRuntime());
       (agent as any).resolveReplanningCycleLimit = vi.fn(() => 1);
 
       await expect(
-        agent.aiAct('填写表单', { loadExtraActions: [filePath] }),
+        agent.aiAct('Fill the form', { loadExtraActions: [filePath] }),
       ).resolves.toBe('done');
 
       expect(matchPlanCache.mock.calls[0][0]).toContain(
         '<midscene_extra_actions>',
       );
       expect(matchPlanCache.mock.calls[0][0]).toContain(
-        '"name":"点击确定按钮"',
+        'extra-actions-snapshot:v1:',
+      );
+      expect(updateOrAppendCacheRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'plan',
+          prompt: matchPlanCache.mock.calls[0][0],
+        }),
+        undefined,
       );
       const executionOptions = action.mock.calls[0].at(-1);
       expect(executionOptions).toEqual(
         expect.objectContaining({
           extraActions: expect.objectContaining({
-            actionSpace: [
-              expect.objectContaining({
-                name: 'MidsceneExtraAction_1',
-                description: expect.stringContaining('点击确定按钮'),
-              }),
-            ],
-            expandPlans: expect.any(Function),
+            createSnapshot: expect.any(Function),
+            initialSnapshot: expect.objectContaining({
+              fingerprint: expect.stringMatching(/^extra-actions-snapshot:v1:/),
+            }),
           }),
         }),
       );
+      const snapshot = await executionOptions.extraActions.createSnapshot();
+      expect(snapshot.actionSpace).toEqual([
+        expect.objectContaining({
+          name: 'MidsceneExtraAction_1',
+          description: expect.stringContaining('Click the confirm button'),
+        }),
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -254,7 +378,7 @@ actionParam:
     );
 
     await expect(
-      agent.aiAct('填写表单', {
+      agent.aiAct('Fill the form', {
         loadExtraActions: ['/path/that/does/not/need/to/exist.yaml'],
       }),
     ).rejects.toThrow(

--- a/packages/core/tests/unit-test/bbox-locate-cache.test.ts
+++ b/packages/core/tests/unit-test/bbox-locate-cache.test.ts
@@ -223,7 +223,10 @@ describe('bbox locate cache fix', () => {
       );
       expect(cachedLocate).toBeDefined();
       expect(cachedLocate?.cache).toBeDefined();
-      expect(cachedLocate?.cache?.xpaths).toContain('/html/body/input[1]');
+      expect(cachedLocate?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/input[1]',
+      });
     });
 
     it('should not call AI locate when bbox is available', async () => {
@@ -657,7 +660,7 @@ describe('bbox locate cache fix', () => {
       const internal = getTaskCacheInternal(testCache);
       internal.cache.caches.push({
         type: 'locate',
-        prompt: '高一',
+        prompt: 'Grade 10',
         cache: {
           xpaths: ['/html/body/div[1]/label[2]'], // Old invalid xpath
         },
@@ -684,7 +687,7 @@ describe('bbox locate cache fix', () => {
       // 4. Mock cacheFeatureForPoint to return new xpath
       vi.mocked(mockInterface.cacheFeatureForPoint!).mockResolvedValue({
         xpaths: ['/html/body/div[2]/label[1]'],
-        texts: ['高一'],
+        texts: ['Grade 10'],
       });
 
       // 5. Create taskBuilder with pre-populated cache
@@ -700,11 +703,11 @@ describe('bbox locate cache fix', () => {
           type: 'Tap',
           param: {
             locate: {
-              prompt: '高一',
+              prompt: 'Grade 10',
               // No bbox - will try cache hit
             },
           },
-          thought: 'tap 高一',
+          thought: 'tap Grade 10',
         },
       ];
 
@@ -725,7 +728,12 @@ describe('bbox locate cache fix', () => {
       // 6. Verify:
       // - rectMatchesCacheFeature was called (attempted cache hit)
       expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
-        xpaths: ['/html/body/div[1]/label[2]'],
+        targets: [
+          {
+            strategy: 'xpath',
+            selector: '/html/body/div[1]/label[2]',
+          },
+        ],
       });
 
       // - AI locate was called (cache hit failed, fallback to AI)
@@ -735,15 +743,17 @@ describe('bbox locate cache fix', () => {
       expect(mockInterface.cacheFeatureForPoint).toHaveBeenCalled();
 
       // - Cache was updated with new xpath (not the old one)
-      const updatedCache = findLocateCacheByPrompt(testCache, '高一');
+      const updatedCache = findLocateCacheByPrompt(testCache, 'Grade 10');
       expect(updatedCache).toBeDefined();
       expect(updatedCache?.cache).toBeDefined();
-      expect(updatedCache?.cache?.xpaths).toContain(
-        '/html/body/div[2]/label[1]',
-      );
-      expect(updatedCache?.cache?.xpaths).not.toContain(
-        '/html/body/div[1]/label[2]',
-      );
+      expect(updatedCache?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/div[2]/label[1]',
+      });
+      expect(updatedCache?.cache?.targets).not.toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/div[1]/label[2]',
+      });
     });
 
     it('should update cache when cache validation fails for non-plan-hit scenarios', async () => {
@@ -818,10 +828,14 @@ describe('bbox locate cache fix', () => {
       // Verify cache was updated
       const updatedCache = findLocateCacheByPrompt(testCache, 'submit button');
       expect(updatedCache).toBeDefined();
-      expect(updatedCache?.cache?.xpaths).toContain(
-        '/html/body/form[1]/button[1]',
-      );
-      expect(updatedCache?.cache?.xpaths).not.toContain('/html/body/button[1]');
+      expect(updatedCache?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/form[1]/button[1]',
+      });
+      expect(updatedCache?.cache?.targets).not.toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/button[1]',
+      });
     });
   });
 });

--- a/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
+++ b/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
@@ -61,6 +61,7 @@ describe('dump serialization drops screenshotSequence', () => {
   it('omits screenshotSequence from serializeWithInlineScreenshots() (inline mode)', () => {
     const reportData: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'screenshot-sequence',
       modelBriefs: [],
       executions: [buildExecutionDumpData()],

--- a/packages/core/tests/unit-test/element-xpaths.test.ts
+++ b/packages/core/tests/unit-test/element-xpaths.test.ts
@@ -7,6 +7,10 @@ import {
   elementXpathsPlanningContext,
   loadElementXpaths,
 } from '@/agent/element-xpaths';
+import {
+  getExtraActionSource,
+  setExtraActionSource,
+} from '@/agent/extra-actions';
 import { TaskExecutor } from '@/agent/tasks';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
@@ -162,7 +166,10 @@ elements:
           value: 'Alice',
           locate: {
             prompt: 'the "first NAME input" as specified in known UI elements',
-            xpath: '//*[@id="first-name"]',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
@@ -189,7 +196,10 @@ elements:
           value: 'Dora',
           locate: {
             prompt: 'First name input',
-            xpath: '//*[@id="first-name"]',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
@@ -199,7 +209,10 @@ elements:
           value: 'Eve',
           locate: {
             prompt: 'First name input',
-            xpath: '//*[@id="first-name"]',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
@@ -228,6 +241,32 @@ elements:
     );
 
     expect(mapped).toEqual({ plans, mapped: false });
+  });
+
+  it('preserves internal Extra Action provenance when a map transforms the plan', () => {
+    const plan: PlanningAction = {
+      type: 'Input',
+      param: {
+        value: 'Alice',
+        locate: { prompt: 'First name input' },
+      },
+    };
+    const source = {
+      type: 'extra-action' as const,
+      name: 'Fill the first name',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: '/tmp/profile.actions.yaml',
+    };
+    setExtraActionSource(plan, source);
+
+    const mapped = applyElementXpathsToPlans(
+      [plan],
+      [{ name: 'First name input', xpath: '//*[@id="first-name"]' }],
+      [inputAction()],
+    );
+
+    expect(mapped.mapped).toBe(true);
+    expect(getExtraActionSource(mapped.plans[0])).toEqual(source);
   });
 
   it('rejects invalid and conflicting map entries before planning', async () => {
@@ -359,7 +398,7 @@ elements:
 
     expect(locate).not.toHaveBeenCalled();
     expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
-      xpaths: ['//*[@id="first-name"]'],
+      targets: [{ strategy: 'xpath', selector: '//*[@id="first-name"]' }],
     });
     expect(inputCall).toHaveBeenCalledOnce();
     expect(result.output?.yamlFlow).toEqual([
@@ -368,15 +407,23 @@ elements:
         value: 'Alice',
         locate: {
           prompt: 'First name input',
-          xpath: '//*[@id="first-name"]',
+          target: {
+            strategy: 'xpath',
+            selector: '//*[@id="first-name"]',
+          },
         },
       },
     ]);
     expect(
       result.runner.tasks.find((task) => task.subType === 'Locate')?.hitBy,
     ).toEqual({
-      from: 'User expected path',
-      context: { xpath: '//*[@id="first-name"]' },
+      from: 'User target',
+      context: {
+        target: {
+          strategy: 'xpath',
+          selector: '//*[@id="first-name"]',
+        },
+      },
     });
 
     const replayAction = vi.fn();
@@ -401,7 +448,10 @@ elements:
         value: 'Alice',
         locate: expect.objectContaining({
           prompt: 'First name input',
-          xpath: '//*[@id="first-name"]',
+          target: {
+            strategy: 'xpath',
+            selector: '//*[@id="first-name"]',
+          },
         }),
       }),
     );
@@ -470,13 +520,21 @@ elements:
     );
 
     expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
-      xpaths: ['//*[@id="stale-first-name"]'],
+      targets: [
+        {
+          strategy: 'xpath',
+          selector: '//*[@id="stale-first-name"]',
+        },
+      ],
     });
     expect(locate).toHaveBeenCalledOnce();
     expect(locate.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         prompt: 'First name input',
-        xpath: '//*[@id="stale-first-name"]',
+        target: {
+          strategy: 'xpath',
+          selector: '//*[@id="stale-first-name"]',
+        },
       }),
     );
     expect(locate.mock.calls[0][0]).not.toHaveProperty('locatedPixelBbox');

--- a/packages/core/tests/unit-test/execution-dump.test.ts
+++ b/packages/core/tests/unit-test/execution-dump.test.ts
@@ -165,6 +165,7 @@ describe('ExecutionDump', () => {
 describe('ReportActionDump', () => {
   const createMockReportActionDumpData = (): IReportActionDump => ({
     sdkVersion: '1.0.0',
+    manifestInterface: 'web',
     groupName: 'Test Group',
     groupDescription: 'A test group description',
     modelBriefs: [{ name: 'model1' }, { name: 'model2' }],
@@ -213,6 +214,7 @@ describe('ReportActionDump', () => {
 
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Test',
         modelBriefs: [],
         executions: [executionDump],
@@ -225,6 +227,7 @@ describe('ReportActionDump', () => {
     it('should handle optional fields', () => {
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Minimal Group',
         modelBriefs: [],
         executions: [],
@@ -281,6 +284,7 @@ describe('ReportActionDump', () => {
 
       const dump = new ReportActionDump({
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Inline Screenshot Test',
         modelBriefs: [],
         executions: [
@@ -391,6 +395,7 @@ describe('ReportActionDump', () => {
     it('should handle complex nested structures', () => {
       const complexData: IReportActionDump = {
         sdkVersion: '2.0.0',
+        manifestInterface: 'web',
         groupName: 'Complex Group',
         groupDescription: 'A complex test',
         modelBriefs: [{ name: 'openai/gpt-4' }, { name: 'anthropic/claude' }],
@@ -450,6 +455,7 @@ describe('ExecutionDump and ReportActionDump integration', () => {
     // Create ReportActionDump with ExecutionDump instances
     const groupedDump = new ReportActionDump({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'Integration Test',
       modelBriefs: [],
       executions: [execution1, execution2],

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  expandExtraActionPlans,
-  extraActionsCacheKey,
+  createExtraActionSnapshot,
+  getExtraActionSource,
   loadExtraActions,
 } from '@/agent/extra-actions';
 import { getMidsceneLocationSchema } from '@/ai-model';
@@ -25,7 +25,7 @@ describe('extra actions', () => {
   async function writeExtraAction(content: string) {
     const dir = await mkdtemp(join(tmpdir(), 'midscene-extra-action-'));
     tempDirs.push(dir);
-    const filePath = join(dir, 'extra-action.yaml');
+    const filePath = join(dir, 'example.actions.yaml');
     await writeFile(filePath, content);
     return filePath;
   }
@@ -40,216 +40,519 @@ describe('extra actions', () => {
     call: vi.fn(),
   });
 
-  it('loads the documented YAML shape and expands its xpath shortcut', async () => {
+  it('loads the manifest and expands one alias into one native action', async () => {
     const filePath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+version: 1
+interface: web
+actions:
+  - name: Click the checkout dialog confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout dialog confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 `);
 
-    const loaded = await loadExtraActions([filePath], [tapAction()]);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
 
-    expect(loaded).toHaveLength(1);
-    expect(loaded[0].planningAction).toMatchObject({
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets: vi.fn(async () => [true]),
+    });
+
+    expect(snapshot.actionSpace).toHaveLength(1);
+    expect(snapshot.actionSpace[0]).toMatchObject({
       name: 'MidsceneExtraAction_1',
       description: expect.stringContaining(
-        'always prefer it over rebuilding the operation',
+        'Click the checkout dialog confirm button',
       ),
       sample: {},
     });
-    expect(
-      expandExtraActionPlans(
-        [
-          {
-            type: loaded[0].planningAction.name,
-            param: {},
-            thought: 'confirm the form',
-          },
-        ],
-        loaded,
-      ),
-    ).toEqual([
+    expect(snapshot.actionSpace[0].description).not.toContain('//div');
+    expect(loaded[0].validWhenTargetExists).toEqual({
+      strategy: 'xpath',
+      selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+    });
+
+    const expansion = snapshot.expandPlans([
+      {
+        type: 'MidsceneExtraAction_1',
+        param: {},
+        thought: 'confirm checkout',
+      },
+    ]);
+    expect(expansion.plans).toEqual([
       {
         type: 'Tap',
         param: {
           locate: {
-            prompt: '点击确定按钮',
-            xpath: '/path/to/#confirm-button',
+            prompt: 'Checkout dialog confirm button',
+            target: {
+              strategy: 'xpath',
+              selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+            },
           },
         },
-        thought: 'confirm the form',
+        thought: 'confirm checkout',
       },
     ]);
-    expect(extraActionsCacheKey(loaded)).toContain('"name":"点击确定按钮"');
+    expect(getExtraActionSource(expansion.plans[0])).toEqual({
+      type: 'extra-action',
+      name: 'Click the checkout dialog confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: filePath,
+    });
+    expect(snapshot.fingerprint).toMatch(/^extra-actions-snapshot:v1:/);
   });
 
-  it('keeps non-locator fields at the top level for an Input shortcut', async () => {
+  it('discloses every action whose condition currently exists', async () => {
     const filePath = await writeExtraAction(`
-name: 填写用户名
-actionName: input
-actionParam:
-  - xpath: /html/body/input
-    value: Alice
-    mode: typeOnly
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+  - name: Click the cancel button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="cancel"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Cancel button
+          target: { strategy: xpath, selector: '//button[@id="cancel"]' }
+  - name: Click the help button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Help button
+          target: { strategy: xpath, selector: '//button[@id="help"]' }
 `);
-    const inputAction: DeviceAction = {
-      name: 'Input',
-      interfaceAlias: 'aiInput',
-      paramSchema: z.object({
-        value: z.string(),
-        locate: getMidsceneLocationSchema().optional(),
-        mode: z.enum(['replace', 'clear', 'typeOnly']).default('replace'),
-      }),
-      call: vi.fn(),
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('confirm')),
+    );
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(1);
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_3',
+    ]);
+
+    probeLocatorTargets.mockImplementation(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('cancel')),
+    );
+    const nextSnapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+    expect(nextSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_2',
+      'MidsceneExtraAction_3',
+    ]);
+  });
+
+  it('keeps each disclosure snapshot immutable across page changes', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    let exists = false;
+    const targetProbe = {
+      probeLocatorTargets: vi.fn(async () => [exists]),
     };
 
-    const [loaded] = await loadExtraActions([filePath], [inputAction]);
+    const missingSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    exists = true;
+    const presentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    const repeatedPresentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
 
+    expect(missingSnapshot.actionSpace).toEqual([]);
+    expect(presentSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+    ]);
+    expect(missingSnapshot.fingerprint).not.toBe(presentSnapshot.fingerprint);
+    expect(repeatedPresentSnapshot.fingerprint).toBe(
+      presentSnapshot.fingerprint,
+    );
+    expect(
+      missingSnapshot.expandPlans([
+        { type: 'MidsceneExtraAction_1', param: {} },
+      ]),
+    ).toEqual({
+      plans: [{ type: 'MidsceneExtraAction_1', param: {} }],
+      expanded: false,
+    });
+  });
+
+  it('supports old one-action files as a read compatibility boundary', async () => {
+    const filePath = await writeExtraAction(`
+name: Click the confirm button
+actionName: tap
+actionParam:
+  - xpath: /html/body/button[1]
+`);
+    const [loaded] = await loadExtraActions([filePath], [tapAction()], 'web');
     expect(loaded.plan.param).toEqual({
-      value: 'Alice',
-      mode: 'typeOnly',
       locate: {
-        prompt: '填写用户名',
-        xpath: '/html/body/input',
+        prompt: 'Click the confirm button',
+        target: {
+          strategy: 'xpath',
+          selector: '/html/body/button[1]',
+        },
       },
     });
   });
 
-  it('rejects parameters that do not match the referenced action schema', async () => {
+  it('rejects a manifest for another interface', async () => {
     const filePath = await writeExtraAction(`
-name: 填写用户名
-actionName: input
-actionParam:
-  - xpath: /html/body/input
+version: 1
+interface: android
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
 `);
-    const inputAction: DeviceAction = {
-      name: 'Input',
-      interfaceAlias: 'aiInput',
-      paramSchema: z.object({
-        value: z.string(),
-        locate: getMidsceneLocationSchema().optional(),
-      }),
-      call: vi.fn(),
-    };
-
-    await expect(loadExtraActions([filePath], [inputAction])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": "actionParam[0]" does not match action "Input": value: Required`,
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'interface "android" does not match current interface "web"',
     );
   });
 
-  it('rejects multiple operations in one extra action file', async () => {
+  it('accepts the canonical platform declared by an interface', async () => {
     const filePath = await writeExtraAction(`
-name: 填写完整表单
-actionName: Tap
-actionParam:
-  - xpath: /html/body/input[1]
-  - xpath: /html/body/input[2]
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
-    );
-  });
-
-  it('expands multiple files into one operation per planner action', async () => {
-    const firstPath = await writeExtraAction(`
-name: 点击第一个按钮
-actionName: Tap
-actionParam:
-  - xpath: /html/body/button[1]
-`);
-    const secondPath = await writeExtraAction(`
-name: 点击第二个按钮
-actionName: Tap
-actionParam:
-  - xpath: /html/body/button[2]
-`);
-
-    const loaded = await loadExtraActions(
-      [firstPath, secondPath],
-      [tapAction()],
-    );
-
-    expect(
-      expandExtraActionPlans(
-        loaded.map((action) => ({
-          type: action.planningAction.name,
-          param: {},
-          thought: `run ${action.name}`,
-        })),
-        loaded,
-      ),
-    ).toEqual([
-      {
-        type: 'Tap',
-        param: {
-          locate: {
-            prompt: '点击第一个按钮',
-            xpath: '/html/body/button[1]',
-          },
-        },
-        thought: 'run 点击第一个按钮',
-      },
-      {
-        type: 'Tap',
-        param: {
-          locate: {
-            prompt: '点击第二个按钮',
-            xpath: '/html/body/button[2]',
-          },
-        },
-        thought: 'run 点击第二个按钮',
-      },
-    ]);
-  });
-
-  it('rejects display names that can corrupt the planner protocol', async () => {
-    const filePath = await writeExtraAction(`
-name: Click <Confirm>
-actionName: Tap
-actionParam:
-  - prompt: confirm button
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      '"name" must not contain angle brackets, line breaks, or control characters',
-    );
-  });
-
-  it('rejects an unknown referenced action with the source path', async () => {
-    const filePath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: missing-action
-actionParam:
-  - xpath: /path/to/#confirm-button
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": action "missing-action" is not in the current action space`,
-    );
-  });
-
-  it('rejects duplicate extra action names', async () => {
-    const firstPath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: Tap
-actionParam:
-  - locate:
-      prompt: confirm button
-`);
-    const secondPath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: Tap
-actionParam:
-  - locate:
-      prompt: another confirm button
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
 `);
 
     await expect(
-      loadExtraActions([firstPath, secondPath], [tapAction()]),
-    ).rejects.toThrow(
-      'action name "点击确定按钮" conflicts with another action',
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('prefers an exact native action name over an earlier case-insensitive match', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const lowerCaseTap = {
+      ...tapAction(),
+      name: 'tap',
+      interfaceAlias: 'lowerCaseTap',
+    };
+
+    const [loaded] = await loadExtraActions(
+      [filePath],
+      [lowerCaseTap, tapAction()],
+      'web',
     );
+
+    expect(loaded.plan.type).toBe('Tap');
+  });
+
+  it('reserves native action aliases when assigning stable protocol aliases', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const nativeAction = {
+      ...tapAction(),
+      interfaceAlias: 'MidsceneExtraAction_1',
+    };
+
+    const [loaded] = await loadExtraActions([filePath], [nativeAction], 'web');
+
+    expect(loaded.alias).toBe('MidsceneExtraAction_2');
+  });
+
+  it('allows a display name to match a built-in action name', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Tap
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('rejects target and legacy xpath in the same locator', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          xpath: //button
+          target: { strategy: xpath, selector: //button }
+`);
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      '`target` and `xpath` cannot be used in the same locator',
+    );
+  });
+
+  it('rejects invalid condition targets and duplicate names', async () => {
+    const invalidTarget = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists: { strategy: css, selector: '#confirm' }
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    await expect(
+      loadExtraActions([invalidTarget], [tapAction()], 'web'),
+    ).rejects.toThrow('validWhenTargetExists');
+
+    const duplicate = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Another confirm button }
+`);
+    await expect(
+      loadExtraActions([duplicate], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'action name "Click the confirm button" conflicts with another action',
+    );
+  });
+
+  it('rejects unknown manifest fields before planning', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+unexpected: true
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('Unrecognized key');
+  });
+
+  it('rejects display names that can break the planning protocol', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: <malicious-action>
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('must not contain angle brackets');
+  });
+
+  it('deduplicates condition targets in one batch probe', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the primary confirm button
+    validWhenTargetExists: &confirm
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Primary confirm button }
+  - name: Click the secondary confirm button
+    validWhenTargetExists: *confirm
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Secondary confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(async () => [true]);
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledWith(
+      [{ strategy: 'xpath', selector: '//button[@id="confirm"]' }],
+      {},
+    );
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_2',
+    ]);
+  });
+
+  it('rejects malformed batch probe results', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+
+    await expect(
+      createExtraActionSnapshot(loaded, {
+        probeLocatorTargets: vi.fn(async () => ['yes'] as any),
+      }),
+    ).rejects.toThrow('must return only boolean results');
+  });
+
+  it('aborts condition probing without returning a partial snapshot', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    controller.abort(new Error('test abort'));
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets: vi.fn(async () => [true]) },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('test abort');
+  });
+
+  it('discards probe results when cancellation happens during the batch', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    const probeLocatorTargets = vi.fn(async () => {
+      controller.abort(new Error('cancelled during probe'));
+      return [true];
+    });
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('cancelled during probe');
+    expect(probeLocatorTargets).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -27,6 +27,7 @@ describe('html-utils', () => {
   it('generates a compact agent analysis comment for report HTML', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'checkout -- flow',
       modelBriefs: [
         {
@@ -63,6 +64,7 @@ describe('html-utils', () => {
   it('falls back agent comment model info to task usage', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage model report',
       modelBriefs: [],
       executions: [
@@ -96,6 +98,7 @@ describe('html-utils', () => {
   it('keeps agent analysis comments optional for incomplete execution dumps', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'incomplete report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/merge-browser-parse.test.ts
+++ b/packages/core/tests/unit-test/merge-browser-parse.test.ts
@@ -47,6 +47,7 @@ function createDump(screenshots: ScreenshotItem[]): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName: 'test-group',
     groupDescription: 'test desc',
     modelBriefs: [{ name: 'test-model' }],
@@ -88,6 +89,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,
@@ -130,6 +132,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
       const dump = createDump(screenshots);
       const groupMeta: ReportMeta = {
         sdkVersion: dump.sdkVersion,
+        manifestInterface: dump.manifestInterface,
         groupName: dump.groupName,
         groupDescription: dump.groupDescription,
         modelBriefs: dump.modelBriefs,
@@ -213,6 +216,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -259,6 +259,7 @@ describe('action space', () => {
     const prompt = await systemPromptToTaskPlanning({
       actionSpace: [...mockActionSpace, extraAction],
       includeLocateInPlanning: false,
+      hasExtraActions: true,
     });
 
     expect(prompt).toContain(

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -67,6 +67,7 @@ function createExecution(
 function createActionExecution(options?: {
   xpath?: string;
   includeFailedAction?: boolean;
+  extraActionName?: string;
 }): ExecutionDump {
   const locateHitBy = options?.xpath
     ? {
@@ -74,7 +75,7 @@ function createActionExecution(options?: {
         context: {
           locatedPixelBbox: [10, 20, 110, 70],
           cacheToSave: {
-            xpaths: [options.xpath],
+            targets: [{ strategy: 'xpath', selector: options.xpath }],
           },
         },
       }
@@ -93,7 +94,12 @@ function createActionExecution(options?: {
       param: {},
       output: {
         log: 'Click the confirm button',
-        actions: [],
+        actions: [
+          {
+            type: 'Tap',
+            thought: 'Click the confirm button',
+          },
+        ],
       },
       executor: async () => undefined,
       status: 'finished',
@@ -121,6 +127,17 @@ function createActionExecution(options?: {
           center: [60, 45],
         },
       },
+      ...(options?.extraActionName
+        ? {
+            hitBy: {
+              from: 'Extra Action',
+              context: {
+                extraActionName: options.extraActionName,
+                extraActionAlias: 'MidsceneExtraAction_1',
+              },
+            },
+          }
+        : {}),
       executor: async () => undefined,
       status: 'finished',
     },
@@ -131,7 +148,12 @@ function createActionExecution(options?: {
       param: {},
       output: {
         log: 'Type the saved value',
-        actions: [],
+        actions: [
+          {
+            type: 'Input',
+            thought: 'Type the saved value',
+          },
+        ],
       },
       executor: async () => undefined,
       status: 'finished',
@@ -199,11 +221,13 @@ describe('createReportCliCommands', () => {
     expect(commands.every((command) => !('aliases' in command))).toBe(true);
   });
 
-  it('exports one loadable UI Action file per successful device operation', async () => {
+  it('exports successful device operations into one loadable Action Manifest', async () => {
     const reportPath = join(tmpDir, 'action-report.html');
     const report = new ReportActionDump({
       groupName: 'action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [
         createActionExecution({
@@ -223,24 +247,41 @@ describe('createReportCliCommands', () => {
     const result = analyzeReportActions({ htmlPath: reportPath });
 
     expect(result.actionFiles.map((file) => file.split('/').pop())).toEqual([
-      '001-tap.yaml',
-      '002-input.yaml',
+      'action-report.actions.yaml',
     ]);
+    expect(result.actionCount).toBe(2);
     expect(result.coordinateFallbackFiles).toEqual([]);
     expect(yaml.load(readFileSync(result.actionFiles[0], 'utf-8'))).toEqual({
-      name: 'Click the confirm button',
-      actionName: 'Tap',
-      actionParam: [
+      version: 1,
+      interface: 'web',
+      actions: [
         {
-          prompt: 'Confirm button',
-          xpath: '/html/body/button[1]',
+          name: 'Click the confirm button',
+          validWhenTargetExists: {
+            strategy: 'xpath',
+            selector: '/html/body/button[1]',
+          },
+          action: {
+            name: 'Tap',
+            param: {
+              locate: {
+                prompt: 'Confirm button',
+                target: {
+                  strategy: 'xpath',
+                  selector: '/html/body/button[1]',
+                },
+              },
+            },
+          },
+        },
+        {
+          name: 'Type the saved value',
+          action: {
+            name: 'Input',
+            param: { value: 'saved value' },
+          },
         },
       ],
-    });
-    expect(yaml.load(readFileSync(result.actionFiles[1], 'utf-8'))).toEqual({
-      name: 'Type the saved value',
-      actionName: 'Input',
-      actionParam: [{ value: 'saved value' }],
     });
 
     const loaded = await loadExtraActions(result.actionFiles, [
@@ -267,7 +308,10 @@ describe('createReportCliCommands', () => {
         param: {
           locate: {
             prompt: 'Confirm button',
-            xpath: '/html/body/button[1]',
+            target: {
+              strategy: 'xpath',
+              selector: '/html/body/button[1]',
+            },
           },
         },
       }),
@@ -278,11 +322,488 @@ describe('createReportCliCommands', () => {
     ]);
   });
 
+  it('requires a canonical manifest interface instead of inferring one from deviceType', () => {
+    const reportPath = join(tmpDir, 'missing-manifest-interface.html');
+    const report = new ReportActionDump({
+      groupName: 'missing-manifest-interface',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'puppeteer',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button' })],
+    });
+    const reportWithoutManifestInterface = {
+      ...JSON.parse(report.serialize()),
+      manifestInterface: undefined,
+    };
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(JSON.stringify(reportWithoutManifestInterface), {
+        'data-group-id': 'missing-manifest-interface',
+      }),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'manifestInterface must be a non-empty string',
+    );
+  });
+
+  it('rejects reports that combine executions from different manifest interfaces', () => {
+    const reportPath = join(tmpDir, 'mixed-manifest-interfaces.html');
+    const webReport = new ReportActionDump({
+      groupName: 'web-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="web"]' })],
+    });
+    const androidReport = new ReportActionDump({
+      groupName: 'android-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'android',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="android"]' })],
+    });
+    writeFileSync(
+      reportPath,
+      [
+        generateDumpScriptTag(webReport.serialize(), {
+          'data-group-id': 'web-actions',
+        }),
+        generateDumpScriptTag(androidReport.serialize(), {
+          'data-group-id': 'android-actions',
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'received ["web","android"]',
+    );
+  });
+
+  it('does not pair a failed locate from an earlier plan with a recovered action', () => {
+    const reportPath = join(tmpDir, 'recovered-locate.html');
+    const execution = new ExecutionDump({
+      id: 'recovered-locate',
+      logTime: Date.now(),
+      name: 'recovered locate',
+      tasks: [
+        {
+          taskId: 'wrong-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Try the wrong button',
+            actions: [{ type: 'Tap', thought: 'Try the wrong button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'wrong-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Wrong button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="wrong"]',
+            },
+          },
+          status: 'failed',
+        },
+        {
+          taskId: 'recovery-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Click the correct button',
+            actions: [{ type: 'Tap', thought: 'Click the correct button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Correct button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Correct button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'recovered-locate',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'recovered-locate',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions).toHaveLength(1);
+    expect(manifest.actions[0]).toMatchObject({
+      name: 'Click the correct button',
+      validWhenTargetExists: {
+        strategy: 'xpath',
+        selector: '//button[@id="correct"]',
+      },
+      action: {
+        param: {
+          locate: {
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('exports the fallback target after a supplied target fails to resolve', () => {
+    const reportPath = join(tmpDir, 'target-fallback.html');
+    const failedTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="missing"]',
+    };
+    const fallbackTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="actual"]',
+    };
+    const execution = new ExecutionDump({
+      id: 'target-fallback',
+      logTime: Date.now(),
+      name: 'target fallback',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [
+              { type: 'Tap', thought: 'Click the actual fallback button' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Actual fallback button',
+            target: failedTarget,
+          },
+          hitBy: {
+            from: 'AI',
+            context: {
+              target: failedTarget,
+              targetResolutionError: 'XPath target does not exist',
+              cacheToSave: { targets: [fallbackTarget] },
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Actual fallback button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'target-fallback',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'target-fallback',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: fallbackTarget,
+      action: {
+        param: {
+          locate: {
+            target: fallbackTarget,
+          },
+        },
+      },
+    });
+  });
+
+  it('uses each planned action thought when one plan contains multiple actions', () => {
+    const reportPath = join(tmpDir, 'multi-action-plan.html');
+    const locatedElement = (description: string) => ({
+      description,
+      rect: { left: 10, top: 20, width: 100, height: 50 },
+      center: [60, 45],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-action-plan',
+      logTime: Date.now(),
+      name: 'multi action plan',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Complete both operations',
+            actions: [
+              { type: 'Tap', thought: 'Click the primary button' },
+              { type: 'Input', thought: 'Enter the saved value' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-primary',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Primary button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="primary"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'tap-primary',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: { locate: locatedElement('Primary button') },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-input',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Saved value input',
+            target: {
+              strategy: 'xpath',
+              selector: '//input[@id="saved"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'input-value',
+          type: 'Action Space',
+          subType: 'Input',
+          param: {
+            value: 'saved value',
+            locate: locatedElement('Saved value input'),
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-action-plan',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-action-plan',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions.map((action: any) => action.name)).toEqual([
+      'Click the primary button',
+      'Enter the saved value',
+    ]);
+  });
+
+  it('uses the first of multiple action targets as the disclosure condition', () => {
+    const reportPath = join(tmpDir, 'multi-target-swipe.html');
+    const startTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-handle"]',
+    };
+    const endTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-end"]',
+    };
+    const locatedElement = (description: string, left: number) => ({
+      description,
+      rect: { left, top: 20, width: 20, height: 20 },
+      center: [left + 10, 30],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-target-swipe',
+      logTime: Date.now(),
+      name: 'multi target swipe',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [{ type: 'Swipe', thought: 'Move the slider to the end' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-start',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider handle', target: startTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-end',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider end', target: endTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'swipe',
+          type: 'Action Space',
+          subType: 'Swipe',
+          param: {
+            start: locatedElement('Slider handle', 10),
+            end: locatedElement('Slider end', 200),
+            duration: 300,
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-target-swipe',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-target-swipe',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: startTarget,
+      action: {
+        name: 'Swipe',
+        param: {
+          start: { target: startTarget },
+          end: { target: endTarget },
+          duration: 300,
+        },
+      },
+    });
+  });
+
+  it('preserves the recorded Extra Action name when exporting a replay report', () => {
+    const reportPath = join(tmpDir, 'replayed-extra-action.html');
+    const report = new ReportActionDump({
+      groupName: 'replayed-extra-action',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [
+        createActionExecution({
+          xpath: '//button',
+          extraActionName: 'Recorded checkout confirmation',
+        }),
+      ],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'replayed-extra-action',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0].name).toBe('Recorded checkout confirmation');
+  });
+
   it('falls back to locatedPixelBbox for reports without a recorded xpath', () => {
     const reportPath = join(tmpDir, 'historical-report.html');
     const report = new ReportActionDump({
       groupName: 'historical-action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createActionExecution()],
     });
@@ -295,12 +816,13 @@ describe('createReportCliCommands', () => {
     );
 
     const result = analyzeReportActions({ htmlPath: reportPath });
-    const firstAction = yaml.load(
+    const manifest = yaml.load(
       readFileSync(result.actionFiles[0], 'utf-8'),
     ) as any;
 
     expect(result.coordinateFallbackFiles).toEqual([result.actionFiles[0]]);
-    expect(firstAction.actionParam[0]).toEqual({
+    expect(result.coordinateFallbackActionCount).toBe(1);
+    expect(manifest.actions[0].action.param.locate).toEqual({
       prompt: 'Confirm button',
       locatedPixelBbox: [10, 20, 110, 70],
     });
@@ -311,6 +833,8 @@ describe('createReportCliCommands', () => {
     const report = new ReportActionDump({
       groupName: 'overwrite-action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createActionExecution({ xpath: '//button' })],
     });
@@ -342,6 +866,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -349,6 +874,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -393,6 +919,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-test',
       groupDescription: 'sdk split test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-1', screenshot)],
     });
@@ -456,6 +983,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-markdown-test',
       groupDescription: 'sdk markdown test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-md-1', screenshot)],
     });
@@ -528,6 +1056,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-dir-test',
       groupDescription: 'split-dir-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-dir-1', screenshot)],
     });
@@ -592,6 +1121,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-1', screenshot1)],
     });
@@ -599,6 +1129,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-2', screenshot2)],
     });
@@ -642,6 +1173,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', oldScreenshot)],
     });
@@ -649,6 +1181,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', newScreenshot)],
     });
@@ -699,6 +1232,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-file-test',
       groupDescription: 'markdown export file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-file', screenshotRef)],
     });
@@ -761,6 +1295,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-rel-file-test',
       groupDescription: 'markdown export relative file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-rel', screenshotRef)],
     });
@@ -811,6 +1346,7 @@ describe('createReportCliCommands', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution(executionId, screenshot)],
     });

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -40,6 +40,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 

--- a/packages/core/tests/unit-test/report-issues.test.ts
+++ b/packages/core/tests/unit-test/report-issues.test.ts
@@ -64,6 +64,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 
@@ -98,6 +99,7 @@ describe('Issue 2: default groupName causes unrelated reports to merge', () => {
     const sameReportMeta: ReportMeta = {
       groupName: 'Midscene Report', // default groupName
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 
@@ -146,6 +148,7 @@ describe('Issue 3: execution persistence requires id', () => {
     const groupMeta: ReportMeta = {
       groupName: 'dedup-test',
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -88,6 +88,7 @@ describe('report-markdown', () => {
   it('merges all executions into one markdown and keeps file snapshot', async () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'report-group',
       modelBriefs: [],
       executions: [
@@ -249,6 +250,7 @@ describe('report-markdown', () => {
   it('includes model metadata, token usage, and task context for agent analysis', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'agent-ready-report',
       modelBriefs: [
         {
@@ -331,6 +333,7 @@ describe('report-markdown', () => {
   it('falls back report model info to task usage when model briefs are missing', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage-model-report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/report-merge-count.test.ts
+++ b/packages/core/tests/unit-test/report-merge-count.test.ts
@@ -42,6 +42,7 @@ async function writeAndFinalize(
     groupName: dump.groupName,
     groupDescription: dump.groupDescription,
     sdkVersion: dump.sdkVersion,
+    manifestInterface: dump.manifestInterface,
     modelBriefs: dump.modelBriefs,
     deviceType: dump.deviceType,
   };
@@ -69,6 +70,7 @@ function createDump(groupName: string, taskCount: number): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName,
     groupDescription: `desc of ${groupName}`,
     modelBriefs: [{ name: 'test-model' }],
@@ -404,6 +406,7 @@ describe('ReportMergingTool merged dump count verification', () => {
       const groupMeta: ReportMeta = {
         groupName: `multi-group-${i}`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [{ name: 'test-model' }],
       };
       for (let e = 0; e < execsPerReport; e++) {

--- a/packages/core/tests/unit-test/report-merge-status.test.ts
+++ b/packages/core/tests/unit-test/report-merge-status.test.ts
@@ -109,6 +109,7 @@ describe('mergeReportFiles status derivation', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [execution],
     });
@@ -186,6 +187,7 @@ describe('mergeReportFiles status derivation', () => {
         groupName,
         groupDescription: `${groupName}-desc`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [exec],
       });

--- a/packages/core/tests/unit-test/report-split.test.ts
+++ b/packages/core/tests/unit-test/report-split.test.ts
@@ -77,6 +77,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -84,6 +85,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -144,6 +146,7 @@ describe('splitReportHtmlByExecution', () => {
         groupName: 'large-split-test',
         groupDescription: 'large-split-test',
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [createExecution(`exec-${i}`, sharedScreenshot)],
       });
@@ -174,6 +177,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', oldScreenshot)],
     });
@@ -181,6 +185,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', newScreenshot)],
     });
@@ -234,6 +239,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'absolute-path-test',
       groupDescription: 'absolute-path-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshotRef)],
     });
@@ -280,6 +286,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'fallback-test',
       groupDescription: 'fallback-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-fallback', screenshotRef)],
     });

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -1,3 +1,4 @@
+import { setExtraActionSource } from '@/agent/extra-actions';
 import { TaskBuilder, locatePlanForLocate } from '@/agent/task-builder';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
@@ -66,6 +67,246 @@ describe('TaskBuilder', () => {
       deepLocate: true,
     });
     expect(plan.param).not.toHaveProperty('deepThink');
+  });
+
+  it('normalizes the legacy xpath alias into a target', () => {
+    const plan = locatePlanForLocate({
+      prompt: 'confirm button',
+      xpath: '//button[@id="confirm"]',
+    });
+
+    expect(plan.param).toEqual({
+      prompt: 'confirm button',
+      target: {
+        strategy: 'xpath',
+        selector: '//button[@id="confirm"]',
+      },
+    });
+    expect(() =>
+      locatePlanForLocate({
+        prompt: 'confirm button',
+        xpath: '//button',
+        target: { strategy: 'xpath', selector: '//button' },
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
+  });
+
+  it('resolves a target before AI locate and reports the Extra Action source', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 40,
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate: vi.fn(),
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const extraActionPlan: PlanningAction = {
+      type: 'Tap',
+      param: {
+        locate: {
+          prompt: 'confirm button',
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+        },
+      },
+    };
+    setExtraActionSource(extraActionPlan, {
+      type: 'extra-action',
+      name: 'Click the confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: '/tmp/example.actions.yaml',
+    });
+    const { tasks } = await taskBuilder.build(
+      [extraActionPlan],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+
+    expect(insightService.locate).not.toHaveBeenCalled();
+    expect(locateResult).toMatchObject({
+      output: {
+        element: {
+          center: [59, 39],
+          rect: { left: 10, top: 20, width: 100, height: 40 },
+        },
+      },
+      hitBy: {
+        from: 'Extra Action target',
+        context: {
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+
+    const actionResult = await tasks[1].executor(tasks[1].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+    expect(actionResult).toMatchObject({
+      hitBy: {
+        from: 'Extra Action',
+        context: {
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution fails', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => {
+      throw new Error('target is stale');
+    });
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate,
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          target: { strategy: 'xpath', selector: '//button' },
+          targetResolutionError: 'target is stale',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution returns an invalid rect', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 0,
+      height: 40,
+    }));
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30] as [number, number],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: { contextRetrieverFn: vi.fn(), locate } as unknown as Service,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          targetResolutionError: expect.stringContaining(
+            'Invalid locate result rect size',
+          ),
+        },
+      },
+    });
   });
 
   it('dispatches plans using handler registry', async () => {

--- a/packages/core/tests/unit-test/task-cache-poisoning.test.ts
+++ b/packages/core/tests/unit-test/task-cache-poisoning.test.ts
@@ -20,7 +20,9 @@ function seedStaleLocate(taskCache: TaskCache, prompt: string, xpath: string) {
   internal.cache.caches.push({
     type: 'locate',
     prompt,
-    cache: { xpaths: [xpath] },
+    cache: {
+      targets: [{ strategy: 'xpath', selector: xpath }],
+    },
   });
   internal.cacheOriginalLength = internal.cache.caches.length;
 }
@@ -36,7 +38,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     // First locate consumes the stale entry (cache hit on the wrong element).
     const matched = cache.matchLocateCache('click submit');
     expect(matched).toBeDefined();
-    expect(matched?.cacheContent.cache?.xpaths).toEqual(['wrong/xpath']);
+    expect(matched?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'wrong/xpath' },
+    ]);
 
     // The action using that element failed -> the replan loop marks it stale.
     cache.markLocateCacheStale('click submit');
@@ -50,19 +54,23 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'correct/xpath' },
+    ]);
   });
 
   it('appends (does not replace) a consumed entry that was never marked stale', () => {
     // Without a stale mark, a re-locate after a consumed hit must append, not
-    // overwrite — the prior hit may have been correct.
+    // overwrite because the prior hit may have been correct.
     const cache = new TaskCache(uuid(), true);
     seedStaleLocate(cache, 'click submit', 'first/xpath');
 
@@ -73,15 +81,21 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['second/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'second/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['first/xpath']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['second/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'first/xpath' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'second/xpath' },
+    ]);
   });
 
   it('appends a new entry when nothing was consumed for the prompt', () => {
@@ -91,14 +105,18 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'fresh prompt',
-        cache: { xpaths: ['some/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'some/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['some/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'some/xpath' },
+    ]);
   });
 
   it('does not cross-replace entries for different prompts', () => {
@@ -115,7 +133,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click cancel',
-        cache: { xpaths: ['cancel/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'cancel/xpath' }],
+        },
       },
       undefined,
     );
@@ -123,7 +143,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
     expect(internal.cache.caches[0].prompt).toBe('click submit');
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['wrong/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'wrong/xpath' },
+    ]);
     expect(internal.cache.caches[1].prompt).toBe('click cancel');
   });
 
@@ -133,18 +155,30 @@ describe('locate cache poisoning regression (#2529)', () => {
     const cache = new TaskCache(uuid(), true);
 
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/1' }] },
+      },
       undefined,
     );
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/2' }] },
+      },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/1' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/2' },
+    ]);
   });
 
   it('appends instead of overwriting when the same prompt overflows without failure', () => {
@@ -154,30 +188,48 @@ describe('locate cache poisoning regression (#2529)', () => {
     const cache = new TaskCache(uuid(), true);
     const internal = getTaskCacheInternal(cache);
     internal.cache.caches.push(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/1' }] },
+      },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/2' }] },
+      },
     );
     internal.cacheOriginalLength = 2;
 
     // Three occurrences in one run: the first two hit, the third misses.
     expect(
-      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
-    ).toEqual(['row/1']);
+      cache.matchLocateCache('row action')?.cacheContent.cache?.targets,
+    ).toEqual([{ strategy: 'xpath', selector: 'row/1' }]);
     expect(
-      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
-    ).toEqual(['row/2']);
+      cache.matchLocateCache('row action')?.cacheContent.cache?.targets,
+    ).toEqual([{ strategy: 'xpath', selector: 'row/2' }]);
     expect(cache.matchLocateCache('row action')).toBeUndefined();
 
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/3'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/3' }] },
+      },
       undefined,
     );
 
     // Both original entries are preserved; the third occurrence is appended.
     expect(internal.cache.caches).toHaveLength(3);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
-    expect(internal.cache.caches[2].cache?.xpaths).toEqual(['row/3']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/1' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/2' },
+    ]);
+    expect(internal.cache.caches[2].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/3' },
+    ]);
   });
 
   it('markLocateCacheStale is a no-op when nothing was consumed', () => {
@@ -191,7 +243,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
@@ -213,7 +267,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
@@ -221,7 +277,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     const internal = getTaskCacheInternal(cache);
     // In-memory entry is replaced in place...
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'correct/xpath' },
+    ]);
     // ...but nothing is written to disk in read-only mode.
     expect(existsSync(filePath)).toBe(false);
   });

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -237,7 +237,7 @@ describe('utils', () => {
       await new Promise((resolve) => setTimeout(resolve, 5000));
 
       // We expect the file to be approximately 700MB plus template overhead
-      const expectedMinSize = 1000; // 10 reports × 100MB
+      const expectedMinSize = 1000; // 10 reports x 100MB
       expect(fileSizeInMB).toBeGreaterThan(expectedMinSize);
     },
   );
@@ -308,6 +308,23 @@ describe('buildDetailedLocateParam', () => {
       cacheable: false,
       xpath: undefined,
     });
+  });
+
+  it('accepts target and rejects target with the legacy xpath alias', () => {
+    const target = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="confirm"]',
+    };
+
+    expect(
+      buildDetailedLocateParam('Click the confirm button', { target }),
+    ).toMatchObject({ target });
+    expect(() =>
+      buildDetailedLocateParam('Click the confirm button', {
+        target,
+        xpath: '//button[@id="confirm"]',
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
   });
 });
 
@@ -441,7 +458,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     <h1>Bug Case</h1>
   </body>
   <script>
-    { "hello": "你好", "world": "世界" }
+    { "hello": "hello", "world": "world" }
   </script>
 </html>`;
     const filePath = createTempHtmlFile(html);
@@ -464,7 +481,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     //       <h1>Bug Case</h1>
     //     </body>
     //     <script>
-    //       { "hello": "你好", "world": "世界" }
+    //       { "hello": "hello", "world": "world" }
     // -   </script>
     // - <script>large</script>
     // +   </scri<script>large</script>

--- a/packages/shared/src/extractor/index.ts
+++ b/packages/shared/src/extractor/index.ts
@@ -38,6 +38,7 @@ export { extractTreeNodeAsString as webExtractNodeTreeAsString } from './web-ext
 export {
   getXpathsByPoint,
   getXpathsById,
+  getNodeCountByXpath,
   getNodeInfoByXpath,
   getElementInfoByXpath,
   getElementXpath,

--- a/packages/shared/src/extractor/locator.ts
+++ b/packages/shared/src/extractor/locator.ts
@@ -427,6 +427,54 @@ export function getNodeInfoByXpath(xpath: string): Node | null {
   return node;
 }
 
+/**
+ * Count matches without scrolling or otherwise changing page state. Composite
+ * iframe XPaths require each intermediate iframe segment to resolve uniquely;
+ * the final segment may match any number of nodes.
+ */
+export function getNodeCountByXpath(xpath: string): number {
+  const parts = xpath
+    .split(SUB_XPATH_SEPARATOR)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return 0;
+
+  let currentDocument: Document =
+    typeof document !== 'undefined' ? document : (undefined as any);
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const xpathResult = currentDocument.evaluate(
+      parts[index],
+      currentDocument,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null,
+    );
+    if (index === parts.length - 1) {
+      return xpathResult.snapshotLength;
+    }
+    if (xpathResult.snapshotLength !== 1) return 0;
+
+    const node = xpathResult.snapshotItem(0);
+    if (
+      !node ||
+      node.nodeType !== Node.ELEMENT_NODE ||
+      (node as Element).tagName.toLowerCase() !== 'iframe'
+    ) {
+      return 0;
+    }
+    try {
+      const contentDocument = (node as HTMLIFrameElement).contentDocument;
+      if (!contentDocument) return 0;
+      currentDocument = contentDocument;
+    } catch {
+      return 0;
+    }
+  }
+
+  return 0;
+}
+
 export function getElementInfoByXpath(xpath: string): ElementInfo | null {
   const node = getNodeInfoByXpath(xpath);
   if (!node) return null;

--- a/packages/shared/tests/unit-test/iife-bundle.test.ts
+++ b/packages/shared/tests/unit-test/iife-bundle.test.ts
@@ -16,6 +16,7 @@ interface GlobalWithMidscene {
     isNotContainerElement: unknown;
     getElementXpath: unknown;
     getElementInfoByXpath: unknown;
+    getNodeCountByXpath: unknown;
     descriptionOfTree: unknown;
     getXpathsByPoint: unknown;
     truncateText: unknown;
@@ -92,6 +93,8 @@ describe('IIFE bundle runtime behavior', () => {
         'getElementXpath',
         // Used by Puppeteer and Chrome Extension cache lookup flows.
         'getElementInfoByXpath',
+        // Used by Extra Action disclosure to batch-check target existence.
+        'getNodeCountByXpath',
         // Not found in runtime calls; suspected removable from the IIFE surface.
         'descriptionOfTree',
         // Used by Puppeteer and Chrome Extension cache lookup flows.

--- a/packages/shared/tests/unit-test/locator.test.ts
+++ b/packages/shared/tests/unit-test/locator.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getElementInfoByXpath,
+  getNodeCountByXpath,
   getNodeInfoByXpath,
   getXpathsByPoint,
 } from '../../src/extractor/locator';
@@ -303,6 +304,59 @@ describe('locator', () => {
 
       // Restore original mock
       global.document.evaluate = originalEvaluate;
+    });
+  });
+
+  describe('getNodeCountByXpath', () => {
+    it('returns every match without requiring a unique final node', () => {
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 3,
+            snapshotItem: () => null,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('//button')).toBe(3);
+    });
+
+    it('counts matches inside a uniquely resolved iframe', () => {
+      const frameDocument = {
+        evaluate: vi.fn(
+          () =>
+            ({
+              snapshotLength: 2,
+              snapshotItem: () => null,
+            }) as unknown as XPathResult,
+        ),
+      } as unknown as Document;
+      const iframe = {
+        nodeType: Node.ELEMENT_NODE,
+        tagName: 'IFRAME',
+        contentDocument: frameDocument,
+      } as unknown as HTMLIFrameElement;
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 1,
+            snapshotItem: () => iframe,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('/html/body/iframe[1]|>>|//button')).toBe(2);
+      expect(frameDocument.evaluate).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an ambiguous intermediate iframe without probing children', () => {
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 2,
+            snapshotItem: () => null,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('/html/body/iframe|>>|//button')).toBe(0);
     });
   });
 

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -122,6 +122,10 @@ export const getBridgePageInCliSide = (options?: {
         return BridgePageType;
       }
 
+      if (prop === 'manifestInterface') {
+        return () => 'web';
+      }
+
       if (prop === 'actionSpace') {
         return () => commonWebActionsForWebPage(proxyPage);
       }
@@ -168,6 +172,18 @@ export const getBridgePageInCliSide = (options?: {
               return fileChooserError;
             },
           };
+        };
+      }
+
+      if (prop === 'probeLocatorTargets') {
+        return async (
+          targets: unknown[],
+          options?: { signal?: AbortSignal },
+        ) => {
+          options?.signal?.throwIfAborted();
+          const result = await bridgeCaller(prop)(targets);
+          options?.signal?.throwIfAborted();
+          return result;
         };
       }
 

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -9,6 +9,7 @@ import { limitOpenNewTabScript } from '@/web-element';
 import type {
   ElementCacheFeature,
   ElementTreeNode,
+  LocatorTarget,
   Point,
   Rect,
   Size,
@@ -30,7 +31,9 @@ import {
   type WebElementCacheFeature,
   buildRectFromElementInfo,
   judgeOrderSensitive,
+  sanitizeLocatorTargets,
   sanitizeXpaths,
+  targetsFromXpaths,
 } from '../common/cache-helper';
 import {
   type KeyInput,
@@ -156,6 +159,10 @@ function serializeError(error: Error): {
 
 export default class ChromeExtensionProxyPage implements AbstractInterface {
   interfaceType = 'chrome-extension-proxy';
+
+  manifestInterface() {
+    return 'web';
+  }
 
   public forceSameTabNavigation: boolean;
 
@@ -742,29 +749,68 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     try {
       const isOrderSensitive = await judgeOrderSensitive(options, debug);
       const xpaths = await this.getXpathsByPoint(point, isOrderSensitive);
-      return { xpaths: sanitizeXpaths(xpaths) };
+      return { targets: targetsFromXpaths(xpaths) };
     } catch (error) {
       debug('cacheFeatureForPoint failed: %O', error);
-      return { xpaths: [] };
+      return { targets: [] };
     }
   }
 
-  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
-    const xpaths = sanitizeXpaths((feature as WebElementCacheFeature).xpaths);
+  async probeLocatorTargets(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]> {
+    options?.signal?.throwIfAborted();
+    const selectors = targets.map((target) => {
+      if (target.strategy !== 'xpath') {
+        throw new Error(
+          `Unsupported locator target strategy: ${target.strategy}`,
+        );
+      }
+      return target.selector;
+    });
+    const script = await getHtmlElementScript();
+    await this.sendCommandToDebugger('Runtime.evaluate', {
+      expression: script,
+    });
+    const result = await this.sendCommandToDebugger('Runtime.evaluate', {
+      expression: `${JSON.stringify(selectors)}.map((xpath) => window.midscene_element_inspector.getNodeCountByXpath(xpath) > 0)`,
+      returnByValue: true,
+    });
+    options?.signal?.throwIfAborted();
+    return result.result.value;
+  }
 
-    for (const xpath of xpaths) {
+  async resolveLocatorTarget(target: LocatorTarget): Promise<Rect> {
+    if (target.strategy !== 'xpath') {
+      throw new Error(
+        `Unsupported locator target strategy: ${target.strategy}`,
+      );
+    }
+    const elementInfo = await this.getElementInfoByXpath(target.selector);
+    if (!elementInfo?.rect) {
+      throw new Error(`XPath target does not exist: ${target.selector}`);
+    }
+    return buildRectFromElementInfo(elementInfo);
+  }
+
+  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
+    const targets = sanitizeLocatorTargets(feature as WebElementCacheFeature);
+
+    for (const target of targets) {
       try {
-        const elementInfo = await this.getElementInfoByXpath(xpath);
-        if (elementInfo?.rect) {
-          return buildRectFromElementInfo(elementInfo);
-        }
+        return await this.resolveLocatorTarget(target);
       } catch (error) {
-        debug('rectMatchesCacheFeature failed for xpath %s: %O', xpath, error);
+        debug(
+          'rectMatchesCacheFeature failed for target %o: %O',
+          target,
+          error,
+        );
       }
     }
 
     throw new Error(
-      `No matching element rect found for cache feature (tried ${xpaths.length} xpath(s))`,
+      `No matching element rect found for cache feature (tried ${targets.length} target(s))`,
     );
   }
 

--- a/packages/web-integration/src/common/cache-helper.ts
+++ b/packages/web-integration/src/common/cache-helper.ts
@@ -1,10 +1,17 @@
-import type { ElementCacheFeature, Point, Rect } from '@midscene/core';
+import type {
+  ElementCacheFeature,
+  LocatorTarget,
+  Point,
+  Rect,
+} from '@midscene/core';
 import { AiJudgeOrderSensitive } from '@midscene/core/ai-model';
 import type { ModelRuntime } from '@midscene/core/ai-model';
 import type { DebugFunction } from '@midscene/shared/logger';
 
 // Shared type for web element cache feature
 export type WebElementCacheFeature = ElementCacheFeature & {
+  targets?: LocatorTarget[];
+  /** @deprecated Read-only compatibility with caches written before target. */
   xpaths?: string[];
 };
 
@@ -17,6 +24,27 @@ export const sanitizeXpaths = (xpaths: unknown): string[] => {
   return xpaths.filter(
     (xpath): xpath is string => typeof xpath === 'string' && xpath.length > 0,
   );
+};
+
+export const targetsFromXpaths = (xpaths: unknown): LocatorTarget[] =>
+  sanitizeXpaths(xpaths).map((selector) => ({
+    strategy: 'xpath',
+    selector,
+  }));
+
+export const sanitizeLocatorTargets = (
+  feature: WebElementCacheFeature,
+): LocatorTarget[] => {
+  if (Array.isArray(feature.targets)) {
+    const targets = feature.targets.filter(
+      (target): target is LocatorTarget =>
+        target?.strategy === 'xpath' &&
+        typeof target.selector === 'string' &&
+        target.selector.length > 0,
+    );
+    if (targets.length > 0) return targets;
+  }
+  return targetsFromXpaths(feature.xpaths);
 };
 
 // Cache feature extraction options interface
@@ -54,11 +82,23 @@ export async function judgeOrderSensitive(
 export function buildRectFromElementInfo(elementInfo: {
   rect: { left: number; top: number; width: number; height: number };
 }): Rect {
+  const { left, top, width, height } = elementInfo.rect;
+  if (
+    [left, top, width, height].some(
+      (value) => typeof value !== 'number' || !Number.isFinite(value),
+    ) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(
+      `Element info contains an invalid rect: ${JSON.stringify(elementInfo.rect)}`,
+    );
+  }
   const matchedRect: Rect = {
-    left: elementInfo.rect.left,
-    top: elementInfo.rect.top,
-    width: elementInfo.rect.width,
-    height: elementInfo.rect.height,
+    left,
+    top,
+    width,
+    height,
   };
   return matchedRect;
 }

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -4,6 +4,7 @@ import type {
   DeviceAction,
   ElementCacheFeature,
   ElementTreeNode,
+  LocatorTarget,
   Point,
   Rect,
   Size,
@@ -40,7 +41,9 @@ import {
   type WebElementCacheFeature,
   buildRectFromElementInfo,
   judgeOrderSensitive,
+  sanitizeLocatorTargets,
   sanitizeXpaths,
+  targetsFromXpaths,
 } from '../common/cache-helper';
 import {
   type KeyInput,
@@ -225,6 +228,10 @@ export class Page<
   private visualUpdateFollowupTimer?: ReturnType<typeof setTimeout>;
   interfaceType: AgentType;
 
+  manifestInterface() {
+    return 'web';
+  }
+
   actionSpace(): DeviceAction[] {
     const defaultActions = commonWebActionsForWebPage(
       this,
@@ -390,43 +397,65 @@ export class Page<
       if (!sanitized.length) {
         debugPage('cacheFeatureForPoint: no xpath found at point %o', center);
       }
-      return { xpaths: sanitized };
+      return { targets: targetsFromXpaths(sanitized) };
     } catch (error) {
       debugPage('cacheFeatureForPoint failed: %s', error);
-      return { xpaths: [] };
+      return { targets: [] };
     }
   }
 
-  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
-    const xpaths = sanitizeXpaths((feature as WebElementCacheFeature).xpaths);
-    debugPage('rectMatchesCacheFeature: trying %d xpath(s)', xpaths.length);
-
-    for (const xpath of xpaths) {
-      try {
-        debugPage('rectMatchesCacheFeature: evaluating xpath: %s', xpath);
-        const elementInfo = await this.getElementInfoByXpath(xpath);
-        if (elementInfo?.rect) {
-          debugPage(
-            'rectMatchesCacheFeature: found element, rect: %o',
-            elementInfo.rect,
-          );
-          return buildRectFromElementInfo(elementInfo);
-        }
-        debugPage(
-          'rectMatchesCacheFeature: element found but no rect (elementInfo: %o)',
-          elementInfo,
+  async probeLocatorTargets(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]> {
+    options?.signal?.throwIfAborted();
+    const selectors = targets.map((target) => {
+      if (target.strategy !== 'xpath') {
+        throw new Error(
+          `Unsupported locator target strategy: ${target.strategy}`,
         );
+      }
+      return target.selector;
+    });
+    const elementInfosScriptContent = getElementInfosScriptContent();
+    const result = await this.evaluateJavaScript<boolean[]>(
+      `${elementInfosScriptContent}${JSON.stringify(selectors)}.map((xpath) => midscene_element_inspector.getNodeCountByXpath(xpath) > 0)`,
+    );
+    options?.signal?.throwIfAborted();
+    return result;
+  }
+
+  async resolveLocatorTarget(target: LocatorTarget): Promise<Rect> {
+    if (target.strategy !== 'xpath') {
+      throw new Error(
+        `Unsupported locator target strategy: ${target.strategy}`,
+      );
+    }
+    const elementInfo = await this.getElementInfoByXpath(target.selector);
+    if (!elementInfo?.rect) {
+      throw new Error(`XPath target does not exist: ${target.selector}`);
+    }
+    return buildRectFromElementInfo(elementInfo);
+  }
+
+  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
+    const targets = sanitizeLocatorTargets(feature as WebElementCacheFeature);
+    debugPage('rectMatchesCacheFeature: trying %d target(s)', targets.length);
+
+    for (const target of targets) {
+      try {
+        return await this.resolveLocatorTarget(target);
       } catch (error) {
         debugPage(
-          'rectMatchesCacheFeature failed for xpath %s: %s',
-          xpath,
+          'rectMatchesCacheFeature failed for target %o: %s',
+          target,
           error,
         );
       }
     }
 
     throw new Error(
-      `No matching element rect found for the provided cache feature (tried ${xpaths.length} xpath(s): ${xpaths.join(', ')})`,
+      `No matching element rect found for the provided cache feature (tried ${targets.length} target(s))`,
     );
   }
 

--- a/packages/web-integration/tests/ai/fixtures/element-xpath-complex-scenes.html
+++ b/packages/web-integration/tests/ai/fixtures/element-xpath-complex-scenes.html
@@ -259,6 +259,19 @@
         background: white;
         box-shadow: 0 5px 16px rgba(38, 51, 77, 0.08);
       }
+      .workflow-card[data-collapsed='true'] {
+        min-height: 0;
+      }
+      .workflow-card[data-collapsed='true'] .card-body {
+        display: none;
+      }
+      .workflow-card[data-rejected='true'] {
+        border-color: #f97066;
+        box-shadow: 0 0 0 3px #fee4e2;
+      }
+      .workflow-card[data-rejected='true'] .card-head {
+        background: #fff4f2;
+      }
       .card-head {
         display: flex;
         align-items: center;
@@ -487,7 +500,9 @@
     <script>
       const params = new URLSearchParams(location.search);
       const scene = params.get('scene') || 'grouped-table';
+      const benchmarkCase = params.get('case');
       window.__complexBenchmarkActions = [];
+      window.__complexBenchmarkMisses = [];
 
       function record(targetId, action) {
         window.__complexBenchmarkActions.push({ targetId, action });
@@ -631,11 +646,25 @@
         ['finish-workflow', 'Finish workflow', 'End', 'Return success'],
       ];
 
+      const recoveryCards = [
+        ...cards.slice(0, 6),
+        ['write-audit-log-preview', 'Write audit log', 'Preview', 'Read-only template'],
+        ['finish-workflow', 'Finish workflow', 'End', 'Return success'],
+        ['archive-orders', 'Archive completed orders', 'Storage', 'Cold archive'],
+        ['publish-metrics', 'Publish workflow metrics', 'Analytics', 'Operations board'],
+        ['write-audit-log', 'Write audit log', 'Live workflow', 'Compliance archive'],
+        ['close-run', 'Close workflow run', 'End', 'Return success'],
+      ];
+
       function renderWorkflowCards() {
+        const visibleCards =
+          benchmarkCase === 'card-audit-collapse-recovery'
+            ? recoveryCards
+            : cards;
         document.querySelector('#root').innerHTML = shell(
           'Workflow designer',
-          'Eight visually similar cards · four icon-only tools on every card',
-          `<div class="canvas-grid">${cards.map(([id, title, type, detail]) => `
+          `${visibleCards.length} visually similar cards · four icon-only tools on every card`,
+          `<div class="canvas-grid">${visibleCards.map(([id, title, type, detail]) => `
             <article class="workflow-card" data-card-id="${id}">
               <header class="card-head"><span class="card-title">${title}</span>
                 <span class="card-tools">${Object.entries(toolIcons).map(([action, icon]) => `
@@ -647,9 +676,37 @@
         );
         document.querySelectorAll('.card-tools button').forEach((button) => {
           const action = button.getAttribute('aria-label');
-          button.addEventListener('click', () =>
-            record(button.dataset.targetId, action),
-          );
+          button.addEventListener('click', () => {
+            const targetId = button.dataset.targetId;
+            record(targetId, action);
+            if (targetId === 'card-write-audit-log-collapse') {
+              button.closest('.workflow-card').dataset.collapsed = 'true';
+              button.setAttribute('aria-expanded', 'false');
+              document.querySelector('#last-action').textContent =
+                'Success: Write audit log card is collapsed';
+            } else if (benchmarkCase === 'card-audit-collapse-recovery') {
+              const card = button.closest('.workflow-card');
+              const cardTitle = card
+                ?.querySelector('.card-title')
+                ?.textContent?.trim();
+              const cardDetail = card
+                ?.querySelector('.card-body strong:last-child')
+                ?.textContent?.trim();
+              const clickedDescription = `${action} control in the "${cardTitle}" card (${cardDetail})`;
+              const miss = {
+                attempt: window.__complexBenchmarkMisses.length + 1,
+                clickedDescription,
+              };
+              window.__complexBenchmarkMisses.push(miss);
+              card.dataset.rejected = 'true';
+              document.querySelector('#last-action').textContent =
+                `Attempt ${miss.attempt} missed: clicked ${clickedDescription}. This is not the live Write audit log card. The live card uses "Compliance archive"; retry its collapse control.`;
+              document.querySelectorAll('.workflow-card').forEach((item) => {
+                item.hidden = item.dataset.cardId !== 'write-audit-log';
+              });
+              window.scrollTo({ top: 0, behavior: 'instant' });
+            }
+          });
         });
       }
 
@@ -758,6 +815,37 @@
       const render = renderers[scene];
       if (!render) throw new Error(`Unknown scene: ${scene}`);
       render();
+
+      if (benchmarkCase === 'card-audit-collapse') {
+        document.addEventListener('click', (event) => {
+          const clickedElement =
+            event.target instanceof Element ? event.target : null;
+          const requestedControl = clickedElement?.closest(
+            '[data-target-id="card-write-audit-log-collapse"]',
+          );
+          if (requestedControl) return;
+
+          const card = clickedElement?.closest('.workflow-card');
+          const cardTitle = card
+            ?.querySelector('.card-title')
+            ?.textContent?.trim();
+          const controlName = clickedElement
+            ?.closest('button')
+            ?.getAttribute('aria-label');
+          const clickedDescription = cardTitle
+            ? controlName
+              ? `${controlName} control in the "${cardTitle}" card`
+              : `the "${cardTitle}" card`
+            : 'an element outside the requested card control';
+          const miss = {
+            attempt: window.__complexBenchmarkMisses.length + 1,
+            clickedDescription,
+          };
+          window.__complexBenchmarkMisses.push(miss);
+          document.querySelector('#last-action').textContent =
+            `Attempt ${miss.attempt} missed: clicked ${clickedDescription}. The Write audit log card is still expanded; reinspect and retry.`;
+        });
+      }
     </script>
   </body>
 </html>

--- a/packages/web-integration/tests/ai/web/puppeteer/element-xpath-complex-benchmark.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/element-xpath-complex-benchmark.test.ts
@@ -26,6 +26,11 @@ interface BenchmarkCase {
   targetId: string;
   action: string;
   expectXpathHit: boolean;
+  acceptance?: {
+    visibleText: string;
+    allowIntermediateActions: boolean;
+    requireWrongThenTargetOnRecord?: boolean;
+  };
 }
 
 const aiActEfforts = ['fast', 'balance', 'deepThink'] as const;
@@ -133,12 +138,31 @@ const benchmarkCases: Record<string, BenchmarkCase> = {
     'card-reserve-stock-copy',
     'copy',
   ),
-  'card-audit-collapse': benchmarkCase(
-    'workflow-cards',
-    'Click the collapse icon in the Write audit log card exactly once.',
-    'card-write-audit-log-collapse',
-    'collapse',
-  ),
+  'card-audit-collapse': {
+    ...benchmarkCase(
+      'workflow-cards',
+      'Click the collapse icon in the Write audit log card exactly once. Acceptance criteria: do not finish until the Write audit log card body is no longer visible and the fixed status panel at the bottom-right reads "Success: Write audit log card is collapsed". If both conditions are not visible after an attempt, that attempt missed the requested control; use the status panel description of the actual hit element to locate it again and retry. A missed click does not count as clicking the requested control.',
+      'card-write-audit-log-collapse',
+      'collapse',
+    ),
+    acceptance: {
+      visibleText: 'Success: Write audit log card is collapsed',
+      allowIntermediateActions: true,
+    },
+  },
+  'card-audit-collapse-recovery': {
+    ...benchmarkCase(
+      'workflow-cards',
+      'Click the collapse icon in the live Write audit log workflow card exactly once. Do not finish until the fixed status panel reads "Success: Write audit log card is collapsed". If the page reports that a click reached a read-only preview or another wrong control, use that feedback to find the live card and retry within this same aiAct.',
+      'card-write-audit-log-collapse',
+      'collapse',
+    ),
+    acceptance: {
+      visibleText: 'Success: Write audit log card is collapsed',
+      allowIntermediateActions: true,
+      requireWrongThenTargetOnRecord: true,
+    },
+  },
   'overlay-policy-dialog': benchmarkCase(
     'overlay',
     'Close the Unsaved policy changes dialog using its top-right close icon exactly once.',
@@ -374,6 +398,7 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
 
     const fixtureUrl = new URL(`file://${fixturePath}`);
     fixtureUrl.searchParams.set('scene', selectedCase.scene);
+    fixtureUrl.searchParams.set('case', caseId);
     const { originPage, reset } = await launchPage(fixtureUrl.toString(), {
       viewport: { width: 1440, height: 900 },
     });
@@ -432,7 +457,36 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
         ).__complexBenchmarkActions,
     );
     const stateEvidence = await originPage.evaluate(
-      ({ scene, targetId }) => {
+      ({ scene, targetId, acceptance }) => {
+        if (acceptance) {
+          const misses = (
+            window as typeof window & {
+              __complexBenchmarkMisses?: Array<{
+                attempt: number;
+                clickedDescription: string;
+              }>;
+            }
+          ).__complexBenchmarkMisses;
+          const targetElement = document.querySelector<HTMLElement>(
+            `[data-target-id="${targetId}"]`,
+          );
+          const targetCardCollapsed =
+            targetElement?.closest<HTMLElement>('.workflow-card')?.dataset
+              .collapsed === 'true';
+          const actualText =
+            document.querySelector<HTMLElement>('#last-action')?.textContent;
+          return {
+            expectation: 'card-collapsed-and-visible-acceptance-text',
+            expectedText: acceptance.visibleText,
+            actualText,
+            targetCardCollapsed,
+            missCount: misses?.length ?? 0,
+            misses: misses ?? [],
+            matched:
+              targetCardCollapsed && actualText === acceptance.visibleText,
+          };
+        }
+
         if (scene === 'overlay') {
           const targetElementPresent = Array.from(
             document.querySelectorAll<HTMLElement>('[data-target-id]'),
@@ -468,7 +522,11 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
           matched: true,
         };
       },
-      { scene: selectedCase.scene, targetId: selectedCase.targetId },
+      {
+        scene: selectedCase.scene,
+        targetId: selectedCase.targetId,
+        acceptance: selectedCase.acceptance,
+      },
     );
     const expectedClicks = [
       {
@@ -476,15 +534,36 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
         action: selectedCase.action,
       },
     ];
-    const domMatched =
-      JSON.stringify(actualClicks) === JSON.stringify(expectedClicks);
+    const targetClickCount = actualClicks.filter(
+      (click) =>
+        click.targetId === selectedCase.targetId &&
+        click.action === selectedCase.action,
+    ).length;
+    const endsAtExpectedTarget =
+      targetClickCount === 1 &&
+      JSON.stringify(actualClicks.at(-1)) === JSON.stringify(expectedClicks[0]);
+    const requireWrongThenTarget =
+      variant === 'baseline' &&
+      generateRecordMap &&
+      selectedCase.acceptance?.requireWrongThenTargetOnRecord;
+    const wrongThenTargetMatched =
+      actualClicks.length === 2 &&
+      JSON.stringify(actualClicks[0]) !== JSON.stringify(expectedClicks[0]) &&
+      endsAtExpectedTarget;
+    const domMatched = requireWrongThenTarget
+      ? wrongThenTargetMatched
+      : selectedCase.acceptance?.allowIntermediateActions
+        ? endsAtExpectedTarget
+        : JSON.stringify(actualClicks) === JSON.stringify(expectedClicks);
     const xpathResolved = useGeneratedXpath
       ? locate.xpathHits > 0
       : useElementXpaths
         ? selectedCase.expectXpathHit
-          ? locate.xpathHits === 1 &&
-            locate.resolvedXpaths.length === 1 &&
-            locate.resolvedXpaths[0] === expectedXpath
+          ? selectedCase.acceptance
+            ? locate.xpathHits >= 1 && locate.resolvedXpaths.length >= 1
+            : locate.xpathHits === 1 &&
+              locate.resolvedXpaths.length === 1 &&
+              locate.resolvedXpaths[0] === expectedXpath
           : locate.xpathHits === 0
         : locate.xpathHits === 0;
 
@@ -541,6 +620,7 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
         recordXpath,
         generateRecordMap,
         modelRetryCount: process.env.MIDSCENE_MODEL_RETRY_COUNT,
+        modelTemperature: process.env.MIDSCENE_MODEL_TEMPERATURE,
         modelReasoningEnabled: process.env.MIDSCENE_MODEL_REASONING_ENABLED,
       },
       model: {
@@ -554,6 +634,14 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
       locateEvidence: locate,
       expectedClicks,
       actualClicks,
+      targetClickCount,
+      recoveryEvidence: {
+        requiredOnRecord: Boolean(requireWrongThenTarget),
+        wrongThenTargetMatched,
+        firstAction: actualClicks[0],
+        finalAction: actualClicks.at(-1),
+      },
+      acceptance: selectedCase.acceptance,
       stateEvidence,
       expectedXpath,
       domMatched,
@@ -601,7 +689,7 @@ it.skipIf(!process.env.ELEMENT_XPATH_COMPLEX_VARIANT)(
     );
 
     if (runError) throw runError;
-    expect(actualClicks).toEqual(expectedClicks);
+    expect(domMatched).toBe(true);
     expect(xpathResolved).toBe(true);
     expect(stateEvidence.matched).toBe(true);
   },

--- a/packages/web-integration/tests/ai/web/puppeteer/record-replay-utils.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/record-replay-utils.ts
@@ -6,8 +6,16 @@ import yaml from 'js-yaml';
 
 interface UIActionDefinition {
   name: string;
-  actionName: string;
-  actionParam: [unknown];
+  action: {
+    name: string;
+    param?: unknown;
+  };
+}
+
+interface UIActionManifest {
+  version: 1;
+  interface: string;
+  actions: UIActionDefinition[];
 }
 
 interface XpathLocator {
@@ -25,22 +33,32 @@ function xpathLocators(value: unknown): XpathLocator[] {
   }
   if (!isRecord(value)) return [];
 
-  const ownLocator =
-    typeof value.xpath === 'string' && value.xpath.trim()
-      ? [
-          {
-            prompt:
-              typeof value.prompt === 'string' && value.prompt.trim()
-                ? value.prompt.trim()
-                : undefined,
-            xpath: value.xpath.trim(),
-          },
-        ]
-      : [];
+  const target = isRecord(value.target) ? value.target : undefined;
+  const xpath =
+    target?.strategy === 'xpath' &&
+    typeof target.selector === 'string' &&
+    target.selector.trim()
+      ? target.selector.trim()
+      : typeof value.xpath === 'string' && value.xpath.trim()
+        ? value.xpath.trim()
+        : undefined;
+  const ownLocator = xpath
+    ? [
+        {
+          prompt:
+            typeof value.prompt === 'string' && value.prompt.trim()
+              ? value.prompt.trim()
+              : undefined,
+          xpath,
+        },
+      ]
+    : [];
   return [
     ...ownLocator,
     ...Object.entries(value)
-      .filter(([key]) => key !== 'xpath' && key !== 'prompt')
+      .filter(
+        ([key]) => key !== 'xpath' && key !== 'target' && key !== 'prompt',
+      )
       .flatMap(([, item]) => xpathLocators(item)),
   ];
 }
@@ -76,32 +94,36 @@ export async function generateRecordXpathMap(
   const elements: Record<string, string> = {};
   const steps: RecordXpathMapArtifact['steps'] = [];
 
-  for (const [actionIndex, actionFile] of analysis.actionFiles.entries()) {
-    const definition = yaml.load(
+  let actionIndex = 0;
+  for (const actionFile of analysis.actionFiles) {
+    const manifest = yaml.load(
       await readFile(actionFile, 'utf8'),
-    ) as UIActionDefinition;
-    for (const [locatorIndex, locator] of xpathLocators(
-      definition.actionParam[0],
-    ).entries()) {
-      const baseName = locator.prompt || definition.name;
-      let elementName = baseName;
-      let suffix = 2;
-      while (
-        elements[elementName] !== undefined &&
-        elements[elementName] !== locator.xpath
-      ) {
-        elementName = `${baseName} [observed step ${actionIndex + 1}.${locatorIndex + 1}; alternative ${suffix}]`;
-        suffix += 1;
+    ) as UIActionManifest;
+    for (const definition of manifest.actions) {
+      actionIndex += 1;
+      for (const [locatorIndex, locator] of xpathLocators(
+        definition.action.param,
+      ).entries()) {
+        const baseName = locator.prompt || definition.name;
+        let elementName = baseName;
+        let suffix = 2;
+        while (
+          elements[elementName] !== undefined &&
+          elements[elementName] !== locator.xpath
+        ) {
+          elementName = `${baseName} [observed step ${actionIndex}.${locatorIndex + 1}; alternative ${suffix}]`;
+          suffix += 1;
+        }
+        elements[elementName] = locator.xpath;
+        steps.push({
+          step: actionIndex,
+          actionFile: path.basename(actionFile),
+          actionName: definition.action.name,
+          actionDisplayName: definition.name,
+          elementName,
+          xpath: locator.xpath,
+        });
       }
-      elements[elementName] = locator.xpath;
-      steps.push({
-        step: actionIndex + 1,
-        actionFile: path.basename(actionFile),
-        actionName: definition.actionName,
-        actionDisplayName: definition.name,
-        elementName,
-        xpath: locator.xpath,
-      });
     }
   }
 
@@ -112,7 +134,7 @@ export async function generateRecordXpathMap(
   }
   if (analysis.coordinateFallbackFiles.length > 0) {
     throw new Error(
-      `Record report contains ${analysis.coordinateFallbackFiles.length} coordinate-only action(s); cannot build a complete XPath Map: ${reportPath}`,
+      `Record report contains ${analysis.coordinateFallbackActionCount} coordinate-only action(s); cannot build a complete XPath Map: ${reportPath}`,
     );
   }
 

--- a/packages/web-integration/tests/unit-test/__snapshots__/task-cache.test.ts.snap
+++ b/packages/web-integration/tests/unit-test/__snapshots__/task-cache.test.ts.snap
@@ -9,9 +9,15 @@ exports[`TaskCache > save and retrieve cache from file 1`] = `
   },
   {
     "cache": {
-      "xpaths": [
-        "test-xpath-1",
-        "test-xpath-2",
+      "targets": [
+        {
+          "selector": "test-xpath-1",
+          "strategy": "xpath",
+        },
+        {
+          "selector": "test-xpath-2",
+          "strategy": "xpath",
+        },
       ],
     },
     "prompt": "test-locate",
@@ -29,9 +35,15 @@ exports[`TaskCache > save and retrieve cache from file 2`] = `
   },
   {
     "cache": {
-      "xpaths": [
-        "test-xpath-3",
-        "test-xpath-4",
+      "targets": [
+        {
+          "selector": "test-xpath-3",
+          "strategy": "xpath",
+        },
+        {
+          "selector": "test-xpath-4",
+          "strategy": "xpath",
+        },
       ],
     },
     "prompt": "test-locate",
@@ -50,9 +62,11 @@ caches:
   - type: locate
     prompt: test-locate
     cache:
-      xpaths:
-        - test-xpath-3
-        - test-xpath-4
+      targets:
+        - strategy: xpath
+          selector: test-xpath-3
+        - strategy: xpath
+          selector: test-xpath-4
 "
 `;
 

--- a/packages/web-integration/tests/unit-test/bridge/io.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/io.test.ts
@@ -277,6 +277,10 @@ describe('bridge-io', () => {
     await server.listen();
 
     const callOrder: string[] = [];
+    let resolveCallProcessed!: () => void;
+    const callProcessed = new Promise<void>((resolve) => {
+      resolveCallProcessed = resolve;
+    });
 
     // Simulate OLD behavior: no gate before connect
     let confirmationPromise: Promise<boolean> | null = null;
@@ -291,6 +295,7 @@ describe('bridge-io', () => {
           if (!allowed) throw new Error('Connection denied by user');
         }
         callOrder.push(`processed:${method}`);
+        resolveCallProcessed();
         return 'ok';
       },
     );
@@ -302,13 +307,12 @@ describe('bridge-io', () => {
 
     // OLD: connect first, THEN set gate — too late!
     await client.connect();
+    await callProcessed;
 
     // Gate set after connect — queued call already arrived and bypassed the check
     confirmationPromise = new Promise<boolean>((resolve) => {
       resolveConfirmation = resolve;
     });
-
-    await new Promise((resolve) => setTimeout(resolve, 200));
 
     // BUG: call was processed without waiting for confirmation!
     expect(callOrder).toEqual(['processed:connectNewTabWithUrl']);

--- a/packages/web-integration/tests/unit-test/chrome-extension-cache.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-cache.test.ts
@@ -21,6 +21,10 @@ vi.mock('@midscene/shared/logger', () => ({
   getDebug: vi.fn(() => vi.fn()),
 }));
 
+vi.mock('../../src/chrome-extension/dynamic-scripts', () => ({
+  getHtmlElementScript: vi.fn().mockResolvedValue(''),
+}));
+
 import { AiJudgeOrderSensitive } from '@midscene/core/ai-model';
 import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
 
@@ -37,13 +41,18 @@ describe('ChromeExtensionProxyPage cache methods', () => {
   });
 
   describe('cacheFeatureForPoint', () => {
-    it('should return xpaths for a valid point', async () => {
+    it('should return locator targets for a valid point', async () => {
       const mockXpaths = ['/html/body/div[1]', '/html/body/div[1]/button[1]'];
       vi.spyOn(page, 'getXpathsByPoint').mockResolvedValue(mockXpaths);
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: mockXpaths });
+      expect(result).toEqual({
+        targets: mockXpaths.map((selector) => ({
+          strategy: 'xpath',
+          selector,
+        })),
+      });
       expect(page.getXpathsByPoint).toHaveBeenCalledWith(
         { left: 100, top: 200 },
         false,
@@ -63,17 +72,22 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       const result = await page.cacheFeatureForPoint([50, 50]);
 
-      expect(result).toEqual({ xpaths: ['/valid/xpath', '/another/valid'] });
+      expect(result).toEqual({
+        targets: [
+          { strategy: 'xpath', selector: '/valid/xpath' },
+          { strategy: 'xpath', selector: '/another/valid' },
+        ],
+      });
     });
 
-    it('should return empty xpaths when getXpathsByPoint fails', async () => {
+    it('should return empty targets when getXpathsByPoint fails', async () => {
       vi.spyOn(page, 'getXpathsByPoint').mockRejectedValue(
         new Error('CDP error'),
       );
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: [] });
+      expect(result).toEqual({ targets: [] });
     });
 
     it('should call AiJudgeOrderSensitive when targetDescription and modelRuntime are provided', async () => {
@@ -126,21 +140,21 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: [] });
+      expect(result).toEqual({ targets: [] });
     });
   });
 
   describe('rectMatchesCacheFeature', () => {
-    it('should return rect when xpath matches an element', async () => {
-      const mockElementInfo = {
-        rect: { left: 10, top: 20, width: 100, height: 50 },
-      };
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue(
-        mockElementInfo as any,
-      );
+    it('should return rect when a target resolves', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 10,
+        top: 20,
+        width: 100,
+        height: 50,
+      });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/html/body/button[1]'],
+        targets: [{ strategy: 'xpath', selector: '/html/body/button[1]' }],
       });
 
       expect(result).toEqual({
@@ -151,15 +165,16 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       });
     });
 
-    it('should try multiple xpaths and return first match', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath')
-        .mockResolvedValueOnce(null as any) // First xpath fails
-        .mockResolvedValueOnce({
-          rect: { left: 5, top: 10, width: 50, height: 25 },
-        } as any);
+    it('should try multiple targets and return the first match', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget')
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ left: 5, top: 10, width: 50, height: 25 });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/invalid/xpath', '/valid/xpath'],
+        targets: [
+          { strategy: 'xpath', selector: '/invalid/xpath' },
+          { strategy: 'xpath', selector: '/valid/xpath' },
+        ],
       });
 
       expect(result).toEqual({
@@ -168,30 +183,36 @@ describe('ChromeExtensionProxyPage cache methods', () => {
         width: 50,
         height: 25,
       });
-      expect(page.getElementInfoByXpath).toHaveBeenCalledTimes(2);
+      expect(page.resolveLocatorTarget).toHaveBeenCalledTimes(2);
     });
 
-    it('should throw error when no xpath matches', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue(null as any);
+    it('should throw error when no target matches', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockRejectedValue(
+        new Error('not found'),
+      );
 
       await expect(
         page.rectMatchesCacheFeature({
-          xpaths: ['/xpath1', '/xpath2'],
+          targets: [
+            { strategy: 'xpath', selector: '/xpath1' },
+            { strategy: 'xpath', selector: '/xpath2' },
+          ],
         }),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 2 xpath(s))',
+        'No matching element rect found for cache feature (tried 2 target(s))',
       );
     });
 
-    it('should handle xpath lookup errors gracefully', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath')
+    it('should handle target lookup errors gracefully', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget')
         .mockRejectedValueOnce(new Error('Lookup error'))
-        .mockResolvedValueOnce({
-          rect: { left: 1, top: 2, width: 3, height: 4 },
-        } as any);
+        .mockResolvedValueOnce({ left: 1, top: 2, width: 3, height: 4 });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/error/xpath', '/valid/xpath'],
+        targets: [
+          { strategy: 'xpath', selector: '/error/xpath' },
+          { strategy: 'xpath', selector: '/valid/xpath' },
+        ],
       });
 
       expect(result).toEqual({
@@ -202,10 +223,13 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       });
     });
 
-    it('should filter out invalid xpaths before processing', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue({
-        rect: { left: 0, top: 0, width: 10, height: 10 },
-      } as any);
+    it('should read legacy xpaths and filter invalid entries', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 0,
+        top: 0,
+        width: 10,
+        height: 10,
+      });
 
       const feature = {
         xpaths: ['', null, '/valid/xpath', undefined, 123] as any,
@@ -213,15 +237,38 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       await page.rectMatchesCacheFeature(feature);
 
-      expect(page.getElementInfoByXpath).toHaveBeenCalledTimes(1);
-      expect(page.getElementInfoByXpath).toHaveBeenCalledWith('/valid/xpath');
+      expect(page.resolveLocatorTarget).toHaveBeenCalledTimes(1);
+      expect(page.resolveLocatorTarget).toHaveBeenCalledWith({
+        strategy: 'xpath',
+        selector: '/valid/xpath',
+      });
+    });
+
+    it('should fall back to legacy xpaths when targets contain no valid entry', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 0,
+        top: 0,
+        width: 10,
+        height: 10,
+      });
+
+      await page.rectMatchesCacheFeature({
+        targets: [{ strategy: 'xpath', selector: '' }] as any,
+        xpaths: ['/legacy/valid/xpath'],
+      });
+
+      expect(page.resolveLocatorTarget).toHaveBeenCalledOnce();
+      expect(page.resolveLocatorTarget).toHaveBeenCalledWith({
+        strategy: 'xpath',
+        selector: '/legacy/valid/xpath',
+      });
     });
 
     it('should throw error for empty xpaths array', async () => {
       await expect(
         page.rectMatchesCacheFeature({ xpaths: [] }),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 0 xpath(s))',
+        'No matching element rect found for cache feature (tried 0 target(s))',
       );
     });
 
@@ -229,8 +276,75 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       await expect(
         page.rectMatchesCacheFeature({ xpaths: 'invalid' } as any),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 0 xpath(s))',
+        'No matching element rect found for cache feature (tried 0 target(s))',
       );
+    });
+  });
+
+  describe('locator targets', () => {
+    it('probes XPath existence without invoking the execution resolver', async () => {
+      const sendCommand = vi
+        .spyOn(page as any, 'sendCommandToDebugger')
+        .mockResolvedValue({ result: { value: [true] } });
+      const resolveSpy = vi.spyOn(page, 'resolveLocatorTarget');
+
+      await expect(
+        page.probeLocatorTargets([
+          {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+        ]),
+      ).resolves.toEqual([true]);
+      expect(resolveSpy).not.toHaveBeenCalled();
+      const evaluateOptions = sendCommand.mock.calls[1][1] as {
+        expression: string;
+      };
+      expect(evaluateOptions.expression).toContain('getNodeCountByXpath');
+      expect(evaluateOptions.expression).not.toContain('scrollIntoView');
+    });
+
+    it('uses the execution resolver only when the target is selected', async () => {
+      const sendCommand = vi
+        .spyOn(page as any, 'sendCommandToDebugger')
+        .mockResolvedValue({
+          result: {
+            value: {
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+            },
+          },
+        });
+
+      await expect(
+        page.resolveLocatorTarget({
+          strategy: 'xpath',
+          selector: '//button[@id="confirm"]',
+        }),
+      ).resolves.toEqual({ left: 10, top: 20, width: 100, height: 50 });
+      const evaluateOptions = sendCommand.mock.calls[1][1] as {
+        expression: string;
+      };
+      expect(evaluateOptions.expression).toContain('getElementInfoByXpath');
+      expect(evaluateOptions.expression).toContain(
+        '//button[@id=\\"confirm\\"]',
+      );
+    });
+
+    it('rejects an invalid execution rect so callers can fall back', async () => {
+      vi.spyOn(page as any, 'sendCommandToDebugger').mockResolvedValue({
+        result: {
+          value: {
+            rect: { left: 10, top: 20, width: 0, height: 50 },
+          },
+        },
+      });
+
+      await expect(
+        page.resolveLocatorTarget({
+          strategy: 'xpath',
+          selector: '//button[@id="confirm"]',
+        }),
+      ).rejects.toThrow('Element info contains an invalid rect');
     });
   });
 });

--- a/packages/web-integration/tests/unit-test/task-cache.test.ts
+++ b/packages/web-integration/tests/unit-test/task-cache.test.ts
@@ -218,7 +218,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const planningCachedYamlWorkflow = 'test-yaml-workflow';
 
     const locateCachedPrompt = 'test-locate';
-    const locateCachedCache = { xpaths: ['test-xpath-1', 'test-xpath-2'] };
+    const locateCachedCache = {
+      targets: [
+        { strategy: 'xpath', selector: 'test-xpath-1' },
+        { strategy: 'xpath', selector: 'test-xpath-2' },
+      ],
+    };
 
     const cacheFilePath = prepareCache(
       [
@@ -258,7 +263,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
     // test update cache
     cachedLocateCacheUpdateFn((cache) => {
-      cache.cache = { xpaths: ['test-xpath-3', 'test-xpath-4'] };
+      cache.cache = {
+        targets: [
+          { strategy: 'xpath', selector: 'test-xpath-3' },
+          { strategy: 'xpath', selector: 'test-xpath-4' },
+        ],
+      };
     });
 
     expect(newTaskCache.cache.caches).toMatchSnapshot();
@@ -273,8 +283,8 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
   it('should correctly read cache files containing YAML folded block scalar (>-) format', () => {
     const longXpath =
-      '/html/body/div[1]/div[1]/div[10]/section[1]/div[normalize-space()="立即投保"]';
-    const prompt = '立即投保';
+      '/html/body/div[1]/div[1]/div[10]/section[1]/div[normalize-space()="Buy insurance now"]';
+    const prompt = 'Buy insurance now';
 
     // First create a normal cache file
     const cacheFilePath = prepareCache([
@@ -295,7 +305,9 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const newTaskCache = new TaskCache(uuid(), true, cacheFilePath);
     const located = newTaskCache.matchLocateCache(prompt);
     expect(located).toBeDefined();
-    expect(located?.cacheContent.cache?.xpaths).toEqual([longXpath]);
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: longXpath },
+    ]);
   });
 
   it('should match plan cache with image prompt by deep equality', () => {
@@ -351,7 +363,29 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
     const newTaskCache = new TaskCache(uuid(), true, cacheFilePath);
     const located = newTaskCache.matchLocateCache('legacy-locate');
-    expect(located?.cacheContent.cache?.xpaths).toEqual(legacyXpaths);
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: legacyXpaths[0] },
+    ]);
+  });
+
+  it('falls back to legacy xpaths when cached targets are all invalid', () => {
+    const cacheFilePath = prepareCache([
+      {
+        type: 'locate',
+        prompt: 'legacy-fallback',
+        cache: {
+          targets: [{ strategy: 'xpath', selector: '' }],
+          xpaths: ['legacy-valid-xpath'],
+        },
+      },
+    ]);
+
+    const taskCache = new TaskCache(uuid(), true, cacheFilePath);
+    const located = taskCache.matchLocateCache('legacy-fallback');
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'legacy-valid-xpath' },
+    ]);
+    expect(located?.cacheContent.cache).not.toHaveProperty('xpaths');
   });
 
   it('updateOrAppendCacheRecord writes cache entry and clears legacy xpaths', () => {
@@ -371,12 +405,16 @@ describe('TaskCache', { timeout: 20000 }, () => {
       {
         type: 'locate',
         prompt: 'update-locate',
-        cache: { xpaths: ['new-xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'new-xpath' }],
+        },
       },
       matched,
     );
 
-    expect(matched?.cacheContent.cache?.xpaths).toEqual(['new-xpath']);
+    expect(matched?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'new-xpath' },
+    ]);
     expect(matched?.cacheContent.xpaths).toBeUndefined();
 
     const persisted = yaml.load(
@@ -385,7 +423,9 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const persistedLocate = persisted.caches.find(
       (entry: any) => entry.prompt === 'update-locate',
     );
-    expect(persistedLocate.cache.xpaths).toEqual(['new-xpath']);
+    expect(persistedLocate.cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'new-xpath' },
+    ]);
     expect(persistedLocate.xpaths).toBeUndefined();
   });
 
@@ -595,8 +635,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
     expect(diskCaches[1].yamlWorkflow).toBe('workflow-2');
 
     // Verify that locate entries maintain their relative order
-    expect(diskCaches[2].cache.xpaths).toEqual(['xpath-1']);
-    expect(diskCaches[3].cache.xpaths).toEqual(['xpath-2']);
+    expect(diskCaches[2].cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'xpath-1' },
+    ]);
+    expect(diskCaches[3].cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'xpath-2' },
+    ]);
   });
 });
 
@@ -710,7 +754,9 @@ describe('TaskCache read-only mode', () => {
 
     const locateCache = cache.matchLocateCache('locate-prompt');
     expect(locateCache).toBeDefined();
-    expect(locateCache!.cacheContent.cache?.xpaths).toEqual(['test-xpath']);
+    expect(locateCache!.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'test-xpath' },
+    ]);
   });
 
   it('should set readOnlyMode property correctly', () => {

--- a/packages/web-integration/tests/unit-test/web-extractor.test.ts
+++ b/packages/web-integration/tests/unit-test/web-extractor.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@midscene/shared/img';
 import { getElementInfosScriptContent } from '@midscene/shared/node';
 import { createServer } from 'http-server';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { launchPage } from '../ai/web/puppeteer/utils';
 
 const pageDir = join(__dirname, './fixtures/web-extractor');
@@ -354,6 +354,43 @@ describe(
         await reset();
       });
 
+      it('probeLocatorTargets should disclose every existing target without changing page state', async () => {
+        const { page, reset } = await launchPage(`http://127.0.0.1:${port}`, {
+          viewport: {
+            width: 1080,
+            height: 100,
+            deviceScaleFactor: 1,
+          },
+        });
+        await page.evaluateJavaScript?.(`
+          document.body.insertAdjacentHTML('beforeend', \`
+            <button id="extra-action-visible">Visible</button>
+            <button id="extra-action-hidden" hidden>Hidden</button>
+            <button id="extra-action-disabled" disabled>Disabled</button>
+            <button id="extra-action-offscreen" style="position:absolute;top:5000px">Offscreen</button>
+            <button id="extra-action-zero-size" style="width:0;height:0;padding:0;border:0">Zero size</button>
+          \`);
+        `);
+        const scrollYBefore = await page.evaluateJavaScript?.('window.scrollY');
+        const evaluateSpy = vi.spyOn(page, 'evaluateJavaScript');
+
+        const result = await page.probeLocatorTargets([
+          { strategy: 'xpath', selector: '//*[@id="extra-action-visible"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-hidden"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-disabled"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-offscreen"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-zero-size"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-missing"]' },
+        ]);
+
+        expect(result).toEqual([true, true, true, true, true, false]);
+        expect(evaluateSpy).toHaveBeenCalledOnce();
+        expect(await page.evaluateJavaScript?.('window.scrollY')).toBe(
+          scrollYBefore,
+        );
+        await reset();
+      });
+
       it('getXpathsByPoint should handle elements with special characters', async () => {
         const { page, reset } = await launchPage(`http://127.0.0.1:${port}`, {
           viewport: {
@@ -402,12 +439,16 @@ describe(
         const cacheFeature = await page.cacheFeatureForPoint?.([149, 419]);
 
         expect(cacheFeature).toBeDefined();
-        const xpaths = (cacheFeature as any)?.xpaths as string[] | undefined;
-        expect(xpaths).toBeDefined();
-        expect(xpaths?.length).toBeGreaterThan(0);
+        const targets = (cacheFeature as any)?.targets as
+          | Array<{ strategy: string; selector: string }>
+          | undefined;
+        expect(targets).toBeDefined();
+        expect(targets?.length).toBeGreaterThan(0);
 
-        const xpath = xpaths?.[0];
-        expect(xpath).toMatch(/^\/html/);
+        expect(targets?.[0]).toEqual({
+          strategy: 'xpath',
+          selector: expect.stringMatching(/^\/html/),
+        });
 
         await reset();
       });


### PR DESCRIPTION
## Summary

- add versioned `*.actions.yaml` manifests that expose reusable, parameterless Extra Actions to `aiAct`
- disclose conditional actions from a side-effect-free locator snapshot before every planning round while keeping aliases stable
- resolve recorded locator targets to fresh rectangles with AI fallback, and migrate XPath cache data to the extensible `target` contract
- export successful report actions through `midscene analyze` and preserve platform metadata across report dumps
- document the Node.js API and report-to-manifest workflow in English and Chinese

## Dependency

This is a stacked pull request.

- Base branch: `experiment/qwen37-fast-xpath-replay`
- Head branch: `agent/extra-action-manifest`
- Merge the base branch before retargeting or merging this pull request.

## Implementation

- `packages/core/src/agent/extra-action-manifest.ts` owns strict manifest parsing and legacy read compatibility.
- `packages/core/src/agent/extra-actions.ts` loads manifests, allocates stable aliases, creates disclosure snapshots, and expands selected aliases into native actions.
- `packages/core/src/locator.ts` defines the extensible `LocatorTarget` union. Web adapters resolve XPath targets into fresh logical rectangles.
- `packages/core/src/report-analyzer.ts` pairs successful Locate and Action tasks, rejects mixed-platform reports, and exports one loadable manifest.
- Cache and report paths persist canonical targets while still reading legacy XPath cache entries.

## User impact

Applications can now load recorded actions directly:

```ts
await agent.aiAct('Fill the form', {
  loadExtraActions: ['./checkout.actions.yaml'],
});
```

The planner sees high-priority parameterless aliases instead of rebuilding locator parameters. Runtime execution resolves the recorded target to a fresh rectangle and falls back to regular AI locating if target resolution fails.

## Validation

- `pnpm run lint`
- `NX_DAEMON=false pnpm nx test @midscene/core` — 1,454 passed, 8 skipped
- `NX_DAEMON=false pnpm nx build @midscene/core`
- `./node_modules/.bin/tsc -p packages/core/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/web-integration/tsconfig.json --noEmit`
- `git diff --check experiment/qwen37-fast-xpath-replay...agent/extra-action-manifest`

## Validation gap

The final pass did not rerun the credential-dependent AI browser benchmark. Unit tests cover disclosure refresh, alias stability, target fallback, report export, cache migration, multi-action naming, and multi-target Swipe export.

## Review order

1. Review the manifest and locator contracts.
2. Review disclosure, expansion, and execution fallback.
3. Review report export and cache migration.
4. Review Web adapter integration and bilingual documentation.
