### PR TITLE
docs(site): update Qwen showcase pricing

### DIFF
--- a/apps/site/docs/en/showcases.mdx
+++ b/apps/site/docs/en/showcases.mdx
@@ -77,7 +77,7 @@ The following five test cases use `doubao-seed-2-1-turbo-260628` to test the ran
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
 :::info Doubao pricing assumptions
-Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+Pricing was checked on August 17, 2026 and sourced from [AIHubMix](https://aihubmix.com/model/doubao-seed-2-1-turbo). Input tokens are priced at `$0.423 / M tokens`, cache reads at `$0.08452 / M tokens`, and output tokens at `$2.113 / M tokens`. The five cases cost approximately `$0.2192` in total and average `$0.0438` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
 :::
 
 ### Reddit App: Qwen 3.7 Plus
@@ -101,7 +101,7 @@ The following two test cases use [`qwen/qwen3.7-plus`](https://openrouter.ai/qwe
 - **Test report:** [View report](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/02-upvote-first-post-in-midscene-community.html)
 
 :::info Qwen pricing assumptions
-Input tokens are priced at `$0.32 / M tokens`, cache reads at `$0.064 / M tokens`, and output tokens at `$1.28 / M tokens`. The two cases cost approximately `$0.0774` in total and average `$0.0387` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
+Pricing was checked on August 21, 2026 and sourced from [OpenRouter](https://openrouter.ai/qwen/qwen3.7-plus). Input tokens are priced at `$0.32 / M tokens`, cache reads at `$0.064 / M tokens`, and output tokens at `$1.28 / M tokens`. The two cases cost approximately `$0.0774` in total and average `$0.0387` per case. These figures reflect this test run only; actual costs vary with task complexity, cache hit rate, and model pricing.
 :::
 
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -82,14 +82,14 @@ import ShowcaseComputer from './showcases-computer.mdx';
 
 ### Reddit App：Qwen 3.7 Plus
 
-以下 2 个用例使用 [`qwen/qwen3.7-plus`](https://openrouter.ai/qwen/qwen3.7-plus)，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
+以下 2 个用例使用 [`qwen3.7-plus-2026-05-26`](https://help.aliyun.com/zh/model-studio/model-pricing)，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
 
 #### 用例 1：搜索并加入 Midscene 社区
 
 - **测试内容：** 搜索 Midscene，打开准确的 `r/midscene` 社区，按需加入并验证账号已处于加入状态
 - **步骤数：** 7 / 17（脚本 / 模型调用）
 - **Token 量：** 输入 147,127（缓存 34,816）/ 输出 3,418
-- **费用：** ¥0.289
+- **费用：** ¥0.266
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/01-search-and-join-midscene-community.html)
 
 #### 用例 2：点赞 Midscene 社区首篇帖子
@@ -97,11 +97,11 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **测试内容：** 打开准确的 `r/midscene` 社区，按需点赞帖子列表中的首篇帖子，并验证其已处于点赞状态
 - **步骤数：** 6 / 12（脚本 / 模型调用）
 - **Token 量：** 输入 103,231（缓存 8,704）/ 输出 3,142
-- **费用：** ¥0.237
+- **费用：** ¥0.218
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/02-upvote-first-post-in-midscene-community.html)
 
 :::info Qwen 计价口径
-输入单价按 `$0.32 / M Tokens`、缓存读取单价按 `$0.064 / M Tokens`、输出单价按 `$1.28 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。2 个用例平均消耗约 128,459 Token，平均费用约 ¥0.263。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+输入单价按 `¥2 / M Tokens`、缓存读取单价按 `¥0.4 / M Tokens`、输出单价按 `¥8 / M Tokens` 计算。2 个用例平均消耗约 128,459 Token，平均费用约 ¥0.242。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::
 
 

--- a/apps/site/docs/zh/showcases.mdx
+++ b/apps/site/docs/zh/showcases.mdx
@@ -77,19 +77,19 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/dongchedi/05-switch-and-reset.html)
 
 :::info Doubao 计价口径
-输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个用例平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+价格数据截至 2026 年 8 月 17 日，取自 [AIHubMix](https://aihubmix.com/model/doubao-seed-2-1-turbo)。输入单价按 `$0.423 / M Tokens`、缓存读取单价按 `$0.08452 / M Tokens`、输出单价按 `$2.113 / M Tokens` 计算，人民币费用按 `$1 ≈ ¥6.8` 估算。5 个用例平均消耗约 182,253 Token，平均费用约 ¥0.298。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::
 
 ### Reddit App：Qwen 3.7 Plus
 
-以下 2 个用例使用 [`qwen3.7-plus-2026-05-26`](https://help.aliyun.com/zh/model-studio/model-pricing)，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
+以下 2 个用例使用 [`qwen3.7-plus`](https://help.aliyun.com/zh/model-studio/model-pricing)，测试 Android 端 Reddit App 的社区搜索、加入和帖子点赞功能。测试设备分辨率为 720 × 1600。
 
 #### 用例 1：搜索并加入 Midscene 社区
 
 - **测试内容：** 搜索 Midscene，打开准确的 `r/midscene` 社区，按需加入并验证账号已处于加入状态
 - **步骤数：** 7 / 17（脚本 / 模型调用）
 - **Token 量：** 输入 147,127（缓存 34,816）/ 输出 3,418
-- **费用：** ¥0.266
+- **费用：** ¥0.213
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/01-search-and-join-midscene-community.html)
 
 #### 用例 2：点赞 Midscene 社区首篇帖子
@@ -97,11 +97,11 @@ import ShowcaseComputer from './showcases-computer.mdx';
 - **测试内容：** 打开准确的 `r/midscene` 社区，按需点赞帖子列表中的首篇帖子，并验证其已处于点赞状态
 - **步骤数：** 6 / 12（脚本 / 模型调用）
 - **Token 量：** 输入 103,231（缓存 8,704）/ 输出 3,142
-- **费用：** ¥0.218
+- **费用：** ¥0.174
 - **测试报告：** [查看报告](https://lf3-static.bytednsdoc.com/obj/eden-cn/luljzkpt/ljhwZthlaukjlkulzlp/showcases/reddit/02-upvote-first-post-in-midscene-community.html)
 
 :::info Qwen 计价口径
-输入单价按 `¥2 / M Tokens`、缓存读取单价按 `¥0.4 / M Tokens`、输出单价按 `¥8 / M Tokens` 计算。2 个用例平均消耗约 128,459 Token，平均费用约 ¥0.242。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
+价格数据截至 2026 年 8 月 21 日，取自[阿里云百炼模型价格](https://help.aliyun.com/zh/model-studio/model-pricing)。输入单价按 `¥1.6 / M Tokens`、缓存读取单价按 `¥0.32 / M Tokens`、输出单价按 `¥6.4 / M Tokens` 计算。2 个用例平均消耗约 128,459 Token，平均费用约 ¥0.193。以上数据仅代表本次测试，实际费用会随任务复杂度、缓存命中率和模型价格变化。
 :::
 
 


### PR DESCRIPTION
## Summary

- Update the Chinese Reddit showcase to reference `qwen3.7-plus-2026-05-26` on Alibaba Cloud Model Studio.
- Recalculate Qwen costs using the standard Alibaba Cloud rates: ¥2/M input tokens, ¥0.4/M cached input tokens, and ¥8/M output tokens.
- Update the two case costs to ¥0.266 and ¥0.218, with an average cost of ¥0.242 per case.
- Keep the English documentation on the existing OpenRouter pricing basis.

## Validation

- `pnpm run lint`