### PR TITLE
fix(playground-app): bound Android scrcpy preview latency

### DIFF
--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -14,6 +14,7 @@ import {
   SCRCPY_VIDEO_STREAM_TIMEOUT_MS,
 } from '@midscene/shared/constants';
 import { getDebug } from '@midscene/shared/logger';
+import type { ScrcpyVideoTransportPacket } from '@midscene/shared/scrcpy-video';
 import type { Adb, AdbServerClient } from '@yume-chan/adb';
 import cors from 'cors';
 import express from 'express';
@@ -83,9 +84,9 @@ export interface ScrcpyConnectDeviceRequest {
 }
 
 interface ScrcpySourceVideoPacket {
-  type?: string;
   data: Uint8Array;
   keyframe?: boolean;
+  type?: 'configuration' | 'data';
 }
 
 export function buildScrcpyVideoTransportPacket(
@@ -93,16 +94,20 @@ export function buildScrcpyVideoTransportPacket(
   sequence: number,
   receivedAt: number,
   sentAt = Date.now(),
-) {
-  const type = packet.type || 'data';
+): ScrcpyVideoTransportPacket<Uint8Array> {
+  const metadata = { sequence, receivedAt, sentAt, timestamp: sentAt };
+  if (packet.type === 'configuration') {
+    return {
+      ...metadata,
+      data: packet.data,
+      type: 'configuration',
+    };
+  }
   return {
+    ...metadata,
     data: packet.data,
-    type,
-    sequence,
-    receivedAt,
-    sentAt,
-    timestamp: sentAt,
-    keyFrame: type === 'data' ? packet.keyframe : undefined,
+    keyFrame: packet.keyframe === true,
+    type: 'data',
   };
 }
 

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -77,8 +77,33 @@ function isAllowedOrigin(origin?: string) {
 
 export interface ScrcpyConnectDeviceRequest {
   deviceId?: string;
+  maxFps?: number;
   maxSize?: number;
   videoBitRate?: number;
+}
+
+interface ScrcpySourceVideoPacket {
+  type?: string;
+  data: Uint8Array;
+  keyframe?: boolean;
+}
+
+export function buildScrcpyVideoTransportPacket(
+  packet: ScrcpySourceVideoPacket,
+  sequence: number,
+  receivedAt: number,
+  sentAt = Date.now(),
+) {
+  const type = packet.type || 'data';
+  return {
+    data: packet.data,
+    type,
+    sequence,
+    receivedAt,
+    sentAt,
+    timestamp: sentAt,
+    keyFrame: type === 'data' ? packet.keyframe : undefined,
+  };
 }
 
 export interface ScrcpyListedDevice {
@@ -715,9 +740,11 @@ export default class ScrcpyServer {
                 // convert video stream
                 const reader = stream.getReader();
                 const processStream = async () => {
+                  let sequence = 0;
                   try {
                     while (true) {
                       const { done, value } = await reader.read();
+                      const receivedAt = Date.now();
                       if (done) break;
                       if (
                         !isCurrentGeneration() ||
@@ -725,9 +752,6 @@ export default class ScrcpyServer {
                       ) {
                         return;
                       }
-
-                      // ensure type field is correctly set to 'configuration' or 'data'
-                      const frameType = value.type || 'data'; // default to 'data'
 
                       // Forward the raw Uint8Array — socket.io transports it as
                       // a binary frame. Converting via Array.from inflates each
@@ -737,13 +761,19 @@ export default class ScrcpyServer {
                       // Frames are disposable. `volatile` prevents Socket.IO
                       // from retaining an unbounded write buffer when the
                       // renderer is busy decoding or has stopped responding.
-                      socket.volatile.emit('video-data', {
-                        data: value.data,
-                        type: frameType,
-                        timestamp: Date.now(),
-                        // fix keyframe access
-                        keyFrame: value.keyFrame,
-                      });
+                      const transportPacket = buildScrcpyVideoTransportPacket(
+                        value,
+                        sequence,
+                        receivedAt,
+                      );
+                      sequence += 1;
+                      if (transportPacket.type === 'configuration') {
+                        // Decoder configuration is not disposable. Losing it
+                        // leaves every following compressed frame unusable.
+                        socket.emit('video-data', transportPacket);
+                      } else {
+                        socket.volatile.emit('video-data', transportPacket);
+                      }
                     }
                   } catch (error) {
                     console.error('error processing video stream:', error);

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -81,6 +81,27 @@ describe('ScrcpyServer', () => {
     });
   });
 
+  it('uses a discriminated configuration packet without data-only fields', () => {
+    expect(
+      buildScrcpyVideoTransportPacket(
+        {
+          type: 'configuration',
+          data: new Uint8Array([9]),
+        },
+        3,
+        2_000,
+        2_010,
+      ),
+    ).toEqual({
+      data: new Uint8Array([9]),
+      type: 'configuration',
+      sequence: 3,
+      receivedAt: 2_000,
+      sentAt: 2_010,
+      timestamp: 2_010,
+    });
+  });
+
   it('prefers the explicit device from the preview handshake', () => {
     expect(
       resolveRequestedDeviceId(

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -2,6 +2,7 @@ import * as nodeFsActual from 'node:fs' with { rstest: 'importActual' };
 import { describe, expect, it, rs } from '@rstest/core';
 import ScrcpyServer, {
   appendBoundedScrcpyOutput,
+  buildScrcpyVideoTransportPacket,
   resolveRequestedDeviceId,
 } from '../../src/scrcpy-server';
 
@@ -57,6 +58,29 @@ describe('ScrcpyServer', () => {
     expect(lines).toEqual(['line-2', 'line-3', 'line-4']);
   });
 
+  it('maps typed scrcpy packet metadata to the preview wire contract', () => {
+    expect(
+      buildScrcpyVideoTransportPacket(
+        {
+          type: 'data',
+          data: new Uint8Array([1, 2, 3]),
+          keyframe: true,
+        },
+        7,
+        1_000,
+        1_025,
+      ),
+    ).toEqual({
+      data: new Uint8Array([1, 2, 3]),
+      type: 'data',
+      sequence: 7,
+      receivedAt: 1_000,
+      sentAt: 1_025,
+      timestamp: 1_025,
+      keyFrame: true,
+    });
+  });
+
   it('prefers the explicit device from the preview handshake', () => {
     expect(
       resolveRequestedDeviceId(
@@ -81,7 +105,7 @@ describe('ScrcpyServer', () => {
 
     await (server as any).startScrcpy(
       adb,
-      { maxSize: 0, videoBitRate: 8_000_000 },
+      { maxFps: 30, maxSize: 0, videoBitRate: 8_000_000 },
       onProgress,
     );
 
@@ -90,6 +114,7 @@ describe('ScrcpyServer', () => {
       expect.objectContaining({
         audio: false,
         control: true,
+        maxFps: 30,
         maxSize: 0,
         sendFrameMeta: true,
         videoBitRate: 8_000_000,

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -44,6 +44,7 @@ const { Text } = Typography;
 // CPU, memory, and transport cost of a full-resolution 32 Mbps stream.
 export const SCRCPY_PREVIEW_MAX_SIZE = 1600;
 export const SCRCPY_PREVIEW_VIDEO_BIT_RATE = 8_000_000;
+export const SCRCPY_PREVIEW_MAX_FPS = 30;
 
 export interface ScrcpyErrorOverlayContext {
   errorMessage: string | null;
@@ -339,6 +340,7 @@ export function ScrcpyPanel({
             ? { deviceId: deviceId.trim() }
             : {}),
           maxSize: SCRCPY_PREVIEW_MAX_SIZE,
+          maxFps: SCRCPY_PREVIEW_MAX_FPS,
           videoBitRate: SCRCPY_PREVIEW_VIDEO_BIT_RATE,
         });
       });

--- a/packages/playground-app/src/ScrcpyPanel.tsx
+++ b/packages/playground-app/src/ScrcpyPanel.tsx
@@ -22,6 +22,7 @@ import React, {
 void React;
 import type { Socket } from 'socket.io-client';
 import { io } from 'socket.io-client';
+import { createBoundedScrcpyDecoderWritable } from './scrcpy-decoder-admission';
 import {
   SCRCPY_METADATA_TIMEOUT_MS,
   SCRCPY_STABLE_CONNECTION_MS,
@@ -378,12 +379,14 @@ export function ScrcpyPanel({
           const decoder = await createDecoder(codecId);
           decoderRef.current = decoder;
 
-          videoStream.pipeTo(decoder.writable).catch((error: Error) => {
-            if (!isCurrentAttempt()) {
-              return;
-            }
-            scheduleReconnect(error.message);
-          });
+          videoStream
+            .pipeTo(createBoundedScrcpyDecoderWritable(decoder))
+            .catch((error: Error) => {
+              if (!isCurrentAttempt()) {
+                return;
+              }
+              scheduleReconnect(error.message);
+            });
 
           setStatus('waiting-for-stream');
         } catch (error) {

--- a/packages/playground-app/src/scrcpy-decoder-admission.ts
+++ b/packages/playground-app/src/scrcpy-decoder-admission.ts
@@ -1,0 +1,150 @@
+import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
+import {
+  SCRCPY_VIDEO_MAX_PACKET_AGE_MS,
+  type ScrcpyVideoStreamPacket,
+} from './scrcpy-stream';
+
+export const SCRCPY_VIDEO_MAX_DECODER_BACKLOG = 3;
+
+export interface ScrcpyVideoDecoderLike {
+  readonly framesRendered: number;
+  readonly framesSkipped: number;
+  readonly writable: WritableStream<ScrcpyMediaStreamPacket>;
+}
+
+export type ScrcpyDecoderAdmissionDecision =
+  | 'drop'
+  | 'submit'
+  | 'wait-for-capacity';
+
+export class ScrcpyDecoderAdmissionPolicy {
+  private lastSequence: number | undefined;
+  private waitingForKeyframe = false;
+
+  constructor(private readonly maxPacketAgeMs: number) {}
+
+  decide(
+    packet: ScrcpyVideoStreamPacket,
+    options: { decoderOverloaded: boolean; now: number },
+  ): ScrcpyDecoderAdmissionDecision {
+    if (packet.media.type === 'configuration') {
+      if (packet.transport) {
+        this.lastSequence = packet.transport.sequence;
+      }
+      return 'submit';
+    }
+
+    const stale = options.now - packet.receivedAt > this.maxPacketAgeMs;
+    if (packet.transport) {
+      const sequenceDiscontinuity =
+        this.lastSequence !== undefined &&
+        packet.transport.sequence !== this.lastSequence + 1;
+      this.lastSequence = packet.transport.sequence;
+      if (sequenceDiscontinuity || stale) {
+        this.waitingForKeyframe = true;
+      }
+    } else if (stale) {
+      this.waitingForKeyframe = true;
+    }
+
+    if (this.waitingForKeyframe && (!packet.media.keyframe || stale)) {
+      return 'drop';
+    }
+
+    if (options.decoderOverloaded) {
+      this.waitingForKeyframe = true;
+      return packet.media.keyframe && !stale ? 'wait-for-capacity' : 'drop';
+    }
+
+    if (stale) {
+      this.waitingForKeyframe = true;
+      return 'drop';
+    }
+
+    this.waitingForKeyframe = false;
+    return 'submit';
+  }
+
+  resumeRetainedKeyframe(packet: ScrcpyVideoStreamPacket, now: number) {
+    if (
+      packet.media.type !== 'data' ||
+      !packet.media.keyframe ||
+      now - packet.receivedAt > this.maxPacketAgeMs
+    ) {
+      this.waitingForKeyframe = true;
+      return false;
+    }
+    this.waitingForKeyframe = false;
+    return true;
+  }
+}
+
+export interface BoundedScrcpyDecoderOptions {
+  maxDecoderBacklog?: number;
+  maxPacketAgeMs?: number;
+  now?: () => number;
+  waitForDecoderProgress?: () => Promise<void>;
+}
+
+function waitForDecoderTick() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 16));
+}
+
+export function createBoundedScrcpyDecoderWritable(
+  decoder: ScrcpyVideoDecoderLike,
+  options: BoundedScrcpyDecoderOptions = {},
+): WritableStream<ScrcpyVideoStreamPacket> {
+  const maxDecoderBacklog =
+    options.maxDecoderBacklog ?? SCRCPY_VIDEO_MAX_DECODER_BACKLOG;
+  if (!Number.isSafeInteger(maxDecoderBacklog) || maxDecoderBacklog < 1) {
+    throw new Error('maxDecoderBacklog must be a positive integer.');
+  }
+  const maxPacketAgeMs =
+    options.maxPacketAgeMs ?? SCRCPY_VIDEO_MAX_PACKET_AGE_MS;
+  const now = options.now ?? Date.now;
+  const waitForDecoderProgress =
+    options.waitForDecoderProgress ?? waitForDecoderTick;
+  const policy = new ScrcpyDecoderAdmissionPolicy(maxPacketAgeMs);
+  const writer = decoder.writable.getWriter();
+  const initialCompletedFrames = decoder.framesRendered + decoder.framesSkipped;
+  let submittedFrames = 0;
+
+  const getDecoderBacklog = () => {
+    const completedFrames = Math.max(
+      0,
+      decoder.framesRendered + decoder.framesSkipped - initialCompletedFrames,
+    );
+    return Math.max(0, submittedFrames - completedFrames);
+  };
+
+  return new WritableStream<ScrcpyVideoStreamPacket>({
+    async write(packet) {
+      const decision = policy.decide(packet, {
+        decoderOverloaded: getDecoderBacklog() >= maxDecoderBacklog,
+        now: now(),
+      });
+      if (decision === 'drop') {
+        return;
+      }
+      if (decision === 'wait-for-capacity') {
+        while (getDecoderBacklog() >= maxDecoderBacklog) {
+          await waitForDecoderProgress();
+          if (now() - packet.receivedAt > maxPacketAgeMs) {
+            policy.resumeRetainedKeyframe(packet, now());
+            return;
+          }
+        }
+        if (!policy.resumeRetainedKeyframe(packet, now())) {
+          return;
+        }
+      }
+
+      await writer.write(packet.media);
+      if (packet.media.type === 'data') {
+        submittedFrames += 1;
+      }
+    },
+    close: () => writer.close(),
+    abort: (reason) => writer.abort(reason),
+  });
+}

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -1,17 +1,12 @@
+import {
+  type IncomingScrcpyVideoTransportPacket,
+  type ScrcpyVideoTransportData,
+  type ScrcpyVideoTransportMetadata,
+  hasScrcpyVideoTransportMetadata,
+} from '@midscene/shared/scrcpy-video';
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
 
-type RawScrcpyVideoData = ArrayBuffer | ArrayBufferView;
-
-interface RawScrcpyVideoPacket {
-  type?: string;
-  data: RawScrcpyVideoData;
-  keyFrame?: boolean;
-  sequence?: number;
-  receivedAt?: number;
-  sentAt?: number;
-}
-
-function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
+function toUint8Array(data: ScrcpyVideoTransportData): Uint8Array {
   if (data instanceof Uint8Array) {
     return data;
   }
@@ -21,11 +16,25 @@ function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
   return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
+export interface ScrcpyVideoStreamPacket {
+  media: ScrcpyMediaStreamPacket;
+  receivedAt: number;
+  transport?: ScrcpyVideoTransportMetadata;
+}
+
+type IncomingScrcpyVideoPacket = IncomingScrcpyVideoTransportPacket;
+
 interface ScrcpyVideoSocketLike {
-  on(event: 'video-data', handler: (data: RawScrcpyVideoPacket) => void): void;
+  on(
+    event: 'video-data',
+    handler: (data: IncomingScrcpyVideoPacket) => void,
+  ): void;
   on(event: 'disconnect', handler: () => void): void;
   on(event: 'error', handler: (error: Error) => void): void;
-  off(event: 'video-data', handler: (data: RawScrcpyVideoPacket) => void): void;
+  off(
+    event: 'video-data',
+    handler: (data: IncomingScrcpyVideoPacket) => void,
+  ): void;
   off(event: 'disconnect', handler: () => void): void;
   off(event: 'error', handler: (error: Error) => void): void;
 }
@@ -41,21 +50,18 @@ export const SCRCPY_VIDEO_MAX_PACKET_AGE_MS = 500;
 export function createScrcpyVideoStream(
   socket: ScrcpyVideoSocketLike,
   options: ScrcpyVideoStreamOptions = {},
-): ReadableStream<ScrcpyMediaStreamPacket> {
+): ReadableStream<ScrcpyVideoStreamPacket> {
   const maxPacketAgeMs =
     options.maxPacketAgeMs ?? SCRCPY_VIDEO_MAX_PACKET_AGE_MS;
   const now = options.now ?? Date.now;
   let configurationPacketSent = false;
   let firstDataPacketReported = false;
-  let pendingDataPackets: ScrcpyMediaStreamPacket[] = [];
+  let pendingDataPackets: ScrcpyVideoStreamPacket[] = [];
   let cleanupListeners: (() => void) | undefined;
-  let pendingKeyframe:
-    | { packet: ScrcpyMediaStreamPacket; receivedAt?: number }
-    | undefined;
+  let pendingKeyframe: ScrcpyVideoStreamPacket | undefined;
   let lastSequence: number | undefined;
-  let transportMetadataAvailable = false;
   let waitingForKeyframe = false;
-  const readable = new ReadableStream<ScrcpyMediaStreamPacket>(
+  const readable = new ReadableStream<ScrcpyVideoStreamPacket>(
     {
       start(controller) {
         const canEnqueue = () =>
@@ -66,10 +72,10 @@ export function createScrcpyVideoStream(
             options.onFirstDataPacket?.();
           }
         };
-        const handleVideoData = (data: RawScrcpyVideoPacket) => {
+        const handleVideoData = (data: IncomingScrcpyVideoPacket) => {
           try {
             const payload = toUint8Array(data.data);
-            const packet: ScrcpyMediaStreamPacket =
+            const media: ScrcpyMediaStreamPacket =
               data.type === 'configuration'
                 ? {
                     type: 'configuration',
@@ -78,12 +84,24 @@ export function createScrcpyVideoStream(
                 : {
                     type: 'data',
                     data: payload,
-                    keyframe: data.keyFrame,
+                    keyframe: 'keyFrame' in data ? data.keyFrame : undefined,
                   };
-            if (packet.type === 'configuration') {
-              if (Number.isSafeInteger(data.sequence)) {
-                lastSequence = data.sequence;
-                transportMetadataAvailable = true;
+            const transport = hasScrcpyVideoTransportMetadata(data)
+              ? {
+                  sequence: data.sequence,
+                  receivedAt: data.receivedAt,
+                  sentAt: data.sentAt,
+                  timestamp: data.timestamp,
+                }
+              : undefined;
+            const packet: ScrcpyVideoStreamPacket = {
+              media,
+              receivedAt: transport?.receivedAt ?? now(),
+              ...(transport ? { transport } : {}),
+            };
+            if (media.type === 'configuration') {
+              if (transport) {
+                lastSequence = transport.sequence;
               }
               configurationPacketSent = true;
               // This small, bounded initial burst is required by WebCodecs:
@@ -99,23 +117,17 @@ export function createScrcpyVideoStream(
               return;
             }
 
-            const hasFreshnessMetadata =
-              Number.isSafeInteger(data.sequence) &&
-              typeof data.receivedAt === 'number' &&
-              Number.isFinite(data.receivedAt);
-            if (hasFreshnessMetadata) {
-              transportMetadataAvailable = true;
-              const sequence = data.sequence as number;
+            if (transport) {
+              const sequence = transport.sequence;
               const sequenceDiscontinuity =
                 lastSequence !== undefined && sequence !== lastSequence + 1;
-              const stale =
-                now() - (data.receivedAt as number) > maxPacketAgeMs;
+              const stale = now() - transport.receivedAt > maxPacketAgeMs;
               lastSequence = sequence;
               if (sequenceDiscontinuity || stale) {
                 waitingForKeyframe = true;
               }
               if (waitingForKeyframe) {
-                if (!packet.keyframe || stale) {
+                if (media.type !== 'data' || !media.keyframe || stale) {
                   return;
                 }
                 waitingForKeyframe = false;
@@ -124,7 +136,7 @@ export function createScrcpyVideoStream(
               // Legacy packets do not carry enough information to prove that
               // a delta frame follows the retained stream. A keyframe is the
               // only safe point to resume after local overload.
-              if (!packet.keyframe) {
+              if (media.type !== 'data' || !media.keyframe) {
                 return;
               }
               waitingForKeyframe = false;
@@ -134,7 +146,7 @@ export function createScrcpyVideoStream(
               // Socket.IO cannot apply Web Streams backpressure to scrcpy.
               // Keep a tiny pre-configuration buffer instead of retaining
               // every frame while the renderer initializes its decoder.
-              if (packet.keyframe) {
+              if (media.type === 'data' && media.keyframe) {
                 pendingDataPackets = [packet];
               } else if (pendingDataPackets.length < 2) {
                 pendingDataPackets.push(packet);
@@ -145,17 +157,12 @@ export function createScrcpyVideoStream(
             if (canEnqueue()) {
               reportFirstDataPacket();
               controller.enqueue(packet);
-            } else if (packet.keyframe) {
+            } else if (media.type === 'data' && media.keyframe) {
               // Discard delta frames while the decoder is behind. The newest
               // keyframe lets it resume without accumulating stale frames.
-              pendingKeyframe = {
-                packet,
-                ...(hasFreshnessMetadata
-                  ? { receivedAt: data.receivedAt as number }
-                  : {}),
-              };
-              waitingForKeyframe = transportMetadataAvailable;
-            } else if (transportMetadataAvailable) {
+              pendingKeyframe = packet;
+              waitingForKeyframe = true;
+            } else {
               // Once a compressed delta is discarded, later deltas can no
               // longer be decoded safely. Resume only from a keyframe.
               waitingForKeyframe = true;
@@ -186,14 +193,11 @@ export function createScrcpyVideoStream(
           ) {
             const pending = pendingKeyframe;
             pendingKeyframe = undefined;
-            if (
-              pending.receivedAt !== undefined &&
-              now() - pending.receivedAt > maxPacketAgeMs
-            ) {
+            if (now() - pending.receivedAt > maxPacketAgeMs) {
               waitingForKeyframe = true;
               return;
             }
-            controller.enqueue(pending.packet);
+            controller.enqueue(pending);
             waitingForKeyframe = false;
           }
         }

--- a/packages/playground-app/src/scrcpy-stream.ts
+++ b/packages/playground-app/src/scrcpy-stream.ts
@@ -6,6 +6,9 @@ interface RawScrcpyVideoPacket {
   type?: string;
   data: RawScrcpyVideoData;
   keyFrame?: boolean;
+  sequence?: number;
+  receivedAt?: number;
+  sentAt?: number;
 }
 
 function toUint8Array(data: RawScrcpyVideoData): Uint8Array {
@@ -28,18 +31,30 @@ interface ScrcpyVideoSocketLike {
 }
 
 interface ScrcpyVideoStreamOptions {
+  maxPacketAgeMs?: number;
+  now?: () => number;
   onFirstDataPacket?: () => void;
 }
+
+export const SCRCPY_VIDEO_MAX_PACKET_AGE_MS = 500;
 
 export function createScrcpyVideoStream(
   socket: ScrcpyVideoSocketLike,
   options: ScrcpyVideoStreamOptions = {},
 ): ReadableStream<ScrcpyMediaStreamPacket> {
+  const maxPacketAgeMs =
+    options.maxPacketAgeMs ?? SCRCPY_VIDEO_MAX_PACKET_AGE_MS;
+  const now = options.now ?? Date.now;
   let configurationPacketSent = false;
   let firstDataPacketReported = false;
   let pendingDataPackets: ScrcpyMediaStreamPacket[] = [];
   let cleanupListeners: (() => void) | undefined;
-  let pendingKeyframe: ScrcpyMediaStreamPacket | undefined;
+  let pendingKeyframe:
+    | { packet: ScrcpyMediaStreamPacket; receivedAt?: number }
+    | undefined;
+  let lastSequence: number | undefined;
+  let transportMetadataAvailable = false;
+  let waitingForKeyframe = false;
   const readable = new ReadableStream<ScrcpyMediaStreamPacket>(
     {
       start(controller) {
@@ -66,6 +81,10 @@ export function createScrcpyVideoStream(
                     keyframe: data.keyFrame,
                   };
             if (packet.type === 'configuration') {
+              if (Number.isSafeInteger(data.sequence)) {
+                lastSequence = data.sequence;
+                transportMetadataAvailable = true;
+              }
               configurationPacketSent = true;
               // This small, bounded initial burst is required by WebCodecs:
               // it must receive configuration before any retained frame.
@@ -78,6 +97,37 @@ export function createScrcpyVideoStream(
               );
               pendingDataPackets = [];
               return;
+            }
+
+            const hasFreshnessMetadata =
+              Number.isSafeInteger(data.sequence) &&
+              typeof data.receivedAt === 'number' &&
+              Number.isFinite(data.receivedAt);
+            if (hasFreshnessMetadata) {
+              transportMetadataAvailable = true;
+              const sequence = data.sequence as number;
+              const sequenceDiscontinuity =
+                lastSequence !== undefined && sequence !== lastSequence + 1;
+              const stale =
+                now() - (data.receivedAt as number) > maxPacketAgeMs;
+              lastSequence = sequence;
+              if (sequenceDiscontinuity || stale) {
+                waitingForKeyframe = true;
+              }
+              if (waitingForKeyframe) {
+                if (!packet.keyframe || stale) {
+                  return;
+                }
+                waitingForKeyframe = false;
+              }
+            } else if (waitingForKeyframe) {
+              // Legacy packets do not carry enough information to prove that
+              // a delta frame follows the retained stream. A keyframe is the
+              // only safe point to resume after local overload.
+              if (!packet.keyframe) {
+                return;
+              }
+              waitingForKeyframe = false;
             }
 
             if (!configurationPacketSent) {
@@ -98,7 +148,17 @@ export function createScrcpyVideoStream(
             } else if (packet.keyframe) {
               // Discard delta frames while the decoder is behind. The newest
               // keyframe lets it resume without accumulating stale frames.
-              pendingKeyframe = packet;
+              pendingKeyframe = {
+                packet,
+                ...(hasFreshnessMetadata
+                  ? { receivedAt: data.receivedAt as number }
+                  : {}),
+              };
+              waitingForKeyframe = transportMetadataAvailable;
+            } else if (transportMetadataAvailable) {
+              // Once a compressed delta is discarded, later deltas can no
+              // longer be decoded safely. Resume only from a keyframe.
+              waitingForKeyframe = true;
             }
           } catch (error) {
             controller.error(error);
@@ -124,8 +184,17 @@ export function createScrcpyVideoStream(
             pendingKeyframe &&
             (controller.desiredSize === null || controller.desiredSize > 0)
           ) {
-            controller.enqueue(pendingKeyframe);
+            const pending = pendingKeyframe;
             pendingKeyframe = undefined;
+            if (
+              pending.receivedAt !== undefined &&
+              now() - pending.receivedAt > maxPacketAgeMs
+            ) {
+              waitingForKeyframe = true;
+              return;
+            }
+            controller.enqueue(pending.packet);
+            waitingForKeyframe = false;
           }
         }
       },

--- a/packages/playground-app/tests/scrcpy-decoder-admission.test.ts
+++ b/packages/playground-app/tests/scrcpy-decoder-admission.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from '@rstest/core';
+import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
+import { createBoundedScrcpyDecoderWritable } from '../src/scrcpy-decoder-admission';
+import type { ScrcpyVideoStreamPacket } from '../src/scrcpy-stream';
+
+function packet(
+  sequence: number,
+  options: {
+    keyframe?: boolean;
+    receivedAt?: number;
+    type?: 'configuration';
+  } = {},
+): ScrcpyVideoStreamPacket {
+  const receivedAt = options.receivedAt ?? 1_000;
+  const media: ScrcpyMediaStreamPacket =
+    options.type === 'configuration'
+      ? { type: 'configuration', data: new Uint8Array([sequence]) }
+      : {
+          type: 'data',
+          data: new Uint8Array([sequence]),
+          keyframe: options.keyframe,
+        };
+  return {
+    media,
+    receivedAt,
+    transport: {
+      sequence,
+      receivedAt,
+      sentAt: receivedAt,
+      timestamp: receivedAt,
+    },
+  };
+}
+
+function createDecoder() {
+  const submitted: ScrcpyMediaStreamPacket[] = [];
+  const decoder = {
+    framesRendered: 0,
+    framesSkipped: 0,
+    writable: new WritableStream<ScrcpyMediaStreamPacket>({
+      write(media) {
+        submitted.push(media);
+      },
+    }),
+  };
+  return { decoder, submitted };
+}
+
+describe('bounded scrcpy decoder admission', () => {
+  test('bounds synchronous decoder submissions and resumes from a keyframe', async () => {
+    const { decoder, submitted } = createDecoder();
+    let releaseProgress: (() => void) | undefined;
+    const writer = createBoundedScrcpyDecoderWritable(decoder, {
+      maxDecoderBacklog: 1,
+      now: () => 1_100,
+      waitForDecoderProgress: () =>
+        new Promise<void>((resolve) => {
+          releaseProgress = resolve;
+        }),
+    }).getWriter();
+
+    await writer.write(packet(0, { type: 'configuration' }));
+    await writer.write(packet(1, { keyframe: true }));
+    await writer.write(packet(2));
+    expect(submitted.map((item) => item.data[0])).toEqual([0, 1]);
+
+    const retainedKeyframe = writer.write(packet(3, { keyframe: true }));
+    await Promise.resolve();
+    expect(submitted.map((item) => item.data[0])).toEqual([0, 1]);
+
+    decoder.framesSkipped = 1;
+    releaseProgress?.();
+    await retainedKeyframe;
+    expect(submitted.map((item) => item.data[0])).toEqual([0, 1, 3]);
+    await writer.close();
+  });
+
+  test('rechecks retained keyframe age immediately before decode', async () => {
+    const { decoder, submitted } = createDecoder();
+    let currentTime = 1_100;
+    let releaseProgress: (() => void) | undefined;
+    const writer = createBoundedScrcpyDecoderWritable(decoder, {
+      maxDecoderBacklog: 1,
+      maxPacketAgeMs: 500,
+      now: () => currentTime,
+      waitForDecoderProgress: () =>
+        new Promise<void>((resolve) => {
+          releaseProgress = resolve;
+        }),
+    }).getWriter();
+
+    await writer.write(packet(0, { type: 'configuration' }));
+    await writer.write(packet(1, { keyframe: true }));
+    const retainedKeyframe = writer.write(
+      packet(2, { keyframe: true, receivedAt: 1_000 }),
+    );
+    await Promise.resolve();
+
+    currentTime = 1_600;
+    releaseProgress?.();
+    await retainedKeyframe;
+    expect(submitted.map((item) => item.data[0])).toEqual([0, 1]);
+    await writer.close();
+  });
+
+  test('requires a keyframe after a sequence gap at decoder boundary', async () => {
+    const { decoder, submitted } = createDecoder();
+    const writer = createBoundedScrcpyDecoderWritable(decoder, {
+      maxDecoderBacklog: 10,
+      now: () => 1_100,
+    }).getWriter();
+
+    await writer.write(packet(0, { type: 'configuration' }));
+    await writer.write(packet(1, { keyframe: true }));
+    await writer.write(packet(3));
+    await writer.write(packet(4));
+    await writer.write(packet(5, { keyframe: true }));
+
+    expect(submitted.map((item) => item.data[0])).toEqual([0, 1, 5]);
+    await writer.close();
+  });
+});

--- a/packages/playground-app/tests/scrcpy-panel.test.ts
+++ b/packages/playground-app/tests/scrcpy-panel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@rstest/core';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
+  SCRCPY_PREVIEW_MAX_FPS,
   SCRCPY_PREVIEW_MAX_SIZE,
   SCRCPY_PREVIEW_VIDEO_BIT_RATE,
   ScrcpyPanel,
@@ -41,6 +42,7 @@ describe('ScrcpyPanel', () => {
 
   it('uses a higher quality live preview stream profile', () => {
     expect(SCRCPY_PREVIEW_MAX_SIZE).toBe(1600);
+    expect(SCRCPY_PREVIEW_MAX_FPS).toBe(30);
     expect(SCRCPY_PREVIEW_VIDEO_BIT_RATE).toBe(8_000_000);
   });
 });

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -6,6 +6,9 @@ interface RawVideoPayload {
   type?: string;
   data: ArrayBuffer | ArrayBufferView;
   keyFrame?: boolean;
+  sequence?: number;
+  receivedAt?: number;
+  sentAt?: number;
 }
 
 type VideoDataHandler = (data: RawVideoPayload) => void;
@@ -246,5 +249,210 @@ describe('createScrcpyVideoStream', () => {
 
     expect(dataPackets).toHaveLength(1);
     expect(dataPackets[0].pts).toBeUndefined();
+  });
+
+  test('drops stale packets until a fresh keyframe arrives', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, { now: () => 1_000 });
+    const collected = collectStream(stream);
+
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+      sequence: 0,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+      keyFrame: false,
+      sequence: 1,
+      receivedAt: 400,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([2]),
+      keyFrame: false,
+      sequence: 2,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([3]),
+      keyFrame: true,
+      sequence: 3,
+      receivedAt: 900,
+    });
+    socket.dispatchDisconnect();
+
+    const packets = await collected;
+    expect(packets.map((packet) => packet.data[0])).toEqual([0, 3]);
+  });
+
+  test('waits for a keyframe after a sequence discontinuity', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, { now: () => 1_000 });
+    const collected = collectStream(stream);
+
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+      sequence: 0,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+      keyFrame: true,
+      sequence: 1,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([3]),
+      keyFrame: false,
+      sequence: 3,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([4]),
+      keyFrame: false,
+      sequence: 4,
+      receivedAt: 900,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([5]),
+      keyFrame: true,
+      sequence: 5,
+      receivedAt: 900,
+    });
+    socket.dispatchDisconnect();
+
+    const packets = await collected;
+    expect(packets.map((packet) => packet.data[0])).toEqual([0, 1, 5]);
+  });
+
+  test('keeps legacy packets without freshness metadata compatible', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, { now: () => 1_000 });
+    const collected = collectStream(stream);
+
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([2]),
+    });
+    socket.dispatchDisconnect();
+
+    const packets = await collected;
+    expect(packets.map((packet) => packet.data[0])).toEqual([0, 1, 2]);
+  });
+
+  test('does not resume from a delta frame after local queue overload', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, { now: () => 1_000 });
+    const reader = stream.getReader();
+
+    const dispatch = (sequence: number, keyFrame: boolean) => {
+      socket.dispatchVideoData({
+        type: 'data',
+        data: new Uint8Array([sequence]),
+        keyFrame,
+        sequence,
+        receivedAt: 900,
+      });
+    };
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+      sequence: 0,
+      receivedAt: 900,
+    });
+    dispatch(1, true);
+    dispatch(2, false);
+    dispatch(3, false);
+    dispatch(4, false);
+
+    expect((await reader.read()).value?.data[0]).toBe(0);
+    expect((await reader.read()).value?.data[0]).toBe(1);
+    expect((await reader.read()).value?.data[0]).toBe(2);
+    expect((await reader.read()).value?.data[0]).toBe(3);
+
+    dispatch(5, false);
+    dispatch(6, true);
+    socket.dispatchDisconnect();
+
+    expect((await reader.read()).value?.data[0]).toBe(6);
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  test('discards a retained keyframe if it ages before the decoder pulls', async () => {
+    let currentTime = 1_000;
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, {
+      now: () => currentTime,
+    });
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+      sequence: 0,
+      receivedAt: currentTime,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([1]),
+      keyFrame: true,
+      sequence: 1,
+      receivedAt: currentTime,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([2]),
+      keyFrame: true,
+      sequence: 2,
+      receivedAt: currentTime,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([3]),
+      keyFrame: true,
+      sequence: 3,
+      receivedAt: currentTime,
+    });
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([4]),
+      keyFrame: true,
+      sequence: 4,
+      receivedAt: currentTime,
+    });
+    currentTime = 1_600;
+    const reader = stream.getReader();
+    expect((await reader.read()).value?.data[0]).toBe(0);
+    expect((await reader.read()).value?.data[0]).toBe(1);
+    expect((await reader.read()).value?.data[0]).toBe(2);
+    expect((await reader.read()).value?.data[0]).toBe(3);
+    const nextPacket = reader.read();
+    await Promise.resolve();
+    socket.dispatchVideoData({
+      type: 'data',
+      data: new Uint8Array([5]),
+      keyFrame: true,
+      sequence: 5,
+      receivedAt: currentTime,
+    });
+    expect((await nextPacket).value?.data[0]).toBe(5);
+
+    socket.dispatchDisconnect();
+    expect((await reader.read()).done).toBe(true);
   });
 });

--- a/packages/playground-app/tests/scrcpy-stream.test.ts
+++ b/packages/playground-app/tests/scrcpy-stream.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, rs, test } from '@rstest/core';
 import type { ScrcpyMediaStreamPacket } from '@yume-chan/scrcpy';
-import { createScrcpyVideoStream } from '../src/scrcpy-stream';
+import {
+  type ScrcpyVideoStreamPacket,
+  createScrcpyVideoStream,
+} from '../src/scrcpy-stream';
 
 interface RawVideoPayload {
   type?: string;
@@ -9,6 +12,7 @@ interface RawVideoPayload {
   sequence?: number;
   receivedAt?: number;
   sentAt?: number;
+  timestamp?: number;
 }
 
 type VideoDataHandler = (data: RawVideoPayload) => void;
@@ -63,7 +67,16 @@ class MockScrcpySocket {
   }
 
   dispatchVideoData(packet: RawVideoPayload) {
-    this.videoDataHandlers.forEach((handler) => handler(packet));
+    const normalizedPacket =
+      Number.isSafeInteger(packet.sequence) &&
+      typeof packet.receivedAt === 'number'
+        ? {
+            ...packet,
+            sentAt: packet.sentAt ?? packet.receivedAt,
+            timestamp: packet.timestamp ?? packet.sentAt ?? packet.receivedAt,
+          }
+        : packet;
+    this.videoDataHandlers.forEach((handler) => handler(normalizedPacket));
   }
 
   dispatchDisconnect() {
@@ -72,13 +85,13 @@ class MockScrcpySocket {
 }
 
 async function collectStream(
-  stream: ReadableStream<ScrcpyMediaStreamPacket>,
+  stream: ReadableStream<ScrcpyVideoStreamPacket>,
 ): Promise<ScrcpyMediaStreamPacket[]> {
   const packets: ScrcpyMediaStreamPacket[] = [];
   await stream.pipeTo(
-    new WritableStream<ScrcpyMediaStreamPacket>({
+    new WritableStream<ScrcpyVideoStreamPacket>({
       write(packet) {
-        packets.push(packet);
+        packets.push(packet.media);
       },
     }),
   );
@@ -251,6 +264,34 @@ describe('createScrcpyVideoStream', () => {
     expect(dataPackets[0].pts).toBeUndefined();
   });
 
+  test('keeps freshness metadata attached until decoder admission', async () => {
+    const socket = new MockScrcpySocket();
+    const stream = createScrcpyVideoStream(socket, { now: () => 1_050 });
+    const reader = stream.getReader();
+
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+      sequence: 6,
+      receivedAt: 1_000,
+      sentAt: 1_025,
+      timestamp: 1_025,
+    });
+
+    const packet = (await reader.read()).value;
+    expect(packet?.media.type).toBe('configuration');
+    expect(packet?.receivedAt).toBe(1_000);
+    expect(packet?.transport).toEqual({
+      sequence: 6,
+      receivedAt: 1_000,
+      sentAt: 1_025,
+      timestamp: 1_025,
+    });
+
+    socket.dispatchDisconnect();
+    expect((await reader.read()).done).toBe(true);
+  });
+
   test('drops stale packets until a fresh keyframe arrives', async () => {
     const socket = new MockScrcpySocket();
     const stream = createScrcpyVideoStream(socket, { now: () => 1_000 });
@@ -382,16 +423,49 @@ describe('createScrcpyVideoStream', () => {
     dispatch(3, false);
     dispatch(4, false);
 
-    expect((await reader.read()).value?.data[0]).toBe(0);
-    expect((await reader.read()).value?.data[0]).toBe(1);
-    expect((await reader.read()).value?.data[0]).toBe(2);
-    expect((await reader.read()).value?.data[0]).toBe(3);
+    expect((await reader.read()).value?.media.data[0]).toBe(0);
+    expect((await reader.read()).value?.media.data[0]).toBe(1);
+    expect((await reader.read()).value?.media.data[0]).toBe(2);
+    expect((await reader.read()).value?.media.data[0]).toBe(3);
 
     dispatch(5, false);
     dispatch(6, true);
     socket.dispatchDisconnect();
 
-    expect((await reader.read()).value?.data[0]).toBe(6);
+    expect((await reader.read()).value?.media.data[0]).toBe(6);
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  test('also requires a keyframe after legacy queue overload', async () => {
+    const socket = new MockScrcpySocket();
+    const reader = createScrcpyVideoStream(socket).getReader();
+    const dispatch = (value: number, keyFrame = false) => {
+      socket.dispatchVideoData({
+        type: 'data',
+        data: new Uint8Array([value]),
+        keyFrame,
+      });
+    };
+
+    socket.dispatchVideoData({
+      type: 'configuration',
+      data: new Uint8Array([0]),
+    });
+    dispatch(1, true);
+    dispatch(2);
+    dispatch(3);
+    dispatch(4);
+
+    expect((await reader.read()).value?.media.data[0]).toBe(0);
+    expect((await reader.read()).value?.media.data[0]).toBe(1);
+    expect((await reader.read()).value?.media.data[0]).toBe(2);
+    expect((await reader.read()).value?.media.data[0]).toBe(3);
+
+    dispatch(5);
+    dispatch(6, true);
+    socket.dispatchDisconnect();
+
+    expect((await reader.read()).value?.media.data[0]).toBe(6);
     expect((await reader.read()).done).toBe(true);
   });
 
@@ -437,10 +511,10 @@ describe('createScrcpyVideoStream', () => {
     });
     currentTime = 1_600;
     const reader = stream.getReader();
-    expect((await reader.read()).value?.data[0]).toBe(0);
-    expect((await reader.read()).value?.data[0]).toBe(1);
-    expect((await reader.read()).value?.data[0]).toBe(2);
-    expect((await reader.read()).value?.data[0]).toBe(3);
+    expect((await reader.read()).value?.media.data[0]).toBe(0);
+    expect((await reader.read()).value?.media.data[0]).toBe(1);
+    expect((await reader.read()).value?.media.data[0]).toBe(2);
+    expect((await reader.read()).value?.media.data[0]).toBe(3);
     const nextPacket = reader.read();
     await Promise.resolve();
     socket.dispatchVideoData({
@@ -450,7 +524,7 @@ describe('createScrcpyVideoStream', () => {
       sequence: 5,
       receivedAt: currentTime,
     });
-    expect((await nextPacket).value?.data[0]).toBe(5);
+    expect((await nextPacket).value?.media.data[0]).toBe(5);
 
     socket.dispatchDisconnect();
     expect((await reader.read()).done).toBe(true);

--- a/packages/shared/src/scrcpy-video.ts
+++ b/packages/shared/src/scrcpy-video.ts
@@ -1,0 +1,65 @@
+export type ScrcpyVideoTransportData = ArrayBuffer | ArrayBufferView;
+
+export interface ScrcpyVideoTransportMetadata {
+  receivedAt: number;
+  sentAt: number;
+  sequence: number;
+  timestamp: number;
+}
+
+export type ScrcpyVideoTransportPacket<
+  TData extends ScrcpyVideoTransportData = ScrcpyVideoTransportData,
+> =
+  | (ScrcpyVideoTransportMetadata & {
+      data: TData;
+      type: 'configuration';
+    })
+  | (ScrcpyVideoTransportMetadata & {
+      data: TData;
+      keyFrame: boolean;
+      type: 'data';
+    });
+
+/**
+ * Packets emitted by older Android playground servers did not include
+ * sequence or timing metadata. Keep that compatibility explicit instead of
+ * weakening the current transport contract with optional fields.
+ */
+export interface LegacyScrcpyVideoTransportPacket<
+  TData extends ScrcpyVideoTransportData = ScrcpyVideoTransportData,
+> {
+  data: TData;
+  keyFrame?: boolean;
+  type?: string;
+}
+
+export type IncomingScrcpyVideoTransportPacket<
+  TData extends ScrcpyVideoTransportData = ScrcpyVideoTransportData,
+> = ScrcpyVideoTransportPacket<TData> | LegacyScrcpyVideoTransportPacket<TData>;
+
+export function hasScrcpyVideoTransportMetadata<
+  TData extends ScrcpyVideoTransportData,
+>(
+  packet: IncomingScrcpyVideoTransportPacket<TData>,
+): packet is ScrcpyVideoTransportPacket<TData> {
+  const candidate = packet as {
+    keyFrame?: unknown;
+    receivedAt?: unknown;
+    sentAt?: unknown;
+    sequence?: unknown;
+    timestamp?: unknown;
+    type?: unknown;
+  };
+  return (
+    Number.isSafeInteger(candidate.sequence) &&
+    (candidate.sequence as number) >= 0 &&
+    typeof candidate.receivedAt === 'number' &&
+    Number.isFinite(candidate.receivedAt) &&
+    typeof candidate.sentAt === 'number' &&
+    Number.isFinite(candidate.sentAt) &&
+    typeof candidate.timestamp === 'number' &&
+    Number.isFinite(candidate.timestamp) &&
+    (candidate.type === 'configuration' ||
+      (candidate.type === 'data' && typeof candidate.keyFrame === 'boolean'))
+  );
+}


### PR DESCRIPTION
## Summary

- cap the Studio scrcpy preview producer at 30 FPS while retaining the existing 1600px / 8 Mbps profile
- add a shared, discriminated packet contract with monotonic sequence and receive/send timestamps
- preserve freshness metadata through the readable stream to the actual WebCodecs decoder admission boundary
- bound submitted-but-not-completed decoder frames, discard stale/delta backlog, and recover only from a fresh keyframe
- apply the same safe keyframe recovery to legacy packets that do not carry sequence metadata

## Why

The renderer could accept compressed packets faster than WebCodecs actually decoded them, so ReadableStream backpressure alone did not prevent multi-second preview lag. The decoder-boundary admission policy now measures real outstanding decoder work and keeps latency bounded without feeding an invalid delta-frame chain after drops.

Fixes #3020

## Validation

- `pnpm exec nx test @midscene/playground-app -- tests/scrcpy-stream.test.ts tests/scrcpy-decoder-admission.test.ts` (17 tests)
- `pnpm exec nx test @midscene/android-playground -- tests/unit/scrcpy-server.test.ts` (7 tests)
- `pnpm exec nx run-many -t build -p @midscene/shared @midscene/playground-app @midscene/android-playground`
- `pnpm run lint`
- `git diff --check`

A live physical-device latency run was not available locally; decoder backlog, packet freshness, sequence gaps, keyframe recovery, and the wire contract are covered by deterministic tests.
