### PR TITLE
refactor(core): organize DeepSeek model files

### DIFF
--- a/packages/core/src/ai-model/models/deepseek/adapter.ts
+++ b/packages/core/src/ai-model/models/deepseek/adapter.ts
@@ -3,15 +3,15 @@ import type {
   ChatCompletionCallContext,
   ChatCompletionParamsResult,
   ModelAdapterDefinition,
-} from '../model-adapter/types';
+} from '../../model-adapter/types';
 import {
   type LocateResultValue,
   createLocateResultValue,
-} from '../shared/model-locate-result';
+} from '../../shared/model-locate-result';
 import {
   deepSeekElementLocateProtocol,
   deepSeekSearchAreaProtocol,
-} from './deepseek-locate-protocol';
+} from './locate-protocol';
 
 const deepSeekPointCoordinates = {
   shape: 'point',

--- a/packages/core/src/ai-model/models/deepseek/locate-protocol.ts
+++ b/packages/core/src/ai-model/models/deepseek/locate-protocol.ts
@@ -1,11 +1,11 @@
 import type {
   ParsedLocateResponse,
   StandardLocateProtocol,
-} from '../model-adapter/locate-protocol';
+} from '../../model-adapter/locate-protocol';
 import {
   type LocateResultPromptSpec,
   formatLocateExampleValue,
-} from '../shared/model-locate-result';
+} from '../../shared/model-locate-result';
 
 const deepSeekRefBoxPattern =
   /<(?:｜｜|\|)ref(?:｜｜|\|)>\s*[\s\S]*?\s*<(?:｜｜|\|)\/ref(?:｜｜|\|)>\s*<(?:｜｜|\|)box(?:｜｜|\|)>\s*([\s\S]*?)\s*<(?:｜｜|\|)\/box(?:｜｜|\|)>/g;

--- a/packages/core/src/ai-model/models/registry.ts
+++ b/packages/core/src/ai-model/models/registry.ts
@@ -7,7 +7,7 @@ import type {
   ModelRuntime,
 } from '../model-adapter/types';
 import { autoGlmAdapters } from './auto-glm/adapter';
-import { deepSeekAdapters } from './deepseek';
+import { deepSeekAdapters } from './deepseek/adapter';
 import { defaultOpenAICompatibleAdapterConfig } from './default';
 import { doubaoAdapters } from './doubao';
 import { geminiAdapters } from './gemini';

--- a/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
@@ -1,9 +1,9 @@
 import { ResolvedModelAdapter } from '@/ai-model/model-adapter/resolve';
-import { deepSeekAdapters } from '@/ai-model/models/deepseek';
+import { deepSeekAdapters } from '@/ai-model/models/deepseek/adapter';
 import {
   deepSeekElementLocateProtocol,
   deepSeekSearchAreaProtocol,
-} from '@/ai-model/models/deepseek-locate-protocol';
+} from '@/ai-model/models/deepseek/locate-protocol';
 import { systemPromptToLocateElement } from '@/ai-model/prompt/llm-locator';
 import { createLocateResultPromptSpec } from '@/ai-model/shared/model-locate-result/prompt-spec';
 import { describe, expect, it } from 'vitest';


### PR DESCRIPTION
## Summary

- group the DeepSeek model adapter and locate protocol under a dedicated `deepseek` directory
- update the model registry and unit test imports to use the new module paths
- align the DeepSeek model layout with `ui-tars` and `auto-glm`

## Validation

- `pnpm exec nx test @midscene/core -- tests/unit-test/model-adapter/deepseek.test.ts`
- `pnpm run lint`
- `git diff --check`