### PR TITLE
fix(core): commit planning logs after actions succeed

### DIFF
--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -251,6 +251,27 @@ export class TaskExecutor {
   }
 
   /**
+   * Commit the model's action log only after the corresponding action batch
+   * succeeds. Planning logs describe work to be performed, so recording them
+   * before execution would make failed actions appear completed on the next
+   * planning round.
+   */
+  private commitSuccessfulPlanningLog(
+    conversationHistory: ConversationHistory,
+    log: string | undefined,
+    effort: AiActEffort,
+  ): void {
+    if (!log) {
+      return;
+    }
+    if (effort === 'deepThink') {
+      conversationHistory.appendSubGoalLog(log);
+    } else {
+      conversationHistory.appendHistoricalLog(log);
+    }
+  }
+
+  /**
    * Get a readable time string. When device time is enabled, use the
    * device-formatted wall-clock time directly so host timezone formatting does
    * not reinterpret a device timestamp.
@@ -772,6 +793,13 @@ export class TaskExecutor {
       );
       try {
         await session.appendAndRun(executables.tasks);
+        if (executables.tasks.length > 0) {
+          this.commitSuccessfulPlanningLog(
+            conversationHistory,
+            planResult?.log,
+            effort,
+          );
+        }
         this.setPendingFeedbackMessage(
           conversationHistory,
           initialTimeString,

--- a/packages/core/src/ai-model/workflows/planning/standard-planning.ts
+++ b/packages/core/src/ai-model/workflows/planning/standard-planning.ts
@@ -327,9 +327,6 @@ export async function standardPlan(
 
   assert(planFromAI, "can't get plans from AI");
 
-  // TODO: The plan log is recorded before its action has executed, so a failed
-  // action may still appear in the next round as an action already performed.
-  // Move this write to the successful action execution path in TaskExecutor.action.
   // Update sub-goals in conversation history only in planning deep-think mode.
   if (includeSubGoals) {
     if (planFromAI.updateSubGoals?.length) {
@@ -339,15 +336,6 @@ export async function standardPlan(
       for (const index of planFromAI.markFinishedIndexes) {
         conversationHistory.markSubGoalFinished(index);
       }
-    }
-    // Append the planning log to the currently running sub-goal
-    if (planFromAI.log) {
-      conversationHistory.appendSubGoalLog(planFromAI.log);
-    }
-  } else {
-    // Without planning deep-think mode, accumulate logs as historical execution steps.
-    if (planFromAI.log) {
-      conversationHistory.appendHistoricalLog(planFromAI.log);
     }
   }
 

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -275,6 +275,25 @@ describe('plan XML parse retry', () => {
     );
   });
 
+  it('does not record a planning log before its action executes', async () => {
+    const conversationHistory = new ConversationHistory();
+    vi.mocked(callAI).mockResolvedValueOnce(
+      mockAIResponse(`<log>Tap button</log>
+<action-type>Tap</action-type>`),
+    );
+
+    await standardPlan('tap the button', {
+      context: mockContext(),
+      actionSpace: mockActionSpace(),
+      modelRuntime: getModelRuntime(mockModelConfig()),
+      conversationHistory,
+      includeLocateInPlanning: false,
+      effort: 'balance',
+    });
+
+    expect(conversationHistory.historicalLogsToText()).toBe('');
+  });
+
   it('marks planning as requiring original image detail when locate is included', async () => {
     vi.mocked(callAI).mockResolvedValueOnce(
       mockAIResponse(`<log>Tap button</log>

--- a/packages/core/tests/unit-test/task-executor-planning-history.test.ts
+++ b/packages/core/tests/unit-test/task-executor-planning-history.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ai-model/workflows/planning', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/ai-model/workflows/planning')>();
+  return {
+    ...actual,
+    standardPlan: vi.fn(),
+  };
+});
+
+import { TaskExecutor } from '@/agent/tasks';
+import { getModelRuntime } from '@/ai-model/models';
+import { standardPlan } from '@/ai-model/workflows/planning';
+import { ConversationHistory } from '@/ai-model/workflows/planning/conversation-history';
+import type { AbstractInterface } from '@/device';
+import { ScreenshotItem } from '@/screenshot-item';
+import type { AiActEffort, DeviceAction, ExecutionTaskApply } from '@/types';
+import type Service from '../../src';
+
+const validBase64Image =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const planningModel = () =>
+  getModelRuntime({
+    modelName: 'planning-model',
+    modelDescription: 'planning-model',
+    intent: 'planning',
+    slot: 'planning',
+  });
+
+const defaultModel = () =>
+  getModelRuntime({
+    modelName: 'default-model',
+    modelDescription: 'default-model',
+    intent: 'default',
+    slot: 'default',
+  });
+
+describe('TaskExecutor planning history', () => {
+  let taskExecutor: TaskExecutor;
+
+  beforeEach(() => {
+    const actionSpace: DeviceAction[] = [
+      {
+        name: 'Noop',
+        description: 'noop',
+        call: async () => undefined,
+      },
+    ];
+    const mockInterface = {
+      interfaceType: 'web',
+      actionSpace: vi.fn().mockReturnValue(actionSpace),
+    } as unknown as AbstractInterface;
+    const mockService = {
+      contextRetrieverFn: vi.fn().mockResolvedValue({
+        screenshot: ScreenshotItem.create(validBase64Image, Date.now()),
+        shotSize: { width: 1920, height: 1080 },
+        shrunkShotToLogicalRatio: 1,
+        tree: {
+          id: 'root',
+          attributes: {},
+          children: [],
+        },
+      }),
+    } as unknown as Service;
+
+    taskExecutor = new TaskExecutor(mockInterface, mockService, {
+      replanningCycleLimit: 1,
+      actionSpace,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runTwoPlanningRounds(options: {
+    actionExecutor: ExecutionTaskApply['executor'];
+    effort?: AiActEffort;
+  }): Promise<string> {
+    let planningRound = 0;
+    let historySeenBySecondRound = '';
+    vi.mocked(standardPlan).mockImplementation(
+      async (_instruction, planOptions) => {
+        planningRound += 1;
+        if (planningRound === 1) {
+          if (options.effort === 'deepThink') {
+            planOptions.conversationHistory.setSubGoals([
+              {
+                index: 1,
+                status: 'pending',
+                description: 'Complete the action',
+              },
+            ]);
+          }
+          return {
+            actions: [{ type: 'Noop' }],
+            log: 'Performed the planned action',
+            shouldContinuePlanning: true,
+          };
+        }
+
+        planOptions.conversationHistory.resetPendingFeedbackMessageIfExists();
+        historySeenBySecondRound =
+          options.effort === 'deepThink'
+            ? planOptions.conversationHistory.subGoalsToText()
+            : planOptions.conversationHistory.historicalLogsToText();
+        return {
+          actions: [],
+          log: '',
+          shouldContinuePlanning: false,
+          finalizeSuccess: true,
+        };
+      },
+    );
+
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable')
+      .mockResolvedValueOnce({
+        tasks: [
+          {
+            type: 'Action Space',
+            subType: 'Noop',
+            executor: options.actionExecutor,
+          },
+        ],
+        yamlFlow: [],
+      } as never)
+      .mockResolvedValueOnce({
+        tasks: [],
+        yamlFlow: [],
+      } as never);
+
+    await taskExecutor.action(
+      'perform the action',
+      planningModel(),
+      defaultModel(),
+      undefined,
+      undefined,
+      undefined,
+      options.effort,
+    );
+
+    return historySeenBySecondRound;
+  }
+
+  it('commits a planning log after successful action execution', async () => {
+    const history = await runTwoPlanningRounds({
+      actionExecutor: async () => undefined,
+    });
+
+    expect(history).toContain('Performed the planned action');
+    expect(history.match(/Performed the planned action/g)).toHaveLength(1);
+  });
+
+  it('does not commit a planning log when action execution fails', async () => {
+    const appendLog = vi.spyOn(
+      ConversationHistory.prototype,
+      'appendHistoricalLog',
+    );
+    vi.mocked(standardPlan).mockResolvedValue({
+      actions: [{ type: 'Noop' }],
+      log: 'Performed the planned action',
+      shouldContinuePlanning: false,
+    });
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable').mockResolvedValue({
+      tasks: [
+        {
+          type: 'Action Space',
+          subType: 'Noop',
+          executor: async () => {
+            throw new Error('action failed');
+          },
+        },
+      ],
+      yamlFlow: [],
+    } as never);
+
+    await taskExecutor.action(
+      'perform the action',
+      planningModel(),
+      defaultModel(),
+    );
+
+    expect(appendLog).not.toHaveBeenCalled();
+  });
+
+  it('commits successful deepThink logs to the running sub-goal', async () => {
+    const history = await runTwoPlanningRounds({
+      actionExecutor: async () => undefined,
+      effort: 'deepThink',
+    });
+
+    expect(history).toContain(
+      'Actions performed for current sub-goal:\n- Performed the planned action',
+    );
+  });
+});

--- a/packages/core/tests/unit-test/task-executor-planning-history.test.ts
+++ b/packages/core/tests/unit-test/task-executor-planning-history.test.ts
@@ -185,6 +185,30 @@ describe('TaskExecutor planning history', () => {
     expect(appendLog).not.toHaveBeenCalled();
   });
 
+  it('does not commit a planning log when no action is executable', async () => {
+    const appendLog = vi.spyOn(
+      ConversationHistory.prototype,
+      'appendHistoricalLog',
+    );
+    vi.mocked(standardPlan).mockResolvedValue({
+      actions: [],
+      log: 'No action was performed',
+      shouldContinuePlanning: false,
+    });
+    vi.spyOn(taskExecutor, 'convertPlanToExecutable').mockResolvedValue({
+      tasks: [],
+      yamlFlow: [],
+    } as never);
+
+    await taskExecutor.action(
+      'perform the action',
+      planningModel(),
+      defaultModel(),
+    );
+
+    expect(appendLog).not.toHaveBeenCalled();
+  });
+
   it('commits successful deepThink logs to the running sub-goal', async () => {
     const history = await runTwoPlanningRounds({
       actionExecutor: async () => undefined,


### PR DESCRIPTION
## Summary

- defer planning-log persistence until the corresponding action batch succeeds
- prevent failed actions from appearing as completed steps in later planning rounds
- preserve normal and deepThink history semantics
- skip log persistence for empty action batches
- add regression coverage for successful, failed, empty, and deepThink executions

## Problem

`standardPlan()` previously appended the model's planning log to `ConversationHistory` before the planned action was executed.

If the action later failed, the next planning round received contradictory context: the execution history said the action had already been performed, while pending feedback reported that execution failed. This could cause the GUI Agent to skip retries, advance to the wrong sub-goal, or make decisions from an incorrect execution state.

## Changes

Planning-log ownership now lives in `TaskExecutor`, which knows whether the action batch actually completed.

- normal effort: append successful logs to historical execution steps
- deepThink effort: append successful logs to the running sub-goal
- failed batch: do not append
- empty batch: do not append

Sub-goal planning updates and model conversation messages remain in `standardPlan()` because they describe planning state rather than confirmed action execution.

## Validation

- planning-history regression suite: 4 tests passed
- focused planning suite: 15 tests passed
- Core build type-check: passed
- Biome: 1605 files passed

Covered cases:

- successful action commits its log exactly once
- failed action does not commit its log
- empty action batch does not commit its log
- deepThink mode commits the log to the running sub-goal