### PR TITLE
fix(android): avoid unreliable select-all when clearing inputs

### DIFF
--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -73,11 +73,11 @@ const defaultNormalScrollDuration = 1000;
 
 const IME_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const IME_STRATEGY_YADB_FOR_NON_ASCII = 'yadb-for-non-ascii' as const;
-const androidKeyCombinationMinApiLevel = 31;
-const androidKeyCodes = {
-  ctrlLeft: 113,
-  a: 29,
+const androidTextClearKeyRepeatCount = 100;
+const androidClearInputKeyCodes = {
+  backwardDelete: 67,
   forwardDelete: 112,
+  moveEnd: 123,
 } as const;
 const SCREENSHOT_STRATEGY_ALWAYS_YADB = 'always-yadb' as const;
 const SCREENSHOT_STRATEGY_AUTO = 'auto' as const;
@@ -1616,10 +1616,7 @@ ${Object.keys(size)
     }
 
     const adb = await this.getAdb();
-
-    if (!(await this.tryClearInputWithKeyCombination(adb))) {
-      await this.clearInputForLegacyAndroid(adb);
-    }
+    await this.clearInputWithKeyboard(adb);
 
     if (await adb.isSoftKeyboardPresent()) {
       return;
@@ -1630,32 +1627,7 @@ ${Object.keys(size)
     }
   }
 
-  private async tryClearInputWithKeyCombination(adb: ADB): Promise<boolean> {
-    if ((await adb.getApiLevel()) < androidKeyCombinationMinApiLevel) {
-      return false;
-    }
-
-    try {
-      // Android 12 added the shell `input keycombination` command. Select all
-      // before deleting so clearing is independent of the current cursor
-      // position. Forward Delete is intentional: some OEM input fields
-      // collapse the selection and remove only one character for KEYCODE_DEL.
-      await this.shellInputKeyCombination(
-        androidKeyCodes.ctrlLeft,
-        androidKeyCodes.a,
-      );
-      await this.shellInputKeyevent(androidKeyCodes.forwardDelete);
-      return true;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      warnDevice(
-        `Android select-all clear failed; falling back to legacy deletion: ${message}`,
-      );
-      return false;
-    }
-  }
-
-  private async clearInputForLegacyAndroid(adb: ADB): Promise<void> {
+  private async clearInputWithKeyboard(adb: ADB): Promise<void> {
     const isNonDefaultDisplay =
       typeof this.options?.displayId === 'number' &&
       this.options.displayId !== 0;
@@ -1664,28 +1636,31 @@ ${Object.keys(size)
         globalConfigManager.getEnvConfigValue(MIDSCENE_ANDROID_IME_STRATEGY)) ??
       IME_STRATEGY_YADB_FOR_NON_ASCII;
 
-    if (isNonDefaultDisplay) {
-      // Neither yadb nor appium-adb's clearTextField pass -d <displayId>.
-      // On a non-default display we must issue keyevents with the display
-      // argument so deletions land on the correct screen.
-      const keys: number[] = [];
-      for (let i = 0; i < 100; i++) {
-        keys.push(67, 112); // KEYCODE_DEL, KEYCODE_FORWARD_DEL
-      }
-      await this.shellInputKeyevent(...keys);
-    } else if (imeStrategy === IME_STRATEGY_YADB_FOR_NON_ASCII) {
-      // For yadb-for-non-ascii mode, use batch deletion of up to 100 characters
-      // clearTextField() batches all key events into a single shell command for better performance
-      await this.ensureYadb();
-      await adb.clearTextField(100);
-    } else {
-      // Use the yadb tool to clear the input box
+    if (!isNonDefaultDisplay && imeStrategy === IME_STRATEGY_ALWAYS_YADB) {
+      // Honor the explicit compatibility strategy on the default display.
       await this.ensureYadb();
       await adb.shell(
         // `app_process` (ART launcher) does not accept the `-d <displayId>` flag.
         'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboardClear',
       );
+      return;
     }
+
+    // Avoid Ctrl+A because some Huawei/HarmonyOS ROMs silently treat the
+    // Android 12+ `input keycombination` command as a printable "a" while
+    // returning success. MOVE_END positions a common single-line field at
+    // the end; paired backward/forward deletions retain the existing 100-key
+    // clearing bound and still work from the current cursor if an OEM ignores
+    // MOVE_END. This display-aware command avoids Android 12-specific shell
+    // syntax and does not require yadb to be installed.
+    const keys: number[] = [androidClearInputKeyCodes.moveEnd];
+    for (let index = 0; index < androidTextClearKeyRepeatCount; index++) {
+      keys.push(
+        androidClearInputKeyCodes.backwardDelete,
+        androidClearInputKeyCodes.forwardDelete,
+      );
+    }
+    await this.shellInputKeyevent(...keys);
   }
 
   async forceScreenshot(path: string): Promise<void> {
@@ -2500,27 +2475,6 @@ ${Object.keys(size)
     await adb.shell(
       `input${this.getDisplayArg()} keyevent ${keyCodes.join(' ')}`,
     );
-  }
-
-  /**
-   * Send a simultaneous Android key combination through the display-aware
-   * shell input primitive. The command is available on Android 12 / API 31+
-   * and callers must guard older platform versions.
-   */
-  private async shellInputKeyCombination(...keyCodes: number[]): Promise<void> {
-    const adb = await this.getAdb();
-    const command = `input${this.getDisplayArg()} keycombination ${keyCodes.join(' ')}`;
-    const stdout = await runAdbShellStdoutOrThrow(adb, command);
-
-    // Android's input shell command can print errors such as
-    // "Unknown command: keycombination" while still exiting successfully.
-    // A successful keycombination is silent, so any output means the command
-    // was not reliably applied and the caller must use the legacy fallback.
-    if (stdout.trim()) {
-      throw new Error(
-        `Android keycombination command returned unexpected output: ${stdout.trim()}`,
-      );
-    }
   }
 
   /**

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -70,6 +70,14 @@ const fallbackPngBuffer = Buffer.from(
   'base64',
 );
 
+const buildExpectedClearInputCommand = (displayId?: number) => {
+  const displayArgument = displayId === undefined ? '' : ` -d ${displayId}`;
+  const deletionKeyCodes = Array.from({ length: 100 }, () => '67 112').join(
+    ' ',
+  );
+  return `input${displayArgument} keyevent 123 ${deletionKeyCodes}`;
+};
+
 rs.mock('appium-adb', () => {
   const MockADB = rs.fn(() => {
     if (!mockAdbInstance) {
@@ -1962,22 +1970,21 @@ Stdout:
 
     describe('clearInput', () => {
       beforeEach(() => {
-        mockAdb.getApiLevel.mockResolvedValue(35);
         mockAdb.shell.mockResolvedValue('');
       });
 
-      it('should select all and forward-delete on Android 12 and newer', async () => {
-        mockAdb.getApiLevel.mockResolvedValue(31);
+      it('should clear with cursor-independent keyevents without SDK branching', async () => {
+        const ensureYadb = rs.spyOn(device as any, 'ensureYadb');
 
         await device.clearInput();
 
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(
-          1,
-          'input keycombination 113 29',
-          expect.objectContaining({ outputFormat: 'full' }),
+        expect(mockAdb.getApiLevel).not.toHaveBeenCalled();
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          buildExpectedClearInputCommand(),
         );
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
         expect(mockAdb.clearTextField).not.toHaveBeenCalled();
+        expect(ensureYadb).not.toHaveBeenCalled();
       });
 
       it('should clear before typing replacement text', async () => {
@@ -1992,89 +1999,56 @@ Stdout:
 
         expect(mockAdb.shell).toHaveBeenNthCalledWith(
           1,
-          'input keycombination 113 29',
-          expect.objectContaining({ outputFormat: 'full' }),
+          buildExpectedClearInputCommand(),
         );
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(2, 'input keyevent 112');
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(3, "input text '15'");
+        expect(mockAdb.shell).toHaveBeenNthCalledWith(2, "input text '15'");
       });
 
-      it('should target the configured display for select-all and deletion', async () => {
-        device.options = { displayId: 2 };
-
-        await device.clearInput();
-
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(
-          1,
-          'input -d 2 keycombination 113 29',
-          expect.objectContaining({ outputFormat: 'full' }),
-        );
-        expect(mockAdb.shell).toHaveBeenNthCalledWith(
-          2,
-          'input -d 2 keyevent 112',
-        );
-      });
-
-      it('should preserve batch deletion on Android 11 and older', async () => {
-        mockAdb.getApiLevel.mockResolvedValue(30);
-        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-
-        await device.clearInput();
-
-        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
-        expect(mockAdb.shell).not.toHaveBeenCalledWith(
-          expect.stringContaining('keycombination'),
-        );
-      });
-
-      it('should fall back when an Android 12+ device rejects the combination', async () => {
-        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-        mockAdb.shell.mockRejectedValueOnce(
-          new Error('Unknown command: keycombination'),
-        );
-
-        await device.clearInput();
-
-        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
-      });
-
-      it('should fall back when keycombination reports an unknown command on stdout', async () => {
-        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-        mockAdb.shell.mockResolvedValueOnce('Unknown command: keycombination');
-
-        await device.clearInput();
-
-        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
-        expect(mockAdb.shell).toHaveBeenCalledWith(
-          'input keycombination 113 29',
-          expect.objectContaining({ outputFormat: 'full' }),
-        );
-        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
-      });
-
-      it('should fall back when keycombination writes to stderr', async () => {
-        rs.spyOn(device as any, 'ensureYadb').mockResolvedValue(undefined);
-        mockAdb.shell.mockResolvedValueOnce({
-          stdout: '',
-          stderr: 'Unknown command: keycombination',
-        } as any);
-
-        await device.clearInput();
-
-        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
-        expect(mockAdb.clearTextField).toHaveBeenCalledWith(100);
-      });
-
-      it('should preserve display-aware deletion on legacy Android', async () => {
-        mockAdb.getApiLevel.mockResolvedValue(30);
+      it('should target the configured display for all clear keyevents', async () => {
         device.options = { displayId: 2 };
 
         await device.clearInput();
 
         expect(mockAdb.shell).toHaveBeenCalledTimes(1);
         expect(mockAdb.shell).toHaveBeenCalledWith(
-          expect.stringMatching(/^input -d 2 keyevent (?:67 112 ){99}67 112$/),
+          buildExpectedClearInputCommand(2),
         );
+      });
+
+      it('should preserve the explicit always-yadb clear strategy', async () => {
+        device.options = { imeStrategy: 'always-yadb' };
+        const ensureYadb = rs
+          .spyOn(device as any, 'ensureYadb')
+          .mockResolvedValue(undefined);
+
+        await device.clearInput();
+
+        expect(ensureYadb).toHaveBeenCalledTimes(1);
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboardClear',
+        );
+        expect(mockAdb.clearTextField).not.toHaveBeenCalled();
+      });
+
+      it('should use display-aware keyevents instead of yadb on a secondary display', async () => {
+        device.options = { displayId: 2, imeStrategy: 'always-yadb' };
+        const ensureYadb = rs
+          .spyOn(device as any, 'ensureYadb')
+          .mockResolvedValue(undefined);
+
+        await device.clearInput();
+
+        expect(mockAdb.shell).toHaveBeenCalledTimes(1);
+        expect(mockAdb.shell).toHaveBeenCalledWith(
+          buildExpectedClearInputCommand(2),
+        );
+        expect(ensureYadb).not.toHaveBeenCalled();
+      });
+
+      it('should surface keyevent failures', async () => {
+        mockAdb.shell.mockRejectedValueOnce(new Error('keyevent failed'));
+
+        await expect(device.clearInput()).rejects.toThrow('keyevent failed');
       });
     });
 


### PR DESCRIPTION
## Summary

- replace Android 12+ `Ctrl+A` shell combinations with a control-only clear sequence
- move the caret to the end and batch backward/forward deletions in one display-aware command
- preserve the explicit `always-yadb` strategy on the default display
- remove SDK branching and the unreliable stdout-based fallback heuristic

## Root cause

Some Huawei devices running the Android compatibility layer accept `input keycombination 113 29`, return success with no output, but interpret the command as printable text and insert `a`. Because the command appears successful, the previous fallback is never reached.

The replacement uses key events that were already used by the pre-regression Appium clear path, with `MOVE_END` added so common single-line inputs clear reliably even when the caret starts in the middle.

## Review notes

- clear-strategy ownership remains inside `AndroidDevice`
- the SDK/OEM-specific abstraction and obsolete fallback branches are removed
- exact shell commands, display targeting, strategy preservation, replacement ordering, and error propagation are covered by unit tests
- the HarmonyOS HDC implementation was reviewed but intentionally left unchanged because it uses a distinct key-event protocol and there is no verified equivalent failure or key-code mapping

## Validation

- `pnpm run lint`
- `pnpm run check:references`
- `pnpm exec nx test @midscene/android --skip-nx-cache` (406 tests passed)
- `pnpm exec nx build @midscene/android --skip-nx-cache`
- Huawei LIO-AL00, SDK 31: reproduced `TEST` becoming `TESTa` before the fix; the patched path cleared successfully, including with the caret in the middle
- Vivo V2024A, SDK 29: the patched path cleared successfully with the caret in the middle

Closes #3011
