### PR TITLE
feat(core): export action manifests from reports

### DIFF
--- a/apps/report/src/components/detail-side/index.tsx
+++ b/apps/report/src/components/detail-side/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@midscene/visualizer';
 import { Tag, Tooltip } from 'antd';
 import { useState } from 'react';
+import { getExtraActionSourceInfo } from '../../utils/report-task-tags';
 import { isElementField, useExecutionDump } from '../store';
 
 function isPlainObject(value: unknown): value is Record<string, any> {
@@ -454,6 +455,40 @@ const DetailSide = (): JSX.Element => {
               key: 'hitBy',
               content: (() => {
                 const hitBy = task.hitBy as any;
+                const extraActionSource = getExtraActionSourceInfo(task);
+                if (extraActionSource) {
+                  return (
+                    <>
+                      <div>
+                        <strong>from:</strong> {extraActionSource.source}
+                      </div>
+                      {extraActionSource.name ? (
+                        <div>
+                          <strong>name:</strong> {extraActionSource.name}
+                        </div>
+                      ) : null}
+                      {extraActionSource.alias ? (
+                        <div>
+                          <strong>alias:</strong> {extraActionSource.alias}
+                        </div>
+                      ) : null}
+                      {extraActionSource.target !== undefined ? (
+                        <>
+                          <div>
+                            <strong>target:</strong>
+                          </div>
+                          <pre>
+                            {JSON.stringify(
+                              extraActionSource.target,
+                              undefined,
+                              2,
+                            )}
+                          </pre>
+                        </>
+                      ) : null}
+                    </>
+                  );
+                }
                 // Special handling for Cache with yamlString
                 if (hitBy.from === 'Cache' && hitBy.context?.yamlString) {
                   return (

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -505,6 +505,7 @@
 
         // Allow tags to shrink
         .cache-tag,
+        .extra-action-tag,
         .deeplocate-tag,
         .xpath-tag,
         .deepthink-tag,
@@ -621,6 +622,11 @@
 .xpath-tag {
   color: #1890ff;
   background-color: #e0f5ff;
+}
+
+.extra-action-tag {
+  color: #c41d7f;
+  background-color: #fff0f6;
 }
 
 .domincluded-tag {
@@ -901,6 +907,11 @@
     .xpath-tag {
       color: #1890ff !important;
       background-color: rgba(24, 144, 255, 0.15) !important;
+    }
+
+    .extra-action-tag {
+      color: #eb2f96 !important;
+      background-color: rgba(235, 47, 150, 0.15) !important;
     }
 
     .domincluded-tag {

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -26,6 +26,7 @@ import {
   markdownZipDownloadTooltip,
 } from '../../utils/markdown-export';
 import {
+  getExtraActionSourceInfo,
   hasDeepLocateFlag,
   hasDeepThinkFlag,
   hasObserverAssertionFlag,
@@ -193,6 +194,31 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
         Cache
       </Tag>
     ) : null;
+  };
+
+  const getExtraActionTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+    const source = getExtraActionSourceInfo(task);
+    if (!source) {
+      return null;
+    }
+
+    const tooltip = [source.name, source.alias].filter(Boolean).join(' · ');
+    const tag = (
+      <Tag
+        className="extra-action-tag"
+        style={{
+          padding: '0 4px',
+          marginLeft: '4px',
+          marginRight: 0,
+          lineHeight: '16px',
+        }}
+        bordered={false}
+      >
+        {source.label}
+      </Tag>
+    );
+
+    return tooltip ? <Tooltip title={tooltip}>{tag}</Tooltip> : tag;
   };
 
   const getDomIncludedTag = (task: ExecutionTaskWithSearchAreaUsage) => {
@@ -646,6 +672,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
             <span>{taskName}</span>
             {getTitleIcon(task)}
             {getCacheTag(task)}
+            {getExtraActionTag(task)}
             {getDomIncludedTag(task)}
             {getDeepLocateTag(task)}
             {getXPathTag(task)}

--- a/apps/report/src/utils/report-task-tags.ts
+++ b/apps/report/src/utils/report-task-tags.ts
@@ -10,6 +10,14 @@ type PlanningLocateParam = NonNullable<ExecutionTaskPlanningLocate['param']>;
 type EffortParam = Pick<PlanningParam, 'effort'>;
 type DeepLocateParam = Pick<PlanningLocateParam, 'deepLocate'>;
 
+export interface ExtraActionSourceInfo {
+  source: 'Extra Action' | 'Extra Action target';
+  label: 'Extra Action' | 'Extra Target';
+  name?: string;
+  alias?: string;
+  target?: unknown;
+}
+
 type ConsumedDumpFlagKeys = {
   effort: keyof Pick<PlanningParam, 'effort'>;
   deepLocate: keyof Pick<PlanningLocateParam, 'deepLocate'>;
@@ -44,4 +52,27 @@ export function hasDeepLocateFlag(task: ExecutionTask): boolean {
  */
 export function hasObserverAssertionFlag(task: ExecutionTask): boolean {
   return task.recorder?.some((r) => r.timing === 'observed-frame') ?? false;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+export function getExtraActionSourceInfo(
+  task: ExecutionTask,
+): ExtraActionSourceInfo | undefined {
+  const from = task.hitBy?.from;
+  if (from !== 'Extra Action' && from !== 'Extra Action target') {
+    return undefined;
+  }
+
+  const context = task.hitBy?.context;
+
+  return {
+    source: from,
+    label: from === 'Extra Action' ? 'Extra Action' : 'Extra Target',
+    name: nonEmptyString(context?.extraActionName),
+    alias: nonEmptyString(context?.extraActionAlias),
+    ...(context?.target !== undefined ? { target: context.target } : {}),
+  };
 }

--- a/apps/report/tests/report-task-tags.test.ts
+++ b/apps/report/tests/report-task-tags.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@midscene/core';
 import { describe, expect, it } from '@rstest/core';
 import {
+  getExtraActionSourceInfo,
   hasDeepLocateFlag,
   hasDeepThinkFlag,
   hasObserverAssertionFlag,
@@ -133,5 +134,72 @@ describe('report task tag flags', () => {
     } as unknown as ExecutionTask;
 
     expect(hasObserverAssertionFlag(task)).toBe(false);
+  });
+
+  it('describes an action selected from the extra action space', () => {
+    const task = {
+      type: 'Action',
+      subType: 'Tap',
+      taskId: 'extra-action',
+      status: 'finished',
+      hitBy: {
+        from: 'Extra Action',
+        context: {
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+        },
+      },
+    } as unknown as ExecutionTask;
+
+    expect(getExtraActionSourceInfo(task)).toEqual({
+      source: 'Extra Action',
+      label: 'Extra Action',
+      name: 'Click the confirm button',
+      alias: 'MidsceneExtraAction_1',
+    });
+  });
+
+  it('describes target resolution triggered by an extra action', () => {
+    const target = {
+      strategy: 'xpath',
+      selector: '//button[@id="confirm"]',
+    };
+    const task = {
+      type: 'Planning',
+      subType: 'Locate',
+      taskId: 'extra-target',
+      status: 'finished',
+      hitBy: {
+        from: 'Extra Action target',
+        context: {
+          extraActionName: 'Click the confirm button',
+          extraActionAlias: 'MidsceneExtraAction_1',
+          target,
+        },
+      },
+    } as unknown as ExecutionTask;
+
+    expect(getExtraActionSourceInfo(task)).toEqual({
+      source: 'Extra Action target',
+      label: 'Extra Target',
+      name: 'Click the confirm button',
+      alias: 'MidsceneExtraAction_1',
+      target,
+    });
+  });
+
+  it('does not mark unrelated hit sources as extra actions', () => {
+    const task = {
+      type: 'Planning',
+      subType: 'Locate',
+      taskId: 'cached-target',
+      status: 'finished',
+      hitBy: {
+        from: 'Cache',
+        context: {},
+      },
+    } as unknown as ExecutionTask;
+
+    expect(getExtraActionSourceInfo(task)).toBeUndefined();
   });
 });

--- a/apps/site/docs/en/consume-report-file.md
+++ b/apps/site/docs/en/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 Repeat `--htmlReport` once per source report. `--outputDir` and `--outputName` are optional; when omitted, the merged file is written to the default Midscene report directory with an auto-generated name. Pass `--overwrite` to replace an existing merged file.
 
+Export successful operations as an Action Manifest:
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+The command writes one `*.actions.yaml` file. Each device operation whose Action task finished becomes one manifest entry. Recorded XPath cache data is exported as `target`; actions without a stable target keep `locatedPixelBbox` as a fallback. If an action has multiple targets, such as a `Swipe` with `start` and `end`, all targets remain in the action parameters and the first target becomes `validWhenTargetExists`. A finished Action does not prove that it was part of the correct business path, so review recovery detours and mistaken clicks before treating an exported manifest as a reusable asset. Pass `--overwrite` to replace an existing manifest.
+
 ## Parse With The JavaScript SDK
 
 If you prefer to control report parsing in code, use `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` from `@midscene/core`.
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
+`analyzeReportActions`, `splitReportFile`, `reportFileToMarkdown`, and `mergeReportFiles` serve different outputs:
 
+- `analyzeReportActions` exports successful device operations as one `*.actions.yaml` manifest that can be loaded with `aiAct({ loadExtraActions })`. Every report dump that contains executions must declare the same `manifestInterface`; mixed-platform reports are rejected instead of assigning the wrong platform to an action.
 - `splitReportFile` generates JSON files for the original structured objects (one `*.execution.json` per execution). The JSON keeps the raw `ReportActionDump`-style data and exports screenshots alongside it. The returned `executionJsonFiles` and `screenshotFiles` are lists of generated file paths.
 - `reportFileToMarkdown` converts the same report into human-readable Markdown and exports the screenshots referenced by that Markdown. The returned `markdownFiles` contains the generated Markdown file paths.
 - `mergeReportFiles` combines several report files into one merged HTML report. It is a thin wrapper over [`ReportMergingTool`](./reference/#new-reportmergingtool) that derives `testTitle`/`testDescription` from each source report's `groupName` automatically. Use it when you run multiple CLI actions or tests and want to consolidate their reports.

--- a/apps/site/docs/zh/consume-report-file.md
+++ b/apps/site/docs/zh/consume-report-file.md
@@ -72,16 +72,31 @@ npx @midscene/web report-tool --action merge-html \
 
 每多合并一份报告就重复一次 `--htmlReport`。`--outputDir` 和 `--outputName` 都是可选项，留空时合并后的报告会写入 Midscene 默认的报告目录、并生成自动文件名。已存在同名文件时使用 `--overwrite` 进行覆盖。
 
+把成功执行的操作导出为 Action Manifest：
+
+```shell
+npx @midscene/web analyze ./midscene_run/report/puppeteer-2026/index.html --outputDir ./recorded-actions
+```
+
+这个命令会生成一个 `*.actions.yaml` 文件。每个 Action 任务执行完成的设备操作对应一条 Manifest 记录。报告中的 XPath Cache 会导出为 `target`；没有稳定目标的动作保留 `locatedPixelBbox` 作为备用定位信息。如果一个动作包含多个 target，例如同时包含 `start` 和 `end` 的 `Swipe`，这些 target 都会保留在动作参数中，第一个 target 会作为 `validWhenTargetExists`。Action 执行完成不等于它属于正确的业务路径，因此，错误点击和恢复路径需要经过审核，才能作为可复用资产。已有同名文件时，使用 `--overwrite` 覆盖。
+
 ## 使用 JavaScript SDK 解析
 
 如果你希望在代码里控制报告解析，可以使用 `@midscene/core` 提供的 `splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles`。
 
 ```ts
 import {
+  analyzeReportActions,
   mergeReportFiles,
   reportFileToMarkdown,
   splitReportFile,
 } from '@midscene/core';
+
+const actionManifest = analyzeReportActions({
+  htmlPath: './midscene_run/report/puppeteer-2026/index.html',
+  outputDir: './recorded-actions',
+});
+console.log(actionManifest.actionFiles);
 
 const splitResult = splitReportFile({
   htmlPath: './midscene_run/report/puppeteer-2026/index.html',
@@ -106,8 +121,9 @@ const mergedResult = mergeReportFiles({
 console.log(mergedResult.mergedReportPath);
 ```
 
-`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
+`analyzeReportActions`、`splitReportFile`、`reportFileToMarkdown` 和 `mergeReportFiles` 的用途不同：
 
+- `analyzeReportActions` 把成功执行的设备操作导出为一个 `*.actions.yaml` Manifest，可以通过 `aiAct({ loadExtraActions })` 加载。所有包含 execution 的报告 dump 必须声明相同的 `manifestInterface`；如果报告混合了多个平台，命令会直接报错，不会为动作写入错误的平台。
 - `splitReportFile` 会产出“原始对象”对应的 JSON 文件（每个 execution 一个 `*.execution.json`），内容是 `ReportActionDump` 的原始结构化数据，同时会导出截图文件。返回值中的 `executionJsonFiles` 和 `screenshotFiles` 都是生成后的文件路径列表。
 - `reportFileToMarkdown` 会把同一份报告转成更易读、便于给其他工具继续处理的 Markdown 文本，并导出 Markdown 里引用到的截图。返回值里的 `markdownFiles` 对应 Markdown 文件路径。
 - `mergeReportFiles` 会把多份报告合并成一份汇总 HTML 报告，是 [`ReportMergingTool`](./reference/#new-reportmergingtool) 的轻量封装：会自动从每份源报告里读取 `groupName` 作为 `testTitle`/`testDescription`，省去了手工准备 `reportAttributes` 的步骤。命令行多次调用或多个测试用例产生多份报告后，使用它进行汇总最为合适。

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,3 +3,17 @@
 CLI tool for running Midscene automation scripts in YAML format.
 
 See <https://midscenejs.com/yaml-script-runner.html>.
+
+## Export an Action Manifest
+
+Export successful device operations from a Midscene HTML report into one
+reusable `*.actions.yaml` manifest:
+
+```bash
+midscene analyze report.html
+```
+
+The command writes to a sibling `<report-name>-ui-actions` directory by
+default. The generated manifest contains one entry per successful device
+operation and can be loaded by
+`agent.aiAct(..., { loadExtraActions: [...] })`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,12 +7,13 @@ import { createConfig, createFilesConfig } from './config-factory';
 import { loadDotenvConfig } from './dotenv-loader';
 import { runFrameworkTestConfig } from './framework';
 import { runModelCommand } from './model-command';
+import { normalizeReportCommandArgs } from './report-command';
 
 Promise.resolve(
   (async () => {
     const rawArgs = process.argv.slice(2);
     const [firstArg] = rawArgs;
-    if (firstArg === 'report-tool') {
+    if (firstArg === 'report-tool' || firstArg === 'analyze') {
       await runToolsCLI(
         {
           initTools: async () => undefined,
@@ -21,7 +22,7 @@ Promise.resolve(
         } as unknown as BaseMidsceneTools,
         'midscene',
         {
-          argv: rawArgs,
+          argv: normalizeReportCommandArgs(rawArgs),
           version,
           extraCommands: createReportCliCommands(),
         },

--- a/packages/cli/src/report-command.ts
+++ b/packages/cli/src/report-command.ts
@@ -1,0 +1,12 @@
+export function normalizeReportCommandArgs(rawArgs: string[]): string[] {
+  const [commandName, reportPath, ...restArgs] = rawArgs;
+  if (
+    commandName?.toLowerCase() !== 'analyze' ||
+    !reportPath ||
+    reportPath.startsWith('--')
+  ) {
+    return rawArgs;
+  }
+
+  return [commandName, '--htmlPath', reportPath, ...restArgs];
+}

--- a/packages/cli/tests/unit-test/report-command.test.ts
+++ b/packages/cli/tests/unit-test/report-command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeReportCommandArgs } from '../../src/report-command';
+
+describe('normalizeReportCommandArgs', () => {
+  it('maps the positional analyze report path to htmlPath', () => {
+    expect(
+      normalizeReportCommandArgs([
+        'analyze',
+        './report.html',
+        '--output-dir',
+        './actions',
+      ]),
+    ).toEqual([
+      'analyze',
+      '--htmlPath',
+      './report.html',
+      '--output-dir',
+      './actions',
+    ]);
+  });
+
+  it('preserves the explicit htmlPath form', () => {
+    expect(
+      normalizeReportCommandArgs(['analyze', '--htmlPath', './report.html']),
+    ).toEqual(['analyze', '--htmlPath', './report.html']);
+  });
+
+  it('does not change other commands', () => {
+    expect(
+      normalizeReportCommandArgs([
+        'report-tool',
+        '--htmlPath',
+        './report.html',
+      ]),
+    ).toEqual(['report-tool', '--htmlPath', './report.html']);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -617,6 +617,8 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       executions: [],
       modelBriefs: [],
       deviceType: this.interface.interfaceType,
+      manifestInterface:
+        this.interface.manifestInterface?.() ?? this.interface.interfaceType,
     });
     this.executionDumpIndexByRunner = new WeakMap<TaskRunner, number>();
 
@@ -736,6 +738,7 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
       sdkVersion: this.dump.sdkVersion,
       modelBriefs: this.dump.modelBriefs,
       deviceType: this.dump.deviceType,
+      manifestInterface: this.dump.manifestInterface,
     };
   }
 

--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -759,6 +759,19 @@ export class TaskBuilder {
           };
         }
 
+        if (currentCacheEntry && !hitBy?.context.cacheToSave) {
+          if (hitBy) {
+            hitBy.context.cacheToSave = currentCacheEntry;
+          } else {
+            hitBy = {
+              from: 'AI',
+              context: {
+                cacheToSave: currentCacheEntry,
+              },
+            };
+          }
+        }
+
         const promptDisplay = param.promptDisplay;
         const elementForAction = promptDisplay
           ? {

--- a/packages/core/src/dump/report-action-dump.ts
+++ b/packages/core/src/dump/report-action-dump.ts
@@ -160,8 +160,17 @@ export class ReportActionDump implements IReportActionDump {
   modelBriefs: IReportActionDump['modelBriefs'];
   executions: ExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 
   constructor(data: IReportActionDump) {
+    if (
+      typeof data.manifestInterface !== 'string' ||
+      !data.manifestInterface.trim()
+    ) {
+      throw new Error(
+        'ReportActionDump: manifestInterface must be a non-empty string',
+      );
+    }
     this.sdkVersion = data.sdkVersion;
     this.groupName = data.groupName;
     this.groupDescription = data.groupDescription;
@@ -170,6 +179,7 @@ export class ReportActionDump implements IReportActionDump {
       exec instanceof ExecutionDump ? exec : ExecutionDump.fromJSON(exec),
     );
     this.deviceType = data.deviceType;
+    this.manifestInterface = data.manifestInterface.trim();
   }
 
   /**
@@ -218,6 +228,7 @@ export class ReportActionDump implements IReportActionDump {
       modelBriefs: this.modelBriefs,
       executions: this.executions.map((exec) => exec.toJSON()),
       deviceType: this.deviceType,
+      manifestInterface: this.manifestInterface,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,6 +126,13 @@ export {
   type MergeReportFilesOptions,
   type MergeReportFilesResult,
 } from './report-cli';
+export {
+  analyzeReportActions,
+  type AnalyzeReportActionsOptions,
+  type AnalyzeReportActionsResult,
+  type UIActionDefinition,
+  type UIActionManifest,
+} from './report-analyzer';
 
 // ScreenshotItem
 export { ScreenshotItem } from './screenshot-item';

--- a/packages/core/src/report-analyzer.ts
+++ b/packages/core/src/report-analyzer.ts
@@ -1,0 +1,427 @@
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import {
+  type ExtraActionDefinition,
+  type ExtraActionManifest,
+  parseExtraActionManifest,
+} from './agent/extra-action-manifest';
+import {
+  type LocatorTarget,
+  LocatorTargetSchema,
+  xpathLocatorTarget,
+} from './locator';
+import { collectDedupedExecutions } from './report';
+import type { ExecutionTask } from './types';
+
+export type UIActionDefinition = ExtraActionDefinition;
+export type UIActionManifest = ExtraActionManifest;
+
+export interface AnalyzeReportActionsOptions {
+  htmlPath: string;
+  outputDir?: string;
+  overwrite?: boolean;
+}
+
+export interface AnalyzeReportActionsResult {
+  outputDir: string;
+  actionFiles: string[];
+  actionCount: number;
+  coordinateFallbackFiles: string[];
+  coordinateFallbackActionCount: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(
+    (value): value is string =>
+      typeof value === 'string' && value.trim().length > 0,
+  );
+}
+
+function firstTarget(value: unknown): LocatorTarget | undefined {
+  if (!isRecord(value) || !Array.isArray(value.targets)) return undefined;
+  for (const target of value.targets) {
+    const parsed = LocatorTargetSchema.safeParse(target);
+    if (parsed.success) return parsed.data;
+  }
+  return undefined;
+}
+
+function firstLegacyXpath(value: unknown): string | undefined {
+  if (!isRecord(value) || !Array.isArray(value.xpaths)) return undefined;
+  return firstNonEmptyString(...value.xpaths);
+}
+
+function targetFromValue(value: unknown): LocatorTarget | undefined {
+  const parsed = LocatorTargetSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function validLocatedPixelBbox(
+  value: unknown,
+): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === 'number' && Number.isFinite(item))
+  );
+}
+
+function isLocatedElement(value: unknown): value is Record<string, unknown> & {
+  description?: string;
+  rect: { left: number; top: number; width: number; height: number };
+} {
+  if (!isRecord(value) || !isRecord(value.rect)) return false;
+  const { left, top, width, height } = value.rect;
+  return [left, top, width, height].every(
+    (item) => typeof item === 'number' && Number.isFinite(item),
+  );
+}
+
+function locatorFromTask(
+  locateTask: ExecutionTask | undefined,
+  locatedElement: Record<string, unknown> & {
+    description?: string;
+    rect: { left: number; top: number; width: number; height: number };
+  },
+): {
+  value: Record<string, unknown>;
+  target?: LocatorTarget;
+  usedCoordinateFallback: boolean;
+} {
+  const sourceParam = isRecord(locateTask?.param) ? locateTask.param : {};
+  const hitContext = isRecord(locateTask?.hitBy?.context)
+    ? locateTask.hitBy.context
+    : {};
+  const prompt =
+    sourceParam.prompt ??
+    firstNonEmptyString(sourceParam.promptDisplay, locatedElement.description);
+  const attemptedTargetFailed =
+    typeof hitContext.targetResolutionError === 'string' &&
+    hitContext.targetResolutionError.trim().length > 0;
+  const target =
+    (!attemptedTargetFailed
+      ? (targetFromValue(sourceParam.target) ??
+        targetFromValue(hitContext.target))
+      : undefined) ??
+    firstTarget(hitContext.cacheToSave) ??
+    firstTarget(hitContext.cacheEntry);
+  const legacyXpath = firstNonEmptyString(
+    sourceParam.xpath,
+    hitContext.xpath,
+    firstLegacyXpath(hitContext.cacheToSave),
+    firstLegacyXpath(hitContext.cacheEntry),
+  );
+  const normalizedTarget =
+    target ?? (legacyXpath ? xpathLocatorTarget(legacyXpath) : undefined);
+
+  if (normalizedTarget) {
+    return {
+      value: {
+        ...(prompt !== undefined ? { prompt } : {}),
+        target: normalizedTarget,
+      },
+      target: normalizedTarget,
+      usedCoordinateFallback: false,
+    };
+  }
+
+  const sourceBbox = validLocatedPixelBbox(sourceParam.locatedPixelBbox)
+    ? sourceParam.locatedPixelBbox
+    : undefined;
+  const rectBbox: [number, number, number, number] = [
+    locatedElement.rect.left,
+    locatedElement.rect.top,
+    locatedElement.rect.left + locatedElement.rect.width,
+    locatedElement.rect.top + locatedElement.rect.height,
+  ];
+  return {
+    value: {
+      ...(prompt !== undefined ? { prompt } : {}),
+      locatedPixelBbox: sourceBbox ?? rectBbox,
+    },
+    usedCoordinateFallback: true,
+  };
+}
+
+function restoreStableLocators(
+  value: unknown,
+  locateTasks: ExecutionTask[],
+  locateIndex: { value: number },
+): {
+  value: unknown;
+  targets: LocatorTarget[];
+  usedCoordinateFallback: boolean;
+} {
+  if (isLocatedElement(value)) {
+    const result = locatorFromTask(locateTasks[locateIndex.value], value);
+    locateIndex.value += 1;
+    return {
+      value: result.value,
+      targets: result.target ? [result.target] : [],
+      usedCoordinateFallback: result.usedCoordinateFallback,
+    };
+  }
+  if (Array.isArray(value)) {
+    const restored = value.map((item) =>
+      restoreStableLocators(item, locateTasks, locateIndex),
+    );
+    return {
+      value: restored.map((item) => item.value),
+      targets: restored.flatMap((item) => item.targets),
+      usedCoordinateFallback: restored.some(
+        (item) => item.usedCoordinateFallback,
+      ),
+    };
+  }
+  if (isRecord(value)) {
+    const restored = Object.entries(value).map(
+      ([key, item]) =>
+        [key, restoreStableLocators(item, locateTasks, locateIndex)] as const,
+    );
+    return {
+      value: Object.fromEntries(
+        restored.map(([key, item]) => [key, item.value]),
+      ),
+      targets: restored.flatMap(([, item]) => item.targets),
+      usedCoordinateFallback: restored.some(
+        ([, item]) => item.usedCoordinateFallback,
+      ),
+    };
+  }
+  return { value, targets: [], usedCoordinateFallback: false };
+}
+
+function actionNameFromTask(
+  task: ExecutionTask,
+  plannedAction: Record<string, unknown> | undefined,
+  planLog: string | undefined,
+): string {
+  const actionName = task.subType || 'Action';
+  const extraActionName = isRecord(task.hitBy?.context)
+    ? firstNonEmptyString(task.hitBy.context.extraActionName)
+    : undefined;
+  if (task.hitBy?.from === 'Extra Action' && extraActionName) {
+    return extraActionName;
+  }
+  const planningDescription = firstNonEmptyString(
+    plannedAction?.thought,
+    planLog,
+  );
+  if (planningDescription) {
+    const sanitizedPlanningDescription = Array.from(planningDescription)
+      .map((character) => {
+        const codePoint = character.codePointAt(0);
+        const invalid =
+          character === '<' ||
+          character === '>' ||
+          codePoint === undefined ||
+          codePoint < 0x20 ||
+          (codePoint >= 0x7f && codePoint <= 0x9f) ||
+          codePoint === 0x2028 ||
+          codePoint === 0x2029;
+        return invalid ? ' ' : character;
+      })
+      .join('')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (
+      sanitizedPlanningDescription &&
+      sanitizedPlanningDescription.toLowerCase() !== actionName.toLowerCase()
+    ) {
+      return sanitizedPlanningDescription;
+    }
+  }
+  if (isRecord(task.param)) {
+    for (const value of Object.values(task.param)) {
+      if (isLocatedElement(value) && value.description) {
+        return `${actionName}: ${value.description}`;
+      }
+    }
+    const value = firstNonEmptyString(task.param.value);
+    if (value) return `${actionName}: ${value}`;
+  }
+  return `Replay ${actionName}`;
+}
+
+function extractUIActions(
+  executions: ReturnType<typeof collectDedupedExecutions>['executions'],
+): Array<{
+  definition: UIActionDefinition;
+  usedCoordinateFallback: boolean;
+}> {
+  const actions: Array<{
+    definition: UIActionDefinition;
+    usedCoordinateFallback: boolean;
+  }> = [];
+  const nameCounts = new Map<string, number>();
+
+  for (const execution of executions) {
+    let planLog: string | undefined;
+    let plannedActions: Record<string, unknown>[] = [];
+    let planActionCount = 0;
+    let pendingLocateTasks: ExecutionTask[] = [];
+    for (const task of execution.tasks) {
+      if (task.type === 'Planning' && task.subType === 'Plan') {
+        const planOutput = isRecord(task.output) ? task.output : {};
+        planLog = firstNonEmptyString(planOutput.log);
+        plannedActions = Array.isArray(planOutput.actions)
+          ? planOutput.actions.filter(isRecord)
+          : [];
+        planActionCount = plannedActions.length;
+        pendingLocateTasks = [];
+        continue;
+      }
+      if (task.type === 'Planning' && task.subType === 'Locate') {
+        if (task.status === 'finished') {
+          pendingLocateTasks.push(task);
+        }
+        continue;
+      }
+      if (task.type !== 'Action Space') continue;
+
+      if (task.subType === 'Finished') {
+        pendingLocateTasks = [];
+        continue;
+      }
+
+      const locateTasks = pendingLocateTasks;
+      pendingLocateTasks = [];
+      const plannedAction = plannedActions.shift();
+      const currentPlanLog = planActionCount <= 1 ? planLog : undefined;
+      if (task.status !== 'finished') continue;
+
+      const restored = restoreStableLocators(task.param, locateTasks, {
+        value: 0,
+      });
+      const baseName = actionNameFromTask(task, plannedAction, currentPlanLog);
+      const nameCount = (nameCounts.get(baseName) ?? 0) + 1;
+      nameCounts.set(baseName, nameCount);
+      actions.push({
+        definition: {
+          name: nameCount === 1 ? baseName : `${baseName} (${nameCount})`,
+          ...(restored.targets.length > 0
+            ? { validWhenTargetExists: restored.targets[0] }
+            : {}),
+          action: {
+            name: task.subType || 'Action',
+            ...(restored.value !== undefined && restored.value !== null
+              ? { param: restored.value }
+              : {}),
+          },
+        },
+        usedCoordinateFallback: restored.usedCoordinateFallback,
+      });
+    }
+  }
+  return actions;
+}
+
+function resolveReportHtmlPath(htmlPath: string): string {
+  const normalizedPath = path.resolve(htmlPath);
+  if (!existsSync(normalizedPath)) {
+    throw new Error(`analyzeReportActions: report does not exist: ${htmlPath}`);
+  }
+  const stats = statSync(normalizedPath);
+  if (!stats.isDirectory()) return normalizedPath;
+  const indexHtmlPath = path.join(normalizedPath, 'index.html');
+  if (!existsSync(indexHtmlPath)) {
+    throw new Error(
+      `analyzeReportActions: "${htmlPath}" is not an HTML report file, and no index.html was found under this directory.`,
+    );
+  }
+  return indexHtmlPath;
+}
+
+function reportBaseName(resolvedHtmlPath: string): string {
+  const baseName = path.basename(
+    resolvedHtmlPath,
+    path.extname(resolvedHtmlPath),
+  );
+  return baseName === 'index'
+    ? path.basename(path.dirname(resolvedHtmlPath))
+    : baseName;
+}
+
+function defaultAnalyzeOutputDir(resolvedHtmlPath: string): string {
+  const reportDir = path.dirname(resolvedHtmlPath);
+  const baseName = reportBaseName(resolvedHtmlPath);
+  return path.basename(resolvedHtmlPath, path.extname(resolvedHtmlPath)) ===
+    'index'
+    ? path.join(path.dirname(reportDir), `${baseName}-ui-actions`)
+    : path.join(reportDir, `${baseName}-ui-actions`);
+}
+
+export function analyzeReportActions(
+  options: AnalyzeReportActionsOptions,
+): AnalyzeReportActionsResult {
+  if (!options.htmlPath) {
+    throw new Error('analyzeReportActions: htmlPath is required');
+  }
+  const resolvedHtmlPath = resolveReportHtmlPath(options.htmlPath);
+  const outputDir = path.resolve(
+    options.outputDir ?? defaultAnalyzeOutputDir(resolvedHtmlPath),
+  );
+  const { executions, manifestInterfaces } =
+    collectDedupedExecutions(resolvedHtmlPath);
+  const normalizedManifestInterfaces = manifestInterfaces.map((value) =>
+    value.trim(),
+  );
+  const uniqueManifestInterfaces = new Set(normalizedManifestInterfaces);
+  const manifestInterface = Array.from(uniqueManifestInterfaces)[0];
+  if (
+    !manifestInterface ||
+    uniqueManifestInterfaces.size !== 1 ||
+    manifestInterface === 'mixed' ||
+    manifestInterface === 'unknown'
+  ) {
+    throw new Error(
+      `analyzeReportActions: every report dump with executions must declare the same canonical manifestInterface; received ${JSON.stringify(normalizedManifestInterfaces)}`,
+    );
+  }
+  const actions = extractUIActions(executions);
+  if (actions.length === 0) {
+    throw new Error(
+      `analyzeReportActions: no successful UI actions found in ${options.htmlPath}`,
+    );
+  }
+
+  const actionFile = path.join(
+    outputDir,
+    `${reportBaseName(resolvedHtmlPath)}.actions.yaml`,
+  );
+  if (existsSync(actionFile) && !options.overwrite) {
+    throw new Error(
+      `analyzeReportActions: output file already exists: ${actionFile}. Pass overwrite: true or --overwrite to replace the generated Action Manifest.`,
+    );
+  }
+  const manifest: UIActionManifest = {
+    version: 1,
+    interface: manifestInterface,
+    actions: actions.map((action) => action.definition),
+  };
+  const manifestYaml = yaml.dump(manifest, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
+  });
+  parseExtraActionManifest(manifestYaml, actionFile);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(actionFile, manifestYaml, 'utf-8');
+
+  const coordinateFallbackActionCount = actions.filter(
+    (action) => action.usedCoordinateFallback,
+  ).length;
+  return {
+    outputDir,
+    actionFiles: [actionFile],
+    actionCount: actions.length,
+    coordinateFallbackFiles:
+      coordinateFallbackActionCount > 0 ? [actionFile] : [],
+    coordinateFallbackActionCount,
+  };
+}

--- a/packages/core/src/report-cli.ts
+++ b/packages/core/src/report-cli.ts
@@ -15,6 +15,7 @@ import {
   collectDedupedExecutions,
   splitReportHtmlByExecution,
 } from './report';
+import { analyzeReportActions } from './report-analyzer';
 import { reportToMarkdown } from './report-markdown';
 import type { MarkdownAttachment } from './report-markdown';
 import type { ReportFileAttributes, TestStatus } from './types';
@@ -119,6 +120,7 @@ async function markdownFromReport(
     groupDescription: baseDump.groupDescription,
     modelBriefs: baseDump.modelBriefs,
     deviceType: baseDump.deviceType,
+    manifestInterface: baseDump.manifestInterface,
     executions,
   });
 
@@ -456,11 +458,73 @@ const reportCommandDefinition: ReportCliCommandDefinition = {
   },
 };
 
+const analyzeCommandDefinition: ReportCliCommandDefinition = {
+  name: 'analyze',
+  description:
+    'Extract successful UI actions from a Midscene HTML report into a reusable *.actions.yaml manifest.',
+  schema: {
+    htmlPath: z
+      .string()
+      .optional()
+      .describe(
+        'Input report HTML path. The CLI also accepts it positionally: midscene analyze report.html.',
+      ),
+    outputDir: z
+      .string()
+      .optional()
+      .describe(
+        'Output directory. Defaults to a sibling <report-name>-ui-actions directory.',
+      ),
+    overwrite: z
+      .union([z.boolean(), z.string()])
+      .optional()
+      .describe('Overwrite generated UI Action files that already exist.'),
+  },
+  handler: async (args) => {
+    const { htmlPath, outputDir, overwrite } = args as {
+      htmlPath?: string;
+      outputDir?: string;
+      overwrite?: unknown;
+    };
+    if (!htmlPath) {
+      throw new Error(
+        'analyze: report HTML path is required (e.g. midscene analyze report.html)',
+      );
+    }
+
+    const overwriteFlag =
+      overwrite === true || overwrite === 'true' || overwrite === '1';
+    const result = analyzeReportActions({
+      htmlPath,
+      outputDir,
+      overwrite: overwriteFlag,
+    });
+    const fallbackMessage =
+      result.coordinateFallbackActionCount > 0
+        ? ` ${result.coordinateFallbackActionCount} action(s) use locatedPixelBbox because no stable target was recorded.`
+        : '';
+
+    return {
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: `Analyzed ${result.actionCount} UI action(s) into ${result.actionFiles[0]}.${fallbackMessage}`,
+        },
+      ],
+    };
+  },
+};
+
 export function createReportCliCommands(): ReportCliCommandEntry[] {
   return [
     {
       name: 'report-tool',
       def: reportCommandDefinition,
+    },
+    {
+      name: 'analyze',
+      def: analyzeCommandDefinition,
     },
   ];
 }

--- a/packages/core/src/report-generator.ts
+++ b/packages/core/src/report-generator.ts
@@ -328,6 +328,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: reportMeta.groupDescription,
       modelBriefs: reportMeta.modelBriefs,
       deviceType: reportMeta.deviceType,
+      manifestInterface: reportMeta.manifestInterface,
       executions: [execution],
     });
   }
@@ -415,6 +416,7 @@ export class ReportGenerator implements IReportGenerator {
       groupDescription: this.lastReportMeta.groupDescription,
       modelBriefs: this.lastReportMeta.modelBriefs,
       deviceType: this.lastReportMeta.deviceType,
+      manifestInterface: this.lastReportMeta.manifestInterface,
       executions: Array.from(this.executionsByKey.values()),
     });
     await appendFileAsync(

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -181,12 +181,17 @@ function mergedAgentReportComment(reports: ReportActionDump[]): string {
   const deviceTypes = Array.from(
     new Set(reports.map((report) => report.deviceType).filter(Boolean)),
   );
+  const manifestInterfaces = Array.from(
+    new Set(reports.map((report) => report.manifestInterface)),
+  );
   const mergedReport = new ReportActionDump({
     sdkVersion: reports[0].sdkVersion || getVersion(),
     groupName: 'Merged Midscene Report',
     groupDescription: 'Agent-readable summary for merged report HTML',
     modelBriefs: reports.flatMap((report) => report.modelBriefs ?? []),
     deviceType: deviceTypes.length === 1 ? deviceTypes[0] : 'mixed',
+    manifestInterface:
+      manifestInterfaces.length === 1 ? manifestInterfaces[0] : 'mixed',
     executions: reports.flatMap((report) => report.executions ?? []),
   });
   return generateAgentReportComment(mergedReport);
@@ -201,6 +206,7 @@ export class ReportMergingTool {
       groupName,
       groupDescription,
       modelBriefs: [],
+      manifestInterface: 'unknown',
       executions: [],
     }).serialize();
   }
@@ -254,11 +260,17 @@ export class ReportMergingTool {
     // id are always kept (they may be distinct despite sharing the same name).
     const base = ReportActionDump.fromSerializedString(unescaped[0]);
     const allExecutions = [...base.executions];
+    const manifestInterfaces = new Set([base.manifestInterface]);
     for (let i = 1; i < unescaped.length; i++) {
       const other = ReportActionDump.fromSerializedString(unescaped[i]);
       allExecutions.push(...other.executions);
+      manifestInterfaces.add(other.manifestInterface);
     }
     base.executions = dedupeExecutionsKeepLatest(allExecutions);
+    base.manifestInterface =
+      manifestInterfaces.size === 1
+        ? Array.from(manifestInterfaces)[0]
+        : 'mixed';
     return base.serialize();
   }
 
@@ -486,6 +498,7 @@ export interface SplitReportHtmlResult {
 export interface CollectedReportExecutions {
   baseDump: ReportActionDump;
   executions: IExecutionDump[];
+  manifestInterfaces: string[];
 }
 
 /**
@@ -517,6 +530,7 @@ export function collectDedupedExecutions(
   });
 
   const executions: IExecutionDump[] = [];
+  const manifestInterfaces: string[] = [];
   executionSerial = 0;
   streamDumpScriptsSync(htmlPath, (dumpScript) => {
     if (!dumpScript.openTag.includes('data-group-id')) {
@@ -528,6 +542,9 @@ export function collectDedupedExecutions(
     );
     if (!baseDump) {
       baseDump = groupedDump;
+    }
+    if (groupedDump.executions.length > 0) {
+      manifestInterfaces.push(groupedDump.manifestInterface);
     }
 
     for (const execution of groupedDump.executions) {
@@ -551,6 +568,7 @@ export function collectDedupedExecutions(
   return {
     baseDump,
     executions,
+    manifestInterfaces,
   };
 }
 
@@ -645,6 +663,7 @@ export function splitReportHtmlByExecution(
       groupDescription: baseDump.groupDescription,
       modelBriefs: baseDump.modelBriefs,
       deviceType: baseDump.deviceType,
+      manifestInterface: baseDump.manifestInterface,
       executions: [execution],
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -808,6 +808,7 @@ export interface ReportMeta {
   sdkVersion: string;
   modelBriefs: ModelBrief[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.
@@ -823,6 +824,7 @@ export interface IReportActionDump {
   modelBriefs: ModelBrief[];
   executions: IExecutionDump[];
   deviceType?: string;
+  manifestInterface: string;
 }
 
 // Backward-compatible aliases for existing external consumers.

--- a/packages/core/tests/unit-test/bbox-locate-cache.test.ts
+++ b/packages/core/tests/unit-test/bbox-locate-cache.test.ts
@@ -207,6 +207,11 @@ describe('bbox locate cache fix', () => {
       expect(result).toBeDefined();
       expect(result!.output.element).toBeDefined();
       expect(result!.hitBy?.from).toBe('Plan');
+      expect(result!.hitBy?.context.cacheToSave).toEqual(
+        expect.objectContaining({
+          xpaths: ['/html/body/input[1]'],
+        }),
+      );
 
       // Verify cacheFeatureForPoint was called to write cache
       expect(mockInterface.cacheFeatureForPoint).toHaveBeenCalled();

--- a/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
+++ b/packages/core/tests/unit-test/dump-screenshot-sequence.test.ts
@@ -61,6 +61,7 @@ describe('dump serialization drops screenshotSequence', () => {
   it('omits screenshotSequence from serializeWithInlineScreenshots() (inline mode)', () => {
     const reportData: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'screenshot-sequence',
       modelBriefs: [],
       executions: [buildExecutionDumpData()],

--- a/packages/core/tests/unit-test/execution-dump.test.ts
+++ b/packages/core/tests/unit-test/execution-dump.test.ts
@@ -165,6 +165,7 @@ describe('ExecutionDump', () => {
 describe('ReportActionDump', () => {
   const createMockReportActionDumpData = (): IReportActionDump => ({
     sdkVersion: '1.0.0',
+    manifestInterface: 'web',
     groupName: 'Test Group',
     groupDescription: 'A test group description',
     modelBriefs: [{ name: 'model1' }, { name: 'model2' }],
@@ -213,6 +214,7 @@ describe('ReportActionDump', () => {
 
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Test',
         modelBriefs: [],
         executions: [executionDump],
@@ -225,6 +227,7 @@ describe('ReportActionDump', () => {
     it('should handle optional fields', () => {
       const data: IReportActionDump = {
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Minimal Group',
         modelBriefs: [],
         executions: [],
@@ -281,6 +284,7 @@ describe('ReportActionDump', () => {
 
       const dump = new ReportActionDump({
         sdkVersion: '1.0.0',
+        manifestInterface: 'web',
         groupName: 'Inline Screenshot Test',
         modelBriefs: [],
         executions: [
@@ -391,6 +395,7 @@ describe('ReportActionDump', () => {
     it('should handle complex nested structures', () => {
       const complexData: IReportActionDump = {
         sdkVersion: '2.0.0',
+        manifestInterface: 'web',
         groupName: 'Complex Group',
         groupDescription: 'A complex test',
         modelBriefs: [{ name: 'openai/gpt-4' }, { name: 'anthropic/claude' }],
@@ -450,6 +455,7 @@ describe('ExecutionDump and ReportActionDump integration', () => {
     // Create ReportActionDump with ExecutionDump instances
     const groupedDump = new ReportActionDump({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'Integration Test',
       modelBriefs: [],
       executions: [execution1, execution2],

--- a/packages/core/tests/unit-test/html-utils.test.ts
+++ b/packages/core/tests/unit-test/html-utils.test.ts
@@ -27,6 +27,7 @@ describe('html-utils', () => {
   it('generates a compact agent analysis comment for report HTML', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'checkout -- flow',
       modelBriefs: [
         {
@@ -63,6 +64,7 @@ describe('html-utils', () => {
   it('falls back agent comment model info to task usage', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage model report',
       modelBriefs: [],
       executions: [
@@ -96,6 +98,7 @@ describe('html-utils', () => {
   it('keeps agent analysis comments optional for incomplete execution dumps', () => {
     const comment = generateAgentReportComment({
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'incomplete report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/merge-browser-parse.test.ts
+++ b/packages/core/tests/unit-test/merge-browser-parse.test.ts
@@ -47,6 +47,7 @@ function createDump(screenshots: ScreenshotItem[]): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName: 'test-group',
     groupDescription: 'test desc',
     modelBriefs: [{ name: 'test-model' }],
@@ -88,6 +89,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,
@@ -130,6 +132,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
       const dump = createDump(screenshots);
       const groupMeta: ReportMeta = {
         sdkVersion: dump.sdkVersion,
+        manifestInterface: dump.manifestInterface,
         groupName: dump.groupName,
         groupDescription: dump.groupDescription,
         modelBriefs: dump.modelBriefs,
@@ -213,6 +216,7 @@ describe('browser parse simulation for merged directory-mode reports', () => {
     const dump = createDump([screenshot]);
     const groupMeta: ReportMeta = {
       sdkVersion: dump.sdkVersion,
+      manifestInterface: dump.manifestInterface,
       groupName: dump.groupName,
       groupDescription: dump.groupDescription,
       modelBriefs: dump.modelBriefs,

--- a/packages/core/tests/unit-test/report-cli.test.ts
+++ b/packages/core/tests/unit-test/report-cli.test.ts
@@ -8,9 +8,14 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCliArgs, runToolsCLI } from '@midscene/shared/cli';
+import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { loadExtraActions } from '../../src/agent/extra-actions';
+import { getMidsceneLocationSchema } from '../../src/ai-model';
 import { generateDumpScriptTag, generateImageScriptTag } from '../../src/dump';
 import type { ScreenshotRef } from '../../src/dump/screenshot-store';
+import { analyzeReportActions } from '../../src/report-analyzer';
 import {
   createReportCliCommands,
   mergeReportFiles,
@@ -59,6 +64,140 @@ function createExecution(
   });
 }
 
+function createActionExecution(options?: {
+  xpath?: string;
+  includeFailedAction?: boolean;
+  extraActionName?: string;
+}): ExecutionDump {
+  const locateHitBy = options?.xpath
+    ? {
+        from: 'Plan',
+        context: {
+          locatedPixelBbox: [10, 20, 110, 70],
+          cacheToSave: {
+            targets: [{ strategy: 'xpath', selector: options.xpath }],
+          },
+        },
+      }
+    : {
+        from: 'Plan',
+        context: {
+          locatedPixelBbox: [10, 20, 110, 70],
+        },
+      };
+
+  const tasks = [
+    {
+      taskId: 'plan-tap',
+      type: 'Planning',
+      subType: 'Plan',
+      param: {},
+      output: {
+        log: 'Click the confirm button',
+        actions: [
+          {
+            type: 'Tap',
+            thought: 'Click the confirm button',
+          },
+        ],
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'locate-confirm',
+      type: 'Planning',
+      subType: 'Locate',
+      param: {
+        prompt: 'Confirm button',
+        locatedPixelBbox: [10, 20, 110, 70],
+      },
+      hitBy: locateHitBy,
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'tap-confirm',
+      type: 'Action Space',
+      subType: 'Tap',
+      param: {
+        locate: {
+          description: 'Confirm button',
+          rect: { left: 10, top: 20, width: 100, height: 50 },
+          center: [60, 45],
+        },
+      },
+      ...(options?.extraActionName
+        ? {
+            hitBy: {
+              from: 'Extra Action',
+              context: {
+                extraActionName: options.extraActionName,
+                extraActionAlias: 'MidsceneExtraAction_1',
+              },
+            },
+          }
+        : {}),
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'plan-input',
+      type: 'Planning',
+      subType: 'Plan',
+      param: {},
+      output: {
+        log: 'Type the saved value',
+        actions: [
+          {
+            type: 'Input',
+            thought: 'Type the saved value',
+          },
+        ],
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    {
+      taskId: 'input-value',
+      type: 'Action Space',
+      subType: 'Input',
+      param: {
+        value: 'saved value',
+      },
+      executor: async () => undefined,
+      status: 'finished',
+    },
+    ...(options?.includeFailedAction
+      ? [
+          {
+            taskId: 'failed-tap',
+            type: 'Action Space',
+            subType: 'Tap',
+            param: {},
+            executor: async () => undefined,
+            status: 'failed',
+          },
+        ]
+      : []),
+    {
+      taskId: 'finished-marker',
+      type: 'Action Space',
+      subType: 'Finished',
+      param: null,
+      executor: async () => undefined,
+      status: 'finished',
+    },
+  ];
+
+  return new ExecutionDump({
+    id: 'action-execution',
+    logTime: Date.now(),
+    name: 'action execution',
+    tasks: tasks as any,
+  });
+}
+
 describe('createReportCliCommands', () => {
   let tmpDir: string;
 
@@ -73,10 +212,648 @@ describe('createReportCliCommands', () => {
     }
   });
 
-  it('exposes report-tool as the only generic report command', () => {
-    const [command] = createReportCliCommands();
-    expect(command.name).toBe('report-tool');
-    expect('aliases' in command).toBe(false);
+  it('exposes report-tool and analyze as generic report commands', () => {
+    const commands = createReportCliCommands();
+    expect(commands.map((command) => command.name)).toEqual([
+      'report-tool',
+      'analyze',
+    ]);
+    expect(commands.every((command) => !('aliases' in command))).toBe(true);
+  });
+
+  it('exports successful device operations into one loadable Action Manifest', async () => {
+    const reportPath = join(tmpDir, 'action-report.html');
+    const report = new ReportActionDump({
+      groupName: 'action-export',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [
+        createActionExecution({
+          xpath: '/html/body/button[1]',
+          includeFailedAction: true,
+        }),
+      ],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'action-export',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+
+    expect(result.actionFiles.map((file) => file.split('/').pop())).toEqual([
+      'action-report.actions.yaml',
+    ]);
+    expect(result.actionCount).toBe(2);
+    expect(result.coordinateFallbackFiles).toEqual([]);
+    expect(yaml.load(readFileSync(result.actionFiles[0], 'utf-8'))).toEqual({
+      version: 1,
+      interface: 'web',
+      actions: [
+        {
+          name: 'Click the confirm button',
+          validWhenTargetExists: {
+            strategy: 'xpath',
+            selector: '/html/body/button[1]',
+          },
+          action: {
+            name: 'Tap',
+            param: {
+              locate: {
+                prompt: 'Confirm button',
+                target: {
+                  strategy: 'xpath',
+                  selector: '/html/body/button[1]',
+                },
+              },
+            },
+          },
+        },
+        {
+          name: 'Type the saved value',
+          action: {
+            name: 'Input',
+            param: { value: 'saved value' },
+          },
+        },
+      ],
+    });
+
+    const loaded = await loadExtraActions(result.actionFiles, [
+      {
+        name: 'Tap',
+        description: 'Tap an element',
+        paramSchema: z.object({
+          locate: getMidsceneLocationSchema(),
+        }),
+        call: async () => undefined,
+      },
+      {
+        name: 'Input',
+        description: 'Input text',
+        paramSchema: z.object({
+          value: z.string(),
+        }),
+        call: async () => undefined,
+      },
+    ]);
+    expect(loaded.map((action) => action.plan)).toEqual([
+      expect.objectContaining({
+        type: 'Tap',
+        param: {
+          locate: {
+            prompt: 'Confirm button',
+            target: {
+              strategy: 'xpath',
+              selector: '/html/body/button[1]',
+            },
+          },
+        },
+      }),
+      expect.objectContaining({
+        type: 'Input',
+        param: { value: 'saved value' },
+      }),
+    ]);
+  });
+
+  it('requires a canonical manifest interface instead of inferring one from deviceType', () => {
+    const reportPath = join(tmpDir, 'missing-manifest-interface.html');
+    const report = new ReportActionDump({
+      groupName: 'missing-manifest-interface',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'puppeteer',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button' })],
+    });
+    const reportWithoutManifestInterface = {
+      ...JSON.parse(report.serialize()),
+      manifestInterface: undefined,
+    };
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(JSON.stringify(reportWithoutManifestInterface), {
+        'data-group-id': 'missing-manifest-interface',
+      }),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'manifestInterface must be a non-empty string',
+    );
+  });
+
+  it('rejects reports that combine executions from different manifest interfaces', () => {
+    const reportPath = join(tmpDir, 'mixed-manifest-interfaces.html');
+    const webReport = new ReportActionDump({
+      groupName: 'web-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="web"]' })],
+    });
+    const androidReport = new ReportActionDump({
+      groupName: 'android-actions',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'android',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button[@id="android"]' })],
+    });
+    writeFileSync(
+      reportPath,
+      [
+        generateDumpScriptTag(webReport.serialize(), {
+          'data-group-id': 'web-actions',
+        }),
+        generateDumpScriptTag(androidReport.serialize(), {
+          'data-group-id': 'android-actions',
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'received ["web","android"]',
+    );
+  });
+
+  it('does not pair a failed locate from an earlier plan with a recovered action', () => {
+    const reportPath = join(tmpDir, 'recovered-locate.html');
+    const execution = new ExecutionDump({
+      id: 'recovered-locate',
+      logTime: Date.now(),
+      name: 'recovered locate',
+      tasks: [
+        {
+          taskId: 'wrong-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Try the wrong button',
+            actions: [{ type: 'Tap', thought: 'Try the wrong button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'wrong-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Wrong button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="wrong"]',
+            },
+          },
+          status: 'failed',
+        },
+        {
+          taskId: 'recovery-plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Click the correct button',
+            actions: [{ type: 'Tap', thought: 'Click the correct button' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Correct button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'correct-action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Correct button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'recovered-locate',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'recovered-locate',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions).toHaveLength(1);
+    expect(manifest.actions[0]).toMatchObject({
+      name: 'Click the correct button',
+      validWhenTargetExists: {
+        strategy: 'xpath',
+        selector: '//button[@id="correct"]',
+      },
+      action: {
+        param: {
+          locate: {
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="correct"]',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('exports the fallback target after a supplied target fails to resolve', () => {
+    const reportPath = join(tmpDir, 'target-fallback.html');
+    const failedTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="missing"]',
+    };
+    const fallbackTarget = {
+      strategy: 'xpath' as const,
+      selector: '//button[@id="actual"]',
+    };
+    const execution = new ExecutionDump({
+      id: 'target-fallback',
+      logTime: Date.now(),
+      name: 'target fallback',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [
+              { type: 'Tap', thought: 'Click the actual fallback button' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Actual fallback button',
+            target: failedTarget,
+          },
+          hitBy: {
+            from: 'AI',
+            context: {
+              target: failedTarget,
+              targetResolutionError: 'XPath target does not exist',
+              cacheToSave: { targets: [fallbackTarget] },
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'action',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: {
+            locate: {
+              description: 'Actual fallback button',
+              rect: { left: 10, top: 20, width: 100, height: 50 },
+              center: [60, 45],
+            },
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'target-fallback',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'target-fallback',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: fallbackTarget,
+      action: {
+        param: {
+          locate: {
+            target: fallbackTarget,
+          },
+        },
+      },
+    });
+  });
+
+  it('uses each planned action thought when one plan contains multiple actions', () => {
+    const reportPath = join(tmpDir, 'multi-action-plan.html');
+    const locatedElement = (description: string) => ({
+      description,
+      rect: { left: 10, top: 20, width: 100, height: 50 },
+      center: [60, 45],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-action-plan',
+      logTime: Date.now(),
+      name: 'multi action plan',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            log: 'Complete both operations',
+            actions: [
+              { type: 'Tap', thought: 'Click the primary button' },
+              { type: 'Input', thought: 'Enter the saved value' },
+            ],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-primary',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Primary button',
+            target: {
+              strategy: 'xpath',
+              selector: '//button[@id="primary"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'tap-primary',
+          type: 'Action Space',
+          subType: 'Tap',
+          param: { locate: locatedElement('Primary button') },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-input',
+          type: 'Planning',
+          subType: 'Locate',
+          param: {
+            prompt: 'Saved value input',
+            target: {
+              strategy: 'xpath',
+              selector: '//input[@id="saved"]',
+            },
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'input-value',
+          type: 'Action Space',
+          subType: 'Input',
+          param: {
+            value: 'saved value',
+            locate: locatedElement('Saved value input'),
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-action-plan',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-action-plan',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions.map((action: any) => action.name)).toEqual([
+      'Click the primary button',
+      'Enter the saved value',
+    ]);
+  });
+
+  it('uses the first of multiple action targets as the disclosure condition', () => {
+    const reportPath = join(tmpDir, 'multi-target-swipe.html');
+    const startTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-handle"]',
+    };
+    const endTarget = {
+      strategy: 'xpath' as const,
+      selector: '//div[@id="slider-end"]',
+    };
+    const locatedElement = (description: string, left: number) => ({
+      description,
+      rect: { left, top: 20, width: 20, height: 20 },
+      center: [left + 10, 30],
+    });
+    const execution = new ExecutionDump({
+      id: 'multi-target-swipe',
+      logTime: Date.now(),
+      name: 'multi target swipe',
+      tasks: [
+        {
+          taskId: 'plan',
+          type: 'Planning',
+          subType: 'Plan',
+          param: {},
+          output: {
+            actions: [{ type: 'Swipe', thought: 'Move the slider to the end' }],
+          },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-start',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider handle', target: startTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'locate-end',
+          type: 'Planning',
+          subType: 'Locate',
+          param: { prompt: 'Slider end', target: endTarget },
+          status: 'finished',
+        },
+        {
+          taskId: 'swipe',
+          type: 'Action Space',
+          subType: 'Swipe',
+          param: {
+            start: locatedElement('Slider handle', 10),
+            end: locatedElement('Slider end', 200),
+            duration: 300,
+          },
+          status: 'finished',
+        },
+      ] as any,
+    });
+    const report = new ReportActionDump({
+      groupName: 'multi-target-swipe',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [execution],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'multi-target-swipe',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0]).toMatchObject({
+      validWhenTargetExists: startTarget,
+      action: {
+        name: 'Swipe',
+        param: {
+          start: { target: startTarget },
+          end: { target: endTarget },
+          duration: 300,
+        },
+      },
+    });
+  });
+
+  it('preserves the recorded Extra Action name when exporting a replay report', () => {
+    const reportPath = join(tmpDir, 'replayed-extra-action.html');
+    const report = new ReportActionDump({
+      groupName: 'replayed-extra-action',
+      sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [
+        createActionExecution({
+          xpath: '//button',
+          extraActionName: 'Recorded checkout confirmation',
+        }),
+      ],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'replayed-extra-action',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+    expect(manifest.actions[0].name).toBe('Recorded checkout confirmation');
+  });
+
+  it('falls back to locatedPixelBbox for reports without a recorded xpath', () => {
+    const reportPath = join(tmpDir, 'historical-report.html');
+    const report = new ReportActionDump({
+      groupName: 'historical-action-export',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution()],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'historical-action-export',
+      }),
+      'utf-8',
+    );
+
+    const result = analyzeReportActions({ htmlPath: reportPath });
+    const manifest = yaml.load(
+      readFileSync(result.actionFiles[0], 'utf-8'),
+    ) as any;
+
+    expect(result.coordinateFallbackFiles).toEqual([result.actionFiles[0]]);
+    expect(result.coordinateFallbackActionCount).toBe(1);
+    expect(manifest.actions[0].action.param.locate).toEqual({
+      prompt: 'Confirm button',
+      locatedPixelBbox: [10, 20, 110, 70],
+    });
+  });
+
+  it('does not overwrite generated UI Actions unless requested', () => {
+    const reportPath = join(tmpDir, 'overwrite-report.html');
+    const report = new ReportActionDump({
+      groupName: 'overwrite-action-export',
+      sdkVersion: '1.0.0-test',
+      deviceType: 'web',
+      manifestInterface: 'web',
+      modelBriefs: [],
+      executions: [createActionExecution({ xpath: '//button' })],
+    });
+    writeFileSync(
+      reportPath,
+      generateDumpScriptTag(report.serialize(), {
+        'data-group-id': 'overwrite-action-export',
+      }),
+      'utf-8',
+    );
+
+    const first = analyzeReportActions({ htmlPath: reportPath });
+    expect(() => analyzeReportActions({ htmlPath: reportPath })).toThrow(
+      'output file already exists',
+    );
+    expect(() =>
+      analyzeReportActions({ htmlPath: reportPath, overwrite: true }),
+    ).not.toThrow();
+    expect(existsSync(first.actionFiles[0])).toBe(true);
   });
 
   it('runs report split through the generic report command', async () => {
@@ -89,6 +866,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -96,6 +874,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -140,6 +919,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-test',
       groupDescription: 'sdk split test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-1', screenshot)],
     });
@@ -203,6 +983,7 @@ describe('createReportCliCommands', () => {
       groupName: 'sdk-markdown-test',
       groupDescription: 'sdk markdown test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-sdk-md-1', screenshot)],
     });
@@ -275,6 +1056,7 @@ describe('createReportCliCommands', () => {
       groupName: 'split-dir-test',
       groupDescription: 'split-dir-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-dir-1', screenshot)],
     });
@@ -339,6 +1121,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-1', screenshot1)],
     });
@@ -346,6 +1129,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-test',
       groupDescription: 'markdown export test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-2', screenshot2)],
     });
@@ -389,6 +1173,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', oldScreenshot)],
     });
@@ -396,6 +1181,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-dedup-test',
       groupDescription: 'markdown export dedup test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-dedup', newScreenshot)],
     });
@@ -446,6 +1232,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-file-test',
       groupDescription: 'markdown export file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-file', screenshotRef)],
     });
@@ -508,6 +1295,7 @@ describe('createReportCliCommands', () => {
       groupName: 'markdown-rel-file-test',
       groupDescription: 'markdown export relative file ref test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-md-rel', screenshotRef)],
     });
@@ -558,6 +1346,7 @@ describe('createReportCliCommands', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution(executionId, screenshot)],
     });

--- a/packages/core/tests/unit-test/report-generator.test.ts
+++ b/packages/core/tests/unit-test/report-generator.test.ts
@@ -40,6 +40,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 

--- a/packages/core/tests/unit-test/report-issues.test.ts
+++ b/packages/core/tests/unit-test/report-issues.test.ts
@@ -64,6 +64,7 @@ const defaultReportMeta: ReportMeta = {
   groupName: 'test-group',
   groupDescription: 'test',
   sdkVersion: '1.0.0-test',
+  manifestInterface: 'web',
   modelBriefs: [],
 };
 
@@ -98,6 +99,7 @@ describe('Issue 2: default groupName causes unrelated reports to merge', () => {
     const sameReportMeta: ReportMeta = {
       groupName: 'Midscene Report', // default groupName
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 
@@ -146,6 +148,7 @@ describe('Issue 3: execution persistence requires id', () => {
     const groupMeta: ReportMeta = {
       groupName: 'dedup-test',
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       modelBriefs: [],
     };
 

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -88,6 +88,7 @@ describe('report-markdown', () => {
   it('merges all executions into one markdown and keeps file snapshot', async () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'report-group',
       modelBriefs: [],
       executions: [
@@ -249,6 +250,7 @@ describe('report-markdown', () => {
   it('includes model metadata, token usage, and task context for agent analysis', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'agent-ready-report',
       modelBriefs: [
         {
@@ -331,6 +333,7 @@ describe('report-markdown', () => {
   it('falls back report model info to task usage when model briefs are missing', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
+      manifestInterface: 'web',
       groupName: 'usage-model-report',
       modelBriefs: [],
       executions: [

--- a/packages/core/tests/unit-test/report-merge-count.test.ts
+++ b/packages/core/tests/unit-test/report-merge-count.test.ts
@@ -42,6 +42,7 @@ async function writeAndFinalize(
     groupName: dump.groupName,
     groupDescription: dump.groupDescription,
     sdkVersion: dump.sdkVersion,
+    manifestInterface: dump.manifestInterface,
     modelBriefs: dump.modelBriefs,
     deviceType: dump.deviceType,
   };
@@ -69,6 +70,7 @@ function createDump(groupName: string, taskCount: number): ReportActionDump {
 
   return new ReportActionDump({
     sdkVersion: '1.0.0-test',
+    manifestInterface: 'web',
     groupName,
     groupDescription: `desc of ${groupName}`,
     modelBriefs: [{ name: 'test-model' }],
@@ -404,6 +406,7 @@ describe('ReportMergingTool merged dump count verification', () => {
       const groupMeta: ReportMeta = {
         groupName: `multi-group-${i}`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [{ name: 'test-model' }],
       };
       for (let e = 0; e < execsPerReport; e++) {

--- a/packages/core/tests/unit-test/report-merge-status.test.ts
+++ b/packages/core/tests/unit-test/report-merge-status.test.ts
@@ -109,6 +109,7 @@ describe('mergeReportFiles status derivation', () => {
       groupName,
       groupDescription: `${groupName}-desc`,
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [execution],
     });
@@ -186,6 +187,7 @@ describe('mergeReportFiles status derivation', () => {
         groupName,
         groupDescription: `${groupName}-desc`,
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [exec],
       });

--- a/packages/core/tests/unit-test/report-split.test.ts
+++ b/packages/core/tests/unit-test/report-split.test.ts
@@ -77,6 +77,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshot1)],
     });
@@ -84,6 +85,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'split-test',
       groupDescription: 'split-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-2', screenshot2)],
     });
@@ -144,6 +146,7 @@ describe('splitReportHtmlByExecution', () => {
         groupName: 'large-split-test',
         groupDescription: 'large-split-test',
         sdkVersion: '1.0.0-test',
+        manifestInterface: 'web',
         modelBriefs: [],
         executions: [createExecution(`exec-${i}`, sharedScreenshot)],
       });
@@ -174,6 +177,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', oldScreenshot)],
     });
@@ -181,6 +185,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'dedup-test',
       groupDescription: 'dedup-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', newScreenshot)],
     });
@@ -234,6 +239,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'absolute-path-test',
       groupDescription: 'absolute-path-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-1', screenshotRef)],
     });
@@ -280,6 +286,7 @@ describe('splitReportHtmlByExecution', () => {
       groupName: 'fallback-test',
       groupDescription: 'fallback-test',
       sdkVersion: '1.0.0-test',
+      manifestInterface: 'web',
       modelBriefs: [],
       executions: [createExecution('exec-fallback', screenshotRef)],
     });

--- a/packages/ios/tests/unit-test/agent.test.ts
+++ b/packages/ios/tests/unit-test/agent.test.ts
@@ -44,6 +44,7 @@ describe('IOSAgent', () => {
 
     // Create a mock device with actionSpace
     mockDevice = {
+      interfaceType: 'ios',
       connect: vi.fn().mockResolvedValue(undefined),
       launch: vi.fn().mockResolvedValue(undefined),
       terminate: vi.fn().mockResolvedValue(undefined),
@@ -197,6 +198,7 @@ describe('IOSAgent', () => {
       MockedIOSDevice.mockImplementationOnce(
         () =>
           ({
+            interfaceType: 'ios',
             connect: connectSpy,
             actionSpace: vi.fn().mockReturnValue([]),
             setAppNameMapping: vi.fn(),
@@ -219,6 +221,7 @@ describe('IOSAgent', () => {
         moduleName,
         () => ({
           IOSDevice: class {
+            interfaceType = 'ios';
             connect = connectSpy;
             actionSpace = actionSpaceSpy;
             setAppNameMapping = setAppNameMappingSpy;
@@ -247,6 +250,7 @@ describe('IOSAgent', () => {
         moduleName,
         () => ({
           default: class {
+            interfaceType = 'ios';
             connect = connectSpy;
             actionSpace = actionSpaceSpy;
             setAppNameMapping = setAppNameMappingSpy;

--- a/packages/playground/tests/unit/local-execution-adapter.test.ts
+++ b/packages/playground/tests/unit/local-execution-adapter.test.ts
@@ -41,7 +41,9 @@ describe('LocalExecutionAdapter', () => {
       destroy: rs.fn(),
       dumpDataString: rs
         .fn()
-        .mockReturnValue(JSON.stringify({ executions: [{}] })),
+        .mockReturnValue(
+          JSON.stringify({ executions: [{}], manifestInterface: 'web' }),
+        ),
       reportHTMLString: rs.fn().mockReturnValue(''),
       writeOutActionDumps: rs.fn(),
       resetDump: rs.fn(),

--- a/packages/playground/tests/unit/playground.test.ts
+++ b/packages/playground/tests/unit/playground.test.ts
@@ -61,7 +61,8 @@ describe('Playground Integration Tests', () => {
         aiQuery: async (prompt: string, options?: any) => {
           return { result: `Query result for: ${prompt}`, options };
         },
-        dumpDataString: () => JSON.stringify({ executions: [{}] }),
+        dumpDataString: () =>
+          JSON.stringify({ executions: [{}], manifestInterface: 'web' }),
         reportHTMLString: () => '',
         writeOutActionDumps: () => {},
         resetDump: () => {},
@@ -218,7 +219,8 @@ describe('Playground Integration Tests', () => {
         aiQuery: async (prompt: string, options?: any) => {
           return { result: `Query result for: ${prompt}`, options };
         },
-        dumpDataString: () => JSON.stringify({ executions: [{}] }),
+        dumpDataString: () =>
+          JSON.stringify({ executions: [{}], manifestInterface: 'web' }),
         reportHTMLString: () => '',
         writeOutActionDumps: () => {},
         resetDump: () => {},

--- a/packages/visualizer/src/hooks/usePlaygroundExecution.ts
+++ b/packages/visualizer/src/hooks/usePlaygroundExecution.ts
@@ -68,6 +68,19 @@ function buildProgressContent(task: any): string {
   return description ? `${action} - ${description}` : action;
 }
 
+const manifestInterfaceForDeviceType = (deviceType?: string): string => {
+  if (!deviceType) return 'unknown';
+  return [
+    'web',
+    'puppeteer',
+    'playwright',
+    'chrome-extension-proxy',
+    'static',
+  ].includes(deviceType)
+    ? 'web'
+    : deviceType;
+};
+
 /**
  * Convert ExecutionDump to ReportActionDump for replay scripts
  * @param dump - The execution dump containing tasks and their usage information
@@ -85,6 +98,7 @@ function wrapExecutionDumpForReplay(
     modelBriefs: [],
     executions: [dump],
     deviceType,
+    manifestInterface: manifestInterfaceForDeviceType(deviceType),
   };
 }
 

--- a/packages/visualizer/src/utils/replay-scripts.ts
+++ b/packages/visualizer/src/utils/replay-scripts.ts
@@ -207,6 +207,7 @@ const normalizeDump = (dump: DumpInput): IReportActionDump | null => {
         groupName: 'Execution',
         modelBriefs: [],
         executions: [dump as ExecutionDump],
+        manifestInterface: 'unknown',
       };
 };
 

--- a/packages/web-integration/tests/unit-test/agent.test.ts
+++ b/packages/web-integration/tests/unit-test/agent.test.ts
@@ -212,6 +212,7 @@ describe('PageAgent reportFileName', () => {
     const mockPageWithoutType = {
       ...mockPage,
       interfaceType: undefined,
+      manifestInterface: () => 'web',
     } as unknown as AbstractWebPage;
 
     const agent = new PageAgent(mockPageWithoutType, {


### PR DESCRIPTION
## Summary

- add `midscene analyze report.html` and the `analyzeReportActions` API
- export successful device operations into one loadable `*.actions.yaml` Manifest
- persist the canonical manifest interface in report dumps and reject mixed-interface exports
- restore recorded targets from report/cache metadata, preserve multi-target Actions such as Swipe, and retain rectangle fallback data when no stable target exists
- show `Extra Target` and `Extra Action` provenance tags in the report timeline, with structured source, name, alias, and target details
- document CLI and SDK usage in English and Chinese

## Scope

This is PR 3 of 3 and is reviewed relative to the Action Manifest runtime PR. It contains report export, the report metadata needed to make exported manifests platform-safe, and report UI provenance for Extra Action execution.

## Validation

- `pnpm run lint`
- `npx nx run-many -t test -p @midscene/core @midscene/cli @midscene/report @midscene/visualizer @midscene/ios --skip-nx-cache`
- `npx nx run-many -t build -p @midscene/core @midscene/cli @midscene/report @midscene/visualizer --skip-nx-cache`
- `AI_TEST_TYPE=web pnpm --filter @midscene/web exec vitest --run tests/ai/web/puppeteer/parameter-validation.test.ts tests/ai/web/puppeteer/open-new-tab.test.ts` (6 passed)
- generated real Midscene reports and verified the `Extra Target` / `Extra Action` provenance tags plus structured target details
- reran 12 real-model `aiAct` cases with the latest main branch and `effort: 'fast'` (12/12 business assertions passed)

## Evidence

- [Fast-mode overview and raw evidence](https://midscene-fast-extra-action-four-groups-20260818.gf-preview.bytedance.net/)
- [Qwen 3.7 Flash raw Midscene reports](https://midscene-fast-extra-action-reports-flash-20260818.gf-preview.bytedance.net/)
- [Qwen 3.7 Plus raw Midscene reports](https://midscene-fast-extra-action-reports-plus-20260818.gf-preview.bytedance.net/)

## Stack

1. Target resolution foundation
2. Action Manifest runtime
3. **This PR:** report-to-Action-Manifest export and report provenance
