### PR TITLE
fix(core): avoid duplicate YAML assertion errors

### DIFF
--- a/packages/core/src/dump/task-status.ts
+++ b/packages/core/src/dump/task-status.ts
@@ -55,8 +55,9 @@ export function deriveTaskStatus(task: TaskStatusFields): DerivedTaskStatus {
     return 'warning';
   }
 
-  // An `Assert` that finished with a falsy result is a failure. This is a
-  // legacy fallback: modern asserts throw and are caught above.
+  // An `Assert` that finished with a false result is a failure. Callers using
+  // `keepRawResponse` (including the YAML player) receive `{ pass: false }`
+  // and throw at the orchestration layer after this task has been recorded.
   if (task.subType === 'Assert' && isFinished && task.output === false) {
     return 'failed';
   }

--- a/packages/core/src/yaml/player.ts
+++ b/packages/core/src/yaml/player.ts
@@ -40,6 +40,7 @@ type RuntimeYamlFlowItem =
 import type { Agent } from '@/agent/agent';
 import type { TUserPrompt } from '@/common';
 import type { InputStrategy } from '@/device';
+import { deriveCaseStatus } from '@/dump/task-status';
 import type {
   DeviceAction,
   FreeFn,
@@ -326,15 +327,10 @@ export class ScriptPlayer<T extends MidsceneYamlScriptEnv> {
     agent: Agent,
     executionCountBefore: number,
   ) {
-    return (agent.dump?.executions ?? [])
-      .slice(executionCountBefore)
-      .some((execution) =>
-        execution.tasks.some(
-          (task) =>
-            task.status === 'failed' ||
-            Boolean(task.error || task.errorMessage),
-        ),
-      );
+    const executions = (agent.dump?.executions ?? []).slice(
+      executionCountBefore,
+    );
+    return deriveCaseStatus(executions) === 'failed';
   }
 
   private async playFlowItem(

--- a/packages/core/tests/unit-test/task-status.test.ts
+++ b/packages/core/tests/unit-test/task-status.test.ts
@@ -33,7 +33,7 @@ describe('deriveTaskStatus', () => {
     ).toBe('warning');
   });
 
-  it('treats a finished Assert with falsy output as failed (legacy fallback)', () => {
+  it('treats a finished Assert with false output as failed', () => {
     expect(
       deriveTaskStatus({
         status: 'finished',

--- a/packages/core/tests/unit-test/yaml-doc-usage.test.ts
+++ b/packages/core/tests/unit-test/yaml-doc-usage.test.ts
@@ -611,6 +611,62 @@ tasks:
     expect(agent.recordErrorToReport).not.toHaveBeenCalled();
   });
 
+  it('does not duplicate assertion failures returned through keepRawResponse', async () => {
+    const failedAssertionResult = {
+      pass: false,
+      thought: 'the broken button is not visible',
+      message: 'Assertion failed: the broken button is not visible',
+    };
+    const script = parseYamlScript(`
+web:
+  url: about:blank
+tasks:
+  - name: Failed assertion
+    flow:
+      - aiAssert: The broken button is visible
+`);
+    const agent = createDocAgent({
+      aiAssert: rs.fn(async () => {
+        // Mirror Agent.aiAssert({ keepRawResponse: true }): the report task is
+        // recorded first, then the failed result is returned to the YAML layer.
+        agent.dump.executions.push({
+          id: 'failed-assertion',
+          logTime: Date.now(),
+          name: 'The broken button is visible',
+          tasks: [
+            {
+              taskId: 'failed-assertion-task',
+              type: 'Insight',
+              subType: 'Assert',
+              status: 'finished',
+              output: false,
+              executor: async () => {},
+            },
+          ],
+        });
+        return failedAssertionResult;
+      }),
+    });
+    const player = new ScriptPlayer(script, async () => ({
+      agent,
+      freeFn: [],
+    }));
+
+    await player.run();
+
+    expect(player.status).toBe('error');
+    expect(agent.aiAssert).toHaveBeenCalledWith(
+      'The broken button is visible',
+      undefined,
+      { keepRawResponse: true },
+    );
+    expect(player.taskStatusList[0].error?.message).toBe(
+      failedAssertionResult.message,
+    );
+    expect(player.result[0]).toEqual(failedAssertionResult);
+    expect(agent.recordErrorToReport).not.toHaveBeenCalled();
+  });
+
   it('dispatches documented Android and iOS platform-specific actions', async () => {
     const script = parseYamlScript(`
 android:


### PR DESCRIPTION
## Summary

- reuse the canonical report case-status derivation when deciding whether a failed YAML step already produced a report failure
- avoid adding a duplicate YAML runner error when `aiAssert(..., { keepRawResponse: true })` records `output: false`, returns `{ pass: false }`, and the YAML layer raises the assertion failure
- add an Rstest regression test that exercises the current return-value path instead of mocking `aiAssert()` as a direct throw
- clarify the shared Assert status documentation so `output: false` is not described as legacy-only behavior

## Review

- `$code-review`: found that the first implementation still duplicated execution/task aggregation in the YAML runner; replaced it with `deriveCaseStatus`
- `$thermo-nuclear-code-quality-review`: verified status ownership remains in the dump status module and no parallel failure-classification path remains
- follow-up review: aligned the test with current `keepRawResponse` behavior and the repository's Rstest APIs (`rs.fn`)
- final re-review: no remaining blocking findings

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/core -- tests/unit-test/task-status.test.ts tests/unit-test/yaml-doc-usage.test.ts` — 27 tests passed
- `pnpm exec nx build @midscene/core`

## Rebase

- rebased onto `origin/main` at `3a94404b07e135955de3cca527bf3f78abffbfc2`
- updated PR head: `1464ee6aa`

## Origin and acknowledgements

This PR is a focused follow-up to #2957. Thanks @Mcoon and the original contributors for sharing the broader implementation and context that made this YAML runner edge case visible.