### PR TITLE
fix(android): harden scrcpy freshness recovery

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -2215,6 +2215,7 @@ const device = new AndroidDevice(deviceId, {
   - `maxSize?: number` — Maximum screenshot width or height in pixels. The same limit applies to ADB/yadb fallback screenshots while scrcpy is temporarily unavailable, preventing planning and report images from returning to full device resolution. Use a non-negative integer; `0` disables scaling. Default: `0`.
   - `videoBitRate?: number` — scrcpy H.264 encoding bitrate in bits per second. Default: `100000000`. Changing it trades encoded bandwidth against screenshot detail. Tune it only from independent transport measurements and validate recognition quality; a freshness-timeout warning alone is not a reason to change it.
   - `idleTimeoutMs?: number` — Idle time before disconnecting the scrcpy stream. `0` disables automatic disconnection. Default: `30000`.
+  - `videoResetFrameTimeoutMs?: number` — Time to wait for a fresh keyframe after scrcpy accepts an in-band video reset. Use a positive integer. Default: `800`. Increase it only for devices whose display capture pipeline has a slower restart tail.
 
 `device.getScrcpyStatus()` returns the current `enabled`, `connected`, `lastError`, and `retryAfter` state. `device.retryScrcpy()` immediately retries the scrcpy connection and returns `Promise<void>`.
 

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -2172,6 +2172,7 @@ const device = new AndroidDevice(deviceId, {
   - `maxSize?: number` —— 截图的最大宽度或高度。scrcpy 暂时不可用时，ADB/yadb 回退截图也会应用相同限制，避免规划和报告中的图片恢复为设备原始分辨率。必须使用非负整数；默认 `0`，表示不缩放。
   - `videoBitRate?: number` —— scrcpy H.264 编码码率，单位为 bps，默认 `100000000`。调整该值是在编码带宽和截图细节之间取舍；只有独立的链路测量表明有需要时才应调优，并验证识别质量，不能仅凭 freshness 超时告警调整。
   - `idleTimeoutMs?: number` —— 空闲连接的断开时间，单位为毫秒，默认 `30000`；设为 `0` 时禁用。
+  - `videoResetFrameTimeoutMs?: number` —— scrcpy 接受流内视频重置后，等待新鲜关键帧的时间，单位为毫秒。必须使用正整数，默认 `800`。仅当设备的 display capture 重启长尾更慢时再增大该值。
 
 - `device.getScrcpyStatus()` —— 返回 `enabled`、`connected`、`lastError` 和 `retryAfter`。
 - `device.retryScrcpy(): Promise<void>` —— 跳过冷却时间，立即重试 scrcpy 连接。

--- a/packages/android/src/scrcpy-device-adapter.ts
+++ b/packages/android/src/scrcpy-device-adapter.ts
@@ -1,4 +1,5 @@
 import type { Size } from '@midscene/core';
+import type { AndroidDeviceOpt } from '@midscene/core/device';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import type { Adb as YumeAdb } from '@yume-chan/adb';
@@ -32,19 +33,8 @@ export function formatScrcpyFreshFrameFailure(
   return `No usable scrcpy frame crossed the active freshness target within ${timeoutMs}ms. This can happen when a static screen emits no new encoded frame, or when the video stream or transport is interrupted. This timeout does not by itself identify bandwidth or the configured video bitrate as the cause.${bitRateDescription}`;
 }
 
-interface ScrcpyConfig {
-  enabled?: boolean;
-  maxSize?: number;
-  videoBitRate?: number;
-  idleTimeoutMs?: number;
-}
-
-interface ResolvedScrcpyConfig {
-  enabled: boolean;
-  maxSize: number;
-  videoBitRate: number;
-  idleTimeoutMs: number;
-}
+type ScrcpyConfig = NonNullable<AndroidDeviceOpt['scrcpyConfig']>;
+type ResolvedScrcpyConfig = Required<ScrcpyConfig>;
 
 /** ADB capabilities scrcpy needs from the canonical Appium transport. */
 export interface ScrcpyAdbBackend {
@@ -178,6 +168,17 @@ export class ScrcpyDeviceAdapter {
 
     const videoBitRate =
       config?.videoBitRate ?? DEFAULT_SCRCPY_CONFIG.videoBitRate;
+    const videoResetFrameTimeoutMs =
+      config?.videoResetFrameTimeoutMs ??
+      DEFAULT_SCRCPY_CONFIG.videoResetFrameTimeoutMs;
+    if (
+      !Number.isInteger(videoResetFrameTimeoutMs) ||
+      videoResetFrameTimeoutMs <= 0
+    ) {
+      throw new Error(
+        `Invalid scrcpyConfig.videoResetFrameTimeoutMs: expected a positive integer, received ${videoResetFrameTimeoutMs}`,
+      );
+    }
 
     this.resolvedConfig = {
       enabled: this.isConfigured(),
@@ -185,6 +186,7 @@ export class ScrcpyDeviceAdapter {
       idleTimeoutMs:
         config?.idleTimeoutMs ?? DEFAULT_SCRCPY_CONFIG.idleTimeoutMs,
       videoBitRate,
+      videoResetFrameTimeoutMs,
     };
 
     return this.resolvedConfig;
@@ -236,6 +238,7 @@ export class ScrcpyDeviceAdapter {
             maxSize: config.maxSize,
             videoBitRate: config.videoBitRate,
             idleTimeoutMs: config.idleTimeoutMs,
+            videoResetFrameTimeoutMs: config.videoResetFrameTimeoutMs,
           },
         );
 

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -26,9 +26,11 @@ const MAX_KEYFRAME_WAIT_MS = 5_000;
 // before closing the stale epoch and letting the caller use ADB fallback.
 const FRESH_FRAME_TIMEOUT_MS = 300;
 // Give an established stream a brief chance to emit a frame naturally before
-// restarting only its capture/encoder pipeline. The reset stays inside the
-// existing freshness timeout and does not extend the fallback budget.
+// restarting only its capture/encoder pipeline.
 const VIDEO_RESET_DELAY_MS = 10;
+// RESET_VIDEO is only a control-channel write. Once the write succeeds, give
+// the restarted encoder its own budget to emit configuration and an IDR frame.
+const VIDEO_RESET_FRAME_TIMEOUT_MS = 500;
 const KEYFRAME_POLL_INTERVAL_MS = 200;
 const MAX_SCAN_BYTES = 1_000;
 const MAX_SERVER_OUTPUT_LINES = 100;
@@ -109,6 +111,16 @@ export class ScrcpyFreshFrameUnavailableError extends Error {
     this.failureKind = options.failureKind;
     this.timeoutMs = options.timeoutMs;
     this.videoBitRate = options.videoBitRate;
+  }
+}
+
+class ScrcpyFrameWaitTimeoutError extends Error {
+  constructor(
+    message: string,
+    readonly timeoutMs: number,
+  ) {
+    super(message);
+    this.name = 'ScrcpyFrameWaitTimeoutError';
   }
 }
 
@@ -219,6 +231,7 @@ interface VideoResetState {
   previousSpsHeader: Buffer | null;
   writePromise: Promise<void> | null;
   frameAccepted: boolean;
+  dataPacketsSeen: number;
 }
 
 export class ScrcpyScreenshotManager {
@@ -260,6 +273,10 @@ export class ScrcpyScreenshotManager {
   private deviceClockCalibration: DeviceClockCalibration | null = null;
   private deviceClockCalibrationPromise: Promise<DeviceClockCalibration> | null =
     null;
+  // A high-RTT anchor gets at most one best-effort replacement before planning
+  // falls back to estimated age. This prevents repeated planning captures from
+  // replacing reconnect churn with an ADB clock-sampling loop.
+  private hasRetriedUncertainClockCalibration = false;
   private lastFramePtsUs: bigint | null = null;
   private frameFreshnessError: Error | null = null;
   private lastFrameFreshnessWarningAt = 0;
@@ -434,6 +451,13 @@ export class ScrcpyScreenshotManager {
         const { done, value } = await reader.read();
         if (done) break;
 
+        const outputLine = value.trimEnd();
+        if (outputLine) {
+          // RESET_VIDEO has no protocol acknowledgement. Keeping the device
+          // server line next to the host-side request/timeout logs makes it
+          // possible to distinguish a control write from server processing.
+          debugScrcpy(`Scrcpy server: ${outputLine}`);
+        }
         lines.push(value);
         if (lines.length > MAX_SERVER_OUTPUT_LINES) {
           lines.splice(0, lines.length - MAX_SERVER_OUTPUT_LINES);
@@ -609,6 +633,11 @@ export class ScrcpyScreenshotManager {
       return;
     }
 
+    const activeReset = this.videoResetState;
+    if (activeReset) {
+      activeReset.dataPacketsSeen++;
+    }
+
     const receivedAtUs = this.monotonicTimeUs();
     if (!this.isFrameFresh(packet.pts)) {
       return;
@@ -702,8 +731,8 @@ export class ScrcpyScreenshotManager {
     };
   }
 
-  async ensureFrameClockCalibration(): Promise<void> {
-    if (this.deviceClockCalibration) return;
+  private async sampleFrameClockCalibration(force: boolean): Promise<void> {
+    if (!force && this.deviceClockCalibration) return;
     if (this.deviceClockCalibrationPromise) {
       await this.deviceClockCalibrationPromise;
       if (!this.deviceClockCalibration) {
@@ -717,7 +746,7 @@ export class ScrcpyScreenshotManager {
     const calibrationPromise = this.readDeviceClockCalibration();
     this.deviceClockCalibrationPromise = calibrationPromise;
     try {
-      const calibration = await calibrationPromise;
+      const sampledCalibration = await calibrationPromise;
       // disconnect() clears the promise to invalidate an in-flight sample from
       // an obsolete stream epoch.
       if (this.deviceClockCalibrationPromise !== calibrationPromise) {
@@ -725,18 +754,41 @@ export class ScrcpyScreenshotManager {
           'Scrcpy stream epoch changed while calibrating the frame clock',
         );
       }
+
+      const previousCalibration = this.deviceClockCalibration;
+      // A lower-RTT sample has a tighter error bound. Keep the best anchor seen
+      // in this stream epoch so a congested ADB round trip cannot make an
+      // already-good calibration worse.
+      const calibration =
+        force &&
+        previousCalibration &&
+        previousCalibration.roundTripUs <= sampledCalibration.roundTripUs
+          ? previousCalibration
+          : sampledCalibration;
       this.deviceClockCalibration = calibration;
-      this.frameFreshnessBarrierPending = false;
-      this.lastFramePtsUs = null;
-      this.frameFreshnessError = null;
+      if (!previousCalibration) {
+        this.frameFreshnessBarrierPending = false;
+        this.lastFramePtsUs = null;
+        this.frameFreshnessError = null;
+      }
       debugScrcpy(
-        `Calibrated scrcpy frame clock for stream epoch (RTT=${Number(calibration.roundTripUs / 1_000n)}ms)`,
+        force
+          ? `Recalibrated scrcpy frame clock for stream epoch (sample RTT=${Number(sampledCalibration.roundTripUs) / 1_000}ms, selected RTT=${Number(calibration.roundTripUs) / 1_000}ms)`
+          : `Calibrated scrcpy frame clock for stream epoch (RTT=${Number(calibration.roundTripUs) / 1_000}ms)`,
       );
     } finally {
       if (this.deviceClockCalibrationPromise === calibrationPromise) {
         this.deviceClockCalibrationPromise = null;
       }
     }
+  }
+
+  async ensureFrameClockCalibration(): Promise<void> {
+    await this.sampleFrameClockCalibration(false);
+  }
+
+  private async recalibrateFrameClock(): Promise<void> {
+    await this.sampleFrameClockCalibration(true);
   }
 
   /**
@@ -831,6 +883,7 @@ export class ScrcpyScreenshotManager {
         this.frameFreshnessBarrierPtsUs = null;
         this.frameFreshnessBarrierReason = null;
         this.deviceClockCalibration = null;
+        this.hasRetriedUncertainClockCalibration = false;
         this.clearFrameCache();
         this.warnFrameFreshness();
         return false;
@@ -1025,6 +1078,7 @@ export class ScrcpyScreenshotManager {
     this.frameFreshnessBarrierGeneration = 0;
     this.deviceClockCalibration = null;
     this.deviceClockCalibrationPromise = null;
+    this.hasRetriedUncertainClockCalibration = false;
     this.lastFramePtsUs = null;
     this.frameFreshnessError = null;
     this.lastFrameFreshnessWarningAt = 0;
@@ -1057,6 +1111,7 @@ export class ScrcpyScreenshotManager {
       previousSpsHeader: this.spsHeader,
       writePromise: null,
       frameAccepted: false,
+      dataPacketsSeen: 0,
     };
     this.videoResetState = resetState;
 
@@ -1205,9 +1260,91 @@ export class ScrcpyScreenshotManager {
     this.streamStartupWindow = null;
   }
 
+  private async isPlanningCandidateFreshEnough(
+    candidate: RawKeyframe,
+  ): Promise<boolean> {
+    if (candidate.ptsUs === undefined) {
+      throw new Error(
+        'Scrcpy frame has no PTS metadata; cannot prove planning freshness',
+      );
+    }
+
+    // Keep the evaluation instant stable while an ADB clock resample is in
+    // flight. Otherwise the calibration latency itself would age the frame.
+    const ageEvaluatedAtUs = this.monotonicTimeUs();
+    let age = this.estimateFrameAge(candidate.ptsUs, ageEvaluatedAtUs);
+    if (age === null) {
+      throw new Error(
+        'Scrcpy frame clock is not calibrated; cannot prove planning freshness',
+      );
+    }
+
+    if (age.upperBoundUs <= MAX_FRAME_AGE_US) {
+      return true;
+    }
+
+    const uncertaintyOnlyExceededLimit =
+      age.estimatedAgeUs <= MAX_FRAME_AGE_US &&
+      age.upperBoundUs > MAX_FRAME_AGE_US;
+    if (uncertaintyOnlyExceededLimit) {
+      if (!this.hasRetriedUncertainClockCalibration) {
+        this.hasRetriedUncertainClockCalibration = true;
+        debugScrcpy(
+          `Planning candidate PTS ${candidate.ptsUs}µs exceeded the ${Number(MAX_FRAME_AGE_US / 1_000n)}ms upper-bound limit only because clock uncertainty was ${Number(age.calibrationUncertaintyUs) / 1_000}ms; recalibrating once before deciding freshness`,
+        );
+        try {
+          await this.recalibrateFrameClock();
+        } catch (error) {
+          debugScrcpy(
+            `Unable to recalibrate scrcpy frame clock after an uncertainty-only freshness result: ${error}`,
+          );
+        }
+        if (
+          candidate.streamEpoch !== undefined &&
+          candidate.streamEpoch !== this.streamEpoch
+        ) {
+          throw new Error(
+            'Scrcpy stream epoch changed while recalibrating planning frame freshness',
+          );
+        }
+
+        const recalibratedAge = this.estimateFrameAge(
+          candidate.ptsUs,
+          ageEvaluatedAtUs,
+        );
+        if (recalibratedAge) {
+          age = recalibratedAge;
+        }
+        if (age.upperBoundUs <= MAX_FRAME_AGE_US) {
+          debugScrcpy(
+            `Planning candidate PTS ${candidate.ptsUs}µs accepted after clock recalibration (estimated=${Number(age.estimatedAgeUs) / 1_000}ms, uncertainty<=${Number(age.calibrationUncertaintyUs) / 1_000}ms)`,
+          );
+          return true;
+        }
+      }
+
+      if (age.estimatedAgeUs <= MAX_FRAME_AGE_US) {
+        // The RTT-derived uncertainty is measurement noise, not observed frame
+        // age. After at most one resample per calibration lifetime, use the
+        // estimated age as the planning gate instead of turning an ambiguous
+        // clock sample into repeated ADB work, encoder resets, and reconnects.
+        debugScrcpy(
+          `Planning candidate PTS ${candidate.ptsUs}µs remains uncertainty-only after the calibration retry; accepting estimated age ${Number(age.estimatedAgeUs) / 1_000}ms despite clock uncertainty<=${Number(age.calibrationUncertaintyUs) / 1_000}ms`,
+        );
+        return true;
+      }
+    }
+
+    debugScrcpy(
+      `Planning candidate PTS ${candidate.ptsUs}µs has absolute age upper bound ${Number(age.upperBoundUs) / 1_000}ms (estimated=${Number(age.estimatedAgeUs) / 1_000}ms, clock uncertainty<=${Number(age.calibrationUncertaintyUs) / 1_000}ms), exceeding the ${Number(MAX_FRAME_AGE_US / 1_000n)}ms limit; arming a planning freshness barrier`,
+    );
+    return false;
+  }
+
   private async waitForPlanningFrame(): Promise<RawKeyframe> {
     let planningBarrierArmed = false;
     let videoResetAttempted = false;
+    let videoResetWritten = false;
     // A new encoder/stream gets the normal startup allowance while waiting for
     // its first data frame. The allowance never bypasses the age check below.
     // Established epochs still fail fast when they cannot cross a newly armed
@@ -1228,27 +1365,11 @@ export class ScrcpyScreenshotManager {
 
     while (true) {
       if (candidate) {
-        if (candidate.ptsUs === undefined) {
-          throw new Error(
-            'Scrcpy frame has no PTS metadata; cannot prove planning freshness',
-          );
-        }
-
-        const age = this.estimateFrameAge(candidate.ptsUs);
-        if (age === null) {
-          throw new Error(
-            'Scrcpy frame clock is not calibrated; cannot prove planning freshness',
-          );
-        }
-
-        if (age.upperBoundUs <= MAX_FRAME_AGE_US) {
+        if (await this.isPlanningCandidateFreshEnough(candidate)) {
           return candidate;
         }
 
         if (!planningBarrierArmed) {
-          debugScrcpy(
-            `Planning candidate PTS ${candidate.ptsUs}µs has absolute age upper bound ${Number(age.upperBoundUs) / 1_000}ms (estimated=${Number(age.estimatedAgeUs) / 1_000}ms, clock uncertainty<=${Number(age.calibrationUncertaintyUs) / 1_000}ms), exceeding the ${Number(MAX_FRAME_AGE_US / 1_000n)}ms limit; arming a planning freshness barrier`,
-          );
           await this.setFreshnessBarrier('stale planning frame');
           planningBarrierArmed = true;
           deadline = Date.now() + FRESH_FRAME_TIMEOUT_MS;
@@ -1259,6 +1380,9 @@ export class ScrcpyScreenshotManager {
 
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) {
+        if (videoResetWritten) {
+          throw this.createVideoResetFrameTimeoutError();
+        }
         throw new Error(
           `No scrcpy frame crossed the active freshness target within ${FRESH_FRAME_TIMEOUT_MS}ms`,
         );
@@ -1278,12 +1402,20 @@ export class ScrcpyScreenshotManager {
         candidate = await this.waitForNextKeyframe(nextFrameWaitMs);
       } catch (error) {
         if (!shouldTryVideoReset) {
+          if (videoResetWritten) {
+            throw this.createVideoResetFrameTimeoutError();
+          }
           throw error;
         }
 
         videoResetAttempted = true;
         try {
           await this.requestVideoReset(deadline);
+          videoResetWritten = true;
+          deadline = Date.now() + VIDEO_RESET_FRAME_TIMEOUT_MS;
+          debugScrcpy(
+            `Scrcpy video reset control write completed; waiting up to ${VIDEO_RESET_FRAME_TIMEOUT_MS}ms for a post-reset frame`,
+          );
         } catch (resetError) {
           // Preserve the rest of the original 300ms window. A natural frame
           // may still arrive; otherwise the existing full reconnect and ADB
@@ -1298,6 +1430,20 @@ export class ScrcpyScreenshotManager {
     }
   }
 
+  private createVideoResetFrameTimeoutError(): ScrcpyFrameWaitTimeoutError {
+    const dataPacketsSeen = this.videoResetState?.dataPacketsSeen ?? 0;
+    const observation =
+      dataPacketsSeen === 0
+        ? 'no data packets were observed while reset recovery was active'
+        : `${dataPacketsSeen} data packet${dataPacketsSeen === 1 ? ' was' : 's were'} observed while reset recovery was active`;
+    const message = `Scrcpy video reset produced no usable fresh keyframe within the ${VIDEO_RESET_FRAME_TIMEOUT_MS}ms post-reset window; ${observation}`;
+    debugScrcpy(message);
+    return new ScrcpyFrameWaitTimeoutError(
+      message,
+      VIDEO_RESET_FRAME_TIMEOUT_MS,
+    );
+  }
+
   private async closeStaleStreamAndCreateFallbackError(
     error: unknown,
   ): Promise<ScrcpyFreshFrameUnavailableError> {
@@ -1306,9 +1452,11 @@ export class ScrcpyScreenshotManager {
         ? 'stream-startup'
         : 'freshness-target';
     const timeoutMs =
-      failureKind === 'stream-startup'
-        ? MAX_KEYFRAME_WAIT_MS
-        : FRESH_FRAME_TIMEOUT_MS;
+      error instanceof ScrcpyFrameWaitTimeoutError
+        ? error.timeoutMs
+        : failureKind === 'stream-startup'
+          ? MAX_KEYFRAME_WAIT_MS
+          : FRESH_FRAME_TIMEOUT_MS;
     const causeMessage = error instanceof Error ? error.message : String(error);
     await this.disconnect();
     return new ScrcpyFreshFrameUnavailableError(

--- a/packages/android/src/scrcpy-manager.ts
+++ b/packages/android/src/scrcpy-manager.ts
@@ -30,7 +30,7 @@ const FRESH_FRAME_TIMEOUT_MS = 300;
 const VIDEO_RESET_DELAY_MS = 10;
 // RESET_VIDEO is only a control-channel write. Once the write succeeds, give
 // the restarted encoder its own budget to emit configuration and an IDR frame.
-const VIDEO_RESET_FRAME_TIMEOUT_MS = 500;
+const DEFAULT_VIDEO_RESET_FRAME_TIMEOUT_MS = 800;
 const KEYFRAME_POLL_INTERVAL_MS = 200;
 const MAX_SCAN_BYTES = 1_000;
 const MAX_SERVER_OUTPUT_LINES = 100;
@@ -51,12 +51,14 @@ export const DEFAULT_SCRCPY_CONFIG = {
   maxSize: DEFAULT_MAX_SIZE,
   idleTimeoutMs: DEFAULT_IDLE_TIMEOUT_MS,
   videoBitRate: DEFAULT_VIDEO_BIT_RATE,
+  videoResetFrameTimeoutMs: DEFAULT_VIDEO_RESET_FRAME_TIMEOUT_MS,
 } as const;
 
 export interface ScrcpyScreenshotOptions {
   maxSize?: number;
   videoBitRate?: number;
   idleTimeoutMs?: number;
+  videoResetFrameTimeoutMs?: number;
 }
 
 /** Transfers the local scrcpy server binary to its device path. */
@@ -225,6 +227,7 @@ interface ResolvedScrcpyOptions {
   maxSize: number;
   videoBitRate: number;
   idleTimeoutMs: number;
+  videoResetFrameTimeoutMs: number;
 }
 
 interface VideoResetState {
@@ -301,6 +304,9 @@ export class ScrcpyScreenshotManager {
       maxSize: options.maxSize ?? DEFAULT_MAX_SIZE,
       videoBitRate: clampedBitRate,
       idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+      videoResetFrameTimeoutMs:
+        options.videoResetFrameTimeoutMs ??
+        DEFAULT_VIDEO_RESET_FRAME_TIMEOUT_MS,
     };
   }
 
@@ -1412,9 +1418,9 @@ export class ScrcpyScreenshotManager {
         try {
           await this.requestVideoReset(deadline);
           videoResetWritten = true;
-          deadline = Date.now() + VIDEO_RESET_FRAME_TIMEOUT_MS;
+          deadline = Date.now() + this.options.videoResetFrameTimeoutMs;
           debugScrcpy(
-            `Scrcpy video reset control write completed; waiting up to ${VIDEO_RESET_FRAME_TIMEOUT_MS}ms for a post-reset frame`,
+            `Scrcpy video reset control write completed; waiting up to ${this.options.videoResetFrameTimeoutMs}ms for a post-reset frame`,
           );
         } catch (resetError) {
           // Preserve the rest of the original 300ms window. A natural frame
@@ -1431,17 +1437,15 @@ export class ScrcpyScreenshotManager {
   }
 
   private createVideoResetFrameTimeoutError(): ScrcpyFrameWaitTimeoutError {
+    const timeoutMs = this.options.videoResetFrameTimeoutMs;
     const dataPacketsSeen = this.videoResetState?.dataPacketsSeen ?? 0;
     const observation =
       dataPacketsSeen === 0
         ? 'no data packets were observed while reset recovery was active'
         : `${dataPacketsSeen} data packet${dataPacketsSeen === 1 ? ' was' : 's were'} observed while reset recovery was active`;
-    const message = `Scrcpy video reset produced no usable fresh keyframe within the ${VIDEO_RESET_FRAME_TIMEOUT_MS}ms post-reset window; ${observation}`;
+    const message = `Scrcpy video reset produced no usable fresh keyframe within the ${timeoutMs}ms post-reset window; ${observation}`;
     debugScrcpy(message);
-    return new ScrcpyFrameWaitTimeoutError(
-      message,
-      VIDEO_RESET_FRAME_TIMEOUT_MS,
-    );
+    return new ScrcpyFrameWaitTimeoutError(message, timeoutMs);
   }
 
   private async closeStaleStreamAndCreateFallbackError(

--- a/packages/android/tests/unit-test/scrcpy-adapter.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-adapter.test.ts
@@ -178,7 +178,30 @@ describe('ScrcpyDeviceAdapter', () => {
       const config = adapter.resolveConfig();
       expect(config.idleTimeoutMs).toBe(DEFAULT_SCRCPY_CONFIG.idleTimeoutMs);
       expect(config.videoBitRate).toBe(DEFAULT_SCRCPY_CONFIG.videoBitRate);
+      expect(config.videoResetFrameTimeoutMs).toBe(
+        DEFAULT_SCRCPY_CONFIG.videoResetFrameTimeoutMs,
+      );
     });
+
+    it('should honor a custom video reset frame timeout', () => {
+      const adapter = new ScrcpyDeviceAdapter('device', {
+        videoResetFrameTimeoutMs: 1200,
+      });
+
+      expect(adapter.resolveConfig().videoResetFrameTimeoutMs).toBe(1200);
+    });
+
+    it.each([0, -1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
+      'should reject invalid videoResetFrameTimeoutMs %s',
+      (videoResetFrameTimeoutMs) => {
+        const adapter = new ScrcpyDeviceAdapter('device', {
+          videoResetFrameTimeoutMs,
+        });
+        expect(() => adapter.resolveConfig()).toThrow(
+          'Invalid scrcpyConfig.videoResetFrameTimeoutMs: expected a positive integer',
+        );
+      },
+    );
 
     it.each(['10.84.162.47:36967', '127.0.0.1:5555', 'device:5555'])(
       'should not infer videoBitRate from the device endpoint %s',
@@ -287,6 +310,21 @@ describe('ScrcpyDeviceAdapter', () => {
   });
 
   describe('ensureManager', () => {
+    it('should pass the resolved video reset timeout to the manager', async () => {
+      const adapter = new ScrcpyDeviceAdapter('device', {
+        enabled: true,
+        videoResetFrameTimeoutMs: 1200,
+      });
+
+      await adapter.ensureManager(defaultDeviceInfo);
+
+      expect(rs.mocked(ScrcpyScreenshotManager).mock.calls[0][2]).toMatchObject(
+        {
+          videoResetFrameTimeoutMs: 1200,
+        },
+      );
+    });
+
     it('should use the local ADB server endpoint by default', async () => {
       const adapter = new ScrcpyDeviceAdapter('device', { enabled: true });
 

--- a/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
@@ -7,7 +7,8 @@ import {
 const noopPushServer: ScrcpyServerPusher = async () => {};
 const createManager = (
   adb: ConstructorParameters<typeof ScrcpyScreenshotManager>[0],
-) => new ScrcpyScreenshotManager(adb, noopPushServer);
+  options: ConstructorParameters<typeof ScrcpyScreenshotManager>[2] = {},
+) => new ScrcpyScreenshotManager(adb, noopPushServer, options);
 
 const prepareEstablishedStaleManager = (
   manager: ScrcpyScreenshotManager,
@@ -166,7 +167,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(waitForNextKeyframe).toHaveBeenCalledTimes(1);
   });
 
-  it('waits up to 500ms after a successful reset control write', async () => {
+  it('waits up to 800ms after a successful reset control write by default', async () => {
     rs.useFakeTimers();
     rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
     const resetVideo = rs.fn().mockImplementation(
@@ -205,7 +206,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
                   streamEpoch: (manager as any).streamEpoch,
                   capturedAt: Date.now(),
                 }),
-              450,
+              650,
             );
           }),
       );
@@ -218,12 +219,12 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(waitForNextKeyframe).toHaveBeenCalledTimes(1);
     await rs.advanceTimersByTimeAsync(1);
     expect(waitForNextKeyframe).toHaveBeenCalledTimes(2);
-    await rs.advanceTimersByTimeAsync(449);
+    await rs.advanceTimersByTimeAsync(649);
     expect(close).not.toHaveBeenCalled();
     await rs.advanceTimersByTimeAsync(1);
 
     await expect(capture).resolves.toEqual(jpegFrame());
-    expect(waitForNextKeyframe.mock.calls[1][0]).toBe(500);
+    expect(waitForNextKeyframe.mock.calls[1][0]).toBe(800);
     expect(close).not.toHaveBeenCalled();
   });
 
@@ -356,7 +357,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('reports when a successful reset produces no data frames within 500ms', async () => {
+  it('reports when a successful reset produces no data frames within 800ms', async () => {
     rs.useFakeTimers();
     rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
     const resetVideo = rs.fn().mockResolvedValue(undefined);
@@ -368,7 +369,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
 
     const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
       name: 'ScrcpyFreshFrameUnavailableError',
-      timeoutMs: 500,
+      timeoutMs: 800,
       message: expect.stringContaining(
         'no data packets were observed while reset recovery was active',
       ),
@@ -382,7 +383,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(resetVideo).toHaveBeenCalledTimes(1);
     expect(disconnect).not.toHaveBeenCalled();
 
-    await rs.advanceTimersByTimeAsync(499);
+    await rs.advanceTimersByTimeAsync(799);
     expect(disconnect).not.toHaveBeenCalled();
     await rs.advanceTimersByTimeAsync(1);
 
@@ -394,7 +395,9 @@ describe('ScrcpyScreenshotManager video reset', () => {
     rs.useFakeTimers();
     rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
     const resetVideo = rs.fn().mockResolvedValue(undefined);
-    const manager = createManager({} as any);
+    const manager = createManager({} as any, {
+      videoResetFrameTimeoutMs: 950,
+    });
     prepareEstablishedStaleManager(manager, resetVideo, {
       hostWallTimeMs: Date.now(),
     });
@@ -402,7 +405,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
 
     const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
       name: 'ScrcpyFreshFrameUnavailableError',
-      timeoutMs: 500,
+      timeoutMs: 950,
       message: expect.stringContaining(
         '1 data packet was observed while reset recovery was active',
       ),
@@ -410,7 +413,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
     await rs.advanceTimersByTimeAsync(10);
     (manager as any).processFrame(spsPacket());
     (manager as any).processFrame(dataPacket(0x01, 2_005_000n));
-    await rs.advanceTimersByTimeAsync(500);
+    await rs.advanceTimersByTimeAsync(950);
 
     await capture;
     expect(resetVideo).toHaveBeenCalledTimes(1);

--- a/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager-video-reset.test.ts
@@ -166,6 +166,67 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(waitForNextKeyframe).toHaveBeenCalledTimes(1);
   });
 
+  it('waits up to 500ms after a successful reset control write', async () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
+    const resetVideo = rs.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 75);
+        }),
+    );
+    const close = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo, {
+      hostWallTimeMs: Date.now(),
+      clientExtras: { close },
+    });
+    const waitForNextKeyframe = rs
+      .spyOn(manager as any, 'waitForNextKeyframe')
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(
+              () => reject(new Error('no natural frame within 10ms')),
+              10,
+            );
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve({
+                  data: Buffer.from('delayed-post-reset-frame'),
+                  header: Buffer.from('new-header'),
+                  ptsUs: 2_006_000n,
+                  estimatedAgeMs: 0,
+                  streamEpoch: (manager as any).streamEpoch,
+                  capturedAt: Date.now(),
+                }),
+              450,
+            );
+          }),
+      );
+    rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(jpegFrame());
+
+    const capture = manager.getScreenshotJpeg();
+    await rs.advanceTimersByTimeAsync(10);
+    expect(resetVideo).toHaveBeenCalledTimes(1);
+    await rs.advanceTimersByTimeAsync(74);
+    expect(waitForNextKeyframe).toHaveBeenCalledTimes(1);
+    await rs.advanceTimersByTimeAsync(1);
+    expect(waitForNextKeyframe).toHaveBeenCalledTimes(2);
+    await rs.advanceTimersByTimeAsync(449);
+    expect(close).not.toHaveBeenCalled();
+    await rs.advanceTimersByTimeAsync(1);
+
+    await expect(capture).resolves.toEqual(jpegFrame());
+    expect(waitForNextKeyframe.mock.calls[1][0]).toBe(500);
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('shares one video reset across concurrent recovery callers', async () => {
     let finishReset: (() => void) | undefined;
     const resetVideo = rs.fn().mockReturnValue(
@@ -295,7 +356,7 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps video reset and full reconnect fallback inside the original 300ms budget', async () => {
+  it('reports when a successful reset produces no data frames within 500ms', async () => {
     rs.useFakeTimers();
     rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
     const resetVideo = rs.fn().mockResolvedValue(undefined);
@@ -307,7 +368,10 @@ describe('ScrcpyScreenshotManager video reset', () => {
 
     const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
       name: 'ScrcpyFreshFrameUnavailableError',
-      timeoutMs: 300,
+      timeoutMs: 500,
+      message: expect.stringContaining(
+        'no data packets were observed while reset recovery was active',
+      ),
     });
     await rs.advanceTimersByTimeAsync(0);
     await rs.advanceTimersByTimeAsync(9);
@@ -318,11 +382,38 @@ describe('ScrcpyScreenshotManager video reset', () => {
     expect(resetVideo).toHaveBeenCalledTimes(1);
     expect(disconnect).not.toHaveBeenCalled();
 
-    await rs.advanceTimersByTimeAsync(289);
+    await rs.advanceTimersByTimeAsync(499);
     expect(disconnect).not.toHaveBeenCalled();
     await rs.advanceTimersByTimeAsync(1);
 
     await capture;
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unusable data packets observed while reset recovery is active', async () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date('2026-09-01T00:00:00Z'));
+    const resetVideo = rs.fn().mockResolvedValue(undefined);
+    const manager = createManager({} as any);
+    prepareEstablishedStaleManager(manager, resetVideo, {
+      hostWallTimeMs: Date.now(),
+    });
+    const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+
+    const capture = expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+      name: 'ScrcpyFreshFrameUnavailableError',
+      timeoutMs: 500,
+      message: expect.stringContaining(
+        '1 data packet was observed while reset recovery was active',
+      ),
+    });
+    await rs.advanceTimersByTimeAsync(10);
+    (manager as any).processFrame(spsPacket());
+    (manager as any).processFrame(dataPacket(0x01, 2_005_000n));
+    await rs.advanceTimersByTimeAsync(500);
+
+    await capture;
+    expect(resetVideo).toHaveBeenCalledTimes(1);
     expect(disconnect).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/android/tests/unit-test/scrcpy-manager.test.ts
+++ b/packages/android/tests/unit-test/scrcpy-manager.test.ts
@@ -53,6 +53,37 @@ const jpegFrame = (width = 1, height = 1): Buffer =>
     0xd9,
   ]);
 
+const prepareCachedPlanningFrame = (
+  manager: ScrcpyScreenshotManager,
+  options: {
+    ptsUs?: bigint;
+    frameData?: string;
+    roundTripUs?: bigint;
+    resetVideo?: () => Promise<void>;
+  } = {},
+) => {
+  const internals = manager as any;
+  if (options.resetVideo) {
+    internals.scrcpyClient = {
+      controller: { resetVideo: options.resetVideo },
+    };
+  }
+  internals.spsHeader = Buffer.from('header');
+  internals.lastRawKeyframe = Buffer.from(options.frameData ?? 'fresh-frame');
+  internals.lastRawKeyframePtsUs = options.ptsUs ?? 2_000_000n;
+  internals.lastRawKeyframeAt = 2_000;
+  internals.lastRawKeyframeStreamEpoch = internals.streamEpoch;
+  internals.deviceClockCalibration = {
+    deviceUptimeUs: 2_000_000n,
+    hostMonotonicUs: 10_000_000n,
+    hostWallTimeMs: 2_000,
+    roundTripUs: options.roundTripUs ?? 1_544_554n,
+  };
+  rs.spyOn(internals, 'monotonicTimeUs').mockReturnValue(10_000_000n);
+  rs.spyOn(manager, 'ensureConnected').mockResolvedValue();
+  rs.spyOn(internals, 'resetIdleTimer').mockImplementation(() => {});
+};
+
 describe('ScrcpyScreenshotManager', () => {
   afterEach(() => {
     rs.useRealTimers();
@@ -792,6 +823,131 @@ describe('ScrcpyScreenshotManager', () => {
 
       (manager as any).deviceClockCalibration.roundTripUs = 22_000n;
       expect((manager as any).isFrameAgeAcceptable(1_000_000n)).toBe(false);
+    });
+
+    it('recalibrates instead of resetting when only clock uncertainty makes a planning frame look stale', async () => {
+      const resetVideo = rs.fn().mockResolvedValue(undefined);
+      const manager = createManager({} as any);
+      prepareCachedPlanningFrame(manager, { resetVideo });
+      const readClock = rs
+        .spyOn(manager as any, 'readDeviceClockCalibration')
+        .mockResolvedValue({
+          deviceUptimeUs: 2_000_000n,
+          hostMonotonicUs: 10_000_000n,
+          hostWallTimeMs: 2_000,
+          roundTripUs: 20_000n,
+        });
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
+
+      expect(readClock).toHaveBeenCalledTimes(1);
+      expect((manager as any).deviceClockCalibration.roundTripUs).toBe(20_000n);
+      expect(barrier).not.toHaveBeenCalled();
+      expect(resetVideo).not.toHaveBeenCalled();
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+
+    it('retries a persistently uncertain clock only once per calibration lifetime', async () => {
+      const resetVideo = rs.fn().mockResolvedValue(undefined);
+      const manager = createManager({} as any);
+      prepareCachedPlanningFrame(manager, { resetVideo });
+      const readClock = rs
+        .spyOn(manager as any, 'readDeviceClockCalibration')
+        .mockResolvedValue({
+          deviceUptimeUs: 2_000_000n,
+          hostMonotonicUs: 10_000_000n,
+          hostWallTimeMs: 2_000,
+          roundTripUs: 1_600_000n,
+        });
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
+
+      expect(readClock).toHaveBeenCalledTimes(1);
+      expect((manager as any).deviceClockCalibration.roundTripUs).toBe(
+        1_544_554n,
+      );
+      expect(barrier).not.toHaveBeenCalled();
+      expect(resetVideo).not.toHaveBeenCalled();
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+
+    it('uses estimated age when the best-effort recalibration fails without changing epochs', async () => {
+      const resetVideo = rs.fn().mockResolvedValue(undefined);
+      const manager = createManager({} as any);
+      prepareCachedPlanningFrame(manager, { resetVideo });
+      const readClock = rs
+        .spyOn(manager as any, 'readDeviceClockCalibration')
+        .mockRejectedValue(new Error('ADB clock sample failed'));
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+      rs.spyOn(manager as any, 'decodeH264ToJpeg').mockResolvedValue(
+        jpegFrame(),
+      );
+
+      await expect(manager.getScreenshotJpeg()).resolves.toEqual(jpegFrame());
+
+      expect(readClock).toHaveBeenCalledOnce();
+      expect(barrier).not.toHaveBeenCalled();
+      expect(resetVideo).not.toHaveBeenCalled();
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+
+    it('still rejects a genuinely stale planning frame when clock uncertainty is high', async () => {
+      const manager = createManager({} as any);
+      prepareCachedPlanningFrame(manager, {
+        ptsUs: 1_400_000n,
+        frameData: 'stale-frame',
+      });
+      const readClock = rs.spyOn(manager as any, 'readDeviceClockCalibration');
+      const barrier = rs.spyOn(manager, 'setFreshnessBarrier');
+      rs.spyOn(manager as any, 'waitForNextKeyframe').mockRejectedValue(
+        new Error('no fresh frame'),
+      );
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+
+      await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+        name: 'ScrcpyFreshFrameUnavailableError',
+        failureKind: 'freshness-target',
+      });
+
+      expect(readClock).not.toHaveBeenCalled();
+      expect(barrier).toHaveBeenCalledWith('stale planning frame');
+      expect(disconnect).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an uncertainty-only candidate when its stream epoch changes during recalibration', async () => {
+      const manager = createManager({} as any);
+      prepareCachedPlanningFrame(manager, { frameData: 'obsolete-frame' });
+      rs.spyOn(manager as any, 'readDeviceClockCalibration').mockImplementation(
+        async () => {
+          (manager as any).advanceStreamEpoch();
+          (manager as any).deviceClockCalibration = null;
+          throw new Error('calibration invalidated');
+        },
+      );
+      const disconnect = rs.spyOn(manager, 'disconnect').mockResolvedValue();
+      const decode = rs.spyOn(manager as any, 'decodeH264ToJpeg');
+
+      await expect(manager.getScreenshotJpeg()).rejects.toMatchObject({
+        name: 'ScrcpyFreshFrameUnavailableError',
+        message: expect.stringContaining(
+          'stream epoch changed while recalibrating',
+        ),
+      });
+
+      expect(decode).not.toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalledOnce();
     });
 
     it('recalibrates the clock anchor when frame PTS moves backwards', async () => {

--- a/packages/core/src/device/device-options.ts
+++ b/packages/core/src/device/device-options.ts
@@ -111,6 +111,7 @@ export type AndroidDeviceOpt = {
    *     maxSize: 0,        // 0 = no scaling
    *     idleTimeoutMs: 30000,
    *     videoBitRate: 8_000_000,
+   *     videoResetFrameTimeoutMs: 1000,
    *   },
    * });
    * ```
@@ -150,6 +151,13 @@ export type AndroidDeviceOpt = {
      * @default 100000000 (100 Mbps)
      */
     videoBitRate?: number;
+    /**
+     * Time in milliseconds to wait for a fresh keyframe after scrcpy accepts
+     * an in-band video reset. Increase this for devices whose display capture
+     * pipeline has a slower restart tail. Must be a positive integer.
+     * @default 800
+     */
+    videoResetFrameTimeoutMs?: number;
   };
 } & AndroidDeviceInputOpt;
 


### PR DESCRIPTION
## Summary

- Recover stale static scrcpy streams with an in-band `RESET_VIDEO` request before falling back to a full reconnect.
- Give a successful reset write an independent recovery window and raise the default from 500 ms to 800 ms so slow Android display-capture restarts can still produce their first IDR frame.
- Expose the window as `scrcpyConfig.videoResetFrameTimeoutMs`, validate it as a positive integer, and document it in the public type and English/Chinese reference pages.
- Recalibrate uncertainty-only frame ages once per clock-anchor lifetime, then use the estimated age so ADB RTT uncertainty alone cannot trigger reset and reconnect storms.
- Add diagnostics for reset control writes, scrcpy server output, zero-frame recovery, unusable packets, and stream-epoch replacement.

## Context

The original workload reconnected about 585 times per hour. A first beta with in-band reset reduced that to 267 reconnects per hour but only 53% of resets produced a frame before the reused 300 ms deadline.

A second beta with a dedicated 500 ms post-reset window and uncertainty handling reduced reconnects to 61 per hour, raised reset success to 94% (73/78), reduced reconnect wall time to 4.3%, and produced no ADB fallback in the observed window. The five remaining failures all occurred on one Android 16 OPPO device. Server logs showed that the reset reached the server in 13 ms, while display capture recreation took 368-377 ms before the encoder could begin producing the first IDR frame. The fixed 500 ms window therefore clipped the device-side long tail.

The new 800 ms default covers the observed tail while the public option lets callers tune unusually slow devices. The existing one-time clock recalibration remains in place because the available four-sample result is not sufficient evidence to remove that diagnostic and recovery step.

## Validation

- `pnpm --dir packages/android test tests/unit-test/scrcpy-manager-video-reset.test.ts tests/unit-test/scrcpy-adapter.test.ts` — 75 tests passed.
- `pnpm exec nx test @midscene/android --skip-nx-cache` — 467 tests passed across 22 files.
- `pnpm exec nx run-many -t build -p @midscene/core @midscene/android --skip-nx-cache` — passed, including required dependencies.
- `pnpm run lint` — 1627 files checked, no fixes required.
- `git diff --check` — passed.

## Runtime validation

The 61 reconnects/hour and 94% reset success figures came from the two-device Android 16 soak of the 500 ms beta. The downstream host should repeat the same soak against the new prepatch to confirm that the 800 ms window absorbs the remaining OPPO restart tail.