### PR TITLE
perf(chrome-extension): cache water-flow pointer element

### DIFF
--- a/apps/chrome-extension/src/scripts/water-flow.ts
+++ b/apps/chrome-extension/src/scripts/water-flow.ts
@@ -3,6 +3,8 @@ const midsceneWaterFlowAnimation = {
 
   mousePointerAttribute: 'data-water-flow-pointer',
 
+  pointerElement: null as null | HTMLDivElement,
+
   lastCallTime: 0,
 
   cleanupTimeout: null as null | number,
@@ -28,9 +30,11 @@ const midsceneWaterFlowAnimation = {
   showMousePointer(x: number, y: number) {
     this.enable(); // show water flow animation
     this.registerSelfCleaning();
-    const existingPointer = document.querySelector(
-      `div[${this.mousePointerAttribute}]`,
-    ) as HTMLDivElement | null;
+    let existingPointer =
+      this.pointerElement ||
+      (document.querySelector(
+        `div[${this.mousePointerAttribute}]`,
+      ) as HTMLDivElement | null);
 
     // Clear any existing timeouts to prevent race conditions
     if (existingPointer) {
@@ -40,6 +44,14 @@ const midsceneWaterFlowAnimation = {
         existingPointer.getAttribute('data-remove-timeout-id'),
       );
       if (removeTimeoutId) clearTimeout(removeTimeoutId);
+    }
+
+    // Clear detached cached nodes so a new pointer can be created.
+    if (existingPointer && !document.body.contains(existingPointer)) {
+      if (this.pointerElement === existingPointer) {
+        this.pointerElement = null;
+      }
+      existingPointer = null;
     }
 
     const size = 30;
@@ -61,6 +73,7 @@ const midsceneWaterFlowAnimation = {
         p.style.left = `${x - size / 2}px`;
         p.style.top = `${y - size / 2}px`;
         document.body.appendChild(p);
+        this.pointerElement = p;
         return p;
       })();
 
@@ -77,6 +90,9 @@ const midsceneWaterFlowAnimation = {
         if (pointer.parentNode) {
           document.body.removeChild(pointer);
         }
+        if (this.pointerElement === pointer) {
+          this.pointerElement = null;
+        }
       }, 500);
       pointer.setAttribute('data-remove-timeout-id', String(removeTimeoutId));
     }, 3000);
@@ -85,11 +101,18 @@ const midsceneWaterFlowAnimation = {
 
   hideMousePointer() {
     this.registerSelfCleaning();
-    const pointer = document.querySelector(
-      `div[${this.mousePointerAttribute}]`,
-    ) as HTMLDivElement | null;
+    const pointer =
+      this.pointerElement ||
+      (document.querySelector(
+        `div[${this.mousePointerAttribute}]`,
+      ) as HTMLDivElement | null);
     if (pointer) {
-      document.body.removeChild(pointer);
+      if (pointer.parentNode) {
+        document.body.removeChild(pointer);
+      }
+      if (this.pointerElement === pointer) {
+        this.pointerElement = null;
+      }
     }
   },
 
@@ -178,8 +201,11 @@ const midsceneWaterFlowAnimation = {
       `div[${this.mousePointerAttribute}]`,
     );
     mousePointers.forEach((element) => {
-      document.body.removeChild(element);
+      if (element.parentNode) {
+        document.body.removeChild(element);
+      }
     });
+    this.pointerElement = null;
   },
 };
 

--- a/apps/chrome-extension/src/scripts/water-flow.ts
+++ b/apps/chrome-extension/src/scripts/water-flow.ts
@@ -9,6 +9,42 @@ const midsceneWaterFlowAnimation = {
 
   cleanupTimeout: null as null | number,
 
+  clearPointerTimeouts(pointer: HTMLDivElement) {
+    const timeoutId = Number(pointer.getAttribute('data-timeout-id'));
+    if (timeoutId) clearTimeout(timeoutId);
+    const removeTimeoutId = Number(
+      pointer.getAttribute('data-remove-timeout-id'),
+    );
+    if (removeTimeoutId) clearTimeout(removeTimeoutId);
+  },
+
+  getPointerElement(): HTMLDivElement | null {
+    if (this.pointerElement) {
+      if (document.body.contains(this.pointerElement)) {
+        return this.pointerElement;
+      }
+      this.clearPointerTimeouts(this.pointerElement);
+      this.pointerElement = null;
+    }
+
+    const existingPointer = document.querySelector(
+      `div[${this.mousePointerAttribute}]`,
+    ) as HTMLDivElement | null;
+    if (existingPointer && document.body.contains(existingPointer)) {
+      this.pointerElement = existingPointer;
+      return existingPointer;
+    }
+    return null;
+  },
+
+  removePointerElement(pointer: HTMLDivElement) {
+    this.clearPointerTimeouts(pointer);
+    pointer.remove();
+    if (this.pointerElement === pointer) {
+      this.pointerElement = null;
+    }
+  },
+
   // call to reset the self cleaning timer
   registerSelfCleaning() {
     // clean up all the indicators if there is no call for 30 seconds
@@ -30,28 +66,11 @@ const midsceneWaterFlowAnimation = {
   showMousePointer(x: number, y: number) {
     this.enable(); // show water flow animation
     this.registerSelfCleaning();
-    let existingPointer =
-      this.pointerElement ||
-      (document.querySelector(
-        `div[${this.mousePointerAttribute}]`,
-      ) as HTMLDivElement | null);
+    const existingPointer = this.getPointerElement();
 
     // Clear any existing timeouts to prevent race conditions
     if (existingPointer) {
-      const timeoutId = Number(existingPointer.getAttribute('data-timeout-id'));
-      if (timeoutId) clearTimeout(timeoutId);
-      const removeTimeoutId = Number(
-        existingPointer.getAttribute('data-remove-timeout-id'),
-      );
-      if (removeTimeoutId) clearTimeout(removeTimeoutId);
-    }
-
-    // Clear detached cached nodes so a new pointer can be created.
-    if (existingPointer && !document.body.contains(existingPointer)) {
-      if (this.pointerElement === existingPointer) {
-        this.pointerElement = null;
-      }
-      existingPointer = null;
+      this.clearPointerTimeouts(existingPointer);
     }
 
     const size = 30;
@@ -87,12 +106,7 @@ const midsceneWaterFlowAnimation = {
     const fadeTimeoutId = setTimeout(() => {
       pointer.style.opacity = '0';
       const removeTimeoutId = setTimeout(() => {
-        if (pointer.parentNode) {
-          document.body.removeChild(pointer);
-        }
-        if (this.pointerElement === pointer) {
-          this.pointerElement = null;
-        }
+        this.removePointerElement(pointer);
       }, 500);
       pointer.setAttribute('data-remove-timeout-id', String(removeTimeoutId));
     }, 3000);
@@ -101,18 +115,9 @@ const midsceneWaterFlowAnimation = {
 
   hideMousePointer() {
     this.registerSelfCleaning();
-    const pointer =
-      this.pointerElement ||
-      (document.querySelector(
-        `div[${this.mousePointerAttribute}]`,
-      ) as HTMLDivElement | null);
+    const pointer = this.getPointerElement();
     if (pointer) {
-      if (pointer.parentNode) {
-        document.body.removeChild(pointer);
-      }
-      if (this.pointerElement === pointer) {
-        this.pointerElement = null;
-      }
+      this.removePointerElement(pointer);
     }
   },
 
@@ -201,9 +206,7 @@ const midsceneWaterFlowAnimation = {
       `div[${this.mousePointerAttribute}]`,
     );
     mousePointers.forEach((element) => {
-      if (element.parentNode) {
-        document.body.removeChild(element);
-      }
+      this.removePointerElement(element as HTMLDivElement);
     });
     this.pointerElement = null;
   },

--- a/apps/chrome-extension/tests/water-flow.test.ts
+++ b/apps/chrome-extension/tests/water-flow.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+type WaterFlowAnimation = Window['midsceneWaterFlowAnimation'];
+
+describe('water-flow pointer lifecycle', () => {
+  let animation: WaterFlowAnimation;
+
+  beforeEach(async () => {
+    rs.resetModules();
+    rs.useFakeTimers();
+    rs.stubGlobal(
+      'requestAnimationFrame',
+      rs.fn((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }),
+    );
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    (window as Partial<Window>).midsceneWaterFlowAnimation = undefined;
+
+    await import('../src/scripts/water-flow');
+    animation = window.midsceneWaterFlowAnimation;
+  });
+
+  afterEach(() => {
+    animation.disable();
+    rs.clearAllTimers();
+    rs.useRealTimers();
+    rs.unstubAllGlobals();
+    (window as Partial<Window>).midsceneWaterFlowAnimation = undefined;
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('adopts a pointer found in the DOM and reuses the cache', () => {
+    const existingPointer = document.createElement('div');
+    existingPointer.setAttribute(animation.mousePointerAttribute, 'true');
+    document.body.appendChild(existingPointer);
+    const querySelectorSpy = rs.spyOn(document, 'querySelector');
+
+    animation.showMousePointer(20, 30);
+    expect(animation.pointerElement).toBe(existingPointer);
+    expect(querySelectorSpy).toHaveBeenCalledTimes(1);
+
+    querySelectorSpy.mockClear();
+    animation.showMousePointer(40, 50);
+    expect(animation.pointerElement).toBe(existingPointer);
+    expect(querySelectorSpy).not.toHaveBeenCalled();
+  });
+
+  it('replaces a cached pointer that was detached externally', () => {
+    animation.showMousePointer(20, 30);
+    const detachedPointer = animation.pointerElement;
+    expect(detachedPointer).not.toBeNull();
+    detachedPointer?.remove();
+
+    animation.showMousePointer(40, 50);
+
+    expect(animation.pointerElement).not.toBe(detachedPointer);
+    expect(document.body.contains(animation.pointerElement)).toBe(true);
+  });
+
+  it('does not let an old timeout clear a newer pointer', async () => {
+    animation.showMousePointer(20, 30);
+    animation.hideMousePointer();
+    await rs.advanceTimersByTimeAsync(1_000);
+
+    animation.showMousePointer(40, 50);
+    const currentPointer = animation.pointerElement;
+    await rs.advanceTimersByTimeAsync(2_500);
+
+    expect(animation.pointerElement).toBe(currentPointer);
+    expect(document.body.contains(currentPointer)).toBe(true);
+  });
+
+  it('clears the cache when timeout, hide, or disable removes the pointer', async () => {
+    animation.showMousePointer(20, 30);
+    await rs.advanceTimersByTimeAsync(3_500);
+    expect(animation.pointerElement).toBeNull();
+
+    animation.showMousePointer(30, 40);
+    animation.hideMousePointer();
+    expect(animation.pointerElement).toBeNull();
+
+    animation.showMousePointer(40, 50);
+    animation.disable();
+    expect(animation.pointerElement).toBeNull();
+    expect(
+      document.querySelectorAll(`div[${animation.mousePointerAttribute}]`),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/chrome-extension/tests/water-flow.test.ts
+++ b/apps/chrome-extension/tests/water-flow.test.ts
@@ -52,16 +52,22 @@ describe('water-flow pointer lifecycle', () => {
     expect(querySelectorSpy).not.toHaveBeenCalled();
   });
 
-  it('replaces a cached pointer that was detached externally', () => {
+  it('adopts a live replacement after the cached pointer is detached', () => {
     animation.showMousePointer(20, 30);
     const detachedPointer = animation.pointerElement;
     expect(detachedPointer).not.toBeNull();
+    const replacementPointer = detachedPointer?.cloneNode(
+      true,
+    ) as HTMLDivElement;
     detachedPointer?.remove();
+    document.body.appendChild(replacementPointer);
 
     animation.showMousePointer(40, 50);
 
-    expect(animation.pointerElement).not.toBe(detachedPointer);
-    expect(document.body.contains(animation.pointerElement)).toBe(true);
+    expect(animation.pointerElement).toBe(replacementPointer);
+    expect(
+      document.querySelectorAll(`div[${animation.mousePointerAttribute}]`),
+    ).toHaveLength(1);
   });
 
   it('does not let an old timeout clear a newer pointer', async () => {


### PR DESCRIPTION
## Summary

- Cache the water-flow mouse pointer element instead of querying the DOM on every move.
- Centralize pointer lookup, DOM adoption, timeout cancellation, removal, and cache invalidation.
- Safely recreate externally detached pointers and prevent stale cleanup from affecting newer nodes.
- Add jsdom/fake-timer regression coverage for reuse, detach, timeout, hide, and disable paths.

## Dependency

- Base: `main`
- Independent of the other fork-absorption PRs.

## Validation

- `pnpm run lint`
- `pnpm exec nx build chrome-extension`
- `pnpm exec nx test chrome-extension` — 58 passed

## Validation gap

- The packaged extension was not manually loaded in Chrome to exercise SPA route changes.

## Source

- vincerevu/midscene commit `32e10e93`.
