### PR TITLE
perf(shared): cache system Chrome path resolution

### DIFF
--- a/packages/shared/src/agent-tools/chrome-path.ts
+++ b/packages/shared/src/agent-tools/chrome-path.ts
@@ -8,8 +8,17 @@ import { getDebug } from '../logger';
 
 const warnChromePath = getDebug('agent-tools:chrome-path', { console: true });
 let hasWarnedLegacyChromePath = false;
+let cachedSystemChromePath: string | undefined;
+
+export function clearSystemChromePathCache() {
+  cachedSystemChromePath = undefined;
+}
 
 export function getSystemChromePath(): string | undefined {
+  if (cachedSystemChromePath !== undefined) {
+    return cachedSystemChromePath;
+  }
+
   const platform = process.platform;
 
   const chromePaths: Record<string, string[]> = {
@@ -37,7 +46,11 @@ export function getSystemChromePath(): string | undefined {
   };
 
   const paths = chromePaths[platform] ?? [];
-  return paths.find((p) => existsSync(p));
+  const foundPath = paths.find((p) => existsSync(p));
+  if (foundPath) {
+    cachedSystemChromePath = foundPath;
+  }
+  return foundPath;
 }
 
 export function resolveChromePath(): string {

--- a/packages/shared/src/agent-tools/chrome-path.ts
+++ b/packages/shared/src/agent-tools/chrome-path.ts
@@ -10,10 +10,6 @@ const warnChromePath = getDebug('agent-tools:chrome-path', { console: true });
 let hasWarnedLegacyChromePath = false;
 let cachedSystemChromePath: string | undefined;
 
-export function clearSystemChromePathCache() {
-  cachedSystemChromePath = undefined;
-}
-
 export function getSystemChromePath(): string | undefined {
   if (cachedSystemChromePath !== undefined) {
     return cachedSystemChromePath;

--- a/packages/shared/tests/unit-test/chrome-path.test.ts
+++ b/packages/shared/tests/unit-test/chrome-path.test.ts
@@ -8,6 +8,7 @@ import {
   test,
 } from '@rstest/core';
 import {
+  clearSystemChromePathCache,
   getSystemChromePath,
   resolveChromePath,
 } from '../../src/agent-tools/chrome-path';
@@ -34,6 +35,7 @@ describe('Chrome Path Resolution', () => {
   beforeEach(() => {
     rs.clearAllMocks();
     rs.mocked(existsSync).mockReturnValue(false);
+    clearSystemChromePathCache();
   });
 
   afterEach(() => {
@@ -84,6 +86,30 @@ describe('Chrome Path Resolution', () => {
     test('should return undefined when no Chrome found', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       expect(getSystemChromePath()).toBeUndefined();
+    });
+
+    test('should cache the resolved Chrome path', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      const optPath = '/opt/google/chrome/chrome';
+      rs.mocked(existsSync).mockImplementation((path) => path === optPath);
+
+      expect(getSystemChromePath()).toBe(optPath);
+      expect(existsSync).toHaveBeenCalled();
+
+      rs.mocked(existsSync).mockClear();
+      expect(getSystemChromePath()).toBe(optPath);
+      expect(existsSync).not.toHaveBeenCalled();
+    });
+
+    test('should not cache when Chrome is not found', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      rs.mocked(existsSync).mockReturnValue(false);
+
+      expect(getSystemChromePath()).toBeUndefined();
+
+      rs.mocked(existsSync).mockClear();
+      expect(getSystemChromePath()).toBeUndefined();
+      expect(existsSync).toHaveBeenCalled();
     });
   });
 

--- a/packages/shared/tests/unit-test/chrome-path.test.ts
+++ b/packages/shared/tests/unit-test/chrome-path.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import type * as FsModule from 'node:fs';
 import {
   afterEach,
   beforeEach,
@@ -7,11 +7,7 @@ import {
   rs,
   test,
 } from '@rstest/core';
-import {
-  clearSystemChromePathCache,
-  getSystemChromePath,
-  resolveChromePath,
-} from '../../src/agent-tools/chrome-path';
+import type * as ChromePathModule from '../../src/agent-tools/chrome-path';
 
 rs.mock('node:fs', () => ({
   existsSync: rs.fn(),
@@ -31,11 +27,18 @@ rs.mock('../../src/env', () => ({
 
 describe('Chrome Path Resolution', () => {
   const originalPlatform = process.platform;
+  let existsSync: typeof FsModule.existsSync;
+  let getSystemChromePath: typeof ChromePathModule.getSystemChromePath;
+  let resolveChromePath: typeof ChromePathModule.resolveChromePath;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    rs.resetModules();
+    ({ existsSync } = await import('node:fs'));
     rs.clearAllMocks();
     rs.mocked(existsSync).mockReturnValue(false);
-    clearSystemChromePathCache();
+    ({ getSystemChromePath, resolveChromePath } = await import(
+      '../../src/agent-tools/chrome-path'
+    ));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Cache the first successfully resolved system Chrome path for the process lifetime.
- Keep failed lookups uncached so later calls can detect a newly available installation.
- Keep the cache private and isolate tests with module resets instead of exporting a test-only reset API.
- Cover successful caching and retry-after-miss behavior.

## Dependency

- Base: `main`
- Independent of the other fork-absorption PRs.

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/shared`
- `pnpm exec nx test @midscene/shared` — 496 passed

## Source

- Adapted from vincerevu/midscene commit `ff69c363` to the current `agent-tools` path.
