### PR TITLE
test(computer): stabilize action mode selection

### DIFF
--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -87,7 +87,9 @@ describe('chrome extension playground advanced tests', () => {
       `${SIDE_PANEL} shows an input area with placeholder text containing "assert"`,
     );
 
-    await agent.aiAct(`Click the "Action" button in ${SIDE_PANEL}`);
+    await agent.aiAct(
+      `In ${SIDE_PANEL}, horizontally scroll the action mode selector all the way left if needed, then click the "Action" button immediately to the left of "Tap". Do not click "Tap".`,
+    );
     await sleep(500);
   });
 


### PR DESCRIPTION
## Summary

- make the Chrome extension Playground AI test recover when the narrow mode selector is horizontally offset
- identify the Action mode by its stable position immediately to the left of Tap
- preserve the existing AI-driven interaction coverage

## Why

The same shard can pass or fail depending on whether the model sees the leftmost Action mode after switching through Query and Assert. The failing run only recognized Tap, Query, Assert, and more, then spent the retry budget searching for a button it considered absent.

This is a standalone CI stability change targeting `main`; it is intentionally separate from the WebP stack.

## Validation

- `pnpm run lint`

The Chrome extension Playground AI E2E is exercised by this PR CI because it requires the extension/browser/model integration environment.