### PR TITLE
fix(android): clear Android and Harmony inputs with select all

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -70,6 +70,12 @@ const defaultNormalScrollDuration = 1000;
 
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
+const androidKeyCombinationMinApiLevel = 31;
+const androidKeyCodes = {
+  ctrlLeft: 113,
+  a: 29,
+  forwardDelete: 112,
+} as const;
 const SCREENSHOT_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const SCREENSHOT_STRATEGY_AUTO = 'auto' as const;
 type ScrollDirection = 'up' | 'down' | 'left' | 'right';
@@ -1595,11 +1601,50 @@ ${Object.keys(size)
     }
 
     const adb = await this.getAdb();
+
+    if (!(await this.tryClearInputWithKeyCombination(adb))) {
+      await this.clearInputForLegacyAndroid(adb);
+    }
+
+    if (await adb.isSoftKeyboardPresent()) {
+      return;
+    }
+
+    if (element) {
+      await this.tapPoint({ x: element.center[0], y: element.center[1] });
+    }
+  }
+
+  private async tryClearInputWithKeyCombination(adb: ADB): Promise<boolean> {
+    if ((await adb.getApiLevel()) < androidKeyCombinationMinApiLevel) {
+      return false;
+    }
+
+    try {
+      // Android 12 added the shell `input keycombination` command. Select all
+      // before deleting so clearing is independent of the current cursor
+      // position. Forward Delete is intentional: some OEM input fields
+      // collapse the selection and remove only one character for KEYCODE_DEL.
+      await this.shellInputKeyCombination(
+        androidKeyCodes.ctrlLeft,
+        androidKeyCodes.a,
+      );
+      await this.shellInputKeyevent(androidKeyCodes.forwardDelete);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnDevice(
+        `Android select-all clear failed; falling back to legacy deletion: ${message}`,
+      );
+      return false;
+    }
+  }
+
+  private async clearInputForLegacyAndroid(adb: ADB): Promise<void> {
     const isNonDefaultDisplay =
       typeof this.options?.displayId === 'number' &&
       this.options.displayId !== 0;
-
-    const IME_STRATEGY =
+    const imeStrategy =
       (this.options?.imeStrategy ||
         globalConfigManager.getEnvConfigValue(MIDSCENE_ANDROID_IME_STRATEGY)) ??
       IME_STRATEGY_YADB_FOR_NON_ASCII;
@@ -1613,7 +1658,7 @@ ${Object.keys(size)
         keys.push(67, 112); // KEYCODE_DEL, KEYCODE_FORWARD_DEL
       }
       await this.shellInputKeyevent(...keys);
-    } else if (IME_STRATEGY === IME_STRATEGY_YADB_FOR_NON_ASCII) {
+    } else if (imeStrategy === IME_STRATEGY_YADB_FOR_NON_ASCII) {
       // For yadb-for-non-ascii mode, use batch deletion of up to 100 characters
       // clearTextField() batches all key events into a single shell command for better performance
       await this.ensureYadb();
@@ -1625,14 +1670,6 @@ ${Object.keys(size)
         // `app_process` (ART launcher) does not accept the `-d <displayId>` flag.
         'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboardClear',
       );
-    }
-
-    if (await adb.isSoftKeyboardPresent()) {
-      return;
-    }
-
-    if (element) {
-      await this.tapPoint({ x: element.center[0], y: element.center[1] });
     }
   }
 
@@ -2442,6 +2479,18 @@ ${Object.keys(size)
     const adb = await this.getAdb();
     await adb.shell(
       `input${this.getDisplayArg()} keyevent ${keyCodes.join(' ')}`,
+    );
+  }
+
+  /**
+   * Send a simultaneous Android key combination through the display-aware
+   * shell input primitive. The command is available on Android 12 / API 31+
+   * and callers must guard older platform versions.
+   */
+  private async shellInputKeyCombination(...keyCodes: number[]): Promise<void> {
+    const adb = await this.getAdb();
+    await adb.shell(
+      `input${this.getDisplayArg()} keycombination ${keyCodes.join(' ')}`,
     );
   }
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -2489,9 +2489,18 @@ ${Object.keys(size)
    */
   private async shellInputKeyCombination(...keyCodes: number[]): Promise<void> {
     const adb = await this.getAdb();
-    await adb.shell(
-      `input${this.getDisplayArg()} keycombination ${keyCodes.join(' ')}`,
-    );
+    const command = `input${this.getDisplayArg()} keycombination ${keyCodes.join(' ')}`;
+    const stdout = await runAdbShellStdoutOrThrow(adb, command);
+
+    // Android's input shell command can print errors such as
+    // "Unknown command: keycombination" while still exiting successfully.
+    // A successful keycombination is silent, so any output means the command
+    // was not reliably applied and the caller must use the legacy fallback.
+    if (stdout.trim()) {
+      throw new Error(
+        `Android keycombination command returned unexpected output: ${stdout.trim()}`,
+      );
+    }
   }
 
   /**

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -40,6 +40,7 @@ const createMockAdb = () => ({
   hideKeyboard: vi.fn(),
   push: vi.fn(),
   isSoftKeyboardPresent: vi.fn().mockResolvedValue(false),
+  getApiLevel: vi.fn().mockResolvedValue(35),
 });
 
 let mockAdbInstance: ReturnType<typeof createMockAdb>;
@@ -1870,6 +1871,93 @@ Stdout:
     it('press should call keyevent for mapped keys', async () => {
       await device.inputPrimitives.keyboard.keyboardPress('Enter');
       expect(mockAdb.shell).toHaveBeenCalledWith('input keyevent 66');
+    });
+
+    describe('clearInput', () => {
+      beforeEach(() => {
+        mockAdb.getApiLevel.mockResolvedValue(35);
+      });
+
+      it('should select all and forward-delete on Android 12 and newer', async () => {
+        mockAdb.getApiLevel.mockResolvedValue(31);
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(
+          1,
+          'input keycombination 113 29',
+        );
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
+        expect(mockAdb.clearTextField).not.toHaveBeenCalled();
+      });
+
+      it('should clear before typing replacement text', async () => {
+        const target = { center: [100, 200] as [number, number] } as any;
+        vi.spyOn(device as any, 'tapPoint').mockResolvedValue(undefined);
+
+        await device.inputPrimitives.keyboard.typeText('15', {
+          target,
+          replace: true,
+          autoDismissKeyboard: false,
+        });
+
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(
+          1,
+          'input keycombination 113 29',
+        );
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(3, "input text '15'");
+      });
+
+      it('should target the configured display for select-all and deletion', async () => {
+        device.options = { displayId: 2 };
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(
+          1,
+          'input -d 2 keycombination 113 29',
+        );
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(
+          2,
+          'input -d 2 keyevent 112',
+        );
+      });
+
+      it('should preserve batch deletion on Android 11 and older', async () => {
+        mockAdb.getApiLevel.mockResolvedValue(30);
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+
+        await device.clearInput();
+
+        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
+        expect(mockAdb.shell).not.toHaveBeenCalledWith(
+          expect.stringContaining('keycombination'),
+        );
+      });
+
+      it('should fall back when an Android 12+ device rejects the combination', async () => {
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        mockAdb.shell.mockRejectedValueOnce(
+          new Error('Unknown command: keycombination'),
+        );
+
+        await device.clearInput();
+
+        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
+      });
+
+      it('should preserve display-aware deletion on legacy Android', async () => {
+        mockAdb.getApiLevel.mockResolvedValue(30);
+        device.options = { displayId: 2 };
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          expect.stringMatching(/^input -d 2 keyevent (?:67 112 ){99}67 112$/),
+        );
+      });
     });
 
     it('press should reject key combinations before invoking ADB', async () => {

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1876,6 +1876,7 @@ Stdout:
     describe('clearInput', () => {
       beforeEach(() => {
         mockAdb.getApiLevel.mockResolvedValue(35);
+        mockAdb.shell.mockResolvedValue('');
       });
 
       it('should select all and forward-delete on Android 12 and newer', async () => {
@@ -1886,6 +1887,7 @@ Stdout:
         expect(mockAdb.shell).toHaveBeenNthCalledWith(
           1,
           'input keycombination 113 29',
+          expect.objectContaining({ outputFormat: 'full' }),
         );
         expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
         expect(mockAdb.clearTextField).not.toHaveBeenCalled();
@@ -1904,6 +1906,7 @@ Stdout:
         expect(mockAdb.shell).toHaveBeenNthCalledWith(
           1,
           'input keycombination 113 29',
+          expect.objectContaining({ outputFormat: 'full' }),
         );
         expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
         expect(mockAdb.shell).toHaveBeenNthCalledWith(3, "input text '15'");
@@ -1917,6 +1920,7 @@ Stdout:
         expect(mockAdb.shell).toHaveBeenNthCalledWith(
           1,
           'input -d 2 keycombination 113 29',
+          expect.objectContaining({ outputFormat: 'full' }),
         );
         expect(mockAdb.shell).toHaveBeenNthCalledWith(
           2,
@@ -1944,6 +1948,33 @@ Stdout:
 
         await device.clearInput();
 
+        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
+      });
+
+      it('should fall back when keycombination reports an unknown command on stdout', async () => {
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        mockAdb.shell.mockResolvedValueOnce('Unknown command: keycombination');
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          'input keycombination 113 29',
+          expect.objectContaining({ outputFormat: 'full' }),
+        );
+        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
+      });
+
+      it('should fall back when keycombination writes to stderr', async () => {
+        vi.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
+        mockAdb.shell.mockResolvedValueOnce({
+          stdout: '',
+          stderr: 'Unknown command: keycombination',
+        } as any);
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
         expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
       });
 

--- a/packages/harmony/src/device.ts
+++ b/packages/harmony/src/device.ts
@@ -46,64 +46,6 @@ const debugDevice = getDebug('harmony:device');
 
 let screenshotResizeScaleWarned = false;
 
-// ArkUI input component types that hold user-editable text. Used by
-// `resolveClearLength` to size `clearTextField` calls precisely instead of
-// always defaulting to the 100-key upper bound.
-const INPUT_FIELD_TYPES = new Set(['TextInput', 'TextArea', 'SearchField']);
-
-interface InputField {
-  text: string;
-  bounds: { x1: number; y1: number; x2: number; y2: number };
-}
-
-function parseBounds(raw: unknown): InputField['bounds'] | null {
-  // Harmony layout bounds look like "[x1,y1][x2,y2]".
-  if (typeof raw !== 'string') return null;
-  const m = raw.match(/\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]/);
-  if (!m) return null;
-  return {
-    x1: Number(m[1]),
-    y1: Number(m[2]),
-    x2: Number(m[3]),
-    y2: Number(m[4]),
-  };
-}
-
-function collectInputFields(layout: unknown): InputField[] {
-  const fields: InputField[] = [];
-  const visit = (node: unknown) => {
-    if (!node || typeof node !== 'object') return;
-    const n = node as {
-      attributes?: Record<string, unknown>;
-      children?: unknown[];
-    };
-    const attrs = n.attributes ?? {};
-    if (INPUT_FIELD_TYPES.has(String(attrs.type))) {
-      const bounds = parseBounds(attrs.bounds);
-      if (bounds) {
-        fields.push({ text: String(attrs.text ?? ''), bounds });
-      }
-    }
-    for (const child of n.children ?? []) visit(child);
-  };
-  visit(layout);
-  return fields;
-}
-
-function pickFieldByPoint(
-  fields: InputField[],
-  point: [number, number],
-): InputField | undefined {
-  const [px, py] = point;
-  return fields.find(
-    ({ bounds: b }) => px >= b.x1 && px <= b.x2 && py >= b.y1 && py <= b.y2,
-  );
-}
-
-function pickLongestField(fields: InputField[]): InputField {
-  return fields.reduce((a, b) => (b.text.length > a.text.length ? b : a));
-}
-
 export class HarmonyDevice implements AbstractInterface {
   private deviceId: string;
   private hdc: HdcClient | null = null;
@@ -485,15 +427,10 @@ export class HarmonyDevice implements AbstractInterface {
     }
 
     if (shouldReplace) {
-      // Focus the field, then send precisely enough Backspaces to clear it.
-      // The length is taken from the current layout to avoid the ~10s cost of
-      // always sending 100 keys (each `uitest uiInput keyEvent` is ~300ms).
+      // Focus the field, select all text, then delete the selection.
       await hdc.click(x, y);
       await sleep(100);
-      const length = await this.resolveClearLength(element);
-      if (length > 0) {
-        await hdc.clearTextField(length);
-      }
+      await hdc.clearTextField();
       await sleep(100);
     }
 
@@ -528,41 +465,7 @@ export class HarmonyDevice implements AbstractInterface {
       await sleep(100);
     }
 
-    const length = await this.resolveClearLength(element);
-    if (length > 0) {
-      await hdc.clearTextField(length);
-    }
-  }
-
-  /**
-   * Decide how many Backspaces `clearTextField` should send. Each
-   * `uitest uiInput keyEvent` invocation costs ~300ms cold-start, so blindly
-   * defaulting to 100 makes every clear take ~10s. Instead, snapshot the UI
-   * once (~1s for `uitest dumpLayout`) and tighten the bound to the current
-   * field's text length plus a small padding for transient IME composing.
-   * Falls back to the safe upper bound if the layout can't be parsed.
-   */
-  private async resolveClearLength(element?: {
-    center: [number, number];
-  }): Promise<number> {
-    const PADDING = 2;
-    const FALLBACK_LENGTH = 100;
-    try {
-      const hdc = await this.getHdc();
-      const layoutJson = await hdc.dumpLayout();
-      const layout = JSON.parse(layoutJson);
-      const fields = collectInputFields(layout);
-      if (fields.length === 0) return FALLBACK_LENGTH;
-      const target = element
-        ? (pickFieldByPoint(fields, element.center) ?? pickLongestField(fields))
-        : pickLongestField(fields);
-      return target.text.length + PADDING;
-    } catch (e) {
-      debugDevice(
-        `resolveClearLength: layout probe failed, falling back to ${FALLBACK_LENGTH}: ${e}`,
-      );
-      return FALLBACK_LENGTH;
-    }
+    await hdc.clearTextField();
   }
 
   private async pressKey(key: string): Promise<void> {

--- a/packages/harmony/src/hdc.ts
+++ b/packages/harmony/src/hdc.ts
@@ -319,27 +319,6 @@ export class HdcClient {
     return await this.shell(`snapshot_display -f ${remotePath}`);
   }
 
-  /**
-   * Capture the current UI layout via `uitest dumpLayout` and return the JSON
-   * string. The dump is written to a fixed device path then `cat`'d back in
-   * the same shell round-trip to avoid a separate `hdc file recv` call.
-   */
-  async dumpLayout(): Promise<string> {
-    const remotePath = '/data/local/tmp/midscene_layout.json';
-    const output = await this.shell(
-      `uitest dumpLayout -p ${remotePath} && cat ${remotePath}`,
-    );
-    // `uitest dumpLayout` prints a "DumpLayout saved to:..." preamble before
-    // `cat`'s JSON body. Find the first JSON object brace and return the rest.
-    const jsonStart = output.indexOf('{');
-    if (jsonStart < 0) {
-      throw new Error(
-        `dumpLayout: no JSON body in output: ${output.slice(0, 200)}`,
-      );
-    }
-    return output.slice(jsonStart);
-  }
-
   async click(x: number, y: number): Promise<void> {
     await this.runUiInput(
       'click',
@@ -433,33 +412,11 @@ export class HdcClient {
     await this.runUiInput('keyEvent', joinedKeys, joinedKeys);
   }
 
-  /**
-   * Clear the focused text field by sending repeated Backspace(2055) key
-   * events. `uitest uiInput keyEvent` only accepts up to 3 keyCodes per call
-   * (any more triggers "Too many parameters." with zero presses injected),
-   * so we pack codes into 3-key batches and chain the calls with shell `;`
-   * to keep a single hdc round-trip — mirroring Android adb's
-   * "one shell, many keys" design despite the per-call cap.
-   */
-  async clearTextField(length = 100): Promise<void> {
-    if (!Number.isSafeInteger(length) || length < 0) {
-      throw new Error(
-        'HDC clearTextField length must be a non-negative safe integer',
-      );
-    }
-    if (length === 0) return;
-
-    const maxKeysPerCall = 3;
-    const backspaceKeyCode = '2055';
-    const cmds: string[] = [];
-    let remaining = length;
-    while (remaining > 0) {
-      const n = Math.min(maxKeysPerCall, remaining);
-      const codes = Array(n).fill(backspaceKeyCode).join(' ');
-      cmds.push(`uitest uiInput keyEvent ${codes}`);
-      remaining -= n;
-    }
-    const output = await this.shell(cmds.join(';'));
+  /** Select all text in the focused field with Ctrl+A, then delete it. */
+  async clearTextField(): Promise<void> {
+    const output = await this.shell(
+      'uitest uiInput keyEvent 2072 2017;uitest uiInput keyEvent 2055',
+    );
     this.assertUiInputSucceeded('clearTextField', output);
   }
 

--- a/packages/harmony/tests/unit-test/device.test.ts
+++ b/packages/harmony/tests/unit-test/device.test.ts
@@ -261,8 +261,8 @@ describe('HarmonyDevice', () => {
 
       // 1. click to focus
       expect(mockHdc.click).toHaveBeenCalledWith(100, 200);
-      // 2. clearTextField to batch-delete existing content
-      expect(mockHdc.clearTextField).toHaveBeenCalledWith(100);
+      // 2. clearTextField to select and delete existing content
+      expect(mockHdc.clearTextField).toHaveBeenCalledWith();
       // 3. actual inputText
       expect(mockHdc.inputText).toHaveBeenCalledWith(100, 200, 'new text');
     });
@@ -366,10 +366,10 @@ describe('HarmonyDevice', () => {
   });
 
   describe('clearInput', () => {
-    it('should call clearTextField to batch-delete text', async () => {
+    it('should call clearTextField to select and delete text', async () => {
       await device.connect();
       await device.clearInput();
-      expect(mockHdc.clearTextField).toHaveBeenCalledWith(100);
+      expect(mockHdc.clearTextField).toHaveBeenCalledWith();
     });
 
     it('should click element before clearing when element is provided', async () => {
@@ -377,7 +377,7 @@ describe('HarmonyDevice', () => {
       const element = { center: [100, 200] as [number, number] } as any;
       await device.clearInput(element);
       expect(mockHdc.click).toHaveBeenCalledWith(100, 200);
-      expect(mockHdc.clearTextField).toHaveBeenCalledWith(100);
+      expect(mockHdc.clearTextField).toHaveBeenCalledWith();
     });
   });
 

--- a/packages/harmony/tests/unit-test/hdc.test.ts
+++ b/packages/harmony/tests/unit-test/hdc.test.ts
@@ -759,46 +759,8 @@ activeMode: 1216x2688, refreshRate=60`,
     });
   });
 
-  describe('dumpLayout', () => {
-    it('should dump and cat layout in a single shell round-trip and strip the preamble', async () => {
-      mockExecFile.mockResolvedValue({
-        stdout:
-          'DumpLayout saved to:/data/local/tmp/midscene_layout.json\n{"attributes":{"type":"Root"},"children":[]}\n',
-        stderr: '',
-      });
-
-      const hdc = new HdcClient({});
-      const json = await hdc.dumpLayout();
-
-      expect(mockExecFile).toHaveBeenCalledTimes(1);
-      expect(mockExecFile).toHaveBeenCalledWith(
-        expect.any(String),
-        [
-          'shell',
-          'uitest dumpLayout -p /data/local/tmp/midscene_layout.json && cat /data/local/tmp/midscene_layout.json',
-        ],
-        expect.any(Object),
-      );
-      expect(json.startsWith('{')).toBe(true);
-      expect(JSON.parse(json)).toEqual({
-        attributes: { type: 'Root' },
-        children: [],
-      });
-    });
-
-    it('should throw when the shell output contains no JSON body', async () => {
-      mockExecFile.mockResolvedValue({
-        stdout: 'uitest: cannot find display',
-        stderr: '',
-      });
-
-      const hdc = new HdcClient({});
-      await expect(hdc.dumpLayout()).rejects.toThrow('no JSON body');
-    });
-  });
-
   describe('clearTextField', () => {
-    it('should throw when a batched key event reports an error', async () => {
+    it('should throw when the select-all and delete command reports an error', async () => {
       mockExecFile.mockResolvedValue({
         stdout: 'Too many parameters.\n',
         stderr: '',
@@ -806,69 +768,26 @@ activeMode: 1216x2688, refreshRate=60`,
 
       const hdc = new HdcClient({});
 
-      await expect(hdc.clearTextField(4)).rejects.toThrow(
+      await expect(hdc.clearTextField()).rejects.toThrow(
         'HDC uiInput clearTextField failed: Too many parameters.',
       );
     });
 
-    it.each([-1, 1.5, Number.NaN])(
-      'should reject invalid clear length %s before invoking HDC',
-      async (length) => {
-        const hdc = new HdcClient({});
-
-        await expect(hdc.clearTextField(length)).rejects.toThrow(
-          'HDC clearTextField length must be a non-negative safe integer',
-        );
-        expect(mockExecFile).not.toHaveBeenCalled();
-      },
-    );
-
-    it('should chain 3-key batches with semicolons in a single shell call', async () => {
+    it('should select all with Ctrl+A and delete in one shell call', async () => {
       mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
 
       const hdc = new HdcClient({});
-      await hdc.clearTextField(7);
-
-      // 7 Backspaces packed into 3+3+1 batches, chained with `;`
-      const expected = [
-        'uitest uiInput keyEvent 2055 2055 2055',
-        'uitest uiInput keyEvent 2055 2055 2055',
-        'uitest uiInput keyEvent 2055',
-      ].join(';');
+      await hdc.clearTextField();
 
       expect(mockExecFile).toHaveBeenCalledTimes(1);
       expect(mockExecFile).toHaveBeenCalledWith(
         expect.any(String),
-        ['shell', expected],
+        [
+          'shell',
+          'uitest uiInput keyEvent 2072 2017;uitest uiInput keyEvent 2055',
+        ],
         expect.any(Object),
       );
-    });
-
-    it('should cap each uitest invocation at 3 keyCodes (uitest limit)', async () => {
-      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
-
-      const hdc = new HdcClient({});
-      await hdc.clearTextField(100);
-
-      const args = mockExecFile.mock.calls[0][1] as string[];
-      expect(args[0]).toBe('shell');
-      const cmds = args[1].split(';');
-      // 100 keys / 3 per batch = 34 calls (33 full + 1 with a single key)
-      expect(cmds).toHaveLength(34);
-      for (const cmd of cmds) {
-        const codes = cmd.replace('uitest uiInput keyEvent ', '').split(' ');
-        expect(codes.length).toBeLessThanOrEqual(3);
-        for (const c of codes) expect(c).toBe('2055');
-      }
-    });
-
-    it('should no-op when length is 0', async () => {
-      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
-
-      const hdc = new HdcClient({});
-      await hdc.clearTextField(0);
-
-      expect(mockExecFile).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- clear focused HarmonyOS inputs with Ctrl+A followed by Backspace
- clear Android inputs on API 31+ with the official shell key-combination command followed by Forward Delete
- inspect the Android key-combination command's full stdout/stderr and fall back before deletion when the shell reports an error despite exiting successfully
- retain the existing Android deletion strategies for older devices and unsupported OEM command implementations
- add direct coverage for clear, replace, multi-display, legacy, rejected-command, stdout-error, and stderr-error behavior

## Root cause

Both platforms previously relied on repeated Backspace/Delete events after tapping an input field. Tapping can place the caret in the middle of the value, so the deletion sequence could leave text on one side of the caret. As a result, `aiClearInput` left content behind and `aiInput` in replace mode appended the new value to the remaining text.

On Android, physical-device testing also showed that `KEYCODE_DEL` collapses a selected range and removes only one character in Samsung's input field. `KEYCODE_FORWARD_DEL` correctly deletes the full selection.

Some Android implementations print `Unknown command: keycombination` to stdout while the shell process still exits successfully. The fast path therefore now requires both an empty stdout and an empty stderr before sending Forward Delete; otherwise it logs the failure and uses the legacy clear path.

## Impact

`aiClearInput` and replace-mode `aiInput` now clear the complete focused value before typing. Android 11 and older keep the previous compatibility path, and Android 12+ devices whose shell does not actually support `keycombination` safely fall back as well.

## Validation

- `pnpm run lint`
- `pnpm run check:references`
- `pnpm exec nx test @midscene/android --skip-nx-cache`
  - Android: 408 tests passed
  - includes resolved stdout `Unknown command: keycombination` and full-output stderr fallback cases
- `pnpm exec nx test @midscene/harmony --skip-nx-cache`
  - HarmonyOS: 256 tests passed
- `pnpm exec nx build @midscene/android --skip-nx-cache`
- `pnpm exec nx build @midscene/harmony --skip-nx-cache`
- Android package smoke checks for CJS, ESM, declarations, CLI version, and packed files
- Samsung SM-N9860, Android 13 / API 33 physical-device verification: replacing `0155` with `15` produced exactly `15`
- HarmonyOS physical-device smoke was not available because `hdc list targets` returned no connected target
