### PR TITLE
fix(workflow): replace simple-git-hooks with husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:report": "nx run @midscene/web:e2e:report --verbose  --exclude-task-dependencies",
     "e2e:visualizer": "nx run @midscene/visualizer:e2e --verbose  --exclude-task-dependencies",
     "test:ai:all": "npm run e2e && npm run e2e:cache && npm run e2e:report && npm run test:ai && npm run e2e:visualizer",
-    "prepare": "simple-git-hooks && pnpm run build",
+    "prepare": "husky && pnpm run build",
     "check-dependency-version": "check-dependency-version-consistency .",
     "check:references": "node scripts/check-tsconfig-references.mjs",
     "check:report-build-feedback-loop": "node scripts/check-report-build-feedback-loop.mjs",
@@ -27,10 +27,6 @@
     "commit": "cz",
     "check-spell": "npx cspell",
     "clean": "rimraf --glob .nx/cache packages/playground/static packages/ios/static \"packages/*/dist\" \"packages/*/node_modules/.cache\" \"apps/*/dist\" \"apps/*/node_modules/.cache\""
-  },
-  "simple-git-hooks": {
-    "pre-commit": "npx lint-staged",
-    "commit-msg": "npx --no -- commitlint --edit $1"
   },
   "lint-staged": {
     "*.{json,css}": ["npx biome check --diagnostic-level=info --fix"],
@@ -66,13 +62,13 @@
     "commitizen": "4.2.5",
     "cspell-ban-words": "^0.0.3",
     "dayjs": "^1.11.11",
+    "husky": "9.1.7",
     "minimist": "1.2.5",
     "nx": "22.1.3",
     "prettier": "^3.6.2",
     "pretty-quick": "3.1.3",
     "semver": "7.5.2",
     "rimraf": "~5.0.10",
-    "simple-git-hooks": "^2.13.1",
     "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       dayjs:
         specifier: ^1.11.11
         version: 1.11.19
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       minimist:
         specifier: 1.2.5
         version: 1.2.5
@@ -74,9 +77,6 @@ importers:
       semver:
         specifier: 7.5.2
         version: 7.5.2
-      simple-git-hooks:
-        specifier: ^2.13.1
-        version: 2.13.1
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -7236,6 +7236,11 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
@@ -10401,10 +10406,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -18929,6 +18930,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  husky@9.1.7: {}
+
   hyperdyperid@1.2.0: {}
 
   iconv-corefoundation@1.1.7:
@@ -22603,8 +22606,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git-hooks@2.13.1: {}
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

- replace `simple-git-hooks` with Husky for project-managed Git hooks
- keep `pre-commit` running `lint-staged` and `commit-msg` running `commitlint`
- store both hook entrypoints in the version-controlled `.husky/` directory
- run Husky from `prepare` so clones and linked worktrees configure `core.hooksPath` consistently

## Motivation

`simple-git-hooks@2.13.x` can resolve the default hooks directory as `<worktree>/.git/hooks` in a linked worktree, where `.git` is a file rather than a directory. Existing clones may also retain Husky's old `.husky/_` value in `core.hooksPath`, causing `simple-git-hooks` to recreate `.husky` unexpectedly.

Using a single Husky setup avoids competing hook managers and keeps the project hook commands visible and reviewable in the repository.

## Validation

- `pnpm run lint`
- `sh -n .husky/pre-commit .husky/commit-msg`
- `corepack pnpm install --lockfile-only --offline --frozen-lockfile --ignore-scripts`
- `pnpm exec husky`
- created the commit with the installed hooks, verifying both `lint-staged` and `commitlint` execute successfully
