### PR TITLE
feat(cli): add structured JSON output

### DIFF
--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -169,6 +169,7 @@ The command writes exactly one versioned JSON object to stdout and suppresses no
 ```json
 {
   "schemaVersion": 1,
+  "kind": "run",
   "ok": true,
   "exitCode": 0,
   "summary": {
@@ -196,7 +197,7 @@ The command writes exactly one versioned JSON object to stdout and suppresses no
 }
 ```
 
-If the CLI cannot create or serialize a run result, stdout still contains a structured error object with `ok: false`, `exitCode`, and `error.name` / `error.message`. A declared YAML output file must exist and contain valid JSON; otherwise serialization fails explicitly instead of returning a silent `null` value.
+If the CLI cannot create or serialize a run result, stdout still contains a structured error object with `kind: "error"`, `ok: false`, `exitCode`, and `error.name` / `error.message`. Completed runs use `kind: "run"`, including runs with failed scripts, so consumers can distinguish the two result shapes without inspecting optional fields. A declared YAML output file must exist and contain valid JSON; otherwise serialization fails explicitly instead of returning a silent `null` value.
 
 `--json` cannot be combined with `--keep-window`, because that command intentionally does not terminate, or with `--dotenv-debug`, because dotenv debug messages are not machine-readable. Diagnostic warnings from dependencies may still use stderr; stdout remains the JSON contract.
 

--- a/apps/site/docs/en/yaml-script-runner.mdx
+++ b/apps/site/docs/en/yaml-script-runner.mdx
@@ -156,6 +156,50 @@ After execution, the output directory contains:
 - Individual execution results for each YAML file (JSON).
 - Visual reports for each script (HTML).
 
+### Consume the result as JSON
+
+Use `--json` when another program or Agent needs to consume the final result:
+
+```bash
+midscene ./bing-search.yaml --json | jq .
+```
+
+The command writes exactly one versioned JSON object to stdout and suppresses normal progress output. It preserves the usual process exit code: `0` when every script succeeds and a non-zero value otherwise. A completed run, including one with failed scripts, has this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "ok": true,
+  "exitCode": 0,
+  "summary": {
+    "path": "/path/to/midscene_run/output/summary.json",
+    "total": 1,
+    "successful": 1,
+    "failed": 0,
+    "partialFailed": 0,
+    "notExecuted": 0,
+    "totalDuration": 85490
+  },
+  "results": [
+    {
+      "file": "/path/to/bing-search.yaml",
+      "success": true,
+      "executed": true,
+      "resultType": "success",
+      "duration": 85490,
+      "error": null,
+      "report": "/path/to/midscene_run/report/bing-search.html",
+      "outputPath": "/path/to/midscene_run/output/bing-search.json",
+      "output": { "answer": "done" }
+    }
+  ]
+}
+```
+
+If the CLI cannot create or serialize a run result, stdout still contains a structured error object with `ok: false`, `exitCode`, and `error.name` / `error.message`. A declared YAML output file must exist and contain valid JSON; otherwise serialization fails explicitly instead of returning a silent `null` value.
+
+`--json` cannot be combined with `--keep-window`, because that command intentionally does not terminate, or with `--dotenv-debug`, because dotenv debug messages are not machine-readable. Diagnostic warnings from dependencies may still use stderr; stdout remains the JSON contract.
+
 ### Run in headed mode
 
 > Web page scenarios only
@@ -219,6 +263,7 @@ The CLI provides parameters to control how scripts run:
 - `--retry <number>`: Number of extra attempts for a failed script. Only failed scripts are retried, which helps with unstable networks or unstable model output. Default `0`. Puppeteer Web setup retries use a clean BrowserContext and Page, while main-script retries preserve the successful setup context. Other targets create a new player and Agent for each retry without resetting their underlying environment.
 - `--share-browser-context`: Share one Puppeteer BrowserContext (cookies, same-origin `localStorage`, etc.) across scripts while giving every YAML script an independent Page. Page-scoped state such as `sessionStorage`, the DOM, URL, and `window.name` is not shared, even with `--concurrent 1`. Every setup and main script in the batch must use a Puppeteer Web target. Bridge mode and non-Web targets are not supported. Because the browser is created or connected only once, put browser-level options (`cdpEndpoint`, `chromeArgs`, `acceptInsecureCerts`, and `downloadPath`) in the batch config's global Web target, not in an individual setup or main script. Default off.
 - `--summary <filename>`: Path for the JSON summary report.
+- `--json`: Write one versioned, machine-readable result to stdout. Normal progress output is suppressed. Cannot be combined with `--keep-window` or `--dotenv-debug`.
 - `--headed`: Run in a headed browser instead of headless.
 - `--keep-window`: Keep the browser window after execution; enables `--headed` automatically.
 - `--config <filename>`: Config file whose values become defaults for CLI arguments.

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -180,6 +180,7 @@ midscene ./bing-search.yaml --json | jq .
 ```json
 {
   "schemaVersion": 1,
+  "kind": "run",
   "ok": true,
   "exitCode": 0,
   "summary": {
@@ -207,7 +208,7 @@ midscene ./bing-search.yaml --json | jq .
 }
 ```
 
-如果 CLI 无法创建或序列化运行结果，stdout 仍会输出结构化错误对象，其中包含 `ok: false`、`exitCode` 以及 `error.name` / `error.message`。YAML 声明的输出文件必须存在并包含合法 JSON；否则序列化会明确失败，而不是静默返回 `null`。
+如果 CLI 无法创建或序列化运行结果，stdout 仍会输出结构化错误对象，其中包含 `kind: "error"`、`ok: false`、`exitCode` 以及 `error.name` / `error.message`。已完成的运行统一使用 `kind: "run"`（包括脚本执行失败的运行），因此消费者无需检查可选字段即可区分两种结果结构。YAML 声明的输出文件必须存在并包含合法 JSON；否则序列化会明确失败，而不是静默返回 `null`。
 
 `--json` 不能与 `--keep-window` 一起使用，因为后者会让命令保持运行；也不能与 `--dotenv-debug` 一起使用，因为 dotenv 调试信息不是机器可读数据。依赖产生的诊断警告仍可能写入 stderr，但 stdout 会保持 JSON 契约。
 

--- a/apps/site/docs/zh/yaml-script-runner.mdx
+++ b/apps/site/docs/zh/yaml-script-runner.mdx
@@ -167,6 +167,49 @@ midscene './scripts/**/*.yaml'
 - 每个 YAML 文件对应的独立执行结果（JSON 格式）。
 - 每个脚本生成的可视化报告（HTML 格式）。
 
+### 以 JSON 格式消费执行结果
+
+当其他程序或 Agent 需要直接消费最终结果时，可以使用 `--json`：
+
+```bash
+midscene ./bing-search.yaml --json | jq .
+```
+
+命令会向 stdout 只写入一个带版本号的 JSON 对象，并关闭常规进度输出。进程退出码保持不变：所有脚本成功时为 `0`，否则为非零值。一次已完成的运行（包括脚本执行失败的情况）具有以下结构：
+
+```json
+{
+  "schemaVersion": 1,
+  "ok": true,
+  "exitCode": 0,
+  "summary": {
+    "path": "/path/to/midscene_run/output/summary.json",
+    "total": 1,
+    "successful": 1,
+    "failed": 0,
+    "partialFailed": 0,
+    "notExecuted": 0,
+    "totalDuration": 85490
+  },
+  "results": [
+    {
+      "file": "/path/to/bing-search.yaml",
+      "success": true,
+      "executed": true,
+      "resultType": "success",
+      "duration": 85490,
+      "error": null,
+      "report": "/path/to/midscene_run/report/bing-search.html",
+      "outputPath": "/path/to/midscene_run/output/bing-search.json",
+      "output": { "answer": "done" }
+    }
+  ]
+}
+```
+
+如果 CLI 无法创建或序列化运行结果，stdout 仍会输出结构化错误对象，其中包含 `ok: false`、`exitCode` 以及 `error.name` / `error.message`。YAML 声明的输出文件必须存在并包含合法 JSON；否则序列化会明确失败，而不是静默返回 `null`。
+
+`--json` 不能与 `--keep-window` 一起使用，因为后者会让命令保持运行；也不能与 `--dotenv-debug` 一起使用，因为 dotenv 调试信息不是机器可读数据。依赖产生的诊断警告仍可能写入 stderr，但 stdout 会保持 JSON 契约。
 
 ### 运行在可视化（Headed）模式
 
@@ -231,6 +274,7 @@ page:
 - `--retry <number>`：失败脚本的额外尝试次数。只有失败的脚本会被重试，可缓解网络波动或大模型输出不稳定导致的偶发失败。默认 `0`。Puppeteer Web setup retry 使用全新的 BrowserContext 和 Page，主脚本 retry 则保留成功的 setup 上下文。其他 target 每次 retry 会创建新的 player 和 Agent，但不会重置底层运行环境。
 - `--share-browser-context`：在多个 Puppeteer Web 脚本之间共享同一个 BrowserContext（Cookies、同源 `localStorage` 等），同时每个 YAML 使用独立 Page。即使 `--concurrent 1`，`sessionStorage`、DOM、URL、`window.name` 等页面级状态也不会共享。同一批次中的 setup 和主脚本必须全部使用 Puppeteer Web target；不支持桥接模式和非 Web target。由于 Browser 只会创建或连接一次，浏览器级选项（`cdpEndpoint`、`chromeArgs`、`acceptInsecureCerts` 和 `downloadPath`）必须放在批次配置的全局 Web target 中，不能放在单个 setup 或主脚本中。默认关闭。
 - `--summary <filename>`：指定生成的 JSON 总结报告路径。
+- `--json`：向 stdout 写入一个带版本号、机器可读的结果对象，并关闭常规进度输出。不能与 `--keep-window` 或 `--dotenv-debug` 同时使用。
 - `--headed`：在带界面的浏览器中运行脚本，而非默认的无头模式。
 - `--keep-window`：脚本执行完成后保持浏览器窗口，会自动开启 `--headed` 模式。
 - `--config <filename>`：指定配置文件，文件中的参数会作为命令行参数的默认值。

--- a/packages/cli/src/cli-utils.ts
+++ b/packages/cli/src/cli-utils.ts
@@ -22,12 +22,14 @@ function camelToKebab(str: string): string {
     .replace(/^-/, ''); // Remove leading dash if present
 }
 
-export const parseProcessArgs = async (): Promise<{
+export const parseProcessArgs = async (
+  processArgs: string[] = process.argv,
+): Promise<{
   path?: string;
   files?: string[];
   options: Record<string, any>;
 }> => {
-  const args = yargs(hideBin(process.argv))
+  const args = yargs(hideBin(processArgs))
     .parserConfiguration({
       'dot-notation': true, // Enable dot notation to parse --web.userAgent as nested object
     })
@@ -92,6 +94,11 @@ Usage:
       'dotenv-debug': {
         type: 'boolean',
         description: `Turn on logging to help debug why certain keys or values are not being set as you expect, default is ${defaultConfig.dotenvDebug}`,
+      },
+      json: {
+        type: 'boolean',
+        description:
+          'Write one machine-readable JSON result to stdout without progress logs',
       },
     })
     .version('version', 'Show version number', __VERSION__)

--- a/packages/cli/src/execution-summary.ts
+++ b/packages/cli/src/execution-summary.ts
@@ -233,6 +233,16 @@ export function getExecutionSummary(
   };
 }
 
+export function isExecutionSummarySuccessful(
+  summary: ExecutionSummary,
+): boolean {
+  return (
+    summary.failed === 0 &&
+    summary.partialFailed === 0 &&
+    summary.notExecuted === 0
+  );
+}
+
 export function getResultsByType(
   results: MidsceneYamlConfigResult[],
   resultType: ResultType,
@@ -437,10 +447,7 @@ export function printExecutionSummary(
   const failedFiles = getResultsByType(results, 'failed');
   const partialFailedFiles = getResultsByType(results, 'partialFailed');
   const notExecutedFiles = getResultsByType(results, 'notExecuted');
-  const success =
-    summary.failed === 0 &&
-    summary.partialFailed === 0 &&
-    summary.notExecuted === 0;
+  const success = isExecutionSummarySuccessful(summary);
 
   console.log('\n📊 Execution Summary:');
   console.log(`   Total files: ${summary.total}`);

--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -133,7 +133,8 @@ export async function runFrameworkTestConfigDetailed(
     return runConfigInMainProcess(config, commandOptions);
   }
 
-  const shouldPrintHumanOutput = commandOptions.outputMode !== 'json';
+  const isJsonOutput = commandOptions.outputMode === 'json';
+  const shouldPrintHumanOutput = !isJsonOutput;
   if (shouldPrintHumanOutput) {
     printExecutionPlan(config);
   }
@@ -147,19 +148,26 @@ export async function runFrameworkTestConfigDetailed(
     caseOptions: createCaseOptions(config),
     webRuntimeOptions: createWebRuntimeOptions(config, commandOptions),
     maxConcurrency: commandOptions.concurrent ?? config.concurrent,
-    bail: config.continueOnError ? 0 : 1,
+    // Rstest logs its bail message directly to stdout even with no reporters.
+    // In JSON mode, keep Rstest's bail disabled and let the batch executor own
+    // stop-on-error behavior so stdout remains reserved for the final result.
+    bail: isJsonOutput ? 0 : config.continueOnError ? 0 : 1,
     retry: config.retry,
-    // setup requires one orchestrated batch even when its target does not use
-    // a shared Puppeteer BrowserContext (for example Android or Computer).
+    // JSON output also uses one orchestrated batch so stop-on-error and retry
+    // semantics do not depend on Rstest's stdout-producing bail mechanism.
+    // Setup requires the same treatment even when its target does not use a
+    // shared Puppeteer BrowserContext (for example Android or Computer).
     batchConfig:
-      config.shareBrowserContext || config.setup ? config : undefined,
+      isJsonOutput || config.shareBrowserContext || config.setup
+        ? config
+        : undefined,
   });
 
   const runner = commandOptions.rstestRunner || runRstestYamlProject;
   const exitCode = await runner({
     project,
     cwd: projectDir,
-    stdio: commandOptions.outputMode === 'json' ? 'pipe' : commandOptions.stdio,
+    stdio: isJsonOutput ? 'pipe' : commandOptions.stdio,
   });
 
   const results = readProjectResults(project);

--- a/packages/cli/src/framework/command.ts
+++ b/packages/cli/src/framework/command.ts
@@ -4,7 +4,9 @@ import type { MidsceneYamlConfigResult } from '@midscene/core';
 import { BatchRunner, type BatchRunnerConfig } from '../batch-runner';
 import {
   createNotExecutedYamlResult,
+  getExecutionSummary,
   getSummaryAbsolutePath,
+  isExecutionSummarySuccessful,
   printExecutionFinished,
   printExecutionPlan,
   printExecutionSummary,
@@ -22,6 +24,9 @@ interface WebRuntimeOptions {
   headed?: boolean;
   keepWindow?: boolean;
 }
+
+export const JSON_KEEP_WINDOW_ERROR =
+  'JSON output mode cannot be used when keepWindow is enabled because the command does not terminate.';
 
 export interface FrameworkTestCommandOptions extends WebRuntimeOptions {
   projectDir?: string;
@@ -41,6 +46,16 @@ export interface FrameworkTestCommandOptions extends WebRuntimeOptions {
   ) => Promise<MidsceneYamlConfigResult[]>;
 }
 
+type FrameworkTestCommandDetailedOptions = FrameworkTestCommandOptions & {
+  outputMode?: 'human' | 'json';
+};
+
+export interface FrameworkTestCommandResult {
+  exitCode: number;
+  results: MidsceneYamlConfigResult[];
+  summaryPath: string;
+}
+
 const defaultInProcessRunner = (
   config: BatchRunnerConfig,
 ): Promise<MidsceneYamlConfigResult[]> => new BatchRunner(config).run();
@@ -54,15 +69,17 @@ const defaultInProcessRunner = (
 // pass --keep-window in the first place.
 async function runConfigInMainProcess(
   config: BatchRunnerConfig,
-  commandOptions: FrameworkTestCommandOptions,
-): Promise<number> {
+  commandOptions: FrameworkTestCommandDetailedOptions,
+): Promise<FrameworkTestCommandResult> {
   const runner = commandOptions.inProcessRunner ?? defaultInProcessRunner;
   const results = await runner(config);
-  const success = printExecutionSummary(
+  const summaryPath = getSummaryAbsolutePath(config.summary);
+  const success = printExecutionSummary(results, summaryPath);
+  return {
+    exitCode: success ? 0 : 1,
     results,
-    getSummaryAbsolutePath(config.summary),
-  );
-  return success ? 0 : 1;
+    summaryPath,
+  };
 }
 
 const createCaseOptions = (
@@ -104,15 +121,22 @@ const readProjectResults = (
     return createNotExecutedYamlResult(item.yamlFile);
   });
 
-export async function runFrameworkTestConfig(
+export async function runFrameworkTestConfigDetailed(
   config: BatchRunnerConfig,
-  commandOptions: FrameworkTestCommandOptions = {},
-): Promise<number> {
+  commandOptions: FrameworkTestCommandDetailedOptions = {},
+): Promise<FrameworkTestCommandResult> {
+  if (config.keepWindow && commandOptions.outputMode === 'json') {
+    throw new Error(JSON_KEEP_WINDOW_ERROR);
+  }
+
   if (config.keepWindow) {
     return runConfigInMainProcess(config, commandOptions);
   }
 
-  printExecutionPlan(config);
+  const shouldPrintHumanOutput = commandOptions.outputMode !== 'json';
+  if (shouldPrintHumanOutput) {
+    printExecutionPlan(config);
+  }
 
   const projectDir = resolve(commandOptions.projectDir || process.cwd());
   const project = createRstestYamlProject({
@@ -135,13 +159,30 @@ export async function runFrameworkTestConfig(
   const exitCode = await runner({
     project,
     cwd: projectDir,
-    stdio: commandOptions.stdio,
+    stdio: commandOptions.outputMode === 'json' ? 'pipe' : commandOptions.stdio,
   });
 
   const results = readProjectResults(project);
   const summaryPath = writeExecutionSummaryFile(config.summary, results);
-  printExecutionFinished();
-  const success = printExecutionSummary(results, summaryPath);
+  let success: boolean;
+  if (shouldPrintHumanOutput) {
+    printExecutionFinished();
+    success = printExecutionSummary(results, summaryPath);
+  } else {
+    success = isExecutionSummarySuccessful(getExecutionSummary(results));
+  }
 
-  return success ? exitCode : 1;
+  return {
+    exitCode: success ? exitCode : 1,
+    results,
+    summaryPath,
+  };
+}
+
+export async function runFrameworkTestConfig(
+  config: BatchRunnerConfig,
+  commandOptions: FrameworkTestCommandOptions = {},
+): Promise<number> {
+  const result = await runFrameworkTestConfigDetailed(config, commandOptions);
+  return result.exitCode;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,11 @@
 import { runCli } from './run-cli';
 
 void runCli()
-  .then(({ exitCode, keepAlive }) => {
-    if (keepAlive) {
-      process.exitCode = exitCode;
-    } else {
+  .then(({ exitCode, termination }) => {
+    if (termination === 'force') {
       process.exit(exitCode);
+    } else {
+      process.exitCode = exitCode;
     }
   })
   .catch((error) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,118 +1,14 @@
-import { createReportCliCommands } from '@midscene/core';
-import type { BaseMidsceneTools } from '@midscene/shared/agent-tools/base-tools';
-import { runToolsCLI } from '@midscene/shared/cli';
-import { version } from '../package.json';
-import { matchYamlFiles, parseProcessArgs } from './cli-utils';
-import { createConfig, createFilesConfig } from './config-factory';
-import { loadDotenvConfig } from './dotenv-loader';
-import { runFrameworkTestConfig } from './framework';
-import { runModelCommand } from './model-command';
+import { runCli } from './run-cli';
 
-Promise.resolve(
-  (async () => {
-    const rawArgs = process.argv.slice(2);
-    const [firstArg] = rawArgs;
-    if (firstArg === 'report-tool') {
-      await runToolsCLI(
-        {
-          initTools: async () => undefined,
-          destroy: async () => undefined,
-          getToolDefinitions: () => [],
-        } as unknown as BaseMidsceneTools,
-        'midscene',
-        {
-          argv: rawArgs,
-          version,
-          extraCommands: createReportCliCommands(),
-        },
-      );
-      return;
-    }
-
-    if (firstArg === 'model') {
-      const exitCode = await runModelCommand(rawArgs);
-      process.exit(exitCode);
-      return;
-    }
-
-    const { options, path, files: cmdFiles } = await parseProcessArgs();
-
-    const welcome = `\nWelcome to @midscene/cli v${version}\n`;
-    console.log(welcome);
-
-    if (options.url) {
-      console.error(
-        'the cli mode is no longer supported, please use yaml file instead. See https://midscenejs.com/automate-with-scripts-in-yaml for more information. Sorry for the inconvenience.',
-      );
-      process.exit(1);
-    }
-
-    const configFile = options.config as string | undefined;
-
-    if (!configFile && !path && !(cmdFiles && cmdFiles.length > 0)) {
-      console.error('No script path, files, or config provided');
-      process.exit(1);
-    }
-
-    // Extract new configuration options
-    const configOptions = {
-      concurrent: options.concurrent,
-      continueOnError: options['continue-on-error'],
-      retry: options.retry,
-      summary: options.summary,
-      shareBrowserContext: options['share-browser-context'],
-      headed: options.headed,
-      keepWindow: options['keep-window'],
-      dotenvOverride: options['dotenv-override'],
-      dotenvDebug: options['dotenv-debug'],
-      web: options.web,
-      android: options.android,
-      ios: options.ios,
-      files: cmdFiles,
-      setup: options.setup as string | undefined,
-    };
-
-    let config;
-
-    if (configFile) {
-      config = await createConfig(configFile, configOptions);
-      console.log(`   Config file: ${configFile}`);
-    } else if (cmdFiles && cmdFiles.length > 0) {
-      console.log('   Executing YAML files from --files argument...');
-      config = await createFilesConfig(cmdFiles, configOptions);
-    } else if (path) {
-      const files = await matchYamlFiles(path);
-      if (files.length === 0) {
-        console.error(`No yaml files found in ${path}`);
-        process.exit(1);
-      }
-      console.log('   Executing YAML files...');
-      config = await createFilesConfig(files, configOptions);
-    }
-
-    if (!config) {
-      console.error('Could not create a valid configuration.');
-      process.exit(1);
-    }
-
-    loadDotenvConfig({
-      dotenvDebug: config.dotenvDebug,
-      dotenvOverride: config.dotenvOverride,
-      log: console.log,
-    });
-
-    const exitCode = await runFrameworkTestConfig(config);
-
-    if (config.keepWindow) {
-      // hang the process to keep the browser window open
-      setInterval(() => {
-        console.log('browser is still running, use ctrl+c to stop it');
-      }, 5000);
+void runCli()
+  .then(({ exitCode, keepAlive }) => {
+    if (keepAlive) {
+      process.exitCode = exitCode;
     } else {
       process.exit(exitCode);
     }
-  })().catch((e) => {
-    console.error(e);
-    process.exit(1);
-  }),
-);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/packages/cli/src/json-output.ts
+++ b/packages/cli/src/json-output.ts
@@ -30,6 +30,7 @@ export interface CliJsonResult {
 
 export interface CliJsonRunOutput {
   schemaVersion: typeof schemaVersion;
+  kind: 'run';
   ok: boolean;
   exitCode: number;
   summary: ExecutionSummary & { path: string };
@@ -38,6 +39,7 @@ export interface CliJsonRunOutput {
 
 export interface CliJsonErrorOutput {
   schemaVersion: typeof schemaVersion;
+  kind: 'error';
   ok: false;
   exitCode: number;
   error: {
@@ -88,6 +90,7 @@ export function createCliJsonRunOutput(
 ): CliJsonRunOutput {
   return {
     schemaVersion,
+    kind: 'run',
     ok: run.exitCode === 0,
     exitCode: run.exitCode,
     summary: {
@@ -104,6 +107,7 @@ export function createCliJsonErrorOutput(
 ): CliJsonErrorOutput {
   return {
     schemaVersion,
+    kind: 'error',
     ok: false,
     exitCode,
     error: {

--- a/packages/cli/src/json-output.ts
+++ b/packages/cli/src/json-output.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import type { MidsceneYamlConfigResult } from '@midscene/core';
+import {
+  type ExecutionSummary,
+  getExecutionSummary,
+} from './execution-summary';
+import type { FrameworkTestCommandResult } from './framework/command';
+
+const schemaVersion = 1 as const;
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface CliJsonResult {
+  file: string;
+  success: boolean;
+  executed: boolean;
+  resultType: MidsceneYamlConfigResult['resultType'];
+  duration: number;
+  error: string | null;
+  report: string | null;
+  outputPath: string | null;
+  output: JsonValue;
+}
+
+export interface CliJsonRunOutput {
+  schemaVersion: typeof schemaVersion;
+  ok: boolean;
+  exitCode: number;
+  summary: ExecutionSummary & { path: string };
+  results: CliJsonResult[];
+}
+
+export interface CliJsonErrorOutput {
+  schemaVersion: typeof schemaVersion;
+  ok: false;
+  exitCode: number;
+  error: {
+    name: string;
+    message: string;
+  };
+}
+
+export type CliJsonOutput = CliJsonRunOutput | CliJsonErrorOutput;
+
+const readYamlOutput = (outputPath: string | null | undefined): JsonValue => {
+  if (!outputPath) {
+    return null;
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(outputPath, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read YAML output file: ${outputPath}`, {
+      cause: error,
+    });
+  }
+
+  try {
+    return JSON.parse(content) as JsonValue;
+  } catch (error) {
+    throw new Error(`YAML output file is not valid JSON: ${outputPath}`, {
+      cause: error,
+    });
+  }
+};
+
+const createJsonResult = (result: MidsceneYamlConfigResult): CliJsonResult => ({
+  file: result.file,
+  success: result.success,
+  executed: result.executed,
+  resultType: result.resultType,
+  duration: result.duration ?? 0,
+  error: result.error ?? null,
+  report: result.report ?? null,
+  outputPath: result.output ?? null,
+  output: readYamlOutput(result.output),
+});
+
+export function createCliJsonRunOutput(
+  run: FrameworkTestCommandResult,
+): CliJsonRunOutput {
+  return {
+    schemaVersion,
+    ok: run.exitCode === 0,
+    exitCode: run.exitCode,
+    summary: {
+      path: run.summaryPath,
+      ...getExecutionSummary(run.results),
+    },
+    results: run.results.map(createJsonResult),
+  };
+}
+
+export function createCliJsonErrorOutput(
+  error: unknown,
+  exitCode = 1,
+): CliJsonErrorOutput {
+  return {
+    schemaVersion,
+    ok: false,
+    exitCode,
+    error: {
+      name: error instanceof Error ? error.name : 'Error',
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -1,0 +1,197 @@
+import { createReportCliCommands } from '@midscene/core';
+import { BaseMidsceneTools } from '@midscene/shared/agent-tools/base-tools';
+import type { BaseAgent, BaseDevice } from '@midscene/shared/agent-tools/types';
+import { runToolsCLI } from '@midscene/shared/cli';
+import { version } from '../package.json';
+import { matchYamlFiles, parseProcessArgs } from './cli-utils';
+import { createConfig, createFilesConfig } from './config-factory';
+import { loadDotenvConfig } from './dotenv-loader';
+import {
+  JSON_KEEP_WINDOW_ERROR,
+  runFrameworkTestConfigDetailed,
+} from './framework/command';
+import {
+  type CliJsonOutput,
+  createCliJsonErrorOutput,
+  createCliJsonRunOutput,
+} from './json-output';
+import { runModelCommand } from './model-command';
+
+export interface CliOutput {
+  log(message: string): void;
+  error(error: unknown): void;
+  writeJson(output: CliJsonOutput): void | Promise<void>;
+}
+
+export interface CliRunOutcome {
+  exitCode: number;
+  keepAlive: boolean;
+}
+
+class ReportCommandTools extends BaseMidsceneTools<BaseAgent> {
+  public override async initTools(): Promise<void> {}
+
+  public override getToolDefinitions() {
+    return [];
+  }
+
+  public override getCliToolDefinitions() {
+    return [];
+  }
+
+  protected override createTemporaryDevice(): BaseDevice {
+    throw new Error('Report commands do not initialize a Device.');
+  }
+
+  protected override async ensureAgent(): Promise<BaseAgent> {
+    throw new Error('Report commands do not initialize an Agent.');
+  }
+}
+
+const defaultOutput: CliOutput = {
+  log: (message) => console.log(message),
+  error: (error) => console.error(error),
+  writeJson: (output) =>
+    new Promise((resolve, reject) => {
+      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    }),
+};
+
+const rawArgsRequestJson = (rawArgs: string[]): boolean =>
+  rawArgs.some((arg) => arg === '--json' || arg === '--json=true');
+
+export async function runCli(
+  rawArgs: string[] = process.argv.slice(2),
+  output: CliOutput = defaultOutput,
+): Promise<CliRunOutcome> {
+  let jsonOutput = rawArgsRequestJson(rawArgs);
+
+  try {
+    const [firstArg] = rawArgs;
+    if (firstArg === 'report-tool') {
+      await runToolsCLI(new ReportCommandTools(), 'midscene', {
+        argv: rawArgs,
+        version,
+        extraCommands: createReportCliCommands(),
+      });
+      return { exitCode: 0, keepAlive: false };
+    }
+
+    if (firstArg === 'model') {
+      return {
+        exitCode: await runModelCommand(rawArgs),
+        keepAlive: false,
+      };
+    }
+
+    const {
+      options,
+      path,
+      files: cmdFiles,
+    } = await parseProcessArgs([process.execPath, 'midscene', ...rawArgs]);
+    jsonOutput = options.json === true;
+
+    if (!jsonOutput) {
+      output.log(`\nWelcome to @midscene/cli v${version}\n`);
+    }
+
+    if (options.url) {
+      throw new Error(
+        'the cli mode is no longer supported, please use yaml file instead. See https://midscenejs.com/automate-with-scripts-in-yaml for more information. Sorry for the inconvenience.',
+      );
+    }
+
+    const configFile = options.config as string | undefined;
+    if (!configFile && !path && !(cmdFiles && cmdFiles.length > 0)) {
+      throw new Error('No script path, files, or config provided');
+    }
+
+    const configOptions = {
+      concurrent: options.concurrent,
+      continueOnError: options['continue-on-error'],
+      retry: options.retry,
+      summary: options.summary,
+      shareBrowserContext: options['share-browser-context'],
+      headed: options.headed,
+      keepWindow: options['keep-window'],
+      dotenvOverride: options['dotenv-override'],
+      dotenvDebug: options['dotenv-debug'],
+      web: options.web,
+      android: options.android,
+      ios: options.ios,
+      files: cmdFiles,
+      setup: options.setup as string | undefined,
+    };
+
+    let config;
+    if (configFile) {
+      config = await createConfig(configFile, configOptions);
+      if (!jsonOutput) {
+        output.log(`   Config file: ${configFile}`);
+      }
+    } else if (cmdFiles && cmdFiles.length > 0) {
+      if (!jsonOutput) {
+        output.log('   Executing YAML files from --files argument...');
+      }
+      config = await createFilesConfig(cmdFiles, configOptions);
+    } else if (path) {
+      const files = await matchYamlFiles(path);
+      if (files.length === 0) {
+        throw new Error(`No yaml files found in ${path}`);
+      }
+      if (!jsonOutput) {
+        output.log('   Executing YAML files...');
+      }
+      config = await createFilesConfig(files, configOptions);
+    }
+
+    if (!config) {
+      throw new Error('Could not create a valid configuration.');
+    }
+    if (jsonOutput && config.keepWindow) {
+      throw new Error(JSON_KEEP_WINDOW_ERROR);
+    }
+    if (jsonOutput && config.dotenvDebug) {
+      throw new Error(
+        '--json cannot be used with --dotenv-debug because dotenv debug logs are not machine-readable.',
+      );
+    }
+
+    loadDotenvConfig({
+      dotenvDebug: config.dotenvDebug,
+      dotenvOverride: config.dotenvOverride,
+      log: jsonOutput ? undefined : output.log,
+    });
+
+    const run = await runFrameworkTestConfigDetailed(config, {
+      outputMode: jsonOutput ? 'json' : 'human',
+    });
+    if (jsonOutput) {
+      await output.writeJson(createCliJsonRunOutput(run));
+    }
+
+    if (config.keepWindow) {
+      setInterval(() => {
+        output.log('browser is still running, use ctrl+c to stop it');
+      }, 5000);
+    }
+
+    return {
+      exitCode: run.exitCode,
+      keepAlive: config.keepWindow,
+    };
+  } catch (error) {
+    if (jsonOutput) {
+      await output.writeJson(createCliJsonErrorOutput(error));
+    } else {
+      output.error(error);
+    }
+    return { exitCode: 1, keepAlive: false };
+  }
+}

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -1,7 +1,7 @@
 import { createReportCliCommands } from '@midscene/core';
 import { BaseMidsceneTools } from '@midscene/shared/agent-tools/base-tools';
 import type { BaseAgent, BaseDevice } from '@midscene/shared/agent-tools/types';
-import { runToolsCLI } from '@midscene/shared/cli';
+import { CLIError, reportCLIError, runToolsCLI } from '@midscene/shared/cli';
 import { version } from '../package.json';
 import { matchYamlFiles, parseProcessArgs } from './cli-utils';
 import { createConfig, createFilesConfig } from './config-factory';
@@ -25,7 +25,7 @@ export interface CliOutput {
 
 export interface CliRunOutcome {
   exitCode: number;
-  keepAlive: boolean;
+  termination: 'force' | 'natural' | 'keep-alive';
 }
 
 class ReportCommandTools extends BaseMidsceneTools<BaseAgent> {
@@ -80,13 +80,13 @@ export async function runCli(
         version,
         extraCommands: createReportCliCommands(),
       });
-      return { exitCode: 0, keepAlive: false };
+      return { exitCode: 0, termination: 'natural' };
     }
 
     if (firstArg === 'model') {
       return {
         exitCode: await runModelCommand(rawArgs),
-        keepAlive: false,
+        termination: 'force',
       };
     }
 
@@ -102,14 +102,14 @@ export async function runCli(
     }
 
     if (options.url) {
-      throw new Error(
+      throw new CLIError(
         'the cli mode is no longer supported, please use yaml file instead. See https://midscenejs.com/automate-with-scripts-in-yaml for more information. Sorry for the inconvenience.',
       );
     }
 
     const configFile = options.config as string | undefined;
     if (!configFile && !path && !(cmdFiles && cmdFiles.length > 0)) {
-      throw new Error('No script path, files, or config provided');
+      throw new CLIError('No script path, files, or config provided');
     }
 
     const configOptions = {
@@ -143,7 +143,7 @@ export async function runCli(
     } else if (path) {
       const files = await matchYamlFiles(path);
       if (files.length === 0) {
-        throw new Error(`No yaml files found in ${path}`);
+        throw new CLIError(`No yaml files found in ${path}`);
       }
       if (!jsonOutput) {
         output.log('   Executing YAML files...');
@@ -152,13 +152,13 @@ export async function runCli(
     }
 
     if (!config) {
-      throw new Error('Could not create a valid configuration.');
+      throw new CLIError('Could not create a valid configuration.');
     }
     if (jsonOutput && config.keepWindow) {
-      throw new Error(JSON_KEEP_WINDOW_ERROR);
+      throw new CLIError(JSON_KEEP_WINDOW_ERROR);
     }
     if (jsonOutput && config.dotenvDebug) {
-      throw new Error(
+      throw new CLIError(
         '--json cannot be used with --dotenv-debug because dotenv debug logs are not machine-readable.',
       );
     }
@@ -184,14 +184,15 @@ export async function runCli(
 
     return {
       exitCode: run.exitCode,
-      keepAlive: config.keepWindow,
+      termination: config.keepWindow ? 'keep-alive' : 'force',
     };
   } catch (error) {
+    const exitCode = error instanceof CLIError ? error.exitCode : 1;
     if (jsonOutput) {
-      await output.writeJson(createCliJsonErrorOutput(error));
+      await output.writeJson(createCliJsonErrorOutput(error, exitCode));
     } else {
-      output.error(error);
+      reportCLIError(error, (message) => output.error(message));
     }
-    return { exitCode: 1, keepAlive: false };
+    return { exitCode, termination: 'force' };
   }
 }

--- a/packages/cli/tests/e2e/fixtures/json-failure.yaml
+++ b/packages/cli/tests/e2e/fixtures/json-failure.yaml
@@ -1,0 +1,11 @@
+page:
+  serve: ./tests/server_root
+  url: index.html
+
+tasks:
+  - name: Fail deterministically
+    flow:
+      - javascript: |
+          (function() {
+            throw new Error('intentional JSON contract failure');
+          })()

--- a/packages/cli/tests/e2e/fixtures/json-success.yaml
+++ b/packages/cli/tests/e2e/fixtures/json-success.yaml
@@ -1,0 +1,9 @@
+page:
+  serve: ./tests/server_root
+  url: index.html
+
+tasks:
+  - name: Produce deterministic JSON output
+    flow:
+      - javascript: document.querySelector('h1')?.textContent
+        name: heading

--- a/packages/cli/tests/e2e/json-output.test.ts
+++ b/packages/cli/tests/e2e/json-output.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CliJsonOutput } from '@/json-output';
+import { describe, expect, rs, test } from '@rstest/core';
+import { execa } from 'execa';
+
+rs.setConfig({
+  testTimeout: 120 * 1000,
+});
+
+const cliRoot = join(__dirname, '../..');
+const cliEntry = join(cliRoot, 'dist/lib/index.js');
+const fixturesDir = join(__dirname, 'fixtures');
+
+const runBuiltCli = (args: string[], runDir: string) =>
+  execa(process.execPath, [cliEntry, ...args], {
+    cwd: cliRoot,
+    env: {
+      ...process.env,
+      CI: '1',
+      MIDSCENE_RUN_DIR: runDir,
+    },
+    reject: false,
+  });
+
+const parseSingleJsonOutput = (stdout: string): CliJsonOutput =>
+  JSON.parse(stdout) as CliJsonOutput;
+
+describe('built CLI JSON output', () => {
+  test('writes one completed-run object for a successful YAML execution', async () => {
+    const runDir = mkdtempSync(join(tmpdir(), 'midscene-cli-json-success-'));
+
+    try {
+      const result = await runBuiltCli(
+        [join(fixturesDir, 'json-success.yaml'), '--json'],
+        runDir,
+      );
+      const output = parseSingleJsonOutput(result.stdout);
+
+      expect(result.exitCode).toBe(0);
+      expect(output).toMatchObject({
+        schemaVersion: 1,
+        kind: 'run',
+        ok: true,
+        exitCode: 0,
+        summary: {
+          total: 1,
+          successful: 1,
+          failed: 0,
+          partialFailed: 0,
+          notExecuted: 0,
+        },
+        results: [
+          {
+            success: true,
+            executed: true,
+            resultType: 'success',
+            error: null,
+            output: { heading: 'My App' },
+          },
+        ],
+      });
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
+  test('writes one completed-run object when YAML execution fails', async () => {
+    const runDir = mkdtempSync(join(tmpdir(), 'midscene-cli-json-failure-'));
+
+    try {
+      const result = await runBuiltCli(
+        [join(fixturesDir, 'json-failure.yaml'), '--json'],
+        runDir,
+      );
+      const output = parseSingleJsonOutput(result.stdout);
+
+      expect(result.exitCode).toBe(1);
+      expect(output).toMatchObject({
+        schemaVersion: 1,
+        kind: 'run',
+        ok: false,
+        exitCode: 1,
+        summary: {
+          total: 1,
+          successful: 0,
+          failed: 1,
+          partialFailed: 0,
+          notExecuted: 0,
+        },
+        results: [
+          {
+            success: false,
+            executed: true,
+            resultType: 'failed',
+            error: expect.stringContaining('intentional JSON contract failure'),
+          },
+        ],
+      });
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
+  test('writes one error object when execution cannot start', async () => {
+    const runDir = mkdtempSync(join(tmpdir(), 'midscene-cli-json-error-'));
+
+    try {
+      const result = await runBuiltCli(['--json'], runDir);
+      const output = parseSingleJsonOutput(result.stdout);
+
+      expect(result.exitCode).toBe(1);
+      expect(output).toEqual({
+        schemaVersion: 1,
+        kind: 'error',
+        ok: false,
+        exitCode: 1,
+        error: {
+          name: 'Error',
+          message: 'No script path, files, or config provided',
+        },
+      });
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/unit-test/cli-utils.test.ts
+++ b/packages/cli/tests/unit-test/cli-utils.test.ts
@@ -93,6 +93,7 @@ describe('parseProcessArgs', () => {
       '--keep-window',
       '--continue-on-error',
       '--share-browser-context',
+      '--json',
       '--dotenv-override',
       '--dotenv-debug',
       '--concurrent',
@@ -107,6 +108,7 @@ describe('parseProcessArgs', () => {
     expect(options['keep-window']).toBe(true);
     expect(options['continue-on-error']).toBe(true);
     expect(options['share-browser-context']).toBe(true);
+    expect(options.json).toBe(true);
     expect(options['dotenv-override']).toBe(true);
     expect(options['dotenv-debug']).toBe(true);
     expect(options.concurrent).toBe(3);
@@ -197,6 +199,7 @@ describe('parseProcessArgs', () => {
     expect(options['keep-window']).toBeUndefined();
     expect(options['continue-on-error']).toBeUndefined();
     expect(options['share-browser-context']).toBeUndefined();
+    expect(options.json).toBeUndefined();
     expect(options['dotenv-override']).toBeUndefined();
     expect(options['dotenv-debug']).toBeUndefined();
     expect(options.concurrent).toBeUndefined();

--- a/packages/cli/tests/unit-test/framework/command-json-output.test.ts
+++ b/packages/cli/tests/unit-test/framework/command-json-output.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { runFrameworkTestConfigDetailed } from '@/framework/command';
+import { describe, expect, rs, test } from '@rstest/core';
+
+const createTempDir = () =>
+  mkdtempSync(join(tmpdir(), 'midscene-command-json-'));
+
+describe('framework command JSON output', () => {
+  test('returns results without human logs', async () => {
+    const root = createTempDir();
+    const runDir = join(root, 'midscene-run');
+    const outputDir = join(root, 'generated-runner');
+    const yaml = join(root, 'case.yaml');
+    const previousRunDir = process.env.MIDSCENE_RUN_DIR;
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
+
+    process.env.MIDSCENE_RUN_DIR = runDir;
+    writeFileSync(yaml, 'web:\n  url: about:blank\ntasks: []\n');
+
+    try {
+      const result = await runFrameworkTestConfigDetailed(
+        {
+          files: [yaml],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: false,
+          keepWindow: false,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        {
+          outputDir,
+          outputMode: 'json',
+          rstestRunner: async ({ project, stdio }) => {
+            expect(stdio).toBe('pipe');
+            mkdirSync(dirname(project.cases[0].resultFile), {
+              recursive: true,
+            });
+            writeFileSync(
+              project.cases[0].resultFile,
+              JSON.stringify({
+                file: yaml,
+                success: true,
+                executed: true,
+                duration: 5,
+                resultType: 'success',
+              }),
+            );
+            return 0;
+          },
+        },
+      );
+
+      expect(result).toEqual({
+        exitCode: 0,
+        results: [
+          {
+            file: yaml,
+            success: true,
+            executed: true,
+            duration: 5,
+            resultType: 'success',
+          },
+        ],
+        summaryPath: join(runDir, 'output', 'summary.json'),
+      });
+      expect(consoleLog).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.mockRestore();
+      if (previousRunDir === undefined) {
+        Reflect.deleteProperty(process.env, 'MIDSCENE_RUN_DIR');
+      } else {
+        process.env.MIDSCENE_RUN_DIR = previousRunDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects keepWindow because the command would not terminate', async () => {
+    await expect(
+      runFrameworkTestConfigDetailed(
+        {
+          files: ['/tmp/case.yaml'],
+          concurrent: 1,
+          continueOnError: false,
+          summary: 'summary.json',
+          shareBrowserContext: false,
+          globalConfig: {},
+          headed: true,
+          keepWindow: true,
+          dotenvOverride: false,
+          dotenvDebug: false,
+        },
+        { outputMode: 'json' },
+      ),
+    ).rejects.toThrow(
+      'JSON output mode cannot be used when keepWindow is enabled because the command does not terminate.',
+    );
+  });
+});

--- a/packages/cli/tests/unit-test/framework/command-json-output.test.ts
+++ b/packages/cli/tests/unit-test/framework/command-json-output.test.ts
@@ -38,6 +38,11 @@ describe('framework command JSON output', () => {
           outputMode: 'json',
           rstestRunner: async ({ project, stdio }) => {
             expect(stdio).toBe('pipe');
+            expect(project.bail).toBe(0);
+            expect(project.modules).toHaveLength(1);
+            expect(project.modules[0].id).toBe(
+              'virtual:midscene-yaml/batch.test.ts',
+            );
             mkdirSync(dirname(project.cases[0].resultFile), {
               recursive: true,
             });

--- a/packages/cli/tests/unit-test/json-output.test.ts
+++ b/packages/cli/tests/unit-test/json-output.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createCliJsonErrorOutput,
+  createCliJsonRunOutput,
+} from '@/json-output';
+import { describe, expect, test } from '@rstest/core';
+
+describe('CLI JSON output', () => {
+  test('creates a versioned run result with parsed YAML output', () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-cli-json-'));
+    const outputPath = join(root, 'case-output.json');
+    writeFileSync(outputPath, JSON.stringify({ answer: 'done' }));
+
+    try {
+      expect(
+        createCliJsonRunOutput({
+          exitCode: 0,
+          summaryPath: join(root, 'summary.json'),
+          results: [
+            {
+              file: join(root, 'case.yaml'),
+              success: true,
+              executed: true,
+              resultType: 'success',
+              duration: 12,
+              output: outputPath,
+              report: join(root, 'case.html'),
+            },
+          ],
+        }),
+      ).toEqual({
+        schemaVersion: 1,
+        ok: true,
+        exitCode: 0,
+        summary: {
+          path: join(root, 'summary.json'),
+          total: 1,
+          successful: 1,
+          failed: 0,
+          partialFailed: 0,
+          notExecuted: 0,
+          totalDuration: 12,
+        },
+        results: [
+          {
+            file: join(root, 'case.yaml'),
+            success: true,
+            executed: true,
+            resultType: 'success',
+            duration: 12,
+            error: null,
+            report: join(root, 'case.html'),
+            outputPath,
+            output: { answer: 'done' },
+          },
+        ],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when a declared YAML output file is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-cli-json-'));
+    const outputPath = join(root, 'missing.json');
+
+    try {
+      expect(() =>
+        createCliJsonRunOutput({
+          exitCode: 0,
+          summaryPath: join(root, 'summary.json'),
+          results: [
+            {
+              file: join(root, 'case.yaml'),
+              success: true,
+              executed: true,
+              resultType: 'success',
+              output: outputPath,
+            },
+          ],
+        }),
+      ).toThrow(`Failed to read YAML output file: ${outputPath}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when a declared YAML output file is not valid JSON', () => {
+    const root = mkdtempSync(join(tmpdir(), 'midscene-cli-json-'));
+    const outputPath = join(root, 'invalid.json');
+    writeFileSync(outputPath, 'not json');
+
+    try {
+      expect(() =>
+        createCliJsonRunOutput({
+          exitCode: 0,
+          summaryPath: join(root, 'summary.json'),
+          results: [
+            {
+              file: join(root, 'case.yaml'),
+              success: true,
+              executed: true,
+              resultType: 'success',
+              output: outputPath,
+            },
+          ],
+        }),
+      ).toThrow(`YAML output file is not valid JSON: ${outputPath}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('creates a structured error result without exposing a stack', () => {
+    expect(createCliJsonErrorOutput(new TypeError('invalid config'))).toEqual({
+      schemaVersion: 1,
+      ok: false,
+      exitCode: 1,
+      error: {
+        name: 'TypeError',
+        message: 'invalid config',
+      },
+    });
+  });
+
+  test('keeps script failures in the completed run result', () => {
+    expect(
+      createCliJsonRunOutput({
+        exitCode: 1,
+        summaryPath: '/tmp/summary.json',
+        results: [
+          {
+            file: '/tmp/failed.yaml',
+            success: false,
+            executed: true,
+            resultType: 'failed',
+            error: 'assertion failed',
+          },
+        ],
+      }),
+    ).toMatchObject({
+      ok: false,
+      exitCode: 1,
+      summary: { failed: 1 },
+      results: [{ resultType: 'failed', error: 'assertion failed' }],
+    });
+  });
+});

--- a/packages/cli/tests/unit-test/json-output.test.ts
+++ b/packages/cli/tests/unit-test/json-output.test.ts
@@ -32,6 +32,7 @@ describe('CLI JSON output', () => {
         }),
       ).toEqual({
         schemaVersion: 1,
+        kind: 'run',
         ok: true,
         exitCode: 0,
         summary: {
@@ -116,6 +117,7 @@ describe('CLI JSON output', () => {
   test('creates a structured error result without exposing a stack', () => {
     expect(createCliJsonErrorOutput(new TypeError('invalid config'))).toEqual({
       schemaVersion: 1,
+      kind: 'error',
       ok: false,
       exitCode: 1,
       error: {

--- a/packages/cli/tests/unit-test/run-cli.test.ts
+++ b/packages/cli/tests/unit-test/run-cli.test.ts
@@ -98,6 +98,7 @@ describe('runCli', () => {
     expect(output.error).not.toHaveBeenCalled();
     expect(output.writeJson).toHaveBeenCalledWith({
       schemaVersion: 1,
+      kind: 'run',
       ok: true,
       exitCode: 0,
       summary: {
@@ -130,7 +131,7 @@ describe('runCli', () => {
     finishJsonWrite?.();
     await expect(runPromise).resolves.toEqual({
       exitCode: 0,
-      keepAlive: false,
+      termination: 'force',
     });
   });
 
@@ -150,7 +151,7 @@ describe('runCli', () => {
 
     await expect(runCli(['case.yaml'], output)).resolves.toEqual({
       exitCode: 0,
-      keepAlive: false,
+      termination: 'force',
     });
 
     expect(output.log).toHaveBeenCalledWith(
@@ -169,19 +170,51 @@ describe('runCli', () => {
     });
   });
 
+  test('prints expected human CLI errors without a stack trace', async () => {
+    const output = createOutput();
+    mocks.parseProcessArgs.mockResolvedValue({
+      options: {},
+    });
+
+    await expect(runCli([], output)).resolves.toEqual({
+      exitCode: 1,
+      termination: 'force',
+    });
+
+    expect(output.error).toHaveBeenCalledWith(
+      'No script path, files, or config provided',
+    );
+    expect(output.writeJson).not.toHaveBeenCalled();
+  });
+
+  test('lets report-tool exit naturally so its stdout can flush', async () => {
+    const output = createOutput();
+    const consoleLog = rs.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await expect(runCli(['report-tool', '--help'], output)).resolves.toEqual({
+        exitCode: 0,
+        termination: 'natural',
+      });
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
   test('emits a structured error when argument parsing fails in JSON mode', async () => {
     const output = createOutput();
     mocks.parseProcessArgs.mockRejectedValue(new Error('invalid arguments'));
 
     await expect(runCli(['--json'], output)).resolves.toEqual({
       exitCode: 1,
-      keepAlive: false,
+      termination: 'force',
     });
 
     expect(output.log).not.toHaveBeenCalled();
     expect(output.error).not.toHaveBeenCalled();
     expect(output.writeJson).toHaveBeenCalledWith({
       schemaVersion: 1,
+      kind: 'error',
       ok: false,
       exitCode: 1,
       error: {
@@ -218,7 +251,7 @@ describe('runCli', () => {
 
     await expect(runCli(['case.yaml', '--json'], output)).resolves.toEqual({
       exitCode: 1,
-      keepAlive: false,
+      termination: 'force',
     });
 
     expect(mocks.loadDotenvConfig).not.toHaveBeenCalled();

--- a/packages/cli/tests/unit-test/run-cli.test.ts
+++ b/packages/cli/tests/unit-test/run-cli.test.ts
@@ -1,0 +1,233 @@
+import type { CliOutput } from '@/run-cli';
+import { beforeEach, describe, expect, rs, test } from '@rstest/core';
+
+const mocks = rs.hoisted(() => ({
+  createConfig: rs.fn(),
+  createFilesConfig: rs.fn(),
+  loadDotenvConfig: rs.fn(),
+  matchYamlFiles: rs.fn(),
+  parseProcessArgs: rs.fn(),
+  runFrameworkTestConfigDetailed: rs.fn(),
+}));
+
+rs.mock('@/cli-utils', () => ({
+  matchYamlFiles: mocks.matchYamlFiles,
+  parseProcessArgs: mocks.parseProcessArgs,
+}));
+
+rs.mock('@/config-factory', () => ({
+  createConfig: mocks.createConfig,
+  createFilesConfig: mocks.createFilesConfig,
+}));
+
+rs.mock('@/dotenv-loader', () => ({
+  loadDotenvConfig: mocks.loadDotenvConfig,
+}));
+
+rs.mock('@/framework/command', () => ({
+  JSON_KEEP_WINDOW_ERROR:
+    'JSON output mode cannot be used when keepWindow is enabled because the command does not terminate.',
+  runFrameworkTestConfigDetailed: mocks.runFrameworkTestConfigDetailed,
+}));
+
+import { runCli } from '@/run-cli';
+
+const createOutput = (): CliOutput => ({
+  log: rs.fn(),
+  error: rs.fn(),
+  writeJson: rs.fn(),
+});
+
+const config = {
+  files: ['/tmp/case.yaml'],
+  concurrent: 1,
+  continueOnError: false,
+  retry: 0,
+  summary: 'summary.json',
+  shareBrowserContext: false,
+  headed: false,
+  keepWindow: false,
+  dotenvOverride: false,
+  dotenvDebug: false,
+  globalConfig: {},
+};
+
+describe('runCli', () => {
+  beforeEach(() => {
+    rs.clearAllMocks();
+  });
+
+  test('emits only the structured run result through the JSON output boundary', async () => {
+    const output = createOutput();
+    let finishJsonWrite: (() => void) | undefined;
+    const jsonWrite = new Promise<void>((resolve) => {
+      finishJsonWrite = resolve;
+    });
+    output.writeJson = rs.fn(() => jsonWrite);
+    mocks.parseProcessArgs.mockResolvedValue({
+      options: { json: true },
+      path: 'case.yaml',
+    });
+    mocks.matchYamlFiles.mockResolvedValue(['/tmp/case.yaml']);
+    mocks.createFilesConfig.mockResolvedValue(config);
+    mocks.runFrameworkTestConfigDetailed.mockResolvedValue({
+      exitCode: 0,
+      results: [
+        {
+          file: '/tmp/case.yaml',
+          success: true,
+          executed: true,
+          duration: 5,
+          resultType: 'success',
+        },
+      ],
+      summaryPath: '/tmp/midscene_run/output/summary.json',
+    });
+
+    const runPromise = runCli(['case.yaml', '--json'], output);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    let runFinished = false;
+    void runPromise.then(() => {
+      runFinished = true;
+    });
+    await Promise.resolve();
+    expect(runFinished).toBe(false);
+
+    expect(output.log).not.toHaveBeenCalled();
+    expect(output.error).not.toHaveBeenCalled();
+    expect(output.writeJson).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      ok: true,
+      exitCode: 0,
+      summary: {
+        path: '/tmp/midscene_run/output/summary.json',
+        total: 1,
+        successful: 1,
+        failed: 0,
+        partialFailed: 0,
+        notExecuted: 0,
+        totalDuration: 5,
+      },
+      results: [
+        {
+          file: '/tmp/case.yaml',
+          success: true,
+          executed: true,
+          resultType: 'success',
+          duration: 5,
+          error: null,
+          report: null,
+          outputPath: null,
+          output: null,
+        },
+      ],
+    });
+    expect(mocks.runFrameworkTestConfigDetailed).toHaveBeenCalledWith(config, {
+      outputMode: 'json',
+    });
+
+    finishJsonWrite?.();
+    await expect(runPromise).resolves.toEqual({
+      exitCode: 0,
+      keepAlive: false,
+    });
+  });
+
+  test('preserves the existing human output path when JSON is disabled', async () => {
+    const output = createOutput();
+    mocks.parseProcessArgs.mockResolvedValue({
+      options: {},
+      path: 'case.yaml',
+    });
+    mocks.matchYamlFiles.mockResolvedValue(['/tmp/case.yaml']);
+    mocks.createFilesConfig.mockResolvedValue(config);
+    mocks.runFrameworkTestConfigDetailed.mockResolvedValue({
+      exitCode: 0,
+      results: [],
+      summaryPath: '/tmp/midscene_run/output/summary.json',
+    });
+
+    await expect(runCli(['case.yaml'], output)).resolves.toEqual({
+      exitCode: 0,
+      keepAlive: false,
+    });
+
+    expect(output.log).toHaveBeenCalledWith(
+      expect.stringContaining('Welcome to @midscene/cli'),
+    );
+    expect(output.log).toHaveBeenCalledWith('   Executing YAML files...');
+    expect(output.error).not.toHaveBeenCalled();
+    expect(output.writeJson).not.toHaveBeenCalled();
+    expect(mocks.loadDotenvConfig).toHaveBeenCalledWith({
+      dotenvDebug: false,
+      dotenvOverride: false,
+      log: output.log,
+    });
+    expect(mocks.runFrameworkTestConfigDetailed).toHaveBeenCalledWith(config, {
+      outputMode: 'human',
+    });
+  });
+
+  test('emits a structured error when argument parsing fails in JSON mode', async () => {
+    const output = createOutput();
+    mocks.parseProcessArgs.mockRejectedValue(new Error('invalid arguments'));
+
+    await expect(runCli(['--json'], output)).resolves.toEqual({
+      exitCode: 1,
+      keepAlive: false,
+    });
+
+    expect(output.log).not.toHaveBeenCalled();
+    expect(output.error).not.toHaveBeenCalled();
+    expect(output.writeJson).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      ok: false,
+      exitCode: 1,
+      error: {
+        name: 'Error',
+        message: 'invalid arguments',
+      },
+    });
+  });
+
+  test.each([
+    {
+      name: 'dotenv debug logging',
+      configOverride: { dotenvDebug: true },
+      message:
+        '--json cannot be used with --dotenv-debug because dotenv debug logs are not machine-readable.',
+    },
+    {
+      name: 'keepWindow',
+      configOverride: { keepWindow: true },
+      message:
+        'JSON output mode cannot be used when keepWindow is enabled because the command does not terminate.',
+    },
+  ])('rejects $name in JSON mode', async ({ configOverride, message }) => {
+    const output = createOutput();
+    mocks.parseProcessArgs.mockResolvedValue({
+      options: { json: true },
+      path: 'case.yaml',
+    });
+    mocks.matchYamlFiles.mockResolvedValue(['/tmp/case.yaml']);
+    mocks.createFilesConfig.mockResolvedValue({
+      ...config,
+      ...configOverride,
+    });
+
+    await expect(runCli(['case.yaml', '--json'], output)).resolves.toEqual({
+      exitCode: 1,
+      keepAlive: false,
+    });
+
+    expect(mocks.loadDotenvConfig).not.toHaveBeenCalled();
+    expect(mocks.runFrameworkTestConfigDetailed).not.toHaveBeenCalled();
+    expect(output.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add `--json` for one versioned, machine-readable stdout result while preserving process exit codes
- return structured completed-run and pre-run error envelopes with strict YAML output-file parsing
- suppress normal framework progress through its existing pipe/reporter boundary instead of monkeypatching stdout or stderr
- reject `keepWindow` and dotenv debug combinations that cannot preserve the JSON stdout contract
- preserve human CLI behavior through a testable orchestration layer and wait for stdout to flush before exiting
- document the schema and constraints in English and Chinese

## Review

- `$code-review`: fixed process termination and stdout flush semantics, removed a dead `retryReport` field, kept the detailed framework API internal, and covered failed completed runs separately from CLI errors
- `$thermo-nuclear-code-quality-review`: split orchestration, JSON serialization, and framework execution responsibilities; removed the report-tool type assertion; split framework JSON tests before the existing test file crossed 1000 lines; eliminated duplicate summary aggregation
- final re-review: no remaining findings

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/cli -- tests/unit-test/cli-utils.test.ts tests/unit-test/json-output.test.ts tests/unit-test/run-cli.test.ts tests/unit-test/framework/command-json-output.test.ts tests/unit-test/framework/command.test.ts`
- `pnpm exec nx build @midscene/cli`

## Origin and acknowledgements

This PR is a focused, reviewed extraction of the structured JSON output originally proposed in #2957. Thanks @Mcoon and the original contributors for the initial design and implementation.