### PR TITLE
fix(test): load TypeScript configs on Windows

### DIFF
--- a/packages/test/src/cli/test-project.ts
+++ b/packages/test/src/cli/test-project.ts
@@ -633,7 +633,7 @@ export async function loadTestProject<TContext = undefined>(
   assertTypeScriptConfig(absolutePath);
   let loaded: unknown;
   try {
-    loaded = await tsImport(absolutePath, {
+    loaded = await tsImport(pathToFileURL(absolutePath).href, {
       parentURL: pathToFileURL(`${dirname(absolutePath)}${sep}`).href,
       tsconfig: false,
     });

--- a/packages/test/tests/test-project.test.ts
+++ b/packages/test/tests/test-project.test.ts
@@ -13,8 +13,11 @@ afterEach(() => {
   (globalThis as Record<string, unknown>).__testSetupMarker = undefined;
 });
 
-const createConfig = (source: string): { directory: string; path: string } => {
-  const directory = mkdtempSync(join(tmpdir(), 'test-project-config-'));
+const createConfig = (
+  source: string,
+  directoryPrefix = 'test-project-config-',
+): { directory: string; path: string } => {
+  const directory = mkdtempSync(join(tmpdir(), directoryPrefix));
   directories.push(directory);
   const path = join(directory, 'midscene.config.ts');
   writeFileSync(path, source);
@@ -52,6 +55,17 @@ describe('test project config', () => {
       include: ['workflows/**/*.{yaml,yml}'],
       exclude: ['workflows/**/*.draft.yaml'],
     });
+  });
+
+  it('loads configs from paths containing URL control characters', async () => {
+    const { path } = createConfig(
+      'export default { nodes: [] };',
+      'test-project-config-#-',
+    );
+
+    const project = await loadTestProject(path);
+
+    expect(project.hasExplicitProjects).toBe(false);
   });
 
   it('loads adjacent TypeScript modules', async () => {


### PR DESCRIPTION
## Summary

- convert the resolved TypeScript config path to a file URL before passing it to the tsx ESM loader
- keep the native absolute path for diagnostics and the existing CJS fallback

On Windows, passing C:...midscene.config.ts directly makes Node interpret c: as a URL scheme and raises ERR_UNSUPPORTED_ESM_URL_SCHEME. The existing config-loader test reproduces the failure on main and passes with this change.

Fixes #3029

## Validation

- pnpm --filter @midscene/test exec vitest --run tests/test-project.test.ts (48 passed)
- pnpm exec tsc -p packages/test/tsconfig.build.json --noEmit
- pnpm exec biome lint packages/test/src/cli/test-project.ts --diagnostic-level=info
- git diff --check

Additional repository-owned limitations observed on unchanged main:

- pnpm --filter @midscene/test test: 151 passed, 3 existing Windows path-separator assertions failed in test-project-runner.test.ts
- pnpm --filter @midscene/test build: blocked on Node.js 24.14.1 by rsbuild-plugin-dts 0.18.3 ESM/default-export interop
- pnpm --filter @midscene/test test:types: requires package dist output that the blocked build did not produce

Additional validation after adding cross-platform regression coverage:

- pnpm run lint
- npx nx test @midscene/test -- tests/test-project.test.ts -t=URL.control.characters
- pnpm exec tsc -p packages/test/tsconfig.build.json --noEmit
- git diff --check