### PR TITLE
fix(studio): restore packaged Android device preview

### DIFF
--- a/apps/studio/scripts/package-electron.mjs
+++ b/apps/studio/scripts/package-electron.mjs
@@ -14,6 +14,10 @@ import {
   writeAppUpdateYmlIntoResources,
   writeUpdateMetadataForArtifact,
 } from './build-update-metadata.mjs';
+import {
+  assertPackagedExternalResourcesUnpacked,
+  packagedAsarOptions,
+} from './packaged-asar-resources.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -61,19 +65,6 @@ const packagedIgnorePatterns = [
   // Source maps duplicate what `pruneSourceMapFiles` already removed.
   /\.js\.map$/,
 ];
-const packagedAsarUnpackDirs = [
-  'node_modules/@computer-use/libnut',
-  'node_modules/@ffmpeg-installer',
-  'node_modules/@img',
-  'node_modules/@midscene/android/bin',
-  'node_modules/@midscene/computer/bin',
-  'node_modules/@midscene/computer/native',
-  'node_modules/sharp',
-].map((relativePath) => relativePath.split('/').join(path.sep));
-export const packagedAsarOptions = {
-  unpack: '**/{.**,**}/**/*.{node,dll,dylib,so,exe}',
-  unpackDir: `{${packagedAsarUnpackDirs.join(',')}}`,
-};
 const defaultMacEntitlementsPath = path.join(
   studioBuildDir,
   'entitlements.mac.plist',
@@ -1563,7 +1554,7 @@ const findPackagedAppPayloadDir = async (packagedAppPath) => {
   return null;
 };
 
-const findPackagedResourcesDir = async (packagedAppPath) => {
+const resolvePackagedResourcesDir = async (packagedAppPath) => {
   const candidates = await buildPackagedResourcesCandidates(packagedAppPath);
 
   for (const candidatePath of candidates) {
@@ -1579,7 +1570,9 @@ const findPackagedResourcesDir = async (packagedAppPath) => {
     }
   }
 
-  return null;
+  throw new Error(
+    `Unable to locate the resources directory in packaged Midscene Studio app: ${packagedAppPath}`,
+  );
 };
 
 const findPackagedNodeModulesDir = async (packagedAppPath) => {
@@ -2402,8 +2395,12 @@ export const packageStudioElectronApp = async ({
 
   const packagedAppPath = packagedAppPaths[0];
   const artifactPath = path.join(artifactDir, `${baseName}.zip`);
+  const resourcesDir = await resolvePackagedResourcesDir(packagedAppPath);
 
-  await assertPortablePackagedNodeModules(packagedAppPath);
+  await Promise.all([
+    assertPortablePackagedNodeModules(packagedAppPath),
+    assertPackagedExternalResourcesUnpacked(resourcesDir),
+  ]);
   const packagedPayloadDir = await findPackagedAppPayloadDir(packagedAppPath);
   if (packagedPayloadDir) {
     await dedupePlaygroundStatic(path.join(packagedPayloadDir, 'node_modules'));
@@ -2414,10 +2411,7 @@ export const packageStudioElectronApp = async ({
   // at runtime to learn which provider / repo / cache dir to use. Must be
   // written before signing on macOS so it ends up inside the signed
   // bundle.
-  const resourcesDir = await findPackagedResourcesDir(packagedAppPath);
-  if (resourcesDir) {
-    await writeAppUpdateYmlIntoResources(resourcesDir);
-  }
+  await writeAppUpdateYmlIntoResources(resourcesDir);
 
   let dmgArtifactPath;
   if (platform === 'darwin') {

--- a/apps/studio/scripts/packaged-asar-resources.mjs
+++ b/apps/studio/scripts/packaged-asar-resources.mjs
@@ -1,0 +1,58 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const packagedAndroidBinDir = 'node_modules/@midscene/android/bin';
+const packagedAsarUnpackDirs = [
+  'node_modules/@computer-use/libnut',
+  'node_modules/@ffmpeg-installer',
+  'node_modules/@img',
+  packagedAndroidBinDir,
+  'node_modules/@midscene/computer/bin',
+  'node_modules/@midscene/computer/native',
+  'node_modules/sharp',
+];
+
+export const packagedAsarOptions = {
+  unpack: '**/{.**,**}/**/*.{node,dll,dylib,so,exe}',
+  // @electron/asar passes this pattern to minimatch, whose glob syntax uses
+  // forward slashes on every platform. Converting these paths to `path.sep`
+  // makes backslashes escape the pattern on Windows and silently leaves
+  // extensionless helpers such as scrcpy-server inside app.asar.
+  unpackDir: `{${packagedAsarUnpackDirs.join(',')}}`,
+};
+
+const requiredPackagedExternalResources = ['scrcpy-server', 'yadb'].map(
+  (fileName) => `${packagedAndroidBinDir}/${fileName}`,
+);
+
+export const assertPackagedExternalResourcesUnpacked = async (resourcesDir) => {
+  const unpackedRoot = path.join(resourcesDir, 'app.asar.unpacked');
+  const missingResources = [];
+
+  for (const relativePath of requiredPackagedExternalResources) {
+    const resourcePath = path.join(unpackedRoot, relativePath);
+    try {
+      const stats = await fs.stat(resourcePath);
+      if (!stats.isFile()) {
+        missingResources.push(relativePath);
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+      missingResources.push(relativePath);
+    }
+  }
+
+  if (missingResources.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      'Packaged Midscene Studio app is missing required external resources from app.asar.unpacked:',
+      missingResources.join(', '),
+      'External processes cannot read these files from the app.asar virtual filesystem.',
+    ].join(' '),
+  );
+};

--- a/apps/studio/scripts/packaged-asar-resources.mjs
+++ b/apps/studio/scripts/packaged-asar-resources.mjs
@@ -1,12 +1,25 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-const packagedAndroidBinDir = 'node_modules/@midscene/android/bin';
+const requiredPackagedExternalResources = [
+  'node_modules/@midscene/android/bin/scrcpy-server',
+  'node_modules/@midscene/android/bin/yadb',
+  'node_modules/@midscene/android-playground/bin/scrcpy-server',
+];
+
+const packagedExternalResourceDirs = [
+  ...new Set(
+    requiredPackagedExternalResources.map((resourcePath) =>
+      path.posix.dirname(resourcePath),
+    ),
+  ),
+];
+
 const packagedAsarUnpackDirs = [
   'node_modules/@computer-use/libnut',
   'node_modules/@ffmpeg-installer',
   'node_modules/@img',
-  packagedAndroidBinDir,
+  ...packagedExternalResourceDirs,
   'node_modules/@midscene/computer/bin',
   'node_modules/@midscene/computer/native',
   'node_modules/sharp',
@@ -20,10 +33,6 @@ export const packagedAsarOptions = {
   // extensionless helpers such as scrcpy-server inside app.asar.
   unpackDir: `{${packagedAsarUnpackDirs.join(',')}}`,
 };
-
-const requiredPackagedExternalResources = ['scrcpy-server', 'yadb'].map(
-  (fileName) => `${packagedAndroidBinDir}/${fileName}`,
-);
 
 export const assertPackagedExternalResourcesUnpacked = async (resourcesDir) => {
   const unpackedRoot = path.join(resourcesDir, 'app.asar.unpacked');

--- a/apps/studio/tests/package-electron.test.mjs
+++ b/apps/studio/tests/package-electron.test.mjs
@@ -29,7 +29,6 @@ import {
   getStudioElectronVersion,
   loadAppDmg,
   normalizeReleaseVersion,
-  packagedAsarOptions,
   parseBooleanLike,
   pathContainsReportTemplatePlaceholder,
   pruneAntdUmdBundles,
@@ -49,6 +48,7 @@ import {
   shouldUseShellForCommand,
   slimStageNodeModules,
 } from '../scripts/package-electron.mjs';
+import { packagedAsarOptions } from '../scripts/packaged-asar-resources.mjs';
 
 const createThinMacMachOBuffer = (arch) => {
   const cpuTypes = {
@@ -294,21 +294,6 @@ describe('package-electron helpers', () => {
       platform: 'darwin',
       prune: false,
     });
-  });
-
-  it('keeps native modules and helper binaries outside app.asar', () => {
-    expect(packagedAsarOptions.unpack).toContain('*.{node,dll,dylib,so,exe}');
-    expect(packagedAsarOptions.unpackDir).toContain('node_modules/sharp');
-    expect(packagedAsarOptions.unpackDir).toContain('node_modules/@img');
-    expect(packagedAsarOptions.unpackDir).toContain(
-      path.join('node_modules', '@computer-use', 'libnut'),
-    );
-    expect(packagedAsarOptions.unpackDir).toContain(
-      path.join('node_modules', '@ffmpeg-installer'),
-    );
-    expect(packagedAsarOptions.unpackDir).toContain(
-      path.join('node_modules', '@midscene', 'computer', 'bin'),
-    );
   });
 
   it('copies the Inter OFL into the packaged app staging directory', async () => {

--- a/apps/studio/tests/packaged-asar-resources.test.mjs
+++ b/apps/studio/tests/packaged-asar-resources.test.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  assertPackagedExternalResourcesUnpacked,
+  packagedAsarOptions,
+} from '../scripts/packaged-asar-resources.mjs';
+
+describe('packaged ASAR resources', () => {
+  it('uses portable globs for native modules and external helpers', () => {
+    expect(packagedAsarOptions.unpack).toContain('*.{node,dll,dylib,so,exe}');
+    expect(packagedAsarOptions.unpackDir).toContain('node_modules/sharp');
+    expect(packagedAsarOptions.unpackDir).toContain('node_modules/@img');
+    expect(packagedAsarOptions.unpackDir).toContain(
+      'node_modules/@computer-use/libnut',
+    );
+    expect(packagedAsarOptions.unpackDir).toContain(
+      'node_modules/@ffmpeg-installer',
+    );
+    expect(packagedAsarOptions.unpackDir).toContain(
+      'node_modules/@midscene/android/bin',
+    );
+    expect(packagedAsarOptions.unpackDir).toContain(
+      'node_modules/@midscene/computer/bin',
+    );
+    expect(packagedAsarOptions.unpackDir).not.toContain('\\');
+  });
+
+  it('accepts Android helpers that are materialized outside app.asar', async () => {
+    const resourcesDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-resources-'),
+    );
+    try {
+      const unpackedAndroidBinDir = path.join(
+        resourcesDir,
+        'app.asar.unpacked',
+        'node_modules',
+        '@midscene',
+        'android',
+        'bin',
+      );
+      await fs.mkdir(unpackedAndroidBinDir, { recursive: true });
+      await Promise.all([
+        fs.writeFile(path.join(unpackedAndroidBinDir, 'scrcpy-server'), ''),
+        fs.writeFile(path.join(unpackedAndroidBinDir, 'yadb'), ''),
+      ]);
+
+      await expect(
+        assertPackagedExternalResourcesUnpacked(resourcesDir),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(resourcesDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Android helpers that remain trapped in app.asar', async () => {
+    const resourcesDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-resources-'),
+    );
+    try {
+      await fs.writeFile(path.join(resourcesDir, 'app.asar'), 'asar payload');
+
+      await expect(
+        assertPackagedExternalResourcesUnpacked(resourcesDir),
+      ).rejects.toThrow(/scrcpy-server.*yadb.*External processes cannot read/);
+    } finally {
+      await fs.rm(resourcesDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/studio/tests/packaged-asar-resources.test.mjs
+++ b/apps/studio/tests/packaged-asar-resources.test.mjs
@@ -22,12 +22,57 @@ describe('packaged ASAR resources', () => {
       'node_modules/@midscene/android/bin',
     );
     expect(packagedAsarOptions.unpackDir).toContain(
+      'node_modules/@midscene/android-playground/bin',
+    );
+    expect(packagedAsarOptions.unpackDir).toContain(
       'node_modules/@midscene/computer/bin',
     );
     expect(packagedAsarOptions.unpackDir).not.toContain('\\');
   });
 
   it('accepts Android helpers that are materialized outside app.asar', async () => {
+    const resourcesDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'midscene-resources-'),
+    );
+    try {
+      const unpackedAndroidBinDir = path.join(
+        resourcesDir,
+        'app.asar.unpacked',
+        'node_modules',
+        '@midscene',
+        'android',
+        'bin',
+      );
+      const unpackedAndroidPlaygroundBinDir = path.join(
+        resourcesDir,
+        'app.asar.unpacked',
+        'node_modules',
+        '@midscene',
+        'android-playground',
+        'bin',
+      );
+      await Promise.all([
+        fs.mkdir(unpackedAndroidBinDir, { recursive: true }),
+        fs.mkdir(unpackedAndroidPlaygroundBinDir, { recursive: true }),
+      ]);
+      await Promise.all([
+        fs.writeFile(path.join(unpackedAndroidBinDir, 'scrcpy-server'), ''),
+        fs.writeFile(path.join(unpackedAndroidBinDir, 'yadb'), ''),
+        fs.writeFile(
+          path.join(unpackedAndroidPlaygroundBinDir, 'scrcpy-server'),
+          '',
+        ),
+      ]);
+
+      await expect(
+        assertPackagedExternalResourcesUnpacked(resourcesDir),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(resourcesDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a packaged playground scrcpy server that remains inside app.asar', async () => {
     const resourcesDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'midscene-resources-'),
     );
@@ -48,7 +93,9 @@ describe('packaged ASAR resources', () => {
 
       await expect(
         assertPackagedExternalResourcesUnpacked(resourcesDir),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow(
+        /@midscene\/android-playground\/bin\/scrcpy-server.*External processes cannot read/,
+      );
     } finally {
       await fs.rm(resourcesDir, { recursive: true, force: true });
     }
@@ -63,7 +110,9 @@ describe('packaged ASAR resources', () => {
 
       await expect(
         assertPackagedExternalResourcesUnpacked(resourcesDir),
-      ).rejects.toThrow(/scrcpy-server.*yadb.*External processes cannot read/);
+      ).rejects.toThrow(
+        /@midscene\/android\/bin\/scrcpy-server.*@midscene\/android\/bin\/yadb.*@midscene\/android-playground\/bin\/scrcpy-server.*External processes cannot read/,
+      );
     } finally {
       await fs.rm(resourcesDir, { recursive: true, force: true });
     }

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -4,6 +4,7 @@ import type { Server as HttpServer } from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { resolveExternalResourcePath } from '@midscene/android';
 import {
   SCRCPY_ADB_CONNECT_TIMEOUT_MS,
   SCRCPY_PREVIEW_METADATA_TIMEOUT_MS,
@@ -341,7 +342,9 @@ export default class ScrcpyServer {
       typeof __dirname !== 'undefined'
         ? __dirname
         : path.dirname(fileURLToPath(import.meta.url));
-    const serverBinPath = path.resolve(currentDir, '../../bin/scrcpy-server');
+    const serverBinPath = resolveExternalResourcePath(
+      path.resolve(currentDir, '../../bin/scrcpy-server'),
+    );
 
     try {
       // Avoid @yume-chan/adb sync here. Its locked sync socket does not release

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -4,7 +4,12 @@ import ScrcpyServer, {
   resolveRequestedDeviceId,
 } from '../../src/scrcpy-server';
 
-const { mockExecFile, mockStart, mockOptionsCtor } = rs.hoisted(() => ({
+const {
+  mockExecFile,
+  mockStart,
+  mockOptionsCtor,
+  mockResolveExternalResourcePath,
+} = rs.hoisted(() => ({
   mockExecFile: rs.fn(
     (
       _file: string,
@@ -16,9 +21,16 @@ const { mockExecFile, mockStart, mockOptionsCtor } = rs.hoisted(() => ({
   ),
   mockStart: rs.fn(),
   mockOptionsCtor: rs.fn((options) => options),
+  mockResolveExternalResourcePath: rs.fn(
+    (_resourcePath: string) => '/unpacked/scrcpy-server',
+  ),
 }));
 
 rs.mock('node:child_process', () => ({ execFile: mockExecFile }));
+
+rs.mock('@midscene/android', () => ({
+  resolveExternalResourcePath: mockResolveExternalResourcePath,
+}));
 
 rs.mock('@yume-chan/adb-scrcpy', () => ({
   AdbScrcpyClient: {
@@ -79,10 +91,13 @@ describe('ScrcpyServer', () => {
         '-s',
         'device-1',
         'push',
-        expect.stringContaining('bin/scrcpy-server'),
+        '/unpacked/scrcpy-server',
         '/mocked/scrcpy-server.jar',
       ],
       expect.any(Function),
+    );
+    expect(mockResolveExternalResourcePath).toHaveBeenCalledWith(
+      expect.stringContaining('bin/scrcpy-server'),
     );
     expect(mockOptionsCtor).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -8,6 +8,7 @@ export {
   getConnectedDevicesWithDetails,
 } from './utils';
 export type { AndroidConnectedDevice } from './utils';
+export { resolveExternalResourcePath } from './resource-path';
 export {
   ScrcpyDeviceAdapter,
   type ResolveScrcpyAdbBackend,


### PR DESCRIPTION
## Summary

- resolve Electron ASAR virtual paths to their app.asar.unpacked siblings before passing the scrcpy server path to external adb push
- unpack both @midscene/android and @midscene/android-playground helper directories with portable forward-slash ASAR globs
- drive ASAR unpacking and post-package validation from one required-resource manifest
- fail packaging when any external Android helper is missing from app.asar.unpacked

## Root cause

PR #3048 replaced the Node stream upload with external adb push to avoid retaining the scrcpy upload buffer. External adb cannot read Electron virtual app.asar paths.

The initial packaging-only fix covered @midscene/android/bin, but Studio preview loads ScrcpyServer from @midscene/android-playground. Its runtime path therefore pointed to @midscene/android-playground/bin/scrcpy-server, which was still inside app.asar. Even an unpacked file also requires runtime path translation because the module dirname remains under app.asar.

## Regression prevention

- the runtime unit test verifies that adb receives the resolved physical path
- the Studio packaging test requires the exact Android Playground server path
- one resource manifest now drives both unpackDir generation and packaged artifact assertions
- the existing multi-platform Studio package-validation workflow exercises the artifact assertion before release

## Validation

- pnpm run lint
- pnpm exec nx test @midscene/android-playground --outputStyle=stream — 15 passed
- pnpm exec nx test @midscene/android --outputStyle=stream — 438 passed
- pnpm --dir apps/studio exec vitest run tests/packaged-asar-resources.test.mjs — 4 passed
- pnpm exec nx build @midscene/android --outputStyle=stream
- pnpm exec nx build @midscene/android-playground --outputStyle=stream
- pnpm exec nx build studio --outputStyle=stream
- built and launched a packaged arm64 Studio app; the packaged-resource assertion and strict code-signature verification passed
- verified on a physical Samsung SM-N9860 running Android 13: scrcpy started, reported 744 x 1600 video metadata, rendered the preview, and accepted swipe input
- all PR checks passed, including Android emulator, Studio startup, web e2e, and report e2e

## Published prerelease

- version: 1.12.3-beta-20260901112559.0 on the npm beta tag; latest remains 1.12.2
- workflow: https://github.com/web-infra-dev/midscene/actions/runs/33502260537
- Windows x64, Linux x64, macOS x64, and macOS arm64 Studio artifacts all packaged and uploaded successfully
- the official arm64 DMG passed packaged-resource assertions, strict code-signature verification, and Apple notarization assessment

## Local packaging note

The local runnable .app completed successfully. Local DMG wrapping then hit a cached macos-alias native-module ABI mismatch; the official CI DMG completed and passed all final checks.