### PR TITLE
fix(android): avoid scrcpy server upload memory leak

### DIFF
--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -1,5 +1,4 @@
-import { exec } from 'node:child_process';
-import { createReadStream } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { createServer } from 'node:http';
 import type { Server as HttpServer } from 'node:http';
 import path from 'node:path';
@@ -27,7 +26,7 @@ import {
 import { withTimeout } from './timeout';
 
 export const debugPage = getDebug('android:playground');
-const promiseExec = promisify(exec);
+const promiseExecFile = promisify(execFile);
 
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 const MAX_SCRCPY_OUTPUT_LINES = 100;
@@ -255,7 +254,7 @@ export default class ScrcpyServer {
     try {
       if (!this.adbClient) {
         await withTimeout(
-          promiseExec('adb start-server'),
+          promiseExecFile('adb', ['start-server']),
           SCRCPY_ADB_CONNECT_TIMEOUT_MS,
           `Timed out starting adb server after ${Math.round(SCRCPY_ADB_CONNECT_TIMEOUT_MS / 1000)}s`,
         );
@@ -336,7 +335,6 @@ export default class ScrcpyServer {
     const { AdbScrcpyClient, AdbScrcpyOptions3_3_3 } = await import(
       '@yume-chan/adb-scrcpy'
     );
-    const { ReadableStream } = await import('@yume-chan/stream-extra');
     const { DefaultServerPath } = await import('@yume-chan/scrcpy');
     // Use __dirname in a way that works for both ESM and CommonJS
     const currentDir =
@@ -346,13 +344,22 @@ export default class ScrcpyServer {
     const serverBinPath = path.resolve(currentDir, '../../bin/scrcpy-server');
 
     try {
-      // Push server - use file path directly for createReadStream
+      const deviceId = this.currentDeviceId;
+      if (!deviceId) {
+        throw new Error('Cannot push the scrcpy server without a device ID');
+      }
+
+      // Avoid @yume-chan/adb sync here. Its locked sync socket does not release
+      // the WritableStream writer after close, retaining the uploaded buffer.
       onProgress?.('pushing-server');
       await withTimeout(
-        AdbScrcpyClient.pushServer(
-          adb,
-          ReadableStream.from(createReadStream(serverBinPath)),
-        ),
+        promiseExecFile('adb', [
+          '-s',
+          deviceId,
+          'push',
+          serverBinPath,
+          DefaultServerPath,
+        ]),
         SCRCPY_PUSH_TIMEOUT_MS,
         `Timed out pushing scrcpy server to device after ${Math.round(SCRCPY_PUSH_TIMEOUT_MS / 1000)}s`,
       );

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -344,18 +344,13 @@ export default class ScrcpyServer {
     const serverBinPath = path.resolve(currentDir, '../../bin/scrcpy-server');
 
     try {
-      const deviceId = this.currentDeviceId;
-      if (!deviceId) {
-        throw new Error('Cannot push the scrcpy server without a device ID');
-      }
-
       // Avoid @yume-chan/adb sync here. Its locked sync socket does not release
       // the WritableStream writer after close, retaining the uploaded buffer.
       onProgress?.('pushing-server');
       await withTimeout(
         promiseExecFile('adb', [
           '-s',
-          deviceId,
+          adb.serial,
           'push',
           serverBinPath,
           DefaultServerPath,

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -1,45 +1,34 @@
-import * as nodeFsActual from 'node:fs' with { rstest: 'importActual' };
 import { describe, expect, it, rs } from '@rstest/core';
 import ScrcpyServer, {
   appendBoundedScrcpyOutput,
   resolveRequestedDeviceId,
 } from '../../src/scrcpy-server';
 
-const {
-  mockPushServer,
-  mockStart,
-  mockReadableFrom,
-  mockCreateReadStream,
-  mockOptionsCtor,
-} = rs.hoisted(() => ({
-  mockPushServer: rs.fn(),
+const { mockExecFile, mockStart, mockOptionsCtor } = rs.hoisted(() => ({
+  mockExecFile: rs.fn(
+    (
+      _file: string,
+      _args: string[],
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      callback(null, '', '');
+    },
+  ),
   mockStart: rs.fn(),
-  mockReadableFrom: rs.fn(),
-  mockCreateReadStream: rs.fn(),
   mockOptionsCtor: rs.fn((options) => options),
 }));
 
+rs.mock('node:child_process', () => ({ execFile: mockExecFile }));
+
 rs.mock('@yume-chan/adb-scrcpy', () => ({
   AdbScrcpyClient: {
-    pushServer: mockPushServer,
     start: mockStart,
   },
   AdbScrcpyOptions3_3_3: mockOptionsCtor,
 }));
 
-rs.mock('@yume-chan/stream-extra', () => ({
-  ReadableStream: {
-    from: mockReadableFrom,
-  },
-}));
-
 rs.mock('@yume-chan/scrcpy', () => ({
   DefaultServerPath: '/mocked/scrcpy-server.jar',
-}));
-
-rs.mock('node:fs', () => ({
-  ...nodeFsActual,
-  createReadStream: mockCreateReadStream,
 }));
 
 describe('ScrcpyServer', () => {
@@ -71,11 +60,10 @@ describe('ScrcpyServer', () => {
   });
 
   it('enables frame metadata for the scrcpy web preview stream', async () => {
-    mockCreateReadStream.mockReturnValue({ stream: true });
-    mockReadableFrom.mockReturnValue({ readable: true });
     mockStart.mockResolvedValue({ videoStream: Promise.resolve(null) });
 
     const server = new ScrcpyServer();
+    server.currentDeviceId = 'device-1';
     const adb = { serial: 'device-1' };
     const onProgress = rs.fn();
 
@@ -85,7 +73,17 @@ describe('ScrcpyServer', () => {
       onProgress,
     );
 
-    expect(mockPushServer).toHaveBeenCalledOnce();
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'adb',
+      [
+        '-s',
+        'device-1',
+        'push',
+        expect.stringContaining('bin/scrcpy-server'),
+        '/mocked/scrcpy-server.jar',
+      ],
+      expect.any(Function),
+    );
     expect(mockOptionsCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         audio: false,

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -63,7 +63,7 @@ describe('ScrcpyServer', () => {
     mockStart.mockResolvedValue({ videoStream: Promise.resolve(null) });
 
     const server = new ScrcpyServer();
-    server.currentDeviceId = 'device-1';
+    server.currentDeviceId = 'another-device';
     const adb = { serial: 'device-1' };
     const onProgress = rs.fn();
 

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -727,16 +727,7 @@ ${Object.keys(size)
       this.scrcpyAdapter = new ScrcpyDeviceAdapter(
         this.deviceId,
         this.options?.scrcpyConfig,
-        async () => {
-          const adb = await this.getAdb();
-          return {
-            host: adb.adbHost ?? '127.0.0.1',
-            port: adb.adbPort ?? 5037,
-            pushServer: async (localPath: string, remotePath: string) => {
-              await adb.push(localPath, remotePath);
-            },
-          };
-        },
+        () => this.getAdb(),
       );
     }
     return this.scrcpyAdapter;

--- a/packages/android/src/device.ts
+++ b/packages/android/src/device.ts
@@ -732,6 +732,9 @@ ${Object.keys(size)
           return {
             host: adb.adbHost ?? '127.0.0.1',
             port: adb.adbPort ?? 5037,
+            pushServer: async (localPath: string, remotePath: string) => {
+              await adb.push(localPath, remotePath);
+            },
           };
         },
       );

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -10,5 +10,7 @@ export {
 export type { AndroidConnectedDevice } from './utils';
 export {
   ScrcpyDeviceAdapter,
+  type ResolveScrcpyAdbBackend,
+  type ScrcpyAdbBackend,
   type ScrcpyStatus,
 } from './scrcpy-device-adapter';

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -2,7 +2,12 @@ import type { Size } from '@midscene/core';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { Adb as YumeAdb } from '@yume-chan/adb';
-import type { RawKeyframe, ScrcpyScreenshotManager } from './scrcpy-manager';
+import { ADB } from 'appium-adb';
+import type {
+  RawKeyframe,
+  ScrcpyScreenshotManager,
+  ScrcpyServerPusher,
+} from './scrcpy-manager';
 import {
   DEFAULT_SCRCPY_CONFIG,
   type ScrcpyFreshFrameUnavailableError,
@@ -45,16 +50,17 @@ interface ResolvedScrcpyConfig {
   idleTimeoutMs: number;
 }
 
-interface AdbServerEndpoint {
+interface AdbServerConnection {
   host: string;
   port: number;
+  pushServer?: ScrcpyServerPusher;
 }
 
-type ResolveAdbServerEndpoint = () =>
-  | AdbServerEndpoint
-  | Promise<AdbServerEndpoint>;
+type ResolveAdbServerConnection = () =>
+  | AdbServerConnection
+  | Promise<AdbServerConnection>;
 
-const DEFAULT_ADB_SERVER_ENDPOINT: AdbServerEndpoint = {
+const DEFAULT_ADB_SERVER_CONNECTION: AdbServerConnection = {
   host: '127.0.0.1',
   port: 5037,
 };
@@ -99,8 +105,8 @@ export class ScrcpyDeviceAdapter {
   constructor(
     private deviceId: string,
     private scrcpyConfig: ScrcpyConfig | undefined,
-    private resolveAdbServerEndpoint: ResolveAdbServerEndpoint = () =>
-      DEFAULT_ADB_SERVER_ENDPOINT,
+    private resolveAdbServerEndpoint: ResolveAdbServerConnection = () =>
+      DEFAULT_ADB_SERVER_CONNECTION,
   ) {}
 
   isEnabled(): boolean {
@@ -217,20 +223,30 @@ export class ScrcpyDeviceAdapter {
           './scrcpy-manager'
         );
 
-        const adbServerEndpoint = await this.resolveAdbServerEndpoint();
+        const adbServerConnection = await this.resolveAdbServerEndpoint();
         const adbClient = new AdbServerClient(
-          new AdbServerNodeTcpConnector(adbServerEndpoint),
+          new AdbServerNodeTcpConnector({
+            host: adbServerConnection.host,
+            port: adbServerConnection.port,
+          }),
         );
         adb = new Adb(
           await adbClient.createTransport({ serial: this.deviceId }),
         );
 
         const config = this.resolveConfig();
-        manager = new ScrcpyManager(adb, {
-          maxSize: config.maxSize,
-          videoBitRate: config.videoBitRate,
-          idleTimeoutMs: config.idleTimeoutMs,
-        });
+        const serverPusher =
+          adbServerConnection.pushServer ??
+          this.createDefaultServerPusher(adbServerConnection);
+        manager = new ScrcpyManager(
+          adb,
+          {
+            maxSize: config.maxSize,
+            videoBitRate: config.videoBitRate,
+            idleTimeoutMs: config.idleTimeoutMs,
+          },
+          serverPusher,
+        );
 
         // Validate environment prerequisites (ffmpeg, etc.) once before caching.
         // If validation fails, dispose the owned ADB transport before propagating
@@ -274,6 +290,20 @@ export class ScrcpyDeviceAdapter {
         this.managerPromise = null;
       }
     }
+  }
+
+  private createDefaultServerPusher(
+    endpoint: Pick<AdbServerConnection, 'host' | 'port'>,
+  ): ScrcpyServerPusher {
+    let fileTransferAdb: ADB | undefined;
+    return async (localPath, remotePath) => {
+      fileTransferAdb ??= new ADB({
+        udid: this.deviceId,
+        remoteAdbHost: endpoint.host,
+        remoteAdbPort: endpoint.port,
+      });
+      await fileTransferAdb.push(localPath, remotePath);
+    };
   }
 
   /**

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -2,12 +2,8 @@ import type { Size } from '@midscene/core';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { Adb as YumeAdb } from '@yume-chan/adb';
-import { ADB } from 'appium-adb';
-import type {
-  RawKeyframe,
-  ScrcpyScreenshotManager,
-  ScrcpyServerPusher,
-} from './scrcpy-manager';
+import { createAndroidAdb } from './adb';
+import type { RawKeyframe, ScrcpyScreenshotManager } from './scrcpy-manager';
 import {
   DEFAULT_SCRCPY_CONFIG,
   type ScrcpyFreshFrameUnavailableError,
@@ -50,20 +46,16 @@ interface ResolvedScrcpyConfig {
   idleTimeoutMs: number;
 }
 
-interface AdbServerConnection {
-  host: string;
-  port: number;
-  pushServer?: ScrcpyServerPusher;
+/** ADB capabilities scrcpy needs from the canonical Appium transport. */
+export interface ScrcpyAdbBackend {
+  adbHost?: string;
+  adbPort?: number;
+  push(localPath: string, remotePath: string): Promise<unknown>;
 }
 
-type ResolveAdbServerConnection = () =>
-  | AdbServerConnection
-  | Promise<AdbServerConnection>;
-
-const DEFAULT_ADB_SERVER_CONNECTION: AdbServerConnection = {
-  host: '127.0.0.1',
-  port: 5037,
-};
+export type ResolveScrcpyAdbBackend = () =>
+  | ScrcpyAdbBackend
+  | Promise<ScrcpyAdbBackend>;
 
 export interface DevicePhysicalInfo {
   physicalWidth: number;
@@ -105,8 +97,8 @@ export class ScrcpyDeviceAdapter {
   constructor(
     private deviceId: string,
     private scrcpyConfig: ScrcpyConfig | undefined,
-    private resolveAdbServerEndpoint: ResolveAdbServerConnection = () =>
-      DEFAULT_ADB_SERVER_CONNECTION,
+    private resolveAdbBackend: ResolveScrcpyAdbBackend = () =>
+      createAndroidAdb({ adbExecTimeout: 60_000, deviceId }),
   ) {}
 
   isEnabled(): boolean {
@@ -223,11 +215,11 @@ export class ScrcpyDeviceAdapter {
           './scrcpy-manager'
         );
 
-        const adbServerConnection = await this.resolveAdbServerEndpoint();
+        const adbBackend = await this.resolveAdbBackend();
         const adbClient = new AdbServerClient(
           new AdbServerNodeTcpConnector({
-            host: adbServerConnection.host,
-            port: adbServerConnection.port,
+            host: adbBackend.adbHost ?? '127.0.0.1',
+            port: adbBackend.adbPort ?? 5037,
           }),
         );
         adb = new Adb(
@@ -235,17 +227,16 @@ export class ScrcpyDeviceAdapter {
         );
 
         const config = this.resolveConfig();
-        const serverPusher =
-          adbServerConnection.pushServer ??
-          this.createDefaultServerPusher(adbServerConnection);
         manager = new ScrcpyManager(
           adb,
+          async (localPath, remotePath) => {
+            await adbBackend.push(localPath, remotePath);
+          },
           {
             maxSize: config.maxSize,
             videoBitRate: config.videoBitRate,
             idleTimeoutMs: config.idleTimeoutMs,
           },
-          serverPusher,
         );
 
         // Validate environment prerequisites (ffmpeg, etc.) once before caching.
@@ -290,20 +281,6 @@ export class ScrcpyDeviceAdapter {
         this.managerPromise = null;
       }
     }
-  }
-
-  private createDefaultServerPusher(
-    endpoint: Pick<AdbServerConnection, 'host' | 'port'>,
-  ): ScrcpyServerPusher {
-    let fileTransferAdb: ADB | undefined;
-    return async (localPath, remotePath) => {
-      fileTransferAdb ??= new ADB({
-        udid: this.deviceId,
-        remoteAdbHost: endpoint.host,
-        remoteAdbPort: endpoint.port,
-      });
-      await fileTransferAdb.push(localPath, remotePath);
-    };
   }
 
   /**

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -1,4 +1,3 @@
-import { createReadStream } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { getDebug } from '@midscene/shared/logger';
@@ -52,6 +51,16 @@ export interface ScrcpyScreenshotOptions {
   videoBitRate?: number;
   idleTimeoutMs?: number;
 }
+
+/** Transfers the local scrcpy server binary to its device path. */
+export type ScrcpyServerPusher = (
+  localPath: string,
+  remotePath: string,
+) => Promise<void>;
+
+const missingScrcpyServerPusher: ScrcpyServerPusher = async () => {
+  throw new Error('Scrcpy server pusher is not configured');
+};
 
 /**
  * A raw (not yet decoded) H.264 keyframe emitted by the scrcpy stream.
@@ -239,7 +248,11 @@ export class ScrcpyScreenshotManager {
   private lastFrameFreshnessWarningAt = 0;
   private disposePromise: Promise<void> | null = null;
 
-  constructor(adb: Adb, options: ScrcpyScreenshotOptions = {}) {
+  constructor(
+    adb: Adb,
+    options: ScrcpyScreenshotOptions = {},
+    private readonly pushServer: ScrcpyServerPusher = missingScrcpyServerPusher,
+  ) {
     this.adb = adb;
     const requestedBitRate = options.videoBitRate ?? DEFAULT_VIDEO_BIT_RATE;
     const clampedBitRate = Math.min(requestedBitRate, MAX_VIDEO_BIT_RATE);
@@ -306,15 +319,11 @@ export class ScrcpyScreenshotManager {
       debugScrcpy('Starting scrcpy connection...');
 
       const { AdbScrcpyClient } = await import('@yume-chan/adb-scrcpy');
-      const { ReadableStream } = await import('@yume-chan/stream-extra');
       const { DefaultServerPath } = await import('@yume-chan/scrcpy');
 
       // Use local scrcpy-server file
       const serverBinPath = this.resolveServerBinPath();
-      await AdbScrcpyClient.pushServer(
-        this.adb,
-        ReadableStream.from(createReadStream(serverBinPath)),
-      );
+      await this.pushServerBinary(serverBinPath, DefaultServerPath);
 
       const scrcpyOptions = await this.createScrcpyOptions();
 
@@ -365,6 +374,13 @@ export class ScrcpyScreenshotManager {
       }
       throw this.createConnectionError(error, serverOutput);
     }
+  }
+
+  private async pushServerBinary(
+    serverBinPath: string,
+    remoteServerPath: string,
+  ): Promise<void> {
+    await this.pushServer(serverBinPath, remoteServerPath);
   }
 
   private async createScrcpyOptions(): Promise<any> {

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -58,10 +58,6 @@ export type ScrcpyServerPusher = (
   remotePath: string,
 ) => Promise<void>;
 
-const missingScrcpyServerPusher: ScrcpyServerPusher = async () => {
-  throw new Error('Scrcpy server pusher is not configured');
-};
-
 /**
  * A raw (not yet decoded) H.264 keyframe emitted by the scrcpy stream.
  * Holding these is cheap — decoding to JPEG costs an ffmpeg run per frame, so
@@ -250,8 +246,8 @@ export class ScrcpyScreenshotManager {
 
   constructor(
     adb: Adb,
+    private readonly pushServer: ScrcpyServerPusher,
     options: ScrcpyScreenshotOptions = {},
-    private readonly pushServer: ScrcpyServerPusher = missingScrcpyServerPusher,
   ) {
     this.adb = adb;
     const requestedBitRate = options.videoBitRate ?? DEFAULT_VIDEO_BIT_RATE;
@@ -323,7 +319,7 @@ export class ScrcpyScreenshotManager {
 
       // Use local scrcpy-server file
       const serverBinPath = this.resolveServerBinPath();
-      await this.pushServerBinary(serverBinPath, DefaultServerPath);
+      await this.pushServer(serverBinPath, DefaultServerPath);
 
       const scrcpyOptions = await this.createScrcpyOptions();
 
@@ -374,13 +370,6 @@ export class ScrcpyScreenshotManager {
       }
       throw this.createConnectionError(error, serverOutput);
     }
-  }
-
-  private async pushServerBinary(
-    serverBinPath: string,
-    remoteServerPath: string,
-  ): Promise<void> {
-    await this.pushServer(serverBinPath, remoteServerPath);
   }
 
   private async createScrcpyOptions(): Promise<any> {

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -3,7 +3,13 @@ import { AndroidDevice } from '../../src/device';
 import {
   type RawKeyframe,
   ScrcpyScreenshotManager,
+  type ScrcpyServerPusher,
 } from '../../src/scrcpy-manager';
+
+const noopPushServer: ScrcpyServerPusher = async () => {};
+const createManager = (
+  adb: ConstructorParameters<typeof ScrcpyScreenshotManager>[0],
+) => new ScrcpyScreenshotManager(adb, noopPushServer);
 
 // A minimal H.264 "keyframe": 4-byte start code + IDR NAL (type 5).
 const idrFrame = (tag: number): Buffer =>
@@ -36,7 +42,7 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
   });
 
   it('fans out raw keyframes (with header + ts) to subscribers', () => {
-    const manager = new ScrcpyScreenshotManager({} as any);
+    const manager = createManager({} as any);
     calibrateFrameClock(manager);
     const received: RawKeyframe[] = [];
     manager.subscribeKeyframes((frame) => received.push(frame));
@@ -54,7 +60,7 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
   });
 
   it('stops delivering after unsubscribe', () => {
-    const manager = new ScrcpyScreenshotManager({} as any);
+    const manager = createManager({} as any);
     calibrateFrameClock(manager);
     const received: RawKeyframe[] = [];
     const unsubscribe = manager.subscribeKeyframes((f) => received.push(f));
@@ -68,7 +74,7 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
   });
 
   it('keeps the connection alive while subscribed (resets idle timer per frame)', () => {
-    const manager = new ScrcpyScreenshotManager({} as any);
+    const manager = createManager({} as any);
     calibrateFrameClock(manager);
     const resetSpy = rs.spyOn(manager as any, 'resetIdleTimer');
     manager.subscribeKeyframes(() => {});
@@ -82,7 +88,7 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
   });
 
   it('exposes the latest raw keyframe', () => {
-    const manager = new ScrcpyScreenshotManager({} as any);
+    const manager = createManager({} as any);
     calibrateFrameClock(manager);
     expect(manager.getLatestRawKeyframe()).toBeNull();
 

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -215,29 +215,6 @@ describe('AndroidDevice', () => {
     );
   });
 
-  it('should share the resolved ADB server endpoint with scrcpy', async () => {
-    Object.assign(mockAdb, {
-      adbHost: '192.168.1.10',
-      adbPort: 5038,
-    });
-    const adapter = (device as any).getScrcpyAdapter();
-
-    const connection = await (adapter as any).resolveAdbServerEndpoint();
-
-    expect(connection).toMatchObject({
-      host: '192.168.1.10',
-      port: 5038,
-    });
-    await connection.pushServer(
-      '/tmp/scrcpy-server',
-      '/data/local/tmp/scrcpy-server',
-    );
-    expect(mockAdb.push).toHaveBeenCalledWith(
-      '/tmp/scrcpy-server',
-      '/data/local/tmp/scrcpy-server',
-    );
-  });
-
   it('pushes yadb from unpacked Electron resources', async () => {
     const unpackedYadbPath = String.raw`C:\Program Files\Midscene Studio\resources\app.asar.unpacked\node_modules\@midscene\android\bin\yadb`;
     rs.spyOn(device as any, 'resolveYadbBinPath').mockReturnValue(

--- a/packages/android/tests/unit-test/page.test.ts
+++ b/packages/android/tests/unit-test/page.test.ts
@@ -222,10 +222,20 @@ describe('AndroidDevice', () => {
     });
     const adapter = (device as any).getScrcpyAdapter();
 
-    await expect((adapter as any).resolveAdbServerEndpoint()).resolves.toEqual({
+    const connection = await (adapter as any).resolveAdbServerEndpoint();
+
+    expect(connection).toMatchObject({
       host: '192.168.1.10',
       port: 5038,
     });
+    await connection.pushServer(
+      '/tmp/scrcpy-server',
+      '/data/local/tmp/scrcpy-server',
+    );
+    expect(mockAdb.push).toHaveBeenCalledWith(
+      '/tmp/scrcpy-server',
+      '/data/local/tmp/scrcpy-server',
+    );
   });
 
   it('pushes yadb from unpacked Electron resources', async () => {

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -26,7 +26,10 @@ const mocks = rs.hoisted(() => {
   };
 });
 
-rs.mock('appium-adb', () => ({ ADB: mocks.AppiumAdb }));
+rs.mock('appium-adb', () => ({
+  ADB: mocks.AppiumAdb,
+  getSdkRootFromEnv: rs.fn(() => undefined),
+}));
 
 // Mock @yume-chan packages (ESM-only, used via dynamic import in ensureManager)
 rs.mock('@yume-chan/adb', () => ({
@@ -296,58 +299,48 @@ describe('ScrcpyDeviceAdapter', () => {
       expect(mocks.createTransport).toHaveBeenCalledWith({ serial: 'device' });
     });
 
-    it('should connect to the resolved ADB server endpoint', async () => {
-      const resolveAdbServerEndpoint = rs.fn().mockResolvedValue({
-        host: '192.168.1.10',
-        port: 5038,
+    it('should use one resolved ADB backend for connection and upload', async () => {
+      const push = rs.fn().mockResolvedValue(undefined);
+      const resolveAdbBackend = rs.fn().mockResolvedValue({
+        adbHost: '192.168.1.10',
+        adbPort: 5038,
+        push,
       });
       const adapter = new ScrcpyDeviceAdapter(
         'device',
         { enabled: true },
-        resolveAdbServerEndpoint,
+        resolveAdbBackend,
       );
 
       await adapter.ensureManager(defaultDeviceInfo);
 
-      expect(resolveAdbServerEndpoint).toHaveBeenCalledTimes(1);
+      expect(resolveAdbBackend).toHaveBeenCalledTimes(1);
       expect(mocks.AdbServerNodeTcpConnector).toHaveBeenCalledWith({
         host: '192.168.1.10',
         port: 5038,
       });
-    });
-
-    it('should forward a configured scrcpy server pusher to the manager', async () => {
-      const pushServer = rs.fn().mockResolvedValue(undefined);
-      const adapter = new ScrcpyDeviceAdapter(
-        'device',
-        { enabled: true },
-        () => ({ host: '127.0.0.1', port: 5037, pushServer }),
+      const [, pushServer] = rs.mocked(ScrcpyScreenshotManager).mock.calls[0];
+      await pushServer('/tmp/scrcpy-server', '/data/local/tmp/scrcpy-server');
+      expect(push).toHaveBeenCalledWith(
+        '/tmp/scrcpy-server',
+        '/data/local/tmp/scrcpy-server',
       );
-
-      await adapter.ensureManager(defaultDeviceInfo);
-
-      const [, options, managerPusher] = rs.mocked(ScrcpyScreenshotManager).mock
-        .calls[0];
-      expect(options).not.toHaveProperty('pushServer');
-      expect(managerPusher).toBe(pushServer);
     });
 
-    it('should create an external ADB server pusher by default', async () => {
+    it('should create its default backend through the canonical ADB factory', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
 
       await adapter.ensureManager(defaultDeviceInfo);
 
-      const [, , pushServer] = rs.mocked(ScrcpyScreenshotManager).mock.calls[0];
-      if (!pushServer) {
-        throw new Error('Expected the manager to receive a server pusher');
-      }
+      const [, pushServer] = rs.mocked(ScrcpyScreenshotManager).mock.calls[0];
       await pushServer('/tmp/scrcpy-server', '/data/local/tmp/scrcpy-server');
 
-      expect(mocks.AppiumAdb).toHaveBeenCalledWith({
-        udid: 'device',
-        remoteAdbHost: '127.0.0.1',
-        remoteAdbPort: 5037,
-      });
+      expect(mocks.AppiumAdb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          adbExecTimeout: 60_000,
+          udid: 'device',
+        }),
+      );
       expect(mocks.fileTransferPush).toHaveBeenCalledWith(
         '/tmp/scrcpy-server',
         '/data/local/tmp/scrcpy-server',

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -8,15 +8,25 @@ import {
   DEFAULT_SCRCPY_CONFIG,
   SCRCPY_FRESH_FRAME_UNAVAILABLE_ERROR_CODE,
   ScrcpyFreshFrameUnavailableError,
+  ScrcpyScreenshotManager,
 } from '../../src/scrcpy-manager';
 import * as scrcpyManagerActual from '../../src/scrcpy-manager' with {
   rstest: 'importActual',
 };
 
-const mocks = rs.hoisted(() => ({
-  AdbServerNodeTcpConnector: rs.fn(),
-  createTransport: rs.fn().mockResolvedValue({}),
-}));
+const mocks = rs.hoisted(() => {
+  const fileTransferPush = rs.fn().mockResolvedValue(undefined);
+  return {
+    AdbServerNodeTcpConnector: rs.fn(),
+    createTransport: rs.fn().mockResolvedValue({}),
+    fileTransferPush,
+    AppiumAdb: rs.fn().mockImplementation(() => ({
+      push: fileTransferPush,
+    })),
+  };
+});
+
+rs.mock('appium-adb', () => ({ ADB: mocks.AppiumAdb }));
 
 // Mock @yume-chan packages (ESM-only, used via dynamic import in ensureManager)
 rs.mock('@yume-chan/adb', () => ({
@@ -304,6 +314,42 @@ describe('ScrcpyDeviceAdapter', () => {
         host: '192.168.1.10',
         port: 5038,
       });
+    });
+
+    it('should forward a configured scrcpy server pusher to the manager', async () => {
+      const pushServer = rs.fn().mockResolvedValue(undefined);
+      const adapter = new ScrcpyDeviceAdapter(
+        'device',
+        { enabled: true },
+        () => ({ host: '127.0.0.1', port: 5037, pushServer }),
+      );
+
+      await adapter.ensureManager(defaultDeviceInfo);
+
+      const [, options, managerPusher] = rs.mocked(ScrcpyScreenshotManager).mock
+        .calls[0];
+      expect(options).not.toHaveProperty('pushServer');
+      expect(managerPusher).toBe(pushServer);
+    });
+
+    it('should create an external ADB server pusher by default', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
+
+      await adapter.ensureManager(defaultDeviceInfo);
+
+      const [, , pushServer] = rs.mocked(ScrcpyScreenshotManager).mock.calls[0];
+      expect(pushServer).toBeDefined();
+      await pushServer('/tmp/scrcpy-server', '/data/local/tmp/scrcpy-server');
+
+      expect(mocks.AppiumAdb).toHaveBeenCalledWith({
+        udid: 'device',
+        remoteAdbHost: '127.0.0.1',
+        remoteAdbPort: 5037,
+      });
+      expect(mocks.fileTransferPush).toHaveBeenCalledWith(
+        '/tmp/scrcpy-server',
+        '/data/local/tmp/scrcpy-server',
+      );
     });
 
     it('should return cached manager without re-validation', async () => {

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -338,7 +338,9 @@ describe('ScrcpyDeviceAdapter', () => {
       await adapter.ensureManager(defaultDeviceInfo);
 
       const [, , pushServer] = rs.mocked(ScrcpyScreenshotManager).mock.calls[0];
-      expect(pushServer).toBeDefined();
+      if (!pushServer) {
+        throw new Error('Expected the manager to receive a server pusher');
+      }
       await pushServer('/tmp/scrcpy-server', '/data/local/tmp/scrcpy-server');
 
       expect(mocks.AppiumAdb).toHaveBeenCalledWith({

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -160,6 +160,32 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
+    it('uses the configured server pusher instead of ADB sync', async () => {
+      const pushServer = rs.fn().mockResolvedValue(undefined);
+      const manager = new ScrcpyScreenshotManager({} as any, {}, pushServer);
+
+      await (manager as any).pushServerBinary(
+        '/tmp/scrcpy-server',
+        '/data/local/tmp/scrcpy-server',
+      );
+
+      expect(pushServer).toHaveBeenCalledWith(
+        '/tmp/scrcpy-server',
+        '/data/local/tmp/scrcpy-server',
+      );
+    });
+
+    it('rejects server transfer when no safe pusher is configured', async () => {
+      const manager = new ScrcpyScreenshotManager({} as any);
+
+      await expect(
+        (manager as any).pushServerBinary(
+          '/tmp/scrcpy-server',
+          '/data/local/tmp/scrcpy-server',
+        ),
+      ).rejects.toThrow('Scrcpy server pusher is not configured');
+    });
+
     it('shares one connection attempt across concurrent callers', async () => {
       const manager = new ScrcpyScreenshotManager({} as any);
       let resolveConnection: (() => void) | undefined;

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -2,8 +2,17 @@ import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import {
   ScrcpyFreshFrameUnavailableError,
   ScrcpyScreenshotManager,
+  type ScrcpyScreenshotOptions,
+  type ScrcpyServerPusher,
   parseDeviceUptimeMs,
 } from '../../src/scrcpy-manager';
+
+const noopPushServer: ScrcpyServerPusher = async () => {};
+const createManager = (
+  adb: ConstructorParameters<typeof ScrcpyScreenshotManager>[0],
+  options: ScrcpyScreenshotOptions = {},
+  pushServer: ScrcpyServerPusher = noopPushServer,
+) => new ScrcpyScreenshotManager(adb, pushServer, options);
 
 // A minimal H.264 keyframe: 4-byte start code + IDR NAL (type 5).
 const idrFrame = (tag: number): Buffer =>
@@ -25,14 +34,14 @@ describe('ScrcpyScreenshotManager', () => {
 
   describe('validateEnvironment', () => {
     it('should succeed when ffmpeg is available', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
 
       await expect(manager.validateEnvironment()).resolves.toBeUndefined();
     });
 
     it('should throw when ffmpeg is not available', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(false);
 
       await expect(manager.validateEnvironment()).rejects.toThrow(
@@ -41,7 +50,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should throw when checkFfmpegAvailable throws an error', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       rs.spyOn(manager as any, 'checkFfmpegAvailable').mockRejectedValue(
         new Error('unexpected error'),
       );
@@ -52,7 +61,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should cache ffmpeg check result (only check once on success)', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const spy = rs
         .spyOn(manager as any, 'checkFfmpegAvailable')
         .mockResolvedValue(true);
@@ -64,7 +73,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should be independent from ensureConnected', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       rs.spyOn(manager as any, 'checkFfmpegAvailable').mockResolvedValue(true);
 
       // validateEnvironment should not trigger ensureConnected logic
@@ -78,7 +87,7 @@ describe('ScrcpyScreenshotManager', () => {
 
   describe('constructor defaults', () => {
     it('should use default options when none provided', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const options = (manager as any).options;
       expect(options.maxSize).toBe(0);
       expect(options.videoBitRate).toBe(100_000_000);
@@ -86,7 +95,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should use provided options', () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
+      const manager = createManager({} as any, {
         maxSize: 1024,
         videoBitRate: 4_000_000,
         idleTimeoutMs: 60_000,
@@ -98,7 +107,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should partially override defaults', () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
+      const manager = createManager({} as any, {
         maxSize: 512,
       });
       const options = (manager as any).options;
@@ -108,7 +117,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should clamp videoBitRate to safe maximum', () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
+      const manager = createManager({} as any, {
         videoBitRate: 500_000_000,
       });
       const options = (manager as any).options;
@@ -118,21 +127,21 @@ describe('ScrcpyScreenshotManager', () => {
 
   describe('getResolution', () => {
     it('should return null when not connected', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       expect(manager.getResolution()).toBeNull();
     });
   });
 
   describe('isConnected', () => {
     it('should return false initially', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       expect(manager.isConnected()).toBe(false);
     });
   });
 
   describe('ensureConnected', () => {
     it('should use a forward tunnel with a fresh scrcpy instance id', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any, {
+      const manager = createManager({} as any, {
         maxSize: 1024,
         videoBitRate: 8_000_000,
       });
@@ -151,7 +160,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('disables repeated frames so unchanged pixels cannot acquire a fresh PTS', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
 
       const options = await (manager as any).createScrcpyOptions();
 
@@ -160,34 +169,45 @@ describe('ScrcpyScreenshotManager', () => {
       );
     });
 
-    it('uses the configured server pusher instead of ADB sync', async () => {
+    it('uses the configured server pusher during connection', async () => {
+      const { AdbScrcpyClient } = await import('@yume-chan/adb-scrcpy');
       const pushServer = rs.fn().mockResolvedValue(undefined);
-      const manager = new ScrcpyScreenshotManager({} as any, {}, pushServer);
-
-      await (manager as any).pushServerBinary(
-        '/tmp/scrcpy-server',
-        '/data/local/tmp/scrcpy-server',
+      const manager = createManager(
+        { close: rs.fn().mockResolvedValue(undefined) } as any,
+        {},
+        pushServer,
       );
+      const videoStream = new ReadableStream();
+      rs.spyOn(manager as any, 'resolveServerBinPath').mockReturnValue(
+        '/tmp/scrcpy-server',
+      );
+      rs.spyOn(manager as any, 'ensureFrameClockCalibration').mockResolvedValue(
+        undefined,
+      );
+      rs.spyOn(AdbScrcpyClient, 'start').mockResolvedValue({
+        close: rs.fn().mockResolvedValue(undefined),
+        output: new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        videoStream: Promise.resolve({
+          metadata: { width: 1080, height: 1920 },
+          stream: videoStream,
+        }),
+      } as any);
+
+      await manager.ensureConnected();
 
       expect(pushServer).toHaveBeenCalledWith(
         '/tmp/scrcpy-server',
-        '/data/local/tmp/scrcpy-server',
+        '/data/local/tmp/scrcpy-server.jar',
       );
-    });
-
-    it('rejects server transfer when no safe pusher is configured', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
-
-      await expect(
-        (manager as any).pushServerBinary(
-          '/tmp/scrcpy-server',
-          '/data/local/tmp/scrcpy-server',
-        ),
-      ).rejects.toThrow('Scrcpy server pusher is not configured');
+      await manager.dispose();
     });
 
     it('shares one connection attempt across concurrent callers', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       let resolveConnection: (() => void) | undefined;
       const connection = new Promise<void>((resolve) => {
         resolveConnection = resolve;
@@ -208,7 +228,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should calibrate an already-started stream only once', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).scrcpyClient = {};
       (manager as any).videoStream = {};
       const readClock = rs
@@ -227,7 +247,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('shares a connection failure across concurrent callers', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const connectionError = new Error('codec unavailable');
       rs.spyOn(manager as any, 'connectScrcpy').mockRejectedValue(
         connectionError,
@@ -240,7 +260,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should include client and server output in connection errors', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const error = Object.assign(new Error('ExactReadable ended'), {
         output: ['server exited before metadata'],
       });
@@ -257,7 +277,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should bound collected server output to the latest lines', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const lines: string[] = [];
       const output = new ReadableStream<string>({
         start(controller) {
@@ -278,7 +298,7 @@ describe('ScrcpyScreenshotManager', () => {
 
   describe('consumeFramesLoop', () => {
     it('should absorb a rejected cancellation after a stream read error', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const streamError = new Error(
         'The underlying readable ended before the struct was deserialized',
       );
@@ -302,7 +322,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should disconnect the current session after a clean stream end', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const reader = {
         read: rs.fn().mockResolvedValue({ done: true }),
         cancel: rs.fn().mockResolvedValue(undefined),
@@ -321,7 +341,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should not disconnect a replacement session when an obsolete reader ends', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const obsoleteReader = {
         read: rs.fn().mockResolvedValue({ done: true }),
         cancel: rs.fn().mockResolvedValue(undefined),
@@ -361,7 +381,7 @@ describe('ScrcpyScreenshotManager', () => {
         stdout: 'mLastWakeTime=1000 (50 ms ago)',
         stderr: '',
       });
-      const manager = new ScrcpyScreenshotManager({
+      const manager = createManager({
         subprocess: {
           shellProtocol: { spawnWaitText },
         },
@@ -385,7 +405,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('drops frames captured before the device-clock barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const listener = rs.fn();
       const warn = rs.spyOn(console, 'warn').mockImplementation(() => {});
       manager.subscribeKeyframes(listener);
@@ -421,7 +441,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('projects every barrier from one stream-epoch clock sample', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValue({
@@ -446,7 +466,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('projects a deferred action barrier from when the action completed', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -468,7 +488,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('preserves a cached frame that already crosses a completed-action barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('post-action-frame');
       (manager as any).lastRawKeyframePtsUs = 1_200_000n;
@@ -491,7 +511,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('rejects a delayed first frame even while the new-stream startup window is active', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('delayed-in-transport');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
@@ -526,7 +546,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('uses the startup timeout while waiting for the first data frame of a new stream', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
@@ -563,7 +583,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('deduplicates concurrent clock calibration for one stream epoch', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       let resolveClock:
         | ((value: {
             deviceUptimeUs: bigint;
@@ -597,7 +617,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('discards an in-flight clock sample from a disconnected epoch', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       let resolveClock:
         | ((value: {
             deviceUptimeUs: bigint;
@@ -626,7 +646,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('requires a stream-epoch clock anchor before arming a barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const readClock = rs.spyOn(manager as any, 'readDeviceClockCalibration');
 
       await expect(
@@ -637,7 +657,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('takes a new clock sample after the stream epoch is reset', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const readClock = rs
         .spyOn(manager as any, 'readDeviceClockCalibration')
         .mockResolvedValueOnce({
@@ -664,7 +684,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('derives host capture time and absolute age from calibrated PTS', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -684,7 +704,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('does not use Android or host wall-clock time for frame age', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -698,7 +718,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('includes half the clock-calibration RTT in the frame-age upper bound', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_000_000n,
         hostMonotonicUs: 10_000_000n,
@@ -716,7 +736,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('accepts a frame only when estimated age plus uncertainty is within 500ms', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_490_000n,
         hostMonotonicUs: 10_000_000n,
@@ -732,7 +752,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('recalibrates the clock anchor when frame PTS moves backwards', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).deviceClockCalibration = {
         deviceUptimeUs: 1_100_000n,
         hostMonotonicUs: 10_000_000n,
@@ -774,7 +794,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('hides over-age frames from continuous frame consumers', () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const listener = rs.fn();
       manager.subscribeKeyframes(listener);
       (manager as any).deviceClockCalibration = {
@@ -796,7 +816,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('reuses a cached frame that crossed the active action barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('post-action');
       (manager as any).lastRawKeyframePtsUs = 1_050_000n;
@@ -827,7 +847,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('adds a planning barrier for a post-action frame that is already over-age', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('post-action-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_100_000n;
@@ -867,7 +887,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('adds a planning barrier after the new-stream startup window expires', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('first-planning-backlog');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
@@ -902,7 +922,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('returns a quiet diagnostic when a static screen cannot cross the Planning barrier', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('old-header');
       (manager as any).lastRawKeyframe = Buffer.from('stale-static-frame');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
@@ -938,7 +958,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('rejects frames without PTS instead of treating arrival time as freshness', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('no-pts');
       (manager as any).deviceClockCalibration = {
@@ -958,7 +978,7 @@ describe('ScrcpyScreenshotManager', () => {
 
   describe('disconnect', () => {
     it('should reset all state', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       // Manually populate state to verify cleanup
       (manager as any).spsHeader = Buffer.from('sps');
       (manager as any).lastRawKeyframe = Buffer.from('keyframe');
@@ -990,7 +1010,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should clear idle timer', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const timer = setTimeout(() => {}, 10000);
       (manager as any).idleTimer = timer;
 
@@ -1000,7 +1020,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should handle scrcpyClient.close() error gracefully', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).scrcpyClient = {
         close: rs.fn().mockRejectedValue(new Error('close failed')),
       };
@@ -1013,7 +1033,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('closes the owned ADB transport only when permanently disposed', async () => {
       const close = rs.fn().mockResolvedValue(undefined);
-      const manager = new ScrcpyScreenshotManager({ close } as any);
+      const manager = createManager({ close } as any);
 
       await manager.disconnect();
       expect(close).not.toHaveBeenCalled();
@@ -1033,7 +1053,7 @@ describe('ScrcpyScreenshotManager', () => {
           finishClose = resolve;
         }),
       );
-      const manager = new ScrcpyScreenshotManager({ close } as any);
+      const manager = createManager({ close } as any);
 
       const firstDispose = manager.dispose();
       const secondDispose = manager.dispose();
@@ -1055,7 +1075,7 @@ describe('ScrcpyScreenshotManager', () => {
 
     it('waits for an in-flight connection before disposing its ADB transport', async () => {
       const close = rs.fn().mockResolvedValue(undefined);
-      const manager = new ScrcpyScreenshotManager({ close } as any);
+      const manager = createManager({ close } as any);
       let resolveConnection: (() => void) | undefined;
       rs.spyOn(manager as any, 'connectScrcpy').mockReturnValue(
         new Promise<void>((resolve) => {
@@ -1076,7 +1096,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should cancel streamReader to stop consumeFramesLoop', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       const cancelFn = rs.fn().mockResolvedValue(undefined);
       (manager as any).streamReader = { cancel: cancelFn };
 
@@ -1087,7 +1107,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should wait for asynchronous streamReader cancellation', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       let resolveCancel: (() => void) | undefined;
       const cancelPromise = new Promise<void>((resolve) => {
         resolveCancel = resolve;
@@ -1110,7 +1130,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should handle streamReader.cancel() error gracefully', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       (manager as any).streamReader = {
         cancel: rs.fn().mockRejectedValue(new Error('stream already errored')),
       };
@@ -1120,7 +1140,7 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('should null references before awaiting close to prevent race conditions', async () => {
-      const manager = new ScrcpyScreenshotManager({} as any);
+      const manager = createManager({} as any);
       let clientNulledBeforeClose = false;
       (manager as any).scrcpyClient = {
         close: rs.fn().mockImplementation(async () => {


### PR DESCRIPTION
## Summary

- replace the leaking `AdbScrcpyClient.pushServer` path with Appium ADB file transfer for Android scrcpy sessions
- resolve one typed ADB backend per adapter and use that same backend for both the Yume ADB endpoint and server upload
- make server upload a required manager dependency, removing the optional fallback, delayed failure state, and pass-through wrapper
- bind Android Playground uploads to `adb.serial` so concurrent device selection cannot split upload and startup across devices
- apply the safe playground upload with argument-safe `execFile` invocation
- add behavior-level coverage for the real connection upload path, canonical backend creation, and device-selection races

## Root cause

`@yume-chan/adb@2.6.3` closes the sync socket without releasing its locked `WritableStream` writer. Each scrcpy server upload can therefore retain the uploaded server buffer. Avoiding the affected sync upload path prevents that retention without patching a transitive dependency for downstream consumers.

## Design

`ScrcpyDeviceAdapter` now resolves a single `ScrcpyAdbBackend`. The backend exposes the ADB server endpoint and the canonical `push()` operation as one required contract. `AndroidDevice` supplies its existing Appium ADB instance, while direct adapter construction uses the repository's `createAndroidAdb()` helper. This keeps executable selection, remote ADB settings, SDK discovery, and logging in the canonical layer.

`ScrcpyScreenshotManager` requires a server pusher at construction and calls it directly during `ensureConnected()`. There is no optional uploader mode or runtime-only "not configured" state.

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/android` — 434 passed
- `pnpm exec nx test @midscene/android-playground` — 15 passed
- `pnpm exec nx build @midscene/android`
- `pnpm exec nx build @midscene/android-playground`
- `git diff --check`

`pnpm run type-check:tests` was also run. It remains blocked by existing workspace declaration-resolution failures across Core consumers; the focused Android and Android Playground builds generated declarations successfully.

The branch is based on the latest fetched `origin/main` (`e8e21d8e3`).
