### PR TITLE
fix(ios): make keyboard auto-dismiss best effort

### DIFF
--- a/apps/site/docs/en/platforms/ios.mdx
+++ b/apps/site/docs/en/platforms/ios.mdx
@@ -133,7 +133,7 @@ After the script finishes, you should see `Midscene - report file updated: /path
 
 ## Keyboard dismissal
 
-`autoDismissKeyboard` defaults to `true`. After entering text, Midscene locates the standard iOS keyboard accessory toolbar, activates its dismissal control, and waits until WebDriverAgent confirms that the keyboard is hidden. If the toolbar cannot be identified safely or the keyboard does not disappear before the operation deadline, the input action fails instead of continuing with an uncertain keyboard state.
+`autoDismissKeyboard` defaults to `true`. After entering text, Midscene makes a best-effort attempt to locate the standard iOS keyboard accessory toolbar, activate its dismissal control, and wait until WebDriverAgent confirms that the keyboard is hidden. Some keyboards, such as the iPhone number pad, do not expose a dismissal control. If the toolbar cannot be identified safely, the keyboard remains visible, or the dismissal request fails, the input action continues and Midscene logs a warning.
 
 When an `Enter`, `Return`, or `Tab` action immediately follows an auto-dismissed input, Midscene can restore that input's focus once before sending the key. A different pointer, touch, system, custom, or text-input action invalidates the pending focus target.
 

--- a/apps/site/docs/en/platforms/ios.mdx
+++ b/apps/site/docs/en/platforms/ios.mdx
@@ -133,7 +133,7 @@ After the script finishes, you should see `Midscene - report file updated: /path
 
 ## Keyboard dismissal
 
-`autoDismissKeyboard` defaults to `true`. After entering text, Midscene makes a best-effort attempt to locate the standard iOS keyboard accessory toolbar, activate its dismissal control, and wait until WebDriverAgent confirms that the keyboard is hidden. Some keyboards, such as the iPhone number pad, do not expose a dismissal control. If the toolbar cannot be identified safely, the keyboard remains visible, or the dismissal request fails, the input action continues and Midscene logs a warning.
+`autoDismissKeyboard` defaults to `true`. After entering text, Midscene makes a best-effort attempt to locate the standard iOS keyboard accessory toolbar, activate its dismissal control, and wait until WebDriverAgent confirms that the keyboard is hidden. Some keyboards, such as the iPhone number pad, do not expose a dismissal control. If the toolbar cannot be identified safely, the keyboard remains visible, or the dismissal request fails, Midscene does not treat the text input as failed for that reason and only logs a warning.
 
 When an `Enter`, `Return`, or `Tab` action immediately follows an auto-dismissed input, Midscene can restore that input's focus once before sending the key. A different pointer, touch, system, custom, or text-input action invalidates the pending focus target.
 

--- a/apps/site/docs/zh/platforms/ios.mdx
+++ b/apps/site/docs/zh/platforms/ios.mdx
@@ -133,7 +133,7 @@ npx tsx demo.ts
 
 ## 隐藏键盘
 
-`autoDismissKeyboard` 默认值为 `true`。文本输入完成后，Midscene 会定位标准的 iOS 键盘辅助工具栏，触发其中的隐藏控件，并等待 WebDriverAgent 确认键盘已经消失。如果无法安全识别工具栏，或者键盘未在操作期限内消失，输入动作会直接失败，不会在键盘状态不确定时继续执行。
+`autoDismissKeyboard` 默认值为 `true`。文本输入完成后，Midscene 会尽力定位标准的 iOS 键盘辅助工具栏、触发其中的隐藏控件，并等待 WebDriverAgent 确认键盘已经消失。部分键盘（例如 iPhone 数字键盘）不提供隐藏控件。如果无法安全识别工具栏、键盘仍然可见或隐藏请求失败，输入动作会继续执行，Midscene 会记录一条警告日志。
 
 如果自动隐藏键盘后紧接着执行 `Enter`、`Return` 或 `Tab`，Midscene 可以在发送按键前恢复一次原输入框的焦点。其他指针、触控、系统、自定义或文本输入动作都会使这个待恢复目标失效。
 

--- a/apps/site/docs/zh/platforms/ios.mdx
+++ b/apps/site/docs/zh/platforms/ios.mdx
@@ -133,7 +133,7 @@ npx tsx demo.ts
 
 ## 隐藏键盘
 
-`autoDismissKeyboard` 默认值为 `true`。文本输入完成后，Midscene 会尽力定位标准的 iOS 键盘辅助工具栏、触发其中的隐藏控件，并等待 WebDriverAgent 确认键盘已经消失。部分键盘（例如 iPhone 数字键盘）不提供隐藏控件。如果无法安全识别工具栏、键盘仍然可见或隐藏请求失败，输入动作会继续执行，Midscene 会记录一条警告日志。
+`autoDismissKeyboard` 默认值为 `true`。文本输入完成后，Midscene 会尽力定位标准的 iOS 键盘辅助工具栏、触发其中的隐藏控件，并等待 WebDriverAgent 确认键盘已经消失。部分键盘（例如 iPhone 数字键盘）不提供隐藏控件。如果无法安全识别工具栏、键盘仍然可见或隐藏请求失败，Midscene 不会因此将本次文本输入判为失败，只会记录一条警告日志。
 
 如果自动隐藏键盘后紧接着执行 `Enter`、`Return` 或 `Tab`，Midscene 可以在发送按键前恢复一次原输入框的焦点。其他指针、触控、系统、自定义或文本输入动作都会使这个待恢复目标失效。
 

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -36,6 +36,7 @@ import { MjpegFrameSource } from './mjpeg-frame-source';
 export type { IOSDeviceOpt, IOSDeviceInputOpt } from '@midscene/core/device';
 
 const debugDevice = getDebug('ios:device');
+const debugDeviceWarning = getDebug('ios:device', { console: true });
 
 /**
  * HTTP methods supported by WebDriverAgent API
@@ -198,6 +199,25 @@ export class IOSDevice implements AbstractInterface {
     }
 
     return pendingFollowUp.target;
+  }
+
+  private async tryAutoDismissKeyboard(): Promise<boolean> {
+    let dismissed: boolean;
+    try {
+      dismissed = await this.hideKeyboard();
+    } catch (error) {
+      debugDeviceWarning(
+        'Text input request completed, but auto-dismissing the iOS keyboard failed',
+        error,
+      );
+      return false;
+    }
+    if (!dismissed) {
+      debugDeviceWarning(
+        'Text input request completed, but the iOS keyboard could not be auto-dismissed because no supported dismissal control was found or the keyboard remained visible',
+      );
+    }
+    return dismissed;
   }
 
   private async tapPoint(point: PointerPoint): Promise<void> {
@@ -673,13 +693,10 @@ ScreenSize: ${size.width}x${size.height} (DPR: ${size.scale})
     }
 
     if (shouldAutoDismissKeyboard) {
-      const dismissed = await this.hideKeyboard();
-      if (!dismissed) {
-        throw new Error(
-          'Failed to auto-dismiss the iOS keyboard: no supported dismissal control was found or the keyboard remained visible',
-        );
+      const dismissed = await this.tryAutoDismissKeyboard();
+      if (dismissed) {
+        this.registerPendingKeyboardFollowUp(focusRestorePoint);
       }
-      this.registerPendingKeyboardFollowUp(focusRestorePoint);
     }
   }
 

--- a/packages/ios/tests/unit-test/device.test.ts
+++ b/packages/ios/tests/unit-test/device.test.ts
@@ -760,13 +760,55 @@ describe('IOSDevice', () => {
       expect(mockBackend.swipe).not.toHaveBeenCalled();
     });
 
-    it('should reject input when auto-dismiss cannot hide the keyboard', async () => {
-      mockWdaClient.isKeyboardVisible = rs.fn().mockResolvedValue(true);
+    it('should continue input when auto-dismiss cannot hide the keyboard', async () => {
       mockWdaClient.dismissKeyboard = rs.fn().mockResolvedValue(false);
+      const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
 
-      await expect(
-        getInternalTextInput(device).typeText('test text'),
-      ).rejects.toThrow('Failed to auto-dismiss the iOS keyboard');
+      try {
+        await expect(
+          device.inputPrimitives.keyboard.typeText('test text', {
+            target: { center: [30, 40] },
+            replace: false,
+          }),
+        ).resolves.toBeUndefined();
+        expect(mockWdaClient.typeText).toHaveBeenCalledWith('test text');
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[Midscene]',
+          expect.stringContaining(
+            'Text input request completed, but the iOS keyboard could not be auto-dismissed',
+          ),
+        );
+
+        mockWdaClient.tap.mockClear();
+        await device.inputPrimitives.keyboard.keyboardPress('Enter');
+        expect(mockWdaClient.tap).not.toHaveBeenCalled();
+        expect(mockWdaClient.pressKey).toHaveBeenCalledWith('Enter');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('should continue input when auto-dismiss throws', async () => {
+      const transportError = new Error('WDA transport failed');
+      mockWdaClient.dismissKeyboard = rs.fn().mockRejectedValue(transportError);
+      const warnSpy = rs.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        await expect(
+          getInternalTextInput(device).typeText('test text'),
+        ).resolves.toBeUndefined();
+        expect(mockWdaClient.typeText).toHaveBeenCalledWith('test text');
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[Midscene]',
+          'Text input request completed, but auto-dismissing the iOS keyboard failed',
+          expect.any(Error),
+        );
+        expect(warnSpy.mock.calls[0][2]).toMatchObject({
+          cause: transportError,
+        });
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('should preserve WDA dismissal errors', async () => {


### PR DESCRIPTION
## Summary

- Treat automatic iOS keyboard dismissal after text input as a best-effort cleanup step.
- Keep explicit `hideKeyboard()` failures observable while logging automatic dismissal failures through the iOS device debug channel.
- Register follow-up focus restoration only after the keyboard is confirmed to be dismissed.
- Document the behavior for keyboards without a dismissal control, including number pads, in English and Chinese.

## Validation

- `pnpm exec nx test @midscene/ios`
- `pnpm --filter @midscene/ios test -- tests/unit-test/device.test.ts`
- `pnpm run lint`
- `git diff --check`

## Review

- Completed the layered standard and thermo-nuclear code-quality reviews.
- Final reconciled verdict: acceptable, with no remaining findings.