### PR TITLE
fix(core): use rstest mock API in core tests

### DIFF
--- a/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
@@ -161,7 +161,7 @@ describe('default locate protocol', () => {
   });
 
   it('rejects a non-object response from a custom JSON parser', () => {
-    const jsonParser = vi.fn(() => [
+    const jsonParser = rs.fn(() => [
       { bbox: [100, 200, 300, 400] },
       { bbox: [500, 600, 700, 800] },
     ]);

--- a/packages/core/tests/unit-test/service-caller-object-response.test.ts
+++ b/packages/core/tests/unit-test/service-caller-object-response.test.ts
@@ -2,7 +2,7 @@ import type { ModelRuntime } from '@/ai-model/model-adapter/types';
 import { getModelRuntime } from '@/ai-model/models';
 import { type callAI, parseAIObjectResponse } from '@/ai-model/service-caller';
 import type { IModelConfig } from '@midscene/shared/env';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, rs } from '@rstest/core';
 
 const modelConfig: IModelConfig = {
   modelName: 'gpt-5',
@@ -32,7 +32,7 @@ describe('parseAIObjectResponse', () => {
 
   it('requires the adapter JSON parser to return an object', () => {
     const modelRuntime = getModelRuntime(modelConfig);
-    const jsonParser = vi.fn(() => ({ answer: 42 }));
+    const jsonParser = rs.fn(() => ({ answer: 42 }));
     const objectResponseModelRuntime: ModelRuntime = {
       ...modelRuntime,
       adapter: {
@@ -58,7 +58,7 @@ describe('parseAIObjectResponse', () => {
       ...modelRuntime,
       adapter: {
         ...modelRuntime.adapter,
-        jsonParser: vi.fn(() => [{ answer: 42 }]),
+        jsonParser: rs.fn(() => [{ answer: 42 }]),
       },
     };
 


### PR DESCRIPTION
## Summary

- replace the remaining Vitest import in the Core object-response unit test with `@rstest/core`
- replace stale `vi.fn()` calls with the canonical Rstest `rs.fn()` mock API
- restore the Core test target so release validation can complete

## Root cause

The Core package migrated from Vitest to Rstest after the affected pull request had already completed CI. When that pull request was merged onto the newer base, it reintroduced Vitest-specific test APIs without rerunning against the migrated test setup.

## Validation

- `pnpm exec nx test @midscene/core --skip-nx-cache`
- `pnpm run lint`
- `git diff --check`