### PR TITLE
fix(core): normalize GPT locate coordinates

### DIFF
--- a/packages/core/src/ai-model/models/gpt.ts
+++ b/packages/core/src/ai-model/models/gpt.ts
@@ -56,7 +56,11 @@ export const gptAdapters = {
     locate: {
       element: {
         resultFormat: {
-          coordinates: { shape: 'bbox', order: 'xy' },
+          // GPT does not receive the screenshot's authoritative pixel size.
+          // Asking it to infer absolute dimensions makes edge coordinates
+          // fragile when the provider presents a resized image. Normalize the
+          // response and map it against the prepared image locally instead.
+          coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
         },
       },
     },

--- a/packages/core/tests/unit-test/model-adapter/gpt.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/gpt.test.ts
@@ -5,6 +5,23 @@ import { describe, expect, it } from 'vitest';
 const gpt5Adapter = new ResolvedModelAdapter(gptAdapters['gpt-5'], 'gpt-5');
 
 describe('gpt model adapter', () => {
+  it('uses normalized locate coordinates for edge elements', () => {
+    const locateAdapter = gpt5Adapter.locate;
+    expect(locateAdapter.kind).toBe('standard');
+    if (locateAdapter.kind !== 'standard') {
+      throw new Error('gpt-5 should use the standard locate adapter');
+    }
+
+    expect(
+      locateAdapter.element.resultCodec.promptSpec.resultValueDescription,
+    ).toContain('normalized to 0-1000 relative to the screenshot');
+    expect(
+      locateAdapter.element.resultCodec.toPixelBbox([43, 951, 485, 1000], {
+        preparedSize: { width: 1440, height: 3200 },
+      }),
+    ).toEqual([62, 3042, 698, 3199]);
+  });
+
   it('keeps GPT-5 image-detail policy in the adapter', () => {
     expect(
       gpt5Adapter.chatCompletion.buildChatCompletionParams({


### PR DESCRIPTION
## Summary

- request GPT-5 bounding boxes in the existing normalized 0-1000 coordinate format
- map normalized boxes against Midscene's authoritative prepared screenshot dimensions
- retain strict out-of-bounds validation instead of clamping invalid model output
- add an edge-element regression covering the reported 1440 x 3200 screenshot

## Why

GPT does not know the authoritative pixel dimensions of the image after provider-side image handling. Asking it for absolute pixels allowed a valid bottom-edge element to be returned beyond the local screenshot height. Normalizing the model contract removes that size guess and lets Midscene perform the only pixel conversion.

Fixes #2929

## Validation

- `pnpm exec nx test @midscene/core -- tests/unit-test/model-adapter/gpt.test.ts` (11 tests)
- `pnpm exec nx test @midscene/core -- tests/unit-test/prompt/prompt.test.ts` (34 tests)
- `pnpm exec nx build @midscene/core`
- `pnpm run lint`
- `git diff --check`

No live GPT request was run because the required model credentials were not available; the adapter prompt and coordinate conversion are covered directly.