### PR TITLE
feat(core): load reusable extra action manifests

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -76,7 +76,6 @@ import {
 } from './element-xpaths';
 import {
   createExtraActionExecutionOptions,
-  extraActionsCacheKey,
   loadExtraActions,
 } from './extra-actions';
 import { FileChooserAccepter } from './file-chooser';
@@ -1107,7 +1106,14 @@ export class Agent<
       const extraActions = await loadExtraActions(
         extraActionPaths,
         this.fullActionSpace,
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
       );
+      const extraActionExecution = createExtraActionExecutionOptions(
+        extraActions,
+        this.interface,
+      );
+      let initialExtraActionSnapshot =
+        await extraActionExecution?.createSnapshot({ signal: abortSignal });
       const elementXpaths = await loadElementXpaths(
         opt?.loadElementXpaths ?? [],
       );
@@ -1124,10 +1130,13 @@ export class Agent<
         taskPrompt,
         aiActContext,
       );
-      const extraActionKey = extraActionsCacheKey(extraActions);
-      const cachePrompt = extraActionKey
-        ? `${promptWithContext}\n\n<midscene_extra_actions>${extraActionKey}</midscene_extra_actions>`
-        : promptWithContext;
+      const cachePromptForSnapshot = (fingerprint?: string) =>
+        fingerprint
+          ? `${promptWithContext}\n\n<midscene_extra_actions>${fingerprint}</midscene_extra_actions>`
+          : promptWithContext;
+      const cachePrompt = cachePromptForSnapshot(
+        initialExtraActionSnapshot?.fingerprint,
+      );
       // Controls the aiAct planning mode, such as sub-goal prompts and locate result strategy.
       let deepThink = opt?.deepThink === true;
       if (deepThink && planningModel.adapter.planning.kind === 'custom') {
@@ -1191,6 +1200,10 @@ export class Agent<
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          initialExtraActionSnapshot =
+            await extraActionExecution?.createSnapshot({
+              signal: abortSignal,
+            });
         }
       }
 
@@ -1210,7 +1223,12 @@ export class Agent<
           deepLocate,
           abortSignal,
           reportOptions: internalReportDisplay,
-          extraActions: createExtraActionExecutionOptions(extraActions),
+          extraActions: extraActionExecution
+            ? {
+                ...extraActionExecution,
+                initialSnapshot: initialExtraActionSnapshot,
+              }
+            : undefined,
           elementXpaths,
         },
       );

--- a/packages/core/src/agent/element-xpaths.ts
+++ b/packages/core/src/agent/element-xpaths.ts
@@ -1,7 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import { findAllMidsceneLocatorField } from '@/ai-model';
+import { xpathLocatorTarget } from '@/locator';
 import type { DeviceAction, PlanningAction } from '@/types';
 import yaml from 'js-yaml';
+import { getExtraActionSource, setExtraActionSource } from './extra-actions';
 
 interface ElementXpathFile {
   elements: Record<string, string>;
@@ -15,7 +17,14 @@ export interface LoadedElementXpath {
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const normalizedElementName = (name: string) => name.trim().toLowerCase();
+const normalizedElementName = (name: string) =>
+  name
+    .normalize('NFKC')
+    .trim()
+    .toLowerCase()
+    .replace(/["“”「」『』]/g, '')
+    .replace(/^(?:the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
 
 function parseElementXpathFile(
   content: string,
@@ -146,12 +155,52 @@ function locatorPromptText(locator: unknown): string | undefined {
 }
 
 function locatorAlreadyResolved(locator: unknown): boolean {
-  return isPlainObject(locator) && typeof locator.xpath === 'string';
+  return (
+    isPlainObject(locator) &&
+    (typeof locator.xpath === 'string' || locator.target !== undefined)
+  );
 }
 
-function locatorWithXpath(locator: unknown, prompt: string, xpath: string) {
+function xpathForLocatorPrompt(
+  prompt: string,
+  elements: LoadedElementXpath[],
+): string | undefined {
+  const normalizedPrompt = normalizedElementName(prompt);
+  const exactMatch = elements.find(
+    ({ name }) => normalizedElementName(name) === normalizedPrompt,
+  );
+  if (exactMatch) {
+    return exactMatch.xpath;
+  }
+
+  const paddedPrompt = ` ${normalizedPrompt} `;
+  const containedMatches = elements
+    .map((element) => ({
+      ...element,
+      normalizedName: normalizedElementName(element.name),
+    }))
+    .filter(({ normalizedName }) =>
+      paddedPrompt.includes(` ${normalizedName} `),
+    )
+    .sort(
+      (left, right) => right.normalizedName.length - left.normalizedName.length,
+    );
+
+  if (containedMatches.length === 0) {
+    return undefined;
+  }
+  if (
+    containedMatches[1]?.normalizedName.length ===
+    containedMatches[0].normalizedName.length
+  ) {
+    return undefined;
+  }
+  return containedMatches[0].xpath;
+}
+
+function locatorWithTarget(locator: unknown, prompt: string, xpath: string) {
   if (typeof locator === 'string') {
-    return { prompt: locator, xpath };
+    return { prompt: locator, target: xpathLocatorTarget(xpath) };
   }
 
   const {
@@ -166,7 +215,7 @@ function locatorWithXpath(locator: unknown, prompt: string, xpath: string) {
   return {
     ...locatorWithoutCoordinates,
     prompt,
-    xpath,
+    target: xpathLocatorTarget(xpath),
   };
 }
 
@@ -179,9 +228,6 @@ export function applyElementXpathsToPlans(
     return { plans, mapped: false };
   }
 
-  const xpathByName = new Map(
-    elements.map(({ name, xpath }) => [normalizedElementName(name), xpath]),
-  );
   let mapped = false;
 
   const transformedPlans = plans.map((plan) => {
@@ -204,17 +250,23 @@ export function applyElementXpathsToPlans(
       if (!prompt) {
         continue;
       }
-      const xpath = xpathByName.get(normalizedElementName(prompt));
+      const xpath = xpathForLocatorPrompt(prompt, elements);
       if (!xpath) {
         continue;
       }
 
       transformedParam ??= { ...plan.param };
-      transformedParam[field] = locatorWithXpath(locator, prompt, xpath);
+      transformedParam[field] = locatorWithTarget(locator, prompt, xpath);
       mapped = true;
     }
 
-    return transformedParam ? { ...plan, param: transformedParam } : plan;
+    if (!transformedParam) return plan;
+    const transformedPlan = { ...plan, param: transformedParam };
+    const extraActionSource = getExtraActionSource(plan);
+    if (extraActionSource) {
+      setExtraActionSource(transformedPlan, extraActionSource);
+    }
+    return transformedPlan;
   });
 
   return { plans: transformedPlans, mapped };

--- a/packages/core/src/agent/extra-action-manifest.ts
+++ b/packages/core/src/agent/extra-action-manifest.ts
@@ -1,0 +1,157 @@
+import { type LocatorTarget, LocatorTargetSchema } from '@/locator';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+const hasInvalidProtocolNameCharacter = (name: string): boolean =>
+  Array.from(name).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      character === '<' ||
+      character === '>' ||
+      codePoint === undefined ||
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+
+const protocolNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((name) => !hasInvalidProtocolNameCharacter(name), {
+    message:
+      'must not contain angle brackets, line breaks, or control characters',
+  });
+
+const extraActionDefinitionSchema = z
+  .object({
+    name: protocolNameSchema,
+    validWhenTargetExists: LocatorTargetSchema.optional(),
+    action: z
+      .object({
+        name: z.string().trim().min(1),
+        param: z.unknown().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const extraActionManifestSchema = z
+  .object({
+    version: z.literal(1),
+    interface: z.string().trim().min(1),
+    actions: z.array(extraActionDefinitionSchema).min(1),
+  })
+  .strict();
+
+const legacyExtraActionFileSchema = z
+  .object({
+    name: protocolNameSchema,
+    actionName: z.string().trim().min(1),
+    actionParam: z.tuple([z.unknown()]),
+  })
+  .strict();
+
+export type ExtraActionDefinition = z.infer<typeof extraActionDefinitionSchema>;
+
+export type ExtraActionManifest = z.infer<typeof extraActionManifestSchema>;
+
+export interface ParsedExtraActionFile {
+  manifestInterface?: string;
+  definitions: ExtraActionDefinition[];
+  legacy: boolean;
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${field}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+function parseYaml(content: string, sourcePath: string): unknown {
+  try {
+    return yaml.load(content, { schema: yaml.JSON_SCHEMA });
+  } catch (error) {
+    throw new Error(
+      `Failed to parse extra action file "${sourcePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * The single parsing boundary for both loaded and generated action manifests.
+ * Legacy one-action files are accepted for reads, but all callers receive the
+ * same canonical definition shape.
+ */
+export function parseExtraActionFile(
+  content: string,
+  sourcePath: string,
+): ParsedExtraActionFile {
+  const parsed = parseYaml(content, sourcePath);
+  const looksLikeManifest =
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    ('version' in parsed || 'interface' in parsed || 'actions' in parsed);
+
+  if (looksLikeManifest) {
+    const result = extraActionManifestSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": ${formatIssues(result.error)}`,
+      );
+    }
+    return {
+      manifestInterface: result.data.interface,
+      definitions: result.data.actions,
+      legacy: false,
+    };
+  }
+
+  const legacy = legacyExtraActionFileSchema.safeParse(parsed);
+  if (!legacy.success) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": ${formatIssues(legacy.error)}`,
+    );
+  }
+  return {
+    definitions: [
+      {
+        name: legacy.data.name,
+        action: {
+          name: legacy.data.actionName,
+          param: legacy.data.actionParam[0],
+        },
+      },
+    ],
+    legacy: true,
+  };
+}
+
+/** Validate generated YAML through the same strict schema used by the loader. */
+export function parseExtraActionManifest(
+  content: string,
+  sourcePath: string,
+): ExtraActionManifest {
+  const parsed = parseExtraActionFile(content, sourcePath);
+  if (parsed.legacy || !parsed.manifestInterface) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": expected a versioned Action Manifest`,
+    );
+  }
+  return {
+    version: 1,
+    interface: parsed.manifestInterface,
+    actions: parsed.definitions,
+  };
+}
+
+export type { LocatorTarget };

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -1,99 +1,71 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { findAllMidsceneLocatorField } from '@/ai-model';
+import type { AbstractInterface } from '@/device';
+import type { LocatorTarget } from '@/locator';
 import type { DeviceAction, PlanningAction } from '@/types';
-import yaml from 'js-yaml';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionFile,
+} from './extra-action-manifest';
 
-interface ExtraActionFile {
-  name: string;
-  actionName: string;
-  actionParam: [unknown];
-}
+export type { ExtraActionDefinition, ExtraActionManifest };
 
 export interface LoadedExtraAction {
+  alias: string;
   name: string;
-  planningAction: DeviceAction;
+  sourcePath: string;
   plan: PlanningAction;
+  validWhenTargetExists?: LocatorTarget;
+}
+
+export interface ExtraActionSource {
+  type: 'extra-action';
+  name: string;
+  alias: string;
+  sourcePath: string;
+}
+
+export interface ExtraActionSnapshot {
+  readonly actionSpace: readonly DeviceAction[];
+  readonly fingerprint: string;
+  expandPlans: (plans: PlanningAction[]) => {
+    plans: PlanningAction[];
+    expanded: boolean;
+  };
+}
+
+const extraActionSourceByPlan = new WeakMap<
+  PlanningAction,
+  ExtraActionSource
+>();
+
+export function getExtraActionSource(
+  plan: PlanningAction,
+): ExtraActionSource | undefined {
+  return extraActionSourceByPlan.get(plan);
+}
+
+export function setExtraActionSource(
+  plan: PlanningAction,
+  source: ExtraActionSource,
+): void {
+  extraActionSourceByPlan.set(plan, source);
 }
 
 const locatorShortcutFields = new Set([
   'prompt',
   'xpath',
+  'target',
   'locatedPixelBbox',
   'deepLocate',
   'deepThink',
   'cacheable',
 ]);
 
-const hasInvalidProtocolNameCharacter = (name: string): boolean =>
-  Array.from(name).some((character) => {
-    const codePoint = character.codePointAt(0);
-    return (
-      character === '<' ||
-      character === '>' ||
-      codePoint === undefined ||
-      codePoint < 0x20 ||
-      (codePoint >= 0x7f && codePoint <= 0x9f) ||
-      codePoint === 0x2028 ||
-      codePoint === 0x2029
-    );
-  });
-
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
-
-function assertNonEmptyString(
-  value: unknown,
-  field: 'name' | 'actionName',
-  sourcePath: string,
-): asserts value is string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "${field}" must be a non-empty string`,
-    );
-  }
-}
-
-function parseExtraActionFile(
-  content: string,
-  sourcePath: string,
-): ExtraActionFile {
-  let parsed: unknown;
-  try {
-    parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA });
-  } catch (error) {
-    throw new Error(
-      `Failed to parse extra action file "${sourcePath}": ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-      { cause: error },
-    );
-  }
-
-  if (!isPlainObject(parsed)) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": expected a YAML object`,
-    );
-  }
-
-  assertNonEmptyString(parsed.name, 'name', sourcePath);
-  assertNonEmptyString(parsed.actionName, 'actionName', sourcePath);
-  if (hasInvalidProtocolNameCharacter(parsed.name)) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "name" must not contain angle brackets, line breaks, or control characters`,
-    );
-  }
-  if (!Array.isArray(parsed.actionParam) || parsed.actionParam.length !== 1) {
-    throw new Error(
-      `Invalid extra action file "${sourcePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
-    );
-  }
-
-  return {
-    name: parsed.name.trim(),
-    actionName: parsed.actionName.trim(),
-    actionParam: [parsed.actionParam[0]],
-  };
-}
 
 function findReferencedAction(
   actionName: string,
@@ -104,18 +76,21 @@ function findReferencedAction(
     (action) =>
       action.name === actionName || action.interfaceAlias === actionName,
   );
-  if (exactMatch) {
-    return exactMatch;
-  }
+  if (exactMatch) return exactMatch;
 
   const normalizedName = actionName.toLowerCase();
-  const caseInsensitiveMatch = actionSpace.find(
+  const caseInsensitiveMatches = actionSpace.filter(
     (action) =>
       action.name.toLowerCase() === normalizedName ||
       action.interfaceAlias?.toLowerCase() === normalizedName,
   );
-  if (caseInsensitiveMatch) {
-    return caseInsensitiveMatch;
+  if (caseInsensitiveMatches.length === 1) return caseInsensitiveMatches[0];
+  if (caseInsensitiveMatches.length > 1) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": action "${actionName}" is ambiguous. Matching actions: ${caseInsensitiveMatches
+        .map((action) => action.name)
+        .join(', ')}`,
+    );
   }
 
   const availableActions = actionSpace
@@ -127,7 +102,7 @@ function findReferencedAction(
   );
 }
 
-function normalizeActionParam(
+function normalizeLegacyActionParam(
   action: DeviceAction,
   actionParam: unknown,
   fallbackPrompt: string,
@@ -135,49 +110,42 @@ function normalizeActionParam(
   if (!action.paramSchema || !isPlainObject(actionParam)) {
     return actionParam;
   }
-
   const locateFields = findAllMidsceneLocatorField(action.paramSchema);
-  if (locateFields.length !== 1) {
-    return actionParam;
-  }
+  if (locateFields.length !== 1) return actionParam;
 
   const locateField = locateFields[0];
   if (Object.prototype.hasOwnProperty.call(actionParam, locateField)) {
     const locateParam = actionParam[locateField];
     if (
       isPlainObject(locateParam) &&
-      (locateParam.xpath || locateParam.locatedPixelBbox) &&
+      (locateParam.xpath ||
+        locateParam.target ||
+        locateParam.locatedPixelBbox) &&
       !locateParam.prompt
     ) {
       return {
         ...actionParam,
-        [locateField]: {
-          prompt: fallbackPrompt,
-          ...locateParam,
-        },
+        [locateField]: { prompt: fallbackPrompt, ...locateParam },
       };
     }
     return actionParam;
   }
 
-  const isLocatorShortcut =
-    Object.prototype.hasOwnProperty.call(actionParam, 'prompt') ||
-    Object.prototype.hasOwnProperty.call(actionParam, 'xpath') ||
-    Object.prototype.hasOwnProperty.call(actionParam, 'locatedPixelBbox');
-  if (!isLocatorShortcut) {
-    return actionParam;
-  }
+  const isLocatorShortcut = [
+    'prompt',
+    'xpath',
+    'target',
+    'locatedPixelBbox',
+  ].some((field) => Object.prototype.hasOwnProperty.call(actionParam, field));
+  if (!isLocatorShortcut) return actionParam;
 
   const locateParam: Record<string, unknown> = {};
   const actionParamWithoutLocate: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(actionParam)) {
-    if (locatorShortcutFields.has(key)) {
-      locateParam[key] = value;
-    } else {
-      actionParamWithoutLocate[key] = value;
-    }
+    (locatorShortcutFields.has(key) ? locateParam : actionParamWithoutLocate)[
+      key
+    ] = value;
   }
-
   return {
     ...actionParamWithoutLocate,
     [locateField]: {
@@ -187,6 +155,31 @@ function normalizeActionParam(
   };
 }
 
+function normalizeActionParamTargets(
+  action: DeviceAction,
+  actionParam: unknown,
+): unknown {
+  if (!action.paramSchema || !isPlainObject(actionParam)) return actionParam;
+  let normalized: Record<string, unknown> | undefined;
+  for (const field of findAllMidsceneLocatorField(action.paramSchema)) {
+    const locator = actionParam[field];
+    if (!isPlainObject(locator)) continue;
+    if (locator.target !== undefined && locator.xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
+    if (typeof locator.xpath !== 'string') continue;
+    const { xpath, ...withoutXpath } = locator;
+    normalized ??= { ...actionParam };
+    normalized[field] = {
+      ...withoutXpath,
+      target: { strategy: 'xpath', selector: xpath },
+    };
+  }
+  return normalized ?? actionParam;
+}
+
 function validateActionParam(
   action: DeviceAction,
   actionParam: unknown,
@@ -194,13 +187,19 @@ function validateActionParam(
   actionIndex: number,
 ): unknown {
   if (!action.paramSchema) {
-    return actionParam;
+    if (
+      actionParam !== undefined &&
+      (!isPlainObject(actionParam) || Object.keys(actionParam).length > 0)
+    ) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" must be omitted for parameterless action "${action.name}"`,
+      );
+    }
+    return undefined;
   }
 
   const result = action.paramSchema.safeParse(actionParam);
-  if (result.success) {
-    return result.data;
-  }
+  if (result.success) return result.data;
 
   const details = result.error.issues
     .map((issue) => {
@@ -209,14 +208,14 @@ function validateActionParam(
     })
     .join('; ');
   throw new Error(
-    `Invalid extra action file "${sourcePath}": "actionParam[${actionIndex}]" does not match action "${action.name}": ${details}`,
+    `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" does not match action "${action.name}": ${details}`,
   );
 }
 
-function createPlanningAction(id: string, name: string): DeviceAction {
+function createPlanningAction(alias: string, name: string): DeviceAction {
   return {
-    name: id,
-    description: `Replay the known-good UI action ${JSON.stringify(name)}. If the user's request matches this action, always prefer it over rebuilding the operation from a low-level action. This action takes no parameters.`,
+    name: alias,
+    description: `High-priority exact UI action: ${JSON.stringify(name)}. Use this parameterless action when it matches the next requested operation.`,
     sample: {},
     call: () => {
       throw new Error(
@@ -229,14 +228,30 @@ function createPlanningAction(id: string, name: string): DeviceAction {
 export async function loadExtraActions(
   paths: string[],
   actionSpace: DeviceAction[],
+  manifestInterface?: string,
 ): Promise<LoadedExtraAction[]> {
-  if (paths.length === 0) {
-    return [];
-  }
-
+  if (paths.length === 0) return [];
   const loadedActions: LoadedExtraAction[] = [];
-  const knownNames = new Set(actionSpace.map((action) => action.name));
-  const knownProtocolIds = new Set(knownNames);
+  const knownNames = new Set<string>();
+  const reservedAliases = new Set(
+    actionSpace.flatMap((action) =>
+      [action.name, action.interfaceAlias]
+        .filter((name): name is string => Boolean(name))
+        .map((name) => name.toLowerCase()),
+    ),
+  );
+  let nextAliasIndex = 1;
+
+  const allocateAlias = (): string => {
+    let alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    while (reservedAliases.has(alias.toLowerCase())) {
+      nextAliasIndex += 1;
+      alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    }
+    nextAliasIndex += 1;
+    reservedAliases.add(alias.toLowerCase());
+    return alias;
+  };
 
   for (const sourcePath of paths) {
     let content: string;
@@ -250,110 +265,193 @@ export async function loadExtraActions(
         { cause: error },
       );
     }
-
-    const definition = parseExtraActionFile(content, sourcePath);
-    if (knownNames.has(definition.name)) {
+    const parsed = parseExtraActionFile(content, sourcePath);
+    if (
+      parsed.manifestInterface &&
+      manifestInterface &&
+      parsed.manifestInterface !== manifestInterface
+    ) {
       throw new Error(
-        `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+        `Invalid extra action file "${sourcePath}": interface "${parsed.manifestInterface}" does not match current interface "${manifestInterface}"`,
       );
     }
 
-    const referencedAction = findReferencedAction(
-      definition.actionName,
-      actionSpace,
-      sourcePath,
-    );
-    knownNames.add(definition.name);
-    let protocolIndex = loadedActions.length + 1;
-    let protocolId = `MidsceneExtraAction_${protocolIndex}`;
-    while (knownProtocolIds.has(protocolId)) {
-      protocolIndex += 1;
-      protocolId = `MidsceneExtraAction_${protocolIndex}`;
-    }
-    knownProtocolIds.add(protocolId);
-
-    const normalizedParam = normalizeActionParam(
-      referencedAction,
-      definition.actionParam[0],
-      definition.name,
-    );
-    const plan = {
-      type: referencedAction.name,
-      param: validateActionParam(
-        referencedAction,
-        normalizedParam,
+    for (const [definitionIndex, definition] of parsed.definitions.entries()) {
+      if (knownNames.has(definition.name)) {
+        throw new Error(
+          `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+        );
+      }
+      const referencedAction = findReferencedAction(
+        definition.action.name,
+        actionSpace,
         sourcePath,
-        0,
-      ),
-      thought: `Run extra action "${definition.name}"`,
-    };
+      );
+      knownNames.add(definition.name);
 
-    loadedActions.push({
-      name: definition.name,
-      planningAction: createPlanningAction(protocolId, definition.name),
-      plan,
-    });
+      // Native manifests use Action Space's param shape directly. Only legacy
+      // one-action files get shortcut normalization; both formats accept
+      // `xpath` as a read-only compatibility alias for `target`.
+      const rawParamBeforeTargetNormalization = parsed.legacy
+        ? normalizeLegacyActionParam(
+            referencedAction,
+            definition.action.param,
+            definition.name,
+          )
+        : definition.action.param;
+      const rawParam = normalizeActionParamTargets(
+        referencedAction,
+        rawParamBeforeTargetNormalization,
+      );
+      const plan: PlanningAction = {
+        type: referencedAction.name,
+        param: validateActionParam(
+          referencedAction,
+          rawParam,
+          sourcePath,
+          definitionIndex,
+        ),
+        thought: `Run extra action "${definition.name}"`,
+      };
+
+      loadedActions.push({
+        alias: allocateAlias(),
+        name: definition.name,
+        sourcePath,
+        plan,
+        validWhenTargetExists: definition.validWhenTargetExists,
+      });
+    }
   }
-
   return loadedActions;
 }
 
-export function expandExtraActionPlans(
-  plans: PlanningAction[],
-  extraActions: LoadedExtraAction[],
-): PlanningAction[] {
-  if (extraActions.length === 0) {
-    return plans;
-  }
+interface SnapshotAction {
+  alias: string;
+  loaded: LoadedExtraAction;
+  planningAction: DeviceAction;
+}
 
-  const extraActionsByName = new Map(
-    extraActions.map((action) => [action.planningAction.name, action]),
-  );
-
-  return plans.map((plan) => {
-    const extraAction = extraActionsByName.get(plan.type);
-    if (!extraAction) {
-      return plan;
-    }
-
+function createSnapshotActions(
+  disclosed: LoadedExtraAction[],
+): SnapshotAction[] {
+  return disclosed.map((loaded) => {
     return {
-      ...extraAction.plan,
-      param: structuredClone(extraAction.plan.param),
-      thought: plan.thought || extraAction.plan.thought,
+      alias: loaded.alias,
+      loaded,
+      planningAction: Object.freeze(
+        createPlanningAction(loaded.alias, loaded.name),
+      ),
     };
   });
 }
 
-export function extraActionsCacheKey(
-  extraActions: LoadedExtraAction[],
-): string | undefined {
-  if (extraActions.length === 0) {
-    return undefined;
-  }
+function expandSnapshotPlans(
+  plans: PlanningAction[],
+  snapshotActions: SnapshotAction[],
+): PlanningAction[] {
+  const byAlias = new Map(snapshotActions.map((entry) => [entry.alias, entry]));
+  return plans.map((plan) => {
+    const entry = byAlias.get(plan.type);
+    if (!entry) return plan;
+    const expanded = {
+      ...entry.loaded.plan,
+      param: structuredClone(entry.loaded.plan.param),
+      thought: plan.thought || entry.loaded.plan.thought,
+    };
+    setExtraActionSource(expanded, {
+      type: 'extra-action',
+      name: entry.loaded.name,
+      alias: entry.alias,
+      sourcePath: entry.loaded.sourcePath,
+    });
+    return expanded;
+  });
+}
 
-  return JSON.stringify(
-    extraActions.map((action) => ({
+function targetKey(target: LocatorTarget): string {
+  return JSON.stringify(target);
+}
+
+export async function createExtraActionSnapshot(
+  extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
+  options: { signal?: AbortSignal } = {},
+): Promise<ExtraActionSnapshot> {
+  options.signal?.throwIfAborted();
+  const conditionalTargets = extraActions.flatMap((action) =>
+    action.validWhenTargetExists ? [action.validWhenTargetExists] : [],
+  );
+  const uniqueTargets = Array.from(
+    new Map(
+      conditionalTargets.map((target) => [targetKey(target), target]),
+    ).values(),
+  );
+  if (uniqueTargets.length > 0 && !interfaceInstance?.probeLocatorTargets) {
+    throw new Error(
+      'Extra actions use validWhenTargetExists, but the current interface cannot probe locator targets',
+    );
+  }
+  const existenceResult =
+    uniqueTargets.length === 0
+      ? []
+      : await interfaceInstance!.probeLocatorTargets!(uniqueTargets, options);
+  options.signal?.throwIfAborted();
+  if (!Array.isArray(existenceResult)) {
+    throw new Error('probeLocatorTargets must return a boolean array');
+  }
+  const existence = existenceResult as readonly unknown[];
+  if (existence.length !== uniqueTargets.length) {
+    throw new Error(
+      `probeLocatorTargets returned ${existence.length} result(s) for ${uniqueTargets.length} target(s)`,
+    );
+  }
+  if (existence.some((value) => typeof value !== 'boolean')) {
+    throw new Error('probeLocatorTargets must return only boolean results');
+  }
+  const existenceByTarget = new Map(
+    uniqueTargets.map((target, index) => [targetKey(target), existence[index]]),
+  );
+  const disclosed = extraActions.filter(
+    (action) =>
+      !action.validWhenTargetExists ||
+      existenceByTarget.get(targetKey(action.validWhenTargetExists)) === true,
+  );
+  const snapshotActions = createSnapshotActions(disclosed);
+  const aliases = new Set(snapshotActions.map((entry) => entry.alias));
+  const fingerprintPayload = JSON.stringify({
+    manifest: extraActions.map((action) => ({
       name: action.name,
+      validWhenTargetExists: action.validWhenTargetExists,
       plan: action.plan,
     })),
-  );
+    disclosed: snapshotActions.map((entry) => ({
+      alias: entry.alias,
+      name: entry.loaded.name,
+    })),
+  });
+  const fingerprint = `extra-actions-snapshot:v1:${createHash('sha256')
+    .update(fingerprintPayload)
+    .digest('hex')}`;
+  return {
+    actionSpace: Object.freeze(
+      snapshotActions.map((entry) => entry.planningAction),
+    ),
+    fingerprint,
+    expandPlans: (plans) => ({
+      plans: expandSnapshotPlans(plans, snapshotActions),
+      expanded: plans.some((plan) => aliases.has(plan.type)),
+    }),
+  };
 }
 
 export function createExtraActionExecutionOptions(
   extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
 ) {
-  if (extraActions.length === 0) {
-    return undefined;
-  }
-
-  const extraActionNames = new Set(
-    extraActions.map((action) => action.planningAction.name),
-  );
+  if (extraActions.length === 0) return undefined;
   return {
-    actionSpace: extraActions.map((action) => action.planningAction),
-    expandPlans: (plans: PlanningAction[]) => ({
-      plans: expandExtraActionPlans(plans, extraActions),
-      expanded: plans.some((plan) => extraActionNames.has(plan.type)),
-    }),
+    createSnapshot: (options?: { signal?: AbortSignal }) =>
+      createExtraActionSnapshot(extraActions, interfaceInstance, options),
   };
 }

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -2,6 +2,7 @@ import { findAllMidsceneLocatorField, parseActionParam } from '@/ai-model';
 import type { ModelRuntime } from '@/ai-model/models';
 import { findActionInActionSpaceOrThrow } from '@/common';
 import type { AbstractInterface } from '@/device';
+import { xpathLocatorTarget } from '@/locator';
 import type Service from '@/service';
 import { setTimingFieldOnce } from '@/task-timing';
 import type {
@@ -25,6 +26,7 @@ import { sleep } from '@/utils';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
+import { getExtraActionSource, setExtraActionSource } from './extra-actions';
 import type { TaskCache } from './task-cache';
 import { withUsageIntent } from './usage-intent';
 import {
@@ -83,9 +85,17 @@ function normalizeLocateParam(
   }
 
   const { deepThink, ...rest } = param as LocateParamWithDeprecatedAlias;
+  if (rest.target !== undefined && rest.xpath !== undefined) {
+    throw new Error('`target` and `xpath` cannot be used in the same locator');
+  }
   const deepLocate = rest.deepLocate ?? deepThink;
+  const { xpath, ...withoutXpath } = rest;
+  const normalized =
+    typeof xpath === 'string'
+      ? { ...withoutXpath, target: xpathLocatorTarget(xpath) }
+      : withoutXpath;
 
-  return deepLocate === undefined ? rest : { ...rest, deepLocate };
+  return deepLocate === undefined ? normalized : { ...normalized, deepLocate };
 }
 
 export function locatePlanForLocate(param: string | DetailedLocateParam) {
@@ -228,12 +238,17 @@ export class TaskBuilder {
       action.paramSchema,
       true,
     );
+    const extraActionSource = getExtraActionSource(plan);
 
     locateFields.forEach((field) => {
       if (param[field]) {
+        const locateParam = param[field];
         // Always use createLocateTask for all locate params.
         // This ensures cache writing happens even when locatedPixelBbox is available
-        const locatePlan = locatePlanForLocate(param[field]);
+        const locatePlan = locatePlanForLocate(locateParam);
+        if (extraActionSource) {
+          setExtraActionSource(locatePlan, extraActionSource);
+        }
         debug(
           'will prepend locate param for field',
           `action.type=${planType}`,
@@ -243,7 +258,7 @@ export class TaskBuilder {
         );
         const locateTask = this.createLocateTask(
           locatePlan,
-          param[field],
+          locateParam,
           context,
           (result) => {
             param[field] = result;
@@ -377,6 +392,17 @@ export class TaskBuilder {
 
         return {
           output: actionResult,
+          ...(extraActionSource
+            ? {
+                hitBy: {
+                  from: 'Extra Action',
+                  context: {
+                    extraActionName: extraActionSource.name,
+                    extraActionAlias: extraActionSource.alias,
+                  },
+                },
+              }
+            : {}),
         };
       },
     };
@@ -477,51 +503,69 @@ export class TaskBuilder {
           ? matchElementFromPlan(paramWithLocatedPixelBbox)
           : undefined;
 
-        // from locatedPixelBbox (direct plan hit)
-        // when deepLocate is enabled, locatedPixelBbox should be used as search
-        // area hint, not as a final direct hit
-        const elementFromPlan = param.deepLocate
-          ? undefined
-          : planLocatedElement;
-        const isPlanDirectHit = !!elementFromPlan;
-
-        // from xpath
-        let rectFromXpath: Rect | undefined;
-        if (
-          !isPlanDirectHit &&
-          param.xpath &&
-          this.interface.rectMatchesCacheFeature
-        ) {
+        // Resolve stable targets before using model-provided coordinates. The
+        // resolver returns a fresh logical-coordinate Rect on every execution.
+        let elementFromTarget: LocateResultElement | undefined;
+        let targetResolutionError: string | undefined;
+        if (param.target) {
           try {
-            rectFromXpath = await this.interface.rectMatchesCacheFeature({
-              xpaths: [param.xpath],
-            });
-          } catch {
-            // xpath locate failed, allow fallback to cache or AI locate
-          }
-        }
-
-        const elementFromXpath = rectFromXpath
-          ? generateElementByRect(
-              // rectFromXpath is in logical coordinates, which should be transformed to screenshot coordinates;
+            let rectFromTarget: Rect | undefined;
+            if (this.interface.resolveLocatorTarget) {
+              rectFromTarget = await this.interface.resolveLocatorTarget(
+                param.target,
+              );
+            } else if (
+              param.target.strategy === 'xpath' &&
+              this.interface.rectMatchesCacheFeature
+            ) {
+              rectFromTarget = await this.interface.rectMatchesCacheFeature({
+                targets: [param.target],
+              });
+            }
+            if (!rectFromTarget) {
+              throw new Error(
+                `Current interface cannot resolve locator target strategy: ${param.target.strategy}`,
+              );
+            }
+            const candidate = generateElementByRect(
+              // target Rect is in logical coordinates and actions use the
+              // screenshot coordinate space inside the task runner.
               transformLogicalRectToScreenshotRect(
-                rectFromXpath,
+                rectFromTarget,
                 shrunkShotToLogicalRatio,
               ),
               typeof param.prompt === 'string'
                 ? param.prompt
                 : param.prompt?.prompt || '',
-            )
-          : undefined;
+            );
+            const invalidTargetReason = invalidLocateElementReason(candidate);
+            if (invalidTargetReason) {
+              throw new Error(invalidTargetReason);
+            }
+            elementFromTarget = candidate;
+          } catch (error) {
+            targetResolutionError =
+              error instanceof Error ? error.message : String(error);
+            debug(
+              'target resolution failed, falling back to cache or AI locate: %s',
+              targetResolutionError,
+            );
+          }
+        }
+        const isTargetHit = !!elementFromTarget;
 
-        const isXpathHit = !!elementFromXpath;
+        // from locatedPixelBbox (direct plan hit). When deepLocate is enabled,
+        // the bbox remains a search-area hint rather than a final direct hit.
+        const elementFromPlan =
+          isTargetHit || param.deepLocate ? undefined : planLocatedElement;
+        const isPlanDirectHit = !!elementFromPlan;
 
         const cachePrompt = param.prompt;
         const locateCacheRecord = this.taskCache?.matchLocateCache(cachePrompt);
         const cacheEntry = locateCacheRecord?.cacheContent?.cache;
 
         const elementFromCacheResult =
-          isPlanDirectHit || isXpathHit
+          isPlanDirectHit || isTargetHit
             ? null
             : await matchElementFromCache(
                 {
@@ -545,7 +589,7 @@ export class TaskBuilder {
 
         let elementFromAiLocate: LocateResultElement | null | undefined;
         const timing = taskContext.task.timing;
-        if (!isXpathHit && !isCacheHit && !isPlanDirectHit) {
+        if (!isTargetHit && !isCacheHit && !isPlanDirectHit) {
           try {
             setTimingFieldOnce(timing, 'callAiStart');
             locateResult = await this.service.locate(
@@ -570,8 +614,8 @@ export class TaskBuilder {
         }
 
         const element =
+          elementFromTarget ||
           elementFromPlan ||
-          elementFromXpath ||
           elementFromCache ||
           elementFromAiLocate;
 
@@ -672,18 +716,31 @@ export class TaskBuilder {
 
         let hitBy: ExecutionTaskHitBy | undefined;
 
-        if (isPlanDirectHit && paramWithLocatedPixelBbox) {
+        const extraActionMetadata = getExtraActionSource(plan);
+        const attemptedTargetContext = param.target
+          ? {
+              target: param.target,
+              ...(targetResolutionError ? { targetResolutionError } : {}),
+              ...(extraActionMetadata?.name
+                ? { extraActionName: extraActionMetadata.name }
+                : {}),
+              ...(extraActionMetadata?.alias
+                ? { extraActionAlias: extraActionMetadata.alias }
+                : {}),
+            }
+          : {};
+
+        if (isTargetHit && param.target) {
+          hitBy = {
+            from: extraActionMetadata ? 'Extra Action target' : 'User target',
+            context: attemptedTargetContext,
+          };
+        } else if (isPlanDirectHit && paramWithLocatedPixelBbox) {
           hitBy = {
             from: 'Plan',
             context: {
               locatedPixelBbox: paramWithLocatedPixelBbox.locatedPixelBbox,
-            },
-          };
-        } else if (isXpathHit) {
-          hitBy = {
-            from: 'User expected path',
-            context: {
-              xpath: param.xpath,
+              ...attemptedTargetContext,
             },
           };
         } else if (isCacheHit) {
@@ -692,7 +749,13 @@ export class TaskBuilder {
             context: {
               cacheEntry,
               cacheToSave: currentCacheEntry,
+              ...attemptedTargetContext,
             },
+          };
+        } else {
+          hitBy = {
+            from: 'AI',
+            context: attemptedTargetContext,
           };
         }
 

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -43,6 +43,7 @@ import {
   applyElementXpathsToPlans,
 } from './element-xpaths';
 import { ExecutionSession } from './execution-session';
+import type { ExtraActionSnapshot } from './extra-actions';
 import { withFileChooser } from './file-chooser';
 import {
   type AgentProgressPublisher,
@@ -90,11 +91,10 @@ interface TaskExecutorActionOptions {
   abortSignal?: AbortSignal;
   reportOptions?: ActionReportOptions;
   extraActions?: {
-    actionSpace: DeviceAction[];
-    expandPlans: (plans: PlanningAction[]) => {
-      plans: PlanningAction[];
-      expanded: boolean;
-    };
+    initialSnapshot?: ExtraActionSnapshot;
+    createSnapshot: (options?: {
+      signal?: AbortSignal;
+    }) => Promise<ExtraActionSnapshot>;
   };
   elementXpaths?: LoadedElementXpath[];
 }
@@ -522,10 +522,10 @@ export class TaskExecutor {
     } = options;
     const conversationHistory = new ConversationHistory();
     const baseActionSpace = this.getActionSpace();
-    const actionSpace = [
-      ...baseActionSpace,
-      ...(extraActions?.actionSpace ?? []),
-    ];
+    let latestExtraActionSnapshot:
+      | Awaited<ReturnType<NonNullable<typeof extraActions>['createSnapshot']>>
+      | undefined;
+    let pendingInitialExtraActionSnapshot = extraActions?.initialSnapshot;
     const promptDisplay =
       reportOptions?.prompt || userPromptToString(userPrompt);
 
@@ -630,6 +630,14 @@ export class TaskExecutor {
             const { uiContext } = executorContext;
             assert(uiContext, 'uiContext is required for Planning task');
             const planningUiContext = uiContext as UIContext;
+            latestExtraActionSnapshot =
+              pendingInitialExtraActionSnapshot ??
+              (await extraActions?.createSnapshot({ signal: abortSignal }));
+            pendingInitialExtraActionSnapshot = undefined;
+            const actionSpace = [
+              ...(latestExtraActionSnapshot?.actionSpace ?? []),
+              ...baseActionSpace,
+            ];
             const timing = executorContext.task.timing;
             await this.emitAiActProgress('plan_thinking', {
               planIndex,
@@ -665,6 +673,8 @@ export class TaskExecutor {
                 includeLocateInPlanning,
                 imagesIncludeCount,
                 deepThink,
+                hasExtraActions:
+                  (latestExtraActionSnapshot?.actionSpace.length ?? 0) > 0,
                 referenceImageMessages,
                 abortSignal,
               });
@@ -780,7 +790,7 @@ export class TaskExecutor {
 
       // Execute planned actions
       const plans = planResult?.actions || [];
-      const expansion = extraActions?.expandPlans(plans) ?? {
+      const expansion = latestExtraActionSnapshot?.expandPlans(plans) ?? {
         plans,
         expanded: false,
       };

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -399,6 +399,18 @@ export async function matchElementFromCache(
   try {
     const rect =
       await context.interfaceInstance.rectMatchesCacheFeature(cacheEntry);
+    const rectValues = [rect.left, rect.top, rect.width, rect.height];
+    if (
+      rectValues.some(
+        (value) => typeof value !== 'number' || !Number.isFinite(value),
+      ) ||
+      rect.width <= 0 ||
+      rect.height <= 0
+    ) {
+      throw new Error(
+        `Cache target returned an invalid rect: ${JSON.stringify(rect)}`,
+      );
+    }
     const element: LocateResultElement = {
       center: [
         Math.round(rect.left + rect.width / 2),

--- a/packages/core/src/ai-model/llm-planning.ts
+++ b/packages/core/src/ai-model/llm-planning.ts
@@ -225,6 +225,7 @@ export async function plan(
     includeLocateInPlanning: opts.includeLocateInPlanning,
     includeThought: true, // always include thought
     includeSubGoals,
+    hasExtraActions: opts.hasExtraActions,
   });
 
   const preparedImage = await prepareModelImage({

--- a/packages/core/src/ai-model/prompt/llm-planning.ts
+++ b/packages/core/src/ai-model/prompt/llm-planning.ts
@@ -44,16 +44,14 @@ const RUN_ADB_SHELL_ACTION_GUIDANCE =
 const EXTRA_ACTION_GUIDANCE =
   '- Actions named MidsceneExtraAction_* are exact pre-recorded operations. When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action such as Tap or Input.';
 
-const buildActionStepNotes = (actionList: string) =>
+const buildActionStepNotes = (actionList: string, hasExtraActions: boolean) =>
   [
     '### Action Guidelines',
     '',
     ...(actionList.includes('RunAdbShell')
       ? [RUN_ADB_SHELL_ACTION_GUIDANCE]
       : []),
-    ...(actionList.includes('MidsceneExtraAction_')
-      ? [EXTRA_ACTION_GUIDANCE]
-      : []),
+    ...(hasExtraActions ? [EXTRA_ACTION_GUIDANCE] : []),
     '- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.',
     '- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.',
     '- For insert/prepend/append edits, use CursorMove when the caret must be adjusted precisely, then use Input with mode "typeOnly" for inserted characters and KeyboardPress for newlines or deletion. If the caret lands in the wrong position, recover with CursorMove, KeyboardPress, or undo and retry cursor placement; do not switch to replace as a fallback for cursor placement failures.',
@@ -242,12 +240,14 @@ export async function systemPromptToTaskPlanning({
   includeLocateInPlanning,
   includeThought,
   includeSubGoals,
+  hasExtraActions = false,
 }: {
   actionSpace: DeviceAction<any>[];
   locatePromptSpec?: LocateResultPromptSpec;
   includeLocateInPlanning: boolean;
   includeThought?: boolean;
   includeSubGoals?: boolean;
+  hasExtraActions?: boolean;
 }) {
   const preferredLanguage = getPreferredLanguage();
 
@@ -266,7 +266,7 @@ export async function systemPromptToTaskPlanning({
     );
   });
   const actionList = actionDescriptionList.join('\n');
-  const actionStepNotes = buildActionStepNotes(actionList);
+  const actionStepNotes = buildActionStepNotes(actionList, hasExtraActions);
 
   const shouldIncludeThought = includeThought ?? true;
   const shouldIncludeSubGoals = includeSubGoals ?? false;

--- a/packages/core/src/ai-model/workflows/planning/types.ts
+++ b/packages/core/src/ai-model/workflows/planning/types.ts
@@ -14,6 +14,7 @@ export interface PlanOptions {
   imagesIncludeCount?: number;
   // Controls aiAct planning prompt shape and state updates, such as sub-goals.
   deepThink?: boolean;
+  hasExtraActions?: boolean;
   referenceImageMessages?: ChatCompletionUserMessageParam[];
   abortSignal?: AbortSignal;
 }

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -4,6 +4,7 @@ import type {
   HarmonyDeviceOpt,
   IOSDeviceOpt,
 } from './device';
+import type { LocatorTarget } from './locator';
 import type { AgentOpt, LocateResultElement, Rect } from './types';
 import type { UIContext } from './types';
 
@@ -16,6 +17,8 @@ export interface LocateOption extends Partial<TMultimodalPrompt> {
   deepThink?: boolean; // alias for deepLocate
   cacheable?: boolean; // user can set this param to false to disable the cache for a single agent api
   xpath?: string; // only available in web
+  /** Stable locator reference. `xpath` remains supported as a legacy alias. */
+  target?: LocatorTarget;
   uiContext?: UIContext;
   fileChooserAccept?: string | string[]; // file path(s) to upload when tapping triggers a file chooser
 }

--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -287,7 +287,8 @@ export function buildDetailedLocateParam(
   let prompt = normalizedLocatePrompt || opt?.prompt || (opt as any)?.locate; // as a shortcut
   let deepLocate = false;
   let cacheable = true;
-  let xpath = undefined;
+  let xpath: LocateOption['xpath'];
+  let target: LocateOption['target'];
 
   if (typeof opt === 'object' && opt !== null) {
     // Backward-compatible: accept `deepThink` as a deprecated alias for `deepLocate`.
@@ -297,6 +298,12 @@ export function buildDetailedLocateParam(
     deepLocate = opt.deepLocate ?? opt.deepThink ?? false;
     cacheable = opt.cacheable ?? true;
     xpath = opt.xpath;
+    target = opt.target;
+    if (target !== undefined && xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
     if (locatePrompt && opt.prompt && locatePrompt !== opt.prompt) {
       console.warn(
         'conflict prompt for item',
@@ -339,7 +346,7 @@ export function buildDetailedLocateParam(
     ...(context ? { promptDisplay, context } : {}),
     deepLocate,
     cacheable,
-    xpath,
+    ...(target ? { target } : { xpath }),
   };
 }
 

--- a/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
+++ b/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
@@ -54,11 +54,6 @@ describe('aiAct extra action integration', () => {
       delayBeforeRunner: 0,
       delayAfterRunner: 0,
     };
-    const extraPlanningAction: DeviceAction = {
-      name: 'MidsceneExtraAction_1',
-      description: 'Run a recorded action',
-      call: vi.fn(),
-    };
     const mockInterface = {
       interfaceType: 'web',
       actionSpace: () => [inputAction],
@@ -83,7 +78,7 @@ describe('aiAct extra action integration', () => {
     vi.mocked(genericXmlPlan).mockResolvedValue({
       actions: [
         {
-          type: extraPlanningAction.name,
+          type: 'MidsceneExtraAction_1',
           param: {},
           thought: 'fill the username',
         },
@@ -94,14 +89,15 @@ describe('aiAct extra action integration', () => {
 
     const extraActions = [
       {
-        name: '填写用户名',
-        planningAction: extraPlanningAction,
+        alias: 'MidsceneExtraAction_1',
+        name: 'Fill the username',
+        sourcePath: '/tmp/example.actions.yaml',
         plan: {
           type: 'Input',
           param: {
             value: 'Alice',
             locate: {
-              prompt: '填写用户名',
+              prompt: 'Username input',
               locatedPixelBbox: [0, 0, 1, 1],
             },
           },
@@ -110,19 +106,28 @@ describe('aiAct extra action integration', () => {
     ];
 
     const result = await taskExecutor.action(
-      '填写表单',
+      'Fill the form',
       modelRuntime(),
       modelRuntime(),
       false,
       {
-        extraActions: createExtraActionExecutionOptions(extraActions),
+        extraActions: createExtraActionExecutionOptions(
+          extraActions,
+          undefined,
+        ),
       },
     );
 
     expect(vi.mocked(genericXmlPlan).mock.calls[0][1].actionSpace).toEqual([
+      expect.objectContaining({
+        name: 'MidsceneExtraAction_1',
+        description: expect.stringContaining('Fill the username'),
+      }),
       inputAction,
-      extraPlanningAction,
     ]);
+    expect(vi.mocked(genericXmlPlan).mock.calls[0][1].hasExtraActions).toBe(
+      true,
+    );
     expect(inputCall).toHaveBeenCalledOnce();
     expect(inputCall.mock.calls[0][0]).toMatchObject({
       value: 'Alice',
@@ -158,9 +163,113 @@ describe('aiAct extra action integration', () => {
       'Input',
       expect.objectContaining({
         value: 'Alice',
-        locate: expect.objectContaining({ prompt: '填写用户名' }),
+        locate: expect.objectContaining({ prompt: 'Username input' }),
       }),
     );
+  });
+
+  it('refreshes disclosure on every planning round while keeping aliases stable', async () => {
+    const tapCall = vi.fn();
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'Tap an element',
+      call: tapCall,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const probeLocatorTargets = vi
+      .fn()
+      .mockResolvedValueOnce([true, false])
+      .mockResolvedValueOnce([false, true]);
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [tapAction],
+      probeLocatorTargets,
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [tapAction],
+    });
+    vi.mocked(genericXmlPlan)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_1',
+            param: {},
+            thought: 'run the first action',
+          },
+        ],
+        shouldContinuePlanning: true,
+      } as any)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_2',
+            param: {},
+            thought: 'run the second action',
+          },
+        ],
+        shouldContinuePlanning: false,
+      } as any);
+
+    await taskExecutor.action(
+      'Complete both steps',
+      modelRuntime(),
+      modelRuntime(),
+      false,
+      {
+        extraActions: createExtraActionExecutionOptions(
+          [
+            {
+              alias: 'MidsceneExtraAction_1',
+              name: 'Run the first action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="first"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+            {
+              alias: 'MidsceneExtraAction_2',
+              name: 'Run the second action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="second"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+          ],
+          mockInterface,
+        ),
+      },
+    );
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(genericXmlPlan)
+        .mock.calls.map((call) =>
+          call[1].actionSpace.map((action) => action.name),
+        ),
+    ).toEqual([
+      ['MidsceneExtraAction_1', 'Tap'],
+      ['MidsceneExtraAction_2', 'Tap'],
+    ]);
+    expect(tapCall).toHaveBeenCalledTimes(2);
   });
 
   it('loads files through the public aiAct option and separates its plan cache', async () => {
@@ -168,10 +277,13 @@ describe('aiAct extra action integration', () => {
     const filePath = join(dir, 'extra-action.yaml');
     await writeFile(
       filePath,
-      `name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+      `version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: tap
+      param: {}
 `,
     );
 
@@ -185,10 +297,11 @@ actionParam:
       const action = vi.fn().mockResolvedValue({
         output: {
           output: 'done',
-          yamlFlow: [],
+          yamlFlow: [{ Tap: {} }],
         },
       });
       const matchPlanCache = vi.fn();
+      const updateOrAppendCacheRecord = vi.fn();
       (agent as any).opts = {};
       (agent as any).interface = { interfaceType: 'web' };
       (agent as any).fullActionSpace = [tapAction];
@@ -196,35 +309,46 @@ actionParam:
       (agent as any).taskCache = {
         matchPlanCache,
         isCacheResultUsed: true,
-        updateOrAppendCacheRecord: vi.fn(),
+        updateOrAppendCacheRecord,
       };
       (agent as any).resolveModelRuntime = vi.fn(() => modelRuntime());
       (agent as any).resolveReplanningCycleLimit = vi.fn(() => 1);
 
       await expect(
-        agent.aiAct('填写表单', { loadExtraActions: [filePath] }),
+        agent.aiAct('Fill the form', { loadExtraActions: [filePath] }),
       ).resolves.toBe('done');
 
       expect(matchPlanCache.mock.calls[0][0]).toContain(
         '<midscene_extra_actions>',
       );
       expect(matchPlanCache.mock.calls[0][0]).toContain(
-        '"name":"点击确定按钮"',
+        'extra-actions-snapshot:v1:',
+      );
+      expect(updateOrAppendCacheRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'plan',
+          prompt: matchPlanCache.mock.calls[0][0],
+        }),
+        undefined,
       );
       const executionOptions = action.mock.calls[0].at(-1);
       expect(executionOptions).toEqual(
         expect.objectContaining({
           extraActions: expect.objectContaining({
-            actionSpace: [
-              expect.objectContaining({
-                name: 'MidsceneExtraAction_1',
-                description: expect.stringContaining('点击确定按钮'),
-              }),
-            ],
-            expandPlans: expect.any(Function),
+            createSnapshot: expect.any(Function),
+            initialSnapshot: expect.objectContaining({
+              fingerprint: expect.stringMatching(/^extra-actions-snapshot:v1:/),
+            }),
           }),
         }),
       );
+      const snapshot = await executionOptions.extraActions.createSnapshot();
+      expect(snapshot.actionSpace).toEqual([
+        expect.objectContaining({
+          name: 'MidsceneExtraAction_1',
+          description: expect.stringContaining('Click the confirm button'),
+        }),
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -254,7 +378,7 @@ actionParam:
     );
 
     await expect(
-      agent.aiAct('填写表单', {
+      agent.aiAct('Fill the form', {
         loadExtraActions: ['/path/that/does/not/need/to/exist.yaml'],
       }),
     ).rejects.toThrow(

--- a/packages/core/tests/unit-test/element-xpaths.test.ts
+++ b/packages/core/tests/unit-test/element-xpaths.test.ts
@@ -7,13 +7,17 @@ import {
   elementXpathsPlanningContext,
   loadElementXpaths,
 } from '@/agent/element-xpaths';
+import {
+  getExtraActionSource,
+  setExtraActionSource,
+} from '@/agent/extra-actions';
 import { TaskExecutor } from '@/agent/tasks';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
 import { genericXmlPlan } from '@/ai-model/workflows/planning';
 import type { AbstractInterface } from '@/device';
 import { ScreenshotItem } from '@/screenshot-item';
-import type { DeviceAction } from '@/types';
+import type { DeviceAction, PlanningAction } from '@/types';
 import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -101,7 +105,10 @@ elements:
           type: 'Input',
           param: {
             value: 'Alice',
-            locate: { prompt: 'first NAME input' },
+            locate: {
+              prompt:
+                'the "first NAME input" as specified in known UI elements',
+            },
           },
         },
         {
@@ -144,7 +151,10 @@ elements:
           },
         },
       ],
-      [{ name: 'First name input', xpath: '//*[@id="first-name"]' }],
+      [
+        { name: 'Name input', xpath: '//*[@id="generic-name"]' },
+        { name: 'First name input', xpath: '//*[@id="first-name"]' },
+      ],
       [action],
     );
 
@@ -155,8 +165,11 @@ elements:
         param: {
           value: 'Alice',
           locate: {
-            prompt: 'first NAME input',
-            xpath: '//*[@id="first-name"]',
+            prompt: 'the "first NAME input" as specified in known UI elements',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
@@ -183,7 +196,10 @@ elements:
           value: 'Dora',
           locate: {
             prompt: 'First name input',
-            xpath: '//*[@id="first-name"]',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
@@ -193,11 +209,64 @@ elements:
           value: 'Eve',
           locate: {
             prompt: 'First name input',
-            xpath: '//*[@id="first-name"]',
+            target: {
+              strategy: 'xpath',
+              selector: '//*[@id="first-name"]',
+            },
           },
         },
       },
     ]);
+  });
+
+  it('falls back when a locator prompt contains equally specific map keys', () => {
+    const action = inputAction();
+    const plans: PlanningAction[] = [
+      {
+        type: 'Input',
+        param: {
+          value: 'Alice',
+          locate: { prompt: 'Use Alpha input or Bravo input' },
+        },
+      },
+    ];
+
+    const mapped = applyElementXpathsToPlans(
+      plans,
+      [
+        { name: 'Alpha input', xpath: '//*[@id="alpha"]' },
+        { name: 'Bravo input', xpath: '//*[@id="bravo"]' },
+      ],
+      [action],
+    );
+
+    expect(mapped).toEqual({ plans, mapped: false });
+  });
+
+  it('preserves internal Extra Action provenance when a map transforms the plan', () => {
+    const plan: PlanningAction = {
+      type: 'Input',
+      param: {
+        value: 'Alice',
+        locate: { prompt: 'First name input' },
+      },
+    };
+    const source = {
+      type: 'extra-action' as const,
+      name: 'Fill the first name',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: '/tmp/profile.actions.yaml',
+    };
+    setExtraActionSource(plan, source);
+
+    const mapped = applyElementXpathsToPlans(
+      [plan],
+      [{ name: 'First name input', xpath: '//*[@id="first-name"]' }],
+      [inputAction()],
+    );
+
+    expect(mapped.mapped).toBe(true);
+    expect(getExtraActionSource(mapped.plans[0])).toEqual(source);
   });
 
   it('rejects invalid and conflicting map entries before planning', async () => {
@@ -294,7 +363,7 @@ elements:
       locate,
     } as unknown as Service;
     const taskExecutor = new TaskExecutor(mockInterface, mockService, {
-      replanningCycleLimit: 1,
+      replanningCycleLimit: 20,
       actionSpace: [action],
     });
     vi.mocked(genericXmlPlan).mockResolvedValue({
@@ -329,7 +398,7 @@ elements:
 
     expect(locate).not.toHaveBeenCalled();
     expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
-      xpaths: ['//*[@id="first-name"]'],
+      targets: [{ strategy: 'xpath', selector: '//*[@id="first-name"]' }],
     });
     expect(inputCall).toHaveBeenCalledOnce();
     expect(result.output?.yamlFlow).toEqual([
@@ -338,15 +407,23 @@ elements:
         value: 'Alice',
         locate: {
           prompt: 'First name input',
-          xpath: '//*[@id="first-name"]',
+          target: {
+            strategy: 'xpath',
+            selector: '//*[@id="first-name"]',
+          },
         },
       },
     ]);
     expect(
       result.runner.tasks.find((task) => task.subType === 'Locate')?.hitBy,
     ).toEqual({
-      from: 'User expected path',
-      context: { xpath: '//*[@id="first-name"]' },
+      from: 'User target',
+      context: {
+        target: {
+          strategy: 'xpath',
+          selector: '//*[@id="first-name"]',
+        },
+      },
     });
 
     const replayAction = vi.fn();
@@ -371,9 +448,96 @@ elements:
         value: 'Alice',
         locate: expect.objectContaining({
           prompt: 'First name input',
-          xpath: '//*[@id="first-name"]',
+          target: {
+            strategy: 'xpath',
+            selector: '//*[@id="first-name"]',
+          },
         }),
       }),
     );
+  });
+
+  it('preserves the locator prompt when a mapped XPath falls back to AI locate', async () => {
+    const inputCall = vi.fn();
+    const locate = vi.fn().mockResolvedValue({
+      element: {
+        description: 'first name input found by AI',
+        center: [1, 1],
+        rect: { left: 0, top: 0, width: 1, height: 1 },
+      },
+    });
+    const action = inputAction(inputCall);
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [action],
+      rectMatchesCacheFeature: vi
+        .fn()
+        .mockRejectedValue(new Error('stale XPath')),
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: { id: 'root', attributes: {}, children: [] },
+      }),
+      locate,
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [action],
+    });
+    vi.mocked(genericXmlPlan).mockResolvedValue({
+      actions: [
+        {
+          type: 'Input',
+          param: {
+            value: 'Alice',
+            locate: {
+              prompt: 'First name input',
+              locatedPixelBbox: [20, 20, 40, 40],
+            },
+          },
+        },
+      ],
+      yamlFlow: [],
+      shouldContinuePlanning: false,
+    } as any);
+
+    await taskExecutor.action(
+      'Fill the profile form',
+      modelRuntime(),
+      modelRuntime(),
+      false,
+      {
+        elementXpaths: [
+          {
+            name: 'First name input',
+            xpath: '//*[@id="stale-first-name"]',
+          },
+        ],
+      },
+    );
+
+    expect(mockInterface.rectMatchesCacheFeature).toHaveBeenCalledWith({
+      targets: [
+        {
+          strategy: 'xpath',
+          selector: '//*[@id="stale-first-name"]',
+        },
+      ],
+    });
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        prompt: 'First name input',
+        target: {
+          strategy: 'xpath',
+          selector: '//*[@id="stale-first-name"]',
+        },
+      }),
+    );
+    expect(locate.mock.calls[0][0]).not.toHaveProperty('locatedPixelBbox');
+    expect(inputCall).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  expandExtraActionPlans,
-  extraActionsCacheKey,
+  createExtraActionSnapshot,
+  getExtraActionSource,
   loadExtraActions,
 } from '@/agent/extra-actions';
 import { getMidsceneLocationSchema } from '@/ai-model';
@@ -25,7 +25,7 @@ describe('extra actions', () => {
   async function writeExtraAction(content: string) {
     const dir = await mkdtemp(join(tmpdir(), 'midscene-extra-action-'));
     tempDirs.push(dir);
-    const filePath = join(dir, 'extra-action.yaml');
+    const filePath = join(dir, 'example.actions.yaml');
     await writeFile(filePath, content);
     return filePath;
   }
@@ -40,216 +40,519 @@ describe('extra actions', () => {
     call: vi.fn(),
   });
 
-  it('loads the documented YAML shape and expands its xpath shortcut', async () => {
+  it('loads the manifest and expands one alias into one native action', async () => {
     const filePath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+version: 1
+interface: web
+actions:
+  - name: Click the checkout dialog confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout dialog confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 `);
 
-    const loaded = await loadExtraActions([filePath], [tapAction()]);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
 
-    expect(loaded).toHaveLength(1);
-    expect(loaded[0].planningAction).toMatchObject({
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets: vi.fn(async () => [true]),
+    });
+
+    expect(snapshot.actionSpace).toHaveLength(1);
+    expect(snapshot.actionSpace[0]).toMatchObject({
       name: 'MidsceneExtraAction_1',
       description: expect.stringContaining(
-        'always prefer it over rebuilding the operation',
+        'Click the checkout dialog confirm button',
       ),
       sample: {},
     });
-    expect(
-      expandExtraActionPlans(
-        [
-          {
-            type: loaded[0].planningAction.name,
-            param: {},
-            thought: 'confirm the form',
-          },
-        ],
-        loaded,
-      ),
-    ).toEqual([
+    expect(snapshot.actionSpace[0].description).not.toContain('//div');
+    expect(loaded[0].validWhenTargetExists).toEqual({
+      strategy: 'xpath',
+      selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+    });
+
+    const expansion = snapshot.expandPlans([
+      {
+        type: 'MidsceneExtraAction_1',
+        param: {},
+        thought: 'confirm checkout',
+      },
+    ]);
+    expect(expansion.plans).toEqual([
       {
         type: 'Tap',
         param: {
           locate: {
-            prompt: '点击确定按钮',
-            xpath: '/path/to/#confirm-button',
+            prompt: 'Checkout dialog confirm button',
+            target: {
+              strategy: 'xpath',
+              selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+            },
           },
         },
-        thought: 'confirm the form',
+        thought: 'confirm checkout',
       },
     ]);
-    expect(extraActionsCacheKey(loaded)).toContain('"name":"点击确定按钮"');
+    expect(getExtraActionSource(expansion.plans[0])).toEqual({
+      type: 'extra-action',
+      name: 'Click the checkout dialog confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: filePath,
+    });
+    expect(snapshot.fingerprint).toMatch(/^extra-actions-snapshot:v1:/);
   });
 
-  it('keeps non-locator fields at the top level for an Input shortcut', async () => {
+  it('discloses every action whose condition currently exists', async () => {
     const filePath = await writeExtraAction(`
-name: 填写用户名
-actionName: input
-actionParam:
-  - xpath: /html/body/input
-    value: Alice
-    mode: typeOnly
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+  - name: Click the cancel button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="cancel"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Cancel button
+          target: { strategy: xpath, selector: '//button[@id="cancel"]' }
+  - name: Click the help button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Help button
+          target: { strategy: xpath, selector: '//button[@id="help"]' }
 `);
-    const inputAction: DeviceAction = {
-      name: 'Input',
-      interfaceAlias: 'aiInput',
-      paramSchema: z.object({
-        value: z.string(),
-        locate: getMidsceneLocationSchema().optional(),
-        mode: z.enum(['replace', 'clear', 'typeOnly']).default('replace'),
-      }),
-      call: vi.fn(),
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('confirm')),
+    );
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(1);
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_3',
+    ]);
+
+    probeLocatorTargets.mockImplementation(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('cancel')),
+    );
+    const nextSnapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+    expect(nextSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_2',
+      'MidsceneExtraAction_3',
+    ]);
+  });
+
+  it('keeps each disclosure snapshot immutable across page changes', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    let exists = false;
+    const targetProbe = {
+      probeLocatorTargets: vi.fn(async () => [exists]),
     };
 
-    const [loaded] = await loadExtraActions([filePath], [inputAction]);
+    const missingSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    exists = true;
+    const presentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    const repeatedPresentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
 
+    expect(missingSnapshot.actionSpace).toEqual([]);
+    expect(presentSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+    ]);
+    expect(missingSnapshot.fingerprint).not.toBe(presentSnapshot.fingerprint);
+    expect(repeatedPresentSnapshot.fingerprint).toBe(
+      presentSnapshot.fingerprint,
+    );
+    expect(
+      missingSnapshot.expandPlans([
+        { type: 'MidsceneExtraAction_1', param: {} },
+      ]),
+    ).toEqual({
+      plans: [{ type: 'MidsceneExtraAction_1', param: {} }],
+      expanded: false,
+    });
+  });
+
+  it('supports old one-action files as a read compatibility boundary', async () => {
+    const filePath = await writeExtraAction(`
+name: Click the confirm button
+actionName: tap
+actionParam:
+  - xpath: /html/body/button[1]
+`);
+    const [loaded] = await loadExtraActions([filePath], [tapAction()], 'web');
     expect(loaded.plan.param).toEqual({
-      value: 'Alice',
-      mode: 'typeOnly',
       locate: {
-        prompt: '填写用户名',
-        xpath: '/html/body/input',
+        prompt: 'Click the confirm button',
+        target: {
+          strategy: 'xpath',
+          selector: '/html/body/button[1]',
+        },
       },
     });
   });
 
-  it('rejects parameters that do not match the referenced action schema', async () => {
+  it('rejects a manifest for another interface', async () => {
     const filePath = await writeExtraAction(`
-name: 填写用户名
-actionName: input
-actionParam:
-  - xpath: /html/body/input
+version: 1
+interface: android
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
 `);
-    const inputAction: DeviceAction = {
-      name: 'Input',
-      interfaceAlias: 'aiInput',
-      paramSchema: z.object({
-        value: z.string(),
-        locate: getMidsceneLocationSchema().optional(),
-      }),
-      call: vi.fn(),
-    };
-
-    await expect(loadExtraActions([filePath], [inputAction])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": "actionParam[0]" does not match action "Input": value: Required`,
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'interface "android" does not match current interface "web"',
     );
   });
 
-  it('rejects multiple operations in one extra action file', async () => {
+  it('accepts the canonical platform declared by an interface', async () => {
     const filePath = await writeExtraAction(`
-name: 填写完整表单
-actionName: Tap
-actionParam:
-  - xpath: /html/body/input[1]
-  - xpath: /html/body/input[2]
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": "actionParam" must contain exactly one item because each extra action represents one device operation`,
-    );
-  });
-
-  it('expands multiple files into one operation per planner action', async () => {
-    const firstPath = await writeExtraAction(`
-name: 点击第一个按钮
-actionName: Tap
-actionParam:
-  - xpath: /html/body/button[1]
-`);
-    const secondPath = await writeExtraAction(`
-name: 点击第二个按钮
-actionName: Tap
-actionParam:
-  - xpath: /html/body/button[2]
-`);
-
-    const loaded = await loadExtraActions(
-      [firstPath, secondPath],
-      [tapAction()],
-    );
-
-    expect(
-      expandExtraActionPlans(
-        loaded.map((action) => ({
-          type: action.planningAction.name,
-          param: {},
-          thought: `run ${action.name}`,
-        })),
-        loaded,
-      ),
-    ).toEqual([
-      {
-        type: 'Tap',
-        param: {
-          locate: {
-            prompt: '点击第一个按钮',
-            xpath: '/html/body/button[1]',
-          },
-        },
-        thought: 'run 点击第一个按钮',
-      },
-      {
-        type: 'Tap',
-        param: {
-          locate: {
-            prompt: '点击第二个按钮',
-            xpath: '/html/body/button[2]',
-          },
-        },
-        thought: 'run 点击第二个按钮',
-      },
-    ]);
-  });
-
-  it('rejects display names that can corrupt the planner protocol', async () => {
-    const filePath = await writeExtraAction(`
-name: Click <Confirm>
-actionName: Tap
-actionParam:
-  - prompt: confirm button
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      '"name" must not contain angle brackets, line breaks, or control characters',
-    );
-  });
-
-  it('rejects an unknown referenced action with the source path', async () => {
-    const filePath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: missing-action
-actionParam:
-  - xpath: /path/to/#confirm-button
-`);
-
-    await expect(loadExtraActions([filePath], [tapAction()])).rejects.toThrow(
-      `Invalid extra action file "${filePath}": action "missing-action" is not in the current action space`,
-    );
-  });
-
-  it('rejects duplicate extra action names', async () => {
-    const firstPath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: Tap
-actionParam:
-  - locate:
-      prompt: confirm button
-`);
-    const secondPath = await writeExtraAction(`
-name: 点击确定按钮
-actionName: Tap
-actionParam:
-  - locate:
-      prompt: another confirm button
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
 `);
 
     await expect(
-      loadExtraActions([firstPath, secondPath], [tapAction()]),
-    ).rejects.toThrow(
-      'action name "点击确定按钮" conflicts with another action',
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('prefers an exact native action name over an earlier case-insensitive match', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const lowerCaseTap = {
+      ...tapAction(),
+      name: 'tap',
+      interfaceAlias: 'lowerCaseTap',
+    };
+
+    const [loaded] = await loadExtraActions(
+      [filePath],
+      [lowerCaseTap, tapAction()],
+      'web',
     );
+
+    expect(loaded.plan.type).toBe('Tap');
+  });
+
+  it('reserves native action aliases when assigning stable protocol aliases', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const nativeAction = {
+      ...tapAction(),
+      interfaceAlias: 'MidsceneExtraAction_1',
+    };
+
+    const [loaded] = await loadExtraActions([filePath], [nativeAction], 'web');
+
+    expect(loaded.alias).toBe('MidsceneExtraAction_2');
+  });
+
+  it('allows a display name to match a built-in action name', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Tap
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('rejects target and legacy xpath in the same locator', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          xpath: //button
+          target: { strategy: xpath, selector: //button }
+`);
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      '`target` and `xpath` cannot be used in the same locator',
+    );
+  });
+
+  it('rejects invalid condition targets and duplicate names', async () => {
+    const invalidTarget = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists: { strategy: css, selector: '#confirm' }
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    await expect(
+      loadExtraActions([invalidTarget], [tapAction()], 'web'),
+    ).rejects.toThrow('validWhenTargetExists');
+
+    const duplicate = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Another confirm button }
+`);
+    await expect(
+      loadExtraActions([duplicate], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'action name "Click the confirm button" conflicts with another action',
+    );
+  });
+
+  it('rejects unknown manifest fields before planning', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+unexpected: true
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('Unrecognized key');
+  });
+
+  it('rejects display names that can break the planning protocol', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: <malicious-action>
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('must not contain angle brackets');
+  });
+
+  it('deduplicates condition targets in one batch probe', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the primary confirm button
+    validWhenTargetExists: &confirm
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Primary confirm button }
+  - name: Click the secondary confirm button
+    validWhenTargetExists: *confirm
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Secondary confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(async () => [true]);
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledWith(
+      [{ strategy: 'xpath', selector: '//button[@id="confirm"]' }],
+      {},
+    );
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_2',
+    ]);
+  });
+
+  it('rejects malformed batch probe results', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+
+    await expect(
+      createExtraActionSnapshot(loaded, {
+        probeLocatorTargets: vi.fn(async () => ['yes'] as any),
+      }),
+    ).rejects.toThrow('must return only boolean results');
+  });
+
+  it('aborts condition probing without returning a partial snapshot', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    controller.abort(new Error('test abort'));
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets: vi.fn(async () => [true]) },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('test abort');
+  });
+
+  it('discards probe results when cancellation happens during the batch', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    const probeLocatorTargets = vi.fn(async () => {
+      controller.abort(new Error('cancelled during probe'));
+      return [true];
+    });
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('cancelled during probe');
+    expect(probeLocatorTargets).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -259,6 +259,7 @@ describe('action space', () => {
     const prompt = await systemPromptToTaskPlanning({
       actionSpace: [...mockActionSpace, extraAction],
       includeLocateInPlanning: false,
+      hasExtraActions: true,
     });
 
     expect(prompt).toContain(

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -267,7 +267,10 @@ describe('createReportCliCommands', () => {
         param: {
           locate: {
             prompt: 'Confirm button',
-            xpath: '/html/body/button[1]',
+            target: {
+              strategy: 'xpath',
+              selector: '/html/body/button[1]',
+            },
           },
         },
       }),

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -1,3 +1,4 @@
+import { setExtraActionSource } from '@/agent/extra-actions';
 import { TaskBuilder, locatePlanForLocate } from '@/agent/task-builder';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
@@ -66,6 +67,246 @@ describe('TaskBuilder', () => {
       deepLocate: true,
     });
     expect(plan.param).not.toHaveProperty('deepThink');
+  });
+
+  it('normalizes the legacy xpath alias into a target', () => {
+    const plan = locatePlanForLocate({
+      prompt: 'confirm button',
+      xpath: '//button[@id="confirm"]',
+    });
+
+    expect(plan.param).toEqual({
+      prompt: 'confirm button',
+      target: {
+        strategy: 'xpath',
+        selector: '//button[@id="confirm"]',
+      },
+    });
+    expect(() =>
+      locatePlanForLocate({
+        prompt: 'confirm button',
+        xpath: '//button',
+        target: { strategy: 'xpath', selector: '//button' },
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
+  });
+
+  it('resolves a target before AI locate and reports the Extra Action source', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 40,
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate: vi.fn(),
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const extraActionPlan: PlanningAction = {
+      type: 'Tap',
+      param: {
+        locate: {
+          prompt: 'confirm button',
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+        },
+      },
+    };
+    setExtraActionSource(extraActionPlan, {
+      type: 'extra-action',
+      name: 'Click the confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: '/tmp/example.actions.yaml',
+    });
+    const { tasks } = await taskBuilder.build(
+      [extraActionPlan],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+
+    expect(insightService.locate).not.toHaveBeenCalled();
+    expect(locateResult).toMatchObject({
+      output: {
+        element: {
+          center: [59, 39],
+          rect: { left: 10, top: 20, width: 100, height: 40 },
+        },
+      },
+      hitBy: {
+        from: 'Extra Action target',
+        context: {
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+
+    const actionResult = await tasks[1].executor(tasks[1].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+    expect(actionResult).toMatchObject({
+      hitBy: {
+        from: 'Extra Action',
+        context: {
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution fails', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => {
+      throw new Error('target is stale');
+    });
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate,
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          target: { strategy: 'xpath', selector: '//button' },
+          targetResolutionError: 'target is stale',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution returns an invalid rect', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 0,
+      height: 40,
+    }));
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30] as [number, number],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: { contextRetrieverFn: vi.fn(), locate } as unknown as Service,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          targetResolutionError: expect.stringContaining(
+            'Invalid locate result rect size',
+          ),
+        },
+      },
+    });
   });
 
   it('dispatches plans using handler registry', async () => {

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -237,7 +237,7 @@ describe('utils', () => {
       await new Promise((resolve) => setTimeout(resolve, 5000));
 
       // We expect the file to be approximately 700MB plus template overhead
-      const expectedMinSize = 1000; // 10 reports × 100MB
+      const expectedMinSize = 1000; // 10 reports x 100MB
       expect(fileSizeInMB).toBeGreaterThan(expectedMinSize);
     },
   );
@@ -308,6 +308,23 @@ describe('buildDetailedLocateParam', () => {
       cacheable: false,
       xpath: undefined,
     });
+  });
+
+  it('accepts target and rejects target with the legacy xpath alias', () => {
+    const target = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="confirm"]',
+    };
+
+    expect(
+      buildDetailedLocateParam('Click the confirm button', { target }),
+    ).toMatchObject({ target });
+    expect(() =>
+      buildDetailedLocateParam('Click the confirm button', {
+        target,
+        xpath: '//button[@id="confirm"]',
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
   });
 });
 
@@ -441,7 +458,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     <h1>Bug Case</h1>
   </body>
   <script>
-    { "hello": "你好", "world": "世界" }
+    { "hello": "hello", "world": "world" }
   </script>
 </html>`;
     const filePath = createTempHtmlFile(html);
@@ -464,7 +481,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     //       <h1>Bug Case</h1>
     //     </body>
     //     <script>
-    //       { "hello": "你好", "world": "世界" }
+    //       { "hello": "hello", "world": "world" }
     // -   </script>
     // - <script>large</script>
     // +   </scri<script>large</script>


### PR DESCRIPTION
## Summary

- add the versioned `*.actions.yaml` manifest schema and strict loader
- allow `aiAct` to load one or more external action manifests
- disclose every manifest action whose `validWhenTargetExists` target is present in the current planning snapshot
- place disclosed actions before generic actions and expand the selected alias into exactly one existing Midscene action
- validate interface compatibility and preserve AI location fallback when target resolution fails

## Stack dependency

This is the second PR in the stack and depends on the target-resolution foundation in #2989.

Review order: **#2989 → this PR → #2991**.

## Validation

- `pnpm run lint`
- `NX_DAEMON=false pnpm nx build @midscene/core`
- `pnpm exec vitest --run tests/unit-test/ai-task/element-xpaths.test.ts tests/unit-test/report-cli.test.ts` from `packages/core` — 32 passed
- final stacked `NX_DAEMON=false pnpm nx test @midscene/core` — 1,412 passed, 8 skipped

The final stacked Core run includes the manifest parsing, disclosure, snapshot, expansion, and fallback coverage introduced here.
