### PR TITLE
docs(site): move DeepSeek guidance into model notes

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -132,15 +132,9 @@ Midscene supports DeepSeek starting from v1.12.0.
 
 | Model version | Commonly used model names | `MIDSCENE_MODEL_FAMILY` | Notes |
 | --- | --- | --- | --- |
-| DeepSeek V4 series | `deepseek-v4-flash-vision-exp` | `deepseek` | |
+| DeepSeek V4 series | `deepseek-v4-flash-vision-exp` | `deepseek` | Currently, only `deepseek-v4-flash-vision-exp` supports the multimodal visual input required by Midscene. Other DeepSeek V4 models, including `deepseek-v4-pro` and `deepseek-v4-flash`, are not suitable for use with Midscene. |
 
 </div>
-
-:::caution
-
-Currently, only `deepseek-v4-flash-vision-exp` supports the multimodal visual input required by Midscene. Other DeepSeek V4 models, including `deepseek-v4-pro` and `deepseek-v4-flash`, are not suitable for use with Midscene.
-
-:::
 
 Environment variable configuration example, using `deepseek-v4-flash-vision-exp`:
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -132,15 +132,9 @@ Midscene 从 v1.12.0 开始支持 DeepSeek。
 
 | 模型版本 | 常用模型名称 | `MIDSCENE_MODEL_FAMILY` | 备注 |
 | --- | --- | --- | --- |
-| DeepSeek V4 系列 | `deepseek-v4-flash-vision-exp` | `deepseek` | |
+| DeepSeek V4 系列 | `deepseek-v4-flash-vision-exp` | `deepseek` | 目前只有 `deepseek-v4-flash-vision-exp` 支持 Midscene 所需的多模态视觉输入。包括 `deepseek-v4-pro` 和普通 `deepseek-v4-flash` 在内的其他 DeepSeek V4 模型均不适用于 Midscene。 |
 
 </div>
-
-:::caution
-
-目前只有 `deepseek-v4-flash-vision-exp` 支持 Midscene 所需的多模态视觉输入。包括 `deepseek-v4-pro` 和普通 `deepseek-v4-flash` 在内的其他 DeepSeek V4 模型均不适用于 Midscene。
-
-:::
 
 环境变量配置示例，以 `deepseek-v4-flash-vision-exp` 为例：
 


### PR DESCRIPTION
## Summary

- move the DeepSeek V4 multimodal compatibility guidance into the model table's notes column
- remove the standalone caution block
- keep the English and Chinese documentation in sync

## Validation

- `pnpm run lint`