### PR TITLE
feat(core): add locator target resolution foundation

### DIFF
--- a/packages/core/src/agent/task-cache.ts
+++ b/packages/core/src/agent/task-cache.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import type { TUserPrompt } from '@/ai-model';
+import { LocatorTargetSchema, xpathLocatorTarget } from '@/locator';
 import type { ElementCacheFeature } from '@/types';
 import { getMidsceneRunSubDir } from '@midscene/shared/common';
 import {
@@ -34,6 +35,35 @@ export interface LocateCache {
   cache?: ElementCacheFeature;
   /** @deprecated kept for backward compatibility */
   xpaths?: string[];
+}
+
+function normalizeLegacyXpathCache(locateCache: LocateCache): LocateCache {
+  const cache = locateCache.cache ?? {};
+  const targets = Array.isArray(cache.targets)
+    ? cache.targets.flatMap((target) => {
+        const result = LocatorTargetSchema.safeParse(target);
+        return result.success ? [result.data] : [];
+      })
+    : [];
+  const nestedXpaths = Array.isArray(cache.xpaths) ? cache.xpaths : [];
+  const topLevelXpaths = Array.isArray(locateCache.xpaths)
+    ? locateCache.xpaths
+    : [];
+  const legacyTargets = [...nestedXpaths, ...topLevelXpaths]
+    .filter(
+      (xpath): xpath is string =>
+        typeof xpath === 'string' && xpath.trim().length > 0,
+    )
+    .map((xpath) => xpathLocatorTarget(xpath));
+  const { xpaths: _legacyXpaths, ...cacheWithoutXpaths } = cache;
+  locateCache.cache = {
+    ...cacheWithoutXpaths,
+    targets: targets.length > 0 ? targets : legacyTargets,
+  };
+  if ('xpaths' in locateCache) {
+    locateCache.xpaths = undefined;
+  }
+  return locateCache;
 }
 
 export interface MatchCacheResult<T extends PlanningCache | LocateCache> {
@@ -163,13 +193,7 @@ export class TaskCache {
         !this.matchedCacheIndices.has(key)
       ) {
         if (item.type === 'locate') {
-          const locateItem = item as LocateCache;
-          if (!locateItem.cache && Array.isArray(locateItem.xpaths)) {
-            locateItem.cache = { xpaths: locateItem.xpaths };
-          }
-          if ('xpaths' in locateItem) {
-            locateItem.xpaths = undefined;
-          }
+          normalizeLegacyXpathCache(item as LocateCache);
         }
         this.matchedCacheIndices.add(key);
         const consumeKey = `${type}:${promptStr}`;
@@ -267,6 +291,9 @@ export class TaskCache {
   }
 
   appendCache(cache: PlanningCache | LocateCache) {
+    if (cache.type === 'locate') {
+      normalizeLegacyXpathCache(cache);
+    }
     debug('will append cache', cache);
     this.cache.caches.push(cache);
 
@@ -390,11 +417,15 @@ export class TaskCache {
 
       // Sort caches to ensure plan entries come before locate entries for better readability
       // Create a sorted copy for writing to disk while keeping in-memory order unchanged
-      const sortedCaches = [...this.cache.caches].sort((a, b) => {
-        if (a.type === 'plan' && b.type === 'locate') return -1;
-        if (a.type === 'locate' && b.type === 'plan') return 1;
-        return 0;
-      });
+      const sortedCaches = this.cache.caches
+        .map((cache) =>
+          cache.type === 'locate' ? normalizeLegacyXpathCache(cache) : cache,
+        )
+        .sort((a, b) => {
+          if (a.type === 'plan' && b.type === 'locate') return -1;
+          if (a.type === 'locate' && b.type === 'plan') return 1;
+          return 0;
+        });
 
       const cacheToWrite = {
         ...this.cache,
@@ -429,7 +460,8 @@ export class TaskCache {
       (target as PlanningCache).yamlWorkflow = newRecord.yamlWorkflow;
     } else {
       const locateCache = target as LocateCache;
-      locateCache.cache = newRecord.cache;
+      const normalizedRecord = normalizeLegacyXpathCache(newRecord);
+      locateCache.cache = normalizedRecord.cache;
       if ('xpaths' in locateCache) {
         locateCache.xpaths = undefined;
       }

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -16,6 +16,7 @@ import {
 import { assert, isPlainObject } from '@midscene/shared/utils';
 import type { ChatCompletionUserMessageParam } from 'openai/resources/index';
 import { z } from 'zod';
+import { LocatorTargetSchema } from './locator';
 
 /**
  * Expand the search area to at least 400 x 400 pixels
@@ -287,6 +288,7 @@ const MidsceneLocationInput = z
       .describe('@deprecated Use `deepLocate` instead.'),
     cacheable: z.boolean().optional(),
     xpath: z.union([z.string(), z.boolean()]).optional(),
+    target: LocatorTargetSchema.optional(),
   })
   .passthrough();
 
@@ -299,10 +301,23 @@ export const getMidsceneLocationSchema = () => {
 };
 
 export const ifMidsceneLocatorField = (field: any): boolean => {
-  // Handle optional fields by getting the inner type
+  // Unwrap optional/nullable/effect wrappers before checking the object shape.
   let actualField = field;
-  if (actualField._def?.typeName === 'ZodOptional') {
-    actualField = actualField._def.innerType;
+  const visited = new Set<unknown>();
+  while (actualField?._def && !visited.has(actualField)) {
+    visited.add(actualField);
+    if (
+      actualField._def.typeName === 'ZodOptional' ||
+      actualField._def.typeName === 'ZodNullable'
+    ) {
+      actualField = actualField._def.innerType;
+      continue;
+    }
+    if (actualField._def.typeName === 'ZodEffects') {
+      actualField = actualField._def.schema;
+      continue;
+    }
+    break;
   }
 
   // Check if this is a ZodObject
@@ -408,7 +423,9 @@ export const dumpActionParam = (
       } else if (typeof fieldValue === 'object') {
         // Check if this field is actually a MidsceneLocationType object
         if (fieldValue.prompt) {
-          const preserveLocatorObject = typeof fieldValue.xpath === 'string';
+          const preserveLocatorObject =
+            typeof fieldValue.xpath === 'string' ||
+            fieldValue.target !== undefined;
           // If prompt is a string, use it directly
           if (typeof fieldValue.prompt === 'string') {
             result[fieldName] = preserveLocatorObject

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -10,6 +10,7 @@ import type { ElementNode } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { _keyDefinitions } from '@midscene/shared/us-keyboard-layout';
 import { z } from 'zod';
+import type { LocatorTarget } from '../locator';
 import type {
   ElementCacheFeature,
   Rect,
@@ -172,6 +173,9 @@ export interface ComputerInputPrimitives extends InputPrimitives {
 export abstract class AbstractInterface {
   abstract interfaceType: string;
 
+  /** Canonical platform name accepted by Extra Action manifests. */
+  manifestInterface?(): string;
+
   abstract screenshotBase64(): Promise<string>;
   abstract size(): Promise<Size>;
   abstract actionSpace(): DeviceAction[];
@@ -186,6 +190,13 @@ export abstract class AbstractInterface {
   abstract rectMatchesCacheFeature?(
     feature: ElementCacheFeature,
   ): Promise<Rect>;
+  /** Side-effect-free batch existence check used for conditional disclosure. */
+  probeLocatorTargets?(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]>;
+  /** Resolve a stable target to a fresh logical-coordinate Rect for execution. */
+  resolveLocatorTarget?(target: LocatorTarget): Promise<Rect>;
 
   abstract getUITree?(): Promise<UITreeSnapshot>;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,12 @@ export {
 } from './types';
 
 export { z };
+export {
+  LocatorTargetSchema,
+  XPathLocatorTargetSchema,
+  xpathLocatorTarget,
+  type LocatorTarget,
+} from './locator';
 
 export default Service;
 export { TaskRunner, Service, getVersion };

--- a/packages/core/src/locator.ts
+++ b/packages/core/src/locator.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/** Zod schema for a Web XPath locator target. */
+export const XPathLocatorTargetSchema = z
+  .object({
+    strategy: z.literal('xpath'),
+    selector: z.string().trim().min(1),
+  })
+  .strict();
+
+/**
+ * A stable, platform-specific reference that can be resolved to a fresh Rect.
+ * Additional strategies can be added as new discriminated-union members.
+ */
+export const LocatorTargetSchema = z.discriminatedUnion('strategy', [
+  XPathLocatorTargetSchema,
+]);
+
+export type LocatorTarget = z.infer<typeof LocatorTargetSchema>;
+
+/** Create and validate an XPath locator target. */
+export function xpathLocatorTarget(selector: string): LocatorTarget {
+  return LocatorTargetSchema.parse({ strategy: 'xpath', selector });
+}

--- a/packages/core/tests/unit-test/bbox-locate-cache.test.ts
+++ b/packages/core/tests/unit-test/bbox-locate-cache.test.ts
@@ -223,7 +223,10 @@ describe('bbox locate cache fix', () => {
       );
       expect(cachedLocate).toBeDefined();
       expect(cachedLocate?.cache).toBeDefined();
-      expect(cachedLocate?.cache?.xpaths).toContain('/html/body/input[1]');
+      expect(cachedLocate?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/input[1]',
+      });
     });
 
     it('should not call AI locate when bbox is available', async () => {
@@ -657,7 +660,7 @@ describe('bbox locate cache fix', () => {
       const internal = getTaskCacheInternal(testCache);
       internal.cache.caches.push({
         type: 'locate',
-        prompt: '高一',
+        prompt: 'Grade 10',
         cache: {
           xpaths: ['/html/body/div[1]/label[2]'], // Old invalid xpath
         },
@@ -684,7 +687,7 @@ describe('bbox locate cache fix', () => {
       // 4. Mock cacheFeatureForPoint to return new xpath
       vi.mocked(mockInterface.cacheFeatureForPoint!).mockResolvedValue({
         xpaths: ['/html/body/div[2]/label[1]'],
-        texts: ['高一'],
+        texts: ['Grade 10'],
       });
 
       // 5. Create taskBuilder with pre-populated cache
@@ -700,11 +703,11 @@ describe('bbox locate cache fix', () => {
           type: 'Tap',
           param: {
             locate: {
-              prompt: '高一',
+              prompt: 'Grade 10',
               // No bbox - will try cache hit
             },
           },
-          thought: 'tap 高一',
+          thought: 'tap Grade 10',
         },
       ];
 
@@ -725,7 +728,12 @@ describe('bbox locate cache fix', () => {
       // 6. Verify:
       // - rectMatchesCacheFeature was called (attempted cache hit)
       expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
-        xpaths: ['/html/body/div[1]/label[2]'],
+        targets: [
+          {
+            strategy: 'xpath',
+            selector: '/html/body/div[1]/label[2]',
+          },
+        ],
       });
 
       // - AI locate was called (cache hit failed, fallback to AI)
@@ -735,15 +743,17 @@ describe('bbox locate cache fix', () => {
       expect(mockInterface.cacheFeatureForPoint).toHaveBeenCalled();
 
       // - Cache was updated with new xpath (not the old one)
-      const updatedCache = findLocateCacheByPrompt(testCache, '高一');
+      const updatedCache = findLocateCacheByPrompt(testCache, 'Grade 10');
       expect(updatedCache).toBeDefined();
       expect(updatedCache?.cache).toBeDefined();
-      expect(updatedCache?.cache?.xpaths).toContain(
-        '/html/body/div[2]/label[1]',
-      );
-      expect(updatedCache?.cache?.xpaths).not.toContain(
-        '/html/body/div[1]/label[2]',
-      );
+      expect(updatedCache?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/div[2]/label[1]',
+      });
+      expect(updatedCache?.cache?.targets).not.toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/div[1]/label[2]',
+      });
     });
 
     it('should update cache when cache validation fails for non-plan-hit scenarios', async () => {
@@ -818,10 +828,14 @@ describe('bbox locate cache fix', () => {
       // Verify cache was updated
       const updatedCache = findLocateCacheByPrompt(testCache, 'submit button');
       expect(updatedCache).toBeDefined();
-      expect(updatedCache?.cache?.xpaths).toContain(
-        '/html/body/form[1]/button[1]',
-      );
-      expect(updatedCache?.cache?.xpaths).not.toContain('/html/body/button[1]');
+      expect(updatedCache?.cache?.targets).toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/form[1]/button[1]',
+      });
+      expect(updatedCache?.cache?.targets).not.toContainEqual({
+        strategy: 'xpath',
+        selector: '/html/body/button[1]',
+      });
     });
   });
 });

--- a/packages/core/tests/unit-test/task-cache-poisoning.test.ts
+++ b/packages/core/tests/unit-test/task-cache-poisoning.test.ts
@@ -20,7 +20,9 @@ function seedStaleLocate(taskCache: TaskCache, prompt: string, xpath: string) {
   internal.cache.caches.push({
     type: 'locate',
     prompt,
-    cache: { xpaths: [xpath] },
+    cache: {
+      targets: [{ strategy: 'xpath', selector: xpath }],
+    },
   });
   internal.cacheOriginalLength = internal.cache.caches.length;
 }
@@ -36,7 +38,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     // First locate consumes the stale entry (cache hit on the wrong element).
     const matched = cache.matchLocateCache('click submit');
     expect(matched).toBeDefined();
-    expect(matched?.cacheContent.cache?.xpaths).toEqual(['wrong/xpath']);
+    expect(matched?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'wrong/xpath' },
+    ]);
 
     // The action using that element failed -> the replan loop marks it stale.
     cache.markLocateCacheStale('click submit');
@@ -50,19 +54,23 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'correct/xpath' },
+    ]);
   });
 
   it('appends (does not replace) a consumed entry that was never marked stale', () => {
     // Without a stale mark, a re-locate after a consumed hit must append, not
-    // overwrite — the prior hit may have been correct.
+    // overwrite because the prior hit may have been correct.
     const cache = new TaskCache(uuid(), true);
     seedStaleLocate(cache, 'click submit', 'first/xpath');
 
@@ -73,15 +81,21 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['second/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'second/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['first/xpath']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['second/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'first/xpath' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'second/xpath' },
+    ]);
   });
 
   it('appends a new entry when nothing was consumed for the prompt', () => {
@@ -91,14 +105,18 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'fresh prompt',
-        cache: { xpaths: ['some/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'some/xpath' }],
+        },
       },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['some/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'some/xpath' },
+    ]);
   });
 
   it('does not cross-replace entries for different prompts', () => {
@@ -115,7 +133,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click cancel',
-        cache: { xpaths: ['cancel/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'cancel/xpath' }],
+        },
       },
       undefined,
     );
@@ -123,7 +143,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
     expect(internal.cache.caches[0].prompt).toBe('click submit');
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['wrong/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'wrong/xpath' },
+    ]);
     expect(internal.cache.caches[1].prompt).toBe('click cancel');
   });
 
@@ -133,18 +155,30 @@ describe('locate cache poisoning regression (#2529)', () => {
     const cache = new TaskCache(uuid(), true);
 
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/1' }] },
+      },
       undefined,
     );
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/2' }] },
+      },
       undefined,
     );
 
     const internal = getTaskCacheInternal(cache);
     expect(internal.cache.caches).toHaveLength(2);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/1' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/2' },
+    ]);
   });
 
   it('appends instead of overwriting when the same prompt overflows without failure', () => {
@@ -154,30 +188,48 @@ describe('locate cache poisoning regression (#2529)', () => {
     const cache = new TaskCache(uuid(), true);
     const internal = getTaskCacheInternal(cache);
     internal.cache.caches.push(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/1'] } },
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/2'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/1' }] },
+      },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/2' }] },
+      },
     );
     internal.cacheOriginalLength = 2;
 
     // Three occurrences in one run: the first two hit, the third misses.
     expect(
-      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
-    ).toEqual(['row/1']);
+      cache.matchLocateCache('row action')?.cacheContent.cache?.targets,
+    ).toEqual([{ strategy: 'xpath', selector: 'row/1' }]);
     expect(
-      cache.matchLocateCache('row action')?.cacheContent.cache?.xpaths,
-    ).toEqual(['row/2']);
+      cache.matchLocateCache('row action')?.cacheContent.cache?.targets,
+    ).toEqual([{ strategy: 'xpath', selector: 'row/2' }]);
     expect(cache.matchLocateCache('row action')).toBeUndefined();
 
     cache.updateOrAppendCacheRecord(
-      { type: 'locate', prompt: 'row action', cache: { xpaths: ['row/3'] } },
+      {
+        type: 'locate',
+        prompt: 'row action',
+        cache: { targets: [{ strategy: 'xpath', selector: 'row/3' }] },
+      },
       undefined,
     );
 
     // Both original entries are preserved; the third occurrence is appended.
     expect(internal.cache.caches).toHaveLength(3);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['row/1']);
-    expect(internal.cache.caches[1].cache?.xpaths).toEqual(['row/2']);
-    expect(internal.cache.caches[2].cache?.xpaths).toEqual(['row/3']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/1' },
+    ]);
+    expect(internal.cache.caches[1].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/2' },
+    ]);
+    expect(internal.cache.caches[2].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'row/3' },
+    ]);
   });
 
   it('markLocateCacheStale is a no-op when nothing was consumed', () => {
@@ -191,7 +243,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
@@ -213,7 +267,9 @@ describe('locate cache poisoning regression (#2529)', () => {
       {
         type: 'locate',
         prompt: 'click submit',
-        cache: { xpaths: ['correct/xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'correct/xpath' }],
+        },
       },
       undefined,
     );
@@ -221,7 +277,9 @@ describe('locate cache poisoning regression (#2529)', () => {
     const internal = getTaskCacheInternal(cache);
     // In-memory entry is replaced in place...
     expect(internal.cache.caches).toHaveLength(1);
-    expect(internal.cache.caches[0].cache?.xpaths).toEqual(['correct/xpath']);
+    expect(internal.cache.caches[0].cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'correct/xpath' },
+    ]);
     // ...but nothing is written to disk in read-only mode.
     expect(existsSync(filePath)).toBe(false);
   });

--- a/packages/shared/src/extractor/index.ts
+++ b/packages/shared/src/extractor/index.ts
@@ -38,6 +38,7 @@ export { extractTreeNodeAsString as webExtractNodeTreeAsString } from './web-ext
 export {
   getXpathsByPoint,
   getXpathsById,
+  getNodeCountByXpath,
   getNodeInfoByXpath,
   getElementInfoByXpath,
   getElementXpath,

--- a/packages/shared/src/extractor/locator.ts
+++ b/packages/shared/src/extractor/locator.ts
@@ -427,6 +427,54 @@ export function getNodeInfoByXpath(xpath: string): Node | null {
   return node;
 }
 
+/**
+ * Count matches without scrolling or otherwise changing page state. Composite
+ * iframe XPaths require each intermediate iframe segment to resolve uniquely;
+ * the final segment may match any number of nodes.
+ */
+export function getNodeCountByXpath(xpath: string): number {
+  const parts = xpath
+    .split(SUB_XPATH_SEPARATOR)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return 0;
+
+  let currentDocument: Document =
+    typeof document !== 'undefined' ? document : (undefined as any);
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const xpathResult = currentDocument.evaluate(
+      parts[index],
+      currentDocument,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null,
+    );
+    if (index === parts.length - 1) {
+      return xpathResult.snapshotLength;
+    }
+    if (xpathResult.snapshotLength !== 1) return 0;
+
+    const node = xpathResult.snapshotItem(0);
+    if (
+      !node ||
+      node.nodeType !== Node.ELEMENT_NODE ||
+      (node as Element).tagName.toLowerCase() !== 'iframe'
+    ) {
+      return 0;
+    }
+    try {
+      const contentDocument = (node as HTMLIFrameElement).contentDocument;
+      if (!contentDocument) return 0;
+      currentDocument = contentDocument;
+    } catch {
+      return 0;
+    }
+  }
+
+  return 0;
+}
+
 export function getElementInfoByXpath(xpath: string): ElementInfo | null {
   const node = getNodeInfoByXpath(xpath);
   if (!node) return null;

--- a/packages/shared/tests/unit-test/iife-bundle.test.ts
+++ b/packages/shared/tests/unit-test/iife-bundle.test.ts
@@ -16,6 +16,7 @@ interface GlobalWithMidscene {
     isNotContainerElement: unknown;
     getElementXpath: unknown;
     getElementInfoByXpath: unknown;
+    getNodeCountByXpath: unknown;
     descriptionOfTree: unknown;
     getXpathsByPoint: unknown;
     truncateText: unknown;
@@ -92,6 +93,8 @@ describe('IIFE bundle runtime behavior', () => {
         'getElementXpath',
         // Used by Puppeteer and Chrome Extension cache lookup flows.
         'getElementInfoByXpath',
+        // Used by Extra Action disclosure to batch-check target existence.
+        'getNodeCountByXpath',
         // Not found in runtime calls; suspected removable from the IIFE surface.
         'descriptionOfTree',
         // Used by Puppeteer and Chrome Extension cache lookup flows.

--- a/packages/shared/tests/unit-test/locator.test.ts
+++ b/packages/shared/tests/unit-test/locator.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getElementInfoByXpath,
+  getNodeCountByXpath,
   getNodeInfoByXpath,
   getXpathsByPoint,
 } from '../../src/extractor/locator';
@@ -303,6 +304,59 @@ describe('locator', () => {
 
       // Restore original mock
       global.document.evaluate = originalEvaluate;
+    });
+  });
+
+  describe('getNodeCountByXpath', () => {
+    it('returns every match without requiring a unique final node', () => {
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 3,
+            snapshotItem: () => null,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('//button')).toBe(3);
+    });
+
+    it('counts matches inside a uniquely resolved iframe', () => {
+      const frameDocument = {
+        evaluate: vi.fn(
+          () =>
+            ({
+              snapshotLength: 2,
+              snapshotItem: () => null,
+            }) as unknown as XPathResult,
+        ),
+      } as unknown as Document;
+      const iframe = {
+        nodeType: Node.ELEMENT_NODE,
+        tagName: 'IFRAME',
+        contentDocument: frameDocument,
+      } as unknown as HTMLIFrameElement;
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 1,
+            snapshotItem: () => iframe,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('/html/body/iframe[1]|>>|//button')).toBe(2);
+      expect(frameDocument.evaluate).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an ambiguous intermediate iframe without probing children', () => {
+      global.document.evaluate = vi.fn(
+        () =>
+          ({
+            snapshotLength: 2,
+            snapshotItem: () => null,
+          }) as unknown as XPathResult,
+      );
+
+      expect(getNodeCountByXpath('/html/body/iframe|>>|//button')).toBe(0);
     });
   });
 

--- a/packages/web-integration/src/bridge-mode/agent-cli-side.ts
+++ b/packages/web-integration/src/bridge-mode/agent-cli-side.ts
@@ -122,6 +122,10 @@ export const getBridgePageInCliSide = (options?: {
         return BridgePageType;
       }
 
+      if (prop === 'manifestInterface') {
+        return () => 'web';
+      }
+
       if (prop === 'actionSpace') {
         return () => commonWebActionsForWebPage(proxyPage);
       }
@@ -168,6 +172,18 @@ export const getBridgePageInCliSide = (options?: {
               return fileChooserError;
             },
           };
+        };
+      }
+
+      if (prop === 'probeLocatorTargets') {
+        return async (
+          targets: unknown[],
+          options?: { signal?: AbortSignal },
+        ) => {
+          options?.signal?.throwIfAborted();
+          const result = await bridgeCaller(prop)(targets);
+          options?.signal?.throwIfAborted();
+          return result;
         };
       }
 

--- a/packages/web-integration/src/chrome-extension/page.ts
+++ b/packages/web-integration/src/chrome-extension/page.ts
@@ -9,6 +9,7 @@ import { limitOpenNewTabScript } from '@/web-element';
 import type {
   ElementCacheFeature,
   ElementTreeNode,
+  LocatorTarget,
   Point,
   Rect,
   Size,
@@ -30,7 +31,9 @@ import {
   type WebElementCacheFeature,
   buildRectFromElementInfo,
   judgeOrderSensitive,
+  sanitizeLocatorTargets,
   sanitizeXpaths,
+  targetsFromXpaths,
 } from '../common/cache-helper';
 import {
   type KeyInput,
@@ -156,6 +159,10 @@ function serializeError(error: Error): {
 
 export default class ChromeExtensionProxyPage implements AbstractInterface {
   interfaceType = 'chrome-extension-proxy';
+
+  manifestInterface() {
+    return 'web';
+  }
 
   public forceSameTabNavigation: boolean;
 
@@ -742,29 +749,68 @@ export default class ChromeExtensionProxyPage implements AbstractInterface {
     try {
       const isOrderSensitive = await judgeOrderSensitive(options, debug);
       const xpaths = await this.getXpathsByPoint(point, isOrderSensitive);
-      return { xpaths: sanitizeXpaths(xpaths) };
+      return { targets: targetsFromXpaths(xpaths) };
     } catch (error) {
       debug('cacheFeatureForPoint failed: %O', error);
-      return { xpaths: [] };
+      return { targets: [] };
     }
   }
 
-  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
-    const xpaths = sanitizeXpaths((feature as WebElementCacheFeature).xpaths);
+  async probeLocatorTargets(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]> {
+    options?.signal?.throwIfAborted();
+    const selectors = targets.map((target) => {
+      if (target.strategy !== 'xpath') {
+        throw new Error(
+          `Unsupported locator target strategy: ${target.strategy}`,
+        );
+      }
+      return target.selector;
+    });
+    const script = await getHtmlElementScript();
+    await this.sendCommandToDebugger('Runtime.evaluate', {
+      expression: script,
+    });
+    const result = await this.sendCommandToDebugger('Runtime.evaluate', {
+      expression: `${JSON.stringify(selectors)}.map((xpath) => window.midscene_element_inspector.getNodeCountByXpath(xpath) > 0)`,
+      returnByValue: true,
+    });
+    options?.signal?.throwIfAborted();
+    return result.result.value;
+  }
 
-    for (const xpath of xpaths) {
+  async resolveLocatorTarget(target: LocatorTarget): Promise<Rect> {
+    if (target.strategy !== 'xpath') {
+      throw new Error(
+        `Unsupported locator target strategy: ${target.strategy}`,
+      );
+    }
+    const elementInfo = await this.getElementInfoByXpath(target.selector);
+    if (!elementInfo?.rect) {
+      throw new Error(`XPath target does not exist: ${target.selector}`);
+    }
+    return buildRectFromElementInfo(elementInfo);
+  }
+
+  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
+    const targets = sanitizeLocatorTargets(feature as WebElementCacheFeature);
+
+    for (const target of targets) {
       try {
-        const elementInfo = await this.getElementInfoByXpath(xpath);
-        if (elementInfo?.rect) {
-          return buildRectFromElementInfo(elementInfo);
-        }
+        return await this.resolveLocatorTarget(target);
       } catch (error) {
-        debug('rectMatchesCacheFeature failed for xpath %s: %O', xpath, error);
+        debug(
+          'rectMatchesCacheFeature failed for target %o: %O',
+          target,
+          error,
+        );
       }
     }
 
     throw new Error(
-      `No matching element rect found for cache feature (tried ${xpaths.length} xpath(s))`,
+      `No matching element rect found for cache feature (tried ${targets.length} target(s))`,
     );
   }
 

--- a/packages/web-integration/src/common/cache-helper.ts
+++ b/packages/web-integration/src/common/cache-helper.ts
@@ -1,10 +1,17 @@
-import type { ElementCacheFeature, Point, Rect } from '@midscene/core';
+import type {
+  ElementCacheFeature,
+  LocatorTarget,
+  Point,
+  Rect,
+} from '@midscene/core';
 import { AiJudgeOrderSensitive } from '@midscene/core/ai-model';
 import type { ModelRuntime } from '@midscene/core/ai-model';
 import type { DebugFunction } from '@midscene/shared/logger';
 
 // Shared type for web element cache feature
 export type WebElementCacheFeature = ElementCacheFeature & {
+  targets?: LocatorTarget[];
+  /** @deprecated Read-only compatibility with caches written before target. */
   xpaths?: string[];
 };
 
@@ -17,6 +24,27 @@ export const sanitizeXpaths = (xpaths: unknown): string[] => {
   return xpaths.filter(
     (xpath): xpath is string => typeof xpath === 'string' && xpath.length > 0,
   );
+};
+
+export const targetsFromXpaths = (xpaths: unknown): LocatorTarget[] =>
+  sanitizeXpaths(xpaths).map((selector) => ({
+    strategy: 'xpath',
+    selector,
+  }));
+
+export const sanitizeLocatorTargets = (
+  feature: WebElementCacheFeature,
+): LocatorTarget[] => {
+  if (Array.isArray(feature.targets)) {
+    const targets = feature.targets.filter(
+      (target): target is LocatorTarget =>
+        target?.strategy === 'xpath' &&
+        typeof target.selector === 'string' &&
+        target.selector.length > 0,
+    );
+    if (targets.length > 0) return targets;
+  }
+  return targetsFromXpaths(feature.xpaths);
 };
 
 // Cache feature extraction options interface
@@ -54,11 +82,23 @@ export async function judgeOrderSensitive(
 export function buildRectFromElementInfo(elementInfo: {
   rect: { left: number; top: number; width: number; height: number };
 }): Rect {
+  const { left, top, width, height } = elementInfo.rect;
+  if (
+    [left, top, width, height].some(
+      (value) => typeof value !== 'number' || !Number.isFinite(value),
+    ) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(
+      `Element info contains an invalid rect: ${JSON.stringify(elementInfo.rect)}`,
+    );
+  }
   const matchedRect: Rect = {
-    left: elementInfo.rect.left,
-    top: elementInfo.rect.top,
-    width: elementInfo.rect.width,
-    height: elementInfo.rect.height,
+    left,
+    top,
+    width,
+    height,
   };
   return matchedRect;
 }

--- a/packages/web-integration/src/puppeteer/base-page.ts
+++ b/packages/web-integration/src/puppeteer/base-page.ts
@@ -4,6 +4,7 @@ import type {
   DeviceAction,
   ElementCacheFeature,
   ElementTreeNode,
+  LocatorTarget,
   Point,
   Rect,
   Size,
@@ -40,7 +41,9 @@ import {
   type WebElementCacheFeature,
   buildRectFromElementInfo,
   judgeOrderSensitive,
+  sanitizeLocatorTargets,
   sanitizeXpaths,
+  targetsFromXpaths,
 } from '../common/cache-helper';
 import {
   type KeyInput,
@@ -225,6 +228,10 @@ export class Page<
   private visualUpdateFollowupTimer?: ReturnType<typeof setTimeout>;
   interfaceType: AgentType;
 
+  manifestInterface() {
+    return 'web';
+  }
+
   actionSpace(): DeviceAction[] {
     const defaultActions = commonWebActionsForWebPage(
       this,
@@ -390,43 +397,65 @@ export class Page<
       if (!sanitized.length) {
         debugPage('cacheFeatureForPoint: no xpath found at point %o', center);
       }
-      return { xpaths: sanitized };
+      return { targets: targetsFromXpaths(sanitized) };
     } catch (error) {
       debugPage('cacheFeatureForPoint failed: %s', error);
-      return { xpaths: [] };
+      return { targets: [] };
     }
   }
 
-  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
-    const xpaths = sanitizeXpaths((feature as WebElementCacheFeature).xpaths);
-    debugPage('rectMatchesCacheFeature: trying %d xpath(s)', xpaths.length);
-
-    for (const xpath of xpaths) {
-      try {
-        debugPage('rectMatchesCacheFeature: evaluating xpath: %s', xpath);
-        const elementInfo = await this.getElementInfoByXpath(xpath);
-        if (elementInfo?.rect) {
-          debugPage(
-            'rectMatchesCacheFeature: found element, rect: %o',
-            elementInfo.rect,
-          );
-          return buildRectFromElementInfo(elementInfo);
-        }
-        debugPage(
-          'rectMatchesCacheFeature: element found but no rect (elementInfo: %o)',
-          elementInfo,
+  async probeLocatorTargets(
+    targets: readonly LocatorTarget[],
+    options?: { signal?: AbortSignal },
+  ): Promise<readonly boolean[]> {
+    options?.signal?.throwIfAborted();
+    const selectors = targets.map((target) => {
+      if (target.strategy !== 'xpath') {
+        throw new Error(
+          `Unsupported locator target strategy: ${target.strategy}`,
         );
+      }
+      return target.selector;
+    });
+    const elementInfosScriptContent = getElementInfosScriptContent();
+    const result = await this.evaluateJavaScript<boolean[]>(
+      `${elementInfosScriptContent}${JSON.stringify(selectors)}.map((xpath) => midscene_element_inspector.getNodeCountByXpath(xpath) > 0)`,
+    );
+    options?.signal?.throwIfAborted();
+    return result;
+  }
+
+  async resolveLocatorTarget(target: LocatorTarget): Promise<Rect> {
+    if (target.strategy !== 'xpath') {
+      throw new Error(
+        `Unsupported locator target strategy: ${target.strategy}`,
+      );
+    }
+    const elementInfo = await this.getElementInfoByXpath(target.selector);
+    if (!elementInfo?.rect) {
+      throw new Error(`XPath target does not exist: ${target.selector}`);
+    }
+    return buildRectFromElementInfo(elementInfo);
+  }
+
+  async rectMatchesCacheFeature(feature: ElementCacheFeature): Promise<Rect> {
+    const targets = sanitizeLocatorTargets(feature as WebElementCacheFeature);
+    debugPage('rectMatchesCacheFeature: trying %d target(s)', targets.length);
+
+    for (const target of targets) {
+      try {
+        return await this.resolveLocatorTarget(target);
       } catch (error) {
         debugPage(
-          'rectMatchesCacheFeature failed for xpath %s: %s',
-          xpath,
+          'rectMatchesCacheFeature failed for target %o: %s',
+          target,
           error,
         );
       }
     }
 
     throw new Error(
-      `No matching element rect found for the provided cache feature (tried ${xpaths.length} xpath(s): ${xpaths.join(', ')})`,
+      `No matching element rect found for the provided cache feature (tried ${targets.length} target(s))`,
     );
   }
 

--- a/packages/web-integration/tests/unit-test/__snapshots__/task-cache.test.ts.snap
+++ b/packages/web-integration/tests/unit-test/__snapshots__/task-cache.test.ts.snap
@@ -9,9 +9,15 @@ exports[`TaskCache > save and retrieve cache from file 1`] = `
   },
   {
     "cache": {
-      "xpaths": [
-        "test-xpath-1",
-        "test-xpath-2",
+      "targets": [
+        {
+          "selector": "test-xpath-1",
+          "strategy": "xpath",
+        },
+        {
+          "selector": "test-xpath-2",
+          "strategy": "xpath",
+        },
       ],
     },
     "prompt": "test-locate",
@@ -29,9 +35,15 @@ exports[`TaskCache > save and retrieve cache from file 2`] = `
   },
   {
     "cache": {
-      "xpaths": [
-        "test-xpath-3",
-        "test-xpath-4",
+      "targets": [
+        {
+          "selector": "test-xpath-3",
+          "strategy": "xpath",
+        },
+        {
+          "selector": "test-xpath-4",
+          "strategy": "xpath",
+        },
       ],
     },
     "prompt": "test-locate",
@@ -50,9 +62,11 @@ caches:
   - type: locate
     prompt: test-locate
     cache:
-      xpaths:
-        - test-xpath-3
-        - test-xpath-4
+      targets:
+        - strategy: xpath
+          selector: test-xpath-3
+        - strategy: xpath
+          selector: test-xpath-4
 "
 `;
 

--- a/packages/web-integration/tests/unit-test/chrome-extension-cache.test.ts
+++ b/packages/web-integration/tests/unit-test/chrome-extension-cache.test.ts
@@ -21,6 +21,10 @@ vi.mock('@midscene/shared/logger', () => ({
   getDebug: vi.fn(() => vi.fn()),
 }));
 
+vi.mock('../../src/chrome-extension/dynamic-scripts', () => ({
+  getHtmlElementScript: vi.fn().mockResolvedValue(''),
+}));
+
 import { AiJudgeOrderSensitive } from '@midscene/core/ai-model';
 import ChromeExtensionProxyPage from '../../src/chrome-extension/page';
 
@@ -37,13 +41,18 @@ describe('ChromeExtensionProxyPage cache methods', () => {
   });
 
   describe('cacheFeatureForPoint', () => {
-    it('should return xpaths for a valid point', async () => {
+    it('should return locator targets for a valid point', async () => {
       const mockXpaths = ['/html/body/div[1]', '/html/body/div[1]/button[1]'];
       vi.spyOn(page, 'getXpathsByPoint').mockResolvedValue(mockXpaths);
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: mockXpaths });
+      expect(result).toEqual({
+        targets: mockXpaths.map((selector) => ({
+          strategy: 'xpath',
+          selector,
+        })),
+      });
       expect(page.getXpathsByPoint).toHaveBeenCalledWith(
         { left: 100, top: 200 },
         false,
@@ -63,17 +72,22 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       const result = await page.cacheFeatureForPoint([50, 50]);
 
-      expect(result).toEqual({ xpaths: ['/valid/xpath', '/another/valid'] });
+      expect(result).toEqual({
+        targets: [
+          { strategy: 'xpath', selector: '/valid/xpath' },
+          { strategy: 'xpath', selector: '/another/valid' },
+        ],
+      });
     });
 
-    it('should return empty xpaths when getXpathsByPoint fails', async () => {
+    it('should return empty targets when getXpathsByPoint fails', async () => {
       vi.spyOn(page, 'getXpathsByPoint').mockRejectedValue(
         new Error('CDP error'),
       );
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: [] });
+      expect(result).toEqual({ targets: [] });
     });
 
     it('should call AiJudgeOrderSensitive when targetDescription and modelRuntime are provided', async () => {
@@ -126,21 +140,21 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       const result = await page.cacheFeatureForPoint([100, 200]);
 
-      expect(result).toEqual({ xpaths: [] });
+      expect(result).toEqual({ targets: [] });
     });
   });
 
   describe('rectMatchesCacheFeature', () => {
-    it('should return rect when xpath matches an element', async () => {
-      const mockElementInfo = {
-        rect: { left: 10, top: 20, width: 100, height: 50 },
-      };
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue(
-        mockElementInfo as any,
-      );
+    it('should return rect when a target resolves', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 10,
+        top: 20,
+        width: 100,
+        height: 50,
+      });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/html/body/button[1]'],
+        targets: [{ strategy: 'xpath', selector: '/html/body/button[1]' }],
       });
 
       expect(result).toEqual({
@@ -151,15 +165,16 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       });
     });
 
-    it('should try multiple xpaths and return first match', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath')
-        .mockResolvedValueOnce(null as any) // First xpath fails
-        .mockResolvedValueOnce({
-          rect: { left: 5, top: 10, width: 50, height: 25 },
-        } as any);
+    it('should try multiple targets and return the first match', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget')
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ left: 5, top: 10, width: 50, height: 25 });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/invalid/xpath', '/valid/xpath'],
+        targets: [
+          { strategy: 'xpath', selector: '/invalid/xpath' },
+          { strategy: 'xpath', selector: '/valid/xpath' },
+        ],
       });
 
       expect(result).toEqual({
@@ -168,30 +183,36 @@ describe('ChromeExtensionProxyPage cache methods', () => {
         width: 50,
         height: 25,
       });
-      expect(page.getElementInfoByXpath).toHaveBeenCalledTimes(2);
+      expect(page.resolveLocatorTarget).toHaveBeenCalledTimes(2);
     });
 
-    it('should throw error when no xpath matches', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue(null as any);
+    it('should throw error when no target matches', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockRejectedValue(
+        new Error('not found'),
+      );
 
       await expect(
         page.rectMatchesCacheFeature({
-          xpaths: ['/xpath1', '/xpath2'],
+          targets: [
+            { strategy: 'xpath', selector: '/xpath1' },
+            { strategy: 'xpath', selector: '/xpath2' },
+          ],
         }),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 2 xpath(s))',
+        'No matching element rect found for cache feature (tried 2 target(s))',
       );
     });
 
-    it('should handle xpath lookup errors gracefully', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath')
+    it('should handle target lookup errors gracefully', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget')
         .mockRejectedValueOnce(new Error('Lookup error'))
-        .mockResolvedValueOnce({
-          rect: { left: 1, top: 2, width: 3, height: 4 },
-        } as any);
+        .mockResolvedValueOnce({ left: 1, top: 2, width: 3, height: 4 });
 
       const result = await page.rectMatchesCacheFeature({
-        xpaths: ['/error/xpath', '/valid/xpath'],
+        targets: [
+          { strategy: 'xpath', selector: '/error/xpath' },
+          { strategy: 'xpath', selector: '/valid/xpath' },
+        ],
       });
 
       expect(result).toEqual({
@@ -202,10 +223,13 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       });
     });
 
-    it('should filter out invalid xpaths before processing', async () => {
-      vi.spyOn(page, 'getElementInfoByXpath').mockResolvedValue({
-        rect: { left: 0, top: 0, width: 10, height: 10 },
-      } as any);
+    it('should read legacy xpaths and filter invalid entries', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 0,
+        top: 0,
+        width: 10,
+        height: 10,
+      });
 
       const feature = {
         xpaths: ['', null, '/valid/xpath', undefined, 123] as any,
@@ -213,15 +237,38 @@ describe('ChromeExtensionProxyPage cache methods', () => {
 
       await page.rectMatchesCacheFeature(feature);
 
-      expect(page.getElementInfoByXpath).toHaveBeenCalledTimes(1);
-      expect(page.getElementInfoByXpath).toHaveBeenCalledWith('/valid/xpath');
+      expect(page.resolveLocatorTarget).toHaveBeenCalledTimes(1);
+      expect(page.resolveLocatorTarget).toHaveBeenCalledWith({
+        strategy: 'xpath',
+        selector: '/valid/xpath',
+      });
+    });
+
+    it('should fall back to legacy xpaths when targets contain no valid entry', async () => {
+      vi.spyOn(page, 'resolveLocatorTarget').mockResolvedValue({
+        left: 0,
+        top: 0,
+        width: 10,
+        height: 10,
+      });
+
+      await page.rectMatchesCacheFeature({
+        targets: [{ strategy: 'xpath', selector: '' }] as any,
+        xpaths: ['/legacy/valid/xpath'],
+      });
+
+      expect(page.resolveLocatorTarget).toHaveBeenCalledOnce();
+      expect(page.resolveLocatorTarget).toHaveBeenCalledWith({
+        strategy: 'xpath',
+        selector: '/legacy/valid/xpath',
+      });
     });
 
     it('should throw error for empty xpaths array', async () => {
       await expect(
         page.rectMatchesCacheFeature({ xpaths: [] }),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 0 xpath(s))',
+        'No matching element rect found for cache feature (tried 0 target(s))',
       );
     });
 
@@ -229,8 +276,75 @@ describe('ChromeExtensionProxyPage cache methods', () => {
       await expect(
         page.rectMatchesCacheFeature({ xpaths: 'invalid' } as any),
       ).rejects.toThrow(
-        'No matching element rect found for cache feature (tried 0 xpath(s))',
+        'No matching element rect found for cache feature (tried 0 target(s))',
       );
+    });
+  });
+
+  describe('locator targets', () => {
+    it('probes XPath existence without invoking the execution resolver', async () => {
+      const sendCommand = vi
+        .spyOn(page as any, 'sendCommandToDebugger')
+        .mockResolvedValue({ result: { value: [true] } });
+      const resolveSpy = vi.spyOn(page, 'resolveLocatorTarget');
+
+      await expect(
+        page.probeLocatorTargets([
+          {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+        ]),
+      ).resolves.toEqual([true]);
+      expect(resolveSpy).not.toHaveBeenCalled();
+      const evaluateOptions = sendCommand.mock.calls[1][1] as {
+        expression: string;
+      };
+      expect(evaluateOptions.expression).toContain('getNodeCountByXpath');
+      expect(evaluateOptions.expression).not.toContain('scrollIntoView');
+    });
+
+    it('uses the execution resolver only when the target is selected', async () => {
+      const sendCommand = vi
+        .spyOn(page as any, 'sendCommandToDebugger')
+        .mockResolvedValue({
+          result: {
+            value: {
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+            },
+          },
+        });
+
+      await expect(
+        page.resolveLocatorTarget({
+          strategy: 'xpath',
+          selector: '//button[@id="confirm"]',
+        }),
+      ).resolves.toEqual({ left: 10, top: 20, width: 100, height: 50 });
+      const evaluateOptions = sendCommand.mock.calls[1][1] as {
+        expression: string;
+      };
+      expect(evaluateOptions.expression).toContain('getElementInfoByXpath');
+      expect(evaluateOptions.expression).toContain(
+        '//button[@id=\\"confirm\\"]',
+      );
+    });
+
+    it('rejects an invalid execution rect so callers can fall back', async () => {
+      vi.spyOn(page as any, 'sendCommandToDebugger').mockResolvedValue({
+        result: {
+          value: {
+            rect: { left: 10, top: 20, width: 0, height: 50 },
+          },
+        },
+      });
+
+      await expect(
+        page.resolveLocatorTarget({
+          strategy: 'xpath',
+          selector: '//button[@id="confirm"]',
+        }),
+      ).rejects.toThrow('Element info contains an invalid rect');
     });
   });
 });

--- a/packages/web-integration/tests/unit-test/task-cache.test.ts
+++ b/packages/web-integration/tests/unit-test/task-cache.test.ts
@@ -218,7 +218,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const planningCachedYamlWorkflow = 'test-yaml-workflow';
 
     const locateCachedPrompt = 'test-locate';
-    const locateCachedCache = { xpaths: ['test-xpath-1', 'test-xpath-2'] };
+    const locateCachedCache = {
+      targets: [
+        { strategy: 'xpath', selector: 'test-xpath-1' },
+        { strategy: 'xpath', selector: 'test-xpath-2' },
+      ],
+    };
 
     const cacheFilePath = prepareCache(
       [
@@ -258,7 +263,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
     // test update cache
     cachedLocateCacheUpdateFn((cache) => {
-      cache.cache = { xpaths: ['test-xpath-3', 'test-xpath-4'] };
+      cache.cache = {
+        targets: [
+          { strategy: 'xpath', selector: 'test-xpath-3' },
+          { strategy: 'xpath', selector: 'test-xpath-4' },
+        ],
+      };
     });
 
     expect(newTaskCache.cache.caches).toMatchSnapshot();
@@ -273,8 +283,8 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
   it('should correctly read cache files containing YAML folded block scalar (>-) format', () => {
     const longXpath =
-      '/html/body/div[1]/div[1]/div[10]/section[1]/div[normalize-space()="立即投保"]';
-    const prompt = '立即投保';
+      '/html/body/div[1]/div[1]/div[10]/section[1]/div[normalize-space()="Buy insurance now"]';
+    const prompt = 'Buy insurance now';
 
     // First create a normal cache file
     const cacheFilePath = prepareCache([
@@ -295,7 +305,9 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const newTaskCache = new TaskCache(uuid(), true, cacheFilePath);
     const located = newTaskCache.matchLocateCache(prompt);
     expect(located).toBeDefined();
-    expect(located?.cacheContent.cache?.xpaths).toEqual([longXpath]);
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: longXpath },
+    ]);
   });
 
   it('should match plan cache with image prompt by deep equality', () => {
@@ -351,7 +363,29 @@ describe('TaskCache', { timeout: 20000 }, () => {
 
     const newTaskCache = new TaskCache(uuid(), true, cacheFilePath);
     const located = newTaskCache.matchLocateCache('legacy-locate');
-    expect(located?.cacheContent.cache?.xpaths).toEqual(legacyXpaths);
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: legacyXpaths[0] },
+    ]);
+  });
+
+  it('falls back to legacy xpaths when cached targets are all invalid', () => {
+    const cacheFilePath = prepareCache([
+      {
+        type: 'locate',
+        prompt: 'legacy-fallback',
+        cache: {
+          targets: [{ strategy: 'xpath', selector: '' }],
+          xpaths: ['legacy-valid-xpath'],
+        },
+      },
+    ]);
+
+    const taskCache = new TaskCache(uuid(), true, cacheFilePath);
+    const located = taskCache.matchLocateCache('legacy-fallback');
+    expect(located?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'legacy-valid-xpath' },
+    ]);
+    expect(located?.cacheContent.cache).not.toHaveProperty('xpaths');
   });
 
   it('updateOrAppendCacheRecord writes cache entry and clears legacy xpaths', () => {
@@ -371,12 +405,16 @@ describe('TaskCache', { timeout: 20000 }, () => {
       {
         type: 'locate',
         prompt: 'update-locate',
-        cache: { xpaths: ['new-xpath'] },
+        cache: {
+          targets: [{ strategy: 'xpath', selector: 'new-xpath' }],
+        },
       },
       matched,
     );
 
-    expect(matched?.cacheContent.cache?.xpaths).toEqual(['new-xpath']);
+    expect(matched?.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'new-xpath' },
+    ]);
     expect(matched?.cacheContent.xpaths).toBeUndefined();
 
     const persisted = yaml.load(
@@ -385,7 +423,9 @@ describe('TaskCache', { timeout: 20000 }, () => {
     const persistedLocate = persisted.caches.find(
       (entry: any) => entry.prompt === 'update-locate',
     );
-    expect(persistedLocate.cache.xpaths).toEqual(['new-xpath']);
+    expect(persistedLocate.cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'new-xpath' },
+    ]);
     expect(persistedLocate.xpaths).toBeUndefined();
   });
 
@@ -595,8 +635,12 @@ describe('TaskCache', { timeout: 20000 }, () => {
     expect(diskCaches[1].yamlWorkflow).toBe('workflow-2');
 
     // Verify that locate entries maintain their relative order
-    expect(diskCaches[2].cache.xpaths).toEqual(['xpath-1']);
-    expect(diskCaches[3].cache.xpaths).toEqual(['xpath-2']);
+    expect(diskCaches[2].cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'xpath-1' },
+    ]);
+    expect(diskCaches[3].cache.targets).toEqual([
+      { strategy: 'xpath', selector: 'xpath-2' },
+    ]);
   });
 });
 
@@ -710,7 +754,9 @@ describe('TaskCache read-only mode', () => {
 
     const locateCache = cache.matchLocateCache('locate-prompt');
     expect(locateCache).toBeDefined();
-    expect(locateCache!.cacheContent.cache?.xpaths).toEqual(['test-xpath']);
+    expect(locateCache!.cacheContent.cache?.targets).toEqual([
+      { strategy: 'xpath', selector: 'test-xpath' },
+    ]);
   });
 
   it('should set readOnlyMode property correctly', () => {

--- a/packages/web-integration/tests/unit-test/web-extractor.test.ts
+++ b/packages/web-integration/tests/unit-test/web-extractor.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@midscene/shared/img';
 import { getElementInfosScriptContent } from '@midscene/shared/node';
 import { createServer } from 'http-server';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { launchPage } from '../ai/web/puppeteer/utils';
 
 const pageDir = join(__dirname, './fixtures/web-extractor');
@@ -354,6 +354,43 @@ describe(
         await reset();
       });
 
+      it('probeLocatorTargets should disclose every existing target without changing page state', async () => {
+        const { page, reset } = await launchPage(`http://127.0.0.1:${port}`, {
+          viewport: {
+            width: 1080,
+            height: 100,
+            deviceScaleFactor: 1,
+          },
+        });
+        await page.evaluateJavaScript?.(`
+          document.body.insertAdjacentHTML('beforeend', \`
+            <button id="extra-action-visible">Visible</button>
+            <button id="extra-action-hidden" hidden>Hidden</button>
+            <button id="extra-action-disabled" disabled>Disabled</button>
+            <button id="extra-action-offscreen" style="position:absolute;top:5000px">Offscreen</button>
+            <button id="extra-action-zero-size" style="width:0;height:0;padding:0;border:0">Zero size</button>
+          \`);
+        `);
+        const scrollYBefore = await page.evaluateJavaScript?.('window.scrollY');
+        const evaluateSpy = vi.spyOn(page, 'evaluateJavaScript');
+
+        const result = await page.probeLocatorTargets([
+          { strategy: 'xpath', selector: '//*[@id="extra-action-visible"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-hidden"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-disabled"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-offscreen"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-zero-size"]' },
+          { strategy: 'xpath', selector: '//*[@id="extra-action-missing"]' },
+        ]);
+
+        expect(result).toEqual([true, true, true, true, true, false]);
+        expect(evaluateSpy).toHaveBeenCalledOnce();
+        expect(await page.evaluateJavaScript?.('window.scrollY')).toBe(
+          scrollYBefore,
+        );
+        await reset();
+      });
+
       it('getXpathsByPoint should handle elements with special characters', async () => {
         const { page, reset } = await launchPage(`http://127.0.0.1:${port}`, {
           viewport: {
@@ -402,12 +439,16 @@ describe(
         const cacheFeature = await page.cacheFeatureForPoint?.([149, 419]);
 
         expect(cacheFeature).toBeDefined();
-        const xpaths = (cacheFeature as any)?.xpaths as string[] | undefined;
-        expect(xpaths).toBeDefined();
-        expect(xpaths?.length).toBeGreaterThan(0);
+        const targets = (cacheFeature as any)?.targets as
+          | Array<{ strategy: string; selector: string }>
+          | undefined;
+        expect(targets).toBeDefined();
+        expect(targets?.length).toBeGreaterThan(0);
 
-        const xpath = xpaths?.[0];
-        expect(xpath).toMatch(/^\/html/);
+        expect(targets?.[0]).toEqual({
+          strategy: 'xpath',
+          selector: expect.stringMatching(/^\/html/),
+        });
 
         await reset();
       });


### PR DESCRIPTION
## Summary

- introduce a platform-neutral locator `target` union and resolve it to a fresh element rectangle before execution
- add side-effect-free target probing and XPath node counting for Web adapters
- migrate cache entries to `target` while retaining read compatibility for the existing top-level `xpath` cache field
- keep the existing AI locator as the fallback when a deterministic target cannot be resolved

## Stack dependency

This is the first PR in the new three-PR stack. It is based on #2933 because it builds on the existing XPath-map work.

Review order: **this PR → #2990 → #2991**.

## Validation

- `pnpm run lint`
- `NX_DAEMON=false pnpm nx test @midscene/shared` — 427 passed
- `NX_DAEMON=false pnpm nx test @midscene/core` — passed at this stack revision
- `NX_DAEMON=false pnpm nx build @midscene/core`
- `NX_DAEMON=false pnpm nx build @midscene/web`
- `pnpm exec vitest --run tests/unit-test/chrome-extension-cache.test.ts tests/unit-test/task-cache.test.ts tests/unit-test/web-extractor.test.ts` from `packages/web-integration` — 72 passed, 1 skipped

The full Web suite was also attempted locally, but an unrelated process outside this worktree already owns port 5800. The focused tests covering the changed Web target/cache paths pass; CI remains the source of truth for the complete suite.
