### PR TITLE
fix(android): configure bitrate and harden scrcpy recovery

### DIFF
--- a/apps/site/docs/en/platforms/android.mdx
+++ b/apps/site/docs/en/platforms/android.mdx
@@ -297,42 +297,22 @@ The default is `auto`, which tries `adb.takeScreenshot` first, falls back to she
 
 ### Why does scrcpy fall back to ADB screenshots?
 
-Midscene rejects scrcpy frames that cannot be proven to have been captured after the latest completed action. A fresh frame can be unavailable for two different reasons:
+Midscene rejects scrcpy frames that cannot be proven to have been captured after the latest completed action and that do not satisfy the absolute frame-age limit. If an established stream cannot provide a valid frame, Midscene restarts scrcpy once. It falls back to an ADB screenshot only if the new stream also fails.
 
-- A bandwidth-constrained remote connection can build up a transport backlog, especially with the default 100 Mbps video bitrate.
-- Some Android encoders stop emitting frames while the screen is static. This can also happen over a healthy local USB connection and is not evidence that the bitrate is too high.
+This can happen when an Android encoder stops emitting frames on a static screen, or when stream startup or transport is interrupted. The freshness warning alone does not diagnose link bandwidth or an excessive video bitrate. Do not change the bitrate solely because this warning appears.
 
-When an established stream does not produce a fresh frame, Midscene restarts scrcpy once and uses the new stream epoch's first frame. It falls back to an ADB screenshot only if that restart also fails.
+### How do I configure the scrcpy video bitrate?
 
-For a constrained remote connection, start with a 4 Mbps video bitrate. Android CLI commands are independent processes, so pass the option to every command that should use this bitrate:
+Use `--scrcpy-video-bit-rate <bits-per-second>` (or `--scrcpyVideoBitRate`) on an Android CLI command. Providing this option enables scrcpy, so `--use-scrcpy` is optional when the bitrate option is present:
 
 ```bash
 midscene-android tap \
   --device-id <device-id> \
   --locate '{"prompt":"the target"}' \
-  --use-scrcpy \
-  --scrcpy-video-bit-rate 4000000
+  --scrcpy-video-bit-rate <bits-per-second>
 ```
 
-The camel-case alias `--scrcpyVideoBitRate` is also accepted. The bitrate option enables scrcpy by itself, so `--use-scrcpy` may be omitted when it is present. The value is in bits per second. Lowering it further may help only when the remote transport is actually congested. If a local USB device still reports no fresh frames at 4 Mbps or less, keep the bitrate and investigate static-screen encoder behavior or stream startup instead. Raising the bitrate can preserve more image detail when the connection has enough bandwidth.
-
-For the JavaScript SDK or YAML configuration, set the equivalent `scrcpyConfig.videoBitRate` option:
-
-```typescript
-const device = new AndroidDevice('device-id', {
-  scrcpyConfig: {
-    enabled: true,
-    videoBitRate: 4_000_000,
-  },
-});
-```
-
-```yaml
-android:
-  scrcpyConfig:
-    enabled: true
-    videoBitRate: 4000000
-```
+Each CLI command is a separate process, so pass the option to every command that should override the default. For the JavaScript SDK or YAML, set `scrcpyConfig.videoBitRate` once on that device configuration. Changing the bitrate trades encoded bandwidth against screenshot detail. Tune it only when independent transport measurements show a need, then validate screenshot and recognition quality. See the [`AndroidDevice` scrcpy reference](../reference/index.mdx#scrcpy) for the default and related options.
 
 ### How do I use a custom adb path or remote adb server?
 

--- a/apps/site/docs/en/platforms/android.mdx
+++ b/apps/site/docs/en/platforms/android.mdx
@@ -295,6 +295,40 @@ export MIDSCENE_ANDROID_SCREENSHOT_STRATEGY=always-yadb
 
 The default is `auto`, which tries `adb.takeScreenshot` first, falls back to shell `screencap`, and uses the yadb tool if `screencap` fails to execute. scrcpy is only tried before these when `scrcpyConfig.enabled` is turned on. `auto` does not analyze screenshot content — even if a method succeeds but returns a black frame, it will not automatically switch to yadb; it only moves to the next method when the previous one fails to execute. For secure pages that produce a valid but black image, set `always-yadb` to bypass the default `auto` flow (`adb.takeScreenshot`, `screencap`, and scrcpy when enabled) and use yadb directly. Yadb can only capture the default display (`displayId=0`), so combining `always-yadb` with a non-zero `displayId` throws an error.
 
+### Why does scrcpy fall back to ADB screenshots?
+
+On a bandwidth-constrained remote device connection, the default 100 Mbps scrcpy video stream can build up a transport backlog. If Midscene cannot obtain a frame captured after the latest action, it rejects the stale frame and falls back to an ADB screenshot.
+
+For the Android CLI, start with a 4 Mbps video bitrate and add both options to every command that uses scrcpy:
+
+```bash
+midscene-android tap \
+  --device-id <device-id> \
+  --locate '{"prompt":"the target"}' \
+  --use-scrcpy \
+  --scrcpy-video-bit-rate 4000000
+```
+
+The camel-case alias `--scrcpyVideoBitRate` is also accepted. The bitrate option enables scrcpy by itself, so `--use-scrcpy` may be omitted when it is present. The value is in bits per second. Lower it further if fallback continues; raising it can preserve more image detail when the connection has enough bandwidth.
+
+For the JavaScript SDK or YAML configuration, set the equivalent `scrcpyConfig.videoBitRate` option:
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  scrcpyConfig: {
+    enabled: true,
+    videoBitRate: 4_000_000,
+  },
+});
+```
+
+```yaml
+android:
+  scrcpyConfig:
+    enabled: true
+    videoBitRate: 4000000
+```
+
 ### How do I use a custom adb path or remote adb server?
 
 Set the environment variables first:

--- a/apps/site/docs/en/platforms/android.mdx
+++ b/apps/site/docs/en/platforms/android.mdx
@@ -297,9 +297,14 @@ The default is `auto`, which tries `adb.takeScreenshot` first, falls back to she
 
 ### Why does scrcpy fall back to ADB screenshots?
 
-On a bandwidth-constrained remote device connection, the default 100 Mbps scrcpy video stream can build up a transport backlog. If Midscene cannot obtain a frame captured after the latest action, it rejects the stale frame and falls back to an ADB screenshot.
+Midscene rejects scrcpy frames that cannot be proven to have been captured after the latest completed action. A fresh frame can be unavailable for two different reasons:
 
-For the Android CLI, start with a 4 Mbps video bitrate and add both options to every command that uses scrcpy:
+- A bandwidth-constrained remote connection can build up a transport backlog, especially with the default 100 Mbps video bitrate.
+- Some Android encoders stop emitting frames while the screen is static. This can also happen over a healthy local USB connection and is not evidence that the bitrate is too high.
+
+When an established stream does not produce a fresh frame, Midscene restarts scrcpy once and uses the new stream epoch's first frame. It falls back to an ADB screenshot only if that restart also fails.
+
+For a constrained remote connection, start with a 4 Mbps video bitrate. Android CLI commands are independent processes, so pass the option to every command that should use this bitrate:
 
 ```bash
 midscene-android tap \
@@ -309,7 +314,7 @@ midscene-android tap \
   --scrcpy-video-bit-rate 4000000
 ```
 
-The camel-case alias `--scrcpyVideoBitRate` is also accepted. The bitrate option enables scrcpy by itself, so `--use-scrcpy` may be omitted when it is present. The value is in bits per second. Lower it further if fallback continues; raising it can preserve more image detail when the connection has enough bandwidth.
+The camel-case alias `--scrcpyVideoBitRate` is also accepted. The bitrate option enables scrcpy by itself, so `--use-scrcpy` may be omitted when it is present. The value is in bits per second. Lowering it further may help only when the remote transport is actually congested. If a local USB device still reports no fresh frames at 4 Mbps or less, keep the bitrate and investigate static-screen encoder behavior or stream startup instead. Raising the bitrate can preserve more image detail when the connection has enough bandwidth.
 
 For the JavaScript SDK or YAML configuration, set the equivalent `scrcpyConfig.videoBitRate` option:
 

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -2190,7 +2190,7 @@ const device = new AndroidDevice(deviceId, {
 - `scrcpyConfig?: object` — High-performance scrcpy screenshot configuration:
   - `enabled?: boolean` — Whether to enable scrcpy screenshots. Default: `false`.
   - `maxSize?: number` — Maximum screenshot width or height in pixels. The same limit applies to ADB/yadb fallback screenshots while scrcpy is temporarily unavailable, preventing planning and report images from returning to full device resolution. Use a non-negative integer; `0` disables scaling. Default: `0`.
-  - `videoBitRate?: number` — scrcpy H.264 encoding bitrate in bits per second. Default: `100000000`. For a bandwidth-constrained remote link, explicitly set a lower value such as `4000000` and tune it for the actual transport.
+  - `videoBitRate?: number` — scrcpy H.264 encoding bitrate in bits per second. Default: `100000000`. Changing it trades encoded bandwidth against screenshot detail. Tune it only from independent transport measurements and validate recognition quality; a freshness-timeout warning alone is not a reason to change it.
   - `idleTimeoutMs?: number` — Idle time before disconnecting the scrcpy stream. `0` disables automatic disconnection. Default: `30000`.
 
 `device.getScrcpyStatus()` returns the current `enabled`, `connected`, `lastError`, and `retryAfter` state. `device.retryScrcpy()` immediately retries the scrcpy connection and returns `Promise<void>`.

--- a/apps/site/docs/zh/platforms/android.mdx
+++ b/apps/site/docs/zh/platforms/android.mdx
@@ -300,9 +300,14 @@ export MIDSCENE_ANDROID_SCREENSHOT_STRATEGY=always-yadb
 
 ### 为什么 scrcpy 会回退到 ADB 截图？
 
-通过带宽受限的远程链路连接设备时，scrcpy 默认的 100 Mbps 视频流可能产生传输积压。如果 Midscene 无法取得晚于最近一次操作的画面，就会拒绝使用旧帧并回退到 ADB 截图。
+Midscene 只会使用能够证明拍摄时间晚于最近一次已完成操作的 scrcpy 帧。无法取得新帧通常有两类原因：
 
-使用 Android CLI 时，可以先从 4 Mbps 开始尝试，并在每条启用 scrcpy 的命令中同时添加以下两个参数：
+- 带宽受限的远程连接可能产生传输积压，使用默认 100 Mbps 视频码率时更容易出现。
+- 部分 Android 编码器会在画面静止时停止输出帧。即使本地 USB 链路正常也可能出现这种情况，并不代表码率过高。
+
+当已有视频流无法提供新帧时，Midscene 会自动重启一次 scrcpy，并使用新视频流的首帧；只有重启后仍然失败时才会回退到 ADB 截图。
+
+对于带宽受限的远程连接，可以先从 4 Mbps 开始。每条 Android CLI 命令都是独立进程，因此需要在每条希望使用该码率的命令中传入参数：
 
 ```bash
 midscene-android tap \
@@ -312,7 +317,7 @@ midscene-android tap \
   --scrcpy-video-bit-rate 4000000
 ```
 
-CLI 也接受驼峰形式 `--scrcpyVideoBitRate`。设置码率参数本身就会启用 scrcpy，因此使用该参数时可以省略 `--use-scrcpy`。该参数的单位是 bit/s。如果仍然发生回退，可以继续降低；链路带宽充足时，提高码率可以保留更多画面细节。
+CLI 也接受驼峰形式 `--scrcpyVideoBitRate`。设置码率参数本身就会启用 scrcpy，因此使用该参数时可以省略 `--use-scrcpy`。该参数的单位是 bit/s。只有远程传输确实拥塞时，继续降低码率才可能有效。如果本地 USB 设备在 4 Mbps 或更低码率下仍提示没有新帧，请保持当前码率，并检查静态画面的编码器行为或视频流启动情况。链路带宽充足时，提高码率可以保留更多画面细节。
 
 使用 JavaScript SDK 或 YAML 配置时，请设置等价的 `scrcpyConfig.videoBitRate`：
 

--- a/apps/site/docs/zh/platforms/android.mdx
+++ b/apps/site/docs/zh/platforms/android.mdx
@@ -300,42 +300,22 @@ export MIDSCENE_ANDROID_SCREENSHOT_STRATEGY=always-yadb
 
 ### 为什么 scrcpy 会回退到 ADB 截图？
 
-Midscene 只会使用能够证明拍摄时间晚于最近一次已完成操作的 scrcpy 帧。无法取得新帧通常有两类原因：
+Midscene 会拒绝无法证明拍摄时间晚于最近一次已完成操作，或不满足绝对帧龄限制的 scrcpy 帧。如果已有视频流无法提供有效帧，Midscene 会自动重启一次 scrcpy；只有新视频流仍然失败时，才会回退到 ADB 截图。
 
-- 带宽受限的远程连接可能产生传输积压，使用默认 100 Mbps 视频码率时更容易出现。
-- 部分 Android 编码器会在画面静止时停止输出帧。即使本地 USB 链路正常也可能出现这种情况，并不代表码率过高。
+部分 Android 编码器会在画面静止时停止输出帧，视频流启动或传输中断也可能导致此现象。仅凭 freshness 告警无法判断链路带宽不足或视频码率过高，请勿只因为出现该告警就调整码率。
 
-当已有视频流无法提供新帧时，Midscene 会自动重启一次 scrcpy，并使用新视频流的首帧；只有重启后仍然失败时才会回退到 ADB 截图。
+### 如何配置 scrcpy 视频码率？
 
-对于带宽受限的远程连接，可以先从 4 Mbps 开始。每条 Android CLI 命令都是独立进程，因此需要在每条希望使用该码率的命令中传入参数：
+在 Android CLI 命令中使用 `--scrcpy-video-bit-rate <bits-per-second>`（或 `--scrcpyVideoBitRate`）。设置该参数本身就会启用 scrcpy，因此可以省略 `--use-scrcpy`：
 
 ```bash
 midscene-android tap \
   --device-id <device-id> \
   --locate '{"prompt":"目标元素"}' \
-  --use-scrcpy \
-  --scrcpy-video-bit-rate 4000000
+  --scrcpy-video-bit-rate <bits-per-second>
 ```
 
-CLI 也接受驼峰形式 `--scrcpyVideoBitRate`。设置码率参数本身就会启用 scrcpy，因此使用该参数时可以省略 `--use-scrcpy`。该参数的单位是 bit/s。只有远程传输确实拥塞时，继续降低码率才可能有效。如果本地 USB 设备在 4 Mbps 或更低码率下仍提示没有新帧，请保持当前码率，并检查静态画面的编码器行为或视频流启动情况。链路带宽充足时，提高码率可以保留更多画面细节。
-
-使用 JavaScript SDK 或 YAML 配置时，请设置等价的 `scrcpyConfig.videoBitRate`：
-
-```typescript
-const device = new AndroidDevice('device-id', {
-  scrcpyConfig: {
-    enabled: true,
-    videoBitRate: 4_000_000,
-  },
-});
-```
-
-```yaml
-android:
-  scrcpyConfig:
-    enabled: true
-    videoBitRate: 4000000
-```
+每条 CLI 命令都是独立进程，因此每条需要覆盖默认码率的命令都要传入该参数。使用 JavaScript SDK 或 YAML 时，只需在对应设备配置中设置一次 `scrcpyConfig.videoBitRate`。调整码率是在编码带宽和截图细节之间取舍；只有独立的链路测量表明有需要时才应调优，并验证截图与识别质量。默认值和相关选项见 [`AndroidDevice` scrcpy 参考](../reference/index.mdx#scrcpy)。
 
 ### 如何使用自定义的 adb 路径或远程 adb 服务器？
 

--- a/apps/site/docs/zh/platforms/android.mdx
+++ b/apps/site/docs/zh/platforms/android.mdx
@@ -298,6 +298,40 @@ export MIDSCENE_ANDROID_SCREENSHOT_STRATEGY=always-yadb
 
 默认值为 `auto`，即先使用 `adb.takeScreenshot`，失败后回退到 shell `screencap`；如果 `screencap` 执行失败，则改用 yadb 工具。scrcpy 仅当 `scrcpyConfig.enabled` 开启时才会在这些方法之前优先尝试。`auto` 不会分析截图内容：即使某个截图方法执行成功但返回全黑图片，也不会自动切换到 yadb；只有当前一种截图方法执行失败时，才会尝试下一种方法。安全页面生成有效但全黑的图片时，请设置 `always-yadb`，绕过默认的 `auto` 截图流程（`adb.takeScreenshot`、`screencap`，以及开启时的 scrcpy），直接使用 yadb 截图。yadb 只能截取默认显示器（`displayId=0`）；如果同时设置 `always-yadb` 和非零 `displayId`，Midscene 会抛出错误。
 
+### 为什么 scrcpy 会回退到 ADB 截图？
+
+通过带宽受限的远程链路连接设备时，scrcpy 默认的 100 Mbps 视频流可能产生传输积压。如果 Midscene 无法取得晚于最近一次操作的画面，就会拒绝使用旧帧并回退到 ADB 截图。
+
+使用 Android CLI 时，可以先从 4 Mbps 开始尝试，并在每条启用 scrcpy 的命令中同时添加以下两个参数：
+
+```bash
+midscene-android tap \
+  --device-id <device-id> \
+  --locate '{"prompt":"目标元素"}' \
+  --use-scrcpy \
+  --scrcpy-video-bit-rate 4000000
+```
+
+CLI 也接受驼峰形式 `--scrcpyVideoBitRate`。设置码率参数本身就会启用 scrcpy，因此使用该参数时可以省略 `--use-scrcpy`。该参数的单位是 bit/s。如果仍然发生回退，可以继续降低；链路带宽充足时，提高码率可以保留更多画面细节。
+
+使用 JavaScript SDK 或 YAML 配置时，请设置等价的 `scrcpyConfig.videoBitRate`：
+
+```typescript
+const device = new AndroidDevice('device-id', {
+  scrcpyConfig: {
+    enabled: true,
+    videoBitRate: 4_000_000,
+  },
+});
+```
+
+```yaml
+android:
+  scrcpyConfig:
+    enabled: true
+    videoBitRate: 4000000
+```
+
 ### 如何使用自定义的 adb 路径或远程 adb 服务器？
 
 通过环境变量设置：

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -2147,7 +2147,7 @@ const device = new AndroidDevice(deviceId, {
 - `scrcpyConfig?: object` —— scrcpy 截图配置，默认关闭。
   - `enabled?: boolean` —— 是否启用 scrcpy 截图，默认 `false`。
   - `maxSize?: number` —— 截图的最大宽度或高度。scrcpy 暂时不可用时，ADB/yadb 回退截图也会应用相同限制，避免规划和报告中的图片恢复为设备原始分辨率。必须使用非负整数；默认 `0`，表示不缩放。
-  - `videoBitRate?: number` —— scrcpy H.264 编码码率，单位为 bps，默认 `100000000`。带宽受限的远程链路可以显式设置较低值（如 `4000000`），并根据实际网络调优。
+  - `videoBitRate?: number` —— scrcpy H.264 编码码率，单位为 bps，默认 `100000000`。调整该值是在编码带宽和截图细节之间取舍；只有独立的链路测量表明有需要时才应调优，并验证识别质量，不能仅凭 freshness 超时告警调整。
   - `idleTimeoutMs?: number` —— 空闲连接的断开时间，单位为毫秒，默认 `30000`；设为 `0` 时禁用。
 
 - `device.getScrcpyStatus()` —— 返回 `enabled`、`connected`、`lastError` 和 `retryAfter`。

--- a/packages/android/src/agent-tools.ts
+++ b/packages/android/src/agent-tools.ts
@@ -82,7 +82,7 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
         .positive()
         .optional()
         .describe(
-          'scrcpy H.264 video bitrate in bits per second; providing this option also enables scrcpy. Default with --use-scrcpy: 100000000 (100 Mbps). For constrained remote links, start with 4000000 (4 Mbps).',
+          'scrcpy H.264 video bitrate in bits per second; providing this option also enables scrcpy. Default with --use-scrcpy: 100000000 (100 Mbps). Changing it trades encoded bandwidth against screenshot detail; tune it only from independent transport measurements, not from a freshness-timeout warning alone.',
         ),
       ...agentBehaviorInitArgShape,
     },

--- a/packages/android/src/agent-tools.ts
+++ b/packages/android/src/agent-tools.ts
@@ -19,6 +19,7 @@ const debug = getDebug('agent-tools:android');
 
 type AndroidInitArgs = AgentBehaviorInitArgs & {
   deviceId?: string;
+  scrcpyVideoBitRate?: number;
   useScrcpy?: boolean;
 };
 
@@ -29,13 +30,21 @@ function adaptAndroidInitArgs(
     return undefined;
   }
 
+  const scrcpyVideoBitRate =
+    typeof extracted.scrcpyVideoBitRate === 'number'
+      ? extracted.scrcpyVideoBitRate
+      : undefined;
+  const requestedUseScrcpy =
+    typeof extracted.useScrcpy === 'boolean' ? extracted.useScrcpy : undefined;
+  const useScrcpy =
+    scrcpyVideoBitRate !== undefined ? true : requestedUseScrcpy;
+
   const initArgs: AndroidInitArgs = {
     ...(typeof extracted.deviceId === 'string'
       ? { deviceId: extracted.deviceId }
       : {}),
-    ...(typeof extracted.useScrcpy === 'boolean'
-      ? { useScrcpy: extracted.useScrcpy }
-      : {}),
+    ...(useScrcpy !== undefined ? { useScrcpy } : {}),
+    ...(scrcpyVideoBitRate !== undefined ? { scrcpyVideoBitRate } : {}),
     ...(extractAgentBehaviorInitArgs(extracted as AgentBehaviorInitArgs) ?? {}),
   };
 
@@ -67,6 +76,14 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
         .boolean()
         .optional()
         .describe('Enable scrcpy accelerated screenshots'),
+      scrcpyVideoBitRate: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'scrcpy H.264 video bitrate in bits per second; providing this option also enables scrcpy. Default with --use-scrcpy: 100000000 (100 Mbps). For constrained remote links, start with 4000000 (4 Mbps).',
+        ),
       ...agentBehaviorInitArgShape,
     },
     cli: {
@@ -108,7 +125,16 @@ export class AndroidMidsceneTools extends BaseMidsceneTools<
     const agent = await agentFromAdbDevice(deviceId, {
       autoDismissKeyboard: false,
       ...(extractAgentBehaviorInitArgs(initArgs) ?? {}),
-      ...(initArgs?.useScrcpy ? { scrcpyConfig: { enabled: true } } : {}),
+      ...(initArgs?.useScrcpy
+        ? {
+            scrcpyConfig: {
+              enabled: true,
+              ...(initArgs.scrcpyVideoBitRate !== undefined
+                ? { videoBitRate: initArgs.scrcpyVideoBitRate }
+                : {}),
+            },
+          }
+        : {}),
       ...(reportOptions ?? {}),
     });
     this.agent = agent;

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -52,10 +52,7 @@ import {
   ScrcpyDeviceAdapter,
   type ScrcpyStatus,
 } from './scrcpy-device-adapter';
-import {
-  type RawKeyframe,
-  SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT,
-} from './scrcpy-manager';
+import type { RawKeyframe } from './scrcpy-manager';
 import { captureAndroidUITree } from './ui-tree-capture';
 import { createVisualActionRegistry } from './visual-action-registry';
 
@@ -1394,7 +1391,7 @@ ${Object.keys(size)
         return result;
       } catch (error) {
         warnDevice(
-          `Scrcpy screenshot failed, falling back to standard ADB method. This may be caused by transport backlog. ${SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT}\nError: ${error}`,
+          `Scrcpy screenshot failed, falling back to standard ADB method.\nError: ${error}`,
         );
         // Continue to standard ADB path
       }

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -51,8 +51,12 @@ import {
   type DevicePhysicalInfo,
   ScrcpyDeviceAdapter,
   type ScrcpyStatus,
+  formatScrcpyFreshFrameFailure,
 } from './scrcpy-device-adapter';
-import type { RawKeyframe } from './scrcpy-manager';
+import {
+  type RawKeyframe,
+  isScrcpyFreshFrameUnavailableError,
+} from './scrcpy-manager';
 import { captureAndroidUITree } from './ui-tree-capture';
 import { createVisualActionRegistry } from './visual-action-registry';
 
@@ -1381,17 +1385,19 @@ ${Object.keys(size)
     }
 
     // Try scrcpy mode first (if enabled and initialized)
-    let scrcpyDeviceInfo: DevicePhysicalInfo | null = null;
     if (adapter.isEnabled()) {
       try {
         debugDevice('Attempting scrcpy screenshot...');
-        scrcpyDeviceInfo = await this.getDevicePhysicalInfo();
+        const scrcpyDeviceInfo = await this.getDevicePhysicalInfo();
         const result = await adapter.screenshotBase64(scrcpyDeviceInfo);
         debugDevice('screenshotBase64 end (scrcpy mode)');
         return result;
       } catch (error) {
+        const diagnostic = isScrcpyFreshFrameUnavailableError(error)
+          ? `\n${formatScrcpyFreshFrameFailure(error)}`
+          : '';
         warnDevice(
-          `Scrcpy screenshot failed, falling back to standard ADB method.\nError: ${error}`,
+          `Scrcpy screenshot failed, falling back to standard ADB method.${diagnostic}\nError: ${error}`,
         );
         // Continue to standard ADB path
       }
@@ -1472,11 +1478,6 @@ ${Object.keys(size)
         },
       );
       debugDevice('screenshotBase64 end (fallback)');
-      if (scrcpyDeviceInfo) {
-        // Start a new stream only after ADB has finished, so the fallback
-        // capture does not compete with scrcpy startup on the same transport.
-        adapter.recoverAfterAdbScreenshot(scrcpyDeviceInfo);
-      }
       return this.prepareFallbackScreenshot(result);
     }
 
@@ -1490,11 +1491,6 @@ ${Object.keys(size)
       screenshotBuffer.toString('base64'),
     );
     debugDevice('screenshotBase64 end');
-    if (scrcpyDeviceInfo) {
-      // Start a new stream only after ADB has finished, so the fallback capture
-      // does not compete with scrcpy startup on the same remote transport.
-      adapter.recoverAfterAdbScreenshot(scrcpyDeviceInfo);
-    }
     return this.prepareFallbackScreenshot(result);
   }
 

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -333,13 +333,16 @@ export class ScrcpyDeviceAdapter {
   private async applyPendingActionBarrier(
     manager: ScrcpyScreenshotManager,
   ): Promise<void> {
-    const actionCompletedAtHostUs = this.pendingActionBarrierAtHostUs;
-    if (actionCompletedAtHostUs === null) return;
+    const actionStartedAtHostUs = this.pendingActionBarrierAtHostUs;
+    if (actionStartedAtHostUs === null) return;
     await manager.setFreshnessBarrier(
-      'completed input action while scrcpy was unavailable',
-      actionCompletedAtHostUs,
+      'input action started while scrcpy was unavailable',
+      {
+        allowOverAgeForNextCapture: true,
+        hostMonotonicUs: actionStartedAtHostUs,
+      },
     );
-    if (this.pendingActionBarrierAtHostUs === actionCompletedAtHostUs) {
+    if (this.pendingActionBarrierAtHostUs === actionStartedAtHostUs) {
       this.pendingActionBarrierAtHostUs = null;
     }
   }
@@ -348,12 +351,12 @@ export class ScrcpyDeviceAdapter {
     return process.hrtime.bigint() / 1_000n;
   }
 
-  private deferActionBarrier(actionCompletedAtHostUs: bigint): void {
+  private deferActionBarrier(actionStartedAtHostUs: bigint): void {
     if (
       this.pendingActionBarrierAtHostUs === null ||
-      actionCompletedAtHostUs > this.pendingActionBarrierAtHostUs
+      actionStartedAtHostUs > this.pendingActionBarrierAtHostUs
     ) {
-      this.pendingActionBarrierAtHostUs = actionCompletedAtHostUs;
+      this.pendingActionBarrierAtHostUs = actionStartedAtHostUs;
     }
   }
 
@@ -403,32 +406,33 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
-   * Move the scrcpy PTS barrier past a completed input action. Barrier failures
-   * must not turn a successfully injected action into an action error; disable
-   * the stream and let subsequent captures use the existing ADB fallback.
+   * Move the scrcpy PTS barrier to immediately before an input action. Frames
+   * produced while the ADB command is returning then remain valid candidates.
+   * Barrier failures must not block the input action; disable the stream and
+   * let subsequent captures use the existing ADB fallback.
    */
   async markActionBarrier(): Promise<void> {
-    const actionCompletedAtHostUs = this.monotonicTimeUs();
+    const actionStartedAtHostUs = this.monotonicTimeUs();
     const manager = this.manager;
     if (!manager?.isConnected()) {
-      this.deferActionBarrier(actionCompletedAtHostUs);
+      this.deferActionBarrier(actionStartedAtHostUs);
       return;
     }
 
     try {
-      await manager.setFreshnessBarrier(
-        'completed input action',
-        actionCompletedAtHostUs,
-      );
+      await manager.setFreshnessBarrier('input action started', {
+        allowOverAgeForNextCapture: true,
+        hostMonotonicUs: actionStartedAtHostUs,
+      });
       if (
         this.pendingActionBarrierAtHostUs !== null &&
-        this.pendingActionBarrierAtHostUs <= actionCompletedAtHostUs
+        this.pendingActionBarrierAtHostUs <= actionStartedAtHostUs
       ) {
         this.pendingActionBarrierAtHostUs = null;
       }
       this.clearFailure();
     } catch (error) {
-      this.deferActionBarrier(actionCompletedAtHostUs);
+      this.deferActionBarrier(actionStartedAtHostUs);
       this.recordFailure(error);
       debugAdapter(
         `Unable to mark scrcpy action barrier; disabling this stream: ${error}`,

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -10,8 +10,32 @@ import {
 } from './scrcpy-manager';
 
 const debugAdapter = getDebug('android:scrcpy-adapter');
-const warnAdapter = getDebug('android:scrcpy-adapter', { console: true });
 const SCRCPY_RETRY_COOLDOWN_MS = 5_000;
+const CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE = 4_000_000;
+
+export function formatScrcpyFreshFrameFailure(
+  error: ScrcpyFreshFrameUnavailableError,
+): string {
+  const videoBitRate = error.videoBitRate;
+  const timeoutMs = Number.isFinite(error.timeoutMs)
+    ? error.timeoutMs
+    : error.failureKind === 'stream-startup'
+      ? 5_000
+      : 300;
+  if (error.failureKind === 'stream-startup') {
+    return `The new scrcpy stream did not produce a usable baseline frame within ${timeoutMs}ms. This is a stream startup or encoder-readiness failure, not evidence that the configured video bitrate is too high.`;
+  }
+
+  const bitRateDescription = Number.isFinite(videoBitRate)
+    ? ` Current videoBitRate: ${videoBitRate} bps (${videoBitRate / 1_000_000} Mbps).`
+    : '';
+  const networkHint =
+    Number.isFinite(videoBitRate) &&
+    videoBitRate <= CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE
+      ? 'The current scrcpy video bitrate is already at or below 4 Mbps. Lowering it further is unlikely to help on a local USB connection; check whether the screen was static or the device encoder emitted no new frame.'
+      : 'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, pass --scrcpy-video-bit-rate 4000000 in the Android CLI, or set scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) in SDK/YAML configuration. Lower it further if backlog persists.';
+  return `No usable scrcpy frame crossed the active freshness target within ${timeoutMs}ms. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint}${bitRateDescription}`;
+}
 
 interface ScrcpyConfig {
   enabled?: boolean;
@@ -66,9 +90,7 @@ export class ScrcpyDeviceAdapter {
   private resolvedConfig: ResolvedScrcpyConfig | null = null;
   private lastError: string | null = null;
   private retryAfter: number | null = null;
-  private freshnessRecoveryPending = false;
   private freshnessRestartPromise: Promise<Buffer> | null = null;
-  private recoveryPromise: Promise<void> | null = null;
   private lifecycleGeneration = 0;
   private pendingActionBarrierAtHostUs: bigint | null = null;
   private keyframeListeners = new Set<(frame: RawKeyframe) => void>();
@@ -86,7 +108,6 @@ export class ScrcpyDeviceAdapter {
 
   isEnabled(): boolean {
     if (!this.isConfigured()) return false;
-    if (this.freshnessRecoveryPending || this.recoveryPromise) return false;
     return this.retryAfter === null || Date.now() >= this.retryAfter;
   }
 
@@ -107,11 +128,6 @@ export class ScrcpyDeviceAdapter {
    * Initialize scrcpy connection. Called during device.connect() and explicit retries.
    */
   async initialize(deviceInfo: DevicePhysicalInfo): Promise<void> {
-    if (this.recoveryPromise) {
-      await this.recoveryPromise;
-      if (this.manager?.isConnected()) return;
-    }
-    this.freshnessRecoveryPending = false;
     try {
       const manager = await this.ensureManager(deviceInfo);
       await manager.ensureConnected();
@@ -126,19 +142,14 @@ export class ScrcpyDeviceAdapter {
   private recordFailure(error: unknown): void {
     this.lastError = error instanceof Error ? error.message : String(error);
     this.retryAfter = Date.now() + SCRCPY_RETRY_COOLDOWN_MS;
-    this.freshnessRecoveryPending = false;
   }
 
   private clearFailure(): void {
     this.lastError = null;
     this.retryAfter = null;
-    this.freshnessRecoveryPending = false;
   }
 
   private ensureRetryReady(): void {
-    if (this.freshnessRecoveryPending || this.recoveryPromise) {
-      throw new Error('scrcpy freshness recovery is in progress');
-    }
     if (this.retryAfter === null || Date.now() >= this.retryAfter) {
       return;
     }
@@ -293,7 +304,6 @@ export class ScrcpyDeviceAdapter {
         throw error;
       }
 
-      this.markFreshnessRecoveryPending(error);
       debugAdapter(
         `Scrcpy freshness target was unavailable; restarting the stream once before ADB fallback: ${error}`,
       );
@@ -311,12 +321,8 @@ export class ScrcpyDeviceAdapter {
         debugAdapter('Scrcpy screenshot recovered on a new stream epoch');
         return this.jpegBufferToBase64(screenshotBuffer);
       } catch (retryError) {
-        if (isScrcpyFreshFrameUnavailableError(retryError)) {
-          this.markFreshnessRecoveryPending(retryError);
-        } else {
-          this.recordFailure(retryError);
-        }
-        this.warnFreshnessFallback(error, retryError);
+        this.keyframeUnsubscribers.clear();
+        this.recordFailure(retryError);
         throw retryError;
       }
     }
@@ -352,22 +358,6 @@ export class ScrcpyDeviceAdapter {
 
   private jpegBufferToBase64(screenshotBuffer: Buffer): string {
     return createImgBase64ByFormat('jpeg', screenshotBuffer.toString('base64'));
-  }
-
-  private warnFreshnessFallback(
-    firstError: ScrcpyFreshFrameUnavailableError,
-    retryError: unknown,
-  ): void {
-    const retryDiagnostic = isScrcpyFreshFrameUnavailableError(retryError)
-      ? retryError.diagnosticMessage
-      : undefined;
-    warnAdapter(
-      retryDiagnostic ??
-        (firstError.diagnosticMessage
-          ? `${firstError.diagnosticMessage}\nScrcpy stream restart error: ${retryError}`
-          : undefined) ??
-        `Scrcpy stream restart failed; falling back to ADB screenshot. Error: ${retryError}`,
-    );
   }
 
   /**
@@ -425,17 +415,6 @@ export class ScrcpyDeviceAdapter {
     }
   }
 
-  private markFreshnessRecoveryPending(
-    error: ScrcpyFreshFrameUnavailableError,
-  ): void {
-    this.lastError = error.message;
-    this.retryAfter = null;
-    this.freshnessRecoveryPending = true;
-    this.keyframeUnsubscribers.clear();
-    // ScrcpyScreenshotManager closes only the stale video epoch for this error.
-    // Keep the manager so the retry reuses its owned yume ADB transport.
-  }
-
   private async applyPendingActionBarrier(
     manager: ScrcpyScreenshotManager,
   ): Promise<void> {
@@ -444,7 +423,6 @@ export class ScrcpyDeviceAdapter {
     await manager.setFreshnessBarrier(
       'completed input action while scrcpy was unavailable',
       {
-        allowOverAgeForNextCapture: true,
         hostMonotonicUs: actionCompletedAtHostUs,
       },
     );
@@ -467,51 +445,6 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
-   * Start a new scrcpy epoch only after the independent ADB screenshot has
-   * completed, so stream startup does not compete with the fallback capture.
-   */
-  recoverAfterAdbScreenshot(deviceInfo: DevicePhysicalInfo): void {
-    if (!this.freshnessRecoveryPending || this.recoveryPromise) return;
-
-    const generation = this.lifecycleGeneration;
-    const recovery = (async () => {
-      let manager: ScrcpyScreenshotManager | null = null;
-      try {
-        manager = await this.ensureManager(deviceInfo);
-        await manager.ensureConnected();
-        await this.applyPendingActionBarrier(manager);
-        await manager.prepareFreshFrame();
-        if (generation !== this.lifecycleGeneration) {
-          await manager.dispose();
-          if (this.manager === manager) this.manager = null;
-          return;
-        }
-        this.attachKeyframeListeners(manager);
-        this.clearFailure();
-        debugAdapter('Scrcpy freshness recovery completed in background');
-      } catch (error) {
-        if (manager) {
-          await manager.dispose();
-          if (this.manager === manager) this.manager = null;
-        }
-        this.freshnessRecoveryPending = false;
-        this.recordFailure(error);
-        debugAdapter(`Scrcpy background freshness recovery failed: ${error}`);
-        throw error;
-      }
-    })();
-
-    this.recoveryPromise = recovery;
-    void recovery
-      .catch(() => {})
-      .finally(() => {
-        if (this.recoveryPromise === recovery) {
-          this.recoveryPromise = null;
-        }
-      });
-  }
-
-  /**
    * Move the scrcpy PTS barrier past a completed input action. Barrier failures
    * must not turn a successfully injected action into an action error; disable
    * the stream and let subsequent captures use the existing ADB fallback.
@@ -526,7 +459,6 @@ export class ScrcpyDeviceAdapter {
 
     try {
       await manager.setFreshnessBarrier('completed input action', {
-        allowOverAgeForNextCapture: true,
         hostMonotonicUs: actionCompletedAtHostUs,
       });
       if (
@@ -605,17 +537,12 @@ export class ScrcpyDeviceAdapter {
 
   async disconnect(): Promise<void> {
     this.lifecycleGeneration += 1;
-    this.freshnessRecoveryPending = false;
     this.pendingActionBarrierAtHostUs = null;
     for (const unsubscribe of this.keyframeUnsubscribers.values()) {
       unsubscribe();
     }
     this.keyframeUnsubscribers.clear();
     this.keyframeListeners.clear();
-
-    if (this.recoveryPromise) {
-      await this.recoveryPromise.catch(() => {});
-    }
 
     if (this.freshnessRestartPromise) {
       await this.freshnessRestartPromise.catch(() => {});

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -9,6 +9,7 @@ import {
 } from './scrcpy-manager';
 
 const debugAdapter = getDebug('android:scrcpy-adapter');
+const warnAdapter = getDebug('android:scrcpy-adapter', { console: true });
 const SCRCPY_RETRY_COOLDOWN_MS = 5_000;
 
 interface ScrcpyConfig {
@@ -235,7 +236,9 @@ export class ScrcpyDeviceAdapter {
 
   /**
    * Take a screenshot via scrcpy, returns base64 string.
-   * Throws on failure (caller should fallback to ADB).
+   * A stale established stream is restarted once so a static screen can use
+   * the new epoch's baseline frame. Throws only when that retry also fails, so
+   * the caller can fall back to ADB.
    */
   async screenshotBase64(deviceInfo: DevicePhysicalInfo): Promise<string> {
     this.ensureRetryReady();
@@ -248,18 +251,57 @@ export class ScrcpyDeviceAdapter {
       const screenshotBuffer = await manager.getScreenshotJpeg();
       this.clearFailure();
 
-      return createImgBase64ByFormat(
-        'jpeg',
-        screenshotBuffer.toString('base64'),
-      );
+      return this.jpegBufferToBase64(screenshotBuffer);
     } catch (error) {
-      if (isScrcpyFreshFrameUnavailableError(error)) {
-        this.markFreshnessRecoveryPending(manager, error);
+      if (!isScrcpyFreshFrameUnavailableError(error)) {
+        this.recordFailure(error);
         throw error;
       }
-      this.recordFailure(error);
-      throw error;
+
+      this.markFreshnessRecoveryPending(manager, error);
+      debugAdapter(
+        `Scrcpy freshness target was unavailable; restarting the stream once before ADB fallback: ${error}`,
+      );
+
+      try {
+        manager = await this.ensureManager(deviceInfo);
+        await manager.ensureConnected();
+        await this.applyPendingActionBarrier(manager);
+        const screenshotBuffer = await manager.getScreenshotJpeg();
+        this.attachKeyframeListeners(manager);
+        this.clearFailure();
+        debugAdapter('Scrcpy screenshot recovered on a new stream epoch');
+        return this.jpegBufferToBase64(screenshotBuffer);
+      } catch (retryError) {
+        if (isScrcpyFreshFrameUnavailableError(retryError)) {
+          this.markFreshnessRecoveryPending(manager, retryError);
+        } else {
+          this.recordFailure(retryError);
+        }
+        this.warnFreshnessFallback(error, retryError);
+        throw retryError;
+      }
     }
+  }
+
+  private jpegBufferToBase64(screenshotBuffer: Buffer): string {
+    return createImgBase64ByFormat('jpeg', screenshotBuffer.toString('base64'));
+  }
+
+  private warnFreshnessFallback(
+    firstError: ScrcpyFreshFrameUnavailableError,
+    retryError: unknown,
+  ): void {
+    const retryDiagnostic = isScrcpyFreshFrameUnavailableError(retryError)
+      ? retryError.diagnosticMessage
+      : undefined;
+    warnAdapter(
+      retryDiagnostic ??
+        (firstError.diagnosticMessage
+          ? `${firstError.diagnosticMessage}\nScrcpy stream restart error: ${retryError}`
+          : undefined) ??
+        `Scrcpy stream restart failed; falling back to ADB screenshot. Error: ${retryError}`,
+    );
   }
 
   /**

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -11,7 +11,6 @@ import {
 
 const debugAdapter = getDebug('android:scrcpy-adapter');
 const SCRCPY_RETRY_COOLDOWN_MS = 5_000;
-const CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE = 4_000_000;
 
 export function formatScrcpyFreshFrameFailure(
   error: ScrcpyFreshFrameUnavailableError,
@@ -29,12 +28,7 @@ export function formatScrcpyFreshFrameFailure(
   const bitRateDescription = Number.isFinite(videoBitRate)
     ? ` Current videoBitRate: ${videoBitRate} bps (${videoBitRate / 1_000_000} Mbps).`
     : '';
-  const networkHint =
-    Number.isFinite(videoBitRate) &&
-    videoBitRate <= CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE
-      ? 'The current scrcpy video bitrate is already at or below 4 Mbps. Lowering it further is unlikely to help on a local USB connection; check whether the screen was static or the device encoder emitted no new frame.'
-      : 'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, pass --scrcpy-video-bit-rate 4000000 in the Android CLI, or set scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) in SDK/YAML configuration. Lower it further if backlog persists.';
-  return `No usable scrcpy frame crossed the active freshness target within ${timeoutMs}ms. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint}${bitRateDescription}`;
+  return `No usable scrcpy frame crossed the active freshness target within ${timeoutMs}ms. This can happen when a static screen emits no new encoded frame, or when the video stream or transport is interrupted. This timeout does not by itself identify bandwidth or the configured video bitrate as the cause.${bitRateDescription}`;
 }
 
 interface ScrcpyConfig {
@@ -96,7 +90,10 @@ export class ScrcpyDeviceAdapter {
   private keyframeListeners = new Set<(frame: RawKeyframe) => void>();
   private keyframeUnsubscribers = new Map<
     (frame: RawKeyframe) => void,
-    () => void
+    {
+      manager: ScrcpyScreenshotManager;
+      unsubscribe: () => void;
+    }
   >();
 
   constructor(
@@ -129,8 +126,7 @@ export class ScrcpyDeviceAdapter {
    */
   async initialize(deviceInfo: DevicePhysicalInfo): Promise<void> {
     try {
-      const manager = await this.ensureManager(deviceInfo);
-      await manager.ensureConnected();
+      const manager = await this.ensureConnectedManager(deviceInfo);
       await this.applyPendingActionBarrier(manager);
       this.clearFailure();
     } catch (error) {
@@ -281,18 +277,31 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
+   * Connect the current manager and restore adapter-owned frame subscriptions
+   * whenever this call establishes a new stream epoch. Existing connections
+   * keep their current subscriptions without churn.
+   */
+  private async ensureConnectedManager(
+    deviceInfo: DevicePhysicalInfo,
+  ): Promise<ScrcpyScreenshotManager> {
+    const manager = await this.ensureManager(deviceInfo);
+    const wasConnected = manager.isConnected();
+    await manager.ensureConnected();
+    this.attachKeyframeListeners(manager, !wasConnected);
+    return manager;
+  }
+
+  /**
    * Take a screenshot via scrcpy, returns base64 string.
-   * A stale established stream is restarted once so a static screen can use
-   * the new epoch's baseline frame. Throws only when that retry also fails, so
+   * A stale established stream is restarted once so a static screen can use a
+   * fresh frame from the new epoch. Throws only when that retry also fails, so
    * the caller can fall back to ADB.
    */
   async screenshotBase64(deviceInfo: DevicePhysicalInfo): Promise<string> {
     this.ensureRetryReady();
 
-    let manager: ScrcpyScreenshotManager | null = null;
     try {
-      manager = await this.ensureManager(deviceInfo);
-      await manager.ensureConnected();
+      const manager = await this.ensureConnectedManager(deviceInfo);
       await this.applyPendingActionBarrier(manager);
       const screenshotBuffer = await manager.getScreenshotJpeg();
       this.clearFailure();
@@ -310,13 +319,6 @@ export class ScrcpyDeviceAdapter {
 
       try {
         const screenshotBuffer = await this.restartAndCaptureOnce(deviceInfo);
-        manager = this.manager;
-        if (!manager) {
-          throw new Error(
-            'Scrcpy manager disappeared after freshness recovery',
-          );
-        }
-        this.attachKeyframeListeners(manager);
         this.clearFailure();
         debugAdapter('Scrcpy screenshot recovered on a new stream epoch');
         return this.jpegBufferToBase64(screenshotBuffer);
@@ -337,8 +339,7 @@ export class ScrcpyDeviceAdapter {
 
     const generation = this.lifecycleGeneration;
     const restartPromise = (async () => {
-      const manager = await this.ensureManager(deviceInfo);
-      await manager.ensureConnected();
+      const manager = await this.ensureConnectedManager(deviceInfo);
       await this.applyPendingActionBarrier(manager);
       if (generation !== this.lifecycleGeneration) {
         throw new Error('Scrcpy freshness restart was cancelled by cleanup');
@@ -374,19 +375,19 @@ export class ScrcpyDeviceAdapter {
     this.keyframeListeners.add(listener);
 
     try {
-      const manager = await this.ensureManager(deviceInfo);
-      await manager.ensureConnected();
+      const manager = await this.ensureConnectedManager(deviceInfo);
       await this.applyPendingActionBarrier(manager);
       await manager.ensureFrameClockCalibration();
       this.clearFailure();
-      this.attachKeyframeListener(manager, listener);
       return () => {
         this.keyframeListeners.delete(listener);
-        this.keyframeUnsubscribers.get(listener)?.();
+        this.keyframeUnsubscribers.get(listener)?.unsubscribe();
         this.keyframeUnsubscribers.delete(listener);
       };
     } catch (error) {
       this.keyframeListeners.delete(listener);
+      this.keyframeUnsubscribers.get(listener)?.unsubscribe();
+      this.keyframeUnsubscribers.delete(listener);
       this.recordFailure(error);
       throw error;
     }
@@ -400,18 +401,23 @@ export class ScrcpyDeviceAdapter {
   private attachKeyframeListener(
     manager: ScrcpyScreenshotManager,
     listener: (frame: RawKeyframe) => void,
+    force: boolean,
   ): void {
-    this.keyframeUnsubscribers.get(listener)?.();
-    this.keyframeUnsubscribers.set(
-      listener,
-      manager.subscribeKeyframes(listener),
-    );
+    const existing = this.keyframeUnsubscribers.get(listener);
+    if (!force && existing?.manager === manager) return;
+    existing?.unsubscribe();
+    this.keyframeUnsubscribers.set(listener, {
+      manager,
+      unsubscribe: manager.subscribeKeyframes(listener),
+    });
   }
 
-  private attachKeyframeListeners(manager: ScrcpyScreenshotManager): void {
-    this.keyframeUnsubscribers.clear();
+  private attachKeyframeListeners(
+    manager: ScrcpyScreenshotManager,
+    force: boolean,
+  ): void {
     for (const listener of this.keyframeListeners) {
-      this.attachKeyframeListener(manager, listener);
+      this.attachKeyframeListener(manager, listener, force);
     }
   }
 
@@ -538,7 +544,7 @@ export class ScrcpyDeviceAdapter {
   async disconnect(): Promise<void> {
     this.lifecycleGeneration += 1;
     this.pendingActionBarrierAtHostUs = null;
-    for (const unsubscribe of this.keyframeUnsubscribers.values()) {
+    for (const { unsubscribe } of this.keyframeUnsubscribers.values()) {
       unsubscribe();
     }
     this.keyframeUnsubscribers.clear();

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -1,6 +1,7 @@
 import type { Size } from '@midscene/core';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
+import type { Adb as YumeAdb } from '@yume-chan/adb';
 import type { RawKeyframe, ScrcpyScreenshotManager } from './scrcpy-manager';
 import {
   DEFAULT_SCRCPY_CONFIG,
@@ -61,10 +62,12 @@ export interface ScrcpyStatus {
  */
 export class ScrcpyDeviceAdapter {
   private manager: ScrcpyScreenshotManager | null = null;
+  private managerPromise: Promise<ScrcpyScreenshotManager> | null = null;
   private resolvedConfig: ResolvedScrcpyConfig | null = null;
   private lastError: string | null = null;
   private retryAfter: number | null = null;
   private freshnessRecoveryPending = false;
+  private freshnessRestartPromise: Promise<Buffer> | null = null;
   private recoveryPromise: Promise<void> | null = null;
   private lifecycleGeneration = 0;
   private pendingActionBarrierAtHostUs: bigint | null = null;
@@ -187,50 +190,82 @@ export class ScrcpyDeviceAdapter {
    * Uses dynamic import for @yume-chan packages (ESM-only, must use await import in CJS builds).
    */
   async ensureManager(
-    deviceInfo: DevicePhysicalInfo,
+    _deviceInfo: DevicePhysicalInfo,
   ): Promise<ScrcpyScreenshotManager> {
     if (this.manager) return this.manager;
+    if (this.managerPromise) return this.managerPromise;
 
     debugAdapter('Initializing Scrcpy manager...');
 
+    const generation = this.lifecycleGeneration;
+    const managerPromise = (async () => {
+      let adb: YumeAdb | null = null;
+      let manager: ScrcpyScreenshotManager | null = null;
+      try {
+        const { Adb, AdbServerClient } = await import('@yume-chan/adb');
+        const { AdbServerNodeTcpConnector } = await import(
+          '@yume-chan/adb-server-node-tcp'
+        );
+        const { ScrcpyScreenshotManager: ScrcpyManager } = await import(
+          './scrcpy-manager'
+        );
+
+        const adbServerEndpoint = await this.resolveAdbServerEndpoint();
+        const adbClient = new AdbServerClient(
+          new AdbServerNodeTcpConnector(adbServerEndpoint),
+        );
+        adb = new Adb(
+          await adbClient.createTransport({ serial: this.deviceId }),
+        );
+
+        const config = this.resolveConfig();
+        manager = new ScrcpyManager(adb, {
+          maxSize: config.maxSize,
+          videoBitRate: config.videoBitRate,
+          idleTimeoutMs: config.idleTimeoutMs,
+        });
+
+        // Validate environment prerequisites (ffmpeg, etc.) once before caching.
+        // If validation fails, dispose the owned ADB transport before propagating
+        // the error to the caller, which can fall back to ADB screenshots.
+        await manager.validateEnvironment();
+
+        if (generation !== this.lifecycleGeneration) {
+          throw new Error(
+            'Scrcpy manager initialization was superseded by device cleanup',
+          );
+        }
+
+        this.manager = manager;
+        debugAdapter('Scrcpy manager initialized');
+        return manager;
+      } catch (error) {
+        try {
+          if (manager) {
+            await manager.dispose();
+          } else {
+            await adb?.close();
+          }
+        } catch (cleanupError) {
+          debugAdapter(
+            `Failed to clean up Scrcpy manager initialization: ${cleanupError}`,
+          );
+        }
+        debugAdapter(`Failed to initialize Scrcpy manager: ${error}`);
+        throw new Error(
+          `Failed to initialize Scrcpy for device ${this.deviceId}. ` +
+            `Ensure ADB server is running and device is connected. Error: ${error}`,
+        );
+      }
+    })();
+
+    this.managerPromise = managerPromise;
     try {
-      const { Adb, AdbServerClient } = await import('@yume-chan/adb');
-      const { AdbServerNodeTcpConnector } = await import(
-        '@yume-chan/adb-server-node-tcp'
-      );
-      const { ScrcpyScreenshotManager: ScrcpyManager } = await import(
-        './scrcpy-manager'
-      );
-
-      const adbServerEndpoint = await this.resolveAdbServerEndpoint();
-      const adbClient = new AdbServerClient(
-        new AdbServerNodeTcpConnector(adbServerEndpoint),
-      );
-      const adb = new Adb(
-        await adbClient.createTransport({ serial: this.deviceId }),
-      );
-
-      const config = this.resolveConfig();
-      const manager = new ScrcpyManager(adb, {
-        maxSize: config.maxSize,
-        videoBitRate: config.videoBitRate,
-        idleTimeoutMs: config.idleTimeoutMs,
-      });
-
-      // Validate environment prerequisites (ffmpeg, etc.) once before caching.
-      // If validation fails, the manager is not cached and the error propagates
-      // to the caller, which falls back to ADB.
-      await manager.validateEnvironment();
-
-      this.manager = manager;
-      debugAdapter('Scrcpy manager initialized');
-      return this.manager;
-    } catch (error) {
-      debugAdapter(`Failed to initialize Scrcpy manager: ${error}`);
-      throw new Error(
-        `Failed to initialize Scrcpy for device ${this.deviceId}. ` +
-          `Ensure ADB server is running and device is connected. Error: ${error}`,
-      );
+      return await managerPromise;
+    } finally {
+      if (this.managerPromise === managerPromise) {
+        this.managerPromise = null;
+      }
     }
   }
 
@@ -258,28 +293,59 @@ export class ScrcpyDeviceAdapter {
         throw error;
       }
 
-      this.markFreshnessRecoveryPending(manager, error);
+      this.markFreshnessRecoveryPending(error);
       debugAdapter(
         `Scrcpy freshness target was unavailable; restarting the stream once before ADB fallback: ${error}`,
       );
 
       try {
-        manager = await this.ensureManager(deviceInfo);
-        await manager.ensureConnected();
-        await this.applyPendingActionBarrier(manager);
-        const screenshotBuffer = await manager.getScreenshotJpeg();
+        const screenshotBuffer = await this.restartAndCaptureOnce(deviceInfo);
+        manager = this.manager;
+        if (!manager) {
+          throw new Error(
+            'Scrcpy manager disappeared after freshness recovery',
+          );
+        }
         this.attachKeyframeListeners(manager);
         this.clearFailure();
         debugAdapter('Scrcpy screenshot recovered on a new stream epoch');
         return this.jpegBufferToBase64(screenshotBuffer);
       } catch (retryError) {
         if (isScrcpyFreshFrameUnavailableError(retryError)) {
-          this.markFreshnessRecoveryPending(manager, retryError);
+          this.markFreshnessRecoveryPending(retryError);
         } else {
           this.recordFailure(retryError);
         }
         this.warnFreshnessFallback(error, retryError);
         throw retryError;
+      }
+    }
+  }
+
+  private async restartAndCaptureOnce(
+    deviceInfo: DevicePhysicalInfo,
+  ): Promise<Buffer> {
+    if (this.freshnessRestartPromise) {
+      return this.freshnessRestartPromise;
+    }
+
+    const generation = this.lifecycleGeneration;
+    const restartPromise = (async () => {
+      const manager = await this.ensureManager(deviceInfo);
+      await manager.ensureConnected();
+      await this.applyPendingActionBarrier(manager);
+      if (generation !== this.lifecycleGeneration) {
+        throw new Error('Scrcpy freshness restart was cancelled by cleanup');
+      }
+      return manager.getScreenshotJpeg();
+    })();
+
+    this.freshnessRestartPromise = restartPromise;
+    try {
+      return await restartPromise;
+    } finally {
+      if (this.freshnessRestartPromise === restartPromise) {
+        this.freshnessRestartPromise = null;
       }
     }
   }
@@ -360,31 +426,29 @@ export class ScrcpyDeviceAdapter {
   }
 
   private markFreshnessRecoveryPending(
-    manager: ScrcpyScreenshotManager | null,
     error: ScrcpyFreshFrameUnavailableError,
   ): void {
     this.lastError = error.message;
     this.retryAfter = null;
     this.freshnessRecoveryPending = true;
     this.keyframeUnsubscribers.clear();
-    if (manager && this.manager === manager) {
-      this.manager = null;
-    }
+    // ScrcpyScreenshotManager closes only the stale video epoch for this error.
+    // Keep the manager so the retry reuses its owned yume ADB transport.
   }
 
   private async applyPendingActionBarrier(
     manager: ScrcpyScreenshotManager,
   ): Promise<void> {
-    const actionStartedAtHostUs = this.pendingActionBarrierAtHostUs;
-    if (actionStartedAtHostUs === null) return;
+    const actionCompletedAtHostUs = this.pendingActionBarrierAtHostUs;
+    if (actionCompletedAtHostUs === null) return;
     await manager.setFreshnessBarrier(
-      'input action started while scrcpy was unavailable',
+      'completed input action while scrcpy was unavailable',
       {
         allowOverAgeForNextCapture: true,
-        hostMonotonicUs: actionStartedAtHostUs,
+        hostMonotonicUs: actionCompletedAtHostUs,
       },
     );
-    if (this.pendingActionBarrierAtHostUs === actionStartedAtHostUs) {
+    if (this.pendingActionBarrierAtHostUs === actionCompletedAtHostUs) {
       this.pendingActionBarrierAtHostUs = null;
     }
   }
@@ -393,12 +457,12 @@ export class ScrcpyDeviceAdapter {
     return process.hrtime.bigint() / 1_000n;
   }
 
-  private deferActionBarrier(actionStartedAtHostUs: bigint): void {
+  private deferActionBarrier(actionCompletedAtHostUs: bigint): void {
     if (
       this.pendingActionBarrierAtHostUs === null ||
-      actionStartedAtHostUs > this.pendingActionBarrierAtHostUs
+      actionCompletedAtHostUs > this.pendingActionBarrierAtHostUs
     ) {
-      this.pendingActionBarrierAtHostUs = actionStartedAtHostUs;
+      this.pendingActionBarrierAtHostUs = actionCompletedAtHostUs;
     }
   }
 
@@ -418,7 +482,7 @@ export class ScrcpyDeviceAdapter {
         await this.applyPendingActionBarrier(manager);
         await manager.prepareFreshFrame();
         if (generation !== this.lifecycleGeneration) {
-          await manager.disconnect();
+          await manager.dispose();
           if (this.manager === manager) this.manager = null;
           return;
         }
@@ -427,7 +491,7 @@ export class ScrcpyDeviceAdapter {
         debugAdapter('Scrcpy freshness recovery completed in background');
       } catch (error) {
         if (manager) {
-          await manager.disconnect();
+          await manager.dispose();
           if (this.manager === manager) this.manager = null;
         }
         this.freshnessRecoveryPending = false;
@@ -448,39 +512,38 @@ export class ScrcpyDeviceAdapter {
   }
 
   /**
-   * Move the scrcpy PTS barrier to immediately before an input action. Frames
-   * produced while the ADB command is returning then remain valid candidates.
-   * Barrier failures must not block the input action; disable the stream and
-   * let subsequent captures use the existing ADB fallback.
+   * Move the scrcpy PTS barrier past a completed input action. Barrier failures
+   * must not turn a successfully injected action into an action error; disable
+   * the stream and let subsequent captures use the existing ADB fallback.
    */
   async markActionBarrier(): Promise<void> {
-    const actionStartedAtHostUs = this.monotonicTimeUs();
+    const actionCompletedAtHostUs = this.monotonicTimeUs();
     const manager = this.manager;
     if (!manager?.isConnected()) {
-      this.deferActionBarrier(actionStartedAtHostUs);
+      this.deferActionBarrier(actionCompletedAtHostUs);
       return;
     }
 
     try {
-      await manager.setFreshnessBarrier('input action started', {
+      await manager.setFreshnessBarrier('completed input action', {
         allowOverAgeForNextCapture: true,
-        hostMonotonicUs: actionStartedAtHostUs,
+        hostMonotonicUs: actionCompletedAtHostUs,
       });
       if (
         this.pendingActionBarrierAtHostUs !== null &&
-        this.pendingActionBarrierAtHostUs <= actionStartedAtHostUs
+        this.pendingActionBarrierAtHostUs <= actionCompletedAtHostUs
       ) {
         this.pendingActionBarrierAtHostUs = null;
       }
       this.clearFailure();
     } catch (error) {
-      this.deferActionBarrier(actionStartedAtHostUs);
+      this.deferActionBarrier(actionCompletedAtHostUs);
       this.recordFailure(error);
       debugAdapter(
         `Unable to mark scrcpy action barrier; disabling this stream: ${error}`,
       );
       try {
-        await manager.disconnect();
+        await manager.dispose();
       } catch (disconnectError) {
         debugAdapter(
           `Error disconnecting scrcpy after barrier failure: ${disconnectError}`,
@@ -554,9 +617,17 @@ export class ScrcpyDeviceAdapter {
       await this.recoveryPromise.catch(() => {});
     }
 
+    if (this.freshnessRestartPromise) {
+      await this.freshnessRestartPromise.catch(() => {});
+    }
+
+    if (this.managerPromise) {
+      await this.managerPromise.catch(() => {});
+    }
+
     if (this.manager) {
       try {
-        await this.manager.disconnect();
+        await this.manager.dispose();
       } catch (error) {
         debugAdapter(`Error disconnecting scrcpy: ${error}`);
       }

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -66,7 +66,7 @@ export class ScrcpyDeviceAdapter {
   private freshnessRecoveryPending = false;
   private recoveryPromise: Promise<void> | null = null;
   private lifecycleGeneration = 0;
-  private pendingActionBarrier = false;
+  private pendingActionBarrierAtHostUs: bigint | null = null;
   private keyframeListeners = new Set<(frame: RawKeyframe) => void>();
   private keyframeUnsubscribers = new Map<
     (frame: RawKeyframe) => void,
@@ -333,11 +333,28 @@ export class ScrcpyDeviceAdapter {
   private async applyPendingActionBarrier(
     manager: ScrcpyScreenshotManager,
   ): Promise<void> {
-    if (!this.pendingActionBarrier) return;
+    const actionCompletedAtHostUs = this.pendingActionBarrierAtHostUs;
+    if (actionCompletedAtHostUs === null) return;
     await manager.setFreshnessBarrier(
       'completed input action while scrcpy was unavailable',
+      actionCompletedAtHostUs,
     );
-    this.pendingActionBarrier = false;
+    if (this.pendingActionBarrierAtHostUs === actionCompletedAtHostUs) {
+      this.pendingActionBarrierAtHostUs = null;
+    }
+  }
+
+  private monotonicTimeUs(): bigint {
+    return process.hrtime.bigint() / 1_000n;
+  }
+
+  private deferActionBarrier(actionCompletedAtHostUs: bigint): void {
+    if (
+      this.pendingActionBarrierAtHostUs === null ||
+      actionCompletedAtHostUs > this.pendingActionBarrierAtHostUs
+    ) {
+      this.pendingActionBarrierAtHostUs = actionCompletedAtHostUs;
+    }
   }
 
   /**
@@ -391,18 +408,27 @@ export class ScrcpyDeviceAdapter {
    * the stream and let subsequent captures use the existing ADB fallback.
    */
   async markActionBarrier(): Promise<void> {
+    const actionCompletedAtHostUs = this.monotonicTimeUs();
     const manager = this.manager;
     if (!manager?.isConnected()) {
-      this.pendingActionBarrier = true;
+      this.deferActionBarrier(actionCompletedAtHostUs);
       return;
     }
 
     try {
-      await manager.setFreshnessBarrier('completed input action');
-      this.pendingActionBarrier = false;
+      await manager.setFreshnessBarrier(
+        'completed input action',
+        actionCompletedAtHostUs,
+      );
+      if (
+        this.pendingActionBarrierAtHostUs !== null &&
+        this.pendingActionBarrierAtHostUs <= actionCompletedAtHostUs
+      ) {
+        this.pendingActionBarrierAtHostUs = null;
+      }
       this.clearFailure();
     } catch (error) {
-      this.pendingActionBarrier = true;
+      this.deferActionBarrier(actionCompletedAtHostUs);
       this.recordFailure(error);
       debugAdapter(
         `Unable to mark scrcpy action barrier; disabling this stream: ${error}`,
@@ -471,7 +497,7 @@ export class ScrcpyDeviceAdapter {
   async disconnect(): Promise<void> {
     this.lifecycleGeneration += 1;
     this.freshnessRecoveryPending = false;
-    this.pendingActionBarrier = false;
+    this.pendingActionBarrierAtHostUs = null;
     for (const unsubscribe of this.keyframeUnsubscribers.values()) {
       unsubscribe();
     }

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -225,11 +225,10 @@ export class ScrcpyScreenshotManager {
   private streamReader: any = null;
   private frameFreshnessBarrierPtsUs: bigint | null = null;
   private frameFreshnessBarrierReason: string | null = null;
-  // A newly created stream may emit its only frame before clock calibration
-  // finishes. On a static screen no replacement frame follows, so the first
-  // screenshot may use that epoch-local baseline once when no action barrier
-  // is active. Later planning screenshots remain subject to the age limit.
-  private streamBaselineWindow: { deadlineAt: number } | null = null;
+  // A newly created stream gets longer to emit its first frame. This startup
+  // allowance affects only how long Midscene waits; every candidate still has
+  // to satisfy the same absolute frame-age limit as an established stream.
+  private streamStartupWindow: { deadlineAt: number } | null = null;
   private frameFreshnessBarrierPending = false;
   private frameFreshnessBarrierGeneration = 0;
   private deviceClockCalibration: DeviceClockCalibration | null = null;
@@ -319,6 +318,11 @@ export class ScrcpyScreenshotManager {
 
       const scrcpyOptions = await this.createScrcpyOptions();
 
+      // Sample the device clock immediately before starting the encoder. This
+      // lets the frame consumer validate the first packet without delaying
+      // consumption until after a second ADB round trip.
+      await this.ensureFrameClockCalibration();
+
       this.scrcpyClient = await AdbScrcpyClient.start(
         this.adb,
         DefaultServerPath,
@@ -340,11 +344,7 @@ export class ScrcpyScreenshotManager {
       // Store the actual video resolution
       this.videoResolution = { width, height };
 
-      // Establish exactly one device/host monotonic clock anchor for this
-      // stream epoch. Frame age and all later barriers are projected from this
-      // anchor without another ADB clock read.
-      await this.ensureFrameClockCalibration();
-      this.streamBaselineWindow = {
+      this.streamStartupWindow = {
         deadlineAt: Date.now() + MAX_KEYFRAME_WAIT_MS,
       };
       this.startFrameConsumer();
@@ -953,7 +953,7 @@ export class ScrcpyScreenshotManager {
   private resetFrameFreshnessState(): void {
     this.frameFreshnessBarrierPtsUs = null;
     this.frameFreshnessBarrierReason = null;
-    this.streamBaselineWindow = null;
+    this.streamStartupWindow = null;
     this.frameFreshnessBarrierPending = false;
     this.frameFreshnessBarrierGeneration = 0;
     this.deviceClockCalibration = null;
@@ -1001,16 +1001,6 @@ export class ScrcpyScreenshotManager {
     };
   }
 
-  private canUseStreamBaseline(frame: RawKeyframe): boolean {
-    return (
-      this.streamBaselineWindow !== null &&
-      !this.frameFreshnessBarrierPending &&
-      this.frameFreshnessBarrierPtsUs === null &&
-      Date.now() <= this.streamBaselineWindow.deadlineAt &&
-      frame.ptsUs !== undefined
-    );
-  }
-
   /**
    * Decode a raw keyframe (from {@link subscribeKeyframes} or
    * {@link getLatestRawKeyframe}) to a JPEG buffer. This is the deferred,
@@ -1023,15 +1013,16 @@ export class ScrcpyScreenshotManager {
 
   private async waitForPlanningFrame(): Promise<RawKeyframe> {
     let planningBarrierArmed = false;
-    // A new encoder/stream gets the normal startup allowance for its first
-    // data frame. Established epochs still fail fast when they cannot cross a
-    // newly armed freshness barrier.
+    // A new encoder/stream gets the normal startup allowance while waiting for
+    // its first data frame. The allowance never bypasses the age check below.
+    // Established epochs still fail fast when they cannot cross a newly armed
+    // freshness barrier.
     const planningStartedAt = Date.now();
-    const startupWindowRemainingMs = this.streamBaselineWindow
-      ? this.streamBaselineWindow.deadlineAt - planningStartedAt
+    const startupWindowRemainingMs = this.streamStartupWindow
+      ? this.streamStartupWindow.deadlineAt - planningStartedAt
       : 0;
-    if (this.streamBaselineWindow && startupWindowRemainingMs <= 0) {
-      this.streamBaselineWindow = null;
+    if (this.streamStartupWindow && startupWindowRemainingMs <= 0) {
+      this.streamStartupWindow = null;
     }
     let deadline =
       planningStartedAt +
@@ -1046,13 +1037,6 @@ export class ScrcpyScreenshotManager {
           throw new Error(
             'Scrcpy frame has no PTS metadata; cannot prove planning freshness',
           );
-        }
-
-        if (this.canUseStreamBaseline(candidate)) {
-          debugScrcpy(
-            `Using frame PTS ${candidate.ptsUs}µs as the first planning baseline for the new scrcpy stream epoch`,
-          );
-          return candidate;
         }
 
         const age = this.estimateFrameAge(candidate.ptsUs);
@@ -1093,7 +1077,7 @@ export class ScrcpyScreenshotManager {
     error: unknown,
   ): Promise<ScrcpyFreshFrameUnavailableError> {
     const failureKind: ScrcpyFreshFrameFailureKind =
-      this.streamBaselineWindow && this.frameFreshnessBarrierPtsUs === null
+      this.streamStartupWindow && this.frameFreshnessBarrierPtsUs === null
         ? 'stream-startup'
         : 'freshness-target';
     const timeoutMs =
@@ -1115,13 +1099,11 @@ export class ScrcpyScreenshotManager {
 
   /**
    * Get screenshot as JPEG.
-   * A newly connected stream may use its first epoch-local frame once during
-   * the bounded startup window, because a static screen will not emit another
-   * frame after clock calibration completes.
-   * Frames that crossed an input-action barrier must still satisfy the absolute
-   * age limit at capture time. Over-age candidates arm a planning barrier on
-   * demand. If no frame crosses the resulting freshness target in time, close
-   * this stream epoch and let the caller restart it or use ADB.
+   * A newly connected stream gets a bounded startup window to produce its
+   * first frame. All candidates, including that first frame, must satisfy the
+   * absolute age limit at capture time. Over-age candidates arm a planning
+   * barrier on demand. If no frame crosses the resulting freshness target in
+   * time, close this stream epoch and let the caller restart it or use ADB.
    */
   async getScreenshotJpeg(): Promise<Buffer> {
     const perfStart = Date.now();
@@ -1151,7 +1133,7 @@ export class ScrcpyScreenshotManager {
     const t5 = Date.now();
     const result = await this.decodeH264ToJpeg(keyframeBuffer);
     const decodeTime = Date.now() - t5;
-    this.streamBaselineWindow = null;
+    this.streamStartupWindow = null;
 
     const totalTime = Date.now() - perfStart;
     debugScrcpy(

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -225,6 +225,12 @@ export class ScrcpyScreenshotManager {
   private frameFreshnessBarrierPtsUs: bigint | null = null;
   private frameFreshnessBarrierReason: string | null = null;
   private frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
+  // A newly created stream may emit its only frame before clock calibration
+  // finishes. On a static screen no replacement frame follows, so the first
+  // screenshot may use that epoch-local baseline once when no action barrier
+  // is active. Later planning screenshots remain subject to the age limit.
+  private streamBaselineFramePending = false;
+  private streamBaselineFrameDeadlineAt = 0;
   private frameFreshnessBarrierPending = false;
   private frameFreshnessBarrierGeneration = 0;
   private deviceClockCalibration: DeviceClockCalibration | null = null;
@@ -332,6 +338,8 @@ export class ScrcpyScreenshotManager {
       // stream epoch. Frame age and all later barriers are projected from this
       // anchor without another ADB clock read.
       await this.ensureFrameClockCalibration();
+      this.streamBaselineFramePending = true;
+      this.streamBaselineFrameDeadlineAt = Date.now() + MAX_KEYFRAME_WAIT_MS;
       this.startFrameConsumer();
       this.resetIdleTimer();
       this.isInitialized = true;
@@ -902,6 +910,16 @@ export class ScrcpyScreenshotManager {
 
     const cause = this.frameFreshnessError ?? error;
     const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    if (
+      this.streamBaselineFramePending &&
+      this.frameFreshnessBarrierPtsUs === null
+    ) {
+      warnScrcpy(
+        `The new scrcpy stream did not produce a usable baseline frame within its ${MAX_KEYFRAME_WAIT_MS}ms startup window; closing the stream epoch and falling back to ADB screenshot. This is a stream startup or encoder-readiness failure, not evidence that the configured video bitrate is too high.\nError: ${causeMessage}`,
+      );
+      this.lastTransportBacklogWarningAt = now;
+      return;
+    }
     const currentBitRateMbps = this.options.videoBitRate / 1_000_000;
     const networkHint = getScrcpyVideoBitRateNetworkHint(
       this.options.videoBitRate,
@@ -950,6 +968,8 @@ export class ScrcpyScreenshotManager {
     this.frameFreshnessBarrierPtsUs = null;
     this.frameFreshnessBarrierReason = null;
     this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
+    this.streamBaselineFramePending = false;
+    this.streamBaselineFrameDeadlineAt = 0;
     this.frameFreshnessBarrierPending = false;
     this.frameFreshnessBarrierGeneration = 0;
     this.deviceClockCalibration = null;
@@ -1006,6 +1026,16 @@ export class ScrcpyScreenshotManager {
     );
   }
 
+  private canUseStreamBaseline(frame: RawKeyframe): boolean {
+    return (
+      this.streamBaselineFramePending &&
+      !this.frameFreshnessBarrierPending &&
+      this.frameFreshnessBarrierPtsUs === null &&
+      Date.now() <= this.streamBaselineFrameDeadlineAt &&
+      frame.ptsUs !== undefined
+    );
+  }
+
   private consumeActionFreshnessBarrier(frame: RawKeyframe): void {
     if (!this.canReuseFrameAcrossActionWait(frame)) return;
     this.frameFreshnessBarrierPtsUs = null;
@@ -1024,38 +1054,36 @@ export class ScrcpyScreenshotManager {
     return this.decodeH264ToJpeg(Buffer.concat([frame.header, frame.data]));
   }
 
-  private async waitForUsableKeyframe(timeoutMs: number): Promise<RawKeyframe> {
-    const deadline = Date.now() + timeoutMs;
-    let candidate = this.getCachedKeyframeCandidate();
-
-    while (true) {
-      if (candidate && this.isFrameAgeAcceptable(candidate.ptsUs)) {
-        return candidate;
-      }
-
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) {
-        throw new Error(`No fresh keyframe received within ${timeoutMs}ms`);
-      }
-
-      candidate = await this.waitForNextKeyframe(remainingMs);
-    }
-  }
-
   /**
-   * Ensure a newly connected stream has a calibrated, temporally fresh frame
-   * before it is exposed again after ADB fallback.
+   * Ensure a newly connected stream has a calibrated, usable epoch baseline
+   * or a frame that crossed its active action barrier before exposing it again
+   * after ADB fallback.
    */
   async prepareFreshFrame(): Promise<void> {
     await this.ensureConnected();
     await this.ensureFrameClockCalibration();
     await this.waitForKeyframe();
-    await this.waitForUsableKeyframe(MAX_KEYFRAME_WAIT_MS);
+    await this.waitForPlanningFrame();
   }
 
   private async waitForPlanningFrame(): Promise<RawKeyframe> {
     let planningBarrierArmed = false;
-    let deadline = Date.now() + FRESH_FRAME_TIMEOUT_MS;
+    // A new encoder/stream gets the normal startup allowance for its first
+    // data frame. Established epochs still fail fast when they cannot cross a
+    // newly armed freshness barrier.
+    const planningStartedAt = Date.now();
+    const startupWindowRemainingMs = this.streamBaselineFramePending
+      ? this.streamBaselineFrameDeadlineAt - planningStartedAt
+      : 0;
+    if (this.streamBaselineFramePending && startupWindowRemainingMs <= 0) {
+      this.streamBaselineFramePending = false;
+      this.streamBaselineFrameDeadlineAt = 0;
+    }
+    let deadline =
+      planningStartedAt +
+      (startupWindowRemainingMs > 0
+        ? startupWindowRemainingMs
+        : FRESH_FRAME_TIMEOUT_MS);
     let candidate = this.getCachedKeyframeCandidate();
 
     while (true) {
@@ -1069,6 +1097,13 @@ export class ScrcpyScreenshotManager {
         if (this.canReuseFrameAcrossActionWait(candidate)) {
           debugScrcpy(
             `Using frame PTS ${candidate.ptsUs}µs that crossed the active input-action barrier; preserving the settled frame across wait-after-action`,
+          );
+          return candidate;
+        }
+
+        if (this.canUseStreamBaseline(candidate)) {
+          debugScrcpy(
+            `Using frame PTS ${candidate.ptsUs}µs as the first planning baseline for the new scrcpy stream epoch`,
           );
           return candidate;
         }
@@ -1121,6 +1156,9 @@ export class ScrcpyScreenshotManager {
 
   /**
    * Get screenshot as JPEG.
+   * A newly connected stream may use its first epoch-local frame once during
+   * the bounded startup window, because a static screen will not emit another
+   * frame after clock calibration completes.
    * Reuses one frame that crossed the active input-action barrier even if a
    * long wait-after-action made its absolute age exceed the planning limit.
    * Other over-age candidates arm a planning barrier on demand. If no frame
@@ -1156,6 +1194,8 @@ export class ScrcpyScreenshotManager {
     const result = await this.decodeH264ToJpeg(keyframeBuffer);
     const decodeTime = Date.now() - t5;
     this.consumeActionFreshnessBarrier(frame);
+    this.streamBaselineFramePending = false;
+    this.streamBaselineFrameDeadlineAt = 0;
 
     const totalTime = Date.now() - perfStart;
     debugScrcpy(

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -36,7 +36,7 @@ const TRANSPORT_BACKLOG_WARN_INTERVAL_MS = 5_000;
 const DEVICE_UPTIME_COMMAND = ['dumpsys', 'power'] as const;
 
 export const SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT =
-  'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, consider setting scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) as a starting point, and lower it further if backlog persists.';
+  'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, pass --scrcpy-video-bit-rate 4000000 in the Android CLI, or set scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) in SDK/YAML configuration. Lower it further if backlog persists.';
 
 // Busy-loop detection thresholds
 const BUSY_LOOP_WINDOW_MS = 1_000; // Sliding window for measuring frame rate

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -31,22 +31,7 @@ const MAX_SERVER_OUTPUT_LINES = 100;
 const SERVER_OUTPUT_DRAIN_TIMEOUT_MS = 500;
 const MAX_FRAME_AGE_US = 500_000n;
 const FRAME_FRESHNESS_WARN_INTERVAL_MS = 5_000;
-const TRANSPORT_BACKLOG_WARN_INTERVAL_MS = 5_000;
 const DEVICE_UPTIME_COMMAND = ['dumpsys', 'power'] as const;
-
-export const SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT =
-  'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, pass --scrcpy-video-bit-rate 4000000 in the Android CLI, or set scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) in SDK/YAML configuration. Lower it further if backlog persists.';
-
-const CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE = 4_000_000;
-
-export function getScrcpyVideoBitRateNetworkHint(
-  currentVideoBitRate: number,
-): string {
-  if (currentVideoBitRate <= CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE) {
-    return 'The current scrcpy video bitrate is already at or below 4 Mbps. Lowering it further is unlikely to help on a local USB connection; check whether the screen was static or the device encoder emitted no new frame.';
-  }
-  return SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT;
-}
 
 // Busy-loop detection thresholds
 const BUSY_LOOP_WINDOW_MS = 1_000; // Sliding window for measuring frame rate
@@ -89,21 +74,29 @@ export interface RawKeyframe {
 export const SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE =
   'ERR_SCRCPY_FRESH_FRAME_UNAVAILABLE';
 
+export type ScrcpyFreshFrameFailureKind = 'stream-startup' | 'freshness-target';
+
 interface ScrcpyFreshFrameUnavailableErrorOptions extends ErrorOptions {
-  diagnosticMessage?: string;
+  failureKind: ScrcpyFreshFrameFailureKind;
+  timeoutMs: number;
+  videoBitRate: number;
 }
 
 export class ScrcpyFreshFrameUnavailableError extends Error {
   readonly code = SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE;
-  readonly diagnosticMessage?: string;
+  readonly failureKind: ScrcpyFreshFrameFailureKind;
+  readonly timeoutMs: number;
+  readonly videoBitRate: number;
 
   constructor(
     message: string,
-    options?: ScrcpyFreshFrameUnavailableErrorOptions,
+    options: ScrcpyFreshFrameUnavailableErrorOptions,
   ) {
     super(message, options);
     this.name = 'ScrcpyFreshFrameUnavailableError';
-    this.diagnosticMessage = options?.diagnosticMessage;
+    this.failureKind = options.failureKind;
+    this.timeoutMs = options.timeoutMs;
+    this.videoBitRate = options.videoBitRate;
   }
 }
 
@@ -133,7 +126,6 @@ interface FrameAgeEstimate {
 
 export interface ScrcpyFreshnessBarrierOptions {
   hostMonotonicUs?: bigint;
-  allowOverAgeForNextCapture?: boolean;
 }
 
 /**
@@ -233,13 +225,11 @@ export class ScrcpyScreenshotManager {
   private streamReader: any = null;
   private frameFreshnessBarrierPtsUs: bigint | null = null;
   private frameFreshnessBarrierReason: string | null = null;
-  private frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
   // A newly created stream may emit its only frame before clock calibration
   // finishes. On a static screen no replacement frame follows, so the first
   // screenshot may use that epoch-local baseline once when no action barrier
   // is active. Later planning screenshots remain subject to the age limit.
-  private streamBaselineFramePending = false;
-  private streamBaselineFrameDeadlineAt = 0;
+  private streamBaselineWindow: { deadlineAt: number } | null = null;
   private frameFreshnessBarrierPending = false;
   private frameFreshnessBarrierGeneration = 0;
   private deviceClockCalibration: DeviceClockCalibration | null = null;
@@ -248,9 +238,7 @@ export class ScrcpyScreenshotManager {
   private lastFramePtsUs: bigint | null = null;
   private frameFreshnessError: Error | null = null;
   private lastFrameFreshnessWarningAt = 0;
-  // Keep this across stream epoch rebuilds so repeated recovery attempts do
-  // not emit the same network-tuning hint for every screenshot.
-  private lastTransportBacklogWarningAt = 0;
+  private disposePromise: Promise<void> | null = null;
 
   constructor(adb: Adb, options: ScrcpyScreenshotOptions = {}) {
     this.adb = adb;
@@ -356,8 +344,9 @@ export class ScrcpyScreenshotManager {
       // stream epoch. Frame age and all later barriers are projected from this
       // anchor without another ADB clock read.
       await this.ensureFrameClockCalibration();
-      this.streamBaselineFramePending = true;
-      this.streamBaselineFrameDeadlineAt = Date.now() + MAX_KEYFRAME_WAIT_MS;
+      this.streamBaselineWindow = {
+        deadlineAt: Date.now() + MAX_KEYFRAME_WAIT_MS,
+      };
       this.startFrameConsumer();
       this.resetIdleTimer();
       this.isInitialized = true;
@@ -696,10 +685,8 @@ export class ScrcpyScreenshotManager {
    * the host-monotonic action/planning boundary projected onto the device
    * clock. A caller recovering an unavailable stream can pass the original
    * action-boundary timestamp so connection startup latency does not move the
-   * barrier forward. Action barriers may allow the first proven post-boundary
-   * frame to survive a long wait-after-action delay. The projection reuses the
-   * single calibration for this stream epoch and does not issue another ADB
-   * clock read.
+   * barrier forward. The projection reuses the single calibration for this
+   * stream epoch and does not issue another ADB clock read.
    */
   async setFreshnessBarrier(
     reason: string,
@@ -708,7 +695,6 @@ export class ScrcpyScreenshotManager {
     const cachedFrame = this.getCachedKeyframeCandidate();
     const generation = ++this.frameFreshnessBarrierGeneration;
     this.frameFreshnessBarrierPending = true;
-    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
     this.clearFrameCache();
 
     try {
@@ -741,8 +727,6 @@ export class ScrcpyScreenshotManager {
           ? barrierPtsUs
           : this.frameFreshnessBarrierPtsUs;
       this.frameFreshnessBarrierReason = reason;
-      this.frameFreshnessBarrierAllowsOverAgeForNextCapture =
-        options.allowOverAgeForNextCapture ?? false;
       this.frameFreshnessBarrierPending = false;
       this.frameFreshnessError = null;
       this.lastFramePtsUs = null;
@@ -787,7 +771,6 @@ export class ScrcpyScreenshotManager {
         this.frameFreshnessBarrierPending = true;
         this.frameFreshnessBarrierPtsUs = null;
         this.frameFreshnessBarrierReason = null;
-        this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
         this.deviceClockCalibration = null;
         this.clearFrameCache();
         this.warnFrameFreshness();
@@ -926,35 +909,6 @@ export class ScrcpyScreenshotManager {
     }
   }
 
-  private transportBacklogMessage(error: unknown): string {
-    const cause = this.frameFreshnessError ?? error;
-    const causeMessage = cause instanceof Error ? cause.message : String(cause);
-    if (
-      this.streamBaselineFramePending &&
-      this.frameFreshnessBarrierPtsUs === null
-    ) {
-      return `The new scrcpy stream did not produce a usable baseline frame within its ${MAX_KEYFRAME_WAIT_MS}ms startup window; closing the stream epoch and falling back to ADB screenshot. This is a stream startup or encoder-readiness failure, not evidence that the configured video bitrate is too high.\nError: ${causeMessage}`;
-    }
-    const currentBitRateMbps = this.options.videoBitRate / 1_000_000;
-    const networkHint = getScrcpyVideoBitRateNetworkHint(
-      this.options.videoBitRate,
-    );
-    return `No usable scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms; closing the stale stream epoch and falling back to ADB screenshot. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint} Current videoBitRate: ${this.options.videoBitRate} bps (${currentBitRateMbps} Mbps).\nError: ${causeMessage}`;
-  }
-
-  private warnTransportBacklog(error: unknown): void {
-    const now = Date.now();
-    if (
-      now - this.lastTransportBacklogWarningAt <
-      TRANSPORT_BACKLOG_WARN_INTERVAL_MS
-    ) {
-      return;
-    }
-
-    warnScrcpy(this.transportBacklogMessage(error));
-    this.lastTransportBacklogWarningAt = now;
-  }
-
   private estimateFrameTiming(
     packetPtsUs: bigint | undefined,
     receivedAtUs: bigint,
@@ -999,9 +953,7 @@ export class ScrcpyScreenshotManager {
   private resetFrameFreshnessState(): void {
     this.frameFreshnessBarrierPtsUs = null;
     this.frameFreshnessBarrierReason = null;
-    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
-    this.streamBaselineFramePending = false;
-    this.streamBaselineFrameDeadlineAt = 0;
+    this.streamBaselineWindow = null;
     this.frameFreshnessBarrierPending = false;
     this.frameFreshnessBarrierGeneration = 0;
     this.deviceClockCalibration = null;
@@ -1049,31 +1001,14 @@ export class ScrcpyScreenshotManager {
     };
   }
 
-  private canReuseFrameAcrossActionWait(frame: RawKeyframe): boolean {
-    return (
-      this.frameFreshnessBarrierAllowsOverAgeForNextCapture &&
-      this.frameFreshnessBarrierPtsUs !== null &&
-      frame.ptsUs !== undefined &&
-      frame.ptsUs >= this.frameFreshnessBarrierPtsUs
-    );
-  }
-
   private canUseStreamBaseline(frame: RawKeyframe): boolean {
     return (
-      this.streamBaselineFramePending &&
+      this.streamBaselineWindow !== null &&
       !this.frameFreshnessBarrierPending &&
       this.frameFreshnessBarrierPtsUs === null &&
-      Date.now() <= this.streamBaselineFrameDeadlineAt &&
+      Date.now() <= this.streamBaselineWindow.deadlineAt &&
       frame.ptsUs !== undefined
     );
-  }
-
-  private consumeActionFreshnessBarrier(frame: RawKeyframe): void {
-    if (!this.canReuseFrameAcrossActionWait(frame)) return;
-    this.frameFreshnessBarrierPtsUs = null;
-    this.frameFreshnessBarrierReason = null;
-    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
-    this.frameFreshnessError = null;
   }
 
   /**
@@ -1086,30 +1021,17 @@ export class ScrcpyScreenshotManager {
     return this.decodeH264ToJpeg(Buffer.concat([frame.header, frame.data]));
   }
 
-  /**
-   * Ensure a newly connected stream has a calibrated, usable epoch baseline
-   * or a frame that crossed its active action barrier before exposing it again
-   * after ADB fallback.
-   */
-  async prepareFreshFrame(): Promise<void> {
-    await this.ensureConnected();
-    await this.ensureFrameClockCalibration();
-    await this.waitForKeyframe();
-    await this.waitForPlanningFrame();
-  }
-
   private async waitForPlanningFrame(): Promise<RawKeyframe> {
     let planningBarrierArmed = false;
     // A new encoder/stream gets the normal startup allowance for its first
     // data frame. Established epochs still fail fast when they cannot cross a
     // newly armed freshness barrier.
     const planningStartedAt = Date.now();
-    const startupWindowRemainingMs = this.streamBaselineFramePending
-      ? this.streamBaselineFrameDeadlineAt - planningStartedAt
+    const startupWindowRemainingMs = this.streamBaselineWindow
+      ? this.streamBaselineWindow.deadlineAt - planningStartedAt
       : 0;
-    if (this.streamBaselineFramePending && startupWindowRemainingMs <= 0) {
-      this.streamBaselineFramePending = false;
-      this.streamBaselineFrameDeadlineAt = 0;
+    if (this.streamBaselineWindow && startupWindowRemainingMs <= 0) {
+      this.streamBaselineWindow = null;
     }
     let deadline =
       planningStartedAt +
@@ -1124,13 +1046,6 @@ export class ScrcpyScreenshotManager {
           throw new Error(
             'Scrcpy frame has no PTS metadata; cannot prove planning freshness',
           );
-        }
-
-        if (this.canReuseFrameAcrossActionWait(candidate)) {
-          debugScrcpy(
-            `Using frame PTS ${candidate.ptsUs}µs that crossed the active input-action barrier; preserving the settled frame across wait-after-action`,
-          );
-          return candidate;
         }
 
         if (this.canUseStreamBaseline(candidate)) {
@@ -1177,12 +1092,24 @@ export class ScrcpyScreenshotManager {
   private async closeStaleStreamAndCreateFallbackError(
     error: unknown,
   ): Promise<ScrcpyFreshFrameUnavailableError> {
-    const diagnosticMessage = this.transportBacklogMessage(error);
+    const failureKind: ScrcpyFreshFrameFailureKind =
+      this.streamBaselineWindow && this.frameFreshnessBarrierPtsUs === null
+        ? 'stream-startup'
+        : 'freshness-target';
+    const timeoutMs =
+      failureKind === 'stream-startup'
+        ? MAX_KEYFRAME_WAIT_MS
+        : FRESH_FRAME_TIMEOUT_MS;
     const causeMessage = error instanceof Error ? error.message : String(error);
     await this.disconnect();
     return new ScrcpyFreshFrameUnavailableError(
       `Unable to obtain a fresh scrcpy frame; the stale stream epoch was closed so the caller can restart it or use ADB screenshot fallback. ${causeMessage}`,
-      { cause: error, diagnosticMessage },
+      {
+        cause: error,
+        failureKind,
+        timeoutMs,
+        videoBitRate: this.options.videoBitRate,
+      },
     );
   }
 
@@ -1191,11 +1118,10 @@ export class ScrcpyScreenshotManager {
    * A newly connected stream may use its first epoch-local frame once during
    * the bounded startup window, because a static screen will not emit another
    * frame after clock calibration completes.
-   * Reuses one frame that crossed the active input-action barrier even if a
-   * long wait-after-action made its absolute age exceed the planning limit.
-   * Other over-age candidates arm a planning barrier on demand. If no frame
-   * crosses the resulting freshness target in time, close this stream epoch
-   * and let the caller use ADB.
+   * Frames that crossed an input-action barrier must still satisfy the absolute
+   * age limit at capture time. Over-age candidates arm a planning barrier on
+   * demand. If no frame crosses the resulting freshness target in time, close
+   * this stream epoch and let the caller restart it or use ADB.
    */
   async getScreenshotJpeg(): Promise<Buffer> {
     const perfStart = Date.now();
@@ -1225,9 +1151,7 @@ export class ScrcpyScreenshotManager {
     const t5 = Date.now();
     const result = await this.decodeH264ToJpeg(keyframeBuffer);
     const decodeTime = Date.now() - t5;
-    this.consumeActionFreshnessBarrier(frame);
-    this.streamBaselineFramePending = false;
-    this.streamBaselineFrameDeadlineAt = 0;
+    this.streamBaselineWindow = null;
 
     const totalTime = Date.now() - perfStart;
     debugScrcpy(
@@ -1485,13 +1409,18 @@ export class ScrcpyScreenshotManager {
    * Unlike disconnect(), a disposed manager cannot be reconnected.
    */
   async dispose(): Promise<void> {
-    if (this.disposed) return;
+    if (this.disposePromise) return this.disposePromise;
+
     this.disposed = true;
-    if (this.connectionPromise) {
-      await this.connectionPromise.catch(() => {});
-    }
-    await this.disconnect();
-    await this.adb.close();
+    const disposePromise = (async () => {
+      if (this.connectionPromise) {
+        await this.connectionPromise.catch(() => {});
+      }
+      await this.disconnect();
+      await this.adb.close();
+    })();
+    this.disposePromise = disposePromise;
+    return disposePromise;
   }
 
   /**

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -90,12 +90,21 @@ export interface RawKeyframe {
 export const SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE =
   'ERR_SCRCPY_FRESH_FRAME_UNAVAILABLE';
 
+interface ScrcpyFreshFrameUnavailableErrorOptions extends ErrorOptions {
+  diagnosticMessage?: string;
+}
+
 export class ScrcpyFreshFrameUnavailableError extends Error {
   readonly code = SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE;
+  readonly diagnosticMessage?: string;
 
-  constructor(message: string, options?: ErrorOptions) {
+  constructor(
+    message: string,
+    options?: ScrcpyFreshFrameUnavailableErrorOptions,
+  ) {
     super(message, options);
     this.name = 'ScrcpyFreshFrameUnavailableError';
+    this.diagnosticMessage = options?.diagnosticMessage;
   }
 }
 
@@ -899,6 +908,22 @@ export class ScrcpyScreenshotManager {
     }
   }
 
+  private transportBacklogMessage(error: unknown): string {
+    const cause = this.frameFreshnessError ?? error;
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    if (
+      this.streamBaselineFramePending &&
+      this.frameFreshnessBarrierPtsUs === null
+    ) {
+      return `The new scrcpy stream did not produce a usable baseline frame within its ${MAX_KEYFRAME_WAIT_MS}ms startup window; closing the stream epoch and falling back to ADB screenshot. This is a stream startup or encoder-readiness failure, not evidence that the configured video bitrate is too high.\nError: ${causeMessage}`;
+    }
+    const currentBitRateMbps = this.options.videoBitRate / 1_000_000;
+    const networkHint = getScrcpyVideoBitRateNetworkHint(
+      this.options.videoBitRate,
+    );
+    return `No usable scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms; closing the stale stream epoch and falling back to ADB screenshot. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint} Current videoBitRate: ${this.options.videoBitRate} bps (${currentBitRateMbps} Mbps).\nError: ${causeMessage}`;
+  }
+
   private warnTransportBacklog(error: unknown): void {
     const now = Date.now();
     if (
@@ -908,25 +933,7 @@ export class ScrcpyScreenshotManager {
       return;
     }
 
-    const cause = this.frameFreshnessError ?? error;
-    const causeMessage = cause instanceof Error ? cause.message : String(cause);
-    if (
-      this.streamBaselineFramePending &&
-      this.frameFreshnessBarrierPtsUs === null
-    ) {
-      warnScrcpy(
-        `The new scrcpy stream did not produce a usable baseline frame within its ${MAX_KEYFRAME_WAIT_MS}ms startup window; closing the stream epoch and falling back to ADB screenshot. This is a stream startup or encoder-readiness failure, not evidence that the configured video bitrate is too high.\nError: ${causeMessage}`,
-      );
-      this.lastTransportBacklogWarningAt = now;
-      return;
-    }
-    const currentBitRateMbps = this.options.videoBitRate / 1_000_000;
-    const networkHint = getScrcpyVideoBitRateNetworkHint(
-      this.options.videoBitRate,
-    );
-    warnScrcpy(
-      `No usable scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms; closing the stale stream epoch and falling back to ADB screenshot. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint} Current videoBitRate: ${this.options.videoBitRate} bps (${currentBitRateMbps} Mbps).\nError: ${causeMessage}`,
-    );
+    warnScrcpy(this.transportBacklogMessage(error));
     this.lastTransportBacklogWarningAt = now;
   }
 
@@ -1145,12 +1152,12 @@ export class ScrcpyScreenshotManager {
   private async closeStaleStreamAndCreateFallbackError(
     error: unknown,
   ): Promise<ScrcpyFreshFrameUnavailableError> {
-    this.warnTransportBacklog(error);
+    const diagnosticMessage = this.transportBacklogMessage(error);
     const causeMessage = error instanceof Error ? error.message : String(error);
     await this.disconnect();
     return new ScrcpyFreshFrameUnavailableError(
-      `Unable to obtain a fresh scrcpy frame; the stale stream epoch was closed so the caller can use ADB screenshot fallback. ${causeMessage}`,
-      { cause: error },
+      `Unable to obtain a fresh scrcpy frame; the stale stream epoch was closed so the caller can restart it or use ADB screenshot fallback. ${causeMessage}`,
+      { cause: error, diagnosticMessage },
     );
   }
 

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -123,6 +123,11 @@ interface FrameAgeEstimate {
   upperBoundUs: bigint;
 }
 
+export interface ScrcpyFreshnessBarrierOptions {
+  hostMonotonicUs?: bigint;
+  allowOverAgeForNextCapture?: boolean;
+}
+
 /**
  * Reconstruct SystemClock.uptimeMillis() from TimeUtils.formatUptime(), which
  * PowerManagerService uses for the `mLastWakeTime` line.
@@ -219,6 +224,7 @@ export class ScrcpyScreenshotManager {
   private streamReader: any = null;
   private frameFreshnessBarrierPtsUs: bigint | null = null;
   private frameFreshnessBarrierReason: string | null = null;
+  private frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
   private frameFreshnessBarrierPending = false;
   private frameFreshnessBarrierGeneration = 0;
   private deviceClockCalibration: DeviceClockCalibration | null = null;
@@ -665,16 +671,19 @@ export class ScrcpyScreenshotManager {
    * Invalidate cached frames and require future packets to be captured after
    * the host-monotonic action/planning boundary projected onto the device
    * clock. A caller recovering an unavailable stream can pass the original
-   * action-completion timestamp so connection startup latency does not move the
-   * barrier forward. The projection reuses the single calibration for this
-   * stream epoch and does not issue another ADB clock read.
+   * action-boundary timestamp so connection startup latency does not move the
+   * barrier forward. Action barriers may allow the first proven post-boundary
+   * frame to survive a long wait-after-action delay. The projection reuses the
+   * single calibration for this stream epoch and does not issue another ADB
+   * clock read.
    */
   async setFreshnessBarrier(
     reason: string,
-    hostMonotonicUs = this.monotonicTimeUs(),
+    options: ScrcpyFreshnessBarrierOptions = {},
   ): Promise<bigint> {
     const generation = ++this.frameFreshnessBarrierGeneration;
     this.frameFreshnessBarrierPending = true;
+    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
     this.clearFrameCache();
 
     try {
@@ -685,6 +694,7 @@ export class ScrcpyScreenshotManager {
         );
       }
 
+      const hostMonotonicUs = options.hostMonotonicUs ?? this.monotonicTimeUs();
       const estimatedDeviceNowUs = this.estimateDeviceTimeUs(
         hostMonotonicUs,
         calibration,
@@ -706,6 +716,8 @@ export class ScrcpyScreenshotManager {
           ? barrierPtsUs
           : this.frameFreshnessBarrierPtsUs;
       this.frameFreshnessBarrierReason = reason;
+      this.frameFreshnessBarrierAllowsOverAgeForNextCapture =
+        options.allowOverAgeForNextCapture ?? false;
       this.frameFreshnessBarrierPending = false;
       this.frameFreshnessError = null;
       this.lastFramePtsUs = null;
@@ -740,6 +752,7 @@ export class ScrcpyScreenshotManager {
         this.frameFreshnessBarrierPending = true;
         this.frameFreshnessBarrierPtsUs = null;
         this.frameFreshnessBarrierReason = null;
+        this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
         this.deviceClockCalibration = null;
         this.clearFrameCache();
         this.warnFrameFreshness();
@@ -775,7 +788,7 @@ export class ScrcpyScreenshotManager {
       `Scrcpy frame predates the ${this.frameFreshnessBarrierReason ?? 'active'} freshness barrier by ${Number(behindBarrierUs) / 1_000}ms; refusing to use it`,
     );
     this.clearFrameCache();
-    this.warnFrameFreshness();
+    debugScrcpy(this.frameFreshnessError.message);
     return false;
   }
 
@@ -936,6 +949,7 @@ export class ScrcpyScreenshotManager {
   private resetFrameFreshnessState(): void {
     this.frameFreshnessBarrierPtsUs = null;
     this.frameFreshnessBarrierReason = null;
+    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
     this.frameFreshnessBarrierPending = false;
     this.frameFreshnessBarrierGeneration = 0;
     this.deviceClockCalibration = null;
@@ -981,6 +995,23 @@ export class ScrcpyScreenshotManager {
       estimatedAgeMs: this.lastRawKeyframeEstimatedAgeMs,
       capturedAt: this.lastRawKeyframeAt,
     };
+  }
+
+  private canReuseFrameAcrossActionWait(frame: RawKeyframe): boolean {
+    return (
+      this.frameFreshnessBarrierAllowsOverAgeForNextCapture &&
+      this.frameFreshnessBarrierPtsUs !== null &&
+      frame.ptsUs !== undefined &&
+      frame.ptsUs >= this.frameFreshnessBarrierPtsUs
+    );
+  }
+
+  private consumeActionFreshnessBarrier(frame: RawKeyframe): void {
+    if (!this.canReuseFrameAcrossActionWait(frame)) return;
+    this.frameFreshnessBarrierPtsUs = null;
+    this.frameFreshnessBarrierReason = null;
+    this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
+    this.frameFreshnessError = null;
   }
 
   /**
@@ -1035,6 +1066,13 @@ export class ScrcpyScreenshotManager {
           );
         }
 
+        if (this.canReuseFrameAcrossActionWait(candidate)) {
+          debugScrcpy(
+            `Using frame PTS ${candidate.ptsUs}µs that crossed the active input-action barrier; preserving the settled frame across wait-after-action`,
+          );
+          return candidate;
+        }
+
         const age = this.estimateFrameAge(candidate.ptsUs);
         if (age === null) {
           throw new Error(
@@ -1083,10 +1121,11 @@ export class ScrcpyScreenshotManager {
 
   /**
    * Get screenshot as JPEG.
-   * Reuses a frame only when it crossed the active action barrier and its
-   * absolute age is within the accepted limit. An over-age candidate arms a
-   * planning barrier on demand. If no frame crosses the resulting freshness
-   * target in time, close this stream epoch and let the caller use ADB.
+   * Reuses one frame that crossed the active input-action barrier even if a
+   * long wait-after-action made its absolute age exceed the planning limit.
+   * Other over-age candidates arm a planning barrier on demand. If no frame
+   * crosses the resulting freshness target in time, close this stream epoch
+   * and let the caller use ADB.
    */
   async getScreenshotJpeg(): Promise<Buffer> {
     const perfStart = Date.now();
@@ -1116,6 +1155,7 @@ export class ScrcpyScreenshotManager {
     const t5 = Date.now();
     const result = await this.decodeH264ToJpeg(keyframeBuffer);
     const decodeTime = Date.now() - t5;
+    this.consumeActionFreshnessBarrier(frame);
 
     const totalTime = Date.now() - perfStart;
     debugScrcpy(

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -38,6 +38,17 @@ const DEVICE_UPTIME_COMMAND = ['dumpsys', 'power'] as const;
 export const SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT =
   'The appropriate scrcpy video bitrate depends on network conditions. For constrained remote links, pass --scrcpy-video-bit-rate 4000000 in the Android CLI, or set scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps) in SDK/YAML configuration. Lower it further if backlog persists.';
 
+const CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE = 4_000_000;
+
+export function getScrcpyVideoBitRateNetworkHint(
+  currentVideoBitRate: number,
+): string {
+  if (currentVideoBitRate <= CONSTRAINED_LINK_STARTING_VIDEO_BIT_RATE) {
+    return 'The current scrcpy video bitrate is already at or below 4 Mbps. Lowering it further is unlikely to help on a local USB connection; check whether the screen was static or the device encoder emitted no new frame.';
+  }
+  return SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT;
+}
+
 // Busy-loop detection thresholds
 const BUSY_LOOP_WINDOW_MS = 1_000; // Sliding window for measuring frame rate
 const BUSY_LOOP_MAX_READS = 500; // Max reads per window before considered busy-loop
@@ -653,10 +664,15 @@ export class ScrcpyScreenshotManager {
   /**
    * Invalidate cached frames and require future packets to be captured after
    * the host-monotonic action/planning boundary projected onto the device
-   * clock. The projection reuses the single calibration for this stream epoch
-   * and does not issue another ADB clock read.
+   * clock. A caller recovering an unavailable stream can pass the original
+   * action-completion timestamp so connection startup latency does not move the
+   * barrier forward. The projection reuses the single calibration for this
+   * stream epoch and does not issue another ADB clock read.
    */
-  async setFreshnessBarrier(reason: string): Promise<bigint> {
+  async setFreshnessBarrier(
+    reason: string,
+    hostMonotonicUs = this.monotonicTimeUs(),
+  ): Promise<bigint> {
     const generation = ++this.frameFreshnessBarrierGeneration;
     this.frameFreshnessBarrierPending = true;
     this.clearFrameCache();
@@ -669,7 +685,6 @@ export class ScrcpyScreenshotManager {
         );
       }
 
-      const hostMonotonicUs = this.monotonicTimeUs();
       const estimatedDeviceNowUs = this.estimateDeviceTimeUs(
         hostMonotonicUs,
         calibration,
@@ -875,8 +890,11 @@ export class ScrcpyScreenshotManager {
     const cause = this.frameFreshnessError ?? error;
     const causeMessage = cause instanceof Error ? cause.message : String(cause);
     const currentBitRateMbps = this.options.videoBitRate / 1_000_000;
+    const networkHint = getScrcpyVideoBitRateNetworkHint(
+      this.options.videoBitRate,
+    );
     warnScrcpy(
-      `No usable scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms; closing the stale stream epoch and falling back to ADB screenshot. This may indicate transport backlog or a static screen that emitted no new frame. ${SCRCPY_VIDEO_BIT_RATE_NETWORK_HINT} Current videoBitRate: ${this.options.videoBitRate} bps (${currentBitRateMbps} Mbps).\nError: ${causeMessage}`,
+      `No usable scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms; closing the stale stream epoch and falling back to ADB screenshot. This may indicate transport backlog or a static screen that emitted no new frame. ${networkHint} Current videoBitRate: ${this.options.videoBitRate} bps (${currentBitRateMbps} Mbps).\nError: ${causeMessage}`,
     );
     this.lastTransportBacklogWarningAt = now;
   }

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -27,7 +27,6 @@ const MAX_KEYFRAME_WAIT_MS = 5_000;
 const FRESH_FRAME_TIMEOUT_MS = 300;
 const KEYFRAME_POLL_INTERVAL_MS = 200;
 const MAX_SCAN_BYTES = 1_000;
-const CONNECTION_WAIT_MS = 1_000;
 const MAX_SERVER_OUTPUT_LINES = 100;
 const SERVER_OUTPUT_DRAIN_TIMEOUT_MS = 500;
 const MAX_FRAME_AGE_US = 500_000n;
@@ -219,7 +218,8 @@ export class ScrcpyScreenshotManager {
   private videoStream: any = null;
   private spsHeader: Buffer | null = null;
   private idleTimer: NodeJS.Timeout | null = null;
-  private isConnecting = false;
+  private connectionPromise: Promise<void> | null = null;
+  private disposed = false;
   private isInitialized = false;
   private options: ResolvedScrcpyOptions;
   private ffmpegAvailable: boolean | null = null;
@@ -281,6 +281,10 @@ export class ScrcpyScreenshotManager {
    * Ensure scrcpy connection is active
    */
   async ensureConnected(): Promise<void> {
+    if (this.disposed) {
+      throw new Error('Scrcpy manager has been disposed');
+    }
+
     if (this.scrcpyClient && this.videoStream) {
       debugScrcpy('Scrcpy already connected');
       await this.ensureFrameClockCalibration();
@@ -288,25 +292,30 @@ export class ScrcpyScreenshotManager {
       return;
     }
 
-    if (this.isConnecting) {
-      debugScrcpy('Connection already in progress, waiting...');
-      await new Promise((resolve) => setTimeout(resolve, CONNECTION_WAIT_MS));
-      // After waiting, check if the other connection attempt succeeded
-      if (this.scrcpyClient && this.videoStream) {
-        await this.ensureFrameClockCalibration();
-        this.resetIdleTimer();
-        return;
-      }
-      throw new Error(
-        'Scrcpy connection failed: another connection attempt did not complete in time',
+    if (this.connectionPromise) {
+      debugScrcpy(
+        'Connection already in progress, sharing the same attempt...',
       );
+      await this.connectionPromise;
+      return;
     }
 
+    const connectionPromise = this.connectScrcpy();
+    this.connectionPromise = connectionPromise;
+    try {
+      await connectionPromise;
+    } finally {
+      if (this.connectionPromise === connectionPromise) {
+        this.connectionPromise = null;
+      }
+    }
+  }
+
+  private async connectScrcpy(): Promise<void> {
     const serverOutput: string[] = [];
     let serverOutputTask: Promise<void> | null = null;
 
     try {
-      this.isConnecting = true;
       debugScrcpy('Starting scrcpy connection...');
 
       const { AdbScrcpyClient } = await import('@yume-chan/adb-scrcpy');
@@ -366,8 +375,6 @@ export class ScrcpyScreenshotManager {
         ]);
       }
       throw this.createConnectionError(error, serverOutput);
-    } finally {
-      this.isConnecting = false;
     }
   }
 
@@ -698,6 +705,7 @@ export class ScrcpyScreenshotManager {
     reason: string,
     options: ScrcpyFreshnessBarrierOptions = {},
   ): Promise<bigint> {
+    const cachedFrame = this.getCachedKeyframeCandidate();
     const generation = ++this.frameFreshnessBarrierGeneration;
     this.frameFreshnessBarrierPending = true;
     this.frameFreshnessBarrierAllowsOverAgeForNextCapture = false;
@@ -738,7 +746,17 @@ export class ScrcpyScreenshotManager {
       this.frameFreshnessBarrierPending = false;
       this.frameFreshnessError = null;
       this.lastFramePtsUs = null;
-      this.clearFrameCache();
+      if (
+        cachedFrame?.ptsUs !== undefined &&
+        cachedFrame.ptsUs >= this.frameFreshnessBarrierPtsUs
+      ) {
+        this.restoreFrameCache(cachedFrame);
+        debugScrcpy(
+          `Preserved cached frame PTS ${cachedFrame.ptsUs}µs because it crosses the newly armed ${reason} barrier`,
+        );
+      } else {
+        this.clearFrameCache();
+      }
 
       debugScrcpy(
         `Armed frame freshness barrier at PTS ${this.frameFreshnessBarrierPtsUs}µs (${reason}, projected from stream-epoch clock anchor, uncertainty<=${Number(this.getCalibrationUncertaintyUs(calibration)) / 1_000}ms)`,
@@ -965,6 +983,13 @@ export class ScrcpyScreenshotManager {
     this.lastRawKeyframeAt = 0;
     this.lastRawKeyframePtsUs = undefined;
     this.lastRawKeyframeEstimatedAgeMs = undefined;
+  }
+
+  private restoreFrameCache(frame: RawKeyframe): void {
+    this.lastRawKeyframe = frame.data;
+    this.lastRawKeyframeAt = frame.capturedAt;
+    this.lastRawKeyframePtsUs = frame.ptsUs;
+    this.lastRawKeyframeEstimatedAgeMs = frame.estimatedAgeMs;
   }
 
   private monotonicTimeUs(): bigint {
@@ -1453,6 +1478,20 @@ export class ScrcpyScreenshotManager {
     }
 
     debugScrcpy('Scrcpy disconnected');
+  }
+
+  /**
+   * Permanently release the scrcpy stream and the owned yume ADB transport.
+   * Unlike disconnect(), a disposed manager cannot be reconnected.
+   */
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.connectionPromise) {
+      await this.connectionPromise.catch(() => {});
+    }
+    await this.disconnect();
+    await this.adb.close();
   }
 
   /**

--- a/packages/android/src/visual-action-registry.ts
+++ b/packages/android/src/visual-action-registry.ts
@@ -6,14 +6,16 @@ type VisualActionDefinitions<TActions> = {
 
 /**
  * Register visual actions at one boundary so every caller observes the same
- * post-action frame freshness behavior. Composite actions belong in a single
- * registered callback and therefore settle the boundary only once.
+ * frame freshness behavior. The boundary is armed before dispatch so frames
+ * produced while an ADB input command is still returning count as post-action
+ * candidates. Composite actions belong in a single registered callback and
+ * therefore arm the boundary only once.
  */
 export function createVisualActionRegistry<
   TActions extends VisualActionDefinitions<TActions>,
 >(
   definitions: TActions,
-  onActionSettled: (actionName: keyof TActions & string) => Promise<void>,
+  onActionStarting: (actionName: keyof TActions & string) => Promise<void>,
 ): TActions {
   const registeredActions = {} as TActions;
 
@@ -22,11 +24,8 @@ export function createVisualActionRegistry<
   >) {
     const dispatch = definitions[actionName];
     registeredActions[actionName] = (async (...args: unknown[]) => {
-      try {
-        return await dispatch(...args);
-      } finally {
-        await onActionSettled(actionName);
-      }
+      await onActionStarting(actionName);
+      return await dispatch(...args);
     }) as TActions[typeof actionName];
   }
 

--- a/packages/android/src/visual-action-registry.ts
+++ b/packages/android/src/visual-action-registry.ts
@@ -6,16 +6,14 @@ type VisualActionDefinitions<TActions> = {
 
 /**
  * Register visual actions at one boundary so every caller observes the same
- * frame freshness behavior. The boundary is armed before dispatch so frames
- * produced while an ADB input command is still returning count as post-action
- * candidates. Composite actions belong in a single registered callback and
- * therefore arm the boundary only once.
+ * post-action frame freshness behavior. Composite actions belong in a single
+ * registered callback and therefore settle the boundary only once.
  */
 export function createVisualActionRegistry<
   TActions extends VisualActionDefinitions<TActions>,
 >(
   definitions: TActions,
-  onActionStarting: (actionName: keyof TActions & string) => Promise<void>,
+  onActionSettled: (actionName: keyof TActions & string) => Promise<void>,
 ): TActions {
   const registeredActions = {} as TActions;
 
@@ -24,8 +22,11 @@ export function createVisualActionRegistry<
   >) {
     const dispatch = definitions[actionName];
     registeredActions[actionName] = (async (...args: unknown[]) => {
-      await onActionStarting(actionName);
-      return await dispatch(...args);
+      try {
+        return await dispatch(...args);
+      } finally {
+        await onActionSettled(actionName);
+      }
     }) as TActions[typeof actionName];
   }
 

--- a/packages/android/tests/unit-test/cli.test.ts
+++ b/packages/android/tests/unit-test/cli.test.ts
@@ -276,8 +276,9 @@ describe('Android CLI integration', () => {
     expect(output.join('\n')).toContain('--scrcpy-video-bit-rate');
     expect(output.join('\n')).toContain('--scrcpyVideoBitRate');
     expect(output.join('\n')).toContain(
-      'For constrained remote links, start with 4000000 (4 Mbps)',
+      'tune it only from independent transport measurements',
     );
+    expect(output.join('\n')).not.toContain('start with 4000000 (4 Mbps)');
     expect(output.join('\n')).toContain(
       'high values may reduce recognition quality, especially on mobile',
     );

--- a/packages/android/tests/unit-test/cli.test.ts
+++ b/packages/android/tests/unit-test/cli.test.ts
@@ -179,6 +179,61 @@ describe('Android CLI integration', () => {
     });
   });
 
+  it('sets the scrcpy video bitrate from the CLI', async () => {
+    const tools = new AndroidMidsceneTools();
+
+    await runToolsCLI(tools, 'midscene-android', {
+      stripPrefix: 'android_',
+      argv: [
+        'take_screenshot',
+        '--device-id',
+        'remote-scrcpy-device',
+        '--use-scrcpy',
+        '--scrcpy-video-bit-rate',
+        '4000000',
+      ],
+    });
+
+    expect(agentFromAdbDevice).toHaveBeenCalledWith('remote-scrcpy-device', {
+      autoDismissKeyboard: false,
+      scrcpyConfig: { enabled: true, videoBitRate: 4_000_000 },
+    });
+  });
+
+  it('rejects a non-positive scrcpy video bitrate', async () => {
+    const tools = new AndroidMidsceneTools();
+
+    await expect(
+      runToolsCLI(tools, 'midscene-android', {
+        stripPrefix: 'android_',
+        argv: [
+          'take_screenshot',
+          '--use-scrcpy',
+          '--scrcpy-video-bit-rate',
+          '0',
+        ],
+      }),
+    ).rejects.toThrow(
+      'Invalid value for "--scrcpy-video-bit-rate" in midscene-android take_screenshot',
+    );
+
+    expect(agentFromAdbDevice).not.toHaveBeenCalled();
+  });
+
+  it('enables scrcpy when a video bitrate is provided by itself', async () => {
+    const tools = new AndroidMidsceneTools();
+
+    await runToolsCLI(tools, 'midscene-android', {
+      stripPrefix: 'android_',
+      argv: ['take_screenshot', '--scrcpy-video-bit-rate', '4000000'],
+    });
+
+    expect(agentFromAdbDevice).toHaveBeenCalledWith(undefined, {
+      autoDismissKeyboard: false,
+      scrcpyConfig: { enabled: true, videoBitRate: 4_000_000 },
+    });
+  });
+
   it('strips init args from the payload passed to the action', async () => {
     const mockAgent = createMockAgent();
     rs.mocked(agentFromAdbDevice).mockResolvedValue(mockAgent as any);
@@ -218,6 +273,11 @@ describe('Android CLI integration', () => {
     expect(output.join('\n')).not.toContain('--ai-action-context');
     expect(output.join('\n')).not.toContain('--aiActionContext');
     expect(output.join('\n')).toContain('--screenshot-shrink-factor');
+    expect(output.join('\n')).toContain('--scrcpy-video-bit-rate');
+    expect(output.join('\n')).toContain('--scrcpyVideoBitRate');
+    expect(output.join('\n')).toContain(
+      'For constrained remote links, start with 4000000 (4 Mbps)',
+    );
     expect(output.join('\n')).toContain(
       'high values may reduce recognition quality, especially on mobile',
     );

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1178,7 +1178,7 @@ Stdout:
       expect(warn).toHaveBeenCalledWith(
         '[Midscene]',
         expect.stringContaining(
-          'scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps)',
+          '--scrcpy-video-bit-rate 4000000 in the Android CLI',
         ),
       );
     });

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1255,8 +1255,12 @@ Stdout:
       expect(warn).toHaveBeenCalledWith(
         '[Midscene]',
         expect.stringContaining(
-          'Lowering it further is unlikely to help on a local USB connection',
+          'does not by itself identify bandwidth or the configured video bitrate as the cause',
         ),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('--scrcpy-video-bit-rate'),
       );
       expect(warn).toHaveBeenCalledTimes(1);
     });

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1153,7 +1153,7 @@ Stdout:
       expect(forceScreenshotSpy).not.toHaveBeenCalled();
     });
 
-    it('should recommend a network-aware videoBitRate when scrcpy falls back to ADB', async () => {
+    it('should report the scrcpy failure cause without assuming network backlog', async () => {
       const adapter = (device as any).getScrcpyAdapter();
       rs.spyOn(adapter, 'isEnabled').mockReturnValue(true);
       rs.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
@@ -1177,9 +1177,11 @@ Stdout:
       );
       expect(warn).toHaveBeenCalledWith(
         '[Midscene]',
-        expect.stringContaining(
-          '--scrcpy-video-bit-rate 4000000 in the Android CLI',
-        ),
+        expect.stringContaining('stream recovery failed'),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('--scrcpy-video-bit-rate'),
       );
     });
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -1193,11 +1193,12 @@ Stdout:
       rs.spyOn(fallbackDevice, 'getAdb').mockResolvedValue(mockAdb);
       const adapter = (fallbackDevice as any).getScrcpyAdapter();
       rs.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
-        new ScrcpyFreshFrameUnavailableError('stale stream closed'),
+        new ScrcpyFreshFrameUnavailableError('stale stream closed', {
+          failureKind: 'freshness-target',
+          timeoutMs: 300,
+          videoBitRate: 100_000_000,
+        }),
       );
-      const recover = rs
-        .spyOn(adapter, 'recoverAfterAdbScreenshot')
-        .mockImplementation(() => {});
       const deviceInfo = {
         physicalWidth: 8,
         physicalHeight: 6,
@@ -1220,18 +1221,18 @@ Stdout:
         width: 4,
         height: 3,
       });
-      expect(recover).toHaveBeenCalledWith(deviceInfo);
     });
 
-    it('starts scrcpy recovery only after the ADB fallback screenshot completes', async () => {
+    it('reports structured scrcpy freshness diagnostics before using ADB fallback', async () => {
       const adapter = (device as any).getScrcpyAdapter();
       rs.spyOn(adapter, 'isEnabled').mockReturnValue(true);
       rs.spyOn(adapter, 'screenshotBase64').mockRejectedValue(
-        new ScrcpyFreshFrameUnavailableError('stale stream closed'),
+        new ScrcpyFreshFrameUnavailableError('stale stream closed', {
+          failureKind: 'freshness-target',
+          timeoutMs: 300,
+          videoBitRate: 4_000_000,
+        }),
       );
-      const recover = rs
-        .spyOn(adapter, 'recoverAfterAdbScreenshot')
-        .mockImplementation(() => {});
       const deviceInfo = {
         physicalWidth: 1080,
         physicalHeight: 1920,
@@ -1242,19 +1243,22 @@ Stdout:
         deviceInfo,
       );
       const mockBuffer = createValidPngBuffer();
-      mockAdb.takeScreenshot.mockImplementation(async () => {
-        expect(recover).not.toHaveBeenCalled();
-        return mockBuffer;
-      });
+      mockAdb.takeScreenshot.mockResolvedValue(mockBuffer);
       rs.spyOn(ImgUtils, 'createImgBase64ByFormat').mockReturnValue(
         `data:image/png;base64,${mockBuffer.toString('base64')}`,
       );
-      rs.spyOn(console, 'warn').mockImplementation(() => {});
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
       await expect(device.screenshotBase64()).resolves.toContain(
         mockBuffer.toString('base64'),
       );
-      expect(recover).toHaveBeenCalledWith(deviceInfo);
+      expect(warn).toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining(
+          'Lowering it further is unlikely to help on a local USB connection',
+        ),
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
     });
 
     it('should fall back to screencap and pull if takeScreenshot fails', async () => {

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -498,18 +498,50 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   describe('freshness recovery', () => {
-    it('keeps the current screenshot on ADB and warms a new stream afterward', async () => {
+    it('restarts a stale stream once and returns the new epoch baseline', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
       currentMockManager.getScreenshotJpeg.mockRejectedValueOnce(
-        new ScrcpyFreshFrameUnavailableError('stale stream closed'),
+        new ScrcpyFreshFrameUnavailableError('stale stream closed', {
+          diagnosticMessage: 'first stream diagnostic',
+        }),
       );
 
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
+      );
+      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(2);
+      expect(adapter.isEnabled()).toBe(true);
+      expect(adapter.getStatus().lastError).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('keeps the current screenshot on ADB when the restarted stream also fails', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+      (adapter as any).manager = currentMockManager;
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
+      currentMockManager.getScreenshotJpeg
+        .mockRejectedValueOnce(
+          new ScrcpyFreshFrameUnavailableError('first stale stream closed', {
+            diagnosticMessage: 'first stream diagnostic',
+          }),
+        )
+        .mockRejectedValueOnce(
+          new ScrcpyFreshFrameUnavailableError('retry stream closed', {
+            diagnosticMessage: 'retry stream diagnostic',
+          }),
+        );
+
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
-        'stale stream closed',
+        'retry stream closed',
       );
       expect(adapter.isEnabled()).toBe(false);
       expect((adapter as any).manager).toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        '[Midscene]',
+        'retry stream diagnostic',
+      );
 
       adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
       await rs.waitFor(() => {
@@ -519,7 +551,7 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(adapter.isEnabled()).toBe(true);
     });
 
-    it('recognizes freshness fallback across duplicated module instances', async () => {
+    it('recognizes and retries freshness errors across duplicated module instances', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       const crossModuleError = Object.assign(new Error('stale stream closed'), {
@@ -529,19 +561,15 @@ describe('ScrcpyDeviceAdapter', () => {
         crossModuleError,
       );
 
-      await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toBe(
-        crossModuleError,
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
       );
-      expect(adapter.isEnabled()).toBe(false);
+      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(2);
+      expect(adapter.isEnabled()).toBe(true);
       expect(adapter.getStatus().retryAfter).toBeNull();
-
-      adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
-      await rs.waitFor(() => {
-        expect(currentMockManager.prepareFreshFrame).toHaveBeenCalledTimes(1);
-      });
     });
 
-    it('reattaches active frame listeners after background recovery', async () => {
+    it('reattaches active frame listeners after in-band stream recovery', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       const listener = rs.fn();
@@ -553,14 +581,10 @@ describe('ScrcpyDeviceAdapter', () => {
         new ScrcpyFreshFrameUnavailableError('stale stream closed'),
       );
 
-      await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
-        'stale stream closed',
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
       );
-      adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
-
-      await rs.waitFor(() => {
-        expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(2);
-      });
+      expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(2);
       unsubscribe();
       expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledWith(
         listener,

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -361,11 +361,13 @@ describe('ScrcpyDeviceAdapter', () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       currentMockManager.isConnected.mockReturnValue(true);
+      rs.spyOn(adapter as any, 'monotonicTimeUs').mockReturnValue(10_100_000n);
 
       await adapter.markActionBarrier();
 
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
         'completed input action',
+        10_100_000n,
       );
     });
 
@@ -387,17 +389,22 @@ describe('ScrcpyDeviceAdapter', () => {
       });
     });
 
-    it('defers an action barrier until a recovering stream is connected', async () => {
+    it('defers the latest action barrier until a recovering stream is connected', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       currentMockManager.isConnected.mockReturnValue(false);
+      rs.spyOn(adapter as any, 'monotonicTimeUs')
+        .mockReturnValueOnce(10_100_000n)
+        .mockReturnValueOnce(10_200_000n);
 
+      await adapter.markActionBarrier();
       await adapter.markActionBarrier();
       expect(currentMockManager.setFreshnessBarrier).not.toHaveBeenCalled();
 
       await adapter.screenshotBase64(defaultDeviceInfo);
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
         'completed input action while scrcpy was unavailable',
+        10_200_000n,
       );
       expect(
         currentMockManager.setFreshnessBarrier.mock.invocationCallOrder[0],

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -527,16 +527,21 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   describe('freshness diagnostics', () => {
-    it('does not recommend lowering an already-low bitrate for a local USB link', () => {
-      const message = formatScrcpyFreshFrameFailure(
-        createFreshnessError('no post-action frame'),
-      );
+    it.each([4_000_000, 100_000_000])(
+      'does not prescribe bitrate changes for a freshness timeout at %i bps',
+      (videoBitRate) => {
+        const message = formatScrcpyFreshFrameFailure(
+          createFreshnessError('no post-action frame', { videoBitRate }),
+        );
 
-      expect(message).toContain(
-        'Lowering it further is unlikely to help on a local USB connection',
-      );
-      expect(message).not.toContain('Lower it further if backlog persists');
-    });
+        expect(message).toContain(
+          'does not by itself identify bandwidth or the configured video bitrate as the cause',
+        );
+        expect(message.toLowerCase()).not.toContain('lower');
+        expect(message).not.toContain('--scrcpy-video-bit-rate');
+        expect(message.toLowerCase()).not.toContain('start with');
+      },
+    );
 
     it('classifies a missing new-epoch frame as a startup failure', () => {
       const message = formatScrcpyFreshFrameFailure(
@@ -547,7 +552,7 @@ describe('ScrcpyDeviceAdapter', () => {
       );
 
       expect(message).toContain('stream startup or encoder-readiness failure');
-      expect(message).not.toContain('Lowering it further');
+      expect(message.toLowerCase()).not.toContain('lower');
     });
   });
 
@@ -644,6 +649,10 @@ describe('ScrcpyDeviceAdapter', () => {
     it('reattaches active frame listeners after in-band stream recovery', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
+      currentMockManager.isConnected
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
       const listener = rs.fn();
       const unsubscribe = await adapter.subscribeKeyframes(
         defaultDeviceInfo,
@@ -661,6 +670,41 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledWith(
         listener,
       );
+    });
+
+    it('reattaches active frame listeners after a double freshness failure and cooldown reconnect', async () => {
+      rs.useFakeTimers();
+      rs.setSystemTime(new Date('2026-08-25T00:00:00Z'));
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+      (adapter as any).manager = currentMockManager;
+      currentMockManager.isConnected
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false);
+      currentMockManager.getScreenshotJpeg
+        .mockRejectedValueOnce(createFreshnessError('stale stream closed'))
+        .mockRejectedValueOnce(createFreshnessError('retry stream closed'));
+      const listener = rs.fn();
+      const unsubscribe = await adapter.subscribeKeyframes(
+        defaultDeviceInfo,
+        listener,
+      );
+
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
+        'retry stream closed',
+      );
+      expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(2);
+
+      rs.advanceTimersByTime(5_000);
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
+      );
+      expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(3);
+      expect(currentMockManager.subscribeKeyframes).toHaveBeenLastCalledWith(
+        listener,
+      );
+      unsubscribe();
     });
   });
 

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -357,7 +357,7 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(1);
     });
 
-    it('moves the barrier after a completed input action', async () => {
+    it('moves the barrier before an input action starts', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       currentMockManager.isConnected.mockReturnValue(true);
@@ -366,8 +366,11 @@ describe('ScrcpyDeviceAdapter', () => {
       await adapter.markActionBarrier();
 
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
-        'completed input action',
-        10_100_000n,
+        'input action started',
+        {
+          allowOverAgeForNextCapture: true,
+          hostMonotonicUs: 10_100_000n,
+        },
       );
     });
 
@@ -403,8 +406,11 @@ describe('ScrcpyDeviceAdapter', () => {
 
       await adapter.screenshotBase64(defaultDeviceInfo);
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
-        'completed input action while scrcpy was unavailable',
-        10_200_000n,
+        'input action started while scrcpy was unavailable',
+        {
+          allowOverAgeForNextCapture: true,
+          hostMonotonicUs: 10_200_000n,
+        },
       );
       expect(
         currentMockManager.setFreshnessBarrier.mock.invocationCallOrder[0],

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -41,6 +41,7 @@ const createMockManager = () => ({
   getScreenshotJpeg: rs.fn().mockResolvedValue(Buffer.from('fake-png')),
   getResolution: rs.fn().mockReturnValue(null),
   disconnect: rs.fn().mockResolvedValue(undefined),
+  dispose: rs.fn().mockResolvedValue(undefined),
 });
 
 let currentMockManager: ReturnType<typeof createMockManager>;
@@ -357,7 +358,7 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.subscribeKeyframes).toHaveBeenCalledTimes(1);
     });
 
-    it('moves the barrier before an input action starts', async () => {
+    it('moves the barrier after an input action completes', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
       currentMockManager.isConnected.mockReturnValue(true);
@@ -366,7 +367,7 @@ describe('ScrcpyDeviceAdapter', () => {
       await adapter.markActionBarrier();
 
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
-        'input action started',
+        'completed input action',
         {
           allowOverAgeForNextCapture: true,
           hostMonotonicUs: 10_100_000n,
@@ -384,7 +385,7 @@ describe('ScrcpyDeviceAdapter', () => {
 
       await expect(adapter.markActionBarrier()).resolves.toBeUndefined();
 
-      expect(currentMockManager.disconnect).toHaveBeenCalledTimes(1);
+      expect(currentMockManager.dispose).toHaveBeenCalledTimes(1);
       expect((adapter as any).manager).toBeNull();
       expect(adapter.getStatus()).toMatchObject({
         lastError: 'dumpsys unavailable',
@@ -406,7 +407,7 @@ describe('ScrcpyDeviceAdapter', () => {
 
       await adapter.screenshotBase64(defaultDeviceInfo);
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
-        'input action started while scrcpy was unavailable',
+        'completed input action while scrcpy was unavailable',
         {
           allowOverAgeForNextCapture: true,
           hostMonotonicUs: 10_200_000n,
@@ -431,6 +432,19 @@ describe('ScrcpyDeviceAdapter', () => {
       expect((adapter as any).manager).toBe(currentMockManager);
     });
 
+    it('deduplicates concurrent manager initialization', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+
+      const [first, second] = await Promise.all([
+        adapter.ensureManager(defaultDeviceInfo),
+        adapter.ensureManager(defaultDeviceInfo),
+      ]);
+
+      expect(first).toBe(currentMockManager);
+      expect(second).toBe(currentMockManager);
+      expect(currentMockManager.validateEnvironment).toHaveBeenCalledTimes(1);
+    });
+
     it('should record ensureManager failures without permanently disabling scrcpy', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       currentMockManager.validateEnvironment.mockRejectedValue(
@@ -444,6 +458,7 @@ describe('ScrcpyDeviceAdapter', () => {
         lastError: expect.stringContaining('ffmpeg not found'),
         retryAfter: expect.any(Number),
       });
+      expect(currentMockManager.dispose).toHaveBeenCalledTimes(1);
     });
 
     it('should recover after a transient ensureConnected failure', async () => {
@@ -512,6 +527,8 @@ describe('ScrcpyDeviceAdapter', () => {
         'data:image/png;base64,test',
       );
       expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(2);
+      expect(currentMockManager.validateEnvironment).not.toHaveBeenCalled();
+      expect(currentMockManager.dispose).not.toHaveBeenCalled();
       expect(adapter.isEnabled()).toBe(true);
       expect(adapter.getStatus().lastError).toBeNull();
       expect(warn).not.toHaveBeenCalled();
@@ -537,7 +554,8 @@ describe('ScrcpyDeviceAdapter', () => {
         'retry stream closed',
       );
       expect(adapter.isEnabled()).toBe(false);
-      expect((adapter as any).manager).toBeNull();
+      expect((adapter as any).manager).toBe(currentMockManager);
+      expect(currentMockManager.dispose).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(
         '[Midscene]',
         'retry stream diagnostic',
@@ -549,6 +567,37 @@ describe('ScrcpyDeviceAdapter', () => {
         expect(adapter.getStatus().lastError).toBeNull();
       });
       expect(adapter.isEnabled()).toBe(true);
+    });
+
+    it('shares one in-band restart across concurrent stale screenshots', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+      (adapter as any).manager = currentMockManager;
+      let resolveRestart: ((value: Buffer) => void) | undefined;
+      const restartFrame = new Promise<Buffer>((resolve) => {
+        resolveRestart = resolve;
+      });
+      currentMockManager.getScreenshotJpeg
+        .mockRejectedValueOnce(
+          new ScrcpyFreshFrameUnavailableError('first stale call'),
+        )
+        .mockRejectedValueOnce(
+          new ScrcpyFreshFrameUnavailableError('second stale call'),
+        )
+        .mockReturnValueOnce(restartFrame);
+
+      const first = adapter.screenshotBase64(defaultDeviceInfo);
+      const second = adapter.screenshotBase64(defaultDeviceInfo);
+      await rs.waitFor(() => {
+        expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(3);
+      });
+      resolveRestart?.(Buffer.from('recovered-frame'));
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        'data:image/png;base64,test',
+        'data:image/png;base64,test',
+      ]);
+      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(3);
+      expect(currentMockManager.ensureConnected).toHaveBeenCalledTimes(3);
     });
 
     it('recognizes and retries freshness errors across duplicated module instances', async () => {
@@ -602,7 +651,7 @@ describe('ScrcpyDeviceAdapter', () => {
 
       expect((adapter as any).manager).toBeNull();
       expect((adapter as any).resolvedConfig).toBeNull();
-      expect(currentMockManager.disconnect).toHaveBeenCalledTimes(1);
+      expect(currentMockManager.dispose).toHaveBeenCalledTimes(1);
       expect(adapter.getStatus().lastError).toBeNull();
       expect(adapter.getStatus().retryAfter).toBeNull();
     });
@@ -610,7 +659,7 @@ describe('ScrcpyDeviceAdapter', () => {
     it('should handle disconnect errors gracefully (no throw)', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', undefined);
       (adapter as any).manager = currentMockManager;
-      currentMockManager.disconnect.mockRejectedValue(
+      currentMockManager.dispose.mockRejectedValue(
         new Error('disconnect failed'),
       );
 

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { DevicePhysicalInfo } from '../../src/scrcpy-device-adapter';
-import { ScrcpyDeviceAdapter } from '../../src/scrcpy-device-adapter';
+import {
+  ScrcpyDeviceAdapter,
+  formatScrcpyFreshFrameFailure,
+} from '../../src/scrcpy-device-adapter';
 import {
   DEFAULT_SCRCPY_CONFIG,
   SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE,
@@ -32,7 +35,6 @@ const createMockManager = () => ({
   validateEnvironment: rs.fn().mockResolvedValue(undefined),
   ensureConnected: rs.fn().mockResolvedValue(undefined),
   ensureFrameClockCalibration: rs.fn().mockResolvedValue(undefined),
-  prepareFreshFrame: rs.fn().mockResolvedValue(undefined),
   setFreshnessBarrier: rs.fn().mockResolvedValue(1_000_000n),
   subscribeKeyframes: rs.fn().mockReturnValue(rs.fn()),
   getLatestRawKeyframe: rs.fn().mockReturnValue(null),
@@ -63,6 +65,20 @@ const defaultDeviceInfo: DevicePhysicalInfo = {
   dpr: 2.625,
   orientation: 0,
 };
+
+const createFreshnessError = (
+  message: string,
+  options: {
+    failureKind?: 'stream-startup' | 'freshness-target';
+    timeoutMs?: number;
+    videoBitRate?: number;
+  } = {},
+) =>
+  new ScrcpyFreshFrameUnavailableError(message, {
+    failureKind: options.failureKind ?? 'freshness-target',
+    timeoutMs: options.timeoutMs ?? 300,
+    videoBitRate: options.videoBitRate ?? 4_000_000,
+  });
 
 describe('ScrcpyDeviceAdapter', () => {
   beforeEach(() => {
@@ -369,7 +385,6 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
         'completed input action',
         {
-          allowOverAgeForNextCapture: true,
           hostMonotonicUs: 10_100_000n,
         },
       );
@@ -409,7 +424,6 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.setFreshnessBarrier).toHaveBeenCalledWith(
         'completed input action while scrcpy was unavailable',
         {
-          allowOverAgeForNextCapture: true,
           hostMonotonicUs: 10_200_000n,
         },
       );
@@ -512,15 +526,37 @@ describe('ScrcpyDeviceAdapter', () => {
     });
   });
 
+  describe('freshness diagnostics', () => {
+    it('does not recommend lowering an already-low bitrate for a local USB link', () => {
+      const message = formatScrcpyFreshFrameFailure(
+        createFreshnessError('no post-action frame'),
+      );
+
+      expect(message).toContain(
+        'Lowering it further is unlikely to help on a local USB connection',
+      );
+      expect(message).not.toContain('Lower it further if backlog persists');
+    });
+
+    it('classifies a missing new-epoch frame as a startup failure', () => {
+      const message = formatScrcpyFreshFrameFailure(
+        createFreshnessError('no initial data frame', {
+          failureKind: 'stream-startup',
+          timeoutMs: 5_000,
+        }),
+      );
+
+      expect(message).toContain('stream startup or encoder-readiness failure');
+      expect(message).not.toContain('Lowering it further');
+    });
+  });
+
   describe('freshness recovery', () => {
     it('restarts a stale stream once and returns the new epoch baseline', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
-      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
       currentMockManager.getScreenshotJpeg.mockRejectedValueOnce(
-        new ScrcpyFreshFrameUnavailableError('stale stream closed', {
-          diagnosticMessage: 'first stream diagnostic',
-        }),
+        createFreshnessError('stale stream closed'),
       );
 
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
@@ -531,24 +567,18 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(currentMockManager.dispose).not.toHaveBeenCalled();
       expect(adapter.isEnabled()).toBe(true);
       expect(adapter.getStatus().lastError).toBeNull();
-      expect(warn).not.toHaveBeenCalled();
     });
 
-    it('keeps the current screenshot on ADB when the restarted stream also fails', async () => {
+    it('enters cooldown when the restarted stream also fails, then retries with the same manager', async () => {
+      rs.useFakeTimers();
+      rs.setSystemTime(new Date('2026-08-24T00:00:00Z'));
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
       (adapter as any).manager = currentMockManager;
-      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
       currentMockManager.getScreenshotJpeg
         .mockRejectedValueOnce(
-          new ScrcpyFreshFrameUnavailableError('first stale stream closed', {
-            diagnosticMessage: 'first stream diagnostic',
-          }),
+          createFreshnessError('first stale stream closed'),
         )
-        .mockRejectedValueOnce(
-          new ScrcpyFreshFrameUnavailableError('retry stream closed', {
-            diagnosticMessage: 'retry stream diagnostic',
-          }),
-        );
+        .mockRejectedValueOnce(createFreshnessError('retry stream closed'));
 
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).rejects.toThrow(
         'retry stream closed',
@@ -556,17 +586,14 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(adapter.isEnabled()).toBe(false);
       expect((adapter as any).manager).toBe(currentMockManager);
       expect(currentMockManager.dispose).not.toHaveBeenCalled();
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        'retry stream diagnostic',
-      );
 
-      adapter.recoverAfterAdbScreenshot(defaultDeviceInfo);
-      await rs.waitFor(() => {
-        expect(currentMockManager.prepareFreshFrame).toHaveBeenCalledTimes(1);
-        expect(adapter.getStatus().lastError).toBeNull();
-      });
+      rs.advanceTimersByTime(5_000);
+      await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(
+        'data:image/png;base64,test',
+      );
       expect(adapter.isEnabled()).toBe(true);
+      expect(adapter.getStatus().lastError).toBeNull();
+      expect(currentMockManager.getScreenshotJpeg).toHaveBeenCalledTimes(3);
     });
 
     it('shares one in-band restart across concurrent stale screenshots', async () => {
@@ -577,12 +604,8 @@ describe('ScrcpyDeviceAdapter', () => {
         resolveRestart = resolve;
       });
       currentMockManager.getScreenshotJpeg
-        .mockRejectedValueOnce(
-          new ScrcpyFreshFrameUnavailableError('first stale call'),
-        )
-        .mockRejectedValueOnce(
-          new ScrcpyFreshFrameUnavailableError('second stale call'),
-        )
+        .mockRejectedValueOnce(createFreshnessError('first stale call'))
+        .mockRejectedValueOnce(createFreshnessError('second stale call'))
         .mockReturnValueOnce(restartFrame);
 
       const first = adapter.screenshotBase64(defaultDeviceInfo);
@@ -627,7 +650,7 @@ describe('ScrcpyDeviceAdapter', () => {
         listener,
       );
       currentMockManager.getScreenshotJpeg.mockRejectedValueOnce(
-        new ScrcpyFreshFrameUnavailableError('stale stream closed'),
+        createFreshnessError('stale stream closed'),
       );
 
       await expect(adapter.screenshotBase64(defaultDeviceInfo)).resolves.toBe(

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -778,7 +778,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect(warn).toHaveBeenCalledWith(
         '[Midscene]',
         expect.stringContaining(
-          'scrcpyConfig.videoBitRate to 4_000_000 (4 Mbps)',
+          '--scrcpy-video-bit-rate 4000000 in the Android CLI',
         ),
       );
       expect(warn).toHaveBeenCalledWith(

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -469,6 +469,74 @@ describe('ScrcpyScreenshotManager', () => {
       ).toBe(false);
     });
 
+    it('uses the first frame of a new stream as its planning baseline even when startup made it over-age', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).spsHeader = Buffer.from('header');
+      (manager as any).lastRawKeyframe = Buffer.from('initial-static-frame');
+      (manager as any).lastRawKeyframePtsUs = 1_000_000n;
+      (manager as any).streamBaselineFramePending = true;
+      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).deviceClockCalibration = {
+        deviceUptimeUs: 2_000_000n,
+        hostMonotonicUs: 10_000_000n,
+        hostWallTimeMs: 2_000,
+        roundTripUs: 10_000n,
+      };
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      const waitForNextKeyframe = rs
+        .spyOn(manager as any, 'waitForNextKeyframe')
+        .mockRejectedValue(new Error('static screen emitted no new frame'));
+      const setBarrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        Buffer.from('jpeg'),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
+        Buffer.from('jpeg'),
+      );
+      expect(waitForNextKeyframe).not.toHaveBeenCalled();
+      expect(setBarrier).not.toHaveBeenCalled();
+      expect((manager as any).streamBaselineFramePending).toBe(false);
+    });
+
+    it('uses the startup timeout while waiting for the first data frame of a new stream', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).spsHeader = Buffer.from('header');
+      (manager as any).streamBaselineFramePending = true;
+      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).deviceClockCalibration = {
+        deviceUptimeUs: 2_000_000n,
+        hostMonotonicUs: 10_000_000n,
+        hostWallTimeMs: 2_000,
+        roundTripUs: 10_000n,
+      };
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      const waitForNextKeyframe = rs
+        .spyOn(manager as any, 'waitForNextKeyframe')
+        .mockResolvedValue({
+          data: Buffer.from('initial-frame'),
+          header: Buffer.from('header'),
+          ptsUs: 2_000_000n,
+          estimatedAgeMs: 0,
+          capturedAt: 2_000,
+        });
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        Buffer.from('jpeg'),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
+        Buffer.from('jpeg'),
+      );
+      const startupWaitMs = waitForNextKeyframe.mock.calls[0][0];
+      expect(startupWaitMs).toBeGreaterThan(4_000);
+      expect(startupWaitMs).toBeLessThanOrEqual(5_000);
+      expect((manager as any).streamBaselineFramePending).toBe(false);
+    });
+
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       let resolveClock:
@@ -739,6 +807,8 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).lastRawKeyframe = Buffer.from('post-action-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_100_000n;
       (manager as any).frameFreshnessBarrierPtsUs = 1_000_000n;
+      (manager as any).streamBaselineFramePending = true;
+      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -770,11 +840,13 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
-    it('adds a planning barrier for an over-age first Planning frame', async () => {
+    it('adds a planning barrier after the new-stream baseline window expires', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('first-planning-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
+      (manager as any).streamBaselineFramePending = true;
+      (manager as any).streamBaselineFrameDeadlineAt = Date.now() - 1;
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -870,6 +942,25 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
+    it('reports a missing first frame as stream startup failure instead of bitrate backlog', () => {
+      const manager = new ScrcpyScreenshotManager({} as any, {
+        videoBitRate: 4_000_000,
+      });
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
+      (manager as any).streamBaselineFramePending = true;
+
+      (manager as any).warnTransportBacklog(new Error('no initial data frame'));
+
+      expect(warn).toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('stream startup or encoder-readiness failure'),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('Lowering it further'),
+      );
+    });
+
     it('rejects frames without PTS instead of treating arrival time as freshness', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
@@ -902,6 +993,8 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).deviceClockCalibration = {};
       (manager as any).lastFramePtsUs = 456n;
       (manager as any).frameFreshnessError = new Error('stale');
+      (manager as any).streamBaselineFramePending = true;
+      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
 
       await manager.disconnect();
 
@@ -916,6 +1009,8 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).deviceClockCalibration).toBeNull();
       expect((manager as any).lastFramePtsUs).toBeNull();
       expect((manager as any).frameFreshnessError).toBeNull();
+      expect((manager as any).streamBaselineFramePending).toBe(false);
+      expect((manager as any).streamBaselineFrameDeadlineAt).toBe(0);
     });
 
     it('should clear idle timer', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -160,13 +160,25 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
-    it('should throw instead of recursing when isConnecting is true', async () => {
+    it('shares one connection attempt across concurrent callers', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      (manager as any).isConnecting = true;
+      let resolveConnection: (() => void) | undefined;
+      const connection = new Promise<void>((resolve) => {
+        resolveConnection = resolve;
+      });
+      const connectScrcpy = rs
+        .spyOn(manager as any, 'connectScrcpy')
+        .mockReturnValue(connection);
 
-      await expect(manager.ensureConnected()).rejects.toThrow(
-        /another connection attempt/,
-      );
+      const first = manager.ensureConnected();
+      const second = manager.ensureConnected();
+      expect(connectScrcpy).toHaveBeenCalledTimes(1);
+      resolveConnection?.();
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        undefined,
+        undefined,
+      ]);
     });
 
     it('should calibrate an already-started stream only once', async () => {
@@ -188,23 +200,17 @@ describe('ScrcpyScreenshotManager', () => {
       expect(readClock).toHaveBeenCalledTimes(1);
     });
 
-    it('should succeed if another connection finishes while waiting', async () => {
+    it('shares a connection failure across concurrent callers', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
-      (manager as any).isConnecting = true;
+      const connectionError = new Error('codec unavailable');
+      rs.spyOn(manager as any, 'connectScrcpy').mockRejectedValue(
+        connectionError,
+      );
 
-      // Simulate the other connection finishing during the wait
-      setTimeout(() => {
-        (manager as any).scrcpyClient = {};
-        (manager as any).videoStream = {};
-        (manager as any).deviceClockCalibration = {
-          deviceUptimeUs: 1_000_000n,
-          hostMonotonicUs: 10_000_000n,
-          hostWallTimeMs: 2_000,
-          roundTripUs: 10_000n,
-        };
-      }, 100);
-
-      await expect(manager.ensureConnected()).resolves.toBeUndefined();
+      const first = manager.ensureConnected();
+      const second = manager.ensureConnected();
+      await expect(first).rejects.toBe(connectionError);
+      await expect(second).rejects.toBe(connectionError);
     });
 
     it('should include client and server output in connection errors', () => {
@@ -365,7 +371,9 @@ describe('ScrcpyScreenshotManager', () => {
       };
       rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
-      const barrier = await manager.setFreshnessBarrier('input action started');
+      const barrier = await manager.setFreshnessBarrier(
+        'completed input action',
+      );
       expect(barrier).toBe(1_006_000n);
 
       (manager as any).processFrame(spsPacket());
@@ -373,11 +381,11 @@ describe('ScrcpyScreenshotManager', () => {
       expect(manager.getLatestRawKeyframe()).toBeNull();
       expect(listener).not.toHaveBeenCalled();
       expect((manager as any).frameFreshnessError?.message).toContain(
-        'input action started',
+        'completed input action',
       );
       expect(warn).not.toHaveBeenCalledWith(
         '[Midscene]',
-        expect.stringContaining('predates the input action started'),
+        expect.stringContaining('predates the completed input action'),
       );
 
       (manager as any).processFrame(dataPacket(0x02, 1_006_000n));
@@ -411,7 +419,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect(readClock).toHaveBeenCalledTimes(1);
     });
 
-    it('projects a deferred action barrier from when the action started', async () => {
+    it('projects a deferred action barrier from when the action completed', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
@@ -422,7 +430,7 @@ describe('ScrcpyScreenshotManager', () => {
       rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_500_000n);
 
       const barrier = await manager.setFreshnessBarrier(
-        'input action started while scrcpy was unavailable',
+        'completed input action while scrcpy was unavailable',
         { hostMonotonicUs: 10_100_000n },
       );
 
@@ -433,6 +441,30 @@ describe('ScrcpyScreenshotManager', () => {
       expect(manager.getLatestRawKeyframe()?.data[5]).toBe(0x01);
     });
 
+    it('preserves a cached frame that already crosses a completed-action barrier', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).spsHeader = Buffer.from('header');
+      (manager as any).lastRawKeyframe = Buffer.from('post-action-frame');
+      (manager as any).lastRawKeyframePtsUs = 1_200_000n;
+      (manager as any).lastRawKeyframeAt = 2_000;
+      (manager as any).deviceClockCalibration = {
+        deviceUptimeUs: 1_000_000n,
+        hostMonotonicUs: 10_000_000n,
+        hostWallTimeMs: 2_000,
+        roundTripUs: 10_000n,
+      };
+
+      await manager.setFreshnessBarrier('completed input action', {
+        allowOverAgeForNextCapture: true,
+        hostMonotonicUs: 10_100_000n,
+      });
+
+      expect((manager as any).lastRawKeyframe).toEqual(
+        Buffer.from('post-action-frame'),
+      );
+      expect((manager as any).lastRawKeyframePtsUs).toBe(1_200_000n);
+    });
+
     it('reuses an over-age frame once when it crossed the input-action barrier', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
@@ -440,7 +472,7 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).lastRawKeyframePtsUs = 1_100_000n;
       (manager as any).lastRawKeyframeAt = 2_000;
       (manager as any).frameFreshnessBarrierPtsUs = 1_006_000n;
-      (manager as any).frameFreshnessBarrierReason = 'input action started';
+      (manager as any).frameFreshnessBarrierReason = 'completed input action';
       (manager as any).frameFreshnessBarrierAllowsOverAgeForNextCapture = true;
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
@@ -1021,6 +1053,43 @@ describe('ScrcpyScreenshotManager', () => {
       await expect(manager.disconnect()).resolves.toBeUndefined();
       // References are nulled before close is called
       expect((manager as any).scrcpyClient).toBeNull();
+    });
+
+    it('closes the owned ADB transport only when permanently disposed', async () => {
+      const close = rs.fn().mockResolvedValue(undefined);
+      const manager = new ScrcpyScreenshotManager({ close } as any);
+
+      await manager.disconnect();
+      expect(close).not.toHaveBeenCalled();
+
+      await manager.dispose();
+      await manager.dispose();
+      expect(close).toHaveBeenCalledTimes(1);
+      await expect(manager.ensureConnected()).rejects.toThrow(
+        'Scrcpy manager has been disposed',
+      );
+    });
+
+    it('waits for an in-flight connection before disposing its ADB transport', async () => {
+      const close = rs.fn().mockResolvedValue(undefined);
+      const manager = new ScrcpyScreenshotManager({ close } as any);
+      let resolveConnection: (() => void) | undefined;
+      rs.spyOn(manager as any, 'connectScrcpy').mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveConnection = resolve;
+        }),
+      );
+
+      const connecting = manager.ensureConnected();
+      const disposing = manager.dispose();
+      expect(close).not.toHaveBeenCalled();
+      resolveConnection?.();
+
+      await expect(Promise.all([connecting, disposing])).resolves.toEqual([
+        undefined,
+        undefined,
+      ]);
+      expect(close).toHaveBeenCalledTimes(1);
     });
 
     it('should cancel streamReader to stop consumeFramesLoop', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -464,16 +464,16 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).lastRawKeyframePtsUs).toBe(1_200_000n);
     });
 
-    it('uses the first frame of a new stream as its planning baseline even when startup made it over-age', async () => {
+    it('rejects a delayed first frame even while the new-stream startup window is active', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
-      (manager as any).lastRawKeyframe = Buffer.from('initial-static-frame');
+      (manager as any).lastRawKeyframe = Buffer.from('delayed-in-transport');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
-      (manager as any).streamBaselineWindow = {
+      (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
       };
       (manager as any).deviceClockCalibration = {
-        deviceUptimeUs: 2_000_000n,
+        deviceUptimeUs: 5_000_000n,
         hostMonotonicUs: 10_000_000n,
         hostWallTimeMs: 2_000,
         roundTripUs: 10_000n,
@@ -483,24 +483,26 @@ describe('ScrcpyScreenshotManager', () => {
       rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
       const waitForNextKeyframe = rs
         .spyOn(manager as any, 'waitForNextKeyframe')
-        .mockRejectedValue(new Error('static screen emitted no new frame'));
+        .mockRejectedValue(new Error('no fresh frame after delayed baseline'));
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
       const setBarrier = rs.spyOn(manager, 'setFreshnessBarrier');
-      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
-        Buffer.from('jpeg'),
-      );
+      const decode = rs.spyOn(manager as any, 'decodeH264ToJpeg');
 
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
-      expect(waitForNextKeyframe).not.toHaveBeenCalled();
-      expect(setBarrier).not.toHaveBeenCalled();
-      expect((manager as any).streamBaselineWindow).toBeNull();
+      await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+        name: 'ScrcpyFreshFrameUnavailableError',
+        failureKind: 'freshness-target',
+        timeoutMs: 300,
+      });
+      expect(waitForNextKeyframe).toHaveBeenCalledOnce();
+      expect(setBarrier).toHaveBeenCalledWith('stale planning frame');
+      expect(disconnect).toHaveBeenCalledOnce();
+      expect(decode).not.toHaveBeenCalled();
     });
 
     it('uses the startup timeout while waiting for the first data frame of a new stream', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
-      (manager as any).streamBaselineWindow = {
+      (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
       };
       (manager as any).deviceClockCalibration = {
@@ -531,7 +533,7 @@ describe('ScrcpyScreenshotManager', () => {
       const startupWaitMs = waitForNextKeyframe.mock.calls[0][0];
       expect(startupWaitMs).toBeGreaterThan(4_000);
       expect(startupWaitMs).toBeLessThanOrEqual(5_000);
-      expect((manager as any).streamBaselineWindow).toBeNull();
+      expect((manager as any).streamStartupWindow).toBeNull();
     });
 
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {
@@ -804,7 +806,7 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).lastRawKeyframe = Buffer.from('post-action-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_100_000n;
       (manager as any).frameFreshnessBarrierPtsUs = 1_000_000n;
-      (manager as any).streamBaselineWindow = {
+      (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
       };
       (manager as any).deviceClockCalibration = {
@@ -838,12 +840,12 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
-    it('adds a planning barrier after the new-stream baseline window expires', async () => {
+    it('adds a planning barrier after the new-stream startup window expires', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('first-planning-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
-      (manager as any).streamBaselineWindow = {
+      (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() - 1,
       };
       (manager as any).deviceClockCalibration = {
@@ -941,7 +943,7 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).deviceClockCalibration = {};
       (manager as any).lastFramePtsUs = 456n;
       (manager as any).frameFreshnessError = new Error('stale');
-      (manager as any).streamBaselineWindow = {
+      (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
       };
 
@@ -958,7 +960,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).deviceClockCalibration).toBeNull();
       expect((manager as any).lastFramePtsUs).toBeNull();
       expect((manager as any).frameFreshnessError).toBeNull();
-      expect((manager as any).streamBaselineWindow).toBeNull();
+      expect((manager as any).streamStartupWindow).toBeNull();
     });
 
     it('should clear idle timer', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -455,7 +455,6 @@ describe('ScrcpyScreenshotManager', () => {
       };
 
       await manager.setFreshnessBarrier('completed input action', {
-        allowOverAgeForNextCapture: true,
         hostMonotonicUs: 10_100_000n,
       });
 
@@ -465,49 +464,14 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).lastRawKeyframePtsUs).toBe(1_200_000n);
     });
 
-    it('reuses an over-age frame once when it crossed the input-action barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
-      (manager as any).spsHeader = Buffer.from('header');
-      (manager as any).lastRawKeyframe = Buffer.from('post-action-frame');
-      (manager as any).lastRawKeyframePtsUs = 1_100_000n;
-      (manager as any).lastRawKeyframeAt = 2_000;
-      (manager as any).frameFreshnessBarrierPtsUs = 1_006_000n;
-      (manager as any).frameFreshnessBarrierReason = 'completed input action';
-      (manager as any).frameFreshnessBarrierAllowsOverAgeForNextCapture = true;
-      (manager as any).deviceClockCalibration = {
-        deviceUptimeUs: 1_000_000n,
-        hostMonotonicUs: 10_000_000n,
-        hostWallTimeMs: 2_000,
-        roundTripUs: 10_000n,
-      };
-      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(11_100_000n);
-      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
-      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
-      const waitForNextKeyframe = rs.spyOn(
-        manager as any,
-        'waitForNextKeyframe',
-      );
-      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
-        Buffer.from('jpeg'),
-      );
-
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
-      expect(waitForNextKeyframe).not.toHaveBeenCalled();
-      expect((manager as any).frameFreshnessBarrierPtsUs).toBeNull();
-      expect(
-        (manager as any).frameFreshnessBarrierAllowsOverAgeForNextCapture,
-      ).toBe(false);
-    });
-
     it('uses the first frame of a new stream as its planning baseline even when startup made it over-age', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('initial-static-frame');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
-      (manager as any).streamBaselineFramePending = true;
-      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).streamBaselineWindow = {
+        deadlineAt: Date.now() + 5_000,
+      };
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -530,14 +494,15 @@ describe('ScrcpyScreenshotManager', () => {
       );
       expect(waitForNextKeyframe).not.toHaveBeenCalled();
       expect(setBarrier).not.toHaveBeenCalled();
-      expect((manager as any).streamBaselineFramePending).toBe(false);
+      expect((manager as any).streamBaselineWindow).toBeNull();
     });
 
     it('uses the startup timeout while waiting for the first data frame of a new stream', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
-      (manager as any).streamBaselineFramePending = true;
-      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).streamBaselineWindow = {
+        deadlineAt: Date.now() + 5_000,
+      };
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -566,7 +531,7 @@ describe('ScrcpyScreenshotManager', () => {
       const startupWaitMs = waitForNextKeyframe.mock.calls[0][0];
       expect(startupWaitMs).toBeGreaterThan(4_000);
       expect(startupWaitMs).toBeLessThanOrEqual(5_000);
-      expect((manager as any).streamBaselineFramePending).toBe(false);
+      expect((manager as any).streamBaselineWindow).toBeNull();
     });
 
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {
@@ -839,8 +804,9 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).lastRawKeyframe = Buffer.from('post-action-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_100_000n;
       (manager as any).frameFreshnessBarrierPtsUs = 1_000_000n;
-      (manager as any).streamBaselineFramePending = true;
-      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).streamBaselineWindow = {
+        deadlineAt: Date.now() + 5_000,
+      };
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -877,8 +843,9 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('first-planning-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
-      (manager as any).streamBaselineFramePending = true;
-      (manager as any).streamBaselineFrameDeadlineAt = Date.now() - 1;
+      (manager as any).streamBaselineWindow = {
+        deadlineAt: Date.now() - 1,
+      };
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 2_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -931,54 +898,15 @@ describe('ScrcpyScreenshotManager', () => {
 
       await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
         name: 'ScrcpyFreshFrameUnavailableError',
-        diagnosticMessage: expect.stringContaining(
-          'falling back to ADB screenshot',
-        ),
+        failureKind: 'freshness-target',
+        timeoutMs: 300,
+        videoBitRate: 100_000_000,
       });
       expect(ensureConnected).toHaveBeenCalledTimes(1);
       expect(disconnect).toHaveBeenCalledTimes(1);
       expect(barrier).toHaveBeenCalledWith('stale planning frame');
       expect(decode).not.toHaveBeenCalled();
       expect(warn).not.toHaveBeenCalled();
-    });
-
-    it('does not recommend lowering an already-low bitrate for a local USB link', () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
-        videoBitRate: 4_000_000,
-      });
-      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
-
-      (manager as any).warnTransportBacklog(new Error('no post-action frame'));
-
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining(
-          'Lowering it further is unlikely to help on a local USB connection',
-        ),
-      );
-      expect(warn).not.toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining('Lower it further if backlog persists'),
-      );
-    });
-
-    it('reports a missing first frame as stream startup failure instead of bitrate backlog', () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
-        videoBitRate: 4_000_000,
-      });
-      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
-      (manager as any).streamBaselineFramePending = true;
-
-      (manager as any).warnTransportBacklog(new Error('no initial data frame'));
-
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining('stream startup or encoder-readiness failure'),
-      );
-      expect(warn).not.toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining('Lowering it further'),
-      );
     });
 
     it('rejects frames without PTS instead of treating arrival time as freshness', async () => {
@@ -1013,8 +941,9 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).deviceClockCalibration = {};
       (manager as any).lastFramePtsUs = 456n;
       (manager as any).frameFreshnessError = new Error('stale');
-      (manager as any).streamBaselineFramePending = true;
-      (manager as any).streamBaselineFrameDeadlineAt = Date.now() + 5_000;
+      (manager as any).streamBaselineWindow = {
+        deadlineAt: Date.now() + 5_000,
+      };
 
       await manager.disconnect();
 
@@ -1029,8 +958,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).deviceClockCalibration).toBeNull();
       expect((manager as any).lastFramePtsUs).toBeNull();
       expect((manager as any).frameFreshnessError).toBeNull();
-      expect((manager as any).streamBaselineFramePending).toBe(false);
-      expect((manager as any).streamBaselineFrameDeadlineAt).toBe(0);
+      expect((manager as any).streamBaselineWindow).toBeNull();
     });
 
     it('should clear idle timer', async () => {
@@ -1068,6 +996,33 @@ describe('ScrcpyScreenshotManager', () => {
       await expect(manager.ensureConnected()).rejects.toThrow(
         'Scrcpy manager has been disposed',
       );
+    });
+
+    it('shares one complete disposal across concurrent callers', async () => {
+      let finishClose: (() => void) | undefined;
+      const close = rs.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          finishClose = resolve;
+        }),
+      );
+      const manager = new ScrcpyScreenshotManager({ close } as any);
+
+      const firstDispose = manager.dispose();
+      const secondDispose = manager.dispose();
+      let secondFinished = false;
+      void secondDispose.then(() => {
+        secondFinished = true;
+      });
+
+      await Promise.resolve();
+      expect(secondFinished).toBe(false);
+      expect(close).toHaveBeenCalledTimes(1);
+
+      finishClose?.();
+      await expect(Promise.all([firstDispose, secondDispose])).resolves.toEqual(
+        [undefined, undefined],
+      );
+      expect(close).toHaveBeenCalledTimes(1);
     });
 
     it('waits for an in-flight connection before disposing its ADB transport', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -355,6 +355,7 @@ describe('ScrcpyScreenshotManager', () => {
     it('drops frames captured before the device-clock barrier', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       const listener = rs.fn();
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
       manager.subscribeKeyframes(listener);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
@@ -364,9 +365,7 @@ describe('ScrcpyScreenshotManager', () => {
       };
       rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
 
-      const barrier = await manager.setFreshnessBarrier(
-        'completed input action',
-      );
+      const barrier = await manager.setFreshnessBarrier('input action started');
       expect(barrier).toBe(1_006_000n);
 
       (manager as any).processFrame(spsPacket());
@@ -374,7 +373,11 @@ describe('ScrcpyScreenshotManager', () => {
       expect(manager.getLatestRawKeyframe()).toBeNull();
       expect(listener).not.toHaveBeenCalled();
       expect((manager as any).frameFreshnessError?.message).toContain(
-        'completed input action',
+        'input action started',
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('predates the input action started'),
       );
 
       (manager as any).processFrame(dataPacket(0x02, 1_006_000n));
@@ -408,7 +411,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect(readClock).toHaveBeenCalledTimes(1);
     });
 
-    it('projects a deferred action barrier from when the action completed', async () => {
+    it('projects a deferred action barrier from when the action started', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
@@ -419,8 +422,8 @@ describe('ScrcpyScreenshotManager', () => {
       rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_500_000n);
 
       const barrier = await manager.setFreshnessBarrier(
-        'completed input action while scrcpy was unavailable',
-        10_100_000n,
+        'input action started while scrcpy was unavailable',
+        { hostMonotonicUs: 10_100_000n },
       );
 
       expect(barrier).toBe(1_106_000n);
@@ -428,6 +431,42 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).processFrame(spsPacket());
       (manager as any).processFrame(dataPacket(0x01, 1_200_000n));
       expect(manager.getLatestRawKeyframe()?.data[5]).toBe(0x01);
+    });
+
+    it('reuses an over-age frame once when it crossed the input-action barrier', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).spsHeader = Buffer.from('header');
+      (manager as any).lastRawKeyframe = Buffer.from('post-action-frame');
+      (manager as any).lastRawKeyframePtsUs = 1_100_000n;
+      (manager as any).lastRawKeyframeAt = 2_000;
+      (manager as any).frameFreshnessBarrierPtsUs = 1_006_000n;
+      (manager as any).frameFreshnessBarrierReason = 'input action started';
+      (manager as any).frameFreshnessBarrierAllowsOverAgeForNextCapture = true;
+      (manager as any).deviceClockCalibration = {
+        deviceUptimeUs: 1_000_000n,
+        hostMonotonicUs: 10_000_000n,
+        hostWallTimeMs: 2_000,
+        roundTripUs: 10_000n,
+      };
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(11_100_000n);
+      rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+      rs.spyOn(manager as any, 'resetIdleTimer').mockImplementation(() => {});
+      const waitForNextKeyframe = rs.spyOn(
+        manager as any,
+        'waitForNextKeyframe',
+      );
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        Buffer.from('jpeg'),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
+        Buffer.from('jpeg'),
+      );
+      expect(waitForNextKeyframe).not.toHaveBeenCalled();
+      expect((manager as any).frameFreshnessBarrierPtsUs).toBeNull();
+      expect(
+        (manager as any).frameFreshnessBarrierAllowsOverAgeForNextCapture,
+      ).toBe(false);
     });
 
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -408,6 +408,28 @@ describe('ScrcpyScreenshotManager', () => {
       expect(readClock).toHaveBeenCalledTimes(1);
     });
 
+    it('projects a deferred action barrier from when the action completed', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+      (manager as any).deviceClockCalibration = {
+        deviceUptimeUs: 1_000_000n,
+        hostMonotonicUs: 10_000_000n,
+        hostWallTimeMs: 2_000,
+        roundTripUs: 10_000n,
+      };
+      rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_500_000n);
+
+      const barrier = await manager.setFreshnessBarrier(
+        'completed input action while scrcpy was unavailable',
+        10_100_000n,
+      );
+
+      expect(barrier).toBe(1_106_000n);
+
+      (manager as any).processFrame(spsPacket());
+      (manager as any).processFrame(dataPacket(0x01, 1_200_000n));
+      expect(manager.getLatestRawKeyframe()?.data[5]).toBe(0x01);
+    });
+
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       let resolveClock:
@@ -786,6 +808,26 @@ describe('ScrcpyScreenshotManager', () => {
         expect.stringContaining(
           'Current videoBitRate: 100000000 bps (100 Mbps)',
         ),
+      );
+    });
+
+    it('does not recommend lowering an already-low bitrate for a local USB link', () => {
+      const manager = new ScrcpyScreenshotManager({} as any, {
+        videoBitRate: 4_000_000,
+      });
+      const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+      (manager as any).warnTransportBacklog(new Error('no post-action frame'));
+
+      expect(warn).toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining(
+          'Lowering it further is unlikely to help on a local USB connection',
+        ),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        '[Midscene]',
+        expect.stringContaining('Lower it further if backlog persists'),
       );
     });
 

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -874,7 +874,7 @@ describe('ScrcpyScreenshotManager', () => {
       expect(barrier).toHaveBeenCalledWith('stale planning frame');
     });
 
-    it('falls back when a static screen cannot cross the Planning barrier', async () => {
+    it('returns a quiet diagnostic when a static screen cannot cross the Planning barrier', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       (manager as any).spsHeader = Buffer.from('old-header');
       (manager as any).lastRawKeyframe = Buffer.from('stale-static-frame');
@@ -897,29 +897,17 @@ describe('ScrcpyScreenshotManager', () => {
       );
       const decode = rs.spyOn(manager as any, 'decodeH264ToJpeg');
 
-      await expect(manager.getScreenshotJpeg()).rejects.toBeInstanceOf(
-        ScrcpyFreshFrameUnavailableError,
-      );
+      await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+        name: 'ScrcpyFreshFrameUnavailableError',
+        diagnosticMessage: expect.stringContaining(
+          'falling back to ADB screenshot',
+        ),
+      });
       expect(ensureConnected).toHaveBeenCalledTimes(1);
       expect(disconnect).toHaveBeenCalledTimes(1);
       expect(barrier).toHaveBeenCalledWith('stale planning frame');
       expect(decode).not.toHaveBeenCalled();
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining('falling back to ADB screenshot'),
-      );
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining(
-          '--scrcpy-video-bit-rate 4000000 in the Android CLI',
-        ),
-      );
-      expect(warn).toHaveBeenCalledWith(
-        '[Midscene]',
-        expect.stringContaining(
-          'Current videoBitRate: 100000000 bps (100 Mbps)',
-        ),
-      );
+      expect(warn).not.toHaveBeenCalled();
     });
 
     it('does not recommend lowering an already-low bitrate for a local USB link', () => {

--- a/packages/android/tests/unit-test/visual-action-registry.test.ts
+++ b/packages/android/tests/unit-test/visual-action-registry.test.ts
@@ -84,31 +84,31 @@ function calledVisualAction(call: ts.CallExpression): string | undefined {
 }
 
 describe('createVisualActionRegistry', () => {
-  it('runs the freshness hook before dispatch with the registered action name', async () => {
+  it('runs the completion hook after dispatch with the registered action name', async () => {
     const dispatch = rs
       .fn()
       .mockImplementation(async (uri: string) => `launched:${uri}`);
-    const onActionStarting = rs.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         launch: dispatch,
       },
-      onActionStarting,
+      onActionSettled,
     );
 
     await expect(actions.launch('com.example.app')).resolves.toBe(
       'launched:com.example.app',
     );
-    expect(onActionStarting).toHaveBeenCalledOnce();
-    expect(onActionStarting).toHaveBeenCalledWith('launch');
-    expect(onActionStarting.mock.invocationCallOrder[0]).toBeLessThan(
-      dispatch.mock.invocationCallOrder[0],
+    expect(onActionSettled).toHaveBeenCalledOnce();
+    expect(onActionSettled).toHaveBeenCalledWith('launch');
+    expect(dispatch.mock.invocationCallOrder[0]).toBeLessThan(
+      onActionSettled.mock.invocationCallOrder[0],
     );
   });
 
-  it('marks a composite action only once', async () => {
+  it('settles a composite action only once', async () => {
     const dispatchStep = rs.fn().mockResolvedValue(undefined);
-    const onActionStarting = rs.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async (repeat: number) => {
@@ -117,23 +117,23 @@ describe('createVisualActionRegistry', () => {
           }
         },
       },
-      onActionStarting,
+      onActionSettled,
     );
 
     await actions.swipe(3);
 
     expect(dispatchStep).toHaveBeenCalledTimes(3);
-    expect(onActionStarting).toHaveBeenCalledOnce();
-    expect(onActionStarting).toHaveBeenCalledWith('swipe');
+    expect(onActionSettled).toHaveBeenCalledOnce();
+    expect(onActionSettled).toHaveBeenCalledWith('swipe');
   });
 
-  it('marks an action before a dispatch that later fails', async () => {
+  it('settles an action after a dispatch that fails', async () => {
     const actionError = new Error('second gesture failed');
     const dispatchStep = rs
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(actionError);
-    const onActionStarting = rs.fn().mockResolvedValue(undefined);
+    const onActionSettled = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async () => {
@@ -141,14 +141,14 @@ describe('createVisualActionRegistry', () => {
           await dispatchStep();
         },
       },
-      onActionStarting,
+      onActionSettled,
     );
 
     await expect(actions.swipe()).rejects.toBe(actionError);
-    expect(onActionStarting).toHaveBeenCalledOnce();
-    expect(onActionStarting).toHaveBeenCalledWith('swipe');
-    expect(onActionStarting.mock.invocationCallOrder[0]).toBeLessThan(
-      dispatchStep.mock.invocationCallOrder[0],
+    expect(onActionSettled).toHaveBeenCalledOnce();
+    expect(onActionSettled).toHaveBeenCalledWith('swipe');
+    expect(dispatchStep.mock.invocationCallOrder[1]).toBeLessThan(
+      onActionSettled.mock.invocationCallOrder[0],
     );
   });
 });

--- a/packages/android/tests/unit-test/visual-action-registry.test.ts
+++ b/packages/android/tests/unit-test/visual-action-registry.test.ts
@@ -84,25 +84,31 @@ function calledVisualAction(call: ts.CallExpression): string | undefined {
 }
 
 describe('createVisualActionRegistry', () => {
-  it('runs the completion hook once with the registered action name', async () => {
-    const onActionSettled = rs.fn().mockResolvedValue(undefined);
+  it('runs the freshness hook before dispatch with the registered action name', async () => {
+    const dispatch = rs
+      .fn()
+      .mockImplementation(async (uri: string) => `launched:${uri}`);
+    const onActionStarting = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
-        launch: async (uri: string) => `launched:${uri}`,
+        launch: dispatch,
       },
-      onActionSettled,
+      onActionStarting,
     );
 
     await expect(actions.launch('com.example.app')).resolves.toBe(
       'launched:com.example.app',
     );
-    expect(onActionSettled).toHaveBeenCalledOnce();
-    expect(onActionSettled).toHaveBeenCalledWith('launch');
+    expect(onActionStarting).toHaveBeenCalledOnce();
+    expect(onActionStarting).toHaveBeenCalledWith('launch');
+    expect(onActionStarting.mock.invocationCallOrder[0]).toBeLessThan(
+      dispatch.mock.invocationCallOrder[0],
+    );
   });
 
-  it('settles a composite action only once', async () => {
+  it('marks a composite action only once', async () => {
     const dispatchStep = rs.fn().mockResolvedValue(undefined);
-    const onActionSettled = rs.fn().mockResolvedValue(undefined);
+    const onActionStarting = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async (repeat: number) => {
@@ -111,23 +117,23 @@ describe('createVisualActionRegistry', () => {
           }
         },
       },
-      onActionSettled,
+      onActionStarting,
     );
 
     await actions.swipe(3);
 
     expect(dispatchStep).toHaveBeenCalledTimes(3);
-    expect(onActionSettled).toHaveBeenCalledOnce();
-    expect(onActionSettled).toHaveBeenCalledWith('swipe');
+    expect(onActionStarting).toHaveBeenCalledOnce();
+    expect(onActionStarting).toHaveBeenCalledWith('swipe');
   });
 
-  it('settles an action that fails after dispatch begins', async () => {
+  it('marks an action before a dispatch that later fails', async () => {
     const actionError = new Error('second gesture failed');
     const dispatchStep = rs
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(actionError);
-    const onActionSettled = rs.fn().mockResolvedValue(undefined);
+    const onActionStarting = rs.fn().mockResolvedValue(undefined);
     const actions = createVisualActionRegistry(
       {
         swipe: async () => {
@@ -135,12 +141,15 @@ describe('createVisualActionRegistry', () => {
           await dispatchStep();
         },
       },
-      onActionSettled,
+      onActionStarting,
     );
 
     await expect(actions.swipe()).rejects.toBe(actionError);
-    expect(onActionSettled).toHaveBeenCalledOnce();
-    expect(onActionSettled).toHaveBeenCalledWith('swipe');
+    expect(onActionStarting).toHaveBeenCalledOnce();
+    expect(onActionStarting).toHaveBeenCalledWith('swipe');
+    expect(onActionStarting.mock.invocationCallOrder[0]).toBeLessThan(
+      dispatchStep.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -136,9 +136,9 @@ export type AndroidDeviceOpt = {
     idleTimeoutMs?: number;
     /**
      * Video bit rate for H.264 encoding in bits per second.
-     * Higher values improve quality but increase bandwidth usage.
-     * For bandwidth-constrained remote links, explicitly set a lower value
-     * such as 4000000 (4 Mbps) and tune it for the actual transport.
+     * Changing it trades encoded bandwidth against screenshot detail. Tune it
+     * only from independent transport measurements, then validate recognition
+     * quality. A freshness-timeout warning alone is not a reason to change it.
      * @default 100000000 (100 Mbps)
      */
     videoBitRate?: number;


### PR DESCRIPTION
## Summary

- add `--scrcpy-video-bit-rate` and `--scrcpyVideoBitRate` to the Android CLI
- forward the configured value to `scrcpyConfig.videoBitRate` and implicitly enable scrcpy when a bitrate is provided
- establish freshness barriers only after ADB input dispatch completes, so cached frames cannot predate the completed action
- keep the normal 500 ms frame-age limit for every returned frame, including action frames and new-stream baselines
- give only a newly created stream a bounded startup window in which to produce its first usable frame
- restart a stale scrcpy stream once in-band on the same manager and yume ADB transport, then fall back to ADB if the restarted stream also fails
- restore continuous-frame listeners whenever recovery establishes a new stream epoch
- remove the competing background recovery path and use the normal cooldown before a later capture retries scrcpy
- report structured freshness diagnostics once at the Android device boundary, without duplicate manager/adapter warnings
- make permanent manager disposal a true async singleflight operation
- replace bitrate advice with neutral diagnostics in runtime output, CLI help, and bilingual Android documentation

## Root cause

The reported failures are not evidence of insufficient USB bandwidth.

Midscene deliberately disables MediaCodec repeated-frame output because a duplicate packet can carry a newer PTS while its pixels are unchanged. Treating that packet as fresh could return a stale image after an input action. Some device encoders, including the Redmi K80 Pro encoder observed in the report, may therefore emit no packet while the screen is static. Lowering the bitrate from 100 Mbps to 4 Mbps cannot make a static encoder emit a frame.

After a long locate/model wait, or after a tap that causes no visible change, an established stream may have no frame that satisfies the 300 ms freshness target. The safe recovery is to close only that video epoch and reconnect scrcpy on the existing ADB transport. The new stream must still produce a frame that satisfies the normal age invariant before it is returned.

## Recovery and freshness guarantees

Action barriers are projected from the host monotonic completion time onto the device PTS clock. Device clock calibration now happens immediately before encoder startup. A frame must cross the active barrier and be at most 500 ms old when captured; startup waiting changes how long Midscene waits, not which frames are accepted.

The adapter owns exactly one synchronous restart attempt. A successful restart returns the new epoch JPEG directly. If the restarted stream also fails, the adapter records the normal five-second cooldown and the device performs one ADB fallback. A later screenshot retries through the same manager and transport; there is no competing background recovery.

`ScrcpyFreshFrameUnavailableError` carries a failure kind, timeout, and bitrate. The manager emits domain state rather than CLI wording, and the Android device formats one user-facing diagnostic at the final fallback boundary.

`ScrcpyScreenshotManager.disconnect()` remains a reusable stream-level operation. `dispose()` permanently closes the stream and owned yume ADB transport, and concurrent callers await the same complete disposal promise.

## Validation

- `pnpm install --frozen-lockfile` (including successful builds for all 28 workspace projects)
- `pnpm run lint`
- `pnpm exec nx test android` (435 tests passed in 21 files)
- `git diff --check origin/main...HEAD`
- verified the built CLI exposes both bitrate flag spellings
- GitHub checks currently passing include Android Emulator, CI, Lint, Windows Desktop, iOS Simulator, Headless Linux chrome-extension bridge, and Cloudflare Pages; remaining checks are still running
- previously reproduced the original failure on a Dora physical Redmi K80 Pro (`24122RKC7C`, Android 15, 1440x3200) with `1.11.1-beta-20260820121924.0` and `--scrcpy-video-bit-rate 4000000`
- the published build reproduced `No fresh keyframe received within 300ms` and ADB fallback after an eight-second locate-style delay
- final physical revalidation of commit `f022118aa160d7e416fec0f071cd97b34e713f35` is reserved on Redmi K80 Pro serial `256b30f0`; the current long-running device-farm session is scheduled to release at 18:06 CST

Unit coverage includes completed-action ordering, strict post-action frame age, bounded startup waiting, delayed first-frame rejection, manager/connection/restart singleflight, cooldown retry, structured one-time fallback diagnostics, transport disposal, cleanup during an in-flight connection, and listener reattachment after a double-failure/cooldown/reconnect sequence.

## Prerelease history

- `1.11.1-beta-20260820101203.0` is superseded and does not contain the new-stream recovery fix
- `1.11.1-beta-20260820121924.0` contains earlier timing fixes but not the in-band stale-stream restart
- `1.11.1-beta-20260821071735.0` contains the initial in-band restart from commit `7400b2499b08b9a4a575926dde98bda69b40c422`
- current commit `f022118aa160d7e416fec0f071cd97b34e713f35` contains the final startup-age invariant, listener lifecycle fix, structured diagnostics, simplified recovery ownership, and disposal hardening; a new prepatch prerelease will be published after the reserved physical-device validation
