### PR TITLE
fix(core): validate locate coordinate types strictly

### DIFF
--- a/packages/core/src/ai-model/shared/model-locate-result/parse.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/parse.ts
@@ -43,9 +43,18 @@ export function parseCoordinateList(input: unknown, label: string): number[] {
     throw new Error(`invalid ${label} data: ${JSON.stringify(input)} `);
   }
 
-  const numericValues = values.map((value) =>
-    typeof value === 'number' ? value : Number(value),
-  );
+  const numericValues = values.map((value) => {
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (
+      typeof value !== 'string' ||
+      !/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(value.trim())
+    ) {
+      return Number.NaN;
+    }
+    return Number(value);
+  });
 
   if (!numericValues.every((value) => Number.isFinite(value))) {
     throw new Error(`invalid ${label} data: ${JSON.stringify(input)} `);
@@ -90,7 +99,7 @@ export function parseNumericLocateResult(
 ): LocateResultValue {
   if (resolvedCoordinates.shape === 'point') {
     const point = parseCoordinateList(input, 'point');
-    if (point.length < 2) {
+    if (point.length !== 2) {
       throw new Error(`invalid point data: ${JSON.stringify(input)} `);
     }
     return createLocateResultValue(resolvedCoordinates, point);

--- a/packages/core/tests/unit-test/locate-result-codec.test.ts
+++ b/packages/core/tests/unit-test/locate-result-codec.test.ts
@@ -122,6 +122,35 @@ describe('createLocateResultCodec', () => {
     ).toThrow(/invalid bbox data/);
   });
 
+  it.each([null, true, false, '', '   '])(
+    'rejects coercible non-coordinate bbox value: %j',
+    (invalidValue) => {
+      const codec = createLocateResultCodec({
+        coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      });
+
+      expect(() =>
+        codec.toPixelBbox(
+          [invalidValue, 100, 300, 400] as never,
+          locateCtx(640, 360),
+        ),
+      ).toThrow(/invalid bbox data/);
+    },
+  );
+
+  it('accepts decimal coordinate strings without general JavaScript coercion', () => {
+    const codec = createLocateResultCodec({
+      coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+    });
+
+    expect(
+      codec.toPixelBbox(
+        ['100', '200.5', '300.25', '400'] as never,
+        locateCtx(200, 100),
+      ),
+    ).toEqual([20, 20, 60, 40]);
+  });
+
   it('rejects invalid parsed adapter results before coordinate range checks', () => {
     const codec = createLocateResultCodec({
       coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
@@ -156,6 +185,16 @@ describe('createLocateResultCodec', () => {
     expect(() => codec.toPixelBbox([500], locateCtx(640, 360))).toThrow(
       /invalid point data/,
     );
+  });
+
+  it('rejects point coordinate values with more than two entries', () => {
+    const codec = createLocateResultCodec({
+      coordinates: { shape: 'point', order: 'xy', normalizedBy: 1000 },
+    });
+
+    expect(() =>
+      codec.toPixelBbox([500, 500, 500], locateCtx(640, 360)),
+    ).toThrow(/invalid point data/);
   });
 
   it('rejects non-positive normalizedBy values', () => {


### PR DESCRIPTION
## Summary

- reject null, boolean, empty, and whitespace-only coordinate values
- preserve support for valid decimal coordinate strings
- require point results to contain exactly two coordinates
- add regression coverage for JavaScript coercion edge cases

## Problem

The shared locate-result parser used `Number(value)` for arbitrary values. This allowed malformed model output such as `null`, `false`, or an empty string to become finite coordinates and proceed into the grounding pipeline:

```ts
Number(null)  // 0
Number(false) // 0
Number(true)  // 1
Number('')    // 0
```

Point responses with extra coordinates were also silently truncated because the parser only required at least two values.

## Changes

Coordinate values now accept only finite numbers or complete decimal number strings. General JavaScript coercion is no longer used, and point responses must contain exactly two values.

This keeps compatibility with numeric strings while ensuring malformed model output reaches the existing semantic-retry path instead of becoming a real device coordinate.

## Validation

- locate-result codec tests: 33 passed
- model-adapter and codec suite: 28 files, 314 tests passed
- Core build type-check: passed
- Biome: 1604 files passed