### PR TITLE
fix(test): settle running steps on cancellation

### DIFF
--- a/packages/test/src/engine/execute-step.ts
+++ b/packages/test/src/engine/execute-step.ts
@@ -89,7 +89,7 @@ async function executeNode<TOutputData>(
   else parentSignal?.addEventListener('abort', abortFromParent, { once: true });
   const timeoutMs = step.meta.timeoutMs ?? options.defaultTimeoutMs;
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: StepTimeoutError | undefined;
+  let abortTimeout: ReturnType<typeof setTimeout> | undefined;
   const execution = Promise.resolve().then(() => {
     if (abortController.signal.aborted) {
       throw (
@@ -99,23 +99,48 @@ async function executeNode<TOutputData>(
     }
     return execute(abortController.signal);
   });
-  const timedExecution =
+  let abortExecution: (() => void) | undefined;
+  const abortedExecution = new Promise<never>((_, reject) => {
+    abortExecution = () => {
+      abortTimeout = setTimeout(() => {
+        reject(
+          abortController.signal.reason ??
+            new Error('Workflow execution aborted.'),
+        );
+      }, 0);
+    };
+    if (abortController.signal.aborted) abortExecution();
+    else
+      abortController.signal.addEventListener('abort', abortExecution, {
+        once: true,
+      });
+  });
+  const timeoutExecution =
     timeoutMs === undefined
-      ? execution
-      : Promise.race([
-          execution,
-          new Promise<never>((_, reject) => {
-            timeout = setTimeout(() => {
-              timeoutError = new StepTimeoutError(timeoutMs, step.node);
-              abortController.abort(timeoutError);
-              reject(timeoutError);
-            }, timeoutMs);
-          }),
-        ]);
+      ? undefined
+      : new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            if (abortController.signal.aborted) {
+              reject(
+                abortController.signal.reason ??
+                  new Error('Workflow execution aborted.'),
+              );
+              return;
+            }
+            const timeoutError = new StepTimeoutError(timeoutMs, step.node);
+            abortController.abort(timeoutError);
+            reject(timeoutError);
+          }, timeoutMs);
+        });
+  const settledExecution = Promise.race([
+    execution,
+    abortedExecution,
+    ...(timeoutExecution === undefined ? [] : [timeoutExecution]),
+  ]);
 
   try {
     const output = validateNodeOutput<TOutputData>(
-      await timedExecution,
+      await settledExecution,
       step.node,
     );
     return {
@@ -129,10 +154,14 @@ async function executeNode<TOutputData>(
       ...createStepResultBase(step, startedAt, phase, stepIndex),
       status: 'failed',
       continuedAfterError: step.meta.continueOnError,
-      error: normalizeNodeExecutionError(timeoutError ?? error, step.node),
+      error: normalizeNodeExecutionError(error, step.node),
     };
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
+    if (abortTimeout !== undefined) clearTimeout(abortTimeout);
+    if (abortExecution !== undefined) {
+      abortController.signal.removeEventListener('abort', abortExecution);
+    }
     parentSignal?.removeEventListener('abort', abortFromParent);
   }
 }
@@ -181,6 +210,9 @@ export async function executeStep<
     step,
     async (signal) => {
       const input = await parseNodeInput(node, step.input);
+      if (signal.aborted) {
+        throw signal.reason ?? new Error('Workflow execution aborted.');
+      }
       const common = {
         input,
         $: step.meta,

--- a/packages/test/tests/run-collected-case.test.ts
+++ b/packages/test/tests/run-collected-case.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 import { type CollectedCase, NodeRegistry, defineNode } from '../src';
 import { runCollectedCase } from '../src/engine/run-collected-case';
 
@@ -17,6 +18,10 @@ const collected = (
   sourcePath: 'flows/example.yaml',
   caseIndex: 2,
   definition: { name: 'example case', steps },
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('runCollectedCase', () => {
@@ -215,5 +220,238 @@ describe('runCollectedCase', () => {
       resolve('/tmp/second.html'),
       resolve('/tmp/first.html'),
     ]);
+  });
+
+  it('does not execute a node when the parent signal is already aborted', async () => {
+    const execute = vi.fn();
+    const controller = new AbortController();
+    const cancellationReason = new Error('cancelled before execution');
+    const node = defineNode({ name: 'never-started', execute });
+    const registry = new NodeRegistry([node]);
+    controller.abort(cancellationReason);
+
+    const result = await runCollectedCase(collected([step(node.name)]), {
+      resolveNode: registry.require.bind(registry),
+      signal: controller.signal,
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+  });
+
+  it('does not execute a node after async input parsing finishes following parent cancellation', async () => {
+    vi.useFakeTimers();
+    const execute = vi.fn();
+    const controller = new AbortController();
+    const cancellationReason = new Error('cancelled during input parsing');
+    let markParsingStarted: (() => void) | undefined;
+    let releaseValidation: (() => void) | undefined;
+    let markParsingFinished: (() => void) | undefined;
+    const parsingStarted = new Promise<void>((resolve) => {
+      markParsingStarted = resolve;
+    });
+    const validationGate = new Promise<void>((resolve) => {
+      releaseValidation = resolve;
+    });
+    const parsingFinished = new Promise<void>((resolve) => {
+      markParsingFinished = resolve;
+    });
+    const inputSchema = z.strictObject({
+      value: z.string().refine(async () => {
+        markParsingStarted?.();
+        await validationGate;
+        return true;
+      }),
+    });
+    const safeParseAsync = inputSchema.safeParseAsync.bind(inputSchema);
+    vi.spyOn(inputSchema, 'safeParseAsync').mockImplementation(
+      async (input) => {
+        const parsed = await safeParseAsync(input);
+        markParsingFinished?.();
+        return parsed;
+      },
+    );
+    const node = defineNode({
+      name: 'cancelled-during-input-parse',
+      inputSchema,
+      execute,
+    });
+    const registry = new NodeRegistry([node]);
+
+    const execution = runCollectedCase(
+      collected([
+        {
+          node: node.name,
+          input: { value: 'valid' },
+          meta: { continueOnError: false },
+        },
+      ]),
+      {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await parsingStarted;
+    controller.abort(cancellationReason);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await execution;
+
+    releaseValidation?.();
+    await parsingFinished;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+  });
+
+  it('preserves parent cancellation when the step timeout expires in the same timer turn', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const cancellationReason = new Error(
+      'parent cancelled at timeout boundary',
+    );
+    const node = defineNode({
+      name: 'parent-cancelled-at-timeout',
+      execute() {
+        return new Promise<void>(() => {});
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    setTimeout(() => controller.abort(cancellationReason), 50);
+
+    const execution = runCollectedCase(
+      collected([
+        {
+          node: node.name,
+          input: {},
+          meta: { continueOnError: false, timeoutMs: 50 },
+        },
+      ]),
+      {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await execution;
+
+    expect(result.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+  });
+
+  it('handles a late node rejection after cancellation settles the runner', async () => {
+    const controller = new AbortController();
+    let rejectNode: ((reason?: unknown) => void) | undefined;
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const node = defineNode({
+      name: 'late-rejection',
+      execute() {
+        markStarted?.();
+        return new Promise<void>((_, reject) => {
+          rejectNode = reject;
+        });
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const execution = runCollectedCase(collected([step(node.name)]), {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      });
+      await started;
+      controller.abort(new Error('cancel running node'));
+      await execution;
+
+      if (!rejectNode) throw new Error('Node rejection was not captured.');
+      rejectNode(new Error('late node failure'));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('settles a running step on parent cancellation and runs cleanup', async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    const controller = new AbortController();
+    const cancellationReason = new Error('workflow interrupted');
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const registry = new NodeRegistry([
+      defineNode({
+        name: 'blocking',
+        execute({ onTeardown }) {
+          calls.push('step');
+          onTeardown(() => {
+            calls.push('teardown');
+          });
+          markStarted?.();
+          return new Promise<void>(() => {});
+        },
+      }),
+      defineNode({
+        name: 'after',
+        execute() {
+          calls.push('afterEach');
+        },
+      }),
+    ]);
+
+    const execution = runCollectedCase(
+      collected([
+        {
+          node: 'blocking',
+          input: {},
+          meta: { continueOnError: false, timeoutMs: 60_000 },
+        },
+      ]),
+      {
+        afterEach: [step('after')],
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await started;
+
+    let result: Awaited<typeof execution> | undefined;
+    const settled = execution.then((value) => {
+      result = value;
+      return true;
+    });
+    controller.abort(cancellationReason);
+    const observed = Promise.race([
+      settled,
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 50)),
+    ]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(await observed).toBe(true);
+    expect(result?.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+    expect(calls).toEqual(['step', 'afterEach', 'teardown']);
   });
 });


### PR DESCRIPTION
## Summary

- race running node execution against parent cancellation and optional step timeout
- preserve the first cancellation reason while allowing cooperative nodes to finish
- stop nodes from starting when cancellation occurs during async input parsing
- clean up cancellation timers and abort listeners after the race settles

## Tests

- cover non-cooperative pending nodes and cleanup execution
- cover pre-aborted signals and cancellation during async input parsing
- cover late node rejection without `unhandledRejection`
- cover parent cancellation racing a due step timeout

## Verification

- `@midscene/test`: 186 tests passed
- `@midscene/test` build and declaration generation passed
- `@midscene/test` API type tests passed
- Biome and `git diff --check` passed

Closes #3086