### PR TITLE
fix(web-integration): validate CDP endpoint protocol

### DIFF
--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -35,7 +35,13 @@
  *                           upstream has changed and replace the proxy.
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
 import { createServer } from 'node:http';
 import WebSocket, { WebSocketServer } from 'ws';
 import {
@@ -50,25 +56,37 @@ import {
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Report a startup configuration error before exiting.
+ *
+ * Startup validation runs before the proxy's async lifecycle is installed.
+ * Use a synchronous write so a piped stderr cannot lose the diagnostic when
+ * process.exit() terminates the process immediately afterwards.
+ */
+function exitWithStartupError(message: string): never {
+  try {
+    writeSync(process.stderr.fd, message);
+  } finally {
+    process.exit(1);
+  }
+}
+
 const chromeEndpoint = process.argv[2];
 if (!chromeEndpoint) {
-  process.stderr.write('Usage: node cdp-proxy.js <chrome-ws-endpoint>\n');
-  process.exit(1);
+  exitWithStartupError('Usage: node cdp-proxy.js <chrome-ws-endpoint>\n');
 }
 
 let parsedEndpoint: URL;
 try {
   parsedEndpoint = new URL(chromeEndpoint);
 } catch {
-  process.stderr.write(`Invalid CDP endpoint URL: ${chromeEndpoint}\n`);
-  process.exit(1);
+  exitWithStartupError(`Invalid CDP endpoint URL: ${chromeEndpoint}\n`);
 }
 
 if (parsedEndpoint.protocol !== 'ws:' && parsedEndpoint.protocol !== 'wss:') {
-  process.stderr.write(
+  exitWithStartupError(
     `Invalid CDP endpoint protocol: ${parsedEndpoint.protocol}. Only ws: and wss: are allowed.\n`,
   );
-  process.exit(1);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web-integration/src/cdp-proxy.ts
+++ b/packages/web-integration/src/cdp-proxy.ts
@@ -56,6 +56,21 @@ if (!chromeEndpoint) {
   process.exit(1);
 }
 
+let parsedEndpoint: URL;
+try {
+  parsedEndpoint = new URL(chromeEndpoint);
+} catch {
+  process.stderr.write(`Invalid CDP endpoint URL: ${chromeEndpoint}\n`);
+  process.exit(1);
+}
+
+if (parsedEndpoint.protocol !== 'ws:' && parsedEndpoint.protocol !== 'wss:') {
+  process.stderr.write(
+    `Invalid CDP endpoint protocol: ${parsedEndpoint.protocol}. Only ws: and wss: are allowed.\n`,
+  );
+  process.exit(1);
+}
+
 // ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -143,6 +143,22 @@ function startProxy(chromeEndpoint: string): Promise<{
   });
 }
 
+function runProxyToExit(
+  chromeEndpoint: string,
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [PROXY_SCRIPT, chromeEndpoint], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    proc.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stderr }));
+  });
+}
+
 function cleanupFiles() {
   try {
     if (existsSync(PROXY_ENDPOINT_FILE)) unlinkSync(PROXY_ENDPOINT_FILE);
@@ -176,6 +192,22 @@ describe('CDP WebSocket Proxy', () => {
     fakeChrome.wss.close();
     fakeChrome.server.close();
     cleanupFiles();
+  });
+
+  it('rejects a malformed CDP endpoint URL', async () => {
+    const result = await runProxyToExit('not-a-url');
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Invalid CDP endpoint URL: not-a-url');
+  });
+
+  it('rejects a non-WebSocket CDP endpoint protocol', async () => {
+    const result = await runProxyToExit('http://127.0.0.1:9222');
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      'Invalid CDP endpoint protocol: http:. Only ws: and wss: are allowed.',
+    );
   });
 
   it('starts and writes endpoint/pid files', async () => {

--- a/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
+++ b/packages/web-integration/tests/unit-test/cdp-proxy.test.ts
@@ -17,6 +17,7 @@ const PROXY_ENDPOINT_FILE = join(tmpdir(), 'midscene-cdp-proxy-endpoint');
 const PROXY_PID_FILE = join(tmpdir(), 'midscene-cdp-proxy-pid');
 const PROXY_UPSTREAM_FILE = join(tmpdir(), 'midscene-cdp-proxy-upstream');
 const PROXY_SCRIPT = join(__dirname, '../../dist/lib/cdp-proxy.js');
+const PROXY_PROCESS_TIMEOUT_MS = 10000;
 
 /**
  * Spin up a fake "Chrome" WebSocket server that echoes CDP messages.
@@ -154,8 +155,27 @@ function runProxyToExit(
     proc.stderr?.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
     });
-    proc.on('error', reject);
-    proc.on('close', (code) => resolve({ code, stderr }));
+
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+    const timer = setTimeout(() => {
+      settle(() => {
+        proc.kill('SIGKILL');
+        reject(
+          new Error(
+            `Proxy exit timeout for ${chromeEndpoint}. stderr: ${stderr}`,
+          ),
+        );
+      });
+    }, PROXY_PROCESS_TIMEOUT_MS);
+
+    proc.on('error', (error) => settle(() => reject(error)));
+    proc.on('close', (code) => settle(() => resolve({ code, stderr })));
   });
 }
 


### PR DESCRIPTION
## Summary

- Parse the Chrome CDP endpoint before opening the upstream WebSocket.
- Reject malformed URLs and non-`ws:`/`wss:` protocols with actionable startup errors.
- Write startup-fatal diagnostics synchronously so piped stderr is flushed before exit.
- Bound subprocess regression tests with a timeout and forced cleanup.

## Dependency

- Base: `main`
- Independent of the other fork-absorption PRs.

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/web`
- `pnpm exec nx build @midscene/report` (report-test prerequisite)
- `pnpm exec nx test @midscene/web` — 453 passed, 1 skipped
- `pnpm --dir packages/web-integration exec rstest tests/unit-test/cdp-proxy.test.ts` — 15 passed

## Source

- vincerevu/midscene commit `d1c15541`.
