### PR TITLE
fix(core): make JSON object validation explicit

### DIFF
--- a/packages/core/src/ai-model/model-adapter/default-insight-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-insight-protocol.ts
@@ -22,7 +22,6 @@ ${serializedData}
       try {
         return jsonParser(dataJsonContent, {
           source: 'generic-object',
-          requireObject: false,
         }) as T;
       } catch (error) {
         throw new Error(`Failed to parse data-json: ${error}`);

--- a/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
@@ -124,8 +124,13 @@ const createParseRawResponse =
   ): ParsedLocateResponse => {
     const parsedResponse = jsonParser(content, {
       source,
+      requireObject: true,
     });
-    if (!parsedResponse || typeof parsedResponse !== 'object') {
+    if (
+      !parsedResponse ||
+      typeof parsedResponse !== 'object' ||
+      Array.isArray(parsedResponse)
+    ) {
       throw new Error(`Failed to parse JSON locate response: ${content}`);
     }
     const record = parsedResponse as Record<string, unknown>;

--- a/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
@@ -1,5 +1,9 @@
 import { getPreferredLanguage } from '@midscene/shared/env';
-import type { JsonParser, JsonParserSource } from '../shared/json';
+import {
+  type JsonParser,
+  type JsonParserSource,
+  assertJsonObject,
+} from '../shared/json';
 import {
   type LocateResultPromptSpec,
   formatLocateExampleValue,
@@ -124,16 +128,9 @@ const createParseRawResponse =
   ): ParsedLocateResponse => {
     const parsedResponse = jsonParser(content, {
       source,
-      requireObject: true,
     });
-    if (
-      !parsedResponse ||
-      typeof parsedResponse !== 'object' ||
-      Array.isArray(parsedResponse)
-    ) {
-      throw new Error(`Failed to parse JSON locate response: ${content}`);
-    }
-    const record = parsedResponse as Record<string, unknown>;
+    assertJsonObject(parsedResponse);
+    const record = parsedResponse;
     const target =
       record[promptSpec.resultKey] !== undefined
         ? record[promptSpec.resultKey]

--- a/packages/core/src/ai-model/model-adapter/default-planning-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-planning-protocol.ts
@@ -192,6 +192,7 @@ export const createMidscenePlanningActionOutputParser =
       try {
         param = jsonParser(actionParamStr, {
           source: 'planning-action-param',
+          requireObject: false,
           preserveStringValueKeys:
             type.toLowerCase() === 'input' ? ['value'] : undefined,
         });

--- a/packages/core/src/ai-model/model-adapter/default-planning-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-planning-protocol.ts
@@ -5,7 +5,7 @@ import {
 } from '@midscene/shared/zod-schema-utils';
 import type { z } from 'zod';
 import { getZodDefaultValue } from '../shared/action-schema';
-import type { JsonParser } from '../shared/json';
+import { type JsonParser, assertJsonObject } from '../shared/json';
 import {
   type LocateResultPromptSpec,
   formatLocateExampleValue,
@@ -192,10 +192,10 @@ export const createMidscenePlanningActionOutputParser =
       try {
         param = jsonParser(actionParamStr, {
           source: 'planning-action-param',
-          requireObject: false,
           preserveStringValueKeys:
             type.toLowerCase() === 'input' ? ['value'] : undefined,
         });
+        assertJsonObject(param);
       } catch (error) {
         throw new Error(`Failed to parse action-param-json: ${error}`);
       }

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -42,7 +42,7 @@ import type { ChatCompletionMessageParam } from 'openai/resources/index';
 import type { Stream } from 'openai/streaming';
 import { getVersion } from '../../utils';
 import type { ModelRuntime } from '../models';
-import type { JsonParserSource } from '../shared/json';
+import { type JsonParserSource, assertJsonObject } from '../shared/json';
 import {
   callAIWithCodexAppServer,
   isCodexAppServerProvider,
@@ -926,19 +926,12 @@ export function parseAIObjectResponse<T>(
   modelRuntime: ModelRuntime,
   jsonParserSource: JsonParserSource = 'generic-object',
 ): AIObjectResponse<T> {
-  const { config: modelConfig, adapter } = modelRuntime;
+  const { adapter } = modelRuntime;
   assert(response, 'empty response');
   const jsonContent = adapter.jsonParser(response.content, {
     source: jsonParserSource,
-    requireObject: true,
   });
-  // This API expects a JSON object. Bare JSON primitives are valid JSON,
-  // but do not satisfy object-response callers.
-  if (!jsonContent || typeof jsonContent !== 'object') {
-    throw new Error(
-      `failed to parse json response from model (${modelConfig.modelName}): ${response.content}`,
-    );
-  }
+  assertJsonObject(jsonContent);
   return {
     content: jsonContent as T,
     contentString: response.content,

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -930,6 +930,7 @@ export function parseAIObjectResponse<T>(
   assert(response, 'empty response');
   const jsonContent = adapter.jsonParser(response.content, {
     source: jsonParserSource,
+    requireObject: true,
   });
   // This API expects a JSON object. Bare JSON primitives are valid JSON,
   // but do not satisfy object-response callers.

--- a/packages/core/src/ai-model/shared/json.ts
+++ b/packages/core/src/ai-model/shared/json.ts
@@ -52,8 +52,6 @@ export type JsonParserSource =
 export interface JsonParserContext {
   source: JsonParserSource;
   preserveStringValueKeys?: string[];
-  /** Require the parsed top-level JSON value to be an object. Defaults to false. */
-  requireObject?: boolean;
 }
 
 export type JsonParser = (raw: string, context?: JsonParserContext) => unknown;
@@ -118,7 +116,7 @@ function repairKnownJsonIssues(
   return jsonBlock;
 }
 
-function assertJsonObject(
+export function assertJsonObject(
   parsed: unknown,
 ): asserts parsed is Record<string, unknown> {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -146,7 +144,6 @@ export function parseModelResponseJson(
   context?: JsonParserContext,
 ) {
   const cleanJsonString = extractJSONFromCodeBlock(raw);
-  const requireObject = context?.requireObject ?? false;
 
   let parsedObj: unknown;
 
@@ -171,10 +168,6 @@ export function parseModelResponseJson(
         )}. Second error - ${String(e2)}. Response - \n ${raw}`,
       );
     }
-  }
-
-  if (requireObject) {
-    assertJsonObject(parsedObj);
   }
 
   return trimParsedJsonStrings(parsedObj, context);

--- a/packages/core/src/ai-model/shared/json.ts
+++ b/packages/core/src/ai-model/shared/json.ts
@@ -52,6 +52,7 @@ export type JsonParserSource =
 export interface JsonParserContext {
   source: JsonParserSource;
   preserveStringValueKeys?: string[];
+  /** Require the parsed top-level JSON value to be an object. Defaults to false. */
   requireObject?: boolean;
 }
 
@@ -121,10 +122,13 @@ function assertJsonObject(
   parsed: unknown,
 ): asserts parsed is Record<string, unknown> {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    const parsedType = Array.isArray(parsed)
+      ? 'array'
+      : parsed === null
+        ? 'null'
+        : typeof parsed;
     throw new Error(
-      `expected parsed LLM response to be a JSON object, got ${JSON.stringify(
-        parsed,
-      )}`,
+      `LLM response is valid JSON but does not match the expected schema. Expected to be a JSON object, got ${parsedType}: ${JSON.stringify(parsed)}.`,
     );
   }
 }
@@ -142,15 +146,12 @@ export function parseModelResponseJson(
   context?: JsonParserContext,
 ) {
   const cleanJsonString = extractJSONFromCodeBlock(raw);
-  const requireObject = context?.requireObject ?? true;
+  const requireObject = context?.requireObject ?? false;
 
   let parsedObj: unknown;
 
   try {
     parsedObj = parseJsonWithRepair(cleanJsonString);
-    if (requireObject) {
-      assertJsonObject(parsedObj);
-    }
   } catch (e1) {
     const code = repairKnownJsonIssues(cleanJsonString, raw);
     if (code === cleanJsonString) {
@@ -163,9 +164,6 @@ export function parseModelResponseJson(
 
     try {
       parsedObj = parseJsonWithRepair(code);
-      if (requireObject) {
-        assertJsonObject(parsedObj);
-      }
     } catch (e2) {
       throw new Error(
         `failed to parse LLM response into JSON. First error - ${String(
@@ -173,6 +171,10 @@ export function parseModelResponseJson(
         )}. Second error - ${String(e2)}. Response - \n ${raw}`,
       );
     }
+  }
+
+  if (requireObject) {
+    assertJsonObject(parsedObj);
   }
 
   return trimParsedJsonStrings(parsedObj, context);

--- a/packages/core/src/ai-model/workflows/insight/insight-response-parser.ts
+++ b/packages/core/src/ai-model/workflows/insight/insight-response-parser.ts
@@ -21,7 +21,6 @@ export function parseInsightResponse<T>(
     try {
       const parsedErrors = jsonParser(errorsContent, {
         source: 'generic-object',
-        requireObject: false,
       });
       if (Array.isArray(parsedErrors)) {
         errors = parsedErrors;

--- a/packages/core/tests/unit-test/json.test.ts
+++ b/packages/core/tests/unit-test/json.test.ts
@@ -89,13 +89,11 @@ describe('parseModelResponseJson', () => {
     );
   });
 
-  it('should reject top-level non-object JSON values', () => {
-    expect(() => parseModelResponseJson('[1, 2]')).toThrow(
-      /expected parsed LLM response to be a JSON object/,
-    );
+  it('should allow top-level non-object JSON values by default', () => {
+    expect(parseModelResponseJson('[1, 2]')).toEqual([1, 2]);
   });
 
-  it('should allow top-level non-object JSON values when object validation is disabled', () => {
+  it('should allow top-level non-object JSON values when object validation is explicitly disabled', () => {
     expect(
       parseModelResponseJson('[" todo 1 ", " todo 2 "]', {
         source: 'generic-object',
@@ -117,6 +115,24 @@ describe('parseModelResponseJson', () => {
       }),
     ).toBe(42);
   });
+
+  it.each([
+    { input: '[1, 2]', parsedType: 'array', parsedValue: '[1,2]' },
+    { input: 'null', parsedType: 'null', parsedValue: 'null' },
+    { input: '"text"', parsedType: 'string', parsedValue: '"text"' },
+  ])(
+    'should report a schema mismatch for a parsed $parsedType when an object is required',
+    ({ input, parsedType, parsedValue }) => {
+      expect(() =>
+        parseModelResponseJson(input, {
+          source: 'generic-object',
+          requireObject: true,
+        }),
+      ).toThrow(
+        `LLM response is valid JSON but does not match the expected schema. Expected to be a JSON object, got ${parsedType}: ${parsedValue}.`,
+      );
+    },
+  );
 
   it('should parse JSON from code block', () => {
     const input = '```json\n{"key": "value"}\n```';

--- a/packages/core/tests/unit-test/json.test.ts
+++ b/packages/core/tests/unit-test/json.test.ts
@@ -89,50 +89,26 @@ describe('parseModelResponseJson', () => {
     );
   });
 
-  it('should allow top-level non-object JSON values by default', () => {
-    expect(parseModelResponseJson('[1, 2]')).toEqual([1, 2]);
-  });
-
-  it('should allow top-level non-object JSON values when object validation is explicitly disabled', () => {
+  it('should allow top-level non-object JSON values', () => {
     expect(
       parseModelResponseJson('[" todo 1 ", " todo 2 "]', {
         source: 'generic-object',
-        requireObject: false,
       }),
     ).toEqual(['todo 1', 'todo 2']);
 
     expect(
       parseModelResponseJson('" todo list "', {
         source: 'generic-object',
-        requireObject: false,
       }),
     ).toBe('todo list');
 
     expect(
       parseModelResponseJson('42', {
         source: 'generic-object',
-        requireObject: false,
       }),
     ).toBe(42);
+    expect(parseModelResponseJson('null')).toBeNull();
   });
-
-  it.each([
-    { input: '[1, 2]', parsedType: 'array', parsedValue: '[1,2]' },
-    { input: 'null', parsedType: 'null', parsedValue: 'null' },
-    { input: '"text"', parsedType: 'string', parsedValue: '"text"' },
-  ])(
-    'should report a schema mismatch for a parsed $parsedType when an object is required',
-    ({ input, parsedType, parsedValue }) => {
-      expect(() =>
-        parseModelResponseJson(input, {
-          source: 'generic-object',
-          requireObject: true,
-        }),
-      ).toThrow(
-        `LLM response is valid JSON but does not match the expected schema. Expected to be a JSON object, got ${parsedType}: ${parsedValue}.`,
-      );
-    },
-  );
 
   it('should parse JSON from code block', () => {
     const input = '```json\n{"key": "value"}\n```';

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -107,16 +107,27 @@ describe('llm planning - doubao', () => {
 });
 
 describe('llm planning - action parameters', () => {
-  it('parses a primitive action parameter', () => {
-    const result = parseStandardPlanningResponse(`
+  it('rejects a primitive action parameter', () => {
+    expect(() =>
+      parseStandardPlanningResponse(`
 <action-type>CustomAction</action-type>
 <action-param-json>"hello world"</action-param-json>
-    `);
+    `),
+    ).toThrow('Expected to be a JSON object, got string');
+  });
 
-    expect(result.action).toEqual({
-      type: 'CustomAction',
-      param: 'hello world',
+  it('rejects an array returned by a custom JSON parser', () => {
+    const planningProtocol = createDefaultMidscenePlanningProtocol({
+      jsonParser: () => [{ custom: true }],
     });
+
+    expect(() =>
+      planningProtocol.actionOutputProtocol.parseActionOutput(
+        `<action-type>CustomAction</action-type>
+<action-param-json>{custom syntax}</action-param-json>`,
+        [],
+      ),
+    ).toThrow('Expected to be a JSON object, got array');
   });
 });
 

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -106,6 +106,20 @@ describe('llm planning - doubao', () => {
   });
 });
 
+describe('llm planning - action parameters', () => {
+  it('parses a primitive action parameter', () => {
+    const result = parseStandardPlanningResponse(`
+<action-type>CustomAction</action-type>
+<action-param-json>"hello world"</action-param-json>
+    `);
+
+    expect(result.action).toEqual({
+      type: 'CustomAction',
+      param: 'hello world',
+    });
+  });
+});
+
 describe('llm planning - build yaml flow', () => {
   it('throws when planned action is not in actionSpace', () => {
     expect(() =>

--- a/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
@@ -149,7 +149,6 @@ describe('default locate protocol', () => {
     ).toEqual({ kind: 'located', target: [100, 200, 300, 400] });
     expect(jsonParser).toHaveBeenCalledWith('model-specific response', {
       source: 'locate',
-      requireObject: true,
     });
 
     searchAreaProtocol.parseRawResponse(
@@ -158,7 +157,6 @@ describe('default locate protocol', () => {
     );
     expect(jsonParser).toHaveBeenLastCalledWith('model-specific response', {
       source: 'section-locator',
-      requireObject: true,
     });
   });
 
@@ -179,6 +177,6 @@ describe('default locate protocol', () => {
         'model-specific response',
         locatePromptSpec,
       ),
-    ).toThrow('Failed to parse JSON locate response');
+    ).toThrow('Expected to be a JSON object, got array');
   });
 });

--- a/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
@@ -75,7 +75,9 @@ describe('default locate protocol', () => {
     });
     expect(() =>
       elementProtocol.parseRawResponse('null', locatePromptSpec),
-    ).toThrow('failed to parse LLM response into JSON');
+    ).toThrow(
+      'LLM response is valid JSON but does not match the expected schema',
+    );
 
     expect(
       searchAreaProtocol.parseRawResponse(
@@ -147,6 +149,7 @@ describe('default locate protocol', () => {
     ).toEqual({ kind: 'located', target: [100, 200, 300, 400] });
     expect(jsonParser).toHaveBeenCalledWith('model-specific response', {
       source: 'locate',
+      requireObject: true,
     });
 
     searchAreaProtocol.parseRawResponse(
@@ -155,6 +158,27 @@ describe('default locate protocol', () => {
     );
     expect(jsonParser).toHaveBeenLastCalledWith('model-specific response', {
       source: 'section-locator',
+      requireObject: true,
     });
+  });
+
+  it('rejects a non-object response from a custom JSON parser', () => {
+    const jsonParser = vi.fn(() => [
+      { bbox: [100, 200, 300, 400] },
+      { bbox: [500, 600, 700, 800] },
+    ]);
+    const elementProtocol = createDefaultElementProtocol({ jsonParser });
+    const locatePromptSpec = createLocateResultPromptSpec({
+      shape: 'bbox',
+      order: 'xy',
+      normalizedBy: 1000,
+    });
+
+    expect(() =>
+      elementProtocol.parseRawResponse(
+        'model-specific response',
+        locatePromptSpec,
+      ),
+    ).toThrow('Failed to parse JSON locate response');
   });
 });

--- a/packages/core/tests/unit-test/service-caller-object-response.test.ts
+++ b/packages/core/tests/unit-test/service-caller-object-response.test.ts
@@ -1,0 +1,55 @@
+import type { ModelRuntime } from '@/ai-model/model-adapter/types';
+import { getModelRuntime } from '@/ai-model/models';
+import { type callAI, parseAIObjectResponse } from '@/ai-model/service-caller';
+import type { IModelConfig } from '@midscene/shared/env';
+import { describe, expect, it, vi } from 'vitest';
+
+const modelConfig: IModelConfig = {
+  modelName: 'gpt-5',
+  modelDescription: 'test',
+  openaiApiKey: 'test-key',
+  openaiBaseURL: 'https://example.com/v1',
+  intent: 'default',
+  slot: 'default',
+};
+
+const modelResponse = (content: string) =>
+  ({
+    content,
+  }) as Awaited<ReturnType<typeof callAI>>;
+
+describe('parseAIObjectResponse', () => {
+  it('rejects a top-level JSON array', () => {
+    expect(() =>
+      parseAIObjectResponse(
+        modelResponse('[1,2]'),
+        getModelRuntime(modelConfig),
+      ),
+    ).toThrow(
+      'LLM response is valid JSON but does not match the expected schema',
+    );
+  });
+
+  it('requires the adapter JSON parser to return an object', () => {
+    const modelRuntime = getModelRuntime(modelConfig);
+    const jsonParser = vi.fn(() => ({ answer: 42 }));
+    const objectResponseModelRuntime: ModelRuntime = {
+      ...modelRuntime,
+      adapter: {
+        ...modelRuntime.adapter,
+        jsonParser,
+      },
+    };
+
+    expect(
+      parseAIObjectResponse<{ answer: number }>(
+        modelResponse('{"answer":42}'),
+        objectResponseModelRuntime,
+      ).content,
+    ).toEqual({ answer: 42 });
+    expect(jsonParser).toHaveBeenCalledWith('{"answer":42}', {
+      source: 'generic-object',
+      requireObject: true,
+    });
+  });
+});

--- a/packages/core/tests/unit-test/service-caller-object-response.test.ts
+++ b/packages/core/tests/unit-test/service-caller-object-response.test.ts
@@ -49,7 +49,24 @@ describe('parseAIObjectResponse', () => {
     ).toEqual({ answer: 42 });
     expect(jsonParser).toHaveBeenCalledWith('{"answer":42}', {
       source: 'generic-object',
-      requireObject: true,
     });
+  });
+
+  it('rejects an array returned by a custom JSON parser', () => {
+    const modelRuntime = getModelRuntime(modelConfig);
+    const objectResponseModelRuntime: ModelRuntime = {
+      ...modelRuntime,
+      adapter: {
+        ...modelRuntime.adapter,
+        jsonParser: vi.fn(() => [{ answer: 42 }]),
+      },
+    };
+
+    expect(() =>
+      parseAIObjectResponse(
+        modelResponse('[{"answer":42}]'),
+        objectResponseModelRuntime,
+      ),
+    ).toThrow('Expected to be a JSON object, got array');
   });
 });


### PR DESCRIPTION
## Summary

- make the shared model JSON parser accept any top-level JSON value without shape-specific options
- enforce JSON object contracts at the Locate, Planning, and object-response call sites, including for custom parsers
- distinguish valid JSON schema mismatches from syntax parse failures with clearer errors

## Validation

- `pnpm run lint`
- `pnpm --filter @midscene/core test` — 150 test files passed; 1543 tests passed and 8 skipped