### PR TITLE
test(report): select Replay before player assertion

### DIFF
--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -32,6 +32,10 @@ tasks:
   # --- Player area visible with controls ---
   - name: player area is visible with playback controls
     flow:
+      - aiTap:
+          locate:
+            prompt: the "Replay" option in the center task detail Replay/Screenshots/JSON View switcher
+      - sleep: 1000
       - aiAssert: There is a video player area with a progress bar and playback time display
 
   # --- Settings popup ---


### PR DESCRIPTION
## Summary

- explicitly select the Replay tab before asserting that playback controls are visible
- keep the report loading and player checks on Midscene aiTap and aiAssert
- remove the implicit dependency on whichever detail tab was active after switching from Markdown View back to Human View

## Root cause

The report-single E2E switched from Markdown View back to Human View and immediately asserted that a video player was visible. In two consecutive #3001 runs, the active detail tab was Screenshots, so the model correctly reported that the page showed a screenshot preview rather than playback controls.

The test now places the UI in the state required by the assertion before evaluating it.

## Related PR

Discovered while validating #3001. This test-only stabilization is independent of the observation JPEG implementation and therefore targets main in a separate PR.

## Validation

- pnpm run lint
- reproduced the same report-single assertion failure twice in #3001
- attempted the focused local report-single.yaml run; the configured local model endpoint returned 429 RPM limit errors at the first assertion before reaching the changed step
- GitHub AI E2E validation is expected to provide the authoritative model-backed result