### PR TITLE
feat(core): apply preferred language to planning details

### DIFF
--- a/packages/core/src/ai-model/prompt/planning/system-prompt.ts
+++ b/packages/core/src/ai-model/prompt/planning/system-prompt.ts
@@ -94,6 +94,8 @@ ${renderThoughtContent(`### <planning> tag (REQUIRED)
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
 
+Write the content of the <planning> tag in ${preferredLanguage}.
+
 Include your planning details in the <planning> tag. It should answer: ${renderSubGoalsContent(
   "What is the user's requirement? What is the current state based on the screenshot? Are all sub-goals completed? If not, what should be the next action?",
   'What is the current state based on the screenshot? What should be the next action?',

--- a/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
+++ b/packages/core/tests/unit-test/prompt/__snapshots__/prompt.test.ts.snap
@@ -388,6 +388,8 @@ First, observe the current screenshot and previous logs to understand the curren
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
 
+Write the content of the <planning> tag in English.
+
 Include your planning details in the <planning> tag. It should answer: What is the current state based on the screenshot? What should be the next action? Write it naturally without numbering or section headers.
 
 CRITICAL - Following Explicit Instructions: When the user gives you specific operation steps (not high-level goals), you MUST execute ONLY those exact steps - nothing more, nothing less. Do NOT add extra actions even if they seem logical. For example: "fill out the form" means only fill fields, do NOT submit; "click the button" means only click, do NOT wait for page load or verify results; "type 'hello'" means only type, do NOT press Enter.
@@ -767,6 +769,8 @@ First, observe the current screenshot and previous logs to understand the curren
 ### <planning> tag (REQUIRED)
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
+
+Write the content of the <planning> tag in English.
 
 Include your planning details in the <planning> tag. It should answer: What is the current state based on the screenshot? What should be the next action? Write it naturally without numbering or section headers.
 
@@ -1470,6 +1474,8 @@ First, observe the current screenshot and previous logs to understand the curren
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
 
+Write the content of the <planning> tag in English.
+
 Include your planning details in the <planning> tag. It should answer: What is the current state based on the screenshot? What should be the next action? Write it naturally without numbering or section headers.
 
 CRITICAL - Following Explicit Instructions: When the user gives you specific operation steps (not high-level goals), you MUST execute ONLY those exact steps - nothing more, nothing less. Do NOT add extra actions even if they seem logical. For example: "fill out the form" means only fill fields, do NOT submit; "click the button" means only click, do NOT wait for page load or verify results; "type 'hello'" means only type, do NOT press Enter.
@@ -1852,6 +1858,8 @@ First, observe the current screenshot and previous logs, then break down the use
 ### <planning> tag (REQUIRED)
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
+
+Write the content of the <planning> tag in English.
 
 Include your planning details in the <planning> tag. It should answer: What is the user's requirement? What is the current state based on the screenshot? Are all sub-goals completed? If not, what should be the next action? Write it naturally without numbering or section headers.
 
@@ -2331,6 +2339,8 @@ First, observe the current screenshot and previous logs to understand the curren
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
 
+Write the content of the <planning> tag in English.
+
 Include your planning details in the <planning> tag. It should answer: What is the current state based on the screenshot? What should be the next action? Write it naturally without numbering or section headers.
 
 CRITICAL - Following Explicit Instructions: When the user gives you specific operation steps (not high-level goals), you MUST execute ONLY those exact steps - nothing more, nothing less. Do NOT add extra actions even if they seem logical. For example: "fill out the form" means only fill fields, do NOT submit; "click the button" means only click, do NOT wait for page load or verify results; "type 'hello'" means only type, do NOT press Enter.
@@ -2710,6 +2720,8 @@ First, observe the current screenshot and previous logs to understand the curren
 ### <planning> tag (REQUIRED)
 
 REQUIRED: You MUST always output the <planning> tag. Never skip it.
+
+Write the content of the <planning> tag in English.
 
 Include your planning details in the <planning> tag. It should answer: What is the current state based on the screenshot? What should be the next action? Write it naturally without numbering or section headers.
 

--- a/packages/core/tests/unit-test/prompt/prompt.test.ts
+++ b/packages/core/tests/unit-test/prompt/prompt.test.ts
@@ -182,6 +182,18 @@ describe('system prompts', () => {
     expect(prompt).toContain('<action-type>...</action-type>');
   });
 
+  it('planning uses the preferred language in the planning tag', async () => {
+    const prompt = await buildStandardPlanningSystemPrompt({
+      ...defaultPlanningProtocolOptions,
+      actionSpace: mockActionSpace,
+      includeLocateInPlanning: false,
+    });
+
+    expect(prompt).toContain(
+      'Write the content of the <planning> tag in English.',
+    );
+  });
+
   it('planning - cot', async () => {
     const prompt = await buildStandardPlanningSystemPrompt({
       ...defaultPlanningProtocolOptions,


### PR DESCRIPTION
## Summary

- require Standard Planning to write `<planning>` content in the language resolved from `MIDSCENE_PREFERRED_LANGUAGE`
- add focused prompt coverage for the preferred-language instruction
- update affected Planning prompt snapshots

## Validation

- `pnpm exec nx test @midscene/core -- tests/unit-test/prompt/prompt.test.ts -u`
- `pnpm run lint`