### PR TITLE
fix(android): recover static scrcpy screenshots in-band

### DIFF
--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { encodedImageInfoOfBuffer } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { Adb } from '@yume-chan/adb';
 import { resolveExternalResourcePath } from './resource-path';
@@ -24,6 +25,10 @@ const MAX_KEYFRAME_WAIT_MS = 5_000;
 // Maximum time to wait for a frame that crosses the active freshness target
 // before closing the stale epoch and letting the caller use ADB fallback.
 const FRESH_FRAME_TIMEOUT_MS = 300;
+// Give an established stream a brief chance to emit a frame naturally before
+// restarting only its capture/encoder pipeline. The reset stays inside the
+// existing freshness timeout and does not extend the fallback budget.
+const VIDEO_RESET_DELAY_MS = 10;
 const KEYFRAME_POLL_INTERVAL_MS = 200;
 const MAX_SCAN_BYTES = 1_000;
 const MAX_SERVER_OUTPUT_LINES = 100;
@@ -73,6 +78,8 @@ export interface RawKeyframe {
   ptsUs?: bigint;
   /** Estimated frame age when the packet reached the host. */
   estimatedAgeMs?: number;
+  /** Encoder epoch that produced this frame (always set by this manager). */
+  streamEpoch?: symbol;
   capturedAt: number;
 }
 
@@ -208,6 +215,12 @@ interface ResolvedScrcpyOptions {
   idleTimeoutMs: number;
 }
 
+interface VideoResetState {
+  previousSpsHeader: Buffer | null;
+  writePromise: Promise<void> | null;
+  frameAccepted: boolean;
+}
+
 export class ScrcpyScreenshotManager {
   private adb: Adb;
   // Using 'any' for external library types to avoid type compatibility issues
@@ -226,6 +239,14 @@ export class ScrcpyScreenshotManager {
   private lastRawKeyframeAt = 0;
   private lastRawKeyframePtsUs: bigint | undefined;
   private lastRawKeyframeEstimatedAgeMs: number | undefined;
+  private lastRawKeyframeStreamEpoch: symbol | undefined;
+  // Changes to a unique identity for every new stream and encoder reset.
+  // Deferred frame references from an older epoch may still be decoded, but
+  // must never update state belonging to the current encoder.
+  private streamEpoch = Symbol('scrcpy-stream');
+  // Separately identifies the transport reader. An in-band encoder reset
+  // advances `streamEpoch` while deliberately keeping this reader alive.
+  private streamReaderEpoch = 0;
   private videoResolution: { width: number; height: number } | null = null;
   private streamReader: any = null;
   private frameFreshnessBarrierPtsUs: bigint | null = null;
@@ -242,6 +263,8 @@ export class ScrcpyScreenshotManager {
   private lastFramePtsUs: bigint | null = null;
   private frameFreshnessError: Error | null = null;
   private lastFrameFreshnessWarningAt = 0;
+  private hasEstablishedVideoFrame = false;
+  private videoResetState: VideoResetState | null = null;
   private disposePromise: Promise<void> | null = null;
 
   constructor(
@@ -348,6 +371,8 @@ export class ScrcpyScreenshotManager {
 
       // Store the actual video resolution
       this.videoResolution = { width, height };
+      this.advanceStreamEpoch();
+      this.streamReaderEpoch++;
 
       this.streamStartupWindow = {
         deadlineAt: Date.now() + MAX_KEYFRAME_WAIT_MS,
@@ -379,7 +404,12 @@ export class ScrcpyScreenshotManager {
 
     return new AdbScrcpyOptions3_3_3({
       audio: false,
-      control: false,
+      // RESET_VIDEO is carried by scrcpy's control channel. Keep the channel
+      // enabled without allowing scrcpy to wake the device or synchronize the
+      // clipboard as a side effect of screenshot capture.
+      control: true,
+      powerOn: false,
+      clipboardAutosync: false,
       tunnelForward: true,
       scid: ScrcpyInstanceId.random(),
       maxSize: this.options.maxSize,
@@ -482,7 +512,7 @@ export class ScrcpyScreenshotManager {
 
     const reader = this.videoStream.stream.getReader();
     this.streamReader = reader;
-    this.consumeFramesLoop(reader);
+    this.consumeFramesLoop(reader, this.streamReaderEpoch);
   }
 
   /**
@@ -490,7 +520,10 @@ export class ScrcpyScreenshotManager {
    * Includes busy-loop detection: if reader.read() resolves too fast
    * (e.g. broken stream returning immediately), we throttle to prevent 100% CPU.
    */
-  private async consumeFramesLoop(reader: any): Promise<void> {
+  private async consumeFramesLoop(
+    reader: any,
+    streamReaderEpoch = this.streamReaderEpoch,
+  ): Promise<void> {
     let readCount = 0;
     let windowStart = Date.now();
     let lastBusyWarn = 0;
@@ -533,7 +566,7 @@ export class ScrcpyScreenshotManager {
           windowStart = Date.now();
         }
 
-        this.processFrame(value);
+        this.processFrame(value, streamReaderEpoch);
       }
     } catch (error) {
       endReason = 'stream error';
@@ -561,7 +594,14 @@ export class ScrcpyScreenshotManager {
    * This avoids the frame-splitting issue that occurs with sendFrameMeta: false
    * at high resolutions where raw chunks may not align with frame boundaries.
    */
-  private processFrame(packet: any): void {
+  private processFrame(
+    packet: any,
+    streamReaderEpoch = this.streamReaderEpoch,
+  ): void {
+    if (streamReaderEpoch !== this.streamReaderEpoch) {
+      return;
+    }
+
     if (packet.type === 'configuration') {
       // Configuration packet contains SPS/PPS in Annex B format
       this.spsHeader = Buffer.from(packet.data);
@@ -584,13 +624,27 @@ export class ScrcpyScreenshotManager {
       this.lastRawKeyframeAt = timing.capturedAt;
       this.lastRawKeyframePtsUs = packet.pts;
       this.lastRawKeyframeEstimatedAgeMs = timing.estimatedAgeMs;
+      // Receiving a fresh keyframe with codec configuration proves that the
+      // stream is established even when a continuous observer defers JPEG
+      // decoding. Later static captures may use in-band reset immediately.
+      this.hasEstablishedVideoFrame = true;
+      this.streamStartupWindow = null;
       const frame: RawKeyframe = {
         data: frameBuffer,
         header: this.spsHeader,
         ptsUs: packet.pts,
         estimatedAgeMs: timing.estimatedAgeMs,
+        streamEpoch: this.streamEpoch,
         capturedAt: this.lastRawKeyframeAt,
       };
+      this.lastRawKeyframeStreamEpoch = this.streamEpoch;
+      const resetState = this.videoResetState;
+      if (resetState) {
+        resetState.frameAccepted = true;
+        if (resetState.writePromise === null) {
+          this.videoResetState = null;
+        }
+      }
       if (this.keyframeResolvers.length > 0) {
         this.notifyKeyframeWaiters(frame);
       }
@@ -942,6 +996,7 @@ export class ScrcpyScreenshotManager {
     this.lastRawKeyframeAt = 0;
     this.lastRawKeyframePtsUs = undefined;
     this.lastRawKeyframeEstimatedAgeMs = undefined;
+    this.lastRawKeyframeStreamEpoch = undefined;
   }
 
   private restoreFrameCache(frame: RawKeyframe): void {
@@ -949,10 +1004,17 @@ export class ScrcpyScreenshotManager {
     this.lastRawKeyframeAt = frame.capturedAt;
     this.lastRawKeyframePtsUs = frame.ptsUs;
     this.lastRawKeyframeEstimatedAgeMs = frame.estimatedAgeMs;
+    this.lastRawKeyframeStreamEpoch = frame.streamEpoch;
   }
 
   private monotonicTimeUs(): bigint {
     return process.hrtime.bigint() / 1_000n;
+  }
+
+  private advanceStreamEpoch(): void {
+    // Symbols stay unique across manager instances without shared mutable
+    // counters, so deferred frame handles cannot collide after replacement.
+    this.streamEpoch = Symbol('scrcpy-stream');
   }
 
   private resetFrameFreshnessState(): void {
@@ -966,6 +1028,107 @@ export class ScrcpyScreenshotManager {
     this.lastFramePtsUs = null;
     this.frameFreshnessError = null;
     this.lastFrameFreshnessWarningAt = 0;
+    this.hasEstablishedVideoFrame = false;
+    this.videoResetState = null;
+  }
+
+  /**
+   * Restart scrcpy's capture and encoder pipeline without rebuilding the video
+   * stream or the underlying ADB transport. One request is shared by all
+   * concurrent capture callers until a post-reset keyframe is accepted.
+   */
+  private async requestVideoReset(
+    deadlineAt = Date.now() + FRESH_FRAME_TIMEOUT_MS,
+  ): Promise<void> {
+    const activeReset = this.videoResetState;
+    if (activeReset) {
+      if (activeReset.writePromise) {
+        await this.waitForVideoResetWrite(activeReset.writePromise, deadlineAt);
+      }
+      return;
+    }
+
+    const controller = this.scrcpyClient?.controller;
+    if (!controller?.resetVideo) {
+      throw new Error('Scrcpy control channel is unavailable for video reset');
+    }
+
+    const resetState: VideoResetState = {
+      previousSpsHeader: this.spsHeader,
+      writePromise: null,
+      frameAccepted: false,
+    };
+    this.videoResetState = resetState;
+
+    // Keep the planning/action barrier that made this frame wait necessary.
+    // Moving it forward to the reset request would add the device-clock
+    // calibration uncertainty a second time and can reject the first frame
+    // from the restarted encoder on high-latency ADB transports.
+    this.advanceStreamEpoch();
+    this.clearFrameCache();
+    // RESET_VIDEO recreates the encoder and emits a new configuration packet.
+    // Discard the old SPS/PPS so a new frame can never be decoded with stale
+    // codec configuration (for example after rotation).
+    this.spsHeader = null;
+
+    const resetPromise = Promise.resolve()
+      .then(() => controller.resetVideo())
+      .then(
+        () => {
+          debugScrcpy('Requested scrcpy in-band video reset');
+          if (this.videoResetState === resetState) {
+            resetState.writePromise = null;
+            if (resetState.frameAccepted) {
+              this.videoResetState = null;
+            }
+          }
+        },
+        (error) => {
+          if (this.videoResetState === resetState) {
+            // A failed RESET_VIDEO leaves the existing encoder alive. Restore
+            // its codec configuration so a naturally emitted frame can still
+            // satisfy the remainder of the original freshness window.
+            if (this.spsHeader === null) {
+              this.spsHeader = resetState.previousSpsHeader;
+            }
+            this.videoResetState = null;
+          }
+          throw error;
+        },
+      );
+    resetState.writePromise = resetPromise;
+    // A caller may time out before the underlying stream write settles. Keep
+    // observing it so a later rejection never becomes unhandled.
+    void resetPromise.catch(() => {});
+    await this.waitForVideoResetWrite(resetPromise, deadlineAt);
+  }
+
+  private async waitForVideoResetWrite(
+    writePromise: Promise<void>,
+    deadlineAt: number,
+  ): Promise<void> {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error('Scrcpy video reset exceeded the freshness deadline');
+    }
+
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        writePromise,
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new Error('Scrcpy video reset exceeded the freshness deadline'),
+              ),
+            remainingMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
   }
 
   /**
@@ -1002,6 +1165,7 @@ export class ScrcpyScreenshotManager {
       header: this.spsHeader,
       ptsUs: this.lastRawKeyframePtsUs,
       estimatedAgeMs: this.lastRawKeyframeEstimatedAgeMs,
+      streamEpoch: this.lastRawKeyframeStreamEpoch,
       capturedAt: this.lastRawKeyframeAt,
     };
   }
@@ -1013,11 +1177,37 @@ export class ScrcpyScreenshotManager {
    * sampled frames, never inside a capture loop.
    */
   async decodeRawKeyframeToJpeg(frame: RawKeyframe): Promise<Buffer> {
-    return this.decodeH264ToJpeg(Buffer.concat([frame.header, frame.data]));
+    const result = await this.decodeH264ToJpeg(
+      Buffer.concat([frame.header, frame.data]),
+    );
+    this.recordDecodedFrame(frame, result);
+    return result;
+  }
+
+  private recordDecodedFrame(frame: RawKeyframe, jpeg: Buffer): void {
+    // Every frame emitted by this manager is tagged. Untagged compatibility
+    // inputs may still be decoded, but fail closed for lifecycle state updates.
+    if (frame.streamEpoch !== this.streamEpoch) {
+      return;
+    }
+
+    const decodedResolution = encodedImageInfoOfBuffer(jpeg);
+    if (
+      this.videoResolution?.width !== decodedResolution.width ||
+      this.videoResolution?.height !== decodedResolution.height
+    ) {
+      debugScrcpy(
+        `Updating scrcpy resolution from ${this.videoResolution?.width ?? 0}x${this.videoResolution?.height ?? 0} to decoded frame ${decodedResolution.width}x${decodedResolution.height}`,
+      );
+      this.videoResolution = decodedResolution;
+    }
+    this.hasEstablishedVideoFrame = true;
+    this.streamStartupWindow = null;
   }
 
   private async waitForPlanningFrame(): Promise<RawKeyframe> {
     let planningBarrierArmed = false;
+    let videoResetAttempted = false;
     // A new encoder/stream gets the normal startup allowance while waiting for
     // its first data frame. The allowance never bypasses the age check below.
     // Established epochs still fail fast when they cannot cross a newly armed
@@ -1074,7 +1264,37 @@ export class ScrcpyScreenshotManager {
         );
       }
 
-      candidate = await this.waitForNextKeyframe(remainingMs);
+      const shouldTryVideoReset =
+        !videoResetAttempted &&
+        this.hasEstablishedVideoFrame &&
+        this.streamStartupWindow === null &&
+        Boolean(this.scrcpyClient?.controller?.resetVideo) &&
+        remainingMs > VIDEO_RESET_DELAY_MS;
+      const nextFrameWaitMs = shouldTryVideoReset
+        ? VIDEO_RESET_DELAY_MS
+        : remainingMs;
+
+      try {
+        candidate = await this.waitForNextKeyframe(nextFrameWaitMs);
+      } catch (error) {
+        if (!shouldTryVideoReset) {
+          throw error;
+        }
+
+        videoResetAttempted = true;
+        try {
+          await this.requestVideoReset(deadline);
+        } catch (resetError) {
+          // Preserve the rest of the original 300ms window. A natural frame
+          // may still arrive; otherwise the existing full reconnect and ADB
+          // fallback path will run at the unchanged deadline.
+          debugScrcpy(`Unable to request scrcpy video reset: ${resetError}`);
+        }
+        // The encoder can emit its one post-reset keyframe before the control
+        // write promise settles. Re-read the cache before subscribing for a
+        // later frame, otherwise a static screen may never emit another one.
+        candidate = this.getCachedKeyframeCandidate();
+      }
     }
   }
 
@@ -1138,7 +1358,7 @@ export class ScrcpyScreenshotManager {
     const t5 = Date.now();
     const result = await this.decodeH264ToJpeg(keyframeBuffer);
     const decodeTime = Date.now() - t5;
-    this.streamStartupWindow = null;
+    this.recordDecodedFrame(frame, result);
 
     const totalTime = Date.now() - perfStart;
     debugScrcpy(
@@ -1369,6 +1589,10 @@ export class ScrcpyScreenshotManager {
     this.keyframeResolvers = [];
     this.keyframeListeners.clear();
     this.resetFrameFreshnessState();
+    // Invalidate deferred refs before awaiting transport teardown. A blocked
+    // control-channel RESET_VIDEO write must not block disconnect/dispose.
+    this.advanceStreamEpoch();
+    this.streamReaderEpoch++;
 
     // Cancel reader first to stop consumeFramesLoop
     if (reader) {

--- a/packages/android/tests/unit-test/open-frame-source.test.ts
+++ b/packages/android/tests/unit-test/open-frame-source.test.ts
@@ -46,6 +46,9 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
     calibrateFrameClock(manager);
     const received: RawKeyframe[] = [];
     manager.subscribeKeyframes((frame) => received.push(frame));
+    (manager as any).streamStartupWindow = {
+      deadlineAt: Date.now() + 5_000,
+    };
 
     (manager as any).processFrame(spsPacket());
     (manager as any).processFrame(dataPacket(0x01));
@@ -56,7 +59,11 @@ describe('ScrcpyScreenshotManager keyframe subscription', () => {
     expect(received[1].data[5]).toBe(0x02);
     // header is the SPS/PPS configuration buffer
     expect(received[0].header[4]).toBe(0x67);
+    expect(received[0].streamEpoch).toBeDefined();
+    expect(received[1].streamEpoch).toBe(received[0].streamEpoch);
     expect(received[0].capturedAt).toBeGreaterThan(0);
+    expect((manager as any).hasEstablishedVideoFrame).toBe(true);
+    expect((manager as any).streamStartupWindow).toBeNull();
   });
 
   it('stops delivering after unsubscribe', () => {
@@ -122,11 +129,13 @@ describe('AndroidDevice frame-source capability', () => {
     const frameA: RawKeyframe = {
       data: idrFrame(0x0a),
       header: Buffer.from([0x67]),
+      streamEpoch: Symbol('stream-a'),
       capturedAt: 1000,
     };
     const frameB: RawKeyframe = {
       data: idrFrame(0x0b),
       header: Buffer.from([0x67]),
+      streamEpoch: frameA.streamEpoch,
       capturedAt: 2000,
     };
     let latestFrame: RawKeyframe | null = frameA;

--- a/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import {
+  ScrcpyScreenshotManager,
+  type ScrcpyServerPusher,
+} from '../../src/scrcpy-manager';
+
+const noopPushServer: ScrcpyServerPusher = async () => {};
+const createManager = (
+  adb: ConstructorParameters<typeof ScrcpyScreenshotManager>[0],
+) => new ScrcpyScreenshotManager(adb, noopPushServer);
+
+const prepareEstablishedStaleManager = (
+  manager: ScrcpyScreenshotManager,
+  resetVideo: () => Promise<void>,
+  options: {
+    hostWallTimeMs?: number;
+    clientExtras?: Record<string, unknown>;
+  } = {},
+) => {
+  const internals = manager as any;
+  internals.hasEstablishedVideoFrame = true;
+  internals.scrcpyClient = {
+    ...options.clientExtras,
+    controller: { resetVideo },
+  };
+  internals.spsHeader = Buffer.from('old-header');
+  internals.lastRawKeyframe = Buffer.from('stale-static-frame');
+  internals.lastRawKeyframePtsUs = 1_000_000n;
+  internals.deviceClockCalibration = {
+    deviceUptimeUs: 2_000_000n,
+    hostMonotonicUs: 10_000_000n,
+    hostWallTimeMs: options.hostWallTimeMs ?? 2_000,
+    roundTripUs: 10_000n,
+  };
+  rs.spyOn(internals, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+  rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+  rs.spyOn(internals, 'resetIdleTimer').mockImplementation(() => {});
+};
+
+const idrFrame = (tag: number): Buffer =>
+  Buffer.from([0x00, 0x00, 0x00, 0x01, 0x65, tag]);
+const spsPacket = () => ({
+  type: 'configuration',
+  data: Buffer.from([0x00, 0x00, 0x00, 0x01, 0x67, 0xaa]),
+});
+const dataPacket = (tag: number, pts: bigint) => ({
+  type: 'data',
+  data: idrFrame(tag),
+  pts,
+});
+const jpegFrame = (width = 1, height = 1): Buffer =>
+  Buffer.from([
+    0xff,
+    0xd8,
+    0xff,
+    0xc0,
+    0x00,
+    0x11,
+    0x08,
+    (height >> 8) & 0xff,
+    height & 0xff,
+    (width >> 8) & 0xff,
+    width & 0xff,
+    0x03,
+    0x01,
+    0x11,
+    0x00,
+    0x02,
+    0x11,
+    0x00,
+    0x03,
+    0x11,
+    0x00,
+    0xff,
+    0xd9,
+  ]);
+
+describe('ScrcpyScreenshotManager video reset', () => {
+  afterEach(() => {
+    rs.useRealTimers();
+    rs.restoreAllMocks();
+  });
+
+  it('resets an established static video stream before closing the connection', async () => {
+    const resetVideo = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo);
+    const freshFrame = {
+      data: Buffer.from('post-reset-frame'),
+      header: Buffer.from('new-header'),
+      ptsUs: 2_006_000n,
+      estimatedAgeMs: 0,
+      capturedAt: 2_000,
+    };
+    const waitForNextKeyframe = rs
+      .spyOn(manager as any, 'waitForNextKeyframe')
+      .mockRejectedValueOnce(new Error('no natural frame within 10ms'))
+      .mockImplementationOnce(async () => ({
+        ...freshFrame,
+        streamEpoch: (manager as any).streamEpoch,
+      }));
+    const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+    const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+    rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+      jpegFrame(1200, 2608),
+    );
+    const streamEpochBeforeReset = (manager as any).streamEpoch;
+
+    await expect(manager.getScreenshotJpeg()).resolves.toEqual(
+      jpegFrame(1200, 2608),
+    );
+
+    expect(waitForNextKeyframe.mock.calls[0][0]).toBe(10);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    expect((manager as any).streamEpoch).not.toBe(streamEpochBeforeReset);
+    expect(barrier).toHaveBeenCalledOnce();
+    expect(barrier).toHaveBeenCalledWith('stale planning frame');
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(manager.getResolution()).toEqual({ width: 1200, height: 2608 });
+  });
+
+  it('uses a natural fresh frame without resetting video when it arrives within 10ms', async () => {
+    const resetVideo = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo);
+    (manager as any).spsHeader = Buffer.from('header');
+    const waitForNextKeyframe = rs
+      .spyOn(manager as any, 'waitForNextKeyframe')
+      .mockResolvedValue({
+        data: Buffer.from('natural-frame'),
+        header: Buffer.from('header'),
+        ptsUs: 2_000_000n,
+        estimatedAgeMs: 0,
+        streamEpoch: (manager as any).streamEpoch,
+        capturedAt: 2_000,
+      });
+    rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(jpegFrame());
+
+    await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
+
+    expect(waitForNextKeyframe).toHaveBeenCalledWith(10);
+    expect(resetVideo).not.toHaveBeenCalled();
+  });
+
+  it('uses a post-reset frame that arrives before the control write settles', async () => {
+    let finishReset: (() => void) | undefined;
+    const resetVideo = rs.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishReset = resolve;
+      }),
+    );
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo);
+    const waitForNextKeyframe = rs
+      .spyOn(manager as any, 'waitForNextKeyframe')
+      .mockRejectedValueOnce(new Error('no natural frame within 10ms'));
+    rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(jpegFrame());
+
+    const capture = manager.getScreenshotJpeg();
+    await rs.waitFor(() => expect(resetVideo).toHaveBeenCalledTimes(1));
+    (manager as any).processFrame(spsPacket());
+    (manager as any).processFrame(dataPacket(0x01, 2_006_000n));
+    finishReset?.();
+
+    await expect(capture).resolves.toEqual(jpegFrame());
+    expect(waitForNextKeyframe).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one video reset across concurrent recovery callers', async () => {
+    let finishReset: (() => void) | undefined;
+    const resetVideo = rs.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishReset = resolve;
+      }),
+    );
+    const manager = createManager({} as any);
+    (manager as any).scrcpyClient = { controller: { resetVideo } };
+    (manager as any).deviceClockCalibration = {
+      deviceUptimeUs: 2_000_000n,
+      hostMonotonicUs: 10_000_000n,
+      hostWallTimeMs: 2_000,
+      roundTripUs: 10_000n,
+    };
+    rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+
+    const first = (manager as any).requestVideoReset();
+    const second = (manager as any).requestVideoReset();
+    await rs.waitFor(() => expect(resetVideo).toHaveBeenCalledTimes(1));
+    finishReset?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps reset singleflight ownership until both the write and a new frame complete', async () => {
+    let finishReset: (() => void) | undefined;
+    const resetVideo = rs.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishReset = resolve;
+      }),
+    );
+    const manager = createManager({} as any);
+    (manager as any).scrcpyClient = { controller: { resetVideo } };
+    (manager as any).deviceClockCalibration = {
+      deviceUptimeUs: 2_000_000n,
+      hostMonotonicUs: 10_000_000n,
+      hostWallTimeMs: 2_000,
+      roundTripUs: 10_000n,
+    };
+    rs.spyOn(manager as any, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+
+    const first = (manager as any).requestVideoReset();
+    await rs.waitFor(() => expect(resetVideo).toHaveBeenCalledTimes(1));
+    (manager as any).processFrame(spsPacket());
+    (manager as any).processFrame(dataPacket(0x01, 2_000_000n));
+    expect((manager as any).videoResetState?.frameAccepted).toBe(true);
+
+    const second = (manager as any).requestVideoReset();
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    finishReset?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    expect((manager as any).videoResetState).toBeNull();
+  });
+
+  it('restores the prior SPS header when the reset control write fails', async () => {
+    const manager = createManager({} as any);
+    const oldHeader = Buffer.from('old-header');
+    (manager as any).spsHeader = oldHeader;
+    (manager as any).scrcpyClient = {
+      controller: {
+        resetVideo: rs
+          .fn()
+          .mockRejectedValue(new Error('control stream write failed')),
+      },
+    };
+
+    await expect((manager as any).requestVideoReset()).rejects.toThrow(
+      'control stream write failed',
+    );
+
+    expect((manager as any).spsHeader).toEqual(oldHeader);
+    expect((manager as any).videoResetState).toBeNull();
+  });
+
+  it('bounds a blocked reset write by the original 300ms capture deadline', async () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
+    const resetVideo = rs.fn().mockReturnValue(new Promise<void>(() => {}));
+    const close = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo, {
+      hostWallTimeMs: Date.now(),
+      clientExtras: { close },
+    });
+
+    const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+      name: 'ScrcpyFreshFrameUnavailableError',
+      timeoutMs: 300,
+    });
+    await rs.advanceTimersByTimeAsync(299);
+    expect(close).not.toHaveBeenCalled();
+    await rs.advanceTimersByTimeAsync(1);
+
+    await capture;
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect((manager as any).videoResetState).toBeNull();
+  });
+
+  it('falls back to closing the stream when video reset cannot produce a frame', async () => {
+    const resetVideo = rs
+      .fn()
+      .mockRejectedValue(new Error('control stream write failed'));
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo);
+    rs.spyOn(manager as any, 'waitForNextKeyframe')
+      .mockRejectedValueOnce(new Error('no natural frame within 10ms'))
+      .mockRejectedValueOnce(new Error('no frame after reset attempt'));
+    const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+
+    await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+      name: 'ScrcpyFreshFrameUnavailableError',
+      failureKind: 'freshness-target',
+    });
+
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps video reset and full reconnect fallback inside the original 300ms budget', async () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
+    const resetVideo = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo, {
+      hostWallTimeMs: Date.now(),
+    });
+    const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+
+    const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+      name: 'ScrcpyFreshFrameUnavailableError',
+      timeoutMs: 300,
+    });
+    await rs.advanceTimersByTimeAsync(0);
+    await rs.advanceTimersByTimeAsync(9);
+    expect(resetVideo).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+
+    await rs.advanceTimersByTimeAsync(1);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    await rs.advanceTimersByTimeAsync(289);
+    expect(disconnect).not.toHaveBeenCalled();
+    await rs.advanceTimersByTimeAsync(1);
+
+    await capture;
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('observes a reset rejection that arrives after the caller deadline', async () => {
+    rs.useFakeTimers();
+    let rejectReset: ((reason: Error) => void) | undefined;
+    const resetVideo = rs.fn().mockReturnValue(
+      new Promise<void>((_resolve, reject) => {
+        rejectReset = reject;
+      }),
+    );
+    const manager = createManager({} as any);
+    const oldHeader = Buffer.from('old-header');
+    (manager as any).spsHeader = oldHeader;
+    (manager as any).scrcpyClient = { controller: { resetVideo } };
+
+    const resetOutcome = expect(
+      (manager as any).requestVideoReset(Date.now() + 50),
+    ).rejects.toThrow(/exceeded the freshness deadline/);
+    await rs.advanceTimersByTimeAsync(50);
+    await resetOutcome;
+
+    rejectReset?.(new Error('late control stream rejection'));
+    await rs.advanceTimersByTimeAsync(0);
+
+    expect((manager as any).spsHeader).toEqual(oldHeader);
+    expect((manager as any).videoResetState).toBeNull();
+  });
+
+  it('does not wait for a blocked RESET_VIDEO control write', async () => {
+    rs.useFakeTimers();
+    const resetVideo = rs.fn().mockReturnValue(new Promise<void>(() => {}));
+    const close = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    (manager as any).hasEstablishedVideoFrame = true;
+    (manager as any).streamStartupWindow = { deadlineAt: Date.now() + 5_000 };
+    (manager as any).scrcpyClient = {
+      controller: { resetVideo },
+      close,
+    };
+
+    const resetRequest = (manager as any).requestVideoReset();
+    const resetOutcome = expect(resetRequest).rejects.toThrow(
+      /exceeded the freshness deadline/,
+    );
+    await rs.advanceTimersByTimeAsync(0);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+
+    await expect(manager.disconnect()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect((manager as any).videoResetState).toBeNull();
+    expect((manager as any).hasEstablishedVideoFrame).toBe(false);
+    expect((manager as any).streamStartupWindow).toBeNull();
+
+    await rs.advanceTimersByTimeAsync(300);
+    await resetOutcome;
+  });
+});

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -26,9 +26,36 @@ const dataPacket = (tag: number, pts: bigint) => ({
   data: idrFrame(tag),
   pts,
 });
+const jpegFrame = (width = 1, height = 1): Buffer =>
+  Buffer.from([
+    0xff,
+    0xd8,
+    0xff,
+    0xc0,
+    0x00,
+    0x11,
+    0x08,
+    (height >> 8) & 0xff,
+    height & 0xff,
+    (width >> 8) & 0xff,
+    width & 0xff,
+    0x03,
+    0x01,
+    0x11,
+    0x00,
+    0x02,
+    0x11,
+    0x00,
+    0x03,
+    0x11,
+    0x00,
+    0xff,
+    0xd9,
+  ]);
 
 describe('ScrcpyScreenshotManager', () => {
   afterEach(() => {
+    rs.useRealTimers();
     rs.restoreAllMocks();
   });
 
@@ -150,6 +177,9 @@ describe('ScrcpyScreenshotManager', () => {
       const secondOptions = await (manager as any).createScrcpyOptions();
 
       expect(firstOptions.value).toMatchObject({
+        control: true,
+        powerOn: false,
+        clipboardAutosync: false,
         tunnelForward: true,
         maxSize: 1024,
         videoBitRate: 8_000_000,
@@ -440,6 +470,17 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).frameFreshnessError).toBeNull();
     });
 
+    it('ignores packets delivered by an obsolete stream reader', () => {
+      const manager = createManager({} as any);
+      (manager as any).streamReaderEpoch = 2;
+
+      (manager as any).processFrame(spsPacket(), 1);
+      (manager as any).processFrame(dataPacket(0x01, 1_000_000n), 1);
+
+      expect((manager as any).spsHeader).toBeNull();
+      expect((manager as any).lastRawKeyframe).toBeNull();
+    });
+
     it('projects every barrier from one stream-epoch clock sample', async () => {
       const manager = createManager({} as any);
       const readClock = rs
@@ -511,7 +552,9 @@ describe('ScrcpyScreenshotManager', () => {
     });
 
     it('rejects a delayed first frame even while the new-stream startup window is active', async () => {
+      const resetVideo = rs.fn().mockResolvedValue(undefined);
       const manager = createManager({} as any);
+      (manager as any).scrcpyClient = { controller: { resetVideo } };
       (manager as any).spsHeader = Buffer.from('header');
       (manager as any).lastRawKeyframe = Buffer.from('delayed-in-transport');
       (manager as any).lastRawKeyframePtsUs = 1_000_000n;
@@ -541,6 +584,7 @@ describe('ScrcpyScreenshotManager', () => {
       });
       expect(waitForNextKeyframe).toHaveBeenCalledOnce();
       expect(setBarrier).toHaveBeenCalledWith('stale planning frame');
+      expect(resetVideo).not.toHaveBeenCalled();
       expect(disconnect).toHaveBeenCalledOnce();
       expect(decode).not.toHaveBeenCalled();
     });
@@ -567,15 +611,14 @@ describe('ScrcpyScreenshotManager', () => {
           header: Buffer.from('header'),
           ptsUs: 2_000_000n,
           estimatedAgeMs: 0,
+          streamEpoch: (manager as any).streamEpoch,
           capturedAt: 2_000,
         });
       rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
-        Buffer.from('jpeg'),
+        jpegFrame(),
       );
 
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
       const startupWaitMs = waitForNextKeyframe.mock.calls[0][0];
       expect(startupWaitMs).toBeGreaterThan(4_000);
       expect(startupWaitMs).toBeLessThanOrEqual(5_000);
@@ -834,11 +877,9 @@ describe('ScrcpyScreenshotManager', () => {
       const setBarrier = rs.spyOn(manager, 'setFreshnessBarrier');
       const decode = rs
         .spyOn(manager as any, 'decodeH264ToJpeg')
-        .mockResolvedValue(Buffer.from('jpeg'));
+        .mockResolvedValue(jpegFrame());
 
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
       expect(setBarrier).not.toHaveBeenCalled();
       expect(waitForNext).not.toHaveBeenCalled();
       expect(decode).toHaveBeenCalledWith(
@@ -874,11 +915,9 @@ describe('ScrcpyScreenshotManager', () => {
       const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
       const decode = rs
         .spyOn(manager as any, 'decodeH264ToJpeg')
-        .mockResolvedValue(Buffer.from('jpeg'));
+        .mockResolvedValue(jpegFrame());
 
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
       expect(barrier).toHaveBeenCalledWith('stale planning frame');
       expect((manager as any).frameFreshnessBarrierPtsUs).toBe(2_006_000n);
       expect(decode).toHaveBeenCalledWith(
@@ -912,12 +951,10 @@ describe('ScrcpyScreenshotManager', () => {
       });
       const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
       rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
-        Buffer.from('jpeg'),
+        jpegFrame(),
       );
 
-      await expect(manager.getScreenshotJpeg()).resolves.toEqual(
-        Buffer.from('jpeg'),
-      );
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
       expect(barrier).toHaveBeenCalledWith('stale planning frame');
     });
 
@@ -957,6 +994,82 @@ describe('ScrcpyScreenshotManager', () => {
       expect(warn).not.toHaveBeenCalled();
     });
 
+    it('updates capture state when a current deferred keyframe is decoded', async () => {
+      const manager = createManager({} as any);
+      const currentStreamEpoch = Symbol('current-stream');
+      (manager as any).streamEpoch = currentStreamEpoch;
+      (manager as any).videoResolution = { width: 1080, height: 1920 };
+      (manager as any).streamStartupWindow = {
+        deadlineAt: Date.now() + 5_000,
+      };
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(1200, 2608),
+      );
+
+      await expect(
+        manager.decodeRawKeyframeToJpeg({
+          data: Buffer.from('frame'),
+          header: Buffer.from('header'),
+          streamEpoch: currentStreamEpoch,
+          capturedAt: Date.now(),
+        }),
+      ).resolves.toEqual(jpegFrame(1200, 2608));
+
+      expect(manager.getResolution()).toEqual({ width: 1200, height: 2608 });
+      expect((manager as any).hasEstablishedVideoFrame).toBe(true);
+      expect((manager as any).streamStartupWindow).toBeNull();
+    });
+
+    it('decodes an untagged keyframe without mutating current stream state', async () => {
+      const manager = createManager({} as any);
+      const startupWindow = { deadlineAt: Date.now() + 5_000 };
+      (manager as any).videoResolution = { width: 1080, height: 1920 };
+      (manager as any).streamStartupWindow = startupWindow;
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(1200, 2608),
+      );
+
+      await expect(
+        manager.decodeRawKeyframeToJpeg({
+          data: Buffer.from('compatibility-frame'),
+          header: Buffer.from('header'),
+          capturedAt: Date.now(),
+        }),
+      ).resolves.toEqual(jpegFrame(1200, 2608));
+
+      expect(manager.getResolution()).toEqual({ width: 1080, height: 1920 });
+      expect((manager as any).hasEstablishedVideoFrame).toBe(false);
+      expect((manager as any).streamStartupWindow).toBe(startupWindow);
+    });
+
+    it('does not let a deferred keyframe from a replaced manager overwrite current state', async () => {
+      const oldManager = createManager({} as any);
+      const manager = createManager({} as any);
+      const startupWindow = { deadlineAt: Date.now() + 5_000 };
+      (oldManager as any).advanceStreamEpoch();
+      (manager as any).advanceStreamEpoch();
+      const oldStreamEpoch = (oldManager as any).streamEpoch;
+      expect((manager as any).streamEpoch).not.toBe(oldStreamEpoch);
+      (manager as any).videoResolution = { width: 1080, height: 1920 };
+      (manager as any).streamStartupWindow = startupWindow;
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(1200, 2608),
+      );
+
+      await expect(
+        manager.decodeRawKeyframeToJpeg({
+          data: Buffer.from('old-frame'),
+          header: Buffer.from('old-header'),
+          streamEpoch: oldStreamEpoch,
+          capturedAt: Date.now(),
+        }),
+      ).resolves.toEqual(jpegFrame(1200, 2608));
+
+      expect(manager.getResolution()).toEqual({ width: 1080, height: 1920 });
+      expect((manager as any).hasEstablishedVideoFrame).toBe(false);
+      expect((manager as any).streamStartupWindow).toBe(startupWindow);
+    });
+
     it('rejects frames without PTS instead of treating arrival time as freshness', async () => {
       const manager = createManager({} as any);
       (manager as any).spsHeader = Buffer.from('header');
@@ -989,6 +1102,8 @@ describe('ScrcpyScreenshotManager', () => {
       (manager as any).deviceClockCalibration = {};
       (manager as any).lastFramePtsUs = 456n;
       (manager as any).frameFreshnessError = new Error('stale');
+      (manager as any).hasEstablishedVideoFrame = true;
+      (manager as any).videoResetState = { frameAccepted: true };
       (manager as any).streamStartupWindow = {
         deadlineAt: Date.now() + 5_000,
       };
@@ -1006,6 +1121,8 @@ describe('ScrcpyScreenshotManager', () => {
       expect((manager as any).deviceClockCalibration).toBeNull();
       expect((manager as any).lastFramePtsUs).toBeNull();
       expect((manager as any).frameFreshnessError).toBeNull();
+      expect((manager as any).hasEstablishedVideoFrame).toBe(false);
+      expect((manager as any).videoResetState).toBeNull();
       expect((manager as any).streamStartupWindow).toBeNull();
     });
 

--- a/packages/shared/src/img/index.ts
+++ b/packages/shared/src/img/index.ts
@@ -1,4 +1,5 @@
 export {
+  encodedImageInfoOfBuffer,
   imageInfoOfBase64,
   isValidPNGImageBuffer,
   isValidJPEGImageBuffer,


### PR DESCRIPTION
## Summary

- recover stale screenshots on static Android screens by requesting an in-band scrcpy `RESET_VIDEO` after a short natural-frame grace period
- keep reset, reconnect, and ADB fallback inside the existing freshness deadline while isolating obsolete readers and deferred frames by transport and encoder epoch
- refresh the reported resolution from the decoded JPEG and harden reset singleflight, timeout, late-rejection, and disconnect cleanup behavior
- split the reset-specific regression coverage into a dedicated unit-test suite

## Validation

- `pnpm --dir packages/android test tests/unit-test/scrcpy-manager-video-reset.test.ts tests/unit-test/scrcpy-manager.test.ts tests/unit-test/open-frame-source.test.ts` (78 passed)
- `pnpm exec nx test android` (453 passed)
- `pnpm exec nx build shared`
- `pnpm exec nx build android`
- `pnpm run type-check:tests`
- `pnpm run lint`
- manual reproduction and verification on a K80 device running Android 11

## Review

- baseline code review: clean after fixes
- thermo-nuclear maintainability review: clean after fixes
- reviewed immutable patch SHA-256: `77cd9940bd3cdfeb136a707d963abcd127ad94f393e4eb0f2f4d09080d5853b7`