### PR TITLE
fix(core): omit DeepSeek temperature in thinking mode

### DIFF
--- a/packages/core/src/ai-model/models/deepseek.ts
+++ b/packages/core/src/ai-model/models/deepseek.ts
@@ -60,8 +60,15 @@ const buildDeepSeekChatCompletionParams = (
   const { midsceneDefaults, userConfig } = input;
   const { reasoningEnabled, reasoningEffort } = userConfig;
   const commonOverrideConfig: Record<string, unknown> = {};
+  const isThinkingMode =
+    reasoningEnabled === true || reasoningEnabled === 'default';
 
-  if (userConfig.temperature !== undefined) {
+  // DeepSeek thinking mode does not support temperature. `default` also uses
+  // thinking mode because DeepSeek enables it by default.
+  // https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
+  if (isThinkingMode) {
+    commonOverrideConfig.temperature = undefined;
+  } else if (userConfig.temperature !== undefined) {
     commonOverrideConfig.temperature = userConfig.temperature;
   }
 

--- a/packages/core/src/ai-model/models/deepseek.ts
+++ b/packages/core/src/ai-model/models/deepseek.ts
@@ -63,8 +63,10 @@ const buildDeepSeekChatCompletionParams = (
   const isThinkingMode =
     reasoningEnabled === true || reasoningEnabled === 'default';
 
-  // DeepSeek thinking mode does not support temperature. `default` also uses
-  // thinking mode because DeepSeek enables it by default.
+  // DeepSeek thinking mode does not support temperature. For compatibility,
+  // DeepSeek ignores this parameter instead of rejecting the request, so omit
+  // the ineffective setting. `default` also uses thinking mode because
+  // DeepSeek enables it by default.
   // https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
   if (isThinkingMode) {
     commonOverrideConfig.temperature = undefined;

--- a/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
@@ -264,6 +264,14 @@ describe('deepseek model adapter', () => {
         userConfig: {
           reasoningEnabled: 'default',
           reasoningEffort: 'max',
+          temperature: 0.7,
+        },
+      });
+    const reasoningDisabledResult =
+      deepSeekAdapter.chatCompletion.buildChatCompletionParams({
+        userConfig: {
+          reasoningEnabled: false,
+          temperature: 0.7,
         },
       });
 
@@ -272,11 +280,15 @@ describe('deepseek model adapter', () => {
       thinking: { type: 'disabled' },
     });
     expect(reasoningResult.config).toEqual({
-      temperature: 0,
+      temperature: undefined,
       thinking: { type: 'enabled' },
       reasoning_effort: 'max',
     });
-    expect(providerDefaultResult.config).toEqual({ temperature: 0 });
+    expect(providerDefaultResult.config).toEqual({ temperature: undefined });
+    expect(reasoningDisabledResult.config).toEqual({
+      temperature: 0.7,
+      thinking: { type: 'disabled' },
+    });
   });
 
   it('does not replay raw assistant messages without tool calls', () => {


### PR DESCRIPTION
## Summary

- omit `temperature` from DeepSeek requests when thinking mode is explicitly enabled
- also omit it when `reasoningEnabled` uses the DeepSeek provider default, whose thinking mode is enabled by default
- preserve configured temperature when thinking mode is disabled
- document the DeepSeek API constraint in the adaptor and cover the behavior with unit tests

## Validation

- `pnpm --filter @midscene/core test -- tests/unit-test/model-adapter/deepseek.test.ts`
- `pnpm run lint`
- `git diff --check`