### PR TITLE
feat(core): load reusable extra action manifests

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -138,6 +138,7 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     fileChooserAllowedDir?: string;
+    loadExtraActions?: string[];
     abortSignal?: AbortSignal;
     context?: string;
   },
@@ -159,6 +160,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // s
       - **Note**: In Chrome extension Bridge mode, local file uploads require the Midscene extension's "Allow access to file URLs" permission. Enable it in `chrome://extensions` > Midscene > "Details", then reconnect Bridge mode from the target `http(s)://` page.
       - **Note**: Chrome extension Bridge mode does not support directory upload inputs (`webkitdirectory` / `directory`). Use Playwright for directory uploads.
     - `fileChooserAllowedDir?: string` — Explicitly authorizes the directory this `aiAct` call may access for prompt-driven file uploads. Without it, model-planned file uploads are rejected. Relative paths in the prompt are resolved against this directory and then validated; absolute paths are validated directly against this directory. Symlinks located within this directory are also allowed. We recommend using the test case's `fixtures` directory to reduce the risk of sensitive-file uploads caused by AI hallucinations or page prompt injection.
+    - `loadExtraActions?: string[]` — Loads one or more versioned `*.actions.yaml` manifests for this call. Midscene exposes every manifest action whose `validWhenTargetExists` target exists in the current planning snapshot. Extra Actions are listed before generic Actions and expand into one existing device Action when selected. This Node.js-only option requires the generic planning adapter. Relative paths are resolved from the current working directory.
     - `abortSignal?: AbortSignal` — Signal used to cancel the `aiAct` call. When aborted, Midscene stops the planning loop and throws an error. Use it to implement timeouts or user-initiated cancellation.
 
 - Return value:
@@ -200,6 +202,38 @@ await agent.aiAct('Complete the GitHub account registration form. The region mus
 `deepThink` accepts `'unset' | true | false`. The legacy `'unset'` value behaves the same as `false`.
 
 `deepThink` does not control model-native thinking. See [Model-native thinking](../model-config#model-native-reasoning) for the related environment variables.
+
+##### Load reusable Extra Actions
+
+An Action Manifest stores named device operations together with deterministic locator targets:
+
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: Click the checkout confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+```
+
+Load one or more manifests for a single call:
+
+```typescript
+await agent.aiAct('Confirm checkout', {
+  loadExtraActions: ['./checkout.actions.yaml'],
+});
+```
+
+Disclosure only probes the declared `validWhenTargetExists` targets and does not change page state. If a selected target resolves, Midscene converts it to a fresh rectangle and executes the underlying Action. If target resolution fails, Midscene falls back to the existing cache and AI locate path. Invalid manifests, incompatible interfaces, duplicate names, unsupported custom planning adapters, and unavailable underlying Actions throw before planning.
 
 ##### Upload files from an `aiAct` prompt
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -136,6 +136,7 @@ function aiAct(
     deepLocate?: boolean;
     fileChooserAccept?: string | string[];
     fileChooserAllowedDir?: string;
+    loadExtraActions?: string[];
     abortSignal?: AbortSignal;
     context?: string;
   },
@@ -157,6 +158,7 @@ function ai(prompt: string, options?: Object): Promise<string | undefined>; // �
       - **注意**：Chrome extension Bridge mode 上传本地文件时，需要在 `chrome://extensions` > Midscene > “Details” 中开启插件的 “Allow access to file URLs” 权限。开启后请从目标 `http(s)://` 页面重新连接桥接模式。
       - **注意**：Chrome extension Bridge mode 不支持目录上传输入框（`webkitdirectory` / `directory`）。如需上传目录，请使用 Playwright。
     - `fileChooserAllowedDir?: string`：显式授权当前 `aiAct` 通过提示词上传文件时可访问的目录。未配置时，模型规划的文件上传会被拒绝。配置后，提示词中的相对路径会基于此目录解析，并校验是否位于此目录下；绝对路径则直接校验是否位于此目录下。位于此目录下的 symlink 也允许上传。建议将其设置为测试用例的 `fixtures` 目录，以避免 AI 幻觉或页面提示词攻击导致 `aiAct` 上传敏感文件。
+    - `loadExtraActions?: string[]`：为本次调用加载一个或多个带版本的 `*.actions.yaml` Manifest。Midscene 会披露当前规划快照中 `validWhenTargetExists` 对应 target 存在的全部 Extra Action，并将它们排在通用 Action 前面。模型选中后，每个 Extra Action 只展开成一个现有设备 Action。该选项仅支持 Node.js 和通用规划适配器；相对路径基于当前工作目录解析。
     - `abortSignal?: AbortSignal` - 可选的 [AbortSignal](https://developer.mozilla.org/zh-CN/docs/Web/API/AbortSignal)，用于中止 `aiAct` 的执行。当信号被触发时，Midscene 会停止当前的规划循环并抛出错误。适用于实现超时控制或用户主动取消操作的场景。
 
 - 返回值：
@@ -197,6 +199,38 @@ await agent.aiAct('完成 github 账号注册的表单填写。地区必须选�
 `deepThink` 支持 `'unset' | true | false`。`'unset'` 是兼容旧写法的取值，与 `false` 的行为相同。
 
 `deepThink` 不控制模型原生思考。相关环境变量请参考[模型原生思考](../model-config#model-native-reasoning)。
+
+##### 加载可复用的 Extra Action
+
+Action Manifest 使用名称和确定性 target 描述可复用的设备操作：
+
+```yaml title="checkout.actions.yaml"
+version: 1
+interface: web
+actions:
+  - name: Click the checkout confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+```
+
+一次调用可以加载一个或多个 Manifest：
+
+```typescript
+await agent.aiAct('Confirm checkout', {
+  loadExtraActions: ['./checkout.actions.yaml'],
+});
+```
+
+披露阶段只探测 Manifest 声明的 `validWhenTargetExists` target，不会改变页面状态。模型选中 Extra Action 后，Midscene 会把 target 解析为最新 rect，再执行底层 Action；如果 target 解析失败，则回退到原有缓存和 AI Locate。Manifest 无效、interface 不兼容、名称重复、自定义规划适配器不受支持或底层 Action 不存在时，会在规划前抛出错误。
 
 ##### 在 `aiAct` 提示词中上传文件
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -78,6 +78,10 @@ import {
   defineActionSleep,
 } from '../device';
 import { validateAgentCacheInput } from './cache-config';
+import {
+  createExtraActionExecutionOptions,
+  loadExtraActions,
+} from './extra-actions';
 import { FileChooserAccepter } from './file-chooser';
 import { Insight } from './insight';
 import { MetricsCollector, type MidsceneUsageMetrics } from './metrics';
@@ -120,6 +124,7 @@ export type AiActOptions = {
   fileChooserAccept?: string | string[];
   fileChooserAllowedDir?: string;
   effort?: AiActEffort;
+  loadExtraActions?: string[];
   deepThink?: DeepThinkOption;
   deepLocate?: boolean;
   abortSignal?: AbortSignal;
@@ -1133,10 +1138,36 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
 
     const runAiAct = async () => {
       const planningModel = this.resolveModelRuntime('planning');
+      const extraActionPaths = opt?.loadExtraActions ?? [];
+      if (
+        extraActionPaths.length > 0 &&
+        planningModel.adapter.planning.kind === 'custom'
+      ) {
+        throw new Error(
+          `The "loadExtraActions" option is not supported by custom planning adapters (modelFamily: ${planningModel.config.modelFamily ?? 'unknown'}). Use a model with the generic planning adapter.`,
+        );
+      }
+      const extraActions = await loadExtraActions(
+        extraActionPaths,
+        this.fullActionSpace,
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
+      );
+      const extraActionExecution = createExtraActionExecutionOptions(
+        extraActions,
+        this.interface,
+      );
+      let initialExtraActionSnapshot =
+        await extraActionExecution?.createSnapshot({ signal: abortSignal });
       const defaultModel = this.resolveModelRuntime('default');
       const aiActContext =
         opt?.context !== undefined ? opt.context : this.aiActContext;
-      const cachePrompt = buildPromptWithContext(taskPrompt, aiActContext);
+      const promptWithContext = buildPromptWithContext(
+        taskPrompt,
+        aiActContext,
+      );
+      const cachePrompt = initialExtraActionSnapshot?.fingerprint
+        ? `${promptWithContext}\n\n<midscene_extra_actions>${initialExtraActionSnapshot.fingerprint}</midscene_extra_actions>`
+        : promptWithContext;
       // Resolve the public planning controls at the API boundary. Internal
       // aiAct plumbing only uses effort from this point onward. The explicit
       // effort option takes precedence over deepThink when both are provided.
@@ -1216,6 +1247,10 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          initialExtraActionSnapshot =
+            await extraActionExecution?.createSnapshot({
+              signal: abortSignal,
+            });
         }
       }
 
@@ -1224,14 +1259,21 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
         taskPrompt,
         planningModel,
         defaultModel,
-        aiActContext,
-        cacheable,
-        replanningCycleLimit,
-        effort,
-        undefined,
-        deepLocate,
-        abortSignal,
-        internalReportDisplay,
+        {
+          aiActContext,
+          cacheable,
+          replanningCycleLimitOverride: replanningCycleLimit,
+          effort,
+          deepLocate,
+          abortSignal,
+          reportOptions: internalReportDisplay,
+          extraActions: extraActionExecution
+            ? {
+                ...extraActionExecution,
+                initialSnapshot: initialExtraActionSnapshot,
+              }
+            : undefined,
+        },
       );
 
       // update cache

--- a/packages/core/src/agent/extra-action-manifest.ts
+++ b/packages/core/src/agent/extra-action-manifest.ts
@@ -1,0 +1,157 @@
+import { type LocatorTarget, LocatorTargetSchema } from '@/locator';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+const hasInvalidProtocolNameCharacter = (name: string): boolean =>
+  Array.from(name).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      character === '<' ||
+      character === '>' ||
+      codePoint === undefined ||
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+
+const protocolNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((name) => !hasInvalidProtocolNameCharacter(name), {
+    message:
+      'must not contain angle brackets, line breaks, or control characters',
+  });
+
+const extraActionDefinitionSchema = z
+  .object({
+    name: protocolNameSchema,
+    validWhenTargetExists: LocatorTargetSchema.optional(),
+    action: z
+      .object({
+        name: z.string().trim().min(1),
+        param: z.unknown().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const extraActionManifestSchema = z
+  .object({
+    version: z.literal(1),
+    interface: z.string().trim().min(1),
+    actions: z.array(extraActionDefinitionSchema).min(1),
+  })
+  .strict();
+
+const legacyExtraActionFileSchema = z
+  .object({
+    name: protocolNameSchema,
+    actionName: z.string().trim().min(1),
+    actionParam: z.tuple([z.unknown()]),
+  })
+  .strict();
+
+export type ExtraActionDefinition = z.infer<typeof extraActionDefinitionSchema>;
+
+export type ExtraActionManifest = z.infer<typeof extraActionManifestSchema>;
+
+export interface ParsedExtraActionFile {
+  manifestInterface?: string;
+  definitions: ExtraActionDefinition[];
+  legacy: boolean;
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${field}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+function parseYaml(content: string, sourcePath: string): unknown {
+  try {
+    return yaml.load(content, { schema: yaml.JSON_SCHEMA });
+  } catch (error) {
+    throw new Error(
+      `Failed to parse extra action file "${sourcePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * The single parsing boundary for both loaded and generated action manifests.
+ * Legacy one-action files are accepted for reads, but all callers receive the
+ * same canonical definition shape.
+ */
+export function parseExtraActionFile(
+  content: string,
+  sourcePath: string,
+): ParsedExtraActionFile {
+  const parsed = parseYaml(content, sourcePath);
+  const looksLikeManifest =
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    ('version' in parsed || 'interface' in parsed || 'actions' in parsed);
+
+  if (looksLikeManifest) {
+    const result = extraActionManifestSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": ${formatIssues(result.error)}`,
+      );
+    }
+    return {
+      manifestInterface: result.data.interface,
+      definitions: result.data.actions,
+      legacy: false,
+    };
+  }
+
+  const legacy = legacyExtraActionFileSchema.safeParse(parsed);
+  if (!legacy.success) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": ${formatIssues(legacy.error)}`,
+    );
+  }
+  return {
+    definitions: [
+      {
+        name: legacy.data.name,
+        action: {
+          name: legacy.data.actionName,
+          param: legacy.data.actionParam[0],
+        },
+      },
+    ],
+    legacy: true,
+  };
+}
+
+/** Validate generated YAML through the same strict schema used by the loader. */
+export function parseExtraActionManifest(
+  content: string,
+  sourcePath: string,
+): ExtraActionManifest {
+  const parsed = parseExtraActionFile(content, sourcePath);
+  if (parsed.legacy || !parsed.manifestInterface) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": expected a versioned Action Manifest`,
+    );
+  }
+  return {
+    version: 1,
+    interface: parsed.manifestInterface,
+    actions: parsed.definitions,
+  };
+}
+
+export type { LocatorTarget };

--- a/packages/core/src/agent/extra-actions.ts
+++ b/packages/core/src/agent/extra-actions.ts
@@ -1,0 +1,457 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { findAllMidsceneLocatorField } from '@/ai-model';
+import type { AbstractInterface } from '@/device';
+import type { LocatorTarget } from '@/locator';
+import type { DeviceAction, PlanningAction } from '@/types';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionFile,
+} from './extra-action-manifest';
+
+export type { ExtraActionDefinition, ExtraActionManifest };
+
+export interface LoadedExtraAction {
+  alias: string;
+  name: string;
+  sourcePath: string;
+  plan: PlanningAction;
+  validWhenTargetExists?: LocatorTarget;
+}
+
+export interface ExtraActionSource {
+  type: 'extra-action';
+  name: string;
+  alias: string;
+  sourcePath: string;
+}
+
+export interface ExtraActionSnapshot {
+  readonly actionSpace: readonly DeviceAction[];
+  readonly fingerprint: string;
+  expandPlans: (plans: PlanningAction[]) => {
+    plans: PlanningAction[];
+    expanded: boolean;
+  };
+}
+
+const extraActionSourceByPlan = new WeakMap<
+  PlanningAction,
+  ExtraActionSource
+>();
+
+export function getExtraActionSource(
+  plan: PlanningAction,
+): ExtraActionSource | undefined {
+  return extraActionSourceByPlan.get(plan);
+}
+
+export function setExtraActionSource(
+  plan: PlanningAction,
+  source: ExtraActionSource,
+): void {
+  extraActionSourceByPlan.set(plan, source);
+}
+
+const locatorShortcutFields = new Set([
+  'prompt',
+  'xpath',
+  'target',
+  'locatedPixelBbox',
+  'deepLocate',
+  'deepThink',
+  'cacheable',
+]);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+function findReferencedAction(
+  actionName: string,
+  actionSpace: DeviceAction[],
+  sourcePath: string,
+): DeviceAction {
+  const exactMatch = actionSpace.find(
+    (action) =>
+      action.name === actionName || action.interfaceAlias === actionName,
+  );
+  if (exactMatch) return exactMatch;
+
+  const normalizedName = actionName.toLowerCase();
+  const caseInsensitiveMatches = actionSpace.filter(
+    (action) =>
+      action.name.toLowerCase() === normalizedName ||
+      action.interfaceAlias?.toLowerCase() === normalizedName,
+  );
+  if (caseInsensitiveMatches.length === 1) return caseInsensitiveMatches[0];
+  if (caseInsensitiveMatches.length > 1) {
+    throw new Error(
+      `Invalid extra action file "${sourcePath}": action "${actionName}" is ambiguous. Matching actions: ${caseInsensitiveMatches
+        .map((action) => action.name)
+        .join(', ')}`,
+    );
+  }
+
+  const availableActions = actionSpace
+    .flatMap((action) => [action.name, action.interfaceAlias])
+    .filter(Boolean)
+    .join(', ');
+  throw new Error(
+    `Invalid extra action file "${sourcePath}": action "${actionName}" is not in the current action space. Available actions: ${availableActions || '(none)'}`,
+  );
+}
+
+function normalizeLegacyActionParam(
+  action: DeviceAction,
+  actionParam: unknown,
+  fallbackPrompt: string,
+): unknown {
+  if (!action.paramSchema || !isPlainObject(actionParam)) {
+    return actionParam;
+  }
+  const locateFields = findAllMidsceneLocatorField(action.paramSchema);
+  if (locateFields.length !== 1) return actionParam;
+
+  const locateField = locateFields[0];
+  if (Object.prototype.hasOwnProperty.call(actionParam, locateField)) {
+    const locateParam = actionParam[locateField];
+    if (
+      isPlainObject(locateParam) &&
+      (locateParam.xpath ||
+        locateParam.target ||
+        locateParam.locatedPixelBbox) &&
+      !locateParam.prompt
+    ) {
+      return {
+        ...actionParam,
+        [locateField]: { prompt: fallbackPrompt, ...locateParam },
+      };
+    }
+    return actionParam;
+  }
+
+  const isLocatorShortcut = [
+    'prompt',
+    'xpath',
+    'target',
+    'locatedPixelBbox',
+  ].some((field) => Object.prototype.hasOwnProperty.call(actionParam, field));
+  if (!isLocatorShortcut) return actionParam;
+
+  const locateParam: Record<string, unknown> = {};
+  const actionParamWithoutLocate: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(actionParam)) {
+    (locatorShortcutFields.has(key) ? locateParam : actionParamWithoutLocate)[
+      key
+    ] = value;
+  }
+  return {
+    ...actionParamWithoutLocate,
+    [locateField]: {
+      ...(!locateParam.prompt ? { prompt: fallbackPrompt } : {}),
+      ...locateParam,
+    },
+  };
+}
+
+function normalizeActionParamTargets(
+  action: DeviceAction,
+  actionParam: unknown,
+): unknown {
+  if (!action.paramSchema || !isPlainObject(actionParam)) return actionParam;
+  let normalized: Record<string, unknown> | undefined;
+  for (const field of findAllMidsceneLocatorField(action.paramSchema)) {
+    const locator = actionParam[field];
+    if (!isPlainObject(locator)) continue;
+    if (locator.target !== undefined && locator.xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
+    if (typeof locator.xpath !== 'string') continue;
+    const { xpath, ...withoutXpath } = locator;
+    normalized ??= { ...actionParam };
+    normalized[field] = {
+      ...withoutXpath,
+      target: { strategy: 'xpath', selector: xpath },
+    };
+  }
+  return normalized ?? actionParam;
+}
+
+function validateActionParam(
+  action: DeviceAction,
+  actionParam: unknown,
+  sourcePath: string,
+  actionIndex: number,
+): unknown {
+  if (!action.paramSchema) {
+    if (
+      actionParam !== undefined &&
+      (!isPlainObject(actionParam) || Object.keys(actionParam).length > 0)
+    ) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" must be omitted for parameterless action "${action.name}"`,
+      );
+    }
+    return undefined;
+  }
+
+  const result = action.paramSchema.safeParse(actionParam);
+  if (result.success) return result.data;
+
+  const details = result.error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${field}: ${issue.message}`;
+    })
+    .join('; ');
+  throw new Error(
+    `Invalid extra action file "${sourcePath}": "actions[${actionIndex}].action.param" does not match action "${action.name}": ${details}`,
+  );
+}
+
+function createPlanningAction(alias: string, name: string): DeviceAction {
+  return {
+    name: alias,
+    description: `High-priority exact UI action: ${JSON.stringify(name)}. Use this parameterless action when it matches the next requested operation.`,
+    sample: {},
+    call: () => {
+      throw new Error(
+        `Extra action "${name}" must be expanded before execution`,
+      );
+    },
+  };
+}
+
+export async function loadExtraActions(
+  paths: string[],
+  actionSpace: DeviceAction[],
+  manifestInterface?: string,
+): Promise<LoadedExtraAction[]> {
+  if (paths.length === 0) return [];
+  const loadedActions: LoadedExtraAction[] = [];
+  const knownNames = new Set<string>();
+  const reservedAliases = new Set(
+    actionSpace.flatMap((action) =>
+      [action.name, action.interfaceAlias]
+        .filter((name): name is string => Boolean(name))
+        .map((name) => name.toLowerCase()),
+    ),
+  );
+  let nextAliasIndex = 1;
+
+  const allocateAlias = (): string => {
+    let alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    while (reservedAliases.has(alias.toLowerCase())) {
+      nextAliasIndex += 1;
+      alias = `MidsceneExtraAction_${nextAliasIndex}`;
+    }
+    nextAliasIndex += 1;
+    reservedAliases.add(alias.toLowerCase());
+    return alias;
+  };
+
+  for (const sourcePath of paths) {
+    let content: string;
+    try {
+      content = await readFile(sourcePath, 'utf-8');
+    } catch (error) {
+      throw new Error(
+        `Failed to read extra action file "${sourcePath}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+    const parsed = parseExtraActionFile(content, sourcePath);
+    if (
+      parsed.manifestInterface &&
+      manifestInterface &&
+      parsed.manifestInterface !== manifestInterface
+    ) {
+      throw new Error(
+        `Invalid extra action file "${sourcePath}": interface "${parsed.manifestInterface}" does not match current interface "${manifestInterface}"`,
+      );
+    }
+
+    for (const [definitionIndex, definition] of parsed.definitions.entries()) {
+      if (knownNames.has(definition.name)) {
+        throw new Error(
+          `Invalid extra action file "${sourcePath}": action name "${definition.name}" conflicts with another action`,
+        );
+      }
+      const referencedAction = findReferencedAction(
+        definition.action.name,
+        actionSpace,
+        sourcePath,
+      );
+      knownNames.add(definition.name);
+
+      // Native manifests use Action Space's param shape directly. Only legacy
+      // one-action files get shortcut normalization; both formats accept
+      // `xpath` as a read-only compatibility alias for `target`.
+      const rawParamBeforeTargetNormalization = parsed.legacy
+        ? normalizeLegacyActionParam(
+            referencedAction,
+            definition.action.param,
+            definition.name,
+          )
+        : definition.action.param;
+      const rawParam = normalizeActionParamTargets(
+        referencedAction,
+        rawParamBeforeTargetNormalization,
+      );
+      const plan: PlanningAction = {
+        type: referencedAction.name,
+        param: validateActionParam(
+          referencedAction,
+          rawParam,
+          sourcePath,
+          definitionIndex,
+        ),
+        thought: `Run extra action "${definition.name}"`,
+      };
+
+      loadedActions.push({
+        alias: allocateAlias(),
+        name: definition.name,
+        sourcePath,
+        plan,
+        validWhenTargetExists: definition.validWhenTargetExists,
+      });
+    }
+  }
+  return loadedActions;
+}
+
+interface SnapshotAction {
+  alias: string;
+  loaded: LoadedExtraAction;
+  planningAction: DeviceAction;
+}
+
+function createSnapshotActions(
+  disclosed: LoadedExtraAction[],
+): SnapshotAction[] {
+  return disclosed.map((loaded) => {
+    return {
+      alias: loaded.alias,
+      loaded,
+      planningAction: Object.freeze(
+        createPlanningAction(loaded.alias, loaded.name),
+      ),
+    };
+  });
+}
+
+function expandSnapshotPlans(
+  plans: PlanningAction[],
+  snapshotActions: SnapshotAction[],
+): PlanningAction[] {
+  const byAlias = new Map(snapshotActions.map((entry) => [entry.alias, entry]));
+  return plans.map((plan) => {
+    const entry = byAlias.get(plan.type);
+    if (!entry) return plan;
+    const expanded = {
+      ...entry.loaded.plan,
+      param: structuredClone(entry.loaded.plan.param),
+      thought: plan.thought || entry.loaded.plan.thought,
+    };
+    setExtraActionSource(expanded, {
+      type: 'extra-action',
+      name: entry.loaded.name,
+      alias: entry.alias,
+      sourcePath: entry.loaded.sourcePath,
+    });
+    return expanded;
+  });
+}
+
+function targetKey(target: LocatorTarget): string {
+  return JSON.stringify(target);
+}
+
+export async function createExtraActionSnapshot(
+  extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
+  options: { signal?: AbortSignal } = {},
+): Promise<ExtraActionSnapshot> {
+  options.signal?.throwIfAborted();
+  const conditionalTargets = extraActions.flatMap((action) =>
+    action.validWhenTargetExists ? [action.validWhenTargetExists] : [],
+  );
+  const uniqueTargets = Array.from(
+    new Map(
+      conditionalTargets.map((target) => [targetKey(target), target]),
+    ).values(),
+  );
+  if (uniqueTargets.length > 0 && !interfaceInstance?.probeLocatorTargets) {
+    throw new Error(
+      'Extra actions use validWhenTargetExists, but the current interface cannot probe locator targets',
+    );
+  }
+  const existenceResult =
+    uniqueTargets.length === 0
+      ? []
+      : await interfaceInstance!.probeLocatorTargets!(uniqueTargets, options);
+  options.signal?.throwIfAborted();
+  if (!Array.isArray(existenceResult)) {
+    throw new Error('probeLocatorTargets must return a boolean array');
+  }
+  const existence = existenceResult as readonly unknown[];
+  if (existence.length !== uniqueTargets.length) {
+    throw new Error(
+      `probeLocatorTargets returned ${existence.length} result(s) for ${uniqueTargets.length} target(s)`,
+    );
+  }
+  if (existence.some((value) => typeof value !== 'boolean')) {
+    throw new Error('probeLocatorTargets must return only boolean results');
+  }
+  const existenceByTarget = new Map(
+    uniqueTargets.map((target, index) => [targetKey(target), existence[index]]),
+  );
+  const disclosed = extraActions.filter(
+    (action) =>
+      !action.validWhenTargetExists ||
+      existenceByTarget.get(targetKey(action.validWhenTargetExists)) === true,
+  );
+  const snapshotActions = createSnapshotActions(disclosed);
+  const aliases = new Set(snapshotActions.map((entry) => entry.alias));
+  const fingerprintPayload = JSON.stringify({
+    manifest: extraActions.map((action) => ({
+      name: action.name,
+      validWhenTargetExists: action.validWhenTargetExists,
+      plan: action.plan,
+    })),
+    disclosed: snapshotActions.map((entry) => ({
+      alias: entry.alias,
+      name: entry.loaded.name,
+    })),
+  });
+  const fingerprint = `extra-actions-snapshot:v1:${createHash('sha256')
+    .update(fingerprintPayload)
+    .digest('hex')}`;
+  return {
+    actionSpace: Object.freeze(
+      snapshotActions.map((entry) => entry.planningAction),
+    ),
+    fingerprint,
+    expandPlans: (plans) => ({
+      plans: expandSnapshotPlans(plans, snapshotActions),
+      expanded: plans.some((plan) => aliases.has(plan.type)),
+    }),
+  };
+}
+
+export function createExtraActionExecutionOptions(
+  extraActions: LoadedExtraAction[],
+  interfaceInstance?: Pick<AbstractInterface, 'probeLocatorTargets'>,
+) {
+  if (extraActions.length === 0) return undefined;
+  return {
+    createSnapshot: (options?: { signal?: AbortSignal }) =>
+      createExtraActionSnapshot(extraActions, interfaceInstance, options),
+  };
+}

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -2,6 +2,7 @@ import { findAllMidsceneLocatorField, parseActionParam } from '@/ai-model';
 import type { ModelRuntime } from '@/ai-model/models';
 import { findActionInActionSpaceOrThrow } from '@/common';
 import type { AbstractInterface } from '@/device';
+import { xpathLocatorTarget } from '@/locator';
 import type Service from '@/service';
 import { setTimingFieldOnce } from '@/task-timing';
 import type {
@@ -25,6 +26,7 @@ import { sleep } from '@/utils';
 import { generateElementByRect } from '@midscene/shared/extractor';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
+import { getExtraActionSource, setExtraActionSource } from './extra-actions';
 import type { TaskCache } from './task-cache';
 import { withUsageIntent } from './usage-intent';
 import {
@@ -83,9 +85,17 @@ function normalizeLocateParam(
   }
 
   const { deepThink, ...rest } = param as LocateParamWithDeprecatedAlias;
+  if (rest.target !== undefined && rest.xpath !== undefined) {
+    throw new Error('`target` and `xpath` cannot be used in the same locator');
+  }
   const deepLocate = rest.deepLocate ?? deepThink;
+  const { xpath, ...withoutXpath } = rest;
+  const normalized =
+    typeof xpath === 'string'
+      ? { ...withoutXpath, target: xpathLocatorTarget(xpath) }
+      : withoutXpath;
 
-  return deepLocate === undefined ? rest : { ...rest, deepLocate };
+  return deepLocate === undefined ? normalized : { ...normalized, deepLocate };
 }
 
 export function locatePlanForLocate(param: string | DetailedLocateParam) {
@@ -228,12 +238,17 @@ export class TaskBuilder {
       action.paramSchema,
       true,
     );
+    const extraActionSource = getExtraActionSource(plan);
 
     locateFields.forEach((field) => {
       if (param[field]) {
+        const locateParam = param[field];
         // Always use createLocateTask for all locate params.
         // This ensures cache writing happens even when locatedPixelBbox is available
-        const locatePlan = locatePlanForLocate(param[field]);
+        const locatePlan = locatePlanForLocate(locateParam);
+        if (extraActionSource) {
+          setExtraActionSource(locatePlan, extraActionSource);
+        }
         debug(
           'will prepend locate param for field',
           `action.type=${planType}`,
@@ -243,7 +258,7 @@ export class TaskBuilder {
         );
         const locateTask = this.createLocateTask(
           locatePlan,
-          param[field],
+          locateParam,
           context,
           (result) => {
             param[field] = result;
@@ -377,6 +392,17 @@ export class TaskBuilder {
 
         return {
           output: actionResult,
+          ...(extraActionSource
+            ? {
+                hitBy: {
+                  from: 'Extra Action',
+                  context: {
+                    extraActionName: extraActionSource.name,
+                    extraActionAlias: extraActionSource.alias,
+                  },
+                },
+              }
+            : {}),
         };
       },
     };
@@ -477,51 +503,69 @@ export class TaskBuilder {
           ? matchElementFromPlan(paramWithLocatedPixelBbox)
           : undefined;
 
-        // from locatedPixelBbox (direct plan hit)
-        // when deepLocate is enabled, locatedPixelBbox should be used as search
-        // area hint, not as a final direct hit
-        const elementFromPlan = param.deepLocate
-          ? undefined
-          : planLocatedElement;
-        const isPlanDirectHit = !!elementFromPlan;
-
-        // from xpath
-        let rectFromXpath: Rect | undefined;
-        if (
-          !isPlanDirectHit &&
-          param.xpath &&
-          this.interface.rectMatchesCacheFeature
-        ) {
+        // Resolve stable targets before using model-provided coordinates. The
+        // resolver returns a fresh logical-coordinate Rect on every execution.
+        let elementFromTarget: LocateResultElement | undefined;
+        let targetResolutionError: string | undefined;
+        if (param.target) {
           try {
-            rectFromXpath = await this.interface.rectMatchesCacheFeature({
-              xpaths: [param.xpath],
-            });
-          } catch {
-            // xpath locate failed, allow fallback to cache or AI locate
-          }
-        }
-
-        const elementFromXpath = rectFromXpath
-          ? generateElementByRect(
-              // rectFromXpath is in logical coordinates, which should be transformed to screenshot coordinates;
+            let rectFromTarget: Rect | undefined;
+            if (this.interface.resolveLocatorTarget) {
+              rectFromTarget = await this.interface.resolveLocatorTarget(
+                param.target,
+              );
+            } else if (
+              param.target.strategy === 'xpath' &&
+              this.interface.rectMatchesCacheFeature
+            ) {
+              rectFromTarget = await this.interface.rectMatchesCacheFeature({
+                targets: [param.target],
+              });
+            }
+            if (!rectFromTarget) {
+              throw new Error(
+                `Current interface cannot resolve locator target strategy: ${param.target.strategy}`,
+              );
+            }
+            const candidate = generateElementByRect(
+              // target Rect is in logical coordinates and actions use the
+              // screenshot coordinate space inside the task runner.
               transformLogicalRectToScreenshotRect(
-                rectFromXpath,
+                rectFromTarget,
                 shrunkShotToLogicalRatio,
               ),
               typeof param.prompt === 'string'
                 ? param.prompt
                 : param.prompt?.prompt || '',
-            )
-          : undefined;
+            );
+            const invalidTargetReason = invalidLocateElementReason(candidate);
+            if (invalidTargetReason) {
+              throw new Error(invalidTargetReason);
+            }
+            elementFromTarget = candidate;
+          } catch (error) {
+            targetResolutionError =
+              error instanceof Error ? error.message : String(error);
+            debug(
+              'target resolution failed, falling back to cache or AI locate: %s',
+              targetResolutionError,
+            );
+          }
+        }
+        const isTargetHit = !!elementFromTarget;
 
-        const isXpathHit = !!elementFromXpath;
+        // from locatedPixelBbox (direct plan hit). When deepLocate is enabled,
+        // the bbox remains a search-area hint rather than a final direct hit.
+        const elementFromPlan =
+          isTargetHit || param.deepLocate ? undefined : planLocatedElement;
+        const isPlanDirectHit = !!elementFromPlan;
 
         const cachePrompt = param.prompt;
         const locateCacheRecord = this.taskCache?.matchLocateCache(cachePrompt);
         const cacheEntry = locateCacheRecord?.cacheContent?.cache;
 
         const elementFromCacheResult =
-          isPlanDirectHit || isXpathHit
+          isPlanDirectHit || isTargetHit
             ? null
             : await matchElementFromCache(
                 {
@@ -545,7 +589,7 @@ export class TaskBuilder {
 
         let elementFromAiLocate: LocateResultElement | null | undefined;
         const timing = taskContext.task.timing;
-        if (!isXpathHit && !isCacheHit && !isPlanDirectHit) {
+        if (!isTargetHit && !isCacheHit && !isPlanDirectHit) {
           try {
             setTimingFieldOnce(timing, 'callAiStart');
             locateResult = await this.service.locate(
@@ -570,8 +614,8 @@ export class TaskBuilder {
         }
 
         const element =
+          elementFromTarget ||
           elementFromPlan ||
-          elementFromXpath ||
           elementFromCache ||
           elementFromAiLocate;
 
@@ -672,18 +716,31 @@ export class TaskBuilder {
 
         let hitBy: ExecutionTaskHitBy | undefined;
 
-        if (isPlanDirectHit && paramWithLocatedPixelBbox) {
+        const extraActionMetadata = getExtraActionSource(plan);
+        const attemptedTargetContext = param.target
+          ? {
+              target: param.target,
+              ...(targetResolutionError ? { targetResolutionError } : {}),
+              ...(extraActionMetadata?.name
+                ? { extraActionName: extraActionMetadata.name }
+                : {}),
+              ...(extraActionMetadata?.alias
+                ? { extraActionAlias: extraActionMetadata.alias }
+                : {}),
+            }
+          : {};
+
+        if (isTargetHit && param.target) {
+          hitBy = {
+            from: extraActionMetadata ? 'Extra Action target' : 'User target',
+            context: attemptedTargetContext,
+          };
+        } else if (isPlanDirectHit && paramWithLocatedPixelBbox) {
           hitBy = {
             from: 'Plan',
             context: {
               locatedPixelBbox: paramWithLocatedPixelBbox.locatedPixelBbox,
-            },
-          };
-        } else if (isXpathHit) {
-          hitBy = {
-            from: 'User expected path',
-            context: {
-              xpath: param.xpath,
+              ...attemptedTargetContext,
             },
           };
         } else if (isCacheHit) {
@@ -692,7 +749,13 @@ export class TaskBuilder {
             context: {
               cacheEntry,
               cacheToSave: currentCacheEntry,
+              ...attemptedTargetContext,
             },
+          };
+        } else {
+          hitBy = {
+            from: 'AI',
+            context: attemptedTargetContext,
           };
         }
 

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -6,6 +6,7 @@ import { standardPlan } from '@/ai-model/workflows/planning';
 import {
   type TMultimodalPrompt,
   type TUserPrompt,
+  buildYamlFlowFromPlans,
   getReadableTimeString,
   userPromptToMultimodalPrompt,
   userPromptToString,
@@ -39,6 +40,7 @@ import { ServiceError, aiActProgressScope } from '@/types';
 import { getDebug } from '@midscene/shared/logger';
 import { assert } from '@midscene/shared/utils';
 import { ExecutionSession } from './execution-session';
+import type { ExtraActionSnapshot } from './extra-actions';
 import { withFileChooser } from './file-chooser';
 import {
   type AgentProgressPublisher,
@@ -74,6 +76,35 @@ export type ActionReportOptions = {
   type?: TaskTitleType;
   prompt?: string;
 };
+
+interface TaskExecutorExtraActions {
+  initialSnapshot?: ExtraActionSnapshot;
+  createSnapshot: (options?: {
+    signal?: AbortSignal;
+  }) => Promise<ExtraActionSnapshot>;
+}
+
+interface TaskExecutorActionOptions {
+  aiActContext?: string;
+  cacheable?: boolean;
+  replanningCycleLimitOverride?: number;
+  effort?: AiActEffort;
+  fileChooserAccept?: string[];
+  deepLocate?: boolean;
+  abortSignal?: AbortSignal;
+  reportOptions?: ActionReportOptions;
+  extraActions?: TaskExecutorExtraActions;
+}
+
+type TaskExecutorActionResult = Promise<
+  ExecutionResult<
+    | {
+        yamlFlow?: MidsceneYamlFlowItem[];
+        output?: string;
+      }
+    | undefined
+  >
+>;
 
 const debug = getDebug('device-task-executor');
 const warnLog = getDebug('device-task-executor', { console: true });
@@ -363,7 +394,27 @@ export class TaskExecutor {
     userPrompt: TUserPrompt,
     planningModel: ModelRuntime,
     defaultModel: ModelRuntime,
+    options?: TaskExecutorActionOptions,
+  ): TaskExecutorActionResult;
+  async action(
+    userPrompt: TUserPrompt,
+    planningModel: ModelRuntime,
+    defaultModel: ModelRuntime,
     aiActContext?: string,
+    cacheable?: boolean,
+    replanningCycleLimitOverride?: number,
+    effort?: AiActEffort,
+    fileChooserAccept?: string[],
+    deepLocate?: boolean,
+    abortSignal?: AbortSignal,
+    reportOptions?: ActionReportOptions,
+    extraActions?: TaskExecutorExtraActions,
+  ): TaskExecutorActionResult;
+  async action(
+    userPrompt: TUserPrompt,
+    planningModel: ModelRuntime,
+    defaultModel: ModelRuntime,
+    aiActContextOrOptions?: string | TaskExecutorActionOptions,
     cacheable?: boolean,
     replanningCycleLimitOverride?: number,
     effort: AiActEffort = 'balance',
@@ -371,29 +422,43 @@ export class TaskExecutor {
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
     reportOptions?: ActionReportOptions,
-  ): Promise<
-    ExecutionResult<
-      | {
-          yamlFlow?: MidsceneYamlFlowItem[]; // for cache use
-          output?: string;
-        }
-      | undefined
-    >
-  > {
-    return withFileChooser(this.interface, fileChooserAccept, async () => {
-      return this.runAction(
-        userPrompt,
-        planningModel,
-        defaultModel,
-        aiActContext,
-        cacheable,
-        replanningCycleLimitOverride,
-        effort,
-        deepLocate,
-        abortSignal,
-        reportOptions,
-      );
-    });
+    extraActions?: TaskExecutorExtraActions,
+  ): TaskExecutorActionResult {
+    const options: TaskExecutorActionOptions =
+      typeof aiActContextOrOptions === 'object' &&
+      aiActContextOrOptions !== null
+        ? aiActContextOrOptions
+        : {
+            aiActContext: aiActContextOrOptions,
+            cacheable,
+            replanningCycleLimitOverride,
+            effort,
+            fileChooserAccept,
+            deepLocate,
+            abortSignal,
+            reportOptions,
+            extraActions,
+          };
+
+    return withFileChooser(
+      this.interface,
+      options.fileChooserAccept,
+      async () => {
+        return this.runAction(
+          userPrompt,
+          planningModel,
+          defaultModel,
+          options.aiActContext,
+          options.cacheable,
+          options.replanningCycleLimitOverride,
+          options.effort,
+          options.deepLocate,
+          options.abortSignal,
+          options.reportOptions,
+          options.extraActions,
+        );
+      },
+    );
   }
 
   /**
@@ -441,6 +506,7 @@ export class TaskExecutor {
     deepLocate?: boolean,
     abortSignal?: AbortSignal,
     reportOptions?: ActionReportOptions,
+    extraActions?: TaskExecutorExtraActions,
   ): Promise<
     ExecutionResult<
       | {
@@ -451,6 +517,11 @@ export class TaskExecutor {
     >
   > {
     const conversationHistory = new ConversationHistory();
+    const baseActionSpace = this.getActionSpace();
+    let latestExtraActionSnapshot:
+      | Awaited<ReturnType<TaskExecutorExtraActions['createSnapshot']>>
+      | undefined;
+    let pendingInitialExtraActionSnapshot = extraActions?.initialSnapshot;
     const promptDisplay =
       reportOptions?.prompt || userPromptToString(userPrompt);
 
@@ -568,6 +639,10 @@ export class TaskExecutor {
             assert(uiContext, 'uiContext is required for Planning task');
             assert(param.effort, 'effort is required for Planning Plan task');
             const planningUiContext = uiContext as UIContext;
+            latestExtraActionSnapshot =
+              pendingInitialExtraActionSnapshot ??
+              (await extraActions?.createSnapshot({ signal: abortSignal }));
+            pendingInitialExtraActionSnapshot = undefined;
             const timing = executorContext.task.timing;
             await this.emitAiActProgress('plan_thinking', {
               planIndex,
@@ -575,7 +650,10 @@ export class TaskExecutor {
               screenshot: planningUiContext.screenshot,
             });
 
-            const actionSpace = this.getActionSpace();
+            const actionSpace = [
+              ...(latestExtraActionSnapshot?.actionSpace ?? []),
+              ...baseActionSpace,
+            ];
             debug(
               'actionSpace for this interface is:',
               actionSpace.map((action) => action.name).join(', '),
@@ -604,6 +682,8 @@ export class TaskExecutor {
                 includeLocateInPlanning,
                 imagesIncludeCount: param.imagesIncludeCount,
                 effort: param.effort,
+                hasExtraActions:
+                  (latestExtraActionSnapshot?.actionSpace.length ?? 0) > 0,
                 referenceImageMessages,
                 abortSignal,
               });
@@ -719,12 +799,20 @@ export class TaskExecutor {
 
       // Execute planned actions
       const plans = planResult?.actions || [];
-      yamlFlow.push(...(planResult?.yamlFlow || []));
+      const expansion = latestExtraActionSnapshot?.expandPlans(plans) ?? {
+        plans,
+        expanded: false,
+      };
+      yamlFlow.push(
+        ...(expansion.expanded
+          ? buildYamlFlowFromPlans(expansion.plans, baseActionSpace)
+          : planResult?.yamlFlow || []),
+      );
 
       let executables: Awaited<ReturnType<typeof this.convertPlanToExecutable>>;
       try {
         executables = await this.convertPlanToExecutable(
-          plans,
+          expansion.plans,
           planningModel,
           defaultModel,
           {

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -399,6 +399,18 @@ export async function matchElementFromCache(
   try {
     const rect =
       await context.interfaceInstance.rectMatchesCacheFeature(cacheEntry);
+    const rectValues = [rect.left, rect.top, rect.width, rect.height];
+    if (
+      rectValues.some(
+        (value) => typeof value !== 'number' || !Number.isFinite(value),
+      ) ||
+      rect.width <= 0 ||
+      rect.height <= 0
+    ) {
+      throw new Error(
+        `Cache target returned an invalid rect: ${JSON.stringify(rect)}`,
+      );
+    }
     const element: LocateResultElement = {
       center: [
         Math.round(rect.left + rect.width / 2),

--- a/packages/core/src/ai-model/prompt/planning/action-guidelines.ts
+++ b/packages/core/src/ai-model/prompt/planning/action-guidelines.ts
@@ -1,0 +1,26 @@
+import type { DeviceAction } from '@/types';
+
+export const buildPlanningActionGuidelines = (
+  actionSpace: DeviceAction<any>[],
+  hasExtraActions = false,
+) => {
+  const hasRunAdbShell = actionSpace.some(
+    (action) => action.name === 'RunAdbShell',
+  );
+
+  const adbShellExtraRule =
+    "- If the user's task can be completed with the RunAdbShell action, prefer using the RunAdbShell action.";
+  const extraActionRule =
+    '- Actions named MidsceneExtraAction_* are exact pre-recorded operations. When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action such as Tap or Input.';
+  const conditionalRules = [
+    hasRunAdbShell ? adbShellExtraRule : undefined,
+    hasExtraActions ? extraActionRule : undefined,
+  ].filter((rule): rule is string => Boolean(rule));
+
+  return `### Action Guidelines
+
+${conditionalRules.length > 0 ? `${conditionalRules.join('\n')}\n` : '\n'}- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.
+- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.
+- For insert/prepend/append edits, use CursorMove when the caret must be adjusted precisely, then use Input with mode "typeOnly" for inserted characters and KeyboardPress for newlines or deletion. If the caret lands in the wrong position, recover with CursorMove, KeyboardPress, or undo and retry cursor placement; do not switch to replace as a fallback for cursor placement failures.
+`;
+};

--- a/packages/core/src/ai-model/prompt/planning/system-prompt.ts
+++ b/packages/core/src/ai-model/prompt/planning/system-prompt.ts
@@ -5,6 +5,7 @@ import { planningModelFamilyRequiredForLocateMessage } from '../../shared/model-
 import { locateGroundingRules } from '../locate-grounding-rules';
 import { buildActionSpaceDescription } from './action-description';
 import { buildActionExample, createSampleTapAction } from './action-example';
+import { buildPlanningActionGuidelines } from './action-guidelines';
 import {
   type PlanningActionOutputProtocol,
   defaultMidsceneActionOutputProtocol,
@@ -17,6 +18,7 @@ type BuildStandardPlanningSystemPromptInput = {
   includeThought?: boolean;
   includeLog?: boolean;
   actionOutputProtocol?: PlanningActionOutputProtocol;
+  hasExtraActions?: boolean;
 } & (
   | {
       includeLocateInPlanning: true;
@@ -39,6 +41,7 @@ export async function buildStandardPlanningSystemPrompt(
     includeThought = true,
     includeLog = true,
     actionOutputProtocol = defaultMidsceneActionOutputProtocol,
+    hasExtraActions,
   } = input;
   const preferredLanguage = getPreferredLanguage();
 
@@ -51,9 +54,10 @@ export async function buildStandardPlanningSystemPrompt(
     locatePromptSpec,
     actionOutputProtocol,
   });
-  const hasRunAdbShell = actionSpace.some(
-    (action) => action.name === 'RunAdbShell',
-  );
+  const actionStepNotes = buildPlanningActionGuidelines(
+    actionSpace,
+    hasExtraActions,
+  ).trimEnd();
   const actionOutputTagsText = actionOutputProtocol.actionOutputTagNames
     .map((tagName) => `<${tagName}>`)
     .join(', ');
@@ -258,16 +262,7 @@ ONLY if the task is not complete: Think what the next action is according to the
 - Give just the next ONE action you should do (if any)
 - If there are some error messages reported by the previous actions, don't give up, try parse a new action to recover. If the error persists for more than 3 times, you should think this is an error and set the "error" field to the error message.
 
-### Action Guidelines
-
-${
-  hasRunAdbShell
-    ? "- If the user's task can be completed with the RunAdbShell action, prefer using the RunAdbShell action."
-    : ''
-}
-- For touch continuous controls that set a value along a track, such as a slider, prefer Swipe from the current handle or filled position to the requested track endpoint instead of tapping the endpoint.
-- When editing existing text in a UI field, preserve all existing text by moving the cursor and typing/deleting the minimal necessary characters.
-- For insert/prepend/append edits, use CursorMove when the caret must be adjusted precisely, then use Input with mode "typeOnly" for inserted characters and KeyboardPress for newlines or deletion. If the caret lands in the wrong position, recover with CursorMove, KeyboardPress, or undo and retry cursor placement; do not switch to replace as a fallback for cursor placement failures.
+${actionStepNotes}
 
 ${includeLocateInPlanning ? locateGroundingRules() : ''}
 

--- a/packages/core/src/ai-model/workflows/planning/standard-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning.ts
@@ -164,6 +164,7 @@ export async function standardPlan(
     includeThought,
     includeLog,
     includeSubGoals,
+    hasExtraActions: opts.hasExtraActions,
     ...(opts.includeLocateInPlanning && locateResultAdapter
       ? {
           includeLocateInPlanning: true,

--- a/packages/core/src/ai-model/workflows/planning/types.ts
+++ b/packages/core/src/ai-model/workflows/planning/types.ts
@@ -19,6 +19,7 @@ export interface PlanOptions {
   imagesIncludeCount?: number;
   // Controls aiAct planning prompt shape and state updates, such as sub-goals.
   effort: AiActEffort;
+  hasExtraActions?: boolean;
   referenceImageMessages?: ChatCompletionUserMessageParam[];
   abortSignal?: AbortSignal;
 }

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -4,6 +4,7 @@ import type {
   HarmonyDeviceOpt,
   IOSDeviceOpt,
 } from './device';
+import type { LocatorTarget } from './locator';
 import type { AgentOpt, LocateResultElement, Rect } from './types';
 import type { UIContext } from './types';
 
@@ -16,6 +17,8 @@ export interface LocateOption extends Partial<TMultimodalPrompt> {
   deepThink?: boolean; // alias for deepLocate
   cacheable?: boolean; // user can set this param to false to disable the cache for a single agent api
   xpath?: string; // only available in web
+  /** Stable locator reference. `xpath` remains supported as a legacy alias. */
+  target?: LocatorTarget;
   uiContext?: UIContext;
   fileChooserAccept?: string | string[]; // file path(s) to upload when tapping triggers a file chooser
 }

--- a/packages/core/src/yaml/utils.ts
+++ b/packages/core/src/yaml/utils.ts
@@ -287,7 +287,8 @@ export function buildDetailedLocateParam(
   let prompt = normalizedLocatePrompt || opt?.prompt || (opt as any)?.locate; // as a shortcut
   let deepLocate = false;
   let cacheable = true;
-  let xpath = undefined;
+  let xpath: LocateOption['xpath'];
+  let target: LocateOption['target'];
 
   if (typeof opt === 'object' && opt !== null) {
     // Backward-compatible: accept `deepThink` as a deprecated alias for `deepLocate`.
@@ -297,6 +298,12 @@ export function buildDetailedLocateParam(
     deepLocate = opt.deepLocate ?? opt.deepThink ?? false;
     cacheable = opt.cacheable ?? true;
     xpath = opt.xpath;
+    target = opt.target;
+    if (target !== undefined && xpath !== undefined) {
+      throw new Error(
+        '`target` and `xpath` cannot be used in the same locator',
+      );
+    }
     if (locatePrompt && opt.prompt && locatePrompt !== opt.prompt) {
       console.warn(
         'conflict prompt for item',
@@ -339,7 +346,7 @@ export function buildDetailedLocateParam(
     ...(context ? { promptDisplay, context } : {}),
     deepLocate,
     cacheable,
-    xpath,
+    ...(target ? { target } : { xpath }),
   };
 }
 

--- a/packages/core/tests/unit-test/agent-context-option.test.ts
+++ b/packages/core/tests/unit-test/agent-context-option.test.ts
@@ -66,8 +66,10 @@ describe('Agent per-call context option', () => {
       'Context for this request:\nUse buyer checkout rules.\n\nClick the submit button',
     );
     expect(taskExecutor.action).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.action.mock.calls[0][3]).toBe(
-      'Use buyer checkout rules.',
+    expect(taskExecutor.action.mock.calls[0][3]).toEqual(
+      expect.objectContaining({
+        aiActContext: 'Use buyer checkout rules.',
+      }),
     );
   });
 
@@ -79,7 +81,9 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Context for this request:\nGlobal action context.\n\nClick the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][3]).toBe('Global action context.');
+    expect(taskExecutor.action.mock.calls[0][3]).toEqual(
+      expect.objectContaining({ aiActContext: 'Global action context.' }),
+    );
   });
 
   it('allows blank per-call context to override global aiActContext', async () => {
@@ -92,7 +96,9 @@ describe('Agent per-call context option', () => {
     expect(taskCache.matchPlanCache).toHaveBeenCalledWith(
       'Click the submit button',
     );
-    expect(taskExecutor.action.mock.calls[0][3]).toBe('');
+    expect(taskExecutor.action.mock.calls[0][3]).toEqual(
+      expect.objectContaining({ aiActContext: '' }),
+    );
   });
 
   it('does not register a file chooser for an empty fileChooserAccept array', async () => {

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -503,7 +503,9 @@ describe('Agent with custom OpenAI client', () => {
       await agent.aiAct('click the submit button');
 
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][6]).toBe('balance');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'balance' }),
+      );
       expect(
         (agent as any).modelConfigManager.getModelConfig('planning').slot,
       ).toBe('planning');
@@ -525,7 +527,9 @@ describe('Agent with custom OpenAI client', () => {
       await agent.aiAct('click the submit button');
 
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][6]).toBe('balance');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'balance' }),
+      );
       expect(
         (agent as any).modelConfigManager.getModelConfig('planning').slot,
       ).toBe('default');
@@ -556,7 +560,9 @@ describe('Agent with custom OpenAI client', () => {
         '[Midscene]',
         'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
       );
-      expect(actionSpy.mock.calls[0][6]).toBe('deepThink');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'deepThink' }),
+      );
     });
 
     it('should prefer balance effort over deepThink and use the experimental warning', async () => {
@@ -584,7 +590,9 @@ describe('Agent with custom OpenAI client', () => {
         '[Midscene]',
         'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
       );
-      expect(actionSpy.mock.calls[0][6]).toBe('balance');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'balance' }),
+      );
     });
 
     it('should keep supporting deepThink without an experimental warning', async () => {
@@ -606,7 +614,9 @@ describe('Agent with custom OpenAI client', () => {
       await agent.aiAct('click the submit button', { deepThink: true });
 
       expect(warnSpy).not.toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][6]).toBe('deepThink');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'deepThink' }),
+      );
     });
 
     it('should use the unified experimental warning for fast effort', async () => {
@@ -631,7 +641,9 @@ describe('Agent with custom OpenAI client', () => {
         '[Midscene]',
         'The "effort" option is experimental and not yet open for public use. Do not use it. When both "effort" and "deepThink" are provided, "effort" takes precedence.',
       );
-      expect(actionSpy.mock.calls[0][6]).toBe('fast');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'fast' }),
+      );
     });
 
     it('should reject fast effort before running custom planning', async () => {
@@ -680,7 +692,9 @@ describe('Agent with custom OpenAI client', () => {
         'The "deepThink" aiAct effort is not supported with custom planning adapters (modelFamily: auto-glm). It will be ignored.',
       );
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][6]).toBe('balance');
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ effort: 'balance' }),
+      );
     });
 
     it('should disable deepLocate before running custom planning', async () => {
@@ -709,7 +723,9 @@ describe('Agent with custom OpenAI client', () => {
         'The "deepLocate" option is not supported for aiAct with the current planning adapter (modelFamily: auto-glm). It will be ignored.',
       );
       expect(actionSpy).toHaveBeenCalled();
-      expect(actionSpy.mock.calls[0][8]).toBe(false);
+      expect(actionSpy.mock.calls[0][3]).toEqual(
+        expect.objectContaining({ deepLocate: false }),
+      );
     });
   });
 });

--- a/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
+++ b/packages/core/tests/unit-test/ai-act-extra-actions.test.ts
@@ -1,0 +1,385 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Agent } from '@/agent';
+import { createExtraActionExecutionOptions } from '@/agent/extra-actions';
+import { TaskExecutor } from '@/agent/tasks';
+import { getMidsceneLocationSchema } from '@/ai-model';
+import { getModelRuntime } from '@/ai-model/models';
+import { standardPlan } from '@/ai-model/workflows/planning';
+import type { AbstractInterface } from '@/device';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { DeviceAction } from '@/types';
+import yaml from 'js-yaml';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type Service from '../../src';
+
+vi.mock('@/ai-model/workflows/planning', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@/ai-model/workflows/planning')>();
+  return {
+    ...original,
+    standardPlan: vi.fn(),
+  };
+});
+
+const validBase64Image =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const modelRuntime = () =>
+  getModelRuntime({
+    modelName: 'mock-model',
+    modelDescription: 'mock-model',
+    intent: 'default',
+    slot: 'default',
+  });
+
+describe('aiAct extra action integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('expands an extra Input action and executes the underlying action', async () => {
+    const inputCall = vi.fn();
+    const inputAction: DeviceAction = {
+      name: 'Input',
+      description: 'Input text into an element',
+      interfaceAlias: 'aiInput',
+      paramSchema: z.object({
+        value: z.string(),
+        locate: getMidsceneLocationSchema(),
+      }),
+      call: inputCall,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [inputAction],
+      cacheFeatureForPoint: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [inputAction],
+    });
+    vi.mocked(standardPlan).mockResolvedValue({
+      actions: [
+        {
+          type: 'MidsceneExtraAction_1',
+          param: {},
+          thought: 'fill the username',
+        },
+      ],
+      yamlFlow: [{ MidsceneExtraAction_1: {} }],
+      shouldContinuePlanning: false,
+    } as any);
+
+    const extraActions = [
+      {
+        alias: 'MidsceneExtraAction_1',
+        name: 'Fill the username',
+        sourcePath: '/tmp/example.actions.yaml',
+        plan: {
+          type: 'Input',
+          param: {
+            value: 'Alice',
+            locate: {
+              prompt: 'Username input',
+              locatedPixelBbox: [0, 0, 1, 1],
+            },
+          },
+        },
+      },
+    ];
+
+    const result = await taskExecutor.action(
+      'Fill the form',
+      modelRuntime(),
+      modelRuntime(),
+      {
+        extraActions: createExtraActionExecutionOptions(
+          extraActions,
+          undefined,
+        ),
+      },
+    );
+
+    expect(vi.mocked(standardPlan).mock.calls[0][1].actionSpace).toEqual([
+      expect.objectContaining({
+        name: 'MidsceneExtraAction_1',
+        description: expect.stringContaining('Fill the username'),
+      }),
+      inputAction,
+    ]);
+    expect(vi.mocked(standardPlan).mock.calls[0][1].hasExtraActions).toBe(true);
+    expect(inputCall).toHaveBeenCalledOnce();
+    expect(inputCall.mock.calls[0][0]).toMatchObject({
+      value: 'Alice',
+      locate: {
+        center: expect.any(Array),
+        rect: expect.objectContaining({
+          left: expect.any(Number),
+          top: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        }),
+      },
+    });
+
+    const replayAction = vi.fn();
+    const replayAgent = {
+      callActionInActionSpace: replayAction,
+      getActionSpace: vi.fn().mockResolvedValue([inputAction]),
+      onTaskStartTip: undefined,
+    };
+    await Agent.prototype.runYaml.call(
+      replayAgent as any,
+      yaml.dump({
+        tasks: [
+          {
+            name: 'cached extra action',
+            flow: result.output?.yamlFlow,
+          },
+        ],
+      }),
+    );
+    expect(replayAction).toHaveBeenCalledWith(
+      'Input',
+      expect.objectContaining({
+        value: 'Alice',
+        locate: expect.objectContaining({ prompt: 'Username input' }),
+      }),
+    );
+  });
+
+  it('refreshes disclosure on every planning round while keeping aliases stable', async () => {
+    const tapCall = vi.fn();
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'Tap an element',
+      call: tapCall,
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const probeLocatorTargets = vi
+      .fn()
+      .mockResolvedValueOnce([true, false])
+      .mockResolvedValueOnce([false, true]);
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: () => [tapAction],
+      probeLocatorTargets,
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1, height: 1 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+    const taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace: [tapAction],
+    });
+    vi.mocked(standardPlan)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_1',
+            param: {},
+            thought: 'run the first action',
+          },
+        ],
+        shouldContinuePlanning: true,
+      } as any)
+      .mockResolvedValueOnce({
+        actions: [
+          {
+            type: 'MidsceneExtraAction_2',
+            param: {},
+            thought: 'run the second action',
+          },
+        ],
+        shouldContinuePlanning: false,
+      } as any);
+
+    await taskExecutor.action(
+      'Complete both steps',
+      modelRuntime(),
+      modelRuntime(),
+      {
+        extraActions: createExtraActionExecutionOptions(
+          [
+            {
+              alias: 'MidsceneExtraAction_1',
+              name: 'Run the first action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="first"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+            {
+              alias: 'MidsceneExtraAction_2',
+              name: 'Run the second action',
+              sourcePath: '/tmp/example.actions.yaml',
+              validWhenTargetExists: {
+                strategy: 'xpath',
+                selector: '//button[@id="second"]',
+              },
+              plan: { type: 'Tap', param: undefined },
+            },
+          ],
+          mockInterface,
+        ),
+      },
+    );
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(standardPlan)
+        .mock.calls.map((call) =>
+          call[1].actionSpace.map((action) => action.name),
+        ),
+    ).toEqual([
+      ['MidsceneExtraAction_1', 'Tap'],
+      ['MidsceneExtraAction_2', 'Tap'],
+    ]);
+    expect(tapCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('loads files through the public aiAct option and separates its plan cache', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'midscene-ai-act-extra-action-'));
+    const filePath = join(dir, 'extra-action.yaml');
+    await writeFile(
+      filePath,
+      `version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: tap
+      param: {}
+`,
+    );
+
+    try {
+      const tapAction: DeviceAction = {
+        name: 'Tap',
+        description: 'Tap an element',
+        call: vi.fn(),
+      };
+      const agent = Object.create(Agent.prototype) as Agent<any>;
+      const action = vi.fn().mockResolvedValue({
+        output: {
+          output: 'done',
+          yamlFlow: [{ Tap: {} }],
+        },
+      });
+      const matchPlanCache = vi.fn();
+      const updateOrAppendCacheRecord = vi.fn();
+      (agent as any).opts = {};
+      (agent as any).interface = { interfaceType: 'web' };
+      (agent as any).fullActionSpace = [tapAction];
+      (agent as any).taskExecutor = { action };
+      (agent as any).taskCache = {
+        matchPlanCache,
+        isCacheResultUsed: true,
+        updateOrAppendCacheRecord,
+      };
+      (agent as any).resolveModelRuntime = vi.fn(() => modelRuntime());
+      (agent as any).resolveReplanningCycleLimit = vi.fn(() => 1);
+
+      await expect(
+        agent.aiAct('Fill the form', { loadExtraActions: [filePath] }),
+      ).resolves.toBe('done');
+
+      expect(matchPlanCache.mock.calls[0][0]).toContain(
+        '<midscene_extra_actions>',
+      );
+      expect(matchPlanCache.mock.calls[0][0]).toContain(
+        'extra-actions-snapshot:v1:',
+      );
+      expect(updateOrAppendCacheRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'plan',
+          prompt: matchPlanCache.mock.calls[0][0],
+        }),
+        undefined,
+      );
+      const executionOptions = action.mock.calls[0].at(-1);
+      expect(executionOptions).toEqual(
+        expect.objectContaining({
+          extraActions: expect.objectContaining({
+            createSnapshot: expect.any(Function),
+            initialSnapshot: expect.objectContaining({
+              fingerprint: expect.stringMatching(/^extra-actions-snapshot:v1:/),
+            }),
+          }),
+        }),
+      );
+      const snapshot = await executionOptions.extraActions.createSnapshot();
+      expect(snapshot.actionSpace).toEqual([
+        expect.objectContaining({
+          name: 'MidsceneExtraAction_1',
+          description: expect.stringContaining('Click the confirm button'),
+        }),
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects loadExtraActions before planning with a custom adapter', async () => {
+    const agent = Object.create(Agent.prototype) as Agent<any>;
+    const action = vi.fn();
+    const customPlanningModel = {
+      ...modelRuntime(),
+      config: {
+        ...modelRuntime().config,
+        modelFamily: 'custom-test',
+      },
+      adapter: {
+        planning: {
+          kind: 'custom',
+        },
+      },
+    } as any;
+    (agent as any).opts = {};
+    (agent as any).interface = { interfaceType: 'web' };
+    (agent as any).fullActionSpace = [];
+    (agent as any).taskExecutor = { action };
+    (agent as any).resolveModelRuntime = vi.fn((intent: string) =>
+      intent === 'planning' ? customPlanningModel : modelRuntime(),
+    );
+
+    await expect(
+      agent.aiAct('Fill the form', {
+        loadExtraActions: ['/path/that/does/not/need/to/exist.yaml'],
+      }),
+    ).rejects.toThrow(
+      'The "loadExtraActions" option is not supported by custom planning adapters (modelFamily: custom-test)',
+    );
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/unit-test/extra-actions.test.ts
+++ b/packages/core/tests/unit-test/extra-actions.test.ts
@@ -1,0 +1,558 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createExtraActionSnapshot,
+  getExtraActionSource,
+  loadExtraActions,
+} from '@/agent/extra-actions';
+import { getMidsceneLocationSchema } from '@/ai-model';
+import type { DeviceAction } from '@/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+describe('extra actions', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function writeExtraAction(content: string) {
+    const dir = await mkdtemp(join(tmpdir(), 'midscene-extra-action-'));
+    tempDirs.push(dir);
+    const filePath = join(dir, 'example.actions.yaml');
+    await writeFile(filePath, content);
+    return filePath;
+  }
+
+  const tapAction = (): DeviceAction => ({
+    name: 'Tap',
+    interfaceAlias: 'aiTap',
+    description: 'Tap an element',
+    paramSchema: z.object({
+      locate: getMidsceneLocationSchema(),
+    }),
+    call: vi.fn(),
+  });
+
+  it('loads the manifest and expands one alias into one native action', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the checkout dialog confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Checkout dialog confirm button
+          target:
+            strategy: xpath
+            selector: //div[@role="dialog"]//button[@data-testid="confirm"]
+`);
+
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets: vi.fn(async () => [true]),
+    });
+
+    expect(snapshot.actionSpace).toHaveLength(1);
+    expect(snapshot.actionSpace[0]).toMatchObject({
+      name: 'MidsceneExtraAction_1',
+      description: expect.stringContaining(
+        'Click the checkout dialog confirm button',
+      ),
+      sample: {},
+    });
+    expect(snapshot.actionSpace[0].description).not.toContain('//div');
+    expect(loaded[0].validWhenTargetExists).toEqual({
+      strategy: 'xpath',
+      selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+    });
+
+    const expansion = snapshot.expandPlans([
+      {
+        type: 'MidsceneExtraAction_1',
+        param: {},
+        thought: 'confirm checkout',
+      },
+    ]);
+    expect(expansion.plans).toEqual([
+      {
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: 'Checkout dialog confirm button',
+            target: {
+              strategy: 'xpath',
+              selector: '//div[@role="dialog"]//button[@data-testid="confirm"]',
+            },
+          },
+        },
+        thought: 'confirm checkout',
+      },
+    ]);
+    expect(getExtraActionSource(expansion.plans[0])).toEqual({
+      type: 'extra-action',
+      name: 'Click the checkout dialog confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: filePath,
+    });
+    expect(snapshot.fingerprint).toMatch(/^extra-actions-snapshot:v1:/);
+  });
+
+  it('discloses every action whose condition currently exists', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+  - name: Click the cancel button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="cancel"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Cancel button
+          target: { strategy: xpath, selector: '//button[@id="cancel"]' }
+  - name: Click the help button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Help button
+          target: { strategy: xpath, selector: '//button[@id="help"]' }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('confirm')),
+    );
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledTimes(1);
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_3',
+    ]);
+
+    probeLocatorTargets.mockImplementation(
+      async (targets: readonly { selector: string }[]) =>
+        targets.map((target) => target.selector.includes('cancel')),
+    );
+    const nextSnapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+    expect(nextSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_2',
+      'MidsceneExtraAction_3',
+    ]);
+  });
+
+  it('keeps each disclosure snapshot immutable across page changes', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          target: { strategy: xpath, selector: '//button[@id="confirm"]' }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    let exists = false;
+    const targetProbe = {
+      probeLocatorTargets: vi.fn(async () => [exists]),
+    };
+
+    const missingSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    exists = true;
+    const presentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+    const repeatedPresentSnapshot = await createExtraActionSnapshot(
+      loaded,
+      targetProbe,
+    );
+
+    expect(missingSnapshot.actionSpace).toEqual([]);
+    expect(presentSnapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+    ]);
+    expect(missingSnapshot.fingerprint).not.toBe(presentSnapshot.fingerprint);
+    expect(repeatedPresentSnapshot.fingerprint).toBe(
+      presentSnapshot.fingerprint,
+    );
+    expect(
+      missingSnapshot.expandPlans([
+        { type: 'MidsceneExtraAction_1', param: {} },
+      ]),
+    ).toEqual({
+      plans: [{ type: 'MidsceneExtraAction_1', param: {} }],
+      expanded: false,
+    });
+  });
+
+  it('supports old one-action files as a read compatibility boundary', async () => {
+    const filePath = await writeExtraAction(`
+name: Click the confirm button
+actionName: tap
+actionParam:
+  - xpath: /html/body/button[1]
+`);
+    const [loaded] = await loadExtraActions([filePath], [tapAction()], 'web');
+    expect(loaded.plan.param).toEqual({
+      locate: {
+        prompt: 'Click the confirm button',
+        target: {
+          strategy: 'xpath',
+          selector: '/html/body/button[1]',
+        },
+      },
+    });
+  });
+
+  it('rejects a manifest for another interface', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: android
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'interface "android" does not match current interface "web"',
+    );
+  });
+
+  it('accepts the canonical platform declared by an interface', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('prefers an exact native action name over an earlier case-insensitive match', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const lowerCaseTap = {
+      ...tapAction(),
+      name: 'tap',
+      interfaceAlias: 'lowerCaseTap',
+    };
+
+    const [loaded] = await loadExtraActions(
+      [filePath],
+      [lowerCaseTap, tapAction()],
+      'web',
+    );
+
+    expect(loaded.plan.type).toBe('Tap');
+  });
+
+  it('reserves native action aliases when assigning stable protocol aliases', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const nativeAction = {
+      ...tapAction(),
+      interfaceAlias: 'MidsceneExtraAction_1',
+    };
+
+    const [loaded] = await loadExtraActions([filePath], [nativeAction], 'web');
+
+    expect(loaded.alias).toBe('MidsceneExtraAction_2');
+  });
+
+  it('allows a display name to match a built-in action name', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Tap
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('rejects target and legacy xpath in the same locator', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate:
+          prompt: Confirm button
+          xpath: //button
+          target: { strategy: xpath, selector: //button }
+`);
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      '`target` and `xpath` cannot be used in the same locator',
+    );
+  });
+
+  it('rejects invalid condition targets and duplicate names', async () => {
+    const invalidTarget = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists: { strategy: css, selector: '#confirm' }
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    await expect(
+      loadExtraActions([invalidTarget], [tapAction()], 'web'),
+    ).rejects.toThrow('validWhenTargetExists');
+
+    const duplicate = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Another confirm button }
+`);
+    await expect(
+      loadExtraActions([duplicate], [tapAction()], 'web'),
+    ).rejects.toThrow(
+      'action name "Click the confirm button" conflicts with another action',
+    );
+  });
+
+  it('rejects unknown manifest fields before planning', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+unexpected: true
+actions:
+  - name: Click the confirm button
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('Unrecognized key');
+  });
+
+  it('rejects display names that can break the planning protocol', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: <malicious-action>
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+
+    await expect(
+      loadExtraActions([filePath], [tapAction()], 'web'),
+    ).rejects.toThrow('must not contain angle brackets');
+  });
+
+  it('deduplicates condition targets in one batch probe', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the primary confirm button
+    validWhenTargetExists: &confirm
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Primary confirm button }
+  - name: Click the secondary confirm button
+    validWhenTargetExists: *confirm
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Secondary confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const probeLocatorTargets = vi.fn(async () => [true]);
+
+    const snapshot = await createExtraActionSnapshot(loaded, {
+      probeLocatorTargets,
+    });
+
+    expect(probeLocatorTargets).toHaveBeenCalledWith(
+      [{ strategy: 'xpath', selector: '//button[@id="confirm"]' }],
+      {},
+    );
+    expect(snapshot.actionSpace.map((action) => action.name)).toEqual([
+      'MidsceneExtraAction_1',
+      'MidsceneExtraAction_2',
+    ]);
+  });
+
+  it('rejects malformed batch probe results', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+
+    await expect(
+      createExtraActionSnapshot(loaded, {
+        probeLocatorTargets: vi.fn(async () => ['yes'] as any),
+      }),
+    ).rejects.toThrow('must return only boolean results');
+  });
+
+  it('aborts condition probing without returning a partial snapshot', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    controller.abort(new Error('test abort'));
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets: vi.fn(async () => [true]) },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('test abort');
+  });
+
+  it('discards probe results when cancellation happens during the batch', async () => {
+    const filePath = await writeExtraAction(`
+version: 1
+interface: web
+actions:
+  - name: Click the confirm button
+    validWhenTargetExists:
+      strategy: xpath
+      selector: //button[@id="confirm"]
+    action:
+      name: Tap
+      param:
+        locate: { prompt: Confirm button }
+`);
+    const loaded = await loadExtraActions([filePath], [tapAction()], 'web');
+    const controller = new AbortController();
+    const probeLocatorTargets = vi.fn(async () => {
+      controller.abort(new Error('cancelled during probe'));
+      return [true];
+    });
+
+    await expect(
+      createExtraActionSnapshot(
+        loaded,
+        { probeLocatorTargets },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow('cancelled during probe');
+    expect(probeLocatorTargets).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -99,6 +99,25 @@ describe('action space', () => {
       "If the user's task can be completed with the RunAdbShell action, prefer using the RunAdbShell action",
     );
   });
+
+  it('requires matching pre-recorded operations when extra actions are available', async () => {
+    const extraAction = {
+      name: 'MidsceneExtraAction_1',
+      description: 'Fill the first name field with Alice',
+      sample: {},
+      call: async () => {},
+    };
+
+    const prompt = await buildStandardPlanningSystemPrompt({
+      actionSpace: [...mockActionSpace, extraAction],
+      includeLocateInPlanning: false,
+      hasExtraActions: true,
+    });
+
+    expect(prompt).toContain(
+      'When one matches the next requested operation, you MUST use it instead of rebuilding that operation with a low-level action',
+    );
+  });
 });
 
 describe('system prompts', () => {

--- a/packages/core/tests/unit-test/task-builder.test.ts
+++ b/packages/core/tests/unit-test/task-builder.test.ts
@@ -1,3 +1,4 @@
+import { setExtraActionSource } from '@/agent/extra-actions';
 import { TaskBuilder, locatePlanForLocate } from '@/agent/task-builder';
 import { getMidsceneLocationSchema } from '@/ai-model';
 import { getModelRuntime } from '@/ai-model/models';
@@ -66,6 +67,246 @@ describe('TaskBuilder', () => {
       deepLocate: true,
     });
     expect(plan.param).not.toHaveProperty('deepThink');
+  });
+
+  it('normalizes the legacy xpath alias into a target', () => {
+    const plan = locatePlanForLocate({
+      prompt: 'confirm button',
+      xpath: '//button[@id="confirm"]',
+    });
+
+    expect(plan.param).toEqual({
+      prompt: 'confirm button',
+      target: {
+        strategy: 'xpath',
+        selector: '//button[@id="confirm"]',
+      },
+    });
+    expect(() =>
+      locatePlanForLocate({
+        prompt: 'confirm button',
+        xpath: '//button',
+        target: { strategy: 'xpath', selector: '//button' },
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
+  });
+
+  it('resolves a target before AI locate and reports the Extra Action source', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+      delayBeforeRunner: 0,
+      delayAfterRunner: 0,
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 40,
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate: vi.fn(),
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const extraActionPlan: PlanningAction = {
+      type: 'Tap',
+      param: {
+        locate: {
+          prompt: 'confirm button',
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+        },
+      },
+    };
+    setExtraActionSource(extraActionPlan, {
+      type: 'extra-action',
+      name: 'Click the confirm button',
+      alias: 'MidsceneExtraAction_1',
+      sourcePath: '/tmp/example.actions.yaml',
+    });
+    const { tasks } = await taskBuilder.build(
+      [extraActionPlan],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+
+    expect(insightService.locate).not.toHaveBeenCalled();
+    expect(locateResult).toMatchObject({
+      output: {
+        element: {
+          center: [59, 39],
+          rect: { left: 10, top: 20, width: 100, height: 40 },
+        },
+      },
+      hitBy: {
+        from: 'Extra Action target',
+        context: {
+          target: {
+            strategy: 'xpath',
+            selector: '//button[@id="confirm"]',
+          },
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+
+    const actionResult = await tasks[1].executor(tasks[1].param, {
+      task: { timing: {} },
+      uiContext: {
+        shrunkShotToLogicalRatio: 1,
+        deprecatedDpr: 1,
+      },
+    } as any);
+    expect(actionResult).toMatchObject({
+      hitBy: {
+        from: 'Extra Action',
+        context: {
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution fails', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => {
+      throw new Error('target is stale');
+    });
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const insightService = {
+      contextRetrieverFn: vi.fn(),
+      locate,
+    } as unknown as Service;
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: insightService,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          target: { strategy: 'xpath', selector: '//button' },
+          targetResolutionError: 'target is stale',
+        },
+      },
+    });
+  });
+
+  it('falls back to AI locate when target resolution returns an invalid rect', async () => {
+    const tapAction: DeviceAction = {
+      name: 'Tap',
+      description: 'tap an element',
+      paramSchema: z.object({ locate: getMidsceneLocationSchema() }),
+      call: vi.fn(),
+    };
+    const mockInterface = new MockInterface([tapAction]);
+    mockInterface.resolveLocatorTarget = vi.fn(async () => ({
+      left: 10,
+      top: 20,
+      width: 0,
+      height: 40,
+    }));
+    const locate = vi.fn(async () => ({
+      element: {
+        center: [30, 30] as [number, number],
+        rect: { left: 20, top: 20, width: 20, height: 20 },
+        description: 'confirm button',
+      },
+      dump: { taskInfo: { durationMs: 1 } },
+    }));
+    const taskBuilder = new TaskBuilder({
+      interfaceInstance: mockInterface,
+      service: { contextRetrieverFn: vi.fn(), locate } as unknown as Service,
+      actionSpace: mockInterface.actionSpace(),
+    });
+    const { tasks } = await taskBuilder.build(
+      [
+        {
+          type: 'Tap',
+          param: {
+            locate: {
+              prompt: 'confirm button',
+              target: { strategy: 'xpath', selector: '//button' },
+            },
+          },
+        },
+      ],
+      mockModelRuntime,
+      mockModelRuntime,
+    );
+
+    const locateResult = await tasks[0].executor(tasks[0].param, {
+      task: { timing: {} },
+      uiContext: { shrunkShotToLogicalRatio: 1, deprecatedDpr: 1 },
+    } as any);
+
+    expect(locate).toHaveBeenCalledOnce();
+    expect(locateResult).toMatchObject({
+      hitBy: {
+        from: 'AI',
+        context: {
+          targetResolutionError: expect.stringContaining(
+            'Invalid locate result rect size',
+          ),
+        },
+      },
+    });
   });
 
   it('dispatches plans using handler registry', async () => {

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -237,7 +237,7 @@ describe('utils', () => {
       await new Promise((resolve) => setTimeout(resolve, 5000));
 
       // We expect the file to be approximately 700MB plus template overhead
-      const expectedMinSize = 1000; // 10 reports × 100MB
+      const expectedMinSize = 1000; // 10 reports x 100MB
       expect(fileSizeInMB).toBeGreaterThan(expectedMinSize);
     },
   );
@@ -308,6 +308,23 @@ describe('buildDetailedLocateParam', () => {
       cacheable: false,
       xpath: undefined,
     });
+  });
+
+  it('accepts target and rejects target with the legacy xpath alias', () => {
+    const target = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="confirm"]',
+    };
+
+    expect(
+      buildDetailedLocateParam('Click the confirm button', { target }),
+    ).toMatchObject({ target });
+    expect(() =>
+      buildDetailedLocateParam('Click the confirm button', {
+        target,
+        xpath: '//button[@id="confirm"]',
+      }),
+    ).toThrow('`target` and `xpath` cannot be used in the same locator');
   });
 });
 
@@ -441,7 +458,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     <h1>Bug Case</h1>
   </body>
   <script>
-    { "hello": "你好", "world": "世界" }
+    { "hello": "hello", "world": "world" }
   </script>
 </html>`;
     const filePath = createTempHtmlFile(html);
@@ -464,7 +481,7 @@ describe('insertScriptBeforeClosingHtml', () => {
     //       <h1>Bug Case</h1>
     //     </body>
     //     <script>
-    //       { "hello": "你好", "world": "世界" }
+    //       { "hello": "hello", "world": "world" }
     // -   </script>
     // - <script>large</script>
     // +   </scri<script>large</script>

--- a/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
@@ -40,16 +40,22 @@ describe('agent with forceSameTabNavigation', () => {
       xpath: inputXpath,
     });
     const log = await agent._unstableLogContent();
-    expect(log.executions[0].tasks[0].hitBy?.from).toBe('User expected path');
-    expect(log.executions[0].tasks[0].hitBy?.context?.xpath).toBe(inputXpath);
+    expect(log.executions[0].tasks[0].hitBy?.from).toBe('User target');
+    expect(log.executions[0].tasks[0].hitBy?.context?.target).toEqual({
+      strategy: 'xpath',
+      selector: inputXpath,
+    });
     await agent.aiKeyboardPress('The search input box', {
       keyName: 'Enter',
       xpath: inputXpath,
     });
     await sleep(2000);
     const log1 = await agent._unstableLogContent();
-    expect(log1.executions[1].tasks[0].hitBy?.from).toBe('User expected path');
-    expect(log1.executions[1].tasks[0].hitBy?.context?.xpath).toBe(inputXpath);
+    expect(log1.executions[1].tasks[0].hitBy?.from).toBe('User target');
+    expect(log1.executions[1].tasks[0].hitBy?.context?.target).toEqual({
+      strategy: 'xpath',
+      selector: inputXpath,
+    });
     await agent.aiTap('The search result link for "midscene" project');
     const log2 = await agent._unstableLogContent();
     expect(log2.executions[2].tasks[0].hitBy?.from).toBe('AI');

--- a/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/open-new-tab.test.ts
@@ -52,7 +52,7 @@ describe('agent with forceSameTabNavigation', () => {
     expect(log1.executions[1].tasks[0].hitBy?.context?.xpath).toBe(inputXpath);
     await agent.aiTap('The search result link for "midscene" project');
     const log2 = await agent._unstableLogContent();
-    expect(log2.executions[2].tasks[0].hitBy?.from).toBe(undefined); // AI model
+    expect(log2.executions[2].tasks[0].hitBy?.from).toBe('AI');
     await sleep(2000);
     await agent.aiAssert('the page is "midscene github"');
   });

--- a/packages/web-integration/tests/ai/web/puppeteer/parameter-validation.test.ts
+++ b/packages/web-integration/tests/ai/web/puppeteer/parameter-validation.test.ts
@@ -78,7 +78,7 @@ describe('parameter validation', () => {
     // If execution reaches here without throwing error, it means locatorField wasn't validated
     const log = await agent._unstableLogContent();
     expect(log.executions.length).toBeGreaterThan(0);
-    expect(log.executions[0].tasks[0].hitBy?.from).toBe('User expected path');
+    expect(log.executions[0].tasks[0].hitBy?.from).toBe('User target');
   });
 
   it('should reject invalid type for parameters', async () => {

--- a/packages/web-integration/tests/unit-test/agent.test.ts
+++ b/packages/web-integration/tests/unit-test/agent.test.ts
@@ -705,9 +705,12 @@ describe('PageAgent aiAct abortSignal', () => {
       abortSignal: controller.signal,
     });
 
-    // Verify the abortSignal argument is passed before report options.
-    const callArgs = mockTaskExecutor.action.mock.calls[0];
-    expect(callArgs[callArgs.length - 2]).toBe(controller.signal);
+    const actionOptions = mockTaskExecutor.action.mock.calls[0][3];
+    expect(actionOptions).toEqual(
+      expect.objectContaining({
+        abortSignal: controller.signal,
+      }),
+    );
   });
 
   it('should work normally without abortSignal', async () => {
@@ -722,9 +725,12 @@ describe('PageAgent aiAct abortSignal', () => {
 
     await agent.aiAct('click the button');
 
-    // AbortSignal argument should be undefined when no signal is provided.
-    const callArgs = mockTaskExecutor.action.mock.calls[0];
-    expect(callArgs[callArgs.length - 2]).toBeUndefined();
+    const actionOptions = mockTaskExecutor.action.mock.calls[0][3];
+    expect(actionOptions).toEqual(
+      expect.objectContaining({
+        abortSignal: undefined,
+      }),
+    );
   });
 
   it('should throw with default reason when aborted without reason', async () => {


### PR DESCRIPTION
## Summary

- define the versioned `*.actions.yaml` Manifest schema with `validWhenTargetExists`, native Action parameters, and canonical `target`
- allow `aiAct` to load one or more manifests through `loadExtraActions`
- disclose every action whose target exists in the same, side-effect-free planning snapshot and place Extra Actions before generic Actions
- expand the selected parameterless alias into exactly one native Action, with deterministic target resolution, cache fallback, and AI locate fallback
- preserve the latest `aiAct` effort protocol, including `effort: 'fast'`, when Extra Actions are loaded
- document the API and Manifest format in English and Chinese

## Scope

This is PR 2 of 3 and is reviewed relative to the target foundation PR. It does not contain report parsing, the `midscene analyze` command, benchmark fixtures, or the deprecated XPath Map API.

## Validation

- `pnpm run lint`
- `npx nx build @midscene/web --skip-nx-cache`
- `npx nx test @midscene/core --skip-nx-cache`
- `pnpm --filter @midscene/web exec vitest --run tests/unit-test/agent.test.ts` (37 passed)
- `AI_TEST_TYPE=web pnpm --filter @midscene/web exec vitest --run tests/ai/web/puppeteer/parameter-validation.test.ts tests/ai/web/puppeteer/open-new-tab.test.ts` (6 passed)
- full `@midscene/web` test run: 435 passed and 3 skipped; the unrelated playground-server suite could not bind to a locally occupied port `127.0.0.1:5800`
- 12 real-model `aiAct` runs with `effort: 'fast'` across Qwen 3.7 Flash/Plus and Baseline/Extra Action groups (12/12 business assertions passed)

## Stack

1. Target resolution foundation
2. **This PR:** Action Manifest runtime
3. Report-to-Action-Manifest export (`midscene analyze`)
