### PR TITLE
fix(cli): restore YAML task progress output

### DIFF
--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -47,7 +47,11 @@ tasks:
               thumbnail
             deepLocate: true
       - sleep: 300
-      - aiAssert: The report is in replay-all mode. The main report area shows the interactive replay player, and its visible bottom overlay control bar contains a play or pause control, current and total playback time, a horizontal seek/progress bar, settings, and fullscreen controls.
+      - aiAssert: >-
+          The report is in replay-all mode. The main report area shows the
+          interactive replay player, and its visible bottom overlay control bar
+          contains a play or pause control, current and total playback time, a
+          horizontal seek/progress bar, settings, and fullscreen controls.
 
   # --- Settings popup ---
   - name: settings popup opens and shows options

--- a/apps/report/e2e/report-single.yaml
+++ b/apps/report/e2e/report-single.yaml
@@ -31,12 +31,23 @@ tasks:
       - aiTap:
           locate:
             prompt: >-
-              the black triangular report-wide replay button at the far right
-              of the top-left sidebar toolbar, immediately to the right of
-              "Switch: Command ..."; not a task row, timeline thumbnail, or
-              video player control
-      - sleep: 1000
-      - aiAssert: There is a video player area with a progress bar and playback time display
+              the button labeled "Replay all tasks", shown as a black
+              triangular play icon at the far right of the top-left sidebar
+              toolbar and immediately to the right of the visible text
+              "Switch: Command + Up / Down"; do not click a task row,
+              timeline thumbnail, copy button, download button, or player
+              control
+            deepLocate: true
+      - sleep: 500
+      - aiHover:
+          locate:
+            prompt: >-
+              the large central replay canvas below the Record timeline in the
+              main report area; not the left task sidebar and not a timeline
+              thumbnail
+            deepLocate: true
+      - sleep: 300
+      - aiAssert: The report is in replay-all mode. The main report area shows the interactive replay player, and its visible bottom overlay control bar contains a play or pause control, current and total playback time, a horizontal seek/progress bar, settings, and fullscreen controls.
 
   # --- Settings popup ---
   - name: settings popup opens and shows options

--- a/apps/report/src/components/sidebar/index.less
+++ b/apps/report/src/components/sidebar/index.less
@@ -143,11 +143,20 @@
           align-items: center;
           justify-content: center;
           padding: 6px;
+          border: 0;
           border-radius: 8px;
+          background: transparent;
+          color: inherit;
+          font: inherit;
           transition: all 0.2s;
 
           &:hover {
             background: #e6e8eb;
+          }
+
+          &:focus-visible {
+            outline: 2px solid #1677ff;
+            outline-offset: 1px;
           }
         }
       }

--- a/apps/report/src/components/sidebar/index.tsx
+++ b/apps/report/src/components/sidebar/index.tsx
@@ -904,14 +904,16 @@ const Sidebar = (props: SidebarProps = {}): JSX.Element => {
       </div>
     ) : (
       <div className="page-nav-toolbar">
-        <div
+        <button
+          type="button"
           className="icon-button"
+          aria-label="Replay all tasks"
           onClick={() => {
             setReplayAllMode?.(true);
           }}
         >
           <PlayIcon />
-        </div>
+        </button>
       </div>
     );
 

--- a/apps/report/src/components/sidebar/sidebar-layout.test.ts
+++ b/apps/report/src/components/sidebar/sidebar-layout.test.ts
@@ -48,4 +48,15 @@ describe('sidebar layout', () => {
       /\.total-time-tooltip-metric,\s*\.total-time-tooltip-description\s*{[^}]*grid-column: 1 \/ -1;/s,
     );
   });
+
+  it('exposes replay-all as a labeled keyboard-accessible button', () => {
+    expect(source).toMatch(
+      /<button\s+type="button"\s+className="icon-button"\s+aria-label="Replay all tasks"/,
+    );
+    expect(source).not.toMatch(/<div\s+className="icon-button"/);
+    expect(styles).toMatch(
+      /\.icon-button\s*{[^}]*border: 0;[^}]*background: transparent;/s,
+    );
+    expect(styles).toMatch(/\.icon-button\s*{[\s\S]*?&:focus-visible\s*{/);
+  });
 });

--- a/apps/report/src/e2e-yaml.test.ts
+++ b/apps/report/src/e2e-yaml.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseYamlScript } from '@midscene/core/yaml';
+import { describe, expect, it } from '@rstest/core';
+
+const e2eDirectory = fileURLToPath(new URL('../e2e/', import.meta.url));
+const e2eFiles = readdirSync(e2eDirectory)
+  .filter((file) => file.endsWith('.yaml'))
+  .sort();
+
+describe('report e2e YAML', () => {
+  for (const file of e2eFiles) {
+    it(`parses ${file}`, () => {
+      const filePath = join(e2eDirectory, file);
+      const content = readFileSync(filePath, 'utf8');
+
+      expect(() => parseYamlScript(content, filePath)).not.toThrow();
+    });
+  }
+});

--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -213,11 +213,11 @@ Call the Agent's [`runYaml`](./reference/#runyaml) method to execute YAML from J
 The CLI provides parameters to control how scripts run:
 
 - `--files <file1> <file2> ...`: List of script files. Executes in order, sequentially by default (`--concurrent` is `1`), or concurrently when `--concurrent` is set. Supports [glob](https://www.npmjs.com/package/glob) patterns; when a glob pattern or directory matches multiple files, matched files are added to the execution list in lexicographic path order.
-- `--setup <file>`: A setup script that runs before the main `--files`. The successful setup attempt's browser context is shared with every main script, so prerequisite state such as a login remains visible. When retry is enabled, each setup attempt starts with a clean BrowserContext and Page. If all setup attempts fail, the batch is aborted and the main scripts are reported as not executed. Requires `--share-browser-context`.
+- `--setup <file>`: A setup script that runs before the main `--files` for any supported target. If all setup attempts fail, the batch is aborted and the main scripts are reported as not executed. Puppeteer Web setup requires `--share-browser-context`; each retry then starts with a clean BrowserContext and Page, and the successful context is shared with the main scripts. Bridge mode and non-Web targets must omit `--share-browser-context`; their retries create a new player and Agent but do not reset the underlying browser, device, desktop, or external interface state.
 - `--concurrent <number>`: Number of concurrent executions. Default `1`.
 - `--continue-on-error`: Continue running remaining scripts even if one fails. Default off.
-- `--retry <number>`: Number of extra attempts for a failed script. Only failed scripts are retried, which helps with unstable networks or unstable model output. Default `0`. With `--share-browser-context`, this applies to both setup and main scripts: setup retries use a clean BrowserContext and Page, while main-script retries preserve the successful setup context.
-- `--share-browser-context`: Share browser context (cookies, `localStorage`, etc.) across scripts. Default off.
+- `--retry <number>`: Number of extra attempts for a failed script. Only failed scripts are retried, which helps with unstable networks or unstable model output. Default `0`. Puppeteer Web setup retries use a clean BrowserContext and Page, while main-script retries preserve the successful setup context. Other targets create a new player and Agent for each retry without resetting their underlying environment.
+- `--share-browser-context`: Share one Puppeteer BrowserContext and Page (cookies, `localStorage`, etc.) across scripts. Every setup and main script in the batch must use a Puppeteer Web target. Bridge mode and non-Web targets are not supported. Default off.
 - `--summary <filename>`: Path for the JSON summary report.
 - `--headed`: Run in a headed browser instead of headless.
 - `--keep-window`: Keep the browser window after execution; enables `--headed` automatically.
@@ -269,7 +269,7 @@ midscene --config ./config.yaml
 
 #### Run a setup before parallel scripts
 
-When several independent scripts all depend on the same prerequisite (for example a login), put the prerequisite under `setup`. The setup script runs before the main `files`; once it succeeds, the main scripts run with the configured concurrency. The successful setup attempt's browser context is shared with the main scripts, so the login state is carried over. `setup` requires `shareBrowserContext: true`.
+When several independent Puppeteer Web scripts all depend on the same prerequisite (for example a login), put the prerequisite under `setup`. The setup script runs before the main `files`; once it succeeds, the main scripts run with the configured concurrency. Set `shareBrowserContext: true` so the successful setup attempt's browser context, including the login state, is carried over. Every script in this shared batch must use a Puppeteer Web target; bridge mode is not supported.
 
 ```yaml
 setup: ./scripts/login.yaml
@@ -285,6 +285,8 @@ retry: 2
 ```
 
 `retry` is the number of extra attempts, so `retry: 2` allows up to three attempts. Every setup retry gets a new BrowserContext and Page, preventing cookies, local storage, navigation state, and other browser-side effects from a failed attempt from leaking into the next one. After setup succeeds, its context is shared with the main scripts. A failed main script is retried in that same context so the successful setup state is preserved. If all setup attempts fail, the batch is aborted and the main scripts are reported as not executed.
+
+`setup` also works with bridge mode, Android, iOS, HarmonyOS, Computer, and custom Interface targets. Omit `shareBrowserContext` for those targets. A retry creates a new script player and Agent, but the underlying browser profile, device, desktop session, or custom interface is not automatically reset. If a clean retry environment is required, make the setup script restore that environment explicitly.
 
 ## FAQ
 

--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -217,7 +217,7 @@ The CLI provides parameters to control how scripts run:
 - `--concurrent <number>`: Number of concurrent executions. Default `1`.
 - `--continue-on-error`: Continue running remaining scripts even if one fails. Default off.
 - `--retry <number>`: Number of extra attempts for a failed script. Only failed scripts are retried, which helps with unstable networks or unstable model output. Default `0`. Puppeteer Web setup retries use a clean BrowserContext and Page, while main-script retries preserve the successful setup context. Other targets create a new player and Agent for each retry without resetting their underlying environment.
-- `--share-browser-context`: Share one Puppeteer BrowserContext and Page (cookies, `localStorage`, etc.) across scripts. Every setup and main script in the batch must use a Puppeteer Web target. Bridge mode and non-Web targets are not supported. Default off.
+- `--share-browser-context`: Share one Puppeteer BrowserContext and Page (cookies, `localStorage`, etc.) across scripts. Every setup and main script in the batch must use a Puppeteer Web target. Bridge mode and non-Web targets are not supported. Because the browser is created or connected only once, put browser-level options (`cdpEndpoint`, `chromeArgs`, `acceptInsecureCerts`, and `downloadPath`) in the batch config's global Web target, not in an individual setup or main script. Default off.
 - `--summary <filename>`: Path for the JSON summary report.
 - `--headed`: Run in a headed browser instead of headless.
 - `--keep-window`: Keep the browser window after execution; enables `--headed` automatically.
@@ -270,6 +270,8 @@ midscene --config ./config.yaml
 #### Run a setup before parallel scripts
 
 When several independent Puppeteer Web scripts all depend on the same prerequisite (for example a login), put the prerequisite under `setup`. The setup script runs before the main `files`; once it succeeds, the main scripts run with the configured concurrency. Set `shareBrowserContext: true` so the successful setup attempt's browser context, including the login state, is carried over. Every script in this shared batch must use a Puppeteer Web target; bridge mode is not supported.
+
+The shared Browser is launched or connected from the batch config once. Configure `cdpEndpoint`, `chromeArgs`, `acceptInsecureCerts`, and `downloadPath` in the batch config's global Web target. Defining any of these browser-level options in an individual setup or main script is rejected because it cannot be applied to the already-created shared Browser.
 
 ```yaml
 setup: ./scripts/login.yaml

--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -213,10 +213,10 @@ Call the Agent's [`runYaml`](./reference/#runyaml) method to execute YAML from J
 The CLI provides parameters to control how scripts run:
 
 - `--files <file1> <file2> ...`: List of script files. Executes in order, sequentially by default (`--concurrent` is `1`), or concurrently when `--concurrent` is set. Supports [glob](https://www.npmjs.com/package/glob) patterns; when a glob pattern or directory matches multiple files, matched files are added to the execution list in lexicographic path order.
-- `--setup <file>`: A setup script that runs before the main `--files`. It runs inside the same shared browser context, so prerequisite state such as a login established here is visible to every main script. A setup failure aborts the whole batch and the main scripts are reported as not executed. Requires `--share-browser-context`.
+- `--setup <file>`: A setup script that runs before the main `--files`. The successful setup attempt's browser context is shared with every main script, so prerequisite state such as a login remains visible. When retry is enabled, each setup attempt starts with a clean BrowserContext and Page. If all setup attempts fail, the batch is aborted and the main scripts are reported as not executed. Requires `--share-browser-context`.
 - `--concurrent <number>`: Number of concurrent executions. Default `1`.
 - `--continue-on-error`: Continue running remaining scripts even if one fails. Default off.
-- `--retry <number>`: Number of times to retry a failed script. Only the scripts that failed in the previous attempt are retried, which helps with unstable networks or unstable model output. Default `0`. (Not effective together with `--share-browser-context`, where the whole batch shares a single run.)
+- `--retry <number>`: Number of extra attempts for a failed script. Only failed scripts are retried, which helps with unstable networks or unstable model output. Default `0`. With `--share-browser-context`, this applies to both setup and main scripts: setup retries use a clean BrowserContext and Page, while main-script retries preserve the successful setup context.
 - `--share-browser-context`: Share browser context (cookies, `localStorage`, etc.) across scripts. Default off.
 - `--summary <filename>`: Path for the JSON summary report.
 - `--headed`: Run in a headed browser instead of headless.
@@ -269,7 +269,7 @@ midscene --config ./config.yaml
 
 #### Run a setup before parallel scripts
 
-When several independent scripts all depend on the same prerequisite (for example a login), put the prerequisite under `setup`. The setup script runs before the main `files`; once it succeeds, the main scripts run with the configured concurrency. Setup and main scripts share one browser context, so the login state is carried over. `setup` requires `shareBrowserContext: true`.
+When several independent scripts all depend on the same prerequisite (for example a login), put the prerequisite under `setup`. The setup script runs before the main `files`; once it succeeds, the main scripts run with the configured concurrency. The successful setup attempt's browser context is shared with the main scripts, so the login state is carried over. `setup` requires `shareBrowserContext: true`.
 
 ```yaml
 setup: ./scripts/login.yaml
@@ -281,9 +281,10 @@ files:
 
 shareBrowserContext: true
 concurrent: 3
+retry: 2
 ```
 
-If the setup script fails, the batch is aborted and the main scripts are reported as not executed.
+`retry` is the number of extra attempts, so `retry: 2` allows up to three attempts. Every setup retry gets a new BrowserContext and Page, preventing cookies, local storage, navigation state, and other browser-side effects from a failed attempt from leaking into the next one. After setup succeeds, its context is shared with the main scripts. A failed main script is retried in that same context so the successful setup state is preserved. If all setup attempts fail, the batch is aborted and the main scripts are reported as not executed.
 
 ## FAQ
 

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -225,10 +225,10 @@ page:
 命令行工具提供了多项参数，用于控制脚本的执行行为：
 
 - `--files <file1> <file2> ...`：指定脚本文件列表。默认按顺序执行（`--concurrent` 为 `1`），可通过 `--concurrent` 设置并发数量。支持 [glob](https://www.npmjs.com/package/glob) 通配符语法；当 glob 或目录匹配到多个文件时，匹配结果会按文件路径的字典序排序后加入执行列表。
-- `--setup <file>`：在主 `--files` 之前执行的前置脚本。它与主脚本共享同一个浏览器上下文，因此在这里建立的前置状态（如登录态）对每个主脚本都可见。前置脚本失败会中止整个批次，主脚本将被标记为未执行。需要配合 `--share-browser-context` 使用。
+- `--setup <file>`：在主 `--files` 之前执行的前置脚本。成功的 setup attempt 会将浏览器上下文共享给每个主脚本，因此在这里建立的前置状态（如登录态）仍然可见。启用 retry 后，每次 setup attempt 都会使用全新的 BrowserContext 和 Page。如果所有 setup attempt 都失败，整个批次会被中止，主脚本将被标记为未执行。需要配合 `--share-browser-context` 使用。
 - `--concurrent <number>`：设置并发执行的数量，默认 `1`。
 - `--continue-on-error`：启用后，即使某个脚本失败也会继续执行后续脚本。默认关闭。
-- `--retry <number>`：失败脚本的重试次数。每一轮只会重新执行上一轮失败的脚本，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。（与 `--share-browser-context` 同时使用时不生效，该模式下所有脚本共享同一次执行。）
+- `--retry <number>`：失败脚本的额外尝试次数。只有失败的脚本会被重试，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。与 `--share-browser-context` 同时使用时，setup 和主脚本都会应用 retry：setup retry 使用全新的 BrowserContext 和 Page，主脚本 retry 则保留成功的 setup 上下文。
 - `--share-browser-context`：在多个脚本之间共享浏览器上下文（Cookies、`localStorage` 等），适合需要连续登录态的场景。默认关闭。
 - `--summary <filename>`：指定生成的 JSON 总结报告路径。
 - `--headed`：在带界面的浏览器中运行脚本，而非默认的无头模式。
@@ -281,7 +281,7 @@ midscene --config ./config.yaml
 
 #### 在并行脚本之前执行前置任务
 
-当多个互不依赖的脚本都依赖同一个前置条件（例如登录）时,可以把前置任务写在 `setup` 下。前置脚本会在主 `files` 之前执行;成功后,主脚本再按配置的并发数运行。前置脚本与主脚本共享同一个浏览器上下文,因此登录态会被带过去。`setup` 需要配合 `shareBrowserContext: true` 使用。
+当多个互不依赖的脚本都依赖同一个前置条件（例如登录）时，可以把前置任务写在 `setup` 下。前置脚本会在主 `files` 之前执行；成功后，主脚本再按配置的并发数运行。成功的 setup attempt 会将浏览器上下文共享给主脚本，因此登录态会被带过去。`setup` 需要配合 `shareBrowserContext: true` 使用。
 
 ```yaml
 setup: ./scripts/login.yaml
@@ -293,9 +293,10 @@ files:
 
 shareBrowserContext: true
 concurrent: 3
+retry: 2
 ```
 
-如果前置脚本失败,整个批次会被中止,主脚本将被标记为未执行。
+`retry` 表示额外尝试次数，因此 `retry: 2` 最多会执行三次。每次 setup retry 都会创建新的 BrowserContext 和 Page，避免失败 attempt 留下的 Cookies、`localStorage`、页面导航状态及其他浏览器副作用污染下一次尝试。setup 成功后，其上下文会与主脚本共享；主脚本失败时会在同一上下文中重试，从而保留成功 setup 建立的状态。如果所有 setup attempt 都失败，整个批次会被中止，主脚本将被标记为未执行。
 
 ## 常见问题
 

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -225,11 +225,11 @@ page:
 命令行工具提供了多项参数，用于控制脚本的执行行为：
 
 - `--files <file1> <file2> ...`：指定脚本文件列表。默认按顺序执行（`--concurrent` 为 `1`），可通过 `--concurrent` 设置并发数量。支持 [glob](https://www.npmjs.com/package/glob) 通配符语法；当 glob 或目录匹配到多个文件时，匹配结果会按文件路径的字典序排序后加入执行列表。
-- `--setup <file>`：在主 `--files` 之前执行的前置脚本。成功的 setup attempt 会将浏览器上下文共享给每个主脚本，因此在这里建立的前置状态（如登录态）仍然可见。启用 retry 后，每次 setup attempt 都会使用全新的 BrowserContext 和 Page。如果所有 setup attempt 都失败，整个批次会被中止，主脚本将被标记为未执行。需要配合 `--share-browser-context` 使用。
+- `--setup <file>`：在主 `--files` 之前执行的前置脚本，适用于所有受支持的 target。如果所有 setup attempt 都失败，整个批次会被中止，主脚本将被标记为未执行。Puppeteer Web setup 必须配合 `--share-browser-context` 使用；此时每次 retry 都从全新的 BrowserContext 和 Page 开始，成功 attempt 的上下文会共享给主脚本。桥接模式和非 Web target 必须省略 `--share-browser-context`；它们在 retry 时会创建新的 player 和 Agent，但不会重置底层浏览器、设备、桌面或外部 Interface 的状态。
 - `--concurrent <number>`：设置并发执行的数量，默认 `1`。
 - `--continue-on-error`：启用后，即使某个脚本失败也会继续执行后续脚本。默认关闭。
-- `--retry <number>`：失败脚本的额外尝试次数。只有失败的脚本会被重试，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。与 `--share-browser-context` 同时使用时，setup 和主脚本都会应用 retry：setup retry 使用全新的 BrowserContext 和 Page，主脚本 retry 则保留成功的 setup 上下文。
-- `--share-browser-context`：在多个脚本之间共享浏览器上下文（Cookies、`localStorage` 等），适合需要连续登录态的场景。默认关闭。
+- `--retry <number>`：失败脚本的额外尝试次数。只有失败的脚本会被重试，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。Puppeteer Web setup retry 使用全新的 BrowserContext 和 Page，主脚本 retry 则保留成功的 setup 上下文。其他 target 每次 retry 会创建新的 player 和 Agent，但不会重置底层运行环境。
+- `--share-browser-context`：在多个 Puppeteer Web 脚本之间共享同一个 BrowserContext 和 Page（Cookies、`localStorage` 等）。同一批次中的 setup 和主脚本必须全部使用 Puppeteer Web target；不支持桥接模式和非 Web target。默认关闭。
 - `--summary <filename>`：指定生成的 JSON 总结报告路径。
 - `--headed`：在带界面的浏览器中运行脚本，而非默认的无头模式。
 - `--keep-window`：脚本执行完成后保持浏览器窗口，会自动开启 `--headed` 模式。
@@ -281,7 +281,7 @@ midscene --config ./config.yaml
 
 #### 在并行脚本之前执行前置任务
 
-当多个互不依赖的脚本都依赖同一个前置条件（例如登录）时，可以把前置任务写在 `setup` 下。前置脚本会在主 `files` 之前执行；成功后，主脚本再按配置的并发数运行。成功的 setup attempt 会将浏览器上下文共享给主脚本，因此登录态会被带过去。`setup` 需要配合 `shareBrowserContext: true` 使用。
+当多个互不依赖的 Puppeteer Web 脚本都依赖同一个前置条件（例如登录）时，可以把前置任务写在 `setup` 下。前置脚本会在主 `files` 之前执行；成功后，主脚本再按配置的并发数运行。设置 `shareBrowserContext: true` 后，成功 setup attempt 的浏览器上下文（包括登录态）会被主脚本复用。同一共享批次中的所有脚本都必须使用 Puppeteer Web target，不支持桥接模式。
 
 ```yaml
 setup: ./scripts/login.yaml
@@ -297,6 +297,8 @@ retry: 2
 ```
 
 `retry` 表示额外尝试次数，因此 `retry: 2` 最多会执行三次。每次 setup retry 都会创建新的 BrowserContext 和 Page，避免失败 attempt 留下的 Cookies、`localStorage`、页面导航状态及其他浏览器副作用污染下一次尝试。setup 成功后，其上下文会与主脚本共享；主脚本失败时会在同一上下文中重试，从而保留成功 setup 建立的状态。如果所有 setup attempt 都失败，整个批次会被中止，主脚本将被标记为未执行。
+
+`setup` 也支持桥接模式、Android、iOS、HarmonyOS、Computer 和自定义 Interface target。这些 target 应省略 `shareBrowserContext`。retry 会创建新的脚本 player 和 Agent，但不会自动重置底层浏览器配置、设备、桌面会话或自定义 Interface；如果 retry 必须从干净环境开始，需要由 setup 脚本显式恢复环境。
 
 ## 常见问题
 

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -229,7 +229,7 @@ page:
 - `--concurrent <number>`：设置并发执行的数量，默认 `1`。
 - `--continue-on-error`：启用后，即使某个脚本失败也会继续执行后续脚本。默认关闭。
 - `--retry <number>`：失败脚本的额外尝试次数。只有失败的脚本会被重试，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。Puppeteer Web setup retry 使用全新的 BrowserContext 和 Page，主脚本 retry 则保留成功的 setup 上下文。其他 target 每次 retry 会创建新的 player 和 Agent，但不会重置底层运行环境。
-- `--share-browser-context`：在多个 Puppeteer Web 脚本之间共享同一个 BrowserContext 和 Page（Cookies、`localStorage` 等）。同一批次中的 setup 和主脚本必须全部使用 Puppeteer Web target；不支持桥接模式和非 Web target。默认关闭。
+- `--share-browser-context`：在多个 Puppeteer Web 脚本之间共享同一个 BrowserContext 和 Page（Cookies、`localStorage` 等）。同一批次中的 setup 和主脚本必须全部使用 Puppeteer Web target；不支持桥接模式和非 Web target。由于 Browser 只会创建或连接一次，浏览器级选项（`cdpEndpoint`、`chromeArgs`、`acceptInsecureCerts` 和 `downloadPath`）必须放在批次配置的全局 Web target 中，不能放在单个 setup 或主脚本中。默认关闭。
 - `--summary <filename>`：指定生成的 JSON 总结报告路径。
 - `--headed`：在带界面的浏览器中运行脚本，而非默认的无头模式。
 - `--keep-window`：脚本执行完成后保持浏览器窗口，会自动开启 `--headed` 模式。
@@ -282,6 +282,8 @@ midscene --config ./config.yaml
 #### 在并行脚本之前执行前置任务
 
 当多个互不依赖的 Puppeteer Web 脚本都依赖同一个前置条件（例如登录）时，可以把前置任务写在 `setup` 下。前置脚本会在主 `files` 之前执行；成功后，主脚本再按配置的并发数运行。设置 `shareBrowserContext: true` 后，成功 setup attempt 的浏览器上下文（包括登录态）会被主脚本复用。同一共享批次中的所有脚本都必须使用 Puppeteer Web target，不支持桥接模式。
+
+共享 Browser 只会根据批次配置创建或连接一次。请在批次配置的全局 Web target 中设置 `cdpEndpoint`、`chromeArgs`、`acceptInsecureCerts` 和 `downloadPath`。如果在单个 setup 或主脚本中定义这些浏览器级选项，CLI 会直接报错，因为它们无法应用到已经创建的共享 Browser。
 
 ```yaml
 setup: ./scripts/login.yaml

--- a/packages/cli/src/cli-utils.ts
+++ b/packages/cli/src/cli-utils.ts
@@ -50,7 +50,7 @@ Usage:
       setup: {
         type: 'string',
         description:
-          'A yaml file to run before the main files. Requires --share-browser-context',
+          'A yaml file to run before the main files. Puppeteer Web setup requires --share-browser-context',
       },
       config: {
         type: 'string',
@@ -83,7 +83,7 @@ Usage:
       },
       'share-browser-context': {
         type: 'boolean',
-        description: `Share browser context across multiple yaml files, default is ${defaultConfig.shareBrowserContext}`,
+        description: `Share a Puppeteer Web browser context across multiple yaml files, default is ${defaultConfig.shareBrowserContext}`,
       },
       'dotenv-override': {
         type: 'boolean',

--- a/packages/cli/src/config-factory.ts
+++ b/packages/cli/src/config-factory.ts
@@ -91,23 +91,6 @@ async function expandFilePatterns(
 }
 
 /**
- * A setup file only makes sense when the batch shares one browser context: the
- * prerequisite state it establishes (typically a login) is carried to the main
- * files through the shared page. Without sharing, that state cannot reach the
- * main files, so reject the combination loudly instead of silently dropping it.
- */
-function assertSetupUsage(
-  setup: string | undefined,
-  shareBrowserContext: boolean,
-): void {
-  if (setup && !shareBrowserContext) {
-    throw new Error(
-      'setup requires shareBrowserContext: true, otherwise the setup state cannot be shared with the main files',
-    );
-  }
-}
-
-/**
  * Resolve the optional single setup file. It supports glob/relative paths like
  * the main files, but must reference exactly one file.
  */
@@ -239,7 +222,6 @@ export async function createConfig(
 
   const shareBrowserContext =
     options?.shareBrowserContext ?? parsedConfig.shareBrowserContext;
-  assertSetupUsage(setup, shareBrowserContext);
 
   return {
     files,
@@ -275,7 +257,6 @@ export async function createFilesConfig(
 
   const shareBrowserContext =
     options.shareBrowserContext ?? defaultConfig.shareBrowserContext;
-  assertSetupUsage(setup, shareBrowserContext);
 
   return {
     files,

--- a/packages/cli/src/execution-summary.ts
+++ b/packages/cli/src/execution-summary.ts
@@ -1,6 +1,14 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, relative, resolve } from 'node:path';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
 import type {
   MidsceneYamlConfigAttempt,
   MidsceneYamlConfigResult,
@@ -129,6 +137,58 @@ export function createYamlAttempt(
     duration: result.duration,
     resultType: result.resultType,
   };
+}
+
+export function getYamlAttemptsDuration(
+  attempts: MidsceneYamlConfigAttempt[],
+): number {
+  return attempts.reduce(
+    (total, attempt) => total + (attempt.duration ?? 0),
+    0,
+  );
+}
+
+const retryAttemptReportPath = (
+  reportFile: string,
+  attempt: number,
+): string => {
+  if (basename(reportFile) === 'index.html') {
+    const reportDir = dirname(reportFile);
+    return join(
+      dirname(reportDir),
+      `${basename(reportDir)}-attempt-${attempt}`,
+      'index.html',
+    );
+  }
+
+  const extension = extname(reportFile);
+  const stem = basename(reportFile, extension);
+  return join(dirname(reportFile), `${stem}-attempt-${attempt}${extension}`);
+};
+
+/**
+ * Move a completed attempt's report aside before a stable, user-configured
+ * reportFileName is reused by the next attempt.
+ */
+export function preserveYamlAttemptReport(
+  attempt: MidsceneYamlConfigAttempt,
+): MidsceneYamlConfigAttempt {
+  const source = attempt.report;
+  if (!source || !existsSync(source)) return attempt;
+
+  const target = retryAttemptReportPath(source, attempt.attempt);
+  if (basename(source) === 'index.html') {
+    const sourceDir = dirname(source);
+    const targetDir = dirname(target);
+    rmSync(targetDir, { recursive: true, force: true });
+    cpSync(sourceDir, targetDir, { recursive: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  } else {
+    copyFileSync(source, target);
+    unlinkSync(source);
+  }
+
+  return { ...attempt, report: target };
 }
 
 export function getExecutionSummary(

--- a/packages/cli/src/execution-summary.ts
+++ b/packages/cli/src/execution-summary.ts
@@ -111,6 +111,26 @@ export function createExecutedYamlResult(options: {
   };
 }
 
+export function resolveYamlMaxAttempts(retry?: number): number {
+  if (!Number.isFinite(retry) || !retry || retry < 1) return 1;
+  return Math.floor(retry) + 1;
+}
+
+export function createYamlAttempt(
+  result: MidsceneYamlConfigResult,
+  attempt: number,
+): MidsceneYamlConfigAttempt {
+  return {
+    attempt,
+    success: result.success,
+    output: result.output,
+    report: result.report,
+    error: result.error,
+    duration: result.duration,
+    resultType: result.resultType,
+  };
+}
+
 export function getExecutionSummary(
   results: MidsceneYamlConfigResult[],
 ): ExecutionSummary {

--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -125,7 +125,10 @@ export async function runFrameworkTestConfig(
     maxConcurrency: commandOptions.concurrent ?? config.concurrent,
     bail: config.continueOnError ? 0 : 1,
     retry: config.retry,
-    batchConfig: config.shareBrowserContext ? config : undefined,
+    // setup requires one orchestrated batch even when its target does not use
+    // a shared Puppeteer BrowserContext (for example Android or Computer).
+    batchConfig:
+      config.shareBrowserContext || config.setup ? config : undefined,
   });
 
   const runner = commandOptions.rstestRunner || runRstestYamlProject;

--- a/packages/cli/src/framework/progress-reporter.ts
+++ b/packages/cli/src/framework/progress-reporter.ts
@@ -1,0 +1,23 @@
+import type { Reporter } from '@rstest/core/api';
+
+/** @internal Prefix used to identify Midscene progress in worker console logs. */
+export const yamlProgressLogPrefix = '__MIDSCENE_YAML_PROGRESS__:';
+
+/**
+ * Send YAML progress through Rstest's intercepted console channel. The parent
+ * process reporter below only forwards messages with this prefix, keeping
+ * Rstest's own reporter noise suppressed.
+ */
+export const emitYamlProgress = (message: string): void => {
+  console.log(`${yamlProgressLogPrefix}${message}`);
+};
+
+/** @internal Creates the parent-side reporter that forwards YAML progress. */
+export const createYamlProgressReporter = (): Reporter => ({
+  onUserConsoleLog(log) {
+    if (!log.content.startsWith(yamlProgressLogPrefix)) return;
+
+    const message = log.content.slice(yamlProgressLogPrefix.length);
+    console.log(message.replace(/\r?\n$/, ''));
+  },
+});

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -6,11 +6,14 @@ import type {
 } from '@midscene/core';
 import type { test as rstestTest } from '@rstest/core';
 import type { BatchRunnerConfig } from '../batch-runner';
+import { contextTaskListSummary } from '../printer';
+import { emitYamlProgress } from './progress-reporter';
 import { runYamlBatchInRstest } from './yaml-batch';
 import {
   type RunYamlCaseOptions,
+  type YamlPlayerSnapshotHandler,
   createYamlCaseFailure,
-  runYamlCaseResult,
+  runYamlCaseResultWithSnapshots,
 } from './yaml-case';
 
 export type RstestTest = typeof rstestTest;
@@ -102,6 +105,15 @@ const createRuntimeFailureResult = (
   error: errorMessageOf(error),
 });
 
+const reportYamlPlayerProgress: YamlPlayerSnapshotHandler = ({
+  file,
+  player,
+}) => {
+  emitYamlProgress(
+    contextTaskListSummary(player.taskStatusList, { file, player }),
+  );
+};
+
 export const defineYamlCaseTest = (
   test: RstestTest,
   options: DefineYamlCaseTestOptions,
@@ -112,11 +124,14 @@ export const defineYamlCaseTest = (
     let result: MidsceneYamlConfigResult | undefined;
 
     try {
-      result = await runYamlCaseResult({
-        ...options.caseOptions,
-        ...options.webRuntimeOptions,
-        file,
-      });
+      result = await runYamlCaseResultWithSnapshots(
+        {
+          ...options.caseOptions,
+          ...options.webRuntimeOptions,
+          file,
+        },
+        reportYamlPlayerProgress,
+      );
       result = appendAttemptHistory(options.resultFile, result);
       writeResultFile(options.resultFile, result);
 

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -4,10 +4,13 @@ import type {
   MidsceneYamlConfigAttempt,
   MidsceneYamlConfigResult,
 } from '@midscene/core';
+import { parseYamlScript } from '@midscene/core/yaml';
 import type { test as rstestTest } from '@rstest/core';
 import type { BatchRunnerConfig } from '../batch-runner';
 import {
   createYamlAttempt,
+  getYamlAttemptsDuration,
+  preserveYamlAttemptReport,
   resolveYamlMaxAttempts,
 } from '../execution-summary';
 import { contextTaskListSummary, formatYamlProgressSnapshot } from '../printer';
@@ -65,8 +68,8 @@ const readAttemptHistory = (
 const appendAttemptHistory = (
   resultFile: string,
   result: MidsceneYamlConfigResult,
+  attempts: MidsceneYamlConfigAttempt[],
 ): MidsceneYamlConfigResult => {
-  const attempts = readAttemptHistory(resultFile);
   const nextAttempts = [
     ...attempts,
     createYamlAttempt(result, attempts.length + 1),
@@ -80,8 +83,39 @@ const appendAttemptHistory = (
 
   return {
     ...result,
+    duration: getYamlAttemptsDuration(nextAttempts),
     attempts: nextAttempts,
   };
+};
+
+const hasExplicitReportFileName = (
+  file: string,
+  caseOptions: DefineYamlCaseTestOptions['caseOptions'],
+): boolean => {
+  if (caseOptions?.executionConfig) {
+    return Boolean(caseOptions.executionConfig.agent?.reportFileName);
+  }
+
+  const script = parseYamlScript(readFileSync(file, 'utf8'), file);
+  return Boolean(script.agent?.reportFileName);
+};
+
+const prepareAttemptHistory = (
+  resultFile: string,
+  attempts: MidsceneYamlConfigAttempt[],
+  preserveReport: boolean,
+): MidsceneYamlConfigAttempt[] => {
+  if (!preserveReport || attempts.length === 0) return attempts;
+
+  const nextAttempts = [...attempts];
+  nextAttempts[nextAttempts.length - 1] = preserveYamlAttemptReport(
+    nextAttempts[nextAttempts.length - 1],
+  );
+  writeFileSync(
+    attemptHistoryFileFor(resultFile),
+    JSON.stringify(nextAttempts, null, 2),
+  );
+  return nextAttempts;
 };
 
 const createRuntimeFailureResult = (
@@ -116,11 +150,19 @@ export const defineYamlCaseTest = (
   test(options.testName, async () => {
     const file = resolve(options.yamlFile);
     const startTime = Date.now();
-    const attempt = readAttemptHistory(options.resultFile).length + 1;
+    let attempts = readAttemptHistory(options.resultFile);
+    const attempt = attempts.length + 1;
     const totalAttempts = resolveYamlMaxAttempts(options.retry);
     let result: MidsceneYamlConfigResult | undefined;
 
     try {
+      if (attempt > 1) {
+        attempts = prepareAttemptHistory(
+          options.resultFile,
+          attempts,
+          hasExplicitReportFileName(file, options.caseOptions),
+        );
+      }
       result = await runYamlCaseResultWithSnapshots(
         {
           ...options.caseOptions,
@@ -129,7 +171,7 @@ export const defineYamlCaseTest = (
         },
         createYamlPlayerProgressReporter(attempt, totalAttempts),
       );
-      result = appendAttemptHistory(options.resultFile, result);
+      result = appendAttemptHistory(options.resultFile, result, attempts);
       writeResultFile(options.resultFile, result);
 
       if (!result.success) {
@@ -140,6 +182,7 @@ export const defineYamlCaseTest = (
         const failureResult = appendAttemptHistory(
           options.resultFile,
           createRuntimeFailureResult(file, startTime, error),
+          attempts,
         );
         writeResultFile(options.resultFile, failureResult);
       }

--- a/packages/cli/src/framework/rstest-entry.ts
+++ b/packages/cli/src/framework/rstest-entry.ts
@@ -6,7 +6,11 @@ import type {
 } from '@midscene/core';
 import type { test as rstestTest } from '@rstest/core';
 import type { BatchRunnerConfig } from '../batch-runner';
-import { contextTaskListSummary } from '../printer';
+import {
+  createYamlAttempt,
+  resolveYamlMaxAttempts,
+} from '../execution-summary';
+import { contextTaskListSummary, formatYamlProgressSnapshot } from '../printer';
 import { emitYamlProgress } from './progress-reporter';
 import { runYamlBatchInRstest } from './yaml-batch';
 import {
@@ -22,6 +26,7 @@ export interface DefineYamlCaseTestOptions {
   testName: string;
   yamlFile: string;
   resultFile: string;
+  retry?: number;
   caseOptions?: Omit<RunYamlCaseOptions, 'file' | 'headed' | 'keepWindow'>;
   webRuntimeOptions?: Pick<RunYamlCaseOptions, 'headed' | 'keepWindow'>;
 }
@@ -57,19 +62,6 @@ const readAttemptHistory = (
   ) as MidsceneYamlConfigAttempt[];
 };
 
-const toAttemptResult = (
-  result: MidsceneYamlConfigResult,
-  attempt: number,
-): MidsceneYamlConfigAttempt => ({
-  attempt,
-  success: result.success,
-  output: result.output,
-  report: result.report,
-  error: result.error,
-  duration: result.duration,
-  resultType: result.resultType,
-});
-
 const appendAttemptHistory = (
   resultFile: string,
   result: MidsceneYamlConfigResult,
@@ -77,7 +69,7 @@ const appendAttemptHistory = (
   const attempts = readAttemptHistory(resultFile);
   const nextAttempts = [
     ...attempts,
-    toAttemptResult(result, attempts.length + 1),
+    createYamlAttempt(result, attempts.length + 1),
   ];
 
   mkdirSync(dirname(resultFile), { recursive: true });
@@ -105,14 +97,17 @@ const createRuntimeFailureResult = (
   error: errorMessageOf(error),
 });
 
-const reportYamlPlayerProgress: YamlPlayerSnapshotHandler = ({
-  file,
-  player,
-}) => {
-  emitYamlProgress(
-    contextTaskListSummary(player.taskStatusList, { file, player }),
-  );
-};
+const createYamlPlayerProgressReporter =
+  (attempt: number, totalAttempts: number): YamlPlayerSnapshotHandler =>
+  ({ file, player }) => {
+    const summary = contextTaskListSummary(player.taskStatusList, {
+      file,
+      player,
+    });
+    emitYamlProgress(
+      formatYamlProgressSnapshot(summary, attempt, totalAttempts),
+    );
+  };
 
 export const defineYamlCaseTest = (
   test: RstestTest,
@@ -121,6 +116,8 @@ export const defineYamlCaseTest = (
   test(options.testName, async () => {
     const file = resolve(options.yamlFile);
     const startTime = Date.now();
+    const attempt = readAttemptHistory(options.resultFile).length + 1;
+    const totalAttempts = resolveYamlMaxAttempts(options.retry);
     let result: MidsceneYamlConfigResult | undefined;
 
     try {
@@ -130,7 +127,7 @@ export const defineYamlCaseTest = (
           ...options.webRuntimeOptions,
           file,
         },
-        reportYamlPlayerProgress,
+        createYamlPlayerProgressReporter(attempt, totalAttempts),
       );
       result = appendAttemptHistory(options.resultFile, result);
       writeResultFile(options.resultFile, result);

--- a/packages/cli/src/framework/rstest-project.ts
+++ b/packages/cli/src/framework/rstest-project.ts
@@ -99,6 +99,7 @@ const createGeneratedTestContent = (options: {
   yamlFile: string;
   resultFile: string;
   testName: string;
+  retry?: number;
   caseOptions?: RstestYamlCaseOptions;
   webRuntimeOptions?: WebYamlRuntimeOptions;
 }): string => {
@@ -106,6 +107,7 @@ const createGeneratedTestContent = (options: {
     testName: options.testName,
     yamlFile: options.yamlFile,
     resultFile: options.resultFile,
+    ...(options.retry && options.retry > 0 ? { retry: options.retry } : {}),
     ...(options.caseOptions ? { caseOptions: options.caseOptions } : {}),
     ...(options.webRuntimeOptions
       ? { webRuntimeOptions: options.webRuntimeOptions }
@@ -215,6 +217,7 @@ export function createRstestYamlProject(
       yamlFile,
       resultFile,
       testName,
+      retry: options.retry,
       caseOptions: options.caseOptions?.[yamlFile],
       webRuntimeOptions: options.webRuntimeOptions?.[yamlFile],
     });

--- a/packages/cli/src/framework/rstest-runner.ts
+++ b/packages/cli/src/framework/rstest-runner.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
 import type { RstestUserConfig, TestRunResult } from '@rstest/core/api';
+import { createYamlProgressReporter } from './progress-reporter';
 import { resolvePackageFromRstestCore } from './rstest-dependencies';
 import type {
   GeneratedRstestYamlProject,
@@ -206,7 +207,7 @@ export async function runRstestYamlProject(
     ...(project.retry !== undefined && project.retry > 0
       ? { retry: project.retry }
       : {}),
-    reporters: [],
+    reporters: options.stdio === 'pipe' ? [] : [createYamlProgressReporter()],
     tools: {
       rspack: (_config, { appendPlugins }) => {
         appendPlugins(

--- a/packages/cli/src/framework/yaml-batch.ts
+++ b/packages/cli/src/framework/yaml-batch.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
 import { type BatchRunnerConfig, runYamlBatch } from '../yaml-batch-executor';
+import { emitYamlProgress } from './progress-reporter';
 
 export interface RunYamlBatchInRstestOptions {
   config: BatchRunnerConfig;
@@ -29,6 +30,7 @@ export async function runYamlBatchInRstest(
   const results = await runYamlBatch(options.config, {
     generateSummary: false,
     printExecutionPlan: false,
+    onProgress: emitYamlProgress,
   });
 
   for (const result of results) {

--- a/packages/cli/src/framework/yaml-case.ts
+++ b/packages/cli/src/framework/yaml-case.ts
@@ -30,6 +30,12 @@ export interface RunYamlCaseOptions {
   keepWindow?: boolean;
 }
 
+/** @internal Used by the Rstest worker to forward player state snapshots. */
+export type YamlPlayerSnapshotHandler = (context: {
+  file: string;
+  player: ScriptPlayer<MidsceneYamlScriptEnv>;
+}) => void;
+
 export interface RunYamlCaseResult {
   file: string;
   output?: string;
@@ -158,9 +164,10 @@ export const createYamlCaseFailure = (
   );
 };
 
-export async function runYamlCaseResult(
+const executeYamlCaseResult = async (
   options: RunYamlCaseOptions,
-): Promise<MidsceneYamlConfigResult> {
+  onPlayerSnapshot?: YamlPlayerSnapshotHandler,
+): Promise<MidsceneYamlConfigResult> => {
   const file = resolve(options.file);
   const startTime = Date.now();
   const executionConfig =
@@ -173,9 +180,32 @@ export async function runYamlCaseResult(
     keepWindow: options.keepWindow,
   });
 
-  await player.run();
+  const reportSnapshot = () => {
+    onPlayerSnapshot?.({ file, player });
+  };
+
+  reportSnapshot();
+  try {
+    await player.run();
+  } finally {
+    reportSnapshot();
+  }
 
   return createYamlCaseResult(file, player, Date.now() - startTime);
+};
+
+/** @internal Used by the generated Rstest entry to observe player state. */
+export function runYamlCaseResultWithSnapshots(
+  options: RunYamlCaseOptions,
+  onPlayerSnapshot: YamlPlayerSnapshotHandler,
+): Promise<MidsceneYamlConfigResult> {
+  return executeYamlCaseResult(options, onPlayerSnapshot);
+}
+
+export function runYamlCaseResult(
+  options: RunYamlCaseOptions,
+): Promise<MidsceneYamlConfigResult> {
+  return executeYamlCaseResult(options);
 }
 
 export async function runYamlCase(

--- a/packages/cli/src/printer.ts
+++ b/packages/cli/src/printer.ts
@@ -182,3 +182,12 @@ export const contextTaskListSummary = (
   if (suffixText.length > 0) lines.push(...paddingLines(suffixText));
   return lines.join('\n');
 };
+
+export const formatYamlProgressSnapshot = (
+  message: string,
+  attempt: number,
+  totalAttempts: number,
+): string =>
+  totalAttempts > 1
+    ? `Attempt ${attempt}/${totalAttempts}\n${message}`
+    : message;

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -23,7 +23,12 @@ import {
 
 import merge from 'lodash.merge';
 import pLimit from 'p-limit';
-import puppeteer, { type Browser, type Page } from 'puppeteer';
+import puppeteer, {
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+  type Page,
+} from 'puppeteer';
 import { createYamlPlayer } from './create-yaml-player';
 import {
   createExecutedYamlResult,
@@ -47,19 +52,20 @@ import { TTYWindowRenderer } from './tty-renderer';
 export interface BatchRunnerConfig {
   files: string[];
   /**
-   * A setup yaml file executed before the main `files`. It reuses the shared
-   * browser context, so any prerequisite state (e.g. a login) is visible to
-   * every main file. A setup failure aborts the batch and leaves the main files
-   * not executed. Only honored when `shareBrowserContext` is true; the config
-   * layer rejects other combinations.
+   * A setup yaml file executed before the main `files`. Each failed setup
+   * attempt is discarded with its isolated browser context. The successful
+   * attempt's context is shared with every main file. A setup failure aborts
+   * the batch and leaves the main files not executed. Only honored when
+   * `shareBrowserContext` is true; the config layer rejects other combinations.
    */
   setup?: string;
   concurrent: number;
   continueOnError: boolean;
   /**
    * Number of extra attempts for a failed yaml file. The batch executor owns
-   * retries so shared-browser runs can re-execute only failed files while
-   * preserving the browser context. Defaults to 0 (no retry).
+   * retries so shared-browser runs can re-execute only failed files. Setup
+   * retries receive a clean browser context; main-file retries preserve the
+   * successful setup context. Defaults to 0 (no retry).
    */
   retry?: number;
   summary: string;
@@ -94,6 +100,34 @@ interface ExecutedBatchFileContext extends MidsceneYamlFileContext {
   duration: number;
   yamlResult: MidsceneYamlConfigResult;
 }
+
+interface SharedBrowserRuntime {
+  browserContext: BrowserContext;
+  page: Page;
+}
+
+const createSharedBrowserRuntime = async (
+  browser: Browser,
+  browserContextOptions?: BrowserContextOptions,
+): Promise<SharedBrowserRuntime> => {
+  const browserContext = await browser.createBrowserContext(
+    browserContextOptions,
+  );
+  try {
+    const page = await browserContext.newPage();
+    return { browserContext, page };
+  } catch (error) {
+    try {
+      await browserContext.close();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        'Failed to create and clean up a shared browser runtime',
+      );
+    }
+    throw error;
+  }
+};
 
 export interface RunYamlBatchOptions {
   generateSummary?: boolean;
@@ -139,11 +173,11 @@ class YamlBatchExecutor {
     let setupContext: BatchFileContext | undefined;
     const fileContextList: BatchFileContext[] = [];
     let browser: Browser | null = null;
-    let sharedPage: Page | null = null;
+    const sharedRuntime = { current: null as SharedBrowserRuntime | null };
 
     try {
       // Create the setup context (prerequisite) before the main files so the
-      // TTY plan lists it first and it reuses the same browser context.
+      // TTY plan lists it first and its successful state can be handed off.
       if (setup) {
         const fileConfig = await this.loadFileConfig(setup);
         setupContext = await this.createFileContext(setup, fileConfig, {
@@ -185,20 +219,25 @@ class YamlBatchExecutor {
       const needsBrowser = allContexts.some(
         (ctx) => typeof resolveWebTarget(ctx.executionConfig) !== 'undefined',
       );
+      let resetSetupRuntime: (() => Promise<void>) | undefined;
 
       if (needsBrowser && this.config.shareBrowserContext) {
         const globalWebConfig = resolveWebTarget(
           this.config.globalConfig ?? {},
         )?.target;
+        const downloadBehavior = buildDownloadBehavior(
+          globalWebConfig?.downloadPath,
+        );
+        const browserContextOptions = downloadBehavior
+          ? { downloadBehavior }
+          : undefined;
 
         if (globalWebConfig?.cdpEndpoint) {
           // CDP mode: connect to an existing browser
           browser = await puppeteer.connect({
             browserWSEndpoint: globalWebConfig.cdpEndpoint,
             defaultViewport: null,
-            downloadBehavior: buildDownloadBehavior(
-              globalWebConfig.downloadPath,
-            ),
+            downloadBehavior,
           });
         } else {
           // Extract viewport dimensions from global config or use defaults
@@ -217,46 +256,67 @@ class YamlBatchExecutor {
           browser = await puppeteer.launch({
             headless: !headed,
             defaultViewport: headed ? null : { width, height },
-            downloadBehavior: buildDownloadBehavior(
-              globalWebConfig?.downloadPath,
-            ),
+            downloadBehavior,
             args,
             acceptInsecureCerts: globalWebConfig?.acceptInsecureCerts,
           });
         }
 
-        // Create a shared page instance that will be reused across all YAML files
-        // This ensures localStorage and sessionStorage are preserved between files
-        sharedPage = await browser.newPage();
+        resetSetupRuntime = async () => {
+          if (!browser) {
+            throw new Error('Cannot create a shared runtime without a browser');
+          }
 
-        // Assign the browser instance and shared page to all contexts
-        for (const context of allContexts) {
-          context.options.browser = browser;
-          context.options.page = sharedPage;
-        }
+          if (sharedRuntime.current) {
+            const staleRuntime = sharedRuntime.current;
+            sharedRuntime.current = null;
+            await staleRuntime.browserContext.close();
+          }
+
+          sharedRuntime.current = await createSharedBrowserRuntime(
+            browser,
+            browserContextOptions,
+          );
+          for (const context of allContexts) {
+            context.options.browser = browser;
+            context.options.page = sharedRuntime.current.page;
+          }
+        };
+
+        await resetSetupRuntime();
       }
 
-      // Execute files
+      // A failed setup attempt replaces the shared runtime; main-file retries
+      // keep using the successful setup runtime.
       const { executedResults, notExecutedContexts } = await this.executeFiles(
         setupContext,
         fileContextList,
-        options.onProgress,
+        {
+          onProgress: options.onProgress,
+          resetSetupRuntime,
+        },
       );
 
-      // Process results
       this.results = await this.processResults(
         executedResults,
         notExecutedContexts,
       );
     } finally {
       if (browser && !this.config.keepWindow) {
-        // For CDP mode, disconnect instead of closing the externally managed browser
-        const isCdp = !!resolveWebTarget(this.config.globalConfig ?? {})?.target
-          .cdpEndpoint;
-        if (isCdp) {
-          browser.disconnect();
-        } else {
-          await browser.close();
+        try {
+          if (sharedRuntime.current) {
+            await sharedRuntime.current.browserContext.close();
+            sharedRuntime.current = null;
+          }
+        } finally {
+          // For CDP mode, disconnect instead of closing the externally managed browser.
+          const isCdp = !!resolveWebTarget(this.config.globalConfig ?? {})
+            ?.target.cdpEndpoint;
+          if (isCdp) {
+            browser.disconnect();
+          } else {
+            await browser.close();
+          }
         }
       }
       if (generateSummary) {
@@ -291,7 +351,10 @@ class YamlBatchExecutor {
   private async executeFiles(
     setupContext: BatchFileContext | undefined,
     fileContextList: BatchFileContext[],
-    onProgress?: (message: string) => void,
+    options: {
+      onProgress?: (message: string) => void;
+      resetSetupRuntime?: () => Promise<void>;
+    },
   ): Promise<{
     executedResults: ExecutedBatchFileContext[];
     notExecutedContexts: Array<{
@@ -299,29 +362,29 @@ class YamlBatchExecutor {
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
     }>;
   }> {
+    const { onProgress, resetSetupRuntime } = options;
     const executedResults: ExecutedBatchFileContext[] = [];
     const notExecutedContexts: Array<{
       file: string;
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
     }> = [];
 
-    // Pre-create all player contexts for displaying task lists. The setup file
-    // comes first so the rendered plan reflects the setup-then-parallel order.
+    // Create the setup player first. Main-file players are deferred until the
+    // setup succeeds so they never retain a page from a discarded setup attempt.
     const allFileContexts: MidsceneYamlFileContext[] = [];
-    const orderedContexts = setupContext
-      ? [setupContext, ...fileContextList]
-      : fileContextList;
-    for (const context of orderedContexts) {
-      // Create a ScriptPlayer that will be used for actual execution
-      const player = await createYamlPlayer(
+    const createFilePlayerContext = async (
+      context: BatchFileContext,
+    ): Promise<MidsceneYamlFileContext> => ({
+      file: context.file,
+      player: await createYamlPlayer(
         context.file,
         context.executionConfig,
         context.options,
-      );
-      allFileContexts.push({
-        file: context.file,
-        player,
-      });
+      ),
+    });
+    const initialContexts = setupContext ? [setupContext] : fileContextList;
+    for (const context of initialContexts) {
+      allFileContexts.push(await createFilePlayerContext(context));
     }
 
     // Setup TTY renderer
@@ -362,6 +425,7 @@ class YamlBatchExecutor {
       // Helper function to execute a single file
       const executeFile = async (
         context: BatchFileContext,
+        beforeRetry?: () => Promise<void>,
       ): Promise<ExecutedBatchFileContext> => {
         // Find the corresponding player in allFileContexts
         const allFileContext = allFileContexts.find(
@@ -377,6 +441,7 @@ class YamlBatchExecutor {
 
         for (let attempt = 1; attempt <= totalAttempts; attempt++) {
           if (attempt > 1) {
+            await beforeRetry?.();
             allFileContext.player = await createYamlPlayer(
               context.file,
               context.executionConfig,
@@ -442,7 +507,10 @@ class YamlBatchExecutor {
       // the setup file establishes.
       let setupFailed = false;
       if (setupContext) {
-        const executedContext = await executeFile(setupContext);
+        const executedContext = await executeFile(
+          setupContext,
+          resetSetupRuntime,
+        );
         executedResults.push(executedContext);
         setupFailed = !executedContext.yamlResult.success;
       }
@@ -452,6 +520,11 @@ class YamlBatchExecutor {
           notExecutedContexts.push({ file: context.file, player: null });
         }
       } else {
+        if (setupContext) {
+          for (const context of fileContextList) {
+            allFileContexts.push(await createFilePlayerContext(context));
+          }
+        }
         // Execute based on concurrency and error handling settings
         await this.executeConcurrently(
           fileContextList,

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type {
+  MidsceneYamlConfigAttempt,
   MidsceneYamlConfigResult,
   MidsceneYamlScript,
   MidsceneYamlScriptAndroidEnv,
@@ -27,14 +28,17 @@ import { createYamlPlayer } from './create-yaml-player';
 import {
   createExecutedYamlResult,
   createNotExecutedYamlResult,
+  createYamlAttempt,
   printExecutionFinished,
   printExecutionPlan,
+  resolveYamlMaxAttempts,
   writeExecutionSummaryFile,
 } from './execution-summary';
 import {
   type MidsceneYamlFileContext,
   contextInfo,
   contextTaskListSummary,
+  formatYamlProgressSnapshot,
   isTTY,
   spinnerInterval,
 } from './printer';
@@ -53,9 +57,9 @@ export interface BatchRunnerConfig {
   concurrent: number;
   continueOnError: boolean;
   /**
-   * Number of extra attempts for a failed yaml file. Mapped to Rstest's
-   * `retry` option, so only the cases that failed in the previous attempt
-   * are re-executed. Defaults to 0 (no retry).
+   * Number of extra attempts for a failed yaml file. The batch executor owns
+   * retries so shared-browser runs can re-execute only failed files while
+   * preserving the browser context. Defaults to 0 (no retry).
    */
   retry?: number;
   summary: string;
@@ -84,6 +88,11 @@ interface BatchFileContext {
     browser?: Browser;
     page?: Page;
   };
+}
+
+interface ExecutedBatchFileContext extends MidsceneYamlFileContext {
+  duration: number;
+  yamlResult: MidsceneYamlConfigResult;
 }
 
 export interface RunYamlBatchOptions {
@@ -284,15 +293,13 @@ class YamlBatchExecutor {
     fileContextList: BatchFileContext[],
     onProgress?: (message: string) => void,
   ): Promise<{
-    executedResults: Array<MidsceneYamlFileContext & { duration: number }>;
+    executedResults: ExecutedBatchFileContext[];
     notExecutedContexts: Array<{
       file: string;
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
     }>;
   }> {
-    const executedResults: Array<
-      MidsceneYamlFileContext & { duration: number }
-    > = [];
+    const executedResults: ExecutedBatchFileContext[] = [];
     const notExecutedContexts: Array<{
       file: string;
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
@@ -339,17 +346,23 @@ class YamlBatchExecutor {
       ttyRenderer.start();
     }
 
-    const reportProgressSnapshot = (context: MidsceneYamlFileContext) => {
-      onProgress?.(
-        contextTaskListSummary(context.player.taskStatusList, context),
+    const reportProgressSnapshot = (
+      context: MidsceneYamlFileContext,
+      attempt: number,
+      totalAttempts: number,
+    ) => {
+      const summary = contextTaskListSummary(
+        context.player.taskStatusList,
+        context,
       );
+      onProgress?.(formatYamlProgressSnapshot(summary, attempt, totalAttempts));
     };
 
     try {
       // Helper function to execute a single file
       const executeFile = async (
         context: BatchFileContext,
-      ): Promise<MidsceneYamlFileContext & { duration: number }> => {
+      ): Promise<ExecutedBatchFileContext> => {
         // Find the corresponding player in allFileContexts
         const allFileContext = allFileContexts.find(
           (c) => c.file === context.file,
@@ -358,46 +371,68 @@ class YamlBatchExecutor {
           throw new Error(`Player not found for file: ${context.file}`);
         }
 
-        if (onProgress) {
-          reportProgressSnapshot(allFileContext);
-        } else if (!isTTY) {
-          const { mergedText } = contextInfo(allFileContext);
-          console.log(mergedText);
-        }
+        const totalAttempts = resolveYamlMaxAttempts(this.config.retry);
+        const attempts: MidsceneYamlConfigAttempt[] = [];
+        let executedContext: ExecutedBatchFileContext | undefined;
 
-        // Set output path if specified
-        if (context.outputPath) {
-          allFileContext.player.output = context.outputPath;
-        }
+        for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+          if (attempt > 1) {
+            allFileContext.player = await createYamlPlayer(
+              context.file,
+              context.executionConfig,
+              context.options,
+            );
+          }
 
-        // Record start time
-        const startTime = Date.now();
+          if (onProgress) {
+            reportProgressSnapshot(allFileContext, attempt, totalAttempts);
+          } else if (!isTTY) {
+            const { mergedText } = contextInfo(allFileContext);
+            console.log(mergedText);
+          }
 
-        // Run the player
-        await allFileContext.player.run();
+          if (context.outputPath) {
+            allFileContext.player.output = context.outputPath;
+          }
 
-        // Calculate duration
-        const endTime = Date.now();
-        const duration = endTime - startTime;
-
-        const executedContext: MidsceneYamlFileContext & { duration: number } =
-          {
+          const startTime = Date.now();
+          await allFileContext.player.run();
+          const duration = Date.now() - startTime;
+          const attemptResult = createExecutedYamlResult({
             file: context.file,
             player: allFileContext.player,
             duration,
+          });
+          attempts.push(createYamlAttempt(attemptResult, attempt));
+
+          const yamlResult: MidsceneYamlConfigResult = {
+            ...attemptResult,
+            attempts: [...attempts],
+          };
+          executedContext = {
+            file: context.file,
+            player: allFileContext.player,
+            duration,
+            yamlResult,
           };
 
-        if (onProgress) {
-          reportProgressSnapshot(executedContext);
-        } else if (!isTTY) {
-          console.log(
-            contextTaskListSummary(
-              allFileContext.player.taskStatusList,
-              executedContext,
-            ),
-          );
+          if (onProgress) {
+            reportProgressSnapshot(executedContext, attempt, totalAttempts);
+          } else if (!isTTY) {
+            console.log(
+              contextTaskListSummary(
+                allFileContext.player.taskStatusList,
+                executedContext,
+              ),
+            );
+          }
+
+          if (yamlResult.success) break;
         }
 
+        if (!executedContext) {
+          throw new Error(`No attempts executed for file: ${context.file}`);
+        }
         return executedContext;
       };
 
@@ -409,7 +444,7 @@ class YamlBatchExecutor {
       if (setupContext) {
         const executedContext = await executeFile(setupContext);
         executedResults.push(executedContext);
-        setupFailed = executedContext.player.status === 'error';
+        setupFailed = !executedContext.yamlResult.success;
       }
 
       if (setupFailed) {
@@ -448,8 +483,8 @@ class YamlBatchExecutor {
     fileContextList: BatchFileContext[],
     executeFile: (
       context: BatchFileContext,
-    ) => Promise<MidsceneYamlFileContext & { duration: number }>,
-    executedResults: Array<MidsceneYamlFileContext & { duration: number }>,
+    ) => Promise<ExecutedBatchFileContext>,
+    executedResults: ExecutedBatchFileContext[],
     notExecutedContexts: Array<{
       file: string;
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
@@ -484,7 +519,7 @@ class YamlBatchExecutor {
           const executedContext = await executeFile(context);
           executedResults.push(executedContext);
 
-          if (executedContext.player.status === 'error' && !stopLock.value) {
+          if (!executedContext.yamlResult.success && !stopLock.value) {
             stopLock.value = true;
             shouldStop = true;
           }
@@ -508,7 +543,7 @@ class YamlBatchExecutor {
   }
 
   private async processResults(
-    executedContexts: Array<MidsceneYamlFileContext & { duration: number }>,
+    executedContexts: ExecutedBatchFileContext[],
     notExecutedContexts: Array<{
       file: string;
       player: ScriptPlayer<MidsceneYamlScriptEnv> | null;
@@ -517,8 +552,7 @@ class YamlBatchExecutor {
     const results: MidsceneYamlConfigResult[] = [];
 
     for (const context of executedContexts) {
-      const { file, player, duration } = context;
-      results.push(createExecutedYamlResult({ file, player, duration }));
+      results.push(context.yamlResult);
     }
 
     for (const context of notExecutedContexts) {

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -34,6 +34,8 @@ import {
   createExecutedYamlResult,
   createNotExecutedYamlResult,
   createYamlAttempt,
+  getYamlAttemptsDuration,
+  preserveYamlAttemptReport,
   printExecutionFinished,
   printExecutionPlan,
   resolveYamlMaxAttempts,
@@ -89,6 +91,7 @@ export interface BatchRunnerConfig {
 
 interface BatchFileContext {
   file: string;
+  sourceConfig: MidsceneYamlScript;
   executionConfig: MidsceneYamlScript;
   outputPath?: string;
   options: {
@@ -158,6 +161,25 @@ const assertBrowserContextUsage = (
       throw new Error(
         `shareBrowserContext only supports Puppeteer Web targets, but "${unsupported.context.file}" uses ${batchRuntimeTargetLabel[unsupported.target]}. Remove shareBrowserContext or use a Puppeteer Web target.`,
       );
+    }
+
+    const browserCreationOptions = [
+      'cdpEndpoint',
+      'chromeArgs',
+      'acceptInsecureCerts',
+      'downloadPath',
+    ] as const;
+    for (const { context, target } of resolvedTargets) {
+      if (target !== 'puppeteer-web') continue;
+      const fileWebConfig = resolveWebTarget(context.sourceConfig)?.target;
+      const misplacedOptions = browserCreationOptions.filter(
+        (option) => typeof fileWebConfig?.[option] !== 'undefined',
+      );
+      if (misplacedOptions.length > 0) {
+        throw new Error(
+          `shareBrowserContext creates one browser from the batch global config, so browser-level option(s) ${misplacedOptions.map((option) => `"${option}"`).join(', ')} in "${context.file}" would be ignored. Move them to the batch config's global Web target.`,
+        );
+      }
     }
   }
 
@@ -416,6 +438,7 @@ class YamlBatchExecutor {
 
     return {
       file,
+      sourceConfig: fileConfig,
       executionConfig,
       options,
     };
@@ -514,6 +537,11 @@ class YamlBatchExecutor {
 
         for (let attempt = 1; attempt <= totalAttempts; attempt++) {
           if (attempt > 1) {
+            if (context.executionConfig.agent?.reportFileName) {
+              attempts[attempts.length - 1] = preserveYamlAttemptReport(
+                attempts[attempts.length - 1],
+              );
+            }
             await beforeRetry?.();
             allFileContext.player = await createYamlPlayer(
               context.file,
@@ -542,15 +570,17 @@ class YamlBatchExecutor {
             duration,
           });
           attempts.push(createYamlAttempt(attemptResult, attempt));
+          const totalDuration = getYamlAttemptsDuration(attempts);
 
           const yamlResult: MidsceneYamlConfigResult = {
             ...attemptResult,
+            duration: totalDuration,
             attempts: [...attempts],
           };
           executedContext = {
             file: context.file,
             player: allFileContext.player,
-            duration,
+            duration: totalDuration,
             yamlResult,
           };
 

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -52,23 +52,26 @@ import { TTYWindowRenderer } from './tty-renderer';
 export interface BatchRunnerConfig {
   files: string[];
   /**
-   * A setup yaml file executed before the main `files`. Each failed setup
-   * attempt is discarded with its isolated browser context. The successful
-   * attempt's context is shared with every main file. A setup failure aborts
-   * the batch and leaves the main files not executed. Only honored when
-   * `shareBrowserContext` is true; the config layer rejects other combinations.
+   * A setup yaml file executed before the main `files`. A setup failure aborts
+   * the batch and leaves the main files not executed. Puppeteer Web setup uses
+   * `shareBrowserContext` to pass its successful browser state to the main
+   * files. Other targets run setup in their own target environment without
+   * browser-context sharing.
    */
   setup?: string;
   concurrent: number;
   continueOnError: boolean;
   /**
    * Number of extra attempts for a failed yaml file. The batch executor owns
-   * retries so shared-browser runs can re-execute only failed files. Setup
-   * retries receive a clean browser context; main-file retries preserve the
-   * successful setup context. Defaults to 0 (no retry).
+   * retries so it can re-execute only failed files. Puppeteer Web setup retries
+   * receive a clean browser context; other targets receive a new player/Agent
+   * while their underlying device or external session may retain state.
+   * Main-file retries preserve the successful setup environment. Defaults to 0
+   * (no retry).
    */
   retry?: number;
   summary: string;
+  /** Share one BrowserContext and Page across Puppeteer Web yaml files. */
   shareBrowserContext: boolean;
   globalConfig?: {
     page?: Partial<MidsceneYamlScriptWebEnv>;
@@ -95,6 +98,79 @@ interface BatchFileContext {
     page?: Page;
   };
 }
+
+type BatchRuntimeTarget =
+  | 'puppeteer-web'
+  | 'bridge-web'
+  | 'android'
+  | 'ios'
+  | 'harmony'
+  | 'computer'
+  | 'interface';
+
+const batchRuntimeTargetLabel: Record<BatchRuntimeTarget, string> = {
+  'puppeteer-web': 'Puppeteer Web',
+  'bridge-web': 'Web bridge mode',
+  android: 'Android',
+  ios: 'iOS',
+  harmony: 'HarmonyOS',
+  computer: 'Computer',
+  interface: 'Interface',
+};
+
+/**
+ * Resolve a target only when the script has one unambiguous target family.
+ * Structural target errors remain owned by createYamlPlayer, which provides
+ * the canonical validation messages for missing or conflicting targets.
+ */
+const resolveBatchRuntimeTarget = (
+  config: MidsceneYamlScript,
+): BatchRuntimeTarget | undefined => {
+  const webTarget = resolveWebTarget(config);
+  const targets: BatchRuntimeTarget[] = [];
+  if (webTarget) {
+    targets.push(webTarget.target.bridgeMode ? 'bridge-web' : 'puppeteer-web');
+  }
+  if (typeof config.android !== 'undefined') targets.push('android');
+  if (typeof config.ios !== 'undefined') targets.push('ios');
+  if (typeof config.harmony !== 'undefined') targets.push('harmony');
+  if (typeof config.computer !== 'undefined') targets.push('computer');
+  if (typeof config.interface !== 'undefined') targets.push('interface');
+
+  return targets.length === 1 ? targets[0] : undefined;
+};
+
+const assertBrowserContextUsage = (
+  setupContext: BatchFileContext | undefined,
+  allContexts: BatchFileContext[],
+  shareBrowserContext: boolean,
+): void => {
+  const resolvedTargets = allContexts.map((context) => ({
+    context,
+    target: resolveBatchRuntimeTarget(context.executionConfig),
+  }));
+
+  if (shareBrowserContext) {
+    const unsupported = resolvedTargets.find(
+      ({ target }) => target && target !== 'puppeteer-web',
+    );
+    if (unsupported?.target) {
+      throw new Error(
+        `shareBrowserContext only supports Puppeteer Web targets, but "${unsupported.context.file}" uses ${batchRuntimeTargetLabel[unsupported.target]}. Remove shareBrowserContext or use a Puppeteer Web target.`,
+      );
+    }
+  }
+
+  if (
+    setupContext &&
+    !shareBrowserContext &&
+    resolveBatchRuntimeTarget(setupContext.executionConfig) === 'puppeteer-web'
+  ) {
+    throw new Error(
+      `Puppeteer Web setup "${setupContext.file}" requires shareBrowserContext: true so its browser state can be shared with the main files.`,
+    );
+  }
+};
 
 interface ExecutedBatchFileContext extends MidsceneYamlFileContext {
   duration: number;
@@ -155,15 +231,6 @@ class YamlBatchExecutor {
     const { keepWindow, headed } = this.config;
     const setup = this.config.setup;
 
-    // The setup file relies on the shared page to hand prerequisite state to
-    // the main files. Enforce that invariant here too, so the executor stays
-    // correct even if it is constructed directly, bypassing the config layer.
-    if (setup && !this.config.shareBrowserContext) {
-      throw new Error(
-        'setup requires shareBrowserContext: true, otherwise the setup state cannot be shared with the main files',
-      );
-    }
-
     // Print execution plan
     if (shouldPrintExecutionPlan) {
       printExecutionPlan(this.config);
@@ -214,6 +281,12 @@ class YamlBatchExecutor {
       const allContexts = setupContext
         ? [setupContext, ...fileContextList]
         : fileContextList;
+
+      assertBrowserContextUsage(
+        setupContext,
+        allContexts,
+        this.config.shareBrowserContext,
+      );
 
       // Now, check if any of the tasks require a web browser
       const needsBrowser = allContexts.some(

--- a/packages/cli/src/yaml-batch-executor.ts
+++ b/packages/cli/src/yaml-batch-executor.ts
@@ -89,6 +89,11 @@ interface BatchFileContext {
 export interface RunYamlBatchOptions {
   generateSummary?: boolean;
   printExecutionPlan?: boolean;
+  /**
+   * Receives complete, line-oriented progress snapshots. When provided, the
+   * caller owns progress delivery and direct terminal rendering is disabled.
+   */
+  onProgress?: (message: string) => void;
 }
 
 class YamlBatchExecutor {
@@ -226,6 +231,7 @@ class YamlBatchExecutor {
       const { executedResults, notExecutedContexts } = await this.executeFiles(
         setupContext,
         fileContextList,
+        options.onProgress,
       );
 
       // Process results
@@ -276,6 +282,7 @@ class YamlBatchExecutor {
   private async executeFiles(
     setupContext: BatchFileContext | undefined,
     fileContextList: BatchFileContext[],
+    onProgress?: (message: string) => void,
   ): Promise<{
     executedResults: Array<MidsceneYamlFileContext & { duration: number }>;
     notExecutedContexts: Array<{
@@ -312,7 +319,7 @@ class YamlBatchExecutor {
 
     // Setup TTY renderer
     let ttyRenderer: TTYWindowRenderer | undefined;
-    if (isTTY) {
+    if (isTTY && !onProgress) {
       const summaryContents = () => {
         const summary: string[] = [''];
         for (const context of allFileContexts) {
@@ -332,6 +339,12 @@ class YamlBatchExecutor {
       ttyRenderer.start();
     }
 
+    const reportProgressSnapshot = (context: MidsceneYamlFileContext) => {
+      onProgress?.(
+        contextTaskListSummary(context.player.taskStatusList, context),
+      );
+    };
+
     try {
       // Helper function to execute a single file
       const executeFile = async (
@@ -345,7 +358,9 @@ class YamlBatchExecutor {
           throw new Error(`Player not found for file: ${context.file}`);
         }
 
-        if (!isTTY) {
+        if (onProgress) {
+          reportProgressSnapshot(allFileContext);
+        } else if (!isTTY) {
           const { mergedText } = contextInfo(allFileContext);
           console.log(mergedText);
         }
@@ -372,7 +387,9 @@ class YamlBatchExecutor {
             duration,
           };
 
-        if (!isTTY) {
+        if (onProgress) {
+          reportProgressSnapshot(executedContext);
+        } else if (!isTTY) {
           console.log(
             contextTaskListSummary(
               allFileContext.player.taskStatusList,
@@ -410,7 +427,7 @@ class YamlBatchExecutor {
       }
 
       // Print final summary for non-TTY mode
-      if (!isTTY) {
+      if (!isTTY && !onProgress) {
         console.log('\n📋 Execution Results:');
         for (const context of executedResults) {
           console.log(

--- a/packages/cli/tests/share_context_test_scripts/03-retry-once.yaml
+++ b/packages/cli/tests/share_context_test_scripts/03-retry-once.yaml
@@ -1,0 +1,18 @@
+web:
+  url: http://127.0.0.1:18527/share-context-test.html
+  viewportWidth: 800
+  viewportHeight: 600
+
+tasks:
+  - name: Pass on the second shared-context attempt
+    flow:
+      - javascript: |
+          (function() {
+            const attempt = Number(localStorage.getItem('retryAttempt') || '0') + 1;
+            localStorage.setItem('retryAttempt', String(attempt));
+            if (attempt === 1) {
+              throw new Error('intentional first-attempt failure');
+            }
+            return { attempt };
+          })()
+        name: retry_once

--- a/packages/cli/tests/share_context_test_scripts/04-setup-retry.yaml
+++ b/packages/cli/tests/share_context_test_scripts/04-setup-retry.yaml
@@ -1,0 +1,27 @@
+web:
+  url: http://127.0.0.1:18527/share-context-test.html
+  viewportWidth: 800
+  viewportHeight: 600
+
+tasks:
+  - name: Retry setup without leaking failed-attempt state
+    flow:
+      - javascript: |
+          (async function() {
+            const response = await fetch('http://127.0.0.1:18528/setup-attempt');
+            const { attempt } = await response.json();
+            const failedAttemptResidue = localStorage.getItem('failedSetupResidue');
+
+            if (attempt === 1) {
+              localStorage.setItem('failedSetupResidue', 'must-not-leak');
+              throw new Error('intentional first setup failure');
+            }
+            if (failedAttemptResidue !== null) {
+              throw new Error(`setup retry inherited failed state: ${failedAttemptResidue}`);
+            }
+
+            localStorage.setItem('successfulSetupState', 'ready');
+            document.cookie = 'successfulSetupCookie=ready; path=/';
+            return { attempt, isolated: true };
+          })()
+        name: setup_retry

--- a/packages/cli/tests/share_context_test_scripts/05-check-setup-retry.yaml
+++ b/packages/cli/tests/share_context_test_scripts/05-check-setup-retry.yaml
@@ -1,0 +1,26 @@
+web:
+  url: http://127.0.0.1:18527/share-context-test.html
+  viewportWidth: 800
+  viewportHeight: 600
+
+tasks:
+  - name: Preserve successful setup state across main-file retry
+    flow:
+      - javascript: |
+          (function() {
+            const setupState = localStorage.getItem('successfulSetupState');
+            const failedSetupResidue = localStorage.getItem('failedSetupResidue');
+            const setupCookie = document.cookie.includes('successfulSetupCookie=ready');
+            const attempt = Number(localStorage.getItem('mainFileAttempt') || '0') + 1;
+            localStorage.setItem('mainFileAttempt', String(attempt));
+
+            if (setupState !== 'ready' || !setupCookie || failedSetupResidue !== null) {
+              throw new Error('main file did not receive a clean successful setup context');
+            }
+            if (attempt === 1) {
+              throw new Error('intentional first main-file failure');
+            }
+
+            return { attempt, setupState, setupCookie };
+          })()
+        name: check_setup_retry

--- a/packages/cli/tests/share_context_test_scripts/retry-index.yaml
+++ b/packages/cli/tests/share_context_test_scripts/retry-index.yaml
@@ -1,0 +1,8 @@
+# Retry a failed YAML file while preserving the shared browser context.
+concurrent: 1
+continueOnError: false
+retry: 1
+shareBrowserContext: true
+
+files:
+  - 03-retry-once.yaml

--- a/packages/cli/tests/share_context_test_scripts/setup-retry-index.yaml
+++ b/packages/cli/tests/share_context_test_scripts/setup-retry-index.yaml
@@ -1,0 +1,10 @@
+# Retry setup in isolated contexts, then preserve its successful state for main files.
+concurrent: 1
+continueOnError: false
+retry: 1
+shareBrowserContext: true
+
+setup: 04-setup-retry.yaml
+
+files:
+  - 05-check-setup-retry.yaml

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -1,9 +1,11 @@
 import {
   type Stats,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -199,50 +201,109 @@ describe('BatchRunner', () => {
     });
 
     test('retries only a failed file while reusing the shared browser and page', async () => {
+      rs.mocked(parseYamlScript).mockReturnValue({
+        ...mockYamlScript,
+        agent: { reportFileName: 'custom-report' },
+      } as MidsceneYamlScript);
       let playerCreationCount = 0;
       rs.mocked(createYamlPlayer).mockImplementation(async () => {
         playerCreationCount++;
         return createMockPlayer(playerCreationCount > 1);
       });
       const onProgress = rs.fn();
-      const runner = new BatchRunner({
-        ...mockBatchConfig,
-        shareBrowserContext: true,
-        files: ['retry.yml'],
-        retry: 1,
-      });
+      const dateNow = rs
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(100)
+        .mockReturnValueOnce(110)
+        .mockReturnValueOnce(200)
+        .mockReturnValueOnce(220);
+      try {
+        const runner = new BatchRunner({
+          ...mockBatchConfig,
+          shareBrowserContext: true,
+          files: ['retry.yml'],
+          retry: 1,
+        });
 
-      const results = await runner.run({
-        generateSummary: false,
-        printExecutionPlan: false,
-        onProgress,
-      });
+        const results = await runner.run({
+          generateSummary: false,
+          printExecutionPlan: false,
+          onProgress,
+        });
 
-      expect(createYamlPlayer).toHaveBeenCalledTimes(2);
-      const firstOptions = rs.mocked(createYamlPlayer).mock.calls[0][2];
-      const secondOptions = rs.mocked(createYamlPlayer).mock.calls[1][2];
-      expect(firstOptions?.browser).toBe(secondOptions?.browser);
-      expect(firstOptions?.page).toBe(secondOptions?.page);
-      const browserInstance = (await rs.mocked(puppeteer.launch).mock.results[0]
-        .value) as any;
-      expect(browserInstance.createBrowserContext).toHaveBeenCalledTimes(1);
-      expect(results).toMatchObject([
-        {
-          file: 'retry.yml',
-          success: true,
-          attempts: [
-            { attempt: 1, success: false, resultType: 'failed' },
-            { attempt: 2, success: true, resultType: 'success' },
-          ],
-        },
-      ]);
-      expect(onProgress.mock.calls.map(([message]) => message)).toEqual([
-        'Attempt 1/2\ntest summary',
-        'Attempt 1/2\ntest summary',
-        'Attempt 2/2\ntest summary',
-        'Attempt 2/2\ntest summary',
-      ]);
+        expect(createYamlPlayer).toHaveBeenCalledTimes(2);
+        const firstOptions = rs.mocked(createYamlPlayer).mock.calls[0][2];
+        const secondOptions = rs.mocked(createYamlPlayer).mock.calls[1][2];
+        expect(firstOptions?.browser).toBe(secondOptions?.browser);
+        expect(firstOptions?.page).toBe(secondOptions?.page);
+        const browserInstance = (await rs.mocked(puppeteer.launch).mock
+          .results[0].value) as any;
+        expect(browserInstance.createBrowserContext).toHaveBeenCalledTimes(1);
+        expect(results).toMatchObject([
+          {
+            file: 'retry.yml',
+            success: true,
+            duration: 30,
+            attempts: [
+              {
+                attempt: 1,
+                success: false,
+                resultType: 'failed',
+                duration: 10,
+                report: '/test/report-attempt-1.html',
+              },
+              {
+                attempt: 2,
+                success: true,
+                resultType: 'success',
+                duration: 20,
+                report: '/test/report.html',
+              },
+            ],
+          },
+        ]);
+        expect(copyFileSync).toHaveBeenCalledWith(
+          '/test/report.html',
+          '/test/report-attempt-1.html',
+        );
+        expect(unlinkSync).toHaveBeenCalledWith('/test/report.html');
+        expect(onProgress.mock.calls.map(([message]) => message)).toEqual([
+          'Attempt 1/2\ntest summary',
+          'Attempt 1/2\ntest summary',
+          'Attempt 2/2\ntest summary',
+          'Attempt 2/2\ntest summary',
+        ]);
+      } finally {
+        dateNow.mockRestore();
+      }
     });
+
+    test.each([
+      ['cdpEndpoint', 'ws://localhost:9222/devtools/browser/test'],
+      ['chromeArgs', ['--no-sandbox']],
+      ['acceptInsecureCerts', true],
+      ['downloadPath', './downloads'],
+    ] as const)(
+      'rejects file-level %s instead of silently ignoring it in a shared browser',
+      async (option, value) => {
+        rs.mocked(parseYamlScript).mockReturnValue({
+          tasks: mockYamlScript.tasks,
+          web: { url: 'http://test.com', [option]: value },
+        } as MidsceneYamlScript);
+        const runner = new BatchRunner({
+          ...mockBatchConfig,
+          shareBrowserContext: true,
+          files: ['web1.yml'],
+        });
+
+        await expect(runner.run({ generateSummary: false })).rejects.toThrow(
+          `browser-level option(s) "${option}" in "web1.yml" would be ignored`,
+        );
+        expect(createYamlPlayer).not.toHaveBeenCalled();
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+        expect(puppeteer.connect).not.toHaveBeenCalled();
+      },
+    );
 
     test('should pass chromeArgs from global config to puppeteer.launch when shareBrowserContext is true', async () => {
       const config = {

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -29,22 +29,28 @@ import puppeteer from 'puppeteer';
 rs.mock('node:fs');
 rs.mock('puppeteer', () => ({
   default: {
-    launch: rs.fn().mockResolvedValue({
+    launch: rs.fn().mockImplementation(async () => ({
       close: rs.fn().mockResolvedValue(undefined),
-      newPage: rs.fn().mockResolvedValue({
-        browser: rs.fn().mockReturnValue({}),
+      createBrowserContext: rs.fn().mockImplementation(async () => ({
         close: rs.fn().mockResolvedValue(undefined),
-      }),
-    }),
-    connect: rs.fn().mockResolvedValue({
+        newPage: rs.fn().mockResolvedValue({
+          browser: rs.fn().mockReturnValue({}),
+          close: rs.fn().mockResolvedValue(undefined),
+        }),
+      })),
+    })),
+    connect: rs.fn().mockImplementation(async () => ({
       disconnect: rs.fn(),
       close: rs.fn().mockResolvedValue(undefined),
-      newPage: rs.fn().mockResolvedValue({
-        browser: rs.fn().mockReturnValue({}),
+      createBrowserContext: rs.fn().mockImplementation(async () => ({
         close: rs.fn().mockResolvedValue(undefined),
-      }),
+        newPage: rs.fn().mockResolvedValue({
+          browser: rs.fn().mockReturnValue({}),
+          close: rs.fn().mockResolvedValue(undefined),
+        }),
+      })),
       pages: rs.fn().mockResolvedValue([]),
-    }),
+    })),
   },
 }));
 rs.mock('@/create-yaml-player');
@@ -217,6 +223,9 @@ describe('BatchRunner', () => {
       const secondOptions = rs.mocked(createYamlPlayer).mock.calls[1][2];
       expect(firstOptions?.browser).toBe(secondOptions?.browser);
       expect(firstOptions?.page).toBe(secondOptions?.page);
+      const browserInstance = (await rs.mocked(puppeteer.launch).mock.results[0]
+        .value) as any;
+      expect(browserInstance.createBrowserContext).toHaveBeenCalledTimes(1);
       expect(results).toMatchObject([
         {
           file: 'retry.yml',
@@ -311,6 +320,14 @@ describe('BatchRunner', () => {
         policy: 'allow',
         downloadPath: path.resolve('./downloads'),
       });
+      const browserInstance = (await rs.mocked(puppeteer.launch).mock.results[0]
+        .value) as any;
+      expect(browserInstance.createBrowserContext).toHaveBeenCalledWith({
+        downloadBehavior: {
+          policy: 'allow',
+          downloadPath: path.resolve('./downloads'),
+        },
+      });
     });
 
     test('should not create a shared browser instance when shareBrowserContext is false', async () => {
@@ -403,17 +420,29 @@ describe('BatchRunner', () => {
           downloadPath: path.resolve('./downloads'),
         },
       });
+      const browserInstance = (await rs.mocked(puppeteer.connect).mock
+        .results[0].value) as any;
+      expect(browserInstance.createBrowserContext).toHaveBeenCalledWith({
+        downloadBehavior: {
+          policy: 'allow',
+          downloadPath: path.resolve('./downloads'),
+        },
+      });
     });
 
     test('should disconnect (not close) browser in CDP mode', async () => {
       const mockDisconnect = rs.fn();
       const mockClose = rs.fn().mockResolvedValue(undefined);
+      const mockContextClose = rs.fn().mockResolvedValue(undefined);
       rs.mocked(puppeteer.connect).mockResolvedValue({
         disconnect: mockDisconnect,
         close: mockClose,
-        newPage: rs.fn().mockResolvedValue({
-          browser: rs.fn().mockReturnValue({}),
-          close: rs.fn().mockResolvedValue(undefined),
+        createBrowserContext: rs.fn().mockResolvedValue({
+          close: mockContextClose,
+          newPage: rs.fn().mockResolvedValue({
+            browser: rs.fn().mockReturnValue({}),
+            close: rs.fn().mockResolvedValue(undefined),
+          }),
         }),
         pages: rs.fn().mockResolvedValue([]),
       } as any);
@@ -434,6 +463,7 @@ describe('BatchRunner', () => {
       await runner.run();
 
       // In CDP mode, should disconnect, not close
+      expect(mockContextClose).toHaveBeenCalledTimes(1);
       expect(mockDisconnect).toHaveBeenCalled();
       expect(mockClose).not.toHaveBeenCalled();
     });
@@ -597,40 +627,74 @@ describe('BatchRunner', () => {
       ]);
     });
 
-    test('aborts main files when the setup file fails', async () => {
+    test('aborts main files after setup retries are exhausted', async () => {
       const runOrder: string[] = [];
       trackRunOrder(runOrder, (file) => file !== 'login.yml');
 
-      const runner = new BatchRunner(setupConfig);
-      await runner.run();
+      const runner = new BatchRunner({ ...setupConfig, retry: 1 });
+      const results = await runner.run();
 
       // The main files must never run once the prerequisite setup fails.
-      expect(runOrder).toEqual(['login.yml']);
+      expect(runOrder).toEqual(['login.yml', 'login.yml']);
       expect(runner.getFailedFiles()).toEqual(['login.yml']);
       expect(runner.getNotExecutedFiles().sort()).toEqual([
         'report.yml',
         'search.yml',
       ]);
+      expect(
+        results.find((result) => result.file === 'login.yml'),
+      ).toMatchObject({
+        success: false,
+        attempts: [
+          { attempt: 1, success: false },
+          { attempt: 2, success: false },
+        ],
+      });
+      const browserInstance = (await rs.mocked(puppeteer.launch).mock.results[0]
+        .value) as any;
+      expect(browserInstance.createBrowserContext).toHaveBeenCalledTimes(2);
+      const browserContexts = await Promise.all(
+        browserInstance.createBrowserContext.mock.results.map(
+          (result: { value: Promise<unknown> }) => result.value,
+        ),
+      );
+      for (const browserContext of browserContexts as Array<{
+        close: ReturnType<typeof rs.fn>;
+      }>) {
+        expect(browserContext.close).toHaveBeenCalledTimes(1);
+      }
+      expect(browserInstance.close).toHaveBeenCalledTimes(1);
     });
 
-    test('retries a failed setup before running dependent files', async () => {
+    test('retries setup in a fresh context and shares only the successful context', async () => {
       const runOrder: string[] = [];
       const creationCountByFile = new Map<string, number>();
-      rs.mocked(createYamlPlayer).mockImplementation(async (file) => {
-        const fileName = file as string;
-        const creationCount = (creationCountByFile.get(fileName) ?? 0) + 1;
-        creationCountByFile.set(fileName, creationCount);
-        const shouldSucceed = fileName !== 'login.yml' || creationCount > 1;
-        const player = createMockPlayer(shouldSucceed);
-        const originalRun = player.run;
-        (player as unknown as { run: () => Promise<void> }).run = rs.fn(
-          async () => {
-            runOrder.push(fileName);
-            return originalRun();
-          },
-        );
-        return player;
-      });
+      const setupPages: unknown[] = [];
+      const mainPages: unknown[] = [];
+      const browsers: unknown[] = [];
+      rs.mocked(createYamlPlayer).mockImplementation(
+        async (file, _, options) => {
+          const fileName = file as string;
+          const creationCount = (creationCountByFile.get(fileName) ?? 0) + 1;
+          creationCountByFile.set(fileName, creationCount);
+          browsers.push(options?.browser);
+          if (fileName === 'login.yml') {
+            setupPages.push(options?.page);
+          } else {
+            mainPages.push(options?.page);
+          }
+          const shouldSucceed = fileName !== 'login.yml' || creationCount > 1;
+          const player = createMockPlayer(shouldSucceed);
+          const originalRun = player.run;
+          (player as unknown as { run: () => Promise<void> }).run = rs.fn(
+            async () => {
+              runOrder.push(fileName);
+              return originalRun();
+            },
+          );
+          return player;
+        },
+      );
 
       const runner = new BatchRunner({ ...setupConfig, retry: 1 });
       const results = await runner.run();
@@ -638,6 +702,24 @@ describe('BatchRunner', () => {
       expect(runOrder[0]).toBe('login.yml');
       expect(runOrder[1]).toBe('login.yml');
       expect(runOrder.slice(2).sort()).toEqual(['report.yml', 'search.yml']);
+      expect(rs.mocked(puppeteer.launch)).toHaveBeenCalledTimes(1);
+      const browserInstance = (await rs.mocked(puppeteer.launch).mock.results[0]
+        .value) as any;
+      expect(browserInstance.createBrowserContext).toHaveBeenCalledTimes(2);
+      const firstBrowserContext = (await browserInstance.createBrowserContext
+        .mock.results[0].value) as any;
+      const secondBrowserContext = (await browserInstance.createBrowserContext
+        .mock.results[1].value) as any;
+      expect(firstBrowserContext).not.toBe(secondBrowserContext);
+      expect(firstBrowserContext.close).toHaveBeenCalledTimes(1);
+      expect(secondBrowserContext.close).toHaveBeenCalledTimes(1);
+      expect(browserInstance.close).toHaveBeenCalledTimes(1);
+      expect(setupPages).toHaveLength(2);
+      expect(setupPages[0]).not.toBe(setupPages[1]);
+      expect(mainPages).toEqual([setupPages[1], setupPages[1]]);
+      expect(browsers.every((candidate) => candidate === browserInstance)).toBe(
+        true,
+      );
       expect(
         results.find((result) => result.file === 'login.yml'),
       ).toMatchObject({
@@ -648,6 +730,33 @@ describe('BatchRunner', () => {
         ],
       });
       expect(runner.getNotExecutedFiles()).toEqual([]);
+    });
+
+    test('cleans every context and the browser when setup runtime recreation fails', async () => {
+      const firstBrowserContext = {
+        close: rs.fn().mockResolvedValue(undefined),
+        newPage: rs.fn().mockResolvedValue({}),
+      };
+      const secondBrowserContext = {
+        close: rs.fn().mockResolvedValue(undefined),
+        newPage: rs.fn().mockRejectedValue(new Error('page creation failed')),
+      };
+      const browser = {
+        close: rs.fn().mockResolvedValue(undefined),
+        createBrowserContext: rs
+          .fn()
+          .mockResolvedValueOnce(firstBrowserContext)
+          .mockResolvedValueOnce(secondBrowserContext),
+      };
+      rs.mocked(puppeteer.launch).mockResolvedValueOnce(browser as any);
+      rs.mocked(createYamlPlayer).mockResolvedValue(createMockPlayer(false));
+
+      const runner = new BatchRunner({ ...setupConfig, retry: 1 });
+
+      await expect(runner.run()).rejects.toThrow('page creation failed');
+      expect(firstBrowserContext.close).toHaveBeenCalledTimes(1);
+      expect(secondBrowserContext.close).toHaveBeenCalledTimes(1);
+      expect(browser.close).toHaveBeenCalledTimes(1);
     });
 
     test('throws when setup is set without shareBrowserContext', async () => {

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -142,6 +142,24 @@ describe('BatchRunner', () => {
     rs.mocked(getMidsceneRunSubDir).mockReturnValue('/test/output');
   });
 
+  test('delivers progress snapshots to the caller', async () => {
+    const onProgress = vi.fn();
+    const runner = new BatchRunner({
+      ...mockBatchConfig,
+      files: ['login.yml'],
+    });
+
+    await runner.run({
+      generateSummary: false,
+      printExecutionPlan: false,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'test summary');
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'test summary');
+  });
+
   describe('shareBrowserContext logic', () => {
     test('should create one browser instance when shareBrowserContext is true', async () => {
       const config = {

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -353,10 +353,10 @@ describe('BatchRunner', () => {
       );
     });
 
-    test('should not create any browser instance if no web tasks', async () => {
+    test('should not create any browser instance for non-Web tasks', async () => {
       const config = {
         ...mockBatchConfig,
-        shareBrowserContext: true, // even if true
+        shareBrowserContext: false,
         files: ['android1.yml', 'android2.yml'],
         globalConfig: {},
       };
@@ -759,7 +759,7 @@ describe('BatchRunner', () => {
       expect(browser.close).toHaveBeenCalledTimes(1);
     });
 
-    test('throws when setup is set without shareBrowserContext', async () => {
+    test('requires shareBrowserContext for Puppeteer Web setup', async () => {
       const config = {
         ...mockBatchConfig,
         shareBrowserContext: false,
@@ -768,8 +768,133 @@ describe('BatchRunner', () => {
       };
       const runner = new BatchRunner(config);
       await expect(runner.run()).rejects.toThrow(
-        'setup requires shareBrowserContext: true',
+        'Puppeteer Web setup "login.yml" requires shareBrowserContext: true',
       );
+    });
+
+    const nonPuppeteerTargets: Array<
+      [string, Omit<MidsceneYamlScript, 'tasks'>]
+    > = [
+      [
+        'Web bridge mode',
+        { page: { url: 'about:blank', bridgeMode: 'currentTab' } },
+      ],
+      ['Android', { android: {} }],
+      ['iOS', { ios: {} }],
+      ['HarmonyOS', { harmony: {} }],
+      ['Computer', { computer: {} }],
+      ['Interface', { interface: { module: './test-interface', param: {} } }],
+    ];
+
+    for (const [targetName, targetConfig] of nonPuppeteerTargets) {
+      test(`allows ${targetName} setup without shareBrowserContext`, async () => {
+        rs.mocked(parseYamlScript).mockReturnValue({
+          ...targetConfig,
+          tasks: mockYamlScript.tasks,
+        });
+        const config = {
+          ...mockBatchConfig,
+          globalConfig: {},
+          shareBrowserContext: false,
+          setup: 'prepare.yml',
+          files: ['main.yml'],
+        };
+
+        const runner = new BatchRunner(config);
+        const results = await runner.run({ generateSummary: false });
+
+        expect(results.map((result) => result.file)).toEqual([
+          'prepare.yml',
+          'main.yml',
+        ]);
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+      });
+    }
+
+    test('retries non-Puppeteer setup with a new player before running main files', async () => {
+      rs.mocked(parseYamlScript).mockReturnValue({
+        android: {},
+        tasks: mockYamlScript.tasks,
+      });
+      const runOrder: string[] = [];
+      let setupCreationCount = 0;
+      rs.mocked(createYamlPlayer).mockImplementation(async (file) => {
+        const fileName = file as string;
+        if (fileName === 'prepare.yml') setupCreationCount++;
+        const player = createMockPlayer(
+          fileName !== 'prepare.yml' || setupCreationCount > 1,
+        );
+        const originalRun = player.run;
+        (player as unknown as { run: () => Promise<void> }).run = rs.fn(
+          async () => {
+            runOrder.push(fileName);
+            return originalRun();
+          },
+        );
+        return player;
+      });
+
+      const runner = new BatchRunner({
+        ...mockBatchConfig,
+        globalConfig: {},
+        shareBrowserContext: false,
+        setup: 'prepare.yml',
+        files: ['main.yml'],
+        retry: 1,
+      });
+      const results = await runner.run({ generateSummary: false });
+
+      expect(runOrder).toEqual(['prepare.yml', 'prepare.yml', 'main.yml']);
+      expect(setupCreationCount).toBe(2);
+      expect(
+        results.find((result) => result.file === 'prepare.yml'),
+      ).toMatchObject({
+        success: true,
+        attempts: [
+          { attempt: 1, success: false },
+          { attempt: 2, success: true },
+        ],
+      });
+      expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    test('rejects shareBrowserContext for non-Puppeteer targets', async () => {
+      rs.mocked(parseYamlScript).mockReturnValue({
+        android: {},
+        tasks: mockYamlScript.tasks,
+      });
+      const runner = new BatchRunner({
+        ...mockBatchConfig,
+        globalConfig: {},
+        shareBrowserContext: true,
+        files: ['android.yml'],
+      });
+
+      await expect(runner.run({ generateSummary: false })).rejects.toThrow(
+        'shareBrowserContext only supports Puppeteer Web targets, but "android.yml" uses Android',
+      );
+      expect(createYamlPlayer).not.toHaveBeenCalled();
+      expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    test('rejects shareBrowserContext for Web bridge mode', async () => {
+      rs.mocked(parseYamlScript).mockReturnValue({
+        page: { url: 'about:blank', bridgeMode: 'currentTab' },
+        tasks: mockYamlScript.tasks,
+      });
+      const runner = new BatchRunner({
+        ...mockBatchConfig,
+        globalConfig: {},
+        shareBrowserContext: true,
+        setup: 'prepare.yml',
+        files: ['main.yml'],
+      });
+
+      await expect(runner.run({ generateSummary: false })).rejects.toThrow(
+        'shareBrowserContext only supports Puppeteer Web targets, but "prepare.yml" uses Web bridge mode',
+      );
+      expect(createYamlPlayer).not.toHaveBeenCalled();
+      expect(puppeteer.launch).not.toHaveBeenCalled();
     });
 
     test('throws when a yaml file is both the setup and a main file', async () => {

--- a/packages/cli/tests/unit-test/batch-runner.test.ts
+++ b/packages/cli/tests/unit-test/batch-runner.test.ts
@@ -57,6 +57,12 @@ rs.mock('@/printer', () => ({
   isTTY: false,
   contextInfo: rs.fn().mockReturnValue({ mergedText: 'test info' }),
   contextTaskListSummary: rs.fn().mockReturnValue('test summary'),
+  formatYamlProgressSnapshot: rs.fn(
+    (message: string, attempt: number, totalAttempts: number) =>
+      totalAttempts > 1
+        ? `Attempt ${attempt}/${totalAttempts}\n${message}`
+        : message,
+  ),
   spinnerInterval: 80,
 }));
 rs.mock('@/tty-renderer');
@@ -143,7 +149,7 @@ describe('BatchRunner', () => {
   });
 
   test('delivers progress snapshots to the caller', async () => {
-    const onProgress = vi.fn();
+    const onProgress = rs.fn();
     const runner = new BatchRunner({
       ...mockBatchConfig,
       files: ['login.yml'],
@@ -184,6 +190,49 @@ describe('BatchRunner', () => {
         expect.any(Object),
         expect.objectContaining({ browser: browserInstance }),
       );
+    });
+
+    test('retries only a failed file while reusing the shared browser and page', async () => {
+      let playerCreationCount = 0;
+      rs.mocked(createYamlPlayer).mockImplementation(async () => {
+        playerCreationCount++;
+        return createMockPlayer(playerCreationCount > 1);
+      });
+      const onProgress = rs.fn();
+      const runner = new BatchRunner({
+        ...mockBatchConfig,
+        shareBrowserContext: true,
+        files: ['retry.yml'],
+        retry: 1,
+      });
+
+      const results = await runner.run({
+        generateSummary: false,
+        printExecutionPlan: false,
+        onProgress,
+      });
+
+      expect(createYamlPlayer).toHaveBeenCalledTimes(2);
+      const firstOptions = rs.mocked(createYamlPlayer).mock.calls[0][2];
+      const secondOptions = rs.mocked(createYamlPlayer).mock.calls[1][2];
+      expect(firstOptions?.browser).toBe(secondOptions?.browser);
+      expect(firstOptions?.page).toBe(secondOptions?.page);
+      expect(results).toMatchObject([
+        {
+          file: 'retry.yml',
+          success: true,
+          attempts: [
+            { attempt: 1, success: false, resultType: 'failed' },
+            { attempt: 2, success: true, resultType: 'success' },
+          ],
+        },
+      ]);
+      expect(onProgress.mock.calls.map(([message]) => message)).toEqual([
+        'Attempt 1/2\ntest summary',
+        'Attempt 1/2\ntest summary',
+        'Attempt 2/2\ntest summary',
+        'Attempt 2/2\ntest summary',
+      ]);
     });
 
     test('should pass chromeArgs from global config to puppeteer.launch when shareBrowserContext is true', async () => {
@@ -562,6 +611,43 @@ describe('BatchRunner', () => {
         'report.yml',
         'search.yml',
       ]);
+    });
+
+    test('retries a failed setup before running dependent files', async () => {
+      const runOrder: string[] = [];
+      const creationCountByFile = new Map<string, number>();
+      rs.mocked(createYamlPlayer).mockImplementation(async (file) => {
+        const fileName = file as string;
+        const creationCount = (creationCountByFile.get(fileName) ?? 0) + 1;
+        creationCountByFile.set(fileName, creationCount);
+        const shouldSucceed = fileName !== 'login.yml' || creationCount > 1;
+        const player = createMockPlayer(shouldSucceed);
+        const originalRun = player.run;
+        (player as unknown as { run: () => Promise<void> }).run = rs.fn(
+          async () => {
+            runOrder.push(fileName);
+            return originalRun();
+          },
+        );
+        return player;
+      });
+
+      const runner = new BatchRunner({ ...setupConfig, retry: 1 });
+      const results = await runner.run();
+
+      expect(runOrder[0]).toBe('login.yml');
+      expect(runOrder[1]).toBe('login.yml');
+      expect(runOrder.slice(2).sort()).toEqual(['report.yml', 'search.yml']);
+      expect(
+        results.find((result) => result.file === 'login.yml'),
+      ).toMatchObject({
+        success: true,
+        attempts: [
+          { attempt: 1, success: false },
+          { attempt: 2, success: true },
+        ],
+      });
+      expect(runner.getNotExecutedFiles()).toEqual([]);
     });
 
     test('throws when setup is set without shareBrowserContext', async () => {

--- a/packages/cli/tests/unit-test/config-factory.test.ts
+++ b/packages/cli/tests/unit-test/config-factory.test.ts
@@ -429,7 +429,7 @@ shareBrowserContext: true
       expect(result.files).toEqual(['search.yml']);
     });
 
-    test('should reject setup without shareBrowserContext', async () => {
+    test('should keep setup without deciding target-specific sharing', async () => {
       const mockYamlContent = `
 setup: login.yml
 files:
@@ -445,9 +445,11 @@ files:
         .mockResolvedValueOnce(['search.yml']) // files
         .mockResolvedValueOnce(['login.yml']); // setup
 
-      await expect(createConfig('/test/index.yml')).rejects.toThrow(
-        'setup requires shareBrowserContext: true',
-      );
+      const result = await createConfig('/test/index.yml');
+
+      expect(result.setup).toBe('login.yml');
+      expect(result.files).toEqual(['search.yml']);
+      expect(result.shareBrowserContext).toBe(false);
     });
 
     test('should override config files with command-line files parameter', async () => {
@@ -583,15 +585,19 @@ concurrent: 2
       expect(result.files).toEqual(['search.yml']);
     });
 
-    test('should reject setup without shareBrowserContext', async () => {
+    test('should resolve setup without deciding target-specific sharing', async () => {
       const patterns = ['search.yml'];
       rs.mocked(matchYamlFiles)
         .mockResolvedValueOnce(['search.yml']) // files
         .mockResolvedValueOnce(['login.yml']); // setup
 
-      await expect(
-        createFilesConfig(patterns, { setup: 'login.yml' }),
-      ).rejects.toThrow('setup requires shareBrowserContext: true');
+      const result = await createFilesConfig(patterns, {
+        setup: 'login.yml',
+      });
+
+      expect(result.setup).toBe('login.yml');
+      expect(result.files).toEqual(['search.yml']);
+      expect(result.shareBrowserContext).toBe(false);
     });
 
     test('should forward the retry option through createFilesConfig', async () => {

--- a/packages/cli/tests/unit-test/execution-summary.test.ts
+++ b/packages/cli/tests/unit-test/execution-summary.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@midscene/core';
 import { afterEach, describe, expect, rs, test } from '@rstest/core';
 import {
+  preserveYamlAttemptReport,
   printExecutionPlan,
   printExecutionSummary,
   writeExecutionSummaryFile,
@@ -40,6 +41,44 @@ afterEach(() => {
 });
 
 describe('execution summary', () => {
+  test('preserves a directory-based report as a complete retry artifact', () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-summary-'));
+    const reportFile = join(root, 'custom-report', 'index.html');
+    const screenshotFile = join(root, 'custom-report', 'screenshots', '1.png');
+    mkdirSync(dirname(screenshotFile), { recursive: true });
+    writeFileSync(reportFile, '<html>attempt one</html>', {
+      flag: 'w',
+    });
+    writeFileSync(screenshotFile, 'screenshot');
+
+    try {
+      const preserved = preserveYamlAttemptReport({
+        attempt: 1,
+        success: false,
+        report: reportFile,
+        duration: 10,
+        resultType: 'failed',
+      });
+      const archivedReport = join(
+        root,
+        'custom-report-attempt-1',
+        'index.html',
+      );
+
+      expect(preserved.report).toBe(archivedReport);
+      expect(existsSync(reportFile)).toBe(false);
+      expect(readFileSync(archivedReport, 'utf8')).toContain('attempt one');
+      expect(
+        readFileSync(
+          join(root, 'custom-report-attempt-1', 'screenshots', '1.png'),
+          'utf8',
+        ),
+      ).toBe('screenshot');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('prints the configured retry count in the execution plan', () => {
     printExecutionPlan({
       files: ['/tmp/case.yaml'],

--- a/packages/cli/tests/unit-test/framework/command.test.ts
+++ b/packages/cli/tests/unit-test/framework/command.test.ts
@@ -191,6 +191,83 @@ export function defineYamlCaseTest(test: any, options: any) {
     }
   });
 
+  test('uses one batch virtual entry for setup without browser sharing', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const setupYaml = join(root, 'setup-android.yaml');
+    const mainYaml = join(root, 'main-android.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(setupYaml, 'android: {}\ntasks: []\n');
+    writeFileSync(mainYaml, 'android: {}\ntasks: []\n');
+
+    try {
+      const exitCode = await runFrameworkTestConfig(
+        {
+          setup: setupYaml,
+          files: [mainYaml],
+          concurrent: 1,
+          continueOnError: false,
+          retry: 1,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: false,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          frameworkImport: '@test/framework',
+          stdio: 'pipe',
+          rstestRunner: async ({ project }) => {
+            expect(project.include).toEqual([
+              'virtual:midscene-yaml/batch.test.ts',
+            ]);
+            expect(project.maxConcurrency).toBe(1);
+            const batchModule = project.virtualModules[project.include[0]];
+            expect(batchModule).toContain('defineYamlBatchTest');
+            expect(batchModule).toContain('"shareBrowserContext": false');
+            expect(batchModule).toContain('"retry": 1');
+            expect(project.cases.map((item) => item.yamlFile)).toEqual([
+              setupYaml,
+              mainYaml,
+            ]);
+            for (const item of project.cases) {
+              mkdirSync(dirname(item.resultFile), { recursive: true });
+              writeFileSync(
+                item.resultFile,
+                JSON.stringify({
+                  file: item.yamlFile,
+                  success: true,
+                  executed: true,
+                  duration: 1,
+                  resultType: 'success',
+                }),
+              );
+            }
+            return 0;
+          },
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      const summary = JSON.parse(
+        readFileSync(join(runDir, 'output', 'summary.json'), 'utf8'),
+      );
+      expect(summary.summary).toMatchObject({ total: 2, successful: 2 });
+    } finally {
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('lets Rstest schedule virtual entries by concurrency and stops after failure', async () => {
     const root = createTempDir();
     const runDir = join(root, 'midscene-run');

--- a/packages/cli/tests/unit-test/framework/progress-reporter.test.ts
+++ b/packages/cli/tests/unit-test/framework/progress-reporter.test.ts
@@ -1,0 +1,37 @@
+import {
+  createYamlProgressReporter,
+  emitYamlProgress,
+  yamlProgressLogPrefix,
+} from '@/framework/progress-reporter';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+describe('YAML progress reporter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('emits progress with an internal marker', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    emitYamlProgress('  ◌ login');
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      `${yamlProgressLogPrefix}  ◌ login`,
+    );
+  });
+
+  test('prints only marked worker progress without the internal marker', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const reporter = createYamlProgressReporter();
+
+    reporter.onUserConsoleLog?.({
+      content: `${yamlProgressLogPrefix}◌ login.yaml\n  ◌ open login page\r\n`,
+    } as never);
+    reporter.onUserConsoleLog?.({ content: 'Rstest internal output' } as never);
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith(
+      '◌ login.yaml\n  ◌ open login page',
+    );
+  });
+});

--- a/packages/cli/tests/unit-test/framework/progress-reporter.test.ts
+++ b/packages/cli/tests/unit-test/framework/progress-reporter.test.ts
@@ -3,15 +3,15 @@ import {
   emitYamlProgress,
   yamlProgressLogPrefix,
 } from '@/framework/progress-reporter';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, rs, test } from '@rstest/core';
 
 describe('YAML progress reporter', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    rs.restoreAllMocks();
   });
 
   test('emits progress with an internal marker', () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
 
     emitYamlProgress('  ◌ login');
 
@@ -21,7 +21,7 @@ describe('YAML progress reporter', () => {
   });
 
   test('prints only marked worker progress without the internal marker', () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
     const reporter = createYamlProgressReporter();
 
     reporter.onUserConsoleLog?.({

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -188,4 +188,63 @@ describe('defineYamlCaseTest', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('labels player snapshots with the current retry attempt', async () => {
+    const root = createTempDir();
+    const yaml = join(root, 'case.yaml');
+    const resultFile = join(root, 'results', 'case.json');
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+    let runCount = 0;
+
+    mocks.runYamlCaseResultWithSnapshots.mockImplementation(
+      async (_options, onPlayerSnapshot) => {
+        runCount++;
+        onPlayerSnapshot({
+          file: yaml,
+          player: {
+            status: runCount === 1 ? 'error' : 'done',
+            taskStatusList: [
+              {
+                name: 'enter recruitment credentials',
+                status: runCount === 1 ? 'error' : 'done',
+              },
+            ],
+            result: {},
+          },
+        });
+        return {
+          file: yaml,
+          success: runCount > 1,
+          executed: true,
+          duration: runCount,
+          resultType: runCount === 1 ? 'failed' : 'success',
+          error: runCount === 1 ? 'first attempt failed' : undefined,
+        };
+      },
+    );
+
+    try {
+      defineYamlCaseTest(injectedRstestTest(), {
+        testName: 'case',
+        yamlFile: yaml,
+        resultFile,
+        retry: 1,
+      });
+
+      const [, runCase] = mocks.rstestTest.mock.calls[0];
+      await expect(runCase()).rejects.toThrow('first attempt failed');
+      await expect(runCase()).resolves.toBeUndefined();
+
+      const progressMessages = mocks.emitYamlProgress.mock.calls.map(
+        ([message]) => message,
+      );
+      expect(progressMessages).toHaveLength(2);
+      expect(progressMessages[0]).toContain('Attempt 1/2');
+      expect(progressMessages[0]).toContain('enter recruitment credentials');
+      expect(progressMessages[1]).toContain('Attempt 2/2');
+      expect(progressMessages[1]).toContain('enter recruitment credentials');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -78,6 +79,7 @@ describe('defineYamlCaseTest', () => {
 
       const result = JSON.parse(readFileSync(resultFile, 'utf8'));
       expect(result.success).toBe(true);
+      expect(result.duration).toBe(23);
       expect(result.attempts).toMatchObject([
         {
           attempt: 1,
@@ -92,6 +94,65 @@ describe('defineYamlCaseTest', () => {
         },
       ]);
       expect(existsSync(`${resultFile}.attempts.json`)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves reports that reuse an explicit reportFileName across retries', async () => {
+    const root = createTempDir();
+    const yaml = join(root, 'case.yaml');
+    const resultFile = join(root, 'results', 'case.json');
+    const reportFile = join(root, 'report', 'custom-report.html');
+    writeFileSync(
+      yaml,
+      'web:\n  url: about:blank\nagent:\n  reportFileName: custom-report\ntasks: []\n',
+    );
+    let runCount = 0;
+    mocks.runYamlCaseResultWithSnapshots.mockImplementation(async () => {
+      runCount++;
+      mkdirSync(join(root, 'report'), { recursive: true });
+      writeFileSync(reportFile, `attempt ${runCount}`);
+      return {
+        file: yaml,
+        success: runCount > 1,
+        executed: true,
+        report: reportFile,
+        error: runCount === 1 ? 'first attempt failed' : undefined,
+        duration: runCount === 1 ? 11 : 12,
+        resultType: runCount === 1 ? 'failed' : 'success',
+      };
+    });
+
+    try {
+      defineYamlCaseTest(injectedRstestTest(), {
+        testName: 'case',
+        yamlFile: yaml,
+        resultFile,
+        retry: 1,
+      });
+
+      const [, runCase] = mocks.rstestTest.mock.calls[0];
+      await expect(runCase()).rejects.toThrow('first attempt failed');
+      await expect(runCase()).resolves.toBeUndefined();
+
+      const result = JSON.parse(readFileSync(resultFile, 'utf8'));
+      const archivedReport = join(
+        root,
+        'report',
+        'custom-report-attempt-1.html',
+      );
+      expect(result).toMatchObject({
+        success: true,
+        report: reportFile,
+        duration: 23,
+        attempts: [
+          { attempt: 1, report: archivedReport, duration: 11 },
+          { attempt: 2, report: reportFile, duration: 12 },
+        ],
+      });
+      expect(readFileSync(archivedReport, 'utf8')).toBe('attempt 1');
+      expect(readFileSync(reportFile, 'utf8')).toBe('attempt 2');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-entry.test.ts
@@ -11,8 +11,9 @@ import { type RstestTest, defineYamlCaseTest } from '@/framework/rstest-entry';
 import { beforeEach, describe, expect, rs, test } from '@rstest/core';
 
 const mocks = rs.hoisted(() => ({
+  emitYamlProgress: rs.fn(),
   rstestTest: rs.fn(),
-  runYamlCaseResult: rs.fn(),
+  runYamlCaseResultWithSnapshots: rs.fn(),
 }));
 
 rs.mock('@rstest/core', () => ({
@@ -20,9 +21,13 @@ rs.mock('@rstest/core', () => ({
 }));
 
 rs.mock('@/framework/yaml-case', () => ({
-  runYamlCaseResult: mocks.runYamlCaseResult,
+  runYamlCaseResultWithSnapshots: mocks.runYamlCaseResultWithSnapshots,
   createYamlCaseFailure: (result: { error?: string }) =>
     new Error(result.error || 'YAML case failed'),
+}));
+
+rs.mock('@/framework/progress-reporter', () => ({
+  emitYamlProgress: mocks.emitYamlProgress,
 }));
 
 const createTempDir = () =>
@@ -41,7 +46,7 @@ describe('defineYamlCaseTest', () => {
     const resultFile = join(root, 'results', 'case.json');
     writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
 
-    mocks.runYamlCaseResult
+    mocks.runYamlCaseResultWithSnapshots
       .mockResolvedValueOnce({
         file: yaml,
         success: false,
@@ -98,7 +103,7 @@ describe('defineYamlCaseTest', () => {
     const resultFile = join(root, 'results', 'case.json');
     writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
 
-    mocks.runYamlCaseResult.mockResolvedValueOnce({
+    mocks.runYamlCaseResultWithSnapshots.mockResolvedValueOnce({
       file: yaml,
       success: false,
       executed: true,
@@ -133,6 +138,52 @@ describe('defineYamlCaseTest', () => {
           resultType: 'partialFailed',
         },
       ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('forwards named player snapshots to the Rstest progress channel', async () => {
+    const root = createTempDir();
+    const yaml = join(root, 'case.yaml');
+    const resultFile = join(root, 'results', 'case.json');
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    mocks.runYamlCaseResultWithSnapshots.mockImplementationOnce(
+      async (_options, onPlayerSnapshot) => {
+        onPlayerSnapshot({
+          file: yaml,
+          player: {
+            status: 'init',
+            taskStatusList: [
+              { name: 'enter recruitment credentials', status: 'init' },
+            ],
+            result: {},
+          },
+        });
+        return {
+          file: yaml,
+          success: true,
+          executed: true,
+          duration: 1,
+          resultType: 'success',
+        };
+      },
+    );
+
+    try {
+      defineYamlCaseTest(injectedRstestTest(), {
+        testName: 'case',
+        yamlFile: yaml,
+        resultFile,
+      });
+
+      const [, runCase] = mocks.rstestTest.mock.calls[0];
+      await runCase();
+
+      expect(mocks.emitYamlProgress).toHaveBeenCalledWith(
+        expect.stringContaining('enter recruitment credentials'),
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/tests/unit-test/framework/rstest-project.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-project.test.ts
@@ -142,6 +142,9 @@ describe('rstest yaml project generation', () => {
       });
 
       expect(project.retry).toBe(3);
+      expect(project.virtualModules[project.cases[0].testModule]).toContain(
+        '"retry": 3',
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -226,6 +229,7 @@ describe('rstest yaml project generation', () => {
           files: [yamlA, yamlB],
           concurrent: 1,
           continueOnError: true,
+          retry: 2,
           summary: 'summary.json',
           shareBrowserContext: true,
           globalConfig: {
@@ -251,6 +255,7 @@ describe('rstest yaml project generation', () => {
         yamlB,
       ]);
       expect(project.maxConcurrency).toBe(1);
+      expect(project.retry).toBeUndefined();
       const generated = project.virtualModules[project.include[0]];
       expect(generated).toContain('import { test } from "@test/rstest-core"');
       expect(generated).toContain(
@@ -259,6 +264,7 @@ describe('rstest yaml project generation', () => {
       expect(generated).toContain('defineYamlBatchTest(test, testOptions)');
       expect(generated).not.toContain('defineYamlBatchTest(testOptions)');
       expect(generated).toContain('"shareBrowserContext": true');
+      expect(generated).toContain('"retry": 2');
       expect(generated).toContain(JSON.stringify(setupYaml));
       expect(generated).toContain(JSON.stringify(yamlA));
       expect(generated).toContain(JSON.stringify(yamlB));

--- a/packages/cli/tests/unit-test/framework/rstest-runner-config.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-runner-config.test.ts
@@ -13,7 +13,7 @@ rs.mock('@rstest/core/api', () => ({
 }));
 
 describe('rstest runner config', () => {
-  test('suppresses Rstest reporter output by default', async () => {
+  test('uses the Midscene YAML progress reporter by default', async () => {
     const root = mkdtempSync(join(tmpdir(), 'midscene-rstest-config-'));
     mocks.runRstest.mockResolvedValue({ ok: true, unhandledErrors: [] });
 
@@ -35,13 +35,41 @@ describe('rstest runner config', () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(mocks.runRstest).toHaveBeenCalledWith(
+      const inlineConfig = mocks.runRstest.mock.calls[0]?.[0].inlineConfig;
+      expect(inlineConfig.reporters).toEqual([
         expect.objectContaining({
-          inlineConfig: expect.objectContaining({
-            reporters: [],
-          }),
+          onUserConsoleLog: expect.any(Function),
         }),
-      );
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('suppresses reporter output when stdio is piped', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-rstest-config-'));
+    mocks.runRstest.mockResolvedValue({ ok: true, unhandledErrors: [] });
+
+    try {
+      await runRstestYamlProject({
+        cwd: root,
+        stdio: 'pipe',
+        project: {
+          projectDir: root,
+          outputDir: join(root, 'output'),
+          resultDir: join(root, 'results'),
+          include: ['virtual:a.test.ts'],
+          virtualModules: {
+            'virtual:a.test.ts': 'export {};',
+          },
+          cases: [],
+          maxConcurrency: 1,
+          testTimeout: 0,
+        },
+      });
+
+      const inlineConfig = mocks.runRstest.mock.calls.at(-1)?.[0].inlineConfig;
+      expect(inlineConfig.reporters).toEqual([]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
@@ -56,6 +56,45 @@ test('progress', () => {
     }
   });
 
+  test('does not leak worker console output when stdio is piped', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-rstest-pipe-'));
+    const rstestImport = resolveRstestCoreImportPath();
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const exitCode = await runRstestYamlProject({
+        cwd: root,
+        stdio: 'pipe',
+        project: {
+          projectDir: root,
+          outputDir: join(root, 'output'),
+          resultDir: join(root, 'results'),
+          include: ['virtual:pipe.test.ts'],
+          virtualModules: {
+            'virtual:pipe.test.ts': `import { test } from ${JSON.stringify(
+              rstestImport,
+            )};
+
+test('pipe', () => {
+  console.log(${JSON.stringify(`${yamlProgressLogPrefix}marked progress`)});
+  console.log('plain worker output');
+});
+`,
+          },
+          cases: [],
+          maxConcurrency: 1,
+          testTimeout: 0,
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(consoleLog).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   describe('dependency resolution anchor', () => {
     const originalEntry = process.argv[1];
     let isolatedRoot: string | undefined;

--- a/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
+++ b/packages/cli/tests/unit-test/framework/rstest-runner.test.ts
@@ -1,17 +1,59 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { yamlProgressLogPrefix } from '@/framework/progress-reporter';
 import {
   resolveRstestCoreImportPath,
   runRstestYamlProject,
 } from '@/framework/rstest-runner';
-import { afterEach, describe, expect, test } from '@rstest/core';
+import { afterEach, describe, expect, rs, test } from '@rstest/core';
 
 describe('rstest runner', () => {
   test('resolves the bundled Rstest core import path', () => {
     expect(resolveRstestCoreImportPath()).toMatch(
       /@rstest[/\\]core[/\\]dist[/\\]index\.js$/,
     );
+  });
+
+  test('forwards marked YAML progress from an Rstest worker', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-rstest-progress-'));
+    const rstestImport = resolveRstestCoreImportPath();
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const exitCode = await runRstestYamlProject({
+        cwd: root,
+        project: {
+          projectDir: root,
+          outputDir: join(root, 'output'),
+          resultDir: join(root, 'results'),
+          include: ['virtual:progress.test.ts'],
+          virtualModules: {
+            'virtual:progress.test.ts': `import { test } from ${JSON.stringify(
+              rstestImport,
+            )};
+
+test('progress', () => {
+  console.log(${JSON.stringify(
+    `${yamlProgressLogPrefix}◌ login.yaml\n  ◌ open login page`,
+  )});
+});
+`,
+          },
+          cases: [],
+          maxConcurrency: 1,
+          testTimeout: 0,
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(consoleLog).toHaveBeenCalledWith(
+        '◌ login.yaml\n  ◌ open login page',
+      );
+    } finally {
+      consoleLog.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   describe('dependency resolution anchor', () => {

--- a/packages/cli/tests/unit-test/framework/yaml-batch.test.ts
+++ b/packages/cli/tests/unit-test/framework/yaml-batch.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { emitYamlProgress } from '@/framework/progress-reporter';
 import { runYamlBatchInRstest } from '@/framework/yaml-batch';
 import { runYamlBatch } from '@/yaml-batch-executor';
 import type { MidsceneYamlConfigResult } from '@midscene/core';
@@ -77,6 +78,7 @@ describe('runYamlBatchInRstest', () => {
       expect(runYamlBatch).toHaveBeenCalledWith(config, {
         generateSummary: false,
         printExecutionPlan: false,
+        onProgress: emitYamlProgress,
       });
       expect(JSON.parse(readFileSync(resultA, 'utf8'))).toMatchObject({
         file: yamlA,

--- a/packages/cli/tests/unit-test/framework/yaml-case.test.ts
+++ b/packages/cli/tests/unit-test/framework/yaml-case.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createYamlPlayer } from '@/create-yaml-player';
 import {
+  type YamlPlayerSnapshotHandler,
   runYamlCase,
   runYamlCaseResult,
   runYamlCaseResultWithSnapshots,
 } from '@/framework/yaml-case';
+import type { ScriptPlayerTaskStatus } from '@midscene/core';
 import { beforeEach, describe, expect, rs, test } from '@rstest/core';
 
 rs.mock('@/create-yaml-player', () => ({
@@ -54,18 +56,21 @@ describe('runYamlCase', () => {
   });
 
   test('reports task names before and after the YAML player runs', async () => {
+    const taskStatusList: ScriptPlayerTaskStatus[] = [
+      { name: 'login', status: 'init', totalSteps: 1, flow: [] },
+    ];
     const player = createPlayer({
       status: 'init',
-      taskStatusList: [{ name: 'login', status: 'init' }],
+      taskStatusList,
     });
     player.run.mockImplementation(async () => {
       player.status = 'done';
-      player.taskStatusList[0].status = 'done';
+      taskStatusList[0].status = 'done';
     });
     rs.mocked(createYamlPlayer).mockResolvedValue(player as any);
     const snapshots: Array<{ player: string; task: string }> = [];
-    const onPlayerSnapshot = rs.fn(
-      ({ player: currentPlayer }: { player: typeof player }) => {
+    const onPlayerSnapshot = rs.fn<YamlPlayerSnapshotHandler>(
+      ({ player: currentPlayer }) => {
         snapshots.push({
           player: currentPlayer.status,
           task: currentPlayer.taskStatusList[0].status,

--- a/packages/cli/tests/unit-test/framework/yaml-case.test.ts
+++ b/packages/cli/tests/unit-test/framework/yaml-case.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createYamlPlayer } from '@/create-yaml-player';
-import { runYamlCase, runYamlCaseResult } from '@/framework/yaml-case';
+import {
+  runYamlCase,
+  runYamlCaseResult,
+  runYamlCaseResultWithSnapshots,
+} from '@/framework/yaml-case';
 import { beforeEach, describe, expect, rs, test } from '@rstest/core';
 
 rs.mock('@/create-yaml-player', () => ({
@@ -47,6 +51,42 @@ describe('runYamlCase', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  test('reports task names before and after the YAML player runs', async () => {
+    const player = createPlayer({
+      status: 'init',
+      taskStatusList: [{ name: 'login', status: 'init' }],
+    });
+    player.run.mockImplementation(async () => {
+      player.status = 'done';
+      player.taskStatusList[0].status = 'done';
+    });
+    rs.mocked(createYamlPlayer).mockResolvedValue(player as any);
+    const snapshots: Array<{ player: string; task: string }> = [];
+    const onPlayerSnapshot = rs.fn(
+      ({ player: currentPlayer }: { player: typeof player }) => {
+        snapshots.push({
+          player: currentPlayer.status,
+          task: currentPlayer.taskStatusList[0].status,
+        });
+      },
+    );
+
+    await runYamlCaseResultWithSnapshots(
+      { file: 'relative.yaml' },
+      onPlayerSnapshot,
+    );
+
+    expect(onPlayerSnapshot).toHaveBeenCalledTimes(2);
+    expect(onPlayerSnapshot.mock.calls[0][0]).toMatchObject({
+      file: expect.stringMatching(/relative\.yaml$/),
+    });
+    expect(onPlayerSnapshot.mock.calls[0][0].player).toBe(player);
+    expect(snapshots).toEqual([
+      { player: 'init', task: 'init' },
+      { player: 'done', task: 'done' },
+    ]);
   });
 
   test('passes merged execution config to the YAML player', async () => {

--- a/packages/cli/tests/unit-test/share-browser-context.test.ts
+++ b/packages/cli/tests/unit-test/share-browser-context.test.ts
@@ -66,4 +66,62 @@ describe('shareBrowserContext - Storage Sharing', () => {
       process.chdir(previousCwd);
     }
   });
+
+  test('should retry a failed YAML file in the same shared browser context', async () => {
+    const scriptDir = join(__dirname, '../share_context_test_scripts');
+    const indexYamlPath = join(scriptDir, 'retry-index.yaml');
+    const frameworkImport = join(
+      __dirname,
+      '../../src/framework/rstest-entry.ts',
+    );
+    const previousCwd = process.cwd();
+    const progressLogs: string[] = [];
+    const consoleLog = rs
+      .spyOn(console, 'log')
+      .mockImplementation((...args) => {
+        progressLogs.push(args.join(' '));
+      });
+
+    process.chdir(scriptDir);
+    try {
+      const config = await createConfig(indexYamlPath);
+      const exitCode = await runFrameworkTestConfig(config, {
+        projectDir: scriptDir,
+        frameworkImport,
+      });
+
+      expect(exitCode).toBe(0);
+      const summary = JSON.parse(
+        readFileSync(
+          join(scriptDir, 'midscene_run', 'output', config.summary),
+          'utf8',
+        ),
+      );
+      expect(summary.results).toMatchObject([
+        {
+          script: expect.stringContaining('03-retry-once.yaml'),
+          success: true,
+          resultType: 'success',
+          attempts: [
+            { attempt: 1, success: false, resultType: 'failed' },
+            { attempt: 2, success: true, resultType: 'success' },
+          ],
+        },
+      ]);
+      expect(progressLogs.some((log) => log.includes('Attempt 1/2'))).toBe(
+        true,
+      );
+      expect(progressLogs.some((log) => log.includes('Attempt 2/2'))).toBe(
+        true,
+      );
+      expect(
+        progressLogs.some((log) =>
+          log.includes('Pass on the second shared-context attempt'),
+        ),
+      ).toBe(true);
+    } finally {
+      consoleLog.mockRestore();
+      process.chdir(previousCwd);
+    }
+  });
 });

--- a/packages/cli/tests/unit-test/share-browser-context.test.ts
+++ b/packages/cli/tests/unit-test/share-browser-context.test.ts
@@ -1,8 +1,17 @@
 import { readFileSync } from 'node:fs';
+import { type Server, createServer as createHttpServer } from 'node:http';
 import { basename, join } from 'node:path';
 import { createConfig } from '@/config-factory';
 import { runFrameworkTestConfig } from '@/framework/command';
-import { afterAll, beforeAll, describe, expect, rs, test } from '@rstest/core';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  rs,
+  test,
+} from '@rstest/core';
 import { createServer } from 'http-server';
 
 rs.setConfig({
@@ -11,9 +20,22 @@ rs.setConfig({
 
 // Fixed port for testing - YAML files will use this URL
 const TEST_PORT = 18527;
+const RETRY_COUNTER_PORT = 18528;
+
+const closeServer = (serverToClose?: Server): Promise<void> => {
+  if (!serverToClose) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    serverToClose.close((error?: Error) => (error ? reject(error) : resolve()));
+  });
+};
 
 describe('shareBrowserContext - Storage Sharing', () => {
   let server: ReturnType<typeof createServer>;
+  let retryCounterServer: Server;
+  let setupAttemptCount = 0;
 
   beforeAll(async () => {
     // Start a shared server for all tests
@@ -25,10 +47,32 @@ describe('shareBrowserContext - Storage Sharing', () => {
         resolve();
       });
     });
+
+    retryCounterServer = createHttpServer((request, response) => {
+      response.setHeader('Access-Control-Allow-Origin', '*');
+      response.setHeader('Content-Type', 'application/json');
+      if (request.url === '/setup-attempt') {
+        setupAttemptCount++;
+        response.end(JSON.stringify({ attempt: setupAttemptCount }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: 'not found' }));
+    });
+    await new Promise<void>((resolve) => {
+      retryCounterServer.listen(RETRY_COUNTER_PORT, '127.0.0.1', resolve);
+    });
   });
 
-  afterAll(() => {
-    server?.server.close();
+  beforeEach(() => {
+    setupAttemptCount = 0;
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      closeServer(server?.server),
+      closeServer(retryCounterServer),
+    ]);
   });
 
   test('should run setup before the main file and report both results', async () => {
@@ -121,6 +165,55 @@ describe('shareBrowserContext - Storage Sharing', () => {
       ).toBe(true);
     } finally {
       consoleLog.mockRestore();
+      process.chdir(previousCwd);
+    }
+  });
+
+  test('should isolate setup retries and share only the successful context', async () => {
+    const scriptDir = join(__dirname, '../share_context_test_scripts');
+    const indexYamlPath = join(scriptDir, 'setup-retry-index.yaml');
+    const frameworkImport = join(
+      __dirname,
+      '../../src/framework/rstest-entry.ts',
+    );
+    const previousCwd = process.cwd();
+
+    process.chdir(scriptDir);
+    try {
+      const config = await createConfig(indexYamlPath);
+      const exitCode = await runFrameworkTestConfig(config, {
+        projectDir: scriptDir,
+        frameworkImport,
+        stdio: 'pipe',
+      });
+
+      expect(exitCode).toBe(0);
+      expect(setupAttemptCount).toBe(2);
+      const summary = JSON.parse(
+        readFileSync(
+          join(scriptDir, 'midscene_run', 'output', config.summary),
+          'utf8',
+        ),
+      );
+      expect(summary.results).toMatchObject([
+        {
+          script: expect.stringContaining('04-setup-retry.yaml'),
+          success: true,
+          attempts: [
+            { attempt: 1, success: false },
+            { attempt: 2, success: true },
+          ],
+        },
+        {
+          script: expect.stringContaining('05-check-setup-retry.yaml'),
+          success: true,
+          attempts: [
+            { attempt: 1, success: false },
+            { attempt: 2, success: true },
+          ],
+        },
+      ]);
+    } finally {
       process.chdir(previousCwd);
     }
   });

--- a/packages/computer/tests/ai/chrome-extension-bridge.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-bridge.test.ts
@@ -20,6 +20,7 @@ import {
   injectBridgePermission,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -162,13 +163,7 @@ describe('chrome extension bridge mode start/stop (#2119)', () => {
     'open side panel and switch to Bridge Mode',
     { timeout: 20 * 60 * 1000, retry: 0 },
     async () => {
-      await agent.aiAct(
-        'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-      );
-      await sleep(1000);
-
-      await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-      await sleep(3000);
+      await openExtensionSidePanel(agent);
 
       await agent.aiAssert(
         'The browser shows a side panel on the right side containing Midscene or Playground UI',

--- a/packages/computer/tests/ai/chrome-extension-helpers.ts
+++ b/packages/computer/tests/ai/chrome-extension-helpers.ts
@@ -2,6 +2,7 @@ import { execSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { sleep } from '@midscene/core/utils';
+import type { ComputerAgent } from '../../src';
 import { isHeadlessLinux } from './test-utils';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -134,6 +135,21 @@ export async function launchChromeWithExtension(
 
   child.unref();
   await waitForCdpReady();
+}
+
+export async function openExtensionSidePanel(
+  agent: ComputerAgent,
+): Promise<void> {
+  await agent.aiTap(
+    'the Chrome toolbar Extensions button with a puzzle-piece icon in the top-right browser chrome, not any icon inside the web page',
+    { deepLocate: true },
+  );
+  await sleep(500);
+  await agent.aiTap(
+    'the row labeled "Midscene.js" inside the open Chrome Extensions menu below the toolbar, not any text or control inside the web page',
+    { deepLocate: true },
+  );
+  await sleep(3000);
 }
 
 // Wait until Chrome's CDP endpoint answers, i.e. the browser is actually up.

--- a/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground-dark-timeline.test.ts
@@ -14,6 +14,7 @@ import {
   findPageTargetByUrlPrefix,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -53,16 +54,10 @@ describe('chrome extension dark Playground timeline', () => {
     await sleep(1500);
   }
 
-  // Opening Chrome's extension menu is model-driven and can take several
-  // minutes on a cold CI runner. Keep setup separate so the Bing execution
-  // and visual assertion receive their own test timeout budget.
+  // Keep setup separate so the Bing execution and visual assertion receive
+  // their own test timeout budget.
   it('opens the dark side panel and configures the extension', async () => {
-    await agent.aiAct(
-      'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-    );
-    await sleep(1000);
-    await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-    await sleep(3000);
+    await openExtensionSidePanel(agent);
     await agent.aiAssert(
       'The browser shows a dark side panel on the right side containing Midscene Playground UI, and the Bing page is still visible on the left',
     );

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -15,6 +15,7 @@ import {
   findPageTargetByUrlPrefix,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -56,12 +57,7 @@ describe('chrome extension playground advanced tests', () => {
   }
 
   it('open side panel and configure', async () => {
-    await agent.aiAct(
-      'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-    );
-    await sleep(1000);
-    await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-    await sleep(3000);
+    await openExtensionSidePanel(agent);
     await agent.aiAssert(
       'The browser shows a side panel on the right side containing Midscene or Playground UI, and the TodoMVC page is still visible on the left',
     );

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -85,14 +85,18 @@ describe('chrome extension playground advanced tests', () => {
 
     // Selecting Assert scrolls the narrow mode selector to the right, which can
     // move Action outside the viewport. Select the visible Tap radio first,
-    // then use its native keyboard navigation to return to Action reliably.
+    // then focus it explicitly before using native keyboard navigation. The
+    // composer textarea has autoFocus and otherwise receives the ArrowLeft.
     await agent.aiTap(`the "Tap" action type button in ${SIDE_PANEL}`);
     await sleep(500);
     await agent.aiAssert(
       `${SIDE_PANEL} shows an input area with placeholder text containing "tap"`,
     );
 
-    await agent.aiKeyboardPress(undefined, { keyName: 'ArrowLeft' });
+    await agent.aiKeyboardPress(
+      `the selected "Tap" action type button in ${SIDE_PANEL}`,
+      { keyName: 'ArrowLeft' },
+    );
     await sleep(500);
     await agent.aiAssert(
       `${SIDE_PANEL} shows an input area with placeholder text "What do you want to do?"`,

--- a/packages/computer/tests/ai/chrome-extension-playground.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-playground.test.ts
@@ -75,22 +75,32 @@ describe('chrome extension playground advanced tests', () => {
   });
 
   it('action type switching changes the composer placeholder', async () => {
-    await agent.aiAct(`Click the "Query" button in ${SIDE_PANEL}`);
+    await agent.aiTap(`the "Query" action type button in ${SIDE_PANEL}`);
     await sleep(500);
     await agent.aiAssert(
       `${SIDE_PANEL} shows an input area with placeholder text containing "query"`,
     );
 
-    await agent.aiAct(`Click the "Assert" button in ${SIDE_PANEL}`);
+    await agent.aiTap(`the "Assert" action type button in ${SIDE_PANEL}`);
     await sleep(500);
     await agent.aiAssert(
       `${SIDE_PANEL} shows an input area with placeholder text containing "assert"`,
     );
 
-    await agent.aiAct(
-      `In ${SIDE_PANEL}, horizontally scroll the action mode selector all the way left if needed, then click the "Action" button immediately to the left of "Tap". Do not click "Tap".`,
-    );
+    // Selecting Assert scrolls the narrow mode selector to the right, which can
+    // move Action outside the viewport. Select the visible Tap radio first,
+    // then use its native keyboard navigation to return to Action reliably.
+    await agent.aiTap(`the "Tap" action type button in ${SIDE_PANEL}`);
     await sleep(500);
+    await agent.aiAssert(
+      `${SIDE_PANEL} shows an input area with placeholder text containing "tap"`,
+    );
+
+    await agent.aiKeyboardPress(undefined, { keyName: 'ArrowLeft' });
+    await sleep(500);
+    await agent.aiAssert(
+      `${SIDE_PANEL} shows an input area with placeholder text "What do you want to do?"`,
+    );
   });
 
   it('aiQuery: extract page title and verify result', async () => {

--- a/packages/computer/tests/ai/chrome-extension-recorder.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-recorder.test.ts
@@ -15,6 +15,7 @@ import {
   findExtensionPageTarget,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -46,12 +47,7 @@ describe('chrome extension recorder mode tests', () => {
   });
 
   it('open side panel and configure', async () => {
-    await agent.aiAct(
-      'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-    );
-    await sleep(1000);
-    await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-    await sleep(3000);
+    await openExtensionSidePanel(agent);
     await agent.aiAssert(
       'The browser shows a side panel on the right side containing Midscene or Playground UI',
     );

--- a/packages/computer/tests/ai/chrome-extension-settings.test.ts
+++ b/packages/computer/tests/ai/chrome-extension-settings.test.ts
@@ -15,6 +15,7 @@ import {
   findExtensionPageTarget,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -47,12 +48,7 @@ describe('chrome extension settings and cross-mode tests', () => {
   });
 
   it('open side panel and configure', async () => {
-    await agent.aiAct(
-      'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-    );
-    await sleep(1000);
-    await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-    await sleep(3000);
+    await openExtensionSidePanel(agent);
     await agent.aiAssert(
       'The browser shows a side panel on the right side containing Midscene or Playground UI',
     );

--- a/packages/computer/tests/ai/chrome-extension.test.ts
+++ b/packages/computer/tests/ai/chrome-extension.test.ts
@@ -10,6 +10,7 @@ import {
   findExtensionPageTarget,
   injectExtensionConfig,
   launchChromeWithExtension,
+  openExtensionSidePanel,
   readExtensionId,
   reloadViaWebSocket,
 } from './chrome-extension-helpers';
@@ -38,16 +39,10 @@ describe('chrome extension smoke test', () => {
   });
 
   it('open side panel via extension icon', async () => {
-    await agent.aiAct(
-      'Click the puzzle piece icon (Extensions button) in the top-right area of the Chrome toolbar',
-    );
-    await sleep(1000);
-
-    await agent.aiAct('Click "Midscene.js" in the extensions dropdown list');
-    await sleep(3000);
+    await openExtensionSidePanel(agent);
 
     await agent.aiAssert(
-      'The browser shows a side panel on the right side containing Midscene or Playground UI, and the TodoMVC page is still visible on the left',
+      'A docked browser side panel is visible at the far right and contains Midscene or Playground UI, while the main browser content still shows the TodoMVC todos app',
     );
 
     // Inject env config into the side panel's localStorage via CDP

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -354,6 +354,10 @@ export interface MidsceneYamlConfig {
    */
   retry?: number;
   summary?: string;
+  /**
+   * Share one BrowserContext and Page across Puppeteer Web yaml files. This is
+   * not supported by bridge mode or non-Web targets.
+   */
   shareBrowserContext?: boolean;
   /** @deprecated Use `web`, `page`, or `browser` instead. */
   target?: MidsceneYamlScriptWebEnv;
@@ -363,11 +367,10 @@ export interface MidsceneYamlConfig {
   android?: MidsceneYamlScriptAndroidEnv;
   ios?: MidsceneYamlScriptIOSEnv;
   /**
-   * A setup yaml file that runs before the main `files`. It shares the same
-   * browser context as the main files, so authentication or other prerequisite
-   * state established here is visible to every main file. A setup failure
-   * aborts the whole batch and the main files are marked as not executed. Only
-   * meaningful with `shareBrowserContext: true`.
+   * A setup yaml file that runs before the main `files`. A setup failure aborts
+   * the whole batch and the main files are marked as not executed. Puppeteer
+   * Web setup requires `shareBrowserContext: true` to pass browser state to the
+   * main files. Other targets run setup without browser-context sharing.
    */
   setup?: string;
   files: string[];

--- a/packages/web-integration/src/puppeteer/agent-launcher.ts
+++ b/packages/web-integration/src/puppeteer/agent-launcher.ts
@@ -299,7 +299,7 @@ export async function launchPuppeteerPage(
 
   if (target.cookie) {
     const cookieFileContent = readFileSync(target.cookie, 'utf-8');
-    await browserInstance.setCookie(...JSON.parse(cookieFileContent));
+    await page.browserContext().setCookie(...JSON.parse(cookieFileContent));
   }
 
   if (ua) {

--- a/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
+++ b/packages/web-integration/tests/unit-test/puppeteer/agent-launcher.test.ts
@@ -1,3 +1,5 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
   defaultViewportHeight,
@@ -12,12 +14,14 @@ const { mockLaunch } = rs.hoisted(() => ({
 }));
 
 const mockNewPage = rs.fn();
+const browserContextMock = {
+  setCookie: rs.fn().mockResolvedValue(undefined),
+};
 let pageMock: ReturnType<typeof createPageMock>;
 const browserMock = {
   newPage: mockNewPage,
   on: rs.fn(),
   off: rs.fn(),
-  setCookie: rs.fn(),
   close: rs.fn(),
 };
 
@@ -28,6 +32,7 @@ const createPageMock = () => ({
   goto: rs.fn().mockResolvedValue(undefined),
   waitForNetworkIdle: rs.fn().mockResolvedValue(undefined),
   browser: rs.fn(() => browserMock),
+  browserContext: rs.fn(() => browserContextMock),
   bringToFront: rs.fn().mockResolvedValue(undefined),
   on: rs.fn(),
   isClosed: rs.fn().mockReturnValue(false),
@@ -140,6 +145,33 @@ describe('launchPuppeteerPage', () => {
     await launchPuppeteerPage({ url: 'https://example.com' });
 
     expect(pageMock.setExtraHTTPHeaders).not.toHaveBeenCalled();
+  });
+
+  it('sets cookie files on the active page browser context', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'midscene-cookie-context-'));
+    const cookieFile = path.join(root, 'cookies.json');
+    const cookies = [
+      {
+        name: 'session',
+        value: 'isolated-context',
+        domain: 'example.com',
+      },
+    ];
+    writeFileSync(cookieFile, JSON.stringify(cookies));
+
+    try {
+      await launchPuppeteerPage(
+        { url: 'https://example.com', cookie: cookieFile },
+        undefined,
+        browserMock as any,
+        pageMock as any,
+      );
+
+      expect(pageMock.browserContext).toHaveBeenCalledTimes(1);
+      expect(browserContextMock.setCookie).toHaveBeenCalledWith(...cookies);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('configures Chrome download behavior when downloadPath is provided', async () => {


### PR DESCRIPTION
## Summary

- Forward marked YAML progress snapshots from Rstest workers while keeping internal worker output suppressed.
- Restore YAML file and task names for standalone and shared-browser-context runs.
- Honor `retry` in shared-browser batches and record every attempt in the summary.
- Run every Puppeteer Web setup retry in a fresh BrowserContext and Page while reusing the same browser process.
- Restrict `shareBrowserContext` to Puppeteer Web targets and reject bridge-mode or non-Web no-op configurations.
- Support setup batches for bridge mode, Android, iOS, HarmonyOS, Computer, and custom Interface targets without requiring `shareBrowserContext`.
- Route every setup configuration through one orchestrated Rstest batch so setup always runs before the main files.
- Document that non-Puppeteer setup retries recreate the player and Agent but do not reset the underlying target environment.
- Add unit and real-browser regression coverage, plus matching English and Chinese documentation.
- Make the report-wide replay control semantic and strengthen AI E2E navigation between Human, Markdown, and replay views.
- Stabilize Chrome extension playground mode switching when the narrow selector scrolls Action out of view.
- Use atomic, shared Chrome extension side-panel setup across AI E2E shards to avoid long planner timeouts and retry races.

## Behavior

Before this change, the CLI printed the execution plan and then jumped directly to `Execution finished` without showing YAML file or task names. Shared-browser-context batches also accepted `retry` in configuration but did not execute retries.

After this change, progress includes the attempt, file, and task name:

    Attempt 1/2
    ✖ packages/cli/tests/share_context_test_scripts/03-retry-once.yaml
      ✖ Pass on the second shared-context attempt
    Attempt 2/2
    ✔ packages/cli/tests/share_context_test_scripts/03-retry-once.yaml
      ✔ Pass on the second shared-context attempt

`retry` is the number of extra attempts. Successful files stop immediately.

For Puppeteer Web batches, `setup` requires `shareBrowserContext: true`. A failed setup attempt is discarded together with its BrowserContext and Page, so cookies, storage, and navigation state cannot leak into the next attempt. Once setup succeeds, its context is handed to the main files. Main-file retries remain in that successful context so prerequisite state is preserved.

For bridge mode and non-Web targets, `setup` works without `shareBrowserContext`. Each retry creates a new script player and Agent, while the underlying browser profile, device, desktop session, or custom interface may retain state. Enabling `shareBrowserContext` for these targets now fails with a clear validation error instead of being silently ignored. Exhausting setup retries aborts dependent main files for every target.

## Validation

- `pnpm run lint`
- `pnpm run type-check:tests`
- `NX_DAEMON=false pnpm exec nx test @midscene/cli` (17 files, 227 tests)
- `pnpm --dir packages/web-integration exec rstest tests/unit-test/puppeteer/agent-launcher.test.ts` (18 tests)
- `NX_DAEMON=false pnpm exec nx build @midscene/cli`
- `GITHUB_TOKEN="$(gh auth token)" NX_DAEMON=false pnpm exec nx build doc`
- `NX_DAEMON=false pnpm exec nx build @midscene/web`
- `NX_DAEMON=false pnpm exec nx test @midscene/report` (19 files, 105 tests)
- `NX_DAEMON=false pnpm exec nx build @midscene/report`
- `NX_DAEMON=false pnpm exec nx test @midscene/computer` (14 files, 91 tests)

## Known validation issue

- `NX_DAEMON=false pnpm exec nx test @midscene/web` completed 432 assertions with 1 skipped, but the process failed in the untouched `cli-viewport-e2e.test.ts` teardown with `ENOTEMPTY` while removing a Chrome profile directory. Running that test alone reproduced the same teardown race after its assertion passed; the focused test for the changed Puppeteer launcher passes.