### PR TITLE
fix(web-integration): improve static report playground execution

### DIFF
--- a/packages/playground/src/launcher.ts
+++ b/packages/playground/src/launcher.ts
@@ -97,6 +97,12 @@ function isLoopbackOrigin(origin?: string) {
     return true;
   }
 
+  // Local HTML reports opened through file:// have an opaque origin, which
+  // browsers serialize as "null" in CORS requests.
+  if (origin === 'null') {
+    return true;
+  }
+
   try {
     const url = new URL(origin);
     return LOOPBACK_HOSTS.has(url.hostname);

--- a/packages/playground/tests/unit/launcher.test.ts
+++ b/packages/playground/tests/unit/launcher.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it, rs } from '@rstest/core';
+import cors, { type CorsOptions } from 'cors';
 import {
   playgroundForAgent,
   playgroundForAgentFactory,
@@ -18,6 +19,44 @@ function createMockAgent() {
 }
 
 const staticPath = path.resolve(process.cwd(), 'static');
+
+type CorsOriginResult =
+  | boolean
+  | string
+  | RegExp
+  | Array<boolean | string | RegExp>;
+
+function checkCorsOrigin(options: CorsOptions, origin: string) {
+  return new Promise<CorsOriginResult>((resolve, reject) => {
+    if (typeof options.origin !== 'function') {
+      reject(new Error('Expected a dynamic CORS origin policy'));
+      return;
+    }
+
+    options.origin(origin, (error, allowed) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      if (allowed === undefined) {
+        reject(new Error('Expected the CORS origin policy to return a value'));
+        return;
+      }
+
+      resolve(allowed);
+    });
+  });
+}
+
+function getConfiguredCorsOptions(): CorsOptions {
+  const corsMock = cors as unknown as ReturnType<typeof rs.fn>;
+  const options = corsMock.mock.calls[0]?.[0];
+  if (!options) {
+    throw new Error('Expected CORS middleware to be configured');
+  }
+  return options;
+}
 
 describe('playground launcher', () => {
   it('should build browser URLs for IPv4, hostnames, and IPv6 literals', () => {
@@ -86,6 +125,21 @@ describe('playground launcher', () => {
         process.env.MIDSCENE_PLAYGROUND_HOST = originalHost;
       }
     }
+  });
+
+  it('should allow file protocol reports when CORS is enabled', async () => {
+    const result = await playgroundForAgent(createMockAgent()).launch({
+      port: 5925,
+      openBrowser: false,
+      verbose: false,
+      staticPath,
+      enableCors: true,
+    });
+
+    const corsOptions = getConfiguredCorsOptions();
+    await expect(checkCorsOrigin(corsOptions, 'null')).resolves.toBe(true);
+
+    await result.close();
   });
 
   it('should launch from agent factory and allow server configuration', async () => {

--- a/packages/web-integration/src/platform.ts
+++ b/packages/web-integration/src/platform.ts
@@ -46,7 +46,10 @@ export const webPlaygroundPlatform = definePlaygroundPlatform<
       title: options?.title || 'Midscene Web Playground',
       agent: agent || (!agentFactory ? createDefaultWebAgent() : undefined),
       agentFactory,
-      launchOptions: options?.launchOptions,
+      launchOptions: {
+        enableCors: true,
+        ...options?.launchOptions,
+      },
       preview:
         options?.preview ||
         createMjpegPreviewDescriptor({

--- a/packages/web-integration/tests/unit-test/platform.test.ts
+++ b/packages/web-integration/tests/unit-test/platform.test.ts
@@ -11,6 +11,7 @@ describe('webPlaygroundPlatform', () => {
     expect(prepared.agent).toBeUndefined();
     expect(prepared.agentFactory).toBeTypeOf('function');
     expect(createdAgent).toBeInstanceOf(StaticPageAgent);
+    expect(prepared.launchOptions).toMatchObject({ enableCors: true });
     expect(prepared.preview).toMatchObject({
       kind: 'mjpeg',
       screenshotPath: '/screenshot',
@@ -24,6 +25,7 @@ describe('webPlaygroundPlatform', () => {
       launchOptions: {
         port: 5807,
         openBrowser: true,
+        enableCors: false,
       },
     });
 
@@ -31,6 +33,7 @@ describe('webPlaygroundPlatform', () => {
     expect(prepared.launchOptions).toMatchObject({
       port: 5807,
       openBrowser: true,
+      enableCors: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

- reuse the serialized UI context in `StaticPageAgent` so static reports avoid redundant browser-side screenshot decoding and resizing
- preserve serialized screenshot items and invalidate the cached UI context when static context changes
- enable CORS for the Web Playground platform and allow the opaque `Origin: null` used by `file://` reports
- keep the default CORS policy limited to local browser origins and file reports, while allowing callers to disable it explicitly

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/playground -- launcher.test.ts`
- `pnpm exec nx test @midscene/web -- platform.test.ts`
- `pnpm exec nx test @midscene/web`
- `pnpm exec nx build @midscene/playground`
- `pnpm exec nx build @midscene/web`
- `pnpm exec nx build @midscene/report`