### PR TITLE
style(site): polish homepage toolkit cards and dividers

### DIFF
--- a/apps/site/docs/public/images/backgrounds/section-divider-dark.svg
+++ b/apps/site/docs/public/images/backgrounds/section-divider-dark.svg
@@ -1,0 +1,7 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="1200" height="7.5" viewBox="0 0 1200 7.5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 2147239199">
+<path id="+" d="M3.11364 7.5V0H4.38636V7.5H3.11364ZM0 4.38636V3.11364H7.5V4.38636H0Z" fill="white" fill-opacity="0.16"/>
+<line id="Line 77" x1="27.5" y1="3.25" x2="1172.5" y2="3.25" stroke="white" stroke-opacity="0.08"/>
+<path id="+_2" d="M1195.61 7.5V0H1196.89V7.5H1195.61ZM1192.5 4.38636V3.11364H1200V4.38636H1192.5Z" fill="white" fill-opacity="0.16"/>
+</g>
+</svg>

--- a/apps/site/docs/public/images/backgrounds/section-divider-light.svg
+++ b/apps/site/docs/public/images/backgrounds/section-divider-light.svg
@@ -1,0 +1,7 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="1200" height="7.5" viewBox="0 0 1200 7.5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 2147239200">
+<path id="+" d="M3.11364 7.5V0H4.38636V7.5H3.11364ZM0 4.38636V3.11364H7.5V4.38636H0Z" fill="black" fill-opacity="0.16"/>
+<line id="Line 77" x1="27.5" y1="3.25" x2="1172.5" y2="3.25" stroke="black" stroke-opacity="0.08"/>
+<path id="+_2" d="M1195.61 7.5V0H1196.89V7.5H1195.61ZM1192.5 4.38636V3.11364H1200V4.38636H1192.5Z" fill="black" fill-opacity="0.16"/>
+</g>
+</svg>

--- a/apps/site/styles/index.css
+++ b/apps/site/styles/index.css
@@ -778,13 +778,7 @@
   height: 346px;
 }
 
-.home-feature--platforms .home-feature-card:first-child {
-  border-color: #d1dfff;
-  background: rgb(23 97 255 / 6%);
-}
-
-.dark .home-feature-card,
-.dark .home-feature--platforms .home-feature-card:first-child {
+.dark .home-feature-card {
   border-color: rgb(255 255 255 / 8%);
   background: #111;
 }

--- a/apps/site/styles/index.css
+++ b/apps/site/styles/index.css
@@ -405,40 +405,27 @@
 
 .home-section-divider {
   position: relative;
-  display: flex;
   width: 1200px;
-  height: 8px;
-  align-items: center;
-  color: rgb(16 24 40 / 8%);
+  height: 7.5px;
   pointer-events: none;
 }
 
-.dark .home-section-divider {
-  color: rgb(255 255 255 / 8%);
+.home-section-divider__asset {
+  display: block;
+  width: 100%;
+  height: 7.5px;
 }
 
-.home-section-divider__line {
-  height: 1px;
-  flex: 1 1 auto;
-  background: currentcolor;
+.home-section-divider__asset--dark {
+  display: none;
 }
 
-.home-section-divider__plus {
-  position: absolute;
-  top: 50%;
-  width: 12px;
-  height: 12px;
-  padding: 0;
-  box-sizing: border-box;
-  transform: translateY(-50%);
+.dark .home-section-divider__asset--light {
+  display: none;
 }
 
-.home-section-divider__plus:first-child {
-  left: -18px;
-}
-
-.home-section-divider__plus:last-child {
-  right: -18px;
+.dark .home-section-divider__asset--dark {
+  display: block;
 }
 
 .home-hero__divider {
@@ -450,7 +437,7 @@
 }
 
 .home-feature__divider {
-  height: 8px;
+  height: 7.5px;
   margin-inline: auto;
 }
 

--- a/apps/site/styles/index.css
+++ b/apps/site/styles/index.css
@@ -409,12 +409,12 @@
   width: 1200px;
   height: 8px;
   align-items: center;
-  color: rgb(16 24 40 / 25%);
+  color: rgb(16 24 40 / 8%);
   pointer-events: none;
 }
 
 .dark .home-section-divider {
-  color: rgb(255 255 255 / 25%);
+  color: rgb(255 255 255 / 8%);
 }
 
 .home-section-divider__line {
@@ -891,6 +891,13 @@
   display: flex;
 }
 
+.home-feature--toolkit .home-feature-card__theme {
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
 .home-feature-card__asset {
   display: block;
   max-width: calc(100% - 32px);
@@ -909,8 +916,8 @@
 }
 
 .home-feature-card__asset--tool {
-  width: 64px;
-  height: 64px;
+  width: 40px;
+  height: 40px;
 }
 
 .home-feature-card__phones {

--- a/apps/site/theme/components/SectionDivider.tsx
+++ b/apps/site/theme/components/SectionDivider.tsx
@@ -1,5 +1,3 @@
-import { Plus } from 'lucide-react';
-
 interface SectionDividerProps {
   className?: string;
 }
@@ -10,9 +8,16 @@ export function SectionDivider({ className = '' }: SectionDividerProps) {
       className={`home-section-divider ${className}`.trim()}
       aria-hidden="true"
     >
-      <Plus className="home-section-divider__plus" strokeWidth={1} />
-      <span className="home-section-divider__line" />
-      <Plus className="home-section-divider__plus" strokeWidth={1} />
+      <img
+        className="home-section-divider__asset home-section-divider__asset--light"
+        src="/images/backgrounds/section-divider-light.svg"
+        alt=""
+      />
+      <img
+        className="home-section-divider__asset home-section-divider__asset--dark"
+        src="/images/backgrounds/section-divider-dark.svg"
+        alt=""
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Reduce homepage toolkit icons from 64px to 40px.
- Align toolkit icons to the top-left with a 24px inset.
- Lower section divider opacity from 25% to 8% in light and dark themes.

## Validation

- `pnpm run lint`
- `pnpm --dir apps/site exec rspress build`
- Visually verified the homepage in the local dark-theme preview.
