### PR TITLE
perf(visualizer): memoize selected action lookup

### DIFF
--- a/packages/visualizer/src/component/prompt-input/index.tsx
+++ b/packages/visualizer/src/component/prompt-input/index.tsx
@@ -34,6 +34,7 @@ import {
   isRunButtonEnabled as calculateIsRunButtonEnabled,
 } from '../../utils/playground-utils';
 import {
+  findActionForType,
   getAvailablePromptActionTypes,
   getInlineStructuredFieldConfig,
 } from '../../utils/prompt-input-utils';
@@ -124,16 +125,10 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     [history, selectedType],
   );
 
-  const actionMap = useMemo(() => {
-    const map = new Map<string, DeviceAction<any>>();
-    if (actionSpace) {
-      for (const action of actionSpace) {
-        if (action.name) map.set(action.name, action);
-        if (action.interfaceAlias) map.set(action.interfaceAlias, action);
-      }
-    }
-    return map;
-  }, [actionSpace]);
+  const selectedAction = useMemo(
+    () => findActionForType(actionSpace, selectedType),
+    [actionSpace, selectedType],
+  );
 
   const handleMinimalTypeGateReset = useCallback(() => {
     lastHistoryRef.current = null;
@@ -151,7 +146,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
   const needsStructuredParams = useMemo(() => {
     if (actionSpace) {
       // Use actionSpace to determine if method needs structured params
-      const action = actionMap.get(selectedType);
+      const action = selectedAction;
 
       if (!action?.paramSchema) return false;
 
@@ -167,13 +162,13 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return true;
     }
     return false;
-  }, [selectedType, actionMap, actionSpace]);
+  }, [selectedType, selectedAction, actionSpace]);
 
   // Check if current method needs any input (either prompt or parameters)
   const needsAnyInput = useMemo(() => {
     if (actionSpace && actionSpace.length > 0) {
       // Use actionSpace to determine if method needs any input
-      const action = actionMap.get(selectedType);
+      const action = selectedAction;
 
       // If action exists in actionSpace, check if it has required parameters
       if (action) {
@@ -202,7 +197,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     // Fallback when actionSpace is not loaded yet - assume most methods need input
     return true;
-  }, [selectedType, actionMap, actionSpace]);
+  }, [selectedType, selectedAction, actionSpace]);
 
   // Check if current method supports data extraction options
   const showDataExtractionOptions = useMemo(() => {
@@ -225,7 +220,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     if (actionSpace) {
       // Use actionSpace to determine if method supports deep locate
-      const action = actionMap.get(selectedType);
+      const action = selectedAction;
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         const schema = action.paramSchema as ZodObjectSchema;
@@ -242,7 +237,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return false;
     }
     return false;
-  }, [selectedType, actionMap, actionSpace]);
+  }, [selectedType, selectedAction, actionSpace]);
 
   // Check if current method supports deep think option (for aiAct planning)
   const showDeepThinkOption = useMemo(() => {
@@ -378,7 +373,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     if (!needsStructuredParams || !actionSpace) {
       return {};
     }
-    const action = actionMap.get(selectedType);
+    const action = selectedAction;
 
     if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
       const defaultParams: FormParams = {};
@@ -401,7 +396,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return defaultParams;
     }
     return {};
-  }, [selectedType, needsStructuredParams, actionMap, actionSpace]);
+  }, [selectedType, needsStructuredParams, selectedAction, actionSpace]);
 
   // Initialize form with last selected type when component mounts
   useEffect(() => {
@@ -567,7 +562,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     if (!needsStructuredParams || !actionSpace) {
       return false;
     }
-    const action = actionMap.get(selectedType);
+    const action = selectedAction;
 
     if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
       const schema = action.paramSchema as ZodObjectSchema;
@@ -575,7 +570,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return Object.keys(shape).length === 1;
     }
     return false;
-  }, [selectedType, needsStructuredParams, actionMap, actionSpace]);
+  }, [selectedType, needsStructuredParams, selectedAction, actionSpace]);
 
   const minimalInlineFieldConfig = useMemo(
     () =>
@@ -592,15 +587,13 @@ export const PromptInput: React.FC<PromptInputProps> = ({
         runButtonEnabled,
         !!needsStructuredParams,
         params,
-        actionMap,
-        selectedType,
+        selectedAction,
         promptValue,
       ),
     [
       runButtonEnabled,
       needsStructuredParams,
-      selectedType,
-      actionMap,
+      selectedAction,
       promptValue,
       params,
     ],
@@ -623,7 +616,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     // For structured params, create a display string for history - dynamically
     let historyPrompt = '';
     if (needsStructuredParams && values.params && actionSpace) {
-      const action = actionMap.get(selectedType);
+      const action = selectedAction;
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         // Separate locate field from other fields for legacy format compatibility
@@ -695,7 +688,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     selectedType,
     clearPromptAfterRun,
     actionSpace,
-    actionMap,
+    selectedAction,
     getDefaultParams,
   ]);
 
@@ -751,7 +744,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     // Try to get action from actionSpace first
     if (actionSpace) {
-      const action = actionMap.get(selectedType);
+      const action = selectedAction;
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         const schema = action.paramSchema as ZodObjectSchema;
@@ -783,7 +776,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
             // Try to get from action's paramSchema directly
             if (actionSpace) {
-              const action = actionMap.get(selectedType);
+              const action = selectedAction;
               if (
                 action?.paramSchema &&
                 typeof action.paramSchema === 'object' &&
@@ -865,7 +858,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
             // Try to get from action's paramSchema directly
             if (actionSpace) {
-              const action = actionMap.get(selectedType);
+              const action = selectedAction;
               if (
                 action?.paramSchema &&
                 typeof action.paramSchema === 'object' &&
@@ -960,7 +953,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     selectedType,
     needsStructuredParams,
     actionSpace,
-    actionMap,
+    selectedAction,
     handleStructuredKeyDown,
   ]);
 

--- a/packages/visualizer/src/component/prompt-input/index.tsx
+++ b/packages/visualizer/src/component/prompt-input/index.tsx
@@ -124,6 +124,17 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     [history, selectedType],
   );
 
+  const actionMap = useMemo(() => {
+    const map = new Map<string, DeviceAction<any>>();
+    if (actionSpace) {
+      for (const action of actionSpace) {
+        if (action.name) map.set(action.name, action);
+        if (action.interfaceAlias) map.set(action.interfaceAlias, action);
+      }
+    }
+    return map;
+  }, [actionSpace]);
+
   const handleMinimalTypeGateReset = useCallback(() => {
     lastHistoryRef.current = null;
     setPromptValue('');
@@ -140,9 +151,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
   const needsStructuredParams = useMemo(() => {
     if (actionSpace) {
       // Use actionSpace to determine if method needs structured params
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
+      const action = actionMap.get(selectedType);
 
       if (!action?.paramSchema) return false;
 
@@ -158,15 +167,13 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return true;
     }
     return false;
-  }, [selectedType, actionSpace]);
+  }, [selectedType, actionMap, actionSpace]);
 
   // Check if current method needs any input (either prompt or parameters)
   const needsAnyInput = useMemo(() => {
     if (actionSpace && actionSpace.length > 0) {
       // Use actionSpace to determine if method needs any input
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
+      const action = actionMap.get(selectedType);
 
       // If action exists in actionSpace, check if it has required parameters
       if (action) {
@@ -195,7 +202,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     // Fallback when actionSpace is not loaded yet - assume most methods need input
     return true;
-  }, [selectedType, actionSpace]);
+  }, [selectedType, actionMap, actionSpace]);
 
   // Check if current method supports data extraction options
   const showDataExtractionOptions = useMemo(() => {
@@ -218,9 +225,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     if (actionSpace) {
       // Use actionSpace to determine if method supports deep locate
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
+      const action = actionMap.get(selectedType);
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         const schema = action.paramSchema as ZodObjectSchema;
@@ -237,7 +242,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return false;
     }
     return false;
-  }, [selectedType, actionSpace]);
+  }, [selectedType, actionMap, actionSpace]);
 
   // Check if current method supports deep think option (for aiAct planning)
   const showDeepThinkOption = useMemo(() => {
@@ -373,9 +378,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     if (!needsStructuredParams || !actionSpace) {
       return {};
     }
-    const action = actionSpace.find(
-      (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-    );
+    const action = actionMap.get(selectedType);
 
     if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
       const defaultParams: FormParams = {};
@@ -398,7 +401,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return defaultParams;
     }
     return {};
-  }, [selectedType, needsStructuredParams, actionSpace]);
+  }, [selectedType, needsStructuredParams, actionMap, actionSpace]);
 
   // Initialize form with last selected type when component mounts
   useEffect(() => {
@@ -564,9 +567,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     if (!needsStructuredParams || !actionSpace) {
       return false;
     }
-    const action = actionSpace.find(
-      (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-    );
+    const action = actionMap.get(selectedType);
 
     if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
       const schema = action.paramSchema as ZodObjectSchema;
@@ -574,7 +575,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       return Object.keys(shape).length === 1;
     }
     return false;
-  }, [selectedType, needsStructuredParams, actionSpace]);
+  }, [selectedType, needsStructuredParams, actionMap, actionSpace]);
 
   const minimalInlineFieldConfig = useMemo(
     () =>
@@ -591,7 +592,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
         runButtonEnabled,
         !!needsStructuredParams,
         params,
-        actionSpace,
+        actionMap,
         selectedType,
         promptValue,
       ),
@@ -599,7 +600,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
       runButtonEnabled,
       needsStructuredParams,
       selectedType,
-      actionSpace,
+      actionMap,
       promptValue,
       params,
     ],
@@ -622,9 +623,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     // For structured params, create a display string for history - dynamically
     let historyPrompt = '';
     if (needsStructuredParams && values.params && actionSpace) {
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
+      const action = actionMap.get(selectedType);
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         // Separate locate field from other fields for legacy format compatibility
@@ -696,6 +695,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     selectedType,
     clearPromptAfterRun,
     actionSpace,
+    actionMap,
     getDefaultParams,
   ]);
 
@@ -751,9 +751,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
     // Try to get action from actionSpace first
     if (actionSpace) {
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
+      const action = actionMap.get(selectedType);
 
       if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
         const schema = action.paramSchema as ZodObjectSchema;
@@ -785,10 +783,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
             // Try to get from action's paramSchema directly
             if (actionSpace) {
-              const action = actionSpace.find(
-                (a) =>
-                  a.interfaceAlias === selectedType || a.name === selectedType,
-              );
+              const action = actionMap.get(selectedType);
               if (
                 action?.paramSchema &&
                 typeof action.paramSchema === 'object' &&
@@ -870,10 +865,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
             // Try to get from action's paramSchema directly
             if (actionSpace) {
-              const action = actionSpace.find(
-                (a) =>
-                  a.interfaceAlias === selectedType || a.name === selectedType,
-              );
+              const action = actionMap.get(selectedType);
               if (
                 action?.paramSchema &&
                 typeof action.paramSchema === 'object' &&
@@ -968,6 +960,7 @@ export const PromptInput: React.FC<PromptInputProps> = ({
     selectedType,
     needsStructuredParams,
     actionSpace,
+    actionMap,
     handleStructuredKeyDown,
   ]);
 

--- a/packages/visualizer/src/utils/playground-utils.ts
+++ b/packages/visualizer/src/utils/playground-utils.ts
@@ -21,44 +21,35 @@ export const isRunButtonEnabled = (
   runButtonEnabled: boolean,
   needsStructuredParams: boolean,
   params: any,
-  actionMap: Map<string, DeviceAction<any>> | undefined,
-  selectedType: string,
+  action: DeviceAction<any> | undefined,
   promptValue: string,
 ) => {
   if (!runButtonEnabled) {
     return false;
   }
 
-  const action = actionMap?.get(selectedType);
-
   // Check if this method needs any input
   const needsAnyInput = (() => {
-    if (actionMap) {
-      // If action exists in actionMap, check if it has paramSchema with actual fields
-      if (action) {
-        if (!action.paramSchema) return false;
+    if (action) {
+      if (!action.paramSchema) return false;
 
-        // Check if paramSchema actually has fields
-        if (
-          typeof action.paramSchema === 'object' &&
-          'shape' in action.paramSchema
-        ) {
-          const shape =
-            (action.paramSchema as { shape: Record<string, unknown> }).shape ||
-            {};
-          const shapeKeys = Object.keys(shape);
-          return shapeKeys.length > 0; // Only need input if there are actual fields
-        }
-
-        // If paramSchema exists but not in expected format, assume it needs input
-        return true;
+      // Check if paramSchema actually has fields
+      if (
+        typeof action.paramSchema === 'object' &&
+        'shape' in action.paramSchema
+      ) {
+        const shape =
+          (action.paramSchema as { shape: Record<string, unknown> }).shape ||
+          {};
+        const shapeKeys = Object.keys(shape);
+        return shapeKeys.length > 0; // Only need input if there are actual fields
       }
 
-      // If not found in actionMap, assume most methods need input
+      // If paramSchema exists but not in expected format, assume it needs input
       return true;
     }
 
-    // Fallback: most methods need some input
+    // If the action is unavailable, assume most methods need some input.
     return true;
   })();
 

--- a/packages/visualizer/src/utils/playground-utils.ts
+++ b/packages/visualizer/src/utils/playground-utils.ts
@@ -1,4 +1,4 @@
-import type { UIContext } from '@midscene/core';
+import type { DeviceAction, UIContext } from '@midscene/core';
 import { StaticPage, StaticPageAgent } from '@midscene/web/static';
 import type { ZodObjectSchema } from '../types';
 import { isZodObjectSchema, unwrapZodType } from '../types';
@@ -21,7 +21,7 @@ export const isRunButtonEnabled = (
   runButtonEnabled: boolean,
   needsStructuredParams: boolean,
   params: any,
-  actionSpace: any[] | undefined,
+  actionMap: Map<string, DeviceAction<any>> | undefined,
   selectedType: string,
   promptValue: string,
 ) => {
@@ -29,15 +29,12 @@ export const isRunButtonEnabled = (
     return false;
   }
 
+  const action = actionMap?.get(selectedType);
+
   // Check if this method needs any input
   const needsAnyInput = (() => {
-    if (actionSpace) {
-      // Use actionSpace to determine if method needs any input
-      const action = actionSpace.find(
-        (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-      );
-
-      // If action exists in actionSpace, check if it has paramSchema with actual fields
+    if (actionMap) {
+      // If action exists in actionMap, check if it has paramSchema with actual fields
       if (action) {
         if (!action.paramSchema) return false;
 
@@ -57,7 +54,7 @@ export const isRunButtonEnabled = (
         return true;
       }
 
-      // If not found in actionSpace, assume most methods need input
+      // If not found in actionMap, assume most methods need input
       return true;
     }
 
@@ -72,9 +69,6 @@ export const isRunButtonEnabled = (
 
   if (needsStructuredParams) {
     const currentParams = params || {};
-    const action = actionSpace?.find(
-      (a) => a.interfaceAlias === selectedType || a.name === selectedType,
-    );
     if (action?.paramSchema && isZodObjectSchema(action.paramSchema)) {
       // Check if all required fields are filled
       const schema = action.paramSchema as unknown as ZodObjectSchema;

--- a/packages/visualizer/src/utils/prompt-input-utils.ts
+++ b/packages/visualizer/src/utils/prompt-input-utils.ts
@@ -8,6 +8,15 @@ export interface InlineStructuredFieldConfig {
   placeholder?: string;
 }
 
+export const findActionForType = (
+  actionSpace: DeviceAction<any>[] | undefined,
+  selectedType: string,
+): DeviceAction<any> | undefined =>
+  actionSpace?.find(
+    (action) =>
+      action.interfaceAlias === selectedType || action.name === selectedType,
+  );
+
 /**
  * Compute the list of action identifiers that should be offered in the prompt
  * input's action dropdown.
@@ -74,10 +83,7 @@ export const getInlineStructuredFieldConfig = (
     return null;
   }
 
-  const action = actionSpace.find(
-    (item) =>
-      item.interfaceAlias === selectedType || item.name === selectedType,
-  );
+  const action = findActionForType(actionSpace, selectedType);
 
   if (!action?.paramSchema || !isZodObjectSchema(action.paramSchema)) {
     return null;
@@ -127,10 +133,7 @@ export const shouldOffsetEmptyStateForPromptInput = (
     return false;
   }
 
-  const action = actionSpace.find(
-    (item) =>
-      item.interfaceAlias === selectedType || item.name === selectedType,
-  );
+  const action = findActionForType(actionSpace, selectedType);
 
   if (!action?.paramSchema || !isZodObjectSchema(action.paramSchema)) {
     return false;

--- a/packages/visualizer/tests/inline-structured-field-config.test.ts
+++ b/packages/visualizer/tests/inline-structured-field-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@rstest/core';
 import { isLocateField } from '../src/types';
 import {
+  findActionForType,
   getAvailablePromptActionTypes,
   getInlineStructuredFieldConfig,
   shouldOffsetEmptyStateForPromptInput,
@@ -65,6 +66,23 @@ describe('isLocateField', () => {
     expect(
       isLocateField(makeMidsceneLocationField('The position to be dragged')),
     ).toBe(true);
+  });
+});
+
+describe('findActionForType', () => {
+  test('preserves the first-match semantics when names and aliases collide', () => {
+    const firstAction = {
+      name: 'shared',
+      interfaceAlias: 'first',
+    };
+    const laterAction = {
+      name: 'second',
+      interfaceAlias: 'shared',
+    };
+
+    expect(findActionForType([firstAction, laterAction] as any, 'shared')).toBe(
+      firstAction,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Memoize the currently selected action once and reuse it throughout `PromptInput`.
- Preserve the existing first-match semantics for action name/interface-alias collisions.
- Pass the selected action directly into run-button validation instead of leaking an indexing strategy.
- Centralize action matching and add collision regression coverage.

## Dependency

- Base: `main`
- Independent of the other fork-absorption PRs.

## Validation

- `pnpm run lint`
- `pnpm exec nx build @midscene/visualizer`
- `pnpm exec nx test @midscene/visualizer` — 116 passed

## Source

- Adapted from vincerevu/midscene commit `707515f8`.
