### PR TITLE
feat(core): export action manifests from reports

### DIFF
--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 Repeat `--htmlReport` once per source report. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
 
+Export successful operations as an Action Manifest:
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+The command writes one `*.actions.yaml` file. Each device operation whose Action task finished becomes one manifest entry. Recorded XPath cache data is exported as `target`; actions without a stable target keep `locatedPixelBbox` as a fallback. If an action has multiple targets, such as a `Swipe` with `start` and `end`, all targets remain in the action parameters and the first target becomes `validWhenTargetExists`. A finished Action does not prove that it was part of the correct business path, so review recovery detours and mistaken clicks before treating an exported manifest as a reusable asset. Pass `--overwrite` to replace an existing manifest.
+
 ## Parse With The JavaScript SDK
 
 If you prefer to control report parsing in code, use `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` from `@midscene/core`.
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
+`analyzeReportActions`, `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
 
+- `analyzeReportActions` exports successful device operations as one `*.actions.yaml` manifest that can be loaded with `aiAct({ loadExtraActions })`. Every report dump that contains executions must declare the same `manifestInterface`; mixed-platform reports are rejected instead of assigning the wrong platform to an action.
 - `splitReportFile` generates JSON files for the original structured objects (one `*.execution.json` per execution). The JSON keeps the raw `ReportActionDump`-style data and exports screenshots alongside it. The returned `executionJsonFiles` and `screenshotFiles` are lists of generated file paths.
 - `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
 - `mergeReportFiles` combines several report files into one merged HTML report. It is a thin wrapper over [`ReportMergingTool`](./reference/#new-reportmergingtool) that derives `testTitle`/`testDescription` from each source report's `groupName` automatically. Use it when you run multiple CLI actions or tests and want to consolidate their reports.

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -159,7 +159,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
       - **Note**: If a file chooser is triggered but no `fileChooserAccept` parameter is provided, the file chooser will be ignored and the page can continue to operate normally.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
-    - `loadExtraActions?: string[]` — Load pre-recorded UI action YAML files for this call. The default is `undefined`, which loads no extra actions. Each file represents one device operation and becomes a parameterless action available to the generic planner. If selected, Midscene expands it into the recorded low-level action before execution. This option is available only in Node.js and is not supported by custom planning adapters. Relative paths are resolved from the current working directory. Invalid files, duplicate names, unsupported planning adapters, and unavailable underlying actions throw errors before planning starts.
+    - `loadExtraActions?: string[]` — Load one or more `*.actions.yaml` manifests for this call. Each manifest can contain multiple Extra Actions. Actions whose `validWhenTargetExists` target exists on the current page are placed before the generic Action Space; actions without this condition are always available. This Node.js-only option requires the generic planning adapter. Invalid manifests, duplicate names, interface mismatches, and unavailable underlying actions throw errors before planning starts.
     - `loadElementXpaths?: string[]` — Load YAML maps of known UI element names to XPath strings for this call. Midscene gives the map to the planner, then injects a matching XPath into the planned Action before execution. A matching XPath uses deterministic DOM resolution and skips model-based locating. Unmatched names or XPaths that no longer resolve fall back to normal AI locating. This option is available only in Node.js. Relative paths are resolved from the current working directory.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
 
@@ -194,28 +194,37 @@ await agent.aiAct('Complete the GitHub account registration form. The region mus
 
 ##### Load pre-recorded UI actions
 
-An extra action file represents one reusable device operation. It names the operation, identifies an action from the current interface's Action Space, and provides exactly one parameter entry:
+An Action Manifest contains one or more reusable operations. `action.name` references an existing Action Space action, and `action.param` uses that action's native parameter shape:
 
-```yaml title="extra-action.yaml"
-name: Click the confirm button
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: Click the checkout dialog confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout dialog confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 ```
 
-Pass one or more files to a single `aiAct` call:
-
 ```typescript
-await agent.aiAct('Fill in the form', {
-  loadExtraActions: ['./extra-action.yaml'],
+await agent.aiAct('Confirm checkout', {
+  loadExtraActions: ['./checkout.actions.yaml'],
 });
 ```
 
-This Node.js-only option works with the generic planning adapter. If the configured model uses a custom planning adapter, such as UI-TARS or AutoGLM, `aiAct` throws an error before reading the files or calling the model.
+Before each planning round, Midscene checks every `validWhenTargetExists` target without scrolling, focusing, clicking, or changing page state. Every matching action is exposed ahead of the generic actions. Each action keeps the same parameterless alias throughout the `aiAct` call, even when the disclosed set changes. The planner sees the alias and the action's `name`; it does not receive the selector. Midscene uses the same disclosure snapshot to expand the returned alias into exactly one native Action.
 
-The extra action is visible only to this call's planner and does not modify the Agent's Action Space. `name` is the description shown to the planner. It must not contain angle brackets, line breaks, or control characters. `actionName` accepts an Action Space name or `interfaceAlias`, without regard to case. `actionParam` must contain exactly one item, which Midscene validates against the referenced Action before planning starts. To replay multiple operations, record each operation in a separate file and pass all file paths through `loadExtraActions`.
+At execution time, `target` is resolved again to a fresh Rect. If it is stale or missing, Midscene falls back to the Locate Cache and then AI Locate. `target` is the canonical locator field. Existing assets that use `xpath` remain readable, but a locator cannot contain both `target` and `xpath`.
 
-For an Action with one locate field, a parameter containing `prompt`, `xpath`, or `locatedPixelBbox` can use the shortcut shown above. Midscene moves only locator properties into the locate field and keeps other Action parameters, such as Input's `value` and `mode`, at the top level. If a locator contains an XPath or `locatedPixelBbox` but no prompt, the extra action's `name` is used as the fallback locate prompt.
+This option is visible only to the current `aiAct` call and does not modify the Agent. It supports the generic planning adapter only; UI-TARS, AutoGLM, and other custom adapters are rejected before the model is called.
 
 ##### Load known element XPaths
 
@@ -239,7 +248,7 @@ await agent.aiAct(
 );
 ```
 
-The planner still decides which Action to use and generates dynamic parameters such as Input values. When an Action requires a locator for a mapped element, it uses the map key as the locator prompt and Midscene injects the corresponding XPath before building executable tasks. An Action that can operate on the currently focused element does not need to add a redundant locator. If the XPath resolves, the locate task makes no model call. If the planner uses an unmapped prompt or the XPath is stale, Midscene preserves the existing AI-locate fallback. The map is per-call, does not modify the Agent, and participates in the Plan Cache key. Cached YAML retains the XPath so cache replay also avoids model-based locating.
+The planner still decides which Action to use and generates dynamic parameters such as Input values. When an Action requires a locator for a mapped element, it uses the map key as the locator prompt and Midscene injects the corresponding XPath `target` before building executable tasks. An Action that can operate on the currently focused element does not need to add a redundant locator. If the target resolves, the locate task makes no model call. If the planner uses an unmapped prompt or the XPath is stale, Midscene preserves the existing AI-locate fallback. The map is per-call, does not modify the Agent, and participates in the Plan Cache key. Cached YAML retains the target so cache replay also avoids model-based locating.
 
 ##### Upload files from an `aiAct` prompt
 

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 每多合并一份报告就重复一次 `--htmlReport`。`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
 
+把成功执行的操作导出为 Action Manifest：
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+这个命令会生成一个 `*.actions.yaml` 文件。每个 Action 任务执行完成的设备操作对应一条 Manifest 记录。报告中的 XPath Cache 会导出为 `target`；没有稳定目标的动作保留 `locatedPixelBbox` 作为备用定位信息。如果一个动作包含多个 target，例如同时包含 `start` 和 `end` 的 `Swipe`，这些 target 都会保留在动作参数中，第一个 target 会作为 `validWhenTargetExists`。Action 执行完成不等于它属于正确的业务路径，因此，错误点击和恢复路径需要经过审核，才能作为可复用资产。已有同名文件时，使用 `--overwrite` 覆盖。
+
 ## 使用 JavaScript SDK 解析
 
 如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles`。
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
+`analyzeReportActions`、`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
 
+- `analyzeReportActions` 把成功执行的设备操作导出为一个 `*.actions.yaml` Manifest，可以通过 `aiAct({ loadExtraActions })` 加载。所有包含 execution 的报告 dump 必须声明相同的 `manifestInterface`；如果报告混合了多个平台，命令会直接报错，不会为动作写入错误的平台。
 - `splitReportFile` 会产出“原始对象”对应的 JSON 文件（每个 execution 一个 `*.execution.json`），内容是 `ReportActionDump` 的原始结构化数据，同时会导出截图文件。返回值中的 `executionJsonFiles` 和 `screenshotFiles` 都是生成后的文件路径列表。
 - `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
 - `mergeReportFiles` 会把多份报告合并成一份汇总 HTML 报告，是 [`ReportMergingTool`](./reference/#new-reportmergingtool) 的轻量封装：会自动从每份源报告里读取 `groupName` 作为 `testTitle`/`testDescription`，省去了手工准备 `reportAttributes` 的步骤。命令行多次调用或多个测试用例产生多份报告后，使用它进行汇总最为合适。

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -157,7 +157,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
       - **注意**：如果点击触发了文件选择器但没有传入 `fileChooserAccept` 参数，文件选择器会被忽略，页面可以继续正常操作。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
-    - `loadExtraActions?: string[]`：为本次调用加载预先录制的 UI Action YAML 文件。默认值为 `undefined`，即不加载 Extra Action。每个文件代表一次设备操作，并成为一个供通用规划器使用的无参数 Action。规划器选中后，Midscene 会在执行前将其展开为录制好的单个底层 Action。该选项仅支持 Node.js，不支持自定义规划适配器。相对路径基于当前工作目录解析。文件无效、名称重复、规划适配器不受支持或底层 Action 不可用时，Midscene 会在规划开始前抛出错误。
+    - `loadExtraActions?: string[]`：为本次调用加载一个或多个 `*.actions.yaml` Manifest。每个文件可以包含多个 Extra Action。`validWhenTargetExists` 指向的元素存在时，动作会排在通用 Action Space 之前；没有这个条件的动作始终可用。该选项仅支持 Node.js 和通用规划适配器。Manifest 无效、名称重复、界面类型不匹配或底层 Action 不可用时，Midscene 会在规划前抛出错误。
     - `loadElementXpaths?: string[]`：为本次调用加载已知 UI 元素名称到 XPath 的 YAML 映射。Midscene 会把映射提供给规划器，并在执行前为匹配的 Action 注入 XPath。XPath 匹配成功时使用确定性的 DOM 解析，不调用定位模型；元素名未匹配或 XPath 已失效时，回退到普通 AI Locate。该选项仅支持 Node.js，相对路径基于当前工作目录解析。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
@@ -189,30 +189,37 @@ await agent.aiAct('完成 github 账号注册的表单填写。地区必须选�
 
 ##### 加载预先录制的 UI Action
 
-一个 Extra Action 文件定义一次可复用的设备操作。
+一个 Action Manifest 可以包含多个可复用操作。`action.name` 引用 Action Space 中的现有 Action，`action.param` 直接使用该 Action 的参数结构。
 
-`name` 是展示给规划器的操作名称。`actionName` 指向当前界面 `Action Space` 中已有的 Action。`actionParam` 必须且只能包含一项参数：
-
-```yaml title="extra-action.yaml"
-name: 点击确定按钮
-actionName: tap
-actionParam:
-  - xpath: /path/to/#confirm-button
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: 点击结算弹窗的确定按钮
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: 结算弹窗的确定按钮
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
 ```
 
-在单次 `aiAct` 中传入一个或多个文件：
-
 ```typescript
-await agent.aiAct('填写表单', {
-  loadExtraActions: ['./extra-action.yaml'],
+await agent.aiAct('确认结算', {
+  loadExtraActions: ['./checkout.actions.yaml'],
 });
 ```
 
-该选项仅支持 Node.js 和通用规划适配器。如果当前模型使用 UI-TARS、AutoGLM 等自定义规划适配器，`aiAct` 会在读取文件或调用模型之前抛出错误。
+每轮规划前，Midscene 会检查所有 `validWhenTargetExists`，但不会滚动、聚焦、点击或改变页面状态。目标存在的动作会全部披露，并排在通用 Actions 之前。即使披露集合发生变化，同一个动作在本次 `aiAct` 中也始终使用同一个无参数别名。模型只会看到别名和动作 `name`，不会看到 selector。模型返回别名后，Midscene 使用本轮同一份披露快照，将它展开为一个内置 Action。
 
-Extra Action 只对本次调用的规划器可见，不会修改 Agent 的 `Action Space`。`name` 不能包含尖括号、换行符或控制字符。`actionName` 可以填写 Action 名称或 `interfaceAlias`，匹配时不区分大小写。`actionParam` 必须只包含一项，规划开始前 Midscene 会根据目标 Action 校验该参数。若要复用多次操作，请将每次操作分别录制为一个文件，再通过 `loadExtraActions` 传入全部文件路径。
+执行时，Midscene 会重新把 `target` 解析为最新 Rect。如果目标失效，会继续使用 Locate Cache，再回退到 AI Locate。`target` 是正式字段；旧资产中的 `xpath` 仍可读取，但同一个 locator 不能同时包含 `target` 和 `xpath`。
 
-若底层 Action 只有一个定位字段，可以使用上面的简写。参数直接包含 `prompt`、`xpath` 或 `locatedPixelBbox` 即可。Midscene 只会把定位属性移入定位字段，`Input` 的 `value`、`mode` 等其他参数仍保留在顶层。如果定位参数包含 XPath 或 `locatedPixelBbox`，但没有提示词，Midscene 会使用 Extra Action 的 `name` 作为备用定位提示词。
+Extra Action 仅对当前 `aiAct` 生效，不会修改 Agent。该能力只支持通用规划适配器。UI-TARS、AutoGLM 等自定义适配器会在调用模型前报错。
 
 ##### 加载已知元素 XPath
 
@@ -236,7 +243,7 @@ await agent.aiAct(
 );
 ```
 
-规划器仍然负责选择 Action，并生成 Input 值等动态参数。当 Action 需要定位映射内的元素时，规划器使用映射键作为定位提示词，Midscene 在生成可执行任务前注入对应 XPath。可直接作用于当前焦点元素的 Action 不需要重复添加 locator。XPath 解析成功时，Locate 任务不会调用模型；规划器使用了未映射的提示词或 XPath 已失效时，Midscene 保留现有的 AI Locate 回退。该映射仅对本次调用生效，不会修改 Agent，同时会进入 Plan Cache 的键。缓存 YAML 会保留 XPath，因此缓存回放也不需要调用定位模型。
+规划器仍然负责选择 Action，并生成 Input 值等动态参数。当 Action 需要定位映射内的元素时，规划器使用映射键作为定位提示词，Midscene 在生成可执行任务前把对应 XPath 注入为 `target`。可直接作用于当前焦点元素的 Action 不需要重复添加 locator。目标解析成功时，Locate 任务不会调用模型；规划器使用了未映射的提示词或 XPath 已失效时，Midscene 保留现有的 AI Locate 回退。该映射仅对本次调用生效，不会修改 Agent，同时会进入 Plan Cache 的键。缓存 YAML 会保留 target，因此缓存回放也不需要调用定位模型。
 
 ##### 在 `aiAct` 提示词中上传文件
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -580,6 +580,8 @@ export class Agent<
       executions: [],
       modelBriefs: [],
       deviceType: this.interface.interfaceType,
+      manifestInterface:
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
     });
     this.executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
 
@@ -692,6 +694,7 @@ export class Agent<
       sdkVersion: this.dump.sdkVersion,
       modelBriefs: this.dump.modelBriefs,
       deviceType: this.dump.deviceType,
+      manifestInterface: this.dump.manifestInterface,
     };
   }
 

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -160,8 +160,17 @@ export class ReportActionDump implements IReportActionDump {
   modelBriefs: IReportActionDump['modelBriefs'];
   executions: ExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 
   constructor(data: IReportActionDump) {
+    if (
+      typeof data.manifestInterface !== 'string' ||
+      !data.manifestInterface.trim()
+    ) {
+      throw new Error(
+        'ReportActionDump: manifestInterface must be a non-empty string',
+      );
+    }
     this.sdkVersion = data.sdkVersion;
     this.groupName = data.groupName;
     this.groupDescription = data.groupDescription;
@@ -170,6 +179,7 @@ export class ReportActionDump implements IReportActionDump {
       exec instanceof ExecutionDump ? exec : ExecutionDump.fromJSON(exec),
     );
     this.deviceType = data.deviceType;
+    this.manifestInterface = data.manifestInterface.trim();
   }
 
   /**
@@ -218,6 +228,7 @@ export class ReportActionDump implements IReportActionDump {
       modelBriefs: this.modelBriefs,
       executions: this.executions.map((exec) => exec.toJSON()),
       deviceType: this.deviceType,
+      manifestInterface: this.manifestInterface,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,7 @@ export {
   type AnalyzeReportActionsOptions,
   type AnalyzeReportActionsResult,
   type UIActionDefinition,
+  type UIActionManifest,
 } from './report-analyzer';
 
 // ScreenshotItem

--- a/packages/core/src/report-analyzer.ts
+++ b/packages/core/src/report-analyzer.ts
@@ -1,14 +1,21 @@
 import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionManifest,
+} from './agent/extra-action-manifest';
+import {
+  type LocatorTarget,
+  LocatorTargetSchema,
+  xpathLocatorTarget,
+} from './locator';
 import { collectDedupedExecutions } from './report';
 import type { ExecutionTask } from './types';
 
-export interface UIActionDefinition {
-  name: string;
-  actionName: string;
-  actionParam: [unknown];
-}
+export type UIActionDefinition = ExtraActionDefinition;
+export type UIActionManifest = ExtraActionManifest;
 
 export interface AnalyzeReportActionsOptions {
   htmlPath: string;
@@ -19,7 +26,9 @@ export interface AnalyzeReportActionsOptions {
 export interface AnalyzeReportActionsResult {
   outputDir: string;
   actionFiles: string[];
+  actionCount: number;
   coordinateFallbackFiles: string[];
+  coordinateFallbackActionCount: number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -33,11 +42,23 @@ function firstNonEmptyString(...values: unknown[]): string | undefined {
   );
 }
 
-function firstXpath(value: unknown): string | undefined {
-  if (!isRecord(value)) return undefined;
-  const xpaths = value.xpaths;
-  if (!Array.isArray(xpaths)) return undefined;
-  return firstNonEmptyString(...xpaths);
+function firstTarget(value: unknown): LocatorTarget | undefined {
+  if (!isRecord(value) || !Array.isArray(value.targets)) return undefined;
+  for (const target of value.targets) {
+    const parsed = LocatorTargetSchema.safeParse(target);
+    if (parsed.success) return parsed.data;
+  }
+  return undefined;
+}
+
+function firstLegacyXpath(value: unknown): string | undefined {
+  if (!isRecord(value) || !Array.isArray(value.xpaths)) return undefined;
+  return firstNonEmptyString(...value.xpaths);
+}
+
+function targetFromValue(value: unknown): LocatorTarget | undefined {
+  const parsed = LocatorTargetSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function validLocatedPixelBbox(
@@ -52,12 +73,7 @@ function validLocatedPixelBbox(
 
 function isLocatedElement(value: unknown): value is Record<string, unknown> & {
   description?: string;
-  rect: {
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-  };
+  rect: { left: number; top: number; width: number; height: number };
 } {
   if (!isRecord(value) || !isRecord(value.rect)) return false;
   const { left, top, width, height } = value.rect;
@@ -70,35 +86,46 @@ function locatorFromTask(
   locateTask: ExecutionTask | undefined,
   locatedElement: Record<string, unknown> & {
     description?: string;
-    rect: {
-      left: number;
-      top: number;
-      width: number;
-      height: number;
-    };
+    rect: { left: number; top: number; width: number; height: number };
   },
-): { value: Record<string, unknown>; usedCoordinateFallback: boolean } {
+): {
+  value: Record<string, unknown>;
+  target?: LocatorTarget;
+  usedCoordinateFallback: boolean;
+} {
   const sourceParam = isRecord(locateTask?.param) ? locateTask.param : {};
   const hitContext = isRecord(locateTask?.hitBy?.context)
     ? locateTask.hitBy.context
     : {};
-
   const prompt =
     sourceParam.prompt ??
     firstNonEmptyString(sourceParam.promptDisplay, locatedElement.description);
-  const xpath = firstNonEmptyString(
+  const attemptedTargetFailed =
+    typeof hitContext.targetResolutionError === 'string' &&
+    hitContext.targetResolutionError.trim().length > 0;
+  const target =
+    (!attemptedTargetFailed
+      ? (targetFromValue(sourceParam.target) ??
+        targetFromValue(hitContext.target))
+      : undefined) ??
+    firstTarget(hitContext.cacheToSave) ??
+    firstTarget(hitContext.cacheEntry);
+  const legacyXpath = firstNonEmptyString(
     sourceParam.xpath,
     hitContext.xpath,
-    firstXpath(hitContext.cacheToSave),
-    firstXpath(hitContext.cacheEntry),
+    firstLegacyXpath(hitContext.cacheToSave),
+    firstLegacyXpath(hitContext.cacheEntry),
   );
+  const normalizedTarget =
+    target ?? (legacyXpath ? xpathLocatorTarget(legacyXpath) : undefined);
 
-  if (xpath) {
+  if (normalizedTarget) {
     return {
       value: {
         ...(prompt !== undefined ? { prompt } : {}),
-        xpath,
+        target: normalizedTarget,
       },
+      target: normalizedTarget,
       usedCoordinateFallback: false,
     };
   }
@@ -112,7 +139,6 @@ function locatorFromTask(
     locatedElement.rect.left + locatedElement.rect.width,
     locatedElement.rect.top + locatedElement.rect.height,
   ];
-
   return {
     value: {
       ...(prompt !== undefined ? { prompt } : {}),
@@ -126,70 +152,68 @@ function restoreStableLocators(
   value: unknown,
   locateTasks: ExecutionTask[],
   locateIndex: { value: number },
-): { value: unknown; usedCoordinateFallback: boolean } {
+): {
+  value: unknown;
+  targets: LocatorTarget[];
+  usedCoordinateFallback: boolean;
+} {
   if (isLocatedElement(value)) {
     const result = locatorFromTask(locateTasks[locateIndex.value], value);
     locateIndex.value += 1;
-    return result;
+    return {
+      value: result.value,
+      targets: result.target ? [result.target] : [],
+      usedCoordinateFallback: result.usedCoordinateFallback,
+    };
   }
-
   if (Array.isArray(value)) {
-    let usedCoordinateFallback = false;
-    const restored = value.map((item) => {
-      const result = restoreStableLocators(item, locateTasks, locateIndex);
-      usedCoordinateFallback ||= result.usedCoordinateFallback;
-      return result.value;
-    });
-    return { value: restored, usedCoordinateFallback };
-  }
-
-  if (isRecord(value)) {
-    let usedCoordinateFallback = false;
-    const restored = Object.fromEntries(
-      Object.entries(value).map(([key, item]) => {
-        const result = restoreStableLocators(item, locateTasks, locateIndex);
-        usedCoordinateFallback ||= result.usedCoordinateFallback;
-        return [key, result.value];
-      }),
+    const restored = value.map((item) =>
+      restoreStableLocators(item, locateTasks, locateIndex),
     );
-    return { value: restored, usedCoordinateFallback };
+    return {
+      value: restored.map((item) => item.value),
+      targets: restored.flatMap((item) => item.targets),
+      usedCoordinateFallback: restored.some(
+        (item) => item.usedCoordinateFallback,
+      ),
+    };
   }
-
-  return { value, usedCoordinateFallback: false };
-}
-
-function flattenSingleLocatorShortcut(
-  originalParam: unknown,
-  restoredParam: unknown,
-): unknown {
-  if (!isRecord(originalParam) || !isRecord(restoredParam)) {
-    return restoredParam;
+  if (isRecord(value)) {
+    const restored = Object.entries(value).map(
+      ([key, item]) =>
+        [key, restoreStableLocators(item, locateTasks, locateIndex)] as const,
+    );
+    return {
+      value: Object.fromEntries(
+        restored.map(([key, item]) => [key, item.value]),
+      ),
+      targets: restored.flatMap(([, item]) => item.targets),
+      usedCoordinateFallback: restored.some(
+        ([, item]) => item.usedCoordinateFallback,
+      ),
+    };
   }
-
-  const locatorFields = Object.entries(originalParam).filter(([, value]) =>
-    isLocatedElement(value),
-  );
-  if (locatorFields.length !== 1) return restoredParam;
-
-  const [locatorField] = locatorFields[0];
-  const restoredLocator = restoredParam[locatorField];
-  if (!isRecord(restoredLocator)) return restoredParam;
-
-  return {
-    ...Object.fromEntries(
-      Object.entries(restoredParam).filter(([key]) => key !== locatorField),
-    ),
-    ...restoredLocator,
-  };
+  return { value, targets: [], usedCoordinateFallback: false };
 }
 
 function actionNameFromTask(
   task: ExecutionTask,
+  plannedAction: Record<string, unknown> | undefined,
   planLog: string | undefined,
 ): string {
   const actionName = task.subType || 'Action';
-  if (planLog) {
-    const sanitizedPlanLog = Array.from(planLog)
+  const extraActionName = isRecord(task.hitBy?.context)
+    ? firstNonEmptyString(task.hitBy.context.extraActionName)
+    : undefined;
+  if (task.hitBy?.from === 'Extra Action' && extraActionName) {
+    return extraActionName;
+  }
+  const planningDescription = firstNonEmptyString(
+    plannedAction?.thought,
+    planLog,
+  );
+  if (planningDescription) {
+    const sanitizedPlanningDescription = Array.from(planningDescription)
       .map((character) => {
         const codePoint = character.codePointAt(0);
         const invalid =
@@ -206,13 +230,12 @@ function actionNameFromTask(
       .replace(/\s+/g, ' ')
       .trim();
     if (
-      sanitizedPlanLog &&
-      sanitizedPlanLog.toLowerCase() !== actionName.toLowerCase()
+      sanitizedPlanningDescription &&
+      sanitizedPlanningDescription.toLowerCase() !== actionName.toLowerCase()
     ) {
-      return sanitizedPlanLog;
+      return sanitizedPlanningDescription;
     }
   }
-
   if (isRecord(task.param)) {
     for (const value of Object.values(task.param)) {
       if (isLocatedElement(value) && value.description) {
@@ -239,64 +262,72 @@ function extractUIActions(
 
   for (const execution of executions) {
     let planLog: string | undefined;
+    let plannedActions: Record<string, unknown>[] = [];
+    let planActionCount = 0;
     let pendingLocateTasks: ExecutionTask[] = [];
-
     for (const task of execution.tasks) {
       if (task.type === 'Planning' && task.subType === 'Plan') {
-        planLog = isRecord(task.output)
-          ? firstNonEmptyString(task.output.log)
-          : undefined;
+        const planOutput = isRecord(task.output) ? task.output : {};
+        planLog = firstNonEmptyString(planOutput.log);
+        plannedActions = Array.isArray(planOutput.actions)
+          ? planOutput.actions.filter(isRecord)
+          : [];
+        planActionCount = plannedActions.length;
+        pendingLocateTasks = [];
         continue;
       }
-
       if (task.type === 'Planning' && task.subType === 'Locate') {
-        pendingLocateTasks.push(task);
+        if (task.status === 'finished') {
+          pendingLocateTasks.push(task);
+        }
         continue;
       }
-
       if (task.type !== 'Action Space') continue;
+
+      if (task.subType === 'Finished') {
+        pendingLocateTasks = [];
+        continue;
+      }
 
       const locateTasks = pendingLocateTasks;
       pendingLocateTasks = [];
-      const currentPlanLog = planLog;
-      planLog = undefined;
-
-      if (task.status !== 'finished' || task.subType === 'Finished') {
-        continue;
-      }
+      const plannedAction = plannedActions.shift();
+      const currentPlanLog = planActionCount <= 1 ? planLog : undefined;
+      if (task.status !== 'finished') continue;
 
       const restored = restoreStableLocators(task.param, locateTasks, {
         value: 0,
       });
-      const baseName = actionNameFromTask(task, currentPlanLog);
+      const baseName = actionNameFromTask(task, plannedAction, currentPlanLog);
       const nameCount = (nameCounts.get(baseName) ?? 0) + 1;
       nameCounts.set(baseName, nameCount);
       actions.push({
         definition: {
           name: nameCount === 1 ? baseName : `${baseName} (${nameCount})`,
-          actionName: task.subType || 'Action',
-          actionParam: [
-            flattenSingleLocatorShortcut(task.param, restored.value),
-          ],
+          ...(restored.targets.length > 0
+            ? { validWhenTargetExists: restored.targets[0] }
+            : {}),
+          action: {
+            name: task.subType || 'Action',
+            ...(restored.value !== undefined && restored.value !== null
+              ? { param: restored.value }
+              : {}),
+          },
         },
         usedCoordinateFallback: restored.usedCoordinateFallback,
       });
     }
   }
-
   return actions;
 }
 
 function resolveReportHtmlPath(htmlPath: string): string {
   const normalizedPath = path.resolve(htmlPath);
-
   if (!existsSync(normalizedPath)) {
     throw new Error(`analyzeReportActions: report does not exist: ${htmlPath}`);
   }
-
   const stats = statSync(normalizedPath);
   if (!stats.isDirectory()) return normalizedPath;
-
   const indexHtmlPath = path.join(normalizedPath, 'index.html');
   if (!existsSync(indexHtmlPath)) {
     throw new Error(
@@ -306,21 +337,23 @@ function resolveReportHtmlPath(htmlPath: string): string {
   return indexHtmlPath;
 }
 
-function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
-  const reportDir = path.dirname(resolvedHtmlPath);
-  const reportBaseName = path.basename(
+function reportBaseName(resolvedHtmlPath: string): string {
+  const baseName = path.basename(
     resolvedHtmlPath,
     path.extname(resolvedHtmlPath),
   );
+  return baseName === 'index'
+    ? path.basename(path.dirname(resolvedHtmlPath))
+    : baseName;
+}
 
-  if (reportBaseName === 'index') {
-    return path.join(
-      path.dirname(reportDir),
-      `${path.basename(reportDir)}-ui-actions`,
-    );
-  }
-
-  return path.join(reportDir, `${reportBaseName}-ui-actions`);
+function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
+  const reportDir = path.dirname(resolvedHtmlPath);
+  const baseName = reportBaseName(resolvedHtmlPath);
+  return path.basename(resolvedHtmlPath, path.extname(resolvedHtmlPath)) ===
+    'index'
+    ? path.join(path.dirname(reportDir), `${baseName}-ui-actions`)
+    : path.join(reportDir, `${baseName}-ui-actions`);
 }
 
 export function analyzeReportActions(
@@ -329,51 +362,66 @@ export function analyzeReportActions(
   if (!options.htmlPath) {
     throw new Error('analyzeReportActions: htmlPath is required');
   }
-
   const resolvedHtmlPath = resolveReportHtmlPath(options.htmlPath);
   const outputDir = path.resolve(
     options.outputDir ?? defaultAnalyzeOutputDir(resolvedHtmlPath),
   );
-  const { executions } = collectDedupedExecutions(resolvedHtmlPath);
+  const { executions, manifestInterfaces } =
+    collectDedupedExecutions(resolvedHtmlPath);
+  const normalizedManifestInterfaces = manifestInterfaces.map((value) =>
+    value.trim(),
+  );
+  const uniqueManifestInterfaces = new Set(normalizedManifestInterfaces);
+  const manifestInterface = Array.from(uniqueManifestInterfaces)[0];
+  if (
+    !manifestInterface ||
+    uniqueManifestInterfaces.size !== 1 ||
+    manifestInterface === 'mixed' ||
+    manifestInterface === 'unknown'
+  ) {
+    throw new Error(
+      `analyzeReportActions: every report dump with executions must declare the same canonical manifestInterface; received ${JSON.stringify(normalizedManifestInterfaces)}`,
+    );
+  }
   const actions = extractUIActions(executions);
-
   if (actions.length === 0) {
     throw new Error(
       `analyzeReportActions: no successful UI actions found in ${options.htmlPath}`,
     );
   }
 
-  const actionFiles = actions.map((action, index) =>
-    path.join(
-      outputDir,
-      `${String(index + 1).padStart(3, '0')}-${action.definition.actionName.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'action'}.yaml`,
-    ),
+  const actionFile = path.join(
+    outputDir,
+    `${reportBaseName(resolvedHtmlPath)}.actions.yaml`,
   );
-  const existingFiles = actionFiles.filter((file) => existsSync(file));
-  if (existingFiles.length > 0 && !options.overwrite) {
+  if (existsSync(actionFile) && !options.overwrite) {
     throw new Error(
-      `analyzeReportActions: output file already exists: ${existingFiles[0]}. Pass overwrite: true or --overwrite to replace generated UI Actions.`,
+      `analyzeReportActions: output file already exists: ${actionFile}. Pass overwrite: true or --overwrite to replace the generated Action Manifest.`,
     );
   }
-
-  mkdirSync(outputDir, { recursive: true });
-  actions.forEach((action, index) => {
-    writeFileSync(
-      actionFiles[index],
-      yaml.dump(action.definition, {
-        indent: 2,
-        lineWidth: -1,
-        noRefs: true,
-      }),
-      'utf-8',
-    );
+  const manifest: UIActionManifest = {
+    version: 1,
+    interface: manifestInterface,
+    actions: actions.map((action) => action.definition),
+  };
+  const manifestYaml = yaml.dump(manifest, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
   });
+  parseExtraActionManifest(manifestYaml, actionFile);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(actionFile, manifestYaml, 'utf-8');
 
+  const coordinateFallbackActionCount = actions.filter(
+    (action) => action.usedCoordinateFallback,
+  ).length;
   return {
     outputDir,
-    actionFiles,
-    coordinateFallbackFiles: actionFiles.filter(
-      (_file, index) => actions[index].usedCoordinateFallback,
-    ),
+    actionFiles: [actionFile],
+    actionCount: actions.length,
+    coordinateFallbackFiles:
+      coordinateFallbackActionCount > 0 ? [actionFile] : [],
+    coordinateFallbackActionCount,
   };
 }

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -120,6 +120,7 @@ async function markdownFromReport(
     groupDescription: baseDump.groupDescription,
     modelBriefs: baseDump.modelBriefs,
     deviceType: baseDump.deviceType,
+    manifestInterface: baseDump.manifestInterface,
     executions,
   });
 
@@ -460,7 +461,7 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
 const analyzeCommandDefinition: ReportCliCommandDefinition = {
   name: 'analyze',
   description:
-    'Extract successful UI actions from a Midscene HTML report into one reusable YAML file per device operation.',
+    'Extract successful UI actions from a Midscene HTML report into a reusable *.actions.yaml manifest.',
   schema: {
     htmlPath: z
       .string()
@@ -499,8 +500,8 @@ const analyzeCommandDefinition: ReportCliCommandDefinition = {
       overwrite: overwriteFlag,
     });
     const fallbackMessage =
-      result.coordinateFallbackFiles.length > 0
-        ? ` ${result.coordinateFallbackFiles.length} action(s) use locatedPixelBbox because no XPath was recorded.`
+      result.coordinateFallbackActionCount > 0
+        ? ` ${result.coordinateFallbackActionCount} action(s) use locatedPixelBbox because no stable target was recorded.`
         : '';
 
     return {
@@ -508,7 +509,7 @@ const analyzeCommandDefinition: ReportCliCommandDefinition = {
       content: [
         {
           type: 'text',
-          text: `Analyzed ${result.actionFiles.length} UI action(s). Output path: ${result.outputDir}.${fallbackMessage}`,
+          text: `Analyzed ${result.actionCount} UI action(s) into ${result.actionFiles[0]}.${fallbackMessage}`,
         },
       ],
     };

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -327,6 +327,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: reportMeta.groupDescription,
       modelBriefs: reportMeta.modelBriefs,
       deviceType: reportMeta.deviceType,
+      manifestInterface: reportMeta.manifestInterface,
       executions: [execution],
     });
   }
@@ -414,6 +415,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: this.lastReportMeta.groupDescription,
       modelBriefs: this.lastReportMeta.modelBriefs,
       deviceType: this.lastReportMeta.deviceType,
+      manifestInterface: this.lastReportMeta.manifestInterface,
       executions: Array.from(this.executionsByKey.values()),
     });
     await appendFileAsync(

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -161,12 +161,17 @@ function mergedAgentReportComment(reports: ReportActionDump[]): string {
   const deviceTypes = Array.from(
     new Set(reports.map((report) => report.deviceType).filter(Boolean)),
   );
+  const manifestInterfaces = Array.from(
+    new Set(reports.map((report) => report.manifestInterface)),
+  );
   const mergedReport = new ReportActionDump({
     sdkVersion: reports[0].sdkVersion || getVersion(),
     groupName: 'Merged Midscene Report',
     groupDescription: 'Agent-readable summary for merged report HTML',
     modelBriefs: reports.flatMap((report) => report.modelBriefs ?? []),
     deviceType: deviceTypes.length === 1 ? deviceTypes[0] : 'mixed',
+    manifestInterface:
+      manifestInterfaces.length === 1 ? manifestInterfaces[0] : 'mixed',
     executions: reports.flatMap((report) => report.executions ?? []),
   });
   return generateAgentReportComment(mergedReport);
@@ -181,6 +186,7 @@ export class ReportMergingTool {
       groupName,
       groupDescription,
       modelBriefs: [],
+      manifestInterface: 'unknown',
       executions: [],
     }).serialize();
   }
@@ -234,11 +240,17 @@ export class ReportMergingTool {
     // id are always kept (they may be distinct despite sharing the same name).
     const base = ReportActionDump.fromSerializedString(unescaped[0]);
     const allExecutions = [...base.executions];
+    const manifestInterfaces = new Set([base.manifestInterface]);
     for (let i = 1; i < unescaped.length; i++) {
       const other = ReportActionDump.fromSerializedString(unescaped[i]);
       allExecutions.push(...other.executions);
+      manifestInterfaces.add(other.manifestInterface);
     }
     base.executions = dedupeExecutionsKeepLatest(allExecutions);
+    base.manifestInterface =
+      manifestInterfaces.size === 1
+        ? Array.from(manifestInterfaces)[0]
+        : 'mixed';
     return base.serialize();
   }
 
@@ -467,6 +479,7 @@ export interface SplitReportHtmlResult {
 export interface CollectedReportExecutions {
   baseDump: ReportActionDump;
   executions: IExecutionDump[];
+  manifestInterfaces: string[];
 }
 
 /**
@@ -498,6 +511,7 @@ export function collectDedupedExecutions(
   });
 
   const executions: IExecutionDump[] = [];
+  const manifestInterfaces: string[] = [];
   executionSerial = 0;
   streamDumpScriptsSync(htmlPath, (dumpScript) => {
     if (!dumpScript.openTag.includes('data-group-id')) {
@@ -509,6 +523,9 @@ export function collectDedupedExecutions(
     );
     if (!baseDump) {
       baseDump = groupedDump;
+    }
+    if (groupedDump.executions.length > 0) {
+      manifestInterfaces.push(groupedDump.manifestInterface);
     }
 
     for (const execution of groupedDump.executions) {
@@ -532,6 +549,7 @@ export function collectDedupedExecutions(
   return {
     baseDump,
     executions,
+    manifestInterfaces,
   };
 }
 
@@ -626,6 +644,7 @@ export function splitReportHtmlByExecution(
       groupDescription: baseDump.groupDescription,
       modelBriefs: baseDump.modelBriefs,
       deviceType: baseDump.deviceType,
+      manifestInterface: baseDump.manifestInterface,
       executions: [execution],
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -767,6 +767,7 @@ export interface ReportMeta {
   sdkVersion: string;
   modelBriefs: ModelBrief[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.
@@ -782,6 +783,7 @@ export interface IReportActionDump {
   modelBriefs: ModelBrief[];
   executions: IExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.

--- a/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
+++ b/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
@@ -61,6 +61,7 @@ describe('dump serialization drops screenshotSequence', () => {
   it('omits screenshotSequence from serializeWithInlineScreenshots() (inline mode)', () => {
     const reportData: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'screenshot-sequence',
       modelBriefs: [],
       executions: [buildExecutionDumpData()],

--- a/packages/core/tests/unit-test/execution-dump.test.ts
+++ b/packages/core/tests/unit-test/execution-dump.test.ts
@@ -165,6 +165,7 @@ describe('ExecutionDump', () => {
 describe('ReportActionDump', () => {
   const createMockReportActionDumpData = (): IReportActionDump => ({
     sdkVersion: '1.0.0',
+    manifestInterface: 'web',
     groupName: 'Test Group',
     groupDescription: 'A test group description',
     modelBriefs: [{ name: 'model1' }, { name: 'model2' }],
@@ -213,6 +214,7 @@ describe('ReportActionDump', () => {
 
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Test',
         modelBriefs: [],
         executions: [executionDump],
@@ -225,6 +227,7 @@ describe('ReportActionDump', () => {
     it('should handle optional fields', () => {
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Minimal Group',
         modelBriefs: [],
         executions: [],
@@ -281,6 +284,7 @@ describe('ReportActionDump', () => {
 
       const dump = new ReportActionDump({
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Inline Screenshot Test',
         modelBriefs: [],
         executions: [
@@ -391,6 +395,7 @@ describe('ReportActionDump', () => {
     it('should handle complex nested structures', () => {
       const complexData: IReportActionDump = {
         sdkVersion: '2.0.0',
+        manifestInterface: 'web',
         groupName: 'Complex Group',
         groupDescription: 'A complex test',
         modelBriefs: [{ name: 'openai/gpt-4' }, { name: 'anthropic/claude' }],
@@ -450,6 +455,7 @@ describe('ExecutionDump and ReportActionDump integration', () => {
     // Create ReportActionDump with ExecutionDump instances
     const groupedDump = new ReportActionDump({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'Integration Test',
       modelBriefs: [],
       executions: [execution1, execution2],

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -27,6 +27,7 @@ describe('html-utils', () => {
   it('generates a compact agent analysis comment for report HTML', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'checkout -- flow',
       modelBriefs: [
         {
@@ -63,6 +64,7 @@ describe('html-utils', () => {
   it('falls back agent comment model info to task usage', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage model report',
       modelBriefs: [],
       executions: [
@@ -96,6 +98,7 @@ describe('html-utils', () => {
   it('keeps agent analysis comments optional for incomplete execution dumps', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'incomplete report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/merge-browser-parse.test.ts
+++ b/packages/core/tests/unit-test/merge-browser-parse.test.ts
@@ -47,6 +47,7 @@ function createDump(screenshots: ScreenshotItem[]): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName: 'test-group',
     groupDescription: 'test desc',
     modelBriefs: [{ name: 'test-model' }],
@@ -88,6 +89,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,
@@ -130,6 +132,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
       const dump = createDump(screenshots);
       const groupMeta: ReportMeta = {
         sdkVersion: dump.sdkVersion,
+        manifestInterface: dump.manifestInterface,
         groupName: dump.groupName,
         groupDescription: dump.groupDescription,
         modelBriefs: dump.modelBriefs,
@@ -213,6 +216,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -67,6 +67,7 @@ function createExecution(
 function createActionExecution(options?: {
   xpath?: string;
   includeFailedAction?: boolean;
+  extraActionName?: string;
 }): ExecutionDump {
   const locateHitBy = options?.xpath
     ? {
@@ -74,7 +75,7 @@ function createActionExecution(options?: {
         context: {
           locatedPixelBbox: [10, 20, 110, 70],
           cacheToSave: {
-            xpaths: [options.xpath],
+            targets: [{ strategy: 'xpath', selector: options.xpath }],
           },
         },
       }
@@ -93,7 +94,12 @@ function createActionExecution(options?: {
       param: {},
       output: {
         log: 'Click the confirm button',
-        actions: [],
+        actions: [
+          {
+            type: 'Tap',
+            thought: 'Click the confirm button',
+          },
+        ],
       },
       executor: async () => undefined,
       status: 'finished',
@@ -121,6 +127,17 @@ function createActionExecution(options?: {
           center: [60, 45],
         },
       },
+      ...(options?.extraActionName
+        ? {
+            hitBy: {
+              from: 'Extra Action',
+              context: {
+                extraActionName: options.extraActionName,
+                extraActionAlias: 'MidsceneExtraAction_1',
+              },
+            },
+          }
+        : {}),
       executor: async () => undefined,
       status: 'finished',
     },
@@ -131,7 +148,12 @@ function createActionExecution(options?: {
       param: {},
       output: {
         log: 'Type the saved value',
-        actions: [],
+        actions: [
+          {
+            type: 'Input',
+            thought: 'Type the saved value',
+          },
+        ],
       },
       executor: async () => undefined,
       status: 'finished',
@@ -199,11 +221,13 @@ describe('createReportCliCommands', () => {
     expect(commands.every((command) => !('aliases' in command))).toBe(true);
   });
 
-  it('exports one loadable UI Action file per successful device operation', async () => {
+  it('exports successful device operations into one loadable Action Manifest', async () => {
     const reportPath = join(tmpDir, 'action-report.html');
     const report = new ReportActionDump({
       groupName: 'action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [
         createActionExecution({
@@ -223,24 +247,41 @@ describe('createReportCliCommands', () => {
     const result = analyzeReportActions({ htmlPath: reportPath });
 
     expect(result.actionFiles.map((file) => file.split('/').pop())).toEqual([
-      '001-tap.yaml',
-      '002-input.yaml',
+      'action-report.actions.yaml',
     ]);
+    expect(result.actionCount).toBe(2);
     expect(result.coordinateFallbackFiles).toEqual([]);
     expect(yaml.load(readFileSync(result.actionFiles[0], 'utf-8'))).toEqual({
-      name: 'Click the confirm button',
-      actionName: 'Tap',
-      actionParam: [
+      version: 1,
+      interface: 'web',
+      actions: [
         {
-          prompt: 'Confirm button',
-          xpath: '/html/body/button[1]',
+          name: 'Click the confirm button',
+          validWhenTargetExists: {
+            strategy: 'xpath',
+            selector: '/html/body/button[1]',
+          },
+          action: {
+            name: 'Tap',
+            param: {
+              locate: {
+                prompt: 'Confirm button',
+                target: {
+                  strategy: 'xpath',
+                  selector: '/html/body/button[1]',
+                },
+              },
+            },
+          },
+        },
+        {
+          name: 'Type the saved value',
+          action: {
+            name: 'Input',
+            param: { value: 'saved value' },
+          },
         },
       ],
-    });
-    expect(yaml.load(readFileSync(result.actionFiles[1], 'utf-8'))).toEqual({
-      name: 'Type the saved value',
-      actionName: 'Input',
-      actionParam: [{ value: 'saved value' }],
     });
 
     const loaded = await loadExtraActions(result.actionFiles, [
@@ -281,11 +322,488 @@ describe('createReportCliCommands', () => {
     ]);
   });
 
+  it('requires a canonical manifest interface instead of inferring one from deviceType', () => {
+    const reportPath = join(tmpDir, 'missing-manifest-interface.html');
+    const report = new ReportActionDump({
+      groupName: 'missing-manifest-interface',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'puppeteer',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button' })],
+    });
+    const reportWithoutManifestInterface = {
+      ...JSON.parse(report.serialize()),
+      manifestInterface: undefined,
+    };
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(JSON.stringify(reportWithoutManifestInterface), {
+        'data-group-id': 'missing-manifest-interface',
+      }),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'manifestInterface must be a non-empty string',
+    );
+  });
+
+  it('rejects reports that combine executions from different manifest interfaces', () => {
+    const reportPath = join(tmpDir, 'mixed-manifest-interfaces.html');
+    const webReport = new ReportActionDump({
+      groupName: 'web-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="web"]' })],
+    });
+    const androidReport = new ReportActionDump({
+      groupName: 'android-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'android',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="android"]' })],
+    });
+    writeFileSync(
+      reportPath,
+      [
+        generateDumpScriptTag(webReport.serialize(), {
+          'data-group-id': 'web-actions',
+        }),
+        generateDumpScriptTag(androidReport.serialize(), {
+          'data-group-id': 'android-actions',
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'received ["web","android"]',
+    );
+  });
+
+  it('does not pair a failed locate from an earlier plan with a recovered action', () => {
+    const reportPath = join(tmpDir, 'recovered-locate.html');
+    const execution = new ExecutionDump({
+      id: 'recovered-locate',
+      logTime: Date.now(),
+      name: 'recovered locate',
+      tasks: [
+        {
+          taskId: 'wrong-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Try the wrong button',
+            actions: [{ type: 'Tap', thought: 'Try the wrong button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'wrong-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Wrong button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="wrong"]',
+            },
+          },
+          status: 'failed',
+        },
+        {
+          taskId: 'recovery-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Click the correct button',
+            actions: [{ type: 'Tap', thought: 'Click the correct button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Correct button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Correct button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'recovered-locate',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'recovered-locate',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions).toHaveLength(1);
+    expect(manifest.actions[0]).toMatchObject({
+      name: 'Click the correct button',
+      validWhenTargetExists: {
+        strategy: 'xpath',
+        selector: '//button[@id="correct"]',
+      },
+      action: {
+        param: {
+          locate: {
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('exports the fallback target after a supplied target fails to resolve', () => {
+    const reportPath = join(tmpDir, 'target-fallback.html');
+    const failedTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="missing"]',
+    };
+    const fallbackTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="actual"]',
+    };
+    const execution = new ExecutionDump({
+      id: 'target-fallback',
+      logTime: Date.now(),
+      name: 'target fallback',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [
+              { type: 'Tap', thought: 'Click the actual fallback button' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Actual fallback button',
+            target: failedTarget,
+          },
+          hitBy: {
+            from: 'AI',
+            context: {
+              target: failedTarget,
+              targetResolutionError: 'XPath target does not exist',
+              cacheToSave: { targets: [fallbackTarget] },
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Actual fallback button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'target-fallback',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'target-fallback',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: fallbackTarget,
+      action: {
+        param: {
+          locate: {
+            target: fallbackTarget,
+          },
+        },
+      },
+    });
+  });
+
+  it('uses each planned action thought when one plan contains multiple actions', () => {
+    const reportPath = join(tmpDir, 'multi-action-plan.html');
+    const locatedElement = (description: string) => ({
+      description,
+      rect: { left: 10, top: 20, width: 100, height: 50 },
+      center: [60, 45],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-action-plan',
+      logTime: Date.now(),
+      name: 'multi action plan',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Complete both operations',
+            actions: [
+              { type: 'Tap', thought: 'Click the primary button' },
+              { type: 'Input', thought: 'Enter the saved value' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-primary',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Primary button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="primary"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'tap-primary',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: { locate: locatedElement('Primary button') },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-input',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Saved value input',
+            target: {
+              strategy: 'xpath',
+              selector: '//input[@id="saved"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'input-value',
+          type: 'Action Space',
+          subType: 'Input',
+          param: {
+            value: 'saved value',
+            locate: locatedElement('Saved value input'),
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-action-plan',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-action-plan',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions.map((action: any) => action.name)).toEqual([
+      'Click the primary button',
+      'Enter the saved value',
+    ]);
+  });
+
+  it('uses the first of multiple action targets as the disclosure condition', () => {
+    const reportPath = join(tmpDir, 'multi-target-swipe.html');
+    const startTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-handle"]',
+    };
+    const endTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-end"]',
+    };
+    const locatedElement = (description: string, left: number) => ({
+      description,
+      rect: { left, top: 20, width: 20, height: 20 },
+      center: [left + 10, 30],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-target-swipe',
+      logTime: Date.now(),
+      name: 'multi target swipe',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [{ type: 'Swipe', thought: 'Move the slider to the end' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-start',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider handle', target: startTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-end',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider end', target: endTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'swipe',
+          type: 'Action Space',
+          subType: 'Swipe',
+          param: {
+            start: locatedElement('Slider handle', 10),
+            end: locatedElement('Slider end', 200),
+            duration: 300,
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-target-swipe',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-target-swipe',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: startTarget,
+      action: {
+        name: 'Swipe',
+        param: {
+          start: { target: startTarget },
+          end: { target: endTarget },
+          duration: 300,
+        },
+      },
+    });
+  });
+
+  it('preserves the recorded Extra Action name when exporting a replay report', () => {
+    const reportPath = join(tmpDir, 'replayed-extra-action.html');
+    const report = new ReportActionDump({
+      groupName: 'replayed-extra-action',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [
+        createActionExecution({
+          xpath: '//button',
+          extraActionName: 'Recorded checkout confirmation',
+        }),
+      ],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'replayed-extra-action',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0].name).toBe('Recorded checkout confirmation');
+  });
+
   it('falls back to locatedPixelBbox for reports without a recorded xpath', () => {
     const reportPath = join(tmpDir, 'historical-report.html');
     const report = new ReportActionDump({
       groupName: 'historical-action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createActionExecution()],
     });
@@ -298,12 +816,13 @@ describe('createReportCliCommands', () => {
     );
 
     const result = analyzeReportActions({ htmlPath: reportPath });
-    const firstAction = yaml.load(
+    const manifest = yaml.load(
       readFileSync(result.actionFiles[0], 'utf-8'),
     ) as any;
 
     expect(result.coordinateFallbackFiles).toEqual([result.actionFiles[0]]);
-    expect(firstAction.actionParam[0]).toEqual({
+    expect(result.coordinateFallbackActionCount).toBe(1);
+    expect(manifest.actions[0].action.param.locate).toEqual({
       prompt: 'Confirm button',
       locatedPixelBbox: [10, 20, 110, 70],
     });
@@ -314,6 +833,8 @@ describe('createReportCliCommands', () => {
     const report = new ReportActionDump({
       groupName: 'overwrite-action-export',
       sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createActionExecution({ xpath: '//button' })],
     });
@@ -345,6 +866,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -352,6 +874,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -396,6 +919,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-test',
       groupDescription: 'sdk split test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-1', screenshot)],
     });
@@ -459,6 +983,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-markdown-test',
       groupDescription: 'sdk markdown test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-md-1', screenshot)],
     });
@@ -531,6 +1056,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-dir-test',
       groupDescription: 'split-dir-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-dir-1', screenshot)],
     });
@@ -595,6 +1121,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-1', screenshot1)],
     });
@@ -602,6 +1129,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-2', screenshot2)],
     });
@@ -645,6 +1173,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', oldScreenshot)],
     });
@@ -652,6 +1181,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', newScreenshot)],
     });
@@ -702,6 +1232,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-file-test',
       groupDescription: 'markdown export file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-file', screenshotRef)],
     });
@@ -764,6 +1295,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-rel-file-test',
       groupDescription: 'markdown export relative file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-rel', screenshotRef)],
     });
@@ -814,6 +1346,7 @@ describe('createReportCliCommands', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution(executionId, screenshot)],
     });

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -40,6 +40,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 

--- a/packages/core/tests/unit-test/report-issues.test.ts
+++ b/packages/core/tests/unit-test/report-issues.test.ts
@@ -64,6 +64,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 
@@ -98,6 +99,7 @@ describe('Issue 2: default groupName causes unrelated reports to merge', () => {
     const sameReportMeta: ReportMeta = {
       groupName: 'Midscene Report', // default groupName
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 
@@ -146,6 +148,7 @@ describe('Issue 3: execution persistence requires id', () => {
     const groupMeta: ReportMeta = {
       groupName: 'dedup-test',
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -88,6 +88,7 @@ describe('report-markdown', () => {
   it('merges all executions into one markdown and keeps file snapshot', async () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'report-group',
       modelBriefs: [],
       executions: [
@@ -249,6 +250,7 @@ describe('report-markdown', () => {
   it('includes model metadata, token usage, and task context for agent analysis', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'agent-ready-report',
       modelBriefs: [
         {
@@ -331,6 +333,7 @@ describe('report-markdown', () => {
   it('falls back report model info to task usage when model briefs are missing', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage-model-report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/report-merge-count.test.ts
+++ b/packages/core/tests/unit-test/report-merge-count.test.ts
@@ -42,6 +42,7 @@ async function writeAndFinalize(
     groupName: dump.groupName,
     groupDescription: dump.groupDescription,
     sdkVersion: dump.sdkVersion,
+    manifestInterface: dump.manifestInterface,
     modelBriefs: dump.modelBriefs,
     deviceType: dump.deviceType,
   };
@@ -69,6 +70,7 @@ function createDump(groupName: string, taskCount: number): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName,
     groupDescription: `desc of ${groupName}`,
     modelBriefs: [{ name: 'test-model' }],
@@ -404,6 +406,7 @@ describe('ReportMergingTool merged dump count verification', () => {
       const groupMeta: ReportMeta = {
         groupName: `multi-group-${i}`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [{ name: 'test-model' }],
       };
       for (let e = 0; e < execsPerReport; e++) {

--- a/packages/core/tests/unit-test/report-merge-status.test.ts
+++ b/packages/core/tests/unit-test/report-merge-status.test.ts
@@ -109,6 +109,7 @@ describe('mergeReportFiles status derivation', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [execution],
     });
@@ -186,6 +187,7 @@ describe('mergeReportFiles status derivation', () => {
         groupName,
         groupDescription: `${groupName}-desc`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [exec],
       });

--- a/packages/core/tests/unit-test/report-split.test.ts
+++ b/packages/core/tests/unit-test/report-split.test.ts
@@ -77,6 +77,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -84,6 +85,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -144,6 +146,7 @@ describe('splitReportHtmlByExecution', () => {
         groupName: 'large-split-test',
         groupDescription: 'large-split-test',
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [createExecution(`exec-${i}`, sharedScreenshot)],
       });
@@ -174,6 +177,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', oldScreenshot)],
     });
@@ -181,6 +185,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', newScreenshot)],
     });
@@ -234,6 +239,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'absolute-path-test',
       groupDescription: 'absolute-path-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshotRef)],
     });
@@ -280,6 +286,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'fallback-test',
       groupDescription: 'fallback-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-fallback', screenshotRef)],
     });

--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -68,6 +68,19 @@ function buildProgressContent(task: any): string {
   return description ? `${action} - ${description}` : action;
 }
 
+const manifestInterfaceForDeviceType = (deviceType?: string): string => {
+  if (!deviceType) return 'unknown';
+  return [
+    'web',
+    'puppeteer',
+    'playwright',
+    'chrome-extension-proxy',
+    'static',
+  ].includes(deviceType)
+    ? 'web'
+    : deviceType;
+};
+
 /**
  * Convert ExecutionDump to ReportActionDump for replay scripts
  * @param dump - The execution dump containing tasks and their usage information
@@ -85,6 +98,7 @@ function wrapExecutionDumpForReplay(
     modelBriefs: [],
     executions: [dump],
     deviceType,
+    manifestInterface: manifestInterfaceForDeviceType(deviceType),
   };
 }
 

--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -207,6 +207,7 @@ const normalizeDump = (dump: DumpInput): IReportActionDump | null => {
         groupName: 'Execution',
         modelBriefs: [],
         executions: [dump as ExecutionDump],
+        manifestInterface: 'unknown',
       };
 };
 


### PR DESCRIPTION
## Summary

- persist the canonical manifest interface in report dumps
- analyze successful report actions and export them as versioned `*.actions.yaml` manifests
- add the report CLI export path and bilingual documentation
- make Visualizer replay dumps carry a canonical manifest interface, fixing the package-build failure found during the earlier prepatch attempt

## Stack dependency

This is the third and final PR in the stack. It depends on the manifest runtime in #2990.

Review order: **#2989 → #2990 → this PR**.

## Validation

- `pnpm run lint`
- `NX_DAEMON=false pnpm nx test @midscene/core` — 1,412 passed, 8 skipped
- `NX_DAEMON=false pnpm nx test @midscene/shared` — 427 passed
- `NX_DAEMON=false pnpm nx test @midscene/visualizer` — 104 passed
- `NX_DAEMON=false pnpm nx build @midscene/report` — passed; also built Shared, Core, Playground, Web, Visualizer, and Report dependencies
- `pnpm exec vitest --run tests/unit-test/chrome-extension-cache.test.ts tests/unit-test/task-cache.test.ts tests/unit-test/web-extractor.test.ts` from `packages/web-integration` — 72 passed, 1 skipped

No prepatch package was published. The earlier release workflow stopped before publication, and its Visualizer schema blocker is fixed in this PR.
