### PR TITLE
fix(android-playground): correct dev:server bin path

### DIFF
--- a/packages/android-playground/package.json
+++ b/packages/android-playground/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "dev": "npm run build:watch",
-    "dev:server": "npm run build && ./bin/playground",
+    "dev:server": "npm run build && ./bin/android-playground",
     "test": "rstest",
     "prebuild": "node ../android/scripts/download-scrcpy-server.mjs --target=bin/scrcpy-server",
     "build": "rslib build",


### PR DESCRIPTION
## Summary

- Point `dev:server` at the existing `bin/android-playground` executable.
- Keep the package build-and-launch flow unchanged.

## Dependency

- Base: `main`
- Independent of the other fork-absorption PRs.

## Validation

- `pnpm run lint`
- `test -x packages/android-playground/bin/android-playground`
- Verified the package script resolves to `npm run build && ./bin/android-playground`.

## Validation gap

- Did not keep `pnpm run dev:server` running end to end because it starts a long-running Android playground server.

## Source

- Community fork change from weinh/midscene.
