### PR TITLE
refactor(core): decouple planning action response parsing

### DIFF
--- a/packages/core/src/ai-model/prompt/planning/action-output-protocol.ts
+++ b/packages/core/src/ai-model/prompt/planning/action-output-protocol.ts
@@ -1,5 +1,8 @@
+import type { PlanningAction } from '@/types';
+import type { JsonParser } from '../../shared/json';
 import type { LocateResultPromptSpec } from '../../shared/model-locate-result';
 import { formatLocateExampleValue } from '../../shared/model-locate-result';
+import { extractXMLTag } from '../../shared/xml';
 
 export type PlanningActionOutput = {
   type: string;
@@ -19,6 +22,10 @@ export type PlanningActionOutputProtocol = {
     action: PlanningActionOutput,
     options?: BuildPlanningActionOutputOptions,
   ) => string;
+  parseActionOutput: (
+    content: string,
+    jsonParser: JsonParser,
+  ) => PlanningAction | null;
 };
 
 const serializeActionParam = (
@@ -75,6 +82,39 @@ ${
 }
 </action-param-json>`;
 
+export const parseMidscenePlanningActionOutput = (
+  content: string,
+  jsonParser: JsonParser,
+): PlanningAction | null => {
+  const actionType = extractXMLTag(content, 'action-type');
+  const actionParamStr = extractXMLTag(content, 'action-param-json');
+
+  if (!actionType || actionType.toLowerCase() === 'null') {
+    return null;
+  }
+
+  // Strip any trailing XML tags that leaked into the action type.
+  const type = actionType.split('<')[0].trim();
+  let param: any = undefined;
+
+  if (actionParamStr) {
+    try {
+      param = jsonParser(actionParamStr, {
+        source: 'planning-action-param',
+        preserveStringValueKeys:
+          type.toLowerCase() === 'input' ? ['value'] : undefined,
+      });
+    } catch (error) {
+      throw new Error(`Failed to parse action-param-json: ${error}`);
+    }
+  }
+
+  return {
+    type,
+    ...(param !== undefined ? { param } : {}),
+  };
+};
+
 export const defaultMidsceneActionOutputProtocol: PlanningActionOutputProtocol =
   {
     actionOutputTagNames: ['action-type', 'action-param-json'],
@@ -88,4 +128,5 @@ export const defaultMidsceneActionOutputProtocol: PlanningActionOutputProtocol =
       '<action-param-json>...</action-param-json>',
     ].join('\n'),
     buildActionOutput: buildPlanningActionOutput,
+    parseActionOutput: parseMidscenePlanningActionOutput,
   };

--- a/packages/core/src/ai-model/prompt/planning/index.ts
+++ b/packages/core/src/ai-model/prompt/planning/index.ts
@@ -8,6 +8,7 @@ export type { ActionExampleDefinition } from './action-example';
 export {
   buildPlanningActionOutput,
   defaultMidsceneActionOutputProtocol,
+  parseMidscenePlanningActionOutput,
 } from './action-output-protocol';
 export type {
   PlanningActionOutput,

--- a/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning-parser.ts
@@ -4,6 +4,7 @@ import type {
   SubGoal,
   SubGoalStatus,
 } from '@/types';
+import type { PlanningActionOutputProtocol } from '../../prompt/planning/action-output-protocol';
 import type { JsonParser } from '../../shared/json';
 import { extractXMLTag } from '../../shared/xml';
 import { buildPlanningActionLog } from './planning-action-log';
@@ -49,12 +50,46 @@ export function parseMarkFinishedIndexes(xmlContent: string): number[] {
   return indexes;
 }
 
-/** Parse an XML model response into a planning response. */
+type XMLPlanningResponse = Omit<RawResponsePlanningAIResponse, 'action'>;
+
+type XMLPlanningResponseParseResult = {
+  parsed: XMLPlanningResponse;
+  rawActionOutput: string;
+};
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const extractRawActionOutput = (
+  content: string,
+  actionOutputTagNames: PlanningActionOutputProtocol['actionOutputTagNames'],
+) => {
+  const startTagName = actionOutputTagNames[0];
+  const endTagName = actionOutputTagNames.at(-1)!;
+  const startTagRegex = new RegExp(`<${escapeRegExp(startTagName)}>`, 'i');
+  const startTag = startTagRegex.exec(content);
+  if (startTag?.index === undefined) {
+    return '';
+  }
+
+  const contentFromStartTag = content.slice(startTag.index);
+  const endTagRegex = new RegExp(`</${escapeRegExp(endTagName)}>`, 'gi');
+  const endTags = [...contentFromStartTag.matchAll(endTagRegex)];
+  const lastEndTag = endTags.at(-1);
+  const end =
+    lastEndTag?.index !== undefined
+      ? lastEndTag.index + lastEndTag[0].length
+      : contentFromStartTag.length;
+
+  return contentFromStartTag.slice(0, end);
+};
+
+/** Parse common XML fields and retain the raw action-protocol XML. */
 export function parseXMLPlanningResponse(
   xmlString: string,
-  jsonParser: JsonParser,
+  actionOutputTagNames: PlanningActionOutputProtocol['actionOutputTagNames'],
   options: { includeThought: boolean },
-): RawResponsePlanningAIResponse {
+): XMLPlanningResponseParseResult {
   // Use <planning> instead of <thought> to avoid colliding with Gemini thought
   // summaries, which may also be emitted as <thought> in OpenAI-compatible
   // response content.
@@ -64,8 +99,6 @@ export function parseXMLPlanningResponse(
   const memory = extractXMLTag(xmlString, 'memory');
   const log = extractXMLTag(xmlString, 'log') || '';
   const error = extractXMLTag(xmlString, 'error');
-  const actionType = extractXMLTag(xmlString, 'action-type');
-  const actionParamStr = extractXMLTag(xmlString, 'action-param-json');
 
   const completeGoalRegex =
     /<complete\s+success="(true|false)">([\s\S]*?)<\/complete>/i;
@@ -87,45 +120,24 @@ export function parseXMLPlanningResponse(
     ? parseMarkFinishedIndexes(markSubGoalDone)
     : undefined;
 
-  let action: any = null;
-  if (actionType && actionType.toLowerCase() !== 'null') {
-    // Strip any trailing XML tags that leaked into the action type.
-    const type = actionType.split('<')[0].trim();
-    let param: any = undefined;
-
-    if (actionParamStr) {
-      try {
-        param = jsonParser(actionParamStr, {
-          source: 'planning-action-param',
-          preserveStringValueKeys:
-            type.toLowerCase() === 'input' ? ['value'] : undefined,
-        });
-      } catch (error) {
-        throw new Error(`Failed to parse action-param-json: ${error}`);
-      }
-    }
-
-    action = {
-      type,
-      ...(param !== undefined ? { param } : {}),
-    };
-  }
-
   return {
-    ...(thought ? { thought } : {}),
-    ...(memory ? { memory } : {}),
-    log,
-    ...(error ? { error } : {}),
-    action,
-    ...(finalizeMessage !== undefined ? { finalizeMessage } : {}),
-    ...(finalizeSuccess !== undefined ? { finalizeSuccess } : {}),
-    ...(updateSubGoals?.length ? { updateSubGoals } : {}),
-    ...(markFinishedIndexes?.length ? { markFinishedIndexes } : {}),
+    parsed: {
+      ...(thought ? { thought } : {}),
+      ...(memory ? { memory } : {}),
+      log,
+      ...(error ? { error } : {}),
+      ...(finalizeMessage !== undefined ? { finalizeMessage } : {}),
+      ...(finalizeSuccess !== undefined ? { finalizeSuccess } : {}),
+      ...(updateSubGoals?.length ? { updateSubGoals } : {}),
+      ...(markFinishedIndexes?.length ? { markFinishedIndexes } : {}),
+    },
+    rawActionOutput: extractRawActionOutput(xmlString, actionOutputTagNames),
   };
 }
 
 type ParseStandardPlanningResponseOptions = {
   includeThought: boolean;
+  actionOutputProtocol: PlanningActionOutputProtocol;
 } & (
   | {
       logSource?: 'model';
@@ -162,9 +174,18 @@ export function parseStandardPlanningResponse(
   jsonParser: JsonParser,
   options: ParseStandardPlanningResponseOptions,
 ): RawResponsePlanningAIResponse {
-  const response = parseXMLPlanningResponse(xmlString, jsonParser, {
-    includeThought: options.includeThought,
-  });
+  const { parsed, rawActionOutput } = parseXMLPlanningResponse(
+    xmlString,
+    options.actionOutputProtocol.actionOutputTagNames,
+    { includeThought: options.includeThought },
+  );
+  const response: RawResponsePlanningAIResponse = {
+    ...parsed,
+    action: options.actionOutputProtocol.parseActionOutput(
+      rawActionOutput,
+      jsonParser,
+    ),
+  };
 
   if (options.logSource !== 'action') {
     return response;

--- a/packages/core/src/ai-model/workflows/planning/standard-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning.ts
@@ -9,7 +9,11 @@ import { assert } from '@midscene/shared/utils';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
 import { buildYamlFlowFromPlans } from '../../../common';
 import { prepareModelImage } from '../../model-adapter/image-preprocess';
-import { buildStandardPlanningSystemPrompt } from '../../prompt/planning';
+import {
+  type PlanningActionOutputProtocol,
+  buildStandardPlanningSystemPrompt,
+  defaultMidsceneActionOutputProtocol,
+} from '../../prompt/planning';
 import { AIResponseParseError, callAI } from '../../service-caller/index';
 import {
   callAiAndParseWithRetry,
@@ -41,6 +45,7 @@ type CallAndParsePlanningResponseOptions = {
   locateResultContext: LocateResultContext;
   includeThought: boolean;
   includeLog: boolean;
+  actionOutputProtocol: PlanningActionOutputProtocol;
 };
 
 async function callAndParsePlanningResponse(
@@ -61,6 +66,7 @@ async function callAndParsePlanningResponse(
     locateResultContext,
     includeThought,
     includeLog,
+    actionOutputProtocol,
   } = options;
   return callAiAndParseWithRetry({
     callAi: (retryAttempt, previousParseError) =>
@@ -79,6 +85,7 @@ async function callAndParsePlanningResponse(
         modelRuntime.adapter.jsonParser,
         {
           includeThought,
+          actionOutputProtocol,
           ...(includeLog
             ? { logSource: 'model' }
             : { logSource: 'action', actionSpace }),
@@ -152,6 +159,7 @@ export async function standardPlan(
   const includeSubGoals = opts.effort === 'deepThink';
   const includeThought = opts.effort !== 'fast';
   const includeLog = opts.effort !== 'fast';
+  const actionOutputProtocol = defaultMidsceneActionOutputProtocol;
 
   if (opts.includeLocateInPlanning && !locateResultAdapter) {
     throw new Error(
@@ -164,6 +172,7 @@ export async function standardPlan(
     includeThought,
     includeLog,
     includeSubGoals,
+    actionOutputProtocol,
     ...(opts.includeLocateInPlanning && locateResultAdapter
       ? {
           includeLocateInPlanning: true,
@@ -290,6 +299,7 @@ export async function standardPlan(
     },
     includeThought,
     includeLog,
+    actionOutputProtocol,
   });
 
   let shouldContinuePlanning = true;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -358,12 +358,14 @@ export type PlanningLocateParamWithLocatedPixelBbox = PlanningLocateParam & {
   locatedPixelBbox: PixelBbox;
 };
 
-export interface PlanningAction<ParamType = any> {
+type PlanningActionBase = {
   thought?: string;
   log?: string; // a brief preamble to the user explaining what you’re about to do
   type: string;
-  param: ParamType;
-}
+};
+
+export type PlanningAction<ParamType = undefined> = PlanningActionBase &
+  ([ParamType] extends [undefined] ? { param?: any } : { param: ParamType });
 
 export type SubGoalStatus = 'pending' | 'running' | 'finished';
 
@@ -375,7 +377,7 @@ export interface SubGoal {
 }
 
 export interface RawResponsePlanningAIResponse {
-  action: PlanningAction;
+  action: PlanningAction | null;
   thought?: string;
   log: string;
   memory?: string;

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -1,8 +1,6 @@
 import { getModelAdapter } from '@/ai-model/models';
-import {
-  parseStandardPlanningResponse,
-  parseXMLPlanningResponse as parseXMLPlanningResponseWithOptions,
-} from '@/ai-model/workflows/planning';
+import { defaultMidsceneActionOutputProtocol } from '@/ai-model/prompt/planning';
+import { parseStandardPlanningResponse as parseStandardPlanningResponseWithOptions } from '@/ai-model/workflows/planning';
 import {
   parseMarkFinishedIndexes,
   parseSubGoalsFromXML,
@@ -10,6 +8,7 @@ import {
 import { getMidsceneLocationSchema } from '@/common';
 import { buildYamlFlowFromPlans } from '@/common';
 import { actionInputParamSchema, actionTapParamSchema } from '@/device';
+import type { DeviceAction } from '@/types';
 import {
   MIDSCENE_USE_DOUBAO_VISION,
   OPENAI_API_KEY,
@@ -18,12 +17,23 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
-const parseXMLPlanningResponse = (
+const parseStandardPlanningResponse = (
   xmlString: string,
-  jsonParser: Parameters<typeof parseXMLPlanningResponseWithOptions>[1],
+  jsonParser: Parameters<typeof parseStandardPlanningResponseWithOptions>[1],
+  options:
+    | {
+        includeThought: boolean;
+        logSource?: 'model';
+      }
+    | {
+        includeThought: boolean;
+        logSource: 'action';
+        actionSpace: DeviceAction<any>[];
+      } = { includeThought: true },
 ) =>
-  parseXMLPlanningResponseWithOptions(xmlString, jsonParser, {
-    includeThought: true,
+  parseStandardPlanningResponseWithOptions(xmlString, jsonParser, {
+    ...options,
+    actionOutputProtocol: defaultMidsceneActionOutputProtocol,
   });
 
 describe('llm planning - doubao', () => {
@@ -419,7 +429,7 @@ describe('llm planning - build yaml flow', () => {
   });
 });
 
-describe('parseXMLPlanningResponse', () => {
+describe('parseStandardPlanningResponse', () => {
   it('should parse complete XML response with all fields', () => {
     const modelFamily = 'doubao-vision';
     const xml = `
@@ -438,7 +448,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -473,7 +483,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -589,7 +599,7 @@ describe('parseXMLPlanningResponse', () => {
 <action-type>null</action-type>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -606,7 +616,7 @@ describe('parseXMLPlanningResponse', () => {
 <log>Just logging</log>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -630,7 +640,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -654,7 +664,7 @@ describe('parseXMLPlanningResponse', () => {
 <action-type>Wait</action-type>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -686,7 +696,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -713,7 +723,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -746,7 +756,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -772,7 +782,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -795,7 +805,7 @@ describe('parseXMLPlanningResponse', () => {
 <complete success="true">Task completed</complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -819,7 +829,10 @@ describe('parseXMLPlanningResponse', () => {
     `.trim();
 
     expect(() =>
-      parseXMLPlanningResponse(xml, getModelAdapter(modelFamily).jsonParser),
+      parseStandardPlanningResponse(
+        xml,
+        getModelAdapter(modelFamily).jsonParser,
+      ),
     ).toThrow('Failed to parse action-param-json');
   });
 
@@ -830,7 +843,7 @@ describe('parseXMLPlanningResponse', () => {
 <ACTION-TYPE>Tap</ACTION-TYPE>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -852,7 +865,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -884,7 +897,7 @@ describe('parseXMLPlanningResponse', () => {
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -901,7 +914,7 @@ describe('parseXMLPlanningResponse', () => {
 <complete success="true">The product names are: 'Product A', 'Product B', 'Product C'</complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -923,7 +936,7 @@ describe('parseXMLPlanningResponse', () => {
 <complete success="false">Unable to find the required element on the page</complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -944,7 +957,7 @@ describe('parseXMLPlanningResponse', () => {
 <complete success="true"></complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -969,7 +982,7 @@ Extracted data:
 </complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -992,7 +1005,7 @@ Extracted data:
 <complete success="true">All 10 items have been processed</complete>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1014,7 +1027,7 @@ Extracted data:
 <COMPLETE success="true">Success message</COMPLETE>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1040,7 +1053,7 @@ Extracted data:
 </update-plan-content>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1066,7 +1079,7 @@ Extracted data:
 </mark-sub-goal-done>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1085,7 +1098,7 @@ Extracted data:
 </mark-sub-goal-done>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1110,7 +1123,7 @@ Extracted data:
 </action-type>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1135,7 +1148,7 @@ Extracted data:
 </action-param-json>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );
@@ -1163,7 +1176,7 @@ Extracted data:
 </mark-sub-goal-done>
     `.trim();
 
-    const result = parseXMLPlanningResponse(
+    const result = parseStandardPlanningResponse(
       xml,
       getModelAdapter(modelFamily).jsonParser,
     );

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -108,6 +108,7 @@ describe('system prompts', () => {
       actionOutputRules: 'CUSTOM_ACTION_OUTPUT_RULES',
       actionOutputPlaceholder: '<custom-action>...</custom-action>',
       buildActionOutput: ({ type }) => `<custom-action type="${type}" />`,
+      parseActionOutput: vi.fn(),
     };
 
     const prompt = await buildStandardPlanningSystemPrompt({

--- a/packages/core/tests/unit-test/standard-planning-parser.test.ts
+++ b/packages/core/tests/unit-test/standard-planning-parser.test.ts
@@ -1,0 +1,18 @@
+import { parseXMLPlanningResponse } from '@/ai-model/workflows/planning';
+import { describe, expect, it } from 'vitest';
+
+describe('parseXMLPlanningResponse', () => {
+  it('extracts the continuous content between the protocol boundary tags', () => {
+    const xml = `<planning>Choose the next action</planning>
+<action-type>Tap</action-type>
+<action-param-json>{"locate":{"prompt":"Submit"}}</action-param-json>
+<memory>Keep this outside the action output</memory>`;
+
+    expect(
+      parseXMLPlanningResponse(xml, ['action-type', 'action-param-json'], {
+        includeThought: true,
+      }).rawActionOutput,
+    ).toBe(`<action-type>Tap</action-type>
+<action-param-json>{"locate":{"prompt":"Submit"}}</action-param-json>`);
+  });
+});


### PR DESCRIPTION
## Stack

- Depends on #2987
- Base branch: `zzy/tool-call`

## Summary

- split standard planning response parsing into common XML parsing and protocol-specific action parsing
- move the default `<action-type>` and `<action-param-json>` interpretation into the Midscene action output protocol
- preserve raw action output between the protocol boundary tags before delegating parsing
- make no-action responses explicit through nullable planning actions

## Why

The planning response parser previously interpreted Midscene-specific action tags directly. Delegating that portion to the configured action output protocol keeps common planning XML parsing independent from the action representation and prepares the standard planning chain for alternative tool-call protocols.

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/llm-planning.test.ts tests/unit-test/standard-planning-parser.test.ts tests/unit-test/prompt/prompt.test.ts` (80 tests passed)
- `pnpm exec nx build @midscene/core`
