### PR TITLE
feat(core): support deepseek-v4-flash-vision-exp

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -122,6 +122,59 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # If you use another Qwen version, replace
   </ModelConfigTab>
 </ModelConfigTabs>
 
+### DeepSeek Series {#deepseek}
+
+- Common model provider: [DeepSeek](https://platform.deepseek.com/)
+
+<div className="model-series-table">
+
+| Model version | Commonly used model names | `MIDSCENE_MODEL_FAMILY` | Notes |
+| --- | --- | --- | --- |
+| DeepSeek V4 series | `deepseek-v4-flash-vision-exp` | `deepseek` | |
+
+</div>
+
+:::caution
+
+Currently, only `deepseek-v4-flash-vision-exp` supports the multimodal visual input required by Midscene. Other DeepSeek V4 models, including `deepseek-v4-pro` and `deepseek-v4-flash`, are not suitable for use with Midscene.
+
+:::
+
+Environment variable configuration example, using `deepseek-v4-flash-vision-exp`:
+
+<ModelConfigTabs>
+  <ModelConfigTab type="default">
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="planning">
+
+```bash
+MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
+MIDSCENE_PLANNING_MODEL_API_KEY="......"
+MIDSCENE_PLANNING_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="insight">
+
+```bash
+MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
+MIDSCENE_INSIGHT_MODEL_API_KEY="......"
+MIDSCENE_INSIGHT_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_INSIGHT_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+</ModelConfigTabs>
+
 ### Google Gemini Series {#gemini}
 
 - Common model provider: [Google Gemini](https://gemini.google.com/)

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -124,7 +124,9 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # If you use another Qwen version, replace
 
 ### DeepSeek Series {#deepseek}
 
-- Common model provider: [DeepSeek](https://platform.deepseek.com/)
+Midscene supports DeepSeek starting from v1.12.0.
+
+- Common model provider: [DeepSeek - Vision](https://api-docs.deepseek.com/guides/vision/)
 
 <div className="model-series-table">
 

--- a/apps/site/docs/en/model-config.mdx
+++ b/apps/site/docs/en/model-config.mdx
@@ -91,6 +91,7 @@ The following model families currently support `MIDSCENE_MODEL_REASONING_ENABLED
 
 - Qwen: Maps to `enable_thinking`.
 - Doubao: Maps to `thinking.type`.
+- DeepSeek: Maps to `thinking.type`.
 - Zhipu GLM: Maps to `thinking.type`.
 - GPT-5: Maps to `reasoning_effort`. Midscene uses `medium` when enabled and `none` when disabled.
 - Gemini: Maps to `thinking_config.thinking_level`. Midscene uses `medium` when enabled and `minimal` when disabled.
@@ -102,6 +103,7 @@ The following model families currently support `MIDSCENE_MODEL_REASONING_ENABLED
 `MIDSCENE_MODEL_REASONING_EFFORT` controls thinking effort. The following model families currently support it:
 
 - Doubao: Maps to `reasoning_effort`.
+- DeepSeek: Maps to `reasoning_effort`.
 - Gemini: Maps to `thinking_config.thinking_level`.
 - GPT-5: Maps to `reasoning_effort`.
 - Kimi K3 series: Maps to `reasoning_effort`.

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -122,6 +122,59 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # 如果你使用了其他版本的 Qwen�
   </ModelConfigTab>
 </ModelConfigTabs>
 
+### DeepSeek 系列 {#deepseek}
+
+- 常用模型供应商：[DeepSeek](https://platform.deepseek.com/)
+
+<div className="model-series-table">
+
+| 模型版本 | 常用模型名称 | `MIDSCENE_MODEL_FAMILY` | 备注 |
+| --- | --- | --- | --- |
+| DeepSeek V4 系列 | `deepseek-v4-flash-vision-exp` | `deepseek` | |
+
+</div>
+
+:::caution
+
+目前只有 `deepseek-v4-flash-vision-exp` 支持 Midscene 所需的多模态视觉输入。包括 `deepseek-v4-pro` 和普通 `deepseek-v4-flash` 在内的其他 DeepSeek V4 模型均不适用于 Midscene。
+
+:::
+
+环境变量配置示例，以 `deepseek-v4-flash-vision-exp` 为例：
+
+<ModelConfigTabs>
+  <ModelConfigTab type="default">
+
+```bash
+MIDSCENE_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
+MIDSCENE_MODEL_API_KEY="......"
+MIDSCENE_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="planning">
+
+```bash
+MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
+MIDSCENE_PLANNING_MODEL_API_KEY="......"
+MIDSCENE_PLANNING_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+  <ModelConfigTab type="insight">
+
+```bash
+MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
+MIDSCENE_INSIGHT_MODEL_API_KEY="......"
+MIDSCENE_INSIGHT_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_INSIGHT_MODEL_FAMILY="deepseek"
+```
+
+  </ModelConfigTab>
+</ModelConfigTabs>
+
 ### Google Gemini 系列 {#gemini}
 
 - 常用模型供应商：[Google Gemini](https://gemini.google.com/)

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -124,7 +124,9 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # 如果你使用了其他版本的 Qwen�
 
 ### DeepSeek 系列 {#deepseek}
 
-- 常用模型供应商：[DeepSeek](https://platform.deepseek.com/)
+Midscene 从 v1.12.0 开始支持 DeepSeek。
+
+- 常用模型供应商：[DeepSeek - 图像理解](https://api-docs.deepseek.com/zh-cn/guides/vision/)
 
 <div className="model-series-table">
 

--- a/apps/site/docs/zh/model-config.mdx
+++ b/apps/site/docs/zh/model-config.mdx
@@ -90,6 +90,7 @@ Midscene 默认关闭模型原生思考，以获得更好的执行速度和稳�
 
 - Qwen：对应 `enable_thinking`。
 - 豆包：对应 `thinking.type`。
+- DeepSeek：对应 `thinking.type`。
 - 智谱 GLM：对应 `thinking.type`。
 - GPT-5：对应 `reasoning_effort`。启用时使用 `medium`，关闭时使用 `none`。
 - Gemini：对应 `thinking_config.thinking_level`。启用时使用 `medium`，关闭时使用 `minimal`。
@@ -101,6 +102,7 @@ Midscene 默认关闭模型原生思考，以获得更好的执行速度和稳�
 `MIDSCENE_MODEL_REASONING_EFFORT` 控制模型的思考力度。目前支持以下模型系列：
 
 - 豆包：对应 `reasoning_effort`。
+- DeepSeek：对应 `reasoning_effort`。
 - Gemini：对应 `thinking_config.thinking_level`。
 - GPT-5：对应 `reasoning_effort`。
 - Kimi K3 系列：对应 `reasoning_effort`。

--- a/packages/core/src/ai-model/models/deepseek-locate-protocol.ts
+++ b/packages/core/src/ai-model/models/deepseek-locate-protocol.ts
@@ -1,0 +1,130 @@
+import type {
+  ParsedLocateResponse,
+  StandardLocateProtocol,
+} from '../model-adapter/locate-protocol';
+import {
+  type LocateResultPromptSpec,
+  formatLocateExampleValue,
+} from '../shared/model-locate-result';
+
+const deepSeekRefBoxPattern =
+  /<(?:｜｜|\|)ref(?:｜｜|\|)>\s*[\s\S]*?\s*<(?:｜｜|\|)\/ref(?:｜｜|\|)>\s*<(?:｜｜|\|)box(?:｜｜|\|)>\s*([\s\S]*?)\s*<(?:｜｜|\|)\/box(?:｜｜|\|)>/g;
+
+const deepSeekPointPattern =
+  /^\s*<(?:｜｜|\|)point(?:｜｜|\|)>\s*([\s\S]*?)\s*<(?:｜｜|\|)\/point(?:｜｜|\|)>\s*$/;
+
+const deepSeekElementSystemPromptIntroduction = `## Role:
+You are a GUI click grounding agent.
+
+## Objective:
+- Identify the UI element in the screenshot that matches the user's description.
+- Return the center point of that element.`;
+
+const buildDeepSeekElementResponseInstructions = (
+  promptSpec: LocateResultPromptSpec,
+) => `## Output Format:
+Return exactly one ${promptSpec.resultNoun} using the following format, without any explanation or additional text:
+
+<｜｜point｜｜>[${promptSpec.resultValueSchema}]<｜｜/point｜｜>
+
+For example:
+<｜｜point｜｜>[${formatLocateExampleValue(promptSpec.exampleValues[0])}]<｜｜/point｜｜>
+
+Coordinate values must be integers.
+Coordinate requirements: ${promptSpec.resultValueDescription}
+The origin is the top-left of the full screenshot.`;
+
+const buildDeepSeekSearchAreaResponseInstructions = (
+  promptSpec: LocateResultPromptSpec,
+) => {
+  const targetExampleValue = formatLocateExampleValue(
+    promptSpec.exampleValues[0],
+  );
+  const referenceExampleValue = formatLocateExampleValue(
+    promptSpec.exampleValues[1] ?? promptSpec.exampleValues[0],
+  );
+
+  return `## Objective:
+- Identify the target UI element in the screenshot.
+- Identify the reference elements that the description uses to select the target, such as an owner label, row value, column value, nearby text, or relative-position anchor.
+- Return a tight ${promptSpec.resultNoun} for the target first, followed by a tight ${promptSpec.resultNoun} for each reference element.
+
+## Reference Rules:
+- If the description explicitly identifies the target through another visible element, you MUST return that visible element as a reference, even if the target appears unique.
+- For descriptions like "B in the row whose A is X", B is the target and the visible X is a reference.
+- For descriptions like "the icon next to label X", the icon is the target and the visible X is a reference.
+- Do not return unrelated landmarks or alternative target candidates.
+
+## Output Format:
+Return one or more ref-box pairs using the following format, without any explanation or additional text:
+
+<｜｜ref｜｜>target: concise target description<｜｜/ref｜｜><｜｜box｜｜>[${promptSpec.resultValueSchema}]<｜｜/box｜｜>
+<｜｜ref｜｜>reference: concise reference description<｜｜/ref｜｜><｜｜box｜｜>[${promptSpec.resultValueSchema}]<｜｜/box｜｜>
+
+For example:
+If the request is "the edit icon in the row whose project name is Apollo", return:
+<｜｜ref｜｜>target: edit icon<｜｜/ref｜｜><｜｜box｜｜>[${targetExampleValue}]<｜｜/box｜｜>
+<｜｜ref｜｜>reference: Apollo<｜｜/ref｜｜><｜｜box｜｜>[${referenceExampleValue}]<｜｜/box｜｜>
+
+The first ref-box pair must represent the target element. Every remaining pair must represent a reference element needed to identify the target. If no reference element is needed, return only the target pair. Each pair must contain exactly one ${promptSpec.resultNoun}.
+Coordinate values must be integers.
+Coordinate requirements: ${promptSpec.resultValueDescription}
+The origin is the top-left of the full screenshot.`;
+};
+
+export function parseDeepSeekLocateOutput(
+  content: string,
+): ParsedLocateResponse {
+  const match = content.match(deepSeekPointPattern);
+  if (!match) {
+    throw new Error(
+      'DeepSeek element locate response does not contain a valid <｜｜point｜｜>value<｜｜/point｜｜> result',
+    );
+  }
+
+  return {
+    kind: 'located',
+    target: match[1],
+  };
+}
+
+export function parseDeepSeekSearchAreaOutput(
+  content: string,
+): ParsedLocateResponse {
+  const rawBoxes = Array.from(
+    content.matchAll(deepSeekRefBoxPattern),
+    (match) => match[1],
+  );
+  if (rawBoxes.length === 0) {
+    throw new Error(
+      'DeepSeek search-area response does not contain a valid <｜｜ref｜｜>label<｜｜/ref｜｜><｜｜box｜｜>[[x1,y1,x2,y2]]<｜｜/box｜｜> result',
+    );
+  }
+
+  const [rawBbox, ...rawReferenceBboxes] = rawBoxes;
+  return {
+    kind: 'located',
+    target: rawBbox,
+    ...(rawReferenceBboxes.length > 0
+      ? { references: rawReferenceBboxes }
+      : {}),
+  };
+}
+
+export const deepSeekElementLocateProtocol: StandardLocateProtocol = {
+  systemPromptIntroduction: deepSeekElementSystemPromptIntroduction,
+  buildResponseInstructions: buildDeepSeekElementResponseInstructions,
+  buildUserPrompt: (targetElementDescription) =>
+    `Locate the center point of the following UI element: ${targetElementDescription}`,
+  expectedJsonObjectResponse: false,
+  parseRawResponse: parseDeepSeekLocateOutput,
+};
+
+export const deepSeekSearchAreaProtocol: StandardLocateProtocol = {
+  systemPromptIntroduction: '',
+  buildResponseInstructions: buildDeepSeekSearchAreaResponseInstructions,
+  buildUserPrompt: (sectionDescription) =>
+    `Locate the target and the reference elements needed to distinguish it: ${sectionDescription}`,
+  expectedJsonObjectResponse: false,
+  parseRawResponse: parseDeepSeekSearchAreaOutput,
+};

--- a/packages/core/src/ai-model/models/deepseek.ts
+++ b/packages/core/src/ai-model/models/deepseek.ts
@@ -1,0 +1,121 @@
+import type { TModelFamily } from '@midscene/shared/env';
+import type {
+  ChatCompletionCallContext,
+  ChatCompletionParamsResult,
+  ModelAdapterDefinition,
+} from '../model-adapter/types';
+import {
+  type LocateResultValue,
+  createLocateResultValue,
+} from '../shared/model-locate-result';
+import {
+  deepSeekElementLocateProtocol,
+  deepSeekSearchAreaProtocol,
+} from './deepseek-locate-protocol';
+
+const deepSeekPointCoordinates = {
+  shape: 'point',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
+
+const deepSeekBboxCoordinates = {
+  shape: 'bbox',
+  order: 'xy',
+  normalizedBy: 1000,
+} as const;
+
+function parseDeepSeekCoordinateValues(
+  input: unknown,
+  expectedLength: number,
+  label: string,
+): number[] {
+  const coordinateTexts = String(input).match(/\d+/g);
+  if (coordinateTexts?.length !== expectedLength) {
+    throw new Error(
+      `DeepSeek ${label} locate result must contain exactly ${expectedLength} positive integers, got ${coordinateTexts?.length ?? 0}`,
+    );
+  }
+
+  return coordinateTexts.map(Number);
+}
+
+function parseDeepSeekPointLocateValue(input: unknown): LocateResultValue {
+  return createLocateResultValue(
+    deepSeekPointCoordinates,
+    parseDeepSeekCoordinateValues(input, 2, 'point'),
+  );
+}
+
+function parseDeepSeekBboxLocateValue(input: unknown): LocateResultValue {
+  return createLocateResultValue(
+    deepSeekBboxCoordinates,
+    parseDeepSeekCoordinateValues(input, 4, 'bbox'),
+  );
+}
+
+const buildDeepSeekChatCompletionParams = (
+  input: ChatCompletionCallContext,
+): ChatCompletionParamsResult => {
+  const { midsceneDefaults, userConfig } = input;
+  const { reasoningEnabled, reasoningEffort } = userConfig;
+  const commonOverrideConfig: Record<string, unknown> = {};
+
+  if (userConfig.temperature !== undefined) {
+    commonOverrideConfig.temperature = userConfig.temperature;
+  }
+
+  if (
+    userConfig.responseFormat !== 'none' &&
+    input.expectedJsonObjectResponse
+  ) {
+    commonOverrideConfig.response_format = { type: 'json_object' };
+  }
+
+  const modelSpecificConfig: Record<string, unknown> = {};
+  if (reasoningEnabled !== 'default') {
+    modelSpecificConfig.thinking = {
+      type: (reasoningEnabled ?? false) ? 'enabled' : 'disabled',
+    };
+    if (reasoningEffort) {
+      modelSpecificConfig.reasoning_effort = reasoningEffort;
+    }
+  }
+
+  return {
+    config: {
+      ...midsceneDefaults,
+      ...commonOverrideConfig,
+      ...modelSpecificConfig,
+    },
+  };
+};
+
+export const deepSeekAdapters = {
+  deepseek: {
+    chatCompletion: {
+      unsupportedUserConfig: ['reasoningBudget'],
+      buildChatCompletionParams: buildDeepSeekChatCompletionParams,
+      useReasoningAsContentFallback: true,
+      // DeepSeek only requires reasoning_content to be replayed after tool
+      // calls. Midscene planning does not use tool calls, so it is unnecessary.
+      replayRawAssistantMessage: false,
+    },
+    locate: {
+      element: {
+        protocol: deepSeekElementLocateProtocol,
+        resultFormat: {
+          coordinates: deepSeekPointCoordinates,
+          parseRawLocateValue: parseDeepSeekPointLocateValue,
+        },
+      },
+      searchArea: {
+        protocol: deepSeekSearchAreaProtocol,
+        resultFormat: {
+          coordinates: deepSeekBboxCoordinates,
+          parseRawLocateValue: parseDeepSeekBboxLocateValue,
+        },
+      },
+    },
+  },
+} satisfies Pick<Record<TModelFamily, ModelAdapterDefinition>, 'deepseek'>;

--- a/packages/core/src/ai-model/models/registry.ts
+++ b/packages/core/src/ai-model/models/registry.ts
@@ -7,6 +7,7 @@ import type {
   ModelRuntime,
 } from '../model-adapter/types';
 import { autoGlmAdapters } from './auto-glm/adapter';
+import { deepSeekAdapters } from './deepseek';
 import { defaultOpenAICompatibleAdapterConfig } from './default';
 import { doubaoAdapters } from './doubao';
 import { geminiAdapters } from './gemini';
@@ -19,6 +20,7 @@ import { uiTarsAdapters } from './ui-tars/adapter';
 
 export const MODEL_ADAPTER_CONFIGS = {
   ...qwenAdapters,
+  ...deepSeekAdapters,
   ...doubaoAdapters,
   ...geminiAdapters,
   ...uiTarsAdapters,

--- a/packages/core/tests/unit-test/model-adapter.test.ts
+++ b/packages/core/tests/unit-test/model-adapter.test.ts
@@ -80,6 +80,7 @@ describe('model adapter registry', () => {
       'kimi',
       'kimi3',
       'xiaomi-mimo',
+      'deepseek',
     ];
     const enabledSet = new Set<TModelFamily>(enabledFamilies);
 

--- a/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
@@ -1,0 +1,293 @@
+import { ResolvedModelAdapter } from '@/ai-model/model-adapter/resolve';
+import { deepSeekAdapters } from '@/ai-model/models/deepseek';
+import {
+  deepSeekElementLocateProtocol,
+  deepSeekSearchAreaProtocol,
+} from '@/ai-model/models/deepseek-locate-protocol';
+import { systemPromptToLocateElement } from '@/ai-model/prompt/llm-locator';
+import { createLocateResultPromptSpec } from '@/ai-model/shared/model-locate-result/prompt-spec';
+import { describe, expect, it } from 'vitest';
+
+const deepSeekAdapter = new ResolvedModelAdapter(
+  deepSeekAdapters.deepseek,
+  'deepseek',
+);
+
+function getStandardLocateAdapter() {
+  if (deepSeekAdapter.locate.kind !== 'standard') {
+    throw new Error('deepseek should use a standard locate adapter');
+  }
+  return deepSeekAdapter.locate;
+}
+
+describe('deepseek model adapter', () => {
+  it('uses point tokens for final element locate', () => {
+    const locateAdapter = getStandardLocateAdapter();
+    const elementProtocol = locateAdapter.element.protocol;
+    const responseInstructions = elementProtocol.buildResponseInstructions(
+      locateAdapter.element.resultCodec.promptSpec,
+    );
+    const systemPrompt = systemPromptToLocateElement({
+      systemPromptIntroduction: elementProtocol.systemPromptIntroduction,
+      responseInstructions,
+    });
+
+    expect(elementProtocol.systemPromptIntroduction).toContain(
+      'You are a GUI click grounding agent.',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜point｜｜>[[number, number]]<｜｜/point｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜point｜｜>[[150, 150]]<｜｜/point｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      'Coordinate requirements: point, should be [x, y] normalized to 0-1000 relative to the screenshot.',
+    );
+    expect(systemPrompt).toContain(
+      '<｜｜point｜｜>[[150, 150]]<｜｜/point｜｜>',
+    );
+    expect(elementProtocol.expectedJsonObjectResponse).toBe(false);
+    expect(elementProtocol.buildUserPrompt('Submit')).toBe(
+      'Locate the center point of the following UI element: Submit',
+    );
+  });
+
+  it('builds coordinate instructions from the result format prompt spec', () => {
+    const pointPromptSpec = createLocateResultPromptSpec({
+      shape: 'point',
+      order: 'yx',
+      normalizedBy: 2000,
+    });
+    const bboxPromptSpec = createLocateResultPromptSpec({
+      shape: 'bbox',
+      order: 'yx',
+      normalizedBy: 2000,
+    });
+    const elementInstructions =
+      deepSeekElementLocateProtocol.buildResponseInstructions(pointPromptSpec);
+    const searchAreaInstructions =
+      deepSeekSearchAreaProtocol.buildResponseInstructions(bboxPromptSpec);
+
+    expect(elementInstructions).toContain('should be [y, x]');
+    expect(elementInstructions).toContain('normalized to 0-2000');
+    expect(elementInstructions).not.toContain('normalized to 0-1000');
+    expect(searchAreaInstructions).toContain(
+      'should be [ymin, xmin, ymax, xmax]',
+    );
+    expect(searchAreaInstructions).toContain('normalized to 0-2000');
+    expect(searchAreaInstructions).not.toContain('normalized to 0-1000');
+  });
+
+  it('parses a normalized final point and maps it to pixels', () => {
+    const locateAdapter = getStandardLocateAdapter();
+    const rawResult = locateAdapter.element.protocol.parseRawResponse(
+      '<｜｜point｜｜>[[928,780]]<｜｜/point｜｜>',
+      locateAdapter.element.resultCodec.promptSpec,
+    );
+
+    expect(rawResult).toEqual({
+      kind: 'located',
+      target: '[[928,780]]',
+    });
+    if (rawResult.kind !== 'located') {
+      throw new Error('DeepSeek response should contain a location');
+    }
+    expect(
+      locateAdapter.element.resultCodec.toPixelBbox(rawResult.target, {
+        preparedSize: { width: 1000, height: 1000 },
+      }),
+    ).toEqual([917, 769, 937, 789]);
+  });
+
+  it('uses ref-box tokens and bbox coordinates for deepLocate search area', () => {
+    const locateAdapter = getStandardLocateAdapter();
+    const searchAreaProtocol = locateAdapter.searchArea?.protocol;
+    const searchAreaResultCodec = locateAdapter.searchArea?.resultCodec;
+    expect(searchAreaProtocol).toBeDefined();
+    expect(searchAreaResultCodec).toBeDefined();
+    if (!searchAreaProtocol || !searchAreaResultCodec) {
+      throw new Error(
+        'deepseek should define search-area protocol and adapter',
+      );
+    }
+
+    const responseInstructions = searchAreaProtocol.buildResponseInstructions(
+      searchAreaResultCodec.promptSpec,
+    );
+    expect(searchAreaProtocol.systemPromptIntroduction).toBe('');
+    expect(responseInstructions).toContain(
+      'you MUST return that visible element as a reference',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜ref｜｜>target: concise target description<｜｜/ref｜｜><｜｜box｜｜>[[number, number, number, number]]<｜｜/box｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜ref｜｜>reference: concise reference description<｜｜/ref｜｜><｜｜box｜｜>[[number, number, number, number]]<｜｜/box｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜ref｜｜>target: edit icon<｜｜/ref｜｜><｜｜box｜｜>[[100, 100, 200, 200]]<｜｜/box｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      '<｜｜ref｜｜>reference: Apollo<｜｜/ref｜｜><｜｜box｜｜>[[345, 442, 458, 483]]<｜｜/box｜｜>',
+    );
+    expect(responseInstructions).toContain(
+      'Coordinate requirements: 2d bounding box, should be [xmin, ymin, xmax, ymax] normalized to 0-1000 relative to the screenshot.',
+    );
+    expect(searchAreaProtocol.buildUserPrompt('the Apollo edit icon')).toBe(
+      'Locate the target and the reference elements needed to distinguish it: the Apollo edit icon',
+    );
+    expect(searchAreaProtocol.expectedJsonObjectResponse).toBe(false);
+    const rawResult = searchAreaProtocol.parseRawResponse(
+      '<｜｜ref｜｜>target: edit icon<｜｜/ref｜｜><｜｜box｜｜>[[845,390,875,430]]<｜｜/box｜｜>\n' +
+        '<｜｜ref｜｜>reference: Apollo<｜｜/ref｜｜><｜｜box｜｜>[[150,390,230,430]]<｜｜/box｜｜>',
+      searchAreaResultCodec.promptSpec,
+    );
+
+    expect(rawResult).toEqual({
+      kind: 'located',
+      target: '[[845,390,875,430]]',
+      references: ['[[150,390,230,430]]'],
+    });
+    if (rawResult.kind !== 'located') {
+      throw new Error('DeepSeek response should contain a location');
+    }
+    const context = { preparedSize: { width: 1000, height: 1000 } };
+    expect(
+      searchAreaResultCodec.toPixelBbox(rawResult.target, context),
+    ).toEqual([844, 390, 874, 430]);
+    expect(
+      rawResult.references?.map((reference) =>
+        searchAreaResultCodec.toPixelBbox(reference, context),
+      ),
+    ).toEqual([[150, 390, 230, 430]]);
+  });
+
+  it('accepts ASCII ref-box delimiters when no reference is needed', () => {
+    expect(
+      deepSeekSearchAreaProtocol.parseRawResponse(
+        '<|ref|>target: Submit button<|/ref|><|box|>[[300,440,360,480]]<|/box|>',
+        getStandardLocateAdapter().searchArea!.resultCodec.promptSpec,
+      ),
+    ).toEqual({ kind: 'located', target: '[[300,440,360,480]]' });
+  });
+
+  it('rejects responses that do not contain exactly two integers', () => {
+    const locateAdapter = getStandardLocateAdapter().element;
+    const rawResult = locateAdapter.protocol.parseRawResponse(
+      '<｜｜point｜｜>[[820,430],[210,430]]<｜｜/point｜｜>',
+      locateAdapter.resultCodec.promptSpec,
+    );
+    if (rawResult.kind !== 'located') {
+      throw new Error('DeepSeek response should contain a raw location');
+    }
+
+    expect(() =>
+      locateAdapter.resultCodec.toPixelBbox(rawResult.target, {
+        preparedSize: { width: 1000, height: 1000 },
+      }),
+    ).toThrow('must contain exactly 2 positive integers');
+  });
+
+  it('rejects responses without exactly one point envelope', () => {
+    const locateAdapter = getStandardLocateAdapter().element;
+
+    expect(() =>
+      locateAdapter.protocol.parseRawResponse(
+        '[[928,780]]',
+        locateAdapter.resultCodec.promptSpec,
+      ),
+    ).toThrow('does not contain a valid');
+    expect(() =>
+      locateAdapter.protocol.parseRawResponse(
+        '<｜｜point｜｜>[[928,780]]<｜｜/point｜｜>extra text',
+        locateAdapter.resultCodec.promptSpec,
+      ),
+    ).toThrow('does not contain a valid');
+  });
+
+  it.each([
+    '<｜｜point｜｜>[[928.5,780]]<｜｜/point｜｜>',
+    '<｜｜point｜｜>no coordinates<｜｜/point｜｜>',
+  ])('rejects output without exactly two integers: %s', (content) => {
+    const locateAdapter = getStandardLocateAdapter().element;
+    const rawResult = locateAdapter.protocol.parseRawResponse(
+      content,
+      locateAdapter.resultCodec.promptSpec,
+    );
+    if (rawResult.kind !== 'located') {
+      throw new Error('DeepSeek response should contain a raw location');
+    }
+
+    expect(() =>
+      locateAdapter.resultCodec.toPixelBbox(rawResult.target, {
+        preparedSize: { width: 1000, height: 1000 },
+      }),
+    ).toThrow('must contain exactly 2 positive integers');
+  });
+
+  it.each([
+    '<｜｜point｜｜>[928,780]<｜｜/point｜｜>',
+    '<｜｜point｜｜>[[928 780]]<｜｜/point｜｜>',
+    '<|point|>928 -> 780<|/point|>',
+  ])('accepts any separator between the two integers: %s', (content) => {
+    const locateAdapter = getStandardLocateAdapter().element;
+    const rawResult = locateAdapter.protocol.parseRawResponse(
+      content,
+      locateAdapter.resultCodec.promptSpec,
+    );
+    if (rawResult.kind !== 'located') {
+      throw new Error('DeepSeek response should contain a raw location');
+    }
+
+    expect(
+      locateAdapter.resultCodec.toPixelBbox(rawResult.target, {
+        preparedSize: { width: 1000, height: 1000 },
+      }),
+    ).toEqual([917, 769, 937, 789]);
+  });
+
+  it('maps DeepSeek reasoning controls and provider defaults', () => {
+    const defaultResult =
+      deepSeekAdapter.chatCompletion.buildChatCompletionParams({
+        userConfig: {},
+      });
+    const reasoningResult =
+      deepSeekAdapter.chatCompletion.buildChatCompletionParams({
+        userConfig: {
+          reasoningEnabled: true,
+          reasoningEffort: 'max',
+        },
+      });
+    const providerDefaultResult =
+      deepSeekAdapter.chatCompletion.buildChatCompletionParams({
+        userConfig: {
+          reasoningEnabled: 'default',
+          reasoningEffort: 'max',
+        },
+      });
+
+    expect(defaultResult.config).toEqual({
+      temperature: 0,
+      thinking: { type: 'disabled' },
+    });
+    expect(reasoningResult.config).toEqual({
+      temperature: 0,
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'max',
+    });
+    expect(providerDefaultResult.config).toEqual({ temperature: 0 });
+  });
+
+  it('does not replay raw assistant messages without tool calls', () => {
+    expect(deepSeekAdapter.chatCompletion.useReasoningAsContentFallback).toBe(
+      true,
+    );
+    expect(deepSeekAdapter.chatCompletion.replayRawAssistantMessage).toBe(
+      false,
+    );
+    expect(deepSeekAdapter.chatCompletion.unsupportedUserConfig).toEqual([
+      'reasoningBudget',
+    ]);
+  });
+});

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -314,6 +314,7 @@ export type TModelFamily =
   | 'auto-glm'
   | 'auto-glm-multilingual'
   | 'gpt-5'
+  | 'deepseek'
   | 'kimi'
   | 'kimi3'
   | 'xiaomi-mimo';
@@ -334,6 +335,7 @@ export const MODEL_FAMILY_VALUES: TModelFamily[] = [
   'auto-glm',
   'auto-glm-multilingual',
   'gpt-5',
+  'deepseek',
   'kimi',
   'kimi3',
   'xiaomi-mimo',


### PR DESCRIPTION
## Summary

- decouple locate protocols from result formats and centralize coordinate conversion through locate result codecs
- add the `deepseek` model family with DeepSeek-specific point and ref-box locate protocols
- scope the temporary `bbox_2d` response alias compatibility to Qwen adapters
- document the DeepSeek configuration in English and Chinese, including the current multimodal model limitation

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test` (143 test files passed; 1487 tests passed, 8 skipped)
