### PR TITLE
test(computer): stabilize extension playground CI

### DIFF
--- a/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
@@ -77,7 +77,7 @@ describe('chrome extension dark Playground timeline', () => {
 
   it('executes a Bing search and renders a visible dark execution timeline', async () => {
     await agent.aiAct(
-      `In ${SIDE_PANEL}, click the "Action" button, then click the text input area and type: Click the Bing search field, type "midscene.js", then press Enter`,
+      `In ${SIDE_PANEL}, click the Action text input area, select and delete any existing text, then type exactly: Click the Bing search field, type "midscene.js", then press Enter`,
     );
     await sleep(500);
     await focusBingPage();

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -87,12 +87,12 @@ describe('chrome extension playground advanced tests', () => {
       `${SIDE_PANEL} shows an input area with placeholder text containing "assert"`,
     );
 
-    await agent.aiAct(`Click the "Action" button in ${SIDE_PANEL}`);
+    await agent.aiAct(`Click the "Tap" tab in ${SIDE_PANEL}`);
     await sleep(500);
   });
 
   it('aiQuery: extract page title and verify result', async () => {
-    await agent.aiAct(`Click the "aiQuery" button in ${SIDE_PANEL}`);
+    await agent.aiAct(`Click the "Query" tab in ${SIDE_PANEL}`);
     await sleep(500);
     await agent.aiAct(
       `In ${SIDE_PANEL}, click the text input area and type: What is the title text shown at the top of the TodoMVC page?`,

--- a/packages/core/tests/unit-test/agent-ui-observer.test.ts
+++ b/packages/core/tests/unit-test/agent-ui-observer.test.ts
@@ -21,8 +21,8 @@ function trackRecordFiles(record: UIObservationRecord): void {
   }
 }
 
-const dataUrl = (text: string) =>
-  `data:image/png;base64,${Buffer.from(text).toString('base64')}`;
+const dataUrl = (_tag: string) =>
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR42mP4HKzauIeNgXXZh/+7OAApSwYLCdgqFgAAAABJRU5ErkJggg==';
 
 const fakeContext = (tag: string): UIContext =>
   ({
@@ -92,8 +92,9 @@ describe('Agent.startObserving', () => {
     expect(sequence.length).toBeGreaterThanOrEqual(2);
     expect(sequence[0].hasBase64()).toBe(false);
     expect(sequence[0].toSerializable()).not.toHaveProperty('path');
-    expect(Buffer.from(sequence[0].rawBase64, 'base64').toString()).toMatch(
-      /^decoded:/,
+    expect(sequence[0].format).toBe('png');
+    expect(Buffer.from(sequence[0].rawBase64, 'base64').subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
     );
   });
 


### PR DESCRIPTION
## Summary

- replace the observation unit test's invalid text-as-PNG fixture with a real 2x2 PNG
- keep the pre-JPEG baseline assertion focused on the persisted PNG signature
- align Chrome Extension Playground AI prompts with the current Tap and Query labels
- keep the multi-step dark-timeline scenario in the default Action mode and clear stale input before typing

## Context

These test-only fixes were discovered while validating #3001 but are independent of the observation-frame JPEG behavior, so they are submitted separately.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/core -- tests/unit-test/agent-ui-observer.test.ts` (7 passed)
- the affected Chrome Extension AI E2E shards passed in the original validation run on #3001