### PR TITLE
fix(ios): make keyboard dismissal deterministic

### DIFF
--- a/apps/site/docs/en/platforms/ios.mdx
+++ b/apps/site/docs/en/platforms/ios.mdx
@@ -131,6 +131,25 @@ npx tsx demo.ts
 
 After the script finishes, you should see `Midscene - report file updated: /path/to/report/some_id.html` in the console. Open the generated HTML file in a browser to replay every interaction, query, and assertion.
 
+## Keyboard dismissal
+
+`autoDismissKeyboard` defaults to `true`. After entering text, Midscene locates the standard iOS keyboard accessory toolbar, activates its dismissal control, and waits until WebDriverAgent confirms that the keyboard is hidden. If the toolbar cannot be identified safely or the keyboard does not disappear before the operation deadline, the input action fails instead of continuing with an uncertain keyboard state.
+
+When an `Enter`, `Return`, or `Tab` action immediately follows an auto-dismissed input, Midscene can restore that input's focus once before sending the key. A different pointer, touch, system, custom, or text-input action invalidates the pending focus target.
+
+:::warning
+An app-defined input accessory can contain business actions such as Save or Submit. Midscene deliberately rejects accessory toolbars that do not match the standard iOS navigation-and-dismiss structure. For a custom toolbar, disable automatic dismissal and call `hideKeyboard()` with the control's stable accessibility name.
+:::
+
+```typescript
+const device = new IOSDevice({
+  autoDismissKeyboard: false,
+});
+
+// After entering text, dismiss a custom keyboard control explicitly.
+await device.hideKeyboard(['Close Keyboard']);
+```
+
 ## Custom actions
 
 Use `defineAction()` to define custom actions. When constructing the Agent with `agentFromWebDriverAgent()`, pass these actions through `customActions`. Midscene appends these actions to the planner so the Agent can call the domain-specific actions you define.

--- a/apps/site/docs/zh/platforms/ios.mdx
+++ b/apps/site/docs/zh/platforms/ios.mdx
@@ -131,6 +131,25 @@ npx tsx demo.ts
 
 脚本运行结束后，你应该能在控制台看到 `Midscene - report file updated: /path/to/report/some_id.html`。在浏览器中打开生成的 HTML 文件，即可回放每次交互、查询和断言。
 
+## 隐藏键盘
+
+`autoDismissKeyboard` 默认值为 `true`。文本输入完成后，Midscene 会定位标准的 iOS 键盘辅助工具栏，触发其中的隐藏控件，并等待 WebDriverAgent 确认键盘已经消失。如果无法安全识别工具栏，或者键盘未在操作期限内消失，输入动作会直接失败，不会在键盘状态不确定时继续执行。
+
+如果自动隐藏键盘后紧接着执行 `Enter`、`Return` 或 `Tab`，Midscene 可以在发送按键前恢复一次原输入框的焦点。其他指针、触控、系统、自定义或文本输入动作都会使这个待恢复目标失效。
+
+:::warning
+App 自定义的输入辅助工具栏可能包含 Save、Submit 等业务操作。对于不符合标准 iOS“左侧导航、右侧隐藏”结构的工具栏，Midscene 会主动拒绝点击。使用自定义工具栏时，请关闭自动隐藏，并向 `hideKeyboard()` 传入该控件稳定的 accessibility name。
+:::
+
+```typescript
+const device = new IOSDevice({
+  autoDismissKeyboard: false,
+});
+
+// 输入完成后，显式触发自定义键盘隐藏控件。
+await device.hideKeyboard(['Close Keyboard']);
+```
+
 ## 自定义动作
 
 使用 `defineAction()` 定义自定义动作。使用 `agentFromWebDriverAgent()` 构造 Agent 时，通过 `customActions` 传入这些动作。Midscene 会把这些动作追加到规划器中，让 Agent 可以调用你定义的领域特定动作。

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -563,7 +563,12 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     }
 
     if (shouldAutoDismissKeyboard) {
-      await this.hideKeyboard();
+      const dismissed = await this.hideKeyboard();
+      if (!dismissed) {
+        throw new Error(
+          'Failed to auto-dismiss the iOS keyboard: no supported dismissal control was found or the keyboard remained visible',
+        );
+      }
     }
   }
 
@@ -864,48 +869,33 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     await this.wdaBackend.appSwitcher();
   }
 
+  /**
+   * Hides the iOS software keyboard using a structurally located accessory
+   * control, or configured key names when provided.
+   *
+   * @returns `true` when the keyboard is hidden, or `false` when the current
+   * application exposes no supported dismissal control.
+   * @throws When communication with WebDriverAgent fails.
+   */
   async hideKeyboard(keyNames?: string[]): Promise<boolean> {
     try {
-      // Always try WDA's dismissKeyboard API first (most reliable)
-      // Use common keyboard button names if not specified
-      const dismissKeys =
+      debugDevice(
         keyNames && keyNames.length > 0
-          ? keyNames
-          : ['return', 'done', 'go', 'search', 'next', 'send'];
-
-      debugDevice(
-        `Attempting to dismiss keyboard using WDA API with keys: ${dismissKeys.join(', ')}`,
+          ? `Attempting to dismiss keyboard using configured buttons: ${keyNames.join(', ')}`
+          : 'Attempting to dismiss keyboard using its accessory toolbar',
       );
-
-      try {
-        await this.wdaBackend.dismissKeyboard(dismissKeys);
-        debugDevice('Successfully dismissed keyboard using WDA API');
-        await sleep(500); // Wait longer to ensure UI is stable
-        return true;
-      } catch (wdaError) {
-        debugDevice(
-          `WDA dismissKeyboard failed, falling back to swipe gesture: ${wdaError}`,
-        );
-      }
-
-      // Fallback: Use swipe gesture if WDA API fails
-      // Use safer coordinates: swipe up from bottom of screen
-      const windowSize = await this.wdaBackend.getWindowSize();
-      const centerX = Math.round(windowSize.width / 2);
-      const startY = Math.round(windowSize.height * 0.9); // Start near bottom
-      const endY = Math.round(windowSize.height * 0.5); // Swipe up to middle
-
-      // Perform swipe up gesture to dismiss keyboard
-      await this.swipeCoordinates(centerX, startY, centerX, endY, 300);
+      const dismissed = await this.wdaBackend.dismissKeyboard(keyNames);
       debugDevice(
-        'Dismissed keyboard with swipe up gesture from bottom of screen',
+        dismissed
+          ? 'Successfully dismissed keyboard'
+          : 'No supported keyboard dismiss control was found',
       );
-
-      await sleep(500); // Wait longer to ensure UI is stable
-      return true;
+      return dismissed;
     } catch (error) {
       debugDevice(`Failed to hide keyboard: ${error}`);
-      return false;
+      throw new Error(`Failed to hide the iOS keyboard through WDA: ${error}`, {
+        cause: error,
+      });
     }
   }
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import {
   type ActionScrollParam,
   type DeviceAction,
+  type ExecutorContext,
   type InterfaceType,
   type Point,
   type Size,
@@ -39,6 +40,17 @@ export const WDA_HTTP_METHODS = ['GET', 'POST', 'DELETE', 'PUT'] as const;
 export type WDAHttpMethod = (typeof WDA_HTTP_METHODS)[number];
 
 const DEFAULT_WDA_MJPEG_PORT = 9100;
+const keyboardFollowUpMaxAgeMs = 30_000;
+const keyboardFollowUpKeys: ReadonlySet<string> = new Set([
+  'enter',
+  'return',
+  'tab',
+]);
+
+type PendingKeyboardFollowUp = {
+  target: PointerPoint;
+  createdAt: number;
+};
 
 export class IOSDevice implements AbstractInterface {
   private deviceId: string;
@@ -60,8 +72,8 @@ export class IOSDevice implements AbstractInterface {
    */
   openFrameSource?: AbstractInterface['openFrameSource'];
   private appNameMapping: Record<string, string> = {};
-  /** Input point blurred by auto-dismiss and eligible for one follow-up key. */
-  private pendingKeyboardFocusRestorePoint: PointerPoint | undefined;
+  /** Auto-dismissed input eligible for one immediate submit/navigation key. */
+  private pendingKeyboardFollowUp: PendingKeyboardFollowUp | undefined;
   interfaceType: InterfaceType = 'ios';
   uri: string | undefined;
   options?: IOSDeviceOpt;
@@ -111,7 +123,7 @@ export class IOSDevice implements AbstractInterface {
         }
       },
       pinch: async (center, opts) => {
-        this.pendingKeyboardFocusRestorePoint = undefined;
+        this.invalidatePendingKeyboardFollowUp('pinch');
         await this.wdaBackend.pinch(
           Math.round(center.x),
           Math.round(center.y),
@@ -126,14 +138,63 @@ export class IOSDevice implements AbstractInterface {
     },
   };
 
+  private invalidatePendingKeyboardFollowUp(reason: string): void {
+    if (!this.pendingKeyboardFollowUp) {
+      return;
+    }
+    debugDevice(`Discarding pending keyboard follow-up: ${reason}`);
+    this.pendingKeyboardFollowUp = undefined;
+  }
+
+  private registerPendingKeyboardFollowUp(target?: PointerPoint): void {
+    if (!target) {
+      return;
+    }
+    this.pendingKeyboardFollowUp = {
+      target,
+      createdAt: Date.now(),
+    };
+    debugDevice(
+      `Registered one keyboard follow-up for (${target.x}, ${target.y})`,
+    );
+  }
+
+  private consumePendingKeyboardFollowUp(
+    key: string,
+  ): PointerPoint | undefined {
+    const pendingFollowUp = this.pendingKeyboardFollowUp;
+    this.pendingKeyboardFollowUp = undefined;
+    if (!pendingFollowUp) {
+      return undefined;
+    }
+
+    const normalizedKey = key.trim().toLowerCase();
+    if (!keyboardFollowUpKeys.has(normalizedKey)) {
+      debugDevice(
+        `Discarding pending keyboard follow-up: ${JSON.stringify(key)} is not a submit/navigation key`,
+      );
+      return undefined;
+    }
+
+    const ageMs = Date.now() - pendingFollowUp.createdAt;
+    if (ageMs > keyboardFollowUpMaxAgeMs) {
+      debugDevice(
+        `Discarding pending keyboard follow-up: expired after ${ageMs}ms`,
+      );
+      return undefined;
+    }
+
+    return pendingFollowUp.target;
+  }
+
   private async tapPoint(point: PointerPoint): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('tap');
     debugDevice(`tap at coordinates (${point.x}, ${point.y})`);
     await this.wdaBackend.tap(Math.round(point.x), Math.round(point.y));
   }
 
   private async doubleTapPoint(point: PointerPoint): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('double tap');
     await this.wdaBackend.doubleTap(Math.round(point.x), Math.round(point.y));
   }
 
@@ -141,7 +202,7 @@ export class IOSDevice implements AbstractInterface {
     point: PointerPoint,
     duration = 1000,
   ): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('long press');
     await this.wdaBackend.longPress(
       Math.round(point.x),
       Math.round(point.y),
@@ -154,7 +215,7 @@ export class IOSDevice implements AbstractInterface {
     end: PointerPoint,
     duration = 500,
   ): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('swipe');
     await this.wdaBackend.swipe(
       Math.round(start.x),
       Math.round(start.y),
@@ -165,6 +226,7 @@ export class IOSDevice implements AbstractInterface {
   }
 
   private async clearInputAt(point?: PointerPoint): Promise<void> {
+    this.invalidatePendingKeyboardFollowUp('clear input');
     if (point) {
       await this.tapPoint(point);
       await sleep(100);
@@ -186,6 +248,7 @@ export class IOSDevice implements AbstractInterface {
       input: this.inputPrimitives,
       size: () => this.size(),
       sleep: async (timeMs: number) => {
+        this.invalidatePendingKeyboardFollowUp('sleep action');
         await sleep(timeMs);
       },
       getDefaultAutoDismissKeyboard: () => this.options?.autoDismissKeyboard,
@@ -194,7 +257,13 @@ export class IOSDevice implements AbstractInterface {
 
     const platformSpecificActions = Object.values(createPlatformActions(this));
 
-    const customActions = this.customActions || [];
+    const customActions = (this.customActions || []).map((action) => ({
+      ...action,
+      call: async (param: any, context?: ExecutorContext) => {
+        this.invalidatePendingKeyboardFollowUp(`custom action ${action.name}`);
+        return await action.call(param, context);
+      },
+    }));
     return [...defaultActions, ...platformSpecificActions, ...customActions];
   }
 
@@ -280,6 +349,7 @@ export class IOSDevice implements AbstractInterface {
       `IOSDevice ${this.deviceId} has been destroyed and cannot execute commands`,
     );
 
+    this.invalidatePendingKeyboardFollowUp('connect');
     debugDevice(`Connecting to iOS device: ${this.deviceId}`);
 
     try {
@@ -342,6 +412,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
   }
 
   public async launch(uri: string): Promise<IOSDevice> {
+    this.invalidatePendingKeyboardFollowUp('launch');
     this.uri = uri;
 
     try {
@@ -373,6 +444,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
    * Supports app name resolution via setAppNameMapping when provided.
    */
   public async terminate(bundleId: string): Promise<void> {
+    this.invalidatePendingKeyboardFollowUp('terminate');
     const resolved = this.resolveBundleId(bundleId) ?? bundleId;
     try {
       debugDevice(`Terminating app: ${resolved}`);
@@ -543,7 +615,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     options?: IOSDeviceInputOpt,
     focusRestorePoint?: PointerPoint,
   ): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('new text input');
     if (!text) return;
 
     const shouldAutoDismissKeyboard =
@@ -582,7 +654,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
           'Failed to auto-dismiss the iOS keyboard: no supported dismissal control was found or the keyboard remained visible',
         );
       }
-      this.pendingKeyboardFocusRestorePoint = focusRestorePoint;
+      this.registerPendingKeyboardFollowUp(focusRestorePoint);
     }
   }
 
@@ -590,9 +662,15 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     const explicitTargetPoint = target
       ? { x: target.center[0], y: target.center[1] }
       : undefined;
-    const focusRestorePoint =
-      explicitTargetPoint ?? this.pendingKeyboardFocusRestorePoint;
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    let focusRestorePoint: PointerPoint | undefined;
+    if (explicitTargetPoint) {
+      this.invalidatePendingKeyboardFollowUp(
+        'keyboard press has an explicit target',
+      );
+      focusRestorePoint = explicitTargetPoint;
+    } else {
+      focusRestorePoint = this.consumePendingKeyboardFollowUp(key);
+    }
 
     if (focusRestorePoint) {
       debugDevice(
@@ -889,12 +967,12 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
 
   // iOS specific methods
   async home(): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('home');
     await this.wdaBackend.pressHomeButton();
   }
 
   async appSwitcher(): Promise<void> {
-    this.pendingKeyboardFocusRestorePoint = undefined;
+    this.invalidatePendingKeyboardFollowUp('app switcher');
     await this.wdaBackend.appSwitcher();
   }
 
@@ -907,6 +985,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
    * @throws When communication with WebDriverAgent fails.
    */
   async hideKeyboard(keyNames?: string[]): Promise<boolean> {
+    this.invalidatePendingKeyboardFollowUp('hide keyboard');
     try {
       debugDevice(
         keyNames && keyNames.length > 0
@@ -940,6 +1019,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
       waitTime?: number;
     },
   ): Promise<void> {
+    this.invalidatePendingKeyboardFollowUp('open URL');
     const opts = {
       useSafariAsBackup: true,
       waitTime: 2000,
@@ -971,6 +1051,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
    * @param url The URL to open
    */
   async openUrlViaSafari(url: string): Promise<void> {
+    this.invalidatePendingKeyboardFollowUp('open URL via Safari');
     try {
       debugDevice(`Opening URL via Safari: ${url}`);
 
@@ -1022,6 +1103,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     endpoint: string,
     data?: any,
   ): Promise<TResult> {
+    this.invalidatePendingKeyboardFollowUp('raw WDA request');
     return await this.wdaBackend.executeRequest<TResult>(
       method,
       endpoint,
@@ -1034,6 +1116,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
       return;
     }
 
+    this.invalidatePendingKeyboardFollowUp('destroy');
     try {
       // Stop the MJPEG frame source if it was started.
       this.mjpegFrameSource?.stop();

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -60,6 +60,8 @@ export class IOSDevice implements AbstractInterface {
    */
   openFrameSource?: AbstractInterface['openFrameSource'];
   private appNameMapping: Record<string, string> = {};
+  /** Input point blurred by auto-dismiss and eligible for one follow-up key. */
+  private pendingKeyboardFocusRestorePoint: PointerPoint | undefined;
   interfaceType: InterfaceType = 'ios';
   uri: string | undefined;
   options?: IOSDeviceOpt;
@@ -72,9 +74,13 @@ export class IOSDevice implements AbstractInterface {
       dragAndDrop: (from, to) => this.swipePoint(from, to, 1000),
     },
     keyboard: {
-      keyboardPress: (keyName) => this.pressKey(keyName),
+      keyboardPress: (keyName, opts) =>
+        this.pressKey(keyName, opts?.target as ElementInfo | undefined),
       typeText: async (value, opts) => {
         const target = opts?.target as ElementInfo | undefined;
+        const focusRestorePoint = target
+          ? { x: target.center[0], y: target.center[1] }
+          : undefined;
         if (target && opts?.replace !== false) {
           await this.clearInput(target);
         } else if (target) {
@@ -85,7 +91,7 @@ export class IOSDevice implements AbstractInterface {
           return;
         }
 
-        await this.typeText(value, opts);
+        await this.typeText(value, opts, focusRestorePoint);
       },
       clearInput: (target) =>
         this.clearInput(target as ElementInfo | undefined),
@@ -105,6 +111,7 @@ export class IOSDevice implements AbstractInterface {
         }
       },
       pinch: async (center, opts) => {
+        this.pendingKeyboardFocusRestorePoint = undefined;
         await this.wdaBackend.pinch(
           Math.round(center.x),
           Math.round(center.y),
@@ -120,11 +127,13 @@ export class IOSDevice implements AbstractInterface {
   };
 
   private async tapPoint(point: PointerPoint): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     debugDevice(`tap at coordinates (${point.x}, ${point.y})`);
     await this.wdaBackend.tap(Math.round(point.x), Math.round(point.y));
   }
 
   private async doubleTapPoint(point: PointerPoint): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     await this.wdaBackend.doubleTap(Math.round(point.x), Math.round(point.y));
   }
 
@@ -132,6 +141,7 @@ export class IOSDevice implements AbstractInterface {
     point: PointerPoint,
     duration = 1000,
   ): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     await this.wdaBackend.longPress(
       Math.round(point.x),
       Math.round(point.y),
@@ -144,6 +154,7 @@ export class IOSDevice implements AbstractInterface {
     end: PointerPoint,
     duration = 500,
   ): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     await this.wdaBackend.swipe(
       Math.round(start.x),
       Math.round(start.y),
@@ -530,7 +541,9 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
   private async typeText(
     text: string,
     options?: IOSDeviceInputOpt,
+    focusRestorePoint?: PointerPoint,
   ): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     if (!text) return;
 
     const shouldAutoDismissKeyboard =
@@ -569,10 +582,24 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
           'Failed to auto-dismiss the iOS keyboard: no supported dismissal control was found or the keyboard remained visible',
         );
       }
+      this.pendingKeyboardFocusRestorePoint = focusRestorePoint;
     }
   }
 
-  private async pressKey(key: string): Promise<void> {
+  private async pressKey(key: string, target?: ElementInfo): Promise<void> {
+    const explicitTargetPoint = target
+      ? { x: target.center[0], y: target.center[1] }
+      : undefined;
+    const focusRestorePoint =
+      explicitTargetPoint ?? this.pendingKeyboardFocusRestorePoint;
+    this.pendingKeyboardFocusRestorePoint = undefined;
+
+    if (focusRestorePoint) {
+      debugDevice(
+        `Restoring text input focus at (${focusRestorePoint.x}, ${focusRestorePoint.y}) before pressing ${key}`,
+      );
+      await this.tapPoint(focusRestorePoint);
+    }
     await this.wdaBackend.pressKey(key);
   }
 
@@ -862,10 +889,12 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
 
   // iOS specific methods
   async home(): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     await this.wdaBackend.pressHomeButton();
   }
 
   async appSwitcher(): Promise<void> {
+    this.pendingKeyboardFocusRestorePoint = undefined;
     await this.wdaBackend.appSwitcher();
   }
 
@@ -955,7 +984,7 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
       // to handle different Safari UI states (new tab, existing tab, etc.)
 
       // Type the URL in the address bar
-      await this.typeText(url);
+      await this.typeText(url, { autoDismissKeyboard: false });
       await sleep(500);
 
       // Press Return to navigate

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -1,5 +1,13 @@
 import { getDebug } from '@midscene/shared/logger';
 import { WebDriverClient } from '@midscene/webdriver';
+import {
+  type KeyboardAccessoryButton,
+  type WebDriverElementRect,
+  isKeyboardAccessoryToolbar,
+  isNamedDismissButtonNearKeyboard,
+  keyboardAccessoryToolbarGap,
+  selectKeyboardAccessoryDismissButton,
+} from './keyboard-dismiss';
 
 const debugIOS = getDebug('webdriver:ios');
 
@@ -8,22 +16,12 @@ const WDA_MJPEG_SCREENSHOT_QUALITY = 50;
 const WDA_MJPEG_FRAMERATE = 30;
 const WDA_MJPEG_SCALING_FACTOR = 50;
 const w3cElementId = 'element-6066-11e4-a52e-4f735466cecf';
-const keyboardDismissTimeoutMs = 2000;
+const keyboardDismissDeadlineMs = 5000;
 const keyboardDismissPollIntervalMs = 100;
-const keyboardAccessoryToolbarGeometry = {
-  minHeight: 24,
-  maxHeight: 80,
-  minHorizontalOverlap: 0.8,
-  minRightButtonCenterRatio: 0.65,
-  maxGap: 48,
-} as const;
-const keyboardNamedButtonMaxDistance = 100;
 
-type WebDriverElementRect = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+type FindElementIdsOptions = {
+  rootElementId?: string;
+  deadline?: number;
 };
 
 export class IOSWebDriverClient extends WebDriverClient {
@@ -354,27 +352,56 @@ export class IOSWebDriverClient extends WebDriverClient {
     });
   }
 
+  private remainingKeyboardDismissTimeout(deadline: number): number {
+    const remainingTimeout = deadline - Date.now();
+    if (remainingTimeout <= 0) {
+      throw new Error(
+        `iOS keyboard dismissal exceeded its ${keyboardDismissDeadlineMs}ms deadline`,
+      );
+    }
+    return Math.max(1, Math.ceil(remainingTimeout));
+  }
+
+  private async makeKeyboardDismissRequest(
+    method: 'GET' | 'POST',
+    endpoint: string,
+    data: unknown,
+    deadline?: number,
+  ): Promise<unknown> {
+    if (deadline === undefined) {
+      return await this.makeRequest(method, endpoint, data);
+    }
+    return await this.makeRequest(method, endpoint, data, {
+      timeout: this.remainingKeyboardDismissTimeout(deadline),
+    });
+  }
+
   private async findElementIds(
     using: string,
     value: string,
-    rootElementId?: string,
+    options: FindElementIdsOptions = {},
   ): Promise<string[]> {
-    const endpoint = rootElementId
-      ? `/session/${this.sessionId}/element/${rootElementId}/elements`
+    const endpoint = options.rootElementId
+      ? `/session/${this.sessionId}/element/${options.rootElementId}/elements`
       : `/session/${this.sessionId}/elements`;
-    const response = await this.makeRequest('POST', endpoint, {
-      using,
-      value,
-    });
+    const response = await this.makeKeyboardDismissRequest(
+      'POST',
+      endpoint,
+      { using, value },
+      options.deadline,
+    );
     return this.getElementIds(response);
   }
 
   private async getElementRect(
     elementId: string,
+    deadline?: number,
   ): Promise<WebDriverElementRect> {
-    const response = await this.makeRequest(
+    const response = await this.makeKeyboardDismissRequest(
       'GET',
       `/session/${this.sessionId}/element/${elementId}/rect`,
+      undefined,
+      deadline,
     );
     const rect = this.getResponseValue(response);
     if (
@@ -397,29 +424,37 @@ export class IOSWebDriverClient extends WebDriverClient {
     };
   }
 
-  private async clickElement(elementId: string): Promise<void> {
-    await this.makeRequest(
+  private async clickElement(
+    elementId: string,
+    deadline?: number,
+  ): Promise<void> {
+    await this.makeKeyboardDismissRequest(
       'POST',
       `/session/${this.sessionId}/element/${elementId}/click`,
+      undefined,
+      deadline,
     );
   }
 
-  private async findVisibleKeyboardIds(): Promise<string[]> {
+  private async findVisibleKeyboardIds(deadline?: number): Promise<string[]> {
     return await this.findElementIds(
       'predicate string',
       'type == "XCUIElementTypeKeyboard" AND visible == true',
+      { deadline },
     );
   }
 
-  private async getVisibleKeyboardRect(): Promise<WebDriverElementRect | null> {
-    const keyboardIds = await this.findVisibleKeyboardIds();
+  private async getVisibleKeyboardRect(
+    deadline?: number,
+  ): Promise<WebDriverElementRect | null> {
+    const keyboardIds = await this.findVisibleKeyboardIds(deadline);
     if (keyboardIds.length === 0) {
       return null;
     }
 
     const keyboardRects: WebDriverElementRect[] = [];
     for (const keyboardId of keyboardIds) {
-      const rect = await this.getElementRect(keyboardId);
+      const rect = await this.getElementRect(keyboardId, deadline);
       if (rect.width > 0 && rect.height > 0) {
         keyboardRects.push(rect);
       }
@@ -437,6 +472,7 @@ export class IOSWebDriverClient extends WebDriverClient {
   private async dismissKeyboardByName(
     keyNames: string[],
     keyboardRect: WebDriverElementRect,
+    deadline: number,
   ): Promise<boolean> {
     const predicateNames = keyNames
       .map(
@@ -446,26 +482,20 @@ export class IOSWebDriverClient extends WebDriverClient {
     const buttonIds = await this.findElementIds(
       'predicate string',
       `type IN {"XCUIElementTypeButton", "XCUIElementTypeKey"} AND enabled == true AND visible == true AND (name IN {${predicateNames}} OR label IN {${predicateNames}})`,
+      { deadline },
     );
     const nearbyButtons: Array<{
       id: string;
       distanceFromKeyboard: number;
     }> = [];
     for (const buttonId of buttonIds) {
-      const rect = await this.getElementRect(buttonId);
-      const centerX = rect.x + rect.width / 2;
-      const centerY = rect.y + rect.height / 2;
-      const isNearKeyboard =
-        rect.width > 0 &&
-        rect.height > 0 &&
-        centerX >= keyboardRect.x &&
-        centerX <= keyboardRect.x + keyboardRect.width &&
-        centerY >= keyboardRect.y - keyboardNamedButtonMaxDistance &&
-        centerY <= keyboardRect.y + keyboardRect.height;
-      if (isNearKeyboard) {
+      const rect = await this.getElementRect(buttonId, deadline);
+      if (isNamedDismissButtonNearKeyboard(rect, keyboardRect)) {
         nearbyButtons.push({
           id: buttonId,
-          distanceFromKeyboard: Math.abs(centerY - keyboardRect.y),
+          distanceFromKeyboard: Math.abs(
+            rect.y + rect.height / 2 - keyboardRect.y,
+          ),
         });
       }
     }
@@ -477,7 +507,7 @@ export class IOSWebDriverClient extends WebDriverClient {
       return false;
     }
 
-    await this.clickElement(dismissButton.id);
+    await this.clickElement(dismissButton.id, deadline);
     debugIOS(
       `Dismissed keyboard using configured button: ${keyNames.join(', ')}`,
     );
@@ -486,10 +516,12 @@ export class IOSWebDriverClient extends WebDriverClient {
 
   private async dismissKeyboardUsingAccessoryToolbar(
     keyboardRect: WebDriverElementRect,
+    deadline: number,
   ): Promise<boolean> {
     const toolbarIds = await this.findElementIds(
       'class name',
       'XCUIElementTypeToolbar',
+      { deadline },
     );
     const toolbarCandidates: Array<{
       id: string;
@@ -498,32 +530,16 @@ export class IOSWebDriverClient extends WebDriverClient {
     }> = [];
 
     for (const toolbarId of toolbarIds) {
-      const rect = await this.getElementRect(toolbarId);
-      const overlapWidth = Math.max(
-        0,
-        Math.min(rect.x + rect.width, keyboardRect.x + keyboardRect.width) -
-          Math.max(rect.x, keyboardRect.x),
-      );
-      const horizontalOverlap = overlapWidth / keyboardRect.width;
-      const gap = keyboardRect.y - (rect.y + rect.height);
-      const maxGap = Math.max(
-        keyboardAccessoryToolbarGeometry.maxGap,
-        rect.height,
-      );
-      const isKeyboardAccessory =
-        rect.width > 0 &&
-        rect.height >= keyboardAccessoryToolbarGeometry.minHeight &&
-        rect.height <= keyboardAccessoryToolbarGeometry.maxHeight &&
-        horizontalOverlap >=
-          keyboardAccessoryToolbarGeometry.minHorizontalOverlap &&
-        rect.y <= keyboardRect.y &&
-        gap >= -rect.height &&
-        gap <= maxGap;
-
-      if (isKeyboardAccessory) {
+      const rect = await this.getElementRect(toolbarId, deadline);
+      if (isKeyboardAccessoryToolbar(rect, keyboardRect)) {
+        const gap = keyboardAccessoryToolbarGap(rect, keyboardRect);
         toolbarCandidates.push({ id: toolbarId, rect, gap });
       }
     }
+
+    debugIOS(
+      `Found ${toolbarCandidates.length} standard keyboard accessory toolbar candidate(s) from ${toolbarIds.length} toolbar(s)`,
+    );
 
     toolbarCandidates.sort(
       (left, right) => Math.abs(left.gap) - Math.abs(right.gap),
@@ -533,43 +549,29 @@ export class IOSWebDriverClient extends WebDriverClient {
       const buttonIds = await this.findElementIds(
         'predicate string',
         'type == "XCUIElementTypeButton" AND enabled == true AND visible == true',
-        toolbar.id,
+        { rootElementId: toolbar.id, deadline },
       );
-      const rightSideButtons: Array<{
-        id: string;
-        rect: WebDriverElementRect;
-      }> = [];
+      const buttons: KeyboardAccessoryButton[] = [];
 
       for (const buttonId of buttonIds) {
-        const rect = await this.getElementRect(buttonId);
-        const centerX = rect.x + rect.width / 2;
-        const centerY = rect.y + rect.height / 2;
-        const isVisibleInsideToolbar =
-          rect.width > 0 &&
-          rect.height > 0 &&
-          centerX >=
-            toolbar.rect.x +
-              toolbar.rect.width *
-                keyboardAccessoryToolbarGeometry.minRightButtonCenterRatio &&
-          centerX <= toolbar.rect.x + toolbar.rect.width &&
-          centerY >= toolbar.rect.y &&
-          centerY <= toolbar.rect.y + toolbar.rect.height;
-
-        if (isVisibleInsideToolbar) {
-          rightSideButtons.push({ id: buttonId, rect });
-        }
+        buttons.push({
+          id: buttonId,
+          rect: await this.getElementRect(buttonId, deadline),
+        });
       }
 
-      rightSideButtons.sort(
-        (left, right) =>
-          right.rect.x + right.rect.width - (left.rect.x + left.rect.width),
+      const dismissButton = selectKeyboardAccessoryDismissButton(
+        toolbar.rect,
+        buttons,
       );
-      const dismissButton = rightSideButtons[0];
       if (!dismissButton) {
+        debugIOS(
+          `Rejected keyboard accessory toolbar ${toolbar.id}: expected left navigation controls and exactly one right-edge dismiss control`,
+        );
         continue;
       }
 
-      await this.clickElement(dismissButton.id);
+      await this.clickElement(dismissButton.id, deadline);
       debugIOS('Dismissed keyboard using the accessory toolbar button');
       return true;
     }
@@ -577,14 +579,20 @@ export class IOSWebDriverClient extends WebDriverClient {
     return false;
   }
 
-  private async waitForKeyboardToHide(): Promise<boolean> {
-    const deadline = Date.now() + keyboardDismissTimeoutMs;
+  private async waitForKeyboardToHide(deadline: number): Promise<boolean> {
     while (Date.now() < deadline) {
-      if (!(await this.isKeyboardVisible())) {
+      if ((await this.findVisibleKeyboardIds(deadline)).length === 0) {
         return true;
       }
+      const remainingTimeout = deadline - Date.now();
+      if (remainingTimeout <= 0) {
+        return false;
+      }
       await new Promise((resolve) =>
-        setTimeout(resolve, keyboardDismissPollIntervalMs),
+        setTimeout(
+          resolve,
+          Math.min(keyboardDismissPollIntervalMs, remainingTimeout),
+        ),
       );
     }
     return false;
@@ -593,9 +601,10 @@ export class IOSWebDriverClient extends WebDriverClient {
   /**
    * Hides the visible software keyboard and waits until WDA confirms it is gone.
    *
-   * By default this locates a full-width accessory toolbar next to the keyboard
-   * and clicks its rightmost enabled button without depending on localized text.
-   * Explicit key names are only matched within the keyboard's nearby region.
+   * By default this locates a standard accessory toolbar next to the keyboard.
+   * It requires left-side navigation controls and exactly one right-edge control
+   * before clicking, without depending on localized text. Explicit key names are
+   * only matched within the keyboard's nearby region.
    *
    * @returns `true` when the keyboard is hidden, or `false` when no supported
    * dismissal control exists or the keyboard remains visible after the timeout.
@@ -603,17 +612,30 @@ export class IOSWebDriverClient extends WebDriverClient {
    */
   async dismissKeyboard(keyNames?: string[]): Promise<boolean> {
     this.ensureSession();
+    const startedAt = Date.now();
+    const deadline = startedAt + keyboardDismissDeadlineMs;
 
-    const keyboardRect = await this.getVisibleKeyboardRect();
+    const keyboardRect = await this.getVisibleKeyboardRect(deadline);
     if (!keyboardRect) {
       return true;
     }
 
     const dismissalStarted =
       keyNames && keyNames.length > 0
-        ? await this.dismissKeyboardByName(keyNames, keyboardRect)
-        : await this.dismissKeyboardUsingAccessoryToolbar(keyboardRect);
-    return dismissalStarted ? await this.waitForKeyboardToHide() : false;
+        ? await this.dismissKeyboardByName(keyNames, keyboardRect, deadline)
+        : await this.dismissKeyboardUsingAccessoryToolbar(
+            keyboardRect,
+            deadline,
+          );
+    if (!dismissalStarted) {
+      return false;
+    }
+
+    const hidden = await this.waitForKeyboardToHide(deadline);
+    debugIOS(
+      `Keyboard dismissal ${hidden ? 'completed' : 'did not complete'} in ${Date.now() - startedAt}ms`,
+    );
+    return hidden;
   }
 
   /** Returns whether WDA currently exposes a visible software keyboard. */

--- a/packages/ios/src/ios-webdriver-client.ts
+++ b/packages/ios/src/ios-webdriver-client.ts
@@ -7,6 +7,24 @@ const debugIOS = getDebug('webdriver:ios');
 const WDA_MJPEG_SCREENSHOT_QUALITY = 50;
 const WDA_MJPEG_FRAMERATE = 30;
 const WDA_MJPEG_SCALING_FACTOR = 50;
+const w3cElementId = 'element-6066-11e4-a52e-4f735466cecf';
+const keyboardDismissTimeoutMs = 2000;
+const keyboardDismissPollIntervalMs = 100;
+const keyboardAccessoryToolbarGeometry = {
+  minHeight: 24,
+  maxHeight: 80,
+  minHorizontalOverlap: 0.8,
+  minRightButtonCenterRatio: 0.65,
+  maxGap: 48,
+} as const;
+const keyboardNamedButtonMaxDistance = 100;
+
+type WebDriverElementRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
 
 export class IOSWebDriverClient extends WebDriverClient {
   async launchApp(bundleId: string): Promise<void> {
@@ -300,23 +318,308 @@ export class IOSWebDriverClient extends WebDriverClient {
     return key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
   }
 
+  private getResponseValue(response: unknown): unknown {
+    if (typeof response !== 'object' || response === null) {
+      return response;
+    }
+    const responseRecord = response as Record<string, unknown>;
+    return 'value' in responseRecord ? responseRecord.value : response;
+  }
+
+  private getElementId(element: unknown): string | null {
+    if (typeof element !== 'object' || element === null) {
+      return null;
+    }
+    const elementRecord = element as Record<string, unknown>;
+    const elementId = elementRecord[w3cElementId] ?? elementRecord.ELEMENT;
+    return typeof elementId === 'string' ? elementId : null;
+  }
+
+  private getElementIds(response: unknown): string[] {
+    const elements = this.getResponseValue(response);
+    if (!Array.isArray(elements)) {
+      throw new Error(
+        `Unexpected WDA elements response: ${JSON.stringify(response)}`,
+      );
+    }
+
+    return elements.map((element, index) => {
+      const elementId = this.getElementId(element);
+      if (!elementId) {
+        throw new Error(
+          `WDA element at index ${index} has no element ID: ${JSON.stringify(element)}`,
+        );
+      }
+      return elementId;
+    });
+  }
+
+  private async findElementIds(
+    using: string,
+    value: string,
+    rootElementId?: string,
+  ): Promise<string[]> {
+    const endpoint = rootElementId
+      ? `/session/${this.sessionId}/element/${rootElementId}/elements`
+      : `/session/${this.sessionId}/elements`;
+    const response = await this.makeRequest('POST', endpoint, {
+      using,
+      value,
+    });
+    return this.getElementIds(response);
+  }
+
+  private async getElementRect(
+    elementId: string,
+  ): Promise<WebDriverElementRect> {
+    const response = await this.makeRequest(
+      'GET',
+      `/session/${this.sessionId}/element/${elementId}/rect`,
+    );
+    const rect = this.getResponseValue(response);
+    if (
+      typeof rect !== 'object' ||
+      rect === null ||
+      !['x', 'y', 'width', 'height'].every((key) =>
+        Number.isFinite((rect as Record<string, unknown>)[key]),
+      )
+    ) {
+      throw new Error(
+        `Unexpected WDA element rect response: ${JSON.stringify(response)}`,
+      );
+    }
+    const rectRecord = rect as Record<keyof WebDriverElementRect, number>;
+    return {
+      x: rectRecord.x,
+      y: rectRecord.y,
+      width: rectRecord.width,
+      height: rectRecord.height,
+    };
+  }
+
+  private async clickElement(elementId: string): Promise<void> {
+    await this.makeRequest(
+      'POST',
+      `/session/${this.sessionId}/element/${elementId}/click`,
+    );
+  }
+
+  private async findVisibleKeyboardIds(): Promise<string[]> {
+    return await this.findElementIds(
+      'predicate string',
+      'type == "XCUIElementTypeKeyboard" AND visible == true',
+    );
+  }
+
+  private async getVisibleKeyboardRect(): Promise<WebDriverElementRect | null> {
+    const keyboardIds = await this.findVisibleKeyboardIds();
+    if (keyboardIds.length === 0) {
+      return null;
+    }
+
+    const keyboardRects: WebDriverElementRect[] = [];
+    for (const keyboardId of keyboardIds) {
+      const rect = await this.getElementRect(keyboardId);
+      if (rect.width > 0 && rect.height > 0) {
+        keyboardRects.push(rect);
+      }
+    }
+
+    const keyboardRect = keyboardRects.sort(
+      (left, right) => right.width * right.height - left.width * left.height,
+    )[0];
+    if (!keyboardRect) {
+      throw new Error('WDA reported a visible keyboard without a valid rect');
+    }
+    return keyboardRect;
+  }
+
+  private async dismissKeyboardByName(
+    keyNames: string[],
+    keyboardRect: WebDriverElementRect,
+  ): Promise<boolean> {
+    const predicateNames = keyNames
+      .map(
+        (name) => `"${name.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`,
+      )
+      .join(', ');
+    const buttonIds = await this.findElementIds(
+      'predicate string',
+      `type IN {"XCUIElementTypeButton", "XCUIElementTypeKey"} AND enabled == true AND visible == true AND (name IN {${predicateNames}} OR label IN {${predicateNames}})`,
+    );
+    const nearbyButtons: Array<{
+      id: string;
+      distanceFromKeyboard: number;
+    }> = [];
+    for (const buttonId of buttonIds) {
+      const rect = await this.getElementRect(buttonId);
+      const centerX = rect.x + rect.width / 2;
+      const centerY = rect.y + rect.height / 2;
+      const isNearKeyboard =
+        rect.width > 0 &&
+        rect.height > 0 &&
+        centerX >= keyboardRect.x &&
+        centerX <= keyboardRect.x + keyboardRect.width &&
+        centerY >= keyboardRect.y - keyboardNamedButtonMaxDistance &&
+        centerY <= keyboardRect.y + keyboardRect.height;
+      if (isNearKeyboard) {
+        nearbyButtons.push({
+          id: buttonId,
+          distanceFromKeyboard: Math.abs(centerY - keyboardRect.y),
+        });
+      }
+    }
+    nearbyButtons.sort(
+      (left, right) => left.distanceFromKeyboard - right.distanceFromKeyboard,
+    );
+    const dismissButton = nearbyButtons[0];
+    if (!dismissButton) {
+      return false;
+    }
+
+    await this.clickElement(dismissButton.id);
+    debugIOS(
+      `Dismissed keyboard using configured button: ${keyNames.join(', ')}`,
+    );
+    return true;
+  }
+
+  private async dismissKeyboardUsingAccessoryToolbar(
+    keyboardRect: WebDriverElementRect,
+  ): Promise<boolean> {
+    const toolbarIds = await this.findElementIds(
+      'class name',
+      'XCUIElementTypeToolbar',
+    );
+    const toolbarCandidates: Array<{
+      id: string;
+      rect: WebDriverElementRect;
+      gap: number;
+    }> = [];
+
+    for (const toolbarId of toolbarIds) {
+      const rect = await this.getElementRect(toolbarId);
+      const overlapWidth = Math.max(
+        0,
+        Math.min(rect.x + rect.width, keyboardRect.x + keyboardRect.width) -
+          Math.max(rect.x, keyboardRect.x),
+      );
+      const horizontalOverlap = overlapWidth / keyboardRect.width;
+      const gap = keyboardRect.y - (rect.y + rect.height);
+      const maxGap = Math.max(
+        keyboardAccessoryToolbarGeometry.maxGap,
+        rect.height,
+      );
+      const isKeyboardAccessory =
+        rect.width > 0 &&
+        rect.height >= keyboardAccessoryToolbarGeometry.minHeight &&
+        rect.height <= keyboardAccessoryToolbarGeometry.maxHeight &&
+        horizontalOverlap >=
+          keyboardAccessoryToolbarGeometry.minHorizontalOverlap &&
+        rect.y <= keyboardRect.y &&
+        gap >= -rect.height &&
+        gap <= maxGap;
+
+      if (isKeyboardAccessory) {
+        toolbarCandidates.push({ id: toolbarId, rect, gap });
+      }
+    }
+
+    toolbarCandidates.sort(
+      (left, right) => Math.abs(left.gap) - Math.abs(right.gap),
+    );
+
+    for (const toolbar of toolbarCandidates) {
+      const buttonIds = await this.findElementIds(
+        'predicate string',
+        'type == "XCUIElementTypeButton" AND enabled == true AND visible == true',
+        toolbar.id,
+      );
+      const rightSideButtons: Array<{
+        id: string;
+        rect: WebDriverElementRect;
+      }> = [];
+
+      for (const buttonId of buttonIds) {
+        const rect = await this.getElementRect(buttonId);
+        const centerX = rect.x + rect.width / 2;
+        const centerY = rect.y + rect.height / 2;
+        const isVisibleInsideToolbar =
+          rect.width > 0 &&
+          rect.height > 0 &&
+          centerX >=
+            toolbar.rect.x +
+              toolbar.rect.width *
+                keyboardAccessoryToolbarGeometry.minRightButtonCenterRatio &&
+          centerX <= toolbar.rect.x + toolbar.rect.width &&
+          centerY >= toolbar.rect.y &&
+          centerY <= toolbar.rect.y + toolbar.rect.height;
+
+        if (isVisibleInsideToolbar) {
+          rightSideButtons.push({ id: buttonId, rect });
+        }
+      }
+
+      rightSideButtons.sort(
+        (left, right) =>
+          right.rect.x + right.rect.width - (left.rect.x + left.rect.width),
+      );
+      const dismissButton = rightSideButtons[0];
+      if (!dismissButton) {
+        continue;
+      }
+
+      await this.clickElement(dismissButton.id);
+      debugIOS('Dismissed keyboard using the accessory toolbar button');
+      return true;
+    }
+
+    return false;
+  }
+
+  private async waitForKeyboardToHide(): Promise<boolean> {
+    const deadline = Date.now() + keyboardDismissTimeoutMs;
+    while (Date.now() < deadline) {
+      if (!(await this.isKeyboardVisible())) {
+        return true;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, keyboardDismissPollIntervalMs),
+      );
+    }
+    return false;
+  }
+
+  /**
+   * Hides the visible software keyboard and waits until WDA confirms it is gone.
+   *
+   * By default this locates a full-width accessory toolbar next to the keyboard
+   * and clicks its rightmost enabled button without depending on localized text.
+   * Explicit key names are only matched within the keyboard's nearby region.
+   *
+   * @returns `true` when the keyboard is hidden, or `false` when no supported
+   * dismissal control exists or the keyboard remains visible after the timeout.
+   * @throws When WDA returns an invalid response or a request fails.
+   */
   async dismissKeyboard(keyNames?: string[]): Promise<boolean> {
     this.ensureSession();
 
-    try {
-      await this.makeRequest(
-        'POST',
-        `/session/${this.sessionId}/wda/keyboard/dismiss`,
-        {
-          keyNames: keyNames || ['done'],
-        },
-      );
-      debugIOS('Dismissed keyboard using WDA API');
+    const keyboardRect = await this.getVisibleKeyboardRect();
+    if (!keyboardRect) {
       return true;
-    } catch (error) {
-      debugIOS(`Failed to dismiss keyboard: ${error}`);
-      return false;
     }
+
+    const dismissalStarted =
+      keyNames && keyNames.length > 0
+        ? await this.dismissKeyboardByName(keyNames, keyboardRect)
+        : await this.dismissKeyboardUsingAccessoryToolbar(keyboardRect);
+    return dismissalStarted ? await this.waitForKeyboardToHide() : false;
+  }
+
+  /** Returns whether WDA currently exposes a visible software keyboard. */
+  async isKeyboardVisible(): Promise<boolean> {
+    this.ensureSession();
+    return (await this.findVisibleKeyboardIds()).length > 0;
   }
 
   /**

--- a/packages/ios/src/keyboard-dismiss.ts
+++ b/packages/ios/src/keyboard-dismiss.ts
@@ -1,0 +1,142 @@
+export type WebDriverElementRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type KeyboardAccessoryButton = {
+  id: string;
+  rect: WebDriverElementRect;
+};
+
+const keyboardAccessoryToolbarGeometry = {
+  minHeight: 24,
+  maxHeight: 80,
+  minHorizontalOverlap: 0.8,
+  minRightButtonCenterRatio: 0.65,
+  maxGap: 48,
+} as const;
+
+const keyboardNamedButtonMaxDistance = 100;
+
+const hasPositiveSize = (rect: WebDriverElementRect): boolean =>
+  rect.width > 0 && rect.height > 0;
+
+const centerOf = (rect: WebDriverElementRect) => ({
+  x: rect.x + rect.width / 2,
+  y: rect.y + rect.height / 2,
+});
+
+export function isNamedDismissButtonNearKeyboard(
+  buttonRect: WebDriverElementRect,
+  keyboardRect: WebDriverElementRect,
+): boolean {
+  if (!hasPositiveSize(buttonRect) || !hasPositiveSize(keyboardRect)) {
+    return false;
+  }
+
+  const buttonCenter = centerOf(buttonRect);
+  return (
+    buttonCenter.x >= keyboardRect.x &&
+    buttonCenter.x <= keyboardRect.x + keyboardRect.width &&
+    buttonCenter.y >= keyboardRect.y - keyboardNamedButtonMaxDistance &&
+    buttonCenter.y <= keyboardRect.y + keyboardRect.height
+  );
+}
+
+export function keyboardAccessoryToolbarGap(
+  toolbarRect: WebDriverElementRect,
+  keyboardRect: WebDriverElementRect,
+): number {
+  return keyboardRect.y - (toolbarRect.y + toolbarRect.height);
+}
+
+export function isKeyboardAccessoryToolbar(
+  toolbarRect: WebDriverElementRect,
+  keyboardRect: WebDriverElementRect,
+): boolean {
+  if (!hasPositiveSize(toolbarRect) || !hasPositiveSize(keyboardRect)) {
+    return false;
+  }
+
+  const overlapWidth = Math.max(
+    0,
+    Math.min(
+      toolbarRect.x + toolbarRect.width,
+      keyboardRect.x + keyboardRect.width,
+    ) - Math.max(toolbarRect.x, keyboardRect.x),
+  );
+  const horizontalOverlap = overlapWidth / keyboardRect.width;
+  const gap = keyboardAccessoryToolbarGap(toolbarRect, keyboardRect);
+  const maxGap = Math.max(
+    keyboardAccessoryToolbarGeometry.maxGap,
+    toolbarRect.height,
+  );
+
+  return (
+    toolbarRect.height >= keyboardAccessoryToolbarGeometry.minHeight &&
+    toolbarRect.height <= keyboardAccessoryToolbarGeometry.maxHeight &&
+    horizontalOverlap >=
+      keyboardAccessoryToolbarGeometry.minHorizontalOverlap &&
+    toolbarRect.y <= keyboardRect.y &&
+    gap >= -toolbarRect.height &&
+    gap <= maxGap
+  );
+}
+
+/**
+ * Selects the dismissal control only when a toolbar has the conservative shape
+ * used by the standard iOS keyboard accessory: navigation controls on the left
+ * and exactly one control aligned to the right edge.
+ */
+export function selectKeyboardAccessoryDismissButton(
+  toolbarRect: WebDriverElementRect,
+  buttons: readonly KeyboardAccessoryButton[],
+): KeyboardAccessoryButton | null {
+  if (!hasPositiveSize(toolbarRect)) {
+    return null;
+  }
+
+  const rightRegionStart =
+    toolbarRect.x +
+    toolbarRect.width *
+      keyboardAccessoryToolbarGeometry.minRightButtonCenterRatio;
+  const buttonsInsideToolbar = buttons.filter(({ rect }) => {
+    if (!hasPositiveSize(rect)) {
+      return false;
+    }
+    const center = centerOf(rect);
+    return (
+      center.x >= toolbarRect.x &&
+      center.x <= toolbarRect.x + toolbarRect.width &&
+      center.y >= toolbarRect.y &&
+      center.y <= toolbarRect.y + toolbarRect.height
+    );
+  });
+  const leftSideButtons = buttonsInsideToolbar.filter(
+    ({ rect }) => centerOf(rect).x < rightRegionStart,
+  );
+  const rightSideButtons = buttonsInsideToolbar.filter(
+    ({ rect }) => centerOf(rect).x >= rightRegionStart,
+  );
+
+  if (leftSideButtons.length === 0 || rightSideButtons.length !== 1) {
+    return null;
+  }
+
+  const dismissButton = rightSideButtons[0];
+  const rightEdgeGap =
+    toolbarRect.x +
+    toolbarRect.width -
+    (dismissButton.rect.x + dismissButton.rect.width);
+  const maxRightEdgeGap = Math.max(
+    toolbarRect.height,
+    dismissButton.rect.width,
+  );
+  if (rightEdgeGap < 0 || rightEdgeGap > maxRightEdgeGap) {
+    return null;
+  }
+
+  return dismissButton;
+}

--- a/packages/ios/tests/ai/ios-simulator-smoke.test.ts
+++ b/packages/ios/tests/ai/ios-simulator-smoke.test.ts
@@ -25,6 +25,11 @@ const REPORT_FILE_NAME = 'ios-simulator-smoke';
 const REPORT_HTML_FILE_NAME = `${REPORT_FILE_NAME}.html`;
 const INPUT_ACCESSIBILITY_ID = 'Midscene Smoke Input';
 const SUBMITTED_TEXT = 'Midscene iOS input 2026';
+const FIRST_DISMISS_INPUT_ACCESSIBILITY_ID = 'First keyboard dismissal input';
+const SECOND_DISMISS_INPUT_ACCESSIBILITY_ID = 'Second keyboard dismissal input';
+const FIRST_DISMISS_INPUT_TEXT = 'first field complete';
+const SECOND_DISMISS_INPUT_TEXT = 'second field remains active';
+const DELAYED_DISMISS_OBSERVATION_MS = 5_000;
 const POLL_INTERVAL_MS = 500;
 const TARGET_TIMEOUT_MS = 60_000;
 const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
@@ -200,6 +205,51 @@ async function startFixtureServer(): Promise<{
   };
 }
 
+async function startKeyboardDismissFixtureServer(): Promise<{
+  server: Server;
+  url: string;
+}> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+    });
+    response.end(`<!doctype html>
+<html lang="en">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Midscene iOS Keyboard Dismissal</title>
+  <style>
+    body { margin: 0; font: 20px -apple-system, sans-serif; background: #f4f7f5; color: #163020; }
+    main { padding: 64px 24px; }
+    label { display: block; margin: 24px 0 12px; font-weight: 700; }
+    input { box-sizing: border-box; width: 100%; padding: 16px; border: 3px solid #16813d; border-radius: 10px; font-size: 20px; }
+  </style>
+  <main>
+    <label for="first-input">First field</label>
+    <input id="first-input" aria-label="${FIRST_DISMISS_INPUT_ACCESSIBILITY_ID}" autocomplete="off">
+    <label for="second-input">Second field</label>
+    <input id="second-input" aria-label="${SECOND_DISMISS_INPUT_ACCESSIBILITY_ID}" autocomplete="off">
+  </main>
+</html>`);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error(
+      'Unable to determine iOS keyboard dismissal fixture server port',
+    );
+  }
+
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}/`,
+  };
+}
+
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
@@ -275,7 +325,185 @@ async function waitForSubmittedValue(
   return submittedValue();
 }
 
+async function isSoftwareKeyboardVisible(agent: IOSAgent): Promise<boolean> {
+  const response = (await agent.runWdaRequest({
+    method: 'POST',
+    endpoint: '/elements',
+    data: {
+      using: 'predicate string',
+      value: 'type == "XCUIElementTypeKeyboard" AND visible == true',
+    },
+  })) as WdaValueResponse<WdaElementValue[]>;
+  return response.value.length > 0;
+}
+
 describe.skipIf(!RUN_LIVE_SMOKE)('iOS Simulator live smoke', () => {
+  it('awaits auto-dismiss before a second input starts', async () => {
+    const diagnosticsEnv = process.env.MIDSCENE_IOS_DIAGNOSTICS_DIR;
+    if (!diagnosticsEnv) {
+      throw new Error(
+        'MIDSCENE_IOS_DIAGNOSTICS_DIR is required for the iOS Simulator smoke',
+      );
+    }
+
+    const diagnosticsDir = path.resolve(diagnosticsEnv);
+    const evidenceFile = path.join(
+      diagnosticsDir,
+      'keyboard-dismiss-evidence.json',
+    );
+    const firstDismissedScreenshotFile = path.join(
+      diagnosticsDir,
+      'keyboard-after-first-dismiss.png',
+    );
+    const secondVisibleScreenshotFile = path.join(
+      diagnosticsDir,
+      'keyboard-second-input-visible.png',
+    );
+    const finalScreenshotFile = path.join(
+      diagnosticsDir,
+      'keyboard-final-hidden.png',
+    );
+    const sourceFile = path.join(diagnosticsDir, 'keyboard-dismiss-source.xml');
+    const evidence: Record<string, unknown> = {
+      observationWindowMs: DELAYED_DISMISS_OBSERVATION_MS,
+    };
+
+    let agent: IOSAgent | undefined;
+    let fixture:
+      | Awaited<ReturnType<typeof startKeyboardDismissFixtureServer>>
+      | undefined;
+    await mkdir(diagnosticsDir, { recursive: true });
+
+    try {
+      fixture = await startKeyboardDismissFixtureServer();
+      evidence.fixtureUrl = fixture.url;
+      agent = await agentFromWebDriverAgent({
+        wdaHost: '127.0.0.1',
+        modelConfig: {
+          [MIDSCENE_MODEL_NAME]: 'ios-ci-model-must-not-run',
+          [MIDSCENE_MODEL_API_KEY]: 'ios-ci-unused-key',
+          [MIDSCENE_MODEL_BASE_URL]: 'http://127.0.0.1:1/v1',
+          [MIDSCENE_MODEL_FAMILY]: 'qwen3-vl',
+          [MIDSCENE_MODEL_TIMEOUT]: '1000',
+          [MIDSCENE_MODEL_RETRY_COUNT]: '0',
+        },
+        autoPrintReportMsg: false,
+        generateReport: false,
+        waitAfterAction: 200,
+      });
+
+      await agent.launch(fixture.url);
+      const firstTarget = await waitForElementRect(
+        agent,
+        sourceFile,
+        FIRST_DISMISS_INPUT_ACCESSIBILITY_ID,
+        'XCUIElementTypeTextField',
+      );
+      const secondTarget = await waitForElementRect(
+        agent,
+        sourceFile,
+        SECOND_DISMISS_INPUT_ACCESSIBILITY_ID,
+        'XCUIElementTypeTextField',
+      );
+      const screenSize = await agent.interface.getScreenSize();
+      const firstLocate = locate(
+        firstTarget.rect,
+        screenSize.scale,
+        FIRST_DISMISS_INPUT_ACCESSIBILITY_ID,
+      );
+      const secondLocate = locate(
+        secondTarget.rect,
+        screenSize.scale,
+        SECOND_DISMISS_INPUT_ACCESSIBILITY_ID,
+      );
+
+      await agent.callActionInActionSpace('Tap', { locate: firstLocate });
+      const firstDismissStartedAt = Date.now();
+      await agent.callActionInActionSpace('Input', {
+        value: FIRST_DISMISS_INPUT_TEXT,
+        mode: 'replace',
+        autoDismissKeyboard: true,
+        locate: firstLocate,
+      });
+      evidence.firstDismissElapsedMs = Date.now() - firstDismissStartedAt;
+      expect(await isSoftwareKeyboardVisible(agent)).toBe(false);
+      await agent.interface
+        .screenshotBase64()
+        .then((base64) =>
+          writeFile(firstDismissedScreenshotFile, screenshotBuffer(base64)),
+        );
+
+      await agent.callActionInActionSpace('Tap', { locate: secondLocate });
+      await agent.callActionInActionSpace('Input', {
+        value: SECOND_DISMISS_INPUT_TEXT,
+        mode: 'replace',
+        autoDismissKeyboard: false,
+        locate: secondLocate,
+      });
+      await sleep(DELAYED_DISMISS_OBSERVATION_MS);
+      expect(await isSoftwareKeyboardVisible(agent)).toBe(true);
+      await agent.interface
+        .screenshotBase64()
+        .then((base64) =>
+          writeFile(secondVisibleScreenshotFile, screenshotBuffer(base64)),
+        );
+
+      const sourceResponse = (await agent.runWdaRequest({
+        method: 'GET',
+        endpoint: '/source',
+      })) as WdaValueResponse<string>;
+      await writeFile(sourceFile, sourceResponse.value, 'utf8');
+      const firstValue = readIOSSimulatorInputValue(
+        sourceResponse.value,
+        FIRST_DISMISS_INPUT_ACCESSIBILITY_ID,
+      );
+      const secondValue = readIOSSimulatorInputValue(
+        sourceResponse.value,
+        SECOND_DISMISS_INPUT_ACCESSIBILITY_ID,
+      );
+      evidence.values = { firstValue, secondValue };
+      expect(firstValue).toBe(FIRST_DISMISS_INPUT_TEXT);
+      expect(secondValue).toBe(SECOND_DISMISS_INPUT_TEXT);
+
+      expect(await agent.interface.hideKeyboard()).toBe(true);
+      expect(await isSoftwareKeyboardVisible(agent)).toBe(false);
+      await agent.interface
+        .screenshotBase64()
+        .then((base64) =>
+          writeFile(finalScreenshotFile, screenshotBuffer(base64)),
+        );
+      evidence.screenshots = {
+        firstDismissedScreenshotFile,
+        secondVisibleScreenshotFile,
+        finalScreenshotFile,
+      };
+      evidence.modelCalls = agent.metrics.calls;
+      expect(agent.metrics.calls).toBe(0);
+    } catch (error) {
+      evidence.error =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : String(error);
+      throw error;
+    } finally {
+      if (agent) {
+        await agent.destroy().catch((error) => {
+          evidence.agentDestroyError = String(error);
+        });
+      }
+      if (fixture) {
+        await closeServer(fixture.server).catch((error) => {
+          evidence.fixtureServerCloseError = String(error);
+        });
+      }
+      await writeFile(
+        evidenceFile,
+        `${JSON.stringify(evidence, null, 2)}\n`,
+        'utf8',
+      );
+    }
+  });
+
   it('drives Safari through WDA without calling a model and emits evidence', async () => {
     const diagnosticsEnv = process.env.MIDSCENE_IOS_DIAGNOSTICS_DIR;
     if (!diagnosticsEnv) {

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -283,6 +283,73 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
     });
 
+    it('should not restore an auto-dismissed target for a non-submit key', async () => {
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device.inputPrimitives.keyboard.keyboardPress('Backspace');
+
+      expect(mockWdaClient.tap).not.toHaveBeenCalled();
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Backspace');
+    });
+
+    it('should discard an expired keyboard follow-up target', async () => {
+      const nowSpy = rs.spyOn(Date, 'now').mockReturnValue(1_000);
+      try {
+        await device.inputPrimitives.keyboard.typeText('draft task', {
+          target: { center: [30, 40] },
+          replace: false,
+        } as any);
+        mockWdaClient.tap.mockClear();
+        nowSpy.mockReturnValue(31_001);
+
+        await device.inputPrimitives.keyboard.keyboardPress('Enter');
+
+        expect(mockWdaClient.tap).not.toHaveBeenCalled();
+        expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('should restore focus for a following Tab navigation key', async () => {
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device.inputPrimitives.keyboard.keyboardPress('Tab');
+
+      expect(mockWdaClient.tap).toHaveBeenCalledWith(30, 40);
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Tab');
+    });
+
+    it('should discard a pending target before a custom action', async () => {
+      const customCall = rs.fn().mockResolvedValue(undefined);
+      (device as any).customActions = [
+        { name: 'CustomMutation', call: customCall },
+      ];
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device
+        .actionSpace()
+        .find(({ name }) => name === 'CustomMutation')
+        ?.call(undefined, mockExecutorContext);
+      await device.inputPrimitives.keyboard.keyboardPress('Enter');
+
+      expect(customCall).toHaveBeenCalledOnce();
+      expect(mockWdaClient.tap).not.toHaveBeenCalled();
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+    });
+
     it('should not restore focus when auto-dismiss is disabled', async () => {
       await device.inputPrimitives.keyboard.typeText('draft task', {
         target: { center: [30, 40] },

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -48,6 +48,7 @@ describe('IOSDevice', () => {
       terminateApp: rs.fn().mockResolvedValue(undefined),
       openUrl: rs.fn().mockResolvedValue(undefined),
       dismissKeyboard: rs.fn().mockResolvedValue(true),
+      isKeyboardVisible: rs.fn().mockResolvedValue(false),
       makeRequest: rs.fn().mockResolvedValue(null),
       sessionInfo: {
         sessionId: 'test-session-id',
@@ -549,34 +550,30 @@ describe('IOSDevice', () => {
     });
 
     it('should handle keyboard dismissal with default strategy', async () => {
-      // Mock dismissKeyboard to fail so it falls back to swipe gesture
-      mockWdaClient.dismissKeyboard = rs
-        .fn()
-        .mockRejectedValue(new Error('dismissKeyboard not available'));
-      mockWdaClient.getWindowSize = rs
-        .fn()
-        .mockResolvedValue({ width: 375, height: 812 });
-      mockWdaClient.swipe = rs.fn().mockResolvedValue(undefined);
-
       const result = await device.hideKeyboard();
       expect(result).toBe(true);
-      expect(mockWdaClient.swipe).toHaveBeenCalled();
+      expect(mockWdaClient.dismissKeyboard).toHaveBeenCalledWith(undefined);
+      expect(mockWdaClient.swipe).not.toHaveBeenCalled();
     });
 
     it('should handle keyboard dismissal failure', async () => {
-      // Mock both dismissKeyboard and swipe to fail to simulate total failure
-      mockWdaClient.dismissKeyboard = rs
-        .fn()
-        .mockRejectedValue(new Error('dismissKeyboard failed'));
-      mockWdaClient.getWindowSize = rs
-        .fn()
-        .mockResolvedValue({ width: 375, height: 812 });
-      mockWdaClient.swipe = rs
-        .fn()
-        .mockRejectedValue(new Error('Swipe failed'));
+      mockWdaClient.isKeyboardVisible = rs.fn().mockResolvedValue(true);
+      mockWdaClient.dismissKeyboard = rs.fn().mockResolvedValue(false);
 
       const result = await device.hideKeyboard();
-      expect(result).toBe(false); // Method returns false on failure, doesn't throw
+      expect(result).toBe(false);
+      expect(mockWdaClient.dismissKeyboard).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should verify a custom dismiss button actually hid the keyboard', async () => {
+      mockWdaClient.dismissKeyboard = rs.fn().mockResolvedValue(true);
+
+      const result = await device.hideKeyboard(['Close Keyboard']);
+
+      expect(result).toBe(true);
+      expect(mockWdaClient.dismissKeyboard).toHaveBeenCalledWith([
+        'Close Keyboard',
+      ]);
     });
 
     it('should auto-dismiss keyboard after text input when enabled', async () => {
@@ -585,9 +582,7 @@ describe('IOSDevice', () => {
         ...mockWdaClient,
         createSession: rs.fn().mockResolvedValue({ sessionId: 'test-session' }),
         typeText: rs.fn().mockResolvedValue(undefined),
-        dismissKeyboard: rs
-          .fn()
-          .mockRejectedValue(new Error('dismissKeyboard not available')),
+        dismissKeyboard: rs.fn().mockResolvedValue(true),
         getWindowSize: rs.fn().mockResolvedValue({ width: 375, height: 812 }),
         getScreenScale: rs.fn().mockResolvedValue(2),
         swipe: rs.fn().mockResolvedValue(undefined),
@@ -602,9 +597,29 @@ describe('IOSDevice', () => {
       await deviceWithAutoDismiss.connect();
       await getInternalTextInput(deviceWithAutoDismiss).typeText('test text');
 
-      // Should call typeText and swipe (for keyboard dismiss)
+      // Should type and synchronously dismiss through a visible keyboard button.
       expect(mockBackend.typeText).toHaveBeenCalledWith('test text');
-      expect(mockBackend.swipe).toHaveBeenCalled();
+      expect(mockBackend.dismissKeyboard).toHaveBeenCalled();
+      expect(mockBackend.swipe).not.toHaveBeenCalled();
+    });
+
+    it('should reject input when auto-dismiss cannot hide the keyboard', async () => {
+      mockWdaClient.isKeyboardVisible = rs.fn().mockResolvedValue(true);
+      mockWdaClient.dismissKeyboard = rs.fn().mockResolvedValue(false);
+
+      await expect(
+        getInternalTextInput(device).typeText('test text'),
+      ).rejects.toThrow('Failed to auto-dismiss the iOS keyboard');
+    });
+
+    it('should preserve WDA dismissal errors', async () => {
+      mockWdaClient.dismissKeyboard = rs
+        .fn()
+        .mockRejectedValue(new Error('WDA transport failed'));
+
+      await expect(device.hideKeyboard()).rejects.toThrow(
+        'Failed to hide the iOS keyboard through WDA: Error: WDA transport failed',
+      );
     });
   });
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -253,6 +253,58 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(1, 'from action');
       expect(mockWdaClient.typeText).toHaveBeenNthCalledWith(2, 'from pointer');
     });
+
+    it('should restore an auto-dismissed input target before a following key press', async () => {
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device.inputPrimitives.keyboard.keyboardPress('Enter');
+
+      expect(mockWdaClient.tap).toHaveBeenCalledOnce();
+      expect(mockWdaClient.tap).toHaveBeenCalledWith(30, 40);
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+    });
+
+    it('should discard a pending focus restore after another pointer tap', async () => {
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device.inputPrimitives.pointer.tap({ x: 100, y: 200 });
+      await device.inputPrimitives.keyboard.keyboardPress('Enter');
+
+      expect(mockWdaClient.tap).toHaveBeenCalledOnce();
+      expect(mockWdaClient.tap).toHaveBeenCalledWith(100, 200);
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+    });
+
+    it('should not restore focus when auto-dismiss is disabled', async () => {
+      await device.inputPrimitives.keyboard.typeText('draft task', {
+        target: { center: [30, 40] },
+        replace: false,
+        autoDismissKeyboard: false,
+      } as any);
+      mockWdaClient.tap.mockClear();
+
+      await device.inputPrimitives.keyboard.keyboardPress('Enter');
+
+      expect(mockWdaClient.tap).not.toHaveBeenCalled();
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+    });
+
+    it('should focus an explicit keyboard press target', async () => {
+      await device.inputPrimitives.keyboard.keyboardPress('Enter', {
+        target: { center: [50, 60] },
+      } as any);
+
+      expect(mockWdaClient.tap).toHaveBeenCalledWith(50, 60);
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+    });
   });
 
   describe('Device Operations', () => {
@@ -378,6 +430,8 @@ describe('IOSDevice', () => {
       expect(mockWdaClient.launchApp).toHaveBeenCalledWith(
         'com.apple.mobilesafari',
       );
+      expect(mockWdaClient.dismissKeyboard).not.toHaveBeenCalled();
+      expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Return');
     });
 
     it('should perform tap operation', async () => {

--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -247,8 +247,15 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
         undefined,
         { timeout: expect.any(Number) },
       );
-      for (const call of makeRequestSpy.mock.calls) {
+      const requestCalls = makeRequestSpy.mock.calls as unknown as Array<
+        [string, string, unknown, { timeout?: number }?]
+      >;
+      for (const call of requestCalls) {
         const timeout = call[3]?.timeout;
+        expect(typeof timeout).toBe('number');
+        if (typeof timeout !== 'number') {
+          throw new Error('Expected keyboard dismissal request timeout');
+        }
         expect(timeout).toBeGreaterThan(0);
         expect(timeout).toBeLessThanOrEqual(5000);
       }
@@ -274,8 +281,11 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
 
       await expect(client.dismissKeyboard()).resolves.toBe(false);
       expect(makeRequestSpy).toHaveBeenCalledTimes(6);
+      const requestCalls = makeRequestSpy.mock.calls as unknown as Array<
+        [string, string, ...unknown[]]
+      >;
       expect(
-        makeRequestSpy.mock.calls.some(([method, endpoint]) =>
+        requestCalls.some(([method, endpoint]) =>
           method === 'POST' ? endpoint.endsWith('/click') : false,
         ),
       ).toBe(false);

--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -227,6 +227,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
           using: 'predicate string',
           value: 'type == "XCUIElementTypeKeyboard" AND visible == true',
         },
+        { timeout: expect.any(Number) },
       );
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
         5,
@@ -237,14 +238,47 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
           value:
             'type == "XCUIElementTypeButton" AND enabled == true AND visible == true',
         },
+        { timeout: expect.any(Number) },
       );
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
         8,
         'POST',
         '/session/test-session-id/element/dismiss-id/click',
+        undefined,
+        { timeout: expect.any(Number) },
       );
+      for (const call of makeRequestSpy.mock.calls) {
+        const timeout = call[3]?.timeout;
+        expect(timeout).toBeGreaterThan(0);
+        expect(timeout).toBeLessThanOrEqual(5000);
+      }
       expect(JSON.stringify(makeRequestSpy.mock.calls)).not.toContain('Done');
       expect(JSON.stringify(makeRequestSpy.mock.calls)).not.toContain('完成');
+    });
+
+    it('should not click a custom accessory toolbar without left navigation controls', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'toolbar-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 508, width: 402, height: 48 },
+        })
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'submit-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 341, y: 513, width: 40, height: 38 },
+        });
+
+      await expect(client.dismissKeyboard()).resolves.toBe(false);
+      expect(makeRequestSpy).toHaveBeenCalledTimes(6);
+      expect(
+        makeRequestSpy.mock.calls.some(([method, endpoint]) =>
+          method === 'POST' ? endpoint.endsWith('/click') : false,
+        ),
+      ).toBe(false);
     });
 
     it('should return false when no accessory toolbar is next to the keyboard', async () => {
@@ -306,11 +340,14 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
           value:
             'type IN {"XCUIElementTypeButton", "XCUIElementTypeKey"} AND enabled == true AND visible == true AND (name IN {"Done", "完成"} OR label IN {"Done", "完成"})',
         },
+        { timeout: expect.any(Number) },
       );
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
         5,
         'POST',
         '/session/test-session-id/element/done-button-id/click',
+        undefined,
+        { timeout: expect.any(Number) },
       );
     });
 
@@ -378,7 +415,10 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
           value: { x: 0, y: 508, width: 402, height: 48 },
         })
         .mockResolvedValueOnce({
-          value: [{ ELEMENT: 'dismiss-id' }],
+          value: [{ ELEMENT: 'previous-id' }, { ELEMENT: 'dismiss-id' }],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 21, y: 513, width: 41, height: 38 },
         })
         .mockResolvedValueOnce({
           value: { x: 341, y: 513, width: 40, height: 38 },
@@ -388,7 +428,7 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
 
       try {
         const dismissalPromise = client.dismissKeyboard();
-        await rs.advanceTimersByTimeAsync(2100);
+        await rs.advanceTimersByTimeAsync(5100);
 
         await expect(dismissalPromise).resolves.toBe(false);
         expect(makeRequestSpy.mock.calls.length).toBeGreaterThan(8);

--- a/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
+++ b/packages/ios/tests/unit-test/ios-webdriver-client-compatibility.test.ts
@@ -142,6 +142,262 @@ describe('IOSWebDriverClient - WDA 5.x-7.x Compatibility', () => {
     });
   });
 
+  describe('isKeyboardVisible()', () => {
+    it('should query WDA for keyboard elements', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValue({ value: [{ ELEMENT: 'keyboard-id' }] });
+
+      await expect(client.isKeyboardVisible()).resolves.toBe(true);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/session/test-session-id/elements',
+        {
+          using: 'predicate string',
+          value: 'type == "XCUIElementTypeKeyboard" AND visible == true',
+        },
+      );
+    });
+
+    it('should return false when WDA finds no keyboard elements', async () => {
+      rs.spyOn(client as any, 'makeRequest').mockResolvedValue({ value: [] });
+
+      await expect(client.isKeyboardVisible()).resolves.toBe(false);
+    });
+
+    it('should reject malformed WDA responses', async () => {
+      rs.spyOn(client as any, 'makeRequest').mockResolvedValue({
+        value: { unexpected: true },
+      });
+
+      await expect(client.isKeyboardVisible()).rejects.toThrow(
+        'Unexpected WDA elements response',
+      );
+    });
+
+    it('should reject element entries without an ID', async () => {
+      rs.spyOn(client as any, 'makeRequest').mockResolvedValue({
+        value: [{ unexpected: true }],
+      });
+
+      await expect(client.isKeyboardVisible()).rejects.toThrow(
+        'WDA element at index 0 has no element ID',
+      );
+    });
+  });
+
+  describe('dismissKeyboard()', () => {
+    it('should locate the accessory toolbar structurally and click its rightmost button', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({
+          value: [{ ELEMENT: 'keyboard-id' }],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({
+          value: [
+            {
+              'element-6066-11e4-a52e-4f735466cecf': 'toolbar-id',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 508, width: 402, height: 48 },
+        })
+        .mockResolvedValueOnce({
+          value: [{ ELEMENT: 'previous-id' }, { ELEMENT: 'dismiss-id' }],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 21, y: 513, width: 41, height: 38 },
+        })
+        .mockResolvedValueOnce({
+          value: { x: 341, y: 513, width: 40, height: 38 },
+        })
+        .mockResolvedValueOnce({ value: null })
+        .mockResolvedValueOnce({ value: [] });
+
+      await expect(client.dismissKeyboard()).resolves.toBe(true);
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        1,
+        'POST',
+        '/session/test-session-id/elements',
+        {
+          using: 'predicate string',
+          value: 'type == "XCUIElementTypeKeyboard" AND visible == true',
+        },
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        5,
+        'POST',
+        '/session/test-session-id/element/toolbar-id/elements',
+        {
+          using: 'predicate string',
+          value:
+            'type == "XCUIElementTypeButton" AND enabled == true AND visible == true',
+        },
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        8,
+        'POST',
+        '/session/test-session-id/element/dismiss-id/click',
+      );
+      expect(JSON.stringify(makeRequestSpy.mock.calls)).not.toContain('Done');
+      expect(JSON.stringify(makeRequestSpy.mock.calls)).not.toContain('完成');
+    });
+
+    it('should return false when no accessory toolbar is next to the keyboard', async () => {
+      rs.spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [] });
+
+      await expect(client.dismissKeyboard()).resolves.toBe(false);
+    });
+
+    it('should ignore a full-width toolbar that is not next to the keyboard', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'toolbar-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 100, width: 402, height: 48 },
+        });
+
+      await expect(client.dismissKeyboard()).resolves.toBe(false);
+      expect(makeRequestSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it('should return true when the keyboard is already hidden', async () => {
+      rs.spyOn(client as any, 'makeRequest').mockResolvedValue({ value: [] });
+
+      await expect(client.dismissKeyboard()).resolves.toBe(true);
+    });
+
+    it('should use names only when the caller explicitly configures them', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'done-button-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 341, y: 513, width: 40, height: 38 },
+        })
+        .mockResolvedValueOnce({ value: null })
+        .mockResolvedValueOnce({ value: [] });
+
+      await expect(client.dismissKeyboard(['Done', '完成'])).resolves.toBe(
+        true,
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        3,
+        'POST',
+        '/session/test-session-id/elements',
+        {
+          using: 'predicate string',
+          value:
+            'type IN {"XCUIElementTypeButton", "XCUIElementTypeKey"} AND enabled == true AND visible == true AND (name IN {"Done", "完成"} OR label IN {"Done", "完成"})',
+        },
+      );
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        5,
+        'POST',
+        '/session/test-session-id/element/done-button-id/click',
+      );
+    });
+
+    it('should not click a configured app button far from the keyboard', async () => {
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'app-done-button-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 320, y: 200, width: 60, height: 40 },
+        });
+
+      await expect(client.dismissKeyboard(['Done'])).resolves.toBe(false);
+      expect(makeRequestSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it('should return false when no dismiss button is found', async () => {
+      rs.spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({ value: [] });
+
+      await expect(client.dismissKeyboard(['Done'])).resolves.toBe(false);
+    });
+
+    it('should propagate WDA request errors', async () => {
+      rs.spyOn(client as any, 'makeRequest').mockRejectedValue(
+        new Error('WDA transport failed'),
+      );
+
+      await expect(client.dismissKeyboard()).rejects.toThrow(
+        'WDA transport failed',
+      );
+    });
+
+    it('should reject a visible keyboard without a usable rect', async () => {
+      rs.spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 0, width: 0, height: 0 },
+        });
+
+      await expect(client.dismissKeyboard()).rejects.toThrow(
+        'WDA reported a visible keyboard without a valid rect',
+      );
+    });
+
+    it('should return false when the keyboard remains visible after dismissal', async () => {
+      rs.useFakeTimers();
+      const makeRequestSpy = rs
+        .spyOn(client as any, 'makeRequest')
+        .mockResolvedValueOnce({ value: [{ ELEMENT: 'keyboard-id' }] })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 583, width: 402, height: 233 },
+        })
+        .mockResolvedValueOnce({
+          value: [{ ELEMENT: 'toolbar-id' }],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 0, y: 508, width: 402, height: 48 },
+        })
+        .mockResolvedValueOnce({
+          value: [{ ELEMENT: 'dismiss-id' }],
+        })
+        .mockResolvedValueOnce({
+          value: { x: 341, y: 513, width: 40, height: 38 },
+        })
+        .mockResolvedValueOnce({ value: null })
+        .mockResolvedValue({ value: [{ ELEMENT: 'keyboard-id' }] });
+
+      try {
+        const dismissalPromise = client.dismissKeyboard();
+        await rs.advanceTimersByTimeAsync(2100);
+
+        await expect(dismissalPromise).resolves.toBe(false);
+        expect(makeRequestSpy.mock.calls.length).toBeGreaterThan(8);
+      } finally {
+        rs.useRealTimers();
+      }
+    });
+  });
+
   describe('getScreenScale() fallback logic', () => {
     it('should return scale when endpoint succeeds with scale value', async () => {
       const makeRequestSpy = rs.spyOn(client as any, 'makeRequest');

--- a/packages/ios/tests/unit-test/keyboard-dismiss.test.ts
+++ b/packages/ios/tests/unit-test/keyboard-dismiss.test.ts
@@ -1,0 +1,96 @@
+import {
+  type KeyboardAccessoryButton,
+  type WebDriverElementRect,
+  isKeyboardAccessoryToolbar,
+  isNamedDismissButtonNearKeyboard,
+  selectKeyboardAccessoryDismissButton,
+} from '@/keyboard-dismiss';
+import { describe, expect, it } from '@rstest/core';
+
+const keyboardRect: WebDriverElementRect = {
+  x: 0,
+  y: 583,
+  width: 402,
+  height: 233,
+};
+const toolbarRect: WebDriverElementRect = {
+  x: 0,
+  y: 508,
+  width: 402,
+  height: 48,
+};
+const leftButton: KeyboardAccessoryButton = {
+  id: 'previous',
+  rect: { x: 21, y: 513, width: 41, height: 38 },
+};
+const rightButton: KeyboardAccessoryButton = {
+  id: 'dismiss',
+  rect: { x: 341, y: 513, width: 40, height: 38 },
+};
+
+describe('keyboard dismissal geometry', () => {
+  it('recognizes a toolbar adjacent to the keyboard in portrait and landscape', () => {
+    expect(isKeyboardAccessoryToolbar(toolbarRect, keyboardRect)).toBe(true);
+    expect(
+      isKeyboardAccessoryToolbar(
+        { x: 0, y: 254, width: 844, height: 48 },
+        { x: 0, y: 302, width: 844, height: 88 },
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['far above the keyboard', { ...toolbarRect, y: 100 }],
+    ['too tall', { ...toolbarRect, height: 120 }],
+    ['insufficiently overlapping', { ...toolbarRect, x: 250, width: 152 }],
+    ['empty', { ...toolbarRect, width: 0 }],
+  ])('rejects a toolbar that is %s', (_description, candidate) => {
+    expect(isKeyboardAccessoryToolbar(candidate, keyboardRect)).toBe(false);
+  });
+
+  it('selects one right-edge control when navigation controls exist on the left', () => {
+    expect(
+      selectKeyboardAccessoryDismissButton(toolbarRect, [
+        leftButton,
+        rightButton,
+      ]),
+    ).toEqual(rightButton);
+  });
+
+  it('rejects a custom toolbar with only a right-side business action', () => {
+    expect(
+      selectKeyboardAccessoryDismissButton(toolbarRect, [rightButton]),
+    ).toBeNull();
+  });
+
+  it('rejects an ambiguous toolbar with multiple right-side controls', () => {
+    expect(
+      selectKeyboardAccessoryDismissButton(toolbarRect, [
+        leftButton,
+        { id: 'save', rect: { x: 275, y: 513, width: 45, height: 38 } },
+        rightButton,
+      ]),
+    ).toBeNull();
+  });
+
+  it('rejects a right-side control that is not aligned to the right edge', () => {
+    expect(
+      selectKeyboardAccessoryDismissButton(toolbarRect, [
+        leftButton,
+        { id: 'submit', rect: { x: 265, y: 513, width: 40, height: 38 } },
+      ]),
+    ).toBeNull();
+  });
+
+  it('accepts configured controls only inside the keyboard region', () => {
+    expect(
+      isNamedDismissButtonNearKeyboard(rightButton.rect, keyboardRect),
+    ).toBe(true);
+    expect(
+      isNamedDismissButtonNearKeyboard(
+        { x: 320, y: 200, width: 60, height: 40 },
+        keyboardRect,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/ios/tests/unit-test/keyboard-dismiss.test.ts
+++ b/packages/ios/tests/unit-test/keyboard-dismiss.test.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
 import {
   type KeyboardAccessoryButton,
   type WebDriverElementRect,
   isKeyboardAccessoryToolbar,
   isNamedDismissButtonNearKeyboard,
   selectKeyboardAccessoryDismissButton,
-} from '@/keyboard-dismiss';
-import { describe, expect, it } from '@rstest/core';
+} from '../../src/keyboard-dismiss';
 
 const keyboardRect: WebDriverElementRect = {
   x: 0,

--- a/packages/ios/tests/unit-test/wda-backend.test.ts
+++ b/packages/ios/tests/unit-test/wda-backend.test.ts
@@ -45,6 +45,8 @@ describe('IOSWebDriverClient - Simple Tests', () => {
         'pressHomeButton',
         'activateApp',
         'terminateApp',
+        'dismissKeyboard',
+        'isKeyboardVisible',
       ] as const satisfies readonly (keyof IOSWebDriverClientType)[];
 
       for (const method of expectedMethods) {

--- a/packages/webdriver/src/clients/WebDriverClient.ts
+++ b/packages/webdriver/src/clients/WebDriverClient.ts
@@ -1,7 +1,13 @@
 import { DEFAULT_WDA_PORT } from '@midscene/shared/constants';
 import { getDebug } from '@midscene/shared/logger';
 import { makeWebDriverRequest } from '../utils/request';
-import type { DeviceInfo, Size, WDASession, WebDriverOptions } from './types';
+import type {
+  DeviceInfo,
+  Size,
+  WDASession,
+  WebDriverOptions,
+  WebDriverRequestOptions,
+} from './types';
 
 const debugClient = getDebug('webdriver:client');
 
@@ -173,13 +179,14 @@ export class WebDriverClient {
     method: string,
     endpoint: string,
     data?: any,
+    options?: WebDriverRequestOptions,
   ): Promise<any> {
     return makeWebDriverRequest(
       this.baseUrl,
       method,
       endpoint,
       data,
-      this.timeout,
+      options?.timeout ?? this.timeout,
     );
   }
 

--- a/packages/webdriver/src/clients/types.ts
+++ b/packages/webdriver/src/clients/types.ts
@@ -37,6 +37,12 @@ export interface WebDriverOptions {
   sessionId?: string;
 }
 
+/** Per-request overrides for WebDriver transport calls. */
+export interface WebDriverRequestOptions {
+  /** Override the client-wide timeout for this request only. */
+  timeout?: number;
+}
+
 export interface Point {
   x: number;
   y: number;

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -12,6 +12,7 @@ export type {
   WDAElement,
   WDAElementInfo,
   WebDriverOptions,
+  WebDriverRequestOptions,
   Point,
   Size,
   DeviceInfo,

--- a/packages/webdriver/tests/unit-test/buildSessionEndpoint.test.ts
+++ b/packages/webdriver/tests/unit-test/buildSessionEndpoint.test.ts
@@ -10,6 +10,10 @@ class TestableWebDriverClient extends WebDriverClient {
   public testBuildSessionEndpoint(endpoint: string): string {
     return this.buildSessionEndpoint(endpoint);
   }
+
+  public testMakeRequest(timeout: number): Promise<unknown> {
+    return this.makeRequest('GET', '/status', undefined, { timeout });
+  }
 }
 
 describe('WebDriverClient.buildSessionEndpoint', () => {
@@ -62,5 +66,38 @@ describe('WebDriverClient external session cleanup', () => {
 
     expect(makeRequestSpy).not.toHaveBeenCalled();
     expect(client.sessionInfo).toBeNull();
+  });
+});
+
+describe('WebDriverClient per-request timeout', () => {
+  it('overrides the client-wide timeout for one request', async () => {
+    const originalFetch = globalThis.fetch;
+    rs.useFakeTimers();
+    globalThis.fetch = ((_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            const abortError = new Error('aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          },
+          { once: true },
+        );
+      })) as typeof fetch;
+
+    try {
+      const client = new TestableWebDriverClient({ timeout: 30_000 });
+      const request = client.testMakeRequest(25);
+      const assertion = expect(request).rejects.toThrow(
+        'Request timeout after 25ms',
+      );
+
+      await rs.advanceTimersByTimeAsync(25);
+      await assertion;
+    } finally {
+      globalThis.fetch = originalFetch;
+      rs.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replace the flaky `/wda/keyboard/dismiss` request with structural discovery of the keyboard accessory toolbar and explicit keyboard-hidden confirmation.
- Bound the complete dismissal operation, including every WebDriver request and confirmation poll, to a shared 5-second deadline so a stalled WDA call cannot consume the normal 30-second request timeout.
- Use a conservative standard-toolbar signature: left navigation controls plus exactly one right-edge dismissal control. Reject ambiguous or app-defined business toolbars; explicitly configured accessibility names remain available for custom controls.
- Track auto-dismissed focus as a typed, one-use follow-up context. Only `Enter`, `Return`, or `Tab` may consume it, it expires after 30 seconds, and intervening input, pointer, touch, system, or custom actions invalidate it.
- Add a deterministic two-field iOS Simulator regression that verifies the first auto-dismiss has completed before the action returns and cannot dismiss the keyboard after the second input starts.
- Document the default and custom-toolbar behavior in the English and Chinese iOS guides.
- Add focused coverage for geometry selection, unsafe custom toolbars, per-request deadlines, keyboard confirmation, focus expiration, and invalidation.

## Validation

- `pnpm run lint`
- `pnpm run type-check:tests`
- `pnpm exec nx test @midscene/webdriver` (6 tests passed)
- `pnpm exec nx test @midscene/ios` (193 tests passed)
- `pnpm exec nx run-many -t build -p @midscene/webdriver @midscene/ios`
- Local live Simulator run: iPhone 17 Pro, iOS 26.5, Appium WebDriverAgent 15.1.6. Both smoke tests passed in 43.093 seconds with zero model calls.
- The two-field regression observed the first dismissal complete in 3366 ms, entered the second value, waited another 5 seconds, and confirmed that the second keyboard was still visible. Both exact field values were preserved, and an explicit final dismissal succeeded.
- GitHub PR checks passed for the unchanged source tree before the co-author history rewrite. Checks are being rerun on commit `989ecb7f0`.

## Co-author

- All five commits include `Co-authored-by: quanruzhuoxiu <quanruzhuoxiu@gmail.com>`.

## Prepatch release

- Earlier revision `1.11.1-beta-20260821044126.0` was published under the npm `beta` dist-tag.
- The latest hardening commits in this PR have not been republished as a new prepatch.
- Earlier release workflow: https://github.com/web-infra-dev/midscene/actions/runs/32447670978