### PR TITLE
fix(test): settle running steps on cancellation

### DIFF
--- a/packages/test/src/engine/execute-step.ts
+++ b/packages/test/src/engine/execute-step.ts
@@ -81,41 +81,54 @@ async function executeNode<TOutputData>(
   const startedAt = new Date();
   const abortController = new AbortController();
   const parentSignal = options.parentSignal;
-  const abortFromParent = () =>
-    abortController.abort(
-      parentSignal?.reason ?? new Error('Workflow execution aborted.'),
-    );
+  const abortFromParent = () => abortController.abort(parentSignal?.reason);
   if (parentSignal?.aborted) abortFromParent();
   else parentSignal?.addEventListener('abort', abortFromParent, { once: true });
   const timeoutMs = step.meta.timeoutMs ?? options.defaultTimeoutMs;
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: StepTimeoutError | undefined;
+  let abortGraceTimeout: ReturnType<typeof setTimeout> | undefined;
   const execution = Promise.resolve().then(() => {
-    if (abortController.signal.aborted) {
-      throw (
-        abortController.signal.reason ??
-        new Error('Workflow execution aborted.')
-      );
-    }
+    abortController.signal.throwIfAborted();
     return execute(abortController.signal);
   });
-  const timedExecution =
+  let settleOnAbort: (() => void) | undefined;
+  const abortedExecution = new Promise<never>((_, reject) => {
+    settleOnAbort = () => {
+      // Abort listeners run synchronously. Wait one task before rejecting so a
+      // cooperative node can settle in response to the forwarded abort first.
+      abortGraceTimeout = setTimeout(() => {
+        reject(abortController.signal.reason);
+      }, 0);
+    };
+    if (abortController.signal.aborted) settleOnAbort();
+    else
+      abortController.signal.addEventListener('abort', settleOnAbort, {
+        once: true,
+      });
+  });
+  const timeoutExecution =
     timeoutMs === undefined
-      ? execution
-      : Promise.race([
-          execution,
-          new Promise<never>((_, reject) => {
-            timeout = setTimeout(() => {
-              timeoutError = new StepTimeoutError(timeoutMs, step.node);
-              abortController.abort(timeoutError);
-              reject(timeoutError);
-            }, timeoutMs);
-          }),
-        ]);
+      ? undefined
+      : new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            if (abortController.signal.aborted) {
+              reject(abortController.signal.reason);
+              return;
+            }
+            const timeoutError = new StepTimeoutError(timeoutMs, step.node);
+            abortController.abort(timeoutError);
+            reject(timeoutError);
+          }, timeoutMs);
+        });
+  const settledExecution = Promise.race([
+    execution,
+    abortedExecution,
+    ...(timeoutExecution === undefined ? [] : [timeoutExecution]),
+  ]);
 
   try {
     const output = validateNodeOutput<TOutputData>(
-      await timedExecution,
+      await settledExecution,
       step.node,
     );
     return {
@@ -129,10 +142,14 @@ async function executeNode<TOutputData>(
       ...createStepResultBase(step, startedAt, phase, stepIndex),
       status: 'failed',
       continuedAfterError: step.meta.continueOnError,
-      error: normalizeNodeExecutionError(timeoutError ?? error, step.node),
+      error: normalizeNodeExecutionError(error, step.node),
     };
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
+    if (abortGraceTimeout !== undefined) clearTimeout(abortGraceTimeout);
+    if (settleOnAbort !== undefined) {
+      abortController.signal.removeEventListener('abort', settleOnAbort);
+    }
     parentSignal?.removeEventListener('abort', abortFromParent);
   }
 }
@@ -181,6 +198,7 @@ export async function executeStep<
     step,
     async (signal) => {
       const input = await parseNodeInput(node, step.input);
+      signal.throwIfAborted();
       const common = {
         input,
         $: step.meta,

--- a/packages/test/tests/run-collected-case.test.ts
+++ b/packages/test/tests/run-collected-case.test.ts
@@ -1,13 +1,32 @@
 import { resolve } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
-import { type CollectedCase, NodeRegistry, defineNode } from '../src';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type CollectedCase,
+  NodeRegistry,
+  StepTimeoutError,
+  defineNode,
+  z,
+} from '../src';
 import { runCollectedCase } from '../src/engine/run-collected-case';
 
-const step = (node: string, continueOnError = false) => ({
+const step = (node: string, continueOnError = false, timeoutMs?: number) => ({
   node,
   input: {},
-  meta: { continueOnError },
+  meta: {
+    continueOnError,
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  },
 });
+
+const createDeferred = <T = void>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
 
 const collected = (
   steps: CollectedCase['definition']['steps'],
@@ -17,6 +36,10 @@ const collected = (
   sourcePath: 'flows/example.yaml',
   caseIndex: 2,
   definition: { name: 'example case', steps },
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('runCollectedCase', () => {
@@ -215,5 +238,295 @@ describe('runCollectedCase', () => {
       resolve('/tmp/second.html'),
       resolve('/tmp/first.html'),
     ]);
+  });
+
+  it('settles a non-cooperative running step on parent cancellation and runs cleanup', async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    const controller = new AbortController();
+    const removeAbortListener = vi.spyOn(
+      controller.signal,
+      'removeEventListener',
+    );
+    const cancellationReason = new Error('workflow interrupted');
+    const started = createDeferred();
+    const registry = new NodeRegistry([
+      defineNode({
+        name: 'blocking',
+        execute({ onTeardown }) {
+          calls.push('step');
+          onTeardown(() => {
+            calls.push('teardown');
+          });
+          started.resolve();
+          return new Promise<void>(() => {});
+        },
+      }),
+      defineNode({
+        name: 'after',
+        execute() {
+          calls.push('afterEach');
+        },
+      }),
+    ]);
+
+    const execution = runCollectedCase(
+      collected([step('blocking', false, 60_000)]),
+      {
+        afterEach: [step('after')],
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await started.promise;
+
+    let result: Awaited<typeof execution> | undefined;
+    const settled = execution.then((value) => {
+      result = value;
+      return true;
+    });
+    controller.abort(cancellationReason);
+    const observed = Promise.race([
+      settled,
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 50)),
+    ]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(await observed).toBe(true);
+    expect(result?.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+    expect(calls).toEqual(['step', 'afterEach', 'teardown']);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(removeAbortListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+  });
+
+  it('preserves a null parent cancellation reason', async () => {
+    const controller = new AbortController();
+    const started = createDeferred();
+    const node = defineNode({
+      name: 'null-cancellation-reason',
+      execute() {
+        started.resolve();
+        return new Promise<void>(() => {});
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    const execution = runCollectedCase(collected([step(node.name)]), {
+      resolveNode: registry.require.bind(registry),
+      signal: controller.signal,
+    });
+    await started.promise;
+
+    controller.abort(null);
+    const result = await execution;
+
+    expect(result.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: null,
+    });
+  });
+
+  it('retains the result of a node that settles cooperatively on parent cancellation', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const started = createDeferred();
+    const node = defineNode({
+      name: 'cooperative',
+      execute({ signal }) {
+        started.resolve();
+        return new Promise<{ summary: string }>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => resolve({ summary: 'stopped cleanly' }),
+            { once: true },
+          );
+        });
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    const execution = runCollectedCase(
+      collected([step(node.name, false, 60_000)]),
+      {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await started.promise;
+
+    controller.abort(new Error('stop requested'));
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await execution;
+
+    expect(result.steps[0]).toMatchObject({
+      status: 'success',
+      output: { summary: 'stopped cleanly' },
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps StepTimeoutError when timeout aborts a cooperative node first', async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const node = defineNode({
+      name: 'timed-cooperative',
+      execute(ctx) {
+        signal = ctx.signal;
+        return new Promise<{ summary: string }>((resolve) => {
+          ctx.signal.addEventListener(
+            'abort',
+            () => resolve({ summary: 'stopped after timeout' }),
+            { once: true },
+          );
+        });
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    const execution = runCollectedCase(
+      collected([step(node.name, false, 50)]),
+      { resolveNode: registry.require.bind(registry) },
+    );
+
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await execution;
+
+    expect(signal?.reason).toBeInstanceOf(StepTimeoutError);
+    expect(result.steps[0].error).toBeInstanceOf(StepTimeoutError);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves parent cancellation when timeout expires in the same timer turn', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const cancellationReason = new Error('cancelled at timeout boundary');
+    const node = defineNode({
+      name: 'parent-cancelled-at-timeout',
+      execute() {
+        return new Promise<void>(() => {});
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    setTimeout(() => controller.abort(cancellationReason), 50);
+
+    const execution = runCollectedCase(
+      collected([step(node.name, false, 50)]),
+      {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await execution;
+
+    expect(result.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+  });
+
+  it('handles a late node rejection after cancellation settles the runner', async () => {
+    const controller = new AbortController();
+    const started = createDeferred();
+    const nodeExecution = createDeferred();
+    const node = defineNode({
+      name: 'late-rejection',
+      execute() {
+        started.resolve();
+        return nodeExecution.promise;
+      },
+    });
+    const registry = new NodeRegistry([node]);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const execution = runCollectedCase(collected([step(node.name)]), {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new Error('cancel running node'));
+      await execution;
+
+      nodeExecution.reject(new Error('late node failure'));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('does not start a node after parent cancellation interrupts input parsing', async () => {
+    const controller = new AbortController();
+    const cancellationReason = new Error('cancelled during input parsing');
+    const execute = vi.fn();
+    const parsingStarted = createDeferred();
+    const validationGate = createDeferred();
+    const parsingFinished = createDeferred();
+    const inputSchema = z.strictObject({
+      value: z.string().refine(async () => {
+        parsingStarted.resolve();
+        await validationGate.promise;
+        return true;
+      }),
+    });
+    const safeParseAsync = inputSchema.safeParseAsync.bind(inputSchema);
+    vi.spyOn(inputSchema, 'safeParseAsync').mockImplementation(
+      async (input) => {
+        const parsed = await safeParseAsync(input);
+        parsingFinished.resolve();
+        return parsed;
+      },
+    );
+    const node = defineNode({
+      name: 'cancelled-during-parse',
+      inputSchema,
+      execute,
+    });
+    const registry = new NodeRegistry([node]);
+    const execution = runCollectedCase(
+      collected([
+        {
+          node: node.name,
+          input: { value: 'valid' },
+          meta: { continueOnError: false },
+        },
+      ]),
+      {
+        resolveNode: registry.require.bind(registry),
+        signal: controller.signal,
+      },
+    );
+    await parsingStarted.promise;
+
+    controller.abort(cancellationReason);
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const observed = await Promise.race([
+      execution,
+      new Promise<'watchdog'>((resolve) => {
+        watchdog = setTimeout(() => resolve('watchdog'), 50);
+      }),
+    ]);
+    if (watchdog !== undefined) clearTimeout(watchdog);
+    validationGate.resolve();
+    await parsingFinished.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(observed).not.toBe('watchdog');
+    if (observed === 'watchdog') return;
+    expect(observed.steps[0].error).toMatchObject({
+      code: 'NODE_EXECUTION_ERROR',
+      cause: cancellationReason,
+    });
+    expect(execute).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- settle running test steps promptly when their parent AbortSignal is cancelled, even when a node ignores cancellation
- preserve cooperative node results, the original cancellation reason, and StepTimeoutError precedence
- prevent node execution after cancellation during asynchronous input parsing and clean up timers and abort listeners
- add regression coverage for cleanup hooks, timeout boundaries, late rejections, and cancellation races

Closes #3086

## Validation

- pnpm exec nx test @midscene/test
- pnpm run lint
- pnpm exec nx build @midscene/test
- git diff --check