### PR TITLE
refactor(core): simplify planning locate parameters

### DIFF
--- a/packages/core/src/agent/task-builder.ts
+++ b/packages/core/src/agent/task-builder.ts
@@ -16,7 +16,6 @@ import type {
   LocateResultElement,
   LocateResultWithDump,
   PlanningAction,
-  PlanningLocateParam,
   Rect,
   ServiceDump,
 } from '@/types';
@@ -28,7 +27,7 @@ import { assert } from '@midscene/shared/utils';
 import type { TaskCache } from './task-cache';
 import { withUsageIntent } from './usage-intent';
 import {
-  ifPlanLocateParamHasLocatedPixelBbox,
+  ifLocateParamHasLocatedPixelBbox,
   matchElementFromCache,
   matchElementFromPlan,
   transformLogicalElementToScreenshot,
@@ -90,7 +89,7 @@ function normalizeLocateParam(
 
 export function locatePlanForLocate(param: string | DetailedLocateParam) {
   const locate = normalizeLocateParam(param);
-  const locatePlan: PlanningAction<PlanningLocateParam> = {
+  const locatePlan: PlanningAction<DetailedLocateParam> = {
     type: 'Locate',
     param: locate,
     thought: '',
@@ -171,7 +170,7 @@ export class TaskBuilder {
         'Locate',
         (plan) =>
           this.handleLocatePlan(
-            plan as PlanningAction<PlanningLocateParam>,
+            plan as PlanningAction<DetailedLocateParam>,
             context,
           ),
       ],
@@ -206,7 +205,7 @@ export class TaskBuilder {
   }
 
   private async handleLocatePlan(
-    plan: PlanningAction<PlanningLocateParam>,
+    plan: PlanningAction<DetailedLocateParam>,
     context: PlanBuildContext,
   ): Promise<void> {
     const taskLocate = this.createLocateTask(plan, plan.param, context);
@@ -239,7 +238,7 @@ export class TaskBuilder {
           `action.type=${planType}`,
           `param=${JSON.stringify(param[field])}`,
           `locatePlan=${JSON.stringify(locatePlan)}`,
-          `hasLocatedPixelBbox=${ifPlanLocateParamHasLocatedPixelBbox(param[field])}`,
+          `hasLocatedPixelBbox=${ifLocateParamHasLocatedPixelBbox(param[field])}`,
         );
         const locateTask = this.createLocateTask(
           locatePlan,
@@ -389,7 +388,7 @@ export class TaskBuilder {
   }
 
   private createLocateTask(
-    plan: PlanningAction<PlanningLocateParam>,
+    plan: PlanningAction<DetailedLocateParam>,
     detailedLocateParam: DetailedLocateParam | string,
     context: PlanBuildContext,
     onResult?: (result: LocateResultElement) => void,
@@ -420,7 +419,7 @@ export class TaskBuilder {
       executor: async (taskContext) => {
         const { task } = taskContext;
         let { uiContext } = taskContext;
-        const paramWithLocatedPixelBbox = ifPlanLocateParamHasLocatedPixelBbox(
+        const paramWithLocatedPixelBbox = ifLocateParamHasLocatedPixelBbox(
           locateParam,
         )
           ? locateParam

--- a/packages/core/src/agent/tasks.ts
+++ b/packages/core/src/agent/tasks.ts
@@ -22,6 +22,7 @@ import type {
   AiActEffort,
   AiActProgressData,
   AiActProgressPhase,
+  DetailedLocateParam,
   DeviceAction,
   ExecutionRecorderItem,
   ExecutionTask,
@@ -33,7 +34,6 @@ import type {
   PlanningAIResponse,
   PlanningAction,
   PlanningActionParamWaitFor,
-  PlanningLocateParam,
   ServiceDump,
   ServiceExtractOption,
   ServiceExtractParam,
@@ -431,7 +431,7 @@ export class TaskExecutor {
         task.subType === 'Locate' &&
         task.hitBy?.from === 'Cache'
       ) {
-        const prompt = (task.param as PlanningLocateParam | undefined)?.prompt;
+        const prompt = (task.param as DetailedLocateParam | undefined)?.prompt;
         if (prompt) {
           this.taskCache.markLocateCacheStale(prompt);
         }

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -5,11 +5,10 @@ import type { TMultimodalPrompt, TUserPrompt } from '@/common';
 import type { AbstractInterface } from '@/device';
 import { ScreenshotItem } from '@/screenshot-item';
 import type {
+  DetailedLocateParam,
   ElementCacheFeature,
   LocateResultElement,
   PixelBbox,
-  PlanningLocateParam,
-  PlanningLocateParamWithLocatedPixelBbox,
   Rect,
   ScrollParam,
   Size,
@@ -283,18 +282,23 @@ export function isPixelBbox(value: unknown): value is PixelBbox {
   );
 }
 
-type PlanningLocateParamWithMaybeLocatedPixelBbox = PlanningLocateParam & {
+type LocateParamWithMaybeLocatedPixelBbox = DetailedLocateParam & {
   locatedPixelBbox?: unknown;
 };
 
-export function ifPlanLocateParamHasLocatedPixelBbox(
-  planLocateParam: PlanningLocateParamWithMaybeLocatedPixelBbox,
-): planLocateParam is PlanningLocateParamWithLocatedPixelBbox {
-  return isPixelBbox(planLocateParam.locatedPixelBbox);
+type LocateParamWithLocatedPixelBbox = DetailedLocateParam & {
+  /** Pixel bbox of the located element in screenshot coordinates. */
+  locatedPixelBbox: PixelBbox;
+};
+
+export function ifLocateParamHasLocatedPixelBbox(
+  locateParam: LocateParamWithMaybeLocatedPixelBbox,
+): locateParam is LocateParamWithLocatedPixelBbox {
+  return isPixelBbox(locateParam.locatedPixelBbox);
 }
 
 export function matchElementFromPlan(
-  planLocateParam: PlanningLocateParamWithLocatedPixelBbox,
+  planLocateParam: LocateParamWithLocatedPixelBbox,
 ): LocateResultElement | undefined {
   if (!planLocateParam) {
     return undefined;

--- a/packages/core/src/ai-model/model-adapter/custom-planning-action.ts
+++ b/packages/core/src/ai-model/model-adapter/custom-planning-action.ts
@@ -1,7 +1,13 @@
-import type { PixelBbox, PlanningAction, PlanningLocateParam } from '@/types';
+import type { LocateResultPoint, PixelBbox, PlanningAction } from '@/types';
+
+// AutoGLM and UI-TARS both produce point coordinates before normalization.
+type PreNormalizedPlanningLocateParam = {
+  prompt: string;
+  point: LocateResultPoint;
+};
 
 export type LocateActionParam = {
-  locate: PlanningLocateParam;
+  locate: PreNormalizedPlanningLocateParam;
 };
 
 export type LocatePlanningAction<TType extends string> =
@@ -19,8 +25,8 @@ export type ScrollPlanningAction = PlanningAction<
 };
 
 export type DragAndDropPlanningAction = PlanningAction<{
-  from: PlanningLocateParam;
-  to: PlanningLocateParam;
+  from: PreNormalizedPlanningLocateParam;
+  to: PreNormalizedPlanningLocateParam;
 }> & {
   type: 'DragAndDrop';
 };

--- a/packages/core/src/ai-model/models/auto-glm/actions.ts
+++ b/packages/core/src/ai-model/models/auto-glm/actions.ts
@@ -4,7 +4,7 @@ import { getDebug } from '@midscene/shared/logger';
 import type {
   LocatePlanningAction,
   ScrollPlanningAction,
-} from '../../model-adapter/planning-action';
+} from '../../model-adapter/custom-planning-action';
 import type { CoordinateDistanceAxis } from '../../shared/model-locate-result';
 
 const debug = getDebug('auto-glm-actions');

--- a/packages/core/src/ai-model/models/auto-glm/locate.ts
+++ b/packages/core/src/ai-model/models/auto-glm/locate.ts
@@ -1,4 +1,4 @@
-import { getTapLocatedPixelBbox } from '../../model-adapter/planning-action';
+import { getTapLocatedPixelBbox } from '../../model-adapter/custom-planning-action';
 import type { PlanningTapLocatorDefinition } from '../../model-adapter/types';
 import {
   getAutoGLMChineseLocatePrompt,

--- a/packages/core/src/ai-model/models/ui-tars/actions.ts
+++ b/packages/core/src/ai-model/models/ui-tars/actions.ts
@@ -5,7 +5,7 @@ import { assert } from '@midscene/shared/utils';
 import type {
   DragAndDropPlanningAction,
   LocatePlanningAction,
-} from '../../model-adapter/planning-action';
+} from '../../model-adapter/custom-planning-action';
 import type { UiTarsParsedPlanningResponse } from './parser';
 
 const debug = getDebug('ui-tars-planning');

--- a/packages/core/src/ai-model/workflows/planning/locate-normalization.ts
+++ b/packages/core/src/ai-model/workflows/planning/locate-normalization.ts
@@ -63,23 +63,30 @@ export function normalizePlanningActionLocateFields(
         locateResultCodec,
         'planning locate normalization requires a locate result codec',
       );
-      const rawLocateValue = (() => {
-        if (typeof locateParameter !== 'object' || locateParameter === null) {
-          return locateParameter;
-        }
 
-        const locateResultRecord = locateParameter as Record<string, unknown>;
-        const resultKey = locateResultCodec.promptSpec.resultKey;
-        if (locateResultRecord[resultKey] !== undefined) {
-          return locateResultRecord[resultKey];
-        }
+      const resultKey = locateResultCodec.promptSpec.resultKey;
+      const rawLocateValue =
+        locateParameter[resultKey] !== undefined
+          ? locateParameter[resultKey]
+          : acceptBbox2dAlias && resultKey === 'bbox'
+            ? locateParameter.bbox_2d
+            : undefined;
 
-        return acceptBbox2dAlias && resultKey === 'bbox'
-          ? locateResultRecord.bbox_2d
-          : undefined;
-      })();
+      // The raw result field is replaced by locatedPixelBbox, so it should not
+      // remain in the normalized locate parameter.
+      const rawCoordinateKeys = new Set([
+        resultKey,
+        ...(acceptBbox2dAlias && resultKey === 'bbox' ? ['bbox_2d'] : []),
+      ]);
+
+      const locateParamWithoutRawCoordinates = Object.fromEntries(
+        Object.entries(locateParameter).filter(
+          ([key]) => !rawCoordinateKeys.has(key),
+        ),
+      );
+
       action.param[field] = {
-        ...locateParameter,
+        ...locateParamWithoutRawCoordinates,
         locatedPixelBbox: locateResultCodec.toPixelBbox(
           rawLocateValue,
           locateResultContext,

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -20,7 +20,6 @@ import type {
   LocateResultElement,
   LocateResultWithDump,
   PartialServiceDumpFromSDK,
-  PlanningLocateParam,
   Rect,
   ServiceExtractOption,
   ServiceExtractParam,
@@ -97,16 +96,14 @@ export default class Service {
   }
 
   async locate(
-    query: PlanningLocateParam,
+    query: DetailedLocateParam,
     opt: LocateOpts,
     modelRuntime: ModelRuntime,
     abortSignal?: AbortSignal,
   ): Promise<LocateResultWithDump> {
     const { config: modelConfig } = modelRuntime;
-    const queryPrompt = typeof query === 'string' ? query : query.prompt;
+    const queryPrompt = query.prompt;
     assert(queryPrompt, 'query is required for locate');
-
-    assert(typeof query === 'object', 'query should be an object for locate');
 
     if (!modelConfig.modelFamily) {
       throw new Error(defaultModelFamilyRequiredForLocateMessage);
@@ -224,7 +221,7 @@ export default class Service {
   }
 
   private async resolveLocateSearchArea(options: {
-    query: PlanningLocateParam;
+    query: DetailedLocateParam;
     queryPrompt: TUserPrompt;
     opt: LocateOpts;
     context: UIContext;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -350,16 +350,6 @@ export interface InsightAPI<
  *
  */
 
-export interface PlanningLocateParam extends DetailedLocateParam {
-  bbox?: LocateResultBbox;
-  point?: LocateResultPoint;
-}
-
-export type PlanningLocateParamWithLocatedPixelBbox = PlanningLocateParam & {
-  /** Pixel bbox of the located element in screenshot coordinates. */
-  locatedPixelBbox: PixelBbox;
-};
-
 type PlanningActionBase = {
   thought?: string;
   log?: string; // a brief preamble to the user explaining what you’re about to do
@@ -674,8 +664,6 @@ export interface IExecutionDump extends DumpMeta {
 /*
 task - service-locate
 */
-export type ExecutionTaskInsightLocateParam = PlanningLocateParam;
-
 export interface ExecutionTaskInsightLocateOutput {
   element: LocateResultElement | null;
 }
@@ -684,7 +672,7 @@ export type ExecutionTaskInsightDump = ServiceDump;
 
 export type ExecutionTaskInsightLocateApply = ExecutionTaskApply<
   'Insight',
-  ExecutionTaskInsightLocateParam,
+  DetailedLocateParam,
   ExecutionTaskInsightLocateOutput,
   ExecutionTaskInsightDump
 >;
@@ -782,8 +770,6 @@ export type ExecutionTaskPlanning = ExecutionTask<ExecutionTaskPlanningApply>;
 /*
 task - planning-locate
 */
-export type ExecutionTaskPlanningLocateParam = PlanningLocateParam;
-
 export interface ExecutionTaskPlanningLocateOutput {
   element: LocateResultElement | null;
 }
@@ -792,7 +778,7 @@ export type ExecutionTaskPlanningDump = ServiceDump;
 
 export type ExecutionTaskPlanningLocateApply = ExecutionTaskApply<
   'Planning',
-  ExecutionTaskPlanningLocateParam,
+  DetailedLocateParam,
   ExecutionTaskPlanningLocateOutput,
   ExecutionTaskPlanningDump
 >;

--- a/packages/core/tests/ai/llm-planning/basic.test.ts
+++ b/packages/core/tests/ai/llm-planning/basic.test.ts
@@ -116,9 +116,7 @@ describe('planning', () => {
       // console.log(actions);
       expect(actions![0].param.locate).toBeTruthy();
       expect(actions![0].param.locate?.prompt).toBeTruthy();
-      expect(
-        actions![0].param.locate?.id || actions![0].param.locate?.bbox,
-      ).toBeTruthy();
+      expect(actions![0].param.locate?.locatedPixelBbox).toBeTruthy();
     });
   });
 

--- a/packages/core/tests/unit-test/llm-planning-retry.test.ts
+++ b/packages/core/tests/unit-test/llm-planning-retry.test.ts
@@ -497,7 +497,6 @@ describe('plan XML parse retry', () => {
         param: {
           locate: {
             prompt: 'submit',
-            bbox: [100, 200, 300, 400],
             locatedPixelBbox: [10, 20, 30, 40],
           },
         },

--- a/packages/core/tests/unit-test/locate-normalization.test.ts
+++ b/packages/core/tests/unit-test/locate-normalization.test.ts
@@ -65,6 +65,9 @@ describe('normalizePlanningActionLocateFields', () => {
         param: {
           locate: {
             prompt: 'submit',
+            deepLocate: true,
+            cacheable: false,
+            xpath: '//button[@type="submit"]',
             point: [50, 60],
           },
         },
@@ -83,7 +86,13 @@ describe('normalizePlanningActionLocateFields', () => {
     });
 
     expect(toPixelBbox).toHaveBeenCalledWith([50, 60], locateResultContext);
-    expect(actions[0].param.locate.locatedPixelBbox).toEqual([10, 20, 30, 40]);
+    expect(actions[0].param.locate).toEqual({
+      prompt: 'submit',
+      deepLocate: true,
+      cacheable: false,
+      xpath: '//button[@type="submit"]',
+      locatedPixelBbox: [10, 20, 30, 40],
+    });
   });
 
   it('accepts bbox_2d when the model adapter enables the alias', () => {
@@ -116,7 +125,10 @@ describe('normalizePlanningActionLocateFields', () => {
       [50, 60, 70, 80],
       locateResultContext,
     );
-    expect(actions[0].param.locate.locatedPixelBbox).toEqual([10, 20, 30, 40]);
+    expect(actions[0].param.locate).toEqual({
+      prompt: 'submit',
+      locatedPixelBbox: [10, 20, 30, 40],
+    });
   });
 
   it('parses protocol-specific locate params after identifying locator fields', () => {
@@ -151,7 +163,6 @@ describe('normalizePlanningActionLocateFields', () => {
     expect(toPixelBbox).toHaveBeenCalledWith([50, 60], locateResultContext);
     expect(actions[0].param.locate).toEqual({
       prompt: 'submit',
-      point: [50, 60],
       locatedPixelBbox: [10, 20, 30, 40],
     });
   });

--- a/packages/core/tests/unit-test/utils.test.ts
+++ b/packages/core/tests/unit-test/utils.test.ts
@@ -8,7 +8,7 @@ import { uuid } from '@midscene/shared/utils';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
-  ifPlanLocateParamHasLocatedPixelBbox,
+  ifLocateParamHasLocatedPixelBbox,
   isPixelBbox,
   transformLogicalElementToScreenshot,
   transformLogicalRectToScreenshotRect,
@@ -788,7 +788,7 @@ describe('dumpActionParam', () => {
   });
 });
 
-describe('ifPlanLocateParamHasLocatedPixelBbox', () => {
+describe('ifLocateParamHasLocatedPixelBbox', () => {
   it('should return true when locatedPixelBbox is valid array with 4 elements', () => {
     const param = {
       prompt: 'test element',
@@ -799,14 +799,14 @@ describe('ifPlanLocateParamHasLocatedPixelBbox', () => {
         number,
       ],
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param)).toBe(true);
+    expect(ifLocateParamHasLocatedPixelBbox(param)).toBe(true);
   });
 
   it('should return false when locatedPixelBbox is undefined', () => {
     const param = {
       prompt: 'test element',
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param)).toBe(false);
   });
 
   it('should return false when locatedPixelBbox is not an array', () => {
@@ -814,7 +814,7 @@ describe('ifPlanLocateParamHasLocatedPixelBbox', () => {
       prompt: 'test element',
       locatedPixelBbox: 'not an array' as any,
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param)).toBe(false);
   });
 
   it('should return false when locatedPixelBbox array length is not 4', () => {
@@ -822,19 +822,19 @@ describe('ifPlanLocateParamHasLocatedPixelBbox', () => {
       prompt: 'test element',
       locatedPixelBbox: [100, 200] as any,
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param1)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param1)).toBe(false);
 
     const param2 = {
       prompt: 'test element',
       locatedPixelBbox: [100, 200, 300] as any,
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param2)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param2)).toBe(false);
 
     const param3 = {
       prompt: 'test element',
       locatedPixelBbox: [100, 200, 300, 400, 500] as any,
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param3)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param3)).toBe(false);
   });
 
   it('should return false when locatedPixelBbox is null', () => {
@@ -842,18 +842,18 @@ describe('ifPlanLocateParamHasLocatedPixelBbox', () => {
       prompt: 'test element',
       locatedPixelBbox: null as any,
     };
-    expect(ifPlanLocateParamHasLocatedPixelBbox(param)).toBe(false);
+    expect(ifLocateParamHasLocatedPixelBbox(param)).toBe(false);
   });
 
   it('should return false when locatedPixelBbox contains non-finite or non-number values', () => {
     expect(
-      ifPlanLocateParamHasLocatedPixelBbox({
+      ifLocateParamHasLocatedPixelBbox({
         prompt: 'test element',
         locatedPixelBbox: [100, Number.NaN, 300, 400] as any,
       }),
     ).toBe(false);
     expect(
-      ifPlanLocateParamHasLocatedPixelBbox({
+      ifLocateParamHasLocatedPixelBbox({
         prompt: 'test element',
         locatedPixelBbox: [100, '200', 300, 400] as any,
       }),


### PR DESCRIPTION
## Summary

- remove the public `PlanningLocateParam` coordinate/result hybrid types and use `DetailedLocateParam` for locate task inputs
- normalize protocol-specific planning coordinates into `locatedPixelBbox` without leaking raw `point`/`bbox` fields into execution params
- clarify custom-planning action types and rename their shared module
- update unit and AI test expectations to use the normalized coordinate field

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test -- tests/unit-test/locate-normalization.test.ts tests/unit-test/utils.test.ts`
- `pnpm --filter @midscene/core test -- tests/unit-test/locate-normalization.test.ts`
- `pnpm exec nx build @midscene/core`