### PR TITLE
feat(report): add wall and model call time summaries

### DIFF
--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -8,6 +8,24 @@ tasks:
       - sleep: 5000
       - aiAssert: The report page is loaded with a left-side task list table showing multiple named task rows and a time or duration column; the main report panel also shows a "Record" timeline with visible screenshot thumbnails or frame previews.
 
+  # --- Report timing summary ---
+  - name: total row distinguishes wall time from model call time
+    flow:
+      - aiAssert: At the bottom of the left-side task table there is one combined "Total" summary row. Its Time cell visibly contains separate "Wall" and "Model" duration values; there is no separate row labeled "Total Time".
+
+  # --- Markdown timing summary ---
+  - name: markdown view explains both timing metrics
+    flow:
+      - aiTap:
+          locate:
+            prompt: the "Markdown View" button in the Report view switch at the top-left of the sidebar
+      - sleep: 500
+      - aiAssert: The left sidebar is showing report Markdown source with a "Timing Summary" section that clearly lists both "Wall Time" and "Model Call Time".
+      - aiTap:
+          locate:
+            prompt: the "Human View" button in the Report view switch at the top-left of the sidebar
+      - sleep: 500
+
   # --- Player area visible with controls ---
   - name: player area is visible with playback controls
     flow:

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -11,7 +11,10 @@ tasks:
   # --- Report timing summary ---
   - name: total row distinguishes wall time from model call time
     flow:
-      - aiAssert: At the bottom of the left-side task table there is one combined "Total" summary row. Its Time cell visibly contains separate "Wall" and "Model" duration values; there is no separate row labeled "Total Time".
+      - aiScroll: the scrollable left-side Execution task list below the Type and Time headers, not the main Record timeline
+        scrollType: scrollToBottom
+      - sleep: 500
+      - aiAssert: The left-side Execution task list is visibly scrolled to its bottom. Below the task rows there is one combined summary row labeled "Total" whose Time cell contains separate "Wall" and "Model" duration values; there is no separate row labeled "Total Time".
 
   # --- Markdown timing summary ---
   - name: markdown view explains both timing metrics

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -9,12 +9,12 @@ tasks:
       - aiAssert: The report page is loaded with a left-side task list table showing multiple named task rows and a time or duration column; the main report panel also shows a "Record" timeline with visible screenshot thumbnails or frame previews.
 
   # --- Report timing summary ---
-  - name: total row distinguishes wall time from model call time
+  - name: total row distinguishes elapsed time from model call time
     flow:
       - aiScroll: the scrollable left-side Execution task list below the Type and Time headers, not the main Record timeline
         scrollType: scrollToBottom
       - sleep: 500
-      - aiAssert: The left-side Execution task list is visibly scrolled to its bottom. Below the task rows there is one combined summary row labeled "Total" whose Time cell contains separate "Wall" and "Model" duration values; there is no separate row labeled "Total Time".
+      - aiAssert: The left-side Execution task list is visibly scrolled to its bottom. Below the task rows there is one combined summary row labeled "Total" whose Time cell contains separate "Elapsed" and "Model" duration values; there is no separate row labeled "Total Time".
 
   # --- Markdown timing summary ---
   - name: markdown view explains both timing metrics
@@ -23,7 +23,7 @@ tasks:
           locate:
             prompt: the "Markdown View" button in the Report view switch at the top-left of the sidebar
       - sleep: 500
-      - aiAssert: The left sidebar is showing report Markdown source with a "Timing Summary" section that clearly lists both "Wall Time" and "Model Call Time".
+      - aiAssert: The left sidebar is showing report Markdown source with a "Timing Summary" section that clearly lists both "Elapsed Time" and "Model Call Time".
       - aiTap:
           locate:
             prompt: the "Human View" button in the Report view switch at the top-left of the sidebar

--- a/apps/report/src/App.tsx
+++ b/apps/report/src/App.tsx
@@ -194,8 +194,12 @@ function Visualizer(props: VisualizerProps): JSX.Element {
     if (reportViewMode !== 'markdown') {
       return null;
     }
-    return getReportMarkdownView(dump, reportToMarkdown);
-  }, [dump, reportViewMode]);
+    return getReportMarkdownView(dump, (report) =>
+      reportToMarkdown(report, {
+        wallTimeFallbackMs: playwrightAttributes?.playwright_test_duration,
+      }),
+    );
+  }, [dump, playwrightAttributes, reportViewMode]);
   const readyReportMarkdown =
     reportMarkdownView?.status === 'ready' ? reportMarkdownView : null;
   const reportArchiveBaseName = useMemo(

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -456,6 +456,24 @@
         height: 44px;
         align-items: center;
 
+        .token-total-label {
+          min-width: 0;
+          overflow: hidden;
+          color: #808080;
+          font-size: 12px;
+          font-weight: 500;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .token-value {
+          color: #595959;
+          font-size: 14px;
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: 'tnum' 1;
+          white-space: nowrap;
+        }
+
         .summary-cell {
           padding: 0 8px;
           display: flex;
@@ -474,6 +492,38 @@
           &.column-completion {
             justify-content: flex-end;
           }
+        }
+
+        .summary-time-values {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+          gap: 2px;
+          width: 100%;
+        }
+
+        .summary-time-item {
+          display: inline-flex;
+          align-items: baseline;
+          justify-content: flex-end;
+          gap: 5px;
+          width: 100%;
+          cursor: help;
+          line-height: 16px;
+        }
+
+        .summary-time-label {
+          color: #808080;
+          font-family: sans-serif;
+          font-size: 10px;
+          line-height: 1;
+        }
+
+        .summary-time-value {
+          color: #595959;
+          font-size: 12px;
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: 'tnum' 1;
         }
       }
     }
@@ -643,9 +693,14 @@
   background-color: #e6f4ff;
 }
 
+.ant-tooltip.total-time-tooltip {
+  max-width: min(360px, calc(100vw - 24px));
+}
+
 .total-time-tooltip-content {
   display: grid;
-  grid-template-columns: max-content max-content;
+  grid-template-columns: max-content minmax(0, 1fr);
+  width: min(320px, calc(100vw - 56px));
   column-gap: 12px;
   row-gap: 4px;
   align-items: baseline;
@@ -659,7 +714,23 @@
 .total-time-tooltip-value {
   font-variant-numeric: tabular-nums;
   font-feature-settings: 'tnum' 1;
+  min-width: 0;
   white-space: nowrap;
+}
+
+.total-time-tooltip-definition-label,
+.total-time-tooltip-description {
+  grid-column: 1 / -1;
+}
+
+.total-time-tooltip-definition-label {
+  text-align: left;
+}
+
+.total-time-tooltip-description {
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 // Dark mode styles
@@ -808,6 +879,18 @@
       .column-cached,
       .column-completion {
         color: #f8fafd;
+      }
+
+      .table-summary .summary-row {
+        .token-total-label,
+        .summary-time-label {
+          color: rgba(255, 255, 255, 0.45);
+        }
+
+        .token-value,
+        .summary-time-value {
+          color: #f8fafd;
+        }
       }
     }
 

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -718,13 +718,19 @@
   white-space: nowrap;
 }
 
-.total-time-tooltip-definition-label,
+.total-time-tooltip-metric,
 .total-time-tooltip-description {
   grid-column: 1 / -1;
 }
 
-.total-time-tooltip-definition-label {
+.total-time-tooltip-metric {
+  color: #fff;
+  font-weight: 600;
   text-align: left;
+
+  &:not(:first-child) {
+    margin-top: 4px;
+  }
 }
 
 .total-time-tooltip-description {

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -5,9 +5,9 @@ import {
   DownloadOutlined,
   FileMarkdownOutlined,
 } from '@ant-design/icons';
-import type { AIUsageInfo, ExecutionTask } from '@midscene/core';
-import { deriveTaskStatus } from '@midscene/core';
+import { type ExecutionTask, deriveTaskStatus } from '@midscene/core';
 import { typeStr } from '@midscene/core/agent';
+import { collectReportSummary } from '@midscene/core/report-stats';
 import {
   type AnimationScript,
   fullTimeStrWithMilliseconds,
@@ -34,17 +34,12 @@ import { anchorIdForTask } from '../../utils/task-anchor';
 import ReportOverview from '../report-overview';
 import MarkdownSource from './markdown-source';
 
-// Extended task type with searchAreaUsage
-type ExecutionTaskWithSearchAreaUsage = ExecutionTask & {
-  searchAreaUsage?: AIUsageInfo;
-};
-
 // Table row data type
 type TableRowData = {
   key: string;
   isGroupHeader?: boolean;
   groupName?: string;
-  task?: ExecutionTaskWithSearchAreaUsage;
+  task?: ExecutionTask;
 };
 
 interface SidebarProps {
@@ -115,7 +110,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
       execution.tasks.forEach((task, taskIndex) => {
         rows.push({
           key: `task-${executionIndex}-${taskIndex}`,
-          task: task as ExecutionTaskWithSearchAreaUsage,
+          task,
         });
       });
     });
@@ -146,16 +141,14 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     return groupedDump.executions.some((execution) =>
       execution.tasks.some((task) => {
         const mainCached = task.usage?.cached_input || 0;
-        const searchAreaCached =
-          (task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-            ?.cached_input || 0;
+        const searchAreaCached = task.searchAreaUsage?.cached_input || 0;
         return mainCached + searchAreaCached > 0;
       }),
     );
   }, [groupedDump]);
 
   // Helper functions for rendering
-  const getStatusIcon = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getStatusIcon = (task: ExecutionTask) => {
     // Share the same failure semantics as the merged-report status derivation
     // (deriveTaskStatus) so step icons and merged Passed/Failed never diverge.
     const status = deriveTaskStatus(task);
@@ -164,7 +157,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     return iconForStatus(status === 'warning' ? 'finishedWithWarning' : status);
   };
 
-  const getTitleIcon = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getTitleIcon = (task: ExecutionTask) => {
     return task.type === 'Planning' && task.subType !== 'LoadYaml' ? (
       <span
         style={{
@@ -178,7 +171,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getCacheTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getCacheTag = (task: ExecutionTask) => {
     return task.hitBy?.from === 'Cache' ? (
       <Tag
         className="cache-tag"
@@ -195,7 +188,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getDomIncludedTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getDomIncludedTag = (task: ExecutionTask) => {
     const isDomIncludedInsightTask =
       task.type === 'Insight' &&
       (
@@ -220,7 +213,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getDeepLocateTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getDeepLocateTag = (task: ExecutionTask) => {
     return hasDeepLocateFlag(task) ? (
       <Tag
         className="deeplocate-tag"
@@ -237,7 +230,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getDeepThinkTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getDeepThinkTag = (task: ExecutionTask) => {
     return hasDeepThinkFlag(task) ? (
       <Tag
         className="deepthink-tag"
@@ -254,7 +247,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getObservedTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getObservedTag = (task: ExecutionTask) => {
     return hasObserverAssertionFlag(task) ? (
       <Tag
         className="observed-tag"
@@ -271,7 +264,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ) : null;
   };
 
-  const getXPathTag = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getXPathTag = (task: ExecutionTask) => {
     if (task.hitBy?.from !== 'User expected path') {
       return null;
     }
@@ -292,17 +285,14 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     );
   };
 
-  const getStatusText = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getStatusText = (task: ExecutionTask) => {
     if (typeof task.timing?.cost === 'number') {
       return timeCostStrElement(task.timing.cost);
     }
     return task.status;
   };
 
-  const getTokens = (
-    task: ExecutionTaskWithSearchAreaUsage,
-    type: 'prompt' | 'completion',
-  ) => {
+  const getTokens = (task: ExecutionTask, type: 'prompt' | 'completion') => {
     const key = type === 'prompt' ? 'prompt_tokens' : 'completion_tokens';
     const mainUsage = task.usage?.[key] || 0;
     const searchAreaUsage = task.searchAreaUsage?.[key] || 0;
@@ -310,7 +300,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     return total > 0 ? total : '-';
   };
 
-  const getCachedTokens = (task: ExecutionTaskWithSearchAreaUsage) => {
+  const getCachedTokens = (task: ExecutionTask) => {
     const mainCached = task.usage?.cached_input || 0;
     const searchAreaCached = task.searchAreaUsage?.cached_input || 0;
     const total = mainCached + searchAreaCached;
@@ -365,18 +355,15 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
         // Token numbers length
         const promptTokens = String(
           (task.usage?.prompt_tokens || 0) +
-            ((task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-              ?.prompt_tokens || 0),
+            (task.searchAreaUsage?.prompt_tokens || 0),
         );
         const cachedTokens = String(
           (task.usage?.cached_input || 0) +
-            ((task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-              ?.cached_input || 0),
+            (task.searchAreaUsage?.cached_input || 0),
         );
         const completionTokens = String(
           (task.usage?.completion_tokens || 0) +
-            ((task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-              ?.completion_tokens || 0),
+            (task.searchAreaUsage?.completion_tokens || 0),
         );
 
         maxPromptLength = Math.max(maxPromptLength, promptTokens.length);
@@ -392,7 +379,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     // Use 9px per char to account for padding and ensure no overflow
     const charWidth = 9;
     const minWidths = {
-      time: 60,
+      time: 96,
       intent: 60,
       model: 80,
       prompt: 70,
@@ -433,7 +420,13 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
   const columnConfig = useMemo(() => {
     return [
       { key: 'type', label: 'Type', width: typeColumnMinWidth, flex: true },
-      { key: 'time', label: 'Time', width: dynamicWidths.time },
+      {
+        key: 'time',
+        label: 'Time',
+        width: dynamicWidths.time,
+        tooltip:
+          'Per-task elapsed time. The Total row separates Wall time from summed Model call time.',
+      },
       ...(proModeEnabled
         ? [
             { key: 'intent', label: 'Intent', width: dynamicWidths.intent },
@@ -465,119 +458,66 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     ];
   }, [hasCachedInput, proModeEnabled, dynamicWidths]);
 
-  // Calculate total tokens by model
-  const tokensByModel = useMemo(() => {
-    const modelStats = new Map<
-      string,
-      { prompt: number; cachedInput: number; completion: number }
-    >();
-
-    groupedDump?.executions
-      .flatMap((e) => e.tasks)
-      .forEach((task) => {
-        // Skip tasks without usage information
-        if (!task.usage) return;
-
-        const modelName = task.usage.model_name || 'Unknown';
-        const mainPrompt = task.usage.prompt_tokens || 0;
-        const mainCompletion = task.usage.completion_tokens || 0;
-        const mainCached = task.usage.cached_input || 0;
-        const searchAreaPrompt =
-          (task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-            ?.prompt_tokens || 0;
-        const searchAreaCompletion =
-          (task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-            ?.completion_tokens || 0;
-        const searchAreaCached =
-          (task as ExecutionTaskWithSearchAreaUsage).searchAreaUsage
-            ?.cached_input || 0;
-
-        const existing = modelStats.get(modelName) || {
-          prompt: 0,
-          cachedInput: 0,
-          completion: 0,
-        };
-        modelStats.set(modelName, {
-          prompt: existing.prompt + mainPrompt + searchAreaPrompt,
-          cachedInput: existing.cachedInput + mainCached + searchAreaCached,
-          completion:
-            existing.completion + mainCompletion + searchAreaCompletion,
-        });
-      });
-
-    return modelStats;
-  }, [groupedDump]);
-
-  const totalPromptTokens = Array.from(tokensByModel.values()).reduce(
-    (sum, stats) => sum + stats.prompt,
-    0,
-  );
-
-  const totalCachedInputTokens = Array.from(tokensByModel.values()).reduce(
-    (sum, stats) => sum + stats.cachedInput,
-    0,
-  );
-
-  const totalCompletionTokens = Array.from(tokensByModel.values()).reduce(
-    (sum, stats) => sum + stats.completion,
-    0,
-  );
-
-  // Calculate total time cost
-  const timingRange = useMemo(() => {
+  const reportSummary = useMemo(() => {
     if (!groupedDump) return null;
-
-    let earliest: number | null = null;
-    let latest: number | null = null;
-
-    groupedDump.executions.forEach((execution) => {
-      execution.tasks.forEach((task) => {
-        const timestamps = [task.timing?.start, task.timing?.end].filter(
-          (timestamp): timestamp is number => typeof timestamp === 'number',
-        );
-
-        timestamps.forEach((timestamp) => {
-          earliest =
-            earliest === null ? timestamp : Math.min(earliest, timestamp);
-          latest = latest === null ? timestamp : Math.max(latest, timestamp);
-        });
-      });
+    return collectReportSummary(groupedDump, {
+      wallTimeFallbackMs: playwrightAttributes?.playwright_test_duration,
     });
+  }, [groupedDump, playwrightAttributes]);
 
-    if (earliest === null || latest === null) {
-      return null;
-    }
+  const wallTimeTooltip = useMemo(() => {
+    if (!reportSummary) return null;
+    const { timing } = reportSummary;
+    const hasTaskTimestamps = timing.wallTimeSource === 'task-timestamps';
 
-    return {
-      earliest,
-      latest,
-      duration: Math.max(0, latest - earliest),
-    };
-  }, [groupedDump]);
-
-  const totalTimeCost = useMemo(() => {
-    if (timingRange) {
-      return timingRange.duration;
-    }
-
-    return playwrightAttributes?.playwright_test_duration || 0;
-  }, [timingRange, playwrightAttributes]);
-
-  const totalTimeTooltip = useMemo(() => {
-    if (!timingRange) return null;
     return (
       <div className="total-time-tooltip-content">
-        <span className="total-time-tooltip-label">Start</span>
-        <span className="total-time-tooltip-value">
-          {fullTimeStrWithMilliseconds(timingRange.earliest)}
+        <span className="total-time-tooltip-label total-time-tooltip-definition-label">
+          Definition
         </span>
-        <span className="total-time-tooltip-label">End</span>
+        <span className="total-time-tooltip-value total-time-tooltip-description">
+          {hasTaskTimestamps
+            ? 'Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps.'
+            : timing.wallTimeSource === 'fallback'
+              ? 'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.'
+              : 'Unavailable because the report has no recorded task timestamps.'}
+        </span>
+        {hasTaskTimestamps && (
+          <>
+            <span className="total-time-tooltip-label">Start</span>
+            <span className="total-time-tooltip-value">
+              {fullTimeStrWithMilliseconds(timing.wallTimeStart)}
+            </span>
+            <span className="total-time-tooltip-label">End</span>
+            <span className="total-time-tooltip-value">
+              {fullTimeStrWithMilliseconds(timing.wallTimeEnd)}
+            </span>
+          </>
+        )}
+      </div>
+    );
+  }, [reportSummary]);
+
+  const modelCallTimeTooltip = useMemo(() => {
+    if (!reportSummary) return null;
+    const { timing } = reportSummary;
+
+    return (
+      <div className="total-time-tooltip-content">
+        <span className="total-time-tooltip-label total-time-tooltip-definition-label">
+          Definition
+        </span>
+        <span className="total-time-tooltip-value total-time-tooltip-description">
+          Sum of all recorded model request durations. Overlapping calls are
+          counted separately, so this can exceed Wall time.
+        </span>
+        <span className="total-time-tooltip-label">Calls</span>
         <span className="total-time-tooltip-value">
-          {fullTimeStrWithMilliseconds(timingRange.latest)}
+          {timing.modelCallCount}
         </span>
       </div>
     );
-  }, [timingRange]);
+  }, [reportSummary]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -630,10 +570,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     reportViewMode === 'human' || (dumps?.length ?? 0) > 1;
 
   // Render cell content based on column key
-  const renderCellContent = (
-    columnKey: string,
-    task: ExecutionTaskWithSearchAreaUsage,
-  ) => {
+  const renderCellContent = (columnKey: string, task: ExecutionTask) => {
     switch (columnKey) {
       case 'type': {
         const taskName =
@@ -785,8 +722,8 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
           {/* Summary */}
           <div className="table-summary">
             <div className="side-seperator side-seperator-line side-seperator-space-up" />
-            {/* Total time row - always visible */}
-            <div className="summary-row">
+            {/* Grand total: timing is always visible; tokens appear in pro mode. */}
+            <div className="summary-row total-summary-row">
               <div
                 className="summary-cell column-type"
                 style={{
@@ -794,21 +731,40 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
                   flex: 1,
                 }}
               >
-                <div className="token-total-label">Total Time</div>
+                <div className="token-total-label">Total</div>
               </div>
               <div
                 className="summary-cell column-time"
                 style={{ width: dynamicWidths.time }}
               >
-                <span className="token-value">
-                  {timingRange ? (
-                    <Tooltip title={totalTimeTooltip}>
-                      {timeCostStrElement(totalTimeCost)}
-                    </Tooltip>
-                  ) : (
-                    timeCostStrElement(totalTimeCost)
-                  )}
-                </span>
+                <div className="summary-time-values">
+                  <Tooltip
+                    title={wallTimeTooltip}
+                    rootClassName="total-time-tooltip"
+                    placement="topLeft"
+                  >
+                    <span className="summary-time-item">
+                      <span className="summary-time-label">Wall</span>
+                      <span className="summary-time-value">
+                        {timeCostStrElement(reportSummary?.timing.wallTimeMs)}
+                      </span>
+                    </span>
+                  </Tooltip>
+                  <Tooltip
+                    title={modelCallTimeTooltip}
+                    rootClassName="total-time-tooltip"
+                    placement="topLeft"
+                  >
+                    <span className="summary-time-item">
+                      <span className="summary-time-label">Model</span>
+                      <span className="summary-time-value">
+                        {timeCostStrElement(
+                          reportSummary?.timing.modelCallTimeMs,
+                        )}
+                      </span>
+                    </span>
+                  </Tooltip>
+                </div>
               </div>
               {proModeEnabled && (
                 <>
@@ -823,110 +779,79 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
                   <div
                     className="summary-cell column-prompt"
                     style={{ width: dynamicWidths.prompt }}
-                  />
+                  >
+                    <span className="token-value">
+                      {reportSummary?.tokens.promptTokens ?? 0}
+                    </span>
+                  </div>
                   {hasCachedInput && (
                     <div
                       className="summary-cell column-cached"
                       style={{ width: dynamicWidths.cached }}
-                    />
+                    >
+                      <span className="token-value">
+                        {reportSummary?.tokens.cachedInputTokens ?? 0}
+                      </span>
+                    </div>
                   )}
                   <div
                     className="summary-cell column-completion"
                     style={{ width: dynamicWidths.completion }}
-                  />
+                  >
+                    <span className="token-value">
+                      {reportSummary?.tokens.completionTokens ?? 0}
+                    </span>
+                  </div>
                 </>
               )}
             </div>
 
-            {/* Token usage rows - only in pro mode */}
+            {/* Keep per-model subtotals when the report used multiple models. */}
             {proModeEnabled &&
-              (() => {
-                const modelEntries = Array.from(tokensByModel.entries());
-                const hasMultipleModels = modelEntries.length > 1;
-
-                return hasMultipleModels
-                  ? modelEntries.map(([modelName, stats]) => (
-                      <div key={modelName} className="summary-row">
-                        <div
-                          className="summary-cell column-type"
-                          style={{
-                            minWidth: typeColumnMinWidth,
-                            flex: 1,
-                          }}
-                        >
-                          <div className="token-total-label">
-                            {modelName}
-                            <Tag bordered={false} style={{ marginLeft: '8px' }}>
-                              Total
-                            </Tag>
-                          </div>
-                        </div>
-                        <div
-                          className="summary-cell column-prompt"
-                          style={{ width: dynamicWidths.prompt }}
-                        >
-                          <span className="token-value">{stats.prompt}</span>
-                        </div>
-                        {hasCachedInput && (
-                          <div
-                            className="summary-cell column-cached"
-                            style={{ width: dynamicWidths.cached }}
-                          >
-                            <span className="token-value">
-                              {stats.cachedInput}
-                            </span>
-                          </div>
-                        )}
-                        <div
-                          className="summary-cell column-completion"
-                          style={{ width: dynamicWidths.completion }}
-                        >
-                          <span className="token-value">
-                            {stats.completion}
-                          </span>
-                        </div>
-                      </div>
-                    ))
-                  : [
-                      <div key="total-tokens" className="summary-row">
-                        <div
-                          className="summary-cell column-type"
-                          style={{
-                            minWidth: typeColumnMinWidth,
-                            flex: 1,
-                          }}
-                        >
-                          <div className="token-total-label">Total</div>
-                        </div>
-                        <div
-                          className="summary-cell column-prompt"
-                          style={{ width: dynamicWidths.prompt }}
-                        >
-                          <span className="token-value">
-                            {totalPromptTokens}
-                          </span>
-                        </div>
-                        {hasCachedInput && (
-                          <div
-                            className="summary-cell column-cached"
-                            style={{ width: dynamicWidths.cached }}
-                          >
-                            <span className="token-value">
-                              {totalCachedInputTokens}
-                            </span>
-                          </div>
-                        )}
-                        <div
-                          className="summary-cell column-completion"
-                          style={{ width: dynamicWidths.completion }}
-                        >
-                          <span className="token-value">
-                            {totalCompletionTokens}
-                          </span>
-                        </div>
-                      </div>,
-                    ];
-              })()}
+              reportSummary &&
+              reportSummary.models.length > 1 &&
+              reportSummary.models.map((model) => (
+                <div key={model.modelName} className="summary-row">
+                  <div
+                    className="summary-cell column-type"
+                    style={{
+                      minWidth: typeColumnMinWidth,
+                      flex: 1,
+                    }}
+                  >
+                    <div className="token-total-label">
+                      {model.modelName}
+                      <Tag bordered={false} style={{ marginLeft: '8px' }}>
+                        Subtotal
+                      </Tag>
+                    </div>
+                  </div>
+                  <div
+                    className="summary-cell column-prompt"
+                    style={{ width: dynamicWidths.prompt }}
+                  >
+                    <span className="token-value">{model.promptTokens}</span>
+                  </div>
+                  {hasCachedInput && (
+                    <div
+                      className="summary-cell column-cached"
+                      style={{ width: dynamicWidths.cached }}
+                    >
+                      <span className="token-value">
+                        {model.cachedInputTokens}
+                      </span>
+                    </div>
+                  )}
+                  <div
+                    className="summary-cell column-completion"
+                    style={{ width: dynamicWidths.completion }}
+                  >
+                    <span className="token-value">
+                      {model.completionTokens}
+                    </span>
+                  </div>
+                </div>
+              ))}
           </div>
         </div>
         <div className="executions-tip">

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -425,7 +425,7 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
         label: 'Time',
         width: dynamicWidths.time,
         tooltip:
-          'Per-task elapsed time. The Total row separates Wall time from summed Model call time.',
+          'Per-task elapsed time. The Total row separates the overall elapsed span from total model call duration.',
       },
       ...(proModeEnabled
         ? [
@@ -465,22 +465,20 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
     });
   }, [groupedDump, playwrightAttributes]);
 
-  const wallTimeTooltip = useMemo(() => {
+  const timingSummaryTooltip = useMemo(() => {
     if (!reportSummary) return null;
     const { timing } = reportSummary;
     const hasTaskTimestamps = timing.wallTimeSource === 'task-timestamps';
 
     return (
       <div className="total-time-tooltip-content">
-        <span className="total-time-tooltip-label total-time-tooltip-definition-label">
-          Definition
-        </span>
-        <span className="total-time-tooltip-value total-time-tooltip-description">
+        <span className="total-time-tooltip-metric">Elapsed</span>
+        <span className="total-time-tooltip-description">
           {hasTaskTimestamps
-            ? 'Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps.'
+            ? 'Total span from the first recorded task start to the last recorded task end, including model calls, actions, waits, and gaps.'
             : timing.wallTimeSource === 'fallback'
-              ? 'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.'
-              : 'Unavailable because the report has no recorded task timestamps.'}
+              ? 'Total elapsed duration reported by the enclosing test runner because task timestamps were unavailable.'
+              : 'The total elapsed span is unavailable because the report has no recorded task timestamps.'}
         </span>
         {hasTaskTimestamps && (
           <>
@@ -494,22 +492,9 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
             </span>
           </>
         )}
-      </div>
-    );
-  }, [reportSummary]);
-
-  const modelCallTimeTooltip = useMemo(() => {
-    if (!reportSummary) return null;
-    const { timing } = reportSummary;
-
-    return (
-      <div className="total-time-tooltip-content">
-        <span className="total-time-tooltip-label total-time-tooltip-definition-label">
-          Definition
-        </span>
-        <span className="total-time-tooltip-value total-time-tooltip-description">
-          Sum of all recorded model request durations. Overlapping calls are
-          counted separately, so this can exceed Wall time.
+        <span className="total-time-tooltip-metric">Model</span>
+        <span className="total-time-tooltip-description">
+          Total duration of all recorded model calls.
         </span>
         <span className="total-time-tooltip-label">Calls</span>
         <span className="total-time-tooltip-value">
@@ -737,24 +722,18 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
                 className="summary-cell column-time"
                 style={{ width: dynamicWidths.time }}
               >
-                <div className="summary-time-values">
-                  <Tooltip
-                    title={wallTimeTooltip}
-                    rootClassName="total-time-tooltip"
-                    placement="topLeft"
-                  >
+                <Tooltip
+                  title={timingSummaryTooltip}
+                  rootClassName="total-time-tooltip"
+                  placement="topLeft"
+                >
+                  <div className="summary-time-values">
                     <span className="summary-time-item">
-                      <span className="summary-time-label">Wall</span>
+                      <span className="summary-time-label">Elapsed</span>
                       <span className="summary-time-value">
                         {timeCostStrElement(reportSummary?.timing.wallTimeMs)}
                       </span>
                     </span>
-                  </Tooltip>
-                  <Tooltip
-                    title={modelCallTimeTooltip}
-                    rootClassName="total-time-tooltip"
-                    placement="topLeft"
-                  >
                     <span className="summary-time-item">
                       <span className="summary-time-label">Model</span>
                       <span className="summary-time-value">
@@ -763,8 +742,8 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
                         )}
                       </span>
                     </span>
-                  </Tooltip>
-                </div>
+                  </div>
+                </Tooltip>
               </div>
               {proModeEnabled && (
                 <>

--- a/apps/report/src/components/sidebar/sidebar-layout.test.ts
+++ b/apps/report/src/components/sidebar/sidebar-layout.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from '@rstest/core';
 
 const styles = readFileSync(new URL('./index.less', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./index.tsx', import.meta.url), 'utf8');
 const commonStyles = readFileSync(
   new URL('../common.less', import.meta.url),
   'utf8',
@@ -34,6 +35,17 @@ describe('sidebar layout', () => {
     );
     expect(screenshotStyles).toMatch(
       /\.agent-screenshot-header\s*{[^}]*height: @report-pane-header-height;/s,
+    );
+  });
+
+  it('keeps timing tooltip definitions readable within the viewport', () => {
+    expect(source.match(/rootClassName="total-time-tooltip"/g)).toHaveLength(2);
+    expect(source.match(/placement="topLeft"/g)).toHaveLength(2);
+    expect(styles).toMatch(
+      /\.ant-tooltip\.total-time-tooltip\s*{[^}]*max-width: min\(360px, calc\(100vw - 24px\)\);/s,
+    );
+    expect(styles).toMatch(
+      /\.total-time-tooltip-definition-label,\s*\.total-time-tooltip-description\s*{[^}]*grid-column: 1 \/ -1;/s,
     );
   });
 });

--- a/apps/report/src/components/sidebar/sidebar-layout.test.ts
+++ b/apps/report/src/components/sidebar/sidebar-layout.test.ts
@@ -39,13 +39,13 @@ describe('sidebar layout', () => {
   });
 
   it('keeps timing tooltip definitions readable within the viewport', () => {
-    expect(source.match(/rootClassName="total-time-tooltip"/g)).toHaveLength(2);
-    expect(source.match(/placement="topLeft"/g)).toHaveLength(2);
+    expect(source.match(/rootClassName="total-time-tooltip"/g)).toHaveLength(1);
+    expect(source.match(/placement="topLeft"/g)).toHaveLength(1);
     expect(styles).toMatch(
       /\.ant-tooltip\.total-time-tooltip\s*{[^}]*max-width: min\(360px, calc\(100vw - 24px\)\);/s,
     );
     expect(styles).toMatch(
-      /\.total-time-tooltip-definition-label,\s*\.total-time-tooltip-description\s*{[^}]*grid-column: 1 \/ -1;/s,
+      /\.total-time-tooltip-metric,\s*\.total-time-tooltip-description\s*{[^}]*grid-column: 1 \/ -1;/s,
     );
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,11 @@
       "import": "./dist/es/report.mjs",
       "require": "./dist/lib/report.js"
     },
+    "./report-stats": {
+      "types": "./dist/types/report-stats.d.ts",
+      "import": "./dist/es/report-stats.mjs",
+      "require": "./dist/lib/report-stats.js"
+    },
     "./skill": {
       "types": "./dist/types/skill/index.d.ts",
       "import": "./dist/es/skill/index.mjs",
@@ -74,6 +79,7 @@
       "device": ["./dist/types/device.d.ts"],
       "dump": ["./dist/types/dump/index.d.ts"],
       "dump/task-service-dump": ["./dist/types/dump/task-service-dump.d.ts"],
+      "report-stats": ["./dist/types/report-stats.d.ts"],
       "agent": ["./dist/types/agent.d.ts"],
       "yaml": ["./dist/types/yaml.d.ts"],
       "skill": ["./dist/types/skill/index.d.ts"]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,6 +130,7 @@ export {
   reportToMarkdown,
   type ExecutionMarkdownOptions,
   type ExecutionMarkdownResult,
+  type ReportMarkdownOptions,
   type ReportMarkdownResult,
   type MarkdownAttachment,
 } from './report-markdown';

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -740,26 +740,26 @@ export function reportToMarkdown(
       : ['- No model metadata recorded.']),
   ];
 
-  const wallTimeDescription =
+  const elapsedTimeDescription =
     reportSummary.timing.wallTimeSource === 'task-timestamps'
-      ? 'Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps.'
+      ? 'Total span from the first recorded task start to the last recorded task end, including model calls, actions, waits, and gaps.'
       : reportSummary.timing.wallTimeSource === 'fallback'
-        ? 'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.'
-        : 'Unavailable because the report has no recorded task timestamps.';
+        ? 'Total elapsed duration reported by the enclosing test runner because task timestamps were unavailable.'
+        : 'The total elapsed span is unavailable because the report has no recorded task timestamps.';
   const timingSummaryLines = [
     '\n## Timing Summary',
     ...markdownTable(
       ['Metric', 'Duration(ms)', 'Definition'],
       [
         [
-          'Wall Time',
+          'Elapsed Time',
           reportSummary.timing.wallTimeMs ?? 'N/A',
-          wallTimeDescription,
+          elapsedTimeDescription,
         ],
         [
           'Model Call Time',
           reportSummary.timing.modelCallTimeMs,
-          'Sum of all recorded model request durations. Overlapping calls are counted separately, so this can exceed Wall Time.',
+          'Total duration of all recorded model calls.',
         ],
       ],
     ),

--- a/packages/core/src/report-markdown.ts
+++ b/packages/core/src/report-markdown.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/types';
 import type { ScreenshotRef } from './dump/screenshot-store';
 import { normalizeScreenshotRef } from './dump/screenshot-store';
+import { collectReportSummary } from './report-stats';
 
 const screenshotDataUrlPattern =
   /^data:image\/(png|jpeg|jpg);base64,([\s\S]*)$/i;
@@ -21,15 +22,6 @@ type ExecutionTaskWithExtraUsage = ExecutionTask & {
   searchAreaUsage?: AIUsageInfo;
   reasoning_content?: string;
 };
-
-interface UsageTotals {
-  calls: number;
-  prompt: number;
-  cachedInput: number;
-  completion: number;
-  total: number;
-  timeCost: number;
-}
 
 export interface MarkdownAttachment {
   id: string;
@@ -54,6 +46,11 @@ export interface MarkdownAttachment {
 
 export interface ExecutionMarkdownOptions {
   screenshotBaseDir?: string;
+}
+
+export interface ReportMarkdownOptions {
+  /** Used only when the report has no recorded task timestamps. */
+  wallTimeFallbackMs?: number;
 }
 
 export interface ExecutionMarkdownResult {
@@ -190,16 +187,6 @@ function usageTotalTokens(usage: AIUsageInfo): number {
   );
 }
 
-function usageModelName(usage: AIUsageInfo): string {
-  return (
-    usage.model_name ||
-    usage.response_model_name ||
-    usage.model_description ||
-    usage.intent ||
-    'Unknown'
-  );
-}
-
 function usageRowsForTask(task: ExecutionTask): unknown[][] {
   const taskWithUsage = task as ExecutionTaskWithExtraUsage;
   const rows: unknown[][] = [];
@@ -222,43 +209,6 @@ function usageRowsForTask(task: ExecutionTask): unknown[][] {
   appendUsage('main', taskWithUsage.usage);
   appendUsage('searchArea', taskWithUsage.searchAreaUsage);
   return rows;
-}
-
-function collectUsageTotals(
-  report: IReportActionDump,
-): Map<string, UsageTotals> {
-  const totalsByModel = new Map<string, UsageTotals>();
-  const addUsage = (usage?: AIUsageInfo) => {
-    if (!hasUsage(usage)) return;
-    const modelName = usageModelName(usage);
-    const current = totalsByModel.get(modelName) ?? {
-      calls: 0,
-      prompt: 0,
-      cachedInput: 0,
-      completion: 0,
-      total: 0,
-      timeCost: 0,
-    };
-
-    totalsByModel.set(modelName, {
-      calls: current.calls + 1,
-      prompt: current.prompt + usageValue(usage, 'prompt_tokens'),
-      cachedInput: current.cachedInput + usageValue(usage, 'cached_input'),
-      completion: current.completion + usageValue(usage, 'completion_tokens'),
-      total: current.total + usageTotalTokens(usage),
-      timeCost: current.timeCost + usageValue(usage, 'time_cost'),
-    });
-  };
-
-  for (const execution of report.executions) {
-    for (const task of execution.tasks) {
-      const taskWithUsage = task as ExecutionTaskWithExtraUsage;
-      addUsage(taskWithUsage.usage);
-      addUsage(taskWithUsage.searchAreaUsage);
-    }
-  }
-
-  return totalsByModel;
 }
 
 function sanitizeJsonForMarkdown(
@@ -720,7 +670,7 @@ function renderExecution(
             'Cached Input',
             'Completion Tokens',
             'Total Tokens',
-            'Time Cost(ms)',
+            'Model Call Time(ms)',
             'Request ID',
           ],
           usageRows,
@@ -765,6 +715,7 @@ export function executionToMarkdown(
 
 export function reportToMarkdown(
   report: ReportActionDump | IReportActionDump,
+  options?: ReportMarkdownOptions,
 ): ReportMarkdownResult {
   const reportDump = toReportDump(report);
 
@@ -777,7 +728,7 @@ export function reportToMarkdown(
   });
 
   const attachments = executionResults.flatMap((item) => item.attachments);
-  const usageTotals = collectUsageTotals(reportDump);
+  const reportSummary = collectReportSummary(reportDump, options);
   const modelRows = reportDump.modelBriefs?.length
     ? modelBriefRows(reportDump.modelBriefs)
     : modelRowsFromUsage(reportDump);
@@ -789,9 +740,34 @@ export function reportToMarkdown(
       : ['- No model metadata recorded.']),
   ];
 
+  const wallTimeDescription =
+    reportSummary.timing.wallTimeSource === 'task-timestamps'
+      ? 'Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps.'
+      : reportSummary.timing.wallTimeSource === 'fallback'
+        ? 'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.'
+        : 'Unavailable because the report has no recorded task timestamps.';
+  const timingSummaryLines = [
+    '\n## Timing Summary',
+    ...markdownTable(
+      ['Metric', 'Duration(ms)', 'Definition'],
+      [
+        [
+          'Wall Time',
+          reportSummary.timing.wallTimeMs ?? 'N/A',
+          wallTimeDescription,
+        ],
+        [
+          'Model Call Time',
+          reportSummary.timing.modelCallTimeMs,
+          'Sum of all recorded model request durations. Overlapping calls are counted separately, so this can exceed Wall Time.',
+        ],
+      ],
+    ),
+  ];
+
   const tokenSummaryLines = [
     '\n## Token Usage Summary',
-    ...(usageTotals.size
+    ...(reportSummary.models.length
       ? markdownTable(
           [
             'Model',
@@ -800,16 +776,16 @@ export function reportToMarkdown(
             'Cached Input',
             'Completion Tokens',
             'Total Tokens',
-            'Time Cost(ms)',
+            'Model Call Time(ms)',
           ],
-          Array.from(usageTotals.entries()).map(([modelName, totals]) => [
-            modelName,
-            totals.calls,
-            totals.prompt,
-            totals.cachedInput,
-            totals.completion,
-            totals.total,
-            totals.timeCost,
+          reportSummary.models.map((model) => [
+            model.modelName,
+            model.callCount,
+            model.promptTokens,
+            model.cachedInputTokens,
+            model.completionTokens,
+            model.totalTokens,
+            model.modelCallTimeMs,
           ]),
         )
       : ['- No token usage recorded.']),
@@ -822,6 +798,7 @@ export function reportToMarkdown(
     reportDump.deviceType ? `- Device Type: ${reportDump.deviceType}` : '',
     `- Execution count: ${reportDump.executions.length}`,
     ...modelInfoLines,
+    ...timingSummaryLines,
     ...tokenSummaryLines,
   ]
     .filter(Boolean)

--- a/packages/core/src/report-stats.ts
+++ b/packages/core/src/report-stats.ts
@@ -1,0 +1,207 @@
+import type { AIUsageInfo, IReportActionDump } from './types';
+
+export interface ReportModelUsageSummary {
+  modelName: string;
+  callCount: number;
+  promptTokens: number;
+  cachedInputTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  modelCallTimeMs: number;
+}
+
+export interface ReportTokenSummary {
+  promptTokens: number;
+  cachedInputTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface ReportTimingSummary {
+  /**
+   * Elapsed time between the earliest and latest recorded task timestamps.
+   * Falls back to `wallTimeFallbackMs` only when no task timestamps exist.
+   */
+  wallTimeMs?: number;
+  wallTimeStart?: number;
+  wallTimeEnd?: number;
+  wallTimeSource: 'task-timestamps' | 'fallback' | 'unavailable';
+  /** Sum of every recorded model request duration. */
+  modelCallTimeMs: number;
+  modelCallCount: number;
+}
+
+export interface ReportSummary {
+  timing: ReportTimingSummary;
+  tokens: ReportTokenSummary;
+  models: ReportModelUsageSummary[];
+}
+
+export interface CollectReportSummaryOptions {
+  /** Generic fallback for reports without task timestamps, such as test time. */
+  wallTimeFallbackMs?: number;
+}
+
+const usageKeys = [
+  'intent',
+  'slot',
+  'model_name',
+  'response_model_name',
+  'model_description',
+  'prompt_tokens',
+  'cached_input',
+  'completion_tokens',
+  'total_tokens',
+  'time_cost',
+  'request_id',
+] as const;
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function usageValue(usage: AIUsageInfo, key: string): number {
+  return Math.max(0, finiteNumber(usage[key]) ?? 0);
+}
+
+function hasUsage(usage: AIUsageInfo | undefined): usage is AIUsageInfo {
+  return Boolean(
+    usage &&
+      usageKeys.some((key) => usage[key] !== undefined && usage[key] !== null),
+  );
+}
+
+function usageTotalTokens(usage: AIUsageInfo): number {
+  const explicitTotal = finiteNumber(usage.total_tokens);
+  if (explicitTotal !== undefined && explicitTotal > 0) {
+    return explicitTotal;
+  }
+  return (
+    usageValue(usage, 'prompt_tokens') + usageValue(usage, 'completion_tokens')
+  );
+}
+
+function usageModelName(usage: AIUsageInfo): string {
+  return (
+    usage.model_name ||
+    usage.response_model_name ||
+    usage.model_description ||
+    usage.intent ||
+    'Unknown'
+  );
+}
+
+export function collectReportSummary(
+  report: Pick<IReportActionDump, 'executions'>,
+  options: CollectReportSummaryOptions = {},
+): ReportSummary {
+  if (!report || !Array.isArray(report.executions)) {
+    throw new Error('collectReportSummary: report.executions must be an array');
+  }
+
+  let earliestTimestamp: number | undefined;
+  let latestTimestamp: number | undefined;
+  let modelCallCount = 0;
+  let modelCallTimeMs = 0;
+  const models = new Map<string, ReportModelUsageSummary>();
+
+  const addTimestamp = (value: unknown) => {
+    const timestamp = finiteNumber(value);
+    if (timestamp === undefined) return;
+    earliestTimestamp =
+      earliestTimestamp === undefined
+        ? timestamp
+        : Math.min(earliestTimestamp, timestamp);
+    latestTimestamp =
+      latestTimestamp === undefined
+        ? timestamp
+        : Math.max(latestTimestamp, timestamp);
+  };
+
+  const addUsage = (usage: AIUsageInfo | undefined) => {
+    if (!hasUsage(usage)) return;
+
+    const modelName = usageModelName(usage);
+    const current = models.get(modelName) ?? {
+      modelName,
+      callCount: 0,
+      promptTokens: 0,
+      cachedInputTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      modelCallTimeMs: 0,
+    };
+    const callTimeMs = usageValue(usage, 'time_cost');
+
+    models.set(modelName, {
+      modelName,
+      callCount: current.callCount + 1,
+      promptTokens: current.promptTokens + usageValue(usage, 'prompt_tokens'),
+      cachedInputTokens:
+        current.cachedInputTokens + usageValue(usage, 'cached_input'),
+      completionTokens:
+        current.completionTokens + usageValue(usage, 'completion_tokens'),
+      totalTokens: current.totalTokens + usageTotalTokens(usage),
+      modelCallTimeMs: current.modelCallTimeMs + callTimeMs,
+    });
+    modelCallCount += 1;
+    modelCallTimeMs += callTimeMs;
+  };
+
+  for (const execution of report.executions) {
+    for (const task of execution.tasks) {
+      addTimestamp(task.timing?.start);
+      addTimestamp(task.timing?.end);
+      addUsage(task.usage);
+      addUsage(task.searchAreaUsage);
+    }
+  }
+
+  const modelSummaries = Array.from(models.values());
+  const tokens = modelSummaries.reduce<ReportTokenSummary>(
+    (total, model) => ({
+      promptTokens: total.promptTokens + model.promptTokens,
+      cachedInputTokens: total.cachedInputTokens + model.cachedInputTokens,
+      completionTokens: total.completionTokens + model.completionTokens,
+      totalTokens: total.totalTokens + model.totalTokens,
+    }),
+    {
+      promptTokens: 0,
+      cachedInputTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+  );
+
+  const fallback = finiteNumber(options.wallTimeFallbackMs);
+  const hasFallback = fallback !== undefined && fallback >= 0;
+  let wallTimeMs: number | undefined;
+  let wallTimeSource: ReportTimingSummary['wallTimeSource'];
+
+  if (earliestTimestamp !== undefined && latestTimestamp !== undefined) {
+    wallTimeMs = Math.max(0, latestTimestamp - earliestTimestamp);
+    wallTimeSource = 'task-timestamps';
+  } else if (hasFallback) {
+    wallTimeMs = fallback;
+    wallTimeSource = 'fallback';
+  } else {
+    wallTimeSource = 'unavailable';
+  }
+
+  return {
+    timing: {
+      wallTimeMs,
+      wallTimeStart:
+        wallTimeSource === 'task-timestamps' ? earliestTimestamp : undefined,
+      wallTimeEnd:
+        wallTimeSource === 'task-timestamps' ? latestTimestamp : undefined,
+      wallTimeSource,
+      modelCallTimeMs,
+      modelCallCount,
+    },
+    tokens,
+    models: modelSummaries,
+  };
+}

--- a/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
+++ b/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
@@ -6,6 +6,12 @@
 ## Model Info
 - No model metadata recorded.
 
+## Timing Summary
+| Metric | Duration(ms) | Definition |
+| --- | --- | --- |
+| Wall Time | 100 | Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps. |
+| Model Call Time | 0 | Sum of all recorded model request durations. Overlapping calls are counted separately, so this can exceed Wall Time. |
+
 ## Token Usage Summary
 - No token usage recorded.
 

--- a/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
+++ b/packages/core/tests/unit-test/__snapshots__/report-markdown.output.md
@@ -9,8 +9,8 @@
 ## Timing Summary
 | Metric | Duration(ms) | Definition |
 | --- | --- | --- |
-| Wall Time | 100 | Elapsed time from the earliest recorded task timestamp to the latest, including model calls, actions, waits, and gaps. |
-| Model Call Time | 0 | Sum of all recorded model request durations. Overlapping calls are counted separately, so this can exceed Wall Time. |
+| Elapsed Time | 100 | Total span from the first recorded task start to the last recorded task end, including model calls, actions, waits, and gaps. |
+| Model Call Time | 0 | Total duration of all recorded model calls. |
 
 ## Token Usage Summary
 - No token usage recorded.

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -305,10 +305,10 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('## Model Info');
     expect(result.markdown).toContain('| planning | gpt-4o | vision planner |');
     expect(result.markdown).toContain('## Timing Summary');
-    expect(result.markdown).toContain('| Wall Time | 100 |');
+    expect(result.markdown).toContain('| Elapsed Time | 100 |');
     expect(result.markdown).toContain('| Model Call Time | 579 |');
     expect(result.markdown).toContain(
-      'Overlapping calls are counted separately, so this can exceed Wall Time.',
+      'Total duration of all recorded model calls.',
     );
     expect(result.markdown).toContain('## Token Usage Summary');
     expect(result.markdown).toContain('Model Call Time(ms)');
@@ -335,7 +335,7 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('Clicking submit completes the form.');
   });
 
-  it('explains the wall-time fallback in markdown', () => {
+  it('explains the elapsed-time fallback in markdown', () => {
     const report: IReportActionDump = {
       sdkVersion: '1.0.0',
       groupName: 'fallback-timing-report',
@@ -351,9 +351,9 @@ describe('report-markdown', () => {
 
     const result = reportToMarkdown(report, { wallTimeFallbackMs: 2_500 });
 
-    expect(result.markdown).toContain('| Wall Time | 2500 |');
+    expect(result.markdown).toContain('| Elapsed Time | 2500 |');
     expect(result.markdown).toContain(
-      'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.',
+      'Total elapsed duration reported by the enclosing test runner because task timestamps were unavailable.',
     );
   });
 

--- a/packages/core/tests/unit-test/report-markdown.test.ts
+++ b/packages/core/tests/unit-test/report-markdown.test.ts
@@ -304,7 +304,14 @@ describe('report-markdown', () => {
 
     expect(result.markdown).toContain('## Model Info');
     expect(result.markdown).toContain('| planning | gpt-4o | vision planner |');
+    expect(result.markdown).toContain('## Timing Summary');
+    expect(result.markdown).toContain('| Wall Time | 100 |');
+    expect(result.markdown).toContain('| Model Call Time | 579 |');
+    expect(result.markdown).toContain(
+      'Overlapping calls are counted separately, so this can exceed Wall Time.',
+    );
     expect(result.markdown).toContain('## Token Usage Summary');
+    expect(result.markdown).toContain('Model Call Time(ms)');
     expect(result.markdown).toContain(
       '| gpt-4o | 1 | 100 | 20 | 30 | 130 | 456 |',
     );
@@ -326,6 +333,28 @@ describe('report-markdown', () => {
     expect(result.markdown).toContain('Submit button is visible.');
     expect(result.markdown).toContain('### Reasoning Content');
     expect(result.markdown).toContain('Clicking submit completes the form.');
+  });
+
+  it('explains the wall-time fallback in markdown', () => {
+    const report: IReportActionDump = {
+      sdkVersion: '1.0.0',
+      groupName: 'fallback-timing-report',
+      modelBriefs: [],
+      executions: [
+        {
+          logTime: 1710000000000,
+          name: 'execution without task timing',
+          tasks: [createTask({ timing: undefined })],
+        },
+      ],
+    };
+
+    const result = reportToMarkdown(report, { wallTimeFallbackMs: 2_500 });
+
+    expect(result.markdown).toContain('| Wall Time | 2500 |');
+    expect(result.markdown).toContain(
+      'Elapsed time reported by the enclosing test runner because task timestamps were unavailable.',
+    );
   });
 
   it('falls back report model info to task usage when model briefs are missing', () => {

--- a/packages/core/tests/unit-test/report-stats.test.ts
+++ b/packages/core/tests/unit-test/report-stats.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { collectReportSummary } from '../../src/report-stats';
+import type {
+  AIUsageInfo,
+  ExecutionTask,
+  IReportActionDump,
+} from '../../src/types';
+
+function createUsage(overrides: Partial<AIUsageInfo>): AIUsageInfo {
+  return {
+    prompt_tokens: undefined,
+    completion_tokens: undefined,
+    total_tokens: undefined,
+    cached_input: undefined,
+    time_cost: undefined,
+    model_name: undefined,
+    model_description: undefined,
+    response_model_name: undefined,
+    intent: undefined,
+    slot: undefined,
+    request_id: undefined,
+    ...overrides,
+  };
+}
+
+function createTask(overrides: Partial<ExecutionTask> = {}): ExecutionTask {
+  return {
+    taskId: 'task',
+    type: 'Log',
+    status: 'finished',
+    executor: async () => {},
+    ...overrides,
+  };
+}
+
+function createReport(
+  tasks: ExecutionTask[],
+): Pick<IReportActionDump, 'executions'> {
+  return {
+    executions: [
+      {
+        logTime: 100,
+        name: 'execution',
+        tasks,
+      },
+    ],
+  };
+}
+
+describe('collectReportSummary', () => {
+  it('aggregates wall time, model call time, and tokens with search-area calls attributed to their own models', () => {
+    const report = createReport([
+      createTask({
+        taskId: 'task-1',
+        timing: { start: 100, end: 300 },
+        usage: createUsage({
+          model_name: 'alpha',
+          prompt_tokens: 10,
+          cached_input: 2,
+          completion_tokens: 3,
+          total_tokens: 13,
+          time_cost: 80,
+        }),
+        searchAreaUsage: createUsage({
+          model_name: 'beta',
+          prompt_tokens: 4,
+          completion_tokens: 1,
+          time_cost: 30,
+        }),
+      }),
+      createTask({
+        taskId: 'task-2',
+        timing: { start: 250, end: 500 },
+        usage: createUsage({
+          model_name: 'alpha',
+          prompt_tokens: 5,
+          completion_tokens: 2,
+          time_cost: 90,
+        }),
+      }),
+      createTask({
+        taskId: 'task-3',
+        timing: { start: 150, end: 450 },
+        searchAreaUsage: createUsage({
+          model_name: 'gamma',
+          prompt_tokens: 7,
+          completion_tokens: 1,
+          time_cost: 20,
+        }),
+      }),
+    ]);
+
+    expect(collectReportSummary(report)).toEqual({
+      timing: {
+        wallTimeMs: 400,
+        wallTimeStart: 100,
+        wallTimeEnd: 500,
+        wallTimeSource: 'task-timestamps',
+        modelCallTimeMs: 220,
+        modelCallCount: 4,
+      },
+      tokens: {
+        promptTokens: 26,
+        cachedInputTokens: 2,
+        completionTokens: 7,
+        totalTokens: 33,
+      },
+      models: [
+        {
+          modelName: 'alpha',
+          callCount: 2,
+          promptTokens: 15,
+          cachedInputTokens: 2,
+          completionTokens: 5,
+          totalTokens: 20,
+          modelCallTimeMs: 170,
+        },
+        {
+          modelName: 'beta',
+          callCount: 1,
+          promptTokens: 4,
+          cachedInputTokens: 0,
+          completionTokens: 1,
+          totalTokens: 5,
+          modelCallTimeMs: 30,
+        },
+        {
+          modelName: 'gamma',
+          callCount: 1,
+          promptTokens: 7,
+          cachedInputTokens: 0,
+          completionTokens: 1,
+          totalTokens: 8,
+          modelCallTimeMs: 20,
+        },
+      ],
+    });
+  });
+
+  it('uses the wall-time fallback only when task timestamps are unavailable', () => {
+    const noTiming = collectReportSummary(createReport([createTask()]), {
+      wallTimeFallbackMs: 1_234,
+    });
+    const withTiming = collectReportSummary(
+      createReport([createTask({ timing: { start: 20, end: 70 } })]),
+      { wallTimeFallbackMs: 1_234 },
+    );
+
+    expect(noTiming.timing).toMatchObject({
+      wallTimeMs: 1_234,
+      wallTimeSource: 'fallback',
+    });
+    expect(withTiming.timing).toMatchObject({
+      wallTimeMs: 50,
+      wallTimeStart: 20,
+      wallTimeEnd: 70,
+      wallTimeSource: 'task-timestamps',
+    });
+  });
+
+  it('reports unavailable wall time and zero model time when no data exists', () => {
+    expect(collectReportSummary(createReport([]))).toEqual({
+      timing: {
+        wallTimeMs: undefined,
+        wallTimeStart: undefined,
+        wallTimeEnd: undefined,
+        wallTimeSource: 'unavailable',
+        modelCallTimeMs: 0,
+        modelCallCount: 0,
+      },
+      tokens: {
+        promptTokens: 0,
+        cachedInputTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      },
+      models: [],
+    });
+  });
+
+  it('throws when executions are not an array', () => {
+    expect(() =>
+      collectReportSummary({ executions: null } as unknown as Pick<
+        IReportActionDump,
+        'executions'
+      >),
+    ).toThrow('collectReportSummary: report.executions must be an array');
+  });
+});

--- a/packages/core/tests/unit-test/report-stats.test.ts
+++ b/packages/core/tests/unit-test/report-stats.test.ts
@@ -48,7 +48,7 @@ function createReport(
 }
 
 describe('collectReportSummary', () => {
-  it('aggregates wall time, model call time, and tokens with search-area calls attributed to their own models', () => {
+  it('aggregates elapsed time, model call time, and tokens with search-area calls attributed to their own models', () => {
     const report = createReport([
       createTask({
         taskId: 'task-1',
@@ -137,7 +137,7 @@ describe('collectReportSummary', () => {
     });
   });
 
-  it('uses the wall-time fallback only when task timestamps are unavailable', () => {
+  it('uses the elapsed-time fallback only when task timestamps are unavailable', () => {
     const noTiming = collectReportSummary(createReport([createTask()]), {
       wallTimeFallbackMs: 1_234,
     });
@@ -158,7 +158,7 @@ describe('collectReportSummary', () => {
     });
   });
 
-  it('reports unavailable wall time and zero model time when no data exists', () => {
+  it('reports unavailable elapsed time and zero model time when no data exists', () => {
     expect(collectReportSummary(createReport([]))).toEqual({
       timing: {
         wallTimeMs: undefined,


### PR DESCRIPTION
## Background

The report previously exposed a single total duration without clearly distinguishing end-to-end elapsed time from accumulated model request time. Human View and Markdown also maintained separate aggregation logic.

## Changes

- Add a shared `collectReportSummary` utility for Wall Time, Model Call Time, call count, and token usage
- Aggregate both primary model usage and `searchAreaUsage`, attributing each call to its actual model
- Replace the separate timing summary with one `Total` row showing both `Wall` and `Model`
- Add definitions explaining both metrics and why overlapping model calls can make Model Call Time exceed Wall Time
- Fix tooltip width, wrapping, positioning, and dark-mode styling
- Add a `Timing Summary` section to Markdown using the same aggregation logic as Human View
- Fall back to the Playwright test duration only when task timestamps are unavailable
- Add unit, Markdown, layout, and Report AI e2e coverage

## Review Focus

- Wall Time calculation and fallback behavior
- Model, token, and call attribution across `usage` and `searchAreaUsage`
- Summary-row alignment in normal, Pro, cached-token, and multi-model scenarios
- Metric consistency between Human View and Markdown
- Public API boundary of `@midscene/core/report-stats`
- Tooltip behavior in narrow sidebars and dark mode

## Validation

- `pnpm run lint`
- `pnpm nx test core` — 1,448 passed, 8 skipped
- `pnpm nx test report` — 92 passed
- `pnpm nx build core`
- `pnpm nx build report`
- `pnpm nx build android --skip-nx-cache`
- `git diff --check`
- Ran the Dongchedi Android ranking-filter case against the local packages successfully
- Verified Wall/Model values and tooltip layout in the original report generated by that run